### PR TITLE
size limit: max ID length

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -60,6 +60,7 @@ var keys = map[Key]string{
 	HistorySizeLimitWarn:   "limit.historySize.warn",
 	HistoryCountLimitError: "limit.historyCount.error",
 	HistoryCountLimitWarn:  "limit.historyCount.warn",
+	MaxIDLengthLimit:       "limit.maxIDLength",
 
 	// frontend settings
 	FrontendPersistenceMaxQPS:      "frontend.persistenceMaxQPS",
@@ -192,6 +193,10 @@ const (
 	HistoryCountLimitError
 	// HistoryCountLimitWarn is the per workflow execution history event count limit for warning
 	HistoryCountLimitWarn
+
+	// MaxIDLengthLimit is the length limit for various IDs, including: Domain, TaskList, WorkflowID, ActivityID, TimerID,
+	// WorkflowType, ActivityType, SignalName, MarkerName, ErrorReason/FailureReason/CancelCause, Identity, RequestID
+	MaxIDLengthLimit
 
 	// key for frontend
 

--- a/common/util.go
+++ b/common/util.go
@@ -71,10 +71,6 @@ const (
 	FailureReasonDecisionBlobSizeExceedsLimit = "DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
 	// TerminateReasonSizeExceedsLimit is reason to terminate workflow when history size exceed limit
 	TerminateReasonSizeExceedsLimit = "HISTORY_SIZE_EXCEEDS_LIMIT"
-
-	// MaxIDLengthLimit is the length limit for various IDs, including: Domain, TaskList, WorkflowID, ActivityID, TimerID,
-	// WorkflowType, ActivityType, SignalName, MarkerName, ErrorReason/FailureReason/CancelCause, Identity, RequestID
-	MaxIDLengthLimit = 1000 // max ID length limit
 )
 
 var (

--- a/common/util.go
+++ b/common/util.go
@@ -71,6 +71,10 @@ const (
 	FailureReasonDecisionBlobSizeExceedsLimit = "DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
 	// TerminateReasonSizeExceedsLimit is reason to terminate workflow when history size exceed limit
 	TerminateReasonSizeExceedsLimit = "HISTORY_SIZE_EXCEEDS_LIMIT"
+
+	// MaxIDLengthLimit is the length limit for various IDs, including: Domain, TaskList, WorkflowID, ActivityID, TimerID,
+	// WorkflowType, ActivityType, SignalName, MarkerName, ErrorReason/FailureReason/CancelCause, Identity, RequestID
+	MaxIDLengthLimit = 1000 // max ID length limit
 )
 
 var (

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -37,6 +37,7 @@ type Config struct {
 	VisibilityListMaxQPS     dynamicconfig.IntPropertyFnWithDomainFilter
 	HistoryMaxPageSize       dynamicconfig.IntPropertyFnWithDomainFilter
 	RPS                      dynamicconfig.IntPropertyFn
+	MaxIDLengthLimit         dynamicconfig.IntPropertyFn
 
 	// Persistence settings
 	HistoryMgrNumConns dynamicconfig.IntPropertyFn
@@ -62,6 +63,7 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		VisibilityListMaxQPS:           dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendVisibilityListMaxQPS, 1),
 		HistoryMaxPageSize:             dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, common.GetHistoryMaxPageSize),
 		RPS:                            dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
+		MaxIDLengthLimit:               dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		HistoryMgrNumConns:             dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
 		MaxDecisionStartToCloseTimeout: dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaxDecisionStartToCloseTimeout, 600),
 		EnableAdminProtection:          dc.GetBoolProperty(dynamicconfig.EnableAdminProtection, false),

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/uber/cadence/common/blobstore"
 	"sync"
 	"time"
 
@@ -43,6 +42,7 @@ import (
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/blobstore"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/logging"
@@ -118,6 +118,15 @@ var (
 	errDisallowedBucketMetadata         = &gen.BadRequestError{Message: "Cannot set bucket owner or bucket retention (must update bucket manually)."}
 	errBucketNameUpdate                 = &gen.BadRequestError{Message: "Cannot update bucket name after after archival has been enabled for the first time."}
 	errUnknownArchivalStatus            = &gen.BadRequestError{Message: "Got unknown archival status."}
+
+	// err for string too long
+	errDomainTooLong       = &gen.BadRequestError{Message: "Domain length exceeds limit."}
+	errWorkflowTypeTooLong = &gen.BadRequestError{Message: "WorkflowType length exceeds limit."}
+	errWorkflowIDTooLong   = &gen.BadRequestError{Message: "WorkflowID length exceeds limit."}
+	errSignalNameTooLong   = &gen.BadRequestError{Message: "SignalName length exceeds limit."}
+	errTaskListTooLong     = &gen.BadRequestError{Message: "TaskList length exceeds limit."}
+	errRequestIDTooLong    = &gen.BadRequestError{Message: "RequestID length exceeds limit."}
+	errIdentityTooLong     = &gen.BadRequestError{Message: "Identity length exceeds limit."}
 
 	// err indicating that this cluster is not the master, so cannot do domain registration or update
 	errNotMasterCluster                = &gen.BadRequestError{Message: "Cluster is not master cluster, cannot do domain registration or domain update."}
@@ -774,12 +783,19 @@ func (wh *WorkflowHandler) PollForActivityTask(
 	}
 
 	wh.Service.GetLogger().Debug("Received PollForActivityTask")
-	if pollRequest.Domain == nil {
+	if pollRequest.Domain == nil || pollRequest.GetDomain() == "" {
 		return nil, wh.error(errDomainNotSet, scope)
+	}
+
+	if len(pollRequest.GetDomain()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errDomainTooLong, scope)
 	}
 
 	if err := wh.validateTaskList(pollRequest.TaskList, scope); err != nil {
 		return nil, err
+	}
+	if len(pollRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errIdentityTooLong, scope)
 	}
 
 	domainID, err := wh.domainCache.GetDomainID(pollRequest.GetDomain())
@@ -830,8 +846,15 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 	}
 
 	wh.Service.GetLogger().Debug("Received PollForDecisionTask")
-	if pollRequest.Domain == nil {
+	if pollRequest.Domain == nil || pollRequest.GetDomain() == "" {
 		return nil, wh.error(errDomainNotSet, scope)
+	}
+	if len(pollRequest.GetDomain()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errDomainTooLong, scope)
+	}
+
+	if len(pollRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errIdentityTooLong, scope)
 	}
 
 	if err := wh.validateTaskList(pollRequest.TaskList, scope); err != nil {
@@ -1095,6 +1118,9 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	if err != nil {
 		return wh.error(err, scope)
 	}
+	if len(completeRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return wh.error(errIdentityTooLong, scope)
+	}
 
 	sizeLimitError := wh.config.BlobSizeLimitError(domainEntry.GetInfo().Name)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainEntry.GetInfo().Name)
@@ -1161,6 +1187,10 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 	}
 	if activityID == "" {
 		return wh.error(errActivityIDNotSet, scope)
+	}
+
+	if len(completeRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return wh.error(errIdentityTooLong, scope)
 	}
 
 	taskToken := &common.TaskToken{
@@ -1250,6 +1280,9 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 	if err != nil {
 		return wh.error(err, scope)
 	}
+	if len(failedRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return wh.error(errIdentityTooLong, scope)
+	}
 
 	sizeLimitError := wh.config.BlobSizeLimitError(domainEntry.GetInfo().Name)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainEntry.GetInfo().Name)
