### PR TITLE
Use the same value for shard tag of metric reporter

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -64,12 +64,14 @@ const (
 const (
 	HostnameTagName  = "hostname"
 	OperationTagName = "operation"
+	// ShardTagName is temporary until we can get all metric data removed for the service
 	ShardTagName     = "shard"
 )
 
 // This package should hold all the metrics and tags for cadence
 const (
 	UnknownDirectoryTagValue = "Unknown"
+	AllShardsTagValue = "ALL"
 )
 
 // Common service base metrics

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -65,13 +65,13 @@ const (
 	HostnameTagName  = "hostname"
 	OperationTagName = "operation"
 	// ShardTagName is temporary until we can get all metric data removed for the service
-	ShardTagName     = "shard"
+	ShardTagName = "shard"
 )
 
 // This package should hold all the metrics and tags for cadence
 const (
 	UnknownDirectoryTagValue = "Unknown"
-	AllShardsTagValue = "ALL"
+	AllShardsTagValue        = "ALL"
 )
 
 // Common service base metrics

--- a/service/history/execMgrFactory.go
+++ b/service/history/execMgrFactory.go
@@ -61,7 +61,7 @@ func (factory *executionMgrFactory) CreateExecutionManager(shardID int) (persist
 	}
 
 	tags := map[string]string{
-		metrics.ShardTagName: string(shardID),
+		metrics.ShardTagName: metrics.AllShardsTagValue,
 	}
 	return persistence.NewWorkflowExecutionPersistenceClient(mgr, factory.metricsClient.Tagged(tags)), nil
 }

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -449,7 +449,7 @@ func acquireShard(shardID int, shardManager persistence.ShardManager, historyMgr
 		logging.TagHistoryShardID: shardID,
 	})
 	tags := map[string]string{
-		metrics.ShardTagName: string(shardID),
+		metrics.ShardTagName: metrics.AllShardsTagValue,
 	}
 	context.metricsClient = reporter.Tagged(tags)
 


### PR DESCRIPTION
Emitting a shard tag for all metric becomes unmanageable when you run
the server with large number of shards.  Using a constant value for now.