### PR TITLE
Use ubercadence/web 3.1.2

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - cassandra
       - statsd
   cadence-web:
-    image: ubercadence/web:3.2.1
+    image: ubercadence/web:3.1.2
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:


### PR DESCRIPTION
Version 3.2.1 does not exist:

```
$ docker-compose up
Pulling cadence-web (ubercadence/web:3.2.1)...
ERROR: manifest for ubercadence/web:3.2.1 not found
```

Change to 3.1.2, which is the latest `ubercadence/web` version.