### PR TITLE
Handling of duplicate StartWorkflowExecution event processing

### DIFF
--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -78,21 +78,26 @@ func (r *historyReplicator) ApplyEvents(request *h.ReplicateEventsRequest) (retE
 
 	execution := *request.WorkflowExecution
 
-	var context *workflowExecutionContext
+	context, release, err := r.historyCache.getOrCreateWorkflowExecution(domainID, execution)
+	if err != nil {
+		return err
+	}
+	defer func() { release(retError) }()
+
 	var msBuilder *mutableStateBuilder
 	firstEvent := request.History.Events[0]
 	switch firstEvent.GetEventType() {
 	case shared.EventTypeWorkflowExecutionStarted:
+		msBuilder, err = context.loadWorkflowExecution()
+		if err == nil {
+			// Workflow execution already exist, looks like a duplicate start event, it is safe to ignore it
+			r.logger.Infof("Dropping stale replication task for start event.  WorkflowID: %v, RunID: %v, Version: %v",
+				execution.GetWorkflowId(), execution.GetRunId(), request.GetVersion())
+			return nil
+		}
 		msBuilder = newMutableStateBuilderWithReplicationState(r.shard.GetConfig(), r.logger, request.GetVersion())
 
 	default:
-		var release releaseWorkflowExecutionFunc
-		context, release, err = r.historyCache.getOrCreateWorkflowExecution(domainID, execution)
-		if err != nil {
-			return err
-		}
-		defer func() { release(retError) }()
-
 		msBuilder, err = context.loadWorkflowExecution()
 		if err != nil {
 			return err
@@ -309,12 +314,11 @@ func (r *historyReplicator) ApplyReplicationTask(context *workflowExecutionConte
 			// set the prev run ID for database conditional update
 			prevRunID := err.RunID
 			prevState := err.State
+			if prevRunID == execution.GetRunId() {
+				// Duplicate processing of StartWorkflowExecution replication task
+				return err
+			}
 			if prevState != persistence.WorkflowStateCompleted {
-				if prevRunID == execution.GetRunId() {
-					// this is a duplicate execution of the start execution event
-					// or this is an execution of the duplicate start execution event
-					return nil
-				}
 				return err
 			}
 			// if the existing workflow is completed, ignore the worklow ID reuse policy
@@ -328,10 +332,29 @@ func (r *historyReplicator) ApplyReplicationTask(context *workflowExecutionConte
 		_, err = createWorkflow(isBrandNew, "")
 		// if err still non nil, see if retry
 		if errExist, ok := err.(*persistence.WorkflowExecutionAlreadyStartedError); ok {
-			if err = workflowExistsErrHandler(errExist); err == nil {
-				isBrandNew = false
-				_, err = createWorkflow(isBrandNew, errExist.RunID)
+			prevRunID := errExist.RunID
+			prevState := errExist.State
+
+			// Check for duplicate processing of StartWorkflowExecution replication task
+			if prevRunID == execution.GetRunId() {
+				r.logger.Infof("Dropping stale replication task for start event.  WorkflowID: %v, RunID: %v, Version: %v",
+					execution.GetWorkflowId(), execution.GetRunId(), request.GetVersion())
+				return nil
 			}
+
+			// Some other workflow is running, for now let's keep on retrying this replication event by an error
+			// to wait for current run to finish so this event could be applied.
+			// TODO: We also need to deal with conflict resolution when workflow with same ID is started on 2 different
+			// clusters.
+			if prevState != persistence.WorkflowStateCompleted {
+				return err
+			}
+
+			// if the existing workflow is completed, ignore the worklow ID reuse policy
+			// since the policy should be applied by the active cluster,
+			// standby cluster should apply this event without question.
+			isBrandNew = false
+			_, err = createWorkflow(isBrandNew, errExist.RunID)
 		}
 
 	default:

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -95,6 +95,13 @@ func (r *historyReplicator) ApplyEvents(request *h.ReplicateEventsRequest) (retE
 				execution.GetWorkflowId(), execution.GetRunId(), request.GetVersion())
 			return nil
 		}
+
+		// GetWorkflowExecution failed with some transient error.  Return err so we can retry the task later
+		if _, ok := err.(*shared.EntityNotExistsError); !ok {
+			return err
+		}
+
+		// WorkflowExecution does not exist, lets proceed with processing of the task
 		msBuilder = newMutableStateBuilderWithReplicationState(r.shard.GetConfig(), r.logger, request.GetVersion())
 
 	default:

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -310,23 +310,6 @@ func (r *historyReplicator) ApplyReplicationTask(context *workflowExecutionConte
 		// The failover version checking && overwriting should be performed here: #675
 		// TODO
 
-		workflowExistsErrHandler := func(err *persistence.WorkflowExecutionAlreadyStartedError) error {
-			// set the prev run ID for database conditional update
-			prevRunID := err.RunID
-			prevState := err.State
-			if prevRunID == execution.GetRunId() {
-				// Duplicate processing of StartWorkflowExecution replication task
-				return err
-			}
-			if prevState != persistence.WorkflowStateCompleted {
-				return err
-			}
-			// if the existing workflow is completed, ignore the worklow ID reuse policy
-			// since the policy should be applied by the active cluster,
-			// standby cluster should apply this event without question.
-			return nil
-		}
-
 		// try to create the workflow execution
 		isBrandNew := true
 		_, err = createWorkflow(isBrandNew, "")


### PR DESCRIPTION
Replicator could potentially see duplicate StartWorkflowExecution
replication events.  Adding logic to replicator to dedupe such events.