### PR TITLE
shardController: revisit shard shutdown order, add latency metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -491,7 +491,6 @@ const (
 	GetEngineForShardErrorCounter
 	GetEngineForShardLatency
 	RemoveEngineForShardLatency
-	AcquireShardsRingpopLookupLatency
 )
 
 // Matching metrics enum
@@ -565,7 +564,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		GetEngineForShardErrorCounter:             {metricName: "get-engine-for-shard-errors", metricType: Counter},
 		GetEngineForShardLatency:                  {metricName: "get-engine-for-shard-latency", metricType: Timer},
 		RemoveEngineForShardLatency:               {metricName: "remove-engine-for-shard-latency", metricType: Timer},
-		AcquireShardsRingpopLookupLatency:         {metricName: "acquire-shards-lookup-latency", metricType: Timer},
 	},
 	Matching: {
 		PollSuccessCounter:          {metricName: "poll.success"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -488,6 +488,10 @@ const (
 	ShardItemRemovedCounter
 	MembershipChangedCounter
 	NumShardsGauge
+	GetEngineForShardErrorCounter
+	GetEngineForShardLatency
+	RemoveEngineForShardLatency
+	AcquireShardsRingpopLookupLatency
 )
 
 // Matching metrics enum
@@ -558,6 +562,10 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ShardItemRemovedCounter:                   {metricName: "sharditem-removed-count", metricType: Counter},
 		MembershipChangedCounter:                  {metricName: "membership-changed-count", metricType: Counter},
 		NumShardsGauge:                            {metricName: "numshards-gauge", metricType: Gauge},
+		GetEngineForShardErrorCounter:             {metricName: "get-engine-for-shard-errors", metricType: Counter},
+		GetEngineForShardLatency:                  {metricName: "get-engine-for-shard-latency", metricType: Timer},
+		RemoveEngineForShardLatency:               {metricName: "remove-engine-for-shard-latency", metricType: Timer},
+		AcquireShardsRingpopLookupLatency:         {metricName: "acquire-shards-lookup-latency", metricType: Timer},
 	},
 	Matching: {
 		PollSuccessCounter:          {metricName: "poll.success"},

--- a/glide.lock
+++ b/glide.lock
@@ -78,10 +78,6 @@ imports:
   - m3/thrift
   - m3/thriftudp
   - statsd
-- name: github.com/uber-go/timer
-  version: 65109e3ba73e9381daba2aaecef1ee4e1cc8fceb
-  subpackages:
-  - twheel
 - name: github.com/uber/ringpop-go
   version: 38331a7fdb7e3d102b4327ef0f1034d5239decaf
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -20,9 +20,6 @@ import:
 - package: github.com/dgryski/go-farm
 - package: github.com/emirpasic/gods
 - package: github.com/davecgh/go-spew
-- package: github.com/uber-go/timer
-  subpackages:
-  - twheel
 - package: github.com/urfave/cli
 - package: gopkg.in/yaml.v2
 - package: gopkg.in/validator.v2

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -392,6 +392,9 @@ func (i *historyShardsItem) stopEngine() {
 		logging.LogShardEngineStoppedEvent(i.logger, i.host.Identity(), i.shardID)
 	}
 
+	// Shutting down executionMgr will close all connections
+	// to cassandra for this engine. So, make sure to
+	// close executionMgr only after stopping the engine
 	if i.executionMgr != nil {
 		i.executionMgr.Close()
 	}

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -275,7 +275,7 @@ func (c *shardController) shardManagementPump() {
 			// To reduce the chance of the race happening, lets
 			// process all closed events at once before we attempt
 			// to acquire new shards again
-			//c.processShardClosedEvents()
+			c.processShardClosedEvents()
 		}
 	}
 }
@@ -388,13 +388,10 @@ func (i *historyShardsItem) stopEngine() {
 	i.Lock()
 	defer i.Unlock()
 
-	if i.executionMgr != nil {
-		i.executionMgr.Close()
-	}
-
 	if i.engine != nil {
 		logging.LogShardEngineStoppingEvent(i.logger, i.host.Identity(), i.shardID)
 		i.engine.Stop()
+		i.executionMgr.Close()
 		i.engine = nil
 		logging.LogShardEngineStoppedEvent(i.logger, i.host.Identity(), i.shardID)
 	}

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -275,7 +275,7 @@ func (c *shardController) shardManagementPump() {
 			// To reduce the chance of the race happening, lets
 			// process all closed events at once before we attempt
 			// to acquire new shards again
-			c.processShardClosedEvents()
+			//c.processShardClosedEvents()
 		}
 	}
 }

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -391,9 +391,12 @@ func (i *historyShardsItem) stopEngine() {
 	if i.engine != nil {
 		logging.LogShardEngineStoppingEvent(i.logger, i.host.Identity(), i.shardID)
 		i.engine.Stop()
-		i.executionMgr.Close()
 		i.engine = nil
 		logging.LogShardEngineStoppedEvent(i.logger, i.host.Identity(), i.shardID)
+	}
+
+	if i.executionMgr != nil {
+		i.executionMgr.Close()
 	}
 }
 


### PR DESCRIPTION
The primary change in this patch is the modification of shutdown order for a shard. Specifically, this patch makes sure engine.Stop() is called before the executionMgr is closed, because closing the executionMgr will close all connections to cassandra (used by the engine).   