### PR TITLE
Add history events pagination API

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -149,6 +149,8 @@ const (
 	PersistenceAppendHistoryEventsScope
 	// PersistenceGetWorkflowExecutionHistoryScope tracks GetWorkflowExecutionHistory calls made by service to persistence layer
 	PersistenceGetWorkflowExecutionHistoryScope
+	// PersistenceListWorkflowExecutionHistoryScope tracks ListWorkflowExecutionHistory calls made by service to persistence layer
+	PersistenceListWorkflowExecutionHistoryScope
 	// PersistenceDeleteWorkflowExecutionHistoryScope tracks DeleteWorkflowExecutionHistory calls made by service to persistence layer
 	PersistenceDeleteWorkflowExecutionHistoryScope
 	// PersistenceCreateDomainScope tracks CreateDomain calls made by service to persistence layer

--- a/common/mocks/HistoryManager.go
+++ b/common/mocks/HistoryManager.go
@@ -85,4 +85,28 @@ func (_m *HistoryManager) GetWorkflowExecutionHistory(
 	return r0, r1
 }
 
+// ListWorkflowExecutionHistory provides a mock function with given fields: request
+func (_m *HistoryManager) ListWorkflowExecutionHistory(
+	request *persistence.ListWorkflowExecutionHistoryRequest) (*persistence.ListWorkflowExecutionHistoryResponse, error) {
+	ret := _m.Called(request)
+
+	var r0 *persistence.ListWorkflowExecutionHistoryResponse
+	if rf, ok := ret.Get(0).(func(*persistence.ListWorkflowExecutionHistoryRequest) *persistence.ListWorkflowExecutionHistoryResponse); ok {
+		r0 = rf(request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*persistence.ListWorkflowExecutionHistoryResponse)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*persistence.ListWorkflowExecutionHistoryRequest) error); ok {
+		r1 = rf(request)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 var _ persistence.HistoryManager = (*HistoryManager)(nil)

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -560,6 +560,30 @@ type (
 		NextPageToken []byte
 	}
 
+	// ListWorkflowExecutionHistoryRequest is used to retrieve history of a workflow execution
+	// this API guarantees number of returned events will not exceed the given page size
+	ListWorkflowExecutionHistoryRequest struct {
+		DomainID  string
+		Execution workflow.WorkflowExecution
+
+		// Get the history events upto NextEventID. Exclusive.
+		NextEventID int64
+		// Maximum number of history append transactions per page
+		PageSize int
+
+		// Token to continue reading next page of workflow events.
+		NextPageToken []byte
+	}
+
+	// ListWorkflowExecutionHistoryResponse is the response to ListWorkflowExecutionHistoryRequest
+	ListWorkflowExecutionHistoryResponse struct {
+		// Slice of history events
+		Events []*workflow.HistoryEvent
+		// Token to read next page if there are more events beyond page size.
+		// Use this to set NextPageToken on ListWorkflowExecutionHistoryRequest to read the next page.
+		NextPageToken []byte
+	}
+
 	// DeleteWorkflowExecutionHistoryRequest is used to delete workflow execution history
 	DeleteWorkflowExecutionHistoryRequest struct {
 		DomainID  string
@@ -676,6 +700,7 @@ type (
 		// GetWorkflowExecutionHistory retrieves the paginated list of history events for given execution
 		GetWorkflowExecutionHistory(request *GetWorkflowExecutionHistoryRequest) (*GetWorkflowExecutionHistoryResponse,
 			error)
+		ListWorkflowExecutionHistory(request *ListWorkflowExecutionHistoryRequest) (*ListWorkflowExecutionHistoryResponse, error)
 		DeleteWorkflowExecutionHistory(request *DeleteWorkflowExecutionHistoryRequest) error
 	}
 

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -422,6 +422,21 @@ func (p *historyPersistenceClient) GetWorkflowExecutionHistory(
 	return response, err
 }
 
+func (p *historyPersistenceClient) ListWorkflowExecutionHistory(
+	request *ListWorkflowExecutionHistoryRequest) (*ListWorkflowExecutionHistoryResponse, error) {
+	p.metricClient.IncCounter(metrics.PersistenceListWorkflowExecutionHistoryScope, metrics.PersistenceRequests)
+
+	sw := p.metricClient.StartTimer(metrics.PersistenceListWorkflowExecutionHistoryScope, metrics.PersistenceLatency)
+	response, err := p.persistence.ListWorkflowExecutionHistory(request)
+	sw.Stop()
+
+	if err != nil {
+		p.updateErrorMetric(metrics.PersistenceListWorkflowExecutionHistoryScope, err)
+	}
+
+	return response, err
+}
+
 func (p *historyPersistenceClient) DeleteWorkflowExecutionHistory(
 	request *DeleteWorkflowExecutionHistoryRequest) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteWorkflowExecutionHistoryScope, metrics.PersistenceRequests)


### PR DESCRIPTION
This API (ListWorkflowExecutionHistory) will supersede the existing GetWorkflowExecutionHistory.

This API provides finer grain of control, i.e. control the number of returned history events, instead of number of returned batch of events.

This commit is part of effort to solve issue #385 