### PR TITLE
Persistence layer changes for domain CRUD

### DIFF
--- a/common/persistence/cassandraHistoryPersistence.go
+++ b/common/persistence/cassandraHistoryPersistence.go
@@ -33,7 +33,6 @@ const (
 type (
 	cassandraHistoryPersistence struct {
 		session      *gocql.Session
-		lowConslevel gocql.Consistency
 		logger       bark.Logger
 	}
 )
@@ -53,7 +52,7 @@ func NewCassandraHistoryPersistence(hosts string, dc string, keyspace string, lo
 		return nil, err
 	}
 
-	return &cassandraHistoryPersistence{session: session, lowConslevel: gocql.One, logger: logger}, nil
+	return &cassandraHistoryPersistence{session: session, logger: logger}, nil
 }
 
 func (h *cassandraHistoryPersistence) AppendHistoryEvents(request *AppendHistoryEventsRequest) error {

--- a/common/persistence/cassandraMetadataPersistence.go
+++ b/common/persistence/cassandraMetadataPersistence.go
@@ -1,0 +1,267 @@
+package persistence
+
+import (
+	"fmt"
+
+	"github.com/gocql/gocql"
+	"github.com/pborman/uuid"
+	"github.com/uber-common/bark"
+
+	workflow "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
+)
+
+const (
+	templateDomainType = `{` +
+		`id: ?, ` +
+		`name: ?, ` +
+		`status: ?, ` +
+		`description: ?, ` +
+		`owner_email: ?` +
+		`}`
+
+	templateDomainConfigType = `{` +
+		`retention: ?, ` +
+		`emit_metric: ?` +
+		`}`
+
+	templateCreateDomainQuery = `INSERT INTO domains (` +
+		`id, domain, config) ` +
+		`VALUES(?, ` + templateDomainType + `, ` + templateDomainConfigType + `)`
+
+	templateCreateDomainByNameQuery = `INSERT INTO domains_by_name (` +
+		`name, domain, config) ` +
+		`VALUES(?, ` + templateDomainType + `, ` + templateDomainConfigType + `) IF NOT EXISTS`
+
+	templateGetDomainQuery = `SELECT domain.id, domain.name, domain.status, domain.description, domain.owner_email, ` +
+		`config.retention, config.emit_metric ` +
+		`FROM domains ` +
+		`WHERE id = ?`
+
+	templateGetDomainByNameQuery = `SELECT domain.id, domain.name, domain.status, domain.description, ` +
+		`domain.owner_email, config.retention, config.emit_metric ` +
+		`FROM domains_by_name ` +
+		`WHERE name = ?`
+
+	templateUpdateDomainQuery = `UPDATE domains ` +
+		`SET domain = ` + templateDomainType + `, ` +
+		`config = ` + templateDomainConfigType +  ` ` +
+		`WHERE id = ?`
+
+	templateUpdateDomainByNameQuery = `UPDATE domains_by_name ` +
+		`SET domain = ` + templateDomainType + `, ` +
+		`config = ` + templateDomainConfigType +  ` ` +
+		`WHERE name = ?`
+
+	templateDeleteDomainQuery = `DELETE FROM domains ` +
+		`WHERE id = ?`
+
+	templateDeleteDomainByNameQuery = `DELETE FROM domains_by_name ` +
+		`WHERE name = ?`
+)
+
+type (
+	cassandraMetadataPersistence struct {
+		session *gocql.Session
+		logger  bark.Logger
+	}
+)
+
+// NewCassandraHistoryPersistence is used to create an instance of HistoryManager implementation
+func NewCassandraMetadataPersistence(hosts string, dc string, keyspace string, logger bark.Logger) (MetadataManager,
+	error) {
+	cluster := common.NewCassandraCluster(hosts, dc)
+	cluster.Keyspace = keyspace
+	cluster.ProtoVersion = cassandraProtoVersion
+	cluster.Consistency = gocql.LocalQuorum
+	cluster.SerialConsistency = gocql.LocalSerial
+	cluster.Timeout = defaultSessionTimeout
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cassandraMetadataPersistence{session: session, logger: logger}, nil
+}
+
+// Cassandra does not support conditional updates across multiple tables.  For this reason we have to first insert into
+// 'Domains' table and then do a conditional insert into domains_by_name table.  If the conditional write fails we
+// delete the orphaned entry from domains table.  There is a chance delete entry could fail and we never delete the
+// orphaned entry from domains table.  We might need a background job to delete those orphaned record.
+func (m *cassandraMetadataPersistence) CreateDomain(request *CreateDomainRequest) (*CreateDomainResponse, error) {
+	domainUUID := uuid.New()
+	if err := m.session.Query(templateCreateDomainQuery,
+		domainUUID,
+		domainUUID,
+		request.Name,
+		request.Status,
+		request.Description,
+		request.OwnerEmail,
+		request.Retention,
+		request.EmitMetric).Exec(); err != nil {
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("CreateDomain operation failed. Inserting into domains table. Error: %v", err),
+		}
+	}
+
+	query := m.session.Query(templateCreateDomainByNameQuery,
+		request.Name,
+		domainUUID,
+		request.Name,
+		request.Status,
+		request.Description,
+		request.OwnerEmail,
+		request.Retention,
+		request.EmitMetric)
+
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("CreateDomain operation failed. Inserting into domains_by_name table. Error: %v", err),
+		}
+	}
+
+	if !applied {
+		// Domain already exist.  Delete orphan domain record before returning back to user
+		if err = m.session.Query(templateDeleteDomainQuery, domainUUID).Exec(); err != nil {
+			m.logger.Warnf("Unable to delete orphan domain record. Error: %v", err)
+		}
+
+		if domain, ok := previous["domain"].(map[string]interface{}); ok {
+			msg := fmt.Sprintf("Domain already exists.  DomainId: %v", domain["id"])
+			return nil, &workflow.DomainAlreadyExistsError{
+				Message: msg,
+			}
+		}
+
+		return nil, &workflow.DomainAlreadyExistsError{
+			Message: fmt.Sprintf("CreateDomain operation failed because of conditional failure."),
+		}
+	}
+
+	return &CreateDomainResponse{ID: domainUUID}, nil
+}
+
+func (m *cassandraMetadataPersistence) GetDomain(request *GetDomainRequest) (*GetDomainResponse, error) {
+	var query *gocql.Query
+	var err error
+	info := &DomainInfo{}
+	config := &DomainConfig{}
+	if len(request.ID) > 0 {
+		if len(request.Name) > 0 {
+			return nil, &workflow.BadRequestError{
+				Message: "GetDomain operation failed.  Both ID and Name specified in request.",
+			}
+		}
+
+		query = m.session.Query(templateGetDomainQuery,
+			request.ID)
+		err = query.Scan(
+			&info.ID,
+			&info.Name,
+			&info.Status,
+			&info.Description,
+			&info.OwnerEmail,
+			&config.Retention,
+			&config.EmitMetric)
+	} else if len(request.Name) > 0 {
+		query = m.session.Query(templateGetDomainByNameQuery,
+			request.Name)
+		err = query.Scan(
+			&info.ID,
+			&info.Name,
+			&info.Status,
+			&info.Description,
+			&info.OwnerEmail,
+			&config.Retention,
+			&config.EmitMetric)
+	} else {
+		return nil, &workflow.BadRequestError{
+			Message: "GetDomain operation failed.  Both ID and Name are empty.",
+		}
+	}
+
+	if err != nil {
+		if err == gocql.ErrNotFound {
+			var d string
+			if len(request.ID) > 0 {
+				d = request.ID
+			} else {
+				d = request.Name
+			}
+
+			return nil, &workflow.EntityNotExistsError{
+				Message: fmt.Sprintf("Domain %s does not exist.", d),
+			}
+		}
+
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("GetDomain operation failed. Error %v", err),
+		}
+	}
+
+	return &GetDomainResponse{
+		Info:   info,
+		Config: config,
+	}, nil
+}
+
+func (m *cassandraMetadataPersistence) UpdateDomain(request *UpdateDomainRequest) error {
+	batch := m.session.NewBatch(gocql.LoggedBatch)
+
+	batch.Query(templateUpdateDomainQuery,
+		request.Info.ID,
+		request.Info.Name,
+		request.Info.Status,
+		request.Info.Description,
+		request.Info.OwnerEmail,
+		request.Config.Retention,
+		request.Config.EmitMetric,
+		request.Info.ID)
+
+	batch.Query(templateUpdateDomainByNameQuery,
+		request.Info.ID,
+		request.Info.Name,
+		request.Info.Status,
+		request.Info.Description,
+		request.Info.OwnerEmail,
+		request.Config.Retention,
+		request.Config.EmitMetric,
+		request.Info.Name)
+
+	if err := m.session.ExecuteBatch(batch); err != nil {
+		return &workflow.InternalServiceError{
+			Message: fmt.Sprintf("UpdateDomain operation failed. Error %v", err),
+		}
+	}
+
+	return nil
+}
+
+func (m *cassandraMetadataPersistence) DeleteDomain(request *DeleteDomainRequest) error {
+	query := m.session.Query(templateDeleteDomainQuery,
+		request.ID)
+
+	if err := query.Exec(); err != nil {
+		return &workflow.InternalServiceError{
+			Message: fmt.Sprintf("DeleteDomain operation failed. Error %v", err),
+		}
+	}
+
+	return nil
+}
+
+func (m *cassandraMetadataPersistence) DeleteDomainByName(request *DeleteDomainByNameRequest) error {
+	query := m.session.Query(templateDeleteDomainByNameQuery,
+		request.Name)
+
+	if err := query.Exec(); err != nil {
+		return &workflow.InternalServiceError{
+			Message: fmt.Sprintf("DeleteDomainByName operation failed. Error %v", err),
+		}
+	}
+
+	return nil
+}

