### PR TITLE
compact duplicate code, add more logging

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -1371,6 +1371,14 @@ func (t *TransferTaskInfo) GetTaskType() int {
 	return t.TaskType
 }
 
+// String returns string
+func (t *TransferTaskInfo) String() string {
+	return fmt.Sprintf(
+		"{DomainID: %v, WorkflowID: %v, RunID: %v, TaskID: %v, TargetDomainID: %v, TargetWorkflowID %v, TargetRunID: %v, TargetChildWorkflowOnly: %v, TaskList: %v, TaskType: %v, ScheduleID: %v, Version: %v.}",
+		t.DomainID, t.WorkflowID, t.RunID, t.TaskID, t.TargetDomainID, t.TargetWorkflowID, t.TargetRunID, t.TargetChildWorkflowOnly, t.TaskList, t.TaskType, t.ScheduleID, t.Version,
+	)
+}
+
 // GetTaskID returns the task ID for replication task
 func (t *ReplicationTaskInfo) GetTaskID() int64 {
 	return t.TaskID
@@ -1399,6 +1407,14 @@ func (t *TimerTaskInfo) GetVersion() int64 {
 // GetTaskType returns the task type for timer task
 func (t *TimerTaskInfo) GetTaskType() int {
 	return t.TaskType
+}
+
+// GetTaskType returns the task type for timer task
+func (t *TimerTaskInfo) String() string {
+	return fmt.Sprintf(
+		"{DomainID: %v, WorkflowID: %v, RunID: %v, VisibilityTimestamp: %v, TaskID: %v, TaskType: %v, TimeoutType: %v, EventID: %v, ScheduleAttempt: %v, Version: %v.}",
+		t.DomainID, t.WorkflowID, t.RunID, t.VisibilityTimestamp, t.TaskID, t.TaskType, t.TimeoutType, t.EventID, t.ScheduleAttempt, t.Version,
+	)
 }
 
 // NewHistoryEventBatch returns a new instance of HistoryEventBatch

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -386,7 +386,7 @@ func (t *timerQueueProcessorBase) processDeleteHistoryEvent(task *persistence.Ti
 	} else if msBuilder == nil {
 		return nil
 	}
-	ok, err := verifyTimerTaskVersion(t.shard, task.DomainID, msBuilder.GetLastWriteVersion(), task)
+	ok, err := verifyTaskVersion(t.shard, t.logger, task.DomainID, msBuilder.GetLastWriteVersion(), task.Version, task)
 	if err != nil {
 		return err
 	} else if !ok {


### PR DESCRIPTION
sample log debug:
```
DEBU[2018-06-12T17:53:22-07:00] DomainID: 005ca0ea-51b0-4595-96ff-01ec968be72a is active, process task: {DomainID: 005ca0ea-51b0-4595-96ff-01ec968be72a, WorkflowID: cron.workflow.sanity/workflow.sanity-1, RunID: 1441a13c-aa24-4846-a4b8-988d95dbfb24, TaskID: 1048594, TargetDomainID: 005ca0ea-51b0-4595-96ff-01ec968be72a, TargetWorkflowID cron.workflow.sanity/workflow.sanity-1/workflow.query, TargetRunID: , TargetChildWorkflowOnly: false, TaskList: , TaskType: 4, ScheduleID: 10, Version: -24.}.  Service=cadence-history shard-id=3 wf-cluster=active wf-component=transfer-queue-processor
```