### PR TITLE
mysql: convert sqlx batch deletes to normal deletes

### DIFF
--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -55,8 +55,9 @@ type (
 			SchemaDir string
 		}
 		SQL struct {
-			DBPort    int
-			SchemaDir string
+			DBPort     int
+			SchemaDir  string
+			DriverName string
 		}
 		// TODO this is used for global domain test
 		// when crtoss DC is public, remove EnableGlobalDomain
@@ -118,7 +119,8 @@ func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
 	if options.DBName == "" {
 		options.DBName = GenerateRandomDBName(10)
 	}
-	defaultCluster := sql.NewTestCluster(options.SQL.DBPort, options.DBName, options.SQL.SchemaDir)
+	sqlOpts := options.SQL
+	defaultCluster := sql.NewTestCluster(sqlOpts.DBPort, options.DBName, sqlOpts.SchemaDir, sqlOpts.DriverName)
 	visibilityCluster := cassandra.NewTestCluster(options.Cassandra.DBPort, options.DBName, options.Cassandra.SchemaDir)
 	return newTestBase(options, defaultCluster, visibilityCluster)
 }

--- a/common/persistence/sql/sqlHelpers.go
+++ b/common/persistence/sql/sqlHelpers.go
@@ -30,9 +30,8 @@ import (
 	"github.com/uber/cadence/common/service/config"
 )
 
-const driverName = "mysql"
+const defaultDriverName = "mysql"
 
