### PR TITLE
Bugfix to pass in domainID with AppendHistory call to persistence

### DIFF
--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -235,7 +235,7 @@ func (s *shardContextImpl) AppendHistoryEvents(request *persistence.AppendHistor
 		}
 	}
 
-	return nil
+	return err0
 }
 
 func (s *shardContextImpl) GetLogger() bark.Logger {

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -106,6 +106,7 @@ func (c *workflowExecutionContext) updateWorkflowExecution(transferTasks []persi
 		}
 
 		if err0 := c.shard.AppendHistoryEvents(&persistence.AppendHistoryEventsRequest{
+			DomainID:      c.domainID,
 			Execution:     c.workflowExecution,
 			TransactionID: transactionID,
 			FirstEventID:  firstEvent.GetEventId(),


### PR DESCRIPTION
Pass in domainID with AppendHistory call as part of execution update.

Fix error handling issue to return the error if first update to
AppendHistory fails with an error.