@@ -1304,6 +1337,9 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 	}
 	if activityID == "" {
 		return wh.error(errActivityIDNotSet, scope)
+	}
+	if len(failedRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return wh.error(errIdentityTooLong, scope)
 	}
 
 	taskToken := &common.TaskToken{
@@ -1383,6 +1419,10 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 		return wh.error(err, scope)
 	}
 
+	if len(cancelRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return wh.error(errIdentityTooLong, scope)
+	}
+
 	sizeLimitError := wh.config.BlobSizeLimitError(domainEntry.GetInfo().Name)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainEntry.GetInfo().Name)
 
@@ -1448,6 +1488,9 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 	}
 	if activityID == "" {
 		return wh.error(errActivityIDNotSet, scope)
+	}
+	if len(cancelRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return wh.error(errIdentityTooLong, scope)
 	}
 
 	taskToken := &common.TaskToken{
@@ -1541,6 +1584,10 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 		return nil, wh.error(err, scope)
 	}
 
+	if len(completeRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errIdentityTooLong, scope)
+	}
+
 	completedResp := &gen.RespondDecisionTaskCompletedResponse{}
 	if completeRequest.GetReturnNewDecisionTask() && histResp != nil && histResp.StartedResponse != nil {
 		taskToken := &common.TaskToken{
@@ -1598,6 +1645,10 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 	domainEntry, err := wh.domainCache.GetDomainByID(taskToken.DomainID)
 	if err != nil {
 		return wh.error(err, scope)
+	}
+
+	if len(failedRequest.GetIdentity()) > common.MaxIDLengthLimit {
+		return wh.error(errIdentityTooLong, scope)
 	}
 
 	sizeLimitError := wh.config.BlobSizeLimitError(domainEntry.GetInfo().Name)
@@ -1682,8 +1733,16 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
+	if len(startRequest.GetDomain()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errDomainTooLong, scope)
+	}
+
 	if startRequest.GetWorkflowId() == "" {
 		return nil, wh.error(errWorkflowIDNotSet, scope)
+	}
+
+	if len(startRequest.GetWorkflowId()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errWorkflowIDTooLong, scope)
 	}
 
 	if err := common.ValidateRetryPolicy(startRequest.RetryPolicy); err != nil {
@@ -1702,6 +1761,10 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(errWorkflowTypeNotSet, scope)
 	}
 
