### PR TITLE
log query failed without actual payload

### DIFF
--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -343,12 +343,12 @@ func LogQueryTaskMissingWorkflowTypeErrorEvent(logger bark.Logger, workflowID, r
 }
 
 // LogQueryTaskFailedEvent is used to log query task failure
-func LogQueryTaskFailedEvent(logger bark.Logger, domain, workflowID, runID, queryType, errMsg string) {
+func LogQueryTaskFailedEvent(logger bark.Logger, domain, workflowID, runID, queryType string) {
 	logger.WithFields(bark.Fields{
 		TagWorkflowEventID: QueryTaskFailedEventID,
 		"Domain":           domain,
 		"WorkflowID":       workflowID,
 		"RunID":            runID,
 		"QueryType":        queryType,
-	}).Info(errMsg)
+	}).Info("QueryWorkflowFailed.")
 }

--- a/service/frontend/handler.go
+++ b/service/frontend/handler.go
@@ -1125,8 +1125,7 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
 			*queryRequest.Domain,
 			*queryRequest.Execution.WorkflowId,
 			*queryRequest.Execution.RunId,
-			*queryRequest.Query.QueryType,
-			err.Error())
+			*queryRequest.Query.QueryType)
 		return nil, wh.error(err, scope)
 	}
 


### PR DESCRIPTION
should not log the client's payload when query failed. 