### PR TITLE
Various fixes for admin commands

### DIFF
--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -23,6 +23,7 @@ package cli
 import (
 	"fmt"
 
+	"code.uber.internal/devexp/cadence-tools/.tmp/.go/goroot/src/encoding/json"
 	"github.com/gocql/gocql"
 	"github.com/uber-common/bark"
 	"github.com/uber/cadence/.gen/go/shared"
@@ -108,7 +109,11 @@ func AdminShowWorkflow(c *cli.Context) {
 			ErrorAndExit("DeserializeBatchEvents err", err)
 		}
 		for _, e := range historyBatch {
-			fmt.Println(e.String())
+			jsonstr, err := json.Marshal(e)
+			if err != nil {
+				ErrorAndExit("json.Marshal err", err)
+			}
+			fmt.Println(jsonstr)
 		}
 	}
 }

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -109,11 +109,11 @@ func AdminShowWorkflow(c *cli.Context) {
 			ErrorAndExit("DeserializeBatchEvents err", err)
 		}
 		for _, e := range historyBatch {
-			jsonstr, err := json.Marshal(*e)
+			jsonstr, err := json.Marshal(e)
 			if err != nil {
 				ErrorAndExit("json.Marshal err", err)
 			}
-			fmt.Println(jsonstr)
+			fmt.Println(string(jsonstr))
 		}
 	}
 }

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -63,7 +63,8 @@ func AdminShowWorkflow(c *cli.Context) {
 	if len(wid) != 0 {
 		histV1 := cassp.NewHistoryPersistenceFromSession(session, bark.NewNopLogger())
 		resp, err := histV1.GetWorkflowExecutionHistory(&persistence.InternalGetWorkflowExecutionHistoryRequest{
-			DomainID: domainID,
+			LastEventBatchVersion: common.EmptyVersion,
+			DomainID:              domainID,
 			Execution: shared.WorkflowExecution{
 				WorkflowId: common.StringPtr(wid),
 				RunId:      common.StringPtr(rid),

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -23,7 +23,8 @@ package cli
 import (
 	"fmt"
 
-	"code.uber.internal/devexp/cadence-tools/.tmp/.go/goroot/src/encoding/json"
+	"encoding/json"
+
 	"github.com/gocql/gocql"
 	"github.com/uber-common/bark"
 	"github.com/uber/cadence/.gen/go/shared"

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -103,7 +103,7 @@ func AdminShowWorkflow(c *cli.Context) {
 		ErrorAndExit("no events", nil)
 	}
 	for idx, b := range history {
-		fmt.Printf("batch %v, blob len: %v \n", idx, len(b.Data))
+		fmt.Printf("======== batch %v, blob len: %v ======\n", idx+1, len(b.Data))
 		historyBatch, err := serializer.DeserializeBatchEvents(b)
 		if err != nil {
 			ErrorAndExit("DeserializeBatchEvents err", err)

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -103,7 +103,9 @@ func AdminShowWorkflow(c *cli.Context) {
 	if len(history) == 0 {
 		ErrorAndExit("no events", nil)
 	}
+	totalSize := 0
 	for idx, b := range history {
+		totalSize += len(b.Data)
 		fmt.Printf("======== batch %v, blob len: %v ======\n", idx+1, len(b.Data))
 		historyBatch, err := serializer.DeserializeBatchEvents(b)
 		if err != nil {
@@ -117,6 +119,7 @@ func AdminShowWorkflow(c *cli.Context) {
 			fmt.Println(string(jsonstr))
 		}
 	}
+	fmt.Printf("======== total batches %v, total blob len: %v ======\n", len(history), totalSize)
 }
 
 // AdminDescribeWorkflow describe a new workflow execution for admin

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -109,7 +109,7 @@ func AdminShowWorkflow(c *cli.Context) {
 			ErrorAndExit("DeserializeBatchEvents err", err)
 		}
 		for _, e := range historyBatch {
-			jsonstr, err := json.Marshal(e)
+			jsonstr, err := json.Marshal(*e)
 			if err != nil {
 				ErrorAndExit("json.Marshal err", err)
 			}

--- a/tools/cli/adminKafkaCommands.go
+++ b/tools/cli/adminKafkaCommands.go
@@ -100,6 +100,11 @@ func AdminKafkaParse(c *cli.Context) {
 
 func buildFilterFn(workflowID, runID string) filterFn {
 	return func(task *replicator.ReplicationTask) bool {
+		if len(workflowID) != 0 || len(runID) != 0 {
+			if task.GetHistoryTaskAttributes() == nil {
+				return false
+			}
+		}
 		if len(workflowID) != 0 && *task.HistoryTaskAttributes.WorkflowId != workflowID {
 			return false
 		}


### PR DESCRIPTION
This API will be useful to know which eventID to reset for using reset API.


```
longer@adhoc20-dca1:~/go/src/github.com/uber/cadence:(admShow)$ ./cadence adm wf show --address compute2487-dca1 --port 9042 --username cadence  -password 'change_me' --keyspace cadence_prod_dca1a -w 'cron.workflow.sanity' -r e06a0899-6858-4dc1-881f-b26c3890ae69 --domain_id 18a07bcd-8c81-4dc7-b93b-7da6fea10ef0
2018/12/05 00:39:16 Found invalid peer '[HostInfo connectAddress="10.67.138.155" peer="10.67.138.155" rpc_address="10.67.138.155" broadcast_address="<nil>" preferred_ip="<nil>" connect_addr="10.67.138.155" connect_addr_source="connect_address" port=9042 data_centre="sjc1" rack="rac1" host_id="daec8571-53ad-43c4-b2fe-61613a3d57b5" version="v3.0.14" state=UP num_tokens=0]' Likely due to a gossip or snitch issue, this host will be ignored


======== batch 1, blob len: 483 ======
{"eventId":1,"timestamp":1543964245899640554,"eventType":"WorkflowExecutionStarted","version":-24,"workflowExecutionStartedEventAttributes":{"workflowType":{"name":"code.uber.internal/devexp/cadence-canary/canary.cronWorkflow"},"taskList":{"name":"canary-task-queue"},"input":"MTU0Mzk2NDI0NTg4OTQxMjIyNwp7IkVudiI6InByb2QiLCJEZXBsb3ltZW50IjoicHJvZF9kY2ExYSIsIkRvbWFpbiI6ImNhZGVuY2UtY2FuYXJ5IiwiU2VydmVySG9zdFBvcnQiOiIiLCJIVFRQTGlzdGVuUG9ydCI6MzE4MDF9CiJ3b3JrZmxvdy5zYW5pdHkiCjUwMDAwMDAwMDAwCg==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":180,"continuedExecutionRunId":"56d8e7c7-0831-41cc-ba55-5614752bddcf","identity":"","attempt":0}}
{"eventId":2,"timestamp":1543964245899642434,"eventType":"DecisionTaskScheduled","version":-24,"decisionTaskScheduledEventAttributes":{"taskList":{"name":"canary-task-queue"},"startToCloseTimeoutSeconds":180,"attempt":0}}
======== batch 2, blob len: 154 ======
{"eventId":3,"timestamp":1543964245912849596,"eventType":"DecisionTaskStarted","version":-24,"decisionTaskStartedEventAttributes":{"scheduledEventId":2,"identity":"145@compute2943-dca1@canary-task-queue","requestId":"1ac0c3c1-3738-4102-9243-0c34ddbe4989"}}
======== batch 3, blob len: 654 ======
{"eventId":4,"timestamp":1543964245924313372,"eventType":"DecisionTaskCompleted","version":-24,"decisionTaskCompletedEventAttributes":{"scheduledEventId":2,"startedEventId":3,"identity":"145@compute2943-dca1@canary-task-queue"}}
{"eventId":5,"timestamp":1543964245924318175,"eventType":"MarkerRecorded","version":-24,"markerRecordedEventAttributes":{"markerName":"Version","details":"ImluaXRpYWwgdmVyc2lvbiIKMwo=","decisionTaskCompletedEventId":4}}
{"eventId":6,"timestamp":1543964245924321670,"eventType":"ActivityTaskScheduled","version":-24,"activityTaskScheduledEventAttributes":{"activityId":"0","activityType":{"name":"code.uber.internal/devexp/cadence-canary/canary.cronActivity"},"taskList":{"name":"canary-task-queue"},"input":"MTU0Mzk2NDI0NTkxMjg0OTU5Ngp7IkVudiI6InByb2QiLCJEZXBsb3ltZW50IjoicHJvZF9kY2ExYSIsIkRvbWFpbiI6ImNhZGVuY2UtY2FuYXJ5IiwiU2VydmVySG9zdFBvcnQiOiIiLCJIVFRQTGlzdGVuUG9ydCI6MzE4MDF9CiJ3b3JrZmxvdy5zYW5pdHkiCjUwMDAwMDAwMDAwCjEK","scheduleToCloseTimeoutSeconds":360,"scheduleToStartTimeoutSeconds":180,"startToCloseTimeoutSeconds":180,"heartbeatTimeoutSeconds":0,"decisionTaskCompletedEventId":4}}
{"eventId":7,"timestamp":1543964245924328274,"eventType":"TimerStarted","version":-24,"timerStartedEventAttributes":{"timerId":"1","startToFireTimeoutSeconds":59,"decisionTaskCompletedEventId":4}}
...
...
======== batch 73, blob len: 508 ======
{"eventId":115,"timestamp":1543964836161707500,"eventType":"DecisionTaskCompleted","version":-24,"decisionTaskCompletedEventAttributes":{"scheduledEventId":113,"startedEventId":114,"identity":"145@compute2943-dca1@canary-task-queue"}}
{"eventId":116,"timestamp":1543964836161731544,"eventType":"WorkflowExecutionContinuedAsNew","version":-24,"workflowExecutionContinuedAsNewEventAttributes":{"newExecutionRunId":"4eeb1a02-8e85-4e99-a86d-e4bf007fd4d0","workflowType":{"name":"code.uber.internal/devexp/cadence-canary/canary.cronWorkflow"},"taskList":{"name":"canary-task-queue"},"input":"MTU0Mzk2NDgzNjE0NjU1OTExNwp7IkVudiI6InByb2QiLCJEZXBsb3ltZW50IjoicHJvZF9kY2ExYSIsIkRvbWFpbiI6ImNhZGVuY2UtY2FuYXJ5IiwiU2VydmVySG9zdFBvcnQiOiIiLCJIVFRQTGlzdGVuUG9ydCI6MzE4MDF9CiJ3b3JrZmxvdy5zYW5pdHkiCjUwMDAwMDAwMDAwCg==","executionStartToCloseTimeoutSeconds":1080,"taskStartToCloseTimeoutSeconds":180,"decisionTaskCompletedEventId":115,"backoffStartIntervalInSeconds":0}}
======== total batches 73, total blob len: 17238 ======
```