### PR TITLE
History engine metric

### DIFF
--- a/common/logging/events.go
+++ b/common/logging/events.go
@@ -22,6 +22,8 @@ package logging
 
 // Events
 const (
+	// Global Events
+
 	// HistoryBuilder events
 	InvalidHistoryActionEventID = 1000
 
@@ -65,4 +67,5 @@ const (
 
 	// General purpose events
 	OperationFailed = 9000
+	OperationPanic  = 9001
 )

--- a/common/logging/events.go
+++ b/common/logging/events.go
@@ -37,6 +37,7 @@ const (
 	DuplicateTaskEventID               = 2030
 	MultipleCompletionDecisionsEventID = 2040
 	DuplicateTransferTaskEventID       = 2050
+	DecisionFailedEventID              = 2060
 
 	// Transfer Queue Processor events
 	TransferQueueProcessorStarting         = 2100

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -42,7 +42,16 @@ func LogPersistantStoreErrorEvent(logger bark.Logger, operation string, err erro
 func LogOperationFailedEvent(logger bark.Logger, msg string, err error) {
 	logger.WithFields(bark.Fields{
 		TagWorkflowEventID: OperationFailed,
+		TagWorkflowErr:     err,
 	}).Warnf("%v.  Error: %v", msg, err)
+}
+
+// LogOperationPanicEvent is used to log fatal errors by application to cause panic
+func LogOperationPanicEvent(logger bark.Logger, msg string, err error) {
+	logger.WithFields(bark.Fields{
+		TagWorkflowEventID: OperationPanic,
+		TagWorkflowErr:     err,
+	}).Fatalf("%v.  Error: %v", msg, err)
 }
 
 //

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -263,3 +263,15 @@ func LogMultipleCompletionDecisionsEvent(lg bark.Logger, decisionType shared.Dec
 		TagDecisionType:    decisionType,
 	}).Warnf("Multiple completion decisions.  DecisionType: %v", decisionType)
 }
+
+// LogMultipleCompletionDecisionsEvent is used to log multiple completion decisions for an execution
+func LogDecisionFailedEvent(lg bark.Logger, domainID, workflowID, runID string,
+	failCause shared.DecisionTaskFailedCause) {
+	lg.WithFields(bark.Fields{
+		TagWorkflowEventID:     DecisionFailedEventID,
+		TagDomainID:            domainID,
+		TagWorkflowExecutionID: workflowID,
+		TagWorkflowRunID:       runID,
+		TagDecisionFailCause:   failCause,
+	}).Info("Failing the decision.")
+}

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -264,7 +264,7 @@ func LogMultipleCompletionDecisionsEvent(lg bark.Logger, decisionType shared.Dec
 	}).Warnf("Multiple completion decisions.  DecisionType: %v", decisionType)
 }
 
