### PR TITLE
Kafka dlq tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,9 @@ copyright: cmd/tools/copyright/licensegen.go
 cadence-cassandra-tool: vendor/glide.updated $(TOOLS_SRC)
 	go build -i -o cadence-cassandra-tool cmd/tools/cassandra/main.go
 
+cadence-kafka-tool: vendor/glide.updated $(TOOLS_SRC)
+	go build -i -o cadence-kafka-tool cmd/tools/kafka/main.go
+
 cadence: vendor/glide.updated $(TOOLS_SRC)
 	go build -i -o cadence cmd/tools/cli/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ cadence: vendor/glide.updated $(TOOLS_SRC)
 cadence-server: vendor/glide.updated $(ALL_SRC)
 	go build -i -o cadence-server cmd/server/cadence.go cmd/server/server.go
 
-bins_nothrift: lint copyright cadence-cassandra-tool cadence cadence-server
+bins_nothrift: lint copyright cadence-cassandra-tool cadence-kafka-tool cadence cadence-server
 
 bins: thriftc bins_nothrift
 

--- a/cmd/tools/kafka/main.go
+++ b/cmd/tools/kafka/main.go
@@ -1,0 +1,31 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package main
+
+import (
+	"os"
+
+	"github.com/uber/cadence/tools/kafka"
+)
+
+func main() {
+	kafka.RunTool(os.Args)
+}

--- a/tools/kafka/README.md
+++ b/tools/kafka/README.md
@@ -1,0 +1,7 @@
+## What
+This package contains the tooling for kafka topic operations.
+
+## How
+- Run `make bins`
+- You should see an executable `cadence-kafka-tool`
+

--- a/tools/kafka/app.go
+++ b/tools/kafka/app.go
@@ -24,6 +24,9 @@ import (
 	"github.com/urfave/cli"
 )
 
