### PR TITLE
Task read fixes

### DIFF
--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -149,27 +149,32 @@ func (t *transferQueueProcessorImpl) processorPump() {
 	}
 
 	pollTimer := time.NewTimer(transferProcessorMaxPollInterval)
-	defer pollTimer.Stop()
 	updateAckTimer := time.NewTimer(transferProcessorUpdateAckInterval)
-	defer updateAckTimer.Stop()
+
+processorPumpLoop:
 	for {
 		select {
 		case <-t.shutdownCh:
-			t.logger.Info("Transfer queue processor pump shutting down.")
-			// This is the only pump which writes to tasksCh, so it is safe to close channel here
-			close(tasksCh)
-			if success := common.AwaitWaitGroup(&workerWG, 10*time.Second); !success {
-				t.logger.Warn("Transfer queue processor timed out on worker shutdown.")
-			}
-			return
+			break processorPumpLoop
 		case <-t.appendCh:
 			t.processTransferTasks(tasksCh)
 		case <-pollTimer.C:
 			t.processTransferTasks(tasksCh)
+			pollTimer = time.NewTimer(transferProcessorMaxPollInterval)
 		case <-updateAckTimer.C:
 			t.ackMgr.updateAckLevel()
+			updateAckTimer = time.NewTimer(transferProcessorUpdateAckInterval)
 		}
 	}
+
+	t.logger.Info("Transfer queue processor pump shutting down.")
+	// This is the only pump which writes to tasksCh, so it is safe to close channel here
+	close(tasksCh)
+	if success := common.AwaitWaitGroup(&workerWG, 10*time.Second); !success {
+		t.logger.Warn("Transfer queue processor timed out on worker shutdown.")
+	}
+	updateAckTimer.Stop()
+	pollTimer.Stop()
 }
 
 func (t *transferQueueProcessorImpl) processTransferTasks(tasksCh chan<- *persistence.TransferTaskInfo) {

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -345,7 +345,6 @@ func (c *taskListManagerImpl) getTasksPump() {
 	defer close(c.taskBuffer)
 
 	updateAckTimer := time.NewTimer(updateAckInterval)
-	defer updateAckTimer.Stop()
 
 getTasksPumpLoop:
 	for {
@@ -393,9 +392,12 @@ getTasksPumpLoop:
 					// keep going as saving ack is not critical
 				}
 				c.signalNewTask() // periodically signal pump to check persistence for tasks
+				updateAckTimer = time.NewTimer(updateAckInterval)
 			}
 		}
 	}
+
+	updateAckTimer.Stop()
 }
 
 // Retry operation on transient error and on rangeID change. On rangeID update by another process calls c.Stop().


### PR DESCRIPTION
- Signal task pump if there are potentially more tasks in cassandra
- Do not create a new timer every time for transfer queue processor