+	if len(startRequest.WorkflowType.GetName()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errWorkflowTypeTooLong, scope)
+	}
+
 	if err := wh.validateTaskList(startRequest.TaskList, scope); err != nil {
 		return nil, err
 	}
@@ -1716,6 +1779,10 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 
 	if startRequest.GetRequestId() == "" {
 		return nil, wh.error(errRequestIDNotSet, scope)
+	}
+
+	if len(startRequest.GetRequestId()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errRequestIDTooLong, scope)
 	}
 
 	maxDecisionTimeout := int32(wh.config.MaxDecisionStartToCloseTimeout(startRequest.GetDomain()))
@@ -1960,12 +2027,24 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 		return wh.error(errDomainNotSet, scope)
 	}
 
+	if len(signalRequest.GetDomain()) > common.MaxIDLengthLimit {
+		return wh.error(errDomainTooLong, scope)
+	}
+
 	if err := wh.validateExecutionAndEmitMetrics(signalRequest.WorkflowExecution, scope); err != nil {
 		return err
 	}
 
 	if signalRequest.GetSignalName() == "" {
 		return wh.error(&gen.BadRequestError{Message: "SignalName is not set on request."}, scope)
+	}
+
+	if len(signalRequest.GetSignalName()) > common.MaxIDLengthLimit {
+		return wh.error(errSignalNameTooLong, scope)
+	}
+
+	if len(signalRequest.GetRequestId()) > common.MaxIDLengthLimit {
+		return wh.error(errRequestIDTooLong, scope)
 	}
 
 	domainID, err := wh.domainCache.GetDomainID(signalRequest.GetDomain())
@@ -2016,20 +2095,40 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
+	if len(signalWithStartRequest.GetDomain()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errDomainTooLong, scope)
+	}
+
 	if signalWithStartRequest.GetWorkflowId() == "" {
 		return nil, wh.error(&gen.BadRequestError{Message: "WorkflowId is not set on request."}, scope)
+	}
+
+	if len(signalWithStartRequest.GetWorkflowId()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errWorkflowIDTooLong, scope)
 	}
 
 	if signalWithStartRequest.GetSignalName() == "" {
 		return nil, wh.error(&gen.BadRequestError{Message: "SignalName is not set on request."}, scope)
 	}
 
+	if len(signalWithStartRequest.GetSignalName()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errSignalNameTooLong, scope)
+	}
+
 	if signalWithStartRequest.WorkflowType == nil || signalWithStartRequest.WorkflowType.GetName() == "" {
 		return nil, wh.error(&gen.BadRequestError{Message: "WorkflowType is not set on request."}, scope)
 	}
 
