### PR TITLE
Use workflowID as partition key on replication message

### DIFF
--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -47,6 +47,7 @@ const (
 	TagTopicName            = "topic-name"
 	TagConsumerName         = "consumer-name"
 	TagPartition            = "partition"
+	TagPartitionKey         = "partition-key"
 	TagOffset               = "offset"
 	TagScope                = "scope"
 	TagFailover             = "failover"


### PR DESCRIPTION
This will give as somewhat ordering of messages published to kafka topic
for a given workflow execution.  Might reduce the number of buffered
task per workflow execution due to out of order processing of
replication tasks.