### PR TITLE
Bugfix: Recreate activity heartbeat timeout after first timer fire

### DIFF
--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -289,7 +289,7 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder *mutableStateBuilder) {
 				td := &timerDetails{
 					TimerSequenceID: TimerSequenceID{VisibilityTimestamp: startToCloseExpiry},
 					ActivityID:      v.ScheduleID,
-					EventID:         v.StartedID,
+					EventID:         v.ScheduleID,
 					TimeoutType:     w.TimeoutTypeStartToClose,
 					TimeoutSec:      v.StartToCloseTimeout,
 					TaskCreated:     (v.TimerTaskStatus & TimerTaskStatusCreatedStartToClose) != 0}
@@ -303,7 +303,7 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder *mutableStateBuilder) {
 					td := &timerDetails{
 						TimerSequenceID: TimerSequenceID{VisibilityTimestamp: heartBeatExpiry},
 						ActivityID:      v.ScheduleID,
-						EventID:         v.StartedID,
+						EventID:         v.ScheduleID,
 						TimeoutType:     w.TimeoutTypeHeartbeat,
 						TimeoutSec:      v.HeartbeatTimeout,
 						TaskCreated:     (v.TimerTaskStatus & TimerTaskStatusCreatedHeartbeat) != 0}


### PR DESCRIPTION
When the heartbeat timeout is created for the very first time it 
uses StartEventID as the dedupe event ID.  But it is possible that
it is a buffered event and no ID is specified when the timer task
is created.  This trips the recreation logic from recreating the 
timer. 
This change instead relies on the schedule ID for the event
for dedupe event ID of the heartbeat timer.