### PR TITLE
Properly handle throttling errors from Cassandra

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -447,6 +447,7 @@ const (
 	PersistenceErrShardOwnershipLostCounter
 	PersistenceErrConditionFailedCounter
 	PersistenceErrTimeoutCounter
+	PersistenceErrBusyCounter
 
 	NumCommonMetrics
 )
@@ -523,6 +524,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PersistenceErrShardOwnershipLostCounter:       {metricName: "persistence.errors.shard-ownership-lost", metricType: Counter},
 		PersistenceErrConditionFailedCounter:          {metricName: "persistence.errors.condition-failed", metricType: Counter},
 		PersistenceErrTimeoutCounter:                  {metricName: "persistence.errors.timeout", metricType: Counter},
+		PersistenceErrBusyCounter:                     {metricName: "persistence.errors.busy", metricType: Counter},
 	},
 	Frontend: {},
 	History: {

--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -595,6 +595,11 @@ func (d *cassandraPersistence) CreateShard(request *CreateShardRequest) error {
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("CreateShard operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("CreateShard operation failed. Error : %v", err),
 		}
@@ -627,6 +632,10 @@ func (d *cassandraPersistence) GetShard(request *GetShardRequest) (*GetShardResp
 		if err == gocql.ErrNotFound {
 			return nil, &workflow.EntityNotExistsError{
 				Message: fmt.Sprintf("Shard not found.  ShardId: %v", shardID),
+			}
+		} else if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("GetShard operation failed. Error: %v", err),
 			}
 		}
 
@@ -665,6 +674,11 @@ func (d *cassandraPersistence) UpdateShard(request *UpdateShardRequest) error {
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
 		}
@@ -724,6 +738,10 @@ func (d *cassandraPersistence) CreateWorkflowExecution(request *CreateWorkflowEx
 			// Write may have succeeded, but we don't know
 			// return this info to the caller so they have the option of trying to find out by executing a read
 			return nil, &TimeoutError{Msg: fmt.Sprintf("CreateWorkflowExecution timed out. Error: %v", err)}
+		} else if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("CreateWorkflowExecution operation failed. Error: %v", err),
+			}
 		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("CreateWorkflowExecution operation failed. Error: %v", err),
@@ -887,6 +905,10 @@ func (d *cassandraPersistence) GetWorkflowExecution(request *GetWorkflowExecutio
 				Message: fmt.Sprintf("Workflow execution not found.  WorkflowId: %v, RunId: %v",
 					execution.GetWorkflowId(), execution.GetRunId()),
 			}
+		} else if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("GetWorkflowExecution operation failed. Error: %v", err),
+			}
 		}
 
 		return nil, &workflow.InternalServiceError{
@@ -1035,6 +1057,10 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(request *UpdateWorkflowEx
 			// Write may have succeeded, but we don't know
 			// return this info to the caller so they have the option of trying to find out by executing a read
 			return &TimeoutError{Msg: fmt.Sprintf("UpdateWorkflowExecution timed out. Error: %v", err)}
+		} else if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("UpdateWorkflowExecution operation failed. Error: %v", err),
+			}
 		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("UpdateWorkflowExecution operation failed. Error: %v", err),
@@ -1109,6 +1135,11 @@ func (d *cassandraPersistence) DeleteWorkflowExecution(request *DeleteWorkflowEx
 
 	err := query.Exec()
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("DeleteWorkflowExecution operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("DeleteWorkflowExecution operation failed. Error: %v", err),
 		}
@@ -1134,6 +1165,10 @@ func (d *cassandraPersistence) GetCurrentExecution(request *GetCurrentExecutionR
 			return nil, &workflow.EntityNotExistsError{
 				Message: fmt.Sprintf("Workflow execution not found.  WorkflowId: %v",
 					request.WorkflowID),
+			}
+		} else if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("GetCurrentExecution operation failed. Error: %v", err),
 			}
 		}
 
@@ -1197,6 +1232,11 @@ func (d *cassandraPersistence) CompleteTransferTask(request *CompleteTransferTas
 
 	err := query.Exec()
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("CompleteTransferTask operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("CompleteTransferTask operation failed. Error: %v", err),
 		}
@@ -1218,6 +1258,11 @@ func (d *cassandraPersistence) CompleteTimerTask(request *CompleteTimerTaskReque
 
 	err := query.Exec()
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err),
 		}
@@ -1256,9 +1301,14 @@ func (d *cassandraPersistence) LeaseTaskList(request *LeaseTaskListRequest) (*Le
 				request.TaskList,
 				request.TaskType,
 				0)
