### PR TITLE
Bugfix: when buffering events, the last write version should remain the same

### DIFF
--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -103,6 +103,11 @@ type (
 
 var _ ShardContext = (*shardContextImpl)(nil)
 
+const (
+	logWarnTransferLevelDiff = 10000000 // 10 million
+	logWarnTimerLevelDiff    = time.Duration(30 * time.Minute)
+)
+
 func (s *shardContextImpl) GetShardID() int {
 	return s.shardID
 }
@@ -636,6 +641,13 @@ func (s *shardContextImpl) emitShardInfoMetricsLogsLocked() {
 		}
 	}
 	diffTimerLevel := maxTimerLevel.Sub(minTimerLevel)
+
+	if logWarnTransferLevelDiff < diffTransferLevel {
+		s.logger.Warn("Transfer level diff exceeds warn threshold.")
+	}
+	if logWarnTimerLevelDiff < diffTimerLevel {
+		s.logger.Warn("Timer level diff exceeds warn threshold.")
+	}
 
 	s.metricsClient.RecordTimer(metrics.ShardInfoScope, metrics.ShardInfoTransferDiffTimer, time.Duration(diffTransferLevel))
 	s.metricsClient.RecordTimer(metrics.ShardInfoScope, metrics.ShardInfoTimerDiffTimer, diffTimerLevel)


### PR DESCRIPTION
* Bugfix: when buffering events, the last write version should remain the same