### PR TITLE
bugfix: related to failover version

### DIFF
--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -62,8 +62,8 @@ clustersInfo:
   masterClusterName: "active"
   currentClusterName: "active"
   clusterInitialFailoverVersion:
-    active: 0
-    standby: 1
+    active: 1
+    standby: 0
 
 kafka:
   clusters:

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -62,8 +62,8 @@ clustersInfo:
   masterClusterName: "active"
   currentClusterName: "standby"
   clusterInitialFailoverVersion:
-    active: 0
-    standby: 1
+    active: 1
+    standby: 0
 
 kafka:
   clusters:

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -318,9 +318,9 @@ func (e *historyEngineImpl) StartWorkflowExecution(startRequest *h.StartWorkflow
 		}
 		replicationTasks = append(replicationTasks, replicationTask)
 	}
+	setTaskVersion(msBuilder.GetCurrentVersion(), transferTasks, timerTasks)
 
 	createWorkflow := func(isBrandNew bool, prevRunID string) (string, error) {
-
 		_, err = e.shard.CreateWorkflowExecution(&persistence.CreateWorkflowExecutionRequest{
 			RequestID:                   common.StringDefault(request.RequestId),
 			DomainID:                    domainID,
@@ -1868,6 +1868,7 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(signalWithStartRequ
 	msBuilder.executionInfo.LastFirstEventID = startedEvent.GetEventId()
 
 	createWorkflow := func(isBrandNew bool, prevRunID string) (string, error) {
+		setTaskVersion(msBuilder.GetCurrentVersion(), transferTasks, timerTasks)
 		_, err = e.shard.CreateWorkflowExecution(&persistence.CreateWorkflowExecutionRequest{
 			RequestID:                   common.StringDefault(request.RequestId),
 			DomainID:                    domainID,
@@ -2572,4 +2573,13 @@ func getStartRequest(domainID string,
 		StartRequest: req,
 	}
 	return startRequest
+}
+
+func setTaskVersion(version int64, transferTasks []persistence.Task, timerTasks []persistence.Task) {
+	for _, task := range transferTasks {
+		task.SetVersion(version)
+	}
+	for _, task := range timerTasks {
+		task.SetVersion(version)
+	}
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1866,9 +1866,9 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(signalWithStartRequ
 		return nil, err
 	}
 	msBuilder.executionInfo.LastFirstEventID = startedEvent.GetEventId()
+	setTaskVersion(msBuilder.GetCurrentVersion(), transferTasks, timerTasks)
 
 	createWorkflow := func(isBrandNew bool, prevRunID string) (string, error) {
-		setTaskVersion(msBuilder.GetCurrentVersion(), transferTasks, timerTasks)
 		_, err = e.shard.CreateWorkflowExecution(&persistence.CreateWorkflowExecutionRequest{
 			RequestID:                   common.StringDefault(request.RequestId),
 			DomainID:                    domainID,

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -259,6 +259,7 @@ func (r *historyReplicator) ApplyReplicationTask(context *workflowExecutionConte
 			decisionStartID = di.StartedID
 			decisionTimeout = di.DecisionTimeout
 		}
+		setTaskVersion(msBuilder.GetCurrentVersion(), sBuilder.transferTasks, sBuilder.timerTasks)
 
 		createWorkflow := func(isBrandNew bool, prevRunID string) (string, error) {
 			_, err = r.shard.CreateWorkflowExecution(&persistence.CreateWorkflowExecutionRequest{

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2134,25 +2134,28 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionContinuedAsNewEvent(sour
 		newStateBuilder.updateReplicationStateLastEventID(sourceClusterName, di.ScheduleID)
 	}
 
+	newTransferTasks := []persistence.Task{&persistence.DecisionTask{
+		DomainID:   domainID,
+		TaskList:   newStateBuilder.executionInfo.TaskList,
+		ScheduleID: di.ScheduleID,
+	}}
+	setTaskVersion(newStateBuilder.GetCurrentVersion(), newTransferTasks, nil)
+
 	e.continueAsNew = &persistence.CreateWorkflowExecutionRequest{
-		RequestID:            uuid.New(),
-		DomainID:             domainID,
-		Execution:            newExecution,
-		ParentDomainID:       parentDomainID,
-		ParentExecution:      parentExecution,
-		InitiatedID:          initiatedID,
-		TaskList:             newStateBuilder.executionInfo.TaskList,
-		WorkflowTypeName:     newStateBuilder.executionInfo.WorkflowTypeName,
-		WorkflowTimeout:      newStateBuilder.executionInfo.WorkflowTimeout,
-		DecisionTimeoutValue: newStateBuilder.executionInfo.DecisionTimeoutValue,
-		ExecutionContext:     nil,
-		NextEventID:          newStateBuilder.GetNextEventID(),
-		LastProcessedEvent:   emptyEventID,
-		TransferTasks: []persistence.Task{&persistence.DecisionTask{
-			DomainID:   domainID,
-			TaskList:   newStateBuilder.executionInfo.TaskList,
-			ScheduleID: di.ScheduleID,
-		}},
+		RequestID:                   uuid.New(),
+		DomainID:                    domainID,
+		Execution:                   newExecution,
+		ParentDomainID:              parentDomainID,
+		ParentExecution:             parentExecution,
+		InitiatedID:                 initiatedID,
+		TaskList:                    newStateBuilder.executionInfo.TaskList,
+		WorkflowTypeName:            newStateBuilder.executionInfo.WorkflowTypeName,
+		WorkflowTimeout:             newStateBuilder.executionInfo.WorkflowTimeout,
+		DecisionTimeoutValue:        newStateBuilder.executionInfo.DecisionTimeoutValue,
+		ExecutionContext:            nil,
+		NextEventID:                 newStateBuilder.GetNextEventID(),
+		LastProcessedEvent:          emptyEventID,
+		TransferTasks:               newTransferTasks,
 		DecisionVersion:             di.Version,
 		DecisionScheduleID:          di.ScheduleID,
 		DecisionStartedID:           di.StartedID,

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -249,14 +249,7 @@ func (c *workflowExecutionContext) updateHelper(builder *historyBuilder, transfe
 		replicationTasks = append(replicationTasks, c.msBuilder.createReplicationTask())
 	}
 
-	// this is the current failover version
-	version := c.msBuilder.GetCurrentVersion()
-	for _, task := range transferTasks {
-		task.SetVersion(version)
-	}
-	for _, task := range timerTasks {
-		task.SetVersion(version)
-	}
+	setTaskVersion(c.msBuilder.GetCurrentVersion(), transferTasks, timerTasks)
 
 	if err1 := c.updateWorkflowExecutionWithRetry(&persistence.UpdateWorkflowExecutionRequest{
 		ExecutionInfo:                 c.msBuilder.executionInfo,


### PR DESCRIPTION
* bugfix: when creating workflow, the timer / transfer tasks should be updated with corresponding version
* bugfix: when continue as new a workflow, the timer / transfer tasks should be updated with corresponding version