### PR TITLE
Conflict Resolver bugfix

### DIFF
--- a/service/history/conflictResolver.go
+++ b/service/history/conflictResolver.go
@@ -110,7 +110,7 @@ func (r *conflictResolver) reset(requestID string, replayEventID int64, startTim
 	// the last updated time is not important here, since this should be updated with event time afterwards
 	resetMutableStateBuilder.executionInfo.LastUpdatedTimestamp = startTime
 
-	sourceCluster := r.clusterMetadata.ClusterNameForFailoverVersion(resetMutableStateBuilder.GetCurrentVersion())
+	sourceCluster := r.clusterMetadata.ClusterNameForFailoverVersion(lastEvent.GetVersion())
 	resetMutableStateBuilder.updateReplicationStateLastEventID(sourceCluster, lastEvent.GetVersion(), replayEventID)
 
 	r.logger.Infof("All events applied for execution.  WorkflowID: %v, RunID: %v, NextEventID: %v",

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -158,7 +158,7 @@ func (r *historyReplicator) ApplyEvents(request *h.ReplicateEventsRequest) (retE
 
 		// Check for duplicate processing of replication task
 		if firstEvent.GetEventId() < msBuilder.GetNextEventID() {
-			logger.Warnf("Dropping replication task.  State: {NextEvent: %v, Version: %v, LastWriteV: %v, LastWriteEvent: %v}",
+			logger.Debugf("Dropping replication task.  State: {NextEvent: %v, Version: %v, LastWriteV: %v, LastWriteEvent: %v}",
 				msBuilder.GetNextEventID(), msBuilder.replicationState.CurrentVersion,
 				msBuilder.replicationState.LastWriteVersion, msBuilder.replicationState.LastWriteEventID)
 			return nil
@@ -166,7 +166,7 @@ func (r *historyReplicator) ApplyEvents(request *h.ReplicateEventsRequest) (retE
 
 		// Check for out of order replication task and store it in the buffer
 		if firstEvent.GetEventId() > msBuilder.GetNextEventID() {
-			logger.Infof("Buffer out of order replication task.  NextEvent: %v, FirstEvent: %v",
+			logger.Debugf("Buffer out of order replication task.  NextEvent: %v, FirstEvent: %v",
 				msBuilder.GetNextEventID(), firstEvent.GetEventId())
 
 			if err := msBuilder.BufferReplicationTask(request); err != nil {


### PR DESCRIPTION
Use version from last event during conflict resolution when resetting
the history.