### PR TITLE
bugfix: timer gate, when updating the next wake up time, can suffer f…

### DIFF
--- a/service/history/timerGate.go
+++ b/service/history/timerGate.go
@@ -133,21 +133,14 @@ func (timerGate *LocalTimerGateImpl) Update(nextTime time.Time) bool {
 	// NOTE: negative duration will make the timer fire immediately
 	now := time.Now()
 
-	if timerGate.timer.Stop() {
-		// this means the timer, before stopped, is active
-
-		if timerGate.nextWakeupTime.Before(nextTime) {
-			timerGate.timer.Reset(timerGate.nextWakeupTime.Sub(now))
-			return false
-		}
-
-		timerGate.nextWakeupTime = nextTime
-		timerGate.timer.Reset(nextTime.Sub(now))
-		// Notifies caller that next notification is reset to fire at passed in 'next' visibility time
-		return true
+	if timerGate.timer.Stop() && timerGate.nextWakeupTime.Before(nextTime) {
+		// this means the timer, before stopped, is active && next wake up time do not have to be upddated
+		timerGate.timer.Reset(timerGate.nextWakeupTime.Sub(now))
+		return false
 	}
 
-	// this means the timer, before stopped, is already fired / never active
+	// this means the timer, before stopped, is active && next wake up time has to be upddated
+	// or this means the timer, before stopped, is already fired / never active
 	timerGate.nextWakeupTime = nextTime
 	timerGate.timer.Reset(nextTime.Sub(now))
 	// Notifies caller that next notification is reset to fire at passed in 'next' visibility time

--- a/service/history/timerGate.go
+++ b/service/history/timerGate.go
@@ -91,6 +91,11 @@ func NewLocalTimerGate() LocalTimerGate {
 		fireChan:       make(chan struct{}),
 		closeChan:      make(chan struct{}),
 	}
+	// the timer should be stopped when initialized
+	if !timer.timer.Stop() {
+		// drain the existing signal if exist
+		<-timer.timer.C
+	}
 
 	go func() {
 		defer close(timer.fireChan)
@@ -125,20 +130,28 @@ func (timerGate *LocalTimerGateImpl) FireAfter(now time.Time) bool {
 // Update update the timer gate, return true if update is a success
 // success means timer is idle or timer is set with a sooner time to fire
 func (timerGate *LocalTimerGateImpl) Update(nextTime time.Time) bool {
+	// NOTE: negative duration will make the timer fire immediately
 	now := time.Now()
 
-	if !timerGate.nextWakeupTime.After(now) || timerGate.nextWakeupTime.After(nextTime) {
-		// if timer will not fire or next wake time is after the "next"
-		// then we need to update the timer to fire
-		timerGate.nextWakeupTime = nextTime
-		// reset timer to fire when the next message should be made 'visible'
-		timerGate.timer.Reset(nextTime.Sub(now))
+	if timerGate.timer.Stop() {
+		// this means the timer, before stopped, is active
 
+		if timerGate.nextWakeupTime.Before(nextTime) {
+			timerGate.timer.Reset(timerGate.nextWakeupTime.Sub(now))
+			return false
+		}
+
+		timerGate.nextWakeupTime = nextTime
+		timerGate.timer.Reset(nextTime.Sub(now))
 		// Notifies caller that next notification is reset to fire at passed in 'next' visibility time
 		return true
 	}
 
-	return false
+	// this means the timer, before stopped, is already fired / never active
+	timerGate.nextWakeupTime = nextTime
+	timerGate.timer.Reset(nextTime.Sub(now))
+	// Notifies caller that next notification is reset to fire at passed in 'next' visibility time
+	return true
 }
 
 // Close shutdown the timer

--- a/service/history/timerGate_test.go
+++ b/service/history/timerGate_test.go
@@ -42,6 +42,14 @@ type (
 	}
 )
 
+func BenchmarkLocalTimer(b *testing.B) {
+	timer := NewLocalTimerGate()
+
+	for i := 0; i < b.N; i++ {
+		timer.Update(time.Now())
+	}
+}
+
 func TestLocalTimerGeteSuite(t *testing.T) {
 	s := new(localTimerGateSuite)
 	suite.Run(t, s)

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -72,6 +72,9 @@ func newTimerQueueActiveProcessor(shard ShardContext, historyService *historyEng
 		return true, nil
 	}
 
+	timerGate := NewLocalTimerGate()
+	// this will trigger a timer gate fire event immediately
+	timerGate.Update(time.Time{})
 	timerQueueAckMgr := newTimerQueueAckMgr(shard, historyService.metricsClient, clusterName, logger)
 	processor := &timerQueueActiveProcessorImpl{
 		shard:                   shard,
@@ -81,7 +84,7 @@ func newTimerQueueActiveProcessor(shard ShardContext, historyService *historyEng
 		logger:                  logger,
 		metricsClient:           historyService.metricsClient,
 		currentClusterName:      clusterName,
-		timerGate:               NewLocalTimerGate(),
+		timerGate:               timerGate,
 		timerQueueProcessorBase: newTimerQueueProcessorBase(shard, historyService, timerQueueAckMgr, timeNow, logger),
 		timerQueueAckMgr:        timerQueueAckMgr,
 	}

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -70,6 +70,10 @@ func newTimerQueueStandbyProcessor(shard ShardContext, historyService *historyEn
 		return true, nil
 	}
 
+	timerGate := NewRemoteTimerGate()
+	// this will trigger a timer gate fire event immediately
+	timerGate.Update(time.Time{})
+	timerGate.SetCurrentTime(shard.GetCurrentTime(clusterName))
 	timerQueueAckMgr := newTimerQueueAckMgr(shard, historyService.metricsClient, clusterName, logger)
 	processor := &timerQueueStandbyProcessorImpl{
 		shard:                   shard,


### PR DESCRIPTION
…rom race condition, causing the imminent timer fired event to be lost.

performance impact:

after the change:
```
cadence|timer-bug ⇒ go test -cpu=1 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer 	100000000	       107 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	10.931s
cadence|timer-bug ⇒ go test -cpu=1 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer 	100000000	       100 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	10.205s
cadence|timer-bug ⇒ go test -cpu=1 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer 	100000000	       108 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	10.945s
cadence|timer-bug ⇒ go test -cpu=4 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer-4   	100000000	       211 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	21.347s
cadence|timer-bug ⇒ go test -cpu=4 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer-4   	100000000	       193 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	19.484s
cadence|timer-bug ⇒ go test -cpu=4 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer-4   	100000000	       236 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	23.771s
```

before the change:
```
cadence|master ⇒ go test -cpu=1 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer 	200000000	        88.8 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	26.831s
cadence|master⚡ ⇒ go test -cpu=1 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer 	200000000	        86.9 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	26.456s
cadence|master⚡ ⇒ go test -cpu=1 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer 	200000000	        88.1 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	26.589s
cadence|master⚡ ⇒ go test -cpu=4 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer-4   	100000000	       183 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	18.578s
cadence|master⚡ ⇒ go test -cpu=4 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer-4   	100000000	       185 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	18.653s
cadence|master⚡ ⇒ go test -cpu=4 -benchtime=10s -benchmem -run=^$ github.com/uber/cadence/service/history -bench ^BenchmarkLocalTimer$
goos: darwin
goarch: amd64
pkg: github.com/uber/cadence/service/history
BenchmarkLocalTimer-4   	100000000	       179 ns/op	       0 B/op	       0 allocs/op
PASS
ok  	github.com/uber/cadence/service/history	18.042s
```

the performance impact is ~<20% latency increase, which is negligible