### PR TITLE
implement standby timer processor, which keeps standby timers which are fired

### DIFF
--- a/service/history/MockTimerQueueAckMgr.go
+++ b/service/history/MockTimerQueueAckMgr.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/uber/cadence/common/persistence"
+)
+
+// MockTimerQueueAckMgr is used as mock implementation for TimerQueueAckMgr
+type MockTimerQueueAckMgr struct {
+	mock.Mock
+}
+
+// readTimerTasks is mock implementation for readTimerTasks of TimerQueueAckMgr
+func (_m *MockTimerQueueAckMgr) readTimerTasks() ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error) {
+	ret := _m.Called()
+
+	var r0 []*persistence.TimerTaskInfo
+	if rf, ok := ret.Get(0).(func() []*persistence.TimerTaskInfo); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*persistence.TimerTaskInfo)
+		}
+	}
+
+	var r1 *persistence.TimerTaskInfo
+	if rf, ok := ret.Get(1).(func() *persistence.TimerTaskInfo); ok {
+		r1 = rf()
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*persistence.TimerTaskInfo)
+		}
+	}
+
+	var r2 bool
+	if rf, ok := ret.Get(2).(func() bool); ok {
+		r2 = rf()
+	} else {
+		r2 = ret.Get(2).(bool)
+	}
+
+	var r3 error
+	if rf, ok := ret.Get(3).(func() error); ok {
+		r3 = rf()
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
+}
+
+func (_m *MockTimerQueueAckMgr) completeTimerTask(taskID TimerSequenceID) {
+	_m.Called(taskID)
+}
+
+func (_m *MockTimerQueueAckMgr) updateAckLevel() {
+	_m.Called()
+}

--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -90,6 +90,12 @@ type (
 		NotifyNewTimer(timerTask []persistence.Task)
 	}
 
