### PR TITLE
Minor fixes for cadence-aws project

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -64,7 +64,7 @@ ENV CADENCE_HOME $GOPATH/src/github.com/uber/cadence
 RUN go get -u github.com/Masterminds/glide
 RUN go get -u github.com/golang/lint/golint
 
-RUN git clone --depth=50 https://github.com/uber/cadence.git $CADENCE_HOME
+RUN git clone https://github.com/uber/cadence.git $CADENCE_HOME
 RUN cd $CADENCE_HOME; git checkout $git_branch; make bins_nothrift
 
 EXPOSE 7933 7934 7935

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -23,7 +23,7 @@ services:
     metrics:
       statsd:
         hostPort: "${STATSD_ENDPOINT}"
-        prefix: "cadence"
+        prefix: "cadence-frontend"
 
   matching:
     rpc:
@@ -32,7 +32,7 @@ services:
     metrics:
       statsd:
         hostPort: "${STATSD_ENDPOINT}"
-        prefix: "cadence"
+        prefix: "cadence-matching"
 
   history:
     rpc:
@@ -41,4 +41,4 @@ services:
     metrics:
       statsd:
         hostPort: "${STATSD_ENDPOINT}"
-        prefix: "cadence"
+        prefix: "cadence-history"


### PR DESCRIPTION
1. Fix statsd prefix for different services(so that it is possible to use '*' to select all operations for frontend/matching/history
2. Fix docker build issue #377