### PR TITLE
fix: do not close gocql.iter() on error

### DIFF
--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -713,6 +713,12 @@ func (d *cassandraPersistence) CreateWorkflowExecution(request *CreateWorkflowEx
 
 	previous := make(map[string]interface{})
 	applied, iter, err := d.session.MapExecuteBatchCAS(batch, previous)
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
+
 	if err != nil {
 		if isTimeoutError(err) {
 			// Write may have succeeded, but we don't know
@@ -724,12 +730,6 @@ func (d *cassandraPersistence) CreateWorkflowExecution(request *CreateWorkflowEx
 		}
 
 	}
-
-	defer func() {
-		if iter != nil {
-			iter.Close()
-		}
-	}()
 
 	if !applied {
 		// There can be two reasons why the query does not get applied. Either the RangeID has changed, or
@@ -1024,6 +1024,12 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(request *UpdateWorkflowEx
 
 	previous := make(map[string]interface{})
 	applied, iter, err := d.session.MapExecuteBatchCAS(batch, previous)
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
+
 	if err != nil {
 		if isTimeoutError(err) {
 			// Write may have succeeded, but we don't know
@@ -1034,12 +1040,6 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(request *UpdateWorkflowEx
 			Message: fmt.Sprintf("UpdateWorkflowExecution operation failed. Error: %v", err),
 		}
 	}
-
-	defer func() {
-		if iter != nil {
-			iter.Close()
-		}
-	}()
 
 	if !applied {
 		// There can be two reasons why the query does not get applied. Either the RangeID has changed, or

--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -713,7 +713,6 @@ func (d *cassandraPersistence) CreateWorkflowExecution(request *CreateWorkflowEx
 
 	previous := make(map[string]interface{})
 	applied, iter, err := d.session.MapExecuteBatchCAS(batch, previous)
-	defer iter.Close()
 	if err != nil {
 		if isTimeoutError(err) {
 			// Write may have succeeded, but we don't know
@@ -725,6 +724,12 @@ func (d *cassandraPersistence) CreateWorkflowExecution(request *CreateWorkflowEx
 		}
 
 	}
+
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
 
 	if !applied {
 		// There can be two reasons why the query does not get applied. Either the RangeID has changed, or
@@ -1019,7 +1024,6 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(request *UpdateWorkflowEx
 
 	previous := make(map[string]interface{})
 	applied, iter, err := d.session.MapExecuteBatchCAS(batch, previous)
-	defer iter.Close()
 	if err != nil {
 		if isTimeoutError(err) {
 			// Write may have succeeded, but we don't know
@@ -1030,6 +1034,12 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(request *UpdateWorkflowEx
 			Message: fmt.Sprintf("UpdateWorkflowExecution operation failed. Error: %v", err),
 		}
 	}
+
+	defer func() {
+		if iter != nil {
+			iter.Close()
+		}
+	}()
 
 	if !applied {
 		// There can be two reasons why the query does not get applied. Either the RangeID has changed, or


### PR DESCRIPTION
When gocql.MapExecuteBatchCAS returns an error, the iterator can be set to nil. In that case, defer iter.Close() can cause an nil pointer deference (panic). This patch fixes this bug.