### PR TITLE
GetWorkflowExecutionHistory returns invalid nextPageToken

### DIFF
--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -2557,7 +2557,7 @@ func (s *integrationSuite) printWorkflowHistory(domain string, execution *workfl
 	historyResponse, err := s.engine.GetWorkflowExecutionHistory(&workflow.GetWorkflowExecutionHistoryRequest{
 		Domain:          common.StringPtr(domain),
 		Execution:       execution,
-		MaximumPageSize: common.Int32Ptr(10),
+		MaximumPageSize: common.Int32Ptr(5),
 	})
 	s.Nil(err)
 

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -2557,7 +2557,7 @@ func (s *integrationSuite) printWorkflowHistory(domain string, execution *workfl
 	historyResponse, err := s.engine.GetWorkflowExecutionHistory(&workflow.GetWorkflowExecutionHistoryRequest{
 		Domain:          common.StringPtr(domain),
 		Execution:       execution,
-		MaximumPageSize: common.Int32Ptr(5),
+		MaximumPageSize: common.Int32Ptr(5), // Use small page size to force pagination code path
 	})
 	s.Nil(err)
 

--- a/service/frontend/handler.go
+++ b/service/frontend/handler.go
@@ -74,14 +74,15 @@ const (
 )
 
 var (
-	errDomainNotSet         = &gen.BadRequestError{Message: "Domain not set on request."}
-	errTaskTokenNotSet      = &gen.BadRequestError{Message: "Task token not set on request."}
-	errTaskListNotSet       = &gen.BadRequestError{Message: "TaskList is not set on request."}
-	errExecutionNotSet      = &gen.BadRequestError{Message: "Execution is not set on request."}
-	errWorkflowIDNotSet     = &gen.BadRequestError{Message: "WorkflowId is not set on request."}
-	errRunIDNotSet          = &gen.BadRequestError{Message: "RunId is not set on request."}
-	errInvalidRunID         = &gen.BadRequestError{Message: "Invalid RunId."}
-	errInvalidNextPageToken = &gen.BadRequestError{Message: "Invalid NextPageToken."}
+	errDomainNotSet               = &gen.BadRequestError{Message: "Domain not set on request."}
+	errTaskTokenNotSet            = &gen.BadRequestError{Message: "Task token not set on request."}
+	errTaskListNotSet             = &gen.BadRequestError{Message: "TaskList is not set on request."}
+	errExecutionNotSet            = &gen.BadRequestError{Message: "Execution is not set on request."}
+	errWorkflowIDNotSet           = &gen.BadRequestError{Message: "WorkflowId is not set on request."}
+	errRunIDNotSet                = &gen.BadRequestError{Message: "RunId is not set on request."}
+	errInvalidRunID               = &gen.BadRequestError{Message: "Invalid RunId."}
+	errInvalidNextPageToken       = &gen.BadRequestError{Message: "Invalid NextPageToken."}
+	errNextPageTokenRunIDMismatch = &gen.BadRequestError{Message: "RunID in the request does not match the NextPageToken."}
 )
 
 // NewWorkflowHandler creates a thrift handler for the cadence service
@@ -644,6 +645,9 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 		token, err = deserializeGetHistoryToken(getRequest.GetNextPageToken())
 		if err != nil {
 			return nil, wh.error(errInvalidNextPageToken, scope)
+		}
+		if getRequest.GetExecution().IsSetRunId() && getRequest.GetExecution().GetRunId() != token.RunID {
+			return nil, wh.error(errNextPageTokenRunIDMismatch, scope)
 		}
 	} else {
 		response, err := wh.history.GetWorkflowExecutionNextEventID(ctx, &h.GetWorkflowExecutionNextEventIDRequest{

--- a/service/frontend/handler.go
+++ b/service/frontend/handler.go
@@ -62,9 +62,9 @@ type (
 	}
 
 	getHistoryContinuationToken struct {
-		runID            string
-		nextEventID      int64
-		persistenceToken []byte
+		RunID            string
+		NextEventID      int64
+		PersistenceToken []byte
 	}
 )
 
@@ -651,8 +651,8 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 			Execution:  getRequest.GetExecution(),
 		})
 		if err == nil {
-			token.nextEventID = response.GetEventId()
-			token.runID = response.GetRunId()
+			token.NextEventID = response.GetEventId()
+			token.RunID = response.GetRunId()
 		} else {
 			if _, ok := err.(*gen.EntityNotExistsError); !ok || !getRequest.GetExecution().IsSetRunId() {
 				return nil, wh.error(err, scope)
@@ -666,27 +666,27 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 			if err != nil {
 				return nil, wh.error(err, scope)
 			}
-			token.nextEventID = visibilityResp.Execution.GetHistoryLength()
-			token.runID = visibilityResp.Execution.GetExecution().GetRunId()
+			token.NextEventID = visibilityResp.Execution.GetHistoryLength()
+			token.RunID = visibilityResp.Execution.GetExecution().GetRunId()
 		}
 	}
 
 	we := gen.WorkflowExecution{
 		WorkflowId: getRequest.GetExecution().WorkflowId,
-		RunId:      common.StringPtr(token.runID),
+		RunId:      common.StringPtr(token.RunID),
 	}
 	history, persistenceToken, err :=
-		wh.getHistory(info.ID, we, token.nextEventID, getRequest.GetMaximumPageSize(), getRequest.GetNextPageToken())
+		wh.getHistory(info.ID, we, token.NextEventID, getRequest.GetMaximumPageSize(), token.PersistenceToken)
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
 
-	nextToken, err := getSerializedGetHistoryToken(persistenceToken, token.runID, history, token.nextEventID)
+	nextToken, err := getSerializedGetHistoryToken(persistenceToken, token.RunID, history, token.NextEventID)
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
 
-	return createGetWorkflowExecutionHistoryResponse(history, token.nextEventID, nextToken), nil
+	return createGetWorkflowExecutionHistoryResponse(history, token.NextEventID, nextToken), nil
 }
 
 // SignalWorkflowExecution is used to send a signal event to running workflow execution.  This results in
@@ -1150,9 +1150,9 @@ func getSerializedGetHistoryToken(persistenceToken []byte, runID string, history
 	events := history.GetEvents()
 	if len(persistenceToken) > 0 && len(events) > 0 && events[len(events)-1].GetEventId() < nextEventID-1 {
 		token := &getHistoryContinuationToken{
-			runID:            runID,
-			nextEventID:      nextEventID,
-			persistenceToken: persistenceToken,
+			RunID:            runID,
+			NextEventID:      nextEventID,
+			PersistenceToken: persistenceToken,
 		}
 		data, err := json.Marshal(token)
 


### PR DESCRIPTION
Make token fields public so they can be serialized properly.
Also change integration test page size to force pagination path to be exercised.
Issue #282 