### PR TITLE
Bug fix to not append event to execution after completion

### DIFF
--- a/common/logging/events.go
+++ b/common/logging/events.go
@@ -45,6 +45,7 @@ const (
 	TransferQueueProcessorShuttingDown     = 2102
 	TransferQueueProcessorShutdown         = 2103
 	TransferQueueProcessorShutdownTimedout = 2104
+	TransferTaskProcessingFailed           = 2105
 
 	// Shard context events
 	ShardRangeUpdatedEventID = 3000

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -38,6 +38,16 @@ func LogPersistantStoreErrorEvent(logger bark.Logger, operation string, err erro
 	}).Errorf("Persistent store operation failure. Operation Details: %v", details)
 }
 
+// LogTransferTaskProcessingFailedEvent is used to log failures from transfer task processing.
+func LogTransferTaskProcessingFailedEvent(logger bark.Logger, taskID int64, taskType int, err error) {
+	logger.WithFields(bark.Fields{
+		TagWorkflowEventID: TransferTaskProcessingFailed,
+		TagTaskID:          taskID,
+		TagTaskType:        taskType,
+		TagWorkflowErr:     err,
+	}).Errorf("Processor failed to process transfer task: %v, type: %v.  Error: %v", taskID, taskType, err)
+}
+
 // LogOperationFailedEvent is used to log generic operation failures.
 func LogOperationFailedEvent(logger bark.Logger, msg string, err error) {
 	logger.WithFields(bark.Fields{

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -40,6 +40,8 @@ const (
 	TagHistoryShardID       = "shard-id"
 	TagDecisionType         = "decision-type"
 	TagDecisionFailCause    = "decision-fail-cause"
+	TagTaskID               = "task-id"
+	TagTaskType             = "task-type"
 
 	// workflow logging tag values
 	// TagWorkflowComponent Values

--- a/service/frontend/handler.go
+++ b/service/frontend/handler.go
@@ -819,7 +819,6 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 		DomainUUID:    common.StringPtr(info.ID),
 		CancelRequest: cancelRequest,
 	})
-	wh.GetLogger().Errorf("***Error: %v", err)
 	if err != nil {
 		return wh.error(err, scope)
 	}

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1241,10 +1241,8 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(
 			}
 
 			isCancelRequested, cancelRequestID := msBuilder.isCancelRequested()
-			e.logger.Errorf("****isCancelRequested: %v, CancelRequestID: %v", isCancelRequested, cancelRequestID)
 			if isCancelRequested {
 				cancelRequest := req.GetCancelRequest()
-				e.logger.Errorf("****CancelRequestSet: %v", cancelRequest.IsSetRequestId())
 				if cancelRequest.IsSetRequestId() {
 					requestID := cancelRequest.GetRequestId()
 					if requestID != "" && cancelRequestID == requestID {
@@ -1252,7 +1250,6 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(
 					}
 				}
 
-				e.logger.Error("***Return Cancellation error.")
 				return &workflow.CancellationAlreadyRequestedError{
 					Message: "Cancellation already requested for this workflow execution.",
 				}


### PR DESCRIPTION
Make transfer task processing resilient when workflow execution finishes
before transfer task can be processed.

Fixes issue #213 