+	if len(signalWithStartRequest.WorkflowType.GetName()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errWorkflowTypeTooLong, scope)
+	}
+
 	if err := wh.validateTaskList(signalWithStartRequest.TaskList, scope); err != nil {
 		return nil, err
+	}
+
+	if len(signalWithStartRequest.GetRequestId()) > common.MaxIDLengthLimit {
+		return nil, wh.error(errRequestIDTooLong, scope)
 	}
 
 	if signalWithStartRequest.GetExecutionStartToCloseTimeoutSeconds() <= 0 {
@@ -2759,6 +2858,9 @@ func (wh *WorkflowHandler) validateTaskListType(t *gen.TaskListType, scope int) 
 func (wh *WorkflowHandler) validateTaskList(t *gen.TaskList, scope int) error {
 	if t == nil || t.Name == nil || t.GetName() == "" {
 		return wh.error(errTaskListNotSet, scope)
+	}
+	if len(t.GetName()) > common.MaxIDLengthLimit {
+		return wh.error(errTaskListTooLong, scope)
 	}
 	return nil
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -787,14 +787,14 @@ func (wh *WorkflowHandler) PollForActivityTask(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if len(pollRequest.GetDomain()) > common.MaxIDLengthLimit {
+	if len(pollRequest.GetDomain()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errDomainTooLong, scope)
 	}
 
 	if err := wh.validateTaskList(pollRequest.TaskList, scope); err != nil {
 		return nil, err
 	}
-	if len(pollRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(pollRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errIdentityTooLong, scope)
 	}
 
@@ -849,11 +849,11 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 	if pollRequest.Domain == nil || pollRequest.GetDomain() == "" {
 		return nil, wh.error(errDomainNotSet, scope)
 	}
-	if len(pollRequest.GetDomain()) > common.MaxIDLengthLimit {
+	if len(pollRequest.GetDomain()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errDomainTooLong, scope)
 	}
 
-	if len(pollRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(pollRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1118,7 +1118,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	if err != nil {
 		return wh.error(err, scope)
 	}
-	if len(completeRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(completeRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1189,7 +1189,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 		return wh.error(errActivityIDNotSet, scope)
 	}
 
-	if len(completeRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(completeRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1280,7 +1280,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 	if err != nil {
 		return wh.error(err, scope)
 	}
-	if len(failedRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(failedRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1338,7 +1338,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 	if activityID == "" {
 		return wh.error(errActivityIDNotSet, scope)
 	}
-	if len(failedRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(failedRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1419,7 +1419,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 		return wh.error(err, scope)
 	}
 
-	if len(cancelRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(cancelRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1489,7 +1489,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 	if activityID == "" {
 		return wh.error(errActivityIDNotSet, scope)
 	}
-	if len(cancelRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(cancelRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1584,7 +1584,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 		return nil, wh.error(err, scope)
 	}
 
-	if len(completeRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(completeRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1647,7 +1647,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 		return wh.error(err, scope)
 	}
 
-	if len(failedRequest.GetIdentity()) > common.MaxIDLengthLimit {
+	if len(failedRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
 
@@ -1733,7 +1733,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if len(startRequest.GetDomain()) > common.MaxIDLengthLimit {
+	if len(startRequest.GetDomain()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errDomainTooLong, scope)
 	}
 
@@ -1741,7 +1741,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(errWorkflowIDNotSet, scope)
 	}
 
-	if len(startRequest.GetWorkflowId()) > common.MaxIDLengthLimit {
+	if len(startRequest.GetWorkflowId()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errWorkflowIDTooLong, scope)
 	}
 
@@ -1761,7 +1761,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(errWorkflowTypeNotSet, scope)
 	}
 
-	if len(startRequest.WorkflowType.GetName()) > common.MaxIDLengthLimit {
+	if len(startRequest.WorkflowType.GetName()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errWorkflowTypeTooLong, scope)
 	}
 
@@ -1781,7 +1781,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(errRequestIDNotSet, scope)
 	}
 
-	if len(startRequest.GetRequestId()) > common.MaxIDLengthLimit {
+	if len(startRequest.GetRequestId()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errRequestIDTooLong, scope)
 	}
 
@@ -2027,7 +2027,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 		return wh.error(errDomainNotSet, scope)
 	}
 
-	if len(signalRequest.GetDomain()) > common.MaxIDLengthLimit {
+	if len(signalRequest.GetDomain()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errDomainTooLong, scope)
 	}
 
@@ -2039,11 +2039,11 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 		return wh.error(&gen.BadRequestError{Message: "SignalName is not set on request."}, scope)
 	}
 
-	if len(signalRequest.GetSignalName()) > common.MaxIDLengthLimit {
+	if len(signalRequest.GetSignalName()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errSignalNameTooLong, scope)
 	}
 
-	if len(signalRequest.GetRequestId()) > common.MaxIDLengthLimit {
+	if len(signalRequest.GetRequestId()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errRequestIDTooLong, scope)
 	}
 
@@ -2095,7 +2095,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if len(signalWithStartRequest.GetDomain()) > common.MaxIDLengthLimit {
+	if len(signalWithStartRequest.GetDomain()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errDomainTooLong, scope)
 	}
 
@@ -2103,7 +2103,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(&gen.BadRequestError{Message: "WorkflowId is not set on request."}, scope)
 	}
 
-	if len(signalWithStartRequest.GetWorkflowId()) > common.MaxIDLengthLimit {
+	if len(signalWithStartRequest.GetWorkflowId()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errWorkflowIDTooLong, scope)
 	}
 
@@ -2111,7 +2111,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(&gen.BadRequestError{Message: "SignalName is not set on request."}, scope)
 	}
 
-	if len(signalWithStartRequest.GetSignalName()) > common.MaxIDLengthLimit {
+	if len(signalWithStartRequest.GetSignalName()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errSignalNameTooLong, scope)
 	}
 
@@ -2119,7 +2119,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(&gen.BadRequestError{Message: "WorkflowType is not set on request."}, scope)
 	}
 
-	if len(signalWithStartRequest.WorkflowType.GetName()) > common.MaxIDLengthLimit {
+	if len(signalWithStartRequest.WorkflowType.GetName()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errWorkflowTypeTooLong, scope)
 	}
 
@@ -2127,7 +2127,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, err
 	}
 
-	if len(signalWithStartRequest.GetRequestId()) > common.MaxIDLengthLimit {
+	if len(signalWithStartRequest.GetRequestId()) > wh.config.MaxIDLengthLimit() {
 		return nil, wh.error(errRequestIDTooLong, scope)
 	}
 
@@ -2859,7 +2859,7 @@ func (wh *WorkflowHandler) validateTaskList(t *gen.TaskList, scope int) error {
 	if t == nil || t.Name == nil || t.GetName() == "" {
 		return wh.error(errTaskListNotSet, scope)
 	}
-	if len(t.GetName()) > common.MaxIDLengthLimit {
+	if len(t.GetName()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errTaskListTooLong, scope)
 	}
 	return nil

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2799,6 +2799,18 @@ func validateActivityScheduleAttributes(attributes *workflow.ScheduleActivityTas
 		return err
 	}
 
+	if len(attributes.GetActivityId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "ActivityID exceeds length limit."}
+	}
+
+	if len(attributes.GetActivityType().GetName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "ActivityType exceeds length limit."}
+	}
+
+	if len(attributes.GetDomain()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "Domain exceeds length limit."}
+	}
+
 	// Only attempt to deduce and fill in unspecified timeouts only when all timeouts are non-negative.
 	if attributes.GetScheduleToCloseTimeoutSeconds() < 0 || attributes.GetScheduleToStartTimeoutSeconds() < 0 ||
 		attributes.GetStartToCloseTimeoutSeconds() < 0 || attributes.GetHeartbeatTimeoutSeconds() < 0 {
@@ -2863,6 +2875,9 @@ func validateTimerScheduleAttributes(attributes *workflow.StartTimerDecisionAttr
 	if attributes.TimerId == nil || *attributes.TimerId == "" {
 		return &workflow.BadRequestError{Message: "TimerId is not set on decision."}
 	}
+	if len(attributes.GetTimerId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "TimerId exceeds length limit."}
+	}
 	if attributes.StartToFireTimeoutSeconds == nil || *attributes.StartToFireTimeoutSeconds <= 0 {
 		return &workflow.BadRequestError{Message: "A valid StartToFireTimeoutSeconds is not set on decision."}
 	}
@@ -2876,6 +2891,9 @@ func validateActivityCancelAttributes(attributes *workflow.RequestCancelActivity
 	if attributes.ActivityId == nil || *attributes.ActivityId == "" {
 		return &workflow.BadRequestError{Message: "ActivityId is not set on decision."}
 	}
+	if len(attributes.GetActivityId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "ActivityId exceeds length limit."}
+	}
 	return nil
 }
 
@@ -2886,6 +2904,9 @@ func validateTimerCancelAttributes(attributes *workflow.CancelTimerDecisionAttri
 	if attributes.TimerId == nil || *attributes.TimerId == "" {
 		return &workflow.BadRequestError{Message: "TimerId is not set on decision."}
 	}
+	if len(attributes.GetTimerId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "TimerId exceeds length limit."}
+	}
 	return nil
 }
 
@@ -2895,6 +2916,9 @@ func validateRecordMarkerAttributes(attributes *workflow.RecordMarkerDecisionAtt
 	}
 	if attributes.MarkerName == nil || *attributes.MarkerName == "" {
 		return &workflow.BadRequestError{Message: "MarkerName is not set on decision."}
+	}
+	if len(attributes.GetMarkerName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "MarkerName exceeds length limit."}
 	}
 
 	return nil
@@ -2931,6 +2955,12 @@ func validateCancelExternalWorkflowExecutionAttributes(attributes *workflow.Requ
 	if attributes.WorkflowId == nil {
 		return &workflow.BadRequestError{Message: "WorkflowId is not set on decision."}
 	}
+	if len(attributes.GetDomain()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "Domain exceeds length limit."}
+	}
+	if len(attributes.GetWorkflowId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "WorkflowId exceeds length limit."}
+	}
 	runID := attributes.GetRunId()
 	if runID != "" && uuid.Parse(runID) == nil {
 		return &workflow.BadRequestError{Message: "Invalid RunId set on decision."}
@@ -2949,6 +2979,13 @@ func validateSignalExternalWorkflowExecutionAttributes(attributes *workflow.Sign
 	if attributes.Execution.WorkflowId == nil {
 		return &workflow.BadRequestError{Message: "WorkflowId is not set on decision."}
 	}
+	if len(attributes.GetDomain()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "Domain exceeds length limit."}
+	}
+	if len(attributes.Execution.GetWorkflowId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "WorkflowId exceeds length limit."}
+	}
+
 	targetRunID := attributes.Execution.GetRunId()
 	if targetRunID != "" && uuid.Parse(targetRunID) == nil {
 		return &workflow.BadRequestError{Message: "Invalid RunId set on decision."}
@@ -2977,6 +3014,12 @@ func validateContinueAsNewWorkflowExecutionAttributes(executionInfo *persistence
 	// Inherit Tasklist from previous execution if not provided on decision
 	if attributes.TaskList == nil || attributes.TaskList.GetName() == "" {
 		attributes.TaskList = &workflow.TaskList{Name: common.StringPtr(executionInfo.TaskList)}
+	}
+	if len(attributes.TaskList.GetName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "TaskList exceeds length limit."}
+	}
+	if len(attributes.WorkflowType.GetName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "WorkflowType exceeds length limit."}
 	}
 
 	// Inherit workflow timeout from previous execution if not provided on decision
@@ -3010,6 +3053,18 @@ func validateStartChildExecutionAttributes(parentInfo *persistence.WorkflowExecu
 		return &workflow.BadRequestError{Message: "Required field ChildPolicy is not set on decision."}
 	}
 
+	if len(attributes.GetDomain()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "Domain exceeds length limit."}
+	}
+
+	if len(attributes.GetWorkflowId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "WorkflowId exceeds length limit."}
+	}
+
+	if len(attributes.WorkflowType.GetName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "WorkflowType exceeds length limit."}
+	}
+
 	if err := common.ValidateRetryPolicy(attributes.RetryPolicy); err != nil {
 		return err
 	}
@@ -3021,6 +3076,10 @@ func validateStartChildExecutionAttributes(parentInfo *persistence.WorkflowExecu
 	// Inherit tasklist from parent workflow execution if not provided on decision
 	if attributes.TaskList == nil || attributes.TaskList.GetName() == "" {
 		attributes.TaskList = &workflow.TaskList{Name: common.StringPtr(parentInfo.TaskList)}
+	}
+
+	if len(attributes.TaskList.GetName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "TaskList exceeds length limit."}
 	}
 
 	// Inherit workflow timeout from parent workflow execution if not provided on decision
@@ -3046,6 +3105,22 @@ func validateStartWorkflowExecutionRequest(request *workflow.StartWorkflowExecut
 	if request.TaskList == nil || request.TaskList.Name == nil || request.TaskList.GetName() == "" {
 		return &workflow.BadRequestError{Message: "Missing Tasklist."}
 	}
+	if request.WorkflowType == nil || request.WorkflowType.Name == nil || request.WorkflowType.GetName() == "" {
+		return &workflow.BadRequestError{Message: "Missing WorkflowType."}
+	}
+	if len(request.GetDomain()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "Domain exceeds length limit."}
+	}
+	if len(request.GetWorkflowId()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "WorkflowId exceeds length limit."}
+	}
+	if len(request.TaskList.GetName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "TaskList exceeds length limit."}
+	}
+	if len(request.WorkflowType.GetName()) > common.MaxIDLengthLimit {
+		return &workflow.BadRequestError{Message: "WorkflowType exceeds length limit."}
+	}
+
 	return common.ValidateRetryPolicy(request.RetryPolicy)
 }
 

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4385,29 +4385,30 @@ func (s *engineSuite) TestRemoveSignalMutableState() {
 
 func (s *engineSuite) TestValidateSignalExternalWorkflowExecutionAttributes() {
 	var attributes *workflow.SignalExternalWorkflowExecutionDecisionAttributes
-	err := validateSignalExternalWorkflowExecutionAttributes(attributes)
+	maxIDLengthLimit := 1000
+	err := validateSignalExternalWorkflowExecutionAttributes(attributes, maxIDLengthLimit)
 	s.EqualError(err, "BadRequestError{Message: SignalExternalWorkflowExecutionDecisionAttributes is not set on decision.}")
 
 	attributes = &workflow.SignalExternalWorkflowExecutionDecisionAttributes{}
-	err = validateSignalExternalWorkflowExecutionAttributes(attributes)
+	err = validateSignalExternalWorkflowExecutionAttributes(attributes, maxIDLengthLimit)
 	s.EqualError(err, "BadRequestError{Message: Execution is nil on decision.}")
 
 	attributes.Execution = &workflow.WorkflowExecution{}
 	attributes.Execution.WorkflowId = common.StringPtr("workflow-id")
-	err = validateSignalExternalWorkflowExecutionAttributes(attributes)
+	err = validateSignalExternalWorkflowExecutionAttributes(attributes, maxIDLengthLimit)
 	s.EqualError(err, "BadRequestError{Message: SignalName is not set on decision.}")
 
 	attributes.Execution.RunId = common.StringPtr("run-id")
-	err = validateSignalExternalWorkflowExecutionAttributes(attributes)
+	err = validateSignalExternalWorkflowExecutionAttributes(attributes, maxIDLengthLimit)
 	s.EqualError(err, "BadRequestError{Message: Invalid RunId set on decision.}")
 	attributes.Execution.RunId = common.StringPtr(validRunID)
 
 	attributes.SignalName = common.StringPtr("my signal name")
-	err = validateSignalExternalWorkflowExecutionAttributes(attributes)
+	err = validateSignalExternalWorkflowExecutionAttributes(attributes, maxIDLengthLimit)
 	s.EqualError(err, "BadRequestError{Message: Input is not set on decision.}")
 
 	attributes.Input = []byte("test input")
-	err = validateSignalExternalWorkflowExecutionAttributes(attributes)
+	err = validateSignalExternalWorkflowExecutionAttributes(attributes, maxIDLengthLimit)
 	s.Nil(err)
 }
 

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -36,6 +36,7 @@ type Config struct {
 
 	EnableSyncActivityHeartbeat dynamicconfig.BoolPropertyFn
 	RPS                         dynamicconfig.IntPropertyFn
+	MaxIDLengthLimit            dynamicconfig.IntPropertyFn
 	PersistenceMaxQPS           dynamicconfig.IntPropertyFn
 	EnableVisibilitySampling    dynamicconfig.BoolPropertyFn
 	VisibilityOpenMaxQPS        dynamicconfig.IntPropertyFnWithDomainFilter
@@ -137,6 +138,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int) *Config {
 		NumberOfShards:                                        numberOfShards,
 		EnableSyncActivityHeartbeat:                           dc.GetBoolProperty(dynamicconfig.EnableSyncActivityHeartbeat, false),
 		RPS:                                                   dc.GetIntProperty(dynamicconfig.HistoryRPS, 3000),
+		MaxIDLengthLimit:                                      dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		PersistenceMaxQPS:                                     dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 9000),
 		EnableVisibilitySampling:                              dc.GetBoolProperty(dynamicconfig.EnableVisibilitySampling, true),
 		VisibilityOpenMaxQPS:                                  dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryVisibilityOpenMaxQPS, 300),


### PR DESCRIPTION
limit string length on various ID fields.
I did not make this dynamic configurable because 1K limit should be enough for all use cases. So this is more to protect some crazy long random string like 1MB of data rather than a control knob that we would want to tweak further.
