### PR TITLE
Pre release cut

### DIFF
--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -369,6 +369,12 @@ func (r *historyReplicator) ApplyOtherEvents(ctx context.Context, context *workf
 		return nil
 	}
 	if firstEventID > msBuilder.GetNextEventID() {
+
+		if !msBuilder.IsWorkflowExecutionRunning() {
+			logger.Warnf("Workflow already terminated due to conflict resolution.")
+			return nil
+		}
+
 		// out of order replication task and store it in the buffer
 		logger.Debugf("Buffer out of order replication task.  NextEvent: %v, FirstEvent: %v",
 			msBuilder.GetNextEventID(), firstEventID)
@@ -415,6 +421,11 @@ func (r *historyReplicator) ApplyOtherEvents(ctx context.Context, context *workf
 
 func (r *historyReplicator) ApplyReplicationTask(ctx context.Context, context *workflowExecutionContext,
 	msBuilder mutableState, request *h.ReplicateEventsRequest, logger bark.Logger) error {
+
+	if !msBuilder.IsWorkflowExecutionRunning() {
+		logger.Warnf("Workflow already terminated due to conflict resolution.")
+		return nil
+	}
 
 	domainID, err := validateDomainUUID(request.DomainUUID)
 	if err != nil {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -65,7 +65,7 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		PersistenceMaxQPS:          dc.GetIntProperty(dynamicconfig.WorkerPersistenceMaxQPS, 500),
 		ReplicatorConcurrency:      1000,
 		ReplicatorBufferRetryCount: 8,
-		ReplicationTaskMaxRetry:    5,
+		ReplicationTaskMaxRetry:    50,
 	}
 }
 


### PR DESCRIPTION
Bugfix: history replicator cannot apply any other events or buffer any event when a workflow is force terminated.
Increase the worker retry count from 5 to 50
Add additional logging for worker nack