### PR TITLE
separate timer queue ack manager in separate file, add functionality …

### DIFF
--- a/common/cluster/metadataTestBase.go
+++ b/common/cluster/metadataTestBase.go
@@ -34,6 +34,11 @@ const (
 var (
 	// TestAllClusterNames is the all cluster names used for test
 	TestAllClusterNames = []string{TestCurrentClusterName, TestAlternativeClusterName}
+	// TestAllClusterNamesMap is the same as above, juse convinent for test mocking
+	TestAllClusterNamesMap = map[string]bool{
+		TestCurrentClusterName:     true,
+		TestAlternativeClusterName: true,
+	}
 )
 
 // GetTestClusterMetadata return an cluster metadata instance, which is initialized

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -619,7 +619,8 @@ const (
 	ScheduleToStartTimeoutCounter
 	StartToCloseTimeoutCounter
 	ScheduleToCloseTimeoutCounter
-	NewTimerCounter
+	NewActiveTimerCounter
+	NewStandbyTimerCounter
 	NewTimerNotifyCounter
 	AcquireShardsCounter
 	AcquireShardsLatency
@@ -711,7 +712,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ScheduleToStartTimeoutCounter:                {metricName: "schedule-to-start-timeout", metricType: Counter},
 		StartToCloseTimeoutCounter:                   {metricName: "start-to-close-timeout", metricType: Counter},
 		ScheduleToCloseTimeoutCounter:                {metricName: "schedule-to-close-timeout", metricType: Counter},
-		NewTimerCounter:                              {metricName: "new-timer", metricType: Counter},
+		NewActiveTimerCounter:                        {metricName: "new-active-timer", metricType: Counter},
+		NewStandbyTimerCounter:                       {metricName: "new-standby-timer", metricType: Counter},
 		NewTimerNotifyCounter:                        {metricName: "new-timer-notifications", metricType: Counter},
 		AcquireShardsCounter:                         {metricName: "acquire-shards-count", metricType: Counter},
 		AcquireShardsLatency:                         {metricName: "acquire-shards-latency", metricType: Timer},

--- a/service/history/MockTimerQueueAckMgr.go
+++ b/service/history/MockTimerQueueAckMgr.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/uber/cadence/common/persistence"
+)
+
+// MockTimerQueueAckMgr is used as mock implementation for TimerQueueAckMgr
+type MockTimerQueueAckMgr struct {
+	mock.Mock
+}
+
+// readTimerTasks is mock implementation for readTimerTasks of TimerQueueAckMgr
+func (_m *MockTimerQueueAckMgr) readTimerTasks(clusterName string) ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error) {
+	ret := _m.Called(clusterName)
+
+	var r0 []*persistence.TimerTaskInfo
+	if rf, ok := ret.Get(0).(func(string) []*persistence.TimerTaskInfo); ok {
+		r0 = rf(clusterName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*persistence.TimerTaskInfo)
+		}
+	}
+
+	var r1 *persistence.TimerTaskInfo
+	if rf, ok := ret.Get(1).(func(string) *persistence.TimerTaskInfo); ok {
+		r1 = rf(clusterName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*persistence.TimerTaskInfo)
+		}
+	}
+
+	var r2 bool
+	if rf, ok := ret.Get(2).(func(string) bool); ok {
+		r2 = rf(clusterName)
+	} else {
+		r2 = ret.Get(2).(bool)
+	}
+
+	var r3 error
+	if rf, ok := ret.Get(3).(func(string) error); ok {
+		r3 = rf(clusterName)
+	} else {
+		r3 = ret.Error(3)
+	}
+
+	return r0, r1, r2, r3
+}
+
+func (_m *MockTimerQueueAckMgr) retryTimerTask(timerTask *persistence.TimerTaskInfo) {
+	_m.Called(timerTask)
+}
+
+func (_m *MockTimerQueueAckMgr) completeTimerTask(taskID TimerSequenceID) {
+	_m.Called(taskID)
+}
+
+func (_m *MockTimerQueueAckMgr) updateAckLevel(clusterName string) {
+	_m.Called(clusterName)
+}
+
+func (_m *MockTimerQueueAckMgr) isProcessNow(expiryTime time.Time) bool {
+	ret := _m.Called(expiryTime)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(time.Time) bool); ok {
+		r0 = rf(expiryTime)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}

--- a/service/history/MockTimerQueueAckMgr.go
+++ b/service/history/MockTimerQueueAckMgr.go
@@ -33,12 +33,12 @@ type MockTimerQueueAckMgr struct {
 }
 
 // readTimerTasks is mock implementation for readTimerTasks of TimerQueueAckMgr
