### PR TITLE
Add client integration test for data converter

### DIFF
--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -167,7 +167,7 @@ func (s *clientIntegrationSuite) setupSuite(enableGlobalDomain bool, isMasterClu
 	s.mockProducer = &mocks.KafkaProducer{}
 	s.mockMessagingClient = mocks.NewMockMessagingClient(s.mockProducer, nil)
 
-	s.host = NewCadence(s.ClusterMetadata, s.mockMessagingClient, s.MetadataManager, s.ShardMgr, s.HistoryMgr, s.ExecutionMgrFactory, s.TaskMgr,
+	s.host = NewCadence(s.ClusterMetadata, s.mockMessagingClient, s.MetadataProxy, s.ShardMgr, s.HistoryMgr, s.ExecutionMgrFactory, s.TaskMgr,
 		s.VisibilityMgr, testNumberOfHistoryShards, testNumberOfHistoryHosts, s.logger, 0, false)
 	s.host.Start()
 

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -1,0 +1,285 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package host
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"flag"
+	"fmt"
+	"github.com/pborman/uuid"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-common/bark"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/mocks"
+	"github.com/uber/cadence/common/persistence"
+	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/client"
+	"go.uber.org/cadence/encoded"
+	cworker "go.uber.org/cadence/worker"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/tchannel"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type (
+	clientIntegrationSuite struct {
+		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
+		// not merely log an error
+		*require.Assertions
+		suite.Suite
+		IntegrationBase
+		domainName string
+		domainID   string
+		wfService  workflowserviceclient.Interface
+		wfClient   client.Client
+		worker     cworker.Worker
+		taskList   string
+	}
+)
+
+func TestClientIntegrationSuite(t *testing.T) {
+	flag.Parse()
+	if *integration {
+		s := new(clientIntegrationSuite)
+		suite.Run(t, s)
+	} else {
+		t.Skip()
+	}
+}
+
+func (s *clientIntegrationSuite) SetupSuite() {
+	if testing.Verbose() {
+		log.SetOutput(os.Stdout)
+	}
+
+	logger := log.New()
+	formatter := &log.TextFormatter{}
+	formatter.FullTimestamp = true
+	logger.Formatter = formatter
+	logger.Level = log.DebugLevel
+	s.logger = bark.NewLoggerFromLogrus(logger)
+	s.setupSuite(false, false)
+
+	var err error
+	s.wfService, err = s.buildServiceClient()
+	if err != nil {
+		s.logger.Fatalf("Error when build service client: %v", err)
+	}
+	s.wfClient = client.NewClient(s.wfService, s.domainName, nil)
+
+	s.taskList = "client-integration-test-tasklist"
+	s.worker = cworker.New(s.wfService, s.domainName, s.taskList, cworker.Options{})
+	if err := s.worker.Start(); err != nil {
+		s.logger.Fatalf("Error when start worker: %v", err)
+	}
+}
+
+func (s *clientIntegrationSuite) buildServiceClient() (workflowserviceclient.Interface, error) {
+	cadenceClientName := "cadence-client"
+	cadenceFrontendService := common.FrontendServiceName
+	hostPort := "127.0.0.1:7104"
+
+	ch, err := tchannel.NewChannelTransport(
+		tchannel.ServiceName(cadenceClientName))
+	if err != nil {
+		s.logger.Fatalf("Failed to create transport channel: %v", err)
+	}
+
+	dispatcher := yarpc.NewDispatcher(yarpc.Config{
+		Name: cadenceClientName,
+		Outbounds: yarpc.Outbounds{
+			cadenceFrontendService: {Unary: ch.NewSingleOutbound(hostPort)},
+		},
+	})
+	if dispatcher == nil {
+		s.logger.Fatal("No RPC dispatcher provided to create a connection to Cadence Service")
+	}
+	if err := dispatcher.Start(); err != nil {
+		s.logger.Fatalf("Failed to create outbound transport channel: %v", err)
+	}
+
+	return workflowserviceclient.New(dispatcher.ClientConfig(cadenceFrontendService)), nil
+}
+
+func (s *clientIntegrationSuite) TearDownSuite() {
+	s.host.Stop()
+	s.host = nil
+	s.worker.Stop()
+	s.TearDownWorkflowStore()
+}
+
+func (s *clientIntegrationSuite) SetupTest() {
+	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+	s.Assertions = require.New(s.T())
+}
+
+func (s *clientIntegrationSuite) TearDownTest() {
+
+}
+
+func (s *clientIntegrationSuite) setupSuite(enableGlobalDomain bool, isMasterCluster bool) {
+	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+	s.Assertions = require.New(s.T())
+	options := persistence.TestBaseOptions{}
+	options.ClusterHost = "127.0.0.1"
+	options.DropKeySpace = true
+	options.SchemaDir = ".."
+	options.EnableGlobalDomain = enableGlobalDomain
+	options.IsMasterCluster = isMasterCluster
+	s.SetupWorkflowStoreWithOptions(options, nil)
+
+	s.setupShards()
+
+	// TODO: Use mock messaging client until we support kafka setup onebox to write end-to-end integration test
+	s.mockProducer = &mocks.KafkaProducer{}
+	s.mockMessagingClient = mocks.NewMockMessagingClient(s.mockProducer, nil)
+
+	s.host = NewCadence(s.ClusterMetadata, s.mockMessagingClient, s.MetadataManager, s.ShardMgr, s.HistoryMgr, s.ExecutionMgrFactory, s.TaskMgr,
+		s.VisibilityMgr, testNumberOfHistoryShards, testNumberOfHistoryHosts, s.logger, 0, false)
+	s.host.Start()
+
+	s.engine = s.host.GetFrontendClient()
+	s.domainName = "integration-test-domain"
+	s.domainID = uuid.New()
+
+	s.MetadataManager.CreateDomain(&persistence.CreateDomainRequest{
+		Info: &persistence.DomainInfo{
+			ID:          s.domainID,
+			Name:        s.domainName,
+			Status:      persistence.DomainStatusRegistered,
+			Description: "Test domain for integration test",
+		},
+		Config: &persistence.DomainConfig{
+			Retention:  1,
+			EmitMetric: false,
+		},
+		ReplicationConfig: &persistence.DomainReplicationConfig{},
+	})
+}
+
+// testDataConverter implements encoded.DataConverter using gob
+type testDataConverter struct{}
+
+func (tdc *testDataConverter) ToData(value ...interface{}) ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	for i, obj := range value {
+		if err := enc.Encode(obj); err != nil {
+			return nil, fmt.Errorf(
+				"unable to encode argument: %d, %v, with gob error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func (tdc *testDataConverter) FromData(input []byte, valuePtr ...interface{}) error {
+	dec := gob.NewDecoder(bytes.NewBuffer(input))
+	for i, obj := range valuePtr {
+		if err := dec.Decode(obj); err != nil {
+			return fmt.Errorf(
+				"unable to decode argument: %d, %v, with gob error: %v", i, reflect.TypeOf(obj), err)
+		}
+	}
+	return nil
+}
+
+func newTestDataConverter() encoded.DataConverter {
+	return &testDataConverter{}
+}
+
+func testActivity(ctx context.Context, msg string) (string, error) {
+	return "hello_" + msg, nil
+}
+
+var activityTaskList = "client-integration-data-converter-activity-tasklist"
+
+func testDataConverterWorkflow(ctx workflow.Context) (string, error) {
+	ao := workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    time.Minute,
+		HeartbeatTimeout:       20 * time.Second,
+	}
+	ctx = workflow.WithActivityOptions(ctx, ao)
+
+	var result string
+	err := workflow.ExecuteActivity(ctx, testActivity, "world").Get(ctx, &result)
+	if err != nil {
+		return "", err
+	}
+
+	// use another converter to run activity,
+	// with new taskList so that worker with same data converter can properly process tasks.
+	var result1 string
+	ctx1 := workflow.WithDataConverter(ctx, newTestDataConverter())
+	ctx1 = workflow.WithTaskList(ctx1, activityTaskList)
+	err1 := workflow.ExecuteActivity(ctx1, testActivity, "world1").Get(ctx1, &result1)
+	if err1 != nil {
+		return "", err1
+	}
+	return result + "," + result1, nil
+}
+
+func (s *clientIntegrationSuite) startWorkerWithDataConverter(tl string) cworker.Worker {
+	opts := cworker.Options{
+		DataConverter: newTestDataConverter(),
+	}
+	worker := cworker.New(s.wfService, s.domainName, tl, opts)
+	if err := worker.Start(); err != nil {
+		s.logger.Fatalf("Error when start worker with data converter: %v", err)
+	}
+	return worker
+}
+
+func (s *clientIntegrationSuite) TestClientDataConverter() {
+	workflow.Register(testDataConverterWorkflow)
+	activity.Register(testActivity)
+
+	worker := s.startWorkerWithDataConverter(activityTaskList)
+	defer worker.Stop()
+
+	id := "client-integration-data-converter-workflow"
+	workflowOptions := client.StartWorkflowOptions{
+		ID:                           id,
+		TaskList:                     s.taskList,
+		ExecutionStartToCloseTimeout: 20 * time.Second,
+	}
+	ctx, _ := context.WithTimeout(context.Background(), 30*time.Second)
+	we, err := s.wfClient.ExecuteWorkflow(ctx, workflowOptions, testDataConverterWorkflow)
+	if err != nil {
+		s.logger.Fatalf("Start workflow with err: %v", err)
+	}
+	s.NotNil(we)
+	s.True(we.GetRunID() != "")
+
+	var res string
+	err = we.Get(ctx, &res)
+	s.NoError(err)
+	s.Equal("hello_world,hello_world1", res)
+}

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -113,7 +113,7 @@ func (s *clientIntegrationSuite) buildServiceClient() (workflowserviceclient.Int
 	hostPort := "127.0.0.1:7104"
 
 	ch, err := tchannel.NewChannelTransport(
-		tchannel.ServiceName(cadenceClientName))
+		tchannel.ServiceName(cadenceClientName), tchannel.ListenAddr("127.0.0.1:0"))
 	if err != nil {
 		s.logger.Fatalf("Failed to create transport channel: %v", err)
 	}

--- a/host/integration_cross_dc_domain_test.go
+++ b/host/integration_cross_dc_domain_test.go
@@ -31,10 +31,8 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
 
-	wsc "github.com/uber/cadence/.gen/go/cadence/workflowserviceclient"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 )
@@ -45,12 +43,7 @@ type (
 		// not merely log an error
 		*require.Assertions
 		suite.Suite
-		persistence.TestBase
-		mockMessagingClient messaging.Client
-		mockProducer        messaging.Producer
-		host                Cadence
-		engine              wsc.Interface
-		logger              bark.Logger
+		IntegrationBase
 	}
 )
 
@@ -113,16 +106,6 @@ func (s *integrationCrossDCSuite) setupTest(enableGlobalDomain bool, isMasterClu
 	s.host.Start()
 
 	s.engine = s.host.GetFrontendClient()
-}
-
-func (s *integrationCrossDCSuite) setupShards() {
-	// shard 0 is always created, we create additional shards if needed
-	for shardID := 1; shardID < testNumberOfHistoryShards; shardID++ {
-		err := s.CreateShard(shardID, "", 0)
-		if err != nil {
-			s.logger.WithField("error", err).Fatal("Failed to create shard")
-		}
-	}
 }
 
 // Note: if the global domain is not enabled, active clusters and clusters


### PR DESCRIPTION
The new added testSuite can be used to write tests using cadence-client.
This pull request contains a test for client feature DataConverter. 

~~On mac, running this test always cause a popup dialog asking you to "accept incoming connections".
Currently there is no good solution to get rid of this, you can press ESC each time or just turn off firewall.~~  This Yarpc related issue is fixed.