### PR TITLE
Changes to Kafka Config

### DIFF
--- a/common/messaging/interface.go
+++ b/common/messaging/interface.go
@@ -29,8 +29,8 @@ import (
 type (
 	// Client is the interface used to abstract out interaction with messaging system for replication
 	Client interface {
-		NewConsumer(cadenceCluster, consumerName string, concurrency int) (kafka.Consumer, error)
-		NewProducer(cadenceCluster string) (Producer, error)
+		NewConsumer(currentCluster, sourceCluster, consumerName string, concurrency int) (kafka.Consumer, error)
+		NewProducer(sourceCluster string) (Producer, error)
 	}
 
 	// Producer is the interface used to send replication tasks to other clusters through replicator

--- a/common/messaging/kafkaClient.go
+++ b/common/messaging/kafkaClient.go
@@ -36,26 +36,27 @@ type (
 )
 
 // NewConsumer is used to create a Kafka consumer
-func (c *kafkaClient) NewConsumer(cadenceCluster, consumerName string, concurrency int) (kafka.Consumer, error) {
-	topics := c.config.getTopicsForCadenceCluster(cadenceCluster)
+func (c *kafkaClient) NewConsumer(currentCluster, sourceCluster, consumerName string, concurrency int) (kafka.Consumer, error) {
+	currentTopics := c.config.getTopicsForCadenceCluster(currentCluster)
+	sourceTopics := c.config.getTopicsForCadenceCluster(sourceCluster)
 
-	topicKafkaCluster := c.config.getKafkaClusterForTopic(topics.Topic)
-	retryTopicKafkaCluster := c.config.getKafkaClusterForTopic(topics.RetryTopic)
-	dqlTopicKafkaCluster := c.config.getKafkaClusterForTopic(topics.DLQTopic)
+	topicKafkaCluster := c.config.getKafkaClusterForTopic(sourceTopics.Topic)
+	retryTopicKafkaCluster := c.config.getKafkaClusterForTopic(currentTopics.RetryTopic)
+	dqlTopicKafkaCluster := c.config.getKafkaClusterForTopic(currentTopics.DLQTopic)
 	topicList := kafka.ConsumerTopicList{
 		kafka.ConsumerTopic{
 			Topic: kafka.Topic{
-				Name:       topics.Topic,
+				Name:       sourceTopics.Topic,
 				Cluster:    topicKafkaCluster,
 				BrokerList: c.config.getBrokersForKafkaCluster(topicKafkaCluster),
 			},
 			RetryQ: kafka.Topic{
-				Name:       topics.RetryTopic,
+				Name:       currentTopics.RetryTopic,
 				Cluster:    retryTopicKafkaCluster,
 				BrokerList: c.config.getBrokersForKafkaCluster(retryTopicKafkaCluster),
 			},
 			DLQ: kafka.Topic{
-				Name:       topics.DLQTopic,
+				Name:       currentTopics.DLQTopic,
 				Cluster:    dqlTopicKafkaCluster,
 				BrokerList: c.config.getBrokersForKafkaCluster(dqlTopicKafkaCluster),
 			},
@@ -71,8 +72,8 @@ func (c *kafkaClient) NewConsumer(cadenceCluster, consumerName string, concurren
 }
 
 // NewProducer is used to create a Kafka producer for shipping replication tasks
-func (c *kafkaClient) NewProducer(cadenceCluster string) (Producer, error) {
-	topics := c.config.getTopicsForCadenceCluster(cadenceCluster)
+func (c *kafkaClient) NewProducer(sourceCluster string) (Producer, error) {
+	topics := c.config.getTopicsForCadenceCluster(sourceCluster)
 	kafkaClusterName := c.config.getKafkaClusterForTopic(topics.Topic)
 	brokers := c.config.getBrokersForKafkaCluster(kafkaClusterName)
 

--- a/common/messaging/kafkaClient.go
+++ b/common/messaging/kafkaClient.go
@@ -32,7 +32,7 @@ import (
 type (
 	kafkaClient struct {
 		config *KafkaConfig
-		client *kafkaclient.Client
+		client kafkaclient.Client
 		logger bark.Logger
 	}
 )
@@ -53,12 +53,12 @@ func (c *kafkaClient) NewConsumer(cadenceCluster, consumerName string, concurren
 					BrokerList: brokers,
 				},
 				RetryQ: kafka.Topic{
-					Name:       strings.Join([]string{topicName, "retry"}, "-"),
+					Name:       strings.Join([]string{topicName, "RETRY"}, "-"),
 					Cluster:    kafkaClusterName,
 					BrokerList: brokers,
 				},
 				DLQ: kafka.Topic{
-					Name:       strings.Join([]string{topicName, "dlq"}, "-"),
+					Name:       strings.Join([]string{topicName, "DLQ"}, "-"),
 					Cluster:    kafkaClusterName,
 					BrokerList: brokers,
 				},
@@ -66,6 +66,9 @@ func (c *kafkaClient) NewConsumer(cadenceCluster, consumerName string, concurren
 		},
 		Concurrency: concurrency,
 	}
+
+	consumerConfig.Offsets.Initial.Offset = kafka.OffsetNewest
+	consumerConfig.Offsets.Initial.Reset = true
 
 	consumer, err := c.client.NewConsumer(consumerConfig)
 	return consumer, err

--- a/common/messaging/kafkaConfig.go
+++ b/common/messaging/kafkaConfig.go
@@ -21,6 +21,7 @@
 package messaging
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/uber-common/bark"
@@ -35,7 +36,7 @@ type (
 	KafkaConfig struct {
 		Clusters       map[string]ClusterConfig `yaml:"clusters"`
 		Topics         map[string]TopicConfig   `yaml:"topics"`
-		ClusterToTopic map[string]string        `yaml:"cadence-cluster-to-topic"`
+		ClusterToTopic map[string]TopicList     `yaml:"cadence-cluster-topics"`
 	}
 
 	// ClusterConfig describes the configuration for a single Kafka cluster
@@ -47,10 +48,19 @@ type (
 	TopicConfig struct {
 		Cluster string `yaml:"cluster"`
 	}
+
+	// TopicList describes the topic names for each cluster
+	TopicList struct {
+		Topic      string `yaml:"topic"`
+		RetryTopic string `yaml:"retry-topic"`
+		DLQTopic   string `yaml:"dlq-topic"`
+	}
 )
 
 // NewKafkaClient is used to create an instance of KafkaClient
 func (k *KafkaConfig) NewKafkaClient(zLogger *zap.Logger, logger bark.Logger, metricScope tally.Scope) Client {
+	k.validate()
+
 	// mapping from cluster name to list of broker ip addresses
 	brokers := map[string][]string{}
 	for cluster, cfg := range k.Clusters {
@@ -77,14 +87,44 @@ func (k *KafkaConfig) NewKafkaClient(zLogger *zap.Logger, logger bark.Logger, me
 	}
 }
 
-func (k *KafkaConfig) getTopicForCadenceCluster(cluster string) string {
-	return k.ClusterToTopic[cluster]
+func (k *KafkaConfig) validate() {
+	if len(k.Clusters) == 0 {
+		panic("Empty Kafka Cluster Config")
+	}
+	if len(k.Topics) == 0 {
+		panic("Empty Topics Config")
+	}
+	if len(k.ClusterToTopic) == 0 {
+		panic("Empty Cluster To Topics Config")
+	}
+
+	validateTopicsFn := func(topic string) {
+		if topic == "" {
+			panic("Empty Topic Name")
+		} else if topicConfig, ok := k.Topics[topic]; !ok {
+			panic(fmt.Sprintf("Missing Topic Config for Topic %v", topic))
+		} else if clusterConfig, ok := k.Clusters[topicConfig.Cluster]; !ok {
+			panic(fmt.Sprintf("Missing Kafka Cluster Config for Cluster %v", topicConfig.Cluster))
+		} else if len(clusterConfig.Brokers) == 0 {
+			panic(fmt.Sprintf("Missing Kafka Brokers Config for Cluster %v", topicConfig.Cluster))
+		}
+	}
+
+	for _, topics := range k.ClusterToTopic {
+		validateTopicsFn(topics.Topic)
+		validateTopicsFn(topics.RetryTopic)
+		validateTopicsFn(topics.DLQTopic)
+	}
+}
+
+func (k *KafkaConfig) getTopicsForCadenceCluster(cadenceCluster string) TopicList {
+	return k.ClusterToTopic[cadenceCluster]
 }
 
 func (k *KafkaConfig) getKafkaClusterForTopic(topic string) string {
 	return k.Topics[topic].Cluster
 }
 
-func (k *KafkaConfig) getBrokersForKafkaCluster(cluster string) []string {
-	return k.Clusters[cluster].Brokers
+func (k *KafkaConfig) getBrokersForKafkaCluster(kafkaCluster string) []string {
+	return k.Clusters[kafkaCluster].Brokers
 }

--- a/common/mocks/ExecutionManager.go
+++ b/common/mocks/ExecutionManager.go
@@ -241,7 +241,7 @@ func (_m *ExecutionManager) UpdateWorkflowExecution(request *persistence.UpdateW
 	return r0
 }
 
-// UpdateWorkflowExecution provides a mock function with given fields: request
+// ResetMutableState provides a mock function with given fields: request
 func (_m *ExecutionManager) ResetMutableState(request *persistence.ResetMutableStateRequest) error {
 	ret := _m.Called(request)
 

--- a/common/mocks/MessagingClient.go
+++ b/common/mocks/MessagingClient.go
@@ -44,11 +44,11 @@ func NewMockMessagingClient(publisher messaging.Producer, consumer kafka.Consume
 }
 
 // NewConsumer generates a dummy implementation of kafka consumer
-func (c *MessagingClient) NewConsumer(topicName, consumerName string, concurrency int) (kafka.Consumer, error) {
+func (c *MessagingClient) NewConsumer(currentCluster, sourceCluster, consumerName string, concurrency int) (kafka.Consumer, error) {
 	return c.consumerMock, nil
 }
 
 // NewProducer generates a dummy implementation of kafka producer
-func (c *MessagingClient) NewProducer(topicName string) (messaging.Producer, error) {
+func (c *MessagingClient) NewProducer(sourceCluster string) (messaging.Producer, error) {
 	return c.publisherMock, nil
 }

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -73,8 +73,22 @@ kafka:
   topics:
     active:
       cluster: test
+    active-retry:
+      cluster: test
+    active-dlq:
+      cluster: test
     standby:
       cluster: test
-  cadence-cluster-to-topic:
-    active: active
-    standby: standby
+    standby-retry:
+      cluster: test
+    standby-dlq:
+      cluster: test
+  cadence-cluster-topics:
+    active:
+      topic: active
+      retry-topic: active-retry
+      dlq-topic: active-dlq
+    standby:
+      topic: standby
+      retry-topic: standby-retry
+      dlq-topic: standby-dlq

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -73,8 +73,22 @@ kafka:
   topics:
     active:
       cluster: test
+    active-retry:
+      cluster: test
+    active-dlq:
+      cluster: test
     standby:
       cluster: test
-  cadence-cluster-to-topic:
-    active: active
-    standby: standby
+    standby-retry:
+      cluster: test
+    standby-dlq:
+      cluster: test
+  cadence-cluster-topics:
+    active:
+      topic: active
+      retry-topic: active-retry
+      dlq-topic: active-dlq
+    standby:
+      topic: standby
+      retry-topic: standby-retry
+      dlq-topic: standby-dlq

--- a/glide.lock
+++ b/glide.lock
@@ -132,7 +132,7 @@ imports:
   subpackages:
   - utils
 - name: github.com/uber-go/kafka-client
-  version: 01a7eeb4f9ea6e4c16a6ec5d159076c88244c947
+  version: d3982364cc55cd78569fc58a587ff5ec0e06ab20
   subpackages:
   - internal/consumer
   - internal/list

--- a/glide.yaml
+++ b/glide.yaml
@@ -46,6 +46,7 @@ import:
   - transport/http
   - transport/tchannel
 - package: github.com/uber-go/kafka-client
+  version: ^0.1.7
 
 # Added excludeDirs to prevent build from failing on the yarpc generated code.
 excludeDirs:

--- a/service/worker/processor.go
+++ b/service/worker/processor.go
@@ -163,15 +163,10 @@ func (p *replicationTaskProcessor) worker(workerWG *sync.WaitGroup) {
 	for {
 		select {
 		case msg, ok := <-p.consumer.Messages():
-			print := func(value interface{}) string {
-				bytes, _ := json.MarshalIndent(value, "", "  ")
-				return string(bytes)
-			}
 			if !ok {
 				p.logger.Info("Worker for replication task processor shutting down.")
 				return // channel closed
 			}
-			fmt.Printf("----------\n%v\n----------\n", print(msg.Value()))
 
 			p.metricsClient.IncCounter(metrics.ReplicatorScope, metrics.ReplicatorMessages)
 			sw := p.metricsClient.StartTimer(metrics.ReplicatorScope, metrics.ReplicatorLatency)

--- a/service/worker/processor.go
+++ b/service/worker/processor.go
@@ -163,10 +163,15 @@ func (p *replicationTaskProcessor) worker(workerWG *sync.WaitGroup) {
 	for {
 		select {
 		case msg, ok := <-p.consumer.Messages():
+			print := func(value interface{}) string {
+				bytes, _ := json.MarshalIndent(value, "", "  ")
+				return string(bytes)
+			}
 			if !ok {
 				p.logger.Info("Worker for replication task processor shutting down.")
 				return // channel closed
 			}
+			fmt.Printf("----------\n%v\n----------\n", print(msg.Value()))
 
 			p.metricsClient.IncCounter(metrics.ReplicatorScope, metrics.ReplicatorMessages)
 			sw := p.metricsClient.StartTimer(metrics.ReplicatorScope, metrics.ReplicatorLatency)

--- a/service/worker/replicator.go
+++ b/service/worker/replicator.go
@@ -70,7 +70,7 @@ func (r *Replicator) Start() error {
 	for cluster := range r.clusterMetadata.GetAllClusterFailoverVersions() {
 		if cluster != currentClusterName {
 			consumerName := getConsumerName(currentClusterName, cluster)
-			r.processors = append(r.processors, newReplicationTaskProcessor(cluster, consumerName, r.client,
+			r.processors = append(r.processors, newReplicationTaskProcessor(currentClusterName, cluster, consumerName, r.client,
 				r.config, r.logger, r.metricsClient, r.domainReplicator, r.historyClient))
 		}
 	}


### PR DESCRIPTION
* Update Kafka Client to 0.1.7
* Change Kafka Config to make DLQ and retry topics configurable
* Use OffsetNewest instead of OffsetOldest (this is the previous value as well as the default from kafka client)

from https://github.com/bsm/sarama-cluster/issues/133:
```
if the group has been consumed before and the offset exists, 
it will always automatically resume from that offset. 
The Consumer.Offsets.Initial setting will only be used if the consumer 
group doesn't exist or if the stored offset cannot be retrieved (e.g. expired)
```
and
```
        // OffsetNewest stands for the log head offset, i.e. the offset that will be
	// assigned to the next message that will be produced to the partition. You
	// can send this to a client's GetOffset method to get this offset, or when
	// calling ConsumePartition to start consuming new messages.
	OffsetNewest int64 = -1
	// OffsetOldest stands for the oldest offset available on the broker for a
	// partition. You can send this to a client's GetOffset method to get this
	// offset, or when calling ConsumePartition to start consuming from the
	// oldest offset that is still available on the broker.
	OffsetOldest int64 = -2
```