### PR TITLE
Shard lost Owner ship Error to preserve the owner host

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -621,7 +621,7 @@ func (h *Handler) convertError(err error) error {
 	case *persistence.ShardOwnershipLostError:
 		shardID := err.(*persistence.ShardOwnershipLostError).ShardID
 		info, err := h.hServiceResolver.Lookup(string(shardID))
-		if err != nil {
+		if err == nil {
 			return createShardOwnershipLostError(h.GetHostInfo().GetAddress(), info.GetAddress())
 		}
 		return createShardOwnershipLostError(h.GetHostInfo().GetAddress(), "")


### PR DESCRIPTION
- We seem to have an issue that we never set the new owner host correct in the error message, so the request is retried appropriately on the new retry.

#361 