### PR TITLE
Shard Controller life-cycle bug fix

### DIFF
--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -18,7 +18,7 @@ const (
 	// RoleKey label is set by every single service as soon as it bootstraps its
 	// ringpop instance. The data for this key is the service name
 	RoleKey                = "serviceName"
-	defaultRefreshInterval = time.Second * 20
+	defaultRefreshInterval = time.Second * 10
 )
 
 type ringpopServiceResolver struct {

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -105,7 +105,6 @@ func (h *serviceImpl) Start(thriftServices []thrift.TChanServer) {
 	if err != nil {
 		h.logger.WithFields(bark.Fields{logging.TagErr: err}).Fatal("Ringpop creation failed")
 	}
-	h.logger = h.logger.WithField("hostname", h.hostPort)
 
 	err = h.bootstrapRingpop(h.rp, h.rpSeedHosts)
 	if err != nil {

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -105,6 +105,7 @@ func (h *serviceImpl) Start(thriftServices []thrift.TChanServer) {
 	if err != nil {
 		h.logger.WithFields(bark.Fields{logging.TagErr: err}).Fatal("Ringpop creation failed")
 	}
+	h.logger = h.logger.WithField("hostname", h.hostPort)
 
 	err = h.bootstrapRingpop(h.rp, h.rpSeedHosts)
 	if err != nil {
@@ -136,7 +137,7 @@ func (h *serviceImpl) Start(thriftServices []thrift.TChanServer) {
 	h.clientFactory = client.NewTChannelClientFactory(h.ch, h.membershipMonitor, metricsClient, h.numberOfHistoryShards)
 
 	// The service is now started up
-	log.Info("service started")
+	h.logger.Info("service started")
 
 	// seed the random generator once for this service
 	rand.Seed(time.Now().UTC().UnixNano())

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -50,6 +50,7 @@ var (
 
 const (
 	testNumberOfHistoryShards = 4
+	testNumberOfHistoryHosts  = 2
 )
 
 type (
@@ -111,7 +112,8 @@ func (s *integrationSuite) SetupTest() {
 
 	s.setupShards()
 
-	s.host = NewCadence(s.ShardMgr, s.ExecutionMgrFactory, s.TaskMgr, testNumberOfHistoryShards, s.logger)
+	s.host = NewCadence(s.ShardMgr, s.ExecutionMgrFactory, s.TaskMgr, testNumberOfHistoryShards, testNumberOfHistoryHosts,
+		s.logger)
 	s.host.Start()
 	s.engine, _ = frontend.NewClient(s.ch, s.host.FrontendAddress())
 }

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -50,7 +50,7 @@ var (
 
 const (
 	testNumberOfHistoryShards = 4
-	testNumberOfHistoryHosts  = 2
+	testNumberOfHistoryHosts  = 1
 )
 
 type (

--- a/service/history/loggingHelpers.go
+++ b/service/history/loggingHelpers.go
@@ -219,11 +219,11 @@ func logRingMembershipChangedEvent(logger bark.Logger, host string, added, remov
 		host, added, removed, updated)
 }
 
-func logShardClosedEvent(logger bark.Logger, shardID int) {
+func logShardClosedEvent(logger bark.Logger, host string, shardID int) {
 	logger.WithFields(bark.Fields{
 		tagWorkflowEventID: shardClosedEvent,
 		tagHistoryShardID:  shardID,
-	}).Infof("ShardController on host '%v' received shard closed event for shardID: %v", shardID)
+	}).Infof("ShardController on host '%v' received shard closed event for shardID: %v", host, shardID)
 }
 
 func logShardItemCreatedEvent(logger bark.Logger, host string, shardID int) {

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -227,6 +227,7 @@ func acquireShard(shardID int, shardManager persistence.ShardManager, executionM
 	updatedShardInfo := copyShardInfo(shardInfo)
 	updatedShardInfo.Owner = owner
 	context := &shardContextImpl{
+		shardID:          shardID,
 		shardManager:     shardManager,
 		executionManager: executionMgr,
 		shardInfo:        updatedShardInfo,

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -220,7 +220,7 @@ func (c *shardController) shardManagementPump() {
 				len(changedEvent.HostsRemoved), len(changedEvent.HostsUpdated))
 			c.acquireShards()
 		case shardID := <-c.shardClosedCh:
-			logShardClosedEvent(c.logger, shardID)
+			logShardClosedEvent(c.logger, c.host.Identity(), shardID)
 			c.removeEngineForShard(shardID)
 		}
 	}

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -99,8 +99,6 @@ func (t *transferQueueProcessorImpl) Start() {
 
 	t.shutdownWG.Add(1)
 	go t.processorPump()
-
-	t.logger.Info("Transfer queue processor started.")
 }
 
 func (t *transferQueueProcessorImpl) Stop() {


### PR DESCRIPTION
We were not setting the shardID on shardContext when the shard is
acquired by a host.  This caused the shardID to be intialized to 0 for
all shards.  We used the same shardID for sending the closed event on
the shardClosedCh which caused us to always remove the shardID 0.

Updated onebox setup to have support for spinning up multiple history
hosts.  Also changed the integration tests to use 2 history hosts for
running the tests.

Also made some minor logging fixes.