### PR TITLE
Activities to create one timer per workflow

### DIFF
--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -141,8 +141,10 @@ const (
 	templateActivityInfoType = `{` +
 		`schedule_id: ?, ` +
 		`scheduled_event: ?, ` +
+		`scheduled_time: ?, ` +
 		`started_id: ?, ` +
 		`started_event: ?, ` +
+		`started_time: ?, ` +
 		`activity_id: ?, ` +
 		`request_id: ?, ` +
 		`details: ?, ` +
@@ -1524,8 +1526,10 @@ func (d *cassandraPersistence) updateActivityInfos(batch *gocql.Batch, activityI
 			a.ScheduleID,
 			a.ScheduleID,
 			a.ScheduledEvent,
+			a.ScheduledTime,
 			a.StartedID,
 			a.StartedEvent,
+			a.StartedTime,
 			a.ActivityID,
 			a.RequestID,
 			a.Details,
@@ -1794,10 +1798,14 @@ func createActivityInfo(result map[string]interface{}) *ActivityInfo {
 			info.ScheduleID = v.(int64)
 		case "scheduled_event":
 			info.ScheduledEvent = v.([]byte)
+		case "scheduled_time":
+			info.ScheduledTime = v.(time.Time)
 		case "started_id":
 			info.StartedID = v.(int64)
 		case "started_event":
 			info.StartedEvent = v.([]byte)
+		case "started_time":
+			info.StartedTime = v.(time.Time)
 		case "activity_id":
 			info.ActivityID = v.(string)
 		case "request_id":

--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -152,7 +152,8 @@ const (
 		`heart_beat_timeout: ?, ` +
 		`cancel_requested: ?, ` +
 		`cancel_request_id: ?, ` +
-		`last_hb_updated_time: ?` +
+		`last_hb_updated_time: ?, ` +
+		`timer_task_status: ?` +
 		`}`
 
 	templateTimerInfoType = `{` +
@@ -1535,6 +1536,7 @@ func (d *cassandraPersistence) updateActivityInfos(batch *gocql.Batch, activityI
 			a.CancelRequested,
 			a.CancelRequestID,
 			a.LastHeartBeatUpdatedTime,
+			a.TimerTaskStatus,
 			d.shardID,
 			rowTypeExecution,
 			domainID,
@@ -1816,6 +1818,8 @@ func createActivityInfo(result map[string]interface{}) *ActivityInfo {
 			info.CancelRequestID = v.(int64)
 		case "last_hb_updated_time":
 			info.LastHeartBeatUpdatedTime = v.(time.Time)
+		case "timer_task_status":
+			info.TimerTaskStatus = int32(v.(int))
 		}
 	}
 

--- a/common/persistence/cassandraPersistence_test.go
+++ b/common/persistence/cassandraPersistence_test.go
@@ -690,8 +690,10 @@ func (s *cassandraPersistenceSuite) TestWorkflowMutableState_Activities() {
 		{
 			ScheduleID:               1,
 			ScheduledEvent:           []byte("scheduled_event_1"),
+			ScheduledTime:            currentTime,
 			StartedID:                2,
 			StartedEvent:             []byte("started_event_1"),
+			StartedTime:              currentTime,
 			ScheduleToCloseTimeout:   1,
 			ScheduleToStartTimeout:   2,
 			StartToCloseTimeout:      3,
@@ -711,8 +713,10 @@ func (s *cassandraPersistenceSuite) TestWorkflowMutableState_Activities() {
 	s.NotNil(ai)
 	s.Equal(int64(1), ai.ScheduleID)
 	s.Equal([]byte("scheduled_event_1"), ai.ScheduledEvent)
+	s.Equal(currentTime.Unix(), ai.ScheduledTime.Unix())
 	s.Equal(int64(2), ai.StartedID)
 	s.Equal([]byte("started_event_1"), ai.StartedEvent)
+	s.Equal(currentTime.Unix(), ai.StartedTime.Unix())
 	s.Equal(int32(1), ai.ScheduleToCloseTimeout)
 	s.Equal(int32(2), ai.ScheduleToStartTimeout)
 	s.Equal(int32(3), ai.StartToCloseTimeout)

--- a/common/persistence/cassandraPersistence_test.go
+++ b/common/persistence/cassandraPersistence_test.go
@@ -699,7 +699,7 @@ func (s *cassandraPersistenceSuite) TestWorkflowMutableState_Activities() {
 			StartToCloseTimeout:      3,
 			HeartbeatTimeout:         4,
 			LastHeartBeatUpdatedTime: currentTime,
-			TimerTaskStatus:          10,
+			TimerTaskStatus:          1,
 		}}
 	err2 := s.UpdateWorkflowExecution(updatedInfo, []int64{int64(4)}, nil, int64(3), nil, nil, activityInfos, nil, nil, nil)
 	s.Nil(err2, "No error expected.")

--- a/common/persistence/cassandraPersistence_test.go
+++ b/common/persistence/cassandraPersistence_test.go
@@ -722,7 +722,7 @@ func (s *cassandraPersistenceSuite) TestWorkflowMutableState_Activities() {
 	s.Equal(int32(3), ai.StartToCloseTimeout)
 	s.Equal(int32(4), ai.HeartbeatTimeout)
 	s.Equal(currentTime.Unix(), ai.LastHeartBeatUpdatedTime.Unix())
-	s.Equal(int32(10), ai.TimerTaskStatus)
+	s.Equal(int32(1), ai.TimerTaskStatus)
 
 	err2 = s.UpdateWorkflowExecution(updatedInfo, nil, nil, int64(5), nil, nil, nil, common.Int64Ptr(1), nil, nil)
 	s.Nil(err2, "No error expected.")

--- a/common/persistence/cassandraPersistence_test.go
+++ b/common/persistence/cassandraPersistence_test.go
@@ -697,6 +697,7 @@ func (s *cassandraPersistenceSuite) TestWorkflowMutableState_Activities() {
 			StartToCloseTimeout:      3,
 			HeartbeatTimeout:         4,
 			LastHeartBeatUpdatedTime: currentTime,
+			TimerTaskStatus:          10,
 		}}
 	err2 := s.UpdateWorkflowExecution(updatedInfo, []int64{int64(4)}, nil, int64(3), nil, nil, activityInfos, nil, nil, nil)
 	s.Nil(err2, "No error expected.")
@@ -717,6 +718,7 @@ func (s *cassandraPersistenceSuite) TestWorkflowMutableState_Activities() {
 	s.Equal(int32(3), ai.StartToCloseTimeout)
 	s.Equal(int32(4), ai.HeartbeatTimeout)
 	s.Equal(currentTime.Unix(), ai.LastHeartBeatUpdatedTime.Unix())
+	s.Equal(int32(10), ai.TimerTaskStatus)
 
 	err2 = s.UpdateWorkflowExecution(updatedInfo, nil, nil, int64(5), nil, nil, nil, common.Int64Ptr(1), nil, nil)
 	s.Nil(err2, "No error expected.")

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -276,8 +276,10 @@ type (
 	ActivityInfo struct {
 		ScheduleID               int64
 		ScheduledEvent           []byte
+		ScheduledTime            time.Time
 		StartedID                int64
 		StartedEvent             []byte
+		StartedTime              time.Time
 		ActivityID               string
 		RequestID                string
 		Details                  []byte

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -288,7 +288,7 @@ type (
 		CancelRequested          bool
 		CancelRequestID          int64
 		LastHeartBeatUpdatedTime time.Time
-		TimerTaskStatus		 int32
+		TimerTaskStatus          int32
 	}
 
 	// TimerInfo details - metadata about user timer info.

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -288,6 +288,7 @@ type (
 		CancelRequested          bool
 		CancelRequestID          int64
 		LastHeartBeatUpdatedTime time.Time
+		TimerTaskStatus		 int32
 	}
 
 	// TimerInfo details - metadata about user timer info.

--- a/schema/cadence/schema.cql
+++ b/schema/cadence/schema.cql
@@ -81,6 +81,7 @@ CREATE TYPE activity_info (
   cancel_requested          boolean, -- If a cancel request is made to cancel the activity in progress.
   cancel_request_id         bigint,  -- Event ID that identifies the cancel request.
   last_hb_updated_time      timestamp, -- Last time the heartbeat is received.
+  timer_task_status         int,    -- Indicates wheter timers are created for this activity.
 );
 
 -- User timer details

--- a/schema/cadence/schema.cql
+++ b/schema/cadence/schema.cql
@@ -69,8 +69,10 @@ CREATE TYPE timer_task (
 CREATE TYPE activity_info (
   schedule_id               bigint,
   scheduled_event           blob,
+  scheduled_time            timestamp,
   started_id                bigint,
   started_event             blob,
+  started_time              timestamp,
   activity_id               text,    -- Client generated unique ID for the activity.
   request_id                text,    -- Identifier used by matching engine for retrying history service calls for recording task is started
   details                   blob,

--- a/schema/cadence/versioned/v0.3/activity_timers.cql
+++ b/schema/cadence/versioned/v0.3/activity_timers.cql
@@ -1,0 +1,3 @@
+ALTER TYPE activity_info ADD scheduled_time timestamp;
+ALTER TYPE activity_info ADD started_time timestamp;
+ALTER TYPE activity_info ADD timer_task_status int;

--- a/schema/cadence/versioned/v0.3/manifest.json
+++ b/schema/cadence/versioned/v0.3/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.3",
+  "MinCompatibleVersion": "0.1",
+  "Description": "Support for optimizing activity timers.",
+  "SchemaUpdateCqlFiles": [
+    "activity_timers.cql"
+  ]
+}

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -312,6 +312,16 @@ func (e *mutableStateBuilder) updateActivityProgress(ai *persistence.ActivityInf
 	e.updateActivityInfos = append(e.updateActivityInfos, ai)
 }
 
+// UpdateActivity updates an activity
+func (e *mutableStateBuilder) UpdateActivity(ai *persistence.ActivityInfo) error {
+	_, ok := e.pendingActivityInfoIDs[ai.ScheduleID]
+	if !ok {
+		return fmt.Errorf("Unable to find activity with schedule event id: %v in mutable state", ai.ScheduleID)
+	}
+	e.updateActivityInfos = append(e.updateActivityInfos, ai)
+	return nil
+}
+
 // DeleteActivity deletes details about an activity.
 func (e *mutableStateBuilder) DeleteActivity(scheduleEventID int64) error {
 	a, ok := e.pendingActivityInfoIDs[scheduleEventID]
@@ -614,7 +624,9 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(decisionCompletedEve
 	ai := &persistence.ActivityInfo{
 		ScheduleID:               scheduleEventID,
 		ScheduledEvent:           scheduleEvent,
+		ScheduledTime:            time.Unix(0, event.GetTimestamp()),
 		StartedID:                emptyEventID,
+		StartedTime:              time.Time{},
 		ActivityID:               attributes.GetActivityId(),
 		ScheduleToStartTimeout:   scheduleToStartTimeout,
 		ScheduleToCloseTimeout:   scheduleToCloseTimeout,
@@ -623,6 +635,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(decisionCompletedEve
 		CancelRequested:          false,
 		CancelRequestID:          emptyEventID,
 		LastHeartBeatUpdatedTime: time.Time{},
+		TimerTaskStatus:          emptyTimerID,
 	}
 
 	e.pendingActivityInfoIDs[scheduleEventID] = ai
@@ -644,6 +657,7 @@ func (e *mutableStateBuilder) AddActivityTaskStartedEvent(ai *persistence.Activi
 
 	ai.StartedID = event.GetEventId()
 	ai.RequestID = requestID
+	ai.StartedTime = time.Unix(0, event.GetTimestamp())
 	e.updateActivityInfos = append(e.updateActivityInfos, ai)
 
 	return event

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -635,7 +635,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(decisionCompletedEve
 		CancelRequested:          false,
 		CancelRequestID:          emptyEventID,
 		LastHeartBeatUpdatedTime: time.Time{},
-		TimerTaskStatus:          emptyTimerID,
+		TimerTaskStatus:          TimerTaskStatusNone,
 	}
 
 	e.pendingActivityInfoIDs[scheduleEventID] = ai
@@ -918,7 +918,7 @@ func (e *mutableStateBuilder) AddTimerStartedEvent(decisionCompletedEventID int6
 		TimerID:    timerID,
 		ExpiryTime: expiryTime,
 		StartedID:  event.GetEventId(),
-		TaskID:     emptyTimerID,
+		TaskID:     TimerTaskStatusNone,
 	}
 
 	e.pendingTimerInfoIDs[timerID] = ti

--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -38,8 +38,6 @@ const (
 	DefaultScheduleToStartActivityTimeoutInSecs = 10
 	DefaultScheduleToCloseActivityTimeoutInSecs = 10
 	DefaultStartToCloseActivityTimeoutInSecs    = 10
-
-	emptyTimerID = -1
 )
 
 // Timer task status
@@ -188,7 +186,7 @@ func (tb *timerBuilder) AddUserTimer(ti *persistence.TimerInfo, msBuilder *mutab
 	timer := &timerDetails{
 		SequenceID:  SequenceID{VisibilityTimestamp: ti.ExpiryTime, TaskID: seqNum},
 		TimerID:     ti.TimerID,
-		TaskCreated: ti.TaskID != emptyTimerID}
+		TaskCreated: ti.TaskID == TimerTaskStatusCreated}
 	tb.insertTimer(timer)
 	tb.logger.Debugf("Added User Timeout for timer ID: %s", ti.TimerID)
 }
@@ -262,7 +260,7 @@ func (tb *timerBuilder) loadUserTimers(msBuilder *mutableStateBuilder) {
 		td := &timerDetails{
 			SequenceID:  SequenceID{VisibilityTimestamp: v.ExpiryTime, TaskID: seqNum},
 			TimerID:     v.TimerID,
-			TaskCreated: v.TaskID != emptyTimerID}
+			TaskCreated: v.TaskID == TimerTaskStatusCreated}
 		tb.userTimers = append(tb.userTimers, td)
 	}
 	sort.Sort(tb.userTimers)

--- a/service/history/timerBuilder_test.go
+++ b/service/history/timerBuilder_test.go
@@ -130,7 +130,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 
 	// Mutable state with out a timer task.
 	tb = newTimerBuilder(s.logger, &mockTimeSource{currTime: time.Now()})
-	tp2 := &persistence.TimerInfo{TimerID: "tid1", StartedID: 201, TaskID: emptyTimerID, ExpiryTime: time.Now().Add(10 * time.Second)}
+	tp2 := &persistence.TimerInfo{TimerID: "tid1", StartedID: 201, TaskID: TimerTaskStatusNone, ExpiryTime: time.Now().Add(10 * time.Second)}
 	timerInfos = map[string]*persistence.TimerInfo{"tid1": tp2}
 	msb = newMutableStateBuilder(s.logger)
 	msb.Load(&persistence.WorkflowMutableState{
@@ -152,7 +152,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 	isRunning, ti := msb.GetUserTimer("tid-after")
 	s.True(isRunning)
 	s.NotNil(ti)
-	s.Equal(int64(emptyTimerID), ti.TaskID)
+	s.Equal(int64(TimerTaskStatusNone), ti.TaskID)
 	s.Equal(int64(203), ti.StartedID)
 }
 

--- a/service/history/timerBuilder_test.go
+++ b/service/history/timerBuilder_test.go
@@ -83,8 +83,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderSingleUserTimer() {
 		StartToFireTimeoutSeconds: common.Int64Ptr(1),
 	})
 
-	tb.LoadUserTimers(msb)
-	tb.AddUserTimer(ti1)
+	tb.AddUserTimer(ti1, msb)
 	t1 := tb.GetUserTimerTaskIfNeeded(msb)
 
 	s.NotNil(t1)
@@ -112,19 +111,17 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 		TimerInfos:    timerInfos,
 	})
 
-	tb.LoadUserTimers(msb)
-
 	_, tiBefore := msb.AddTimerStartedEvent(int64(3), &workflow.StartTimerDecisionAttributes{
 		TimerId:                   common.StringPtr("tid-before"),
 		StartToFireTimeoutSeconds: common.Int64Ptr(1),
 	})
-	tb.AddUserTimer(tiBefore)
+	tb.AddUserTimer(tiBefore, msb)
 
 	_, tiAfter := msb.AddTimerStartedEvent(int64(3), &workflow.StartTimerDecisionAttributes{
 		TimerId:                   common.StringPtr("tid-after"),
 		StartToFireTimeoutSeconds: common.Int64Ptr(15),
 	})
-	tb.AddUserTimer(tiAfter)
+	tb.AddUserTimer(tiAfter, msb)
 
 	t1 := tb.GetUserTimerTaskIfNeeded(msb)
 	s.NotNil(t1)
@@ -132,6 +129,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 	s.Equal(tiBefore.ExpiryTime.Unix(), t1.(*persistence.UserTimerTask).VisibilityTimestamp.Unix())
 
 	// Mutable state with out a timer task.
+	tb = newTimerBuilder(s.logger, &mockTimeSource{currTime: time.Now()})
 	tp2 := &persistence.TimerInfo{TimerID: "tid1", StartedID: 201, TaskID: emptyTimerID, ExpiryTime: time.Now().Add(10 * time.Second)}
 	timerInfos = map[string]*persistence.TimerInfo{"tid1": tp2}
 	msb = newMutableStateBuilder(s.logger)
@@ -140,13 +138,11 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 		TimerInfos:    timerInfos,
 	})
 
-	tb.LoadUserTimers(msb)
-
 	_, ti3 := msb.AddTimerStartedEvent(int64(3), &workflow.StartTimerDecisionAttributes{
 		TimerId:                   common.StringPtr("tid-after"),
 		StartToFireTimeoutSeconds: common.Int64Ptr(15),
 	})
-	tb.AddUserTimer(ti3)
+	tb.AddUserTimer(ti3, msb)
 
 	t1 = tb.GetUserTimerTaskIfNeeded(msb)
 	s.NotNil(t1)

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -587,96 +587,107 @@ Update_History_Loop:
 			continue Update_History_Loop
 		}
 
+		if !msBuilder.isWorkflowExecutionRunning() {
+			// Workflow is completed.
+			return nil
+		}
+
 		var timerTasks []persistence.Task
 		scheduleNewDecision := false
 		updateHistory := false
 
-		if ai, isRunning := msBuilder.GetActivityInfo(scheduleID); isRunning && msBuilder.isWorkflowExecutionRunning() {
-			timeoutType := workflow.TimeoutType(timerTask.TimeoutType)
-			t.logger.Debugf("Activity TimeoutType: %v, scheduledID: %v, startedId: %v. \n",
-				timeoutType, scheduleID, ai.StartedID)
+	ExpireActivityTimers:
+		for _, td := range tBuilder.GetActivityTimers(msBuilder) {
+			//t.logger.Debugf("Processing timer details: %v", td)
+			ai, isRunning := msBuilder.GetActivityInfo(td.ActivityID)
+			if !isRunning {
+				//  We might have time out this activity already.
+				continue ExpireActivityTimers
+			}
 
-			switch timeoutType {
-			case workflow.TimeoutType_SCHEDULE_TO_CLOSE:
-				{
-					t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.ScheduleToCloseTimeoutCounter)
-					if msBuilder.AddActivityTaskTimedOutEvent(scheduleID, ai.StartedID, timeoutType, nil) == nil {
-						return errFailedToAddTimeoutEvent
-					}
+			if isExpired := tBuilder.IsTimerExpired(td, timerTask.VisibilityTimestamp); isExpired {
+				timeoutType := td.TimeoutType
+				t.logger.Debugf("Activity TimeoutType: %v, scheduledID: %v, startedId: %v. \n",
+					timeoutType, ai.ScheduleID, ai.StartedID)
 
-					updateHistory = true
-					scheduleNewDecision = !msBuilder.HasPendingDecisionTask()
-				}
-
-			case workflow.TimeoutType_START_TO_CLOSE:
-				{
-					t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.StartToCloseTimeoutCounter)
-					if ai.StartedID != emptyEventID {
-						if msBuilder.AddActivityTaskTimedOutEvent(scheduleID, ai.StartedID, timeoutType, nil) == nil {
+				switch timeoutType {
+				case workflow.TimeoutType_SCHEDULE_TO_CLOSE:
+					{
+						t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.ScheduleToCloseTimeoutCounter)
+						if msBuilder.AddActivityTaskTimedOutEvent(ai.ScheduleID, ai.StartedID, timeoutType, nil) == nil {
 							return errFailedToAddTimeoutEvent
 						}
-
 						updateHistory = true
-						scheduleNewDecision = !msBuilder.HasPendingDecisionTask()
 					}
-				}
 
-			case workflow.TimeoutType_HEARTBEAT:
-				{
-					t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.HeartbeatTimeoutCounter)
-					lastHeartbeat := ai.LastHeartBeatUpdatedTime.Add(
-						time.Duration(ai.HeartbeatTimeout) * time.Second)
+				case workflow.TimeoutType_START_TO_CLOSE:
+					{
+						t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.StartToCloseTimeoutCounter)
+						if ai.StartedID != emptyEventID {
+							if msBuilder.AddActivityTaskTimedOutEvent(ai.ScheduleID, ai.StartedID, timeoutType, nil) == nil {
+								return errFailedToAddTimeoutEvent
+							}
+							updateHistory = true
+						}
+					}
 
-					if timerTask.VisibilityTimestamp.After(lastHeartbeat) {
+				case workflow.TimeoutType_HEARTBEAT:
+					{
+						t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.HeartbeatTimeoutCounter)
 						t.logger.Debugf("Activity Heartbeat expired: %+v", *ai)
-						if msBuilder.AddActivityTaskTimedOutEvent(scheduleID, ai.StartedID, timeoutType, nil) == nil {
+
+						if msBuilder.AddActivityTaskTimedOutEvent(ai.ScheduleID, ai.StartedID, timeoutType, nil) == nil {
 							return errFailedToAddTimeoutEvent
 						}
-
 						updateHistory = true
-						scheduleNewDecision = !msBuilder.HasPendingDecisionTask()
-					} else {
-						// Re-Schedule next heartbeat.
-						hbTimeoutTask, err := tBuilder.AddHeartBeatActivityTimeout(ai)
-						if err != nil {
-							return err
-						}
-						if hbTimeoutTask != nil {
-							timerTasks = append(timerTasks, hbTimeoutTask)
+					}
+
+				case workflow.TimeoutType_SCHEDULE_TO_START:
+					{
+						t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.ScheduleToStartTimeoutCounter)
+						if ai.StartedID == emptyEventID {
+							if msBuilder.AddActivityTaskTimedOutEvent(ai.ScheduleID, ai.StartedID, timeoutType, nil) == nil {
+								return errFailedToAddTimeoutEvent
+							}
+							updateHistory = true
 						}
 					}
 				}
+			} else {
+				// See if we have next timer in list to be created.
+				if !td.TaskCreated || td.ActivityID == scheduleID {
+					nextTask := tBuilder.createNewTask(td)
+					timerTasks = []persistence.Task{nextTask}
 
-			case workflow.TimeoutType_SCHEDULE_TO_START:
-				{
-					t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.ScheduleToStartTimeoutCounter)
-					if ai.StartedID == emptyEventID {
-						if msBuilder.AddActivityTaskTimedOutEvent(scheduleID, ai.StartedID, timeoutType, nil) == nil {
-							return errFailedToAddTimeoutEvent
-						}
-
-						updateHistory = true
-						scheduleNewDecision = !msBuilder.HasPendingDecisionTask()
-					}
+					// Update the task ID tracking the corresponding timer task.
+					ai.TimerTaskStatus = 1
+					msBuilder.UpdateActivity(ai)
+					at := nextTask.(*persistence.ActivityTimeoutTask)
+					t.logger.Debugf("%s: Adding Activity Timeout: with timeout: %v sec, ExpiryTime: %s, TimeoutType: %v, EventID: %v",
+						time.Now(), td.TimeoutSec, at.VisibilityTimestamp, td.TimeoutType.String(), at.EventID)
 				}
+
+				// Done!
+				break ExpireActivityTimers
 			}
 		}
 
 		if updateHistory {
 			// We apply the update to execution using optimistic concurrency.  If it fails due to a conflict than reload
 			// the history and try the operation again.
-			defer t.NotifyNewTimer(timerTasks)
+			scheduleNewDecision = !msBuilder.HasPendingDecisionTask()
 			err := t.updateWorkflowExecution(context, msBuilder, scheduleNewDecision, false, timerTasks, nil)
 			if err != nil {
 				if err == ErrConflict {
 					continue Update_History_Loop
 				}
 			}
-			return err
+
+			t.NotifyNewTimer(timerTasks)
+			return nil
 		}
 
 		return nil
-
 	}
 	return ErrMaxAttemptsExceeded
 }

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -501,18 +501,15 @@ Update_History_Loop:
 			return nil
 		}
 
-		tBuilder.LoadUserTimers(msBuilder)
-
 		var timerTasks []persistence.Task
-
 		scheduleNewDecision := false
 
 	ExpireUserTimers:
-		for _, td := range tBuilder.AllTimers() {
-			hasTimer, ti := tBuilder.UserTimer(td.TimerID)
+		for _, td := range tBuilder.GetUserTimers(msBuilder) {
+			hasTimer, ti := tBuilder.GetUserTimer(td.TimerID)
 			if !hasTimer {
-				t.logger.Debugf("Failed to find in memory user timer for: %s", td.SequenceID)
-				return fmt.Errorf("failed to find user timer")
+				t.logger.Debugf("Failed to find in memory user timer: %s", td.TimerID)
+				return fmt.Errorf("Failed to find in memory user timer: %s", td.TimerID)
 			}
 
 			if isExpired := tBuilder.IsTimerExpired(td, task.VisibilityTimestamp); isExpired {

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -598,7 +598,6 @@ Update_History_Loop:
 
 	ExpireActivityTimers:
 		for _, td := range tBuilder.GetActivityTimers(msBuilder) {
-			//t.logger.Debugf("Processing timer details: %v", td)
 			ai, isRunning := msBuilder.GetActivityInfo(td.ActivityID)
 			if !isRunning {
 				//  We might have time out this activity already.
@@ -659,8 +658,7 @@ Update_History_Loop:
 					nextTask := tBuilder.createNewTask(td)
 					timerTasks = []persistence.Task{nextTask}
 
-					// Update the task ID tracking the corresponding timer task.
-					ai.TimerTaskStatus = 1
+					ai.TimerTaskStatus = TimerTaskStatusCreated
 					msBuilder.UpdateActivity(ai)
 					at := nextTask.(*persistence.ActivityTimeoutTask)
 					t.logger.Debugf("%s: Adding Activity Timeout: with timeout: %v sec, ExpiryTime: %s, TimeoutType: %v, EventID: %v",

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -44,7 +44,6 @@ type (
 
 		sync.Mutex
 		msBuilder       *mutableStateBuilder
-		tBuilder        *timerBuilder
 		updateCondition int64
 		deleteTimerTask persistence.Task
 	}
@@ -60,14 +59,12 @@ func newWorkflowExecutionContext(domainID string, execution workflow.WorkflowExe
 		logging.TagWorkflowExecutionID: execution.GetWorkflowId(),
 		logging.TagWorkflowRunID:       execution.GetRunId(),
 	})
-	tBuilder := newTimerBuilder(lg, common.NewRealTimeSource())
 
 	return &workflowExecutionContext{
 		domainID:          domainID,
 		workflowExecution: execution,
 		shard:             shard,
 		executionManager:  executionManager,
-		tBuilder:          tBuilder,
 		logger:            lg,
 	}
 }
@@ -282,5 +279,4 @@ func (c *workflowExecutionContext) deleteWorkflowExecutionWithRetry(
 
 func (c *workflowExecutionContext) clear() {
 	c.msBuilder = nil
-	c.tBuilder = newTimerBuilder(c.logger, common.NewRealTimeSource())
 }

--- a/tools/cassandra/updateTask_test.go
+++ b/tools/cassandra/updateTask_test.go
@@ -129,7 +129,7 @@ func (s *UpdateSchemaTestSuite) TestDryrun() {
 	s.Nil(err)
 	// update the version to the latest
 	s.log.Infof("Ver: %v", ver)
-	s.Equal(0, cmpVersion(ver, "0.2"))
+	s.Equal(0, cmpVersion(ver, "0.3"))
 
 	dropAllTablesTypes(client)
 }


### PR DESCRIPTION
Each activity today end up creating 4 timers for each timeout, for a workflow with 'N' number of activities, we would have to create 4x timers. This change is to minimize to create timers so we create only one timer per workflow that would be the minimum of all activities.