### PR TITLE
Add new option WorkflowIdReusePolicy on creating new workflow in cli

### DIFF
--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -81,8 +81,7 @@ User need to run `show` to view workflow history/progress.
 
 **Re-use the same workflow id when starting/running workflow**
 
-The default re-run policy does not allow a workflow execution using the same workflow ID at all.  
-Use option `--workflowidreusepolicy` or `--wrp` to change default policy.  
+Use option `--workflowidreusepolicy` or `--wrp` to configure workflow id re-use policy.  
 **Option 0 AllowDuplicateFailedOnly:** Allow start a workflow execution using the same workflow ID when workflow not running, and the last execution close state is in *[terminated, cancelled, timeouted, failed]*.  
 **Option 1 AllowDuplicate:** Allow start a workflow execution using the same workflow ID when workflow not running.  
 **Option 2 RejectDuplicate:** Do not allow start a workflow execution using the same workflow ID at all.  

--- a/tools/cli/README.md
+++ b/tools/cli/README.md
@@ -79,6 +79,21 @@ and it takes a string as input, so there is the `-i '"cadence"'`. Single quote `
 Workflow `start` command is similar to `run` command and takes same flag options. But it just start the workflow and immediately return workflow_id and run_id.  
 User need to run `show` to view workflow history/progress.  
 
+**Re-use the same workflow id when starting/running workflow**
+
+The default re-run policy does not allow a workflow execution using the same workflow ID at all.  
+Use option `--workflowidreusepolicy` or `--wrp` to change default policy.  
+**Option 0 AllowDuplicateFailedOnly:** Allow start a workflow execution using the same workflow ID when workflow not running, and the last execution close state is in *[terminated, cancelled, timeouted, failed]*.  
+**Option 1 AllowDuplicate:** Allow start a workflow execution using the same workflow ID when workflow not running.  
+**Option 2 RejectDuplicate:** Do not allow start a workflow execution using the same workflow ID at all.  
+```
+# use AllowDuplicateFailedOnly option to start a workflow
+./cadence workflow start --tl helloWorldGroup --wt main.Workflow --et 60 -i '"cadence"' --wid "<duplicated workflow id>" --wrp 0
+
+# use AllowDuplicate option to run a workflow
+./cadence workflow run --tl helloWorldGroup --wt main.Workflow --et 60 -i '"cadence"' --wid "<duplicated workflow id>" --wrp 1
+```
+
 - Show workflow history
 ```
 ./cadence workflow show -w 3ea6b242-b23c-4279-bb13-f215661b4717 -r 866ae14c-88cf-4f1e-980f-571e031d71b0

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -269,10 +269,10 @@ func (s *cliAppSuite) TestStartWorkflow() {
 	resp := &shared.StartWorkflowExecutionResponse{RunId: common.StringPtr(uuid.New())}
 	s.clientFrontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
 	// start with wid
-	err := s.app.Run([]string{"", "--do", domainName, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "-w", "wid"})
+	err := s.app.Run([]string{"", "--do", domainName, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "-w", "wid", "wrp", "2"})
 	s.Nil(err)
 	// start without wid
-	err = s.app.Run([]string{"", "--do", domainName, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60"})
+	err = s.app.Run([]string{"", "--do", domainName, "workflow", "start", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "wrp", "2"})
 	s.Nil(err)
 }
 
@@ -290,10 +290,10 @@ func (s *cliAppSuite) TestRunWorkflow() {
 	s.clientFrontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
 	s.clientFrontendClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), gomock.Any(), callOptions...).Return(history, nil).Times(2)
 	// start with wid
-	err := s.app.Run([]string{"", "--do", domainName, "workflow", "run", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "-w", "wid"})
+	err := s.app.Run([]string{"", "--do", domainName, "workflow", "run", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "-w", "wid", "wrp", "2"})
 	s.Nil(err)
 	// start without wid
-	err = s.app.Run([]string{"", "--do", domainName, "workflow", "run", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60"})
+	err = s.app.Run([]string{"", "--do", domainName, "workflow", "run", "-tl", "testTaskList", "-wt", "testWorkflowType", "-et", "60", "wrp", "2"})
 	s.Nil(err)
 }
 
@@ -561,4 +561,47 @@ func (s *cliAppSuite) TestAnyToString() {
 func (s *cliAppSuite) TestIsAttributeName() {
 	s.True(isAttributeName("WorkflowExecutionStartedEventAttributes"))
 	s.False(isAttributeName("workflowExecutionStartedEventAttributes"))
+}
+
+func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_EmptyOption() {
+	res := getWorkflowIdReusePolicy("")
+	s.Nil(res)
+}
+
+func (s *cliAppSuite) TestGetWorkflowIdReusePolicy() {
+	res := getWorkflowIdReusePolicy("2")
+	s.Equal(res.String(), shared.WorkflowIdReusePolicyRejectDuplicate.String())
+}
+
+func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_InvalidValue() {
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+	var errorCode int
+	osExit = func(code int) {
+		errorCode = code
+	}
+	getWorkflowIdReusePolicy("letters")
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_ExceedRange() {
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+	var errorCode int
+	osExit = func(code int) {
+		errorCode = code
+	}
+	getWorkflowIdReusePolicy("2147483647")
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_Negative() {
+	oldOsExit := osExit
+	defer func() { osExit = oldOsExit }()
+	var errorCode int
+	osExit = func(code int) {
+		errorCode = code
+	}
+	getWorkflowIdReusePolicy("-1")
+	s.Equal(1, errorCode)
 }

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -563,25 +563,9 @@ func (s *cliAppSuite) TestIsAttributeName() {
 	s.False(isAttributeName("workflowExecutionStartedEventAttributes"))
 }
 
-func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_EmptyOption() {
-	res := getWorkflowIdReusePolicy("")
-	s.Nil(res)
-}
-
 func (s *cliAppSuite) TestGetWorkflowIdReusePolicy() {
-	res := getWorkflowIdReusePolicy("2")
+	res := getWorkflowIdReusePolicy(2)
 	s.Equal(res.String(), shared.WorkflowIdReusePolicyRejectDuplicate.String())
-}
-
-func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_InvalidValue() {
-	oldOsExit := osExit
-	defer func() { osExit = oldOsExit }()
-	var errorCode int
-	osExit = func(code int) {
-		errorCode = code
-	}
-	getWorkflowIdReusePolicy("letters")
-	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_ExceedRange() {
@@ -591,7 +575,7 @@ func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_ExceedRange() {
 	osExit = func(code int) {
 		errorCode = code
 	}
-	getWorkflowIdReusePolicy("2147483647")
+	getWorkflowIdReusePolicy(2147483647)
 	s.Equal(1, errorCode)
 }
 
@@ -602,6 +586,6 @@ func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_Negative() {
 	osExit = func(code int) {
 		errorCode = code
 	}
-	getWorkflowIdReusePolicy("-1")
+	getWorkflowIdReusePolicy(-1)
 	s.Equal(1, errorCode)
 }

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -143,6 +143,11 @@ func newWorkflowCommands() []cli.Command {
 					Usage: "Optional input for the workflow from JSON file. If there are multiple JSON, concatenate them and separate by space or newline. " +
 						"Input from file will be overwrite by input from command line",
 				},
+				cli.StringFlag{
+					Name: FlagWorkflowIdReusePolicyAlias,
+					Usage: "Optional input to configure if the same workflow ID is allow to use for new workflow execution (choose from 0 to 2). " +
+						"See: https://github.com/uber/cadence/blob/master/tools/cli/README.md",
+				},
 			},
 			Action: func(c *cli.Context) {
 				StartWorkflow(c)
@@ -185,6 +190,11 @@ func newWorkflowCommands() []cli.Command {
 					Name: FlagInputFileWithAlias,
 					Usage: "Optional input for the workflow from JSON file. If there are multiple JSON, concatenate them and separate by space or newline. " +
 						"Input from file will be overwrite by input from command line",
+				},
+				cli.StringFlag{
+					Name: FlagWorkflowIdReusePolicyAlias,
+					Usage: "Optional input to configure if the same workflow ID is allow to use for new workflow execution (choose from 0 to 2). " +
+						"See: https://github.com/uber/cadence/blob/master/tools/cli/README.md",
 				},
 				cli.BoolFlag{
 					Name:  FlagShowDetailWithAlias,

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -134,6 +134,11 @@ func newWorkflowCommands() []cli.Command {
 					Value: defaultDecisionTimeoutInSeconds,
 					Usage: "Decision task start to close timeout in seconds",
 				},
+				cli.IntFlag{
+					Name: FlagWorkflowIdReusePolicyAlias,
+					Usage: "Optional input to configure if the same workflow ID is allow to use for new workflow execution. " +
+						"Available options: 0: AllowDuplicateFailedOnly, 1: AllowDuplicate, 2: RejectDuplicate",
+				},
 				cli.StringFlag{
 					Name:  FlagInputWithAlias,
 					Usage: "Optional input for the workflow, in JSON format. If there are multiple parameters, concatenate them and separate by space.",
@@ -142,11 +147,6 @@ func newWorkflowCommands() []cli.Command {
 					Name: FlagInputFileWithAlias,
 					Usage: "Optional input for the workflow from JSON file. If there are multiple JSON, concatenate them and separate by space or newline. " +
 						"Input from file will be overwrite by input from command line",
-				},
-				cli.StringFlag{
-					Name: FlagWorkflowIdReusePolicyAlias,
-					Usage: "Optional input to configure if the same workflow ID is allow to use for new workflow execution (choose from 0 to 2). " +
-						"See: https://github.com/uber/cadence/blob/master/tools/cli/README.md",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -182,6 +182,11 @@ func newWorkflowCommands() []cli.Command {
 					Name:  FlagContextTimeoutWithAlias,
 					Usage: "Optional timeout for start command context in seconds, default value is 120",
 				},
+				cli.IntFlag{
+					Name: FlagWorkflowIdReusePolicyAlias,
+					Usage: "Optional input to configure if the same workflow ID is allow to use for new workflow execution. " +
+						"Available options: 0: AllowDuplicateFailedOnly, 1: AllowDuplicate, 2: RejectDuplicate",
+				},
 				cli.StringFlag{
 					Name:  FlagInputWithAlias,
 					Usage: "Optional input for the workflow, in JSON format. If there are multiple parameters, concatenate them and separate by space.",
@@ -190,11 +195,6 @@ func newWorkflowCommands() []cli.Command {
 					Name: FlagInputFileWithAlias,
 					Usage: "Optional input for the workflow from JSON file. If there are multiple JSON, concatenate them and separate by space or newline. " +
 						"Input from file will be overwrite by input from command line",
-				},
-				cli.StringFlag{
-					Name: FlagWorkflowIdReusePolicyAlias,
-					Usage: "Optional input to configure if the same workflow ID is allow to use for new workflow execution (choose from 0 to 2). " +
-						"See: https://github.com/uber/cadence/blob/master/tools/cli/README.md",
 				},
 				cli.BoolFlag{
 					Name:  FlagShowDetailWithAlias,


### PR DESCRIPTION
Add new option WorkflowIdReusePolicy on creating new workflow in cli

Issue: https://github.com/uber/cadence/issues/704
