### PR TITLE
Set context timeout for various history service api calls

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -66,3 +66,8 @@ type (
 
 // MaxTaskTimeout is maximum task timeout allowed. 366 days in seconds
 const MaxTaskTimeout = 31622400
+
+const (
+	// GetHistoryWarnSizeLimit is the threshold for emitting warn log
+	GetHistoryWarnSizeLimit = 500 * 1024 // Warn when size goes over 500KB
+)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -454,6 +454,8 @@ const (
 	HistorySyncShardStatusScope
 	// HistorySyncActivityScope tracks HistoryActivity API calls received by service
 	HistorySyncActivityScope
+	// HistoryDescribeMutableStateScope tracks HistoryActivity API calls received by service
+	HistoryDescribeMutableStateScope
 	// HistoryShardControllerScope is the scope used by shard controller
 	HistoryShardControllerScope
 	// TransferQueueProcessorScope is the scope used by all metric emitted by transfer queue processor
@@ -763,6 +765,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		HistoryReplicateEventsScope:                  {operation: "ReplicateEvents"},
 		HistorySyncShardStatusScope:                  {operation: "SyncShardStatus"},
 		HistorySyncActivityScope:                     {operation: "SyncActivity"},
+		HistoryDescribeMutableStateScope:             {operation: "DescribeMutableState"},
 		HistoryShardControllerScope:                  {operation: "ShardController"},
 		TransferQueueProcessorScope:                  {operation: "TransferQueueProcessor"},
 		TransferActiveQueueProcessorScope:            {operation: "TransferActiveQueueProcessor"},

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -113,10 +113,6 @@ var (
 	frontendServiceRetryPolicy = common.CreateFrontendServiceRetryPolicy()
 )
 
-const (
-	getHistoryWarnSizeLimit = 500 * 1024 // Warn when size goes over 500KB
-)
-
 // NewWorkflowHandler creates a thrift handler for the cadence service
 func NewWorkflowHandler(sVice service.Service, config *Config, metadataMgr persistence.MetadataManager,
 	historyMgr persistence.HistoryManager, historyV2Mgr persistence.HistoryV2Manager, visibilityMgr persistence.VisibilityManager,
@@ -2309,7 +2305,7 @@ func (wh *WorkflowHandler) getHistory(scope int, domainID string, execution gen.
 	if len(historyEvents) > 0 {
 		wh.metricsClient.RecordTimer(scope, metrics.HistorySize, time.Duration(size))
 
-		if size > getHistoryWarnSizeLimit {
+		if size > common.GetHistoryWarnSizeLimit {
 			wh.GetLogger().WithFields(bark.Fields{
 				logging.TagWorkflowExecutionID: execution.GetWorkflowId(),
 				logging.TagWorkflowRunID:       execution.GetRunId(),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -328,7 +328,7 @@ pollLoop:
 
 		// Generate a unique requestId for this task which will be used for all retries
 		requestID := uuid.New()
-		resp, err := tCtx.RecordDecisionTaskStartedWithRetry(&h.RecordDecisionTaskStartedRequest{
+		resp, err := tCtx.RecordDecisionTaskStartedWithRetry(ctx, &h.RecordDecisionTaskStartedRequest{
 			DomainUUID:        common.StringPtr(domainID),
 			WorkflowExecution: &tCtx.workflowExecution,
 			ScheduleId:        &tCtx.info.ScheduleID,
@@ -390,7 +390,7 @@ pollLoop:
 		}
 		// Generate a unique requestId for this task which will be used for all retries
 		requestID := uuid.New()
-		resp, err := tCtx.RecordActivityTaskStartedWithRetry(&h.RecordActivityTaskStartedRequest{
+		resp, err := tCtx.RecordActivityTaskStartedWithRetry(ctx, &h.RecordActivityTaskStartedRequest{
 			DomainUUID:        common.StringPtr(domainID),
 			WorkflowExecution: &tCtx.workflowExecution,
 			ScheduleId:        &tCtx.info.ScheduleID,

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -228,7 +228,7 @@ func (s *matchingEngineSuite) PollForDecisionTasksResultTest() {
 	scheduleID := int64(0)
 
 	// History service is using mock
-	s.historyClient.On("RecordDecisionTaskStarted", nil,
+	s.historyClient.On("RecordDecisionTaskStarted", mock.Anything,
 		mock.AnythingOfType("*history.RecordDecisionTaskStartedRequest")).Return(
 		func(ctx context.Context, taskRequest *gohistory.RecordDecisionTaskStartedRequest) *gohistory.RecordDecisionTaskStartedResponse {
 			s.logger.Debug("Mock Received RecordDecisionTaskStartedRequest")
@@ -489,7 +489,7 @@ func (s *matchingEngineSuite) TestAddThenConsumeActivities() {
 	identity := "nobody"
 
 	// History service is using mock
-	s.historyClient.On("RecordActivityTaskStarted", nil,
+	s.historyClient.On("RecordActivityTaskStarted", mock.Anything,
 		mock.AnythingOfType("*history.RecordActivityTaskStartedRequest")).Return(
 		func(ctx context.Context, taskRequest *gohistory.RecordActivityTaskStartedRequest) *gohistory.RecordActivityTaskStartedResponse {
 			s.logger.Debug("Mock Received RecordActivityTaskStartedRequest")
@@ -599,7 +599,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 	identity := "nobody"
 
 	// History service is using mock
-	s.historyClient.On("RecordActivityTaskStarted", nil,
+	s.historyClient.On("RecordActivityTaskStarted", mock.Anything,
 		mock.AnythingOfType("*history.RecordActivityTaskStartedRequest")).Return(
 		func(ctx context.Context, taskRequest *gohistory.RecordActivityTaskStartedRequest) *gohistory.RecordActivityTaskStartedResponse {
 			s.logger.Debug("Mock Received RecordActivityTaskStartedRequest")
@@ -781,7 +781,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	identity := "nobody"
 
 	// History service is using mock
-	s.historyClient.On("RecordActivityTaskStarted", nil,
+	s.historyClient.On("RecordActivityTaskStarted", mock.Anything,
 		mock.AnythingOfType("*history.RecordActivityTaskStartedRequest")).Return(
 		func(ctx context.Context, taskRequest *gohistory.RecordActivityTaskStartedRequest) *gohistory.RecordActivityTaskStartedResponse {
 			s.logger.Debug("Mock Received RecordActivityTaskStartedRequest")
@@ -905,7 +905,7 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeDecisions() {
 	identity := "nobody"
 
 	// History service is using mock
-	s.historyClient.On("RecordDecisionTaskStarted", nil,
+	s.historyClient.On("RecordDecisionTaskStarted", mock.Anything,
 		mock.AnythingOfType("*history.RecordDecisionTaskStartedRequest")).Return(
 		func(ctx context.Context, taskRequest *gohistory.RecordDecisionTaskStartedRequest) *gohistory.RecordDecisionTaskStartedResponse {
 			s.logger.Debug("Mock Received RecordDecisionTaskStartedRequest")
@@ -1217,7 +1217,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesDecisionsRangeStealing() {
 	startedTasks := make(map[int64]bool)
 
 	// History service is using mock
-	s.historyClient.On("RecordDecisionTaskStarted", nil,
+	s.historyClient.On("RecordDecisionTaskStarted", mock.Anything,
 		mock.AnythingOfType("*history.RecordDecisionTaskStartedRequest")).Return(
 		func(ctx context.Context, taskRequest *gohistory.RecordDecisionTaskStartedRequest) *gohistory.RecordDecisionTaskStartedResponse {
 			if _, ok := startedTasks[*taskRequest.TaskId]; ok {
@@ -1408,7 +1408,7 @@ func (s *matchingEngineSuite) TestTaskListManagerGetTaskBatch() {
 	identity := "nobody"
 
 	// History service is using mock
-	s.historyClient.On("RecordActivityTaskStarted", nil,
+	s.historyClient.On("RecordActivityTaskStarted", mock.Anything,
 		mock.AnythingOfType("*history.RecordActivityTaskStartedRequest")).Return(
 		func(ctx context.Context, taskRequest *gohistory.RecordActivityTaskStartedRequest) *gohistory.RecordActivityTaskStartedResponse {
 			s.logger.Debug("Mock Received RecordActivityTaskStartedRequest")

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -893,11 +893,11 @@ func (c *taskListManagerImpl) signalNewTask() {
 	}
 }
 
-func (c *taskContext) RecordDecisionTaskStartedWithRetry(
+func (c *taskContext) RecordDecisionTaskStartedWithRetry(ctx context.Context,
 	request *h.RecordDecisionTaskStartedRequest) (resp *h.RecordDecisionTaskStartedResponse, err error) {
 	op := func() error {
 		var err error
-		resp, err = c.tlMgr.engine.historyService.RecordDecisionTaskStarted(nil, request)
+		resp, err = c.tlMgr.engine.historyService.RecordDecisionTaskStarted(ctx, request)
 		return err
 	}
 	err = backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {
@@ -910,11 +910,11 @@ func (c *taskContext) RecordDecisionTaskStartedWithRetry(
 	return
 }
 
-func (c *taskContext) RecordActivityTaskStartedWithRetry(
+func (c *taskContext) RecordActivityTaskStartedWithRetry(ctx context.Context,
 	request *h.RecordActivityTaskStartedRequest) (resp *h.RecordActivityTaskStartedResponse, err error) {
 	op := func() error {
 		var err error
-		resp, err = c.tlMgr.engine.historyService.RecordActivityTaskStarted(nil, request)
+		resp, err = c.tlMgr.engine.historyService.RecordActivityTaskStarted(ctx, request)
 		return err
 	}
 	err = backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {


### PR DESCRIPTION
Include timeout on various history service API calls from matching
engine.

Emit size metric from replicator before sending message to kafka.

Standardized logging and metric from history service handler.