### PR TITLE
Bugfix: workflow reset

### DIFF
--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -307,6 +307,7 @@ func (r *historyReplicator) ApplyOtherEventsVersionChecking(ctx context.Context,
 		resolver := r.getNewConflictResolver(context, logger)
 		msBuilder, err = resolver.reset(uuid.New(), ri.GetLastEventId(), msBuilder.GetExecutionInfo().StartTimestamp)
 		logger.Info("Completed Resetting of workflow execution.")
+		context.msBuilder = msBuilder
 		if err != nil {
 			return nil, err
 		}

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -328,6 +328,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	mockConflictResolver.On("reset", mock.Anything, incomingLastEventID, startTimeStamp).Return(msBuilderMid, nil)
 	msBuilderOut, err := s.historyReplicator.ApplyOtherEventsVersionChecking(ctx.Background(), context, msBuilderIn, request, s.logger)
 	s.Equal(msBuilderMid, msBuilderOut)
+	s.Equal(context.msBuilder, msBuilderOut)
 	s.Nil(err)
 }
 


### PR DESCRIPTION
Bugfix: after reset, should update the mutable state inside workflow execution context

solve #995