### PR TITLE
persistence-test: add schemaDir option

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceTest.go
+++ b/common/persistence/cassandra/cassandraPersistenceTest.go
@@ -41,16 +41,21 @@ const (
 
 // TestCluster allows executing cassandra operations in testing.
 type TestCluster struct {
-	keyspace string
-	cluster  *gocql.ClusterConfig
-	session  *gocql.Session
-	cfg      config.Cassandra
+	keyspace  string
+	schemaDir string
+	cluster   *gocql.ClusterConfig
+	session   *gocql.Session
+	cfg       config.Cassandra
 }
 
 // NewTestCluster returns a new cassandra test cluster
-func NewTestCluster(keyspace string) *TestCluster {
+func NewTestCluster(keyspace string, schemaDir string) *TestCluster {
+	if schemaDir == "" {
+		schemaDir = testSchemaDir
+	}
 	var result TestCluster
 	result.keyspace = keyspace
+	result.schemaDir = schemaDir
 	result.cfg = config.Cassandra{
 		User:     testUser,
 		Password: testPassword,
@@ -83,7 +88,7 @@ func (s *TestCluster) DatabaseName() string {
 func (s *TestCluster) SetupTestDatabase() {
 	s.CreateSession()
 	s.CreateDatabase()
-	schemaDir := testSchemaDir + "/"
+	schemaDir := s.schemaDir + "/"
 
 	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
 		cadencePackageDir, err := getCadencePackageDir()

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -47,7 +47,8 @@ type (
 
 	// TestBaseOptions options to configure workflow test base.
 	TestBaseOptions struct {
-		DBName string
+		DBName    string
+		SchemaDir string
 		// TODO this is used for global domain test
 		// when crtoss DC is public, remove EnableGlobalDomain
 		EnableGlobalDomain bool // is global domain enabled
@@ -97,7 +98,7 @@ func NewTestBaseWithCassandra(options *TestBaseOptions) TestBase {
 	if options.DBName == "" {
 		options.DBName = GenerateRandomDBName(10)
 	}
-	testCluster := cassandra.NewTestCluster(options.DBName)
+	testCluster := cassandra.NewTestCluster(options.DBName, options.SchemaDir)
 	return newTestBase(options, testCluster)
 }
 
@@ -106,7 +107,7 @@ func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
 	if options.DBName == "" {
 		options.DBName = GenerateRandomDBName(10)
 	}
-	testCluster := sql.NewTestCluster(options.DBName)
+	testCluster := sql.NewTestCluster(options.DBName, options.SchemaDir)
 	return newTestBase(options, testCluster)
 }
 

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -42,15 +42,20 @@ const (
 
 // TestCluster allows executing cassandra operations in testing.
 type TestCluster struct {
-	dbName string
-	db     *sqlx.DB
-	cfg    config.SQL
+	dbName    string
+	schemaDir string
+	db        *sqlx.DB
+	cfg       config.SQL
 }
 
 // NewTestCluster returns a new SQL test cluster
-func NewTestCluster(dbName string) *TestCluster {
+func NewTestCluster(dbName string, schemaDir string) *TestCluster {
+	if schemaDir == "" {
+		schemaDir = testSchemaDir
+	}
 	var result TestCluster
 	result.dbName = dbName
+	result.schemaDir = schemaDir
 	result.cfg = config.SQL{
 		User:            testUser,
 		Password:        testPassword,
@@ -75,7 +80,7 @@ func (s *TestCluster) SetupTestDatabase() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	schemaDir := cadencePackageDir + testSchemaDir + "/"
+	schemaDir := cadencePackageDir + s.schemaDir + "/"
 	s.LoadSchema([]string{"schema.sql"}, schemaDir)
 	// TODO: Visibility
 	//s.LoadVisibilitySchema([]string{"schema.sql"}, schemaDir)


### PR DESCRIPTION
This patch adds a schemaDir option to the persistence test base. 