### PR TITLE
Fix schema version to be relative to current path

### DIFF
--- a/cmd/server/cadence.go
+++ b/cmd/server/cadence.go
@@ -23,7 +23,6 @@ package main
 import (
 	"log"
 	"os"
-	"path"
 	"strings"
 
 	"github.com/uber/cadence/common/service/config"
@@ -54,12 +53,11 @@ func startHandler(c *cli.Context) {
 	log.Printf("config=\n%v\n", cfg.String())
 
 	cassCfg := cfg.Cassandra
-	dir, err := os.Getwd() // dir = /Users/madhuravi/Uber/gocode/src/github.com/uber/cadence
+	dir, err := os.Getwd()
 	if err != nil {
 		log.Fatal("Unable to get current directory")
 	}
-	root := path.Dir(path.Dir(path.Dir(dir))) // root = /Users/madhuravi/Uber/gocode/src
-	if err := cassandra.VerifyCompatibleVersion(cassCfg, root); err != nil {
+	if err := cassandra.VerifyCompatibleVersion(cassCfg, dir); err != nil {
 		log.Fatalf("Incompatible versions", err)
 	}
 	for _, svc := range getServices(c) {

--- a/tools/cassandra/version.go
+++ b/tools/cassandra/version.go
@@ -130,13 +130,12 @@ func getExpectedVersion(dir string) (string, error) {
 // In most cases, the versions should match. However if after a schema upgrade there is a code
 // rollback, the code version (expected version) would fall lower than the actual version in
 // cassandra.
-func VerifyCompatibleVersion(cfg config.Cassandra, rootFile string) error {
-	projRoot := "github.com/uber/cadence/schema"
-	schemaPath := path.Join(rootFile, projRoot+"/cadence/versioned")
+func VerifyCompatibleVersion(cfg config.Cassandra, rootPath string) error {
+	schemaPath := path.Join(rootPath, "schema/cadence/versioned")
 	if err := checkCompatibleVersion(cfg, cfg.Keyspace, schemaPath); err != nil {
 		return err
 	}
-	schemaPath = path.Join(rootFile, projRoot+"/visibility/versioned")
+	schemaPath = path.Join(rootPath, "schema/visibility/versioned")
 	return checkCompatibleVersion(cfg, cfg.VisibilityKeyspace, schemaPath)
 }
 

--- a/tools/cassandra/version_test.go
+++ b/tools/cassandra/version_test.go
@@ -187,7 +187,7 @@ func (s *VersionTestSuite) TestVerifyCompatibleVersion() {
 		Keyspace:           keyspace,
 		VisibilityKeyspace: visKeyspace,
 	}
-	s.NoError(VerifyCompatibleVersion(cfg, path.Dir(path.Dir(path.Dir(root)))))
+	s.NoError(VerifyCompatibleVersion(cfg, root))
 }
 
 func (s *VersionTestSuite) TestCheckCompatibleVersion() {


### PR DESCRIPTION
Fixes https://github.com/uber/cadence/issues/533