### PR TITLE
Protect gettask to avoid query aborted caused by tombstone

### DIFF
--- a/service/matching/ackManager.go
+++ b/service/matching/ackManager.go
@@ -52,6 +52,10 @@ func (m *ackManager) getReadLevel() int64 {
 	return m.readLevel
 }
 
+func (m *ackManager) setReadLevel(readLevel int64) {
+	m.readLevel = readLevel
+}
+
 func (m *ackManager) getAckLevel() int64 {
 	return m.ackLevel
 }


### PR DESCRIPTION
Currently, get task use `readLevel` and `maxReadLevel` as lower and upper bound. When `maxReadLevel` is too big, it will lead to query error like:

> ERROR [ReadStage-12] 2017-11-06 00:27:53,875 StorageProxy.java:1906 - Scanned over 100001 tombstones during query 'SELECT * FROM cadence.tasks WHERE domain_id, task_list_name, task_list_type = 00cc7948-fd82-4d37-82dd-14fc2f28001f, timer-task-queue-1, 0 AND type = 0 AND task_id > 3074930 AND task_id <= 4616218 LIMIT 1000' (last scanned row partion key was ((00cc7948-fd82-4d37-82dd-14fc2f28001f, timer-task-queue-1, 0), 0, 3174933)); query aborted
> WARN  [MemtableFlushWriter:2996] 2017-11-06 00:27:55,692 NativeLibrary.java:304 - open(/var/lib/cassandra/data/cadence_visibility/open_executions-23376bb0c0f311e78b796d2c86545d91/.open_by_workflow_id, O_RDONLY) failed, errno (24).
> WARN  [ReadStage-13] 2017-11-06 00:27:56,835 ReadCommand.java:533 - Read 0 live rows and 100001 tombstone cells for query SELECT * FROM cadence.tasks WHERE domain_id, task_list_name, task_list_type = 00cc7948-fd82-4d37-82dd-14fc2f28001f, timer-task-queue-0, 0 AND type = 0 AND task_id > 3070896 AND task_id <= 4609145 LIMIT 1000 (see tombstone_warn_threshold)

This PR changed the upper bound to use rangeSize.