### PR TITLE
Increment rangeID on any internal error from persistence

### DIFF
--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 
@@ -154,7 +155,7 @@ Create_Loop:
 						s.closeShard()
 					}
 				}
-			case *persistence.TimeoutError:
+			case *shared.InternalServiceError, *persistence.TimeoutError:
 				{
 					// We have no idea if the write failed or will eventually make it to
 					// persistence. Increment RangeID to guarantee that subsequent reads
@@ -224,7 +225,7 @@ Update_Loop:
 						s.closeShard()
 					}
 				}
-			case *persistence.TimeoutError:
+			case *shared.InternalServiceError, *persistence.TimeoutError:
 				{
 					// We have no idea if the write failed or will eventually make it to
 					// persistence. Increment RangeID to guarantee that subsequent reads


### PR DESCRIPTION
Previously, we were doing this only on specific timeout errors.
However, it is hard to tell all the possible error codes under which we cannot tell if write was finished.
Instead, we white list a few error codes that do not cause rangeID to be incremented
Issue #88