### PR TITLE
Bugfix: history replicator, when calling terminate workflow, should u…

### DIFF
--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -39,6 +39,9 @@ import (
 
 var (
 	errNoHistoryFound = errors.New("no history events found")
+
+	workflowTerminationReason   = "Terminate Workflow Due To Version Conflict."
+	workflowTerminationIdentity = "worker-service"
 )
 
 type (
@@ -319,7 +322,9 @@ func (r *historyReplicator) ApplyOtherEventsVersionChecking(ctx context.Context,
 		logger.Info("Reset to latest common checkpoint.")
 
 		// NOTE: this conflict resolution do not handle fast >= 2 failover
-		return r.resetMutableState(ctx, context, msBuilder, lastValidEventID, logger)
+		lastEvent := request.History.Events[len(request.History.Events)-1]
+		incomingTimestamp := lastEvent.GetTimestamp()
+		return r.resetMutableState(ctx, context, msBuilder, lastValidEventID, incomingVersion, incomingTimestamp, logger)
 	}
 	if rState.LastWriteVersion < ri.GetVersion() {
 		err = ErrImpossibleRemoteClaimSeenHigherVersion
@@ -342,7 +347,9 @@ func (r *historyReplicator) ApplyOtherEventsVersionChecking(ctx context.Context,
 		// the actual action of those buffered event are already applied to mutable state.
 
 		logger.Info("Conflict detected.")
-		return r.resetMutableState(ctx, context, msBuilder, ri.GetLastEventId(), logger)
+		lastEvent := request.History.Events[len(request.History.Events)-1]
+		incomingTimestamp := lastEvent.GetTimestamp()
+		return r.resetMutableState(ctx, context, msBuilder, ri.GetLastEventId(), incomingVersion, incomingTimestamp, logger)
 	}
 
 	// event ID match, no reset
@@ -690,7 +697,8 @@ func (r *historyReplicator) replicateWorkflowStarted(ctx context.Context, contex
 	// start the new workflow from the request
 
 	// same workflow ID, same shard
-	err = r.terminateWorkflow(ctx, domainID, executionInfo.WorkflowID, currentRunID)
+	incomingTimestamp := lastEvent.GetTimestamp()
+	err = r.terminateWorkflow(ctx, domainID, executionInfo.WorkflowID, currentRunID, incomingVersion, incomingTimestamp, logger)
 	if err != nil {
 		if _, ok := err.(*shared.EntityNotExistsError); !ok {
 			return err
@@ -724,7 +732,7 @@ func (r *historyReplicator) flushCurrentWorkflowBuffer(ctx context.Context, doma
 }
 
 func (r *historyReplicator) conflictResolutionTerminateContinueAsNew(ctx context.Context,
-	msBuilder mutableState, logger bark.Logger) (retError error) {
+	msBuilder mutableState, incomingVersion int64, incomingTimestamp int64, logger bark.Logger) (retError error) {
 	// this function aims to solve the edge case when this workflow, when going through
 	// reset, has already started a next generation (continue as new-ed workflow)
 
@@ -814,7 +822,7 @@ func (r *historyReplicator) conflictResolutionTerminateContinueAsNew(ctx context
 	// we will retry on the worker level
 
 	// same workflow ID, same shard
-	err = r.terminateWorkflow(ctx, domainID, workflowID, currentRunID)
+	err = r.terminateWorkflow(ctx, domainID, workflowID, currentRunID, incomingVersion, incomingTimestamp, logger)
 	if err != nil {
 		r.logError(logger, "Conflict resolution err terminating current workflow.", err)
 	}
@@ -853,25 +861,52 @@ func (r *historyReplicator) getCurrentWorkflowMutableState(ctx context.Context, 
 }
 
 func (r *historyReplicator) terminateWorkflow(ctx context.Context, domainID string, workflowID string,
-	runID string) error {
-	domainEntry, err := r.domainCache.GetDomainByID(domainID)
+	runID string, incomingVersion int64, incomingTimestamp int64, logger bark.Logger) (retError error) {
+
+	execution := shared.WorkflowExecution{
+		WorkflowId: common.StringPtr(workflowID),
+		RunId:      common.StringPtr(runID),
+	}
+	context, release, err := r.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
 	if err != nil {
 		return err
 	}
-	// same workflow ID, same shard
-	return r.historyEngine.TerminateWorkflowExecution(ctx, &h.TerminateWorkflowExecutionRequest{
-		DomainUUID: common.StringPtr(domainID),
-		TerminateRequest: &shared.TerminateWorkflowExecutionRequest{
-			Domain: common.StringPtr(domainEntry.GetInfo().Name),
-			WorkflowExecution: &shared.WorkflowExecution{
-				WorkflowId: common.StringPtr(workflowID),
-				RunId:      common.StringPtr(runID),
-			},
-			Reason:   common.StringPtr("Terminate Workflow Due To Version Conflict."),
+	defer func() { release(retError) }()
+
+	msBuilder, err := context.loadWorkflowExecution()
+	if err != nil {
+		return err
+	}
+	if !msBuilder.IsWorkflowExecutionRunning() {
+		return nil
+	}
+
+	nextEventID := msBuilder.GetNextEventID()
+	sourceCluster := r.clusterMetadata.ClusterNameForFailoverVersion(incomingVersion)
+	terminationEvent := &shared.HistoryEvent{
+		EventId:   common.Int64Ptr(nextEventID),
+		Timestamp: common.Int64Ptr(incomingTimestamp),
+		Version:   common.Int64Ptr(incomingVersion),
+		EventType: shared.EventTypeWorkflowExecutionTerminated.Ptr(),
+		WorkflowExecutionTerminatedEventAttributes: &shared.WorkflowExecutionTerminatedEventAttributes{
+			Reason:   common.StringPtr(workflowTerminationReason),
+			Identity: common.StringPtr(workflowTerminationIdentity),
 			Details:  nil,
-			Identity: common.StringPtr("worker-service"),
 		},
-	})
+	}
+	history := &shared.History{Events: []*shared.HistoryEvent{terminationEvent}}
+
+	req := &h.ReplicateEventsRequest{
+		SourceCluster:     common.StringPtr(sourceCluster),
+		DomainUUID:        common.StringPtr(domainID),
+		WorkflowExecution: &execution,
+		FirstEventId:      common.Int64Ptr(nextEventID),
+		NextEventId:       common.Int64Ptr(nextEventID + 1),
+		Version:           common.Int64Ptr(incomingVersion),
+		History:           history,
+		NewRunHistory:     nil,
+	}
+	return r.ApplyReplicationTask(ctx, context, msBuilder, req, logger)
 }
 
 func (r *historyReplicator) getLatestCheckpoint(replicationInfoRemote map[string]*h.ReplicationInfo,
@@ -900,13 +935,13 @@ func (r *historyReplicator) getLatestCheckpoint(replicationInfoRemote map[string
 }
 
 func (r *historyReplicator) resetMutableState(ctx context.Context, context *workflowExecutionContext,
-	msBuilder mutableState, lastEventID int64, logger bark.Logger) (mutableState, error) {
+	msBuilder mutableState, lastEventID int64, incomingVersion int64, incomingTimestamp int64, logger bark.Logger) (mutableState, error) {
 
 	r.metricsClient.IncCounter(metrics.ReplicateHistoryEventsScope, metrics.HistoryConflictsCounter)
 
 	// handling edge case when resetting a workflow, and this workflow has done continue as new
 	// we need to terminate the continue as new-ed workflow
-	err := r.conflictResolutionTerminateContinueAsNew(ctx, msBuilder, logger)
+	err := r.conflictResolutionTerminateContinueAsNew(ctx, msBuilder, incomingVersion, incomingTimestamp, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -108,6 +108,7 @@ func (s *historyReplicatorSuite) SetupTest() {
 		logger:                    s.logger,
 		domainCache:               cache.NewDomainCache(s.mockMetadataMgr, s.mockClusterMetadata, metricsClient, s.logger),
 		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),
+		standbyClusterCurrentTime: make(map[string]time.Time),
 	}
 	s.mockMutableState = &mockMutableState{}
 	historyCache := newHistoryCache(s.mockShard, s.logger)
@@ -251,7 +252,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingLes
 	context.msBuilder = msBuilderIn
 	request := &h.ReplicateEventsRequest{
 		Version: common.Int64Ptr(incomingVersion),
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{LastWriteVersion: currentLastWriteVersion})
 
@@ -276,7 +279,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingEqu
 	context.msBuilder = msBuilderIn
 	request := &h.ReplicateEventsRequest{
 		Version: common.Int64Ptr(incomingVersion),
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{LastWriteVersion: currentLastWriteVersion})
 
@@ -303,7 +308,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 
 	request := &h.ReplicateEventsRequest{
 		Version: common.Int64Ptr(incomingVersion),
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{
 		LastWriteVersion: currentLastWriteVersion,
@@ -335,7 +342,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 
 	request := &h.ReplicateEventsRequest{
 		Version: common.Int64Ptr(incomingVersion),
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{
 		LastWriteVersion: currentLastWriteVersion,
@@ -372,7 +381,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	request := &h.ReplicateEventsRequest{
 		Version:         common.Int64Ptr(incomingVersion),
 		ReplicationInfo: map[string]*h.ReplicationInfo{},
-		History:         &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	startTimeStamp := time.Now()
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{
@@ -431,7 +442,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 				LastEventId: common.Int64Ptr(incomingReplicationInfoLastEventID),
 			},
 		},
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	startTimeStamp := time.Now()
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{
@@ -487,7 +500,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 				LastEventId: common.Int64Ptr(incomingReplicationInfoLastEventID),
 			},
 		},
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	startTimeStamp := time.Now()
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{
@@ -530,7 +545,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 				LastEventId: common.Int64Ptr(incomingReplicationInfoLastEventID),
 			},
 		},
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	startTimeStamp := time.Now()
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{
@@ -580,7 +597,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 				LastEventId: common.Int64Ptr(incomingReplicationInfoLastEventID),
 			},
 		},
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	startTimeStamp := time.Now()
 	msBuilderIn.On("GetReplicationState").Return(&persistence.ReplicationState{
@@ -627,7 +646,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 				LastEventId: common.Int64Ptr(incomingReplicationInfoLastEventID),
 			},
 		},
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	startTimeStamp := time.Now()
 	msBuilderIn.On("HasBufferedEvents").Return(false)
@@ -671,7 +692,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 				LastEventId: common.Int64Ptr(incomingReplicationInfoLastEventID),
 			},
 		},
-		History: &shared.History{},
+		History: &shared.History{[]*shared.HistoryEvent{
+			&shared.HistoryEvent{Timestamp: common.Int64Ptr(time.Now().UnixNano())},
+		}},
 	}
 	startTimeStamp := time.Now()
 	msBuilderIn.On("HasBufferedEvents").Return(true)
@@ -1918,7 +1941,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 }
 
 func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_IncomingLargerThanCurrent() {
-	domainName := "some random domain name"
 	domainID := validDomainID
 	workflowID := "some random workflow ID"
 	runID := uuid.New()
@@ -2062,34 +2084,17 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 		}, input)
 	})).Return(&persistence.CreateWorkflowExecutionResponse{}, nil).Once()
 
-	// this mocks are for the terminate current workflow operation
-	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(
-		&persistence.GetDomainResponse{
-			Info:   &persistence.DomainInfo{ID: domainID, Name: domainName},
-			Config: &persistence.DomainConfig{Retention: 1},
-			ReplicationConfig: &persistence.DomainReplicationConfig{
-				ActiveClusterName: cluster.TestCurrentClusterName,
-				Clusters: []*persistence.ClusterReplicationConfig{
-					&persistence.ClusterReplicationConfig{ClusterName: cluster.TestCurrentClusterName},
-				},
-			},
-			FailoverVersion: currentVersion,
-			IsGlobalDomain:  true,
-			TableVersion:    persistence.DomainTableVersionV1,
-		}, nil,
-	).Once()
 	currentContext, currentRelease, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(domainID, shared.WorkflowExecution{
 		WorkflowId: common.StringPtr(workflowID),
 		RunId:      common.StringPtr(currentRunID),
 	})
 	s.Nil(err)
 	currentMsBuilder := &mockMutableState{}
+	// 2 mocks below are just to by pass unnecessary mocks
+	currentMsBuilder.On("GetReplicationState").Return(nil)
+	currentMsBuilder.On("IsWorkflowExecutionRunning").Return(false)
 	currentContext.msBuilder = currentMsBuilder
 	currentRelease(nil)
-	// all method call to currentMsBuilder are randomly mocked
-	// we are testing the functionality that workflow termination is called, not its detail
-	currentMsBuilder.On("IsWorkflowExecutionRunning").Return(false) // return nil so we can skil a lot of mocking
-	currentMsBuilder.On("GetReplicationState").Return(nil)
 
 	err = s.historyReplicator.replicateWorkflowStarted(ctx.Background(), context, msBuilder, di, sourceCluster, history,
 		sBuilder, s.logger)
@@ -2102,22 +2107,31 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 }
 
 func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_TargetRunning() {
+	incomingVersion := int64(4096)
+	incomingTimestamp := int64(11238)
+
 	msBuilderTarget := &mockMutableState{}
 	msBuilderTarget.On("IsWorkflowExecutionRunning").Return(true)
-	err := s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, s.logger)
+	err := s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, incomingVersion, incomingTimestamp, s.logger)
 	s.Nil(err)
 }
 
 func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_TargetClosed_NotContinueAsNew() {
+	incomingVersion := int64(4096)
+	incomingTimestamp := int64(11238)
+
 	msBuilderTarget := &mockMutableState{}
 	msBuilderTarget.On("IsWorkflowExecutionRunning").Return(false)
 	msBuilderTarget.On("GetExecutionInfo").Return(&persistence.WorkflowExecutionInfo{CloseStatus: persistence.WorkflowCloseStatusCompleted})
 
-	err := s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, s.logger)
+	err := s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, incomingVersion, incomingTimestamp, s.logger)
 	s.Nil(err)
 }
 
 func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_TargetClosed_ContinueAsNew_CurrentClosed() {
+	incomingVersion := int64(4096)
+	incomingTimestamp := int64(11238)
+
 	domainID := validDomainID
 	workflowID := "some random target workflow ID"
 	targetRunID := uuid.New()
@@ -2153,12 +2167,17 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_Ta
 		// other attributes are not used
 	}, nil)
 
