### PR TITLE
Pass config to cadence matching and frontend services during initialization

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -21,14 +21,15 @@
 package main
 
 import (
+	"log"
+	"time"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/service/frontend"
 	"github.com/uber/cadence/service/history"
 	"github.com/uber/cadence/service/matching"
-	"log"
-	"time"
 )
 
 type (
@@ -107,11 +108,11 @@ func (s *server) startService() common.Daemon {
 
 	switch s.name {
 	case frontendService:
-		daemon = frontend.NewService(&params)
+		daemon = frontend.NewService(&params, frontend.NewConfig())
 	case historyService:
 		daemon = history.NewService(&params)
 	case matchingService:
-		daemon = matching.NewService(&params)
+		daemon = matching.NewService(&params, matching.NewConfig())
 	}
 
 	go execute(daemon, s.doneC)

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -203,7 +203,7 @@ func (c *cadenceImpl) startMatching(logger bark.Logger, taskMgr persistence.Task
 	params.CassandraConfig.NumHistoryShards = c.numberOfHistoryShards
 	service := service.New(params)
 	var thriftServices []thrift.TChanServer
-	c.matchingHandler, thriftServices = matching.NewHandler(taskMgr, service, matching.NewConfig())
+	c.matchingHandler, thriftServices = matching.NewHandler(service, matching.NewConfig(), taskMgr)
 	c.matchingHandler.Start(thriftServices)
 	startWG.Done()
 	<-c.shutdownCh

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -155,7 +155,7 @@ func (c *cadenceImpl) startFrontend(logger bark.Logger, rpHosts []string, startW
 	params.CassandraConfig.Hosts = "127.0.0.1"
 	service := service.New(params)
 	var thriftServices []thrift.TChanServer
-	c.frontendHandler, thriftServices = frontend.NewWorkflowHandler(service, c.metadataMgr, c.historyMgr, c.visibilityMgr)
+	c.frontendHandler, thriftServices = frontend.NewWorkflowHandler(service, frontend.NewConfig(), c.metadataMgr, c.historyMgr, c.visibilityMgr)
 	err := c.frontendHandler.Start(thriftServices)
 	if err != nil {
 		c.logger.WithField("error", err).Fatal("Failed to start frontend")
@@ -203,7 +203,7 @@ func (c *cadenceImpl) startMatching(logger bark.Logger, taskMgr persistence.Task
 	params.CassandraConfig.NumHistoryShards = c.numberOfHistoryShards
 	service := service.New(params)
 	var thriftServices []thrift.TChanServer
-	c.matchingHandler, thriftServices = matching.NewHandler(taskMgr, service)
+	c.matchingHandler, thriftServices = matching.NewHandler(taskMgr, service, matching.NewConfig())
 	c.matchingHandler.Start(thriftServices)
 	startWG.Done()
 	<-c.shutdownCh

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -40,16 +40,18 @@ var _ m.TChanMatchingService = (*Handler)(nil)
 type Handler struct {
 	taskPersistence persistence.TaskManager
 	engine          Engine
+	config          *Config
 	metricsClient   metrics.Client
 	startWG         sync.WaitGroup
 	service.Service
 }
 
 // NewHandler creates a thrift handler for the history service
-func NewHandler(taskPersistence persistence.TaskManager, sVice service.Service) (*Handler, []thrift.TChanServer) {
+func NewHandler(taskPersistence persistence.TaskManager, sVice service.Service, config *Config) (*Handler, []thrift.TChanServer) {
 	handler := &Handler{
 		Service:         sVice,
 		taskPersistence: taskPersistence,
+		config:          config,
 	}
 	// prevent us from trying to serve requests before matching engine is started and ready
 	handler.startWG.Add(1)
@@ -64,7 +66,7 @@ func (h *Handler) Start(thriftService []thrift.TChanServer) error {
 		return err
 	}
 	h.metricsClient = h.Service.GetMetricsClient()
-	h.engine = NewEngine(h.taskPersistence, history, h.Service.GetLogger(), h.Service.GetMetricsClient())
+	h.engine = NewEngine(h.taskPersistence, history, h.config, h.Service.GetLogger(), h.Service.GetMetricsClient())
 	h.startWG.Done()
 	return nil
 }

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -47,7 +47,7 @@ type Handler struct {
 }
 
 // NewHandler creates a thrift handler for the history service
-func NewHandler(taskPersistence persistence.TaskManager, sVice service.Service, config *Config) (*Handler, []thrift.TChanServer) {
+func NewHandler(sVice service.Service, config *Config, taskPersistence persistence.TaskManager) (*Handler, []thrift.TChanServer) {
 	handler := &Handler{
 		Service:         sVice,
 		taskPersistence: taskPersistence,

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -34,7 +34,6 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
@@ -68,7 +67,6 @@ var (
 	emptyPollForActivityTaskResponse   = workflow.NewPollForActivityTaskResponse()
 	persistenceOperationRetryPolicy    = common.CreatePersistanceRetryPolicy()
 	historyServiceOperationRetryPolicy = common.CreateHistoryServiceRetryPolicy()
-	//emptyGetTasksRetryPolicy           = createEmptyGetTasksRetryPolicy()
 
 	// ErrNoTasks is exported temporarily for integration test
 	ErrNoTasks    = errors.New("No tasks")
@@ -402,13 +400,6 @@ func (e *matchingEngineImpl) createPollForActivityTaskResponse(context *taskCont
 
 func newTaskListID(domainID, taskListName string, taskType int) *taskListID {
 	return &taskListID{domainID: domainID, taskListName: taskListName, taskType: taskType}
-}
-
-func createEmptyGetTasksRetryPolicy(config *Config) backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(config.EmptyGetRetryInitialInterval)
-	policy.SetMaximumInterval(config.EmptyGetRetryMaxInterval)
-
-	return policy
 }
 
 func workflowExecutionPtr(execution workflow.WorkflowExecution) *workflow.WorkflowExecution {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -23,7 +23,6 @@ package matching
 import (
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/pborman/uuid"
 	"github.com/uber-common/bark"
@@ -46,15 +45,14 @@ import (
 // TODO: Switch implementation from lock/channel based to a partitioned agent
 // to simplify code and reduce possiblity of synchronization errors.
 type matchingEngineImpl struct {
-	taskManager                persistence.TaskManager
-	historyService             history.Client
-	tokenSerializer            common.TaskTokenSerializer
-	rangeSize                  int64
-	logger                     bark.Logger
-	metricsClient              metrics.Client
-	longPollExpirationInterval time.Duration
-	taskListsLock              sync.RWMutex                   // locks mutation of taskLists
-	taskLists                  map[taskListID]taskListManager // Convert to LRU cache
+	taskManager     persistence.TaskManager
+	historyService  history.Client
+	tokenSerializer common.TaskTokenSerializer
+	logger          bark.Logger
+	metricsClient   metrics.Client
+	taskListsLock   sync.RWMutex                   // locks mutation of taskLists
+	taskLists       map[taskListID]taskListManager // Convert to LRU cache
+	config          *Config
 }
 
 type taskListID struct {
@@ -63,12 +61,6 @@ type taskListID struct {
 	taskType     int
 }
 
-const (
-	defaultLongPollExpirationInterval = time.Minute
-	emptyGetRetryInitialInterval      = 100 * time.Millisecond
-	emptyGetRetryMaxInterval          = 1 * time.Second
-)
-
 var (
 	// EmptyPollForDecisionTaskResponse is the response when there are no decision tasks to hand out
 	emptyPollForDecisionTaskResponse = m.NewPollForDecisionTaskResponse()
@@ -76,7 +68,8 @@ var (
 	emptyPollForActivityTaskResponse   = workflow.NewPollForActivityTaskResponse()
 	persistenceOperationRetryPolicy    = common.CreatePersistanceRetryPolicy()
 	historyServiceOperationRetryPolicy = common.CreateHistoryServiceRetryPolicy()
-	emptyGetTasksRetryPolicy           = createEmptyGetTasksRetryPolicy()
+	//emptyGetTasksRetryPolicy           = createEmptyGetTasksRetryPolicy()
+
 	// ErrNoTasks is exported temporarily for integration test
 	ErrNoTasks    = errors.New("No tasks")
 	errPumpClosed = errors.New("Task list pump closed its channel")
@@ -100,20 +93,20 @@ var _ Engine = (*matchingEngineImpl)(nil) // Asserts that interface is indeed im
 // NewEngine creates an instance of matching engine
 func NewEngine(taskManager persistence.TaskManager,
 	historyService history.Client,
+	config *Config,
 	logger bark.Logger,
 	metricsClient metrics.Client) Engine {
 
 	return &matchingEngineImpl{
-		taskManager:                taskManager,
-		historyService:             historyService,
-		tokenSerializer:            common.NewJSONTaskTokenSerializer(),
-		taskLists:                  make(map[taskListID]taskListManager),
-		rangeSize:                  defaultRangeSize,
-		longPollExpirationInterval: defaultLongPollExpirationInterval,
+		taskManager:     taskManager,
+		historyService:  historyService,
+		tokenSerializer: common.NewJSONTaskTokenSerializer(),
+		taskLists:       make(map[taskListID]taskListManager),
 		logger: logger.WithFields(bark.Fields{
 			logging.TagWorkflowComponent: logging.TagValueMatchingEngineComponent,
 		}),
 		metricsClient: metricsClient,
+		config:        config,
 	}
 }
 
@@ -162,7 +155,7 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *taskListID) (taskListM
 	}
 	e.taskListsLock.RUnlock()
 	logging.LogTaskListLoadingEvent(e.logger, taskList.taskListName, taskList.taskType)
-	mgr := newTaskListManager(e, taskList)
+	mgr := newTaskListManager(e, taskList, e.config)
 	e.taskListsLock.Lock()
 	if result, ok := e.taskLists[*taskList]; ok {
 		e.taskListsLock.Unlock()
@@ -411,9 +404,9 @@ func newTaskListID(domainID, taskListName string, taskType int) *taskListID {
 	return &taskListID{domainID: domainID, taskListName: taskListName, taskType: taskType}
 }
 
-func createEmptyGetTasksRetryPolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(emptyGetRetryInitialInterval)
-	policy.SetMaximumInterval(emptyGetRetryMaxInterval)
+func createEmptyGetTasksRetryPolicy(config *Config) backoff.RetryPolicy {
+	policy := backoff.NewExponentialRetryPolicy(config.EmptyGetRetryInitialInterval)
+	policy.SetMaximumInterval(config.EmptyGetRetryMaxInterval)
 
 	return policy
 }

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -97,7 +97,7 @@ func (s *Service) Start() {
 
 	taskPersistence = persistence.NewTaskPersistenceClient(taskPersistence, base.GetMetricsClient())
 
-	handler, tchanServers := NewHandler(taskPersistence, base, s.config)
+	handler, tchanServers := NewHandler(base, s.config, taskPersistence)
 	handler.Start(tchanServers)
 
 	log.Infof("%v started", common.MatchingServiceName)

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -30,10 +30,9 @@ import (
 
 // Config represents configuration for cadence-matching service
 type Config struct {
-	EnableSyncMatch              bool
-	LongPollExpirationInterval   time.Duration
-	EmptyGetRetryInitialInterval time.Duration
-	EmptyGetRetryMaxInterval     time.Duration
+	EnableSyncMatch bool
+	// Time to hold a poll request before returning an empty response if there are no tasks
+	LongPollExpirationInterval time.Duration
 
 	// taskListManager configuration
 	RangeSize         int64
@@ -48,15 +47,11 @@ type Config struct {
 // NewConfig returns new service config with default values
 func NewConfig() *Config {
 	return &Config{
-		EnableSyncMatch:              true,
-		LongPollExpirationInterval:   time.Minute,
-		EmptyGetRetryInitialInterval: 100 * time.Millisecond,
-		EmptyGetRetryMaxInterval:     1 * time.Second,
-
-		RangeSize:         100000,
-		GetTasksBatchSize: 1000,
-		UpdateAckInterval: 10 * time.Second,
-
+		EnableSyncMatch:                 true,
+		LongPollExpirationInterval:      time.Minute,
+		RangeSize:                       100000,
+		GetTasksBatchSize:               1000,
+		UpdateAckInterval:               10 * time.Second,
 		OutstandingTaskAppendsThreshold: 250,
 		MaxTaskBatchSize:                100,
 	}

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -21,21 +21,59 @@
 package matching
 
 import (
+	"time"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
 )
 
+// Config represents configuration for cadence-matching service
+type Config struct {
+	EnableSyncMatch              bool
+	LongPollExpirationInterval   time.Duration
+	EmptyGetRetryInitialInterval time.Duration
+	EmptyGetRetryMaxInterval     time.Duration
+
+	// taskListManager configuration
+	RangeSize         int64
+	GetTasksBatchSize int
+	UpdateAckInterval time.Duration
+
+	// taskWriter configuration
+	OutstandingTaskAppendsThreshold int
+	MaxTaskBatchSize                int
+}
+
+// NewConfig returns new service config with default values
+func NewConfig() *Config {
+	return &Config{
+		EnableSyncMatch:              true,
+		LongPollExpirationInterval:   time.Minute,
+		EmptyGetRetryInitialInterval: 100 * time.Millisecond,
+		EmptyGetRetryMaxInterval:     1 * time.Second,
+
+		RangeSize:         100000,
+		GetTasksBatchSize: 1000,
+		UpdateAckInterval: 10 * time.Second,
+
+		OutstandingTaskAppendsThreshold: 250,
+		MaxTaskBatchSize:                100,
+	}
+}
+
 // Service represents the cadence-matching service
 type Service struct {
 	stopC  chan struct{}
 	params *service.BootstrapParams
+	config *Config
 }
 
 // NewService builds a new cadence-matching service
-func NewService(params *service.BootstrapParams) common.Daemon {
+func NewService(params *service.BootstrapParams, config *Config) common.Daemon {
 	return &Service{
 		params: params,
+		config: config,
 		stopC:  make(chan struct{}),
 	}
 }
@@ -64,7 +102,7 @@ func (s *Service) Start() {
 
 	taskPersistence = persistence.NewTaskPersistenceClient(taskPersistence, base.GetMetricsClient())
 
-	handler, tchanServers := NewHandler(taskPersistence, base)
+	handler, tchanServers := NewHandler(taskPersistence, base, s.config)
 	handler.Start(tchanServers)
 
 	log.Infof("%v started", common.MatchingServiceName)


### PR DESCRIPTION
Replace constant config with a config struct that can be passed to the service during initialization.
Issue #286 