### PR TITLE
Prevent duplicate user timer creation

### DIFF
--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -202,7 +202,7 @@ func (tb *timerBuilder) GetUserTimerTaskIfNeeded(msBuilder *mutableStateBuilder)
 	if timerTask != nil {
 		// Update the task ID tracking if it has created timer task or not.
 		ti := tb.pendingUserTimers[tb.userTimers[0].TimerID]
-		ti.TaskID = 1
+		ti.TaskID = TimerTaskStatusCreated
 		// TODO: We append updates to timer tasks twice.  Why?
 		msBuilder.UpdateUserTimer(ti.TimerID, ti)
 	}
@@ -370,16 +370,6 @@ func (tb *timerBuilder) createActivityTimeoutTask(fireTimeOut int32, timeoutType
 		TimeoutType:         int(timeoutType),
 		EventID:             eventID,
 	}
-}
-
-func (tb *timerBuilder) loadUserTimer(expires time.Time, timerID string, taskCreated bool) (*timerDetails, bool) {
-	seqNum := tb.localSeqNumGen.NextSeq()
-	timer := &timerDetails{
-		TimerSequenceID: TimerSequenceID{VisibilityTimestamp: expires, TaskID: seqNum},
-		TimerID:         timerID,
-		TaskCreated:     taskCreated}
-	isFirst := tb.insertTimer(timer)
-	return timer, isFirst
 }
 
 func (tb *timerBuilder) insertTimer(td *timerDetails) bool {

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -259,7 +259,7 @@ Update_History_Loop:
 					timerTasks = []persistence.Task{nextTask}
 
 					// Update the task ID tracking the corresponding timer task.
-					ti.TaskID = nextTask.GetTaskID()
+					ti.TaskID = TimerTaskStatusCreated
 					msBuilder.UpdateUserTimer(ti.TimerID, ti)
 					defer t.notifyNewTimers(timerTasks)
 				}


### PR DESCRIPTION
TimerQueueProcesor logic is not setting the correct value on timer
information on mutable state to detect if the timer is already created
or not.  This fix creates the value to TimerTaskStatusCreated to prevent
creation of same user timer again.