### PR TITLE
Add maximum timeout protection

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -57,4 +57,5 @@ type (
 	EncodingType string
 )
 
-const MaxTaskTimeout = 31622400 // 366 days in seconds
+// MaxTaskTimeout is maximum task timeout allowed. 366 days in seconds
+const MaxTaskTimeout = 31622400

--- a/common/constants.go
+++ b/common/constants.go
@@ -56,3 +56,5 @@ type (
 	// EncodingType is an enum that represents various data encoding types
 	EncodingType string
 )
+
+const MaxTaskTimeout = 31622400 // 366 days in seconds

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -432,3 +432,12 @@ func LogCriticalErrorEvent(logger bark.Logger, msg string, err error) {
 		TagWorkflowErr:     err,
 	}).Error(msg)
 }
+
+// LogDecisionTimeoutTooLarge is used to log warning msg for workflow that contains large decision timeout
+func LogDecisionTimeoutTooLarge(logger bark.Logger, t int32, domain, wid, wfType string) {
+	logger.WithFields(bark.Fields{
+		"Domain":       domain,
+		"WorkflowID":   wid,
+		"WorkflowType": wfType,
+	}).Warnf("Decision timeout %d is too large", t)
+}

--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -436,8 +436,9 @@ func LogCriticalErrorEvent(logger bark.Logger, msg string, err error) {
 // LogDecisionTimeoutTooLarge is used to log warning msg for workflow that contains large decision timeout
 func LogDecisionTimeoutTooLarge(logger bark.Logger, t int32, domain, wid, wfType string) {
 	logger.WithFields(bark.Fields{
-		"Domain":       domain,
-		"WorkflowID":   wid,
-		"WorkflowType": wfType,
-	}).Warnf("Decision timeout %d is too large", t)
+		"Domain":          domain,
+		"WorkflowID":      wid,
+		"WorkflowType":    wfType,
+		"DecisionTimeout": t,
+	}).Warn("Decision timeout is too large")
 }

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -51,11 +51,11 @@ var keys = map[Key]string{
 	EnableGlobalDomain: "system.enableGlobalDomain",
 
 	// frontend settings
-	FrontendPersistenceMaxQPS:     "frontend.persistenceMaxQPS",
-	FrontendVisibilityMaxPageSize: "frontend.visibilityMaxPageSize",
-	FrontendHistoryMaxPageSize:    "frontend.historyMaxPageSize",
-	FrontendRPS:                   "frontend.rps",
-	FrontendHistoryMgrNumConns:    "frontend.historyMgrNumConns",
+	FrontendPersistenceMaxQPS:      "frontend.persistenceMaxQPS",
+	FrontendVisibilityMaxPageSize:  "frontend.visibilityMaxPageSize",
+	FrontendHistoryMaxPageSize:     "frontend.historyMaxPageSize",
+	FrontendRPS:                    "frontend.rps",
+	FrontendHistoryMgrNumConns:     "frontend.historyMgrNumConns",
 	MaxDecisionStartToCloseTimeout: "frontend.maxDecisionStartToCloseTimeout",
 
 	// matching settings

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -56,6 +56,7 @@ var keys = map[Key]string{
 	FrontendHistoryMaxPageSize:    "frontend.historyMaxPageSize",
 	FrontendRPS:                   "frontend.rps",
 	FrontendHistoryMgrNumConns:    "frontend.historyMgrNumConns",
+	MaxDecisionStartToCloseTimeout: "frontend.maxDecisionStartToCloseTimeout",
 
 	// matching settings
 	MatchingPersistenceMaxQPS:               "matching.persistenceMaxQPS",
@@ -155,6 +156,8 @@ const (
 	FrontendRPS
 	// FrontendHistoryMgrNumConns is for persistence cluster.NumConns
 	FrontendHistoryMgrNumConns
+	// MaxDecisionStartToCloseTimeout is max decision timeout in seconds
+	MaxDecisionStartToCloseTimeout
 
 	// key for matching
 

--- a/common/util.go
+++ b/common/util.go
@@ -255,6 +255,7 @@ func CreateMatchingPollForDecisionTaskResponse(historyResponse *h.RecordDecision
 	return matchingResp
 }
 
+// MinInt32 return smaller one of two inputs int32
 func MinInt32(a, b int32) int32 {
 	if a < b {
 		return a
@@ -262,6 +263,7 @@ func MinInt32(a, b int32) int32 {
 	return b
 }
 
+// MinInt64 return smaller one of two inputs int64
 func MinInt64(a, b int64) int64 {
 	if a < b {
 		return a

--- a/common/util.go
+++ b/common/util.go
@@ -254,3 +254,17 @@ func CreateMatchingPollForDecisionTaskResponse(historyResponse *h.RecordDecision
 	}
 	return matchingResp
 }
+
+func MinInt32(a, b int32) int32 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func MinInt64(a, b int64) int64 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/common/util.go
+++ b/common/util.go
@@ -262,11 +262,3 @@ func MinInt32(a, b int32) int32 {
 	}
 	return b
 }
-
-// MinInt64 return smaller one of two inputs int64
-func MinInt64(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -236,8 +236,8 @@ func testActivity(ctx context.Context, msg string) (string, error) {
 
 func testDataConverterWorkflow(ctx workflow.Context, tl string) (string, error) {
 	ao := workflow.ActivityOptions{
-		ScheduleToStartTimeout: time.Minute,
-		StartToCloseTimeout:    time.Minute,
+		ScheduleToStartTimeout: 20 * time.Second,
+		StartToCloseTimeout:    40 * time.Second,
 	}
 	ctx = workflow.WithActivityOptions(ctx, ao)
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -45,11 +45,11 @@ type Config struct {
 // NewConfig returns new service config with default values
 func NewConfig(dc *dynamicconfig.Collection) *Config {
 	return &Config{
-		PersistenceMaxQPS:     dc.GetFloat64Property(dynamicconfig.FrontendPersistenceMaxQPS, 2000),
-		VisibilityMaxPageSize: dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendVisibilityMaxPageSize, 1000),
-		HistoryMaxPageSize:    dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, 1000),
-		RPS:                   dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
-		HistoryMgrNumConns:    dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
+		PersistenceMaxQPS:              dc.GetFloat64Property(dynamicconfig.FrontendPersistenceMaxQPS, 2000),
+		VisibilityMaxPageSize:          dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendVisibilityMaxPageSize, 1000),
+		HistoryMaxPageSize:             dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, 1000),
+		RPS:                            dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
+		HistoryMgrNumConns:             dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
 		MaxDecisionStartToCloseTimeout: dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaxDecisionStartToCloseTimeout, 600),
 	}
 }

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -38,6 +38,8 @@ type Config struct {
 
 	// Persistence settings
 	HistoryMgrNumConns dynamicconfig.IntPropertyFn
+
+	MaxDecisionStartToCloseTimeout dynamicconfig.IntPropertyFnWithDomainFilter
 }
 
 // NewConfig returns new service config with default values
@@ -48,6 +50,7 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		HistoryMaxPageSize:    dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, 1000),
 		RPS:                   dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
 		HistoryMgrNumConns:    dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
+		MaxDecisionStartToCloseTimeout: dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaxDecisionStartToCloseTimeout, 600),
 	}
 }
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1354,9 +1354,11 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 			Message: "A valid TaskStartToCloseTimeoutSeconds is not set on request."}, scope)
 	}
 
