### PR TITLE
Add Dockerfile for cct and update Makefile to support prod deploys

### DIFF
--- a/Dockerfile-cct
+++ b/Dockerfile-cct
@@ -1,0 +1,24 @@
+FROM golang:1.9 as go-builder
+
+RUN apt-get update && apt-get install -y git
+
+# Install glide
+WORKDIR $GOPATH/src/github.com/Masterminds
+RUN git clone https://github.com/Masterminds/glide.git
+RUN cd glide && git checkout v0.12.3 && make bootstrap-dist && make install
+
+RUN mkdir -p $GOPATH/src/github.com/uber/cadence
+COPY . $GOPATH/src/github.com/uber/cadence
+WORKDIR $GOPATH/src/github.com/uber/cadence
+RUN make cadence-cassandra-tool
+
+FROM phusion/baseimage:0.10.1
+
+RUN apt-get update && apt-get install -y make
+
+COPY --from=go-builder /go/src/github.com/uber/cadence/schema schema
+COPY --from=go-builder /go/src/github.com/uber/cadence/Makefile .
+COPY --from=go-builder /go/src/github.com/uber/cadence/cadence-cassandra-tool .
+COPY --from=go-builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+
+ENTRYPOINT ["./cadence-cassandra-tool"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 PROJECT_ROOT = github.com/uber/cadence
 
 export PATH := $(GOPATH)/bin:$(PATH)
+BUILD_BINS=true
 
 THRIFT_GENDIR=.gen
 
@@ -89,9 +90,13 @@ cadence: vendor/glide.updated $(TOOLS_SRC)
 cadence-server: vendor/glide.updated $(ALL_SRC)
 	go build -i -o cadence-server cmd/server/cadence.go cmd/server/server.go
 
+ifeq ($(BUILD_BINS), true)
 bins_nothrift: lint copyright cadence-cassandra-tool cadence cadence-server
-
 bins: thriftc bins_nothrift
+else
+bins_nothrift:
+bins:
+endif
 
 test: vendor/glide.updated bins
 	@rm -f test
@@ -158,32 +163,35 @@ clean:
 	rm -f cadence-server
 	rm -Rf $(BUILD)
 
+CASSANDRA_HOST=127.0.0.1
+CASSANDRA_REPLICATION_FACTOR=1
+
 install-schema: bins
-	./cadence-cassandra-tool --ep 127.0.0.1 create -k cadence --rf 1
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence setup-schema -v 0.0
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence update-schema -d ./schema/cadence/versioned
-	./cadence-cassandra-tool --ep 127.0.0.1 create -k cadence_visibility --rf 1
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility setup-schema -v 0.0
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/visibility/versioned
+	./cadence-cassandra-tool --ep $(CASSANDRA_HOST) create -k cadence --rf $(CASSANDRA_REPLICATION_FACTOR)
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence setup-schema -v 0.0
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence update-schema -d ./schema/cadence/versioned
+	./cadence-cassandra-tool --ep $(CASSANDRA_HOST) create -k cadence_visibility --rf $(CASSANDRA_REPLICATION_FACTOR)
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_visibility setup-schema -v 0.0
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_visibility update-schema -d ./schema/visibility/versioned
 
 start: bins
 	./cadence-server start
 
 install-schema-cdc: bins
 	@echo Setting up cadence_active key space
-	./cadence-cassandra-tool --ep 127.0.0.1 create -k cadence_active --rf 1
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_active setup-schema -v 0.0
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_active update-schema -d ./schema/cadence/versioned
-	./cadence-cassandra-tool --ep 127.0.0.1 create -k cadence_visibility_active --rf 1
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility_active setup-schema -v 0.0
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility_active update-schema -d ./schema/visibility/versioned
+	./cadence-cassandra-tool --ep $(CASSANDRA_HOST) create -k cadence_active --rf $(CASSANDRA_REPLICATION_FACTOR)
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_active setup-schema -v 0.0
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_active update-schema -d ./schema/cadence/versioned
+	./cadence-cassandra-tool --ep $(CASSANDRA_HOST) create -k cadence_visibility_active --rf $(CASSANDRA_REPLICATION_FACTOR)
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_visibility_active setup-schema -v 0.0
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_visibility_active update-schema -d ./schema/visibility/versioned
 	@echo Setting up cadence_standby key space
-	./cadence-cassandra-tool --ep 127.0.0.1 create -k cadence_standby --rf 1
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_standby setup-schema -v 0.0
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_standby update-schema -d ./schema/cadence/versioned
-	./cadence-cassandra-tool --ep 127.0.0.1 create -k cadence_visibility_standby --rf 1
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility_standby setup-schema -v 0.0
-	./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility_standby update-schema -d ./schema/visibility/versioned
+	./cadence-cassandra-tool --ep $(CASSANDRA_HOST) create -k cadence_standby --rf $(CASSANDRA_REPLICATION_FACTOR)
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_standby setup-schema -v 0.0
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_standby update-schema -d ./schema/cadence/versioned
+	./cadence-cassandra-tool --ep $(CASSANDRA_HOST) create -k cadence_visibility_standby --rf $(CASSANDRA_REPLICATION_FACTOR)
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_visibility_standby setup-schema -v 0.0
+	./cadence-cassandra-tool -ep $(CASSANDRA_HOST) -k cadence_visibility_standby update-schema -d ./schema/visibility/versioned
 
 start-cdc-active: bins
 	./cadence-server --zone active start

--- a/tools/cassandra/README.md
+++ b/tools/cassandra/README.md
@@ -29,3 +29,13 @@ You can only upgrade to a new version after the initial setup done above.
 ./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/visibility/versioned -v x.x -y -- executes a dryrun of upgrade to version x.x
 ./cadence-cassandra-tool -ep 127.0.0.1 -k cadence_visibility update-schema -d ./schema/visibility/versioned -v x.x    -- actually executes the upgrade to version x.x
 ```
+
+## Using Docker 
+There is a docker image for the `cadence-cassandra-tool` located at `ubercadence/cct`.  All the above commands could have the 
+`./cadence-cassandra-tool` part replaced with `docker run --rm -it ubercadence/cct:<cadence version>`.
+
+The docker image also contains the schema migrations and the Makefile for the project.  So to setup the schema for a new cluster 
+run:
+```
+docker run --rm -it --entrypoint /bin/bash ubercadence/cct:<cadence version> -c "make BUILD_BINS=false CASSANDRA_HOST=<cassandra host> CASSANDRA_REPLICATION_FACTOR=3 install-schema" 
+```

--- a/tools/cassandra/README.md
+++ b/tools/cassandra/README.md
@@ -34,6 +34,15 @@ You can only upgrade to a new version after the initial setup done above.
 There is a docker image for the `cadence-cassandra-tool` located at `ubercadence/cct`.  All the above commands could have the 
 `./cadence-cassandra-tool` part replaced with `docker run --rm -it ubercadence/cct:<cadence version>`.
 
+e.g. 
+```
+# old
+./cadence-cassandra-tool -ep 127.0.0.1 -k cadence setup-schema -v 0.0
+
+# new
+docker run --rm -it ubercadence/cct:<cadence version> -ep 127.0.0.1 -k cadence setup-schema -v 0.0
+```
+
 The docker image also contains the schema migrations and the Makefile for the project.  So to setup the schema for a new cluster 
 run:
 ```


### PR DESCRIPTION
This allows the Makefile to be used for production schema setup by
adding variables for changing the cassandra host and the replication
factor.

Also introduces a Dockerfile for the cadence-cassandra-tool that makes
it easier to get started administering cassandra for cadence.

The docker image also allows us to setup the schema in a kubernetes cluster easily.