### PR TITLE
Fix CLI show history to better display long text

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -25,17 +25,18 @@ import (
 	"time"
 
 	"github.com/golang/mock/gomock"
+	"github.com/olekukonko/tablewriter"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber/cadence/common"
 	"github.com/urfave/cli"
-
 	"go.uber.org/cadence/.gen/go/admin"
 	"go.uber.org/cadence/.gen/go/admin/adminserviceclient"
 	"go.uber.org/cadence/.gen/go/admin/adminservicetest"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
 	"go.uber.org/cadence/.gen/go/shared"
+	"strings"
 )
 
 type cliAppSuite struct {
@@ -452,4 +453,33 @@ func (s *cliAppSuite) TestParseTime() {
 	s.Equal(int64(100), parseTime("", 100))
 	s.Equal(int64(1528383845000000000), parseTime("2018-06-07T15:04:05+00:00", 0))
 	s.Equal(int64(1528383845000000000), parseTime("1528383845000000000", 0))
+}
+
+func (s *cliAppSuite) TestBreakLongWords() {
+	s.Equal("111 222 333 4", breakLongWords("1112223334", 3))
+	s.Equal("111 2 223", breakLongWords("1112 223", 3))
+	s.Equal("11 122 23", breakLongWords("11 12223", 3))
+	s.Equal("111", breakLongWords("111", 3))
+	s.Equal("", breakLongWords("", 3))
+	s.Equal("111  222", breakLongWords("111 222", 3))
+}
+
+func (s *cliAppSuite) TestAnyToString() {
+	arg := strings.Repeat("LongText", 80)
+	event := &shared.HistoryEvent{
+		EventId:   common.Int64Ptr(1),
+		EventType: &eventType,
+		WorkflowExecutionStartedEventAttributes: &shared.WorkflowExecutionStartedEventAttributes{
+			WorkflowType: &shared.WorkflowType{Name: common.StringPtr("code.uber.internal/devexp/cadence-samples.git/cmd/samples/recipes/helloworld.Workflow")},
+			TaskList:     &shared.TaskList{Name: common.StringPtr("taskList")},
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(60),
+			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(10),
+			Identity:                            common.StringPtr("tester"),
+			Input:                               []byte(arg),
+		},
+	}
+	res := anyToString(event, false)
+	ss, l := tablewriter.WrapString(res, 10)
+	s.Equal(5, len(ss))
+	s.Equal(147, l)
 }

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -478,8 +478,13 @@ func (s *cliAppSuite) TestAnyToString() {
 			Input:                               []byte(arg),
 		},
 	}
-	res := anyToString(event, false)
+	res := anyToString(event, false, defaultMaxFieldLength)
 	ss, l := tablewriter.WrapString(res, 10)
-	s.Equal(5, len(ss))
+	s.Equal(8, len(ss))
 	s.Equal(147, l)
+}
+
+func (s *cliAppSuite) TestIsAttributeName() {
+	s.True(isAttributeName("WorkflowExecutionStartedEventAttributes"))
+	s.False(isAttributeName("workflowExecutionStartedEventAttributes"))
 }

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -119,8 +119,8 @@ const (
 	FlagClustersWithAlias          = FlagClusters + ", cl"
 	FlagDomainData                 = "domain_data"
 	FlagDomainDataWithAlias        = FlagDomainData + ", dmd"
-	FlagEventId                    = "event_id"
-	FlagEventIdWithAlias           = FlagEventId + ", eid"
+	FlagEventID                    = "event_id"
+	FlagEventIDWithAlias           = FlagEventID + ", eid"
 	FlagMaxFieldLength             = "max_field_length"
 	FlagMaxFieldLengthWithAlias    = FlagMaxFieldLength + ", maxl"
 )
@@ -433,12 +433,12 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 		for _, e := range history.Events {
 			fmt.Println(anyToString(e, true, maxFieldLength))
 		}