+	timerQueueAckMgr interface {
+		readTimerTasks() ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error)
+		completeTimerTask(taskID TimerSequenceID)
+		updateAckLevel()
+	}
+
 	historyEventNotifier interface {
 		common.Daemon
 		NotifyNewHistoryEvent(event *historyEventNotification)

--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -49,13 +49,13 @@ const (
 
 type (
 	timerDetails struct {
-		SequenceID  SequenceID
-		TaskCreated bool
-		TimerID     string
-		ActivityID  int64
-		TimeoutType w.TimeoutType
-		EventID     int64
-		TimeoutSec  int32
+		TimerSequenceID TimerSequenceID
+		TaskCreated     bool
+		TimerID         string
+		ActivityID      int64
+		TimeoutType     w.TimeoutType
+		EventID         int64
+		TimeoutSec      int32
 	}
 
 	timers []*timerDetails
@@ -73,8 +73,8 @@ type (
 		timeSource             common.TimeSource
 	}
 
-	// SequenceID - Visibility timer stamp + Sequence Number.
-	SequenceID struct {
+	// TimerSequenceID - Visibility timer stamp + Sequence Number.
+	TimerSequenceID struct {
 		VisibilityTimestamp time.Time
 		TaskID              int64
 	}
@@ -89,7 +89,7 @@ type (
 	}
 )
 
-func (s SequenceID) String() string {
+func (s TimerSequenceID) String() string {
 	return fmt.Sprintf("timestamp: %v, seq: %v", s.VisibilityTimestamp.UTC(), s.TaskID)
 }
 
@@ -106,12 +106,12 @@ func (t timers) Swap(i, j int) {
 
 // Less implements sort.Interface
 func (t timers) Less(i, j int) bool {
-	return compareTimerIDLess(&t[i].SequenceID, &t[j].SequenceID)
+	return compareTimerIDLess(&t[i].TimerSequenceID, &t[j].TimerSequenceID)
 }
 
 func (td *timerDetails) String() string {
 	return fmt.Sprintf("TimerDetails: SeqID: %s, TimerID: %v, ActivityID: %v, TaskCreated: %v, EventID: %v, TimeoutType: %v, TimeoutSec: %v",
-		td.SequenceID, td.TimerID, td.ActivityID, td.TaskCreated, td.EventID, td.TimeoutType.String(), td.TimeoutSec)
+		td.TimerSequenceID, td.TimerID, td.ActivityID, td.TaskCreated, td.EventID, td.TimeoutType.String(), td.TimeoutSec)
 }
 
 func (l *localSeqNumGenerator) NextSeq() int64 {
@@ -182,9 +182,9 @@ func (tb *timerBuilder) AddUserTimer(ti *persistence.TimerInfo, msBuilder *mutab
 	}
 	seqNum := tb.localSeqNumGen.NextSeq()
 	timer := &timerDetails{
-		SequenceID:  SequenceID{VisibilityTimestamp: ti.ExpiryTime, TaskID: seqNum},
-		TimerID:     ti.TimerID,
-		TaskCreated: ti.TaskID == TimerTaskStatusCreated}
+		TimerSequenceID: TimerSequenceID{VisibilityTimestamp: ti.ExpiryTime, TaskID: seqNum},
+		TimerID:         ti.TimerID,
+		TaskCreated:     ti.TaskID == TimerTaskStatusCreated}
 	tb.insertTimer(timer)
 	tb.logger.Debugf("Added User Timeout for timer ID: %s", ti.TimerID)
 }
@@ -220,7 +220,7 @@ func (tb *timerBuilder) GetUserTimer(timerID string) (bool, *persistence.TimerIn
 // IsTimerExpired - Whether a timer is expired w.r.t reference time.
 func (tb *timerBuilder) IsTimerExpired(td *timerDetails, referenceTime time.Time) bool {
 	// Cql timestamp is in milli sec resolution, here we do the check in terms of second resolution.
-	expiry := td.SequenceID.VisibilityTimestamp.Unix()
+	expiry := td.TimerSequenceID.VisibilityTimestamp.Unix()
 	return expiry <= referenceTime.Unix()
 }
 
@@ -257,9 +257,9 @@ func (tb *timerBuilder) loadUserTimers(msBuilder *mutableStateBuilder) {
 	for _, v := range msBuilder.pendingTimerInfoIDs {
 		seqNum := tb.localSeqNumGen.NextSeq()
 		td := &timerDetails{
-			SequenceID:  SequenceID{VisibilityTimestamp: v.ExpiryTime, TaskID: seqNum},
-			TimerID:     v.TimerID,
-			TaskCreated: v.TaskID == TimerTaskStatusCreated}
+			TimerSequenceID: TimerSequenceID{VisibilityTimestamp: v.ExpiryTime, TaskID: seqNum},
+			TimerID:         v.TimerID,
+			TaskCreated:     v.TaskID == TimerTaskStatusCreated}
 		tb.userTimers = append(tb.userTimers, td)
 	}
 	sort.Sort(tb.userTimers)
@@ -273,23 +273,23 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder *mutableStateBuilder) {
 		if v.ScheduleID != emptyEventID {
 			scheduleToCloseExpiry := v.ScheduledTime.Add(time.Duration(v.ScheduleToCloseTimeout) * time.Second)
 			td := &timerDetails{
-				SequenceID:  SequenceID{VisibilityTimestamp: scheduleToCloseExpiry},
-				ActivityID:  v.ScheduleID,
-				EventID:     v.ScheduleID,
-				TimeoutSec:  v.ScheduleToCloseTimeout,
-				TimeoutType: w.TimeoutTypeScheduleToClose,
-				TaskCreated: (v.TimerTaskStatus & TimerTaskStatusCreatedScheduleToClose) != 0}
+				TimerSequenceID: TimerSequenceID{VisibilityTimestamp: scheduleToCloseExpiry},
+				ActivityID:      v.ScheduleID,
+				EventID:         v.ScheduleID,
+				TimeoutSec:      v.ScheduleToCloseTimeout,
+				TimeoutType:     w.TimeoutTypeScheduleToClose,
+				TaskCreated:     (v.TimerTaskStatus & TimerTaskStatusCreatedScheduleToClose) != 0}
 			tb.activityTimers = append(tb.activityTimers, td)
 
 			if v.StartedID != emptyEventID {
 				startToCloseExpiry := v.StartedTime.Add(time.Duration(v.StartToCloseTimeout) * time.Second)
 				td := &timerDetails{
-					SequenceID:  SequenceID{VisibilityTimestamp: startToCloseExpiry},
-					ActivityID:  v.ScheduleID,
-					EventID:     v.StartedID,
-					TimeoutType: w.TimeoutTypeStartToClose,
-					TimeoutSec:  v.StartToCloseTimeout,
-					TaskCreated: (v.TimerTaskStatus & TimerTaskStatusCreatedStartToClose) != 0}
+					TimerSequenceID: TimerSequenceID{VisibilityTimestamp: startToCloseExpiry},
+					ActivityID:      v.ScheduleID,
+					EventID:         v.StartedID,
+					TimeoutType:     w.TimeoutTypeStartToClose,
+					TimeoutSec:      v.StartToCloseTimeout,
+					TaskCreated:     (v.TimerTaskStatus & TimerTaskStatusCreatedStartToClose) != 0}
 				tb.activityTimers = append(tb.activityTimers, td)
 				if v.HeartbeatTimeout > 0 {
 					lastHeartBeatTS := v.LastHeartBeatUpdatedTime
@@ -298,23 +298,23 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder *mutableStateBuilder) {
 					}
 					heartBeatExpiry := lastHeartBeatTS.Add(time.Duration(v.HeartbeatTimeout) * time.Second)
 					td := &timerDetails{
-						SequenceID:  SequenceID{VisibilityTimestamp: heartBeatExpiry},
-						ActivityID:  v.ScheduleID,
-						EventID:     v.StartedID,
-						TimeoutType: w.TimeoutTypeHeartbeat,
-						TimeoutSec:  v.HeartbeatTimeout,
-						TaskCreated: (v.TimerTaskStatus & TimerTaskStatusCreatedHeartbeat) != 0}
+						TimerSequenceID: TimerSequenceID{VisibilityTimestamp: heartBeatExpiry},
+						ActivityID:      v.ScheduleID,
+						EventID:         v.StartedID,
+						TimeoutType:     w.TimeoutTypeHeartbeat,
+						TimeoutSec:      v.HeartbeatTimeout,
+						TaskCreated:     (v.TimerTaskStatus & TimerTaskStatusCreatedHeartbeat) != 0}
 					tb.activityTimers = append(tb.activityTimers, td)
 				}
 			} else {
 				scheduleToStartExpiry := v.ScheduledTime.Add(time.Duration(v.ScheduleToStartTimeout) * time.Second)
 				td := &timerDetails{
-					SequenceID:  SequenceID{VisibilityTimestamp: scheduleToStartExpiry},
-					ActivityID:  v.ScheduleID,
-					EventID:     v.ScheduleID,
-					TimeoutSec:  v.ScheduleToStartTimeout,
-					TimeoutType: w.TimeoutTypeScheduleToStart,
-					TaskCreated: (v.TimerTaskStatus & TimerTaskStatusCreatedScheduleToStart) != 0}
+					TimerSequenceID: TimerSequenceID{VisibilityTimestamp: scheduleToStartExpiry},
+					ActivityID:      v.ScheduleID,
+					EventID:         v.ScheduleID,
+					TimeoutSec:      v.ScheduleToStartTimeout,
+					TimeoutType:     w.TimeoutTypeScheduleToStart,
+					TaskCreated:     (v.TimerTaskStatus & TimerTaskStatusCreatedScheduleToStart) != 0}
 				tb.activityTimers = append(tb.activityTimers, td)
 			}
 		}
