### PR TITLE
CLI bug fix: allow passing domain data in registering when require li…

### DIFF
--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -201,13 +201,15 @@ func RegisterDomain(c *cli.Context) {
 	}
 
 	domainData := map[string]string{}
-	if len(requiredDomainDataKeys) > 0 {
+	if c.IsSet(FlagDomainData) {
 		domainDataStr := getRequiredOption(c, FlagDomainData)
 		domainData, err = parseDomainDataKVs(domainDataStr)
 		if err != nil {
 			fmt.Printf("Register Domain failed: %v.\n", err.Error())
 			return
 		}
+	}
+	if len(requiredDomainDataKeys) > 0 {
 		err = checkRequiredDomainDataKVs(domainData)
 		if err != nil {
 			fmt.Printf("Register Domain failed: %v.\n", err.Error())


### PR DESCRIPTION
…st is empty


```
longer@~/gocode/src/github.com/uber/cadence:(eventsv2_1001)$ ./cadence --domain longer-test-2 d re --oe longer@uber.com --desc "test" --rd 7 --em true --domain_data UberServiceName:cadence-canary --ac active --cl active
longer@~/gocode/src/github.com/uber/cadence:(eventsv2_1001)$
longer@~/gocode/src/github.com/uber/cadence:(eventsv2_1001)$ ./cadence --domain longer-test-2 d desc
Name: longer-test-2
Description: test
OwnerEmail: longer@uber.com
DomainData: map[UberServiceName:cadence-canary]
Status: REGISTERED
RetentionInDays: 7
EmitMetrics: true
ActiveClusterName: active
Clusters: active
```