### PR TITLE
Replication task processor bugfixes

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -544,6 +544,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		TimerTaskWorkflowTimeoutScope:              {operation: "TimerTaskWorkflowTimeout"},
 		TimerTaskDeleteHistoryEvent:                {operation: "TimerTaskDeleteHistoryEvent"},
 		HistoryEventNotificationScope:              {operation: "HistoryEventNotification"},
+		ReplicatorQueueProcessorScope:              {operation: "ReplicatorQueueProcessor"},
+		ReplicatorTaskHistoryScope:                 {operation: "ReplicatorTaskHistory"},
 	},
 	// Matching Scope Names
 	Matching: {

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -38,7 +38,6 @@ const (
 type (
 	historyBuilder struct {
 		firstEventID int64
-		nextEventID  int64
 		serializer   persistence.HistorySerializer
 		history      []*workflow.HistoryEvent
 		msBuilder    *mutableStateBuilder
@@ -419,7 +418,6 @@ func (b *historyBuilder) AddChildWorkflowExecutionTimedOutEvent(domain *string, 
 
 func (b *historyBuilder) addEventToHistory(event *workflow.HistoryEvent) *workflow.HistoryEvent {
 	b.history = append(b.history, event)
-	b.nextEventID = b.msBuilder.GetNextEventID() // Keep track of nextEventID for generating replication task
 	return event
 }
 

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -37,21 +37,19 @@ const (
 
 type (
 	historyBuilder struct {
-		firstEventID int64
-		serializer   persistence.HistorySerializer
-		history      []*workflow.HistoryEvent
-		msBuilder    *mutableStateBuilder
-		logger       bark.Logger
+		serializer persistence.HistorySerializer
+		history    []*workflow.HistoryEvent
+		msBuilder  *mutableStateBuilder
+		logger     bark.Logger
 	}
 )
 
 func newHistoryBuilder(msBuilder *mutableStateBuilder, logger bark.Logger) *historyBuilder {
 	return &historyBuilder{
-		firstEventID: msBuilder.GetNextEventID(),
-		serializer:   persistence.NewJSONHistorySerializer(),
-		history:      []*workflow.HistoryEvent{},
-		msBuilder:    msBuilder,
-		logger:       logger.WithField(logging.TagWorkflowComponent, logging.TagValueHistoryBuilderComponent),
+		serializer: persistence.NewJSONHistorySerializer(),
+		history:    []*workflow.HistoryEvent{},
+		msBuilder:  msBuilder,
+		logger:     logger.WithField(logging.TagWorkflowComponent, logging.TagValueHistoryBuilderComponent),
 	}
 }
 

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -292,7 +292,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 		}
 
 		replicationTask := &persistence.HistoryReplicationTask{
-			FirstEventID:        msBuilder.hBuilder.firstEventID,
+			FirstEventID:        firstEventID,
 			NextEventID:         msBuilder.GetNextEventID(),
 			Version:             failoverVersion,
 			LastReplicationInfo: nil,

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -293,7 +293,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 
 		replicationTask := &persistence.HistoryReplicationTask{
 			FirstEventID:        msBuilder.hBuilder.firstEventID,
-			NextEventID:         msBuilder.hBuilder.nextEventID,
+			NextEventID:         msBuilder.GetNextEventID(),
 			Version:             failoverVersion,
 			LastReplicationInfo: nil,
 		}

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -156,7 +156,6 @@ func (e *mutableStateBuilder) Load(state *persistence.WorkflowMutableState) {
 	for _, ai := range state.ActivitInfos {
 		e.pendingActivityInfoByActivityID[ai.ActivityID] = ai.ScheduleID
 	}
-	e.hBuilder.firstEventID = state.ExecutionInfo.NextEventID
 }
 
 func (e *mutableStateBuilder) FlushBufferedEvents() error {
@@ -292,7 +291,7 @@ func (e *mutableStateBuilder) CloseUpdateSession(createReplicationTask bool) (*m
 
 func (e *mutableStateBuilder) createReplicationTask() *persistence.HistoryReplicationTask {
 	return &persistence.HistoryReplicationTask{
-		FirstEventID:        e.hBuilder.firstEventID,
+		FirstEventID:        e.GetLastFirstEventID(),
 		NextEventID:         e.GetNextEventID(),
 		Version:             e.replicationState.CurrentVersion,
 		LastReplicationInfo: e.replicationState.LastReplicationInfo,
@@ -1645,7 +1644,7 @@ func (e *mutableStateBuilder) AddContinueAsNewEvent(decisionCompletedEventID int
 		}
 
 		replicationTask := &persistence.HistoryReplicationTask{
-			FirstEventID:        newStateBuilder.hBuilder.firstEventID,
+			FirstEventID:        firstEventID,
 			NextEventID:         newStateBuilder.GetNextEventID(),
 			Version:             failoverVersion,
 			LastReplicationInfo: nil,


### PR DESCRIPTION
Use mutableStateBuilder.GetNextEventID rather than managing event ID on
the history builder for generation of replication tasks.  Managing the
next event ID on history builder does not account for buffered events
and will cause incorrect next event ID set on the replication task.

Fixed missing metric scope definition for replication queue processor.