### PR TITLE
Restrict clustering key in taskList rangeID check

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -460,10 +460,7 @@ type (
 
 	// CreateTasksRequest is used to create a new task for a workflow exectution
 	CreateTasksRequest struct {
-		DomainID     string
-		TaskList     string
-		TaskListType int
-		RangeID      int64
+		TaskListInfo *TaskListInfo
 		Tasks        []*CreateTaskInfo
 	}
 

--- a/common/persistence/persistenceTestBase.go
+++ b/common/persistence/persistenceTestBase.go
@@ -723,11 +723,8 @@ func (s *TestBase) CreateDecisionTask(domainID string, workflowExecution workflo
 	}
 
 	_, err = s.TaskMgr.CreateTasks(&CreateTasksRequest{
-		DomainID:     domainID,
-		TaskList:     taskList,
-		TaskListType: TaskListTypeDecision,
+		TaskListInfo: leaseResponse.TaskListInfo,
 		Tasks:        tasks,
-		RangeID:      leaseResponse.TaskListInfo.RangeID,
 	})
 
 	if err != nil {
@@ -766,11 +763,8 @@ func (s *TestBase) CreateActivityTasks(domainID string, workflowExecution workfl
 			},
 		}
 		_, err := s.TaskMgr.CreateTasks(&CreateTasksRequest{
-			DomainID:     domainID,
-			TaskList:     taskList,
-			TaskListType: TaskListTypeActivity,
+			TaskListInfo: leaseResponse.TaskListInfo,
 			Tasks:        tasks,
-			RangeID:      leaseResponse.TaskListInfo.RangeID,
 		})
 
 		if err != nil {

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -159,15 +159,20 @@ writerLoop:
 					maxReadLevel = taskIDs[i]
 				}
 
-				w.tlMgr.persistenceLock.Lock()
-				r, err := w.taskManager.CreateTasks(&persistence.CreateTasksRequest{
-					DomainID:     w.taskListID.domainID,
-					TaskList:     w.taskListID.taskListName,
-					TaskListType: w.taskListID.taskType,
-					Tasks:        tasks,
+				tlInfo := &persistence.TaskListInfo{
+					DomainID: w.taskListID.domainID,
+					Name:     w.taskListID.taskListName,
+					TaskType: w.taskListID.taskType,
 					// Note that newTaskID could increment range, so rangeID parameter
 					// might be out of sync. This is OK as caller can just retry.
-					RangeID: rangeID,
+					RangeID:  rangeID,
+					AckLevel: w.tlMgr.getAckLevel(),
+				}
+
+				w.tlMgr.persistenceLock.Lock()
+				r, err := w.taskManager.CreateTasks(&persistence.CreateTasksRequest{
+					TaskListInfo: tlInfo,
+					Tasks:        tasks,
 				})
 				w.tlMgr.persistenceLock.Unlock()
 


### PR DESCRIPTION
The CreateTasks query used to write task list tasks to persistence includes a CAS check that verifies that the rangeID has not changed.
The rangeID is a static field in the tasks table, and Cassandra only accepts the partition keys (but not the other clustering keys) in the CAS query to read and update it.
This unrestricted query however causes problems when there is a big backlog in the task list as the coordinator automatically turns it into a LIMIT 1 query.
To fix this we restrict the query with clustering keys, and rewrite non-static fields so that Cassandra accepts the query restrictions.
Issue #277 