### PR TITLE
Fix race issue in signalwithstart

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1135,7 +1135,7 @@ func (d *cassandraPersistence) CreateWorkflowExecution(request *p.CreateWorkflow
 					}
 				}
 
-				if prevRunID, ok := previous["current_run_id"]; ok && prevRunID != request.Execution.GetRunId() {
+				if prevRunID := previous["current_run_id"].(gocql.UUID).String(); prevRunID != request.Execution.GetRunId() {
 					// currentRunID on previous run has been changed, return to caller to handle
 					msg := fmt.Sprintf("Workflow execution creation condition failed by mismatch runID. WorkflowId: %v, CurrentRunID: %v, columns: (%v)",
 						request.Execution.GetWorkflowId(), request.Execution.GetRunId(), strings.Join(columns, ","))

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1203,7 +1203,6 @@ func (d *cassandraPersistence) CreateWorkflowExecutionWithinBatch(request *p.Cre
 			request.CreateWorkflowMode = p.CreateWorkflowModeContinueAsNew
 		}
 	}
-	fmt.Println("vancexu: request.CreateWorkflowMode ", request.CreateWorkflowMode)
 	switch request.CreateWorkflowMode {
 	case p.CreateWorkflowModeContinueAsNew:
 		batch.Query(templateUpdateCurrentWorkflowExecutionQuery,

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1259,7 +1259,7 @@ func (d *cassandraPersistence) CreateWorkflowExecutionWithinBatch(request *p.Cre
 			state,
 		)
 	default:
-		d.logger.Panic(fmt.Sprintf("Unknown CreateWorkflowContinueAsNew Mode: %v", request.CreateWorkflowMode))
+		d.logger.Panic(fmt.Sprintf("Unknown CreateWorkflowMode: %v", request.CreateWorkflowMode))
 	}
 
 	if request.ReplicationState == nil {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1687,10 +1687,17 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	resp, err := wh.history.SignalWithStartWorkflowExecution(ctx, &h.SignalWithStartWorkflowExecutionRequest{
-		DomainUUID:             common.StringPtr(domainID),
-		SignalWithStartRequest: signalWithStartRequest,
-	})
+	var resp *gen.StartWorkflowExecutionResponse
+	op := func() error {
+		var err error
+		resp, err = wh.history.SignalWithStartWorkflowExecution(ctx, &h.SignalWithStartWorkflowExecutionRequest{
+			DomainUUID:             common.StringPtr(domainID),
+			SignalWithStartRequest: signalWithStartRequest,
+		})
+		return err
+	}
+
+	err = backoff.Retry(op, frontendServiceRetryPolicy, common.IsServiceTransientError)
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}


### PR DESCRIPTION
Related issue https://github.com/uber/cadence/issues/1162

In this fix:
concurrent SignalWithStart with same closed workflowID will caused Internal CurrentWorkflowConditionFailedError
retry in frontend to avoid affecting server side SLA