### PR TITLE
Insert visibility store record after creating matching task

### DIFF
--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -1455,6 +1455,7 @@ func (s *integrationSuite) TestVisibility() {
 	startFilter.LatestTime = common.Int64Ptr(time.Now().UnixNano())
 
 	closedCount := 0
+	openCount := 0
 
 ListClosedLoop:
 	for i := 0; i < 10; i++ {
@@ -1474,13 +1475,23 @@ ListClosedLoop:
 	}
 	s.Equal(1, closedCount)
 
-	resp, err4 := s.engine.ListOpenWorkflowExecutions(&workflow.ListOpenWorkflowExecutionsRequest{
-		Domain:          common.StringPtr(s.domainName),
-		MaximumPageSize: common.Int32Ptr(100),
-		StartTimeFilter: startFilter,
-	})
-	s.Nil(err4)
-	s.Equal(1, len(resp.Executions))
+ListOpenLoop:
+	for i := 0; i < 10; i++ {
+		resp, err4 := s.engine.ListOpenWorkflowExecutions(&workflow.ListOpenWorkflowExecutionsRequest{
+			Domain:          common.StringPtr(s.domainName),
+			MaximumPageSize: common.Int32Ptr(100),
+			StartTimeFilter: startFilter,
+		})
+		s.Nil(err4)
+		openCount = len(resp.Executions)
+		if closedCount == 0 {
+			s.logger.Info("Open WorkflowExecution is not yet visibile")
+			time.Sleep(100 * time.Millisecond)
+			continue ListOpenLoop
+		}
+		break ListOpenLoop
+	}
+	s.Equal(1, openCount)
 }
 
 func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -1484,7 +1484,7 @@ ListOpenLoop:
 		})
 		s.Nil(err4)
 		openCount = len(resp.Executions)
-		if closedCount == 0 {
+		if openCount == 0 {
 			s.logger.Info("Open WorkflowExecution is not yet visibile")
 			time.Sleep(100 * time.Millisecond)
 			continue ListOpenLoop

--- a/service/history/transferQueueProcessor_test.go
+++ b/service/history/transferQueueProcessor_test.go
@@ -413,6 +413,7 @@ workerPump:
 		select {
 		case task := <-tasksCh:
 			if task.ScheduleID == firstEventID+1 {
+				s.mockMatching.On("AddDecisionTask", mock.Anything, mock.Anything).Once().Return(nil)
 				s.mockVisibilityMgr.On("RecordWorkflowExecutionStarted", mock.Anything).Once().Return(&workflow.EntityNotExistsError{})
 			}
 			s.processor.processTransferTask(task)


### PR DESCRIPTION
This way the progress of the workflow is not blocked on the visibility store operation.