### PR TITLE
Disallow activity completion from previous attempts

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1556,7 +1556,7 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(ctx context.Context, re
 			}
 
 			if !isRunning || ai.StartedID == common.EmptyEventID ||
-				(token.ScheduleAttempt != 0 && int64(ai.Attempt) != token.ScheduleAttempt) {
+				(token.ScheduleID != common.EmptyEventID && token.ScheduleAttempt != int64(ai.Attempt)) {
 				return nil, ErrActivityTaskNotFound
 			}
 


### PR DESCRIPTION
Dedupe logic on activity completion was broken and allowed completion
from attempt 0 to go through even though activity is being retried
by server with larger attempt.