### PR TITLE
matching: fix crash on task list shutdown

### DIFF
--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -71,7 +71,7 @@ func newTaskListManager(e *matchingEngineImpl, taskList *taskListID) taskListMan
 		taskAckManager: newAckManager(e.logger),
 		syncMatch:      make(chan *getTaskResult),
 	}
-	tlMgr.taskWriter = newTaskWriter(tlMgr, tlMgr.shutdownCh)
+	tlMgr.taskWriter = newTaskWriter(tlMgr)
 	return tlMgr
 }
 
@@ -143,6 +143,7 @@ func (c *taskListManagerImpl) Stop() {
 	}
 	logging.LogTaskListUnloadingEvent(c.logger)
 	close(c.shutdownCh)
+	c.taskWriter.Stop()
 	c.engine.removeTaskListManager(c.taskListID)
 	logging.LogTaskListUnloadedEvent(c.logger)
 }
@@ -153,7 +154,6 @@ func (c *taskListManagerImpl) AddTask(execution *s.WorkflowExecution, taskInfo *
 		if err != nil || r != nil {
 			return r, err
 		}
-
 		r, err = c.taskWriter.appendTask(execution, taskInfo, rangeID)
 		return r, err
 	})

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -21,6 +21,7 @@
 package matching
 
 import (
+	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -28,6 +29,7 @@ import (
 	s "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/persistence"
+	"sync"
 )
 
 const (
@@ -55,29 +57,65 @@ type (
 		taskManager  persistence.TaskManager
 		appendCh     chan *writeTaskRequest
 		maxReadLevel int64
-		shutdownCh   chan struct{}
+		stopped      int64 // set to 1 if the writer is stopped or is shutting down
 		logger       bark.Logger
+		stopCh       chan struct{}  // shutdown signal for all routines in this class
+		writerStopCh chan struct{}  // shutdown signal for the writerLoop()
+		writerWG     sync.WaitGroup // done signal from the writerLoop()
 	}
 )
 
-func newTaskWriter(tlMgr *taskListManagerImpl, shutdownCh chan struct{}) *taskWriter {
+// errShutdown indicates that the task list is shutting down
+var errShutdown = errors.New("task list shutting down")
+
+func newTaskWriter(tlMgr *taskListManagerImpl) *taskWriter {
 	return &taskWriter{
-		tlMgr:       tlMgr,
-		taskListID:  tlMgr.taskListID,
-		taskManager: tlMgr.engine.taskManager,
-		shutdownCh:  shutdownCh,
-		appendCh:    make(chan *writeTaskRequest, outstandingTaskAppendsThreshold),
-		logger:      tlMgr.logger,
+		tlMgr:        tlMgr,
+		taskListID:   tlMgr.taskListID,
+		taskManager:  tlMgr.engine.taskManager,
+		stopCh:       make(chan struct{}),
+		writerStopCh: make(chan struct{}),
+		appendCh:     make(chan *writeTaskRequest, outstandingTaskAppendsThreshold),
+		logger:       tlMgr.logger,
 	}
 }
 
 func (w *taskWriter) Start() {
 	w.maxReadLevel = w.tlMgr.getTaskSequenceNumber() - 1
+	w.writerWG.Add(1)
 	go w.taskWriterLoop()
+}
+
+// Stop stops the taskWriter
+func (w *taskWriter) Stop() {
+
+	// Shutdown needs to happen in a specific order to
+	// avoid duplicate tasks in the task list. Even if
+	// there is a dup, its not the end of the world, but
+	// its best to avoid it
+
+	// step 1: set stopped=1 and stop accepting new tasks in appendTask()
+	// step 2: stop the background routine that writes tasks to cassandra
+	// step 3: wait for the background routine to exit
+	// step 4: stop everything and return
+	if atomic.CompareAndSwapInt64(&w.stopped, 0, 1) { // step1
+		close(w.writerStopCh) // step2
+		w.writerWG.Wait()     // step3
+		close(w.stopCh)       // step4
+	}
+}
+
+func (w *taskWriter) isStopped() bool {
+	return atomic.LoadInt64(&w.stopped) == 1
 }
 
 func (w *taskWriter) appendTask(execution *s.WorkflowExecution,
 	taskInfo *persistence.TaskInfo, rangeID int64) (*persistence.CreateTasksResponse, error) {
+
+	if w.isStopped() {
+		return nil, errShutdown
+	}
+
 	ch := make(chan *writeTaskResponse)
 	req := &writeTaskRequest{
 		execution:  execution,
@@ -88,8 +126,14 @@ func (w *taskWriter) appendTask(execution *s.WorkflowExecution,
 
 	select {
 	case w.appendCh <- req:
-		r := <-ch
-		return r.persistenceResponse, r.err
+		select {
+		case r := <-ch:
+			return r.persistenceResponse, r.err
+		case <-w.stopCh:
+			// if we are shutting down, this request will never make
+			// it to cassandra, just bail out and fail this request
+			return nil, errShutdown
+		}
 	default: // channel is full, throttle
 		return nil, createServiceBusyError()
 	}
@@ -100,67 +144,77 @@ func (w *taskWriter) GetMaxReadLevel() int64 {
 }
 
 func (w *taskWriter) taskWriterLoop() {
-	defer close(w.appendCh)
+
+	defer w.writerWG.Done()
 
 writerLoop:
 	for {
+
 		select {
-		case request := <-w.appendCh:
-			{
-				// read a batch of requests from the channel
-				reqs := []*writeTaskRequest{request}
-				reqs = w.getWriteBatch(reqs)
-				batchSize := len(reqs)
-
-				maxReadLevel := int64(0)
-
-				taskIDs, err := w.tlMgr.newTaskIDs(batchSize)
-				if err != nil {
-					w.sendWriteResponse(reqs, err, nil)
-					continue writerLoop
-				}
-
-				tasks := []*persistence.CreateTaskInfo{}
-				rangeID := int64(0)
-				for i, req := range reqs {
-					tasks = append(tasks, &persistence.CreateTaskInfo{
-						TaskID:    taskIDs[i],
-						Execution: *req.execution,
-						Data:      req.taskInfo,
-					})
-					if req.rangeID > rangeID {
-						rangeID = req.rangeID // use the maximum rangeID provided for the write operation
-					}
-					maxReadLevel = taskIDs[i]
-				}
-
-				w.tlMgr.persistenceLock.Lock()
-				r, err := w.taskManager.CreateTasks(&persistence.CreateTasksRequest{
-					DomainID:     w.taskListID.domainID,
-					TaskList:     w.taskListID.taskListName,
-					TaskListType: w.taskListID.taskType,
-					Tasks:        tasks,
-					// Note that newTaskID could increment range, so rangeID parameter
-					// might be out of sync. This is OK as caller can just retry.
-					RangeID: rangeID,
-				})
-				w.tlMgr.persistenceLock.Unlock()
-
-				if err != nil {
-					logging.LogPersistantStoreErrorEvent(w.logger, logging.TagValueStoreOperationCreateTask, err,
-						fmt.Sprintf("{taskID: [%v, %v], taskType: %v, taskList: %v}",
-							taskIDs[0], taskIDs[batchSize-1], w.taskListID.taskType, w.taskListID.taskListName))
-				}
-
-				// Update the maxReadLevel after the writes are completed.
-				if maxReadLevel > 0 {
-					atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
-				}
-
-				w.sendWriteResponse(reqs, err, r)
-			}
-		case <-w.shutdownCh:
+		case <-w.writerStopCh:
+			// we don't close the appendCh here
+			// because that can cause on a send on closed
+			// channel panic on the appendTask()
 			break writerLoop
+		default:
+			select {
+			case request := <-w.appendCh:
+				{
+					// read a batch of requests from the channel
+					reqs := []*writeTaskRequest{request}
+					reqs = w.getWriteBatch(reqs)
+					batchSize := len(reqs)
+
+					maxReadLevel := int64(0)
+
+					taskIDs, err := w.tlMgr.newTaskIDs(batchSize)
+					if err != nil {
+						w.sendWriteResponse(reqs, err, nil)
+						continue writerLoop
+					}
+
+					tasks := []*persistence.CreateTaskInfo{}
+					rangeID := int64(0)
+					for i, req := range reqs {
+						tasks = append(tasks, &persistence.CreateTaskInfo{
+							TaskID:    taskIDs[i],
+							Execution: *req.execution,
+							Data:      req.taskInfo,
+						})
+						if req.rangeID > rangeID {
+							rangeID = req.rangeID // use the maximum rangeID provided for the write operation
+						}
+						maxReadLevel = taskIDs[i]
+					}
+
+					w.tlMgr.persistenceLock.Lock()
+					r, err := w.taskManager.CreateTasks(&persistence.CreateTasksRequest{
+						DomainID:     w.taskListID.domainID,
+						TaskList:     w.taskListID.taskListName,
+						TaskListType: w.taskListID.taskType,
+						Tasks:        tasks,
+						// Note that newTaskID could increment range, so rangeID parameter
+						// might be out of sync. This is OK as caller can just retry.
+						RangeID: rangeID,
+					})
+					w.tlMgr.persistenceLock.Unlock()
+
+					if err != nil {
+						logging.LogPersistantStoreErrorEvent(w.logger, logging.TagValueStoreOperationCreateTask, err,
+							fmt.Sprintf("{taskID: [%v, %v], taskType: %v, taskList: %v}",
+								taskIDs[0], taskIDs[batchSize-1], w.taskListID.taskType, w.taskListID.taskListName))
+					}
+
+					// Update the maxReadLevel after the writes are completed.
+					if maxReadLevel > 0 {
+						atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
+					}
+
+					w.sendWriteResponse(reqs, err, r)
+				}
+			case <-w.writerStopCh:
+				break writerLoop
+			}
 		}
 	}
 }

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -29,7 +29,6 @@ import (
 	s "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/persistence"
-	"sync"
 )
 
 const (
@@ -59,9 +58,7 @@ type (
 		maxReadLevel int64
 		stopped      int64 // set to 1 if the writer is stopped or is shutting down
 		logger       bark.Logger
-		stopCh       chan struct{}  // shutdown signal for all routines in this class
-		writerStopCh chan struct{}  // shutdown signal for the writerLoop()
-		writerWG     sync.WaitGroup // done signal from the writerLoop()
+		stopCh       chan struct{} // shutdown signal for all routines in this class
 	}
 )
 
@@ -70,38 +67,24 @@ var errShutdown = errors.New("task list shutting down")
 
 func newTaskWriter(tlMgr *taskListManagerImpl) *taskWriter {
 	return &taskWriter{
-		tlMgr:        tlMgr,
-		taskListID:   tlMgr.taskListID,
-		taskManager:  tlMgr.engine.taskManager,
-		stopCh:       make(chan struct{}),
-		writerStopCh: make(chan struct{}),
-		appendCh:     make(chan *writeTaskRequest, outstandingTaskAppendsThreshold),
-		logger:       tlMgr.logger,
+		tlMgr:       tlMgr,
+		taskListID:  tlMgr.taskListID,
+		taskManager: tlMgr.engine.taskManager,
+		stopCh:      make(chan struct{}),
+		appendCh:    make(chan *writeTaskRequest, outstandingTaskAppendsThreshold),
+		logger:      tlMgr.logger,
 	}
 }
 
 func (w *taskWriter) Start() {
 	w.maxReadLevel = w.tlMgr.getTaskSequenceNumber() - 1
-	w.writerWG.Add(1)
 	go w.taskWriterLoop()
 }
 
 // Stop stops the taskWriter
 func (w *taskWriter) Stop() {
-
-	// Shutdown needs to happen in a specific order to
-	// avoid duplicate tasks in the task list. Even if
-	// there is a dup, its not the end of the world, but
-	// its best to avoid it
-
-	// step 1: set stopped=1 and stop accepting new tasks in appendTask()
-	// step 2: stop the background routine that writes tasks to cassandra
-	// step 3: wait for the background routine to exit
-	// step 4: stop everything and return
-	if atomic.CompareAndSwapInt64(&w.stopped, 0, 1) { // step1
-		close(w.writerStopCh) // step2
-		w.writerWG.Wait()     // step3
-		close(w.stopCh)       // step4
+	if atomic.CompareAndSwapInt64(&w.stopped, 0, 1) {
+		close(w.stopCh)
 	}
 }
 
@@ -144,77 +127,68 @@ func (w *taskWriter) GetMaxReadLevel() int64 {
 }
 
 func (w *taskWriter) taskWriterLoop() {
-
-	defer w.writerWG.Done()
-
 writerLoop:
 	for {
-
 		select {
-		case <-w.writerStopCh:
+		case request := <-w.appendCh:
+			{
+				// read a batch of requests from the channel
+				reqs := []*writeTaskRequest{request}
+				reqs = w.getWriteBatch(reqs)
+				batchSize := len(reqs)
+
+				maxReadLevel := int64(0)
+
+				taskIDs, err := w.tlMgr.newTaskIDs(batchSize)
+				if err != nil {
+					w.sendWriteResponse(reqs, err, nil)
+					continue writerLoop
+				}
+
+				tasks := []*persistence.CreateTaskInfo{}
+				rangeID := int64(0)
+				for i, req := range reqs {
+					tasks = append(tasks, &persistence.CreateTaskInfo{
+						TaskID:    taskIDs[i],
+						Execution: *req.execution,
+						Data:      req.taskInfo,
+					})
+					if req.rangeID > rangeID {
+						rangeID = req.rangeID // use the maximum rangeID provided for the write operation
+					}
+					maxReadLevel = taskIDs[i]
+				}
+
+				w.tlMgr.persistenceLock.Lock()
+				r, err := w.taskManager.CreateTasks(&persistence.CreateTasksRequest{
+					DomainID:     w.taskListID.domainID,
+					TaskList:     w.taskListID.taskListName,
+					TaskListType: w.taskListID.taskType,
+					Tasks:        tasks,
+					// Note that newTaskID could increment range, so rangeID parameter
+					// might be out of sync. This is OK as caller can just retry.
+					RangeID: rangeID,
+				})
+				w.tlMgr.persistenceLock.Unlock()
+
+				if err != nil {
+					logging.LogPersistantStoreErrorEvent(w.logger, logging.TagValueStoreOperationCreateTask, err,
+						fmt.Sprintf("{taskID: [%v, %v], taskType: %v, taskList: %v}",
+							taskIDs[0], taskIDs[batchSize-1], w.taskListID.taskType, w.taskListID.taskListName))
+				}
+
+				// Update the maxReadLevel after the writes are completed.
+				if maxReadLevel > 0 {
+					atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
+				}
+
+				w.sendWriteResponse(reqs, err, r)
+			}
+		case <-w.stopCh:
 			// we don't close the appendCh here
 			// because that can cause on a send on closed
 			// channel panic on the appendTask()
 			break writerLoop
-		default:
-			select {
-			case request := <-w.appendCh:
-				{
-					// read a batch of requests from the channel
-					reqs := []*writeTaskRequest{request}
-					reqs = w.getWriteBatch(reqs)
-					batchSize := len(reqs)
-
-					maxReadLevel := int64(0)
-
-					taskIDs, err := w.tlMgr.newTaskIDs(batchSize)
-					if err != nil {
-						w.sendWriteResponse(reqs, err, nil)
-						continue writerLoop
-					}
-
-					tasks := []*persistence.CreateTaskInfo{}
-					rangeID := int64(0)
-					for i, req := range reqs {
-						tasks = append(tasks, &persistence.CreateTaskInfo{
-							TaskID:    taskIDs[i],
-							Execution: *req.execution,
-							Data:      req.taskInfo,
-						})
-						if req.rangeID > rangeID {
-							rangeID = req.rangeID // use the maximum rangeID provided for the write operation
-						}
-						maxReadLevel = taskIDs[i]
-					}
-
-					w.tlMgr.persistenceLock.Lock()
-					r, err := w.taskManager.CreateTasks(&persistence.CreateTasksRequest{
-						DomainID:     w.taskListID.domainID,
-						TaskList:     w.taskListID.taskListName,
-						TaskListType: w.taskListID.taskType,
-						Tasks:        tasks,
-						// Note that newTaskID could increment range, so rangeID parameter
-						// might be out of sync. This is OK as caller can just retry.
-						RangeID: rangeID,
-					})
-					w.tlMgr.persistenceLock.Unlock()
-
-					if err != nil {
-						logging.LogPersistantStoreErrorEvent(w.logger, logging.TagValueStoreOperationCreateTask, err,
-							fmt.Sprintf("{taskID: [%v, %v], taskType: %v, taskList: %v}",
-								taskIDs[0], taskIDs[batchSize-1], w.taskListID.taskType, w.taskListID.taskListName))
-					}
-
-					// Update the maxReadLevel after the writes are completed.
-					if maxReadLevel > 0 {
-						atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
-					}
-
-					w.sendWriteResponse(reqs, err, r)
-				}
-			case <-w.writerStopCh:
-				break writerLoop
-			}
 		}
 	}
 }


### PR DESCRIPTION
This patch fixes a crash that can happen during taskListMgr shutdown. The matching engine is responsible for adding new tasks to a task list and this addition is an async process today: 

  AddTask() -> taskWriter.appendTask() -> [req-channel] -> taskWriter.writerLoop() -> TaskList
                                      /\                                         
                                       |                                                                           
                                       ------------------   [ resp- channel ]  -----------------------

So, during shutdown, writerLoop() exits and closes the request channel, but tasks can still come in through. This can cause a panic due to send on closed channel. This patch fixes this by *never* closing the request channel. In addition, the patch contains a few more changes to the shutdown to avoid duplicate tasks in the task list.