--- a/common/persistence/cassandraMetadataPersistence_test.go
+++ b/common/persistence/cassandraMetadataPersistence_test.go
@@ -1,0 +1,296 @@
+package persistence
+
+import (
+	"os"
+	"testing"
+
+	log "github.com/Sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	gen "github.com/uber/cadence/.gen/go/shared"
+	//"github.com/uber/cadence/common"
+)
+
+type (
+	metadataPersistenceSuite struct {
+		suite.Suite
+		TestBase
+		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
+		// not merely log an error
+		*require.Assertions
+	}
+)
+
+func TestMetadataPersistenceSuite(t *testing.T) {
+	s := new(metadataPersistenceSuite)
+	suite.Run(t, s)
+}
+
+func (m *metadataPersistenceSuite) SetupSuite() {
+	if testing.Verbose() {
+		log.SetOutput(os.Stdout)
+	}
+
+	m.SetupWorkflowStore()
+}
+
+func (m *metadataPersistenceSuite) SetupTest() {
+	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+	m.Assertions = require.New(m.T())
+}
+
+func (m *metadataPersistenceSuite) TearDownSuite() {
+	m.TearDownWorkflowStore()
+}
+
+func (m *metadataPersistenceSuite) TestCreateDomain() {
+	name := "create-domain-test-name"
+	status := DomainStatusRegistered
+	description := "create-domain-test-description"
+	owner := "create-domain-test-owner"
+	retention := 10
+	emitMetric := true
+
+	resp0, err0 := m.CreateDomain(
+		&DomainInfo{
+			Name:        name,
+			Status:      status,
+			Description: description,
+			OwnerEmail:  owner,
+		},
+		&DomainConfig{
+			Retention:  retention,
+			EmitMetric: emitMetric,
+		})
+	m.Nil(err0)
+	m.NotNil(resp0)
+
+	id := resp0.ID
+	m.True(len(id) > 0)
+
+	resp1, err1 := m.CreateDomain(
+		&DomainInfo{
+			Name:        name,
+			Status:      status,
+			Description: "fail",
+			OwnerEmail:  "fail",
+		},
+		&DomainConfig{
+			Retention:  100,
+			EmitMetric: false,
+		})
+	m.NotNil(err1)
+	m.IsType(&gen.DomainAlreadyExistsError{}, err1)
+	m.Nil(resp1)
+}
+
+func (m *metadataPersistenceSuite) TestGetDomain() {
+	name := "get-domain-test-name"
+	status := DomainStatusRegistered
+	description := "get-domain-test-description"
+	owner := "get-domain-test-owner"
+	retention := 10
+	emitMetric := true
+
+	resp0, err0 := m.GetDomain("", "does-not-exist")
+	m.Nil(resp0)
+	m.NotNil(err0)
+	m.IsType(&gen.EntityNotExistsError{}, err0)
+
+	resp1, err1 := m.CreateDomain(
+		&DomainInfo{
+			Name:        name,
+			Status:      status,
+			Description: description,
+			OwnerEmail:  owner,
+		},
+		&DomainConfig{
+			Retention:  retention,
+			EmitMetric: emitMetric,
+		})
+	m.Nil(err1)
+	m.NotNil(resp1)
+
+	id := resp1.ID
+	m.True(len(id) > 0)
+
+	resp2, err2 := m.GetDomain(id, "")
+	m.Nil(err2)
+	m.NotNil(resp2)
+	m.Equal(id, resp2.Info.ID)
+	m.Equal(name, resp2.Info.Name)
+	m.Equal(status, resp2.Info.Status)
+	m.Equal(description, resp2.Info.Description)
+	m.Equal(owner, resp2.Info.OwnerEmail)
+	m.Equal(retention, resp2.Config.Retention)
+	m.Equal(emitMetric, resp2.Config.EmitMetric)
+
+	resp3, err3 := m.GetDomain("", name)
+	m.Nil(err3)
+	m.NotNil(resp3)
+	m.Equal(id, resp3.Info.ID)
+	m.Equal(name, resp3.Info.Name)
+	m.Equal(status, resp3.Info.Status)
+	m.Equal(description, resp3.Info.Description)
+	m.Equal(owner, resp3.Info.OwnerEmail)
+	m.Equal(retention, resp3.Config.Retention)
+	m.Equal(emitMetric, resp3.Config.EmitMetric)
+
+	resp4, err4 := m.GetDomain(id, name)
+	m.NotNil(err4)
+	m.IsType(&gen.BadRequestError{}, err4)
+	m.Nil(resp4)
+}
+
+func (m *metadataPersistenceSuite) TestUpdateDomain() {
+	name := "update-domain-test-name"
+	status := DomainStatusRegistered
+	description := "update-domain-test-description"
+	owner := "update-domain-test-owner"
+	retention := 10
+	emitMetric := true
+
+	resp1, err1 := m.CreateDomain(
+		&DomainInfo{
+			Name:        name,
+			Status:      status,
+			Description: description,
+			OwnerEmail:  owner,
+		},
+		&DomainConfig{
+			Retention:  retention,
+			EmitMetric: emitMetric,
+		})
+	m.Nil(err1)
+
+	id := resp1.ID
+	m.True(len(id) > 0)
+
+	resp2, err2 := m.GetDomain(id, "")
+	m.Nil(err2)
+	updatedStatus := DomainStatusDeprecated
+	updatedDescription := "description-updated"
+	updatedOwner := "owner-updated"
+	updatedRetention := 20
+	updatedEmitMetric := false
+
+	err3 := m.UpdateDomain(
+		&DomainInfo{
+			ID:          resp2.Info.ID,
+			Name:        resp2.Info.Name,
+			Status:      updatedStatus,
+			Description: updatedDescription,
+			OwnerEmail:  updatedOwner,
+		},
+		&DomainConfig{
+			Retention:  updatedRetention,
+			EmitMetric: updatedEmitMetric,
+		})
+
+	m.Nil(err3)
+
+	resp4, err4 := m.GetDomain("", name)
+	m.Nil(err4)
+	m.NotNil(resp4)
+	m.Equal(id, resp4.Info.ID)
+	m.Equal(name, resp4.Info.Name)
+	m.Equal(updatedStatus, resp4.Info.Status)
+	m.Equal(updatedDescription, resp4.Info.Description)
+	m.Equal(updatedOwner, resp4.Info.OwnerEmail)
+	m.Equal(updatedRetention, resp4.Config.Retention)
+	m.Equal(updatedEmitMetric, resp4.Config.EmitMetric)
+
+	resp5, err5 := m.GetDomain("", name)
+	m.Nil(err5)
+	m.NotNil(resp5)
+	m.Equal(id, resp5.Info.ID)
+	m.Equal(name, resp5.Info.Name)
+	m.Equal(updatedStatus, resp5.Info.Status)
+	m.Equal(updatedDescription, resp5.Info.Description)
+	m.Equal(updatedOwner, resp5.Info.OwnerEmail)
+	m.Equal(updatedRetention, resp5.Config.Retention)
+	m.Equal(updatedEmitMetric, resp5.Config.EmitMetric)
+}
+
+func (m *metadataPersistenceSuite) TestDeleteDomain() {
+	name := "delete-domain-test-name"
+	status := DomainStatusRegistered
+	description := "delete-domain-test-description"
+	owner := "delete-domain-test-owner"
+	retention := 10
+	emitMetric := true
+
+	resp1, err1 := m.CreateDomain(
+		&DomainInfo{
+			Name:        name,
+			Status:      status,
+			Description: description,
+			OwnerEmail:  owner,
+		},
+		&DomainConfig{
+			Retention:  retention,
+			EmitMetric: emitMetric,
+		})
+	m.Nil(err1)
+
+	id := resp1.ID
+	m.True(len(id) > 0)
+
+	resp2, err2 := m.GetDomain("", name)
+	m.Nil(err2)
+	m.NotNil(resp2)
+
+	err3 := m.DeleteDomain("", name)
+	m.Nil(err3)
+
+	resp4, err4 := m.GetDomain("", name)
+	m.NotNil(err4)
+	m.IsType(&gen.EntityNotExistsError{}, err4)
+	m.Nil(resp4)
+
+	resp5, err5 := m.GetDomain(id, "")
+	m.Nil(err5)
+	m.NotNil(resp5)
+
+	err6 := m.DeleteDomain(id, "")
+	m.Nil(err6)
+
+	resp7, err7 := m.GetDomain(id, "")
+	m.NotNil(err7)
+	m.IsType(&gen.EntityNotExistsError{}, err7)
+	m.Nil(resp7)
+}
+
+func (m *metadataPersistenceSuite) CreateDomain(info *DomainInfo, config *DomainConfig) (*CreateDomainResponse, error) {
+	return m.MetadataManager.CreateDomain(&CreateDomainRequest{
+		Name:        info.Name,
+		Status:      info.Status,
+		Description: info.Description,
+		OwnerEmail:  info.OwnerEmail,
+		Retention:   config.Retention,
+		EmitMetric:  config.EmitMetric,
+	})
+}
+
+func (m *metadataPersistenceSuite) GetDomain(id, name string) (*GetDomainResponse, error) {
+	return m.MetadataManager.GetDomain(&GetDomainRequest{
+		ID:   id,
+		Name: name,
+	})
+}
+
+func (m *metadataPersistenceSuite) UpdateDomain(info *DomainInfo, config *DomainConfig) error {
+	return m.MetadataManager.UpdateDomain(&UpdateDomainRequest{
+		Info:   info,
+		Config: config,
+	})
+}
+
+func (m *metadataPersistenceSuite) DeleteDomain(id, name string) error {
+	if len(id) > 0 {
+		return m.MetadataManager.DeleteDomain(&DeleteDomainRequest{ID: id})
+	} else {
+		return m.MetadataManager.DeleteDomainByName(&DeleteDomainByNameRequest{Name: name})
+	}
+}

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -6,9 +6,15 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 )
 
