### PR TITLE
Remove throttling logs and set min burst size

### DIFF
--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -491,7 +491,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	dPtr := _defaultTaskDispatchRPS
 	mgr := newTaskListManagerWithRateLimiter(
 		s.matchingEngine, tlID, s.matchingEngine.config,
-		newRateLimiter(&dPtr, dispatchTTL),
+		newRateLimiter(&dPtr, dispatchTTL, _minBurst),
 	)
 	s.matchingEngine.updateTaskList(tlID, mgr)
 	s.taskManager.getTaskListManager(tlID).rangeID = initialRangeID
@@ -648,7 +648,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	dPtr := _defaultTaskDispatchRPS
 	mgr := newTaskListManagerWithRateLimiter(
 		s.matchingEngine, tlID, s.matchingEngine.config,
-		newRateLimiter(&dPtr, dispatchTTL),
+		newRateLimiter(&dPtr, dispatchTTL, _minBurst),
 	)
 	s.matchingEngine.updateTaskList(tlID, mgr)
 	s.taskManager.getTaskListManager(tlID).rangeID = initialRangeID

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -35,9 +35,10 @@ type Config struct {
 	LongPollExpirationInterval time.Duration
 
 	// taskListManager configuration
-	RangeSize         int64
-	GetTasksBatchSize int
-	UpdateAckInterval time.Duration
+	RangeSize                  int64
+	GetTasksBatchSize          int
+	UpdateAckInterval          time.Duration
+	MinTaskThrottlingBurstSize int
 
 	// taskWriter configuration
 	OutstandingTaskAppendsThreshold int
@@ -54,6 +55,7 @@ func NewConfig() *Config {
 		UpdateAckInterval:               10 * time.Second,
 		OutstandingTaskAppendsThreshold: 250,
 		MaxTaskBatchSize:                100,
+		MinTaskThrottlingBurstSize:      5,
 	}
 }
 

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -629,7 +629,10 @@ deliverBufferTasksLoop:
 				c.logger.Info("Tasklist manager context is cancelled, shutting down")
 				break deliverBufferTasksLoop
 			}
-			c.logger.Debugf("Unable to send tasks for poll, rate limit failed: %s", err.Error())
+			c.logger.Debugf(
+				"Unable to send tasks for poll, rate limit failed, domain: %s, tasklist: %s, error: %s",
+				c.taskListID.domainID, c.taskListID.String(), err.Error(),
+			)
 			c.metricsClient.IncCounter(metrics.MatchingTaskListMgrScope, metrics.BufferThrottleCounter)
 			continue
 		}

--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -35,6 +35,8 @@ import (
 	"github.com/uber/cadence/common/persistence"
 )
 
+const _minBurst = 5
+
 func TestDeliverBufferTasks(t *testing.T) {
 	tests := []func(tlm *taskListManagerImpl){
 		func(tlm *taskListManagerImpl) { close(tlm.taskBuffer) },
@@ -57,9 +59,9 @@ func TestDeliverBufferTasks(t *testing.T) {
 
 func TestNewRateLimiter(t *testing.T) {
 	maxDispatch := float64(0.01)
-	rl := newRateLimiter(&maxDispatch, time.Second)
+	rl := newRateLimiter(&maxDispatch, time.Second, _minBurst)
 	limiter := rl.globalLimiter.Load().(*rate.Limiter)
-	assert.Equal(t, 5, limiter.Burst())
+	assert.Equal(t, _minBurst, limiter.Burst())
 }
 
 func createTestTaskListManager() *taskListManagerImpl {

--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -23,6 +23,10 @@ package matching
 import (
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
 
 	"github.com/uber/cadence/common/mocks"
 
@@ -49,6 +53,13 @@ func TestDeliverBufferTasks(t *testing.T) {
 		// deliverBufferTasksForPoll should stop after invokation of the test function
 		wg.Wait()
 	}
+}
+
+func TestNewRateLimiter(t *testing.T) {
+	maxDispatch := float64(0.01)
+	rl := newRateLimiter(&maxDispatch, time.Second)
+	limiter := rl.globalLimiter.Load().(*rate.Limiter)
+	assert.Equal(t, 5, limiter.Burst())
 }
 
 func createTestTaskListManager() *taskListManagerImpl {


### PR DESCRIPTION
Warn logs are clogging up disk space in matching service.