### PR TITLE
Serialize task list persistence writes

### DIFF
--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -85,11 +85,14 @@ type taskContext struct {
 
 // Single task list in memory state
 type taskListManagerImpl struct {
-	taskListID      *taskListID
-	logger          bark.Logger
-	metricsClient   metrics.Client
-	engine          *matchingEngineImpl
-	persistenceLock sync.Mutex // serializes all writes to persistence
+	taskListID    *taskListID
+	logger        bark.Logger
+	metricsClient metrics.Client
+	engine        *matchingEngineImpl
+	// serializes all writes to persistence
+	// This is needed because of a known Cassandra issue where concurrent LWT to the same partition
+	// cause timeout errors.
+	persistenceLock sync.Mutex
 	taskWriter      *taskWriter
 	taskBuffer      chan *persistence.TaskInfo // tasks loaded from persistence
 	// Sync channel used to perform sync matching.

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -134,6 +134,7 @@ writerLoop:
 					maxReadLevel = taskIDs[i]
 				}
 
+				w.tlMgr.persistenceLock.Lock()
 				r, err := w.taskManager.CreateTasks(&persistence.CreateTasksRequest{
 					DomainID:     w.taskListID.domainID,
 					TaskList:     w.taskListID.taskListName,
@@ -143,6 +144,7 @@ writerLoop:
 					// might be out of sync. This is OK as caller can just retry.
 					RangeID: rangeID,
 				})
+				w.tlMgr.persistenceLock.Unlock()
 
 				if err != nil {
 					logging.LogPersistantStoreErrorEvent(w.logger, logging.TagValueStoreOperationCreateTask, err,


### PR DESCRIPTION
Concurrent Cassandra LWT to the same partition are known to cause timeout errors.
This change ensures that all LWT to a task list are serialized by using a mutex.