+const (
+	DomainStatusRegistered = iota
+	DomainStatusDeprecated
+	DomainStatusDeleted
+)
+
 // Workflow execution states
 const (
-	WorkflowStateCreated = iota
+	WorkflowStateCreated   = iota
 	WorkflowStateRunning
 	WorkflowStateCompleted
 )
@@ -21,7 +27,7 @@ const (
 
 // Transfer task types
 const (
-	TransferTaskTypeDecisionTask = iota
+	TransferTaskTypeDecisionTask    = iota
 	TransferTaskTypeActivityTask
 	TransferTaskTypeDeleteExecution
 )
@@ -401,6 +407,64 @@ type (
 		Execution workflow.WorkflowExecution
 	}
 
+	// DomainInfo describes the domain entity
+	DomainInfo struct {
+		ID          string
+		Name        string
+		Status      int
+		Description string
+		OwnerEmail  string
+	}
+
+	// DomainConfig describes the domain configuration
+	DomainConfig struct {
+		Retention  int
+		EmitMetric bool
+	}
+
+	// CreateDomainRequest is used to create the domain
+	CreateDomainRequest struct {
+		Name        string
+		Status      int
+		Description string
+		OwnerEmail  string
+		Retention   int
+		EmitMetric  bool
+	}
+
+	// CreateDomainResponse is the response for CreateDomain
+	CreateDomainResponse struct {
+		ID string
+	}
+
+	// GetDomainRequest is used to read domain
+	GetDomainRequest struct {
+		ID   string
+		Name string
+	}
+
+	// GetDomainResponse is the response for GetDomain
+	GetDomainResponse struct {
+		Info   *DomainInfo
+		Config *DomainConfig
+	}
+
+	// UpdateDomainRequest is used to update domain
+	UpdateDomainRequest struct {
+		Info   *DomainInfo
+		Config *DomainConfig
+	}
+
+	// DeleteDomainRequest is used to delete domain entry from domains table
+	DeleteDomainRequest struct {
+		ID string
+	}
+
+	// DeleteDomainByNameRequest is used to delete domain entry from domains_by_name table
+	DeleteDomainByNameRequest struct {
+		Name string
+	}
+
 	// ShardManager is used to manage all shards
 	ShardManager interface {
 		CreateShard(request *CreateShardRequest) error
@@ -443,6 +507,15 @@ type (
 		GetWorkflowExecutionHistory(request *GetWorkflowExecutionHistoryRequest) (*GetWorkflowExecutionHistoryResponse,
 			error)
 		DeleteWorkflowExecutionHistory(request *DeleteWorkflowExecutionHistoryRequest) error
+	}
+
+	// MetadataManager is used to manage metadata CRUD for various entities
+	MetadataManager interface {
+		CreateDomain(request *CreateDomainRequest) (*CreateDomainResponse, error)
+		GetDomain(request *GetDomainRequest) (*GetDomainResponse, error)
+		UpdateDomain(request *UpdateDomainRequest) error
+		DeleteDomain(request *DeleteDomainRequest) error
+		DeleteDomainByName(request *DeleteDomainByNameRequest) error
 	}
 )
 

--- a/common/persistence/persistenceTestBase.go
+++ b/common/persistence/persistenceTestBase.go
@@ -42,6 +42,7 @@ type (
 		WorkflowMgr         ExecutionManager
 		TaskMgr             TaskManager
 		HistoryMgr          HistoryManager
+		MetadataManager     MetadataManager
 		ShardInfo           *ShardInfo
 		ShardContext        *testShardContext
 		readLevel           int64
@@ -153,7 +154,8 @@ func newTestExecutionMgrFactory(options TestBaseOptions, cassandra CassandraTest
 }
 
 func (f *testExecutionMgrFactory) CreateExecutionManager(shardID int) (ExecutionManager, error) {
-	return NewCassandraWorkflowExecutionPersistence(f.options.ClusterHost, f.options.Datacenter, f.cassandra.keyspace, shardID, f.logger)
+	return NewCassandraWorkflowExecutionPersistence(f.options.ClusterHost, f.options.Datacenter, f.cassandra.keyspace,
+		shardID, f.logger)
 }
 
 // SetupWorkflowStoreWithOptions to setup workflow test base
@@ -163,7 +165,8 @@ func (s *TestBase) SetupWorkflowStoreWithOptions(options TestBaseOptions) {
 	s.CassandraTestCluster.setupTestCluster(options.KeySpace, options.DropKeySpace, options.SchemaDir)
 	shardID := 0
 	var err error
-	s.ShardMgr, err = NewCassandraShardPersistence(options.ClusterHost, options.Datacenter, s.CassandraTestCluster.keyspace, log)
+	s.ShardMgr, err = NewCassandraShardPersistence(options.ClusterHost, options.Datacenter,
+		s.CassandraTestCluster.keyspace, log)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -173,12 +176,20 @@ func (s *TestBase) SetupWorkflowStoreWithOptions(options TestBaseOptions) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	s.TaskMgr, err = NewCassandraTaskPersistence(options.ClusterHost, options.Datacenter, s.CassandraTestCluster.keyspace, log)
+	s.TaskMgr, err = NewCassandraTaskPersistence(options.ClusterHost, options.Datacenter, s.CassandraTestCluster.keyspace,
+		log)
 	if err != nil {
 		log.Fatal(err)
 	}
 
-	s.HistoryMgr, err = NewCassandraHistoryPersistence(options.ClusterHost, options.Datacenter, s.CassandraTestCluster.keyspace, log)
+	s.HistoryMgr, err = NewCassandraHistoryPersistence(options.ClusterHost, options.Datacenter,
+		s.CassandraTestCluster.keyspace, log)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	s.MetadataManager, err = NewCassandraMetadataPersistence(options.ClusterHost, options.Datacenter,
+		s.CassandraTestCluster.keyspace, log)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/schema/workflow_test.cql
+++ b/schema/workflow_test.cql
@@ -78,6 +78,32 @@ CREATE TYPE timer_info (
   task_id       bigint,    -- The task ID if we have one created for this timer
 );
 
+-- Activity or workflow task in a task list
+CREATE TYPE task (
+  workflow_id      text,
+  run_id           uuid,
+  schedule_id      bigint,
+);
+
+CREATE TYPE task_list (
+  name             text,
+  type             int, -- enum TaskRowType {ActivityTask, DecisionTask}
+  ack_level        bigint, -- task_id of the last acknowledged message
+);
+
+CREATE TYPE domain (
+  id          uuid,
+  name        text,
+  status      int, -- enum DomainStatus {Registered, Deprecated, Deleted}
+  description text,
+  owner_email text,
+);
+
+CREATE TYPE domain_config (
+  retention int,
+  emit_metric boolean
+);
+
 CREATE TABLE executions (
   shard_id           int,
   type               int, -- enum RowType { Shard, Execution, TransferTask, TimerTask}
@@ -108,16 +134,16 @@ CREATE TABLE events (
   PRIMARY KEY ((workflow_id, run_id), first_event_id)
 );
 
-CREATE TYPE domain (
-  id          uuid,
-  name        text,
-  status      int, -- enum DomainStatus {Active, Deprecated, Deleted}
-  description text,
-);
-
-CREATE TYPE domain_config (
-  retention int,
-  emitMetric boolean
+-- Stores activity or workflow tasks
+CREATE TABLE tasks (
+  task_list_name   text,
+  task_list_type   int, -- enum TaskListType {ActivityTask, DecisionTask}
+  type             int, -- enum rowType {Task, TaskList}
+  task_id          bigint,  -- unique identifier for tasks, monotonically increasing
+  range_id         bigint static, -- Used to ensure that only one process can write to the table
+  task             frozen<task>,
+  task_list        frozen<task_list>,
+  PRIMARY KEY ((task_list_name, task_list_type), type, task_id)
 );
 
 CREATE TABLE domains (
@@ -132,29 +158,4 @@ CREATE TABLE domains_by_name (
   domain frozen<domain>,
   config frozen<domain_config>,
   PRIMARY KEY (name)
-)
-
--- Activity or workflow task in a task list
-CREATE TYPE task (
-  workflow_id      text,
-  run_id           uuid,
-  schedule_id      bigint,
-);
-
-CREATE TYPE task_list (
-  name             text,
-  type             int, -- enum TaskRowType {ActivityTask, DecisionTask}
-  ack_level        bigint, -- task_id of the last acknowledged message
-);
-
--- Stores activity or workflow tasks
-CREATE TABLE tasks (
-  task_list_name   text,
-  task_list_type   int, -- enum TaskListType {ActivityTask, DecisionTask}
-  type             int, -- enum rowType {Task, TaskList}
-  task_id          bigint,  -- unique identifier for tasks, monotonically increasing
-  range_id         bigint static, -- Used to ensure that only one process can write to the table
-  task             frozen<task>,
-  task_list        frozen<task_list>,
-  PRIMARY KEY ((task_list_name, task_list_type), type, task_id)
 );


### PR DESCRIPTION
Created two separate tables for domains to allow lookup using domain
name or domain uuid.

Created a new persistence interface to deal with metadata CRUD
operations.  All domain CRUD is exposed through this interface.

Implementation of domain CRUD using the two cassandra tables for
managing domains.