### PR TITLE
retry expiration for activity

### DIFF
--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1688,14 +1688,17 @@ func (e *mutableStateBuilder) ReplicateActivityTaskScheduledEvent(
 		TaskList:                 attributes.TaskList.GetName(),
 		HasRetryPolicy:           attributes.RetryPolicy != nil,
 	}
+	ai.ExpirationTime = ai.ScheduledTime.Add(time.Duration(scheduleToCloseTimeout) * time.Second)
 	if ai.HasRetryPolicy {
 		ai.InitialInterval = attributes.RetryPolicy.GetInitialIntervalInSeconds()
 		ai.BackoffCoefficient = attributes.RetryPolicy.GetBackoffCoefficient()
 		ai.MaximumInterval = attributes.RetryPolicy.GetMaximumIntervalInSeconds()
 		ai.MaximumAttempts = attributes.RetryPolicy.GetMaximumAttempts()
 		ai.NonRetriableErrors = attributes.RetryPolicy.NonRetriableErrorReasons
+		if attributes.RetryPolicy.GetExpirationIntervalInSeconds() > scheduleToCloseTimeout {
+			ai.ExpirationTime = ai.ScheduledTime.Add(time.Duration(attributes.RetryPolicy.GetExpirationIntervalInSeconds()) * time.Second)
+		}
 	}
-	ai.ExpirationTime = ai.ScheduledTime.Add(time.Duration(scheduleToCloseTimeout) * time.Second)
 
 	e.pendingActivityInfoIDs[scheduleEventID] = ai
 	e.pendingActivityInfoByActivityID[ai.ActivityID] = scheduleEventID

--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -51,8 +51,7 @@ func prepareNextRetryWithNowTime(a *persistence.ActivityInfo, errReason string, 
 	a.RequestID = ""
 	a.StartedTime = time.Time{}
 	a.LastHeartBeatUpdatedTime = time.Time{}
-	// clear timer created bits except for ScheduleToClose
-	a.TimerTaskStatus = TimerTaskStatusNone | (a.TimerTaskStatus & TimerTaskStatusCreatedScheduleToClose)
+	a.TimerTaskStatus = TimerTaskStatusNone
 
 	return &persistence.ActivityRetryTimerTask{
 		Version:             a.Version,

--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -275,10 +275,10 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder mutableState) {
 	tb.activityTimers = make(timers, 0, len(tb.pendingActivityTimers))
 	for _, v := range tb.pendingActivityTimers {
 		if v.ScheduleID != common.EmptyEventID {
-			scheduleToCloseExpiry := v.ExpirationTime
-			if scheduleToCloseExpiry.IsZero() {
-				// v.ExpirationTime could be zero for old activity_infos before this code change (for retry)
-				scheduleToCloseExpiry = v.ScheduledTime.Add(time.Duration(v.ScheduleToCloseTimeout) * time.Second)
+			scheduleToCloseExpiry := v.ScheduledTime.Add(time.Duration(v.ScheduleToCloseTimeout) * time.Second)
+			if !v.ExpirationTime.IsZero() && v.ExpirationTime.Before(scheduleToCloseExpiry) {
+				// expire before scheduleToClose timeout
+				scheduleToCloseExpiry = v.ExpirationTime
 			}
 			td := &timerDetails{
 				TimerSequenceID: TimerSequenceID{VisibilityTimestamp: scheduleToCloseExpiry},

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -385,7 +385,7 @@ Update_History_Loop:
 				t.logger.Debugf("Activity TimeoutType: %v, scheduledID: %v, startedId: %v. \n",
 					timeoutType, ai.ScheduleID, ai.StartedID)
 
-				if td.Attempt < ai.Attempt && timeoutType != workflow.TimeoutTypeScheduleToClose {
+				if td.Attempt < ai.Attempt {
 					// retry could update ai.Attempt, and we should ignore further timeouts for previous attempt
 					continue
 				}


### PR DESCRIPTION
Properly set retry expiration for activity

Previously, we decided to use activity's Schedule_To_Close as expiration for entire retry process.  However, when we work on workflow/child_workflow retry, we realize we needed a retry policy expiration time. So we want to make it consistent across workflow and activity retry. Thus, we would apply this retryPolicy's expiration time to activity retry. If the expiration is not supplied, there will