### PR TITLE
Make task processors reselient to LimitExceededError

### DIFF
--- a/common/logging/events.go
+++ b/common/logging/events.go
@@ -89,6 +89,7 @@ const (
 	ReplicationTaskProcessingFailed          = 7106
 
 	// General purpose events
-	OperationFailed = 9000
-	OperationPanic  = 9001
+	OperationFailed   = 9000
+	OperationPanic    = 9001
+	OperationCritical = 9002
 )

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -425,7 +425,7 @@ func LogTaskProcessingFailedEvent(logger bark.Logger, err error) {
 	}).Error("Processor failed to process task.")
 }
 
-// LogOperationPanicEvent is used to log fatal errors by application to cause panic
+// LogCriticalErrorEvent is used to log critical errors by application it is expected to have alerts setup on such errors
 func LogCriticalErrorEvent(logger bark.Logger, msg string, err error) {
 	logger.WithFields(bark.Fields{
 		TagWorkflowEventID: OperationCritical,

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -61,7 +61,7 @@ func LogOperationPanicEvent(logger bark.Logger, msg string, err error) {
 	logger.WithFields(bark.Fields{
 		TagWorkflowEventID: OperationPanic,
 		TagWorkflowErr:     err,
-	}).Fatalf("%v.  Error: %v", msg, err)
+	}).Fatal(msg)
 }
 
 // LogInternalServiceError is used to log internal service error
@@ -418,11 +418,17 @@ func LogQueueProcesorShutdownTimedoutEvent(logger bark.Logger) {
 }
 
 // LogTaskProcessingFailedEvent is used to log failures from task processing.
-func LogTaskProcessingFailedEvent(logger bark.Logger, taskID int64, taskType int, err error) {
+func LogTaskProcessingFailedEvent(logger bark.Logger, err error) {
 	logger.WithFields(bark.Fields{
 		TagWorkflowEventID: TransferTaskProcessingFailed,
-		TagTaskID:          taskID,
-		TagTaskType:        taskType,
 		TagWorkflowErr:     err,
-	}).Errorf("Processor failed to process task: %v, type: %v.  Error: %v", taskID, taskType, err)
+	}).Error("Processor failed to process task.")
+}
+
+// LogOperationPanicEvent is used to log fatal errors by application to cause panic
+func LogCriticalErrorEvent(logger bark.Logger, msg string, err error) {
+	logger.WithFields(bark.Fields{
+		TagWorkflowEventID: OperationCritical,
+		TagWorkflowErr:     err,
+	}).Error(msg)
 }

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -54,6 +54,7 @@ const (
 	TagVersion              = "version"
 	TagFirstEventID         = "first-event-id"
 	TagNextEventID          = "next-event-id"
+	TagTimeoutType          = "timeout-type"
 
 	// workflow logging tag values
 	// TagWorkflowComponent Values

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -610,6 +610,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 const (
 	CadenceRequests = iota
 	CadenceFailures
+	CadenceCriticalFailures
 	CadenceLatency
 	CadenceErrBadRequestCounter
 	CadenceErrDomainNotActiveCounter
@@ -716,6 +717,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 	Common: {
 		CadenceRequests:                               {metricName: "cadence.requests", metricType: Counter},
 		CadenceFailures:                               {metricName: "cadence.errors", metricType: Counter},
+		CadenceCriticalFailures:                       {metricName: "cadence.errors.critical", metricType: Counter},
 		CadenceLatency:                                {metricName: "cadence.latency", metricType: Timer},
 		CadenceErrBadRequestCounter:                   {metricName: "cadence.errors.bad-request", metricType: Counter},
 		CadenceErrDomainNotActiveCounter:              {metricName: "cadence.errors.domain-not-active", metricType: Counter},


### PR DESCRIPTION
We have system protection in place which could result in
LimitExceededError while trying to update workflow execution.  This
protection could result in history engine restarts if transfer/timer
processing is blocked due to this error.
This change makes the processors resilient to LimitExceededError and
emits a critical log and metric and skips such tasks.
We expect an alert being setup on any critical level error and someone
manually addressing the cause of such errors rather than resulting in
complete halt of queue processing.

Fixes #861 