### PR TITLE
Bugfix failover should flush buffered events

### DIFF
--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -359,7 +359,7 @@ func (r *historyReplicator) ApplyOtherEvents(ctx context.Context, context *workf
 		history := request.GetHistory()
 		lastEvent := history.Events[len(history.Events)-1]
 		now := time.Unix(0, lastEvent.GetTimestamp())
-		return context.updateHelper(nil, nil, nil, false, sourceCluster, lastWriteVersion, transactionID, now)
+		return context.updateHelper(nil, nil, transactionID, now, false, nil, sourceCluster)
 	}
 
 	// Apply the replication task


### PR DESCRIPTION
* Bugfix: when failover happen and workflow has pending decision, new events on the active side (after the failover) will be buffered. workflow execution context should first store the standby events (after the failover), then flush the active events.

solve #990 