-	} else if c.IsSet(FlagEventId) { // only dump that event
-		eventId := c.Int(FlagEventId)
-		if eventId <= 0 || eventId > len(history.Events) {
-			ErrorAndExit("EventId out of range.", errors.New(fmt.Sprintf("Number should be 1 - %d inclusive", len(history.Events))))
+	} else if c.IsSet(FlagEventID) { // only dump that event
+		eventID := c.Int(FlagEventID)
+		if eventID <= 0 || eventID > len(history.Events) {
+			ErrorAndExit("EventId out of range.", fmt.Errorf("number should be 1 - %d inclusive", len(history.Events)))
 		}
-		e := history.Events[eventId-1]
+		e := history.Events[eventID-1]
 		fmt.Println(anyToString(e, true, 0))
 	} else { // use table to pretty output, will trim long text
 		table := tablewriter.NewWriter(os.Stdout)

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -119,6 +119,8 @@ const (
 	FlagClustersWithAlias          = FlagClusters + ", cl"
 	FlagDomainData                 = "domain_data"
 	FlagDomainDataWithAlias        = FlagDomainData + ", dmd"
+	FlagEventId                    = "event_id"
+	FlagEventIdWithAlias           = FlagEventId + ", eid"
 )
 
 const (
@@ -412,7 +414,6 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 	printRawTime := c.Bool(FlagPrintRawTime)
 	printFully := c.Bool(FlagPrintFullyDetail)
 	printVersion := c.Bool(FlagPrintEventVersion)
-
 	outputFileName := c.String(FlagOutputFilename)
 
 	ctx, cancel := newContext()
@@ -426,6 +427,13 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 		for _, e := range history.Events {
 			fmt.Println(anyToString(e, true))
 		}
+	} else if c.IsSet(FlagEventId) { // only dump that event
+		eventId := c.Int(FlagEventId)
+		if eventId <= 0 || eventId > len(history.Events) {
+			ErrorAndExit("EventId out of range.", errors.New(fmt.Sprintf("Number should be 1 - %d inclusive", len(history.Events))))
+		}
+		e := history.Events[eventId-1]
+		fmt.Println(anyToString(e, true))
 	} else { // use table to pretty output, will trim long text
 		table := tablewriter.NewWriter(os.Stdout)
 		table.SetBorder(false)

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -222,7 +222,7 @@ func anyToString(d interface{}, printFully bool) string {
 			}
 			fieldName := t.Field(i).Name
 			if !printFully {
-				fieldValue = trimInput(fieldValue)
+				fieldValue = trimText(fieldValue)
 			}
 			if fieldName == "Reason" || fieldName == "Details" || fieldName == "Cause" {
 				buf.WriteString(fmt.Sprintf("%s:%s", color.RedString(fieldName), color.MagentaString(fieldValue)))
@@ -260,7 +260,7 @@ func valueToString(v reflect.Value, printFully bool) string {
 }
 
 // limit the maximum length for each field
-func trimInput(input string) string {
+func trimText(input string) string {
 	if len(input) > maxInputLength {
 		input = fmt.Sprintf("%s ... %s", input[:maxInputLength/2], input[(len(input)-maxInputLength/2):])
 	}

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -60,6 +60,11 @@ func newWorkflowCommands() []cli.Command {
 					Name:  FlagEventIdWithAlias,
 					Usage: "Print specific event details",
 				},
+				cli.IntFlag{
+					Name:  FlagMaxFieldLengthWithAlias,
+					Usage: "Maximum length for each attribute field",
+					Value: defaultMaxFieldLength,
+				},
 			},
 			Action: func(c *cli.Context) {
 				ShowHistory(c)
@@ -93,6 +98,11 @@ func newWorkflowCommands() []cli.Command {
 				cli.IntFlag{
 					Name:  FlagEventIdWithAlias,
 					Usage: "Print specific event details",
+				},
+				cli.IntFlag{
+					Name:  FlagMaxFieldLengthWithAlias,
+					Usage: "Maximum length for each attribute field",
+					Value: defaultMaxFieldLength,
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -179,6 +189,10 @@ func newWorkflowCommands() []cli.Command {
 				cli.BoolFlag{
 					Name:  FlagShowDetailWithAlias,
 					Usage: "Show event details",
+				},
+				cli.IntFlag{
+					Name:  FlagMaxFieldLengthWithAlias,
+					Usage: "Maximum length for each attribute field",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -453,7 +467,11 @@ func newWorkflowCommands() []cli.Command {
 				},
 				cli.BoolFlag{
 					Name:  FlagShowDetailWithAlias,
-					Usage: "Show event details",
+					Usage: "Optional show event details",
+				},
+				cli.IntFlag{
+					Name:  FlagMaxFieldLengthWithAlias,
+					Usage: "Optional maximum length for each attribute field when show details",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -471,7 +489,11 @@ func newWorkflowCommands() []cli.Command {
 				},
 				cli.BoolFlag{
 					Name:  FlagShowDetailWithAlias,
-					Usage: "Show event details",
+					Usage: "Optional show event details",
+				},
+				cli.IntFlag{
+					Name:  FlagMaxFieldLengthWithAlias,
+					Usage: "Optional maximum length for each attribute field when show details",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -56,6 +56,10 @@ func newWorkflowCommands() []cli.Command {
 					Name:  FlagOutputFilenameWithAlias,
 					Usage: "Serialize history event to a file",
 				},
+				cli.IntFlag{
+					Name:  FlagEventIdWithAlias,
+					Usage: "Print specific event details",
+				},
 			},
 			Action: func(c *cli.Context) {
 				ShowHistory(c)
@@ -77,6 +81,18 @@ func newWorkflowCommands() []cli.Command {
 				cli.StringFlag{
 					Name:  FlagOutputFilenameWithAlias,
 					Usage: "Serialize history event to a file",
+				},
+				cli.BoolFlag{
+					Name:  FlagPrintFullyDetailWithAlias,
+					Usage: "Print fully event detail",
+				},
+				cli.BoolFlag{
+					Name:  FlagPrintEventVersionWithAlias,
+					Usage: "Print event version",
+				},
+				cli.IntFlag{
+					Name:  FlagEventIdWithAlias,
+					Usage: "Print specific event details",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -57,7 +57,7 @@ func newWorkflowCommands() []cli.Command {
 					Usage: "Serialize history event to a file",
 				},
 				cli.IntFlag{
-					Name:  FlagEventIdWithAlias,
+					Name:  FlagEventIDWithAlias,
 					Usage: "Print specific event details",
 				},
 				cli.IntFlag{
@@ -96,7 +96,7 @@ func newWorkflowCommands() []cli.Command {
 					Usage: "Print event version",
 				},
 				cli.IntFlag{
-					Name:  FlagEventIdWithAlias,
+					Name:  FlagEventIDWithAlias,
 					Usage: "Print specific event details",
 				},
 				cli.IntFlag{


### PR DESCRIPTION
Currently issue is when history has long text in argument such wf input or signal input, the output looks bad with line breaks. for example:
![image](https://user-images.githubusercontent.com/1283368/43107720-3021848c-8e93-11e8-9f2c-286846254e26.png)

The reason is, table lib we use enable autowrap only when text are separate by spaces and newlines. 
This PR provides 3 fixes:
1. Add spaces to long text so that table can autowrap properly.
2. Limit max length 
3. Provide fully print option through -pf / -eid flag (also -maxl flag to custom max length).

Results as follows:
<img width="595" alt="screen shot 2018-07-24 at 6 25 39 pm" src="https://user-images.githubusercontent.com/1283368/43174872-3fb7a5f0-8f71-11e8-85c3-66105863f020.png">
<img width="507" alt="screen shot 2018-07-24 at 6 26 31 pm" src="https://user-images.githubusercontent.com/1283368/43174873-4204fd6c-8f71-11e8-89da-984b5914aea1.png">
<img width="1920" alt="screen shot 2018-07-24 at 6 27 15 pm" src="https://user-images.githubusercontent.com/1283368/43174874-43cb1334-8f71-11e8-9c54-264602751ee0.png">
<img width="1918" alt="screen shot 2018-07-24 at 6 43 12 pm" src="https://user-images.githubusercontent.com/1283368/43174929-76c031ca-8f71-11e8-9524-b756fd55c87f.png">

