### PR TITLE
Add more logs for debugging history panic

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -404,6 +404,10 @@ Update_History_Loop:
 
 	Process_Decision_Loop:
 		for _, d := range request.Decisions {
+			e.logger.Infof("WorkflowComplete Decision received: {WorkflowId: %v, RunId: %v, DecisionType: %v, ScheduledActivityDecision: %v, TimerStartedDecision: %v, RequestCancelActivityDevision: %v, CompleteWorkflowDecision: %v, FailWorkflowDecision: %v}",
+				token.WorkflowID, token.RunID, d.GetDecisionType(), d.GetScheduleActivityTaskDecisionAttributes(),
+				d.GetStartTimerDecisionAttributes(), d.GetRequestCancelActivityTaskDecisionAttributes(),
+				d.GetCompleteWorkflowExecutionDecisionAttributes(), d.GetFailWorkflowExecutionDecisionAttributes())
 			switch d.GetDecisionType() {
 			case workflow.DecisionType_ScheduleActivityTask:
 				attributes := d.GetScheduleActivityTaskDecisionAttributes()


### PR DESCRIPTION
We need more logs to debug history service.  I have added logging to log each decision as part of the RespondDecisionTaskCompleted API.