### PR TITLE
Add start_time to WorkflowExecution

### DIFF
--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -88,8 +88,7 @@ const (
 		`target_domain_id: ?, ` +
 		`task_list: ?, ` +
 		`type: ?, ` +
-		`schedule_id: ?,` +
-		`event_time: ?` +
+		`schedule_id: ?` +
 		`}`
 
 	templateTimerTaskType = `{` +
@@ -1186,7 +1185,6 @@ func (d *cassandraPersistence) createTransferTasks(batch *gocql.Batch, transferT
 			taskList,
 			task.GetType(),
 			scheduleID,
-			cqlNowTimestamp,
 			task.GetTaskID())
 	}
 }
@@ -1401,8 +1399,6 @@ func createTransferTaskInfo(result map[string]interface{}) *TransferTaskInfo {
 			info.TaskType = v.(int)
 		case "schedule_id":
 			info.ScheduleID = v.(int64)
-		case "event_time":
-			info.EventTimestamp = v.(time.Time)
 		}
 	}
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -103,7 +103,6 @@ type (
 		TaskList       string
 		TaskType       int
 		ScheduleID     int64
-		EventTimestamp time.Time
 	}
 
 	// TimerTaskInfo describes a timer task.

--- a/schema/workflow_test.cql
+++ b/schema/workflow_test.cql
@@ -46,7 +46,6 @@ CREATE TYPE transfer_task (
   task_list        text,
   type             int,  -- enum TaskType {ActivityTask, DecisionTask, DeleteExecution}
   schedule_id      bigint,
-  event_time       timestamp,
 );
 
 CREATE TYPE timer_task (


### PR DESCRIPTION
Store the start timestamp in the WorkflowExecution mutable state.
This will used to know the start time of the execution when creating visibility records.
Issue #60 