### PR TITLE
Remove  historyBranches Map for using eventsV2

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -92,9 +92,8 @@ const (
 )
 
 const (
-	taskListTaskID      = -12345
-	initialRangeID      = 1 // Id of the first range of a new task list
-	initialResetVersion = 0
+	taskListTaskID = -12345
+	initialRangeID = 1 // Id of the first range of a new task list
 )
 
 const (
@@ -1301,16 +1300,6 @@ func (d *cassandraPersistence) CreateWorkflowExecutionWithinBatch(request *p.Cre
 		d.logger.Panic(fmt.Sprintf("Unknown CreateWorkflowMode: %v", request.CreateWorkflowMode))
 	}
 
-	historyBranches := map[int32]map[string]interface{}{}
-	if request.EventStoreVersion == p.EventStoreVersionV2 {
-		firstBranch := map[string]interface{}{}
-		firstBranch["branch_token"] = request.BranchToken
-		firstBranch["next_event_id"] = request.NextEventID
-		firstBranch["last_first_event_id"] = common.FirstEventID
-		firstBranch["history_size"] = request.HistorySize
-		historyBranches[initialResetVersion] = firstBranch
-	}
-
 	if request.ReplicationState == nil {
 		// Cross DC feature is currently disabled so we will be creating workflow executions without replication state
 		batch.Query(templateCreateWorkflowExecutionQuery,
@@ -1366,8 +1355,7 @@ func (d *cassandraPersistence) CreateWorkflowExecutionWithinBatch(request *p.Cre
 			request.MaximumAttempts,
 			request.NonRetriableErrors,
 			request.EventStoreVersion,
-			initialResetVersion,
-			historyBranches,
+			request.BranchToken,
 			request.NextEventID,
 			defaultVisibilityTimestamp,
 			rowTypeExecutionTaskID)
@@ -1430,8 +1418,7 @@ func (d *cassandraPersistence) CreateWorkflowExecutionWithinBatch(request *p.Cre
 			request.MaximumAttempts,
 			request.NonRetriableErrors,
 			request.EventStoreVersion,
-			initialResetVersion,
-			historyBranches,
+			request.BranchToken,
 			request.ReplicationState.CurrentVersion,
 			request.ReplicationState.StartVersion,
 			request.ReplicationState.LastWriteVersion,

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -256,17 +256,8 @@ type (
 		MaximumAttempts    int32
 		NonRetriableErrors []string
 		// events V2 related
-		EventStoreVersion   int32
-		CurrentResetVersion int32
-		HistoryBranches     map[int32]*HistoryBranch // map from each resetVersion to the associated branch, resetVersion increase from 0
-	}
-
-	// HistoryBranch represents a history branch
-	HistoryBranch struct {
-		BranchToken      []byte
-		NextEventID      int64
-		HistorySize      int64
-		LastFirstEventID int64
+		EventStoreVersion int32
+		BranchToken       []byte
 	}
 
 	// ReplicationState represents mutable state information for global domains.
@@ -2001,51 +1992,31 @@ func UnixNanoToDBTimestamp(timestamp int64) int64 {
 // SetHistorySize set the historySize
 func (e *WorkflowExecutionInfo) SetHistorySize(size int64) {
 	e.HistorySize = size
-	if e.EventStoreVersion == EventStoreVersionV2 {
-		e.HistoryBranches[e.CurrentResetVersion].HistorySize = size
-	}
 }
 
 // IncreaseHistorySize increase historySize by delta
 func (e *WorkflowExecutionInfo) IncreaseHistorySize(delta int64) {
 	e.HistorySize += delta
-	if e.EventStoreVersion == EventStoreVersionV2 {
-		e.HistoryBranches[e.CurrentResetVersion].HistorySize += delta
-	}
 }
 
 // SetNextEventID sets the nextEventID
 func (e *WorkflowExecutionInfo) SetNextEventID(id int64) {
 	e.NextEventID = id
-	if e.EventStoreVersion == EventStoreVersionV2 {
-		e.HistoryBranches[e.CurrentResetVersion].NextEventID = id
-	}
 }
 
 // IncreaseNextEventID increase the nextEventID by 1
 func (e *WorkflowExecutionInfo) IncreaseNextEventID() {
 	e.NextEventID++
-	if e.EventStoreVersion == EventStoreVersionV2 {
-		e.HistoryBranches[e.CurrentResetVersion].NextEventID++
-	}
 }
 
 // SetLastFirstEventID set the LastFirstEventID
 func (e *WorkflowExecutionInfo) SetLastFirstEventID(id int64) {
 	e.LastFirstEventID = id
-	if e.EventStoreVersion == EventStoreVersionV2 {
-		e.HistoryBranches[e.CurrentResetVersion].LastFirstEventID = id
-	}
 }
 
 // GetCurrentBranch return the current branch token
 func (e *WorkflowExecutionInfo) GetCurrentBranch() []byte {
-	idx := e.CurrentResetVersion
-	br, ok := e.HistoryBranches[idx]
-	if ok {
-		return br.BranchToken
-	}
-	return nil
+	return e.BranchToken
 }
 
 var internalThriftEncoder = codec.NewThriftRWEncoder()

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -21,8 +21,6 @@
 package persistence
 
 import (
-	"fmt"
-
 	"github.com/uber-common/bark"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
@@ -106,24 +104,6 @@ func (m *executionManagerImpl) DeserializeExecutionInfo(info *InternalWorkflowEx
 		return nil, err
 	}
 
-	if info.EventStoreVersion == EventStoreVersionV2 {
-		if info.HistorySize != info.HistoryBranches[info.CurrentResetVersion].HistorySize {
-			return nil, &workflow.InternalServiceError{
-				Message: fmt.Sprintf("HistorySizes of V1/V2 don't match"),
-			}
-		}
-		if info.LastFirstEventID != info.HistoryBranches[info.CurrentResetVersion].LastFirstEventID {
-			return nil, &workflow.InternalServiceError{
-				Message: fmt.Sprintf("LastFirstEventIDs of V1/V2 don't match"),
-			}
-		}
-		if info.NextEventID != info.HistoryBranches[info.CurrentResetVersion].NextEventID {
-			return nil, &workflow.InternalServiceError{
-				Message: fmt.Sprintf("NextEventIDs of V1/V2 don't match"),
-			}
-		}
-	}
-
 	newInfo := &WorkflowExecutionInfo{
 		CompletionEvent: completionEvent,
 
@@ -172,8 +152,7 @@ func (m *executionManagerImpl) DeserializeExecutionInfo(info *InternalWorkflowEx
 		MaximumAttempts:              info.MaximumAttempts,
 		NonRetriableErrors:           info.NonRetriableErrors,
 		EventStoreVersion:            info.EventStoreVersion,
-		CurrentResetVersion:          info.CurrentResetVersion,
-		HistoryBranches:              info.HistoryBranches,
+		BranchToken:                  info.BranchToken,
 	}
 	return newInfo, nil
 }
@@ -466,24 +445,6 @@ func (m *executionManagerImpl) SerializeExecutionInfo(info *WorkflowExecutionInf
 		return nil, err
 	}
 
-	if info.EventStoreVersion == EventStoreVersionV2 {
-		if info.HistorySize != info.HistoryBranches[info.CurrentResetVersion].HistorySize {
-			return nil, &workflow.BadRequestError{
-				Message: fmt.Sprintf("HistorySizes of V1/V2 don't match"),
-			}
-		}
-		if info.LastFirstEventID != info.HistoryBranches[info.CurrentResetVersion].LastFirstEventID {
-			return nil, &workflow.BadRequestError{
-				Message: fmt.Sprintf("LastFirstEventIDs of V1/V2 don't match"),
-			}
-		}
-		if info.NextEventID != info.HistoryBranches[info.CurrentResetVersion].NextEventID {
-			return nil, &workflow.BadRequestError{
-				Message: fmt.Sprintf("NextEventIDs of V1/V2 don't match"),
-			}
-		}
-	}
-
 	return &InternalWorkflowExecutionInfo{
 		DomainID:                     info.DomainID,
 		WorkflowID:                   info.WorkflowID,
@@ -531,8 +492,7 @@ func (m *executionManagerImpl) SerializeExecutionInfo(info *WorkflowExecutionInf
 		MaximumAttempts:              info.MaximumAttempts,
 		NonRetriableErrors:           info.NonRetriableErrors,
 		EventStoreVersion:            info.EventStoreVersion,
-		CurrentResetVersion:          info.CurrentResetVersion,
-		HistoryBranches:              info.HistoryBranches,
+		BranchToken:                  info.BranchToken,
 	}, nil
 }
 

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -3202,8 +3202,7 @@ func copyWorkflowExecutionInfo(sourceInfo *p.WorkflowExecutionInfo) *p.WorkflowE
 		DecisionRequestID:    sourceInfo.DecisionRequestID,
 		DecisionTimeout:      sourceInfo.DecisionTimeout,
 		EventStoreVersion:    sourceInfo.EventStoreVersion,
-		CurrentResetVersion:  sourceInfo.CurrentResetVersion,
-		HistoryBranches:      sourceInfo.HistoryBranches,
+		BranchToken:          sourceInfo.BranchToken,
 	}
 }
 

--- a/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
+++ b/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
@@ -107,11 +107,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowCreation() {
 	info0 := state0.ExecutionInfo
 	s.NotNil(info0, "Valid Workflow info expected.")
 	s.Equal(int32(p.EventStoreVersionV2), info0.EventStoreVersion)
-	s.Equal([]byte("branchToken1"), info0.HistoryBranches[0].BranchToken)
-	s.Equal(info0.HistorySize, info0.HistoryBranches[0].HistorySize)
-	s.Equal(info0.LastFirstEventID, info0.HistoryBranches[0].LastFirstEventID)
-	s.Equal(info0.NextEventID, info0.HistoryBranches[0].NextEventID)
-	s.Equal(int64(3), info0.HistoryBranches[0].NextEventID)
+	s.Equal([]byte("branchToken1"), info0.BranchToken)
 
 	updatedInfo := copyWorkflowExecutionInfo(info0)
 	updatedInfo.NextEventID = int64(5)
@@ -125,13 +121,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowCreation() {
 		TaskID:     2,
 		StartedID:  5,
 	}}
-	updatedInfo.CurrentResetVersion = 1
-	updatedInfo.HistoryBranches[1] = &p.HistoryBranch{
-		BranchToken:      []byte("branchToken2"),
-		NextEventID:      updatedInfo.NextEventID,
-		HistorySize:      updatedInfo.HistorySize,
-		LastFirstEventID: updatedInfo.LastFirstEventID,
-	}
+	updatedInfo.BranchToken = []byte("branchToken2")
 
 	err2 := s.UpdateWorkflowExecution(updatedInfo, []int64{int64(4)}, nil, int64(3), nil, nil, nil, nil, timerInfos, nil)
 	s.NoError(err2)
@@ -155,13 +145,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowCreation() {
 	s.Equal(0, len(state.TimerInfos))
 	info1 := state.ExecutionInfo
 	s.Equal(int32(p.EventStoreVersionV2), info1.EventStoreVersion)
-	s.Equal(int32(1), info1.CurrentResetVersion)
-	currBr := info1.HistoryBranches[1]
-	s.Equal([]byte("branchToken2"), currBr.BranchToken)
-	s.Equal(info1.HistorySize, currBr.HistorySize)
-	s.Equal(info1.LastFirstEventID, currBr.LastFirstEventID)
-	s.Equal(info1.NextEventID, currBr.NextEventID)
-	s.Equal(int64(5), currBr.NextEventID)
+	s.Equal([]byte("branchToken2"), info1.BranchToken)
 }
 
 //TestContinueAsNew test
@@ -248,9 +232,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestContinueAsNew() {
 	s.Equal(common.EmptyEventID, newExecutionInfo.LastProcessedEvent)
 	s.Equal(int64(2), newExecutionInfo.DecisionScheduleID)
 	s.Equal(int32(p.EventStoreVersionV2), newExecutionInfo.EventStoreVersion)
-	s.Equal(int32(0), newExecutionInfo.CurrentResetVersion)
-	s.Equal(newExecutionInfo.NextEventID, newExecutionInfo.HistoryBranches[0].NextEventID)
-	s.Equal([]byte("branchToken1"), newExecutionInfo.HistoryBranches[0].BranchToken)
+	s.Equal([]byte("branchToken1"), newExecutionInfo.BranchToken)
 
 	newRunID, err5 := s.GetCurrentWorkflowRunID(domainID, *workflowExecution.WorkflowId)
 	s.NoError(err5)
@@ -359,8 +341,6 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 	s.Equal(int64(0), info0.LastProcessedEvent)
 	s.Equal(int64(2), info0.DecisionScheduleID)
 	s.Equal(int32(p.EventStoreVersionV2), info0.EventStoreVersion)
-	s.Equal(int32(0), info0.CurrentResetVersion)
-	s.Equal(info0.NextEventID, info0.HistoryBranches[0].NextEventID)
 	s.Equal(int64(9), replicationState0.CurrentVersion)
 	s.Equal(int64(8), replicationState0.StartVersion)
 	s.Equal(int64(7), replicationState0.LastWriteVersion)
@@ -383,13 +363,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 	updatedInfo := copyWorkflowExecutionInfo(info0)
 	updatedInfo.NextEventID = int64(5)
 	updatedInfo.LastProcessedEvent = int64(2)
-	updatedInfo.CurrentResetVersion = 1
-	updatedInfo.HistoryBranches[1] = &p.HistoryBranch{
-		BranchToken:      []byte("branchToken3"),
-		NextEventID:      updatedInfo.NextEventID,
-		HistorySize:      updatedInfo.HistorySize,
-		LastFirstEventID: updatedInfo.LastFirstEventID,
-	}
+	updatedInfo.BranchToken = []byte("branchToken3")
 
 	updatedReplicationState := copyReplicationState(replicationState0)
 	updatedReplicationState.CurrentVersion = int64(10)
@@ -465,9 +439,7 @@ func (s *ExecutionManagerSuiteForEventsV2) TestWorkflowWithReplicationState() {
 	s.Equal(int32(20), info1.WorkflowTimeout)
 	s.Equal(int32(13), info1.DecisionTimeoutValue)
 	s.Equal(int64(5), info1.NextEventID)
-	s.Equal(int32(1), info1.CurrentResetVersion)
-	s.Equal(info1.NextEventID, info1.HistoryBranches[1].NextEventID)
-	s.Equal([]byte("branchToken3"), info1.HistoryBranches[1].BranchToken)
+	s.Equal([]byte("branchToken3"), info1.BranchToken)
 	s.Equal(int64(2), info1.LastProcessedEvent)
 	s.Equal(int64(2), info1.DecisionScheduleID)
 	s.Equal(int64(10), replicationState1.CurrentVersion)

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -167,9 +167,8 @@ type (
 		MaximumAttempts    int32
 		NonRetriableErrors []string
 		// events V2 related
-		EventStoreVersion   int32
-		CurrentResetVersion int32
-		HistoryBranches     map[int32]*HistoryBranch // map from each resetVersion to the associated branch
+		EventStoreVersion int32
+		BranchToken       []byte
 	}
 
 	// InternalWorkflowMutableState indicates workflow related state for Persistence Interface

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -17,14 +17,6 @@ CREATE TYPE shard (
   domain_notification_version bigint, -- the global domain change version this shard is aware of
 );
 
--- History branch information
-CREATE TYPE history_branch_info (
-  branch_token                     blob,
-  next_event_id                    bigint,
-  last_first_event_id              bigint,
-  history_size                     bigint,
-);
-
 --- Workflow execution and mutable state ---
 CREATE TYPE workflow_execution (
   domain_id                        uuid,
@@ -70,12 +62,11 @@ CREATE TYPE workflow_execution (
   max_attempts                     int,    -- max number of attempts including initial non-retry attempt
   non_retriable_errors             list<text>,
   event_store_version              int, -- to indicates which version of events persistence is using
-  current_reset_version            int, -- works with eventsV2
   signal_count                     int,
-  history_branches                 frozen<map<int, history_branch_info>>, -- map from reset_version to the associated branch infomation
-  history_size                     bigint, --deprecated in eventsV2 in favor of history_branch_info
-  last_first_event_id              bigint, --deprecated in eventsV2 in favor of history_branch_info
-  next_event_id                    bigint, --deprecated in eventsV2 in favor of history_branch_info
+  branch_token                     blob,
+  history_size                     bigint,
+  last_first_event_id              bigint,
+  next_event_id                    bigint,
 );
 
 -- Replication information for each cluster

--- a/schema/cassandra/cadence/versioned/v0.12/events_v2.cql
+++ b/schema/cassandra/cadence/versioned/v0.12/events_v2.cql
@@ -26,17 +26,9 @@ CREATE TABLE history_tree (
   'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
 };
 
-CREATE TYPE history_branch_info (
-  branch_token                     blob,
-  next_event_id                    bigint,
-  last_first_event_id              bigint,
-  history_size                     bigint,
-);
-
 --- using eventsV2
 ALTER TYPE workflow_execution ADD  event_store_version           int;
-ALTER TYPE workflow_execution ADD  current_reset_version         int;
-ALTER TYPE workflow_execution ADD  history_branches              frozen<map<int, history_branch_info>>;
+ALTER TYPE workflow_execution ADD  branch_token                  blob;
 ALTER TYPE replication_task ADD  event_store_version             int;
 ALTER TYPE replication_task ADD  branch_token                    blob;
 ALTER TYPE replication_task ADD  new_run_event_store_version     int;

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -677,10 +677,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedConflictOnUpdate() {
 	decisions := []*workflow.Decision{{
 		DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 		ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-			ActivityId:   common.StringPtr(activity3ID),
-			ActivityType: &workflow.ActivityType{Name: common.StringPtr(activity3Type)},
-			TaskList:     &workflow.TaskList{Name: &tl},
-			Input:        activity3Input,
+			ActivityId:                    common.StringPtr(activity3ID),
+			ActivityType:                  &workflow.ActivityType{Name: common.StringPtr(activity3Type)},
+			TaskList:                      &workflow.TaskList{Name: &tl},
+			Input:                         activity3Input,
 			ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(10),
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
@@ -775,10 +775,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedMaxAttemptsExceeded() {
 	decisions := []*workflow.Decision{{
 		DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 		ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-			ActivityId:   common.StringPtr("activity1"),
-			ActivityType: &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
-			TaskList:     &workflow.TaskList{Name: &tl},
-			Input:        input,
+			ActivityId:                    common.StringPtr("activity1"),
+			ActivityType:                  &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
+			TaskList:                      &workflow.TaskList{Name: &tl},
+			Input:                         input,
 			ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(10),
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
@@ -1167,10 +1167,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledAtt
 		decisions := []*workflow.Decision{{
 			DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 			ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-				ActivityId:   common.StringPtr("activity1"),
-				ActivityType: &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
-				TaskList:     &workflow.TaskList{Name: &tl},
-				Input:        input,
+				ActivityId:                    common.StringPtr("activity1"),
+				ActivityType:                  &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
+				TaskList:                      &workflow.TaskList{Name: &tl},
+				Input:                         input,
 				ScheduleToCloseTimeoutSeconds: iVar.scheduleToClose,
 				ScheduleToStartTimeoutSeconds: iVar.scheduleToStart,
 				StartToCloseTimeoutSeconds:    iVar.startToClose,
@@ -1251,10 +1251,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledDec
 	decisions := []*workflow.Decision{{
 		DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 		ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-			ActivityId:   common.StringPtr("activity1"),
-			ActivityType: &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
-			TaskList:     &workflow.TaskList{Name: &tl},
-			Input:        input,
+			ActivityId:                    common.StringPtr("activity1"),
+			ActivityType:                  &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
+			TaskList:                      &workflow.TaskList{Name: &tl},
+			Input:                         input,
 			ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(10),
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
@@ -4452,10 +4452,10 @@ func addWorkflowExecutionStartedEventWithParent(builder mutableState, workflowEx
 	parentInfo *history.ParentExecutionInfo, identity string) *workflow.HistoryEvent {
 	domainID := validDomainID
 	startRequest := &workflow.StartWorkflowExecutionRequest{
-		WorkflowId:   common.StringPtr(*workflowExecution.WorkflowId),
-		WorkflowType: &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
-		TaskList:     &workflow.TaskList{Name: common.StringPtr(taskList)},
-		Input:        input,
+		WorkflowId:                          common.StringPtr(*workflowExecution.WorkflowId),
+		WorkflowType:                        &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
+		TaskList:                            &workflow.TaskList{Name: common.StringPtr(taskList)},
+		Input:                               input,
 		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(executionStartToCloseTimeout),
 		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(taskStartToCloseTimeout),
 		Identity:                            common.StringPtr(identity),
@@ -4512,10 +4512,10 @@ func addActivityTaskScheduledEvent(builder mutableState, decisionCompletedID int
 	taskList string, input []byte, timeout, queueTimeout, heartbeatTimeout int32) (*workflow.HistoryEvent,
 	*persistence.ActivityInfo) {
 	return builder.AddActivityTaskScheduledEvent(decisionCompletedID, &workflow.ScheduleActivityTaskDecisionAttributes{
-		ActivityId:   common.StringPtr(activityID),
-		ActivityType: &workflow.ActivityType{Name: common.StringPtr(activityType)},
-		TaskList:     &workflow.TaskList{Name: common.StringPtr(taskList)},
-		Input:        input,
+		ActivityId:                    common.StringPtr(activityID),
+		ActivityType:                  &workflow.ActivityType{Name: common.StringPtr(activityType)},
+		TaskList:                      &workflow.TaskList{Name: common.StringPtr(taskList)},
+		Input:                         input,
 		ScheduleToCloseTimeoutSeconds: common.Int32Ptr(timeout),
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(queueTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
@@ -4608,11 +4608,11 @@ func addStartChildWorkflowExecutionInitiatedEvent(builder mutableState, decision
 	*persistence.ChildExecutionInfo) {
 	return builder.AddStartChildWorkflowExecutionInitiatedEvent(decisionCompletedID, createRequestID,
 		&workflow.StartChildWorkflowExecutionDecisionAttributes{
-			Domain:       common.StringPtr(domain),
-			WorkflowId:   common.StringPtr(workflowID),
-			WorkflowType: &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
-			TaskList:     &workflow.TaskList{Name: common.StringPtr(tasklist)},
-			Input:        input,
+			Domain:                              common.StringPtr(domain),
+			WorkflowId:                          common.StringPtr(workflowID),
+			WorkflowType:                        &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
+			TaskList:                            &workflow.TaskList{Name: common.StringPtr(tasklist)},
+			Input:                               input,
 			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(executionStartToCloseTimeout),
 			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(taskStartToCloseTimeout),
 			ChildPolicy:                         common.ChildPolicyPtr(workflow.ChildPolicyTerminate),

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -677,10 +677,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedConflictOnUpdate() {
 	decisions := []*workflow.Decision{{
 		DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 		ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-			ActivityId:                    common.StringPtr(activity3ID),
-			ActivityType:                  &workflow.ActivityType{Name: common.StringPtr(activity3Type)},
-			TaskList:                      &workflow.TaskList{Name: &tl},
-			Input:                         activity3Input,
+			ActivityId:   common.StringPtr(activity3ID),
+			ActivityType: &workflow.ActivityType{Name: common.StringPtr(activity3Type)},
+			TaskList:     &workflow.TaskList{Name: &tl},
+			Input:        activity3Input,
 			ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(10),
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
@@ -775,10 +775,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedMaxAttemptsExceeded() {
 	decisions := []*workflow.Decision{{
 		DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 		ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-			ActivityId:                    common.StringPtr("activity1"),
-			ActivityType:                  &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
-			TaskList:                      &workflow.TaskList{Name: &tl},
-			Input:                         input,
+			ActivityId:   common.StringPtr("activity1"),
+			ActivityType: &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
+			TaskList:     &workflow.TaskList{Name: &tl},
+			Input:        input,
 			ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(10),
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
@@ -1167,10 +1167,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledAtt
 		decisions := []*workflow.Decision{{
 			DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 			ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-				ActivityId:                    common.StringPtr("activity1"),
-				ActivityType:                  &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
-				TaskList:                      &workflow.TaskList{Name: &tl},
-				Input:                         input,
+				ActivityId:   common.StringPtr("activity1"),
+				ActivityType: &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
+				TaskList:     &workflow.TaskList{Name: &tl},
+				Input:        input,
 				ScheduleToCloseTimeoutSeconds: iVar.scheduleToClose,
 				ScheduleToStartTimeoutSeconds: iVar.scheduleToStart,
 				StartToCloseTimeoutSeconds:    iVar.startToClose,
@@ -1251,10 +1251,10 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedSingleActivityScheduledDec
 	decisions := []*workflow.Decision{{
 		DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
 		ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
-			ActivityId:                    common.StringPtr("activity1"),
-			ActivityType:                  &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
-			TaskList:                      &workflow.TaskList{Name: &tl},
-			Input:                         input,
+			ActivityId:   common.StringPtr("activity1"),
+			ActivityType: &workflow.ActivityType{Name: common.StringPtr("activity_type1")},
+			TaskList:     &workflow.TaskList{Name: &tl},
+			Input:        input,
 			ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(10),
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
@@ -4452,10 +4452,10 @@ func addWorkflowExecutionStartedEventWithParent(builder mutableState, workflowEx
 	parentInfo *history.ParentExecutionInfo, identity string) *workflow.HistoryEvent {
 	domainID := validDomainID
 	startRequest := &workflow.StartWorkflowExecutionRequest{
-		WorkflowId:                          common.StringPtr(*workflowExecution.WorkflowId),
-		WorkflowType:                        &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
-		TaskList:                            &workflow.TaskList{Name: common.StringPtr(taskList)},
-		Input:                               input,
+		WorkflowId:   common.StringPtr(*workflowExecution.WorkflowId),
+		WorkflowType: &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
+		TaskList:     &workflow.TaskList{Name: common.StringPtr(taskList)},
+		Input:        input,
 		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(executionStartToCloseTimeout),
 		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(taskStartToCloseTimeout),
 		Identity:                            common.StringPtr(identity),
@@ -4512,10 +4512,10 @@ func addActivityTaskScheduledEvent(builder mutableState, decisionCompletedID int
 	taskList string, input []byte, timeout, queueTimeout, heartbeatTimeout int32) (*workflow.HistoryEvent,
 	*persistence.ActivityInfo) {
 	return builder.AddActivityTaskScheduledEvent(decisionCompletedID, &workflow.ScheduleActivityTaskDecisionAttributes{
-		ActivityId:                    common.StringPtr(activityID),
-		ActivityType:                  &workflow.ActivityType{Name: common.StringPtr(activityType)},
-		TaskList:                      &workflow.TaskList{Name: common.StringPtr(taskList)},
-		Input:                         input,
+		ActivityId:   common.StringPtr(activityID),
+		ActivityType: &workflow.ActivityType{Name: common.StringPtr(activityType)},
+		TaskList:     &workflow.TaskList{Name: common.StringPtr(taskList)},
+		Input:        input,
 		ScheduleToCloseTimeoutSeconds: common.Int32Ptr(timeout),
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(queueTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
@@ -4608,11 +4608,11 @@ func addStartChildWorkflowExecutionInitiatedEvent(builder mutableState, decision
 	*persistence.ChildExecutionInfo) {
 	return builder.AddStartChildWorkflowExecutionInitiatedEvent(decisionCompletedID, createRequestID,
 		&workflow.StartChildWorkflowExecutionDecisionAttributes{
-			Domain:                              common.StringPtr(domain),
-			WorkflowId:                          common.StringPtr(workflowID),
-			WorkflowType:                        &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
-			TaskList:                            &workflow.TaskList{Name: common.StringPtr(tasklist)},
-			Input:                               input,
+			Domain:       common.StringPtr(domain),
+			WorkflowId:   common.StringPtr(workflowID),
+			WorkflowType: &workflow.WorkflowType{Name: common.StringPtr(workflowType)},
+			TaskList:     &workflow.TaskList{Name: common.StringPtr(tasklist)},
+			Input:        input,
 			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(executionStartToCloseTimeout),
 			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(taskStartToCloseTimeout),
 			ChildPolicy:                         common.ChildPolicyPtr(workflow.ChildPolicyTerminate),
@@ -4728,8 +4728,7 @@ func copyWorkflowExecutionInfo(sourceInfo *persistence.WorkflowExecutionInfo) *p
 		DecisionRequestID:            sourceInfo.DecisionRequestID,
 		DecisionTimeout:              sourceInfo.DecisionTimeout,
 		EventStoreVersion:            sourceInfo.EventStoreVersion,
-		CurrentResetVersion:          sourceInfo.CurrentResetVersion,
-		HistoryBranches:              sourceInfo.HistoryBranches,
+		BranchToken:                  sourceInfo.BranchToken,
 	}
 }
 

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -193,14 +193,7 @@ func (e *mutableStateBuilder) SetHistoryTree(treeID string) error {
 	}
 	exeInfo := e.GetExecutionInfo()
 	exeInfo.EventStoreVersion = persistence.EventStoreVersionV2
-	exeInfo.CurrentResetVersion = 0
-	exeInfo.HistoryBranches = map[int32]*persistence.HistoryBranch{}
-	exeInfo.HistoryBranches[exeInfo.CurrentResetVersion] = &persistence.HistoryBranch{
-		BranchToken:      initialBranchToken,
-		NextEventID:      common.FirstEventID,
-		LastFirstEventID: common.FirstEventID,
-		HistorySize:      int64(0),
-	}
+	exeInfo.BranchToken = initialBranchToken
 	return nil
 }
 


### PR DESCRIPTION
Since we decided that reset will always use new runID