-	if startRequest.GetTaskStartToCloseTimeoutSeconds() > startRequest.GetExecutionStartToCloseTimeoutSeconds() {
+	maxDecisionTimeout := wh.config.MaxDecisionStartToCloseTimeout(startRequest.GetDomain())
+	if startRequest.GetTaskStartToCloseTimeoutSeconds() > startRequest.GetExecutionStartToCloseTimeoutSeconds() ||
+		startRequest.GetTaskStartToCloseTimeoutSeconds() > int32(maxDecisionTimeout) {
 		return nil, wh.error(&gen.BadRequestError{
-			Message: "TaskStartToCloseTimeoutSeconds is larger than ExecutionStartToCloseTimeout."}, scope)
+			Message: fmt.Sprintf("TaskStartToCloseTimeoutSeconds is larger than ExecutionStartToCloseTimeout or MaxDecisionStartToCloseTimeout (%ds).", maxDecisionTimeout)}, scope)
 	}
 
 	domainName := startRequest.GetDomain()
@@ -1631,9 +1633,11 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 			Message: "A valid TaskStartToCloseTimeoutSeconds is not set on request."}, scope)
 	}
 
-	if signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > signalWithStartRequest.GetExecutionStartToCloseTimeoutSeconds() {
+	maxDecisionTimeout := wh.config.MaxDecisionStartToCloseTimeout(signalWithStartRequest.GetDomain())
+	if signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > signalWithStartRequest.GetExecutionStartToCloseTimeoutSeconds() ||
+		signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > int32(maxDecisionTimeout) {
 		return nil, wh.error(&gen.BadRequestError{
-			Message: "TaskStartToCloseTimeoutSeconds is larger than ExecutionStartToCloseTimeout."}, scope)
+			Message: fmt.Sprintf("TaskStartToCloseTimeoutSeconds is larger than ExecutionStartToCloseTimeout or MaxDecisionStartToCloseTimeout (%ds).", maxDecisionTimeout)}, scope)
 	}
 
 	domainID, err := wh.domainCache.GetDomainID(signalWithStartRequest.GetDomain())

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1354,6 +1354,11 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 			Message: "A valid TaskStartToCloseTimeoutSeconds is not set on request."}, scope)
 	}
 
