### PR TITLE
taskListManager can skip tasks

### DIFF
--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -173,7 +173,7 @@ func (c *taskListManagerImpl) persistAckLevel() error {
 	return err
 }
 
-// initiateTaskAppend returns taskID to use to persist the task
+// newTaskIDs taskID to use to persist the task
 func (c *taskListManagerImpl) newTaskIDs(count int) (taskID []int64, err error) {
 	c.Lock()
 	defer c.Unlock()
@@ -186,6 +186,12 @@ func (c *taskListManagerImpl) newTaskIDs(count int) (taskID []int64, err error) 
 		c.taskSequenceNumber++
 	}
 	return
+}
+
+func (c *taskListManagerImpl) getTaskSequenceNumber() int64 {
+	c.Lock()
+	defer c.Unlock()
+	return c.taskSequenceNumber
 }
 
 func (c *taskListManagerImpl) getAckLevel() (ackLevel int64) {
@@ -233,7 +239,7 @@ func (c *taskListManagerImpl) getTaskBatch() ([]*persistence.TaskInfo, error) {
 			BatchSize:    getTasksBatchSize,
 			RangeID:      c.rangeID,
 			ReadLevel:    c.taskAckManager.getReadLevel(),
-			MaxReadLevel: c.taskSequenceNumber,
+			MaxReadLevel: c.taskWriter.GetMaxReadLevel(),
 		}
 		c.Unlock()
 		return c.engine.taskManager.GetTasks(request)


### PR DESCRIPTION
taskListManager uses Quorum level consistency to read tasks.
These reads are not isolated from in-flight LWT writes running
in Cassandra, which could lead the read to observe partial results.
This can lead to tasks being skipped.

We can use Serial level consistency to deal with this but it is not
supported at the moment by the gocql client, and it might cause reads
to be too expensive. 
Instead, we'll only update the MaxReadLevel afterthe write operations are
complete. This guarantees the read requests do not attempt to read the
results of LWT writes that are still in flight.

Issue #152