### PR TITLE
minor changes to docker and token_bucket_rate_limiter

### DIFF
--- a/common/tb.go
+++ b/common/tb.go
@@ -119,8 +119,8 @@ func (f *tokenBucketFactoryImpl) CreateTokenBucket(rps int, timeSource TimeSourc
 }
 
 func (tb *tokenBucketImpl) TryConsume(count int) (bool, time.Duration) {
-	now := tb.timeSource.Now().UnixNano()
 	tb.Lock()
+	now := tb.timeSource.Now().UnixNano()
 	tb.refill(now)
 	nextRefillTime := time.Duration(tb.nextRefillTime - now)
 	if tb.tokens < count {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@
 
 FROM debian:jessie
 
-# get golang 1.8.1
+# get golang 1.8.2
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		g++ \
 		gcc \

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -43,7 +43,7 @@ init_env() {
     export HOST_IP=`hostname --ip-address`
 
     if [ "$BIND_ON_LOCALHOST" == true ]; then
-            export HOST_IP="127.0.0.1"
+        export HOST_IP="127.0.0.1"
     else
         export BIND_ON_LOCALHOST=false
     fi
@@ -72,6 +72,11 @@ init_env() {
         export NUM_HISTORY_SHARDS=4
     fi
 }
+
+if [ $# -eq 0 ]; then
+    echo 'Missing required argument. Usage: ./start.sh <path_to_Cadence_repo>'
+    exit
+fi
 
 CADENCE_HOME=$1
 


### PR DESCRIPTION
1. Change the Golang version in comments from 1.8.1 to 1.8.2.
2. Update argument check in start.sh.
3. Change the timestamp `now` in `TryConsume` in token bucket from entering the function to acquiring the lock. This is to eliminate the waiting time for the lock.