### PR TITLE
Deadlock in matching engine

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -179,13 +179,15 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *taskListID,
 		e.taskListsLock.Unlock()
 		return result, nil
 	}
+	logging.LogTaskListLoadingEvent(e.logger, taskList.taskListName, taskList.taskType)
 	mgr, err := newTaskListManager(e, taskList, taskListKind, e.config)
 	if err != nil {
+		e.taskListsLock.Unlock()
+		logging.LogTaskListLoadingFailedEvent(e.logger, taskList.taskListName, taskList.taskType, err)
 		return nil, err
 	}
 	e.taskLists[*taskList] = mgr
 	e.taskListsLock.Unlock()
-	logging.LogTaskListLoadingEvent(e.logger, taskList.taskListName, taskList.taskType)
 	err = mgr.Start()
 	if err != nil {
 		logging.LogTaskListLoadingFailedEvent(e.logger, taskList.taskListName, taskList.taskType, err)


### PR DESCRIPTION
Looks like we never release the write lock if creating the new tasklist
fails.  Previously this code can never return error but now it does a
domain reverse lookup for domain name and could fail if domainCache
lookup fails.