-// LogMultipleCompletionDecisionsEvent is used to log multiple completion decisions for an execution
+// LogDecisionFailedEvent is used to log decision failures by RespondDecisionTaskCompleted handler
 func LogDecisionFailedEvent(lg bark.Logger, domainID, workflowID, runID string,
 	failCause shared.DecisionTaskFailedCause) {
 	lg.WithFields(bark.Fields{

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -34,10 +34,12 @@ const (
 	TagWorkflowErr          = "wf-error"
 	TagHistoryBuilderAction = "history-builder-action"
 	TagStoreOperation       = "store-operation"
+	TagDomainID             = "domain-id"
 	TagWorkflowExecutionID  = "execution-id"
 	TagWorkflowRunID        = "run-id"
 	TagHistoryShardID       = "shard-id"
 	TagDecisionType         = "decision-type"
+	TagDecisionFailCause    = "decision-fail-cause"
 
 	// workflow logging tag values
 	// TagWorkflowComponent Values

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -268,12 +268,22 @@ const (
 	HistoryScheduleDecisionTaskScope
 	// HistoryRecordChildExecutionCompletedScope tracks CompleteChildExecution API calls received by service
 	HistoryRecordChildExecutionCompletedScope
-	// HistoryProcessTransferTasksScope tracks number of transfer tasks processed
-	HistoryProcessTransferTasksScope
 	// HistoryRequestCancelWorkflowExecutionScope tracks RequestCancelWorkflowExecution API calls received by service
 	HistoryRequestCancelWorkflowExecutionScope
-	// HistoryMultipleCompletionDecisionsScope tracks number of duplicate completion decisions for an execution
-	HistoryMultipleCompletionDecisionsScope
+	// TransferQueueProcessorScope is the scope used by all metric emitted by transfer queue processor
+	TransferQueueProcessorScope
+	// TransferTaskActivityScope is the scope used for activity task processing by transfer queue processor
+	TransferTaskActivityScope
+	// TransferTaskDecisionScope is the scope used for decision task processing by transfer queue processor
+	TransferTaskDecisionScope
+	// TransferTaskDeleteExecutionScope is the scope used for delete execution task processing by transfer queue processor
+	TransferTaskDeleteExecutionScope
+	// TransferTaskCancelExecutionScope is the scope used for cancel execution task processing by transfer queue processor
+	TransferTaskCancelExecutionScope
+	// TransferTaskStartChildExecutionScope is the scope used for start child execution task processing by transfer queue processor
+	TransferTaskStartChildExecutionScope
+	// TimerQueueProcessorScope is the scope used by all metric emitted by timer queue processor
+	TimerQueueProcessorScope
 
 	NumHistoryScopes
 )
@@ -377,9 +387,14 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		HistoryTerminateWorkflowExecutionScope:      {operation: "TerminateWorkflowExecution"},
 		HistoryScheduleDecisionTaskScope:            {operation: "ScheduleDecisionTask"},
 		HistoryRecordChildExecutionCompletedScope:   {operation: "RecordChildExecutionCompleted"},
-		HistoryProcessTransferTasksScope:            {operation: "ProcessTransferTask"},
 		HistoryRequestCancelWorkflowExecutionScope:  {operation: "RequestCancelWorkflowExecution"},
-		HistoryMultipleCompletionDecisionsScope:     {operation: "MultipleCompletionDecisions"},
+		TransferQueueProcessorScope:                 {operation: "TransferQueueProcessor"},
+		TransferTaskActivityScope:                   {operation: "TransferTaskActivity"},
+		TransferTaskDecisionScope:                   {operation: "TransferTaskDecision"},
+		TransferTaskDeleteExecutionScope:            {operation: "TransferTaskDeleteExecution"},
+		TransferTaskCancelExecutionScope:            {operation: "TransferTaskCancelExecution"},
+		TransferTaskStartChildExecutionScope:        {operation: "TransferTaskStartChildExecution"},
+		TimerQueueProcessorScope:                    {operation: "TimerQueueProcessor"},
 	},
 	// Matching Scope Names
 	Matching: {
@@ -412,9 +427,14 @@ const (
 
 // History Metrics enum
 const (
-	TransferTasksProcessedCounter = iota + NumCommonMetrics
+	TaskRequests = iota + NumCommonMetrics
+	TaskFailures
+	TaskLatency
+	AckLevelUpdateCounter
+	AckLevelUpdateFailedCounter
 	MultipleCompletionDecisionsCounter
 	FailedDecisionsCounter
+	StaleMutableStateCounter
 	CadenceErrEventAlreadyStartedCounter
 	CadenceErrShardOwnershipLostCounter
 )
@@ -439,9 +459,14 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 	},
 	Frontend: {},
 	History: {
-		TransferTasksProcessedCounter:        {metricName: "transfer-tasks-processed", metricType: Counter},
+		TaskRequests:                         {metricName: "task.requests", metricType: Counter},
+		TaskFailures:                         {metricName: "task.errors", metricType: Counter},
+		TaskLatency:                          {metricName: "task.latency", metricType: Counter},
+		AckLevelUpdateCounter:                {metricName: "ack-level-update", metricType: Counter},
+		AckLevelUpdateFailedCounter:          {metricName: "ack-level-update-failed", metricType: Counter},
 		MultipleCompletionDecisionsCounter:   {metricName: "multiple-completion-decisions", metricType: Counter},
 		FailedDecisionsCounter:               {metricName: "failed-decisions", metricType: Counter},
+		StaleMutableStateCounter:             {metricName: "stale-mutable-state", metricType: Counter},
 		CadenceErrShardOwnershipLostCounter:  {metricName: "cadence.errors.shard-ownership-lost", metricType: Counter},
 		CadenceErrEventAlreadyStartedCounter: {metricName: "cadence.errors.event-already-started", metricType: Counter},
 	},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -432,9 +432,21 @@ const (
 	TaskLatency
 	AckLevelUpdateCounter
 	AckLevelUpdateFailedCounter
+	DecisionTypeScheduleActivityCounter
+	DecisionTypeCompleteWorkflowCounter
+	DecisionTypeFailWorkflowCounter
+	DecisionTypeCancelWorkflowCounter
+	DecisionTypeStartTimerCounter
+	DecisionTypeCancelActivityCounter
+	DecisionTypeCancelTimerCounter
+	DecisionTypeRecordMarkerCounter
+	DecisionTypeCancelExternalWorkflowCounter
+	DecisionTypeChildWorkflowCounter
+	DecisionTypeContinueAsNewCounter
 	MultipleCompletionDecisionsCounter
 	FailedDecisionsCounter
 	StaleMutableStateCounter
+	ConcurrencyUpdateFailureCounter
 	CadenceErrEventAlreadyStartedCounter
 	CadenceErrShardOwnershipLostCounter
 )
@@ -459,16 +471,28 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 	},
 	Frontend: {},
 	History: {
-		TaskRequests:                         {metricName: "task.requests", metricType: Counter},
-		TaskFailures:                         {metricName: "task.errors", metricType: Counter},
-		TaskLatency:                          {metricName: "task.latency", metricType: Counter},
-		AckLevelUpdateCounter:                {metricName: "ack-level-update", metricType: Counter},
-		AckLevelUpdateFailedCounter:          {metricName: "ack-level-update-failed", metricType: Counter},
-		MultipleCompletionDecisionsCounter:   {metricName: "multiple-completion-decisions", metricType: Counter},
-		FailedDecisionsCounter:               {metricName: "failed-decisions", metricType: Counter},
-		StaleMutableStateCounter:             {metricName: "stale-mutable-state", metricType: Counter},
-		CadenceErrShardOwnershipLostCounter:  {metricName: "cadence.errors.shard-ownership-lost", metricType: Counter},
-		CadenceErrEventAlreadyStartedCounter: {metricName: "cadence.errors.event-already-started", metricType: Counter},
+		TaskRequests:                              {metricName: "task.requests", metricType: Counter},
+		TaskFailures:                              {metricName: "task.errors", metricType: Counter},
+		TaskLatency:                               {metricName: "task.latency", metricType: Counter},
+		AckLevelUpdateCounter:                     {metricName: "ack-level-update", metricType: Counter},
+		AckLevelUpdateFailedCounter:               {metricName: "ack-level-update-failed", metricType: Counter},
+		DecisionTypeScheduleActivityCounter:       {metricName: "schedule-activity-decision", metricType: Counter},
+		DecisionTypeCompleteWorkflowCounter:       {metricName: "complete-workflow-decision", metricType: Counter},
+		DecisionTypeFailWorkflowCounter:           {metricName: "fail-workflow-decision", metricType: Counter},
+		DecisionTypeCancelWorkflowCounter:         {metricName: "cancel-workflow-decision", metricType: Counter},
+		DecisionTypeStartTimerCounter:             {metricName: "start-timer-decision", metricType: Counter},
+		DecisionTypeCancelActivityCounter:         {metricName: "cancel-activity-decision", metricType: Counter},
+		DecisionTypeCancelTimerCounter:            {metricName: "cancel-timer-decision", metricType: Counter},
+		DecisionTypeRecordMarkerCounter:           {metricName: "record-marker-decision", metricType: Counter},
+		DecisionTypeCancelExternalWorkflowCounter: {metricName: "cancel-external-workflow-decision", metricType: Counter},
+		DecisionTypeContinueAsNewCounter:          {metricName: "continue-as-new-decision", metricType: Counter},
+		DecisionTypeChildWorkflowCounter:          {metricName: "child-workflow-decision", metricType: Counter},
+		MultipleCompletionDecisionsCounter:        {metricName: "multiple-completion-decisions", metricType: Counter},
+		FailedDecisionsCounter:                    {metricName: "failed-decisions", metricType: Counter},
+		StaleMutableStateCounter:                  {metricName: "stale-mutable-state", metricType: Counter},
+		ConcurrencyUpdateFailureCounter:           {metricName: "concurrency-update-failure", metricType: Counter},
+		CadenceErrShardOwnershipLostCounter:       {metricName: "cadence.errors.shard-ownership-lost", metricType: Counter},
+		CadenceErrEventAlreadyStartedCounter:      {metricName: "cadence.errors.event-already-started", metricType: Counter},
 	},
 	Matching: {},
 }

--- a/service/history/historyCache_test.go
+++ b/service/history/historyCache_test.go
@@ -32,8 +32,10 @@ import (
 
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber-go/tally"
 )
 
 type (
@@ -68,6 +70,7 @@ func (s *historyCacheSuite) SetupTest() {
 		maxTransferSequenceNumber: 100000,
 		closeCh:                   make(chan int, 100),
 		logger:                    s.logger,
+		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),
 	}
 	s.cache = newHistoryCache(historyCacheMaxSize, s.mockShard, s.logger)
 }

--- a/service/history/historyCache_test.go
+++ b/service/history/historyCache_test.go
@@ -30,12 +30,12 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
 
+	"github.com/uber-go/tally"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber-go/tally"
 )
 
 type (

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -310,6 +310,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			e.metricsClient.IncCounter(metrics.HistoryRecordDecisionTaskStartedScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop
@@ -339,7 +340,7 @@ Update_History_Loop:
 			logging.LogDuplicateTaskEvent(context.logger, persistence.TaskListTypeDecision, request.GetTaskId(), requestID,
 				scheduleID, di.StartedID, isRunning)
 
-			return nil, &workflow.EntityNotExistsError{Message: "Decision task already started."}
+			return nil, &h.EventAlreadyStartedError{Message: "Decision task already started."}
 		}
 
 		event := msBuilder.AddDecisionTaskStartedEvent(scheduleID, requestID, request.PollRequest)
@@ -396,6 +397,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			e.metricsClient.IncCounter(metrics.HistoryRecordActivityTaskStartedScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop
@@ -436,7 +438,7 @@ Update_History_Loop:
 			logging.LogDuplicateTaskEvent(context.logger, persistence.TransferTaskTypeActivityTask, request.GetTaskId(), requestID,
 				scheduleID, ai.StartedID, isRunning)
 
-			return nil, &workflow.EntityNotExistsError{Message: "Activity task already started."}
+			return nil, &h.EventAlreadyStartedError{Message: "Activity task already started."}
 		}
 
 		startedEvent := msBuilder.AddActivityTaskStartedEvent(ai, scheduleID, requestID, request.PollRequest)
@@ -518,6 +520,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			e.metricsClient.IncCounter(metrics.HistoryRespondDecisionTaskCompletedScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop
@@ -592,7 +595,7 @@ Update_History_Loop:
 
 				// If the decision has more than one completion event than just pick the first one
 				if isComplete {
-					e.metricsClient.IncCounter(metrics.HistoryMultipleCompletionDecisionsScope,
+					e.metricsClient.IncCounter(metrics.HistoryRespondDecisionTaskCompletedScope,
 						metrics.MultipleCompletionDecisionsCounter)
 					logging.LogMultipleCompletionDecisionsEvent(e.logger, d.GetDecisionType())
 					continue Process_Decision_Loop
@@ -614,7 +617,7 @@ Update_History_Loop:
 
 				// If the decision has more than one completion event than just pick the first one
 				if isComplete {
-					e.metricsClient.IncCounter(metrics.HistoryMultipleCompletionDecisionsScope,
+					e.metricsClient.IncCounter(metrics.HistoryRespondDecisionTaskCompletedScope,
 						metrics.MultipleCompletionDecisionsCounter)
 					logging.LogMultipleCompletionDecisionsEvent(e.logger, d.GetDecisionType())
 					continue Process_Decision_Loop
@@ -638,7 +641,7 @@ Update_History_Loop:
 
 				// If the decision has more than one completion event than just pick the first one
 				if isComplete {
-					e.metricsClient.IncCounter(metrics.HistoryMultipleCompletionDecisionsScope,
+					e.metricsClient.IncCounter(metrics.HistoryRespondDecisionTaskCompletedScope,
 						metrics.MultipleCompletionDecisionsCounter)
 					logging.LogMultipleCompletionDecisionsEvent(e.logger, d.GetDecisionType())
 					continue Process_Decision_Loop
@@ -745,7 +748,7 @@ Update_History_Loop:
 
 				// If the decision has more than one completion event than just pick the first one
 				if isComplete {
-					e.metricsClient.IncCounter(metrics.HistoryMultipleCompletionDecisionsScope,
+					e.metricsClient.IncCounter(metrics.HistoryRespondDecisionTaskCompletedScope,
 						metrics.MultipleCompletionDecisionsCounter)
 					logging.LogMultipleCompletionDecisionsEvent(e.logger, d.GetDecisionType())
 					continue Process_Decision_Loop
@@ -881,6 +884,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			e.metricsClient.IncCounter(metrics.HistoryRespondActivityTaskCompletedScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop
@@ -961,6 +965,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			e.metricsClient.IncCounter(metrics.HistoryRespondActivityTaskFailedScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop
@@ -1040,6 +1045,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			e.metricsClient.IncCounter(metrics.HistoryRespondActivityTaskFailedScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop
@@ -1125,6 +1131,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			e.metricsClient.IncCounter(metrics.HistoryRecordActivityTaskHeartbeatScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
 
+	"github.com/uber-go/tally"
 	h "github.com/uber/cadence/.gen/go/history"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
@@ -39,7 +40,6 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber-go/tally"
 )
 
 type (

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -36,8 +36,10 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber-go/tally"
 )
 
 type (
@@ -103,6 +105,7 @@ func (s *engine2Suite) SetupTest() {
 		maxTransferSequenceNumber: 100000,
 		closeCh:                   s.shardClosedCh,
 		logger:                    s.logger,
+		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),
 	}
 
 	historyCache := newHistoryCache(historyCacheMaxSize, mockShard, s.logger)
@@ -116,6 +119,7 @@ func (s *engine2Suite) SetupTest() {
 		historyCache:       historyCache,
 		domainCache:        domainCache,
 		logger:             s.logger,
+		metricsClient:      metrics.NewClient(tally.NoopScope, metrics.History),
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		hSerializerFactory: persistence.NewHistorySerializerFactory(),
 	}

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -215,7 +215,7 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfTaskAlreadyStarted() {
 	})
 	s.Nil(response)
 	s.NotNil(err)
-	s.IsType(&workflow.EntityNotExistsError{}, err)
+	s.IsType(&h.EventAlreadyStartedError{}, err)
 	s.logger.Errorf("RecordDecisionTaskStarted failed with: %v", err)
 }
 
@@ -379,7 +379,7 @@ func (s *engine2Suite) TestRecordDecisionTaskRetryDifferentRequest() {
 
 	s.Nil(response)
 	s.NotNil(err)
-	s.IsType(&workflow.EntityNotExistsError{}, err)
+	s.IsType(&h.EventAlreadyStartedError{}, err)
 	s.logger.Infof("Failed with error: %v", err)
 }
 

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -105,6 +105,7 @@ func (s *engineSuite) SetupTest() {
 		maxTransferSequenceNumber: 100000,
 		closeCh:                   s.shardClosedCh,
 		logger:                    s.logger,
+		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),
 	}
 
 	historyCache := newHistoryCache(historyCacheMaxSize, mockShard, s.logger)
@@ -118,7 +119,7 @@ func (s *engineSuite) SetupTest() {
 		historyCache:       historyCache,
 		domainCache:        domainCache,
 		logger:             s.logger,
-		metricsClient:      metrics.NewClient(tally.NewTestScope("", nil), metrics.History),
+		metricsClient:      metrics.NewClient(tally.NoopScope, metrics.History),
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		hSerializerFactory: persistence.NewHistorySerializerFactory(),
 	}

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -166,7 +166,7 @@ func newTimerQueueProcessor(shard ShardContext, historyService *historyEngineImp
 		shutdownCh:       make(chan struct{}),
 		newTimerCh:       make(chan struct{}, 1),
 		logger:           l,
-    metricsClient: historyService.metricsClient,
+		metricsClient:    historyService.metricsClient,
 	}
 	tp.ackMgr = newTimerAckMgr(tp, shard, executionManager, l)
 	return tp

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -33,6 +33,7 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/logging"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -62,6 +63,7 @@ type (
 		shutdownCh       chan struct{}
 		newTimerCh       chan struct{}
 		logger           bark.Logger
+		metricsClient    metrics.Client
 		timerFiredCount  uint64
 		lock             sync.Mutex // Used to synchronize pending timers.
 		ackMgr           *timerAckMgr
@@ -164,6 +166,7 @@ func newTimerQueueProcessor(shard ShardContext, historyService *historyEngineImp
 		shutdownCh:       make(chan struct{}),
 		newTimerCh:       make(chan struct{}, 1),
 		logger:           l,
+    metricsClient: historyService.metricsClient,
 	}
 	tp.ackMgr = newTimerAckMgr(tp, shard, executionManager, l)
 	return tp
@@ -529,6 +532,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			t.metricsClient.IncCounter(metrics.TimerQueueProcessorScope, metrics.StaleMutableStateCounter)
 			t.logger.Debugf("processActivityTimeout: scheduleID mismatch. MS NextEventID: %v, scheduleID: %v",
 				msBuilder.GetNextEventID(), scheduleID)
 			// Reload workflow execution history
@@ -640,6 +644,7 @@ Update_History_Loop:
 		// First check to see if cache needs to be refreshed as we could potentially have stale workflow execution in
 		// some extreme cassandra failure cases.
 		if scheduleID >= msBuilder.GetNextEventID() {
+			t.metricsClient.IncCounter(metrics.TimerQueueProcessorScope, metrics.StaleMutableStateCounter)
 			// Reload workflow execution history
 			context.clear()
 			continue Update_History_Loop

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -37,8 +37,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
-	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber-go/tally"
+	workflow "github.com/uber/cadence/.gen/go/shared"
 )
 
 type (

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
 	workflow "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber-go/tally"
 )
 
 type (
@@ -91,6 +93,7 @@ func (s *timerQueueProcessor2Suite) SetupTest() {
 		maxTransferSequenceNumber: 100000,
 		closeCh:                   s.shardClosedCh,
 		logger:                    s.logger,
+		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),
 	}
 
 	historyCache := newHistoryCache(historyCacheMaxSize, s.mockShard, s.logger)


### PR DESCRIPTION
Emit metric from transfer queue processor for different type of transfer
tasks.  Also emit metric for updating the ack level for transfer queue
processor.

Fixes #43 