@@ -362,9 +362,9 @@ func (tb *timerBuilder) createActivityTimeoutTask(fireTimeOut int32, timeoutType
 func (tb *timerBuilder) loadUserTimer(expires time.Time, timerID string, taskCreated bool) (*timerDetails, bool) {
 	seqNum := tb.localSeqNumGen.NextSeq()
 	timer := &timerDetails{
-		SequenceID:  SequenceID{VisibilityTimestamp: expires, TaskID: seqNum},
-		TimerID:     timerID,
-		TaskCreated: taskCreated}
+		TimerSequenceID: TimerSequenceID{VisibilityTimestamp: expires, TaskID: seqNum},
+		TimerID:         timerID,
+		TaskCreated:     taskCreated}
 	isFirst := tb.insertTimer(timer)
 	return timer, isFirst
 }
@@ -372,7 +372,7 @@ func (tb *timerBuilder) loadUserTimer(expires time.Time, timerID string, taskCre
 func (tb *timerBuilder) insertTimer(td *timerDetails) bool {
 	size := len(tb.userTimers)
 	i := sort.Search(size,
-		func(i int) bool { return !compareTimerIDLess(&tb.userTimers[i].SequenceID, &td.SequenceID) })
+		func(i int) bool { return !compareTimerIDLess(&tb.userTimers[i].TimerSequenceID, &td.TimerSequenceID) })
 	if i == size {
 		tb.userTimers = append(tb.userTimers, td)
 	} else {
@@ -400,12 +400,12 @@ func (tb *timerBuilder) createNewTask(td *timerDetails) persistence.Task {
 	if td.TimerID != "" {
 		tt := tb.pendingUserTimers[td.TimerID]
 		return &persistence.UserTimerTask{
-			VisibilityTimestamp: td.SequenceID.VisibilityTimestamp,
+			VisibilityTimestamp: td.TimerSequenceID.VisibilityTimestamp,
 			EventID:             tt.StartedID,
 		}
 	} else if td.ActivityID != 0 && td.ActivityID != emptyEventID {
 		return &persistence.ActivityTimeoutTask{
-			VisibilityTimestamp: td.SequenceID.VisibilityTimestamp,
+			VisibilityTimestamp: td.TimerSequenceID.VisibilityTimestamp,
 			EventID:             td.EventID,
 			TimeoutType:         int(td.TimeoutType),
 		}
@@ -413,7 +413,7 @@ func (tb *timerBuilder) createNewTask(td *timerDetails) persistence.Task {
 	return nil
 }
 
-func compareTimerIDLess(first *SequenceID, second *SequenceID) bool {
+func compareTimerIDLess(first *TimerSequenceID, second *TimerSequenceID) bool {
 	if first.VisibilityTimestamp.Before(second.VisibilityTimestamp) {
 		return true
 	}

--- a/service/history/timerBuilder_test.go
+++ b/service/history/timerBuilder_test.go
@@ -220,6 +220,6 @@ func (s *timerBuilderProcessorSuite) TestDecodeHistory() {
 }
 
 func (s *timerBuilderProcessorSuite) TestDecodeKey() {
-	taskID := SequenceID{VisibilityTimestamp: time.Unix(0, 0), TaskID: 1}
-	s.logger.Infof("Timer: %s, expiry: %v", SequenceID(taskID), taskID.VisibilityTimestamp)
+	taskID := TimerSequenceID{VisibilityTimestamp: time.Unix(0, 0), TaskID: 1}
+	s.logger.Infof("Timer: %s, expiry: %v", TimerSequenceID(taskID), taskID.VisibilityTimestamp)
 }

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -103,7 +103,7 @@ func (s *timerQueueProcessorSuite) updateTimerSeqNumbers(timerTasks []persistenc
 		}
 		task.SetTaskID(taskID)
 		s.logger.Infof("%v: TestTimerQueueProcessorSuite: Assigning timer: %s",
-			time.Now().UTC(), SequenceID{VisibilityTimestamp: persistence.GetVisibilityTSFrom(task), TaskID: task.GetTaskID()})
+			time.Now().UTC(), TimerSequenceID{VisibilityTimestamp: persistence.GetVisibilityTSFrom(task), TaskID: task.GetTaskID()})
 	}
 }
 

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -1,0 +1,364 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/uber-common/bark"
+	workflow "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common/persistence"
+)
+
+// NOTE: this whole file is used by standby cluster dealing with
+// workflow timer which got fired.
+
+type (
+	// outstandingTimers keeps all the timer which is fired for a workflow
+	// in standby cluster, and when we do domain failover, all fired timer
+	// will be redirected to timer queue processor for processing.
+	outstandingTimers struct {
+		// workflow timer
+		workflowStartToClose *persistence.TimerTaskInfo
+
+		// decision timers
+		decisionScheduleToStartTimer *persistence.TimerTaskInfo
+		decisionStartToCloseTimer    *persistence.TimerTaskInfo
+
+		// activity timers
+		// timer builder will only create one timer for all activity timers at a given time,
+		// i.e. sort the fire time of all activity timers and use the earlist fire time
+		// as the timer task for activity timer.
+		// what need to be done here is tracking the latest timer task, and that is all.
+		activityTimer *persistence.TimerTaskInfo
+
+		// user timers
+		// timer builder will only create one timer for all user timers at a given time,
+		// i.e. sort the fire time of all user timers and use the earlist fire time
+		// as the timer task for user timer.
+		// what need to be done here is tracking the latest timer task, and that is all.
+		userTimer *persistence.TimerTaskInfo
+	}
+
+	timerQueueStandbyProcessor struct {
+		logger           bark.Logger
+		timerQueueAckMgr timerQueueAckMgr
+
+		sync.Mutex
+		workflowOutstandingTimers map[workflowIdentifier]*outstandingTimers
+	}
+)
+
+// newTimerQueueStandbyProcessor create a new standby timer processor
+func newTimerQueueStandbyProcessor(logger bark.Logger, timerQueueAckMgr timerQueueAckMgr) *timerQueueStandbyProcessor {
+	return &timerQueueStandbyProcessor{
+		logger:                    logger,
+		timerQueueAckMgr:          timerQueueAckMgr,
+		workflowOutstandingTimers: make(map[workflowIdentifier]*outstandingTimers),
+	}
+}
+
+// newOutstandingTimers create a new empty outstandingTimers for a a workflow
+func newOutstandingTimers() *outstandingTimers {
+	return &outstandingTimers{}
+}
+
+func (processor *timerQueueStandbyProcessor) AddTimers(timers []*persistence.TimerTaskInfo) {
+	if len(timers) == 0 {
+		return
+	}
+
+	processor.Lock()
+	defer processor.Unlock()
+
+	for _, timer := range timers {
+		identifier := workflowIdentifier{
+			domainID:   timer.DomainID,
+			workflowID: timer.WorkflowID,
+			runID:      timer.RunID,
+		}
+		outstandingTimers, ok := processor.workflowOutstandingTimers[identifier]
+		if !ok {
+			outstandingTimers = newOutstandingTimers()
+			processor.workflowOutstandingTimers[identifier] = outstandingTimers
+		}
+
+		switch timer.TaskType {
+		case persistence.TaskTypeWorkflowTimeout:
+			// there can only be one workflow start to close timer
+			// so making the check if this timer is set does not make much sense
+			outstandingTimers.workflowStartToClose = timer
+
+		case persistence.TaskTypeDecisionTimeout:
+			switch timer.TimeoutType {
+			case int(workflow.TimeoutTypeStartToClose):
+				if outstandingTimers.decisionStartToCloseTimer != nil {
+					// this should not happen, since there can only be one decision
+					// on the fly and one corresponding decision start to close timer
+					panic(fmt.Sprintf("Decision start to close timer is not cleared, current: %v, incoming %v",
+						outstandingTimers.decisionStartToCloseTimer, timer))
+				}
+				outstandingTimers.decisionStartToCloseTimer = timer
+			case int(workflow.TimeoutTypeScheduleToStart):
+				if outstandingTimers.decisionScheduleToStartTimer != nil {
+					// this should not happen, since there can only be one decision
+					// on the fly and one corresponding decision schedule to start timer
+					panic(fmt.Sprintf("Decision schedule to start timer is not cleared, current: %v, incoming %v",
+						outstandingTimers.decisionScheduleToStartTimer, timer))
+				}
+				outstandingTimers.decisionScheduleToStartTimer = timer
+			default:
+				panic(fmt.Sprintf("Unknown decision task type: %v.", timer.TimeoutType))
+			}
+
+		case persistence.TaskTypeActivityTimeout:
+			if outstandingTimers.activityTimer == nil {
+				outstandingTimers.activityTimer = timer
+			} else {
+				activityTimerSequenceID := &TimerSequenceID{
+					VisibilityTimestamp: outstandingTimers.activityTimer.VisibilityTimestamp,
+					TaskID:              outstandingTimers.activityTimer.TaskID,
+				}
+				timerSequenceID := &TimerSequenceID{
+					VisibilityTimestamp: timer.VisibilityTimestamp,
+					TaskID:              timer.TaskID,
+				}
+				if compareTimerIDLess(activityTimerSequenceID, timerSequenceID) {
+					// the current user timer is processed, update timer queue ack manager
+					processor.ackTimer(outstandingTimers.activityTimer)
+
+					outstandingTimers.activityTimer = timer
+				}
+			}
+
+		case persistence.TaskTypeUserTimer:
+			if outstandingTimers.userTimer == nil {
+				outstandingTimers.userTimer = timer
+			} else {
+				userTimerSequenceID := &TimerSequenceID{
+					VisibilityTimestamp: outstandingTimers.userTimer.VisibilityTimestamp,
+					TaskID:              outstandingTimers.userTimer.TaskID,
+				}
+				timerSequenceID := &TimerSequenceID{
+					VisibilityTimestamp: timer.VisibilityTimestamp,
+					TaskID:              timer.TaskID,
+				}
+				if compareTimerIDLess(userTimerSequenceID, timerSequenceID) {
+					// the current user timer is processed, update timer queue ack manager
+					processor.ackTimer(outstandingTimers.userTimer)
+					outstandingTimers.userTimer = timer
+				}
+			}
+		case persistence.TaskTypeDeleteHistoryEvent:
+			panic("Timer task delete history event should not be buffered.")
+		default:
+			panic(fmt.Sprintf("Unknown timer task type: %v.", timer.TaskType))
+		}
+
+	}
+}
+
+func (processor *timerQueueStandbyProcessor) CompleteTimers(identifier workflowIdentifier, events []*workflow.HistoryEvent) {
+	if len(events) == 0 {
+		return
+	}
+
+	// There are 4 types of timer we need to take care of
+	// 1. decision timer
+	// 2. activity timer
+	// 3. workflow timer
+	// 4. user timer
+	//
+	// The delete history timer should not be processed here,
+	// since there is no event representing history deletion,
+	// moreover this timer is to honor the retention policy
+	// and has nothing to do with timer business logic.
+	for _, event := range events {
+		switch event.GetEventType() {
+		case
+			// below are all workflow state change history event
+			// only put the started event here for reference
+			// workflow.EventTypeWorkflowExecutionStarted
+			workflow.EventTypeWorkflowExecutionCompleted,
+			workflow.EventTypeWorkflowExecutionFailed,
+			workflow.EventTypeWorkflowExecutionTimedOut,
+			workflow.EventTypeWorkflowExecutionCanceled,
+			workflow.EventTypeWorkflowExecutionTerminated,
+			workflow.EventTypeWorkflowExecutionContinuedAsNew:
+			processor.completeWorkflowTimer(identifier, event)
+		case
+			// below are all decision state change history event
+			// only put the schedule event here for reference
+			// workflow.EventTypeDecisionTaskScheduled
+			workflow.EventTypeDecisionTaskStarted,
+			workflow.EventTypeDecisionTaskCompleted,
+			workflow.EventTypeDecisionTaskTimedOut,
+			workflow.EventTypeDecisionTaskFailed:
+			processor.completeDecisionTimer(identifier, event)
+		case
+			// below are all activity state change history event
+			// only put the schedule event here for reference
+			// workflow.EventTypeActivityTaskScheduled
+			workflow.EventTypeActivityTaskStarted,
+			workflow.EventTypeActivityTaskCompleted,
+			workflow.EventTypeActivityTaskFailed,
+			workflow.EventTypeActivityTaskTimedOut,
+			workflow.EventTypeActivityTaskCanceled:
+			// we do not do anything to activity timer event here,
+			// this is because activity timer is triggered by the earlist
+			// time of all activity timers, not a specific activity ID.
+			// NOTE:
+			// the current activity timer is considered completed
+			// when a new activity timer is received
+		case
+			workflow.EventTypeTimerStarted,
+			workflow.EventTypeTimerFired,
+			workflow.EventTypeTimerCanceled:
+			// we do not do anything to user timer event here,
+			// this is because user timer is triggered by the earlist
+			// time of all user timers, not a specific timer ID.
+			// NOTE:
+			// the current user timer is considered completed
+			// when a new user timer is received
+		default:
+			// other event types do not have any timer relations, just skip
+		}
+	}
+}
+
+func (processor *timerQueueStandbyProcessor) GetAndRemoveTimersByDomainID(domainID string) []*persistence.TimerTaskInfo {
+	// TODO pending implementation
+	return nil
+}
+
+func (processor *timerQueueStandbyProcessor) completeWorkflowTimer(identifier workflowIdentifier, event *workflow.HistoryEvent) {
+
+	processor.Lock()
+	defer processor.Unlock()
+
+	outstandingTimers, ok := processor.workflowOutstandingTimers[identifier]
+	if !ok {
+		processor.logger.Debugf("Event %v being processed is an duplicate.", event)
+		return
+	}
+
+	// for each timer within this workflow, update the timer ack manager
+	processor.ackTimer(outstandingTimers.workflowStartToClose)
+	processor.ackTimer(outstandingTimers.decisionScheduleToStartTimer)
+	processor.ackTimer(outstandingTimers.decisionStartToCloseTimer)
+	processor.ackTimer(outstandingTimers.activityTimer)
+	processor.ackTimer(outstandingTimers.userTimer)
+
+	// for workflow timer, there are only 1 type
+	// 1. start to close.
+	// one can use regex `WorkflowTimeoutTask\{` to find out the usage
+	//
+	// we should set the workflowStartToClose to nil, however, since the workflow is finished
+	// just clear all timer related to this workflow
+	delete(processor.workflowOutstandingTimers, identifier)
+}
+
+func (processor *timerQueueStandbyProcessor) completeDecisionTimer(identifier workflowIdentifier, event *workflow.HistoryEvent) {
+
+	processor.Lock()
+	defer processor.Unlock()
+
+	outstandingTimers, ok := processor.workflowOutstandingTimers[identifier]
+	if !ok {
+		processor.logger.Debugf("Event %v being processed is an duplicate.", event)
+		return
+	}
+
+	var scheduleID int64
+	switch event.GetEventType() {
+	case workflow.EventTypeDecisionTaskStarted:
+		scheduleID = event.DecisionTaskStartedEventAttributes.GetScheduledEventId()
+	case workflow.EventTypeDecisionTaskCompleted:
+		scheduleID = event.DecisionTaskCompletedEventAttributes.GetScheduledEventId()
+	case workflow.EventTypeDecisionTaskTimedOut:
+		scheduleID = event.DecisionTaskTimedOutEventAttributes.GetScheduledEventId()
+	case workflow.EventTypeDecisionTaskFailed:
+		scheduleID = event.DecisionTaskFailedEventAttributes.GetScheduledEventId()
+	default:
+		panic(fmt.Sprintf("Unknown decision event type: %v.", event.GetEventType()))
+	}
+
+	// for decision timer, there are 2 types
+	// 1. schedule to start. only used by sticky decision as of Mar 16, 2018
+	// 2. start to close.
+	// one can use regex `\.Add(ScheduleToStart){0,1}DecisionTimoutTask\(` to find out the usage
+	switch event.GetEventType() {
+	case workflow.EventTypeDecisionTaskStarted:
+		if outstandingTimers.decisionScheduleToStartTimer != nil {
+			if outstandingTimers.decisionScheduleToStartTimer.EventID == scheduleID {
+				processor.ackTimer(outstandingTimers.decisionScheduleToStartTimer)
+				outstandingTimers.decisionScheduleToStartTimer = nil
+			} else {
+				panic(fmt.Sprintf("Decision schedule to start timer mismatch, current: %v, incoming %v",
+					outstandingTimers.decisionScheduleToStartTimer, event))
+			}
+		}
+	case workflow.EventTypeDecisionTaskTimedOut:
+		if outstandingTimers.decisionScheduleToStartTimer != nil {
+			if outstandingTimers.decisionScheduleToStartTimer.EventID == scheduleID {
+				processor.ackTimer(outstandingTimers.decisionScheduleToStartTimer)
+				outstandingTimers.decisionScheduleToStartTimer = nil
+			} else {
+				panic(fmt.Sprintf("Decision schedule to start timer mismatch, current: %v, incoming %v",
+					outstandingTimers.decisionScheduleToStartTimer, event))
+			}
+		}
+		if outstandingTimers.decisionStartToCloseTimer != nil {
+			if outstandingTimers.decisionStartToCloseTimer.EventID == scheduleID {
+				processor.ackTimer(outstandingTimers.decisionStartToCloseTimer)
+				outstandingTimers.decisionStartToCloseTimer = nil
+			} else {
+				panic(fmt.Sprintf("Decision start to close timer mismatch, current: %v, incoming %v",
+					outstandingTimers.decisionScheduleToStartTimer, event))
+			}
+		}
+	case workflow.EventTypeDecisionTaskCompleted,
+		workflow.EventTypeDecisionTaskFailed:
+
+		// check start to close timer
+		if outstandingTimers.decisionStartToCloseTimer.EventID == scheduleID {
+			processor.ackTimer(outstandingTimers.decisionStartToCloseTimer)
+			outstandingTimers.decisionStartToCloseTimer = nil
+		} else {
+			panic(fmt.Sprintf("Decision start to close timer mismatch, current: %v, incoming %v",
+				outstandingTimers.decisionScheduleToStartTimer, event))
+		}
+
+	}
+}
+
+func (processor *timerQueueStandbyProcessor) ackTimer(timer *persistence.TimerTaskInfo) {
+	if timer == nil {
+		return
+	}
+	timerSequenceID := TimerSequenceID{
+		VisibilityTimestamp: timer.VisibilityTimestamp,
+		TaskID:              timer.TaskID,
+	}
+
+	processor.timerQueueAckMgr.completeTimerTask(timerSequenceID)
+}

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -1,0 +1,379 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/uber-common/bark"
+	workflow "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/persistence"
+)
+
+type (
+	timerQueueStandbyProcessorSuite struct {
+		suite.Suite
+		logger                     bark.Logger
+		timerQueueAckMgr           *MockTimerQueueAckMgr
+		timerQueueStandbyProcessor *timerQueueStandbyProcessor
+	}
+)
+
+func TestTimerQueueStandbyProcessorSuite(t *testing.T) {
+	s := new(timerQueueStandbyProcessorSuite)
+	suite.Run(t, s)
+}
+
+func (s *timerQueueStandbyProcessorSuite) SetupSuite() {
+	if testing.Verbose() {
+		log.SetOutput(os.Stdout)
+	}
+
+}
+
+func (s *timerQueueStandbyProcessorSuite) TearDownSuite() {
+
+}
+
+func (s *timerQueueStandbyProcessorSuite) SetupTest() {
+	log2 := log.New()
+	log2.Level = log.DebugLevel
+	s.logger = bark.NewLoggerFromLogrus(log2)
+	s.timerQueueAckMgr = &MockTimerQueueAckMgr{}
+	s.timerQueueStandbyProcessor = newTimerQueueStandbyProcessor(s.logger, s.timerQueueAckMgr)
+}
+
+func (s *timerQueueStandbyProcessorSuite) TearDownTest() {
+
+}
+
+func (s *timerQueueStandbyProcessorSuite) TestWorkflowTimer() {
+	domainID := "some random domain ID"
+	workflowID := "some random workflow ID"
+	runID := "some random run ID"
+	timestamp := time.Now()
+	taskID := int64(59)
+	taskType := persistence.TaskTypeWorkflowTimeout
+	timeoutType := 0             // for workflow timeout this is not used
+	eventID := int64(28)         // for workflow timeout this is not used
+	scheduleAttempt := int64(12) // for workflow timeout this is not used
+	identifier := workflowIdentifier{
+		domainID:   domainID,
+		workflowID: workflowID,
+		runID:      runID,
+	}
+
+	timers := []*persistence.TimerTaskInfo{
+		&persistence.TimerTaskInfo{
+			DomainID:            domainID,
+			WorkflowID:          workflowID,
+			RunID:               runID,
+			VisibilityTimestamp: timestamp,
+			TaskID:              taskID,
+			TaskType:            taskType,
+			TimeoutType:         timeoutType,
+			EventID:             eventID,
+			ScheduleAttempt:     scheduleAttempt,
+		},
+	}
+
+	workflowEventTypes := []workflow.EventType{
+		workflow.EventTypeWorkflowExecutionCompleted,
+		workflow.EventTypeWorkflowExecutionFailed,
+		workflow.EventTypeWorkflowExecutionTimedOut,
+		workflow.EventTypeWorkflowExecutionTerminated,
+		workflow.EventTypeWorkflowExecutionCanceled,
+	}
+
+	for _, eventType := range workflowEventTypes {
+		events := []*workflow.HistoryEvent{
+			&workflow.HistoryEvent{
+				EventId:   common.Int64Ptr(11),
+				Timestamp: common.Int64Ptr(time.Now().Unix()),
+				EventType: &eventType,
+				// we are not going to use the workflow end event
+			},
+		}
+		s.timerQueueStandbyProcessor.AddTimers(timers)
+		s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+			VisibilityTimestamp: timestamp,
+			TaskID:              taskID,
+		}).Once()
+		s.timerQueueStandbyProcessor.CompleteTimers(identifier, events)
+	}
+}
+
+func (s *timerQueueStandbyProcessorSuite) TestDecisionTimer_StartToCloseOnly() {
+	domainID := "some random domain ID"
+	workflowID := "some random workflow ID"
+	runID := "some random run ID"
+	timestamp := time.Now()
+	taskType := persistence.TaskTypeDecisionTimeout
+	eventID := int64(28)
+	scheduleAttempt := int64(12) // for decision timeout this is not used
+	identifier := workflowIdentifier{
+		domainID:   domainID,
+		workflowID: workflowID,
+		runID:      runID,
+	}
+
+	prepareTimers := func(taskID int64) {
+		timers := []*persistence.TimerTaskInfo{
+			&persistence.TimerTaskInfo{
+				DomainID:            domainID,
+				WorkflowID:          workflowID,
+				RunID:               runID,
+				VisibilityTimestamp: timestamp,
+				TaskID:              taskID,
+				TaskType:            taskType,
+				TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+				EventID:             eventID,
+				ScheduleAttempt:     scheduleAttempt,
+			},
+		}
+		s.timerQueueStandbyProcessor.AddTimers(timers)
+	}
+
+	taskID := int64(60)
+	eventType := workflow.EventTypeDecisionTaskCompleted
+	events := []*workflow.HistoryEvent{
+		&workflow.HistoryEvent{
+			EventId:   common.Int64Ptr(11),
+			Timestamp: common.Int64Ptr(time.Now().Unix()),
+			EventType: &eventType,
+			DecisionTaskCompletedEventAttributes: &workflow.DecisionTaskCompletedEventAttributes{
+				ScheduledEventId: &eventID,
+			},
+		},
+	}
+	prepareTimers(taskID)
+	s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
+	}).Once()
+	s.timerQueueStandbyProcessor.CompleteTimers(identifier, events)
+
+	taskID = int64(61)
+	eventType = workflow.EventTypeDecisionTaskFailed
+	events = []*workflow.HistoryEvent{
+		&workflow.HistoryEvent{
+			EventId:   common.Int64Ptr(11),
+			Timestamp: common.Int64Ptr(time.Now().Unix()),
+			EventType: &eventType,
+			DecisionTaskFailedEventAttributes: &workflow.DecisionTaskFailedEventAttributes{
+				ScheduledEventId: &eventID,
+			},
+		},
+	}
+	prepareTimers(taskID)
+	s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
+	}).Once()
+	s.timerQueueStandbyProcessor.CompleteTimers(identifier, events)
+
+	taskID = int64(62)
+	eventType = workflow.EventTypeDecisionTaskTimedOut
+	events = []*workflow.HistoryEvent{
+		&workflow.HistoryEvent{
+			EventId:   common.Int64Ptr(11),
+			Timestamp: common.Int64Ptr(time.Now().Unix()),
+			EventType: &eventType,
+			DecisionTaskTimedOutEventAttributes: &workflow.DecisionTaskTimedOutEventAttributes{
+				ScheduledEventId: &eventID,
+			},
+		},
+	}
+	prepareTimers(taskID)
+	s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
+	}).Once()
+	s.timerQueueStandbyProcessor.CompleteTimers(identifier, events)
+}
+
+func (s *timerQueueStandbyProcessorSuite) TestDecisionTimer_ScheduleToStart() {
+	domainID := "some random domain ID"
+	workflowID := "some random workflow ID"
+	runID := "some random run ID"
+	timestamp := time.Now()
+	taskType := persistence.TaskTypeDecisionTimeout
+	eventID := int64(28)
+	scheduleAttempt := int64(12) // for decision timeout this is not used
+	identifier := workflowIdentifier{
+		domainID:   domainID,
+		workflowID: workflowID,
+		runID:      runID,
+	}
+
+	prepareTimers := func(taskID int64) {
+		timers := []*persistence.TimerTaskInfo{
+			&persistence.TimerTaskInfo{
+				DomainID:            domainID,
+				WorkflowID:          workflowID,
+				RunID:               runID,
+				VisibilityTimestamp: timestamp,
+				TaskID:              taskID,
+				TaskType:            taskType,
+				TimeoutType:         int(workflow.TimeoutTypeScheduleToStart),
+				EventID:             eventID,
+				ScheduleAttempt:     scheduleAttempt,
+			},
+		}
+		s.timerQueueStandbyProcessor.AddTimers(timers)
+	}
+
+	taskID := int64(59)
+	eventType := workflow.EventTypeDecisionTaskStarted
+	events := []*workflow.HistoryEvent{
+		&workflow.HistoryEvent{
+			EventId:   common.Int64Ptr(11),
+			Timestamp: common.Int64Ptr(time.Now().Unix()),
+			EventType: &eventType,
+			DecisionTaskStartedEventAttributes: &workflow.DecisionTaskStartedEventAttributes{
+				ScheduledEventId: &eventID,
+			},
+		},
+	}
+	prepareTimers(taskID)
+	s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
+	}).Once()
+	s.timerQueueStandbyProcessor.CompleteTimers(identifier, events)
+
+	taskID = int64(62)
+	eventType = workflow.EventTypeDecisionTaskTimedOut
+	events = []*workflow.HistoryEvent{
+		&workflow.HistoryEvent{
+			EventId:   common.Int64Ptr(11),
+			Timestamp: common.Int64Ptr(time.Now().Unix()),
+			EventType: &eventType,
+			DecisionTaskTimedOutEventAttributes: &workflow.DecisionTaskTimedOutEventAttributes{
+				ScheduledEventId: &eventID,
+			},
+		},
+	}
+	prepareTimers(taskID)
+	s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
+	}).Once()
+	s.timerQueueStandbyProcessor.CompleteTimers(identifier, events)
+}
+
+func (s *timerQueueStandbyProcessorSuite) TestActivityTimers() {
+	domainID := "some random domain ID"
+	workflowID := "some random workflow ID"
+	runID := "some random run ID"
+	timestamp := time.Now()
+	taskID := int64(59)
+	taskType := persistence.TaskTypeActivityTimeout
+	timeoutType := 0             // for activity timeout this is not used
+	eventID := int64(28)         // for activity timeout this is not used
+	scheduleAttempt := int64(12) // for activity timeout this is not used
+
+	timers := []*persistence.TimerTaskInfo{
+		&persistence.TimerTaskInfo{
+			DomainID:            domainID,
+			WorkflowID:          workflowID,
+			RunID:               runID,
+			VisibilityTimestamp: timestamp,
+			TaskID:              taskID,
+			TaskType:            taskType,
+			TimeoutType:         timeoutType,
+			EventID:             eventID,
+			ScheduleAttempt:     scheduleAttempt,
+		},
+	}
+	s.timerQueueStandbyProcessor.AddTimers(timers)
+	s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
+	}).Once()
+
+	timers = []*persistence.TimerTaskInfo{
+		&persistence.TimerTaskInfo{
+			DomainID:            domainID,
+			WorkflowID:          workflowID,
+			RunID:               runID,
+			VisibilityTimestamp: timestamp.Add(1 * time.Second),
+			TaskID:              taskID,
+			TaskType:            taskType,
+			TimeoutType:         timeoutType,
+			EventID:             eventID,
+			ScheduleAttempt:     scheduleAttempt,
+		},
+	}
+	s.timerQueueStandbyProcessor.AddTimers(timers)
+}
+
+func (s *timerQueueStandbyProcessorSuite) TestUserTimers() {
+	domainID := "some random domain ID"
+	workflowID := "some random workflow ID"
+	runID := "some random run ID"
+	timestamp := time.Now()
+	taskID := int64(59)
+	taskType := persistence.TaskTypeUserTimer
+	timeoutType := 0             // for activity timeout this is not used
+	eventID := int64(28)         // for activity timeout this is not used
+	scheduleAttempt := int64(12) // for activity timeout this is not used
+
+	timers := []*persistence.TimerTaskInfo{
+		&persistence.TimerTaskInfo{
+			DomainID:            domainID,
+			WorkflowID:          workflowID,
+			RunID:               runID,
+			VisibilityTimestamp: timestamp,
+			TaskID:              taskID,
+			TaskType:            taskType,
+			TimeoutType:         timeoutType,
+			EventID:             eventID,
+			ScheduleAttempt:     scheduleAttempt,
+		},
+	}
+	s.timerQueueStandbyProcessor.AddTimers(timers)
+	s.timerQueueAckMgr.On("completeTimerTask", TimerSequenceID{
+		VisibilityTimestamp: timestamp,
+		TaskID:              taskID,
+	}).Once()
+
+	timers = []*persistence.TimerTaskInfo{
+		&persistence.TimerTaskInfo{
+			DomainID:            domainID,
+			WorkflowID:          workflowID,
+			RunID:               runID,
+			VisibilityTimestamp: timestamp,
+			TaskID:              taskID + 1,
+			TaskType:            taskType,
+			TimeoutType:         timeoutType,
+			EventID:             eventID,
+			ScheduleAttempt:     scheduleAttempt,
+		},
+	}
+	s.timerQueueStandbyProcessor.AddTimers(timers)
+}


### PR DESCRIPTION
implement standby timer processor, which keeps standby timers which are fired.
rename SequenceID -> TimerSequenceID

Note:
Handling current domain become active, i.e. redirect current timers to timer queue processor is in next PR.
Handling of other domain become active is TBD, probably need to rebuild timers for workflow being active in other cluster