### PR TITLE
Add dedupe logic for heartbeat timer creation

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -434,6 +434,8 @@ type (
 		ExpirationTime     time.Time
 		MaximumAttempts    int32
 		NonRetriableErrors []string
+		// Not written to database - This is used only for deduping heartbeat timer creation
+		LastTimeoutVisibility int64
 	}
 
 	// TimerInfo details - metadata about user timer info.

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -318,7 +318,7 @@ Update_History_Loop:
 			// NOTE: When record activity HB comes in we only update last heartbeat timestamp, this is the place
 			// where we create next timer task based on that new updated timestamp.
 			isHeartBeatTask := timerTask.TimeoutType == int(workflow.TimeoutTypeHeartbeat)
-			if isHeartBeatTask {
+			if isHeartBeatTask && ai.LastTimeoutVisibility <= timerTask.VisibilityTimestamp.Unix() {
 				ai.TimerTaskStatus = ai.TimerTaskStatus &^ TimerTaskStatusCreatedHeartbeat
 				msBuilder.UpdateActivity(ai)
 			}
@@ -415,6 +415,8 @@ Update_History_Loop:
 					at := nextTask.(*persistence.ActivityTimeoutTask)
 
 					ai.TimerTaskStatus = ai.TimerTaskStatus | getActivityTimerStatus(workflow.TimeoutType(at.TimeoutType))
+					// Use second resolution for setting LastTimeoutVisibility, which is used for deduping heartbeat timer creation
+					ai.LastTimeoutVisibility = td.TimerSequenceID.VisibilityTimestamp.Unix()
 					msBuilder.UpdateActivity(ai)
 					createNewTimer = true
 


### PR DESCRIPTION
After moving timer deletion to a background job, it is highly likely to 
process timers multiple times.  Heartbeat timer processing is made 
idempotent by keeping track of the timeout visibility within 
mutable state whenever a new timer is created.  And we only clear
the timer flag if the last timeout visibility is less than or equal to
visibility timestamp of the timer task.