### PR TITLE
Fix heartbeat timeout after retry

### DIFF
--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -322,7 +322,7 @@ func (tb *timerBuilder) loadActivityTimers(msBuilder mutableState) {
 				tb.activityTimers = append(tb.activityTimers, td)
 				if v.HeartbeatTimeout > 0 && tb.enableActivityHeartbeat {
 					lastHeartBeatTS := v.LastHeartBeatUpdatedTime
-					if lastHeartBeatTS.IsZero() {
+					if lastHeartBeatTS.Before(v.StartedTime) {
 						lastHeartBeatTS = v.StartedTime
 					}
 					heartBeatExpiry := lastHeartBeatTS.Add(time.Duration(v.HeartbeatTimeout) * time.Second)


### PR DESCRIPTION
When retry is scheduled, we used to clear the last heartbeat, which breaks the DescribeWorkflowExecution, so fix #1204 solve that by not clear the last heartbeat timestamp when retry is scheduled.
This break the heartbeat timeout because the logic looks at the timestamp and would start counting from last heartbeat timestamp which is before current start time.