### PR TITLE
Remove thrift-gen from instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,10 +7,6 @@ This doc is intended for contributors to `cadence` server (hopefully that's you!
 ## Development Environment
 
 * Go. Install on OS X with `brew install go`.
-* `thrift`. Install on OS X with `brew install thrift`
-* `thrift-gen`. Install with `go get github.com/uber/tchannel-go/thrift/thrift-gen`
-
-Note: `thrift` should be >= 0.10.0. Run `brew upgrade thrift` if you're on an older version.
 
 ## Checking out the code
 

--- a/Makefile
+++ b/Makefile
@@ -24,8 +24,6 @@ TOOLS_CMD_ROOT=./cmd/tools
 INTEG_TEST_ROOT=./host
 INTEG_TEST_DIR=host
 
-export PATH := $(GOPATH)/bin:$(PATH)
-
 define thriftrwrule
 THRIFTRW_GEN_SRC += $(THRIFT_GENDIR)/go/$1/$1.go
 


### PR DESCRIPTION
also remove duplicate export PATH in Makefile