-	err = s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, s.logger)
+	err = s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, incomingVersion, incomingTimestamp, s.logger)
 	s.Nil(err)
 }
 
 func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_TargetClosed_ContinueAsNew_CurrentRunning() {
-	version := int64(4801) // this does nothing in this test
+	incomingVersion := int64(4096)
+	incomingTimestamp := int64(11238)
+	incomingCluster := cluster.TestAlternativeClusterName
+	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", incomingVersion).Return(incomingCluster)
+
+	domainVersion := int64(4081)
 	domainName := "some random domain name"
 	domainID := validDomainID
 	workflowID := "some random target workflow ID"
@@ -2184,7 +2203,7 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_Ta
 					&persistence.ClusterReplicationConfig{ClusterName: cluster.TestCurrentClusterName},
 				},
 			},
-			FailoverVersion: version,
+			FailoverVersion: domainVersion, // this does not matter
 			IsGlobalDomain:  true,
 			TableVersion:    persistence.DomainTableVersionV1,
 		}, nil,
@@ -2197,11 +2216,14 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_Ta
 	})
 	s.Nil(err)
 	msBuilderCurrent := &mockMutableState{}
-	msBuilderCurrent.On("GetLastWriteVersion").Return(int64(999))                      // this is not actually used, but will be called
+	currentNextEventID := int64(999)
+	msBuilderCurrent.On("GetNextEventID").Return(currentNextEventID)
+	msBuilderCurrent.On("GetLastWriteVersion").Return(incomingVersion - 1)             // this is not actually used, but will be called
 	msBuilderCurrent.On("GetReplicationState").Return(&persistence.ReplicationState{}) // this is used to update the version on mutable state
 	msBuilderCurrent.On("IsWorkflowExecutionRunning").Return(true)                     // this is used to update the version on mutable state
 	msBuilderCurrent.On("GetExecutionInfo").Return(&persistence.WorkflowExecutionInfo{RunID: currentRunID, CloseStatus: persistence.WorkflowCloseStatusNone})
