### PR TITLE
mysql: cleanup history, shard, task and domain persistence

### DIFF
--- a/common/persistence/historyStore.go
+++ b/common/persistence/historyStore.go
@@ -143,7 +143,7 @@ func (m *historyManagerImpl) GetWorkflowExecutionHistory(request *GetWorkflowExe
 	newResponse.Size = size
 	newResponse.LastFirstEventID = lastFirstEventID
 	newResponse.History = history
-	newResponse.NextPageToken, err = m.serializeToken(token)
+	newResponse.NextPageToken, err = m.serializeToken(token, request.NextEventID)
 	if err != nil {
 		return nil, err
 	}
@@ -171,11 +171,10 @@ func (m *historyManagerImpl) deserializeToken(request *GetWorkflowExecutionHisto
 	return token, nil
 }
 
-func (m *historyManagerImpl) serializeToken(token *historyToken) ([]byte, error) {
-	if len(token.Data) == 0 {
+func (m *historyManagerImpl) serializeToken(token *historyToken, nextEventID int64) ([]byte, error) {
+	if token.LastEventID+1 >= nextEventID || token == nil {
 		return nil, nil
 	}
-
 	data, err := json.Marshal(token)
 	if err != nil {
 		return nil, &workflow.InternalServiceError{Message: "Error generating history event token."}

--- a/common/persistence/historyStore.go
+++ b/common/persistence/historyStore.go
@@ -172,7 +172,7 @@ func (m *historyManagerImpl) deserializeToken(request *GetWorkflowExecutionHisto
 }
 
 func (m *historyManagerImpl) serializeToken(token *historyToken, nextEventID int64) ([]byte, error) {
-	if token.LastEventID+1 >= nextEventID || token == nil {
+	if token.LastEventID+1 >= nextEventID || len(token.Data) == 0 {
 		return nil, nil
 	}
 	data, err := json.Marshal(token)

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -66,7 +66,7 @@ func (s *MatchingPersistenceSuite) TearDownSuite() {
 func (s *MatchingPersistenceSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
-	s.ClearTasks()
+	//s.ClearTasks()
 }
 
 // TestCreateTask test

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -66,7 +66,6 @@ func (s *MatchingPersistenceSuite) TearDownSuite() {
 func (s *MatchingPersistenceSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
-	//s.ClearTasks()
 }
 
 // TestCreateTask test

--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -164,7 +164,7 @@ func (m *MetadataPersistenceSuiteV2) TestCreateDomain() {
 		failoverVersion,
 	)
 	m.Error(err2)
-	m.IsType(&gen.DomainAlreadyExistsError{}, err2, "error=%v", err2)
+	m.IsType(&gen.DomainAlreadyExistsError{}, err2)
 	m.Nil(resp2)
 }
 

--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -164,7 +164,7 @@ func (m *MetadataPersistenceSuiteV2) TestCreateDomain() {
 		failoverVersion,
 	)
 	m.Error(err2)
-	m.IsType(&gen.DomainAlreadyExistsError{}, err2)
+	m.IsType(&gen.DomainAlreadyExistsError{}, err2, "error=%v", err2)
 	m.Nil(resp2)
 }
 

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -93,7 +93,7 @@ func dereferenceIfNotNil(a *[]byte) []byte {
 func runTransaction(name string, db *sqlx.DB, txFunc func(tx *sqlx.Tx) error) error {
 	convertErr := func(err error) error {
 		switch err.(type) {
-		case *p.ConditionFailedError, *workflow.InternalServiceError:
+		case *p.ConditionFailedError, *workflow.InternalServiceError, *workflow.DomainAlreadyExistsError:
 			return err
 		default:
 			return &workflow.InternalServiceError{

--- a/common/persistence/sql/historyPersistence_test.go
+++ b/common/persistence/sql/historyPersistence_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestHistoryPersistenceSuite(t *testing.T) {
-	t.Skip("Temporary skipping until SQL persistence is fixed")
 	s := new(persistencetests.HistoryPersistenceSuite)
 	sql.InitTestSuite(&s.TestBase)
 	suite.Run(t, s)

--- a/common/persistence/sql/matchingPersistence_test.go
+++ b/common/persistence/sql/matchingPersistence_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestMatchingPersistenceSuite(t *testing.T) {
-	t.Skip("Temporary skipping until SQL persistence is fixed")
 	s := new(persistencetests.MatchingPersistenceSuite)
 	sql.InitTestSuite(&s.TestBase)
 	suite.Run(t, s)

--- a/common/persistence/sql/metadataPersistenceV2_test.go
+++ b/common/persistence/sql/metadataPersistenceV2_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestMetadataPersistenceSuiteV2(t *testing.T) {
-	t.Skip("Temporary skipping until SQL persistence is fixed")
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	sql.InitTestSuite(&s.TestBase)
 	suite.Run(t, s)

--- a/common/persistence/sql/shardPersistence_test.go
+++ b/common/persistence/sql/shardPersistence_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestShardPersistenceSuite(t *testing.T) {
-	t.Skip("Temporary skipping until SQL persistence is fixed")
 	s := new(persistencetests.ShardPersistenceSuite)
 	sql.InitTestSuite(&s.TestBase)
 	suite.Run(t, s)

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -313,10 +313,10 @@ domain_id = ? AND
 workflow_id = ? AND
 run_id = ?`
 
-	transferTaskInfoColumns = `domain_id,
+	transferTaskInfoColumns = `task_id, 
+domain_id,
 workflow_id,
 run_id,
-task_id,
 task_type,
 target_domain_id,
 target_workflow_id,
@@ -326,10 +326,10 @@ task_list,
 schedule_id,
 version`
 
-	transferTaskInfoColumnsTags = `:domain_id,
+	transferTaskInfoColumnsTags = `:task_id,
+:domain_id,
 :workflow_id,
 :run_id,
-:task_id,
 :task_type,
 :target_domain_id,
 :target_workflow_id,
@@ -405,20 +405,20 @@ VALUES
 	completeTransferTaskSQLQuery      = `DELETE FROM transfer_tasks WHERE shard_id = :shard_id AND task_id = :task_id`
 	rangeCompleteTransferTaskSQLQuery = `DELETE FROM transfer_tasks WHERE shard_id = ? AND task_id > ? AND task_id <= ?`
 
-	replicationTaskInfoColumns = `domain_id,
+	replicationTaskInfoColumns = `task_id,
+domain_id,
 workflow_id,
 run_id,
-task_id,
 task_type,
 first_event_id,
 next_event_id,
 version,
 last_replication_info`
 
-	replicationTaskInfoColumnsTags = `:domain_id,
+	replicationTaskInfoColumnsTags = `:task_id,
+:domain_id,
 :workflow_id,
 :run_id,
-:task_id,
 :task_type,
 :first_event_id,
 :next_event_id,
@@ -439,8 +439,8 @@ shard_id = ? AND
 task_id > ? AND
 task_id <= ?`
 
-	timerTaskInfoColumns     = `domain_id, workflow_id, run_id, visibility_timestamp, task_id, task_type, timeout_type, event_id, schedule_attempt, version`
-	timerTaskInfoColumnsTags = `:domain_id, :workflow_id, :run_id, :visibility_timestamp, :task_id, :task_type, :timeout_type, :event_id, :schedule_attempt, :version`
+	timerTaskInfoColumns     = `visibility_timestamp, task_id, domain_id, workflow_id, run_id, task_type, timeout_type, event_id, schedule_attempt, version`
+	timerTaskInfoColumnsTags = `:visibility_timestamp, :task_id, :domain_id, :workflow_id, :run_id, :task_type, :timeout_type, :event_id, :schedule_attempt, :version`
 	timerTasksColumns        = `shard_id,` + timerTaskInfoColumns
 	timerTasksColumnsTags    = `:shard_id,` + timerTaskInfoColumnsTags
 	createTimerTasksSQLQuery = `INSERT INTO timer_tasks (` +

--- a/common/persistence/sql/sqlHelpers.go
+++ b/common/persistence/sql/sqlHelpers.go
@@ -22,15 +22,18 @@ package sql
 
 import (
 	"fmt"
+	"io/ioutil"
+
 	"github.com/iancoleman/strcase"
 	"github.com/jmoiron/sqlx"
 	log "github.com/sirupsen/logrus"
-	"io/ioutil"
 )
+
+const driverName = "mysql"
 
 // TODO: driverName parameter
 func newConnection(host string, port int, username, password, dbName string) (*sqlx.DB, error) {
-	var db, err = sqlx.Connect("mysql",
+	var db, err = sqlx.Connect(driverName,
 		fmt.Sprintf(dataSourceName, username, password, host, port, dbName))
 	if err != nil {
 		return nil, err
@@ -41,7 +44,7 @@ func newConnection(host string, port int, username, password, dbName string) (*s
 }
 
 func createDatabase(host string, port int, username, password, dbName string, overwrite bool) error {
-	var db, err = sqlx.Connect("mysql",
+	var db, err = sqlx.Connect(driverName,
 		fmt.Sprintf(dataSourceName, username, password, host, port, ""))
 	if err != nil {
 		return fmt.Errorf("failure connecting to mysql database: %v", err)

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -24,6 +24,8 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"database/sql"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 	"github.com/uber-common/bark"
@@ -44,12 +46,11 @@ type (
 		WorkflowID   string
 		RunID        string
 		FirstEventID int64
+		BatchVersion int64
+		RangeID      int64
+		TxID         int64
 		Data         []byte
 		DataEncoding string
-		DataVersion  int64
-
-		RangeID int64
-		TxID    int64
 	}
 
 	historyToken struct {
@@ -63,53 +64,34 @@ const (
 	// so we don't do the insert and return a ConditionalUpdate error.
 	ErrDupEntry = 1062
 
-	appendHistorySQLQuery = `INSERT INTO events (
-domain_id,workflow_id,run_id,first_event_id,data,data_encoding,data_version
-) VALUES (
-:domain_id,:workflow_id,:run_id,:first_event_id,:data,:data_encoding,:data_version
-);`
+	appendHistorySQLQuery = `INSERT INTO events (` +
+		`domain_id,workflow_id,run_id,first_event_id,batch_version,range_id,tx_id,data,data_encoding)` +
+		`VALUES (:domain_id,:workflow_id,:run_id,:first_event_id,:batch_version,:range_id,:tx_id,:data,:data_encoding);`
 
 	overwriteHistorySQLQuery = `UPDATE events
 SET
-domain_id = :domain_id,
-workflow_id = :workflow_id,
-run_id = :run_id,
-first_event_id = :first_event_id,
+batch_version = :batch_version,
+range_id = :range_id,
+tx_id = :tx_id,
 data = :data,
-data_encoding = :data_encoding,
-data_version = :data_version
+data_encoding = :data_encoding
 WHERE
 domain_id = :domain_id AND 
 workflow_id = :workflow_id AND 
 run_id = :run_id AND 
 first_event_id = :first_event_id`
 
-	pollHistorySQLQuery = `SELECT 1 FROM events WHERE domain_id = :domain_id AND 
-workflow_id= :workflow_id AND run_id= :run_id AND first_event_id= :first_event_id`
+	getWorkflowExecutionHistorySQLQuery = `SELECT first_event_id, batch_version, data, data_encoding ` +
+		`FROM events ` +
+		`WHERE domain_id = ? AND workflow_id = ? AND run_id = ? AND first_event_id >= ? AND first_event_id < ? ` +
+		`ORDER BY first_event_id LIMIT ?`
 
-	getWorkflowExecutionHistorySQLQuery = `SELECT first_event_id, data, data_encoding, data_version
-FROM events
-WHERE
-domain_id = ? AND
-workflow_id = ? AND
-run_id = ? AND
-first_event_id >= ? AND
-first_event_id < ?
-ORDER BY first_event_id
-LIMIT ?`
+	deleteWorkflowExecutionHistorySQLQuery = `DELETE FROM events WHERE domain_id = ? AND workflow_id = ? AND run_id = ?`
 
-	deleteWorkflowExecutionHistorySQLQuery = `DELETE FROM events WHERE
-domain_id = ? AND workflow_id = ? AND run_id = ?`
-
-	lockRangeIDAndTxIDSQLQuery = `SELECT range_id, tx_id FROM events WHERE
-domain_id = ? AND workflow_id = ? AND run_id = ? AND first_event_id = ?`
+	lockEventSQLQuery = `SELECT range_id, tx_id FROM events ` +
+		`WHERE domain_id = ? AND workflow_id = ? AND run_id = ? AND first_event_id = ? ` +
+		`FOR UPDATE`
 )
-
-func (m *sqlHistoryManager) Close() {
-	if m.db != nil {
-		m.db.Close()
-	}
-}
 
 // NewHistoryPersistence creates an instance of HistoryManager
 func NewHistoryPersistence(host string, port int, username, password, dbName string, logger bark.Logger) (p.HistoryStore, error) {
@@ -129,76 +111,22 @@ func (m *sqlHistoryManager) AppendHistoryEvents(request *p.InternalAppendHistory
 		WorkflowID:   *request.Execution.WorkflowId,
 		RunID:        *request.Execution.RunId,
 		FirstEventID: request.FirstEventID,
-		Data:         request.Events.Data,
-		DataEncoding: string(request.Events.Encoding),
+		BatchVersion: request.EventBatchVersion,
 		RangeID:      request.RangeID,
 		TxID:         request.TransactionID,
+		Data:         request.Events.Data,
+		DataEncoding: string(request.Events.Encoding),
 	}
-
 	if request.Overwrite {
-		tx, err := m.db.Beginx()
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("AppendHistoryEvents operation failed. Failed to begin transaction for overwrite. Error: %v", err),
-			}
-		}
-		defer tx.Rollback()
-
-		if err := lockAndCheckRangeIDAndTxID(tx,
-			request.RangeID,
-			request.TransactionID,
-			request.DomainID,
-			*request.Execution.WorkflowId,
-			*request.Execution.RunId,
-			request.FirstEventID); err != nil {
-			switch err.(type) {
-			case *p.ConditionFailedError:
-				return &p.ConditionFailedError{
-					Msg: fmt.Sprintf("AppendHistoryEvents operation failed. Overwrite failed. Error: %v", err),
-				}
-			default:
-				return &workflow.InternalServiceError{
-					Message: fmt.Sprintf("AppendHistoryEvents operation failed. Failed to lock row for overwrite. Error: %v", err),
-				}
-			}
-		}
-		result, err := tx.NamedExec(overwriteHistorySQLQuery, arg)
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("AppendHistoryEvents operation failed. Update failed. Error: %v", err),
-			}
-		}
-		rowsAffected, err := result.RowsAffected()
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("AppendHistoryEvents operation failed. Failed to check number of rows updated. Error: %v", err),
-			}
-		}
-		if rowsAffected != 1 {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("AppendHistoryEvents operation failed. Updated %v rows instead of one.", rowsAffected),
-			}
-		}
-
-		if err := tx.Commit(); err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("AppendHistoryEvents operation failed. Failed to lock row. Error: %v", err),
-			}
-		}
-	} else {
-		if _, err := m.db.NamedExec(appendHistorySQLQuery, arg); err != nil {
-			// TODO Find another way to do this without inspecting the error message (?)
-			if sqlErr, ok := err.(*mysql.MySQLError); ok && sqlErr.Number == ErrDupEntry {
-				return &p.ConditionFailedError{
-					Msg: fmt.Sprintf("AppendHistoryEvents operaiton failed. Couldn't insert since row already existed. Erorr: %v", err),
-				}
-			}
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("AppendHistoryEvents operation failed. Insert failed. Error: %v", err),
-			}
-		}
+		return m.overWriteHistoryEvents(request, arg)
 	}
-
+	if _, err := m.db.NamedExec(appendHistorySQLQuery, arg); err != nil {
+		// TODO Find another way to do this without inspecting the error message (?)
+		if sqlErr, ok := err.(*mysql.MySQLError); ok && sqlErr.Number == ErrDupEntry {
+			return &p.ConditionFailedError{Msg: fmt.Sprintf("AppendHistoryEvents: event already exist: %v", err)}
+		}
+		return &workflow.InternalServiceError{Message: fmt.Sprintf("AppendHistoryEvents: %v", err)}
+	}
 	return nil
 }
 
@@ -206,92 +134,113 @@ func (m *sqlHistoryManager) AppendHistoryEvents(request *p.InternalAppendHistory
 func (m *sqlHistoryManager) GetWorkflowExecutionHistory(request *p.InternalGetWorkflowExecutionHistoryRequest) (
 	*p.InternalGetWorkflowExecutionHistoryResponse, error) {
 
+	token, err := m.deserializeToken(request)
+	if err != nil {
+		return nil, err
+	}
+
 	var rows []eventsRow
-	if err := m.db.Select(&rows,
-		getWorkflowExecutionHistorySQLQuery,
+	err = m.db.Select(&rows, getWorkflowExecutionHistorySQLQuery,
 		request.DomainID,
 		request.Execution.WorkflowId,
 		request.Execution.RunId,
-		request.FirstEventID,
+		token.LastEventID+1,
 		request.NextEventID,
-		request.PageSize); err != nil {
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetWorkflowExecutionHistory operation failed. Select failed. Error: %v", err),
-		}
-	}
+		request.PageSize)
 
-	if len(rows) == 0 {
+	if err == sql.ErrNoRows || (err == nil && len(rows) == 0) {
 		return nil, &workflow.EntityNotExistsError{
 			Message: fmt.Sprintf("Workflow execution history not found.  WorkflowId: %v, RunId: %v",
 				*request.Execution.WorkflowId, *request.Execution.RunId),
 		}
 	}
 
-	eventBatchVersionPointer := new(int64)
-	eventBatchVersion := common.EmptyVersion
-	lastEventBatchVersion := request.LastEventBatchVersion
+	if err != nil {
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("GetWorkflowExecutionHistory: %v", err),
+		}
+	}
 
 	history := make([]*p.DataBlob, 0)
+	lastEventBatchVersion := request.LastEventBatchVersion
+
 	for _, v := range rows {
 		eventBatch := &p.DataBlob{}
+		eventBatchVersion := common.EmptyVersion
 		eventBatch.Data = v.Data
 		eventBatch.Encoding = common.EncodingType(v.DataEncoding)
-
-		if eventBatchVersionPointer != nil {
-			eventBatchVersion = *eventBatchVersionPointer
+		if v.BatchVersion > 0 {
+			eventBatchVersion = v.BatchVersion
 		}
 		if eventBatchVersion >= lastEventBatchVersion {
 			history = append(history, eventBatch)
 			lastEventBatchVersion = eventBatchVersion
 		}
-
-		eventBatchVersionPointer = new(int64)
-		eventBatchVersion = common.EmptyVersion
+	}
+	var nextToken []byte
+	if (token.LastEventID + 1) < request.NextEventID {
+		nextToken, err = m.serializeToken(token)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	response := &p.InternalGetWorkflowExecutionHistoryResponse{
+	return &p.InternalGetWorkflowExecutionHistoryResponse{
 		History:               history,
 		LastEventBatchVersion: lastEventBatchVersion,
-		NextPageToken:         []byte{},
-	}
-
-	return response, nil
+		NextPageToken:         nextToken,
+	}, nil
 }
 
 func (m *sqlHistoryManager) DeleteWorkflowExecutionHistory(request *p.DeleteWorkflowExecutionHistoryRequest) error {
 	if _, err := m.db.Exec(deleteWorkflowExecutionHistorySQLQuery, request.DomainID, request.Execution.WorkflowId, request.Execution.RunId); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteWorkflowExecutionHistory operation failed. Error: %v", err),
+			Message: fmt.Sprintf("DeleteWorkflowExecutionHistory: %v", err),
 		}
 	}
 	return nil
 }
 
-func lockAndCheckRangeIDAndTxID(tx *sqlx.Tx,
-	maxRangeID int64,
-	maxTxIDPlusOne int64,
-	domainID string,
-	workflowID string,
-	runID string,
-	firstEventID int64) error {
+func (m *sqlHistoryManager) Close() {
+	if m.db != nil {
+		m.db.Close()
+	}
+}
+
+func (m *sqlHistoryManager) overWriteHistoryEvents(request *p.InternalAppendHistoryEventsRequest, row *eventsRow) error {
+	return runTransaction("AppendHistoryEvents", m.db, func(tx *sqlx.Tx) error {
+		if err := lockEventForUpdate(tx, request); err != nil {
+			return err
+		}
+		result, err := tx.NamedExec(overwriteHistorySQLQuery, row)
+		if err != nil {
+			return err
+		}
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return err
+		}
+		if rowsAffected != 1 {
+			return fmt.Errorf("expected 1 row to be affected, got %v", rowsAffected)
+		}
+		return nil
+	})
+}
+
+func lockEventForUpdate(tx *sqlx.Tx, req *p.InternalAppendHistoryEventsRequest) error {
 	var row eventsRow
-	if err := tx.Get(&row,
-		lockRangeIDAndTxIDSQLQuery,
-		domainID,
-		workflowID,
-		runID,
-		firstEventID); err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("Failed to lock range ID and tx ID. Get failed. Error: %v", err),
+	err := tx.Get(&row, lockEventSQLQuery, req.DomainID, *req.Execution.WorkflowId, *req.Execution.RunId, req.FirstEventID)
+	if err != nil {
+		return err
+	}
+	if row.RangeID > req.RangeID {
+		return &p.ConditionFailedError{
+			Msg: fmt.Sprintf("expected rangedID <=%v, got %v", req.RangeID, row.RangeID),
 		}
 	}
-	if !(row.RangeID <= maxRangeID) {
+	if row.TxID >= req.TransactionID {
 		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("Failed to lock range ID and tx ID. %v should've been at most %v.", row.RangeID, maxRangeID),
-		}
-	} else if !(row.TxID < maxTxIDPlusOne) {
-		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("Failed to lock range ID and tx ID. %v should've been strictly less than %v.", row.TxID, maxTxIDPlusOne),
+			Msg: fmt.Sprintf("expected txID < %v, got %v", req.TransactionID, row.TxID),
 		}
 	}
 	return nil
@@ -305,16 +254,14 @@ func (m *sqlHistoryManager) serializeToken(token *historyToken) ([]byte, error) 
 	return data, nil
 }
 
-func (m *sqlHistoryManager) deserializeToken(request *p.GetWorkflowExecutionHistoryRequest) (*historyToken, error) {
+func (m *sqlHistoryManager) deserializeToken(request *p.InternalGetWorkflowExecutionHistoryRequest) (*historyToken, error) {
 	token := &historyToken{
 		LastEventBatchVersion: common.EmptyVersion,
 		LastEventID:           request.FirstEventID - 1,
 	}
-
 	if len(request.NextPageToken) == 0 {
 		return token, nil
 	}
-
 	err := json.Unmarshal(request.NextPageToken, token)
 	if err == nil {
 		return token, nil

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -134,7 +134,7 @@ func (m *sqlHistoryManager) GetWorkflowExecutionHistory(request *p.InternalGetWo
 	*p.InternalGetWorkflowExecutionHistoryResponse, error) {
 
 	token := newHistoryPageToken(request.FirstEventID - 1)
-	if request.NextPageToken != nil {
+	if request.NextPageToken != nil && len(request.NextPageToken) > 0 {
 		if err := token.deserialize(request.NextPageToken); err != nil {
 			return nil, &workflow.InternalServiceError{
 				Message: fmt.Sprintf("invalid next page token %v", request.NextPageToken)}

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -121,7 +121,6 @@ func (m *sqlHistoryManager) AppendHistoryEvents(request *p.InternalAppendHistory
 		return m.overWriteHistoryEvents(request, arg)
 	}
 	if _, err := m.db.NamedExec(appendHistorySQLQuery, arg); err != nil {
-		// TODO Find another way to do this without inspecting the error message (?)
 		if sqlErr, ok := err.(*mysql.MySQLError); ok && sqlErr.Number == ErrDupEntry {
 			return &p.ConditionFailedError{Msg: fmt.Sprintf("AppendHistoryEvents: event already exist: %v", err)}
 		}

--- a/common/persistence/sql/sqlMetadataManagerV2.go
+++ b/common/persistence/sql/sqlMetadataManagerV2.go
@@ -272,7 +272,7 @@ func (m *sqlMetadataManagerV2) CreateDomain(request *persistence.CreateDomainReq
 			}
 			return err1
 		}
-		if err1 := lockMetadata(tx); err != nil {
+		if err1 := lockMetadata(tx); err1 != nil {
 			return err1
 		}
 		if err1 := updateMetadata(tx, metadata.NotificationVersion); err1 != nil {

--- a/common/persistence/sql/sqlMetadataManagerV2.go
+++ b/common/persistence/sql/sqlMetadataManagerV2.go
@@ -240,64 +240,47 @@ func (m *sqlMetadataManagerV2) CreateDomain(request *persistence.CreateDomainReq
 		return nil, err
 	}
 
-	tx, err := m.db.Beginx()
-	if err != nil {
-		return nil, err
-	}
-	commited := false
-	defer func() {
-		if !commited {
-			tx.Rollback()
-		}
-	}()
+	var resp *persistence.CreateDomainResponse
+	err = runTransaction("CreateDomain", m.db, func(tx *sqlx.Tx) error {
+		if _, err1 := tx.NamedExec(createDomainSQLQuery, &domainRow{
+			domainCommon: domainCommon{
+				Name:        request.Info.Name,
+				ID:          request.Info.ID,
+				Status:      request.Info.Status,
+				Description: request.Info.Description,
+				OwnerEmail:  request.Info.OwnerEmail,
+				Data:        &data,
 
-	if _, err := tx.NamedExec(createDomainSQLQuery, &domainRow{
-		domainCommon: domainCommon{
-			Name:        request.Info.Name,
-			ID:          request.Info.ID,
-			Status:      request.Info.Status,
-			Description: request.Info.Description,
-			OwnerEmail:  request.Info.OwnerEmail,
-			Data:        &data,
+				DomainConfig: *(request.Config),
 
-			DomainConfig: *(request.Config),
+				ActiveClusterName: request.ReplicationConfig.ActiveClusterName,
+				Clusters:          &clusters,
 
-			ActiveClusterName: request.ReplicationConfig.ActiveClusterName,
-			Clusters:          &clusters,
+				ConfigVersion:   request.ConfigVersion,
+				FailoverVersion: request.FailoverVersion,
+			},
 
-			ConfigVersion:   request.ConfigVersion,
-			FailoverVersion: request.FailoverVersion,
-		},
-
-		NotificationVersion:         metadata.NotificationVersion,
-		FailoverNotificationVersion: persistence.InitialFailoverNotificationVersion,
-		IsGlobalDomain:              request.IsGlobalDomain,
-	}); err != nil {
-		if sqlErr, ok := err.(*mysql.MySQLError); ok && sqlErr.Number == ErrDupEntry {
-			return nil, &workflow.DomainAlreadyExistsError{
-				Message: fmt.Sprintf("name: %v", request.Info.Name),
+			NotificationVersion:         metadata.NotificationVersion,
+			FailoverNotificationVersion: persistence.InitialFailoverNotificationVersion,
+			IsGlobalDomain:              request.IsGlobalDomain,
+		}); err1 != nil {
+			if sqlErr, ok := err.(*mysql.MySQLError); ok && sqlErr.Number == ErrDupEntry {
+				return &workflow.DomainAlreadyExistsError{
+					Message: fmt.Sprintf("name: %v", request.Info.Name),
+				}
 			}
+			return err1
 		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CreateDomain operation failed. Inserting into domains table. Error: %v", err),
+		if err1 := lockMetadata(tx); err != nil {
+			return err1
 		}
-	}
-
-	if err := lockMetadata(tx); err != nil {
-		return nil, err
-	}
-
-	if err := updateMetadata(tx, metadata.NotificationVersion); err != nil {
-		return nil, err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CreateDomain operation failed. Committing transaction. Error: %v", err),
+		if err1 := updateMetadata(tx, metadata.NotificationVersion); err1 != nil {
+			return err1
 		}
-	}
-	commited = true
-	return &persistence.CreateDomainResponse{ID: request.Info.ID}, nil
+		resp = &persistence.CreateDomainResponse{ID: request.Info.ID}
+		return nil
+	})
+	return resp, err
 }
 
 func (m *sqlMetadataManagerV2) GetDomain(request *persistence.GetDomainRequest) (*persistence.GetDomainResponse, error) {
@@ -408,114 +391,55 @@ func (m *sqlMetadataManagerV2) UpdateDomain(request *persistence.UpdateDomainReq
 		}
 	}
 
-	tx, err := m.db.Beginx()
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateDomain operation failed. Failed to start transaction. Error: %v", err),
+	return runTransaction("UpdateDomain", m.db, func(tx *sqlx.Tx) error {
+		result, err := tx.NamedExec(updateDomainSQLQuery, &flatUpdateDomainRequest{
+			domainCommon: domainCommon{
+				Name:        request.Info.Name,
+				ID:          request.Info.ID,
+				Status:      request.Info.Status,
+				Description: request.Info.Description,
+				OwnerEmail:  request.Info.OwnerEmail,
+				Data:        &data,
+
+				DomainConfig: *(request.Config),
+
+				ActiveClusterName: request.ReplicationConfig.ActiveClusterName,
+				Clusters:          &clusters,
+				ConfigVersion:     request.ConfigVersion,
+				FailoverVersion:   request.FailoverVersion,
+			},
+			FailoverNotificationVersion: request.FailoverNotificationVersion,
+			NotificationVersion:         request.NotificationVersion,
+		})
+		if err != nil {
+			return err
 		}
-	}
-	defer tx.Rollback()
-
-	result, err := tx.NamedExec(updateDomainSQLQuery, &flatUpdateDomainRequest{
-		domainCommon: domainCommon{
-			Name:        request.Info.Name,
-			ID:          request.Info.ID,
-			Status:      request.Info.Status,
-			Description: request.Info.Description,
-			OwnerEmail:  request.Info.OwnerEmail,
-			Data:        &data,
-
-			DomainConfig: *(request.Config),
-
-			ActiveClusterName: request.ReplicationConfig.ActiveClusterName,
-			Clusters:          &clusters,
-			ConfigVersion:     request.ConfigVersion,
-			FailoverVersion:   request.FailoverVersion,
-		},
-		FailoverNotificationVersion: request.FailoverNotificationVersion,
-		NotificationVersion:         request.NotificationVersion,
+		noRowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("rowsAffected error: %v", err)
+		}
+		if noRowsAffected != 1 {
+			return fmt.Errorf("%v rows updated instead of one", noRowsAffected)
+		}
+		if err := lockMetadata(tx); err != nil {
+			return err
+		}
+		return updateMetadata(tx, request.NotificationVersion)
 	})
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateDomain operation failed. Error %v", err),
-		}
-	}
-	noRowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateDomain operation failed. Couldn't verify the number of rows updated. Error: %v", err),
-		}
-	} else if noRowsAffected != 1 {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateDomain operation failed. %v rows updated, where one should have been updated. Error: %v", noRowsAffected, err),
-		}
-	}
-
-	if err := lockMetadata(tx); err != nil {
-		return err
-	}
-
-	if err := updateMetadata(tx, request.NotificationVersion); err != nil {
-		return err
-	}
-
-	if err := tx.Commit(); err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateDomain operation failed. Failed to commit transaction. Error: %v", err),
-		}
-	}
-
-	return nil
 }
 
-// TODO Find a way to get rid of code repetition without using a type switch
-
 func (m *sqlMetadataManagerV2) DeleteDomain(request *persistence.DeleteDomainRequest) error {
-	tx, err := m.db.Beginx()
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteDomain operation failed. Failed to start transaction. Error: %v", err),
-		}
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.NamedExec(deleteDomainByIDSQLQuery, request); err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteDomain operation failed. Error %v", err),
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteDomain operation failed. Failed to commit transaction. Error: %v", err),
-		}
-	}
-
-	return nil
+	return runTransaction("DeleteDomain", m.db, func(tx *sqlx.Tx) error {
+		_, err := tx.NamedExec(deleteDomainByIDSQLQuery, request)
+		return err
+	})
 }
 
 func (m *sqlMetadataManagerV2) DeleteDomainByName(request *persistence.DeleteDomainByNameRequest) error {
-	tx, err := m.db.Beginx()
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteDomainByName operation failed. Failed to start transaction. Error: %v", err),
-		}
-	}
-	defer tx.Rollback()
-
-	if _, err := m.db.NamedExec(deleteDomainByNameSQLQuery, request); err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteDomainByName operation failed. Error %v", err),
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteDomainByName operation failed. Failed to commit transaction. Error: %v", err),
-		}
-	}
-
-	return nil
+	return runTransaction("DeleteDomainByName", m.db, func(tx *sqlx.Tx) error {
+		_, err := m.db.NamedExec(deleteDomainByNameSQLQuery, request)
+		return err
+	})
 }
 
 func (m *sqlMetadataManagerV2) GetMetadata() (*persistence.GetMetadataResponse, error) {
@@ -526,7 +450,6 @@ func (m *sqlMetadataManagerV2) GetMetadata() (*persistence.GetMetadataResponse, 
 			Message: fmt.Sprintf("GetMetadata operation failed. Error: %v", err),
 		}
 	}
-
 	return &persistence.GetMetadataResponse{NotificationVersion: notificationVersion}, nil
 }
 

--- a/common/persistence/sql/sqlMetadataManagerV2.go
+++ b/common/persistence/sql/sqlMetadataManagerV2.go
@@ -23,13 +23,13 @@ package sql
 import (
 	"database/sql"
 	"fmt"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/uber-common/bark"
 
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/persistence"
 
-	_ "github.com/go-sql-driver/mysql" // MySQL driver
 	"github.com/jmoiron/sqlx"
 )
 
@@ -77,10 +77,10 @@ type (
 const (
 	createDomainSQLQuery = `INSERT INTO domains (
 		id,
+		name,
 		retention, 
 		emit_metric,
 		config_version,
-		name, 
 		status, 
 		description, 
 		owner_email,
@@ -94,10 +94,10 @@ const (
 		)
 		VALUES(
 		:id,
+		:name,
 		:retention, 
 		:emit_metric,
 		:config_version,
-		:name, 
 		:status, 
 		:description, 
 		:owner_email,

--- a/common/persistence/sql/sqlShardManager.go
+++ b/common/persistence/sql/sqlShardManager.go
@@ -23,8 +23,9 @@ package sql
 import (
 	"database/sql"
 	"fmt"
-	"github.com/uber-common/bark"
 	"time"
+
+	"github.com/uber-common/bark"
 
 	"github.com/jmoiron/sqlx"
 	workflow "github.com/uber/cadence/.gen/go/shared"

--- a/common/persistence/sql/sqlShardManager.go
+++ b/common/persistence/sql/sqlShardManager.go
@@ -223,54 +223,23 @@ func (m *sqlShardManager) UpdateShard(request *persistence.UpdateShardRequest) e
 			Message: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
 		}
 	}
-
-	tx, err := m.db.Beginx()
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
+	return runTransaction("UpdateShard", m.db, func(tx *sqlx.Tx) error {
+		if err := lockShard(tx, request.ShardInfo.ShardID, request.PreviousRangeID); err != nil {
+			return err
 		}
-	}
-	defer tx.Rollback()
-
-	if err := lockShard(tx, request.ShardInfo.ShardID, request.PreviousRangeID); err != nil {
-		switch err.(type) {
-		case *persistence.ShardOwnershipLostError:
-			return &persistence.ShardOwnershipLostError{
-				Msg: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
-			}
-		default:
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
-			}
+		result, err := tx.NamedExec(updateShardSQLQuery, &row)
+		if err != nil {
+			return err
 		}
-	}
-
-	result, err := tx.NamedExec(updateShardSQLQuery, &row)
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdatedShard operation failed. Failed to update shard with ID: %v. Error: %v", request.ShardInfo.ShardID, err),
+		rowsAffected, err := result.RowsAffected()
+		if err != nil {
+			return fmt.Errorf("rowsAffected returned error for shardID %v: %v", request.ShardInfo.ShardID, err)
 		}
-	}
-
-	rowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdatedShard operation failed. Failed to verify whether we successfully updated shard with ID: %v. Error: %v", request.ShardInfo.ShardID, err),
+		if rowsAffected != 1 {
+			return fmt.Errorf("rowsAffected returned %v shards instead of one", rowsAffected)
 		}
-	}
-	if rowsAffected != 1 {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdatedShard operation failed. Tried to update %v shards instead of one.", rowsAffected),
-		}
-	}
-
-	if err := tx.Commit(); err != nil {
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdatedShard operation failed. Failed to commit transaction. Error: %v", err),
-		}
-	}
-
-	return nil
+		return nil
+	})
 }
 
 func lockShard(tx *sqlx.Tx, shardID int, oldRangeID int64) error {

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -22,13 +22,15 @@ package sql
 
 import (
 	"fmt"
+
 	"github.com/uber-common/bark"
 
 	"database/sql"
+	"time"
+
 	"github.com/jmoiron/sqlx"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/persistence"
-	"time"
 )
 
 type (
@@ -65,9 +67,9 @@ type (
 
 const (
 	taskListCreatePart = `INTO task_lists 
-(domain_id, range_id, name, task_type, ack_level, kind, expiry_ts)
+(domain_id, name, task_type, range_id, ack_level, kind, expiry_ts)
 VALUES
-(:domain_id, :range_id, :name, :task_type, :ack_level, :kind, :expiry_ts)`
+(:domain_id, :name, :task_type, :range_id, :ack_level, :kind, :expiry_ts)`
 
 	// (default range ID: initialRangeID == 1)
 	createTaskListSQLQuery = `INSERT ` + taskListCreatePart
@@ -112,9 +114,9 @@ task_id <= ?
 `
 
 	createTaskSQLQuery = `INSERT INTO tasks
-(domain_id, workflow_id, run_id, schedule_id, task_list_name, task_list_type, task_id, expiry_ts)
+(domain_id, task_list_name, task_list_type, task_id, workflow_id, run_id, schedule_id, expiry_ts)
 VALUES
-(:domain_id, :workflow_id, :run_id, :schedule_id, :task_list_name, :task_list_type, :task_id, :expiry_ts)`
+(:domain_id, :task_list_name, :task_list_type, :task_id, :workflow_id, :run_id, :schedule_id, :expiry_ts)`
 )
 
 // NewTaskPersistence creates a new instance of TaskManager

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -157,7 +157,7 @@ func (m *sqlTaskManager) LeaseTaskList(request *persistence.LeaseTaskListRequest
 		// We need to separately check the condition and do the
 		// update because we want to throw different error codes.
 		// Since we need to do things separately (in a transaction), we need to take a lock.
-		if err1 := lockTaskList(tx, request.DomainID, request.TaskList, request.TaskType, row.RangeID); err != nil {
+		if err1 := lockTaskList(tx, request.DomainID, request.TaskList, request.TaskType, row.RangeID); err1 != nil {
 			return err1
 		}
 		result, err1 := tx.NamedExec(updateTaskListSQLQuery,

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -103,7 +103,7 @@ task_type = :task_type
 		`tasks(domain_id, workflow_id, run_id, schedule_id, task_list_name, task_list_type, task_id, expiry_ts) ` +
 		`VALUES(:domain_id, :workflow_id, :run_id, :schedule_id, :task_list_name, :task_list_type, :task_id, :expiry_ts)`
 
-	deleteTasksSQLQuery = `DELETE FROM tasks ` +
+	deleteTaskSQLQuery = `DELETE FROM tasks ` +
 		`WHERE domain_id = ? AND task_list_name = ? AND task_list_type = ? AND task_id = ?`
 )
 
@@ -314,7 +314,7 @@ func (m *sqlTaskManager) GetTasks(request *persistence.GetTasksRequest) (*persis
 func (m *sqlTaskManager) CompleteTask(request *persistence.CompleteTaskRequest) error {
 	taskID := request.TaskID
 	taskList := request.TaskList
-	_, err := m.db.Exec(deleteTasksSQLQuery, taskList.DomainID, taskList.Name, int64(taskList.TaskType), taskID)
+	_, err := m.db.Exec(deleteTaskSQLQuery, taskList.DomainID, taskList.Name, int64(taskList.TaskType), taskID)
 	if err != nil && err != sql.ErrNoRows {
 		return &workflow.InternalServiceError{Message: err.Error()}
 	}

--- a/schema/mysql/cadence/schema.sql
+++ b/schema/mysql/cadence/schema.sql
@@ -177,18 +177,17 @@ CREATE TABLE timer_tasks (
 );
 
 CREATE TABLE events (
-	domain_id VARCHAR(64) NOT NULL,
-	workflow_id VARCHAR(255) NOT NULL,
-	run_id VARCHAR(64) NOT NULL,
+	domain_id      VARCHAR(64) NOT NULL,
+	workflow_id    VARCHAR(255) NOT NULL,
+	run_id         VARCHAR(64) NOT NULL,
 	first_event_id BIGINT NOT NULL,
-	data BLOB NOT NULL,
-	data_encoding VARCHAR(64) NOT NULL,
-	data_version INT NOT NULL,
-	-- conditional update stuff
-	range_id INT NOT NULL,
-	tx_id INT NOT NULL,
+	batch_version  BIGINT,
+	range_id       INT NOT NULL,
+	tx_id          INT NOT NULL,
+	data BLOB      NOT NULL,
+	data_encoding  VARCHAR(64) NOT NULL,
 	PRIMARY KEY (domain_id, workflow_id, run_id, first_event_id)
-	);
+);
 
 CREATE TABLE activity_info_maps (
 -- each row corresponds to one key of one map<string, ActivityInfo>


### PR DESCRIPTION
This patch mainly fixes the history manager implementation but also contains other minor fixes in the mysql persistence layer. Following is a summary of changes in this patch:
 - Enforces parameter ordering when executing "INSERT INTO.." statements i.e. if there is a table called my_table (k1, k2, v1, v2), then the INSERT statement MUST be of the form INSERT INTO(k1, k2...) and not something like INSERT INTO (k1, v1, v2, k2)
 - Fixes bugs / missing code in history, shard,  task and domain persistence