### PR TITLE
Add shortcut to install cassandra schema on startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,3 +137,11 @@ clean:
 	rm -f cadence
 	rm -f cadence-cassandra-tool
 	rm -Rf $(BUILD)
+
+install-schema: bins
+	./cadence-cassandra-tool --ep 127.0.0.1 create -k "cadence" --rf 1
+	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence setup-schema -v 0.0
+	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cadence/versioned
+	./cadence-cassandra-tool --ep 127.0.0.1 create -k "cadence_visibility" --rf 1
+	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility setup-schema -v 0.0
+	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/visibility/versioned

--- a/README.md
+++ b/README.md
@@ -27,12 +27,7 @@ brew install cassandra
 
 * Setup the cassandra schema:
 ```bash
-./cadence-cassandra-tool --ep 127.0.0.1 create -k "cadence" --rf 1
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence setup-schema -v 0.0
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cadence/versioned
-./cadence-cassandra-tool --ep 127.0.0.1 create -k "cadence_visibility" --rf 1
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility setup-schema -v 0.0
-./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/visibility/versioned
+make install-schema
 ```
 
 * Start the service:


### PR DESCRIPTION
Followup to https://github.com/uber/cadence/pull/438
This is something we have to do often, adding a make target for it to make it easier.