### PR TITLE
Timer task creation marker can identify activity time type

### DIFF
--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -658,6 +658,8 @@ Update_History_Loop:
 
 				// Create next timer task if we don't have one (or)
 				// if current one is HB task and we need to create next HB task for the same.
+				// NOTE: When record activity HB comes in we only update last heartbeat timestamp, this is the place
+				// where we create next timer task based on that new updated timestamp.
 				if !td.TaskCreated || (isHeartBeatTask && td.ActivityID == scheduleID) {
 					nextTask := tBuilder.createNewTask(td)
 					timerTasks = []persistence.Task{nextTask}
@@ -668,16 +670,6 @@ Update_History_Loop:
 
 					t.logger.Debugf("%s: Adding Activity Timeout: with timeout: %v sec, ExpiryTime: %s, TimeoutType: %v, EventID: %v",
 						time.Now(), td.TimeoutSec, at.VisibilityTimestamp, td.TimeoutType.String(), at.EventID)
-				}
-
-				if isHeartBeatTask && td.ActivityID != scheduleID {
-					ai, isRunning := msBuilder.GetActivityInfo(scheduleID)
-					if isRunning {
-						// Unset the time task status for which this timer task is created so we can
-						// create the next HB task when needed.
-						ai.TimerTaskStatus = ai.TimerTaskStatus & ^TimerTaskStatusCreatedHeartbeat
-						msBuilder.UpdateActivity(ai)
-					}
 				}
 
 				// Done!

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -654,15 +654,30 @@ Update_History_Loop:
 				}
 			} else {
 				// See if we have next timer in list to be created.
-				if !td.TaskCreated || td.ActivityID == scheduleID {
+				isHeartBeatTask := timerTask.TimeoutType == int(workflow.TimeoutType_HEARTBEAT)
+
+				// Create next timer task if we don't have one (or)
+				// if current one is HB task and we need to create next HB task for the same.
+				if !td.TaskCreated || (isHeartBeatTask && td.ActivityID == scheduleID) {
 					nextTask := tBuilder.createNewTask(td)
 					timerTasks = []persistence.Task{nextTask}
-
-					ai.TimerTaskStatus = TimerTaskStatusCreated
-					msBuilder.UpdateActivity(ai)
 					at := nextTask.(*persistence.ActivityTimeoutTask)
+
+					ai.TimerTaskStatus = ai.TimerTaskStatus & getActivityTimerStatus(workflow.TimeoutType(at.TimeoutType))
+					msBuilder.UpdateActivity(ai)
+
 					t.logger.Debugf("%s: Adding Activity Timeout: with timeout: %v sec, ExpiryTime: %s, TimeoutType: %v, EventID: %v",
 						time.Now(), td.TimeoutSec, at.VisibilityTimestamp, td.TimeoutType.String(), at.EventID)
+				}
+
+				if isHeartBeatTask && td.ActivityID != scheduleID {
+					ai, isRunning := msBuilder.GetActivityInfo(scheduleID)
+					if isRunning {
+						// Unset the time task status for which this timer task is created so we can
+						// create the next HB task when needed.
+						ai.TimerTaskStatus = ai.TimerTaskStatus & ^TimerTaskStatusCreatedHeartbeat
+						msBuilder.UpdateActivity(ai)
+					}
 				}
 
 				// Done!


### PR DESCRIPTION
In activity mutable state we have timer task status that indicates if the timer task has already been
created for a specific timeout, to give us de-duplication logic for the timer if the next minimum activity in the activity timer list needs a timer task.