-	msBuilderCurrent.On("UpdateReplicationStateVersion", version, false)
+	msBuilderCurrent.On("UpdateReplicationStateVersion", domainVersion, false).Twice()
+	msBuilderCurrent.On("UpdateReplicationStateVersion", incomingVersion, true).Once()
 	contextCurrent.msBuilder = msBuilderCurrent
 	release(nil)
 	s.mockExecutionMgr.On("GetCurrentExecution", &persistence.GetCurrentExecutionRequest{
@@ -2239,10 +2261,23 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateContinueAsNew_Ta
 
 	// return nil, to trigger the history engine to return err, so we can assert on it
 	// this is to save a lot of meaningless mock, since we are not testing functionality of history engine
-	msBuilderCurrent.On("AddWorkflowExecutionTerminatedEvent", mock.Anything).Return(nil)
+	msBuilderCurrent.On("ReplicateWorkflowExecutionTerminatedEvent", mock.MatchedBy(func(input *shared.HistoryEvent) bool {
+		return reflect.DeepEqual(&shared.HistoryEvent{
+			EventId:   common.Int64Ptr(currentNextEventID),
+			Timestamp: common.Int64Ptr(incomingTimestamp),
+			Version:   common.Int64Ptr(incomingVersion),
+			EventType: shared.EventTypeWorkflowExecutionTerminated.Ptr(),
+			WorkflowExecutionTerminatedEventAttributes: &shared.WorkflowExecutionTerminatedEventAttributes{
+				Reason:   common.StringPtr(workflowTerminationReason),
+				Identity: common.StringPtr(workflowTerminationIdentity),
+				Details:  nil,
+			},
+		}, input)
+	})).Return(nil)
 
-	err = s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, s.logger)
-	s.NotNil(err)
-	_, ok := err.(*shared.InternalServiceError)
-	s.True(ok)
+	expectedError := &shared.ServiceBusyError{} // return an error to by pass unnecessary mocks
+	msBuilderCurrent.On("CloseUpdateSession").Return(nil, expectedError).Once()
+
+	err = s.historyReplicator.conflictResolutionTerminateContinueAsNew(ctx.Background(), msBuilderTarget, incomingVersion, incomingTimestamp, s.logger)
+	s.Equal(expectedError, err)
 }

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -189,7 +189,7 @@ func (c *workflowExecutionContext) updateWorkflowExecution(transferTasks []persi
 		}
 
 		// Handling mutable state turn from standby to active, while having a decision on the fly
-		if di, ok := c.msBuilder.GetInFlightDecisionTask(); ok {
+		if di, ok := c.msBuilder.GetInFlightDecisionTask(); ok && c.msBuilder.IsWorkflowExecutionRunning() {
 			if di.Version < currentVersion {
 				// we have a decision on the fly with a lower version, fail it
 				c.msBuilder.AddDecisionTaskFailedEvent(di.ScheduleID, di.StartedID,


### PR DESCRIPTION
…se standby logic rather than active logic, since active logic will do check on version and return domain not active