### PR TITLE
Bugfix: Do not clear heartbeat timestamp when retry

### DIFF
--- a/service/history/retry.go
+++ b/service/history/retry.go
@@ -51,7 +51,6 @@ func prepareActivityNextRetryWithNowTime(version int64, a *persistence.ActivityI
 	a.StartedID = common.EmptyEventID
 	a.RequestID = ""
 	a.StartedTime = time.Time{}
-	a.LastHeartBeatUpdatedTime = time.Time{}
 	a.TimerTaskStatus = TimerTaskStatusNone
 
 	return &persistence.ActivityRetryTimerTask{


### PR DESCRIPTION
Do not clear the last heartbeat timestamp when schedule a retry.