### PR TITLE
Transfer Queue Processor can get stuck on StartChildExecution task

### DIFF
--- a/common/persistence/persistenceTestBase.go
+++ b/common/persistence/persistenceTestBase.go
@@ -519,6 +519,18 @@ func (s *TestBase) UpdateWorkflowExecutionWithTransferTasks(
 	})
 }
 
+// UpdateWorkflowExecutionForChildExecutionsInitiated is a utility method to update workflow execution
+func (s *TestBase) UpdateWorkflowExecutionForChildExecutionsInitiated(
+	updatedInfo *WorkflowExecutionInfo, condition int64, transferTasks []Task, childInfos []*ChildExecutionInfo) error {
+	return s.WorkflowMgr.UpdateWorkflowExecution(&UpdateWorkflowExecutionRequest{
+		ExecutionInfo:             updatedInfo,
+		TransferTasks:             transferTasks,
+		Condition:                 condition,
+		UpsertChildExecutionInfos: childInfos,
+		RangeID:                   s.ShardInfo.RangeID,
+	})
+}
+
 // UpdateWorkflowExecutionForRequestCancel is a utility method to update workflow execution
 func (s *TestBase) UpdateWorkflowExecutionForRequestCancel(
 	updatedInfo *WorkflowExecutionInfo, condition int64, transferTasks []Task,

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -2512,6 +2512,24 @@ func addRequestCancelInitiatedEvent(builder *mutableStateBuilder, decisionComple
 	return event
 }
 
+func addStartChildWorkflowExecutionInitiatedEvent(builder *mutableStateBuilder, decisionCompletedID int64,
+	createRequestID, domain, workflowID, workflowType, tasklist string, input []byte,
+	executionStartToCloseTimeout, taskStartToCloseTimeout int32) (*workflow.HistoryEvent,
+	*persistence.ChildExecutionInfo) {
+	return builder.AddStartChildWorkflowExecutionInitiatedEvent(decisionCompletedID, createRequestID,
+		&workflow.StartChildWorkflowExecutionDecisionAttributes{
+			Domain:       common.StringPtr(domain),
+			WorkflowId:   common.StringPtr(workflowID),
+			WorkflowType: &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
+			TaskList:     &workflow.TaskList{Name: common.StringPtr(tasklist)},
+			Input:        input,
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(executionStartToCloseTimeout),
+			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(taskStartToCloseTimeout),
+			ChildPolicy:                         workflow.ChildPolicyPtr(workflow.ChildPolicy_TERMINATE),
+			Control:                             nil,
+		})
+}
+
 func addCompleteWorkflowEvent(builder *mutableStateBuilder, decisionCompletedEventID int64,
 	result []byte) *workflow.HistoryEvent {
 	e := builder.AddCompletedWorkflowEvent(decisionCompletedEventID, &workflow.CompleteWorkflowExecutionDecisionAttributes{

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -651,21 +651,15 @@ func (t *transferQueueProcessorImpl) processStartChildExecution(task *persistenc
 				return err
 			}
 			// Finally create first decision task for Child execution so it is really started
-			err = t.historyClient.ScheduleDecisionTask(nil, &history.ScheduleDecisionTaskRequest{
-				DomainUUID: common.StringPtr(targetDomainID),
-				WorkflowExecution: &workflow.WorkflowExecution{
-					WorkflowId: common.StringPtr(task.TargetWorkflowID),
-					RunId:      common.StringPtr(startResponse.GetRunId()),
-				},
+			err = t.createFirstDecisionTask(targetDomainID, &workflow.WorkflowExecution{
+				WorkflowId: common.StringPtr(task.TargetWorkflowID),
+				RunId:      common.StringPtr(startResponse.GetRunId()),
 			})
 		} else {
 			// ChildExecution already started, just create DecisionTask and complete transfer task
 			startedEvent, _ := msBuilder.GetChildExecutionStartedEvent(initiatedEventID)
 			startedAttributes := startedEvent.GetChildWorkflowExecutionStartedEventAttributes()
-			err = t.historyClient.ScheduleDecisionTask(nil, &history.ScheduleDecisionTaskRequest{
-				DomainUUID:        common.StringPtr(targetDomainID),
-				WorkflowExecution: startedAttributes.GetWorkflowExecution(),
-			})
+			err = t.createFirstDecisionTask(targetDomainID, startedAttributes.GetWorkflowExecution())
 		}
 	}
 
@@ -742,6 +736,26 @@ func (t *transferQueueProcessorImpl) recordStartChildExecutionFailed(task *persi
 
 			return nil
 		})
+}
+
+// createFirstDecisionTask is used by StartChildExecution transfer task to create the first decision task for
+// child execution.
+func (t *transferQueueProcessorImpl) createFirstDecisionTask(domainID string,
+	execution *workflow.WorkflowExecution) error {
+	err := t.historyClient.ScheduleDecisionTask(nil, &history.ScheduleDecisionTaskRequest{
+		DomainUUID:        common.StringPtr(domainID),
+		WorkflowExecution: execution,
+	})
+
+	if err != nil {
+		if _, ok := err.(*workflow.EntityNotExistsError); ok {
+			// Maybe child workflow execution already timedout or terminated
+			// Safe to discard the error and complete this transfer task
+			return nil
+		}
+	}
+
+	return err
 }
 
 func (t *transferQueueProcessorImpl) requestCancelCompleted(task *persistence.TransferTaskInfo,


### PR DESCRIPTION
Handle EntityNotExistError in the processing of transfer task for
StartChildExecution.

Fixes #304 