+/**
+Flags used to specify cli command line arguments
+*/
 const (
 	FlagKafkaClusterFile          = "clusterfile"
 	FlagKafkaClusterFileWithAlias = FlagKafkaClusterFile + ", f"
@@ -80,7 +83,7 @@ func buildCLIOptions() *cli.App {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagDLQCluster,
-					Usage: "The DLQ cluster that is operated on.",
+					Usage: "The DLQ cluster that is operated on. Optional for local mode.",
 				},
 				cli.StringFlag{
 					Name:  FlagDLQTopic,
@@ -94,7 +97,7 @@ func buildCLIOptions() *cli.App {
 
 				cli.StringFlag{
 					Name:  FlagDestinationCluster,
-					Usage: "The Destination cluster that is operated on.",
+					Usage: "The Destination cluster that is operated on. Optional for local mode.",
 				},
 				cli.StringFlag{
 					Name:  FlagDestinationTopic,
@@ -116,7 +119,7 @@ func buildCLIOptions() *cli.App {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagCluster,
-					Usage: "The cluster that is operated on.",
+					Usage: "The cluster that is operated on. Optional for local mode.",
 				},
 				cli.StringFlag{
 					Name:  FlagTopic,
@@ -137,7 +140,7 @@ func buildCLIOptions() *cli.App {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagCluster,
-					Usage: "The cluster that is operated on.",
+					Usage: "The cluster that is operated on. Optional for local mode.",
 				},
 				cli.StringFlag{
 					Name:  FlagTopic,

--- a/tools/kafka/app.go
+++ b/tools/kafka/app.go
@@ -1,0 +1,158 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package kafka
+
+import (
+	"github.com/urfave/cli"
+)
+
+const (
+	FlagKafkaClusterFile          = "clusterfile"
+	FlagKafkaClusterFileWithAlias = FlagKafkaClusterFile + ", f"
+
+	FlagLocal          = "local"
+	FlagLocalWithAlias = FlagLocal + ", loc"
+
+	FlagCluster       = "cluster"
+	FlagTopic         = "topic"
+	FlagConsumerGroup = "consumerGroup"
+
+	FlagDLQCluster       = "dlqCluster"
+	FlagDLQTopic         = "dlqTopic"
+	FlagDLQConsumerGroup = "dlqConsumerGroup"
+
+	FlagDestinationCluster       = "destCluster"
+	FlagDestinationTopic         = "destTopic"
+	FlagDestinationConsumerGroup = "destConsumerGroup"
+
+	FlagOffsets          = "offsets"
+	FlagOffsetsWithAlias = FlagOffsets + ", off"
+)
+
+// RunTool runs the cadence-cassandra-tool command line tool
+func RunTool(args []string) error {
+	app := buildCLIOptions()
+	return app.Run(args)
+}
+
+func buildCLIOptions() *cli.App {
+
+	app := cli.NewApp()
+	app.Name = "cadence-kafka-tool"
+	app.Usage = "Command line tool for cadence kafka operations."
+	app.Version = "0.0.1"
+
+	app.Flags = []cli.Flag{
+		cli.StringFlag{
+			Name:   FlagKafkaClusterFileWithAlias,
+			Usage:  "A file that contains ip:port of brokers that are connecting to. See kafka_clusters.yaml as an example.",
+			EnvVar: "KAFKA_CLUSTERS_FILE",
+		},
+		cli.BoolFlag{
+			Name:  FlagLocalWithAlias,
+			Usage: "Use local kafka broker: 127.0.0.1:9092 as the broker. Will be ignored if Kafka cluster file is set (" + FlagKafkaClusterFileWithAlias + ")",
+		},
+	}
+
+	app.Commands = []cli.Command{
+		{
+			Name:  "mergeDLQ",
+			Usage: "Merge DLQ topic into another topic",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagDLQCluster,
+					Usage: "The DLQ cluster that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagDLQTopic,
+					Usage: "The DLQ topic that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagDLQConsumerGroup,
+					Usage: "The DLQ consumer group.",
+				},
+
+				cli.StringFlag{
+					Name:  FlagDestinationCluster,
+					Usage: "The Destination cluster that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagDestinationTopic,
+					Usage: "The Destination topic that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagDestinationConsumerGroup,
+					Usage: "The Destination consumer group.",
+				},
+			},
+			Action: func(c *cli.Context) {
+				mergeDLQ(c)
+			},
+		},
+		{
+			Name:  "purge",
+			Usage: "Purge a kafka topic",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagCluster,
+					Usage: "The cluster that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagTopic,
+					Usage: "The topic that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagConsumerGroup,
+					Usage: "The consumer group.",
+				},
+			},
+			Action: func(c *cli.Context) {
+				purgeTopic(c)
+			},
+		},
+		{
+			Name:  "reset",
+			Usage: "Reset offsets of a kafka topic.",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagCluster,
+					Usage: "The cluster that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagTopic,
+					Usage: "The topic that is operated on.",
+				},
+				cli.StringFlag{
+					Name:  FlagConsumerGroup,
+					Usage: "The consumer group.",
+				},
+				cli.StringFlag{
+					Name:  FlagOffsetsWithAlias,
+					Usage: "The offsets for each partition in format of p0:off0,p1:off1. Or '*:off' will set an offset for all partitions ",
+				},
+			},
+			Action: func(c *cli.Context) {
+				resetTopic(c)
+			},
+		},
+	}
+	return app
+}

--- a/tools/kafka/app.go
+++ b/tools/kafka/app.go
@@ -129,6 +129,10 @@ func buildCLIOptions() *cli.App {
 					Name:  FlagConsumerGroup,
 					Usage: "The consumer group.",
 				},
+				cli.StringFlag{
+					Name:  FlagOffsetsWithAlias,
+					Usage: "The offsets for each partition in format of p0:off0,p1:off1.",
+				},
 			},
 			Action: func(c *cli.Context) {
 				purgeTopic(c)

--- a/tools/kafka/app.go
+++ b/tools/kafka/app.go
@@ -39,12 +39,13 @@ const (
 	FlagDLQTopic         = "dlqTopic"
 	FlagDLQConsumerGroup = "dlqConsumerGroup"
 
-	FlagDestinationCluster       = "destCluster"
-	FlagDestinationTopic         = "destTopic"
-	FlagDestinationConsumerGroup = "destConsumerGroup"
+	FlagDestinationCluster = "destCluster"
+	FlagDestinationTopic   = "destTopic"
 
 	FlagOffsets          = "offsets"
 	FlagOffsetsWithAlias = FlagOffsets + ", off"
+
+	FlagConcurrency = "concurrency"
 )
 
 // RunTool runs the cadence-cassandra-tool command line tool
@@ -68,7 +69,7 @@ func buildCLIOptions() *cli.App {
 		},
 		cli.BoolFlag{
 			Name:  FlagLocalWithAlias,
-			Usage: "Use local kafka broker: 127.0.0.1:9092 as the broker. Will be ignored if Kafka cluster file is set (" + FlagKafkaClusterFileWithAlias + ")",
+			Usage: "Use local kafka broker: 127.0.0.1:9092 as the broker. This will ignore Kafka cluster file (" + FlagKafkaClusterFileWithAlias + ") if it is set",
 		},
 	}
 