-// TODO: driverName parameter
 func newConnection(cfg config.SQL) (*sqlx.DB, error) {
 	var db, err = sqlx.Connect(cfg.DriverName,
 		fmt.Sprintf(dataSourceName, cfg.User, cfg.Password, cfg.ConnectProtocol, cfg.ConnectAddr, cfg.DatabaseName))

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -79,11 +79,15 @@ func (s *TestCluster) DatabaseName() string {
 func (s *TestCluster) SetupTestDatabase() {
 	s.CreateDatabase()
 	s.CreateSession()
-	cadencePackageDir, err := getCadencePackageDir()
-	if err != nil {
-		log.Fatal(err)
+
+	schemaDir := s.schemaDir + "/"
+	if !strings.HasPrefix(schemaDir, "/") && !strings.HasPrefix(schemaDir, "../") {
+		cadencePackageDir, err := getCadencePackageDir()
+		if err != nil {
+			log.Fatal(err)
+		}
+		schemaDir = cadencePackageDir + schemaDir
 	}
-	schemaDir := cadencePackageDir + s.schemaDir + "/"
 	s.LoadSchema([]string{"schema.sql"}, schemaDir)
 	// TODO: Visibility
 	//s.LoadVisibilitySchema([]string{"schema.sql"}, schemaDir)

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -49,12 +49,15 @@ type TestCluster struct {
 }
 
 // NewTestCluster returns a new SQL test cluster
-func NewTestCluster(port int, dbName string, schemaDir string) *TestCluster {
+func NewTestCluster(port int, dbName string, schemaDir string, driverName string) *TestCluster {
 	if schemaDir == "" {
 		schemaDir = testSchemaDir
 	}
 	if port == 0 {
 		port = testPort
+	}
+	if driverName == "" {
+		driverName = defaultDriverName
 	}
 	var result TestCluster
 	result.dbName = dbName
@@ -122,7 +125,7 @@ func (s *TestCluster) CreateSession() {
 
 // CreateDatabase from PersistenceTestCluster interface
 func (s *TestCluster) CreateDatabase() {
-	err := createDatabase(driverName, s.cfg.ConnectAddr, testUser, testPassword, s.dbName, true)
+	err := createDatabase(s.cfg.DriverName, s.cfg.ConnectAddr, testUser, testPassword, s.dbName, true)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -309,38 +309,37 @@ func updateActivityInfos(tx *sqlx.Tx,
 	}
 
 	if len(deleteInfos) > 0 {
-		activityInfoMapsPrimaryKeys := make([]*activityInfoMapsPrimaryKey, len(deleteInfos))
-		for i, v := range deleteInfos {
-			activityInfoMapsPrimaryKeys[i] = &activityInfoMapsPrimaryKey{
+		for _, v := range deleteInfos {
+			deleteKeys := &activityInfoMapsPrimaryKey{
 				ShardID:    int64(shardID),
 				DomainID:   domainID,
 				WorkflowID: workflowID,
 				RunID:      runID,
 				ScheduleID: v,
 			}
-		}
 
-		query, args, err := tx.BindNamed(deleteKeyInActivityInfoMapSQLQuery, activityInfoMapsPrimaryKeys)
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update activity info. Failed to bind query. Error: %v", err),
+			query, args, err := tx.BindNamed(deleteKeyInActivityInfoMapSQLQuery, deleteKeys)
+			if err != nil {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update activity info. Failed to bind query. Error: %v", err),
+				}
 			}
-		}
-		result, err := tx.Exec(query, args...)
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update activity info. Failed to execute delete query. Error: %v", err),
+			result, err := tx.Exec(query, args...)
+			if err != nil {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update activity info. Failed to execute delete query. Error: %v", err),
+				}
 			}
-		}
-		rowsAffected, err := result.RowsAffected()
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update activity info. Failed to verify number of rows deleted. Error: %v", err),
+			rowsAffected, err := result.RowsAffected()
+			if err != nil {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update activity info. Failed to verify number of rows deleted. Error: %v", err),
+				}
 			}
-		}
-		if int(rowsAffected) != len(deleteInfos) {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update activity info. Deleted %v rows instead of %v", rowsAffected, len(activityInfos)),
+			if int(rowsAffected) != 1 {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update activity info. Deleted %v rows instead of 1", rowsAffected),
+				}
 			}
 		}
 	}
@@ -507,38 +506,37 @@ func updateTimerInfos(tx *sqlx.Tx,
 
 	}
 	if len(deleteInfos) > 0 {
-		timerInfoMapsPrimaryKeys := make([]*timerInfoMapsPrimaryKey, len(deleteInfos))
-		for i, v := range deleteInfos {
-			timerInfoMapsPrimaryKeys[i] = &timerInfoMapsPrimaryKey{
+		for _, v := range deleteInfos {
+			deleteKeys := &timerInfoMapsPrimaryKey{
 				ShardID:    int64(shardID),
 				DomainID:   domainID,
 				WorkflowID: workflowID,
 				RunID:      runID,
 				TimerID:    v,
 			}
-		}
 
-		query, args, err := tx.BindNamed(deleteKeyInTimerInfoMapSQLQuery, timerInfoMapsPrimaryKeys)
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update timer info. Failed to bind query. Error: %v", err),
+			query, args, err := tx.BindNamed(deleteKeyInTimerInfoMapSQLQuery, deleteKeys)
+			if err != nil {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update timer info. Failed to bind query. Error: %v", err),
+				}
 			}
-		}
-		result, err := tx.Exec(query, args...)
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update timer info. Failed to execute delete query. Error: %v", err),
+			result, err := tx.Exec(query, args...)
+			if err != nil {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update timer info. Failed to execute delete query. Error: %v", err),
+				}
 			}
-		}
-		rowsAffected, err := result.RowsAffected()
-		if err != nil {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update timer info. Failed to verify number of rows deleted. Error: %v", err),
+			rowsAffected, err := result.RowsAffected()
+			if err != nil {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update timer info. Failed to verify number of rows deleted. Error: %v", err),
+				}
 			}
-		}
-		if int(rowsAffected) != len(deleteInfos) {
-			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update timer info. Deleted %v rows instead of %v", rowsAffected, len(timerInfos)),
+			if int(rowsAffected) != 1 {
+				return &workflow.InternalServiceError{
+					Message: fmt.Sprintf("Failed to update timer info. Deleted %v rows instead of 1", rowsAffected),
+				}
 			}
 		}
 	}

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -321,7 +321,7 @@ func updateActivityInfos(tx *sqlx.Tx,
 			query, args, err := tx.BindNamed(deleteKeyInActivityInfoMapSQLQuery, deleteKeys)
 			if err != nil {
 				return &workflow.InternalServiceError{
-					Message: fmt.Sprintf("Failed to update activity info. Failed to bind query. Error: %v", err),
+					Message: fmt.Sprintf("Failed to update activity info. BindNamed failed. Error: %v", err),
 				}
 			}
 			result, err := tx.Exec(query, args...)
@@ -518,7 +518,7 @@ func updateTimerInfos(tx *sqlx.Tx,
 			query, args, err := tx.BindNamed(deleteKeyInTimerInfoMapSQLQuery, deleteKeys)
 			if err != nil {
 				return &workflow.InternalServiceError{
-					Message: fmt.Sprintf("Failed to update timer info. Failed to bind query. Error: %v", err),
+					Message: fmt.Sprintf("Failed to update timer info. BindNamed failed. Error: %v", err),
 				}
 			}
 			result, err := tx.Exec(query, args...)


### PR DESCRIPTION
Looks like there are couple of places in code [ timer_info_maps, activity_info_maps ] where we simply pass a slice of keys to a single delete query hoping that the sqlx library will convert them into a batch delete. This doesn't really work.

This patch converts these *batch deletes* into simple deletes. These deletes happen within a transaction, so there is no risk of partial deletes.