### PR TITLE
Workflow execution start to close timeout

### DIFF
--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -68,6 +68,7 @@ const (
 	TagValueActionActivityTaskCancelRequestFailed = "add-activitytask-cancel-request-failed-event"
 	TagValueActionCompleteWorkflow                = "add-complete-workflow-event"
 	TagValueActionFailWorkflow                    = "add-fail-workflow-event"
+	TagValueActionTimeoutWorkflow                 = "add-timeout-workflow-event"
 	TagValueActionCancelWorkflow                  = "add-cancel-workflow-event"
 	TagValueActionUnknownEvent                    = "add-unknown-event"
 	TagValueActionTimerStarted                    = "add-timer-started-event"

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -292,6 +292,8 @@ const (
 	TimerTaskDecisionTimeoutScope
 	// TimerTaskUserTimerScope is the scope used by metric emitted by timer queue processor for processing user timers
 	TimerTaskUserTimerScope
+	// TimerTaskWorkflowTimeoutScope is the scope used by metric emitted by timer queue processor for processing workflow timeouts.
+	TimerTaskWorkflowTimeoutScope
 
 	NumHistoryScopes
 )
@@ -408,6 +410,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		TimerTaskActivityTimeoutScope:               {operation: "TimerTaskActivityTimeout"},
 		TimerTaskDecisionTimeoutScope:               {operation: "TimerTaskDecisionTimeout"},
 		TimerTaskUserTimerScope:                     {operation: "TimerTaskUserTimer"},
+		TimerTaskWorkflowTimeoutScope:               {operation: "TimerTaskWorkflowTimeout"},
 	},
 	// Matching Scope Names
 	Matching: {

--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -1842,6 +1842,9 @@ func GetVisibilityTSFrom(task Task) time.Time {
 
 	case TaskTypeUserTimer:
 		return task.(*UserTimerTask).VisibilityTimestamp
+
+	case TaskTypeWorkflowTimeout:
+		return task.(*WorkflowTimeoutTask).VisibilityTimestamp
 	}
 	return time.Time{}
 }
@@ -1857,5 +1860,8 @@ func SetVisibilityTSFrom(task Task, t time.Time) {
 
 	case TaskTypeUserTimer:
 		task.(*UserTimerTask).VisibilityTimestamp = t
+
+	case TaskTypeWorkflowTimeout:
+		task.(*WorkflowTimeoutTask).VisibilityTimestamp = t
 	}
 }

