### PR TITLE
History service to return ShardOwnershipLostError for clients to retry

### DIFF
--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -474,6 +474,7 @@ func (d *cassandraPersistence) UpdateShard(request *UpdateShardRequest) error {
 		}
 
 		return &ShardOwnershipLostError{
+			ShardID: d.shardID,
 			Msg: fmt.Sprintf("Failed to update shard.  previous_range_id: %v, columns: (%v)",
 				request.PreviousRangeID, strings.Join(columns, ",")),
 		}
@@ -536,6 +537,7 @@ func (d *cassandraPersistence) CreateWorkflowExecution(request *CreateWorkflowEx
 		if rangeID, ok := previous["range_id"].(int64); ok && rangeID != request.RangeID {
 			// CreateWorkflowExecution failed because rangeID was modified
 			return nil, &ShardOwnershipLostError{
+				ShardID: d.shardID,
 				Msg: fmt.Sprintf("Failed to create workflow execution.  Request RangeID: %v, Actual RangeID: %v",
 					request.RangeID, rangeID),
 			}
@@ -640,6 +642,7 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(request *UpdateWorkflowEx
 		if rangeID, ok := previous["range_id"].(int64); ok && rangeID != request.RangeID {
 			// UpdateWorkflowExecution failed because rangeID was modified
 			return &ShardOwnershipLostError{
+				ShardID: d.shardID,
 				Msg: fmt.Sprintf("Failed to update workflow execution.  Request RangeID: %v, Actual RangeID: %v",
 					request.RangeID, rangeID),
 			}

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -8,7 +8,7 @@ import (
 
 // Workflow execution states
 const (
-	WorkflowStateCreated = iota
+	WorkflowStateCreated   = iota
 	WorkflowStateRunning
 	WorkflowStateCompleted
 )
@@ -39,7 +39,8 @@ type (
 
 	// ShardOwnershipLostError is returned when conditional update fails due to RangeID for the shard
 	ShardOwnershipLostError struct {
-		Msg string
+		ShardID int
+		Msg     string
 	}
 
 	// ShardInfo describes a shard

--- a/common/persistence/persistenceTestBase.go
+++ b/common/persistence/persistenceTestBase.go
@@ -78,10 +78,6 @@ func newTestShardContext(shardInfo *ShardInfo, transferSequenceNumber int64, exe
 	}
 }
 
-func (s *testShardContext) GetShardID() int {
-	return s.shardInfo.ShardID
-}
-
 func (s *testShardContext) GetExecutionManager() ExecutionManager {
 	return s.executionMgr
 }

--- a/service/history/MockHistoryEngine.go
+++ b/service/history/MockHistoryEngine.go
@@ -19,22 +19,6 @@ func (_m *MockHistoryEngine) Stop() {
 	_m.Called()
 }
 
-// GetShardContext returns the context used by History Engine instance
-func (_m *MockHistoryEngine) GetShardContext() ShardContext {
-	ret := _m.Called()
-
-	var r0 ShardContext
-	if rf, ok := ret.Get(0).(func() ShardContext); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(ShardContext)
-		}
-	}
-
-	return r0
-}
-
 // StartWorkflowExecution is mock implementation for StartWorkflowExecution of HistoryEngine
 func (_m *MockHistoryEngine) StartWorkflowExecution(request *shared.StartWorkflowExecutionRequest) (*shared.StartWorkflowExecutionResponse, error) {
 	ret := _m.Called(request)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -100,7 +100,7 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx thrift.Context,
 
 	response, err2 := engine.RecordActivityTaskHeartbeat(heartbeatRequest)
 	if err2 != nil {
-		return nil, h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return nil, h.convertError(err2)
 	}
 
 	return response, nil
@@ -118,7 +118,7 @@ func (h *Handler) RecordActivityTaskStarted(ctx thrift.Context,
 
 	response, err2 := engine.RecordActivityTaskStarted(recordRequest)
 	if err2 != nil {
-		return nil, h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return nil, h.convertError(err2)
 	}
 
 	return response, nil
@@ -145,7 +145,7 @@ func (h *Handler) RecordDecisionTaskStarted(ctx thrift.Context,
 
 	response, err2 := engine.RecordDecisionTaskStarted(recordRequest)
 	if err2 != nil {
-		return nil, h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return nil, h.convertError(err2)
 	}
 
 	return response, nil
@@ -167,7 +167,7 @@ func (h *Handler) RespondActivityTaskCompleted(ctx thrift.Context,
 
 	err2 := engine.RespondActivityTaskCompleted(completeRequest)
 	if err2 != nil {
-		return h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return h.convertError(err2)
 	}
 
 	return nil
@@ -189,7 +189,7 @@ func (h *Handler) RespondActivityTaskFailed(ctx thrift.Context,
 
 	err2 := engine.RespondActivityTaskFailed(failRequest)
 	if err2 != nil {
-		return h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return h.convertError(err2)
 	}
 
 	return nil
@@ -211,7 +211,7 @@ func (h *Handler) RespondActivityTaskCanceled(ctx thrift.Context,
 
 	err2 := engine.RespondActivityTaskCanceled(cancelRequest)
 	if err2 != nil {
-		return h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return h.convertError(err2)
 	}
 
 	return nil
@@ -238,7 +238,7 @@ func (h *Handler) RespondDecisionTaskCompleted(ctx thrift.Context,
 
 	err2 := engine.RespondDecisionTaskCompleted(completeRequest)
 	if err2 != nil {
-		return h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return h.convertError(err2)
 	}
 
 	return nil
@@ -255,7 +255,7 @@ func (h *Handler) StartWorkflowExecution(ctx thrift.Context,
 
 	response, err2 := engine.StartWorkflowExecution(startRequest)
 	if err2 != nil {
-		return nil, h.convertError(engine.GetShardContext().GetShardID(), err2)
+		return nil, h.convertError(err2)
 	}
 
 	return response, nil
@@ -277,9 +277,10 @@ func (h *Handler) GetWorkflowExecutionHistory(ctx thrift.Context,
 // convertError is a helper method to convert ShardOwnershipLostError from persistence layer returned by various
 // HistoryEngine API calls to ShardOwnershipLost error return by HistoryService for client to be redirected to the
 // correct shard.
-func (h *Handler) convertError(shardID int, err error) error {
+func (h *Handler) convertError(err error) error {
 	switch err.(type) {
 	case *persistence.ShardOwnershipLostError:
+		shardID := err.(*persistence.ShardOwnershipLostError).ShardID
 		info, err := h.hServiceResolver.Lookup(string(shardID))
 		if err != nil {
 			return createShardOwnershipLostError(h.GetHostInfo().GetAddress(), info.GetAddress())

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -114,10 +114,6 @@ func (e *historyEngineImpl) Stop() {
 	e.timerProcessor.Stop()
 }
 
-func (e *historyEngineImpl) GetShardContext() ShardContext {
-	return e.shard
-}
-
 // StartWorkflowExecution starts a workflow execution
 func (e *historyEngineImpl) StartWorkflowExecution(request *workflow.StartWorkflowExecutionRequest) (
 	*workflow.StartWorkflowExecutionResponse, error) {

--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -10,7 +10,6 @@ type (
 	// Engine represents an interface for managing workflow execution history.
 	Engine interface {
 		common.Daemon
-		GetShardContext() ShardContext
 		// TODO: Convert workflow.WorkflowExecution to pointer all over the place
 		StartWorkflowExecution(request *workflow.StartWorkflowExecutionRequest) (*workflow.StartWorkflowExecutionResponse, error)
 		GetWorkflowExecutionHistory(

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -17,7 +17,6 @@ const (
 type (
 	// ShardContext represents a history engine shard
 	ShardContext interface {
-		GetShardID() int
 		GetExecutionManager() persistence.ExecutionManager
 		GetNextTransferTaskID() (int64, error)
 		GetTransferSequenceNumber() int64
@@ -50,10 +49,6 @@ type (
 )
 
 var _ ShardContext = (*shardContextImpl)(nil)
-
-func (s *shardContextImpl) GetShardID() int {
-	return s.shardInfo.ShardID
-}
 
 func (s *shardContextImpl) GetExecutionManager() persistence.ExecutionManager {
 	return s.executionManager


### PR DESCRIPTION
History service API returns ShardOwnershipLostError for all API calls to
let the client know about the correct host to retry the request.

ShardController returns ShardOwnershipLostError whenever it detects
client called the host for wrong shard.  This error also has the actual
host information which can be used by the client to retry the call.

All HistoryEngine API calls checks for ShardOwnershipLostError from
persistence layer and wraps it with ShardOwnershipLostError for the
history service calls with the information for correct host to contact.