+	if startRequest.GetTaskStartToCloseTimeoutSeconds() > startRequest.GetExecutionStartToCloseTimeoutSeconds() {
+		return nil, wh.error(&gen.BadRequestError{
+			Message: "TaskStartToCloseTimeoutSeconds is larger than ExecutionStartToCloseTimeout."}, scope)
+	}
+
 	domainName := startRequest.GetDomain()
 	wh.Service.GetLogger().Debugf("Start workflow execution request domain: %v", domainName)
 	domainID, err := wh.domainCache.GetDomainID(domainName)
@@ -1624,6 +1629,11 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	if signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() <= 0 {
 		return nil, wh.error(&gen.BadRequestError{
 			Message: "A valid TaskStartToCloseTimeoutSeconds is not set on request."}, scope)
+	}
+
+	if signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > signalWithStartRequest.GetExecutionStartToCloseTimeoutSeconds() {
+		return nil, wh.error(&gen.BadRequestError{
+			Message: "TaskStartToCloseTimeoutSeconds is larger than ExecutionStartToCloseTimeout."}, scope)
 	}
 
 	domainID, err := wh.domainCache.GetDomainID(signalWithStartRequest.GetDomain())

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1000,7 +1000,7 @@ Update_History_Loop:
 					targetDomainID = domainEntry.GetInfo().ID
 				}
 
