### PR TITLE
Fix CLI parseTime for listworkflow

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -441,3 +441,9 @@ func (s *cliAppSuite) TestObserveWorkflowWithID() {
 	err = s.app.Run([]string{"", "--do", domainName, "workflow", "observeid", "wid", "-sd"})
 	s.Nil(err)
 }
+
+func (s *cliAppSuite) TestParseTime() {
+	s.Equal(int64(100), parseTime("", 100))
+	s.Equal(int64(1528383845000000000), parseTime("2018-06-07T15:04:05+00:00", 0))
+	s.Equal(int64(1528383845000000000), parseTime("1528383845000000000", 0))
+}

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -1109,7 +1109,7 @@ func parseTime(timeStr string, defaultValue int64) int64 {
 	}
 
 	// try to parse
-	parsedTime, err := time.Parse(defaultTimeFormat, timeStr)
+	parsedTime, err := time.Parse(defaultDateTimeFormat, timeStr)
 	if err == nil {
 		return parsedTime.UnixNano()
 	}


### PR DESCRIPTION
Change parse format to time.RFC3339 from wrong one.