### PR TITLE
Use Quorum consistency for reading mutable state

### DIFF
--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -1115,7 +1115,7 @@ func (d *cassandraPersistence) GetWorkflowMutableState(request *GetWorkflowMutab
 		rowTypeExecution,
 		request.WorkflowID,
 		request.RunID,
-		rowTypeExecutionTaskID).Consistency(d.lowConslevel)
+		rowTypeExecutionTaskID)
 
 	result := make(map[string]interface{})
 	if err := query.MapScan(result); err != nil {

--- a/service/history/loggingHelpers.go
+++ b/service/history/loggingHelpers.go
@@ -98,7 +98,7 @@ const (
 	tagValueStoreOperationCreateWorkflowExecution = "create-wf-execution"
 	tagValueStoreOperationGetWorkflowExecution    = "get-wf-execution"
 	tagValueStoreOperationGetWorkflowMutableState = "get-wf-mutable-state"
-	tagValueStoreOperationUpdateWorkflowExecution = "get-wf-execution"
+	tagValueStoreOperationUpdateWorkflowExecution = "update-wf-execution"
 	tagValueStoreOperationDeleteWorkflowExecution = "delete-wf-execution"
 )
 

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -596,7 +596,9 @@ Update_History_Loop:
 		isRunning, di := msBuilder.GetDecision(scheduleID)
 		if isRunning {
 			// Add a decision task timeout event.
-			t.historyService.timeoutDecisionTask(builder, msBuilder, scheduleID, di.StartedID)
+			if err := t.historyService.timeoutDecisionTask(builder, msBuilder, scheduleID, di.StartedID); err != nil {
+				return err
+			}
 			scheduleNewDecision = true
 		}
 

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -158,7 +158,7 @@ func (c *workflowExecutionContext) updateWorkflowExecution(transferTasks []persi
 			return ErrConflict
 		}
 
-		logPersistantStoreErrorEvent(c.logger, tagValueStoreOperationUpdateWorkflowExecution, err,
+		logPersistantStoreErrorEvent(c.logger, tagValueStoreOperationUpdateWorkflowExecution, err1,
 			fmt.Sprintf("{updateCondition: %v}", c.updateCondition))
 		return err1
 	}


### PR DESCRIPTION
History Engine uses mutable state for making lots of decisions like
de-duping events.  Previously we were reading mutable state as low
consistency which is problematic if the update times out and we end up
reading stale mutable state.  I have updated the code to instead to a
Quorum read on getting mutable state.
Also updated the History Engine logic to not ignore errors from history
builder while doing state transitions.
Fixed minor typos in logging tags and incorrectly using the wrong error
for logging.