### PR TITLE
Fix print event version in CLI

### DIFF
--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -406,7 +406,7 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 		}
 
 		if printVersion {
-			columns = append(columns, fmt.Sprintf("(Version: %v)", e.Version))
+			columns = append(columns, fmt.Sprintf("(Version: %v)", *e.Version))
 		}
 
 		columns = append(columns, ColorEvent(e), HistoryEventToString(e))


### PR DESCRIPTION
Verified in my laptop:

```
longer@~/gocode/src/github.com/uber/cadence:(master)$ ./cadence --domain samples-domain wf show -w helloworld_1519c56e-28ab-4591-84f1-16433bf2fa2f -pf
  (EventId:1,Timestamp:1528306125831438314,EventType:WorkflowExecutionStarted,Version:1,WorkflowExecutionStartedEventAttributes:(WorkflowType:(Name:main.Workflow),TaskList:(Name:helloWorldGroup),Input:["Cadence"
  ],ExecutionStartToCloseTimeoutSeconds:60,TaskStartToCloseTimeoutSeconds:60,Identity:35847@longer-C02V60N3HTDG@))
  (EventId:2,Timestamp:1528306125831446770,EventType:DecisionTaskScheduled,Version:1,DecisionTaskScheduledEventAttributes:(TaskList:(Name:helloWorldGroup),StartToCloseTimeoutSeconds:60,Attempt:0))
  (EventId:3,Timestamp:1528306185834489247,EventType:WorkflowExecutionTimedOut,Version:1,WorkflowExecutionTimedOutEventAttributes:(TimeoutType:START_TO_CLOSE))
longer@~/gocode/src/github.com/uber/cadence:(master)$ ./cadence --domain samples-domain wf show -w helloworld_1519c56e-28ab-4591-84f1-16433bf2fa2f -pev
  1  (Version: 1)  WorkflowExecutionStarted   (WorkflowType:(Name:main.Workflow),TaskList:(Name:helloWorldGroup),Input:["Cadence"
                                               ],ExecutionStartToCloseTimeoutSeconds:60,TaskStartToCloseTimeoutSeconds:60,Identity:35847@longer-C02V60N3HTDG@)
  2  (Version: 1)  DecisionTaskScheduled      (TaskList:(Name:helloWorldGroup),StartToCloseTimeoutSeconds:60,Attempt:0)
  3  (Version: 1)  WorkflowExecutionTimedOut  (TimeoutType:START_TO_CLOSE)
```