### PR TITLE
Force a non transient decision on sticky timeout

### DIFF
--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -6229,7 +6229,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
 	s.logger.Infof("StartWorkflowExecution: response: %v \n", *we.RunId)
 	workflowExecution := &workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr(id),
-		RunId: we.RunId,
+		RunId:      we.RunId,
 	}
 
 	// decider logic
@@ -6244,8 +6244,8 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
 			return nil, []*workflow.Decision{{
 				DecisionType: common.DecisionTypePtr(workflow.DecisionTypeRecordMarker),
 				RecordMarkerDecisionAttributes: &workflow.RecordMarkerDecisionAttributes{
-					MarkerName:                    common.StringPtr("local activity marker"),
-					Details:                       []byte("local activity data"),
+					MarkerName: common.StringPtr("local activity marker"),
+					Details:    []byte("local activity data"),
 				},
 			}}, nil
 		}
@@ -6302,7 +6302,7 @@ func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
 
 	// Wait for decision timeout
 	stickyTimeout := false
-	WaitForStickyTimeoutLoop:
+WaitForStickyTimeoutLoop:
 	for i := 0; i < 10; i++ {
 		events := s.getHistory(s.domainName, workflowExecution)
 		for _, event := range events {

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -6193,6 +6193,181 @@ func (s *integrationSuite) TestTaskProcessingProtectionForRateLimitError() {
 	s.Equal(101, signalCount)
 }
 
+func (s *integrationSuite) TestStickyTimeout_NonTransientDecision() {
+	id := "interation-sticky-timeout-non-transient-decision"
+	wt := "interation-sticky-timeout-non-transient-decision-type"
+	tl := "interation-sticky-timeout-non-transient-decision-tasklist"
+	stl := "interation-sticky-timeout-non-transient-decision-tasklist-sticky"
+	identity := "worker1"
+
+	workflowType := &workflow.WorkflowType{}
+	workflowType.Name = common.StringPtr(wt)
+
+	taskList := &workflow.TaskList{}
+	taskList.Name = common.StringPtr(tl)
+
+	stickyTaskList := &workflow.TaskList{}
+	stickyTaskList.Name = common.StringPtr(stl)
+	stickyScheduleToStartTimeoutSeconds := common.Int32Ptr(2)
+
+	// Start workflow execution
+	request := &workflow.StartWorkflowExecutionRequest{
+		RequestId:                           common.StringPtr(uuid.New()),
+		Domain:                              common.StringPtr(s.domainName),
+		WorkflowId:                          common.StringPtr(id),
+		WorkflowType:                        workflowType,
+		TaskList:                            taskList,
+		Input:                               nil,
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(100),
+		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Identity:                            common.StringPtr(identity),
+	}
+
+	we, err0 := s.engine.StartWorkflowExecution(createContext(), request)
+	s.Nil(err0)
+
+	s.logger.Infof("StartWorkflowExecution: response: %v \n", *we.RunId)
+	workflowExecution := &workflow.WorkflowExecution{
+		WorkflowId: common.StringPtr(id),
+		RunId: we.RunId,
+	}
+
+	// decider logic
+	localActivityDone := false
+	failureCount := 5
+	dtHandler := func(execution *workflow.WorkflowExecution, wt *workflow.WorkflowType,
+		previousStartedEventID, startedEventID int64, history *workflow.History) ([]byte, []*workflow.Decision, error) {
+
+		if !localActivityDone {
+			localActivityDone = true
+
+			return nil, []*workflow.Decision{{
+				DecisionType: common.DecisionTypePtr(workflow.DecisionTypeRecordMarker),
+				RecordMarkerDecisionAttributes: &workflow.RecordMarkerDecisionAttributes{
+					MarkerName:                    common.StringPtr("local activity marker"),
+					Details:                       []byte("local activity data"),
+				},
+			}}, nil
+		}
+
+		if failureCount > 0 {
+			// send a signal on third failure to be buffered, forcing a non-transient decision when buffer is flushed
+			/*if failureCount == 3 {
+				err := s.engine.SignalWorkflowExecution(createContext(), &workflow.SignalWorkflowExecutionRequest{
+					Domain:            common.StringPtr(s.domainName),
+					WorkflowExecution: workflowExecution,
+					SignalName:        common.StringPtr("signalB"),
+					Input:             []byte("signal input"),
+					Identity:          common.StringPtr(identity),
+					RequestId:         common.StringPtr(uuid.New()),
+				})
+				s.Nil(err)
+			}*/
+			failureCount--
+			return nil, nil, errors.New("non deterministic error")
+		}
+
+		return nil, []*workflow.Decision{{
+			DecisionType: common.DecisionTypePtr(workflow.DecisionTypeCompleteWorkflowExecution),
+			CompleteWorkflowExecutionDecisionAttributes: &workflow.CompleteWorkflowExecutionDecisionAttributes{
+				Result: []byte("Done."),
+			},
+		}}, nil
+	}
+
+	poller := &TaskPoller{
+		Engine:                              s.engine,
+		Domain:                              s.domainName,
+		TaskList:                            taskList,
+		Identity:                            identity,
+		DecisionHandler:                     dtHandler,
+		Logger:                              s.logger,
+		T:                                   s.T(),
+		StickyTaskList:                      stickyTaskList,
+		StickyScheduleToStartTimeoutSeconds: stickyScheduleToStartTimeoutSeconds,
+	}
+
+	_, err := poller.PollAndProcessDecisionTaskWithAttempt(false, false, false, true, int64(0))
+	s.logger.Infof("PollAndProcessDecisionTask: %v", err)
+	s.Nil(err)
+
+	err = s.engine.SignalWorkflowExecution(createContext(), &workflow.SignalWorkflowExecutionRequest{
+		Domain:            common.StringPtr(s.domainName),
+		WorkflowExecution: workflowExecution,
+		SignalName:        common.StringPtr("signalA"),
+		Input:             []byte("signal input"),
+		Identity:          common.StringPtr(identity),
+		RequestId:         common.StringPtr(uuid.New()),
+	})
+
+	// Wait for decision timeout
+	stickyTimeout := false
+	WaitForStickyTimeoutLoop:
+	for i := 0; i < 10; i++ {
+		events := s.getHistory(s.domainName, workflowExecution)
+		for _, event := range events {
+			if event.GetEventType() == workflow.EventTypeDecisionTaskTimedOut {
+				s.Equal(workflow.TimeoutTypeScheduleToStart, event.DecisionTaskTimedOutEventAttributes.GetTimeoutType())
+				stickyTimeout = true
+				break WaitForStickyTimeoutLoop
+			}
+		}
+		time.Sleep(time.Second)
+	}
+	s.True(stickyTimeout, "Decision not timed out.")
+
+	for i := 0; i < 3; i++ {
+		_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, true, int64(i))
+		s.logger.Infof("PollAndProcessDecisionTask: %v", err)
+		s.Nil(err)
+	}
+
+	err = s.engine.SignalWorkflowExecution(createContext(), &workflow.SignalWorkflowExecutionRequest{
+		Domain:            common.StringPtr(s.domainName),
+		WorkflowExecution: workflowExecution,
+		SignalName:        common.StringPtr("signalB"),
+		Input:             []byte("signal input"),
+		Identity:          common.StringPtr(identity),
+		RequestId:         common.StringPtr(uuid.New()),
+	})
+	s.Nil(err)
+
+	for i := 0; i < 2; i++ {
+		_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, true, int64(i))
+		s.logger.Infof("PollAndProcessDecisionTask: %v", err)
+		s.Nil(err)
+	}
+
+	decisionTaskFailed := false
+	events := s.getHistory(s.domainName, workflowExecution)
+	for _, event := range events {
+		if event.GetEventType() == workflow.EventTypeDecisionTaskFailed {
+			decisionTaskFailed = true
+			break
+		}
+	}
+	s.True(decisionTaskFailed)
+
+	// Complete workflow execution
+	_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, true, int64(2))
+
+	// Assert for single decision task failed and workflow completion
+	failedDecisions := 0
+	workflowComplete := false
+	events = s.getHistory(s.domainName, workflowExecution)
+	for _, event := range events {
+		switch event.GetEventType() {
+		case workflow.EventTypeDecisionTaskFailed:
+			failedDecisions++
+		case workflow.EventTypeWorkflowExecutionCompleted:
+			workflowComplete = true
+		}
+	}
+	s.True(workflowComplete, "Workflow not complete")
+	s.Equal(2, failedDecisions, "Mismatched failed decision count")
+	s.printWorkflowHistory(s.domainName, workflowExecution)
+}
+
 func (s *integrationSuite) getHistory(domain string, execution *workflow.WorkflowExecution) []*workflow.HistoryEvent {
 	historyResponse, err := s.engine.GetWorkflowExecutionHistory(createContext(), &workflow.GetWorkflowExecutionHistoryRequest{
 		Domain:          common.StringPtr(domain),

--- a/service/history/MockMutableState.go
+++ b/service/history/MockMutableState.go
@@ -1023,8 +1023,8 @@ func (_m *mockMutableState) DeleteUserTimer(_a0 string) {
 }
 
 // FailDecision provides a mock function with given fields:
-func (_m *mockMutableState) FailDecision() {
-	_m.Called()
+func (_m *mockMutableState) FailDecision(incrementAttempt bool) {
+	_m.Called(incrementAttempt)
 }
 
 // FlushBufferedEvents provides a mock function with given fields:
@@ -1895,8 +1895,8 @@ func (_m *mockMutableState) ReplicateDecisionTaskCompletedEvent(_a0 int64, _a1 i
 }
 
 // ReplicateDecisionTaskFailedEvent provides a mock function with given fields: _a0, _a1
-func (_m *mockMutableState) ReplicateDecisionTaskFailedEvent(_a0 int64, _a1 int64) {
-	_m.Called(_a0, _a1)
+func (_m *mockMutableState) ReplicateDecisionTaskFailedEvent() {
+	_m.Called()
 }
 
 // ReplicateDecisionTaskScheduledEvent provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4
@@ -1932,8 +1932,8 @@ func (_m *mockMutableState) ReplicateDecisionTaskStartedEvent(_a0 *decisionInfo,
 }
 
 // ReplicateDecisionTaskTimedOutEvent provides a mock function with given fields: _a0, _a1
-func (_m *mockMutableState) ReplicateDecisionTaskTimedOutEvent(_a0 int64, _a1 int64) {
-	_m.Called(_a0, _a1)
+func (_m *mockMutableState) ReplicateDecisionTaskTimedOutEvent(_a0 shared.TimeoutType) {
+	_m.Called(_a0)
 }
 
 // ReplicateExternalWorkflowExecutionCancelRequested provides a mock function with given fields: _a0

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -107,7 +107,7 @@ type (
 		DeleteSignalRequested(requestID string)
 		DeletePendingSignal(int64)
 		DeleteUserTimer(string)
-		FailDecision()
+		FailDecision(bool)
 		FlushBufferedEvents() error
 		GetActivityByActivityID(string) (*persistence.ActivityInfo, bool)
 		GetActivityInfo(int64) (*persistence.ActivityInfo, bool)
@@ -165,10 +165,10 @@ type (
 		ReplicateChildWorkflowExecutionTerminatedEvent(*workflow.HistoryEvent)
 		ReplicateChildWorkflowExecutionTimedOutEvent(*workflow.HistoryEvent)
 		ReplicateDecisionTaskCompletedEvent(int64, int64)
-		ReplicateDecisionTaskFailedEvent(int64, int64)
+		ReplicateDecisionTaskFailedEvent()
 		ReplicateDecisionTaskScheduledEvent(int64, int64, string, int32, int64) *decisionInfo
 		ReplicateDecisionTaskStartedEvent(*decisionInfo, int64, int64, int64, string, int64) *decisionInfo
-		ReplicateDecisionTaskTimedOutEvent(int64, int64)
+		ReplicateDecisionTaskTimedOutEvent(workflow.TimeoutType)
 		ReplicateExternalWorkflowExecutionCancelRequested(*workflow.HistoryEvent)
 		ReplicateExternalWorkflowExecutionSignaled(*workflow.HistoryEvent)
 		ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(*workflow.HistoryEvent)

--- a/service/history/stateBuilder.go
+++ b/service/history/stateBuilder.go
@@ -137,13 +137,10 @@ func (b *stateBuilderImpl) applyEvents(domainID, requestID string, execution sha
 
 		case shared.EventTypeDecisionTaskTimedOut:
 			attributes := event.DecisionTaskTimedOutEventAttributes
-			b.msBuilder.ReplicateDecisionTaskTimedOutEvent(attributes.GetScheduledEventId(),
-				attributes.GetStartedEventId())
+			b.msBuilder.ReplicateDecisionTaskTimedOutEvent(attributes.GetTimeoutType())
 
 		case shared.EventTypeDecisionTaskFailed:
-			attributes := event.DecisionTaskFailedEventAttributes
-			b.msBuilder.ReplicateDecisionTaskFailedEvent(attributes.GetScheduledEventId(),
-				attributes.GetStartedEventId())
+			b.msBuilder.ReplicateDecisionTaskFailedEvent()
 
 		case shared.EventTypeActivityTaskScheduled:
 			ai := b.msBuilder.ReplicateActivityTaskScheduledEvent(event)

--- a/service/history/stateBuilder_test.go
+++ b/service/history/stateBuilder_test.go
@@ -1230,9 +1230,10 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeDecisionTaskTimedOut() {
 		DecisionTaskTimedOutEventAttributes: &shared.DecisionTaskTimedOutEventAttributes{
 			ScheduledEventId: common.Int64Ptr(scheduleID),
 			StartedEventId:   common.Int64Ptr(startedID),
+			TimeoutType:      shared.TimeoutTypeStartToClose.Ptr(),
 		},
 	}
-	s.mockMutableState.On("ReplicateDecisionTaskTimedOutEvent", scheduleID, startedID).Once()
+	s.mockMutableState.On("ReplicateDecisionTaskTimedOutEvent", shared.TimeoutTypeStartToClose).Once()
 	s.mockUpdateVersion(event)
 
 	s.stateBuilder.applyEvents(domainID, requestID, execution, s.toHistory(event), nil)
@@ -1375,7 +1376,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeDecisionTaskFailed() {
 			StartedEventId:   common.Int64Ptr(startedID),
 		},
 	}
-	s.mockMutableState.On("ReplicateDecisionTaskFailedEvent", scheduleID, startedID).Once()
+	s.mockMutableState.On("ReplicateDecisionTaskFailedEvent").Once()
 	s.mockUpdateVersion(event)
 
 	s.stateBuilder.applyEvents(domainID, requestID, execution, s.toHistory(event), nil)


### PR DESCRIPTION
Cadence has generic logic to start creating transient decisions on any
failure including decision scheduleToStartTimeout (sticky timeout),
decision startToCompleteTimeout and decision task failures.  This is
problematic in the situation when client rolls out a bad change to
workflow implementation which restarts the workers.  This causes the
first decisioin to fail due to stickyness causing execution to go into
this mode to start creating transient decisions.  This makes it very
hard to debug bad code changes as actual decision failures will now be
dropped by the client.  This change forces the decision state machine to
force a non-transient decision if it failed due to sticky timeout.