### PR TITLE
Remove mockMatchingEngine from matching engine test suite

### DIFF
--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -52,7 +52,6 @@ type (
 		suite.Suite
 		historyClient        *mocks.HistoryClient
 		matchingEngine       *matchingEngineImpl
-		mockMatchingEngine   *matchingEngineImpl
 		taskManager          *testTaskManager
 		mockTaskManager      *mocks.TaskManager
 		mockExecutionManager *mocks.ExecutionManager
@@ -107,9 +106,6 @@ func (s *matchingEngineSuite) SetupTest() {
 
 	s.matchingEngine = s.newMatchingEngine(defaultTestConfig(), s.taskManager)
 	s.matchingEngine.Start()
-
-	s.mockMatchingEngine = s.newMatchingEngine(defaultTestConfig(), s.mockTaskManager)
-	s.mockMatchingEngine.Start()
 }
 
 func (s *matchingEngineSuite) newMatchingEngine(config *Config, taskMgr persistence.TaskManager) *matchingEngineImpl {
@@ -127,7 +123,6 @@ func (s *matchingEngineSuite) newMatchingEngine(config *Config, taskMgr persiste
 func (s *matchingEngineSuite) TearDownTest() {
 	s.mockExecutionManager.AssertExpectations(s.T())
 	s.matchingEngine.Stop()
-	s.mockMatchingEngine.Stop()
 }
 
 func (s *matchingEngineSuite) TestAckManager() {


### PR DESCRIPTION
This is causing test flakiness due to background goroutines