### PR TITLE
Increase open execution TTL to account for shard outages

### DIFF
--- a/common/persistence/cassandraVisibilityPersistence.go
+++ b/common/persistence/cassandraVisibilityPersistence.go
@@ -35,7 +35,7 @@ import (
 const (
 	domainPartition        = 0
 	defaultCloseTTLSeconds = 86400
-	openExecutionTTLBuffer = int64(20)
+	openExecutionTTLBuffer = int64(86400) // setting it to a day to account for shard going down
 )
 
 const (


### PR DESCRIPTION
Shard can be down for longer than workflow timeout. In that window, workflow would be missing from both open and closed if we set a short buffer.