### PR TITLE
 Move history events out of mutableState to eventsCache

### DIFF
--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -89,6 +89,7 @@ const (
 	TagValueHistoryBuilderComponent           = "history-builder"
 	TagValueHistoryEngineComponent            = "history-engine"
 	TagValueHistoryCacheComponent             = "history-cache"
+	TagValueEventsCacheComponent              = "events-cache"
 	TagValueTransferQueueComponent            = "transfer-queue-processor"
 	TagValueTimerQueueComponent               = "timer-queue-processor"
 	TagValueReplicatorQueueComponent          = "replicator-queue-processor"

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -69,6 +69,7 @@ const (
 	ShardTagName       = "shard"
 	CadenceRoleTagName = "cadence-role"
 	StatsTypeTagName   = "stats-type"
+	CacheTypeTagName   = "cache-type"
 )
 
 // This package should hold all the metrics and tags for cadence
@@ -84,6 +85,9 @@ const (
 
 	SizeStatsTypeTagValue  = "size"
 	CountStatsTypeTagValue = "count"
+
+	MutableStateCacheTypeTagValue = "mutablestate"
+	EventsCacheTypeTagValue       = "events"
 )
 
 // Common service base metrics
@@ -587,6 +591,14 @@ const (
 	HistoryCacheGetOrCreateScope
 	// HistoryCacheGetCurrentExecutionScope is the scope used by history cache for getting current execution
 	HistoryCacheGetCurrentExecutionScope
+	// EventsCacheGetEventScope is the scope used by events cache
+	EventsCacheGetEventScope
+	// EventsCachePutEventScope is the scope used by events cache
+	EventsCachePutEventScope
+	// EventsCacheDeleteEventScope is the scope used by events cache
+	EventsCacheDeleteEventScope
+	// EventsCacheGetFromStoreScope is the scope used by events cache
+	EventsCacheGetFromStoreScope
 	// ExecutionSizeStatsScope is the scope used for emiting workflow execution size related stats
 	ExecutionSizeStatsScope
 	// ExecutionCountStatsScope is the scope used for emiting workflow execution count related stats
@@ -880,9 +892,13 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ReplicateHistoryEventsScope:                  {operation: "ReplicateHistoryEvents"},
 		ShardInfoScope:                               {operation: "ShardInfo"},
 		WorkflowContextScope:                         {operation: "WorkflowContext"},
-		HistoryCacheGetAndCreateScope:                {operation: "HistoryCacheGetAndCreate"},
-		HistoryCacheGetOrCreateScope:                 {operation: "HistoryCacheGetOrCreate"},
-		HistoryCacheGetCurrentExecutionScope:         {operation: "HistoryCacheGetCurrentExecution"},
+		HistoryCacheGetAndCreateScope:                {operation: "HistoryCacheGetAndCreate", tags: map[string]string{CacheTypeTagName: MutableStateCacheTypeTagValue}},
+		HistoryCacheGetOrCreateScope:                 {operation: "HistoryCacheGetOrCreate", tags: map[string]string{CacheTypeTagName: MutableStateCacheTypeTagValue}},
+		HistoryCacheGetCurrentExecutionScope:         {operation: "HistoryCacheGetCurrentExecution", tags: map[string]string{CacheTypeTagName: MutableStateCacheTypeTagValue}},
+		EventsCacheGetEventScope:                     {operation: "EventsCacheGetEvent", tags: map[string]string{CacheTypeTagName: EventsCacheTypeTagValue}},
+		EventsCachePutEventScope:                     {operation: "EventsCachePutEvent", tags: map[string]string{CacheTypeTagName: EventsCacheTypeTagValue}},
+		EventsCacheDeleteEventScope:                  {operation: "EventsCacheDeleteEvent", tags: map[string]string{CacheTypeTagName: EventsCacheTypeTagValue}},
+		EventsCacheGetFromStoreScope:                 {operation: "EventsCacheGetFromStore", tags: map[string]string{CacheTypeTagName: EventsCacheTypeTagValue}},
 		ExecutionSizeStatsScope:                      {operation: "ExecutionStats", tags: map[string]string{StatsTypeTagName: SizeStatsTypeTagValue}},
 		ExecutionCountStatsScope:                     {operation: "ExecutionStats", tags: map[string]string{StatsTypeTagName: CountStatsTypeTagValue}},
 		SessionSizeStatsScope:                        {operation: "SessionStats", tags: map[string]string{StatsTypeTagName: SizeStatsTypeTagValue}},
@@ -1036,9 +1052,9 @@ const (
 	UnbufferReplicationTaskTimer
 	HistoryConflictsCounter
 	CompleteTaskFailedCounter
-	HistoryCacheRequests
-	HistoryCacheFailures
-	HistoryCacheLatency
+	CacheRequests
+	CacheFailures
+	CacheLatency
 	CacheMissCounter
 	AcquireLockFailedCounter
 	WorkflowContextCleared
@@ -1214,9 +1230,9 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		UnbufferReplicationTaskTimer:                 {metricName: "unbuffer-replication-tasks", metricType: Timer},
 		HistoryConflictsCounter:                      {metricName: "history-conflicts", metricType: Counter},
 		CompleteTaskFailedCounter:                    {metricName: "complete-task-fail-count", metricType: Counter},
-		HistoryCacheRequests:                         {metricName: "history-cache.requests", metricType: Counter},
-		HistoryCacheFailures:                         {metricName: "history-cache.errors", metricType: Counter},
-		HistoryCacheLatency:                          {metricName: "history-cache.latency", metricType: Timer},
+		CacheRequests:                                {metricName: "cache.requests", metricType: Counter},
+		CacheFailures:                                {metricName: "cache.errors", metricType: Counter},
+		CacheLatency:                                 {metricName: "cache.latency", metricType: Timer},
 		CacheMissCounter:                             {metricName: "cache-miss", metricType: Counter},
 		AcquireLockFailedCounter:                     {metricName: "acquire-lock-failed", metricType: Counter},
 		WorkflowContextCleared:                       {metricName: "workflow-context-cleared", metricType: Counter},

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -3230,11 +3230,12 @@ func (d *cassandraPersistence) updateChildExecutionInfos(batch *gocql.Batch, chi
 	deleteInfo *int64, domainID, workflowID, runID string, condition int64, rangeID int64) error {
 
 	for _, c := range childExecutionInfos {
-		encoding := c.InitiatedEvent.GetEncoding()
+		initiatedEventData, encoding := p.FromDataBlob(c.InitiatedEvent)
+
 		var startedEventData []byte
 		if c.StartedEvent != nil {
 			startedEventData = c.StartedEvent.Data
-			if c.StartedEvent.GetEncoding() != encoding {
+			if string(c.StartedEvent.GetEncoding()) != encoding {
 				return p.NewHistorySerializationError(fmt.Sprintf("expect to have the same encoding, but %v != %v", encoding, c.StartedEvent.GetEncoding()))
 			}
 		}
@@ -3242,7 +3243,7 @@ func (d *cassandraPersistence) updateChildExecutionInfos(batch *gocql.Batch, chi
 			c.InitiatedID,
 			c.Version,
 			c.InitiatedID,
-			c.InitiatedEvent.Data,
+			initiatedEventData,
 			c.StartedID,
 			startedEventData,
 			c.CreateRequestID,

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -223,7 +223,7 @@ const (
 	templateActivityInfoType = `{` +
 		`version: ?,` +
 		`schedule_id: ?, ` +
-		`schedule_event_batch_id: ?, ` +
+		`scheduled_event_batch_id: ?, ` +
 		`scheduled_event: ?, ` +
 		`scheduled_time: ?, ` +
 		`started_id: ?, ` +
@@ -3807,7 +3807,7 @@ func createActivityInfo(result map[string]interface{}) *p.InternalActivityInfo {
 			info.Version = v.(int64)
 		case "schedule_id":
 			info.ScheduleID = v.(int64)
-		case "schedule_event_batch_id":
+		case "scheduled_event_batch_id":
 			info.ScheduledEventBatchID = v.(int64)
 		case "scheduled_event":
 			scheduledEventData = v.([]byte)
@@ -3996,7 +3996,7 @@ func resetActivityInfoMap(activityInfos []*p.InternalActivityInfo) (map[int64]ma
 		aInfo := make(map[string]interface{})
 		aInfo["version"] = a.Version
 		aInfo["schedule_id"] = a.ScheduleID
-		aInfo["schedule_event_batch_id"] = a.ScheduledEventBatchID
+		aInfo["scheduled_event_batch_id"] = a.ScheduledEventBatchID
 		aInfo["scheduled_event"] = a.ScheduledEvent.Data
 		aInfo["scheduled_time"] = a.ScheduledTime
 		aInfo["started_id"] = a.StartedID

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -4100,7 +4100,11 @@ func resetChildExecutionInfoMap(childExecutionInfos []*p.InternalChildExecutionI
 		cInfo["create_request_id"] = c.CreateRequestID
 		cInfo["started_id"] = c.StartedID
 		cInfo["started_workflow_id"] = c.StartedWorkflowID
-		cInfo["started_run_id"] = c.StartedRunID
+		startedRunID := emptyRunID
+		if c.StartedRunID != "" {
+			startedRunID = c.StartedRunID
+		}
+		cInfo["started_run_id"] = startedRunID
 		cInfo["domain_name"] = c.DomainName
 		cInfo["workflow_type_name"] = c.WorkflowTypeName
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -222,6 +222,7 @@ type (
 		ParentWorkflowID             string
 		ParentRunID                  string
 		InitiatedID                  int64
+		CompletionEventBatchID       int64
 		CompletionEvent              *workflow.HistoryEvent
 		TaskList                     string
 		WorkflowTypeName             string
@@ -573,12 +574,17 @@ type (
 
 	// ChildExecutionInfo has details for pending child executions.
 	ChildExecutionInfo struct {
-		Version         int64
-		InitiatedID     int64
-		InitiatedEvent  *workflow.HistoryEvent
-		StartedID       int64
-		StartedEvent    *workflow.HistoryEvent
-		CreateRequestID string
+		Version               int64
+		InitiatedID           int64
+		InitiatedEventBatchID int64
+		InitiatedEvent        *workflow.HistoryEvent
+		StartedID             int64
+		StartedWorkflowID     string
+		StartedRunID          string
+		StartedEvent          *workflow.HistoryEvent
+		CreateRequestID       string
+		DomainName            string
+		WorkflowTypeName      string
 	}
 
 	// RequestCancelInfo has details for pending external workflow cancellations

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -529,6 +529,7 @@ type (
 	ActivityInfo struct {
 		Version                  int64
 		ScheduleID               int64
+		ScheduledEventBatchID    int64
 		ScheduledEvent           *workflow.HistoryEvent
 		ScheduledTime            time.Time
 		StartedID                int64

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -239,6 +239,7 @@ func (m *executionManagerImpl) DeserializeActivityInfos(infos map[int64]*Interna
 
 			Version:                        v.Version,
 			ScheduleID:                     v.ScheduleID,
+			ScheduledEventBatchID:          v.ScheduledEventBatchID,
 			ScheduledTime:                  v.ScheduledTime,
 			StartedID:                      v.StartedID,
 			StartedTime:                    v.StartedTime,
@@ -402,6 +403,7 @@ func (m *executionManagerImpl) SerializeUpsertActivityInfos(infos []*ActivityInf
 		i := &InternalActivityInfo{
 			Version:                        v.Version,
 			ScheduleID:                     v.ScheduleID,
+			ScheduledEventBatchID:          v.ScheduledEventBatchID,
 			ScheduledEvent:                 scheduledEvent,
 			ScheduledTime:                  v.ScheduledTime,
 			StartedID:                      v.StartedID,

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -200,7 +200,7 @@ func (m *executionManagerImpl) DeserializeBufferedEvents(blobs []*DataBlob) ([]*
 func (m *executionManagerImpl) DeserializeChildExecutionInfos(infos map[int64]*InternalChildExecutionInfo) (map[int64]*ChildExecutionInfo, error) {
 	newInfos := make(map[int64]*ChildExecutionInfo, 0)
 	for k, v := range infos {
-		initiatedEvent, err := m.serializer.DeserializeEvent(&v.InitiatedEvent)
+		initiatedEvent, err := m.serializer.DeserializeEvent(v.InitiatedEvent)
 		if err != nil {
 			return nil, err
 		}
@@ -366,9 +366,6 @@ func (m *executionManagerImpl) SerializeNewBufferedReplicationTask(task *Buffere
 func (m *executionManagerImpl) SerializeUpsertChildExecutionInfos(infos []*ChildExecutionInfo, encoding common.EncodingType) ([]*InternalChildExecutionInfo, error) {
 	newInfos := make([]*InternalChildExecutionInfo, 0)
 	for _, v := range infos {
-		if v.InitiatedEvent == nil {
-			m.logger.Fatalf("nil InitiatedEvent for %v", v.InitiatedID)
-		}
 		initiatedEvent, err := m.serializer.SerializeEvent(v.InitiatedEvent, encoding)
 		if err != nil {
 			return nil, err
@@ -378,7 +375,7 @@ func (m *executionManagerImpl) SerializeUpsertChildExecutionInfos(infos []*Child
 			return nil, err
 		}
 		i := &InternalChildExecutionInfo{
-			InitiatedEvent: *initiatedEvent,
+			InitiatedEvent: initiatedEvent,
 			StartedEvent:   startedEvent,
 
 			Version:         v.Version,

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -27,7 +27,6 @@ import (
 )
 
 type (
-
 	// executionManagerImpl implements ExecutionManager based on ExecutionStore, statsComputer and HistorySerializer
 	executionManagerImpl struct {
 		serializer    HistorySerializer
@@ -114,6 +113,7 @@ func (m *executionManagerImpl) DeserializeExecutionInfo(info *InternalWorkflowEx
 		ParentWorkflowID:             info.ParentWorkflowID,
 		ParentRunID:                  info.ParentRunID,
 		InitiatedID:                  info.InitiatedID,
+		CompletionEventBatchID:       info.CompletionEventBatchID,
 		TaskList:                     info.TaskList,
 		WorkflowTypeName:             info.WorkflowTypeName,
 		WorkflowTimeout:              info.WorkflowTimeout,
@@ -212,10 +212,15 @@ func (m *executionManagerImpl) DeserializeChildExecutionInfos(infos map[int64]*I
 			InitiatedEvent: initiatedEvent,
 			StartedEvent:   startedEvent,
 
-			Version:         v.Version,
-			InitiatedID:     v.InitiatedID,
-			StartedID:       v.StartedID,
-			CreateRequestID: v.CreateRequestID,
+			Version:               v.Version,
+			InitiatedID:           v.InitiatedID,
+			InitiatedEventBatchID: v.InitiatedEventBatchID,
+			StartedID:             v.StartedID,
+			StartedWorkflowID:     v.StartedWorkflowID,
+			StartedRunID:          v.StartedRunID,
+			CreateRequestID:       v.CreateRequestID,
+			DomainName:            v.DomainName,
+			WorkflowTypeName:      v.WorkflowTypeName,
 		}
 		newInfos[k] = c
 	}
@@ -379,10 +384,15 @@ func (m *executionManagerImpl) SerializeUpsertChildExecutionInfos(infos []*Child
 			InitiatedEvent: initiatedEvent,
 			StartedEvent:   startedEvent,
 
-			Version:         v.Version,
-			InitiatedID:     v.InitiatedID,
-			CreateRequestID: v.CreateRequestID,
-			StartedID:       v.StartedID,
+			Version:               v.Version,
+			InitiatedID:           v.InitiatedID,
+			InitiatedEventBatchID: v.InitiatedEventBatchID,
+			CreateRequestID:       v.CreateRequestID,
+			StartedID:             v.StartedID,
+			StartedWorkflowID:     v.StartedWorkflowID,
+			StartedRunID:          v.StartedRunID,
+			DomainName:            v.DomainName,
+			WorkflowTypeName:      v.WorkflowTypeName,
 		}
 		newInfos = append(newInfos, i)
 	}
@@ -455,6 +465,7 @@ func (m *executionManagerImpl) SerializeExecutionInfo(info *WorkflowExecutionInf
 		ParentWorkflowID:             info.ParentWorkflowID,
 		ParentRunID:                  info.ParentRunID,
 		InitiatedID:                  info.InitiatedID,
+		CompletionEventBatchID:       info.CompletionEventBatchID,
 		CompletionEvent:              completionEvent,
 		TaskList:                     info.TaskList,
 		WorkflowTypeName:             info.WorkflowTypeName,

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -394,9 +394,6 @@ func (m *executionManagerImpl) SerializeUpsertChildExecutionInfos(infos []*Child
 func (m *executionManagerImpl) SerializeUpsertActivityInfos(infos []*ActivityInfo, encoding common.EncodingType) ([]*InternalActivityInfo, error) {
 	newInfos := make([]*InternalActivityInfo, 0)
 	for _, v := range infos {
-		if v.ScheduledEvent == nil {
-			m.logger.Fatal("SerializeUpsertActivityInfos ScheduledEvent is required")
-		}
 		scheduledEvent, err := m.serializer.SerializeEvent(v.ScheduledEvent, encoding)
 		if err != nil {
 			return nil, err

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -228,7 +228,8 @@ func (m *executionManagerImpl) DeserializeChildExecutionInfos(infos map[int64]*I
 		// Updated the code to instead directly read WorkflowId and RunId from mutable state
 		// Existing mutable state won't have those values set so instead use started event to set StartedWorkflowID and
 		// StartedRunID on the mutable state before passing it to application
-		if startedEvent != nil {
+		if startedEvent != nil && startedEvent.ChildWorkflowExecutionStartedEventAttributes != nil &&
+			startedEvent.ChildWorkflowExecutionStartedEventAttributes.WorkflowExecution != nil {
 			startedExecution := startedEvent.ChildWorkflowExecutionStartedEventAttributes.WorkflowExecution
 			c.StartedWorkflowID = startedExecution.GetWorkflowId()
 			c.StartedRunID = startedExecution.GetRunId()

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -222,6 +222,17 @@ func (m *executionManagerImpl) DeserializeChildExecutionInfos(infos map[int64]*I
 			DomainName:            v.DomainName,
 			WorkflowTypeName:      v.WorkflowTypeName,
 		}
+
+		// Needed for backward compatibility reason.
+		// ChildWorkflowExecutionStartedEvent was only used by transfer queue processing of StartChildWorkflow.
+		// Updated the code to instead directly read WorkflowId and RunId from mutable state
+		// Existing mutable state won't have those values set so instead use started event to set StartedWorkflowID and
+		// StartedRunID on the mutable state before passing it to application
+		if startedEvent != nil {
+			startedExecution := startedEvent.ChildWorkflowExecutionStartedEventAttributes.WorkflowExecution
+			c.StartedWorkflowID = startedExecution.GetWorkflowId()
+			c.StartedRunID = startedExecution.GetRunId()
+		}
 		newInfos[k] = c
 	}
 	return newInfos, nil

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1490,6 +1490,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 	activityInfos := []*p.ActivityInfo{{
 		Version:                  7789,
 		ScheduleID:               1,
+		ScheduledEventBatchID:    1,
 		ScheduledEvent:           &gen.HistoryEvent{EventId: int64Ptr(1)},
 		ScheduledTime:            currentTime,
 		StartedID:                2,
@@ -1515,6 +1516,7 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 	s.NotNil(ai)
 	s.Equal(int64(7789), ai.Version)
 	s.Equal(int64(1), ai.ScheduleID)
+	s.Equal(int64(1), ai.ScheduledEventBatchID)
 	s.Equal(int64(1), *ai.ScheduledEvent.EventId)
 	s.EqualTimes(currentTime, ai.ScheduledTime)
 	s.Equal(int64(2), ai.StartedID)
@@ -2549,6 +2551,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 			4: {
 				Version:                  7789,
 				ScheduleID:               4,
+				ScheduledEventBatchID:    3,
 				ScheduledEvent:           &gen.HistoryEvent{EventId: int64Ptr(40)},
 				ScheduledTime:            currentTime,
 				StartedID:                6,
@@ -2564,6 +2567,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 			5: {
 				Version:                  7789,
 				ScheduleID:               5,
+				ScheduledEventBatchID:    3,
 				ScheduledEvent:           &gen.HistoryEvent{EventId: int64Ptr(50)},
 				ScheduledTime:            currentTime,
 				StartedID:                7,
@@ -2683,6 +2687,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 	s.NotNil(ai)
 	s.Equal(int64(7789), ai.Version)
 	s.Equal(int64(4), ai.ScheduleID)
+	s.Equal(int64(3), ai.ScheduledEventBatchID)
 	s.Equal(int64(40), *ai.ScheduledEvent.EventId)
 	s.EqualTimes(currentTime, ai.ScheduledTime)
 	s.Equal(int64(6), ai.StartedID)
@@ -2700,6 +2705,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 	s.NotNil(ai)
 	s.Equal(int64(7789), ai.Version)
 	s.Equal(int64(5), ai.ScheduleID)
+	s.Equal(int64(3), ai.ScheduledEventBatchID)
 	s.Equal(int64(50), *ai.ScheduledEvent.EventId)
 	s.EqualTimes(currentTime, ai.ScheduledTime)
 	s.Equal(int64(7), ai.StartedID)
@@ -2775,6 +2781,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 		{
 			Version:                  8789,
 			ScheduleID:               40,
+			ScheduledEventBatchID:    30,
 			ScheduledEvent:           &gen.HistoryEvent{EventId: int64Ptr(400)},
 			ScheduledTime:            currentTime,
 			StartedID:                60,
@@ -2865,6 +2872,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 	s.NotNil(ai)
 	s.Equal(int64(8789), ai.Version)
 	s.Equal(int64(40), ai.ScheduleID)
+	s.Equal(int64(30), ai.ScheduledEventBatchID)
 	s.Equal(int64(400), *ai.ScheduledEvent.EventId)
 	s.Equal(currentTime.Unix(), ai.ScheduledTime.Unix())
 	s.Equal(int64(60), ai.StartedID)

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -29,7 +29,6 @@ import (
 )
 
 type (
-
 	//////////////////////////////////////////////////////////////////////
 	// Persistence interface is a lower layer of dataInterface.
 	// The intention is to let different persistence implementation(SQL,Cassandra/etc) share some common logic
@@ -130,6 +129,7 @@ type (
 		ParentWorkflowID             string
 		ParentRunID                  string
 		InitiatedID                  int64
+		CompletionEventBatchID       int64
 		CompletionEvent              *DataBlob
 		TaskList                     string
 		WorkflowTypeName             string
@@ -229,12 +229,17 @@ type (
 
 	// InternalChildExecutionInfo has details for pending child executions  for Persistence Interface
 	InternalChildExecutionInfo struct {
-		Version         int64
-		InitiatedID     int64
-		InitiatedEvent  *DataBlob
-		StartedID       int64
-		StartedEvent    *DataBlob
-		CreateRequestID string
+		Version               int64
+		InitiatedID           int64
+		InitiatedEventBatchID int64
+		InitiatedEvent        *DataBlob
+		StartedID             int64
+		StartedWorkflowID     string
+		StartedRunID          string
+		StartedEvent          *DataBlob
+		CreateRequestID       string
+		DomainName            string
+		WorkflowTypeName      string
 	}
 
 	// InternalBufferedReplicationTask has details to handle out of order receive of history events  for Persistence Interface

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -194,6 +194,7 @@ type (
 	InternalActivityInfo struct {
 		Version                  int64
 		ScheduleID               int64
+		ScheduledEventBatchID    int64
 		ScheduledEvent           *DataBlob
 		ScheduledTime            time.Time
 		StartedID                int64

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -230,7 +230,7 @@ type (
 	InternalChildExecutionInfo struct {
 		Version         int64
 		InitiatedID     int64
-		InitiatedEvent  DataBlob
+		InitiatedEvent  *DataBlob
 		StartedID       int64
 		StartedEvent    *DataBlob
 		CreateRequestID string

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -69,6 +69,7 @@ type (
 		ParentWorkflowID             *string
 		ParentRunID                  *string
 		InitiatedID                  *int64
+		CompletionEventBatchID       *int64
 		CompletionEvent              *[]byte
 		CompletionEventEncoding      *string
 		TaskList                     string
@@ -233,12 +234,14 @@ execution_context`
 	executionsNonblobParentColumns = `parent_domain_id,
 parent_workflow_id,
 parent_run_id,
-initiated_id`
+initiated_id,
+completion_event_batch_id`
 
 	executionsNonblobParentColumnsTags = `:parent_domain_id,
 :parent_workflow_id,
 :parent_run_id,
-:initiated_id`
+:initiated_id,
+:completion_event_batch_id`
 
 	executionsCancelColumns = `cancel_requested,
 cancel_request_id`
@@ -697,6 +700,7 @@ func (m *sqlExecutionManager) GetWorkflowExecution(request *p.GetWorkflowExecuti
 		ClientImpl:                   execution.ClientImpl,
 		SignalCount:                  int32(execution.SignalCount),
 		CronSchedule:                 execution.CronSchedule,
+		CompletionEventBatchID:       common.EmptyEventID,
 	}
 
 	if execution.ExecutionContext != nil && len(*execution.ExecutionContext) > 0 {
@@ -732,6 +736,10 @@ func (m *sqlExecutionManager) GetWorkflowExecution(request *p.GetWorkflowExecuti
 	if execution.CancelRequested != nil && (*execution.CancelRequested != 0) {
 		state.ExecutionInfo.CancelRequested = true
 		state.ExecutionInfo.CancelRequestID = *execution.CancelRequestID
+	}
+
+	if execution.CompletionEventBatchID != nil {
+		state.ExecutionInfo.CompletionEventBatchID = *execution.CompletionEventBatchID
 	}
 
 	if execution.CompletionEvent != nil {
@@ -2006,6 +2014,7 @@ func updateExecution(tx *sqlx.Tx,
 			ParentWorkflowID:             &executionInfo.ParentWorkflowID,
 			ParentRunID:                  &executionInfo.ParentRunID,
 			InitiatedID:                  &executionInfo.InitiatedID,
+			CompletionEventBatchID:       &executionInfo.CompletionEventBatchID,
 			TaskList:                     executionInfo.TaskList,
 			WorkflowTypeName:             executionInfo.WorkflowTypeName,
 			WorkflowTimeoutSeconds:       int64(executionInfo.WorkflowTimeout),

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -596,12 +596,17 @@ func deleteTimerInfoMap(tx *sqlx.Tx, shardID int, domainID, workflowID, runID st
 var (
 	childExecutionInfoColumns = []string{
 		"version",
+		"initiated_event_batch_id",
 		"initiated_event",
 		"initiated_event_encoding",
 		"started_id",
+		"started_workflow_id",
+		"started_run_id",
 		"started_event",
 		"started_event_encoding",
 		"create_request_id",
+		"domain_name",
+		"workflow_type_name",
 	}
 	childExecutionInfoTableName = "child_execution_info_maps"
 	childExecutionInfoKey       = "initiated_id"
@@ -624,12 +629,17 @@ type (
 	childExecutionInfoMapsRow struct {
 		childExecutionInfoMapsPrimaryKey
 		Version                int64
+		InitiatedEventBatchID  int64
 		InitiatedEvent         *[]byte
 		InitiatedEventEncoding string
 		StartedID              int64
+		StartedWorkflowID      string
+		StartedRunID           string
 		StartedEvent           *[]byte
 		StartedEventEncoding   string
 		CreateRequestID        string
+		DomainName             string
+		WorkflowTypeName       string
 	}
 )
 
@@ -652,10 +662,15 @@ func updateChildExecutionInfos(tx *sqlx.Tx,
 					InitiatedID: v.InitiatedID,
 				},
 				Version:                v.Version,
+				InitiatedEventBatchID:  v.InitiatedEventBatchID,
 				StartedID:              v.StartedID,
+				StartedWorkflowID:      v.StartedWorkflowID,
+				StartedRunID:           v.StartedRunID,
 				InitiatedEvent:         &v.InitiatedEvent.Data,
 				InitiatedEventEncoding: string(v.InitiatedEvent.Encoding),
 				CreateRequestID:        v.CreateRequestID,
+				DomainName:             v.DomainName,
+				WorkflowTypeName:       v.WorkflowTypeName,
 			}
 			if v.StartedEvent != nil {
 				row.StartedEvent = &v.StartedEvent.Data
@@ -716,10 +731,15 @@ func getChildExecutionInfoMap(tx *sqlx.Tx,
 	ret := make(map[int64]*persistence.InternalChildExecutionInfo)
 	for _, v := range childExecutionInfoMapsRows {
 		info := &persistence.InternalChildExecutionInfo{
-			InitiatedID:     v.InitiatedID,
-			Version:         v.Version,
-			StartedID:       v.StartedID,
-			CreateRequestID: v.CreateRequestID,
+			InitiatedID:           v.InitiatedID,
+			InitiatedEventBatchID: v.InitiatedEventBatchID,
+			Version:               v.Version,
+			StartedID:             v.StartedID,
+			StartedWorkflowID:     v.StartedWorkflowID,
+			StartedRunID:          v.StartedRunID,
+			CreateRequestID:       v.CreateRequestID,
+			DomainName:            v.DomainName,
+			WorkflowTypeName:      v.WorkflowTypeName,
 		}
 		if v.InitiatedEvent != nil {
 			info.InitiatedEvent = persistence.NewDataBlob(*v.InitiatedEvent, common.EncodingType(v.InitiatedEventEncoding))

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -128,6 +128,7 @@ var (
 	// Omit shard_id, run_id, domain_id, workflow_id, schedule_id since they're in the primary key
 	activityInfoColumns = []string{
 		"version",
+		"schedule_event_batch_id",
 		"scheduled_event",
 		"scheduled_event_encoding",
 		"scheduled_time",
@@ -178,6 +179,7 @@ type (
 	activityInfoMapsRow struct {
 		activityInfoMapsPrimaryKey
 		Version                  int64
+		ScheduledEventBatchID    int64
 		ScheduledEvent           []byte
 		ScheduledEventEncoding   string
 		ScheduledTime            time.Time
@@ -229,6 +231,7 @@ func updateActivityInfos(tx *sqlx.Tx,
 					ScheduleID: v.ScheduleID,
 				},
 				Version:                  v.Version,
+				ScheduledEventBatchID:    v.ScheduledEventBatchID,
 				ScheduledEvent:           v.ScheduledEvent.Data,
 				ScheduledEventEncoding:   string(v.ScheduledEvent.Encoding),
 				ScheduledTime:            v.ScheduledTime,
@@ -371,6 +374,7 @@ func getActivityInfoMap(tx *sqlx.Tx,
 		info := &persistence.InternalActivityInfo{
 			Version:                  v.Version,
 			ScheduleID:               v.ScheduleID,
+			ScheduledEventBatchID:    v.ScheduledEventBatchID,
 			ScheduledEvent:           persistence.NewDataBlob(v.ScheduledEvent, common.EncodingType(v.ScheduledEventEncoding)),
 			ScheduledTime:            v.ScheduledTime,
 			StartedID:                v.StartedID,

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -716,10 +716,9 @@ func getChildExecutionInfoMap(tx *sqlx.Tx,
 			Version:         v.Version,
 			StartedID:       v.StartedID,
 			CreateRequestID: v.CreateRequestID,
-			InitiatedEvent: persistence.DataBlob{
-				Data:     *v.InitiatedEvent,
-				Encoding: common.EncodingType(v.InitiatedEventEncoding),
-			},
+		}
+		if v.InitiatedEvent != nil {
+			info.InitiatedEvent = persistence.NewDataBlob(*v.InitiatedEvent, common.EncodingType(v.InitiatedEventEncoding))
 		}
 		if v.StartedEvent != nil {
 			info.StartedEvent = persistence.NewDataBlob(*v.StartedEvent, common.EncodingType(v.InitiatedEventEncoding))

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -128,7 +128,7 @@ var (
 	// Omit shard_id, run_id, domain_id, workflow_id, schedule_id since they're in the primary key
 	activityInfoColumns = []string{
 		"version",
-		"schedule_event_batch_id",
+		"scheduled_event_batch_id",
 		"scheduled_event",
 		"scheduled_event_encoding",
 		"scheduled_time",

--- a/common/persistence/statsComputer.go
+++ b/common/persistence/statsComputer.go
@@ -221,7 +221,10 @@ func computeTimerInfoSize(ti *TimerInfo) int {
 }
 
 func computeChildInfoSize(ci *InternalChildExecutionInfo) int {
-	size := len(ci.InitiatedEvent.Data)
+	size := 0
+	if ci.InitiatedEvent != nil {
+		size += len(ci.InitiatedEvent.Data)
+	}
 	if ci.StartedEvent != nil {
 		size += len(ci.StartedEvent.Data)
 	}

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -97,6 +97,9 @@ var keys = map[Key]string{
 	HistoryCacheInitialSize:                               "history.cacheInitialSize",
 	HistoryCacheMaxSize:                                   "history.cacheMaxSize",
 	HistoryCacheTTL:                                       "history.cacheTTL",
+	EventsCacheInitialSize:                                "history.eventsCacheInitialSize",
+	EventsCacheMaxSize:                                    "history.eventsCacheMaxSize",
+	EventsCacheTTL:                                        "history.eventsCacheTTL",
 	AcquireShardInterval:                                  "history.acquireShardInterval",
 	StandbyClusterDelay:                                   "history.standbyClusterDelay",
 	TimerTaskBatchSize:                                    "history.timerTaskBatchSize",
@@ -272,6 +275,12 @@ const (
 	HistoryCacheMaxSize
 	// HistoryCacheTTL is TTL of history cache
 	HistoryCacheTTL
+	// EventsCacheInitialSize is initial size of events cache
+	EventsCacheInitialSize
+	// EventsCacheMaxSize is max size of events cache
+	EventsCacheMaxSize
+	// EventsCacheTTL is TTL of events cache
+	EventsCacheTTL
 	// AcquireShardInterval is interval that timer used to acquire shard
 	AcquireShardInterval
 	// StandbyClusterDelay is the atrificial delay added to standby cluster's view of active cluster's time

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -26,6 +26,7 @@ CREATE TYPE workflow_execution (
   parent_workflow_id               text,   -- ID of parent workflow which started the workflow execution
   parent_run_id                    uuid,   -- RunID of parent workflow which started the workflow execution
   initiated_id                     bigint, -- Initiated event ID of parent workflow which started this execution
+  completion_event_batch_id        bigint,
   completion_event                 blob,   -- Completion event used to communicate result to parent workflow execution
   completion_event_data_encoding   text, -- Protocol used for history serialization
   task_list                        text,
@@ -180,13 +181,18 @@ CREATE TYPE timer_info (
 
 -- Child execution in progress mutable state
 CREATE TYPE child_execution_info (
-  version           bigint,
-  initiated_id      bigint,
-  initiated_event   blob,
-  started_id        bigint,
-  started_event     blob,
-  create_request_id uuid,
-  event_data_encoding   text, -- Protocol used for history serialization
+  version                   bigint,
+  initiated_id              bigint,
+  initiated_event_batch_id  bigint,
+  initiated_event           blob,
+  started_id                bigint,
+  started_workflow_id       text,
+  started_run_id            uuid,
+  started_event             blob, // deprecated
+  create_request_id         uuid,
+  event_data_encoding       text, -- Protocol used for history serialization
+  domain_name               text,
+  workflow_type_name        text,
 );
 
 -- External workflow cancellation in progress mutable state

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -188,7 +188,7 @@ CREATE TYPE child_execution_info (
   started_id                bigint,
   started_workflow_id       text,
   started_run_id            uuid,
-  started_event             blob, // deprecated
+  started_event             blob, -- deprecated
   create_request_id         uuid,
   event_data_encoding       text, -- Protocol used for history serialization
   domain_name               text,

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -139,7 +139,8 @@ CREATE TYPE timer_task (
 CREATE TYPE activity_info (
   version                   bigint,
   schedule_id               bigint,
-  scheduled_event           blob,
+  schedule_event_batch_id   bigint,
+  scheduled_event           blob,  -- deprecated
   scheduled_time            timestamp,
   started_id                bigint,
   started_event             blob,

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -139,7 +139,7 @@ CREATE TYPE timer_task (
 CREATE TYPE activity_info (
   version                   bigint,
   schedule_id               bigint,
-  schedule_event_batch_id   bigint,
+  scheduled_event_batch_id  bigint,
   scheduled_event           blob,  -- deprecated
   scheduled_time            timestamp,
   started_id                bigint,

--- a/schema/cassandra/cadence/versioned/v0.13/events_cache.cql
+++ b/schema/cassandra/cadence/versioned/v0.13/events_cache.cql
@@ -1,1 +1,7 @@
-ALTER TYPE activity_info ADD  scheduled_event_batch_id int;
+ALTER TYPE activity_info ADD  scheduled_event_batch_id bigint;
+ALTER TYPE child_execution_info ADD  initiated_event_batch_id bigint;
+ALTER TYPE child_execution_info ADD  started_workflow_id text;
+ALTER TYPE child_execution_info ADD  started_run_id uuid;
+ALTER TYPE child_execution_info ADD  domain_name text;
+ALTER TYPE child_execution_info ADD  workflow_type_name text;
+ALTER TYPE workflow_execution ADD  completion_event_batch_id bigint;

--- a/schema/cassandra/cadence/versioned/v0.13/events_cache.cql
+++ b/schema/cassandra/cadence/versioned/v0.13/events_cache.cql
@@ -1,1 +1,1 @@
-ALTER TYPE activity_info ADD  schedule_event_batch_id int;
+ALTER TYPE activity_info ADD  scheduled_event_batch_id int;

--- a/schema/cassandra/cadence/versioned/v0.13/events_cache.cql
+++ b/schema/cassandra/cadence/versioned/v0.13/events_cache.cql
@@ -1,0 +1,1 @@
+ALTER TYPE activity_info ADD  schedule_event_batch_id int;

--- a/schema/cassandra/cadence/versioned/v0.13/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.13/manifest.json
@@ -1,8 +1,9 @@
 {
   "CurrVersion": "0.13",
   "MinCompatibleVersion": "0.13",
-  "Description": "Support workflow reset",
+  "Description": "Support workflow reset.  Move history events out of mutable state.",
   "SchemaUpdateCqlFiles": [
-    "reset.cql"
+    "reset.cql",
+    "events_cache.cql"
   ]
 }

--- a/schema/mysql/v56/cadence/schema.sql
+++ b/schema/mysql/v56/cadence/schema.sql
@@ -72,7 +72,8 @@ CREATE TABLE executions(
 	parent_workflow_id VARCHAR(255), -- 2.
 	parent_run_id CHAR(64), -- 3.
 	initiated_id BIGINT, -- 4. these (parent-related fields) are nullable as their default values are not checked by tests
-	completion_event BLOB, -- 5.
+	completion_event_batch_id BIGINT, -- 5.
+	completion_event BLOB, -- 6.
 	completion_event_encoding VARCHAR(64),
 	task_list VARCHAR(255) NOT NULL,
 	workflow_type_name VARCHAR(255) NOT NULL,
@@ -220,6 +221,7 @@ CREATE TABLE activity_info_maps (
 	schedule_id BIGINT NOT NULL, -- the key.
 -- fields of activity_info type follow
 version                     BIGINT NOT NULL,
+scheduled_event_batch_id    BIGINT NOT NULL,
 scheduled_event             BLOB,
 scheduled_event_encoding    VARCHAR(64),
 scheduled_time              DATETIME(6) NOT NULL,
@@ -273,12 +275,17 @@ run_id CHAR(64) NOT NULL,
 initiated_id BIGINT NOT NULL,
 --
 version BIGINT NOT NULL,
+initiated_event_batch_id  BIGINT NOT NULL,
 initiated_event BLOB,
 initiated_event_encoding  VARCHAR(64),
 started_id BIGINT NOT NULL,
+started_workflow_id VARCHAR(255) NOT NULL,
+started_run_id CHAR(64),
 started_event BLOB,
 started_event_encoding  VARCHAR(64),
 create_request_id CHAR(64),
+domain_name VARCHAR(255) NOT NULL,
+workflow_type_name VARCHAR(255) NOT NULL,
 PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
 );
 

--- a/schema/mysql/v57/cadence/schema.sql
+++ b/schema/mysql/v57/cadence/schema.sql
@@ -72,7 +72,8 @@ CREATE TABLE executions(
 	parent_workflow_id VARCHAR(255), -- 2.
 	parent_run_id CHAR(64), -- 3.
 	initiated_id BIGINT, -- 4. these (parent-related fields) are nullable as their default values are not checked by tests
-	completion_event BLOB, -- 5.
+	completion_event_batch_id BIGINT, -- 5.
+	completion_event BLOB, -- 6.
 	completion_event_encoding VARCHAR(64),
 	task_list VARCHAR(255) NOT NULL,
 	workflow_type_name VARCHAR(255) NOT NULL,
@@ -219,6 +220,7 @@ CREATE TABLE activity_info_maps (
 	schedule_id BIGINT NOT NULL, -- the key.
 -- fields of activity_info type follow
 version                     BIGINT NOT NULL,
+scheduled_event_batch_id    BIGINT NOT NULL,
 scheduled_event             BLOB,
 scheduled_event_encoding    VARCHAR(64),
 scheduled_time              TIMESTAMP(3) NOT NULL DEFAULT '1970-01-01 00:00:01.000',
@@ -272,12 +274,17 @@ run_id CHAR(64) NOT NULL,
 initiated_id BIGINT NOT NULL,
 --
 version BIGINT NOT NULL,
+initiated_event_batch_id  BIGINT NOT NULL,
 initiated_event BLOB,
 initiated_event_encoding  VARCHAR(64),
 started_id BIGINT NOT NULL,
+started_workflow_id VARCHAR(255) NOT NULL,
+started_run_id CHAR(64),
 started_event BLOB,
 started_event_encoding  VARCHAR(64),
 create_request_id CHAR(64),
+domain_name VARCHAR(255) NOT NULL,
+workflow_type_name VARCHAR(255) NOT NULL,
 PRIMARY KEY (shard_id, domain_id, workflow_id, run_id, initiated_id)
 );
 

--- a/service/history/MockEventsCache.go
+++ b/service/history/MockEventsCache.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"github.com/stretchr/testify/mock"
+	"github.com/uber/cadence/.gen/go/shared"
+)
+
+// MockEventsCache is used as mock implementation for EventsCache
+type MockEventsCache struct {
+	mock.Mock
+}
+
+// getEvent is mock implementation for getEvent of EventsCache
+func (_m *MockEventsCache) getEvent(domainID, workflowID, runID string, eventID int64, eventStoreVersion int32,
+	branchToken []byte) (*shared.HistoryEvent, error) {
+	ret := _m.Called(domainID, workflowID, runID, eventID, eventStoreVersion, branchToken)
+
+	var r0 *shared.HistoryEvent
+	if rf, ok := ret.Get(0).(func(string, string, string, int64, int32, []byte) *shared.HistoryEvent); ok {
+		r0 = rf(domainID, workflowID, runID, eventID, eventStoreVersion, branchToken)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*shared.HistoryEvent)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(string, string, string, int64, int32, []byte) error); ok {
+		r1 = rf(domainID, workflowID, runID, eventID, eventStoreVersion, branchToken)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// putEvent is mock implementation for putEvent of EventsCache
+func (_m *MockEventsCache) putEvent(domainID, workflowID, runID string, eventID int64, event *shared.HistoryEvent) {
+	_m.Called(domainID, workflowID, runID, eventID, event)
+}
+
+// deleteEvent is mock implementation for deleteEvent of EventsCache
+func (_m *MockEventsCache) deleteEvent(domainID, workflowID, runID string, eventID int64) {
+	_m.Called(domainID, workflowID, runID, eventID)
+}
+
+

--- a/service/history/MockEventsCache.go
+++ b/service/history/MockEventsCache.go
@@ -63,5 +63,3 @@ func (_m *MockEventsCache) putEvent(domainID, workflowID, runID string, eventID 
 func (_m *MockEventsCache) deleteEvent(domainID, workflowID, runID string, eventID int64) {
 	_m.Called(domainID, workflowID, runID, eventID)
 }
-
-

--- a/service/history/MockEventsCache.go
+++ b/service/history/MockEventsCache.go
@@ -31,13 +31,13 @@ type MockEventsCache struct {
 }
 
 // getEvent is mock implementation for getEvent of EventsCache
-func (_m *MockEventsCache) getEvent(domainID, workflowID, runID string, eventID int64, eventStoreVersion int32,
+func (_m *MockEventsCache) getEvent(domainID, workflowID, runID string, firstEventID, eventID int64, eventStoreVersion int32,
 	branchToken []byte) (*shared.HistoryEvent, error) {
-	ret := _m.Called(domainID, workflowID, runID, eventID, eventStoreVersion, branchToken)
+	ret := _m.Called(domainID, workflowID, runID, firstEventID, eventID, eventStoreVersion, branchToken)
 
 	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func(string, string, string, int64, int32, []byte) *shared.HistoryEvent); ok {
-		r0 = rf(domainID, workflowID, runID, eventID, eventStoreVersion, branchToken)
+	if rf, ok := ret.Get(0).(func(string, string, string, int64, int64, int32, []byte) *shared.HistoryEvent); ok {
+		r0 = rf(domainID, workflowID, runID, firstEventID, eventID, eventStoreVersion, branchToken)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*shared.HistoryEvent)

--- a/service/history/MockMutableState.go
+++ b/service/history/MockMutableState.go
@@ -1197,29 +1197,6 @@ func (_m *mockMutableState) GetChildExecutionInitiatedEvent(_a0 int64) (*shared.
 	return r0, r1
 }
 
-// GetChildExecutionStartedEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) GetChildExecutionStartedEvent(_a0 int64) (*shared.HistoryEvent, bool) {
-	ret := _m.Called(_a0)
-
-	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func(int64) *shared.HistoryEvent); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*shared.HistoryEvent)
-		}
-	}
-
-	var r1 bool
-	if rf, ok := ret.Get(1).(func(int64) bool); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-
-	return r0, r1
-}
-
 // GetCompletionEvent provides a mock function with given fields:
 func (_m *mockMutableState) GetCompletionEvent() (*shared.HistoryEvent, bool) {
 	ret := _m.Called()
@@ -1871,12 +1848,12 @@ func (_m *mockMutableState) ReplicateActivityTaskFailedEvent(_a0 *shared.History
 }
 
 // ReplicateActivityTaskScheduledEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) ReplicateActivityTaskScheduledEvent(_a0 *shared.HistoryEvent) *persistence.ActivityInfo {
-	ret := _m.Called(_a0)
+func (_m *mockMutableState) ReplicateActivityTaskScheduledEvent(_a0 int64, _a1 *shared.HistoryEvent) *persistence.ActivityInfo {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 *persistence.ActivityInfo
-	if rf, ok := ret.Get(0).(func(*shared.HistoryEvent) *persistence.ActivityInfo); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(int64, *shared.HistoryEvent) *persistence.ActivityInfo); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*persistence.ActivityInfo)
@@ -2048,13 +2025,13 @@ func (_m *mockMutableState) ReplicateStartChildWorkflowExecutionFailedEvent(_a0 
 	_m.Called(_a0)
 }
 
-// ReplicateStartChildWorkflowExecutionInitiatedEvent provides a mock function with given fields: _a0, _a1
-func (_m *mockMutableState) ReplicateStartChildWorkflowExecutionInitiatedEvent(_a0 *shared.HistoryEvent, _a1 string) *persistence.ChildExecutionInfo {
-	ret := _m.Called(_a0, _a1)
+// ReplicateStartChildWorkflowExecutionInitiatedEvent provides a mock function with given fields: _a0, _a1, _a2
+func (_m *mockMutableState) ReplicateStartChildWorkflowExecutionInitiatedEvent(_a0 int64, _a1 *shared.HistoryEvent, _a2 string) *persistence.ChildExecutionInfo {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 *persistence.ChildExecutionInfo
-	if rf, ok := ret.Get(0).(func(*shared.HistoryEvent, string) *persistence.ChildExecutionInfo); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(int64, *shared.HistoryEvent, string) *persistence.ChildExecutionInfo); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*persistence.ChildExecutionInfo)
@@ -2111,14 +2088,14 @@ func (_m *mockMutableState) ReplicateWorkflowExecutionCancelRequestedEvent(_a0 *
 	_m.Called(_a0)
 }
 
-// ReplicateWorkflowExecutionCanceledEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) ReplicateWorkflowExecutionCanceledEvent(_a0 *shared.HistoryEvent) {
-	_m.Called(_a0)
+// ReplicateWorkflowExecutionCanceledEvent provides a mock function with given fields: _a0, _a1
+func (_m *mockMutableState) ReplicateWorkflowExecutionCanceledEvent(_a0 int64, _a1 *shared.HistoryEvent) {
+	_m.Called(_a0, _a1)
 }
 
-// ReplicateWorkflowExecutionCompletedEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) ReplicateWorkflowExecutionCompletedEvent(_a0 *shared.HistoryEvent) {
-	_m.Called(_a0)
+// ReplicateWorkflowExecutionCompletedEvent provides a mock function with given fields: _a0, _a1
+func (_m *mockMutableState) ReplicateWorkflowExecutionCompletedEvent(_a0 int64, _a1 *shared.HistoryEvent) {
+	_m.Called(_a0, _a1)
 }
 
 // ReplicateWorkflowExecutionContinuedAsNewEvent provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5
@@ -2134,9 +2111,9 @@ func (_m *mockMutableState) ReplicateWorkflowExecutionContinuedAsNewEvent(_a0 st
 	return r0
 }
 
-// ReplicateWorkflowExecutionFailedEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) ReplicateWorkflowExecutionFailedEvent(_a0 *shared.HistoryEvent) {
-	_m.Called(_a0)
+// ReplicateWorkflowExecutionFailedEvent provides a mock function with given fields: _a0, a1
+func (_m *mockMutableState) ReplicateWorkflowExecutionFailedEvent(_a0 int64, _a1 *shared.HistoryEvent) {
+	_m.Called(_a0, _a1)
 }
 
 // ReplicateWorkflowExecutionSignaled provides a mock function with given fields: _a0
@@ -2149,14 +2126,14 @@ func (_m *mockMutableState) ReplicateWorkflowExecutionStartedEvent(_a0 string, _
 	_m.Called(_a0, _a1, _a2, _a3, _a4)
 }
 
-// ReplicateWorkflowExecutionTerminatedEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) ReplicateWorkflowExecutionTerminatedEvent(_a0 *shared.HistoryEvent) {
-	_m.Called(_a0)
+// ReplicateWorkflowExecutionTerminatedEvent provides a mock function with given fields: _a0, _a1
+func (_m *mockMutableState) ReplicateWorkflowExecutionTerminatedEvent(_a0 int64, _a1 *shared.HistoryEvent) {
+	_m.Called(_a0, _a1)
 }
 
-// ReplicateWorkflowExecutionTimedoutEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) ReplicateWorkflowExecutionTimedoutEvent(_a0 *shared.HistoryEvent) {
-	_m.Called(_a0)
+// ReplicateWorkflowExecutionTimedoutEvent provides a mock function with given fields: _a0, _a1
+func (_m *mockMutableState) ReplicateWorkflowExecutionTimedoutEvent(_a0 int64, _a1 *shared.HistoryEvent) {
+	_m.Called(_a0, _a1)
 }
 
 // ResetSnapshot provides a mock function with given fields:

--- a/service/history/MockMutableState.go
+++ b/service/history/MockMutableState.go
@@ -1135,29 +1135,6 @@ func (_m *mockMutableState) GetActivityScheduledEvent(_a0 int64) (*shared.Histor
 	return r0, r1
 }
 
-// GetActivityStartedEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) GetActivityStartedEvent(_a0 int64) (*shared.HistoryEvent, bool) {
-	ret := _m.Called(_a0)
-
-	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func(int64) *shared.HistoryEvent); ok {
-		r0 = rf(_a0)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*shared.HistoryEvent)
-		}
-	}
-
-	var r1 bool
-	if rf, ok := ret.Get(1).(func(int64) bool); ok {
-		r1 = rf(_a0)
-	} else {
-		r1 = ret.Get(1).(bool)
-	}
-
-	return r0, r1
-}
-
 // GetAllBufferedReplicationTasks provides a mock function with given fields:
 func (_m *mockMutableState) GetAllBufferedReplicationTasks() map[int64]*persistence.BufferedReplicationTask {
 	ret := _m.Called()

--- a/service/history/conflictResolver.go
+++ b/service/history/conflictResolver.go
@@ -101,6 +101,7 @@ func (r *conflictResolverImpl) reset(prevRunID string, requestID string, replayE
 			resetMutableStateBuilder = newMutableStateBuilderWithReplicationState(
 				r.clusterMetadata.GetCurrentClusterName(),
 				r.shard.GetConfig(),
+				r.shard.GetEventsCache(),
 				r.logger,
 				firstEvent.GetVersion(),
 			)

--- a/service/history/eventsCache.go
+++ b/service/history/eventsCache.go
@@ -145,8 +145,8 @@ func (e *eventsCacheImpl) getHistoryEventFromStore(domainID, workflowID, runID s
 			return nil, err
 		}
 
-		if len(response.History) > 0 {
-			historyEvent = response.History[0]
+		if len(response.HistoryEvents) > 0 {
+			historyEvent = response.HistoryEvents[0]
 		}
 	} else {
 		response, err := e.eventsMgr.GetWorkflowExecutionHistory(&persistence.GetWorkflowExecutionHistoryRequest{

--- a/service/history/eventsCache.go
+++ b/service/history/eventsCache.go
@@ -63,7 +63,7 @@ func newEventsCache(shardCtx ShardContext) eventsCache {
 	config := shardCtx.GetConfig()
 
 	return newEventsCacheWithOptions(config.EventsCacheInitialSize(), config.EventsCacheMaxSize(), config.EventsCacheTTL(),
-		shardCtx.GetHistoryManager(), shardCtx.GetHistoryV2Manager(), true, shardCtx.GetLogger(), shardCtx.GetMetricsClient())
+		shardCtx.GetHistoryManager(), shardCtx.GetHistoryV2Manager(), false, shardCtx.GetLogger(), shardCtx.GetMetricsClient())
 }
 
 func newEventsCacheWithOptions(initialSize, maxSize int, ttl time.Duration, eventsMgr persistence.HistoryManager,

--- a/service/history/eventsCache.go
+++ b/service/history/eventsCache.go
@@ -99,6 +99,13 @@ func (e *eventsCacheImpl) getEvent(domainID, workflowID, runID string, firstEven
 	event, err := e.getHistoryEventFromStore(domainID, workflowID, runID, firstEventID, eventID, eventStoreVersion, branchToken)
 	if err != nil {
 		e.metricsClient.IncCounter(metrics.EventsCacheGetEventScope, metrics.CacheFailures)
+		e.logger.WithFields(bark.Fields{
+			logging.TagDomainID:            domainID,
+			logging.TagWorkflowExecutionID: workflowID,
+			logging.TagWorkflowRunID:       runID,
+			logging.TagEventID:             eventID,
+			logging.TagErr:                 err,
+		}).Error("EventsCache unable to retrieve event from store")
 		return nil, err
 	}
 
@@ -153,7 +160,7 @@ func (e *eventsCacheImpl) getHistoryEventFromStore(domainID, workflowID, runID s
 				WorkflowId: common.StringPtr(workflowID),
 				RunId:      common.StringPtr(runID),
 			},
-			FirstEventID:  eventID,
+			FirstEventID:  firstEventID,
 			NextEventID:   eventID + 1,
 			PageSize:      1,
 			NextPageToken: nil,

--- a/service/history/eventsCache.go
+++ b/service/history/eventsCache.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"github.com/uber-common/bark"
+
+	"github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/logging"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+)
+
+type (
+	eventsCache struct {
+		cache.Cache
+		eventsMgr     persistence.HistoryManager
+		eventsV2Mgr   persistence.HistoryV2Manager
+		logger        bark.Logger
+		metricsClient metrics.Client
+	}
+
+	eventKey struct {
+		domainID   string
+		workflowID string
+		runID      string
+		eventID    int64
+	}
+)
+
+func newEventsCache(shardCtx ShardContext) *eventsCache {
+	opts := &cache.Options{}
+	config := shardCtx.GetConfig()
+	opts.InitialCapacity = config.EventsCacheInitialSize()
+	opts.TTL = config.EventsCacheTTL()
+	opts.Pin = true
+
+	return &eventsCache{
+		Cache:       cache.New(config.EventsCacheMaxSize(), opts),
+		eventsMgr:   shardCtx.GetHistoryManager(),
+		eventsV2Mgr: shardCtx.GetHistoryV2Manager(),
+		logger: shardCtx.GetLogger().WithFields(bark.Fields{
+			logging.TagWorkflowComponent: logging.TagValueEventsCacheComponent,
+		}),
+		metricsClient: shardCtx.GetMetricsClient(),
+	}
+}
+
+func newEventKey(domainID, workflowID, runID string, eventID int64) eventKey {
+	return eventKey{
+		domainID:   domainID,
+		workflowID: workflowID,
+		runID:      runID,
+		eventID:    eventID,
+	}
+}
+
+func (e *eventsCache) getEvent(domainID, workflowID, runID string, eventID int64, eventStoreVersion int32,
+	branchToken []byte) (*shared.HistoryEvent, error) {
+		key := newEventKey(domainID, workflowID, runID, eventID)
+		event, cacheHit := e.Cache.Get(key).(*shared.HistoryEvent)
+		if !cacheHit {
+
+		}
+}
+
+func (e *eventsCache) getHistoryEventFromStore(domainID, workflowID, runID string, eventID int64,
+	eventStoreVersion int32, branchToken []byte) (*shared.HistoryEvent, error) {
+
+	var historyEvent *shared.HistoryEvent
+	if eventStoreVersion == persistence.EventStoreVersionV2 {
+		response, err := e.eventsV2Mgr.ReadHistoryBranch(&persistence.ReadHistoryBranchRequest{
+			BranchToken:   branchToken,
+			MinEventID:    eventID,
+			MaxEventID:    eventID + 1,
+			PageSize:      1,
+			NextPageToken: nil,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if len(response.History) > 0 {
+			historyEvent = response.History[0]
+		}
+	} else {
+		response, err := e.eventsMgr.GetWorkflowExecutionHistory(&persistence.GetWorkflowExecutionHistoryRequest{
+			DomainID: domainID,
+			Execution: shared.WorkflowExecution{
+				WorkflowId: common.StringPtr(workflowID),
+				RunId:      common.StringPtr(runID),
+			},
+			FirstEventID:  eventID,
+			NextEventID:   eventID + 1,
+			PageSize:      1,
+			NextPageToken: nil,
+		})
+
+		if err != nil {
+			return nil, err
+		}
+
+		if response.History != nil && len(response.History.Events) > 0 {
+			historyEvent = response.History.Events[0]
+		}
+	}
+
+	return historyEvent, nil
+}

--- a/service/history/eventsCache.go
+++ b/service/history/eventsCache.go
@@ -57,6 +57,10 @@ type (
 	}
 )
 
+var (
+	errEventNotFoundInBatch = &shared.InternalServiceError{Message: "History event not found within expected batch"}
+)
+
 var _ eventsCache = (*eventsCacheImpl)(nil)
 
 func newEventsCache(shardCtx ShardContext) eventsCache {
@@ -190,13 +194,11 @@ func (e *eventsCacheImpl) getHistoryEventFromStore(domainID, workflowID, runID s
 	}
 
 	// find history event from batch and return back single event to caller
-	var historyEvent *shared.HistoryEvent
 	for _, e := range historyEvents {
 		if e.GetEventId() == eventID {
-			historyEvent = e
-			break
+			return e, nil
 		}
 	}
 
-	return historyEvent, nil
+	return nil, errEventNotFoundInBatch
 }

--- a/service/history/eventsCache_test.go
+++ b/service/history/eventsCache_test.go
@@ -1,0 +1,328 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	"errors"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/persistence"
+	"os"
+	"testing"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/uber-go/tally"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-common/bark"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/mocks"
+
+	"github.com/uber/cadence/.gen/go/shared"
+)
+
+type (
+	eventsCacheSuite struct {
+		suite.Suite
+		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
+		// not merely log an error
+		*require.Assertions
+		logger bark.Logger
+
+		mockEventsMgr   *mocks.HistoryManager
+		mockEventsV2Mgr *mocks.HistoryV2Manager
+
+		cache *eventsCacheImpl
+	}
+)
+
+func TestEventsCacheSuite(t *testing.T) {
+	s := new(eventsCacheSuite)
+	suite.Run(t, s)
+}
+
+func (s *eventsCacheSuite) SetupSuite() {
+	if testing.Verbose() {
+		log.SetOutput(os.Stdout)
+	}
+}
+
+func (s *eventsCacheSuite) TearDownSuite() {
+
+}
+
+func (s *eventsCacheSuite) SetupTest() {
+	s.logger = bark.NewLoggerFromLogrus(log.New())
+	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+	s.Assertions = require.New(s.T())
+	s.mockEventsMgr = &mocks.HistoryManager{}
+	s.mockEventsV2Mgr = &mocks.HistoryV2Manager{}
+	s.cache = s.newTestEventsCache()
+}
+
+func (s *eventsCacheSuite) TearDownTest() {
+	s.mockEventsMgr.AssertExpectations(s.T())
+	s.mockEventsV2Mgr.AssertExpectations(s.T())
+}
+
+func (s *eventsCacheSuite) newTestEventsCache() *eventsCacheImpl {
+	return newEventsCacheWithOptions(16, 32, time.Minute, s.mockEventsMgr, s.mockEventsV2Mgr, false, s.logger,
+		metrics.NewClient(tally.NoopScope, metrics.History))
+}
+
+func (s *eventsCacheSuite) TestEventsCacheHitSuccess() {
+	domainID := "events-cache-hit-success-domain"
+	workflowID := "events-cache-hit-success-workflow-id"
+	runID := "events-cache-hit-success-run-id"
+	eventID := int64(23)
+	event := &shared.HistoryEvent{
+		EventId:                            &eventID,
+		EventType:                          shared.EventTypeActivityTaskStarted.Ptr(),
+		ActivityTaskStartedEventAttributes: &shared.ActivityTaskStartedEventAttributes{},
+	}
+
+	s.cache.putEvent(domainID, workflowID, runID, eventID, event)
+	actualEvent, err := s.cache.getEvent(domainID, workflowID, runID, eventID, eventID, 0, nil)
+	s.Nil(err)
+	s.Equal(event, actualEvent)
+}
+
+func (s *eventsCacheSuite) TestEventsCacheMissSuccess() {
+	domainID := "events-cache-miss-success-domain"
+	workflowID := "events-cache-miss-success-workflow-id"
+	runID := "events-cache-miss-success-run-id"
+	event1ID := int64(23)
+	event1 := &shared.HistoryEvent{
+		EventId:                            &event1ID,
+		EventType:                          shared.EventTypeActivityTaskStarted.Ptr(),
+		ActivityTaskStartedEventAttributes: &shared.ActivityTaskStartedEventAttributes{},
+	}
+	event2ID := int64(32)
+	event2 := &shared.HistoryEvent{
+		EventId:                            &event2ID,
+		EventType:                          shared.EventTypeActivityTaskStarted.Ptr(),
+		ActivityTaskStartedEventAttributes: &shared.ActivityTaskStartedEventAttributes{},
+	}
+
+	s.mockEventsMgr.On("GetWorkflowExecutionHistory", &persistence.GetWorkflowExecutionHistoryRequest{
+		DomainID:      domainID,
+		Execution:     shared.WorkflowExecution{WorkflowId: common.StringPtr(workflowID), RunId: common.StringPtr(runID)},
+		FirstEventID:  event2ID,
+		NextEventID:   event2ID + 1,
+		PageSize:      1,
+		NextPageToken: nil,
+	}).Return(&persistence.GetWorkflowExecutionHistoryResponse{
+		History:          &shared.History{Events: []*shared.HistoryEvent{event2}},
+		NextPageToken:    nil,
+		LastFirstEventID: event2ID,
+	}, nil)
+
+	s.cache.putEvent(domainID, workflowID, runID, event1ID, event1)
+	actualEvent, err := s.cache.getEvent(domainID, workflowID, runID, event2ID, event2ID, 0, nil)
+	s.Nil(err)
+	s.Equal(event2, actualEvent)
+}
+
+func (s *eventsCacheSuite) TestEventsCacheMissMultiEventsBatchSuccess() {
+	domainID := "events-cache-miss-success-domain"
+	workflowID := "events-cache-miss-success-workflow-id"
+	runID := "events-cache-miss-success-run-id"
+	event1 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(11),
+		EventType:                            shared.EventTypeDecisionTaskCompleted.Ptr(),
+		DecisionTaskCompletedEventAttributes: &shared.DecisionTaskCompletedEventAttributes{},
+	}
+	event2 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(12),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event3 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(13),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event4 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(14),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event5 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(15),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event6 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(16),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+
+	s.mockEventsMgr.On("GetWorkflowExecutionHistory", &persistence.GetWorkflowExecutionHistoryRequest{
+		DomainID:      domainID,
+		Execution:     shared.WorkflowExecution{WorkflowId: common.StringPtr(workflowID), RunId: common.StringPtr(runID)},
+		FirstEventID:  event1.GetEventId(),
+		NextEventID:   event6.GetEventId() + 1,
+		PageSize:      1,
+		NextPageToken: nil,
+	}).Return(&persistence.GetWorkflowExecutionHistoryResponse{
+		History:          &shared.History{Events: []*shared.HistoryEvent{event1, event2, event3, event4, event5, event6}},
+		NextPageToken:    nil,
+		LastFirstEventID: event1.GetEventId(),
+	}, nil)
+
+	s.cache.putEvent(domainID, workflowID, runID, event2.GetEventId(), event2)
+	actualEvent, err := s.cache.getEvent(domainID, workflowID, runID, event1.GetEventId(), event6.GetEventId(), 0, nil)
+	s.Nil(err)
+	s.Equal(event6, actualEvent)
+}
+
+func (s *eventsCacheSuite) TestEventsCacheMissMultiEventsBatchV2Success() {
+	domainID := "events-cache-miss-multi-events-batch-v2-success-domain"
+	workflowID := "events-cache-miss-multi-events-batch-v2-success-workflow-id"
+	runID := "events-cache-miss-multi-events-batch-v2-success-run-id"
+	event1 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(11),
+		EventType:                            shared.EventTypeDecisionTaskCompleted.Ptr(),
+		DecisionTaskCompletedEventAttributes: &shared.DecisionTaskCompletedEventAttributes{},
+	}
+	event2 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(12),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event3 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(13),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event4 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(14),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event5 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(15),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+	event6 := &shared.HistoryEvent{
+		EventId:                              common.Int64Ptr(16),
+		EventType:                            shared.EventTypeActivityTaskScheduled.Ptr(),
+		ActivityTaskScheduledEventAttributes: &shared.ActivityTaskScheduledEventAttributes{},
+	}
+
+	s.mockEventsV2Mgr.On("ReadHistoryBranch", &persistence.ReadHistoryBranchRequest{
+		BranchToken:   []byte("store_token"),
+		MinEventID:    event1.GetEventId(),
+		MaxEventID:    event6.GetEventId() + 1,
+		PageSize:      1,
+		NextPageToken: nil,
+	}).Return(&persistence.ReadHistoryBranchResponse{
+		HistoryEvents:    []*shared.HistoryEvent{event1, event2, event3, event4, event5, event6},
+		NextPageToken:    nil,
+		LastFirstEventID: event1.GetEventId(),
+	}, nil)
+
+	s.cache.putEvent(domainID, workflowID, runID, event2.GetEventId(), event2)
+	actualEvent, err := s.cache.getEvent(domainID, workflowID, runID, event1.GetEventId(), event6.GetEventId(),
+		persistence.EventStoreVersionV2, []byte("store_token"))
+	s.Nil(err)
+	s.Equal(event6, actualEvent)
+}
+
+func (s *eventsCacheSuite) TestEventsCacheMissFailure() {
+	domainID := "events-cache-miss-failure-domain"
+	workflowID := "events-cache-miss-failure-workflow-id"
+	runID := "events-cache-miss-failure-run-id"
+
+	expectedErr := errors.New("persistence call failed")
+	s.mockEventsMgr.On("GetWorkflowExecutionHistory", &persistence.GetWorkflowExecutionHistoryRequest{
+		DomainID:      domainID,
+		Execution:     shared.WorkflowExecution{WorkflowId: common.StringPtr(workflowID), RunId: common.StringPtr(runID)},
+		FirstEventID:  int64(11),
+		NextEventID:   int64(15),
+		PageSize:      1,
+		NextPageToken: nil,
+	}).Return(nil, expectedErr)
+
+	actualEvent, err := s.cache.getEvent(domainID, workflowID, runID, int64(11), int64(14), 0, nil)
+	s.Nil(actualEvent)
+	s.Equal(expectedErr, err)
+}
+
+func (s *eventsCacheSuite) TestEventsCacheMissV2Failure() {
+	domainID := "events-cache-miss-failure-domain"
+	workflowID := "events-cache-miss-failure-workflow-id"
+	runID := "events-cache-miss-failure-run-id"
+
+	expectedErr := errors.New("persistence call failed")
+	s.mockEventsV2Mgr.On("ReadHistoryBranch", &persistence.ReadHistoryBranchRequest{
+		BranchToken:   []byte("store_token"),
+		MinEventID:    int64(11),
+		MaxEventID:    int64(15),
+		PageSize:      1,
+		NextPageToken: nil,
+	}).Return(nil, expectedErr)
+
+	actualEvent, err := s.cache.getEvent(domainID, workflowID, runID, int64(11), int64(14),
+		persistence.EventStoreVersionV2, []byte("store_token"))
+	s.Nil(actualEvent)
+	s.Equal(expectedErr, err)
+}
+
+func (s *eventsCacheSuite) TestEventsCacheDisableSuccess() {
+	domainID := "events-cache-disable-success-domain"
+	workflowID := "events-cache-disable-success-workflow-id"
+	runID := "events-cache-disable-success-run-id"
+	event1 := &shared.HistoryEvent{
+		EventId:                            common.Int64Ptr(23),
+		EventType:                          shared.EventTypeActivityTaskStarted.Ptr(),
+		ActivityTaskStartedEventAttributes: &shared.ActivityTaskStartedEventAttributes{},
+	}
+	event2 := &shared.HistoryEvent{
+		EventId:                            common.Int64Ptr(32),
+		EventType:                          shared.EventTypeActivityTaskStarted.Ptr(),
+		ActivityTaskStartedEventAttributes: &shared.ActivityTaskStartedEventAttributes{},
+	}
+
+	s.mockEventsV2Mgr.On("ReadHistoryBranch", &persistence.ReadHistoryBranchRequest{
+		BranchToken:   []byte("store_token"),
+		MinEventID:    event2.GetEventId(),
+		MaxEventID:    event2.GetEventId() + 1,
+		PageSize:      1,
+		NextPageToken: nil,
+	}).Return(&persistence.ReadHistoryBranchResponse{
+		HistoryEvents:    []*shared.HistoryEvent{event2},
+		NextPageToken:    nil,
+		LastFirstEventID: event2.GetEventId(),
+	}, nil)
+
+	s.cache.putEvent(domainID, workflowID, runID, event1.GetEventId(), event1)
+	s.cache.putEvent(domainID, workflowID, runID, event2.GetEventId(), event2)
+	s.cache.disabled = true
+	actualEvent, err := s.cache.getEvent(domainID, workflowID, runID, event2.GetEventId(), event2.GetEventId(),
+		persistence.EventStoreVersionV2, []byte("store_token"))
+	s.Nil(err)
+	s.Equal(event2, actualEvent)
+}

--- a/service/history/historyBuilder_test.go
+++ b/service/history/historyBuilder_test.go
@@ -656,7 +656,7 @@ func (s *historyBuilderSuite) getPreviousDecisionStartedEventID() int64 {
 }
 
 func (s *historyBuilderSuite) addWorkflowExecutionStartedEvent(we workflow.WorkflowExecution, workflowType,
-taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32,
+	taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32,
 	identity string) *workflow.HistoryEvent {
 
 	request := &workflow.StartWorkflowExecutionRequest{
@@ -702,7 +702,7 @@ func (s *historyBuilderSuite) addDecisionTaskCompletedEvent(scheduleID, startedI
 }
 
 func (s *historyBuilderSuite) addActivityTaskScheduledEvent(decisionCompletedID int64, activityID, activityType,
-taskList string, input []byte, timeout, queueTimeout, hearbeatTimeout int32) (*workflow.HistoryEvent,
+	taskList string, input []byte, timeout, queueTimeout, hearbeatTimeout int32) (*workflow.HistoryEvent,
 	*persistence.ActivityInfo) {
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything).Return()
@@ -720,7 +720,7 @@ taskList string, input []byte, timeout, queueTimeout, hearbeatTimeout int32) (*w
 }
 
 func (s *historyBuilderSuite) addActivityTaskStartedEvent(scheduleID int64, taskList,
-identity string) *workflow.HistoryEvent {
+	identity string) *workflow.HistoryEvent {
 	ai, _ := s.msBuilder.GetActivityInfo(scheduleID)
 	e := s.msBuilder.AddActivityTaskStartedEvent(ai, scheduleID, uuid.New(), identity)
 
@@ -801,7 +801,7 @@ func (s *historyBuilderSuite) addRequestCancelExternalWorkflowExecutionFailedEve
 }
 
 func (s *historyBuilderSuite) validateWorkflowExecutionStartedEvent(event *workflow.HistoryEvent, workflowType,
-taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32, identity string) {
+	taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32, identity string) {
 	s.NotNil(event)
 	s.Equal(workflow.EventTypeWorkflowExecutionStarted, *event.EventType)
 	s.Equal(common.FirstEventID, *event.EventId)
@@ -834,7 +834,7 @@ func (s *historyBuilderSuite) validateDecisionTaskStartedEvent(event *workflow.H
 }
 
 func (s *historyBuilderSuite) validateDecisionTaskCompletedEvent(event *workflow.HistoryEvent, eventID,
-scheduleID, startedID int64, context []byte, identity string) {
+	scheduleID, startedID int64, context []byte, identity string) {
 	s.NotNil(event)
 	s.Equal(workflow.EventTypeDecisionTaskCompleted, *event.EventType)
 	s.Equal(eventID, *event.EventId)
@@ -875,7 +875,7 @@ func (s *historyBuilderSuite) validateActivityTaskStartedEvent(event *workflow.H
 }
 
 func (s *historyBuilderSuite) validateActivityTaskCompletedEvent(event *workflow.HistoryEvent, eventID,
-scheduleID, startedID int64, result []byte, identity string) {
+	scheduleID, startedID int64, result []byte, identity string) {
 	s.NotNil(event)
 	s.Equal(workflow.EventTypeActivityTaskCompleted, *event.EventType)
 	s.Equal(eventID, *event.EventId)
@@ -888,7 +888,7 @@ scheduleID, startedID int64, result []byte, identity string) {
 }
 
 func (s *historyBuilderSuite) validateActivityTaskFailedEvent(event *workflow.HistoryEvent, eventID,
-scheduleID, startedID int64, reason string, details []byte, identity string) {
+	scheduleID, startedID int64, reason string, details []byte, identity string) {
 	s.NotNil(event)
 	s.Equal(workflow.EventTypeActivityTaskFailed, *event.EventType)
 	s.Equal(eventID, *event.EventId)

--- a/service/history/historyBuilder_test.go
+++ b/service/history/historyBuilder_test.go
@@ -60,7 +60,8 @@ func (s *historyBuilderSuite) SetupTest() {
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
 	s.domainID = "history-builder-test-domain"
-	s.msBuilder = newMutableStateBuilder(cluster.TestCurrentClusterName, NewDynamicConfigForTest(), s.logger)
+	s.msBuilder = newMutableStateBuilder(cluster.TestCurrentClusterName, NewDynamicConfigForTest(), &MockEventsCache{},
+	s.logger)
 	s.builder = newHistoryBuilder(s.msBuilder, s.logger)
 }
 

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -70,6 +70,7 @@ type (
 		historyEventNotifier historyEventNotifier
 		tokenSerializer      common.TaskTokenSerializer
 		historyCache         *historyCache
+		eventsCache          *eventsCache
 		metricsClient        metrics.Client
 		logger               bark.Logger
 		config               *Config
@@ -153,6 +154,7 @@ func NewEngineWithShardContext(
 	historyManager := shard.GetHistoryManager()
 	historyV2Manager := shard.GetHistoryV2Manager()
 	historyCache := newHistoryCache(shard)
+	eventsCache := newEventsCache(shard)
 	historyEngImpl := &historyEngineImpl{
 		currentClusterName: currentClusterName,
 		shard:              shard,
@@ -161,6 +163,7 @@ func NewEngineWithShardContext(
 		executionManager:   executionManager,
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		historyCache:       historyCache,
+		eventsCache:        eventsCache,
 		logger: logger.WithFields(bark.Fields{
 			logging.TagWorkflowComponent: logging.TagValueHistoryEngineComponent,
 		}),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -833,7 +833,9 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(ctx context.Context,
 				p.LastHeartbeatTimestamp = common.Int64Ptr(lastHeartbeatUnixNano)
 				p.HeartbeatDetails = ai.Details
 			}
-			p.ActivityType = ai.ScheduledEvent.ActivityTaskScheduledEventAttributes.ActivityType
+			// TODO: move to mutable state instead of loading it from event
+			scheduledEvent, _ := msBuilder.GetActivityScheduledEvent(ai.ScheduleID)
+			p.ActivityType = scheduledEvent.ActivityTaskScheduledEventAttributes.ActivityType
 			p.LastStartedTimestamp = common.Int64Ptr(ai.StartedTime.UnixNano())
 			p.Attempt = common.Int32Ptr(ai.Attempt)
 			result.PendingActivities = append(result.PendingActivities, p)

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -70,7 +70,6 @@ type (
 		historyEventNotifier historyEventNotifier
 		tokenSerializer      common.TaskTokenSerializer
 		historyCache         *historyCache
-		eventsCache          *eventsCache
 		metricsClient        metrics.Client
 		logger               bark.Logger
 		config               *Config
@@ -154,7 +153,6 @@ func NewEngineWithShardContext(
 	historyManager := shard.GetHistoryManager()
 	historyV2Manager := shard.GetHistoryV2Manager()
 	historyCache := newHistoryCache(shard)
-	eventsCache := newEventsCache(shard)
 	historyEngImpl := &historyEngineImpl{
 		currentClusterName: currentClusterName,
 		shard:              shard,
@@ -163,7 +161,6 @@ func NewEngineWithShardContext(
 		executionManager:   executionManager,
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		historyCache:       historyCache,
-		eventsCache:        eventsCache,
 		logger: logger.WithFields(bark.Fields{
 			logging.TagWorkflowComponent: logging.TagValueHistoryEngineComponent,
 		}),
@@ -294,6 +291,7 @@ func (e *historyEngineImpl) createMutableState(clusterMetadata cluster.Metadata,
 		msBuilder = newMutableStateBuilderWithReplicationState(
 			clusterMetadata.GetCurrentClusterName(),
 			e.shard.GetConfig(),
+			e.shard.GetEventsCache(),
 			e.logger,
 			domainEntry.GetFailoverVersion(),
 		)
@@ -301,7 +299,7 @@ func (e *historyEngineImpl) createMutableState(clusterMetadata cluster.Metadata,
 		msBuilder = newMutableStateBuilder(
 			clusterMetadata.GetCurrentClusterName(),
 			e.shard.GetConfig(),
-			e.eventsCache,
+			e.shard.GetEventsCache(),
 			e.logger,
 		)
 	}

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -301,6 +301,7 @@ func (e *historyEngineImpl) createMutableState(clusterMetadata cluster.Metadata,
 		msBuilder = newMutableStateBuilder(
 			clusterMetadata.GetCurrentClusterName(),
 			e.shard.GetConfig(),
+			e.eventsCache,
 			e.logger,
 		)
 	}

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -806,7 +806,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedSuccess() {
 	)
 
 	s.mockEventsCache.On("getEvent", domainID, workflowExecution.GetWorkflowId(), workflowExecution.GetRunId(),
-		scheduledEvent.GetEventId(), mock.Anything, mock.Anything).Return(scheduledEvent, nil)
+		decisionCompletedEvent.GetEventId(), scheduledEvent.GetEventId(), mock.Anything, mock.Anything).Return(scheduledEvent, nil)
 	response, err := s.historyEngine.RecordActivityTaskStarted(context.Background(), &h.RecordActivityTaskStartedRequest{
 		DomainUUID:        common.StringPtr(domainID),
 		WorkflowExecution: &workflowExecution,

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -121,6 +121,8 @@ func (s *engine2Suite) SetupTest() {
 	s.mockDomainCache = &cache.DomainCacheMock{}
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, nil), nil)
 	s.mockEventsCache = &MockEventsCache{}
+	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
+		mock.Anything).Return()
 
 	mockShard := &shardContextImpl{
 		service:                   s.mockService,
@@ -803,6 +805,8 @@ func (s *engine2Suite) TestRecordActivityTaskStartedSuccess() {
 		nil,
 	)
 
+	s.mockEventsCache.On("getEvent", domainID, workflowExecution.GetWorkflowId(), workflowExecution.GetRunId(),
+		scheduledEvent.GetEventId(), mock.Anything, mock.Anything).Return(scheduledEvent, nil)
 	response, err := s.historyEngine.RecordActivityTaskStarted(context.Background(), &h.RecordActivityTaskStartedRequest{
 		DomainUUID:        common.StringPtr(domainID),
 		WorkflowExecution: &workflowExecution,

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -68,6 +68,7 @@ type (
 		mockMessagingClient messaging.Client
 		mockService         service.Service
 		mockDomainCache     *cache.DomainCacheMock
+		mockEventsCache     *MockEventsCache
 
 		shardClosedCh chan int
 		config        *Config
@@ -119,6 +120,7 @@ func (s *engine2Suite) SetupTest() {
 	s.mockClusterMetadata.On("IsGlobalDomainEnabled").Return(false)
 	s.mockDomainCache = &cache.DomainCacheMock{}
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, nil), nil)
+	s.mockEventsCache = &MockEventsCache{}
 
 	mockShard := &shardContextImpl{
 		service:                   s.mockService,
@@ -133,6 +135,7 @@ func (s *engine2Suite) SetupTest() {
 		config:                    s.config,
 		logger:                    s.logger,
 		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),
+		eventsCache:               s.mockEventsCache,
 	}
 
 	historyCache := newHistoryCache(mockShard)
@@ -174,7 +177,8 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 	stickyTl := "stickyTaskList"
 	identity := "testIdentity"
 
-	msBuilder := newMutableStateBuilder("test", s.config, bark.NewLoggerFromLogrus(log.New()))
+	msBuilder := newMutableStateBuilder("test", s.config, s.mockEventsCache,
+		bark.NewLoggerFromLogrus(log.New()))
 	executionInfo := msBuilder.GetExecutionInfo()
 	executionInfo.StickyTaskList = stickyTl
 
@@ -912,7 +916,8 @@ func (s *engine2Suite) TestRequestCancelWorkflowExecutionFail() {
 
 func (s *engine2Suite) createExecutionStartedState(we workflow.WorkflowExecution, tl, identity string,
 	startDecision bool) mutableState {
-	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, s.logger)
+	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, s.mockEventsCache,
+		s.logger)
 	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	if startDecision {
@@ -942,7 +947,8 @@ func (s *engine2Suite) TestRespondDecisionTaskCompletedRecordMarkerDecision() {
 	markerDetails := []byte("marker details")
 	markerName := "marker name"
 
-	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, bark.NewLoggerFromLogrus(log.New()))
+	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, s.mockEventsCache,
+		bark.NewLoggerFromLogrus(log.New()))
 	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 200, identity)
 	di := addDecisionTaskScheduledEvent(msBuilder)
 	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
@@ -1345,7 +1351,8 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 		},
 	}
 
-	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, bark.NewLoggerFromLogrus(log.New()))
+	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, s.mockEventsCache,
+		bark.NewLoggerFromLogrus(log.New()))
 	ms := createMutableState(msBuilder)
 	gwmsResponse := &p.GetWorkflowExecutionResponse{State: ms}
 	gceResponse := &p.GetCurrentExecutionResponse{RunID: runID}
@@ -1454,7 +1461,8 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 		},
 	}
 
-	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, bark.NewLoggerFromLogrus(log.New()))
+	msBuilder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.config, s.mockEventsCache,
+		bark.NewLoggerFromLogrus(log.New()))
 	ms := createMutableState(msBuilder)
 	ms.ExecutionInfo.State = p.WorkflowStateCompleted
 	gwmsResponse := &p.GetWorkflowExecutionResponse{State: ms}

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4542,7 +4542,7 @@ func addDecisionTaskScheduledEvent(builder mutableState) *decisionInfo {
 }
 
 func addDecisionTaskStartedEvent(builder mutableState, scheduleID int64, taskList,
-	identity string) *workflow.HistoryEvent {
+identity string) *workflow.HistoryEvent {
 	return addDecisionTaskStartedEventWithRequestID(builder, scheduleID, validRunID, taskList, identity)
 }
 
@@ -4569,7 +4569,7 @@ func addDecisionTaskCompletedEvent(builder mutableState, scheduleID, startedID i
 }
 
 func addActivityTaskScheduledEvent(builder mutableState, decisionCompletedID int64, activityID, activityType,
-	taskList string, input []byte, timeout, queueTimeout, heartbeatTimeout int32) (*workflow.HistoryEvent,
+taskList string, input []byte, timeout, queueTimeout, heartbeatTimeout int32) (*workflow.HistoryEvent,
 	*persistence.ActivityInfo) {
 
 	return builder.AddActivityTaskScheduledEvent(decisionCompletedID, &workflow.ScheduleActivityTaskDecisionAttributes{
@@ -4769,6 +4769,7 @@ func copyWorkflowExecutionInfo(sourceInfo *persistence.WorkflowExecutionInfo) *p
 		ParentWorkflowID:             sourceInfo.ParentWorkflowID,
 		ParentRunID:                  sourceInfo.ParentRunID,
 		InitiatedID:                  sourceInfo.InitiatedID,
+		CompletionEventBatchID:       sourceInfo.CompletionEventBatchID,
 		CompletionEvent:              sourceInfo.CompletionEvent,
 		TaskList:                     sourceInfo.TaskList,
 		StickyTaskList:               sourceInfo.StickyTaskList,
@@ -4797,6 +4798,7 @@ func copyActivityInfo(sourceInfo *persistence.ActivityInfo) *persistence.Activit
 	return &persistence.ActivityInfo{
 		Version:                  sourceInfo.Version,
 		ScheduleID:               sourceInfo.ScheduleID,
+		ScheduledEventBatchID:    sourceInfo.ScheduledEventBatchID,
 		ScheduledEvent:           sourceInfo.ScheduledEvent,
 		StartedID:                sourceInfo.StartedID,
 		StartedEvent:             sourceInfo.StartedEvent,
@@ -4859,10 +4861,15 @@ func copySignalInfo(sourceInfo *persistence.SignalInfo) *persistence.SignalInfo 
 
 func copyChildInfo(sourceInfo *persistence.ChildExecutionInfo) *persistence.ChildExecutionInfo {
 	result := &persistence.ChildExecutionInfo{
-		Version:         sourceInfo.Version,
-		InitiatedID:     sourceInfo.InitiatedID,
-		StartedID:       sourceInfo.StartedID,
-		CreateRequestID: sourceInfo.CreateRequestID,
+		Version:               sourceInfo.Version,
+		InitiatedID:           sourceInfo.InitiatedID,
+		InitiatedEventBatchID: sourceInfo.InitiatedEventBatchID,
+		StartedID:             sourceInfo.StartedID,
+		StartedWorkflowID:     sourceInfo.StartedWorkflowID,
+		StartedRunID:          sourceInfo.StartedRunID,
+		CreateRequestID:       sourceInfo.CreateRequestID,
+		DomainName:            sourceInfo.DomainName,
+		WorkflowTypeName:      sourceInfo.WorkflowTypeName,
 	}
 
 	if sourceInfo.InitiatedEvent != nil {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4448,17 +4448,6 @@ func (s *engineSuite) getActivityScheduledEvent(msBuilder mutableState,
 	return ai.ScheduledEvent
 }
 
-func (s *engineSuite) getActivityStartedEvent(msBuilder mutableState,
-	scheduleID int64) *workflow.HistoryEvent {
-
-	ai, ok := msBuilder.GetActivityInfo(scheduleID)
-	if !ok {
-		return nil
-	}
-
-	return ai.StartedEvent
-}
-
 func (s *engineSuite) printHistory(builder mutableState) string {
 	return builder.GetHistoryBuilder().GetHistory().String()
 }

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4542,7 +4542,7 @@ func addDecisionTaskScheduledEvent(builder mutableState) *decisionInfo {
 }
 
 func addDecisionTaskStartedEvent(builder mutableState, scheduleID int64, taskList,
-identity string) *workflow.HistoryEvent {
+	identity string) *workflow.HistoryEvent {
 	return addDecisionTaskStartedEventWithRequestID(builder, scheduleID, validRunID, taskList, identity)
 }
 
@@ -4569,7 +4569,7 @@ func addDecisionTaskCompletedEvent(builder mutableState, scheduleID, startedID i
 }
 
 func addActivityTaskScheduledEvent(builder mutableState, decisionCompletedID int64, activityID, activityType,
-taskList string, input []byte, timeout, queueTimeout, heartbeatTimeout int32) (*workflow.HistoryEvent,
+	taskList string, input []byte, timeout, queueTimeout, heartbeatTimeout int32) (*workflow.HistoryEvent,
 	*persistence.ActivityInfo) {
 
 	return builder.AddActivityTaskScheduledEvent(decisionCompletedID, &workflow.ScheduleActivityTaskDecisionAttributes{

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -128,6 +128,7 @@ func newHistoryReplicator(shard ShardContext, historyEngine *historyEngineImpl, 
 			return newMutableStateBuilderWithReplicationState(
 				shard.GetService().GetClusterMetadata().GetCurrentClusterName(),
 				shard.GetConfig(),
+				shard.GetEventsCache(),
 				logger,
 				version,
 			)

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -2943,7 +2943,7 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateCurrentRunningIf
 		NewRunHistory:     nil,
 	}
 
-	msBuilderCurrent.On("ReplicateWorkflowExecutionTerminatedEvent", mock.MatchedBy(func(input *shared.HistoryEvent) bool {
+	msBuilderCurrent.On("ReplicateWorkflowExecutionTerminatedEvent", int64(999), mock.MatchedBy(func(input *shared.HistoryEvent) bool {
 		return reflect.DeepEqual(terminationEvent, input)
 	})).Return(nil)
 	contextCurrent.On("replicateWorkflowExecution", terminateRequest, mock.Anything, mock.Anything, currentNextEventID, mock.Anything, mock.Anything).Return(nil).Once()

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -67,14 +67,14 @@ type (
 	TestShardContext struct {
 		shardID int
 		sync.RWMutex
-		service                   service.Service
-		shardInfo                 *persistence.ShardInfo
-		transferSequenceNumber    int64
-		historyMgr                persistence.HistoryManager
-		historyV2Mgr              persistence.HistoryV2Manager
-		executionMgr              persistence.ExecutionManager
-		domainCache               cache.DomainCache
-		eventsCache               eventsCache
+		service                service.Service
+		shardInfo              *persistence.ShardInfo
+		transferSequenceNumber int64
+		historyMgr             persistence.HistoryManager
+		historyV2Mgr           persistence.HistoryV2Manager
+		executionMgr           persistence.ExecutionManager
+		domainCache            cache.DomainCache
+		eventsCache            eventsCache
 
 		config                    *Config
 		logger                    bark.Logger

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -166,6 +166,7 @@ func (s *TestShardContext) GetDomainCache() cache.DomainCache {
 	return s.domainCache
 }
 
+// GetEventsCache test implementation
 func (s *TestShardContext) GetEventsCache() eventsCache {
 	return s.eventsCache
 }

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -74,6 +74,8 @@ type (
 		historyV2Mgr              persistence.HistoryV2Manager
 		executionMgr              persistence.ExecutionManager
 		domainCache               cache.DomainCache
+		eventsCache               eventsCache
+
 		config                    *Config
 		logger                    bark.Logger
 		metricsClient             metrics.Client
@@ -114,7 +116,7 @@ func newTestShardContext(shardInfo *persistence.ShardInfo, transferSequenceNumbe
 		}
 	}
 
-	return &TestShardContext{
+	shardCtx := &TestShardContext{
 		shardID:                   0,
 		service:                   service.NewTestService(clusterMetadata, nil, metricsClient, clientBean, logger),
 		shardInfo:                 shardInfo,
@@ -129,6 +131,9 @@ func newTestShardContext(shardInfo *persistence.ShardInfo, transferSequenceNumbe
 		standbyClusterCurrentTime: standbyClusterCurrentTime,
 		timerMaxReadLevelMap:      timerMaxReadLevelMap,
 	}
+
+	shardCtx.eventsCache = newEventsCache(shardCtx)
+	return shardCtx
 }
 
 // GetShardID test implementation
@@ -159,6 +164,10 @@ func (s *TestShardContext) GetHistoryV2Manager() persistence.HistoryV2Manager {
 // GetDomainCache test implementation
 func (s *TestShardContext) GetDomainCache() cache.DomainCache {
 	return s.domainCache
+}
+
+func (s *TestShardContext) GetEventsCache() eventsCache {
+	return s.eventsCache
 }
 
 // GetNextTransferTaskID test implementation

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -113,7 +113,6 @@ type (
 		GetAllBufferedReplicationTasks() map[int64]*persistence.BufferedReplicationTask
 		GetChildExecutionInfo(int64) (*persistence.ChildExecutionInfo, bool)
 		GetChildExecutionInitiatedEvent(int64) (*workflow.HistoryEvent, bool)
-		GetChildExecutionStartedEvent(int64) (*workflow.HistoryEvent, bool)
 		GetCompletionEvent() (*workflow.HistoryEvent, bool)
 		GetContinueAsNew() *persistence.CreateWorkflowExecutionRequest
 		GetCurrentBranch() []byte
@@ -159,7 +158,7 @@ type (
 		ReplicateActivityTaskCanceledEvent(*workflow.HistoryEvent) error
 		ReplicateActivityTaskCompletedEvent(*workflow.HistoryEvent) error
 		ReplicateActivityTaskFailedEvent(*workflow.HistoryEvent) error
-		ReplicateActivityTaskScheduledEvent(*workflow.HistoryEvent) *persistence.ActivityInfo
+		ReplicateActivityTaskScheduledEvent(int64, *workflow.HistoryEvent) *persistence.ActivityInfo
 		ReplicateActivityTaskStartedEvent(*workflow.HistoryEvent)
 		ReplicateActivityTaskTimedOutEvent(*workflow.HistoryEvent) error
 		ReplicateChildWorkflowExecutionCanceledEvent(*workflow.HistoryEvent)
@@ -180,20 +179,20 @@ type (
 		ReplicateSignalExternalWorkflowExecutionFailedEvent(*workflow.HistoryEvent)
 		ReplicateSignalExternalWorkflowExecutionInitiatedEvent(*workflow.HistoryEvent, string) *persistence.SignalInfo
 		ReplicateStartChildWorkflowExecutionFailedEvent(*workflow.HistoryEvent)
-		ReplicateStartChildWorkflowExecutionInitiatedEvent(*workflow.HistoryEvent, string) *persistence.ChildExecutionInfo
+		ReplicateStartChildWorkflowExecutionInitiatedEvent(int64, *workflow.HistoryEvent, string) *persistence.ChildExecutionInfo
 		ReplicateTimerCanceledEvent(*workflow.HistoryEvent)
 		ReplicateTimerFiredEvent(*workflow.HistoryEvent)
 		ReplicateTimerStartedEvent(*workflow.HistoryEvent) *persistence.TimerInfo
 		ReplicateTransientDecisionTaskScheduled() *decisionInfo
 		ReplicateWorkflowExecutionCancelRequestedEvent(*workflow.HistoryEvent)
-		ReplicateWorkflowExecutionCanceledEvent(*workflow.HistoryEvent)
-		ReplicateWorkflowExecutionCompletedEvent(*workflow.HistoryEvent)
+		ReplicateWorkflowExecutionCanceledEvent(int64, *workflow.HistoryEvent)
+		ReplicateWorkflowExecutionCompletedEvent(int64, *workflow.HistoryEvent)
 		ReplicateWorkflowExecutionContinuedAsNewEvent(string, string, *workflow.HistoryEvent, *workflow.HistoryEvent, *decisionInfo, mutableState, int32) error
-		ReplicateWorkflowExecutionFailedEvent(*workflow.HistoryEvent)
+		ReplicateWorkflowExecutionFailedEvent(int64, *workflow.HistoryEvent)
 		ReplicateWorkflowExecutionSignaled(*workflow.HistoryEvent)
 		ReplicateWorkflowExecutionStartedEvent(string, *string, workflow.WorkflowExecution, string, *workflow.WorkflowExecutionStartedEventAttributes)
-		ReplicateWorkflowExecutionTerminatedEvent(*workflow.HistoryEvent)
-		ReplicateWorkflowExecutionTimedoutEvent(*workflow.HistoryEvent)
+		ReplicateWorkflowExecutionTerminatedEvent(int64, *workflow.HistoryEvent)
+		ReplicateWorkflowExecutionTimedoutEvent(int64, *workflow.HistoryEvent)
 		ResetSnapshot(string) *persistence.ResetMutableStateRequest
 		SetHistoryBuilder(hBuilder *historyBuilder)
 		SetHistoryTree(treeID string) error

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -110,7 +110,6 @@ type (
 		GetActivityByActivityID(string) (*persistence.ActivityInfo, bool)
 		GetActivityInfo(int64) (*persistence.ActivityInfo, bool)
 		GetActivityScheduledEvent(int64) (*workflow.HistoryEvent, bool)
-		GetActivityStartedEvent(int64) (*workflow.HistoryEvent, bool)
 		GetAllBufferedReplicationTasks() map[int64]*persistence.BufferedReplicationTask
 		GetChildExecutionInfo(int64) (*persistence.ChildExecutionInfo, bool)
 		GetChildExecutionInitiatedEvent(int64) (*workflow.HistoryEvent, bool)

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2532,7 +2532,11 @@ func (e *mutableStateBuilder) AddChildWorkflowExecutionCompletedEvent(initiatedI
 		return nil
 	}
 
-	domain := &ci.DomainName
+
+	var domain *string
+	if len(ci.DomainName) > 0 {
+		domain = &ci.DomainName
+	}
 	workflowType := &workflow.WorkflowType{
 		Name: common.StringPtr(ci.WorkflowTypeName),
 	}
@@ -2561,7 +2565,10 @@ func (e *mutableStateBuilder) AddChildWorkflowExecutionFailedEvent(initiatedID i
 		return nil
 	}
 
-	domain := &ci.DomainName
+	var domain *string
+	if len(ci.DomainName) > 0 {
+		domain = &ci.DomainName
+	}
 	workflowType := &workflow.WorkflowType{
 		Name: common.StringPtr(ci.WorkflowTypeName),
 	}
@@ -2590,7 +2597,10 @@ func (e *mutableStateBuilder) AddChildWorkflowExecutionCanceledEvent(initiatedID
 		return nil
 	}
 
-	domain := &ci.DomainName
+	var domain *string
+	if len(ci.DomainName) > 0 {
+		domain = &ci.DomainName
+	}
 	workflowType := &workflow.WorkflowType{
 		Name: common.StringPtr(ci.WorkflowTypeName),
 	}
@@ -2619,7 +2629,10 @@ func (e *mutableStateBuilder) AddChildWorkflowExecutionTerminatedEvent(initiated
 		return nil
 	}
 
-	domain := &ci.DomainName
+	var domain *string
+	if len(ci.DomainName) > 0 {
+		domain = &ci.DomainName
+	}
 	workflowType := &workflow.WorkflowType{
 		Name: common.StringPtr(ci.WorkflowTypeName),
 	}
@@ -2648,7 +2661,10 @@ func (e *mutableStateBuilder) AddChildWorkflowExecutionTimedOutEvent(initiatedID
 		return nil
 	}
 
-	domain := &ci.DomainName
+	var domain *string
+	if len(ci.DomainName) > 0 {
+		domain = &ci.DomainName
+	}
 	workflowType := &workflow.WorkflowType{
 		Name: common.StringPtr(ci.WorkflowTypeName),
 	}

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -762,6 +762,11 @@ func (e *mutableStateBuilder) GetActivityScheduledEvent(scheduleEventID int64) (
 		return nil, false
 	}
 
+	// Needed for backward compatibility reason
+	if ai.ScheduledEvent != nil {
+		return ai.ScheduledEvent, true
+	}
+
 	scheduledEvent, err := e.eventsCache.getEvent(e.executionInfo.DomainID, e.executionInfo.WorkflowID,
 		e.executionInfo.RunID, ai.ScheduledEventBatchID, ai.ScheduleID, e.executionInfo.EventStoreVersion,
 		e.executionInfo.GetCurrentBranch())
@@ -806,6 +811,11 @@ func (e *mutableStateBuilder) GetChildExecutionInitiatedEvent(initiatedEventID i
 	ci, ok := e.pendingChildExecutionInfoIDs[initiatedEventID]
 	if !ok {
 		return nil, false
+	}
+
+	// Needed for backward compatibility reason
+	if ci.InitiatedEvent != nil {
+		return ci.InitiatedEvent, true
 	}
 
 	initiatedEvent, err := e.eventsCache.getEvent(e.executionInfo.DomainID, e.executionInfo.WorkflowID,
@@ -858,6 +868,11 @@ func (e *mutableStateBuilder) GetAllRequestCancels() map[int64]*persistence.Requ
 func (e *mutableStateBuilder) GetCompletionEvent() (*workflow.HistoryEvent, bool) {
 	if e.executionInfo.State != persistence.WorkflowStateCompleted {
 		return nil, false
+	}
+
+	// Needed for backward compatibility reason
+	if e.executionInfo.CompletionEvent != nil {
+		return e.executionInfo.CompletionEvent, true
 	}
 
 	// Completion EventID is always one less than NextEventID after workflow is completed

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2532,7 +2532,6 @@ func (e *mutableStateBuilder) AddChildWorkflowExecutionCompletedEvent(initiatedI
 		return nil
 	}
 
-
 	var domain *string
 	if len(ci.DomainName) > 0 {
 		domain = &ci.DomainName

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -81,6 +81,7 @@ type (
 		hBuilder         *historyBuilder
 		currentCluster   string
 		historySize      int
+		eventsCache      eventsCache
 		config           *Config
 		logger           bark.Logger
 	}
@@ -117,6 +118,7 @@ func newMutableStateBuilder(currentCluster string, config *Config, logger bark.L
 		deleteSignalRequestedID:   "",
 
 		currentCluster: currentCluster,
+		eventsCache:    eventsCache,
 		config:         config,
 		logger:         logger,
 	}
@@ -1583,6 +1585,8 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(decisionCompletedEve
 	}
 
 	event := e.hBuilder.AddActivityTaskScheduledEvent(decisionCompletedEventID, attributes)
+	e.eventsCache.putEvent(e.executionInfo.DomainID, e.executionInfo.WorkflowID, e.executionInfo.RunID,
+		event.GetEventId(), event)
 
 	ai := e.ReplicateActivityTaskScheduledEvent(event)
 	return event, ai

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -38,8 +38,9 @@ import (
 type (
 	mutableStateSuite struct {
 		suite.Suite
-		msBuilder *mutableStateBuilder
-		logger    bark.Logger
+		msBuilder       *mutableStateBuilder
+		mockEventsCache *MockEventsCache
+		logger          bark.Logger
 	}
 )
 
@@ -61,7 +62,9 @@ func (s *mutableStateSuite) TearDownSuite() {
 
 func (s *mutableStateSuite) SetupTest() {
 	s.logger = bark.NewLoggerFromLogrus(log.New())
-	s.msBuilder = newMutableStateBuilder(cluster.TestCurrentClusterName, NewDynamicConfigForTest(), s.logger)
+	s.mockEventsCache = &MockEventsCache{}
+	s.msBuilder = newMutableStateBuilder(cluster.TestCurrentClusterName, NewDynamicConfigForTest(), s.mockEventsCache,
+		s.logger)
 }
 
 func (s *mutableStateSuite) TearDownTest() {

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -51,6 +51,12 @@ type Config struct {
 	HistoryCacheMaxSize     dynamicconfig.IntPropertyFn
 	HistoryCacheTTL         dynamicconfig.DurationPropertyFn
 
+	// EventsCache settings
+	// Change of these configs require shard restart
+	EventsCacheInitialSize dynamicconfig.IntPropertyFn
+	EventsCacheMaxSize     dynamicconfig.IntPropertyFn
+	EventsCacheTTL         dynamicconfig.DurationPropertyFn
+
 	// ShardController settings
 	RangeSizeBits        uint
 	AcquireShardInterval dynamicconfig.DurationPropertyFn
@@ -149,6 +155,9 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, enableVisibilit
 		HistoryCacheInitialSize:                               dc.GetIntProperty(dynamicconfig.HistoryCacheInitialSize, 128),
 		HistoryCacheMaxSize:                                   dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 512),
 		HistoryCacheTTL:                                       dc.GetDurationProperty(dynamicconfig.HistoryCacheTTL, time.Hour),
+		EventsCacheInitialSize:                                dc.GetIntProperty(dynamicconfig.EventsCacheInitialSize, 128),
+		EventsCacheMaxSize:                                    dc.GetIntProperty(dynamicconfig.EventsCacheMaxSize, 512),
+		EventsCacheTTL:                                        dc.GetDurationProperty(dynamicconfig.EventsCacheTTL, time.Hour),
 		RangeSizeBits:                                         20, // 20 bits for sequencer, 2^20 sequence number for any range
 		AcquireShardInterval:                                  dc.GetDurationProperty(dynamicconfig.AcquireShardInterval, time.Minute),
 		StandbyClusterDelay:                                   dc.GetDurationProperty(dynamicconfig.AcquireShardInterval, 5*time.Minute),

--- a/service/history/stateBuilder.go
+++ b/service/history/stateBuilder.go
@@ -403,6 +403,7 @@ func (b *stateBuilderImpl) applyEvents(domainID, requestID string, execution sha
 			newRunStateBuilder = newMutableStateBuilderWithReplicationState(
 				b.clusterMetadata.GetCurrentClusterName(),
 				b.shard.GetConfig(),
+				b.shard.GetEventsCache(),
 				b.logger,
 				startedEvent.GetVersion(),
 			)

--- a/service/history/stateBuilder.go
+++ b/service/history/stateBuilder.go
@@ -97,6 +97,10 @@ func (b *stateBuilderImpl) applyEvents(domainID, requestID string, execution sha
 	var lastEvent *shared.HistoryEvent
 	var lastDecision *decisionInfo
 	var newRunStateBuilder mutableState
+	var firstEvent *shared.HistoryEvent
+	if len(history) > 0 {
+		firstEvent = history[0]
+	}
 
 	// need to clear the stickness since workflow turned to passive
 	b.msBuilder.ClearStickyness()
@@ -177,7 +181,7 @@ func (b *stateBuilderImpl) applyEvents(domainID, requestID string, execution sha
 			}
 
 		case shared.EventTypeActivityTaskScheduled:
-			ai := b.msBuilder.ReplicateActivityTaskScheduledEvent(event)
+			ai := b.msBuilder.ReplicateActivityTaskScheduledEvent(firstEvent.GetEventId(), event)
 
 			b.transferTasks = append(b.transferTasks, b.scheduleActivityTransferTask(domainID, b.getTaskList(b.msBuilder),
 				ai.ScheduleID))
@@ -253,7 +257,8 @@ func (b *stateBuilderImpl) applyEvents(domainID, requestID string, execution sha
 		case shared.EventTypeStartChildWorkflowExecutionInitiated:
 			// Create a new request ID which is used by transfer queue processor if domain is failed over at this point
 			createRequestID := uuid.New()
-			cei := b.msBuilder.ReplicateStartChildWorkflowExecutionInitiatedEvent(event, createRequestID)
+			cei := b.msBuilder.ReplicateStartChildWorkflowExecutionInitiatedEvent(firstEvent.GetEventId(), event,
+				createRequestID)
 
 			attributes := event.StartChildWorkflowExecutionInitiatedEventAttributes
 			childDomainEntry, err := b.shard.GetDomainCache().GetDomain(attributes.GetDomain())
@@ -344,35 +349,35 @@ func (b *stateBuilderImpl) applyEvents(domainID, requestID string, execution sha
 			b.msBuilder.ReplicateWorkflowExecutionCancelRequestedEvent(event)
 
 		case shared.EventTypeWorkflowExecutionCompleted:
-			b.msBuilder.ReplicateWorkflowExecutionCompletedEvent(event)
+			b.msBuilder.ReplicateWorkflowExecutionCompletedEvent(firstEvent.GetEventId(), event)
 			err := b.appendTasksForFinishedExecutions(event, domainID, execution.GetWorkflowId())
 			if err != nil {
 				return nil, nil, nil, err
 			}
 
 		case shared.EventTypeWorkflowExecutionFailed:
-			b.msBuilder.ReplicateWorkflowExecutionFailedEvent(event)
+			b.msBuilder.ReplicateWorkflowExecutionFailedEvent(firstEvent.GetEventId(), event)
 			err := b.appendTasksForFinishedExecutions(event, domainID, execution.GetWorkflowId())
 			if err != nil {
 				return nil, nil, nil, err
 			}
 
 		case shared.EventTypeWorkflowExecutionTimedOut:
-			b.msBuilder.ReplicateWorkflowExecutionTimedoutEvent(event)
+			b.msBuilder.ReplicateWorkflowExecutionTimedoutEvent(firstEvent.GetEventId(), event)
 			err := b.appendTasksForFinishedExecutions(event, domainID, execution.GetWorkflowId())
 			if err != nil {
 				return nil, nil, nil, err
 			}
 
 		case shared.EventTypeWorkflowExecutionCanceled:
-			b.msBuilder.ReplicateWorkflowExecutionCanceledEvent(event)
+			b.msBuilder.ReplicateWorkflowExecutionCanceledEvent(firstEvent.GetEventId(), event)
 			err := b.appendTasksForFinishedExecutions(event, domainID, execution.GetWorkflowId())
 			if err != nil {
 				return nil, nil, nil, err
 			}
 
 		case shared.EventTypeWorkflowExecutionTerminated:
-			b.msBuilder.ReplicateWorkflowExecutionTerminatedEvent(event)
+			b.msBuilder.ReplicateWorkflowExecutionTerminatedEvent(firstEvent.GetEventId(), event)
 			err := b.appendTasksForFinishedExecutions(event, domainID, execution.GetWorkflowId())
 			if err != nil {
 				return nil, nil, nil, err

--- a/service/history/stateBuilder_test.go
+++ b/service/history/stateBuilder_test.go
@@ -1022,12 +1022,12 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 	}
 
 	ci := &persistence.ChildExecutionInfo{
-		Version:         event.GetVersion(),
-		InitiatedID:     event.GetEventId(),
+		Version:               event.GetVersion(),
+		InitiatedID:           event.GetEventId(),
 		InitiatedEventBatchID: event.GetEventId(),
-		StartedID:       common.EmptyEventID,
-		CreateRequestID: createRequestID,
-		DomainName:      targetDomain,
+		StartedID:             common.EmptyEventID,
+		CreateRequestID:       createRequestID,
+		DomainName:            targetDomain,
 	}
 
 	// the create request ID is generated inside, cannot assert equal

--- a/service/history/stateBuilder_test.go
+++ b/service/history/stateBuilder_test.go
@@ -1022,7 +1022,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 	ci := &persistence.ChildExecutionInfo{
 		Version:         event.GetVersion(),
 		InitiatedID:     event.GetEventId(),
-		InitiatedEvent:  event,
 		StartedID:       common.EmptyEventID,
 		CreateRequestID: createRequestID,
 	}

--- a/service/history/stateBuilder_test.go
+++ b/service/history/stateBuilder_test.go
@@ -229,7 +229,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut()
 			TableVersion:   persistence.DomainTableVersionV1,
 		}, nil,
 	).Once()
-	s.mockMutableState.On("ReplicateWorkflowExecutionTimedoutEvent", event).Once()
+	s.mockMutableState.On("ReplicateWorkflowExecutionTimedoutEvent", event.GetEventId(), event).Once()
 	s.mockUpdateVersion(event)
 
 	s.mockMutableState.On("ClearStickyness").Once()
@@ -279,7 +279,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 			TableVersion:   persistence.DomainTableVersionV1,
 		}, nil,
 	).Once()
-	s.mockMutableState.On("ReplicateWorkflowExecutionTerminatedEvent", event).Once()
+	s.mockMutableState.On("ReplicateWorkflowExecutionTerminatedEvent", event.GetEventId(), event).Once()
 	s.mockUpdateVersion(event)
 
 	s.mockMutableState.On("ClearStickyness").Once()
@@ -359,7 +359,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed() {
 			TableVersion:   persistence.DomainTableVersionV1,
 		}, nil,
 	).Once()
-	s.mockMutableState.On("ReplicateWorkflowExecutionFailedEvent", event).Once()
+	s.mockMutableState.On("ReplicateWorkflowExecutionFailedEvent", event.GetEventId(), event).Once()
 	s.mockUpdateVersion(event)
 
 	s.mockMutableState.On("ClearStickyness").Once()
@@ -577,7 +577,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted(
 			TableVersion:   persistence.DomainTableVersionV1,
 		}, nil,
 	).Once()
-	s.mockMutableState.On("ReplicateWorkflowExecutionCompletedEvent", event).Once()
+	s.mockMutableState.On("ReplicateWorkflowExecutionCompletedEvent", event.GetEventId(), event).Once()
 	s.mockUpdateVersion(event)
 
 	s.mockMutableState.On("ClearStickyness").Once()
@@ -627,7 +627,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCanceled()
 			TableVersion:   persistence.DomainTableVersionV1,
 		}, nil,
 	).Once()
-	s.mockMutableState.On("ReplicateWorkflowExecutionCanceledEvent", event).Once()
+	s.mockMutableState.On("ReplicateWorkflowExecutionCanceledEvent", event.GetEventId(), event).Once()
 	s.mockUpdateVersion(event)
 
 	s.mockMutableState.On("ClearStickyness").Once()
@@ -693,6 +693,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	msBuilder := newMutableStateBuilderWithReplicationState(
 		"currentCluster",
 		s.mockShard.GetConfig(),
+		s.mockShard.GetEventsCache(),
 		s.logger,
 		version,
 	)
@@ -806,6 +807,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	expectedNewRunStateBuilder := newMutableStateBuilderWithReplicationState(
 		s.mockClusterMetadata.GetCurrentClusterName(),
 		s.mockShard.GetConfig(),
+		s.mockShard.GetEventsCache(),
 		s.logger,
 		newRunStartedEvent.GetVersion(),
 	)
@@ -1022,12 +1024,15 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeStartChildWorkflowExecution
 	ci := &persistence.ChildExecutionInfo{
 		Version:         event.GetVersion(),
 		InitiatedID:     event.GetEventId(),
+		InitiatedEventBatchID: event.GetEventId(),
 		StartedID:       common.EmptyEventID,
 		CreateRequestID: createRequestID,
+		DomainName:      targetDomain,
 	}
 
 	// the create request ID is generated inside, cannot assert equal
-	s.mockMutableState.On("ReplicateStartChildWorkflowExecutionInitiatedEvent", event, mock.Anything).Return(ci).Once()
+	s.mockMutableState.On("ReplicateStartChildWorkflowExecutionInitiatedEvent", event.GetEventId(), event,
+		mock.Anything).Return(ci).Once()
 	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{Name: targetDomain}).Return(
 		&persistence.GetDomainResponse{
 			Info:   &persistence.DomainInfo{ID: targetDomainID, Name: targetDomain},
@@ -2030,6 +2035,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskScheduled() {
 	ai := &persistence.ActivityInfo{
 		Version:                  event.GetVersion(),
 		ScheduleID:               event.GetEventId(),
+		ScheduledEventBatchID:    event.GetEventId(),
 		ScheduledEvent:           event,
 		ScheduledTime:            time.Unix(0, event.GetTimestamp()),
 		StartedID:                common.EmptyEventID,
@@ -2051,7 +2057,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeActivityTaskScheduled() {
 	s.mockMutableState.On("GetExecutionInfo").Return(executionInfo)
 	s.mockMutableState.On("GetPendingActivityInfos").Return(map[int64]*persistence.ActivityInfo{event.GetEventId(): ai})
 	s.mockMutableState.On("UpdateActivity", ai).Return(nil).Once()
-	s.mockMutableState.On("ReplicateActivityTaskScheduledEvent", event).Return(ai).Once()
+	s.mockMutableState.On("ReplicateActivityTaskScheduledEvent", event.GetEventId(), event).Return(ai).Once()
 	s.mockUpdateVersion(event)
 
 	s.mockMutableState.On("ClearStickyness").Once()

--- a/service/history/stateBuilder_test.go
+++ b/service/history/stateBuilder_test.go
@@ -498,6 +498,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	expectedNewRunStateBuilder := newMutableStateBuilderWithReplicationState(
 		s.mockClusterMetadata.GetCurrentClusterName(),
 		s.mockShard.GetConfig(),
+		s.mockShard.GetEventsCache(),
 		s.logger,
 		newRunStartedEvent.GetVersion(),
 	)

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -54,6 +54,7 @@ type (
 		mockVisibilityMgr   *mocks.VisibilityManager
 		mockMatchingClient  *mocks.MatchingClient
 		mockClusterMetadata *mocks.ClusterMetadata
+		mockEventsCache     *MockEventsCache
 	}
 )
 
@@ -143,7 +144,8 @@ func (s *timerQueueProcessorSuite) createExecutionWithTimers(domainID string, we
 	identity string, timeOuts []int32) (*persistence.WorkflowMutableState, []persistence.Task) {
 
 	// Generate first decision task event.
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	addWorkflowExecutionStartedEvent(builder, we, "wType", tl, []byte("input"), 100, 200, identity)
 	di := addDecisionTaskScheduledEvent(builder)
 
@@ -157,7 +159,8 @@ func (s *timerQueueProcessorSuite) createExecutionWithTimers(domainID string, we
 	state0, err2 := s.GetWorkflowExecutionInfo(domainID, we)
 	s.NoError(err2, "No error expected.")
 
-	builder = newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder = newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state0)
 	startedEvent := addDecisionTaskStartedEvent(builder, di.ScheduleID, tl, identity)
 	addDecisionTaskCompletedEvent(builder, di.ScheduleID, *startedEvent.EventId, nil, identity)
@@ -195,7 +198,8 @@ func (s *timerQueueProcessorSuite) addDecisionTimer(domainID string, we workflow
 	s.NoError(err)
 
 	condition := state.ExecutionInfo.NextEventID
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 
 	di := addDecisionTaskScheduledEvent(builder)
@@ -216,7 +220,8 @@ func (s *timerQueueProcessorSuite) addDecisionTimer(domainID string, we workflow
 func (s *timerQueueProcessorSuite) addUserTimer(domainID string, we workflow.WorkflowExecution, timerID string, tb *timerBuilder) []persistence.Task {
 	state, err := s.GetWorkflowExecutionInfo(domainID, we)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -236,7 +241,8 @@ func (s *timerQueueProcessorSuite) addHeartBeatTimer(domainID string,
 	we workflow.WorkflowExecution, tb *timerBuilder) (*workflow.HistoryEvent, []persistence.Task) {
 	state, err := s.GetWorkflowExecutionInfo(domainID, we)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -356,7 +362,8 @@ func (s *timerQueueProcessorSuite) checkTimedOutEventFor(domainID string, we wor
 	scheduleID int64) bool {
 	info, err1 := s.GetWorkflowExecutionInfo(domainID, we)
 	s.NoError(err1)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(info)
 	_, isRunning := builder.GetActivityInfo(scheduleID)
 
@@ -367,7 +374,8 @@ func (s *timerQueueProcessorSuite) checkTimedOutEventForUserTimer(domainID strin
 	timerID string) bool {
 	info, err1 := s.GetWorkflowExecutionInfo(domainID, we)
 	s.NoError(err1)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(info)
 
 	isRunning, _ := builder.GetUserTimer(timerID)
@@ -409,7 +417,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithOutS
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -452,7 +461,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithStar
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -497,7 +507,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_MoreThan
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -542,7 +553,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_WithStart()
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -585,7 +597,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_CompletedAc
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -633,7 +646,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_JustSche
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -676,7 +690,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Started(
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -721,7 +736,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Complete
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -796,7 +812,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTask_SameExpiry() {
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -841,7 +858,8 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTask_SameExpiry() {
 	// assert activity infos are deleted
 	state, err = s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder = newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder = newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	s.Equal(0, len(builder.pendingActivityInfoIDs))
 }
@@ -883,7 +901,8 @@ func (s *timerQueueProcessorSuite) TestTimerUserTimers_SameExpiry() {
 
 	state, err := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder := newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	condition := state.ExecutionInfo.NextEventID
 
@@ -916,7 +935,8 @@ func (s *timerQueueProcessorSuite) TestTimerUserTimers_SameExpiry() {
 	// assert user timer infos are deleted
 	state, err = s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err)
-	builder = newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(), s.logger)
+	builder = newMutableStateBuilder(s.mockClusterMetadata.GetCurrentClusterName(), s.ShardContext.GetConfig(),
+		s.ShardContext.GetEventsCache(), s.logger)
 	builder.Load(state)
 	s.Equal(0, len(builder.pendingTimerInfoIDs))
 }

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -789,9 +789,11 @@ func (t *transferQueueActiveProcessorImpl) processStartChildExecution(task *pers
 		})
 	} else {
 		// ChildExecution already started, just create DecisionTask and complete transfer task
-		startedEvent, _ := msBuilder.GetChildExecutionStartedEvent(initiatedEventID)
-		startedAttributes := startedEvent.ChildWorkflowExecutionStartedEventAttributes
-		err = t.createFirstDecisionTask(targetDomainID, startedAttributes.WorkflowExecution)
+		childExecution := &workflow.WorkflowExecution{
+			WorkflowId: common.StringPtr(ci.StartedWorkflowID),
+			RunId:      common.StringPtr(ci.StartedRunID),
+		}
+		err = t.createFirstDecisionTask(targetDomainID, childExecution)
 	}
 
 	return err

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -465,7 +465,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_DecisionNotS
 	stickyTaskListName := "some random sticky task list"
 	stickyTaskListTimeout := int32(233)
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -1335,7 +1335,7 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 	persistenceMutableState := createMutableState(msBuilder)
 	s.mockHistoryMgr.On("GetWorkflowExecutionHistory", mock.Anything).Return(&persistence.GetWorkflowExecutionHistoryResponse{
 		History: &workflow.History{
-			Events:[]*workflow.HistoryEvent{event},
+			Events: []*workflow.HistoryEvent{event},
 		},
 	}, nil)
 	s.mockMetadataMgr.ExpectedCalls = nil

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -126,7 +126,7 @@ func (s *transferQueueActiveProcessorSuite) SetupTest() {
 	s.mockClientBean = &client.MockClientBean{}
 	s.mockService = service.NewTestService(s.mockClusterMetadata, s.mockMessagingClient, metricsClient, s.mockClientBean, s.logger)
 
-	s.mockShard = &shardContextImpl{
+	shardContext := &shardContextImpl{
 		service:                   s.mockService,
 		shardInfo:                 &persistence.ShardInfo{ShardID: shardID, RangeID: 1, TransferAckLevel: 0},
 		transferSequenceNumber:    1,
@@ -141,6 +141,8 @@ func (s *transferQueueActiveProcessorSuite) SetupTest() {
 		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),
 		timerMaxReadLevelMap:      make(map[string]time.Time),
 	}
+	shardContext.eventsCache = newEventsCache(shardContext)
+	s.mockShard = shardContext
 
 	historyCache := newHistoryCache(s.mockShard)
 	h := &historyEngineImpl{
@@ -186,7 +188,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Success() {
 	workflowType := "some random workflow type"
 	taskListName := "some random task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -241,7 +244,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Duplication(
 	workflowType := "some random workflow type"
 	taskListName := "some random task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -298,7 +302,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_FirstDecisio
 	workflowType := "some random workflow type"
 	taskListName := "some random task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -346,7 +351,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_NonFirstDeci
 	workflowType := "some random workflow type"
 	taskListName := "some random task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -400,7 +406,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_Sticky_NonFi
 	stickyTaskListName := "some random sticky task list"
 	stickyTaskListTimeout := int32(233)
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -514,7 +521,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_Duplication(
 	workflowType := "some random workflow type"
 	taskListName := "some random task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -570,7 +578,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_HasParent(
 		RunId:      common.StringPtr(uuid.New()),
 	}
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -635,7 +644,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent()
 	workflowType := "some random workflow type"
 	taskListName := "some random task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -693,7 +703,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Success()
 		RunId:      common.StringPtr(uuid.New()),
 	}
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -756,7 +767,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Failure()
 		RunId:      common.StringPtr(uuid.New()),
 	}
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -820,7 +832,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Duplicati
 		RunId:      common.StringPtr(uuid.New()),
 	}
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -884,7 +897,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Success()
 	signalInput := []byte("some random signal input")
 	signalControl := []byte("some random signal control")
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -960,7 +974,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Failure()
 	signalInput := []byte("some random signal input")
 	signalControl := []byte("some random signal control")
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -1028,7 +1043,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Duplicati
 	signalInput := []byte("some random signal input")
 	signalControl := []byte("some random signal control")
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -1092,7 +1108,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 	childWorkflowType := "some random child workflow type"
 	childTaskListName := "some random child task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -1185,7 +1202,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Failu
 	childWorkflowType := "some random child workflow type"
 	childTaskListName := "some random child task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -1272,7 +1290,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 	childWorkflowType := "some random child workflow type"
 	childTaskListName := "some random child task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{
@@ -1360,7 +1379,8 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Dupli
 	childWorkflowType := "some random child workflow type"
 	childTaskListName := "some random child task list"
 
-	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(), s.mockShard.GetConfig(), s.logger, s.version)
+	msBuilder := newMutableStateBuilderWithReplicationState(s.mockClusterMetadata.GetCurrentClusterName(),
+		s.mockShard.GetConfig(), s.mockShard.GetEventsCache(), s.logger, s.version)
 	msBuilder.AddWorkflowExecutionStartedEvent(
 		execution,
 		&history.StartWorkflowExecutionRequest{

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -1333,6 +1333,11 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 	msBuilder.UpdateReplicationStateLastEventID(s.mockClusterMetadata.GetCurrentClusterName(), s.version, event.GetEventId())
 
 	persistenceMutableState := createMutableState(msBuilder)
+	s.mockHistoryMgr.On("GetWorkflowExecutionHistory", mock.Anything).Return(&persistence.GetWorkflowExecutionHistoryResponse{
+		History: &workflow.History{
+			Events:[]*workflow.HistoryEvent{event},
+		},
+	}, nil)
 	s.mockMetadataMgr.ExpectedCalls = nil
 	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
 		Info:              &persistence.DomainInfo{Name: domainName},

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -1333,11 +1333,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 	msBuilder.UpdateReplicationStateLastEventID(s.mockClusterMetadata.GetCurrentClusterName(), s.version, event.GetEventId())
 
 	persistenceMutableState := createMutableState(msBuilder)
-	s.mockHistoryMgr.On("GetWorkflowExecutionHistory", mock.Anything).Return(&persistence.GetWorkflowExecutionHistoryResponse{
-		History: &workflow.History{
-			Events: []*workflow.HistoryEvent{event},
-		},
-	}, nil)
 	s.mockMetadataMgr.ExpectedCalls = nil
 	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(&persistence.GetDomainResponse{
 		Info:              &persistence.DomainInfo{Name: domainName},

--- a/service/history/transferQueueStandbyProcessor_test.go
+++ b/service/history/transferQueueStandbyProcessor_test.go
@@ -143,7 +143,6 @@ func (s *transferQueueStandbyProcessorSuite) SetupTest() {
 	shardContext.eventsCache = newEventsCache(shardContext)
 	s.mockShard = shardContext
 
-
 	historyCache := newHistoryCache(s.mockShard)
 	h := &historyEngineImpl{
 		currentClusterName: s.mockShard.GetService().GetClusterMetadata().GetCurrentClusterName(),

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -158,7 +158,8 @@ func (c *workflowExecutionContextImpl) loadWorkflowExecutionInternal() error {
 		return err
 	}
 
-	msBuilder := newMutableStateBuilder(c.clusterMetadata.GetCurrentClusterName(), c.shard.GetConfig(), c.logger)
+	msBuilder := newMutableStateBuilder(c.clusterMetadata.GetCurrentClusterName(), c.shard.GetConfig(),
+		c.shard.GetEventsCache(), c.logger)
 	if response != nil && response.State != nil {
 		state := response.State
 		msBuilder.Load(state)

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -535,11 +535,13 @@ func (w *workflowResetorImpl) replayHistoryEvents(decisionFinishEventID int64, r
 					resetMutableState = newMutableStateBuilderWithReplicationState(
 						clusterMetadata.GetCurrentClusterName(),
 						w.eng.shard.GetConfig(),
+						w.eng.shard.GetEventsCache(),
 						w.eng.logger,
 						firstEvent.GetVersion(),
 					)
 				} else {
-					resetMutableState = newMutableStateBuilder(clusterMetadata.GetCurrentClusterName(), w.eng.shard.GetConfig(), w.eng.logger)
+					resetMutableState = newMutableStateBuilder(clusterMetadata.GetCurrentClusterName(), w.eng.shard.GetConfig(),
+						w.eng.shard.GetEventsCache(), w.eng.logger)
 				}
 
 				resetMutableState.executionInfo.EventStoreVersion = persistence.EventStoreVersionV2

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -739,6 +739,7 @@ func (w *workflowResetorImpl) replicateResetEvent(baseMutableState mutableState,
 				newMsBuilder = newMutableStateBuilderWithReplicationState(
 					clusterMetadata.GetCurrentClusterName(),
 					w.eng.shard.GetConfig(),
+					w.eng.shard.GetEventsCache(),
 					w.eng.logger,
 					firstEvent.GetVersion(),
 				)

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -2074,6 +2074,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 	compareCurrExeInfo.NextEventID = 2
 	compareCurrExeInfo.HistorySize = 100
 	compareCurrExeInfo.LastFirstEventID = 1
+	compareCurrExeInfo.CompletionEventBatchID = 1
 	s.Equal(compareCurrExeInfo, resetReq.CurrExecutionInfo)
 	s.Equal(1, len(resetReq.CurrTransferTasks))
 	s.Equal(1, len(resetReq.CurrTimerTasks))

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -794,6 +794,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 	compareCurrExeInfo.CloseStatus = p.WorkflowCloseStatusTerminated
 	compareCurrExeInfo.NextEventID = 2
 	compareCurrExeInfo.HistorySize = 100
+	compareCurrExeInfo.CompletionEventBatchID = 1
 	s.Equal(compareCurrExeInfo, resetReq.CurrExecutionInfo)
 	s.Equal(1, len(resetReq.CurrTransferTasks))
 	s.Equal(1, len(resetReq.CurrTimerTasks))


### PR DESCRIPTION
Storing history events within mutableState limits scalability of the
system.  So moving all history events out of mutableState to
separate eventsCache.  This makes the mutable state size to be quite
small and allows us to store very large number of activities.
EventsCache is a LRU cache which stores the history event.  Any
processing logic which needs the history event like
RecordActivityStarted can get it from the cache without reading
it from the database.  Incase event is not found in cache it
uses the HistoryManager to load it from database and return it
to caller.