### PR TITLE
Fix error during Ringpop refresh

### DIFF
--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -179,8 +179,9 @@ func (r *ringpopServiceResolver) refresh() {
 
 	addrs, err := r.rp.GetReachableMembers(swim.MemberWithLabelAndValue(RoleKey, r.service))
 	if err != nil {
-		// This should never happen!
-		r.logger.Fatalf("Error during ringpop refresh.  Error: %v", err)
+		// This will happen when service stop and destroy ringpop while there are go-routines pending to call this.
+		r.logger.Warnf("Error during ringpop refresh.  Error: %v", err)
+		return
 	}
 
 	for _, addr := range addrs {

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -119,6 +119,8 @@ func (r *ringpopServiceResolver) Stop() error {
 	if success := common.AwaitWaitGroup(&r.shutdownWG, time.Minute); !success {
 		r.logger.Warn("service resolver timed out on shutdown.")
 	}
+
+	r.isStopped = true
 	return nil
 }
 

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -101,7 +101,6 @@ type (
 	}
 
 	ringpopFactoryImpl struct {
-		service string
 		rpHosts []string
 	}
 )
@@ -268,7 +267,7 @@ func (c *cadenceImpl) startFrontend(rpHosts []string, startWG *sync.WaitGroup) {
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.FrontendPProfPort())
 	params.RPCFactory = newRPCFactoryImpl(common.FrontendServiceName, c.FrontendAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(common.FrontendServiceName, make(map[string]string))
-	params.RingpopFactory = newRingpopFactory(common.FrontendServiceName, rpHosts)
+	params.RingpopFactory = newRingpopFactory(rpHosts)
 	params.ClusterMetadata = c.clusterMetadata
 	params.MessagingClient = c.messagingClient
 	params.CassandraConfig.NumHistoryShards = c.numberOfHistoryShards
@@ -312,7 +311,7 @@ func (c *cadenceImpl) startHistory(shardMgr persistence.ShardManager,
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
 		params.RPCFactory = newRPCFactoryImpl(common.HistoryServiceName, hostport, c.logger)
 		params.MetricScope = tally.NewTestScope(common.HistoryServiceName, make(map[string]string))
-		params.RingpopFactory = newRingpopFactory(common.FrontendServiceName, rpHosts)
+		params.RingpopFactory = newRingpopFactory(rpHosts)
 		params.ClusterMetadata = c.clusterMetadata
 		params.MessagingClient = c.messagingClient
 		params.CassandraConfig.NumHistoryShards = c.numberOfHistoryShards
@@ -339,7 +338,7 @@ func (c *cadenceImpl) startMatching(taskMgr persistence.TaskManager,
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.MatchingPProfPort())
 	params.RPCFactory = newRPCFactoryImpl(common.MatchingServiceName, c.MatchingServiceAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(common.MatchingServiceName, make(map[string]string))
-	params.RingpopFactory = newRingpopFactory(common.FrontendServiceName, rpHosts)
+	params.RingpopFactory = newRingpopFactory(rpHosts)
 	params.ClusterMetadata = c.clusterMetadata
 	params.CassandraConfig.NumHistoryShards = c.numberOfHistoryShards
 	service := service.New(params)
@@ -359,7 +358,7 @@ func (c *cadenceImpl) startWorker(rpHosts []string, startWG *sync.WaitGroup) {
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.WorkerPProfPort())
 	params.RPCFactory = newRPCFactoryImpl(common.WorkerServiceName, c.WorkerServiceAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(common.WorkerServiceName, make(map[string]string))
-	params.RingpopFactory = newRingpopFactory(common.FrontendServiceName, rpHosts)
+	params.RingpopFactory = newRingpopFactory(rpHosts)
 	params.ClusterMetadata = c.clusterMetadata
 	params.CassandraConfig.NumHistoryShards = c.numberOfHistoryShards
 	service := service.New(params)
@@ -382,9 +381,8 @@ func (c *cadenceImpl) startWorker(rpHosts []string, startWG *sync.WaitGroup) {
 	c.shutdownWG.Done()
 }
 
-func newRingpopFactory(service string, rpHosts []string) service.RingpopFactory {
+func newRingpopFactory(rpHosts []string) service.RingpopFactory {
 	return &ringpopFactoryImpl{
-		service: service,
 		rpHosts: rpHosts,
 	}
 }


### PR DESCRIPTION
This fix https://github.com/uber/cadence/issues/737 which is bothering us in Travis long time since TestIntegrationCrossDCSuite was added.

The root cause is:  
During stop process of cadence server, it could stop ringpop at the time there are other go routines call refresh (which need ringpop be alive). Because TestIntegrationCrossDCSuite start/stop cadence server for each test case, it exposes this issue more frequently than previously. 

This fix by switching from log.Fatal to log.Warn is safe. 
(Another fix would be change the stop process to wait before stop ringpop, but it will be flaky and slow down our tests, so not used.)