--- a/common/persistence/cassandraPersistence_test.go
+++ b/common/persistence/cassandraPersistence_test.go
@@ -640,16 +640,21 @@ func (s *cassandraPersistenceSuite) TestTimerTasks() {
 	updatedInfo := copyWorkflowExecutionInfo(info0)
 	updatedInfo.NextEventID = int64(5)
 	updatedInfo.LastProcessedEvent = int64(2)
-	tasks := []Task{&DecisionTimeoutTask{time.Now(), 1, 2}}
+	tasks := []Task{&DecisionTimeoutTask{time.Now(), 1, 2}, &WorkflowTimeoutTask{time.Now(), 2}}
 	err2 := s.UpdateWorkflowExecution(updatedInfo, []int64{int64(4)}, nil, int64(3), tasks, nil, nil, nil, nil, nil)
 	s.Nil(err2, "No error expected.")
 
 	timerTasks, err1 := s.GetTimerIndexTasks()
 	s.Nil(err1, "No error expected.")
 	s.NotNil(timerTasks, "expected valid list of tasks.")
+	s.Equal(2, len(timerTasks))
+	s.Equal(TaskTypeWorkflowTimeout, timerTasks[1].TaskType)
 
 	deleteTimerTask := &DecisionTimeoutTask{VisibilityTimestamp: timerTasks[0].VisibilityTimestamp, TaskID: timerTasks[0].TaskID}
 	err2 = s.UpdateWorkflowExecution(updatedInfo, nil, nil, int64(5), nil, deleteTimerTask, nil, nil, nil, nil)
+	s.Nil(err2, "No error expected.")
+
+	err2 = s.CompleteTimerTask(timerTasks[1].VisibilityTimestamp, timerTasks[1].TaskID)
 	s.Nil(err2, "No error expected.")
 
 	timerTasks2, err2 := s.GetTimerIndexTasks()

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -73,6 +73,7 @@ const (
 	TaskTypeDecisionTimeout = iota
 	TaskTypeActivityTimeout
 	TaskTypeUserTimer
+	TaskTypeWorkflowTimeout
 )
 
 type (
@@ -213,6 +214,12 @@ type (
 		VisibilityTimestamp time.Time
 		TaskID              int64
 		EventID             int64
+	}
+
+	// WorkflowTimeoutTask identifies a timeout task.
+	WorkflowTimeoutTask struct {
+		VisibilityTimestamp time.Time
+		TaskID              int64
 	}
 
 	// CancelExecutionTask identifies a transfer task for cancel of execution
@@ -792,6 +799,31 @@ func (u *UserTimerTask) GetVisibilityTimestamp() time.Time {
 
 // SetVisibilityTimestamp gets the visibility time stamp
 func (u *UserTimerTask) SetVisibilityTimestamp(t time.Time) {
+	u.VisibilityTimestamp = t
+}
+
+// GetType returns the type of the timeout task.
+func (u *WorkflowTimeoutTask) GetType() int {
+	return TaskTypeWorkflowTimeout
+}
+
+// GetTaskID returns the sequence ID of the cancel transfer task.
+func (u *WorkflowTimeoutTask) GetTaskID() int64 {
+	return u.TaskID
+}
+
+// SetTaskID sets the sequence ID of the cancel transfer task.
+func (u *WorkflowTimeoutTask) SetTaskID(id int64) {
+	u.TaskID = id
+}
+
+// GetVisibilityTimestamp gets the visibility time stamp
+func (u *WorkflowTimeoutTask) GetVisibilityTimestamp() time.Time {
+	return u.VisibilityTimestamp
+}
+
+// SetVisibilityTimestamp gets the visibility time stamp
+func (u *WorkflowTimeoutTask) SetVisibilityTimestamp(t time.Time) {
 	u.VisibilityTimestamp = t
 }
 

--- a/common/persistence/persistenceTestBase.go
+++ b/common/persistence/persistenceTestBase.go
@@ -208,6 +208,7 @@ func (s *TestShardContext) GetRangeID() int64 {
 	return atomic.LoadInt64(&s.shardInfo.RangeID)
 }
 
+// GetTimeSource test implementation
 func (s *TestShardContext) GetTimeSource() common.TimeSource {
 	return common.NewRealTimeSource()
 }

--- a/common/persistence/persistenceTestBase.go
+++ b/common/persistence/persistenceTestBase.go
@@ -208,6 +208,10 @@ func (s *TestShardContext) GetRangeID() int64 {
 	return atomic.LoadInt64(&s.shardInfo.RangeID)
 }
 
+func (s *TestShardContext) GetTimeSource() common.TimeSource {
+	return common.NewRealTimeSource()
+}
+
 func newTestExecutionMgrFactory(options TestBaseOptions, cassandra CassandraTestCluster,
 	logger bark.Logger) ExecutionManagerFactory {
 	return &testExecutionMgrFactory{

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -2497,7 +2497,6 @@ GetHistoryLoop:
 	s.True(workflowComplete)
 }
 
-
 func (s *integrationSuite) setupShards() {
 	// shard 0 is always created, we create additional shards if needed
 	for shardID := 1; shardID < testNumberOfHistoryShards; shardID++ {

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -2438,6 +2438,66 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 		startedEvent.GetChildWorkflowExecutionStartedEventAttributes().GetWorkflowExecution())
 }
 
+func (s *integrationSuite) TestWorkflowTimeout() {
+	id := "integration-workflow-timeout-test"
+	wt := "integration-workflow-timeout-type"
+	tl := "integration-workflow-timeout-tasklist"
+	identity := "worker1"
+
+	workflowType := workflow.NewWorkflowType()
+	workflowType.Name = common.StringPtr(wt)
+
+	taskList := workflow.NewTaskList()
+	taskList.Name = common.StringPtr(tl)
+
+	request := &workflow.StartWorkflowExecutionRequest{
+		RequestId:    common.StringPtr(uuid.New()),
+		Domain:       common.StringPtr(s.domainName),
+		WorkflowId:   common.StringPtr(id),
+		WorkflowType: workflowType,
+		TaskList:     taskList,
+		Input:        nil,
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1),
+		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Identity:                            common.StringPtr(identity),
+	}
+
+	we, err0 := s.engine.StartWorkflowExecution(request)
+	s.Nil(err0)
+
+	s.logger.Infof("StartWorkflowExecution: response: %v \n", we.GetRunId())
+
+	workflowComplete := false
+
+GetHistoryLoop:
+	for i := 0; i < 10; i++ {
+		historyResponse, err := s.engine.GetWorkflowExecutionHistory(&workflow.GetWorkflowExecutionHistoryRequest{
+			Domain: common.StringPtr(s.domainName),
+			Execution: &workflow.WorkflowExecution{
+				WorkflowId: common.StringPtr(id),
+				RunId:      common.StringPtr(we.GetRunId()),
+			},
+		})
+		s.Nil(err)
+		history := historyResponse.GetHistory()
+		common.PrettyPrintHistory(history, s.logger)
+
+		lastEvent := history.GetEvents()[len(history.GetEvents())-1]
+		if lastEvent.GetEventType() != workflow.EventType_WorkflowExecutionTimedOut {
+			s.logger.Warnf("Execution not timedout yet.")
+			time.Sleep(200 * time.Millisecond)
+			continue GetHistoryLoop
+		}
+
+		timeoutEventAttributes := lastEvent.GetWorkflowExecutionTimedOutEventAttributes()
+		s.Equal(workflow.TimeoutType_START_TO_CLOSE, timeoutEventAttributes.GetTimeoutType())
+		workflowComplete = true
+		break GetHistoryLoop
+	}
+	s.True(workflowComplete)
+}
+
+
 func (s *integrationSuite) setupShards() {
 	// shard 0 is always created, we create additional shards if needed
 	for shardID := 1; shardID < testNumberOfHistoryShards; shardID++ {

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -564,7 +564,6 @@ func (b *historyBuilder) newTimeoutWorkflowExecutionEvent() *workflow.HistoryEve
 	return historyEvent
 }
 
-
 func (b *historyBuilder) newWorkflowExecutionSignaledEvent(
 	request *workflow.SignalWorkflowExecutionRequest) *workflow.HistoryEvent {
 	historyEvent := b.msBuilder.createNewHistoryEvent(workflow.EventType_WorkflowExecutionSignaled)

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -152,6 +152,12 @@ func (b *historyBuilder) AddFailWorkflowEvent(decisionCompletedEventID int64,
 	return b.addEventToHistory(event)
 }
 
+func (b *historyBuilder) AddTimeoutWorkflowEvent() *workflow.HistoryEvent {
+	event := b.newTimeoutWorkflowExecutionEvent()
+
+	return b.addEventToHistory(event)
+}
+
 func (b *historyBuilder) AddWorkflowExecutionTerminatedEvent(
 	request *workflow.TerminateWorkflowExecutionRequest) *workflow.HistoryEvent {
 	event := b.newWorkflowExecutionTerminatedEvent(request)
@@ -548,6 +554,16 @@ func (b *historyBuilder) newFailWorkflowExecutionEvent(decisionTaskCompletedEven
 
 	return historyEvent
 }
+
+func (b *historyBuilder) newTimeoutWorkflowExecutionEvent() *workflow.HistoryEvent {
+	historyEvent := b.msBuilder.createNewHistoryEvent(workflow.EventType_WorkflowExecutionTimedOut)
+	attributes := workflow.NewWorkflowExecutionTimedOutEventAttributes()
+	attributes.TimeoutType = workflow.TimeoutTypePtr(workflow.TimeoutType_START_TO_CLOSE)
+	historyEvent.WorkflowExecutionTimedOutEventAttributes = attributes
+
+	return historyEvent
+}
+
 
 func (b *historyBuilder) newWorkflowExecutionSignaledEvent(
 	request *workflow.SignalWorkflowExecutionRequest) *workflow.HistoryEvent {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -630,7 +630,9 @@ Update_History_Loop:
 					failCause = workflow.DecisionTaskFailedCause_BAD_COMPLETE_WORKFLOW_EXECUTION_ATTRIBUTES
 					break Process_Decision_Loop
 				}
-				msBuilder.AddCompletedWorkflowEvent(completedID, attributes)
+				if e := msBuilder.AddCompletedWorkflowEvent(completedID, attributes); e == nil {
+					return &workflow.InternalServiceError{Message: "Unable to add complete workflow event."}
+				}
 				isComplete = true
 			case workflow.DecisionType_FailWorkflowExecution:
 				e.metricsClient.IncCounter(metrics.HistoryRespondDecisionTaskCompletedScope,
@@ -654,7 +656,9 @@ Update_History_Loop:
 					failCause = workflow.DecisionTaskFailedCause_BAD_FAIL_WORKFLOW_EXECUTION_ATTRIBUTES
 					break Process_Decision_Loop
 				}
-				msBuilder.AddFailWorkflowEvent(completedID, attributes)
+				if e := msBuilder.AddFailWorkflowEvent(completedID, attributes); e == nil {
+					return &workflow.InternalServiceError{Message: "Unable to add fail workflow event."}
+				}
 				isComplete = true
 			case workflow.DecisionType_CancelWorkflowExecution:
 				e.metricsClient.IncCounter(metrics.HistoryRespondDecisionTaskCompletedScope,

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -191,8 +191,9 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 		decisionTimeout = di.DecisionTimeout
 	}
 
+	duration := time.Duration(request.GetExecutionStartToCloseTimeoutSeconds()) * time.Second
 	timerTasks := []persistence.Task{&persistence.WorkflowTimeoutTask{
-		VisibilityTimestamp: time.Now().Add(time.Duration(request.GetExecutionStartToCloseTimeoutSeconds()) * time.Second),
+		VisibilityTimestamp: e.shard.GetTimeSource().Now().Add(duration),
 	}}
 	// Serialize the history
 	serializedHistory, serializedError := msBuilder.hBuilder.Serialize()

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -715,6 +715,7 @@ func (e *mutableStateBuilder) AddCompletedWorkflowEvent(decisionCompletedEventID
 	if e.executionInfo.State == persistence.WorkflowStateCompleted {
 		logging.LogInvalidHistoryActionEvent(e.logger, logging.TagValueActionCompleteWorkflow, e.GetNextEventID(), fmt.Sprintf(
 			"{State: %v}", e.executionInfo.State))
+		return nil
 	}
 
 	e.executionInfo.State = persistence.WorkflowStateCompleted
@@ -730,6 +731,7 @@ func (e *mutableStateBuilder) AddFailWorkflowEvent(decisionCompletedEventID int6
 	if e.executionInfo.State == persistence.WorkflowStateCompleted {
 		logging.LogInvalidHistoryActionEvent(e.logger, logging.TagValueActionFailWorkflow, e.GetNextEventID(), fmt.Sprintf(
 			"{State: %v}", e.executionInfo.State))
+		return nil
 	}
 
 	e.executionInfo.State = persistence.WorkflowStateCompleted
@@ -744,6 +746,7 @@ func (e *mutableStateBuilder) AddTimeoutWorkflowEvent() *workflow.HistoryEvent {
 	if e.executionInfo.State == persistence.WorkflowStateCompleted {
 		logging.LogInvalidHistoryActionEvent(e.logger, logging.TagValueActionTimeoutWorkflow, e.GetNextEventID(), fmt.Sprintf(
 			"{State: %v}", e.executionInfo.State))
+		return nil
 	}
 
 	e.executionInfo.State = persistence.WorkflowStateCompleted

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -740,6 +740,20 @@ func (e *mutableStateBuilder) AddFailWorkflowEvent(decisionCompletedEventID int6
 	return event
 }
 
+func (e *mutableStateBuilder) AddTimeoutWorkflowEvent() *workflow.HistoryEvent {
+	if e.executionInfo.State == persistence.WorkflowStateCompleted {
+		logging.LogInvalidHistoryActionEvent(e.logger, logging.TagValueActionTimeoutWorkflow, e.GetNextEventID(), fmt.Sprintf(
+			"{State: %v}", e.executionInfo.State))
+	}
+
+	e.executionInfo.State = persistence.WorkflowStateCompleted
+	e.executionInfo.CloseStatus = persistence.WorkflowCloseStatusTimedOut
+	event := e.hBuilder.AddTimeoutWorkflowEvent()
+	e.writeCompletionEventToMutableState(event)
+
+	return event
+}
+
 func (e *mutableStateBuilder) AddWorkflowExecutionCancelRequestedEvent(cause string,
 	request *h.RequestCancelWorkflowExecutionRequest) *workflow.HistoryEvent {
 	return e.hBuilder.AddWorkflowExecutionCancelRequestedEvent(cause, request)

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 
 	"github.com/uber-common/bark"
+	"github.com/uber/cadence/common"
 )
 
 const (
@@ -56,6 +57,7 @@ type (
 		GetMetricsClient() metrics.Client
 		GetTimerAckLevel() time.Time
 		UpdateTimerAckLevel(ackLevel time.Time) error
+		GetTimeSource() common.TimeSource
 	}
 
 	shardContextImpl struct {
@@ -422,6 +424,10 @@ func (s *shardContextImpl) allocateTimerIDsLocked(timerTasks []persistence.Task)
 			persistence.GetVisibilityTSFrom(task), task.GetTaskID(), s.shardInfo.TimerAckLevel)
 	}
 	return nil
+}
+
+func (s *shardContextImpl) GetTimeSource() common.TimeSource {
+	return common.NewRealTimeSource()
 }
 
 // TODO: This method has too many parameters.  Clean it up.  Maybe create a struct to pass in as parameter.

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -739,11 +739,7 @@ Update_History_Loop:
 			return nil
 		}
 
-		timeoutEvent := msBuilder.AddTimeoutWorkflowEvent()
-		if timeoutEvent == nil {
-			// Unable to add WorkflowTimeout event to history
-			return &workflow.InternalServiceError{Message: "Unable to add WorkflowTimeout event to history."}
-		}
+		msBuilder.AddTimeoutWorkflowEvent()
 
 		// We apply the update to execution using optimistic concurrency.  If it fails due to a conflict than reload
 		// the history and try the operation again.

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -781,7 +781,11 @@ Update_History_Loop:
 			return nil
 		}
 
-		msBuilder.AddTimeoutWorkflowEvent()
+		if e := msBuilder.AddTimeoutWorkflowEvent(); e == nil {
+			// If we failed to add the event that means the workflow is already completed.
+			// we drop this timeout event.
+			return nil
+		}
 
 		// We apply the update to execution using optimistic concurrency.  If it fails due to a conflict than reload
 		// the history and try the operation again.

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -194,8 +194,8 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 
 	builder := newMutableStateBuilder(s.logger)
 	builder.AddWorkflowExecutionStartedEvent(domainID, we, &workflow.StartWorkflowExecutionRequest{
-		WorkflowType:                   &workflow.WorkflowType{Name: common.StringPtr("wType")},
-		TaskList:                       common.TaskListPtr(workflow.TaskList{Name: common.StringPtr(taskList)}),
+		WorkflowType: &workflow.WorkflowType{Name: common.StringPtr("wType")},
+		TaskList:     common.TaskListPtr(workflow.TaskList{Name: common.StringPtr(taskList)}),
 		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1),
 	})
 
@@ -208,7 +208,7 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 
 	taskID := int64(100)
 	timerTask := &persistence.TimerTaskInfo{WorkflowID: "wid", RunID: "rid", TaskID: taskID,
-		TaskType: persistence.TaskTypeWorkflowTimeout,
+		TaskType:            persistence.TaskTypeWorkflowTimeout,
 		VisibilityTimestamp: mockTS.Now(),
 		EventID:             decisionScheduledEvent.GetEventId()}
 	timerIndexResponse := &persistence.GetTimerIndexTasksResponse{Timers: []*persistence.TimerTaskInfo{timerTask}}

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -185,3 +185,55 @@ func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
 	<-waitCh
 	processor.Stop()
 }
+
+func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
+	domainID := "5bb49df8-71bc-4c63-b57f-05f2a508e7b5"
+	we := workflow.WorkflowExecution{WorkflowId: common.StringPtr("workflow-timesout-test"),
+		RunId: common.StringPtr("0d00698f-08e1-4d36-a3e2-3bf109f5d2d6")}
+	taskList := "task-workflow-times-out"
+
+	builder := newMutableStateBuilder(s.logger)
+	builder.AddWorkflowExecutionStartedEvent(domainID, we, &workflow.StartWorkflowExecutionRequest{
+		WorkflowType:                   &workflow.WorkflowType{Name: common.StringPtr("wType")},
+		TaskList:                       common.TaskListPtr(workflow.TaskList{Name: common.StringPtr(taskList)}),
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1),
+	})
+
+	decisionScheduledEvent, _ := addDecisionTaskScheduledEvent(builder)
+	addDecisionTaskStartedEvent(builder, decisionScheduledEvent.GetEventId(), taskList, uuid.New())
+
+	waitCh := make(chan struct{})
+
+	mockTS := &mockTimeSource{currTime: time.Now()}
+
+	taskID := int64(100)
+	timerTask := &persistence.TimerTaskInfo{WorkflowID: "wid", RunID: "rid", TaskID: taskID,
+		TaskType: persistence.TaskTypeWorkflowTimeout,
+		VisibilityTimestamp: mockTS.Now(),
+		EventID:             decisionScheduledEvent.GetEventId()}
+	timerIndexResponse := &persistence.GetTimerIndexTasksResponse{Timers: []*persistence.TimerTaskInfo{timerTask}}
+
+	s.mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything).Return(timerIndexResponse, nil).Once()
+
+	ms := createMutableState(builder)
+	wfResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
+	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(wfResponse, nil).Once()
+
+	s.mockExecutionMgr.On("CompleteTimerTask", mock.Anything).Return(nil).Once()
+	s.mockHistoryMgr.On("AppendHistoryEvents", mock.Anything).Return(nil).Once()
+	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything).Return(nil).Run(func(arguments mock.Arguments) {
+		// Done.
+		waitCh <- struct{}{}
+	}).Once()
+
+	// Start timer Processor.
+	processor := newTimerQueueProcessor(s.mockShard, s.mockHistoryEngine, s.mockExecutionMgr, s.logger).(*timerQueueProcessorImpl)
+	processor.Start()
+
+	processor.NotifyNewTimer([]persistence.Task{&persistence.WorkflowTimeoutTask{
+		VisibilityTimestamp: timerTask.VisibilityTimestamp,
+	}})
+
+	<-waitCh
+	processor.Stop()
+}


### PR DESCRIPTION
- Add another timer task to track the workflow execution start to close timeout.
- Add integration test for workflow timeout.