-				if err = validateActivityScheduleAttributes(attributes); err != nil {
+				if err = validateActivityScheduleAttributes(attributes, executionInfo.WorkflowTimeout); err != nil {
 					failDecision = true
 					failCause = workflow.DecisionTaskFailedCauseBadScheduleActivityAttributes
 					break Process_Decision_Loop
@@ -2428,7 +2428,7 @@ func (s *shardContextWrapper) NotifyNewHistoryEvent(event *historyEventNotificat
 	return err
 }
 
-func validateActivityScheduleAttributes(attributes *workflow.ScheduleActivityTaskDecisionAttributes) error {
+func validateActivityScheduleAttributes(attributes *workflow.ScheduleActivityTaskDecisionAttributes, wfTimeout int32) error {
 	if attributes == nil {
 		return &workflow.BadRequestError{Message: "ScheduleActivityTaskDecisionAttributes is not set on decision."}
 	}
@@ -2463,6 +2463,13 @@ func validateActivityScheduleAttributes(attributes *workflow.ScheduleActivityTas
 		return &workflow.BadRequestError{Message: "A valid timeout may not be negative."}
 	}
 
+	if attributes.GetScheduleToCloseTimeoutSeconds() > wfTimeout ||
+		attributes.GetScheduleToStartTimeoutSeconds() > wfTimeout ||
+		attributes.GetStartToCloseTimeoutSeconds() > wfTimeout ||
+		attributes.GetHeartbeatTimeoutSeconds() > wfTimeout {
+		return &workflow.BadRequestError{Message: fmt.Sprintf("Timeout cannot be larger than workflow timeout %d.", wfTimeout)}
+	}
+
 	validScheduleToClose := attributes.GetScheduleToCloseTimeoutSeconds() > 0
 	validScheduleToStart := attributes.GetScheduleToStartTimeoutSeconds() > 0
 	validStartToClose := attributes.GetStartToCloseTimeoutSeconds() > 0
@@ -2476,6 +2483,9 @@ func validateActivityScheduleAttributes(attributes *workflow.ScheduleActivityTas
 		}
 	} else if validScheduleToStart && validStartToClose {
 		attributes.ScheduleToCloseTimeoutSeconds = common.Int32Ptr(attributes.GetScheduleToStartTimeoutSeconds() + attributes.GetStartToCloseTimeoutSeconds())
+		if attributes.GetScheduleToCloseTimeoutSeconds() > wfTimeout {
+			return &workflow.BadRequestError{Message: fmt.Sprintf("Timeout cannot be larger than workflow timeout %d.", wfTimeout)}
+		}
 	} else {
 		// Deduction failed as there's not enough information to fill in missing timeouts.
 		return &workflow.BadRequestError{Message: "A valid ScheduleToCloseTimeout is not set on decision."}

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -1128,9 +1128,9 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledAtt
 		// Use workflow timeout
 		{common.Int32Ptr(workflowTimeout), nil, nil, nil,
 			workflowTimeout, workflowTimeout, workflowTimeout, false},
-		// Timeout larger than workflow timeout, expect error return
+		// Timeout larger than workflow timeout
 		{common.Int32Ptr(workflowTimeout + 1), nil, nil, nil,
-			0, 0, 0, true},
+			workflowTimeout, workflowTimeout, workflowTimeout, false},
 		{nil, common.Int32Ptr(workflowTimeout + 1), nil, nil,
 			0, 0, 0, true},
 		{nil, nil, common.Int32Ptr(workflowTimeout + 1), nil,
@@ -1138,8 +1138,8 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledAtt
 		{nil, nil, nil, common.Int32Ptr(workflowTimeout + 1),
 			0, 0, 0, true},
 		// No ScheduleToClose timeout, will use ScheduleToStart + StartToClose, but exceed limit
-		{nil, common.Int32Ptr(workflowTimeout), common.Int32Ptr(workflowTimeout), nil,
-			0, 0, 0, true},
+		{nil, common.Int32Ptr(workflowTimeout), common.Int32Ptr(10), nil,
+			workflowTimeout, workflowTimeout, 10, false},
 	}
 
 	for _, iVar := range testIterationVariables {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -651,7 +651,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedConflictOnUpdate() {
 	activity3Input := []byte("input3")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 25, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di1 := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di1.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di1.ScheduleID,
@@ -747,7 +747,7 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedConflictOnUpdate() {
 
 	di, ok := executionBuilder.GetPendingDecision(15)
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 }
 
 func (s *engineSuite) TestRespondDecisionTaskCompletedMaxAttemptsExceeded() {
@@ -2064,7 +2064,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedConflictOnUpdate() {
 	activity2Input := []byte("input2")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 25, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2121,7 +2121,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedConflictOnUpdate() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(10))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 	s.Equal(int64(10), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -2145,7 +2145,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedMaxAttemptsExceeded() {
 	activityResult := []byte("activity result")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2207,7 +2207,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedSuccess() {
 	activityResult := []byte("activity result")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2254,7 +2254,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedSuccess() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(8))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -2279,7 +2279,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedByIdSuccess() {
 	})
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	decisionScheduledEvent := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, decisionScheduledEvent.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, decisionScheduledEvent.ScheduleID,
@@ -2328,7 +2328,7 @@ func (s *engineSuite) TestRespondActivityTaskCompletedByIdSuccess() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(8))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -2572,7 +2572,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedUpdateExecutionFailed() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2633,7 +2633,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedIfTaskCompleted() {
 	details := []byte("fail details")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2695,7 +2695,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedIfTaskNotStarted() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2757,7 +2757,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedConflictOnUpdate() {
 	activity2Result := []byte("activity2_result")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 25, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 25, 25, identity)
 	di1 := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent1 := addDecisionTaskStartedEvent(msBuilder, di1.ScheduleID, tl, identity)
 	decisionCompletedEvent1 := addDecisionTaskCompletedEvent(msBuilder, di1.ScheduleID,
@@ -2819,7 +2819,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedConflictOnUpdate() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(10))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(25), di.DecisionTimeout)
 	s.Equal(int64(10), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -2842,7 +2842,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedMaxAttemptsExceeded() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2904,7 +2904,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedSuccess() {
 	failDetails := []byte("fail details.")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -2952,7 +2952,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedSuccess() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(8))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -2978,7 +2978,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedByIDSuccess() {
 	})
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	decisionScheduledEvent := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, decisionScheduledEvent.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, decisionScheduledEvent.ScheduleID,
@@ -3028,7 +3028,7 @@ func (s *engineSuite) TestRespondActivityTaskFailedByIDSuccess() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(8))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 	s.Equal(int64(8), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -3051,7 +3051,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_NoTimer() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3111,7 +3111,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatSuccess_TimerRunning() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3178,7 +3178,7 @@ func (s *engineSuite) TestRecordActivityTaskHeartBeatByIDSuccess() {
 	})
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3238,7 +3238,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Scheduled() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3295,7 +3295,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3343,7 +3343,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceled_Started() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(9))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 	s.Equal(int64(9), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -3366,7 +3366,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledByID_Started() {
 	})
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	decisionScheduledEvent := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, decisionScheduledEvent.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, decisionScheduledEvent.ScheduleID,
@@ -3416,7 +3416,7 @@ func (s *engineSuite) TestRespondActivityTaskCanceledByID_Started() {
 	s.True(executionBuilder.HasPendingDecisionTask())
 	di, ok := executionBuilder.GetPendingDecision(int64(9))
 	s.True(ok)
-	s.Equal(int32(200), di.DecisionTimeout)
+	s.Equal(int32(100), di.DecisionTimeout)
 	s.Equal(int64(9), di.ScheduleID)
 	s.Equal(common.EmptyEventID, di.StartedID)
 }
@@ -3553,7 +3553,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_NotSchedule
 	activityID := "activity1_id"
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -3620,7 +3620,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Scheduled()
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3694,7 +3694,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_NoHeartBeat
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3824,7 +3824,7 @@ func (s *engineSuite) TestRequestCancel_RespondDecisionTaskCompleted_Success() {
 	activityInput := []byte("input1")
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -3953,7 +3953,7 @@ func (s *engineSuite) TestStarTimer_DuplicateTimerID() {
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
 
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 
@@ -4067,7 +4067,7 @@ func (s *engineSuite) TestUserTimer_RespondDecisionTaskCompleted() {
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
 	// Verify cancel timer with a start event.
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	decisionStartedEvent := addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 	decisionCompletedEvent := addDecisionTaskCompletedEvent(msBuilder, di.ScheduleID,
@@ -4139,7 +4139,7 @@ func (s *engineSuite) TestCancelTimer_RespondDecisionTaskCompleted_NoStartTimer(
 
 	msBuilder := newMutableStateBuilder(s.config, bark.NewLoggerFromLogrus(log.New()))
 	// Verify cancel timer with a start event.
-	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
 

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -281,7 +281,7 @@ func (t *transferQueueActiveProcessorImpl) processActivityTask(task *persistence
 		return nil
 	}
 
-	timeout := ai.ScheduleToStartTimeout
+	timeout := common.MinInt32(ai.ScheduleToStartTimeout, common.MaxTaskTimeout)
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
@@ -341,7 +341,7 @@ func (t *transferQueueActiveProcessorImpl) processDecisionTask(task *persistence
 
 	executionInfo := msBuilder.GetExecutionInfo()
 	workflowTimeout := executionInfo.WorkflowTimeout
-	decisionTimeout := workflowTimeout
+	decisionTimeout := common.MinInt32(workflowTimeout, common.MaxTaskTimeout)
 	wfTypeName := executionInfo.WorkflowTypeName
 	startTimestamp := executionInfo.StartTimestamp
 	if msBuilder.IsStickyTaskListEnabled() {


### PR DESCRIPTION
Currently we do not limit workflow timeout for customers. But because Cassandra TTL maximum is 630720000 (20 years) and if customer put a number larger than that, it will cause errors like "RecordWorkflowExecutionStarted operation failed" , and CreateTask failure. 

This PR protects:
1. Task ScheduleToClose
2. Visibility TTL