### PR TITLE
Remove extra query in transfer queue processor if queue is empty

### DIFF
--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -221,9 +221,11 @@ func (t *transferQueueProcessorImpl) processTransferTasks(tasksCh chan<- *persis
 		tasksCh <- tsk
 	}
 
-	// There might be more task
-	// We return now to yield, but enqueue an event to poll later
-	t.NotifyNewTask()
+	if len(tasks) == transferTaskBatchSize {
+		// There might be more task
+		// We return now to yield, but enqueue an event to poll later
+		t.NotifyNewTask()
+	}
 	return
 }
 


### PR DESCRIPTION
Do not notify the transfer queue processor if we read fewer tasks than the batch size,
since this means that we know the queue is empty.
