### PR TITLE
Separate xdc tests from local make test

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -69,6 +69,9 @@ Run all the tests:
 ```bash
 make test
 
+# `make test` currently do not include crossdc tests, start kafka and run 
+make test_xdc
+
 # or go to folder with *_test.go, e.g
 cd service/history/ 
 go test -v

--- a/Makefile
+++ b/Makefile
@@ -98,8 +98,12 @@ test: vendor/glide.updated bins
 	@rm -f test.log
 	@for dir in $(TEST_DIRS); do \
 		go test -timeout 15m -race -coverprofile=$@ "$$dir" | tee -a test.log; \
-	done; \
-	# need to run xdc tests with race detector off because of ringpop bug causing data race issue
+	done;
+
+# need to run xdc tests with race detector off because of ringpop bug causing data race issue
+test_xdc: vendor/glide.updated bins
+	@rm -f test
+	@rm -f test.log
 	@for dir in $(INTEG_TEST_XDC_ROOT); do \
 		go test -timeout 15m -coverprofile=$@ "$$dir" | tee -a test.log; \
 	done;


### PR DESCRIPTION
With this pull request, developer do not need to start kafka if no xdc tests wanted to run locally.  
To run xdc tests, one needs to additionally run `make test_xdc`. 
Travis will run all tests include xdc tests anyway without affected. 