### PR TITLE
Skip staled batch of events

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -806,11 +806,12 @@ type (
 
 	// GetWorkflowExecutionHistoryResponse is the response to GetWorkflowExecutionHistoryRequest
 	GetWorkflowExecutionHistoryResponse struct {
-		// Slice of history append transaction batches
-		Events []SerializedHistoryEventBatch
+		History *workflow.History
 		// Token to read next page if there are more events beyond page size.
 		// Use this to set NextPageToken on GetworkflowExecutionHistoryRequest to read the next page.
 		NextPageToken []byte
+		// the first_event_id of last loaded batch
+		LastFirstEventID int64
 	}
 
 	// DeleteWorkflowExecutionHistoryRequest is used to delete workflow execution history

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -6553,19 +6553,7 @@ func (s *integrationSuite) getHistoryFrom(domainID string, execution workflow.Wo
 		return nil, err
 	}
 
-	historyEvents := []*workflow.HistoryEvent{}
-	factory := persistence.NewHistorySerializerFactory()
-	for _, e := range resp.Events {
-		persistence.SetSerializedHistoryDefaults(&e)
-		s, _ := factory.Get(e.EncodingType)
-		history, err1 := s.Deserialize(&e)
-		if err1 != nil {
-			return nil, err1
-		}
-		historyEvents = append(historyEvents, history.Events...)
-	}
-
-	return historyEvents, nil
+	return resp.History.Events, nil
 }
 
 func (s *integrationSuite) sendSignal(domainName string, execution *workflow.WorkflowExecution, signalName string,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1458,7 +1458,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 	token := &getHistoryContinuationToken{}
 
 	var runID string
-	var lastFirstEventID int64
+	lastFirstEventID := common.FirstEventID
 	var nextEventID int64
 	var isWorkflowRunning bool
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2191,16 +2191,7 @@ func (wh *WorkflowHandler) getHistory(domainID string, execution gen.WorkflowExe
 		return nil, nil, err
 	}
 
-	for _, e := range response.Events {
-		persistence.SetSerializedHistoryDefaults(&e)
-		s, _ := wh.hSerializerFactory.Get(e.EncodingType)
-		history, err1 := s.Deserialize(&e)
-		if err1 != nil {
-			return nil, nil, err1
-		}
-		historyEvents = append(historyEvents, history.Events...)
-	}
-
+	historyEvents = append(historyEvents, response.History.Events...)
 	nextPageToken = response.NextPageToken
 	if len(nextPageToken) == 0 && transientDecision != nil {
 		// Append the transient decision events once we are done enumerating everything from the events table

--- a/service/history/conflictResolver.go
+++ b/service/history/conflictResolver.go
@@ -148,24 +148,7 @@ func (r *conflictResolverImpl) getHistory(domainID string, execution shared.Work
 		return nil, nil, common.EmptyEventID, err
 	}
 
-	lastFirstEventID := common.EmptyEventID
-	historyEvents := []*shared.HistoryEvent{}
-	for _, e := range response.Events {
-		persistence.SetSerializedHistoryDefaults(&e)
-		s, _ := r.hSerializerFactory.Get(e.EncodingType)
-		history, err1 := s.Deserialize(&e)
-		if err1 != nil {
-			return nil, nil, common.EmptyEventID, err1
-		}
-		if len(history.Events) > 0 {
-			lastFirstEventID = history.Events[0].GetEventId()
-		}
-		historyEvents = append(historyEvents, history.Events...)
-	}
-
-	executionHistory := &shared.History{}
-	executionHistory.Events = historyEvents
-	return executionHistory, response.NextPageToken, lastFirstEventID, nil
+	return response.History, response.NextPageToken, response.LastFirstEventID, nil
 }
 
 func (r *conflictResolverImpl) logError(msg string, err error) {

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -778,27 +778,7 @@ func (r *historyReplicator) conflictResolutionTerminateContinueAsNew(ctx context
 			r.logError(logger, "Conflict resolution current workflow finished.", err)
 			return "", err
 		}
-		if len(response.Events) == 0 {
-			logger.WithFields(bark.Fields{
-				logging.TagWorkflowExecutionID: workflowID,
-				logging.TagWorkflowRunID:       runID,
-			})
-			r.logError(logger, errNoHistoryFound.Error(), errNoHistoryFound)
-			return "", errNoHistoryFound
-		}
-		serializedHistoryEventBatch := response.Events[0]
-		persistence.SetSerializedHistoryDefaults(&serializedHistoryEventBatch)
-		serializer, err := persistence.NewHistorySerializerFactory().Get(serializedHistoryEventBatch.EncodingType)
-		if err != nil {
-			r.logError(logger, "Conflict resolution error getting serializer.", err)
-			return "", err
-		}
-		history, err := serializer.Deserialize(&serializedHistoryEventBatch)
-		if err != nil {
-			r.logError(logger, "Conflict resolution error deserialize events.", err)
-			return "", err
-		}
-		if len(history.Events) == 0 {
+		if len(response.History.Events) == 0 {
 			logger.WithFields(bark.Fields{
 				logging.TagWorkflowExecutionID: workflowID,
 				logging.TagWorkflowRunID:       runID,
@@ -807,7 +787,7 @@ func (r *historyReplicator) conflictResolutionTerminateContinueAsNew(ctx context
 			return "", errNoHistoryFound
 		}
 
-		return history.Events[0].WorkflowExecutionStartedEventAttributes.GetContinuedExecutionRunId(), nil
+		return response.History.Events[0].WorkflowExecutionStartedEventAttributes.GetContinuedExecutionRunId(), nil
 	}
 
 	targetRunID := msBuilder.GetExecutionInfo().RunID

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -2220,8 +2220,6 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_Ta
 			// other attributes are not used
 		},
 	}
-	currentStartEventBatch := persistence.NewHistoryEventBatch(persistence.GetDefaultHistoryVersion(), []*shared.HistoryEvent{currentStartEvent})
-	serializedStartEventBatch, err := persistence.NewJSONHistorySerializer().Serialize(currentStartEventBatch)
 	s.Nil(err)
 	s.mockHistoryMgr.On("GetWorkflowExecutionHistory", &persistence.GetWorkflowExecutionHistoryRequest{
 		DomainID: domainID,
@@ -2234,8 +2232,9 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_Ta
 		PageSize:      defaultHistoryPageSize,
 		NextPageToken: nil,
 	}).Return(&persistence.GetWorkflowExecutionHistoryResponse{
-		Events:        []persistence.SerializedHistoryEventBatch{*serializedStartEventBatch},
-		NextPageToken: nil,
+		History:          &shared.History{Events: []*shared.HistoryEvent{currentStartEvent}},
+		NextPageToken:    nil,
+		LastFirstEventID: currentStartEvent.GetEventId(),
 	}, nil)
 
 	// return nil, to trigger the history engine to return err, so we can assert on it

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -267,16 +267,7 @@ func (p *replicatorQueueProcessorImpl) getHistory(domainID, workflowID, runID st
 			return nil, err
 		}
 
-		for _, e := range response.Events {
-			persistence.SetSerializedHistoryDefaults(&e)
-			s, _ := p.hSerializerFactory.Get(e.EncodingType)
-			history, err1 := s.Deserialize(&e)
-			if err1 != nil {
-				return nil, err1
-			}
-			historyEvents = append(historyEvents, history.Events...)
-		}
-
+		historyEvents = append(historyEvents, response.History.Events...)
 		nextPageToken = response.NextPageToken
 	}
 


### PR DESCRIPTION
When server complete transient decision, it write transient decision in its own batch of events and then followed by a new batch of events containing DecisionTaskCompleted and decision events. The problem comes if the 2 batches (let's say batch A and B) were successfully append but the update mutable state failed. In that case, the NextEventID won't move forward. GetHistory will not look beyond NextEventID so batch A and B just sitting in events table doing no harm. Later, when new events comes in (let's say batch C and D). We know batch C will overwrite batch A (because they have same first_event_id) but D may not overwrite B. Because batch C and batch A may have different number of events so the first_event_id for batch B and D could be different. This would result in staled batch of events to be left in events table. When NextEventID go beyond first_event_id of batch B, then that batch B become problematic. We need to skip that batch.