@@ -88,6 +89,7 @@ func buildCLIOptions() *cli.App {
 				cli.StringFlag{
 					Name:  FlagDLQConsumerGroup,
 					Usage: "The DLQ consumer group.",
+					Value: "DLQConsumerGroup",
 				},
 
 				cli.StringFlag{
@@ -98,9 +100,10 @@ func buildCLIOptions() *cli.App {
 					Name:  FlagDestinationTopic,
 					Usage: "The Destination topic that is operated on.",
 				},
-				cli.StringFlag{
-					Name:  FlagDestinationConsumerGroup,
-					Usage: "The Destination consumer group.",
+				cli.Int64Flag{
+					Name:  FlagConcurrency,
+					Usage: "number of go routines processing messages in parallel",
+					Value: 10,
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/kafka/app.go
+++ b/tools/kafka/app.go
@@ -152,7 +152,7 @@ func buildCLIOptions() *cli.App {
 				},
 				cli.StringFlag{
 					Name:  FlagOffsetsWithAlias,
-					Usage: "The offsets for each partition in format of p0:off0,p1:off1. Or '*:off' will set an offset for all partitions ",
+					Usage: "The offsets for each partition in format of p0:off0,p1:off1.",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/kafka/commands.go
+++ b/tools/kafka/commands.go
@@ -208,7 +208,6 @@ outloop:
 
 	for p, off := range offsetPerPartition {
 		fmt.Printf("partition %v setting to offset %v \n", p, off)
-		consumer.MarkPartitionOffset(topic, p, off, "")
 		if isForward {
 			consumer.MarkPartitionOffset(topic, p, off, "")
 		} else {

--- a/tools/kafka/commands.go
+++ b/tools/kafka/commands.go
@@ -1,0 +1,57 @@
+package kafka
+
+import (
+	"fmt"
+	"os"
+
+	"io/ioutil"
+
+	"github.com/fatih/color"
+	"github.com/uber/cadence/common/messaging"
+	"github.com/urfave/cli"
+	yaml "gopkg.in/yaml.v2"
+)
+
+type (
+	// ClustersConfig describes the kafka clusters
+	ClustersConfig struct {
+		Clusters map[string]messaging.ClusterConfig
+	}
+)
+
+var (
+	colorRed     = color.New(color.FgRed).SprintFunc()
+	colorMagenta = color.New(color.FgMagenta).SprintFunc()
+	colorGreen   = color.New(color.FgGreen).SprintFunc()
+)
+
+func mergeDLQ(c *cli.Context) {
+
+}
+
+func purgeTopic(c *cli.Context) {
+
+}
+
+func resetTopic(c *cli.Context) {
+
+}
+
+// load the kafka cluster config file from host and convert it to a useable config
+func loadClusterConfig(clusterFile string) (map[string]messaging.ClusterConfig, error) {
+	contents, err := ioutil.ReadFile(clusterFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load kafka cluster info from %v., error: %v", clusterFile, err)
+	}
+	clustersConfig := ClustersConfig{}
+	if err := yaml.Unmarshal(contents, &clustersConfig); err != nil {
+		return nil, err
+	}
+	return clustersConfig.Clusters, nil
+}
+
+// ErrorAndExit print easy to understand error msg first then error detail in a new line
+func ErrorAndExit(msg string, err error) {
+	fmt.Printf("%s %s\n%s %+v\n", colorRed("Error:"), msg, colorMagenta("Error Details:"), err)
+	os.Exit(1)
+}

--- a/tools/kafka/commands.go
+++ b/tools/kafka/commands.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package kafka
 
 import (

--- a/tools/kafka/commands.go
+++ b/tools/kafka/commands.go
@@ -74,8 +74,8 @@ func mergeDLQ(c *cli.Context) {
 	dlqGroup := c.String(FlagDLQConsumerGroup)
 	dlqCluster := c.String(FlagDLQCluster)
 	destCluster := c.String(FlagDestinationCluster)
-	clusterFile := c.String(FlagKafkaClusterFile)
-	useLocal := c.Bool(FlagLocal)
+	clusterFile := c.GlobalString(FlagKafkaClusterFile)
+	useLocal := c.GlobalBool(FlagLocal)
 	concurrency := c.Int64(FlagConcurrency)
 	brokers := map[string][]string{}
 	var err error
@@ -162,8 +162,8 @@ func markTopicOffsets(c *cli.Context, offsetPerPartition map[int32]int64) {
 	group := c.String(FlagConsumerGroup)
 
 	cluster := c.String(FlagCluster)
-	clusterFile := c.String(FlagKafkaClusterFile)
-	useLocal := c.Bool(FlagLocal)
+	clusterFile := c.GlobalString(FlagKafkaClusterFile)
+	useLocal := c.GlobalBool(FlagLocal)
 	brokers := map[string][]string{}
 	var err error
 	if useLocal {

--- a/tools/kafka/commands.go
+++ b/tools/kafka/commands.go
@@ -6,9 +6,23 @@ import (
 
 	"io/ioutil"
 
+	"github.com/uber-go/kafka-client"
+	"github.com/uber-go/kafka-client/kafka"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
+
+	"strings"
+
+	"os/signal"
+
+	"github.com/Shopify/sarama"
 	"github.com/fatih/color"
+	kafkaclient "github.com/uber-go/kafka-client"
+	"github.com/uber-go/kafka-client/kafka"
+	"github.com/uber-go/tally"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/urfave/cli"
+	"go.uber.org/zap"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -26,19 +40,135 @@ var (
 )
 
 func mergeDLQ(c *cli.Context) {
+	if !c.IsSet(FlagDLQTopic) {
+		ErrorAndExit("", fmt.Errorf("DLQ topic name must be provided by flag %v", FlagDLQTopic))
+	}
+	dlqTopic := c.String(FlagDLQTopic)
+	if !c.IsSet(FlagDestinationTopic) {
+		ErrorAndExit("", fmt.Errorf("destination topic name must be provided by flag %v", FlagDestinationTopic))
+	}
+	destTopic := c.String(FlagDestinationTopic)
 
+	dlqGroup := c.String(FlagDLQConsumerGroup)
+	dlqCluster := c.String(FlagDLQCluster)
+	destCluster := c.String(FlagDestinationCluster)
+	clusterFile := c.String(FlagKafkaClusterFile)
+	useLocal := c.Bool(FlagLocal)
+	concurrency := c.Int64(FlagConcurrency)
+	brokers := map[string][]string{}
+	var err error
+	if useLocal {
+		brokers = map[string][]string{
+			dlqCluster:  {"127.0.0.1:9092"},
+			destCluster: {"127.0.0.1:9092"},
+		}
+	} else {
+		// if not using local mode, cluster names and host file must be provided
+		if len(clusterFile) == 0 || len(dlqCluster) == 0 || len(destCluster) == 0 {
+			ErrorAndExit("", fmt.Errorf("DLQ and destination cluster names and host file must be provided must be provided by flags %v,%v,%v", FlagDLQCluster, FlagDestinationCluster, FlagKafkaClusterFile))
+		}
+		brokers, err = loadClusterConfig(clusterFile, []string{dlqCluster, destCluster})
+		if err != nil {
+			ErrorAndExit("failed to load cluster from file", err)
+		}
+	}
+
+	topicClusterAssignment := map[string][]string{
+		dlqTopic:  {dlqCluster},
+		destTopic: {destCluster},
+	}
+	client := kafkaclient.New(kafka.NewStaticNameResolver(topicClusterAssignment, brokers), zap.NewNop(), tally.NoopScope)
+
+	dlqConsumerConfig := &kafka.ConsumerConfig{
+		TopicList: kafka.ConsumerTopicList{
+			kafka.ConsumerTopic{
+				Topic: kafka.Topic{
+					Name:    dlqTopic,
+					Cluster: dlqCluster,
+				},
+			},
+		},
+		GroupName:   dlqGroup,
+		Concurrency: int(concurrency),
+	}
+
+	consumer, err := client.NewConsumer(dlqConsumerConfig)
+	if err != nil {
+		ErrorAndExit("failed to create DLQ consumer", err)
+	}
+
+	producer, err := sarama.NewSyncProducer(brokers[destCluster], nil)
+	if err != nil {
+		ErrorAndExit("failed to create destination topic producer", err)
+	}
+
+	if err := consumer.Start(); err != nil {
+		ErrorAndExit("", fmt.Errorf("failed to start DLQ consumer"))
+	}
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt)
+
+	for {
+		select {
+		case cmsg, ok := <-consumer.Messages():
+			if !ok {
+				return
+			}
+
+			pmsg := &sarama.ProducerMessage{
+				Topic: destTopic,
+				Key:   getKey(cmsg.Key()),
+				Value: sarama.ByteEncoder(cmsg.Value()),
+			}
+
+			partition, offset, err := producer.SendMessage(pmsg)
+
+			if err != nil {
+				cmsg.Nack()
+			} else {
+				cmsg.Ack()
+				fmt.Println("Message [%v],[%v] is sent to [%v],[%v] in DLQ", cmsg.Partition(), cmsg.Offset(), partition, offset)
+			}
+		case <-sigCh:
+			consumer.Stop()
+			<-consumer.Closed()
+		}
+	}
+}
+
+// use the same key as we sent to DLQ
+func getKey(originKey []byte) sarama.Encoder {
+	if originKey == nil || len(originKey) == 0 {
+		return nil
+	}
+	return sarama.StringEncoder(string(originKey))
 }
 
 func purgeTopic(c *cli.Context) {
-
+	if !c.IsSet(FlagTopic) {
+		ErrorAndExit("", fmt.Errorf("target topic name must be provided by flag %v", FlagTopic))
+	}
+	if !c.IsSet(FlagConsumerGroup) {
+		ErrorAndExit("", fmt.Errorf("target consumer group name must be provided by flag %v", FlagConsumerGroup))
+	}
 }
 
 func resetTopic(c *cli.Context) {
+	if !c.IsSet(FlagTopic) {
+		ErrorAndExit("", fmt.Errorf("target topic name must be provided by flag %v", FlagTopic))
+	}
+	if !c.IsSet(FlagConsumerGroup) {
+		ErrorAndExit("", fmt.Errorf("target consumer group name must be provided by flag %v", FlagConsumerGroup))
+	}
+}
+
+func buildConsumer() {
 
 }
 
 // load the kafka cluster config file from host and convert it to a useable config
-func loadClusterConfig(clusterFile string) (map[string]messaging.ClusterConfig, error) {
+func loadClusterConfig(clusterFile string, clusterNames []string) (map[string][]string, error) {
 	contents, err := ioutil.ReadFile(clusterFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load kafka cluster info from %v., error: %v", clusterFile, err)
@@ -47,7 +177,23 @@ func loadClusterConfig(clusterFile string) (map[string]messaging.ClusterConfig, 
 	if err := yaml.Unmarshal(contents, &clustersConfig); err != nil {
 		return nil, err
 	}
-	return clustersConfig.Clusters, nil
+	ret := map[string][]string{}
+	for _, name := range clusterNames {
+		c, ok := clustersConfig.Clusters[name]
+		if !ok {
+			return nil, fmt.Errorf("failed to load cluster %v from file %v", name, clusterFile)
+		}
+		brokers := []string{}
+		for i := range c.Brokers {
+			if !strings.Contains(c.Brokers[i], ":") {
+				brokers = append(brokers, c.Brokers[i]+":9092")
+			} else {
+				brokers = append(brokers, c.Brokers[i])
+			}
+		}
+		ret[name] = brokers
+	}
+	return ret, nil
 }
 
 // ErrorAndExit print easy to understand error msg first then error detail in a new line

--- a/tools/kafka/kafka_cluster.yaml
+++ b/tools/kafka/kafka_cluster.yaml
@@ -1,0 +1,4 @@
+clusters:
+  test:
+    brokers:
+    - 127.0.0.1:9092


### PR DESCRIPTION
Same example of my local tests:
```
./cadence-kafka-tool --local mergeDLQ --dlqTopic active-dlq --destTopic active
```
```
./cadence-kafka-tool --local reset --topic active  --consumerGroup DLQConsumerGroup --offsets 0:1,1:1
```
```
./cadence-kafka-tool -f tools/kafka/kafka_cluster.yaml purge --topic active  --consumerGroup DLQConsumerGroup --offsets 0:8,1:8 --cluster test
partition 0 setting to offset 8
partition 1 setting to offset 8
mark offset for topic active group DLQConsumerGroup is completed
```

```
./kafka-consumer-groups.sh  --bootstrap-server localhost:9092  --group DLQConsumerGroup --describe
Note: This will not show information about old Zookeeper-based consumers.

Consumer group 'DLQConsumerGroup' has no active members.

TOPIC                          PARTITION  CURRENT-OFFSET  LOG-END-OFFSET  LAG        CONSUMER-ID                                       HOST                           CLIENT-ID
active                         0          9               24              15         -                                                 -                              -
active-dlq                     0          6               31              25         -                                                 -                              -
active                         1          9               3               -6         -                                                 -                              -
```