### PR TITLE
Mitigate kafka message loss issue

### DIFF
--- a/service/worker/processor.go
+++ b/service/worker/processor.go
@@ -188,9 +188,12 @@ func (p *replicationTaskProcessor) messageProcessLoop(workerWG *sync.WaitGroup, 
 
 	for {
 		select {
+		case <-p.shutdownCh:
+			p.logger.Info("Worker for replication task processor shutting down by shutdownCh.")
+			return
 		case msg, ok := <-p.consumer.Messages():
 			if !ok {
-				p.logger.Info("Worker for replication task processor shutting down.")
+				p.logger.Info("Worker for replication task processor shutting down by message channel.")
 				return // channel closed
 			}
 			p.processWithRetry(msg, workerID)

--- a/service/worker/processor.go
+++ b/service/worker/processor.go
@@ -164,6 +164,8 @@ func (p *replicationTaskProcessor) processorPump() {
 
 	select {
 	case <-p.shutdownCh:
+		//wait for process function to finish
+		time.Sleep(time.Second * 2)
 		// Processor is shutting down, close the underlying consumer
 		p.consumer.Stop()
 	}


### PR DESCRIPTION
To mitigate message loss issue, wait for all messageProcessLoop to finish before ask consumer to stop
We may remove these code after  https://github.com/bsm/sarama-cluster/issues/255 is fixed