### PR TITLE
Passing in root path to determine cassandra version

### DIFF
--- a/cmd/server/cadence.go
+++ b/cmd/server/cadence.go
@@ -23,6 +23,7 @@ package main
 import (
 	"log"
 	"os"
+	"path"
 	"strings"
 
 	"github.com/uber/cadence/common/service/config"
@@ -53,7 +54,12 @@ func startHandler(c *cli.Context) {
 	log.Printf("config=\n%v\n", cfg.String())
 
 	cassCfg := cfg.Cassandra
-	if err := cassandra.VerifyCompatibleVersion(cassCfg); err != nil {
+	dir, err := os.Getwd() // dir = /Users/madhuravi/Uber/gocode/src/github.com/uber/cadence
+	if err != nil {
+		log.Fatal("Unable to get current directory")
+	}
+	root := path.Dir(path.Dir(path.Dir(dir))) // root = /Users/madhuravi/Uber/gocode/src
+	if err := cassandra.VerifyCompatibleVersion(cassCfg, root); err != nil {
 		log.Fatalf("Incompatible versions", err)
 	}
 	for _, svc := range getServices(c) {
@@ -105,7 +111,7 @@ func isValidService(in string) bool {
 }
 
 func getConfigDir(c *cli.Context) string {
-	return path(getRootDir(c), c.GlobalString("config"))
+	return constructPath(getRootDir(c), c.GlobalString("config"))
 }
 
 func getRootDir(c *cli.Context) string {
@@ -120,7 +126,7 @@ func getRootDir(c *cli.Context) string {
 	return dirpath
 }
 
-func path(dir string, file string) string {
+func constructPath(dir string, file string) string {
 	return dir + "/" + file
 }
 

--- a/cmd/server/cadence_test.go
+++ b/cmd/server/cadence_test.go
@@ -21,9 +21,10 @@
 package main
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type CadenceSuite struct {
@@ -50,5 +51,5 @@ func (s *CadenceSuite) TestIsValidService() {
 }
 
 func (s *CadenceSuite) TestPath() {
-	s.Equal("foo/bar", path("foo", "bar"))
+	s.Equal("foo/bar", constructPath("foo", "bar"))
 }

--- a/tools/cassandra/version.go
+++ b/tools/cassandra/version.go
@@ -21,12 +21,10 @@
 package cassandra
 
 import (
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"path"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 
@@ -132,28 +130,13 @@ func getExpectedVersion(dir string) (string, error) {
 // In most cases, the versions should match. However if after a schema upgrade there is a code
 // rollback, the code version (expected version) would fall lower than the actual version in
 // cassandra.
-func VerifyCompatibleVersion(cfg config.Cassandra) error {
-	_, filename, _, ok := runtime.Caller(0)
-	if !ok {
-		return errors.New("unable to get the current function path")
-	}
-	return verifyCompatibleVersionWithRoot(cfg, filename)
-}
-
-func verifyCompatibleVersionWithRoot(cfg config.Cassandra, rootFile string) error {
-	// Traverse until project root i.e. "cadence" dir to navigate to the schema/ directory
-	projRoot := rootFile
-	for path.Base(projRoot) != "cadence" {
-		projRoot = path.Dir(projRoot) // According to spec, returns "." when it cannot go any further
-		if projRoot == "." {
-			return fmt.Errorf("Unable to get project root from path: %s", rootFile)
-		}
-	}
-	schemaPath := path.Join(projRoot, "schema/cadence/versioned")
+func VerifyCompatibleVersion(cfg config.Cassandra, rootFile string) error {
+	projRoot := "github.com/uber/cadence/schema"
+	schemaPath := path.Join(rootFile, projRoot+"/cadence/versioned")
 	if err := checkCompatibleVersion(cfg, cfg.Keyspace, schemaPath); err != nil {
 		return err
 	}
-	schemaPath = path.Join(projRoot, "schema/visibility/versioned")
+	schemaPath = path.Join(rootFile, projRoot+"/visibility/versioned")
 	return checkCompatibleVersion(cfg, cfg.VisibilityKeyspace, schemaPath)
 }
 

--- a/tools/cassandra/version_test.go
+++ b/tools/cassandra/version_test.go
@@ -187,7 +187,7 @@ func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
 		Keyspace:           keyspace,
 		VisibilityKeyspace: visKeyspace,
 	}
-	s.NoError(verifyCompatibleVersionWithRoot(cfg, filename))
+	s.NoError(VerifyCompatibleVersion(cfg, path.Dir(path.Dir(path.Dir(root)))))
 }
 
 func (s *VersionTestSuite) TestCheckCompatibleVersion() {


### PR DESCRIPTION
runtime.Caller does not return absolute path in all cases. Changed to pass in the root path so dependent repos can send in appropriate roots.