### PR TITLE
Add retry in some frontend API

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -42,6 +42,10 @@ const (
 	historyServiceOperationInitialInterval    = 50 * time.Millisecond
 	historyServiceOperationMaxInterval        = 10 * time.Second
 	historyServiceOperationExpirationInterval = 30 * time.Second
+
+	frontendServiceOperationInitialInterval    = 200 * time.Millisecond
+	frontendServiceOperationMaxInterval        = 5 * time.Second
+	frontendServiceOperationExpirationInterval = 15 * time.Second
 )
 
 // MergeDictoRight copies the contents of src to dest
@@ -103,6 +107,15 @@ func CreateHistoryServiceRetryPolicy() backoff.RetryPolicy {
 	return policy
 }
 
+// CreateFrontendServiceRetryPolicy creates a retry policy for calls to frontend service
+func CreateFrontendServiceRetryPolicy() backoff.RetryPolicy {
+	policy := backoff.NewExponentialRetryPolicy(frontendServiceOperationInitialInterval)
+	policy.SetMaximumInterval(frontendServiceOperationMaxInterval)
+	policy.SetExpirationInterval(frontendServiceOperationExpirationInterval)
+
+	return policy
+}
+
 // IsPersistenceTransientError checks if the error is a transient persistence error
 func IsPersistenceTransientError(err error) bool {
 	switch err.(type) {
@@ -111,6 +124,11 @@ func IsPersistenceTransientError(err error) bool {
 	}
 
 	return false
+}
+
+// IsServiceTransientError checks if the error is a retryable error.
+func IsServiceTransientError(err error) bool {
+	return !IsServiceNonRetryableError(err)
 }
 
 // IsServiceNonRetryableError checks if the error is a non retryable error.

--- a/service/history/timerGate.go
+++ b/service/history/timerGate.go
@@ -40,7 +40,7 @@ type (
 	}
 
 	// TimerGateImpl is an timer implementation,
-	// which basically is an wrrapper of golang's timer and
+	// which basically is an wrapper of golang's timer and
 	// additional feature
 	TimerGateImpl struct {
 		// the channel which will be used to proxy the fired timer


### PR DESCRIPTION
Oncall observed multiple pollForActivity/Decision error in short period which affects our SLA.

Error log shows as:
handler.go:385 PollForDecisionTask failed. TaskList: adjust_ledgerv2, Error: code:unknown message:received unknown error calling service: "cadence-matching", procedure: "MatchingService::PollForDecisionTask", err: dial tcp 10.189.33.24:31849: getsockopt: connection refused

We need to add retry logic in Frontend to mitigate such error affecting our SLA to client. 