### PR TITLE
Move testShardContext from persistence package to history package

### DIFF
--- a/common/persistence/cassandraPersistence_test.go
+++ b/common/persistence/cassandraPersistence_test.go
@@ -95,7 +95,7 @@ func (s *cassandraPersistenceSuite) TestPersistenceStartWorkflow() {
 		ExecutionContext:     nil,
 		NextEventID:          int64(3),
 		LastProcessedEvent:   0,
-		RangeID:              s.ShardContext.GetRangeID() - 1,
+		RangeID:              s.ShardInfo.RangeID - 1,
 		TransferTasks: []Task{
 			&DecisionTask{
 				TaskID:     s.GetNextSequenceNumber(),

--- a/common/persistence/persistenceTestBase.go
+++ b/common/persistence/persistenceTestBase.go
@@ -24,7 +24,6 @@ import (
 	"math"
 	"math/rand"
 	"strings"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -33,11 +32,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/uber-common/bark"
 
-	"github.com/uber-go/tally"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/logging"
-	"github.com/uber/cadence/common/metrics"
 )
 
 const (
@@ -50,6 +47,11 @@ const (
 )
 
 type (
+	// TransferTaskIDGenerator generates IDs for transfer tasks written by helper methods
+	TransferTaskIDGenerator interface {
+		GetNextTransferTaskID() (int64, error)
+	}
+
 	// TestBaseOptions options to configure workflow test base.
 	TestBaseOptions struct {
 		ClusterHost     string
@@ -62,7 +64,7 @@ type (
 		SchemaDir       string
 	}
 
-	// TestBase wraps the base setup needed to create workflows over engine layer.
+	// TestBase wraps the base setup needed to create workflows over persistence layer.
 	TestBase struct {
 		ShardMgr            ShardManager
 		ExecutionMgrFactory ExecutionManagerFactory
@@ -72,7 +74,8 @@ type (
 		MetadataManager     MetadataManager
 		VisibilityMgr       VisibilityManager
 		ShardInfo           *ShardInfo
-		ShardContext        *TestShardContext
+		TaskIDGenerator     TransferTaskIDGenerator
+		seqNum              int64
 		readLevel           int64
 		CassandraTestCluster
 	}
@@ -84,140 +87,12 @@ type (
 		session  *gocql.Session
 	}
 
-	// TestShardContext shard context for testing.
-	// TODO: Cleanup, move this out of persistence
-	TestShardContext struct {
-		sync.RWMutex
-		shardInfo              *ShardInfo
-		transferSequenceNumber int64
-		historyMgr             HistoryManager
-		executionMgr           ExecutionManager
-		logger                 bark.Logger
-		metricsClient          metrics.Client
-	}
-
 	testExecutionMgrFactory struct {
 		options   TestBaseOptions
 		cassandra CassandraTestCluster
 		logger    bark.Logger
 	}
 )
-
-func newTestShardContext(shardInfo *ShardInfo, transferSequenceNumber int64, historyMgr HistoryManager,
-	executionMgr ExecutionManager, logger bark.Logger) *TestShardContext {
-	return &TestShardContext{
-		shardInfo:              shardInfo,
-		transferSequenceNumber: transferSequenceNumber,
-		historyMgr:             historyMgr,
-		executionMgr:           executionMgr,
-		logger:                 logger,
-		metricsClient:          metrics.NewClient(tally.NoopScope, metrics.History),
-	}
-}
-
-// GetExecutionManager test implementation
-func (s *TestShardContext) GetExecutionManager() ExecutionManager {
-	return s.executionMgr
-}
-
-// GetHistoryManager test implementation
-func (s *TestShardContext) GetHistoryManager() HistoryManager {
-	return s.historyMgr
-}
-
-// GetNextTransferTaskID test implementation
-func (s *TestShardContext) GetNextTransferTaskID() (int64, error) {
-	return atomic.AddInt64(&s.transferSequenceNumber, 1), nil
-}
-
-// GetTransferMaxReadLevel test implementation
-func (s *TestShardContext) GetTransferMaxReadLevel() int64 {
-	return atomic.LoadInt64(&s.transferSequenceNumber)
-}
-
-// GetTransferAckLevel test implementation
-func (s *TestShardContext) GetTransferAckLevel() int64 {
-	return atomic.LoadInt64(&s.shardInfo.TransferAckLevel)
-}
-
-// UpdateTransferAckLevel test implementation
-func (s *TestShardContext) UpdateTransferAckLevel(ackLevel int64) error {
-	atomic.StoreInt64(&s.shardInfo.TransferAckLevel, ackLevel)
-	return nil
-}
-
-// GetTransferSequenceNumber test implementation
-func (s *TestShardContext) GetTransferSequenceNumber() int64 {
-	return atomic.LoadInt64(&s.transferSequenceNumber)
-}
-
-// GetTimerAckLevel test implementation
-func (s *TestShardContext) GetTimerAckLevel() time.Time {
-	s.RLock()
-	defer s.RLock()
-	return s.shardInfo.TimerAckLevel
-}
-
-// UpdateTimerAckLevel test implementation
-func (s *TestShardContext) UpdateTimerAckLevel(ackLevel time.Time) error {
-	s.Lock()
-	defer s.Unlock()
-	s.shardInfo.TimerAckLevel = ackLevel
-	return nil
-}
-
-// CreateWorkflowExecution test implementation
-func (s *TestShardContext) CreateWorkflowExecution(request *CreateWorkflowExecutionRequest) (
-	*CreateWorkflowExecutionResponse, error) {
-	return s.executionMgr.CreateWorkflowExecution(request)
-}
-
-// UpdateWorkflowExecution test implementation
-func (s *TestShardContext) UpdateWorkflowExecution(request *UpdateWorkflowExecutionRequest) error {
-	// assign IDs for the timer tasks. They need to be assigned under shard lock.
-	// TODO: This needs to be moved out of persistence.
-	for _, task := range request.TimerTasks {
-		seqID, err := s.GetNextTransferTaskID()
-		if err != nil {
-			panic(err)
-		}
-		task.SetTaskID(seqID)
-		s.logger.Infof("%v: TestShardContext: Assigning timer (timestamp: %v, seq: %v)",
-			time.Now().UTC(), GetVisibilityTSFrom(task).UTC(), task.GetTaskID())
-	}
-	return s.executionMgr.UpdateWorkflowExecution(request)
-}
-
-// AppendHistoryEvents test implementation
-func (s *TestShardContext) AppendHistoryEvents(request *AppendHistoryEventsRequest) error {
-	return s.historyMgr.AppendHistoryEvents(request)
-}
-
-// GetLogger test implementation
-func (s *TestShardContext) GetLogger() bark.Logger {
-	return s.logger
-}
-
-// GetMetricsClient test implementation
-func (s *TestShardContext) GetMetricsClient() metrics.Client {
-	return s.metricsClient
-}
-
-// Reset test implementation
-func (s *TestShardContext) Reset() {
-	atomic.StoreInt64(&s.shardInfo.RangeID, 0)
-	atomic.StoreInt64(&s.shardInfo.TransferAckLevel, 0)
-}
-
-// GetRangeID test implementation
-func (s *TestShardContext) GetRangeID() int64 {
-	return atomic.LoadInt64(&s.shardInfo.RangeID)
-}
-
-// GetTimeSource test implementation
-func (s *TestShardContext) GetTimeSource() common.TimeSource {
-	return common.NewRealTimeSource()
-}
 
 func newTestExecutionMgrFactory(options TestBaseOptions, cassandra CassandraTestCluster,
 	logger bark.Logger) ExecutionManagerFactory {
@@ -284,7 +159,7 @@ func (s *TestBase) SetupWorkflowStoreWithOptions(options TestBaseOptions) {
 		RangeID:          0,
 		TransferAckLevel: 0,
 	}
-	s.ShardContext = newTestShardContext(s.ShardInfo, 0, s.HistoryMgr, s.WorkflowMgr, log)
+
 	err1 := s.ShardMgr.CreateShard(&CreateShardRequest{
 		ShardInfo: s.ShardInfo,
 	})
@@ -341,7 +216,7 @@ func (s *TestBase) CreateWorkflowExecution(domainID string, workflowExecution wo
 		ExecutionContext:     executionContext,
 		NextEventID:          nextEventID,
 		LastProcessedEvent:   lastProcessedEventID,
-		RangeID:              s.ShardContext.GetRangeID(),
+		RangeID:              s.ShardInfo.RangeID,
 		TransferTasks: []Task{
 			&DecisionTask{
 				TaskID:     s.GetNextSequenceNumber(),
@@ -398,7 +273,7 @@ func (s *TestBase) CreateWorkflowExecutionManyTasks(domainID string, workflowExe
 		NextEventID:                 nextEventID,
 		LastProcessedEvent:          lastProcessedEventID,
 		TransferTasks:               transferTasks,
-		RangeID:                     s.ShardContext.GetRangeID(),
+		RangeID:                     s.ShardInfo.RangeID,
 		DecisionScheduleID:          common.EmptyEventID,
 		DecisionStartedID:           common.EmptyEventID,
 		DecisionStartToCloseTimeout: 1,
@@ -429,7 +304,7 @@ func (s *TestBase) CreateChildWorkflowExecution(domainID string, workflowExecuti
 		ExecutionContext:     executionContext,
 		NextEventID:          nextEventID,
 		LastProcessedEvent:   lastProcessedEventID,
-		RangeID:              s.ShardContext.GetRangeID(),
+		RangeID:              s.ShardInfo.RangeID,
 		TransferTasks: []Task{
 			&DecisionTask{
 				TaskID:     s.GetNextSequenceNumber(),
@@ -495,7 +370,7 @@ func (s *TestBase) ContinueAsNewExecution(updatedInfo *WorkflowExecutionInfo, co
 		TimerTasks:          nil,
 		Condition:           condition,
 		DeleteTimerTask:     nil,
-		RangeID:             s.ShardContext.GetRangeID(),
+		RangeID:             s.ShardInfo.RangeID,
 		UpsertActivityInfos: nil,
 		DeleteActivityInfo:  nil,
 		UpserTimerInfos:     nil,
@@ -510,7 +385,7 @@ func (s *TestBase) ContinueAsNewExecution(updatedInfo *WorkflowExecutionInfo, co
 			ExecutionContext:            nil,
 			NextEventID:                 nextEventID,
 			LastProcessedEvent:          common.EmptyEventID,
-			RangeID:                     s.ShardContext.GetRangeID(),
+			RangeID:                     s.ShardInfo.RangeID,
 			TransferTasks:               nil,
 			TimerTasks:                  nil,
 			DecisionScheduleID:          decisionScheduleID,
@@ -527,7 +402,7 @@ func (s *TestBase) UpdateWorkflowExecution(updatedInfo *WorkflowExecutionInfo, d
 	upsertActivityInfos []*ActivityInfo, deleteActivityInfo *int64,
 	upsertTimerInfos []*TimerInfo, deleteTimerInfos []string) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, decisionScheduleIDs, activityScheduleIDs,
-		s.ShardContext.GetRangeID(), condition, timerTasks, deleteTimerTask, upsertActivityInfos, deleteActivityInfo,
+		s.ShardInfo.RangeID, condition, timerTasks, deleteTimerTask, upsertActivityInfos, deleteActivityInfo,
 		upsertTimerInfos, deleteTimerInfos, nil, nil, nil, nil)
 }
 
@@ -541,7 +416,7 @@ func (s *TestBase) UpdateWorkflowExecutionAndDelete(updatedInfo *WorkflowExecuti
 		TimerTasks:          nil,
 		Condition:           condition,
 		DeleteTimerTask:     nil,
-		RangeID:             s.ShardContext.GetRangeID(),
+		RangeID:             s.ShardInfo.RangeID,
 		UpsertActivityInfos: nil,
 		DeleteActivityInfo:  nil,
 		UpserTimerInfos:     nil,
@@ -554,7 +429,7 @@ func (s *TestBase) UpdateWorkflowExecutionAndDelete(updatedInfo *WorkflowExecuti
 func (s *TestBase) UpsertChildExecutionsState(updatedInfo *WorkflowExecutionInfo, condition int64,
 	upsertChildInfos []*ChildExecutionInfo) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, nil, nil,
-		s.ShardContext.GetRangeID(), condition, nil, nil, nil, nil,
+		s.ShardInfo.RangeID, condition, nil, nil, nil, nil,
 		nil, nil, upsertChildInfos, nil, nil, nil)
 }
 
@@ -562,7 +437,7 @@ func (s *TestBase) UpsertChildExecutionsState(updatedInfo *WorkflowExecutionInfo
 func (s *TestBase) UpsertRequestCancelState(updatedInfo *WorkflowExecutionInfo, condition int64,
 	upsertCancelInfos []*RequestCancelInfo) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, nil, nil,
-		s.ShardContext.GetRangeID(), condition, nil, nil, nil, nil,
+		s.ShardInfo.RangeID, condition, nil, nil, nil, nil,
 		nil, nil, nil, nil, upsertCancelInfos, nil)
 }
 
@@ -570,7 +445,7 @@ func (s *TestBase) UpsertRequestCancelState(updatedInfo *WorkflowExecutionInfo, 
 func (s *TestBase) DeleteChildExecutionsState(updatedInfo *WorkflowExecutionInfo, condition int64,
 	deleteChildInfo int64) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, nil, nil,
-		s.ShardContext.GetRangeID(), condition, nil, nil, nil, nil,
+		s.ShardInfo.RangeID, condition, nil, nil, nil, nil,
 		nil, nil, nil, &deleteChildInfo, nil, nil)
 }
 
@@ -578,7 +453,7 @@ func (s *TestBase) DeleteChildExecutionsState(updatedInfo *WorkflowExecutionInfo
 func (s *TestBase) DeleteCancelState(updatedInfo *WorkflowExecutionInfo, condition int64,
 	deleteCancelInfo int64) error {
 	return s.UpdateWorkflowExecutionWithRangeID(updatedInfo, nil, nil,
-		s.ShardContext.GetRangeID(), condition, nil, nil, nil, nil,
+		s.ShardInfo.RangeID, condition, nil, nil, nil, nil,
 		nil, nil, nil, nil, nil, &deleteCancelInfo)
 }
 
@@ -631,7 +506,7 @@ func (s *TestBase) UpdateWorkflowExecutionWithTransferTasks(
 		TransferTasks:       transferTasks,
 		Condition:           condition,
 		UpsertActivityInfos: upsertActivityInfo,
-		RangeID:             s.ShardContext.GetRangeID(),
+		RangeID:             s.ShardInfo.RangeID,
 	})
 }
 
@@ -644,7 +519,7 @@ func (s *TestBase) UpdateWorkflowExecutionForRequestCancel(
 		TransferTasks:            transferTasks,
 		Condition:                condition,
 		UpsertRequestCancelInfos: upsertRequestCancelInfo,
-		RangeID:                  s.ShardContext.GetRangeID(),
+		RangeID:                  s.ShardInfo.RangeID,
 	})
 }
 
@@ -836,27 +711,6 @@ func (s *TestBase) CompleteTask(domainID, taskList string, taskType int, taskID 
 	})
 }
 
-// ClearTransferQueue completes all tasks in transfer queue
-func (s *TestBase) ClearTransferQueue() {
-	log.Infof("Clearing transfer tasks (RangeID: %v, ReadLevel: %v, AckLevel: %v)", s.ShardContext.GetRangeID(),
-		s.GetReadLevel(), s.ShardContext.GetTransferAckLevel())
-	tasks, err := s.GetTransferTasks(100)
-	if err != nil {
-		log.Fatalf("Error during cleanup: %v", err)
-	}
-
-	counter := 0
-	for _, t := range tasks {
-		log.Infof("Deleting transfer task with ID: %v", t.TaskID)
-		s.CompleteTransferTask(t.TaskID)
-		counter++
-	}
-
-	log.Infof("Deleted '%v' transfer tasks.", counter)
-	s.ShardContext.Reset()
-	atomic.StoreInt64(&s.readLevel, 0)
-}
-
 // SetupWorkflowStore to setup workflow test base
 func (s *TestBase) SetupWorkflowStore() {
 	s.SetupWorkflowStoreWithOptions(TestBaseOptions{
@@ -876,13 +730,36 @@ func (s *TestBase) TearDownWorkflowStore() {
 
 // GetNextSequenceNumber generates a unique sequence number for can be used for transfer queue taskId
 func (s *TestBase) GetNextSequenceNumber() int64 {
-	taskID, _ := s.ShardContext.GetNextTransferTaskID()
-	return taskID
+	if s.TaskIDGenerator != nil {
+		taskID, _ := s.TaskIDGenerator.GetNextTransferTaskID()
+		return taskID
+	}
+	return atomic.AddInt64(&s.seqNum, 1)
 }
 
 // GetReadLevel returns the current read level for shard
 func (s *TestBase) GetReadLevel() int64 {
 	return atomic.LoadInt64(&s.readLevel)
+}
+
+// ClearTransferQueue completes all tasks in transfer queue
+func (s *TestBase) ClearTransferQueue() {
+	log.Infof("Clearing transfer tasks (RangeID: %v, ReadLevel: %v)",
+		s.ShardInfo.RangeID, s.GetReadLevel())
+	tasks, err := s.GetTransferTasks(100)
+	if err != nil {
+		log.Fatalf("Error during cleanup: %v", err)
+	}
+
+	counter := 0
+	for _, t := range tasks {
+		log.Infof("Deleting transfer task with ID: %v", t.TaskID)
+		s.CompleteTransferTask(t.TaskID)
+		counter++
+	}
+
+	log.Infof("Deleted '%v' transfer tasks.", counter)
+	atomic.StoreInt64(&s.readLevel, 0)
 }
 
 func (s *CassandraTestCluster) setupTestCluster(keySpace string, dropKeySpace bool, schemaDir string) {

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -1,0 +1,171 @@
+package history
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/uber-common/bark"
+	"github.com/uber-go/tally"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+)
+
+const (
+	testWorkflowClusterHosts = "127.0.0.1"
+	testDatacenter           = ""
+	testSchemaDir            = "../.."
+)
+
+type (
+	// TestShardContext shard context for testing.
+	TestShardContext struct {
+		sync.RWMutex
+		shardInfo              *persistence.ShardInfo
+		transferSequenceNumber int64
+		historyMgr             persistence.HistoryManager
+		executionMgr           persistence.ExecutionManager
+		logger                 bark.Logger
+		metricsClient          metrics.Client
+	}
+
+	// TestBase wraps the base setup needed to create workflows over engine layer.
+	TestBase struct {
+		persistence.TestBase
+		ShardContext *TestShardContext
+	}
+)
+
+func newTestShardContext(shardInfo *persistence.ShardInfo, transferSequenceNumber int64, historyMgr persistence.HistoryManager,
+	executionMgr persistence.ExecutionManager, logger bark.Logger) *TestShardContext {
+	return &TestShardContext{
+		shardInfo:              shardInfo,
+		transferSequenceNumber: transferSequenceNumber,
+		historyMgr:             historyMgr,
+		executionMgr:           executionMgr,
+		logger:                 logger,
+		metricsClient:          metrics.NewClient(tally.NoopScope, metrics.History),
+	}
+}
+
+// GetExecutionManager test implementation
+func (s *TestShardContext) GetExecutionManager() persistence.ExecutionManager {
+	return s.executionMgr
+}
+
+// GetHistoryManager test implementation
+func (s *TestShardContext) GetHistoryManager() persistence.HistoryManager {
+	return s.historyMgr
+}
+
+// GetNextTransferTaskID test implementation
+func (s *TestShardContext) GetNextTransferTaskID() (int64, error) {
+	return atomic.AddInt64(&s.transferSequenceNumber, 1), nil
+}
+
+// GetTransferMaxReadLevel test implementation
+func (s *TestShardContext) GetTransferMaxReadLevel() int64 {
+	return atomic.LoadInt64(&s.transferSequenceNumber)
+}
+
+// GetTransferAckLevel test implementation
+func (s *TestShardContext) GetTransferAckLevel() int64 {
+	return atomic.LoadInt64(&s.shardInfo.TransferAckLevel)
+}
+
+// UpdateTransferAckLevel test implementation
+func (s *TestShardContext) UpdateTransferAckLevel(ackLevel int64) error {
+	atomic.StoreInt64(&s.shardInfo.TransferAckLevel, ackLevel)
+	return nil
+}
+
+// GetTransferSequenceNumber test implementation
+func (s *TestShardContext) GetTransferSequenceNumber() int64 {
+	return atomic.LoadInt64(&s.transferSequenceNumber)
+}
+
+// GetTimerAckLevel test implementation
+func (s *TestShardContext) GetTimerAckLevel() time.Time {
+	s.RLock()
+	defer s.RLock()
+	return s.shardInfo.TimerAckLevel
+}
+
+// UpdateTimerAckLevel test implementation
+func (s *TestShardContext) UpdateTimerAckLevel(ackLevel time.Time) error {
+	s.Lock()
+	defer s.Unlock()
+	s.shardInfo.TimerAckLevel = ackLevel
+	return nil
+}
+
+// CreateWorkflowExecution test implementation
+func (s *TestShardContext) CreateWorkflowExecution(request *persistence.CreateWorkflowExecutionRequest) (
+	*persistence.CreateWorkflowExecutionResponse, error) {
+	return s.executionMgr.CreateWorkflowExecution(request)
+}
+
+// UpdateWorkflowExecution test implementation
+func (s *TestShardContext) UpdateWorkflowExecution(request *persistence.UpdateWorkflowExecutionRequest) error {
+	// assign IDs for the timer tasks. They need to be assigned under shard lock.
+	for _, task := range request.TimerTasks {
+		seqID, err := s.GetNextTransferTaskID()
+		if err != nil {
+			panic(err)
+		}
+		task.SetTaskID(seqID)
+		s.logger.Infof("%v: TestShardContext: Assigning timer (timestamp: %v, seq: %v)",
+			time.Now().UTC(), persistence.GetVisibilityTSFrom(task).UTC(), task.GetTaskID())
+	}
+	return s.executionMgr.UpdateWorkflowExecution(request)
+}
+
+// AppendHistoryEvents test implementation
+func (s *TestShardContext) AppendHistoryEvents(request *persistence.AppendHistoryEventsRequest) error {
+	return s.historyMgr.AppendHistoryEvents(request)
+}
+
+// GetLogger test implementation
+func (s *TestShardContext) GetLogger() bark.Logger {
+	return s.logger
+}
+
+// GetMetricsClient test implementation
+func (s *TestShardContext) GetMetricsClient() metrics.Client {
+	return s.metricsClient
+}
+
+// Reset test implementation
+func (s *TestShardContext) Reset() {
+	atomic.StoreInt64(&s.shardInfo.RangeID, 0)
+	atomic.StoreInt64(&s.shardInfo.TransferAckLevel, 0)
+}
+
+// GetRangeID test implementation
+func (s *TestShardContext) GetRangeID() int64 {
+	return atomic.LoadInt64(&s.shardInfo.RangeID)
+}
+
+// GetTimeSource test implementation
+func (s *TestShardContext) GetTimeSource() common.TimeSource {
+	return common.NewRealTimeSource()
+}
+
+// SetupWorkflowStoreWithOptions to setup workflow test base
+func (s *TestBase) SetupWorkflowStoreWithOptions(options persistence.TestBaseOptions) {
+	s.TestBase.SetupWorkflowStoreWithOptions(options)
+	log := bark.NewLoggerFromLogrus(log.New())
+	s.ShardContext = newTestShardContext(s.ShardInfo, 0, s.HistoryMgr, s.WorkflowMgr, log)
+	s.TestBase.TaskIDGenerator = s.ShardContext
+}
+
+// SetupWorkflowStore to setup workflow test base
+func (s *TestBase) SetupWorkflowStore() {
+	s.TestBase.SetupWorkflowStore()
+	log := bark.NewLoggerFromLogrus(log.New())
+	s.ShardContext = newTestShardContext(s.ShardInfo, 0, s.HistoryMgr, s.WorkflowMgr, log)
+	s.TestBase.TaskIDGenerator = s.ShardContext
+}

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package history
 
 import (

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -42,7 +42,7 @@ import (
 type (
 	timerQueueProcessorSuite struct {
 		suite.Suite
-		persistence.TestBase
+		TestBase
 		engineImpl       *historyEngineImpl
 		mockShardManager *mocks.ShardManager
 		shardClosedCh    chan int

--- a/service/history/transferQueueProcessor_test.go
+++ b/service/history/transferQueueProcessor_test.go
@@ -40,7 +40,7 @@ import (
 type (
 	transferQueueProcessorSuite struct {
 		suite.Suite
-		persistence.TestBase
+		TestBase
 		processor         *transferQueueProcessorImpl
 		mockMatching      *mocks.MatchingClient
 		mockHistoryClient *mocks.HistoryClient
@@ -80,6 +80,7 @@ func (s *transferQueueProcessorSuite) TearDownTest() {
 func (s *transferQueueProcessorSuite) SetupTest() {
 	// First cleanup transfer tasks from other tests and reset shard context
 	s.ClearTransferQueue()
+	s.ShardContext.Reset()
 
 	s.mockMatching = &mocks.MatchingClient{}
 	s.mockHistoryClient = &mocks.HistoryClient{}


### PR DESCRIPTION
ShardContext is a history service concept, and does not belong in the persistence package.
This change refactors test code to move testShardContext to the history package.
Issue #109 