### PR TITLE
WorkflowExecution stuck fix on transient decision timeout

### DIFF
--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -3253,13 +3253,13 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 
 	// fail decision 1 more times
 	for i := 0; i < 2; i++ {
-		err := poller.pollAndProcessDecisionTaskWithAttempt(false, false, int64(i))
+		err := poller.pollAndProcessDecisionTaskWithAttempt(false, false, 3+int64(i))
 		s.Nil(err)
 	}
 	s.Equal(12, signalCount)
 
 	// Make complete workflow decision
-	err = poller.pollAndProcessDecisionTaskWithAttempt(true, false, int64(2))
+	err = poller.pollAndProcessDecisionTaskWithAttempt(true, false, int64(5))
 	s.logger.Infof("pollAndProcessDecisionTask: %v", err)
 	s.Nil(err)
 	s.True(workflowComplete)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -67,6 +67,7 @@ var _ EngineFactory = (*Handler)(nil)
 var (
 	errDomainNotSet            = &gen.BadRequestError{Message: "Domain not set on request."}
 	errWorkflowExecutionNotSet = &gen.BadRequestError{Message: "WorkflowExecution not set on request."}
+	errTaskListNotSet          = &gen.BadRequestError{Message: "Tasklist not set."}
 )
 
 // NewHandler creates a thrift handler for the history service
@@ -227,6 +228,11 @@ func (h *Handler) RecordDecisionTaskStarted(ctx context.Context,
 
 	if recordRequest.DomainUUID == nil {
 		return nil, errDomainNotSet
+	}
+
+	if recordRequest.PollRequest == nil || recordRequest.PollRequest.TaskList == nil ||
+		recordRequest.PollRequest.TaskList.GetName() == "" {
+		return nil, errTaskListNotSet
 	}
 
 	workflowExecution := recordRequest.WorkflowExecution

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -977,9 +977,6 @@ Update_History_Loop:
 			continueAsNewBuilder = nil
 		}
 
-		// flush event if needed after processing decisions
-		msBuilder.FlushBufferedEvents()
-
 		if tt := tBuilder.GetUserTimerTaskIfNeeded(msBuilder); tt != nil {
 			timerTasks = append(timerTasks, tt)
 		}

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -761,6 +761,12 @@ func (e *mutableStateBuilder) AddDecisionTaskScheduledEvent() *decisionInfo {
 		return nil
 	}
 
+	// Flush any buffered events before creating the decision, otherwise it will result in invalid IDs for transient
+	// decision and will cause in timeout processing to not work for transient decisions
+	if err := e.FlushBufferedEvents(); err != nil {
+		return nil
+	}
+
 	var newDecisionEvent *workflow.HistoryEvent
 	scheduleID := e.GetNextEventID() // we will generate the schedule event later for repeatedly failing decisions
 	// Avoid creating new history events when decisions are continuously failing
@@ -796,11 +802,12 @@ func (e *mutableStateBuilder) AddDecisionTaskStartedEvent(scheduleEventID int64,
 	var event *workflow.HistoryEvent
 	scheduleID := di.ScheduleID
 	startedID := scheduleID + 1
+	tasklist := request.TaskList.GetName()
 	timestamp := time.Now().UnixNano()
 	// First check to see if new events came since transient decision was scheduled
 	if di.Attempt > 0 && di.ScheduleID != e.GetNextEventID() {
 		// Also create a new DecisionTaskScheduledEvent since new events came in when it was scheduled
-		scheduleEvent := e.hBuilder.AddDecisionTaskScheduledEvent(di.Tasklist, di.DecisionTimeout, 0)
+		scheduleEvent := e.hBuilder.AddDecisionTaskScheduledEvent(tasklist, di.DecisionTimeout, 0)
 		scheduleID = scheduleEvent.GetEventId()
 		di.Attempt = 0
 	}


### PR DESCRIPTION
Mutable state generates decision task without incrementing the next
event id.  This could cause problem if there are buffered events and
transient decisions are generated in the same update.
Mutable state now flushes buffered events before generating the decision
task to prevent this condition to happen as it can result in workflows
getting stuck.

fixes: #451 