### PR TITLE
After update timer ack level go back to waiting on any event

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -153,6 +153,11 @@ func (c *cadenceImpl) GetFrontendClient() workflowserviceclient.Interface {
 	return fecli.New(c.frontEndService.GetDispatcher())
 }
 
+// For integration tests to get hold of FE instance.
+func (c *cadenceImpl) GetFrontendService() service.Service {
+	return c.frontEndService
+}
+
 func (c *cadenceImpl) startFrontend(logger bark.Logger, rpHosts []string, startWG *sync.WaitGroup) {
 	params := new(service.BootstrapParams)
 	params.Name = common.FrontendServiceName

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -274,6 +274,7 @@ func (t *timerQueueProcessorImpl) internalProcessor(tasksCh chan<- *persistence.
 	updateAckChan := time.NewTicker(t.config.TimerProcessorUpdateAckInterval).C
 	var nextKeyTask *persistence.TimerTaskInfo
 
+continueProcessor:
 	for {
 		isWokeByNewTimer := false
 
@@ -301,7 +302,7 @@ func (t *timerQueueProcessorImpl) internalProcessor(tasksCh chan<- *persistence.
 
 			case <-updateAckChan:
 				t.ackMgr.updateAckLevel()
-				continue
+				continue continueProcessor
 			}
 		}
 

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -301,6 +301,7 @@ func (t *timerQueueProcessorImpl) internalProcessor(tasksCh chan<- *persistence.
 
 			case <-updateAckChan:
 				t.ackMgr.updateAckLevel()
+				continue
 			}
 		}
 


### PR DESCRIPTION
When we are trying to update timer ack level,it tries to make extra query GetTimerTasks(...) to see if we can make any progress and then checkpoint, this seems not necessary and number of calls can quickly go up based on number of shards.