### PR TITLE
Bugfix replication protocol

### DIFF
--- a/common/cluster/metadata.go
+++ b/common/cluster/metadata.go
@@ -22,6 +22,7 @@ package cluster
 
 import (
 	"fmt"
+
 	"github.com/uber/cadence/common/service/dynamicconfig"
 )
 
@@ -35,6 +36,8 @@ type (
 		IsMasterCluster() bool
 		// GetNextFailoverVersion return the next failover version for domain failover
 		GetNextFailoverVersion(string, int64) int64
+		// IsVersionFromSameCluster return true if 2 version are used for the same cluster
+		IsVersionFromSameCluster(version1 int64, version2 int64) bool
 		// GetMasterClusterName return the master cluster name
 		GetMasterClusterName() string
 		// GetCurrentClusterName return the current cluster name
@@ -130,6 +133,11 @@ func (metadata *metadataImpl) GetNextFailoverVersion(cluster string, currentFail
 		return failoverVersion + metadata.failoverVersionIncrement
 	}
 	return failoverVersion
+}
+
+// IsVersionFromSameCluster return true if 2 version are used for the same cluster
+func (metadata *metadataImpl) IsVersionFromSameCluster(version1 int64, version2 int64) bool {
+	return (version1-version2)%metadata.failoverVersionIncrement == 0
 }
 
 func (metadata *metadataImpl) IsMasterCluster() bool {

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -59,6 +59,9 @@ const (
 	TagNextEventID          = "next-event-id"
 	TagTimeoutType          = "timeout-type"
 	TagReplicationInfo      = "replication-info"
+	TagAttemptCount         = "attempt-count"
+	TagAttemptStart         = "attempt-start"
+	TagAttemptEnd           = "attempt-end"
 
 	// workflow logging tag values
 	// TagWorkflowComponent Values

--- a/common/mocks/ClusterMetadata.go
+++ b/common/mocks/ClusterMetadata.go
@@ -85,7 +85,7 @@ func (_m *ClusterMetadata) GetMasterClusterName() string {
 	return r0
 }
 
-// GetNextFailoverVersion provides a mock function with given fields: _a0
+// GetNextFailoverVersion provides a mock function with given fields: _a0, _a1
 func (_m *ClusterMetadata) GetNextFailoverVersion(_a0 string, _a1 int64) int64 {
 	ret := _m.Called(_a0, _a1)
 
@@ -94,6 +94,20 @@ func (_m *ClusterMetadata) GetNextFailoverVersion(_a0 string, _a1 int64) int64 {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(int64)
+	}
+
+	return r0
+}
+
+// IsVersionFromSameCluster provides a mock function with given fields: _a0, _a1
+func (_m *ClusterMetadata) IsVersionFromSameCluster(_a0 int64, _a1 int64) bool {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(int64, int64) bool); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Get(0).(bool)
 	}
 
 	return r0

--- a/service/worker/processor.go
+++ b/service/worker/processor.go
@@ -199,7 +199,10 @@ func (p *replicationTaskProcessor) processWithRetry(msg kafka.Message, workerID 
 	forceBuffer := false
 	remainingRetryCount := p.config.ReplicationTaskMaxRetry
 
+	attempt := 0
+	startTime := time.Now()
 	op := func() error {
+		attempt++
 		processErr := p.process(msg, forceBuffer)
 		if processErr != nil && p.isRetryTaskError(processErr) {
 			// Enable buffering of replication tasks for next attempt
@@ -258,6 +261,9 @@ ProcessRetryLoop:
 			logging.TagErr:          err,
 			logging.TagPartitionKey: msg.Partition(),
 			logging.TagOffset:       msg.Offset(),
+			logging.TagAttemptCount: attempt,
+			logging.TagAttemptStart: startTime,
+			logging.TagAttemptEnd:   time.Now(),
 		}).Error("Error processing replication task.")
 		msg.Nack()
 	}
@@ -346,8 +352,14 @@ Loop:
 		}
 	}
 	if !processTask {
-		p.logger.Debugf("Dropping non-targeted history task with domainID: %v, workflowID: %v, runID: %v, firstEventID: %v, nextEventID: %v.",
-			attr.GetDomainId(), attr.GetWorkflowId(), attr.GetRunId(), attr.GetFirstEventId(), attr.GetNextEventId())
+		p.logger.WithFields(bark.Fields{
+			logging.TagDomainID:            attr.GetDomainId(),
+			logging.TagWorkflowExecutionID: attr.GetWorkflowId(),
+			logging.TagWorkflowRunID:       attr.GetRunId(),
+			logging.TagFirstEventID:        attr.GetFirstEventId(),
+			logging.TagNextEventID:         attr.GetNextEventId(),
+			logging.TagVersion:             attr.GetVersion(),
+		}).Warn("Dropping non-targeted history task.")
 		return nil
 	}
 


### PR DESCRIPTION
* Bugfix: when workflow is idle during the failover, no event will be generated, thus not replication info will be added; if a double failover is done for this workflow, the source cluster is not changed at all, so no replication info is needed.

* Add more metrics on worker