-func (_m *MockTimerQueueAckMgr) readTimerTasks(clusterName string) ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error) {
-	ret := _m.Called(clusterName)
+func (_m *MockTimerQueueAckMgr) readTimerTasks() ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error) {
+	ret := _m.Called()
 
 	var r0 []*persistence.TimerTaskInfo
-	if rf, ok := ret.Get(0).(func(string) []*persistence.TimerTaskInfo); ok {
-		r0 = rf(clusterName)
+	if rf, ok := ret.Get(0).(func() []*persistence.TimerTaskInfo); ok {
+		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*persistence.TimerTaskInfo)
@@ -46,8 +46,8 @@ func (_m *MockTimerQueueAckMgr) readTimerTasks(clusterName string) ([]*persisten
 	}
 
 	var r1 *persistence.TimerTaskInfo
-	if rf, ok := ret.Get(1).(func(string) *persistence.TimerTaskInfo); ok {
-		r1 = rf(clusterName)
+	if rf, ok := ret.Get(1).(func() *persistence.TimerTaskInfo); ok {
+		r1 = rf()
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*persistence.TimerTaskInfo)
@@ -55,15 +55,15 @@ func (_m *MockTimerQueueAckMgr) readTimerTasks(clusterName string) ([]*persisten
 	}
 
 	var r2 bool
-	if rf, ok := ret.Get(2).(func(string) bool); ok {
-		r2 = rf(clusterName)
+	if rf, ok := ret.Get(2).(func() bool); ok {
+		r2 = rf()
 	} else {
 		r2 = ret.Get(2).(bool)
 	}
 
 	var r3 error
-	if rf, ok := ret.Get(3).(func(string) error); ok {
-		r3 = rf(clusterName)
+	if rf, ok := ret.Get(3).(func() error); ok {
+		r3 = rf()
 	} else {
 		r3 = ret.Error(3)
 	}
@@ -79,8 +79,8 @@ func (_m *MockTimerQueueAckMgr) completeTimerTask(taskID TimerSequenceID) {
 	_m.Called(taskID)
 }
 
-func (_m *MockTimerQueueAckMgr) updateAckLevel(clusterName string) {
-	_m.Called(clusterName)
+func (_m *MockTimerQueueAckMgr) updateAckLevel() {
+	_m.Called()
 }
 
 func (_m *MockTimerQueueAckMgr) isProcessNow(expiryTime time.Time) bool {

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -149,8 +149,7 @@ func (h *Handler) Stop() {
 
 // CreateEngine is implementation for HistoryEngineFactory used for creating the engine instance for shard
 func (h *Handler) CreateEngine(context ShardContext) Engine {
-	return NewEngineWithShardContext(context, context.GetDomainCache(), h.visibilityMgr,
-		h.matchingServiceClient, h.historyServiceClient, h.historyEventNotifier, h.publisher)
+	return NewEngineWithShardContext(context, h.visibilityMgr, h.matchingServiceClient, h.historyServiceClient, h.historyEventNotifier, h.publisher)
 }
 
 // Health is for health check

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -141,9 +141,8 @@ func (s *engine2Suite) SetupTest() {
 		hSerializerFactory: persistence.NewHistorySerializerFactory(),
 	}
 
-	// setup the basics of cluster metadata, since during the initialization of * queue processor, those cluster metadata will be used
+	// this is used by shard context, not relevent to this test, so we do not care how many times "GetCurrentClusterName" os called
 	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
-	s.mockClusterMetadata.On("GetAllClusterNames").Return(cluster.TestAllClusterNamesMap)
 	h.txProcessor = newTransferQueueProcessor(mockShard, h, s.mockVisibilityMgr, s.mockMatchingClient, s.mockHistoryClient)
 	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockExecutionMgr, s.logger)
 	s.historyEngine = h

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -40,6 +40,7 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
@@ -134,12 +135,15 @@ func (s *engine2Suite) SetupTest() {
 		executionManager:   s.mockExecutionMgr,
 		historyMgr:         s.mockHistoryMgr,
 		historyCache:       historyCache,
-		domainCache:        domainCache,
 		logger:             s.logger,
 		metricsClient:      metrics.NewClient(tally.NoopScope, metrics.History),
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		hSerializerFactory: persistence.NewHistorySerializerFactory(),
 	}
+
+	// setup the basics of cluster metadata, since during the initialization of * queue processor, those cluster metadata will be used
+	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
+	s.mockClusterMetadata.On("GetAllClusterNames").Return(cluster.TestAllClusterNamesMap)
 	h.txProcessor = newTransferQueueProcessor(mockShard, h, s.mockVisibilityMgr, s.mockMatchingClient, s.mockHistoryClient)
 	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockExecutionMgr, s.logger)
 	s.historyEngine = h

--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -107,6 +107,14 @@ type (
 		NotifyNewTimers(timerTask []persistence.Task)
 	}
 
+	timerQueueAckMgr interface {
+		readTimerTasks(clusterName string) ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error)
+		retryTimerTask(timerTask *persistence.TimerTaskInfo)
+		completeTimerTask(taskID TimerSequenceID)
+		updateAckLevel(clusterName string)
+		isProcessNow(time.Time) bool
+	}
+
 	historyEventNotifier interface {
 		common.Daemon
 		NotifyNewHistoryEvent(event *historyEventNotification)

--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -108,10 +108,10 @@ type (
 	}
 
 	timerQueueAckMgr interface {
-		readTimerTasks(clusterName string) ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error)
+		readTimerTasks() ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error)
 		retryTimerTask(timerTask *persistence.TimerTaskInfo)
 		completeTimerTask(taskID TimerSequenceID)
-		updateAckLevel(clusterName string)
+		updateAckLevel()
 		isProcessNow(time.Time) bool
 	}
 

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -119,7 +119,7 @@ func (s *engineSuite) SetupTest() {
 			return len(workflowID)
 		},
 	)
-	domainCache := cache.NewDomainCache(s.mockMetadataMgr, cluster.GetTestClusterMetadata(false, false), s.logger)
+	domainCache := cache.NewDomainCache(s.mockMetadataMgr, s.mockClusterMetadata, s.logger)
 	mockShard := &shardContextImpl{
 		service:                   s.mockService,
 		shardInfo:                 &persistence.ShardInfo{ShardID: shardID, RangeID: 1, TransferAckLevel: 0},
@@ -145,13 +145,16 @@ func (s *engineSuite) SetupTest() {
 		executionManager:     s.mockExecutionMgr,
 		historyMgr:           s.mockHistoryMgr,
 		historyCache:         historyCache,
-		domainCache:          domainCache,
 		logger:               s.logger,
 		metricsClient:        metrics.NewClient(tally.NoopScope, metrics.History),
 		tokenSerializer:      common.NewJSONTaskTokenSerializer(),
 		hSerializerFactory:   persistence.NewHistorySerializerFactory(),
 		historyEventNotifier: historyEventNotifier,
 	}
+
+	// setup the basics of cluster metadata, since during the initialization of * queue processor, those cluster metadata will be used
+	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
+	s.mockClusterMetadata.On("GetAllClusterNames").Return(cluster.TestAllClusterNamesMap)
 	h.txProcessor = newTransferQueueProcessor(shardContextWrapper, h, s.mockVisibilityMgr, s.mockMatchingClient, s.mockHistoryClient)
 	h.timerProcessor = newTimerQueueProcessor(shardContextWrapper, h, s.mockExecutionMgr, s.logger)
 	h.historyEventNotifier.Start()

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -152,9 +152,8 @@ func (s *engineSuite) SetupTest() {
 		historyEventNotifier: historyEventNotifier,
 	}
 
-	// setup the basics of cluster metadata, since during the initialization of * queue processor, those cluster metadata will be used
+	// this is used by shard context, not relevent to this test, so we do not care how many times "GetCurrentClusterName" os called
 	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
-	s.mockClusterMetadata.On("GetAllClusterNames").Return(cluster.TestAllClusterNamesMap)
 	h.txProcessor = newTransferQueueProcessor(shardContextWrapper, h, s.mockVisibilityMgr, s.mockMatchingClient, s.mockHistoryClient)
 	h.timerProcessor = newTimerQueueProcessor(shardContextWrapper, h, s.mockExecutionMgr, s.logger)
 	h.historyEventNotifier.Start()

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -138,13 +138,14 @@ func (s *TestShardContext) GetTransferAckLevel() int64 {
 	s.RLock()
 	defer s.RUnlock()
 
-	// TODO change make this cluster input parameter
+	// TODO cluster should be an input parameter
 	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
-	// if can find corresponding ack level in the cluster to timer ack level map
+	// if we can find corresponding ack level
 	if ackLevel, ok := s.shardInfo.ClusterTransferAckLevel[cluster]; ok {
 		return ackLevel
 	}
 	// otherwise, default to existing ack level, which belongs to local cluster
+	// this can happen if you add more cluster
 	return s.shardInfo.TransferAckLevel
 }
 
@@ -153,7 +154,7 @@ func (s *TestShardContext) UpdateTransferAckLevel(ackLevel int64) error {
 	s.RLock()
 	defer s.RUnlock()
 
-	// TODO change make this cluster input parameter
+	// TODO cluster should be an input parameter
 	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
 	if cluster == s.GetService().GetClusterMetadata().GetCurrentClusterName() {
 		s.shardInfo.TransferAckLevel = ackLevel
@@ -178,11 +179,12 @@ func (s *TestShardContext) GetTimerAckLevel(cluster string) time.Time {
 	s.RLock()
 	defer s.RUnlock()
 
-	// if can find corresponding ack level in the cluster to timer ack level map
+	// if we can find corresponding ack level
 	if ackLevel, ok := s.shardInfo.ClusterTimerAckLevel[cluster]; ok {
 		return ackLevel
 	}
 	// otherwise, default to existing ack level, which belongs to local cluster
+	// this can happen if you add more cluster
 	return s.shardInfo.TimerAckLevel
 }
 

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -44,6 +44,22 @@ const (
 	testSchemaDir            = "../.."
 )
 
+var (
+	testDomainActiveID           = "7b3fe0f6-e98f-4960-bdb7-220d0fb3f521"
+	testDomainStandbyID          = "ede1e8a6-bdb7-e98f-4960-448b0cdef134"
+	testDomainActiveName         = "test active domain name"
+	testDomainStandbyName        = "test standby domain name"
+	testDomainRetention          = int32(10)
+	testDomainEmitMetric         = true
+	testDomainActiveClusterName  = cluster.TestCurrentClusterName
+	testDomainStandbyClusterName = cluster.TestAlternativeClusterName
+	testDomainIsGlobalDomain     = true
+	testDomainAllClusters        = []*persistence.ClusterReplicationConfig{
+		&persistence.ClusterReplicationConfig{ClusterName: testDomainActiveClusterName},
+		&persistence.ClusterReplicationConfig{ClusterName: testDomainStandbyClusterName},
+	}
+)
+
 type (
 	// TestShardContext shard context for testing.
 	TestShardContext struct {
@@ -119,12 +135,30 @@ func (s *TestShardContext) GetTransferMaxReadLevel() int64 {
 
 // GetTransferAckLevel test implementation
 func (s *TestShardContext) GetTransferAckLevel() int64 {
-	return atomic.LoadInt64(&s.shardInfo.TransferAckLevel)
+	s.RLock()
+	defer s.RUnlock()
+
+	// TODO change make this cluster input parameter
+	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
+	// if can find corresponding ack level in the cluster to timer ack level map
+	if ackLevel, ok := s.shardInfo.ClusterTransferAckLevel[cluster]; ok {
+		return ackLevel
+	}
+	// otherwise, default to existing ack level, which belongs to local cluster
+	return s.shardInfo.TransferAckLevel
 }
 
 // UpdateTransferAckLevel test implementation
 func (s *TestShardContext) UpdateTransferAckLevel(ackLevel int64) error {
-	atomic.StoreInt64(&s.shardInfo.TransferAckLevel, ackLevel)
+	s.RLock()
+	defer s.RUnlock()
+
+	// TODO change make this cluster input parameter
+	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
+	if cluster == s.GetService().GetClusterMetadata().GetCurrentClusterName() {
+		s.shardInfo.TransferAckLevel = ackLevel
+	}
+	s.shardInfo.ClusterTransferAckLevel[cluster] = ackLevel
 	return nil
 }
 
@@ -140,17 +174,27 @@ func (s *TestShardContext) UpdateReplicatorAckLevel(ackLevel int64) error {
 }
 
 // GetTimerAckLevel test implementation
-func (s *TestShardContext) GetTimerAckLevel() time.Time {
+func (s *TestShardContext) GetTimerAckLevel(cluster string) time.Time {
 	s.RLock()
-	defer s.RLock()
+	defer s.RUnlock()
+
+	// if can find corresponding ack level in the cluster to timer ack level map
+	if ackLevel, ok := s.shardInfo.ClusterTimerAckLevel[cluster]; ok {
+		return ackLevel
+	}
+	// otherwise, default to existing ack level, which belongs to local cluster
 	return s.shardInfo.TimerAckLevel
 }
 
 // UpdateTimerAckLevel test implementation
-func (s *TestShardContext) UpdateTimerAckLevel(ackLevel time.Time) error {
-	s.Lock()
-	defer s.Unlock()
-	s.shardInfo.TimerAckLevel = ackLevel
+func (s *TestShardContext) UpdateTimerAckLevel(cluster string, ackLevel time.Time) error {
+	s.RLock()
+	defer s.RUnlock()
+
+	if cluster == s.GetService().GetClusterMetadata().GetCurrentClusterName() {
+		s.shardInfo.TimerAckLevel = ackLevel
+	}
+	s.shardInfo.ClusterTimerAckLevel[cluster] = ackLevel
 	return nil
 }
 
@@ -236,4 +280,36 @@ func (s *TestBase) SetupWorkflowStore() {
 	s.ShardContext = newTestShardContext(s.ShardInfo, 0, s.HistoryMgr, s.WorkflowMgr, s.MetadataManager, clusterMetadata,
 		config, log)
 	s.TestBase.TaskIDGenerator = s.ShardContext
+}
+
+// SetupDomains setup the domains used for testing
+func (s *TestBase) SetupDomains() {
+	// create the domains which are active / standby
+	createDomainRequest := &persistence.CreateDomainRequest{
+		Info: &persistence.DomainInfo{
+			ID:     testDomainActiveID,
+			Name:   testDomainActiveName,
+			Status: persistence.DomainStatusRegistered,
+		},
+		Config: &persistence.DomainConfig{
+			Retention:  testDomainRetention,
+			EmitMetric: testDomainEmitMetric,
+		},
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: testDomainActiveClusterName,
+			Clusters:          testDomainAllClusters,
+		},
+		IsGlobalDomain: testDomainIsGlobalDomain,
+	}
+	s.MetadataManager.CreateDomain(createDomainRequest)
+	createDomainRequest.Info.ID = testDomainStandbyID
+	createDomainRequest.Info.Name = testDomainStandbyName
+	createDomainRequest.ReplicationConfig.ActiveClusterName = testDomainStandbyClusterName
+	s.MetadataManager.CreateDomain(createDomainRequest)
+}
+
+// TeardownDomains delete the domains used for testing
+func (s *TestBase) TeardownDomains() {
+	s.MetadataManager.DeleteDomain(&persistence.DeleteDomainRequest{ID: testDomainActiveID})
+	s.MetadataManager.DeleteDomain(&persistence.DeleteDomainRequest{ID: testDomainStandbyID})
 }

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -115,13 +115,14 @@ func (s *shardContextImpl) GetTransferAckLevel() int64 {
 	s.RLock()
 	defer s.RUnlock()
 
-	// TODO change make this cluster input parameter
+	// TODO cluster should be an input parameter
 	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
-	// if can find corresponding ack level in the cluster to timer ack level map
+	// if we can find corresponding ack level
 	if ackLevel, ok := s.shardInfo.ClusterTransferAckLevel[cluster]; ok {
 		return ackLevel
 	}
 	// otherwise, default to existing ack level, which belongs to local cluster
+	// this can happen if you add more cluster
 	return s.shardInfo.TransferAckLevel
 }
 
@@ -135,7 +136,7 @@ func (s *shardContextImpl) UpdateTransferAckLevel(ackLevel int64) error {
 	s.Lock()
 	defer s.Unlock()
 
-	// TODO change make this cluster input parameter
+	// TODO cluster should be an input parameter
 	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
 	if cluster == s.GetService().GetClusterMetadata().GetCurrentClusterName() {
 		s.shardInfo.TransferAckLevel = ackLevel
@@ -164,11 +165,12 @@ func (s *shardContextImpl) GetTimerAckLevel(cluster string) time.Time {
 	s.RLock()
 	defer s.RUnlock()
 
-	// if can find corresponding ack level in the cluster to timer ack level map
+	// if we can find corresponding ack level
 	if ackLevel, ok := s.shardInfo.ClusterTimerAckLevel[cluster]; ok {
 		return ackLevel
 	}
 	// otherwise, default to existing ack level, which belongs to local cluster
+	// this can happen if you add more cluster
 	return s.shardInfo.TimerAckLevel
 }
 

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -59,8 +59,8 @@ type (
 		GetConfig() *Config
 		GetLogger() bark.Logger
 		GetMetricsClient() metrics.Client
-		GetTimerAckLevel() time.Time
-		UpdateTimerAckLevel(ackLevel time.Time) error
+		GetTimerAckLevel(cluster string) time.Time
+		UpdateTimerAckLevel(cluster string, ackLevel time.Time) error
 		GetTimeSource() common.TimeSource
 	}
 
@@ -115,6 +115,13 @@ func (s *shardContextImpl) GetTransferAckLevel() int64 {
 	s.RLock()
 	defer s.RUnlock()
 
+	// TODO change make this cluster input parameter
+	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
+	// if can find corresponding ack level in the cluster to timer ack level map
+	if ackLevel, ok := s.shardInfo.ClusterTransferAckLevel[cluster]; ok {
+		return ackLevel
+	}
+	// otherwise, default to existing ack level, which belongs to local cluster
 	return s.shardInfo.TransferAckLevel
 }
 
@@ -127,7 +134,13 @@ func (s *shardContextImpl) GetTransferMaxReadLevel() int64 {
 func (s *shardContextImpl) UpdateTransferAckLevel(ackLevel int64) error {
 	s.Lock()
 	defer s.Unlock()
-	s.shardInfo.TransferAckLevel = ackLevel
+
+	// TODO change make this cluster input parameter
+	cluster := s.GetService().GetClusterMetadata().GetCurrentClusterName()
+	if cluster == s.GetService().GetClusterMetadata().GetCurrentClusterName() {
+		s.shardInfo.TransferAckLevel = ackLevel
+	}
+	s.shardInfo.ClusterTransferAckLevel[cluster] = ackLevel
 	s.shardInfo.StolenSinceRenew = 0
 	return s.updateShardInfoLocked()
 }
@@ -147,17 +160,26 @@ func (s *shardContextImpl) UpdateReplicatorAckLevel(ackLevel int64) error {
 	return s.updateShardInfoLocked()
 }
 
-func (s *shardContextImpl) GetTimerAckLevel() time.Time {
+func (s *shardContextImpl) GetTimerAckLevel(cluster string) time.Time {
 	s.RLock()
 	defer s.RUnlock()
+
+	// if can find corresponding ack level in the cluster to timer ack level map
+	if ackLevel, ok := s.shardInfo.ClusterTimerAckLevel[cluster]; ok {
+		return ackLevel
+	}
+	// otherwise, default to existing ack level, which belongs to local cluster
 	return s.shardInfo.TimerAckLevel
 }
 
-func (s *shardContextImpl) UpdateTimerAckLevel(ackLevel time.Time) error {
+func (s *shardContextImpl) UpdateTimerAckLevel(cluster string, ackLevel time.Time) error {
 	s.Lock()
 	defer s.Unlock()
 
-	s.shardInfo.TimerAckLevel = ackLevel
+	if cluster == s.GetService().GetClusterMetadata().GetCurrentClusterName() {
+		s.shardInfo.TimerAckLevel = ackLevel
+	}
+	s.shardInfo.ClusterTimerAckLevel[cluster] = ackLevel
 	s.shardInfo.StolenSinceRenew = 0
 	return s.updateShardInfoLocked()
 }
@@ -537,13 +559,24 @@ func acquireShard(shardID int, svc service.Service, shardManager persistence.Sha
 }
 
 func copyShardInfo(shardInfo *persistence.ShardInfo) *persistence.ShardInfo {
+	clusterTransferAckLevel := make(map[string]int64)
+	for k, v := range shardInfo.ClusterTransferAckLevel {
+		clusterTransferAckLevel[k] = v
+	}
+	clusterTimerAckLevel := make(map[string]time.Time)
+	for k, v := range shardInfo.ClusterTimerAckLevel {
+		clusterTimerAckLevel[k] = v
+	}
 	shardInfoCopy := &persistence.ShardInfo{
-		ShardID:          shardInfo.ShardID,
-		Owner:            shardInfo.Owner,
-		RangeID:          shardInfo.RangeID,
-		StolenSinceRenew: shardInfo.StolenSinceRenew,
-		TransferAckLevel: atomic.LoadInt64(&shardInfo.TransferAckLevel),
-		TimerAckLevel:    shardInfo.TimerAckLevel,
+		ShardID:                 shardInfo.ShardID,
+		Owner:                   shardInfo.Owner,
+		RangeID:                 shardInfo.RangeID,
+		StolenSinceRenew:        shardInfo.StolenSinceRenew,
+		ReplicationAckLevel:     shardInfo.ReplicationAckLevel,
+		TransferAckLevel:        atomic.LoadInt64(&shardInfo.TransferAckLevel), // TODO the meaning of atomic load is unclear
+		TimerAckLevel:           shardInfo.TimerAckLevel,
+		ClusterTransferAckLevel: clusterTransferAckLevel,
+		ClusterTimerAckLevel:    clusterTimerAckLevel,
 	}
 
 	return shardInfoCopy

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -88,7 +88,7 @@ type (
 func newShardController(svc service.Service, host *membership.HostInfo, resolver membership.ServiceResolver,
 	shardMgr persistence.ShardManager, historyMgr persistence.HistoryManager, metadataMgr persistence.MetadataManager,
 	executionMgrFactory persistence.ExecutionManagerFactory, factory EngineFactory,
-	config *Config, logger bark.Logger, reporter metrics.Client) *shardController {
+	config *Config, logger bark.Logger, metricsClient metrics.Client) *shardController {
 	logger = logger.WithFields(bark.Fields{
 		logging.TagWorkflowComponent: logging.TagValueShardController,
 	})
@@ -108,7 +108,7 @@ func newShardController(svc service.Service, host *membership.HostInfo, resolver
 		shutdownCh:          make(chan struct{}),
 		logger:              logger,
 		config:              config,
-		metricsClient:       reporter,
+		metricsClient:       metricsClient,
 	}
 }
 

--- a/service/history/timerBuilder_test.go
+++ b/service/history/timerBuilder_test.go
@@ -220,6 +220,6 @@ func (s *timerBuilderProcessorSuite) TestDecodeHistory() {
 }
 
 func (s *timerBuilderProcessorSuite) TestDecodeKey() {
-	taskID := SequenceID{VisibilityTimestamp: time.Unix(0, 0), TaskID: 1}
-	s.logger.Infof("Timer: %s, expiry: %v", SequenceID(taskID), taskID.VisibilityTimestamp)
+	taskID := TimerSequenceID{VisibilityTimestamp: time.Unix(0, 0), TaskID: 1}
+	s.logger.Infof("Timer: %s, expiry: %v", TimerSequenceID(taskID), taskID.VisibilityTimestamp)
 }

--- a/service/history/timerQueueAckMgr.go
+++ b/service/history/timerQueueAckMgr.go
@@ -1,0 +1,306 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"math"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/uber-common/bark"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+)
+
+var (
+	timerQueueAckMgrMaxTimestamp = time.Unix(0, math.MaxInt64)
+)
+
+type (
+	timerSequenceIDs []TimerSequenceID
+
+	timerQueueAckMgrImpl struct {
+		shard         ShardContext
+		executionMgr  persistence.ExecutionManager
+		logger        bark.Logger
+		metricsClient metrics.Client
+		lastUpdated   time.Time
+		config        *Config
+
+		sync.Mutex
+		// outstanding tasks, key cluster name, value map of outstanding timer task -> finished (true)
+		clusterOutstandingTasks map[string]map[TimerSequenceID]bool
+		// outstanding tasks, which cannot be processed right now
+		clusterRetryTasks map[string][]*persistence.TimerTaskInfo
+		// cluster -> task read level
+		clusterReadLevel map[string]TimerSequenceID
+		// cluster -> task ack level
+		clusterAckLevel map[string]time.Time
+		// task -> corresponding cluster name
+		taskToCluster map[TimerSequenceID]string
+	}
+	// for each cluster, the ack level is the point in time when
+	// all timers before the ack level are processed.
+	// for each cluster, the read level is the point in time when
+	// all timers from ack level to read level are loaded in memory.
+
+	// TODO this processing logic potentially has bug, refer to #605, #608
+)
+
+// Len implements sort.Interace
+func (t timerSequenceIDs) Len() int {
+	return len(t)
+}
+
+// Swap implements sort.Interface.
+func (t timerSequenceIDs) Swap(i, j int) {
+	t[i], t[j] = t[j], t[i]
+}
+
+// Less implements sort.Interface
+func (t timerSequenceIDs) Less(i, j int) bool {
+	return compareTimerIDLess(&t[i], &t[j])
+}
+
+func newTimerQueueAckMgr(shard ShardContext, metricsClient metrics.Client, executionMgr persistence.ExecutionManager, logger bark.Logger) *timerQueueAckMgrImpl {
+	config := shard.GetConfig()
+	timerQueueAckMgrImpl := &timerQueueAckMgrImpl{
+		shard:                   shard,
+		executionMgr:            executionMgr,
+		metricsClient:           metricsClient,
+		logger:                  logger,
+		lastUpdated:             time.Now(),
+		config:                  config,
+		clusterOutstandingTasks: make(map[string]map[TimerSequenceID]bool),
+		clusterRetryTasks:       make(map[string][]*persistence.TimerTaskInfo),
+		clusterReadLevel:        make(map[string]TimerSequenceID),
+		clusterAckLevel:         make(map[string]time.Time),
+		taskToCluster:           make(map[TimerSequenceID]string),
+	}
+	// initialize all cluster read level to initial ack level, provided by shard
+	for cluster := range timerQueueAckMgrImpl.shard.GetService().GetClusterMetadata().GetAllClusterNames() {
+		ackLevel := shard.GetTimerAckLevel(cluster)
+		timerQueueAckMgrImpl.clusterOutstandingTasks[cluster] = make(map[TimerSequenceID]bool)
+		timerQueueAckMgrImpl.clusterRetryTasks[cluster] = []*persistence.TimerTaskInfo{}
+		timerQueueAckMgrImpl.clusterReadLevel[cluster] = TimerSequenceID{VisibilityTimestamp: ackLevel}
+		timerQueueAckMgrImpl.clusterAckLevel[cluster] = ackLevel
+	}
+
+	return timerQueueAckMgrImpl
+}
+
+func (t *timerQueueAckMgrImpl) readTimerTasks(clusterName string) ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error) {
+	t.Lock()
+	readLevel, ok := t.clusterReadLevel[clusterName]
+	if !ok {
+		t.panicUnknownCluster(clusterName)
+	}
+	timerTaskRetrySize := len(t.clusterRetryTasks[clusterName])
+	t.Unlock()
+
+	var tasks []*persistence.TimerTaskInfo
+	morePage := timerTaskRetrySize > 0
+	var err error
+	if timerTaskRetrySize < t.config.TimerTaskBatchSize {
+		var token []byte
+		tasks, token, err = t.getTimerTasks(readLevel.VisibilityTimestamp, timerQueueAckMgrMaxTimestamp, t.config.TimerTaskBatchSize)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		t.logger.Debugf("readTimerTasks: ReadLevel: (%s) count: %v, next token: %v", readLevel, len(tasks), token)
+		morePage = len(token) > 0
+	}
+
+	// We filter tasks so read only moves to desired timer tasks.
+	// We also get a look ahead task but it doesn't move the read level, this is for timer
+	// to wait on it instead of doing queries.
+
+	var lookAheadTask *persistence.TimerTaskInfo
+	t.Lock()
+	defer t.Unlock()
+	// fillin the retry task
+	filteredTasks := t.clusterRetryTasks[clusterName]
+	t.clusterRetryTasks[clusterName] = []*persistence.TimerTaskInfo{}
+
+	// since we have already checked that the clusterName is a valid key of clusterReadLevel
+	// there shall be no validation
+	readLevel = t.clusterReadLevel[clusterName]
+	outstandingTasks := t.clusterOutstandingTasks[clusterName]
+TaskFilterLoop:
+	for _, task := range tasks {
+		timerSequenceID := TimerSequenceID{VisibilityTimestamp: task.VisibilityTimestamp, TaskID: task.TaskID}
+		_, isLoaded := t.taskToCluster[timerSequenceID]
+		if isLoaded {
+			// timer already loaded
+			t.logger.Infof("Skipping task: %v. WorkflowID: %v, RunID: %v, Type: %v",
+				timerSequenceID.String(), task.WorkflowID, task.RunID, task.TaskType)
+			continue TaskFilterLoop
+		}
+
+		domainEntry, err := t.shard.GetDomainCache().GetDomainByID(task.DomainID)
+		if err != nil {
+			return nil, nil, false, err
+		}
+		if domainEntry.GetReplicationConfig().ActiveClusterName != clusterName {
+			// timer task does not belong to cluster name
+			continue TaskFilterLoop
+		}
+
+		// TODO potential bug here
+		// there can be several case when this readTimerTasks is called multiple times
+		// and one of the call is really slow, causing the read level updated by other threads,
+		// leading the if below to be true
+		if task.VisibilityTimestamp.Before(readLevel.VisibilityTimestamp) {
+			t.logger.Fatalf(
+				"Next timer task time stamp is less than current timer task read level. timer task: (%s), ReadLevel: (%s)",
+				timerSequenceID, readLevel)
+		}
+
+		if !t.isProcessNow(task.VisibilityTimestamp) {
+			lookAheadTask = task
+			break TaskFilterLoop
+		}
+
+		t.logger.Debugf("Moving timer read level: (%s)", timerSequenceID)
+		readLevel = timerSequenceID
+		t.taskToCluster[timerSequenceID] = clusterName
+		outstandingTasks[timerSequenceID] = false
+		filteredTasks = append(filteredTasks, task)
+	}
+	t.clusterReadLevel[clusterName] = readLevel
+
+	// We may have large number of timers which need to be fired immediately.  Return true in such case so the pump
+	// can call back immediately to retrieve more tasks
+	moreTasks := lookAheadTask == nil && morePage
+
+	return filteredTasks, lookAheadTask, moreTasks, nil
+}
+
+func (t *timerQueueAckMgrImpl) retryTimerTask(timerTask *persistence.TimerTaskInfo) {
+	timerSequenceID := TimerSequenceID{VisibilityTimestamp: timerTask.VisibilityTimestamp, TaskID: timerTask.TaskID}
+	t.Lock()
+	defer t.Unlock()
+	clusterName, ok := t.taskToCluster[timerSequenceID]
+	if !ok {
+		t.panicMissingTaskMetadata(timerSequenceID)
+	}
+
+	t.clusterRetryTasks[clusterName] = append(t.clusterRetryTasks[clusterName], timerTask)
+}
+
+func (t *timerQueueAckMgrImpl) completeTimerTask(timerSequenceID TimerSequenceID) {
+	t.Lock()
+	defer t.Unlock()
+	clusterName, ok := t.taskToCluster[timerSequenceID]
+	if !ok {
+		t.panicMissingTaskMetadata(timerSequenceID)
+	}
+
+	outstandingTasks, ok := t.clusterOutstandingTasks[clusterName]
+	if !ok {
+		t.panicUnknownCluster(clusterName)
+	}
+	outstandingTasks[timerSequenceID] = true
+}
+
+func (t *timerQueueAckMgrImpl) updateAckLevel(clusterName string) {
+	t.metricsClient.IncCounter(metrics.TimerQueueProcessorScope, metrics.AckLevelUpdateCounter)
+
+	t.Lock()
+	ackLevel, ok := t.clusterAckLevel[clusterName]
+	if !ok {
+		t.panicUnknownCluster(clusterName)
+	}
+	outstandingTasks := t.clusterOutstandingTasks[clusterName]
+	initialAckLevel := ackLevel
+	updatedAckLevel := ackLevel
+
+	// Timer Sequence IDs can have holes in the middle. So we sort the map to get the order to
+	// check. TODO: we can maintain a sorted slice as well.
+	var sequenceIDs timerSequenceIDs
+	for k := range outstandingTasks {
+		sequenceIDs = append(sequenceIDs, k)
+	}
+	sort.Sort(sequenceIDs)
+
+MoveAckLevelLoop:
+	for _, current := range sequenceIDs {
+		acked := outstandingTasks[current]
+		if acked {
+			updatedAckLevel = current.VisibilityTimestamp
+			delete(t.taskToCluster, current)
+			delete(outstandingTasks, current)
+		} else {
+			break MoveAckLevelLoop
+		}
+	}
+	t.clusterAckLevel[clusterName] = updatedAckLevel
+	t.Unlock()
+
+	// Do not update Acklevel if nothing changed upto force update interval
+	if initialAckLevel == updatedAckLevel && time.Since(t.lastUpdated) < t.config.TimerProcessorForceUpdateInterval {
+		return
+	}
+
+	t.logger.Debugf("Updating timer ack level: %v", updatedAckLevel)
+
+	// Always update ackLevel to detect if the shared is stolen
+	if err := t.shard.UpdateTimerAckLevel(clusterName, updatedAckLevel); err != nil {
+		t.metricsClient.IncCounter(metrics.TimerQueueProcessorScope, metrics.AckLevelUpdateFailedCounter)
+		t.logger.Errorf("Error updating timer ack level for shard: %v", err)
+	} else {
+		t.lastUpdated = time.Now()
+	}
+}
+
+// this function does not take cluster name as parameter, due to we only have one timer queue on Cassandra
+// all timer tasks are in this queue and filter will be applied.
+func (t *timerQueueAckMgrImpl) getTimerTasks(minTimestamp time.Time, maxTimestamp time.Time, batchSize int) ([]*persistence.TimerTaskInfo, []byte, error) {
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: minTimestamp,
+		MaxTimestamp: maxTimestamp,
+		BatchSize:    batchSize,
+	}
+
+	retryCount := t.config.TimerProcessorGetFailureRetryCount
+	for attempt := 0; attempt < retryCount; attempt++ {
+		response, err := t.executionMgr.GetTimerIndexTasks(request)
+		if err == nil {
+			return response.Timers, response.NextPageToken, nil
+		}
+		backoff := time.Duration(attempt * 100)
+		time.Sleep(backoff * time.Millisecond)
+	}
+	return nil, nil, ErrMaxAttemptsExceeded
+}
+
+func (t *timerQueueAckMgrImpl) isProcessNow(expiryTime time.Time) bool {
+	return !expiryTime.IsZero() && expiryTime.UnixNano() <= time.Now().UnixNano()
+}
+
+func (t *timerQueueAckMgrImpl) panicMissingTaskMetadata(timerSequenceID TimerSequenceID) {
+	t.logger.Fatalf("Cannot find information about timer sequence ID: %v.", timerSequenceID)
+}
+
+func (t *timerQueueAckMgrImpl) panicUnknownCluster(clusterName string) {
+	t.logger.Fatalf("Cannot find target cluster: %v, all known clusters %v.", clusterName, t.shard.GetService().GetClusterMetadata().GetAllClusterNames())
+}

--- a/service/history/timerQueueAckMgr_test.go
+++ b/service/history/timerQueueAckMgr_test.go
@@ -1,0 +1,524 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-common/bark"
+	"github.com/uber-go/tally"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/messaging"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/mocks"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/service/dynamicconfig"
+)
+
+type (
+	timerQueueAckMgrSuite struct {
+		suite.Suite
+
+		mockExecutionMgr    *mocks.ExecutionManager
+		mockShardMgr        *mocks.ShardManager
+		mockMetadataMgr     *mocks.MetadataManager
+		mockHistoryMgr      *mocks.HistoryManager
+		mockShard           ShardContext
+		mockService         service.Service
+		mockMessagingClient messaging.Client
+		mockProducer        *mocks.KafkaProducer
+		mockClusterMetadata *mocks.ClusterMetadata
+		metricsClient       metrics.Client
+		logger              bark.Logger
+		timerQueueAckMgr    *timerQueueAckMgrImpl
+	}
+)
+
+func TestTimerQueueAckMgrSuite(t *testing.T) {
+	s := new(timerQueueAckMgrSuite)
+	suite.Run(t, s)
+}
+
+func (s *timerQueueAckMgrSuite) SetupSuite() {
+	if testing.Verbose() {
+		log.SetOutput(os.Stdout)
+	}
+
+}
+
+func (s *timerQueueAckMgrSuite) TearDownSuite() {
+
+}
+
+func (s *timerQueueAckMgrSuite) SetupTest() {
+	s.mockExecutionMgr = &mocks.ExecutionManager{}
+	s.mockShardMgr = &mocks.ShardManager{}
+	s.mockMetadataMgr = &mocks.MetadataManager{}
+	s.mockHistoryMgr = &mocks.HistoryManager{}
+	s.logger = bark.NewLoggerFromLogrus(log.New())
+	s.metricsClient = metrics.NewClient(tally.NoopScope, metrics.History)
+	s.mockClusterMetadata = &mocks.ClusterMetadata{}
+	s.mockProducer = &mocks.KafkaProducer{}
+	s.mockMessagingClient = mocks.NewMockMessagingClient(s.mockProducer, nil)
+	s.mockService = service.NewTestService(s.mockClusterMetadata, s.mockMessagingClient, s.metricsClient, s.logger)
+	s.mockShard = &shardContextImpl{
+		service:                   s.mockService,
+		shardInfo:                 copyShardInfo(&persistence.ShardInfo{ShardID: 0, RangeID: 1}),
+		transferSequenceNumber:    1,
+		executionManager:          s.mockExecutionMgr,
+		shardManager:              s.mockShardMgr,
+		historyMgr:                s.mockHistoryMgr,
+		maxTransferSequenceNumber: 100000,
+		closeCh:                   make(chan int, 100),
+		config:                    NewConfig(dynamicconfig.NewNopCollection(), 1),
+		logger:                    s.logger,
+		domainCache:               cache.NewDomainCache(s.mockMetadataMgr, s.mockClusterMetadata, s.logger),
+		metricsClient:             s.metricsClient,
+	}
+	// setup the basics of cluster metadata, since during the initialization of * queue processor, those cluster metadata will be used
+	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
+	s.mockClusterMetadata.On("GetAllClusterNames").Return(cluster.TestAllClusterNamesMap)
+	s.timerQueueAckMgr = newTimerQueueAckMgr(s.mockShard, s.metricsClient, s.mockExecutionMgr, s.logger)
+}
+
+func (s *timerQueueAckMgrSuite) TearDownTest() {
+
+}
+
+func (s *timerQueueAckMgrSuite) TestIsProcessNow() {
+	timeBefore := time.Now().Add(-10 * time.Second)
+	s.True(s.timerQueueAckMgr.isProcessNow(timeBefore))
+
+	timeAfter := time.Now().Add(10 * time.Second)
+	s.False(s.timerQueueAckMgr.isProcessNow(timeAfter))
+}
+
+func (s *timerQueueAckMgrSuite) TestGetTimerTasks() {
+	minTimestamp := time.Now().Add(-10 * time.Second)
+	maxTimestamp := time.Now().Add(10 * time.Second)
+	batchSize := 10
+
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: minTimestamp,
+		MaxTimestamp: maxTimestamp,
+		BatchSize:    batchSize,
+	}
+
+	response := &persistence.GetTimerIndexTasksResponse{
+		Timers: []*persistence.TimerTaskInfo{
+			&persistence.TimerTaskInfo{
+				DomainID:            "some random domain ID",
+				WorkflowID:          "some random workflow ID",
+				RunID:               "some random run ID",
+				VisibilityTimestamp: time.Now().Add(-5 * time.Second),
+				TaskID:              int64(59),
+				TaskType:            1,
+				TimeoutType:         2,
+				EventID:             int64(28),
+				ScheduleAttempt:     0,
+			},
+		},
+		NextPageToken: []byte("some random next page token"),
+	}
+
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+
+	timers, token, err := s.timerQueueAckMgr.getTimerTasks(minTimestamp, maxTimestamp, batchSize)
+	s.Nil(err)
+	s.Equal(response.Timers, timers)
+	s.Equal(response.NextPageToken, token)
+}
+
+func (s *timerQueueAckMgrSuite) TestReadTimerTasks_NoLookAhead_NoNextPage() {
+	clusterName := cluster.TestCurrentClusterName
+	domainID := "some random domain ID"
+	ackLevel := s.timerQueueAckMgr.clusterAckLevel[clusterName]
+	readLevel := s.timerQueueAckMgr.clusterReadLevel[clusterName]
+
+	// test ack && read level is initialized correctly
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), ackLevel)
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), readLevel.VisibilityTimestamp)
+
+	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
+		// only thing used is the replication config
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: clusterName,
+			// Clusters attr is not used.
+		},
+	}, nil).Once()
+
+	timer := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: time.Now().Add(-5 * time.Second),
+		TaskID:              int64(59),
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(28),
+		ScheduleAttempt:     0,
+	}
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: readLevel.VisibilityTimestamp,
+		MaxTimestamp: timerQueueAckMgrMaxTimestamp,
+		BatchSize:    s.mockShard.GetConfig().TimerTaskBatchSize,
+	}
+	response := &persistence.GetTimerIndexTasksResponse{
+		Timers:        []*persistence.TimerTaskInfo{timer},
+		NextPageToken: nil,
+	}
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueAckMgr.readTimerTasks(clusterName)
+	s.Nil(err)
+	s.Equal([]*persistence.TimerTaskInfo{timer}, filteredTasks)
+	s.Nil(lookAheadTask)
+	s.False(moreTasks)
+	timerSequenceID := TimerSequenceID{VisibilityTimestamp: timer.VisibilityTimestamp, TaskID: timer.TaskID}
+	s.Equal(map[TimerSequenceID]bool{timerSequenceID: false}, s.timerQueueAckMgr.clusterOutstandingTasks[clusterName])
+	s.Equal(timerSequenceID, s.timerQueueAckMgr.clusterReadLevel[clusterName])
+	s.Equal(ackLevel, s.timerQueueAckMgr.clusterAckLevel[clusterName])
+	s.Equal(map[TimerSequenceID]string{timerSequenceID: clusterName}, s.timerQueueAckMgr.taskToCluster)
+}
+
+func (s *timerQueueAckMgrSuite) TestReadTimerTasks_NoLookAhead_HasNextPage() {
+	clusterName := cluster.TestCurrentClusterName
+	domainID := "some random domain ID"
+	ackLevel := s.timerQueueAckMgr.clusterAckLevel[clusterName]
+	readLevel := s.timerQueueAckMgr.clusterReadLevel[clusterName]
+
+	// test ack && read level is initialized correctly
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), ackLevel)
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), readLevel.VisibilityTimestamp)
+
+	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
+		// only thing used is the replication config
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: clusterName,
+			// Clusters attr is not used.
+		},
+	}, nil).Once()
+
+	timer := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: time.Now().Add(-5 * time.Second),
+		TaskID:              int64(59),
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(28),
+		ScheduleAttempt:     0,
+	}
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: readLevel.VisibilityTimestamp,
+		MaxTimestamp: timerQueueAckMgrMaxTimestamp,
+		BatchSize:    s.mockShard.GetConfig().TimerTaskBatchSize,
+	}
+	response := &persistence.GetTimerIndexTasksResponse{
+		Timers:        []*persistence.TimerTaskInfo{timer},
+		NextPageToken: []byte("some random next page token"),
+	}
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueAckMgr.readTimerTasks(clusterName)
+	s.Nil(err)
+	s.Equal([]*persistence.TimerTaskInfo{timer}, filteredTasks)
+	s.Nil(lookAheadTask)
+	s.True(moreTasks)
+	timerSequenceID := TimerSequenceID{VisibilityTimestamp: timer.VisibilityTimestamp, TaskID: timer.TaskID}
+	s.Equal(map[TimerSequenceID]bool{timerSequenceID: false}, s.timerQueueAckMgr.clusterOutstandingTasks[clusterName])
+	s.Equal(timerSequenceID, s.timerQueueAckMgr.clusterReadLevel[clusterName])
+	s.Equal(ackLevel, s.timerQueueAckMgr.clusterAckLevel[clusterName])
+	s.Equal(map[TimerSequenceID]string{timerSequenceID: clusterName}, s.timerQueueAckMgr.taskToCluster)
+}
+
+func (s *timerQueueAckMgrSuite) TestReadTimerTasks_HasLookAhead_NoNextPage() {
+	clusterName := cluster.TestCurrentClusterName
+	domainID := "some random domain ID"
+	ackLevel := s.timerQueueAckMgr.clusterAckLevel[clusterName]
+	readLevel := s.timerQueueAckMgr.clusterReadLevel[clusterName]
+
+	// test ack && read level is initialized correctly
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), ackLevel)
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), readLevel.VisibilityTimestamp)
+
+	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
+		// only thing used is the replication config
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: clusterName,
+			// Clusters attr is not used.
+		},
+	}, nil).Once()
+
+	timer := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: time.Now().Add(5 * time.Second),
+		TaskID:              int64(59),
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(28),
+		ScheduleAttempt:     0,
+	}
+
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: readLevel.VisibilityTimestamp,
+		MaxTimestamp: timerQueueAckMgrMaxTimestamp,
+		BatchSize:    s.mockShard.GetConfig().TimerTaskBatchSize,
+	}
+	response := &persistence.GetTimerIndexTasksResponse{
+		Timers:        []*persistence.TimerTaskInfo{timer},
+		NextPageToken: nil,
+	}
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueAckMgr.readTimerTasks(clusterName)
+	s.Nil(err)
+	s.Equal([]*persistence.TimerTaskInfo{}, filteredTasks)
+	s.Equal(timer, lookAheadTask)
+	s.False(moreTasks)
+
+	s.Equal(map[TimerSequenceID]bool{}, s.timerQueueAckMgr.clusterOutstandingTasks[clusterName])
+	s.Equal(readLevel, s.timerQueueAckMgr.clusterReadLevel[clusterName])
+	s.Equal(ackLevel, s.timerQueueAckMgr.clusterAckLevel[clusterName])
+	s.Equal(map[TimerSequenceID]string{}, s.timerQueueAckMgr.taskToCluster)
+}
+
+func (s *timerQueueAckMgrSuite) TestReadTimerTasks_HasLookAhead_HasNextPage() {
+	clusterName := cluster.TestCurrentClusterName
+	domainID := "some random domain ID"
+	ackLevel := s.timerQueueAckMgr.clusterAckLevel[clusterName]
+	readLevel := s.timerQueueAckMgr.clusterReadLevel[clusterName]
+
+	// test ack && read level is initialized correctly
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), ackLevel)
+	s.Equal(s.mockShard.GetTimerAckLevel(clusterName), readLevel.VisibilityTimestamp)
+
+	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
+		// only thing used is the replication config
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: clusterName,
+			// Clusters attr is not used.
+		},
+	}, nil).Once()
+
+	timer := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: time.Now().Add(5 * time.Second),
+		TaskID:              int64(59),
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(28),
+		ScheduleAttempt:     0,
+	}
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: readLevel.VisibilityTimestamp,
+		MaxTimestamp: timerQueueAckMgrMaxTimestamp,
+		BatchSize:    s.mockShard.GetConfig().TimerTaskBatchSize,
+	}
+	response := &persistence.GetTimerIndexTasksResponse{
+		Timers:        []*persistence.TimerTaskInfo{timer},
+		NextPageToken: []byte("some random next page token"),
+	}
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueAckMgr.readTimerTasks(clusterName)
+	s.Nil(err)
+	s.Equal([]*persistence.TimerTaskInfo{}, filteredTasks)
+	s.Equal(timer, lookAheadTask)
+	s.False(moreTasks)
+
+	s.Equal(map[TimerSequenceID]bool{}, s.timerQueueAckMgr.clusterOutstandingTasks[clusterName])
+	s.Equal(readLevel, s.timerQueueAckMgr.clusterReadLevel[clusterName])
+	s.Equal(ackLevel, s.timerQueueAckMgr.clusterAckLevel[clusterName])
+	s.Equal(map[TimerSequenceID]string{}, s.timerQueueAckMgr.taskToCluster)
+}
+
+func (s *timerQueueAckMgrSuite) TestReadCompleteUpdateTimerTasks() {
+	clusterName := cluster.TestCurrentClusterName
+	domainID := "some random domain ID"
+	readLevel := s.timerQueueAckMgr.clusterReadLevel[clusterName]
+
+	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
+		// only thing used is the replication config
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: clusterName,
+			// Clusters attr is not used.
+		},
+	}, nil).Once()
+
+	// create 3 timers, timer1 < timer2 < timer3 < now
+	timer1 := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: time.Now().Add(-5 * time.Second),
+		TaskID:              int64(59),
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(28),
+		ScheduleAttempt:     0,
+	}
+	timer2 := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: timer1.VisibilityTimestamp,
+		TaskID:              timer1.TaskID + 1,
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(29),
+		ScheduleAttempt:     0,
+	}
+	timer3 := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: timer1.VisibilityTimestamp.Add(1 * time.Second),
+		TaskID:              timer2.TaskID + 1,
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(30),
+		ScheduleAttempt:     0,
+	}
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: readLevel.VisibilityTimestamp,
+		MaxTimestamp: timerQueueAckMgrMaxTimestamp,
+		BatchSize:    s.mockShard.GetConfig().TimerTaskBatchSize,
+	}
+	response := &persistence.GetTimerIndexTasksResponse{
+		Timers:        []*persistence.TimerTaskInfo{timer1, timer2, timer3},
+		NextPageToken: nil,
+	}
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueAckMgr.readTimerTasks(clusterName)
+	s.Nil(err)
+	s.Equal([]*persistence.TimerTaskInfo{timer1, timer2, timer3}, filteredTasks)
+	s.Nil(lookAheadTask)
+	s.False(moreTasks)
+
+	// we are not testing shard context
+	s.mockShardMgr.On("UpdateShard", mock.Anything).Return(nil).Once()
+	timerSequenceID1 := TimerSequenceID{VisibilityTimestamp: timer1.VisibilityTimestamp, TaskID: timer1.TaskID}
+	s.timerQueueAckMgr.completeTimerTask(timerSequenceID1)
+	s.True(s.timerQueueAckMgr.clusterOutstandingTasks[clusterName][timerSequenceID1])
+	s.timerQueueAckMgr.updateAckLevel(clusterName)
+	s.Equal(timer1.VisibilityTimestamp, s.mockShard.GetTimerAckLevel(clusterName))
+
+	// there will be no call to update shard
+	timerSequenceID3 := TimerSequenceID{VisibilityTimestamp: timer3.VisibilityTimestamp, TaskID: timer3.TaskID}
+	s.timerQueueAckMgr.completeTimerTask(timerSequenceID3)
+	s.True(s.timerQueueAckMgr.clusterOutstandingTasks[clusterName][timerSequenceID3])
+	s.timerQueueAckMgr.updateAckLevel(clusterName)
+	// ack level remains unchanged
+	s.Equal(timer1.VisibilityTimestamp, s.mockShard.GetTimerAckLevel(clusterName))
+
+	// we are not testing shard context
+	s.mockShardMgr.On("UpdateShard", mock.Anything).Return(nil).Once()
+	timerSequenceID2 := TimerSequenceID{VisibilityTimestamp: timer2.VisibilityTimestamp, TaskID: timer2.TaskID}
+	s.timerQueueAckMgr.completeTimerTask(timerSequenceID2)
+	s.True(s.timerQueueAckMgr.clusterOutstandingTasks[clusterName][timerSequenceID2])
+	s.timerQueueAckMgr.updateAckLevel(clusterName)
+	s.Equal(timer3.VisibilityTimestamp, s.mockShard.GetTimerAckLevel(clusterName))
+}
+
+func (s *timerQueueAckMgrSuite) TestReadRetryCompleteUpdateTimerTasks() {
+	clusterName := cluster.TestCurrentClusterName
+	domainID := "some random domain ID"
+	ackLevel := s.timerQueueAckMgr.clusterAckLevel[clusterName]
+	readLevel := s.timerQueueAckMgr.clusterReadLevel[clusterName]
+
+	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
+		// only thing used is the replication config
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: clusterName,
+			// Clusters attr is not used.
+		},
+	}, nil).Once()
+
+	// create 3 timers, timer1 < timer2 < timer3 < now
+	timer := &persistence.TimerTaskInfo{
+		DomainID:            "some random domain ID",
+		WorkflowID:          "some random workflow ID",
+		RunID:               "some random run ID",
+		VisibilityTimestamp: time.Now().Add(-5 * time.Second),
+		TaskID:              int64(59),
+		TaskType:            1,
+		TimeoutType:         2,
+		EventID:             int64(28),
+		ScheduleAttempt:     0,
+	}
+	request := &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: readLevel.VisibilityTimestamp,
+		MaxTimestamp: timerQueueAckMgrMaxTimestamp,
+		BatchSize:    s.mockShard.GetConfig().TimerTaskBatchSize,
+	}
+	response := &persistence.GetTimerIndexTasksResponse{
+		Timers:        []*persistence.TimerTaskInfo{timer},
+		NextPageToken: nil,
+	}
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+	filteredTasks, lookAheadTask, moreTasks, err := s.timerQueueAckMgr.readTimerTasks(clusterName)
+	s.Nil(err)
+	s.Equal([]*persistence.TimerTaskInfo{timer}, filteredTasks)
+	s.Nil(lookAheadTask)
+	s.False(moreTasks)
+
+	timerSequenceID := TimerSequenceID{VisibilityTimestamp: timer.VisibilityTimestamp, TaskID: timer.TaskID}
+	s.timerQueueAckMgr.retryTimerTask(timer)
+	// nothing changed to ack level, as well as outstanding task and task to cluster map
+	s.False(s.timerQueueAckMgr.clusterOutstandingTasks[clusterName][timerSequenceID])
+	s.Equal(timerSequenceID, s.timerQueueAckMgr.clusterReadLevel[clusterName])
+	s.Equal(ackLevel, s.timerQueueAckMgr.clusterAckLevel[clusterName])
+	s.Equal(map[TimerSequenceID]string{timerSequenceID: clusterName}, s.timerQueueAckMgr.taskToCluster)
+	s.Equal([]*persistence.TimerTaskInfo{timer}, s.timerQueueAckMgr.clusterRetryTasks[clusterName])
+
+	// do another round of processing, db layer return nothing
+	request = &persistence.GetTimerIndexTasksRequest{
+		MinTimestamp: s.timerQueueAckMgr.clusterReadLevel[clusterName].VisibilityTimestamp,
+		MaxTimestamp: timerQueueAckMgrMaxTimestamp,
+		BatchSize:    s.mockShard.GetConfig().TimerTaskBatchSize,
+	}
+	response = &persistence.GetTimerIndexTasksResponse{
+		Timers:        []*persistence.TimerTaskInfo{},
+		NextPageToken: nil,
+	}
+	s.mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
+	filteredTasks, lookAheadTask, moreTasks, err = s.timerQueueAckMgr.readTimerTasks(clusterName)
+	s.Nil(err)
+	s.Equal([]*persistence.TimerTaskInfo{timer}, filteredTasks)
+	s.Nil(lookAheadTask)
+	s.False(moreTasks)
+	// nothing changed to ack level, as well as outstanding task and task to cluster map
+	s.False(s.timerQueueAckMgr.clusterOutstandingTasks[clusterName][timerSequenceID])
+	s.Equal(timerSequenceID, s.timerQueueAckMgr.clusterReadLevel[clusterName])
+	s.Equal(ackLevel, s.timerQueueAckMgr.clusterAckLevel[clusterName])
+	s.Equal(map[TimerSequenceID]string{timerSequenceID: clusterName}, s.timerQueueAckMgr.taskToCluster)
+	s.Equal([]*persistence.TimerTaskInfo{}, s.timerQueueAckMgr.clusterRetryTasks[clusterName])
+}

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -24,7 +24,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -48,6 +47,7 @@ var (
 
 type (
 	timerQueueProcessorImpl struct {
+		shard            ShardContext
 		historyService   *historyEngineImpl
 		cache            *historyCache
 		executionManager persistence.ExecutionManager
@@ -60,44 +60,30 @@ type (
 		logger           bark.Logger
 		metricsClient    metrics.Client
 		timerFiredCount  uint64
-		ackMgr           *timerAckMgr
+		timerQueueAckMgr timerQueueAckMgr
 
 		newTimeLock sync.Mutex
 		newTime     time.Time
 	}
-
-	timerAckMgr struct {
-		sync.RWMutex
-		processor        *timerQueueProcessorImpl
-		shard            ShardContext
-		executionMgr     persistence.ExecutionManager
-		logger           bark.Logger
-		outstandingTasks map[SequenceID]bool
-		readLevel        SequenceID
-		ackLevel         time.Time
-		metricsClient    metrics.Client
-		lastUpdated      time.Time
-		config           *Config
-	}
 )
 
-func newTimerQueueProcessor(shard ShardContext, historyService *historyEngineImpl, executionManager persistence.ExecutionManager,
-	logger bark.Logger) timerQueueProcessor {
-	l := logger.WithFields(bark.Fields{
+func newTimerQueueProcessor(shard ShardContext, historyService *historyEngineImpl, executionManager persistence.ExecutionManager, logger bark.Logger) timerQueueProcessor {
+	log := logger.WithFields(bark.Fields{
 		logging.TagWorkflowComponent: logging.TagValueTimerQueueComponent,
 	})
-	tp := &timerQueueProcessorImpl{
+	timerQueueProcessor := &timerQueueProcessorImpl{
+		shard:            shard,
 		historyService:   historyService,
 		cache:            historyService.historyCache,
 		executionManager: executionManager,
 		shutdownCh:       make(chan struct{}),
 		newTimerCh:       make(chan struct{}, 1),
 		config:           shard.GetConfig(),
-		logger:           l,
+		logger:           log,
 		metricsClient:    historyService.metricsClient,
+		timerQueueAckMgr: newTimerQueueAckMgr(shard, historyService.metricsClient, executionManager, log),
 	}
-	tp.ackMgr = newTimerAckMgr(tp, shard, executionManager, l)
-	return tp
+	return timerQueueProcessor
 }
 
 func (t *timerQueueProcessorImpl) Start() {
@@ -127,14 +113,14 @@ func (t *timerQueueProcessorImpl) Stop() {
 	t.logger.Info("Timer queue processor stopped.")
 }
 
-// NotifyNewTimer - Notify the processor about the new timer arrival.
-// This should be called each time new timer created, otherwise timer maybe fired unexpected.
+// NotifyNewTimers - Notify the processor about the new active timer events arrival.
+// This should be called each time new timer events arrives, otherwise timers maybe fired unexpected.
 func (t *timerQueueProcessorImpl) NotifyNewTimers(timerTasks []persistence.Task) {
 	if len(timerTasks) == 0 {
 		return
 	}
-	t.metricsClient.AddCounter(metrics.TimerQueueProcessorScope, metrics.NewTimerCounter, int64(len(timerTasks)))
 
+	t.metricsClient.AddCounter(metrics.TimerQueueProcessorScope, metrics.NewActiveTimerCounter, int64(len(timerTasks)))
 	newTime := persistence.GetVisibilityTSFrom(timerTasks[0])
 	for _, task := range timerTasks {
 		ts := persistence.GetVisibilityTSFrom(task)
@@ -144,15 +130,16 @@ func (t *timerQueueProcessorImpl) NotifyNewTimers(timerTasks []persistence.Task)
 
 		switch task.GetType() {
 		case persistence.TaskTypeDecisionTimeout:
-			t.metricsClient.IncCounter(metrics.TimerTaskDecisionTimeoutScope, metrics.NewTimerCounter)
+			t.metricsClient.IncCounter(metrics.TimerTaskDecisionTimeoutScope, metrics.NewActiveTimerCounter)
 		case persistence.TaskTypeActivityTimeout:
-			t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.NewTimerCounter)
+			t.metricsClient.IncCounter(metrics.TimerTaskActivityTimeoutScope, metrics.NewActiveTimerCounter)
 		case persistence.TaskTypeUserTimer:
-			t.metricsClient.IncCounter(metrics.TimerTaskUserTimerScope, metrics.NewTimerCounter)
+			t.metricsClient.IncCounter(metrics.TimerTaskUserTimerScope, metrics.NewActiveTimerCounter)
 		case persistence.TaskTypeWorkflowTimeout:
-			t.metricsClient.IncCounter(metrics.TimerTaskWorkflowTimeoutScope, metrics.NewTimerCounter)
+			t.metricsClient.IncCounter(metrics.TimerTaskWorkflowTimeoutScope, metrics.NewActiveTimerCounter)
 		case persistence.TaskTypeDeleteHistoryEvent:
-			t.metricsClient.IncCounter(metrics.TimerTaskDeleteHistoryEvent, metrics.NewTimerCounter)
+			t.metricsClient.IncCounter(metrics.TimerTaskDeleteHistoryEvent, metrics.NewActiveTimerCounter)
+			// TODO add default
 		}
 	}
 
@@ -167,6 +154,12 @@ func (t *timerQueueProcessorImpl) NotifyNewTimers(timerTasks []persistence.Task)
 			// Channel "full" -> drop and move on, this will happen only if service is in high load.
 		}
 	}
+}
+
+// NotifyNewTimerEvents - Notify the processor about the new standby history events arrival.
+// This should be called each time new timer events arrives, otherwise timers maybe fired unexpected.
+func (t *timerQueueProcessorImpl) NotifyNewTimerEvents() {
+	// TODO pending implementation
 }
 
 func (t *timerQueueProcessorImpl) processorPump(taskWorkerCount int) {
@@ -226,7 +219,7 @@ continueProcessor:
 				// Timer Fired.
 
 			case <-updateAckChan:
-				t.ackMgr.updateAckLevel()
+				t.timerQueueAckMgr.updateAckLevel(t.shard.GetService().GetClusterMetadata().GetCurrentClusterName())
 				continue continueProcessor
 
 			case <-t.newTimerCh:
@@ -256,7 +249,7 @@ continueProcessor:
 	ProcessPendingTimers:
 		for {
 			// Get next set of timer tasks.
-			timerTasks, lookAheadTask, moreTasks, err := t.getTasksAndNextKey()
+			timerTasks, lookAheadTask, moreTasks, err := t.timerQueueAckMgr.readTimerTasks(t.shard.GetService().GetClusterMetadata().GetCurrentClusterName())
 			if err != nil {
 				return err
 			}
@@ -274,45 +267,12 @@ continueProcessor:
 		}
 
 		if nextKeyTask != nil {
-			nextKey := SequenceID{VisibilityTimestamp: nextKeyTask.VisibilityTimestamp, TaskID: nextKeyTask.TaskID}
+			nextKey := TimerSequenceID{VisibilityTimestamp: nextKeyTask.VisibilityTimestamp, TaskID: nextKeyTask.TaskID}
 			t.logger.Debugf("%s: GetNextKey: %s", time.Now().UTC(), nextKey)
 
 			timerGate.Update(nextKey.VisibilityTimestamp)
 		}
 	}
-}
-
-func (t *timerQueueProcessorImpl) isProcessNow(expiryTime time.Time) bool {
-	return !expiryTime.IsZero() && expiryTime.UnixNano() <= time.Now().UnixNano()
-}
-
-func (t *timerQueueProcessorImpl) getTasksAndNextKey() ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool,
-	error) {
-	tasks, lookAheadTask, moreTasks, err := t.ackMgr.readTimerTasks()
-	if err != nil {
-		return nil, nil, false, err
-	}
-	return tasks, lookAheadTask, moreTasks, nil
-}
-
-func (t *timerQueueProcessorImpl) getTimerTasks(
-	minTimestamp time.Time,
-	maxTimestamp time.Time,
-	batchSize int) ([]*persistence.TimerTaskInfo, error) {
-	request := &persistence.GetTimerIndexTasksRequest{
-		MinTimestamp: minTimestamp,
-		MaxTimestamp: maxTimestamp,
-		BatchSize:    batchSize}
-
-	for attempt := 1; attempt <= t.config.TimerProcessorGetFailureRetryCount; attempt++ {
-		response, err := t.executionManager.GetTimerIndexTasks(request)
-		if err == nil {
-			return response.Timers, nil
-		}
-		backoff := time.Duration(attempt * 100)
-		time.Sleep(backoff * time.Millisecond)
-	}
-	return nil, ErrMaxAttemptsExceeded
 }
 
 func (t *timerQueueProcessorImpl) processTaskWorker(tasksCh <-chan *persistence.TimerTaskInfo, workerWG *sync.WaitGroup) {
@@ -328,17 +288,17 @@ func (t *timerQueueProcessorImpl) processTaskWorker(tasksCh <-chan *persistence.
 
 		UpdateFailureLoop:
 			for attempt := 1; attempt <= t.config.TimerProcessorUpdateFailureRetryCount; attempt++ {
-				taskID := SequenceID{VisibilityTimestamp: task.VisibilityTimestamp, TaskID: task.TaskID}
+				taskID := TimerSequenceID{VisibilityTimestamp: task.VisibilityTimestamp, TaskID: task.TaskID}
 				err = t.processTimerTask(task)
 				if err != nil && err != errTimerTaskNotFound {
 					// We will retry until we don't find the timer task any more.
-					t.logger.Infof("Failed to process timer with SequenceID: %s with error: %v",
+					t.logger.Infof("Failed to process timer with TimerSequenceID: %s with error: %v",
 						taskID, err)
 					backoff := time.Duration(attempt * 100)
 					time.Sleep(backoff * time.Millisecond)
 				} else {
 					// Completed processing the timer task.
-					t.ackMgr.completeTimerTask(taskID)
+					t.timerQueueAckMgr.completeTimerTask(taskID)
 					break UpdateFailureLoop
 				}
 			}
@@ -347,7 +307,7 @@ func (t *timerQueueProcessorImpl) processTaskWorker(tasksCh <-chan *persistence.
 }
 
 func (t *timerQueueProcessorImpl) processTimerTask(timerTask *persistence.TimerTaskInfo) error {
-	taskID := SequenceID{VisibilityTimestamp: timerTask.VisibilityTimestamp, TaskID: timerTask.TaskID}
+	taskID := TimerSequenceID{VisibilityTimestamp: timerTask.VisibilityTimestamp, TaskID: timerTask.TaskID}
 	t.logger.Debugf("Processing timer: (%s), for WorkflowID: %v, RunID: %v, Type: %v, TimeoutType: %v, EventID: %v",
 		taskID, timerTask.WorkflowID, timerTask.RunID, t.getTimerTaskType(timerTask.TaskType),
 		workflow.TimeoutType(timerTask.TimeoutType).String(), timerTask.EventID)
@@ -834,144 +794,4 @@ func (t *timerQueueProcessorImpl) getTimerTaskType(taskType int) string {
 		return "DeleteHistoryEvent"
 	}
 	return "UnKnown"
-}
-
-type timerTaskIDs []SequenceID
-
-// Len implements sort.Interace
-func (t timerTaskIDs) Len() int {
-	return len(t)
-}
-
-// Swap implements sort.Interface.
-func (t timerTaskIDs) Swap(i, j int) {
-	t[i], t[j] = t[j], t[i]
-}
-
-// Less implements sort.Interface
-func (t timerTaskIDs) Less(i, j int) bool {
-	return compareTimerIDLess(&t[i], &t[j])
-}
-
-func newTimerAckMgr(processor *timerQueueProcessorImpl, shard ShardContext, executionMgr persistence.ExecutionManager,
-	logger bark.Logger) *timerAckMgr {
-	ackLevel := shard.GetTimerAckLevel()
-	config := shard.GetConfig()
-	return &timerAckMgr{
-		processor:        processor,
-		shard:            shard,
-		executionMgr:     executionMgr,
-		outstandingTasks: make(map[SequenceID]bool),
-		readLevel:        SequenceID{VisibilityTimestamp: ackLevel},
-		ackLevel:         ackLevel,
-		metricsClient:    processor.metricsClient,
-		logger:           logger,
-		lastUpdated:      time.Now(),
-		config:           config,
-	}
-}
-
-func (t *timerAckMgr) readTimerTasks() ([]*persistence.TimerTaskInfo, *persistence.TimerTaskInfo, bool, error) {
-	t.RLock()
-	rLevel := t.readLevel
-	t.RUnlock()
-
-	tasks, err := t.processor.getTimerTasks(rLevel.VisibilityTimestamp, maxTimestamp, t.processor.config.TimerTaskBatchSize)
-	if err != nil {
-		return nil, nil, false, err
-	}
-
-	taskCount := len(tasks)
-	t.logger.Debugf("readTimerTasks: ReadLevel: (%s) count: %v", rLevel, taskCount)
-
-	// We filter tasks so read only moves to desired timer tasks.
-	// We also get a look ahead task but it doesn't move the read level, this is for timer
-	// to wait on it instead of doing queries.
-
-	var lookAheadTask *persistence.TimerTaskInfo
-	filteredTasks := []*persistence.TimerTaskInfo{}
-
-	t.Lock()
-	for _, task := range tasks {
-		taskSeq := SequenceID{VisibilityTimestamp: task.VisibilityTimestamp, TaskID: task.TaskID}
-		if _, ok := t.outstandingTasks[taskSeq]; ok {
-			t.logger.Infof("Skipping task: %v.  WorkflowID: %v, RunID: %v, Type: %v", taskSeq.String(), task.WorkflowID,
-				task.RunID, task.TaskType)
-			continue
-		}
-		if task.VisibilityTimestamp.Before(t.readLevel.VisibilityTimestamp) {
-			t.logger.Fatalf(
-				"Next timer task time stamp is less than current timer task read level. timer task: (%s), ReadLevel: (%s)",
-				taskSeq, t.readLevel)
-		}
-
-		if !t.processor.isProcessNow(task.VisibilityTimestamp) {
-			lookAheadTask = task
-			break
-		}
-
-		t.logger.Debugf("Moving timer read level: (%s)", taskSeq)
-		t.readLevel = taskSeq
-		t.outstandingTasks[t.readLevel] = false
-		filteredTasks = append(filteredTasks, task)
-	}
-	t.Unlock()
-
-	// We may have large number of timers which need to be fired immediately.  Return true in such case so the pump
-	// can call back immediately to retrieve more tasks
-	moreTasks := lookAheadTask == nil && taskCount == t.processor.config.TimerTaskBatchSize
-
-	return filteredTasks, lookAheadTask, moreTasks, nil
-}
-
-func (t *timerAckMgr) completeTimerTask(taskID SequenceID) {
-	t.Lock()
-	if _, ok := t.outstandingTasks[taskID]; ok {
-		t.outstandingTasks[taskID] = true
-	}
-	t.Unlock()
-}
-
-func (t *timerAckMgr) updateAckLevel() {
-	t.metricsClient.IncCounter(metrics.TimerQueueProcessorScope, metrics.AckLevelUpdateCounter)
-	initialAckLevel := t.ackLevel
-	updatedAckLevel := t.ackLevel
-	t.Lock()
-
-	// Timer IDs can have holes in the middle. So we sort the map to get the order to
-	// check. TODO: we can maintain a sorted slice as well.
-	var taskIDs timerTaskIDs
-	for k := range t.outstandingTasks {
-		taskIDs = append(taskIDs, k)
-	}
-	sort.Sort(taskIDs)
-
-MoveAckLevelLoop:
-	for _, current := range taskIDs {
-		if acked, ok := t.outstandingTasks[current]; ok {
-			if acked {
-				t.ackLevel = current.VisibilityTimestamp
-				updatedAckLevel = current.VisibilityTimestamp
-				delete(t.outstandingTasks, current)
-			} else {
-				break MoveAckLevelLoop
-			}
-		}
-	}
-	t.Unlock()
-
-	// Do not update Acklevel if nothing changed upto force update interval
-	if initialAckLevel == updatedAckLevel && time.Since(t.lastUpdated) < t.config.TimerProcessorForceUpdateInterval {
-		return
-	}
-
-	t.logger.Debugf("Updating timer ack level: %v", updatedAckLevel)
-
-	// Always update ackLevel to detect if the shared is stolen
-	if err := t.shard.UpdateTimerAckLevel(updatedAckLevel); err != nil {
-		t.metricsClient.IncCounter(metrics.TimerQueueProcessorScope, metrics.AckLevelUpdateFailedCounter)
-		t.logger.Errorf("Error updating timer ack level for shard: %v", err)
-	} else {
-		t.lastUpdated = time.Now()
-	}
 }

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -81,7 +81,7 @@ func newTimerQueueProcessor(shard ShardContext, historyService *historyEngineImp
 		config:           shard.GetConfig(),
 		logger:           log,
 		metricsClient:    historyService.metricsClient,
-		timerQueueAckMgr: newTimerQueueAckMgr(shard, historyService.metricsClient, executionManager, log),
+		timerQueueAckMgr: newTimerQueueAckMgr(shard, historyService.metricsClient, executionManager, shard.GetService().GetClusterMetadata().GetCurrentClusterName(), log),
 	}
 	return timerQueueProcessor
 }
@@ -219,7 +219,7 @@ continueProcessor:
 				// Timer Fired.
 
 			case <-updateAckChan:
-				t.timerQueueAckMgr.updateAckLevel(t.shard.GetService().GetClusterMetadata().GetCurrentClusterName())
+				t.timerQueueAckMgr.updateAckLevel()
 				continue continueProcessor
 
 			case <-t.newTimerCh:
@@ -249,7 +249,7 @@ continueProcessor:
 	ProcessPendingTimers:
 		for {
 			// Get next set of timer tasks.
-			timerTasks, lookAheadTask, moreTasks, err := t.timerQueueAckMgr.readTimerTasks(t.shard.GetService().GetClusterMetadata().GetCurrentClusterName())
+			timerTasks, lookAheadTask, moreTasks, err := t.timerQueueAckMgr.readTimerTasks()
 			if err != nil {
 				return err
 			}

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -135,9 +135,8 @@ func (s *timerQueueProcessor2Suite) SetupTest() {
 		hSerializerFactory: persistence.NewHistorySerializerFactory(),
 		metricsClient:      s.mockShard.GetMetricsClient(),
 	}
-	// setup the basics of cluster metadata, since during the initialization of * queue processor, those cluster metadata will be used
+	// this is used by shard context, not relevent to this test, so we do not care how many times "GetCurrentClusterName" os called
 	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
-	s.mockClusterMetadata.On("GetAllClusterNames").Return(cluster.TestAllClusterNamesMap)
 	h.txProcessor = newTransferQueueProcessor(s.mockShard, h, s.mockVisibilityMgr, s.mockMatchingClient, &mocks.HistoryClient{})
 	h.timerProcessor = newTimerQueueProcessor(s.mockShard, h, s.mockExecutionMgr, s.logger)
 	s.mockHistoryEngine = h

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -93,13 +93,22 @@ func (s *timerQueueProcessor2Suite) SetupTest() {
 	s.mockVisibilityMgr = &mocks.VisibilityManager{}
 	s.mockMetadataMgr = &mocks.MetadataManager{}
 	s.mockClusterMetadata = &mocks.ClusterMetadata{}
+	// ack manager will use the domain information
+	s.mockMetadataMgr.On("GetDomain", mock.Anything).Return(&persistence.GetDomainResponse{
+		// only thing used is the replication config
+		Config: &persistence.DomainConfig{Retention: 1},
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			// Clusters attr is not used.
+		},
+	}, nil).Once()
 	s.mockProducer = &mocks.KafkaProducer{}
 	s.shardClosedCh = make(chan int, 100)
 	metricsClient := metrics.NewClient(tally.NoopScope, metrics.History)
 	s.mockMessagingClient = mocks.NewMockMessagingClient(s.mockProducer, nil)
 	s.mockService = service.NewTestService(s.mockClusterMetadata, s.mockMessagingClient, metricsClient, s.logger)
 
-	domainCache := cache.NewDomainCache(s.mockMetadataMgr, cluster.GetTestClusterMetadata(false, false), s.logger)
+	domainCache := cache.NewDomainCache(s.mockMetadataMgr, s.mockClusterMetadata, s.logger)
 	s.mockShard = &shardContextImpl{
 		service:                   s.mockService,
 		shardInfo:                 &persistence.ShardInfo{ShardID: shardID, RangeID: 1, TransferAckLevel: 0},
@@ -125,8 +134,10 @@ func (s *timerQueueProcessor2Suite) SetupTest() {
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		hSerializerFactory: persistence.NewHistorySerializerFactory(),
 		metricsClient:      s.mockShard.GetMetricsClient(),
-		domainCache:        domainCache,
 	}
+	// setup the basics of cluster metadata, since during the initialization of * queue processor, those cluster metadata will be used
+	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
+	s.mockClusterMetadata.On("GetAllClusterNames").Return(cluster.TestAllClusterNamesMap)
 	h.txProcessor = newTransferQueueProcessor(s.mockShard, h, s.mockVisibilityMgr, s.mockMatchingClient, &mocks.HistoryClient{})
 	h.timerProcessor = newTimerQueueProcessor(s.mockShard, h, s.mockExecutionMgr, s.logger)
 	s.mockHistoryEngine = h
@@ -143,7 +154,7 @@ func (s *timerQueueProcessor2Suite) TearDownTest() {
 }
 
 func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
-	domainID := "5bb49df8-71bc-4c63-b57f-05f2a508e7b5"
+	domainID := testDomainActiveID
 	we := workflow.WorkflowExecution{WorkflowId: common.StringPtr("timer-update-timesout-test"),
 		RunId: common.StringPtr("0d00698f-08e1-4d36-a3e2-3bf109f5d2d6")}
 
@@ -165,8 +176,12 @@ func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
 	mockTS := &mockTimeSource{currTime: time.Now()}
 
 	taskID := int64(100)
-	timerTask := &persistence.TimerTaskInfo{WorkflowID: "wid", RunID: "rid", TaskID: taskID,
-		TaskType: persistence.TaskTypeDecisionTimeout, TimeoutType: int(workflow.TimeoutTypeStartToClose),
+	timerTask := &persistence.TimerTaskInfo{
+		DomainID:   domainID,
+		WorkflowID: "wid",
+		RunID:      "rid",
+		TaskID:     taskID,
+		TaskType:   persistence.TaskTypeDecisionTimeout, TimeoutType: int(workflow.TimeoutTypeStartToClose),
 		VisibilityTimestamp: mockTS.Now(),
 		EventID:             di.ScheduleID}
 	timerIndexResponse := &persistence.GetTimerIndexTasksResponse{Timers: []*persistence.TimerTaskInfo{timerTask}}
@@ -210,7 +225,7 @@ func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
 }
 
 func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
-	domainID := "5bb49df8-71bc-4c63-b57f-05f2a508e7b5"
+	domainID := testDomainActiveID
 	we := workflow.WorkflowExecution{WorkflowId: common.StringPtr("workflow-timesout-test"),
 		RunId: common.StringPtr("0d00698f-08e1-4d36-a3e2-3bf109f5d2d6")}
 	taskList := "task-workflow-times-out"
@@ -231,7 +246,11 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 	mockTS := &mockTimeSource{currTime: time.Now()}
 
 	taskID := int64(100)
-	timerTask := &persistence.TimerTaskInfo{WorkflowID: "wid", RunID: "rid", TaskID: taskID,
+	timerTask := &persistence.TimerTaskInfo{
+		DomainID:            domainID,
+		WorkflowID:          "wid",
+		RunID:               "rid",
+		TaskID:              taskID,
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
 		VisibilityTimestamp: mockTS.Now(),
 		EventID:             di.ScheduleID}
@@ -241,8 +260,6 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 	wfResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(wfResponse, nil).Once()
 
-	s.mockMetadataMgr.On("GetDomain", mock.Anything).Return(
-		&persistence.GetDomainResponse{Config: &persistence.DomainConfig{Retention: 1}}, nil)
 	s.mockExecutionMgr.On("CompleteTimerTask", mock.Anything).Return(nil).Once()
 	s.mockHistoryMgr.On("AppendHistoryEvents", mock.Anything).Return(nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything).Return(nil).Run(func(arguments mock.Arguments) {

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -26,6 +26,7 @@ import (
 	"github.com/uber-common/bark"
 
 	"errors"
+
 	"github.com/uber/cadence/.gen/go/history"
 	m "github.com/uber/cadence/.gen/go/matching"
 	workflow "github.com/uber/cadence/.gen/go/shared"
@@ -354,7 +355,7 @@ func (t *transferQueueProcessorImpl) processCloseExecution(task *persistence.Tra
 
 	// Record closing in visibility store
 	retentionSeconds := int64(0)
-	domainEntry, err := t.domainCache.GetDomainByID(task.DomainID)
+	domainEntry, err := t.shard.GetDomainCache().GetDomainByID(task.DomainID)
 	if err != nil {
 		if _, ok := err.(*workflow.EntityNotExistsError); !ok {
 			return err

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -83,7 +83,7 @@ func newTransferQueueProcessor(shard ShardContext, historyService *historyEngine
 		historyClient:     historyClient,
 		visibilityManager: visibilityMgr,
 		cache:             historyService.historyCache,
-		domainCache:       historyService.domainCache,
+		domainCache:       shard.GetDomainCache(),
 	}
 	baseProcessor := newQueueProcessor(shard, options, processor, shard.GetTransferAckLevel())
 	processor.queueProcessorBase = baseProcessor


### PR DESCRIPTION
…to timer queue processor to be cluster aware

rename SequenceID -> TimerSequenceID

Standby timer processing logic && domain failover timer ack manager scan DB for domain specific timer in next PR.