### PR TITLE
Whitelist context deadline exceeded error for retry

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -171,6 +171,10 @@ func IsServiceNonRetryableError(err error) bool {
 
 // IsWhitelistServiceTransientError checks if the error is a transient error.
 func IsWhitelistServiceTransientError(err error) bool {
+	if err == context.DeadlineExceeded {
+		return true
+	}
+
 	switch err.(type) {
 	case *workflow.InternalServiceError:
 		return true


### PR DESCRIPTION
The context deadline exceed error can be return by the logic below. 

Ref: 
1. https://github.com/uber/cadence/blob/a496241aae71e53196b4b16c354c90814815930a/client/history/client.go#L629

2. https://github.com/uber/cadence/blob/b21b8096385244a2658419c5b0b65c7f78db15d3/common/util.go#L219

The logic is checking whether the context is done, if not redirect and retry on shard ownership lost error