### PR TITLE
Change protection of decision timeout to warn instead of reject

### DIFF
--- a/common/logging/helpers.go
+++ b/common/logging/helpers.go
@@ -442,3 +442,13 @@ func LogDecisionTimeoutTooLarge(logger bark.Logger, t int32, domain, wid, wfType
 		"DecisionTimeout": t,
 	}).Warn("Decision timeout is too large")
 }
+
+// LogDecisionTimeoutLargerThanWorkflowTimeout is used to log warning msg for workflow that contains large decision timeout
+func LogDecisionTimeoutLargerThanWorkflowTimeout(logger bark.Logger, t int32, domain, wid, wfType string) {
+	logger.WithFields(bark.Fields{
+		"Domain":          domain,
+		"WorkflowID":      wid,
+		"WorkflowType":    wfType,
+		"DecisionTimeout": t,
+	}).Warn("Decision timeout is larger than workflow timeout")
+}

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1356,14 +1356,23 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 
 	maxDecisionTimeout := int32(wh.config.MaxDecisionStartToCloseTimeout(startRequest.GetDomain()))
 	// TODO: remove this assignment and logging in future, so that frontend will just return bad request for large decision timeout
+	if startRequest.GetTaskStartToCloseTimeoutSeconds() > startRequest.GetExecutionStartToCloseTimeoutSeconds() {
+		logging.LogDecisionTimeoutLargerThanWorkflowTimeout(wh.Service.GetLogger(),
+			startRequest.GetTaskStartToCloseTimeoutSeconds(),
+			startRequest.GetDomain(),
+			startRequest.GetWorkflowId(),
+			startRequest.WorkflowType.GetName(),
+		)
+		startRequest.TaskStartToCloseTimeoutSeconds = common.Int32Ptr(startRequest.GetExecutionStartToCloseTimeoutSeconds())
+	}
 	if startRequest.GetTaskStartToCloseTimeoutSeconds() > maxDecisionTimeout {
-		startRequest.TaskStartToCloseTimeoutSeconds = common.Int32Ptr(maxDecisionTimeout)
 		logging.LogDecisionTimeoutTooLarge(wh.Service.GetLogger(),
 			startRequest.GetTaskStartToCloseTimeoutSeconds(),
 			startRequest.GetDomain(),
 			startRequest.GetWorkflowId(),
 			startRequest.WorkflowType.GetName(),
 		)
+		startRequest.TaskStartToCloseTimeoutSeconds = common.Int32Ptr(maxDecisionTimeout)
 	}
 	if startRequest.GetTaskStartToCloseTimeoutSeconds() > startRequest.GetExecutionStartToCloseTimeoutSeconds() ||
 		startRequest.GetTaskStartToCloseTimeoutSeconds() > maxDecisionTimeout {
@@ -1645,14 +1654,23 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 
 	maxDecisionTimeout := int32(wh.config.MaxDecisionStartToCloseTimeout(signalWithStartRequest.GetDomain()))
 	// TODO: remove this assignment and logging in future, so that frontend will just return bad request for large decision timeout
+	if signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > signalWithStartRequest.GetExecutionStartToCloseTimeoutSeconds() {
+		logging.LogDecisionTimeoutLargerThanWorkflowTimeout(wh.Service.GetLogger(),
+			signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds(),
+			signalWithStartRequest.GetDomain(),
+			signalWithStartRequest.GetWorkflowId(),
+			signalWithStartRequest.WorkflowType.GetName(),
+		)
+		signalWithStartRequest.TaskStartToCloseTimeoutSeconds = common.Int32Ptr(signalWithStartRequest.GetExecutionStartToCloseTimeoutSeconds())
+	}
 	if signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > maxDecisionTimeout {
-		signalWithStartRequest.TaskStartToCloseTimeoutSeconds = common.Int32Ptr(maxDecisionTimeout)
 		logging.LogDecisionTimeoutTooLarge(wh.Service.GetLogger(),
 			signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds(),
 			signalWithStartRequest.GetDomain(),
 			signalWithStartRequest.GetWorkflowId(),
 			signalWithStartRequest.WorkflowType.GetName(),
 		)
+		signalWithStartRequest.TaskStartToCloseTimeoutSeconds = common.Int32Ptr(maxDecisionTimeout)
 	}
 	if signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > signalWithStartRequest.GetExecutionStartToCloseTimeoutSeconds() ||
 		signalWithStartRequest.GetTaskStartToCloseTimeoutSeconds() > maxDecisionTimeout {


### PR DESCRIPTION
Warn for decision timeout that are larger than workflow timeout. 