+		} else if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("LeaseTaskList operation failed. TaskList: %v, TaskType: %v, Error: %v",
+					request.TaskList, request.TaskType, err),
+			}
 		} else {
 			return nil, &workflow.InternalServiceError{
-				Message: fmt.Sprintf("LeaseTaskList operation failed. TaskList: %v, TaskType: %v, Error : %v",
+				Message: fmt.Sprintf("LeaseTaskList operation failed. TaskList: %v, TaskType: %v, Error: %v",
 					request.TaskList, request.TaskType, err),
 			}
 		}
@@ -1281,6 +1331,11 @@ func (d *cassandraPersistence) LeaseTaskList(request *LeaseTaskListRequest) (*Le
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("LeaseTaskList operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("LeaseTaskList operation failed. Error : %v", err),
 		}
@@ -1316,6 +1371,11 @@ func (d *cassandraPersistence) UpdateTaskList(request *UpdateTaskListRequest) (*
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("LeaseTaskList operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("UpdateTaskList operation failed. Error: %v", err),
 		}
@@ -1390,8 +1450,13 @@ func (d *cassandraPersistence) CreateTasks(request *CreateTasksRequest) (*Create
 	previous := make(map[string]interface{})
 	applied, _, err := d.session.MapExecuteBatchCAS(batch, previous)
 	if err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("CreateTasks operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CreateTask operation failed. Error : %v", err),
+			Message: fmt.Sprintf("CreateTasks operation failed. Error : %v", err),
 		}
 	}
 	if !applied {
@@ -1466,6 +1531,11 @@ func (d *cassandraPersistence) CompleteTask(request *CompleteTaskRequest) error 
 
 	err := query.Exec()
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("CompleteTask operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("CompleteTask operation failed. Error: %v", err),
 		}
@@ -1507,6 +1577,11 @@ func (d *cassandraPersistence) GetTimerIndexTasks(request *GetTimerIndexTasksReq
 	}
 
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("GetTimerTasks operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("GetTimerTasks operation failed. Error: %v", err),
 		}
@@ -2033,6 +2108,14 @@ func isTimeoutError(err error) bool {
 	}
 	_, ok := err.(*gocql.RequestErrWriteTimeout)
 	return ok
+}
+
+func isThrottlingError(err error) bool {
+	if req, ok := err.(gocql.RequestError); ok {
+		// gocql does not expose the constant errOverloaded = 0x1001
+		return req.Code() == 0x1001
+	}
+	return false
 }
 
 // GetVisibilityTSFrom - helper method to get visibility timestamp

--- a/common/persistence/cassandraPersistence.go
+++ b/common/persistence/cassandraPersistence.go
@@ -1373,7 +1373,7 @@ func (d *cassandraPersistence) UpdateTaskList(request *UpdateTaskListRequest) (*
 	if err != nil {
 		if isThrottlingError(err) {
 			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("LeaseTaskList operation failed. Error: %v", err),
+				Message: fmt.Sprintf("UpdateTaskList operation failed. Error: %v", err),
 			}
 		}
 		return nil, &workflow.InternalServiceError{

--- a/common/persistence/cassandraVisibilityPersistence.go
+++ b/common/persistence/cassandraVisibilityPersistence.go
@@ -160,6 +160,11 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionStarted(
 	query = query.WithTimestamp(common.UnixNanoToCQLTimestamp(request.StartTimestamp))
 	err := query.Exec()
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("RecordWorkflowExecutionStarted operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("RecordWorkflowExecutionStarted operation failed. Error: %v", err),
 		}
@@ -204,6 +209,11 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionClosed(
 	batch = batch.WithTimestamp(common.UnixNanoToCQLTimestamp(request.CloseTimestamp))
 	err := v.session.ExecuteBatch(batch)
 	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("RecordWorkflowExecutionClosed operation failed. Error: %v", err),
+			}
+		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("RecordWorkflowExecutionClosed operation failed. Error: %v", err),
 		}
@@ -238,6 +248,11 @@ func (v *cassandraVisibilityPersistence) ListOpenWorkflowExecutions(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListOpenWorkflowExecutions operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("ListOpenWorkflowExecutions operation failed. Error: %v", err),
 		}
@@ -257,7 +272,7 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutions(
 	if iter == nil {
 		// TODO: should return a bad request error if the token is invalid
 		return nil, &workflow.InternalServiceError{
-			Message: "ListOpenWorkflowExecutions operation failed.  Not able to create query iterator.",
+			Message: "ListClosedWorkflowExecutions operation failed.  Not able to create query iterator.",
 		}
 	}
 
@@ -273,8 +288,13 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutions(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListOpenWorkflowExecutions operation failed. Error: %v", err),
+			Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
 		}
 	}
 
@@ -309,6 +329,11 @@ func (v *cassandraVisibilityPersistence) ListOpenWorkflowExecutionsByType(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListOpenWorkflowExecutionsByType operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("ListOpenWorkflowExecutionsByType operation failed. Error: %v", err),
 		}
@@ -345,6 +370,11 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutionsByType(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
 		}
@@ -381,6 +411,11 @@ func (v *cassandraVisibilityPersistence) ListOpenWorkflowExecutionsByWorkflowID(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListOpenWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("ListOpenWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
 		}
@@ -417,6 +452,11 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutionsByWorkflowI
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
 		}
@@ -453,6 +493,11 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutionsByStatus(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
 		}
@@ -486,6 +531,11 @@ func (v *cassandraVisibilityPersistence) GetClosedWorkflowExecution(
 	}
 
 	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("GetClosedWorkflowExecution operation failed. Error: %v", err),
+			}
+		}
 		return nil, &workflow.InternalServiceError{
 			Message: fmt.Sprintf("GetClosedWorkflowExecution operation failed. Error: %v", err),
 		}

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -295,6 +295,9 @@ func (p *workflowExecutionPersistenceClient) updateErrorMetric(scope int, err er
 	case *TimeoutError:
 		p.metricClient.IncCounter(scope, metrics.PersistenceErrTimeoutCounter)
 		p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
+	case *workflow.ServiceBusyError:
+		p.metricClient.IncCounter(scope, metrics.PersistenceErrBusyCounter)
+		p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
 	default:
 		p.metricClient.IncCounter(scope, metrics.PersistenceFailures)
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -107,7 +107,7 @@ func CreateHistoryServiceRetryPolicy() backoff.RetryPolicy {
 // IsPersistenceTransientError checks if the error is a transient persistence error
 func IsPersistenceTransientError(err error) bool {
 	switch err.(type) {
-	case *workflow.InternalServiceError:
+	case *workflow.InternalServiceError, *workflow.ServiceBusyError:
 		return true
 	}
 

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -166,6 +166,8 @@ Create_Loop:
 		response, err := s.executionManager.CreateWorkflowExecution(request)
 		if err != nil {
 			switch err.(type) {
+			case *shared.WorkflowExecutionAlreadyStartedError, *shared.ServiceBusyError:
+				// No special handling required for these errors
 			case *persistence.ShardOwnershipLostError:
 				{
 					// RangeID might have been renewed by the same host while this update was in flight
@@ -177,7 +179,6 @@ Create_Loop:
 						s.closeShard()
 					}
 				}
-			case *shared.WorkflowExecutionAlreadyStartedError:
 			default:
 				{
 					// We have no idea if the write failed or will eventually make it to
@@ -241,6 +242,8 @@ Update_Loop:
 		err := s.executionManager.UpdateWorkflowExecution(request)
 		if err != nil {
 			switch err.(type) {
+			case *persistence.ConditionFailedError, *shared.ServiceBusyError:
+				// No special handling required for these errors
 			case *persistence.ShardOwnershipLostError:
 				{
 					// RangeID might have been renewed by the same host while this update was in flight
@@ -252,7 +255,6 @@ Update_Loop:
 						s.closeShard()
 					}
 				}
-			case *persistence.ConditionFailedError:
 			default:
 				{
 					// We have no idea if the write failed or will eventually make it to

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1143,20 +1143,6 @@ func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
 	s.EqualValues(0, s.taskManager.getTaskCount(tlID))
 }
 
-func (s *matchingEngineSuite) TestLoadTaskListError() {
-	domainID := "domainId"
-	tl := "makeToast"
-
-	tlID := newTaskListID(domainID, tl, persistence.TaskListTypeDecision)
-	s.mockTaskManager.On("GetTasks", mock.Anything).Return(nil, &persistence.GetTasksResponse{})
-	s.mockTaskManager.On("LeaseTaskList", mock.Anything).Once().Return(nil, errors.New("load error"))
-	tlMgr, err := s.mockMatchingEngine.getTaskListManager(tlID)
-	s.Nil(tlMgr)
-	s.NotNil(err)
-	_, ok := s.mockMatchingEngine.taskLists[*tlID]
-	s.False(ok)
-}
-
 func newActivityTaskScheduledEvent(eventID int64, decisionTaskCompletedEventID int64,
 	scheduleAttributes *workflow.ScheduleActivityTaskDecisionAttributes) *workflow.HistoryEvent {
 	historyEvent := newHistoryEvent(eventID, workflow.EventType_ActivityTaskScheduled)


### PR DESCRIPTION
Handle overload errors returned from Cassandra differently from timeouts and internal service errors.
This is because in the case of throttling errors we know that the query never executed, so we do not have to invoke the cache consistency maintenance part.
Issue #300