### PR TITLE
Missing Tasklist name on DecisionTaskScheduled history event

### DIFF
--- a/service/frontend/handler.go
+++ b/service/frontend/handler.go
@@ -1664,6 +1664,7 @@ func (wh *WorkflowHandler) createPollForDecisionTaskResponse(ctx context.Context
 		StartedEventId:         matchingResp.StartedEventId,
 		Query:                  matchingResp.Query,
 		BacklogCountHint:       matchingResp.BacklogCountHint,
+		Attempt:                matchingResp.Attempt,
 		History:                history,
 		NextPageToken:          continuation,
 	}

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -896,7 +896,7 @@ func (e *mutableStateBuilder) AddDecisionTaskCompletedEvent(scheduleEventID, sta
 
 	if di.Attempt > 0 {
 		// Create corresponding DecisionTaskSchedule and DecisionTaskStarted events for decisions we have been retrying
-		scheduledEvent := e.hBuilder.AddDecisionTaskScheduledEvent(di.Tasklist, di.DecisionTimeout, di.Attempt)
+		scheduledEvent := e.hBuilder.AddDecisionTaskScheduledEvent(e.executionInfo.TaskList, di.DecisionTimeout, di.Attempt)
 		startedEvent := e.hBuilder.AddDecisionTaskStartedEvent(scheduledEvent.GetEventId(), di.RequestID,
 			request.GetIdentity())
 		startedEventID = startedEvent.GetEventId()


### PR DESCRIPTION
When decision goes into retry loop due to DecisionTimeout or
DecisionFailed, and then eventually completes we write incorrect
tasklist name on DecisionTaskScheduledEvent for the transient decisions.
Also DecisionAttempt got incorrected removed due to bad merge, so
putting that back in.

fixes #498 