### PR TITLE
ChildWorkflow timeout not communicated to parent execution

### DIFF
--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -85,7 +85,7 @@ const (
 	TagValueActionChildExecutionFailed            = "add-childexecution-failed-event"
 	TagValueActionChildExecutionCanceled          = "add-childexecution-canceled-event"
 	TagValueActionChildExecutionTerminated        = "add-childexecution-terminated-event"
-	TagValueActionChildExecutionTimedOut          = "add-childexecution-timedOut-event"
+	TagValueActionChildExecutionTimedOut          = "add-childexecution-timedout-event"
 	TagValueActionRequestCancelWorkflow           = "add-request-cancel-workflow-event"
 	TagValueActionWorkflowCancelRequested         = "add-workflow-execution-cancel-requested-event"
 	TagValueActionWorkflowCancelFailed            = "add-workflow-execution-cancel-failed-event"

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -85,6 +85,7 @@ const (
 	TagValueActionChildExecutionFailed            = "add-childexecution-failed-event"
 	TagValueActionChildExecutionCanceled          = "add-childexecution-canceled-event"
 	TagValueActionChildExecutionTerminated        = "add-childexecution-terminated-event"
+	TagValueActionChildExecutionTimedOut          = "add-childexecution-timedOut-event"
 	TagValueActionRequestCancelWorkflow           = "add-request-cancel-workflow-event"
 	TagValueActionWorkflowCancelRequested         = "add-workflow-execution-cancel-requested-event"
 	TagValueActionWorkflowCancelFailed            = "add-workflow-execution-cancel-failed-event"

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -382,6 +382,15 @@ func (b *historyBuilder) AddChildWorkflowExecutionTerminatedEvent(domain string,
 	return b.addEventToHistory(event)
 }
 
+func (b *historyBuilder) AddChildWorkflowExecutionTimedOutEvent(domain string, execution *workflow.WorkflowExecution,
+	workflowType *workflow.WorkflowType, initiatedID, startedID int64,
+	timedOutAttributes *workflow.WorkflowExecutionTimedOutEventAttributes) *workflow.HistoryEvent {
+	event := b.newChildWorkflowExecutionTimedOutEvent(domain, execution, workflowType, initiatedID, startedID,
+		timedOutAttributes)
+
+	return b.addEventToHistory(event)
+}
+
 func (b *historyBuilder) addEventToHistory(event *workflow.HistoryEvent) *workflow.HistoryEvent {
 	b.history = append(b.history, event)
 	return event
@@ -793,6 +802,22 @@ func (b *historyBuilder) newChildWorkflowExecutionTerminatedEvent(domain string,
 	attributes.InitiatedEventId = common.Int64Ptr(initiatedID)
 	attributes.StartedEventId = common.Int64Ptr(startedID)
 	historyEvent.ChildWorkflowExecutionTerminatedEventAttributes = attributes
+
+	return historyEvent
+}
+
+func (b *historyBuilder) newChildWorkflowExecutionTimedOutEvent(domain string, execution *workflow.WorkflowExecution,
+	workflowType *workflow.WorkflowType, initiatedID, startedID int64,
+	timedOutAttributes *workflow.WorkflowExecutionTimedOutEventAttributes) *workflow.HistoryEvent {
+	historyEvent := b.msBuilder.createNewHistoryEvent(workflow.EventTypeChildWorkflowExecutionTimedOut)
+	attributes := &workflow.ChildWorkflowExecutionTimedOutEventAttributes{}
+	attributes.Domain = common.StringPtr(domain)
+	attributes.TimeoutType = timedOutAttributes.TimeoutType
+	attributes.WorkflowExecution = execution
+	attributes.WorkflowType = workflowType
+	attributes.InitiatedEventId = common.Int64Ptr(initiatedID)
+	attributes.StartedEventId = common.Int64Ptr(startedID)
+	historyEvent.ChildWorkflowExecutionTimedOutEventAttributes = attributes
 
 	return historyEvent
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1739,6 +1739,9 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(completionRequest *h.R
 			case workflow.EventTypeWorkflowExecutionTerminated:
 				attributes := completionEvent.WorkflowExecutionTerminatedEventAttributes
 				msBuilder.AddChildWorkflowExecutionTerminatedEvent(initiatedID, completedExecution, attributes)
+			case workflow.EventTypeWorkflowExecutionTimedOut:
+				attributes := completionEvent.WorkflowExecutionTimedOutEventAttributes
+				msBuilder.AddChildWorkflowExecutionTimedOutEvent(initiatedID, completedExecution, attributes)
 			}
 
 			return nil


### PR DESCRIPTION
RecordChildWorkflowCompletion is missing handling for child execution
getting timedout event.  This results in a empty decision task getting
created without the ChildWorkflowExecutionTimedOut getting recorded in
history.

fixes #503 