### PR TITLE
Added Prometheus metrics

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -299,6 +299,17 @@
   version = "v1.0.2"
 
 [[projects]]
+  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
+  name = "github.com/m3db/prometheus_client_golang"
+  packages = [
+    "prometheus",
+    "prometheus/promhttp",
+  ]
+  pruneopts = ""
+  revision = "c5b7fccd204277076155f10851dad72b76a49317"
+  version = "v0.8.0"
+
+[[projects]]
   branch = "master"
   digest = "1:b7ac1ad7d98781c0168803a258d7bf8b3544fd59f356a0e2dd65c43312cf6aac"
   name = "github.com/mailru/easyjson"
@@ -560,6 +571,7 @@
     "m3/customtransports",
     "m3/thrift",
     "m3/thriftudp",
+    "prometheus",
     "statsd",
   ]
   pruneopts = ""
@@ -942,6 +954,7 @@
     "github.com/uber-go/kafka-client/kafka",
     "github.com/uber-go/tally",
     "github.com/uber-go/tally/m3",
+    "github.com/uber-go/tally/prometheus",
     "github.com/uber-go/tally/statsd",
     "github.com/uber/ringpop-go",
     "github.com/uber/ringpop-go/discovery",

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"encoding/json"
+	"github.com/uber-go/tally/prometheus"
 	"time"
 
 	"github.com/uber/cadence/common/blobstore/filestore"
@@ -242,9 +243,19 @@ type (
 		M3 *m3.Configuration `yaml:"m3"`
 		// Statsd is the configuration for statsd reporter
 		Statsd *Statsd `yaml:"statsd"`
+		// Reporter is the configuration for Reporter metrics reporter
+		Prometheus *Prometheus `yaml:"prometheus"`
 		// Tags is the set of key-value pairs to be reported
 		// as part of every metric
 		Tags map[string]string `yaml:"tags"`
+	}
+
+	// Prometheus contains the config items for prometheus metrics reporter
+	Prometheus struct {
+		// The prefix to use in reporting to prometheus metrics
+		Prefix string `yaml:"prefix" validate:"nonzero"`
+		// Reporter is the configuration for Prometheus metrics reporter
+		Reporter *prometheus.Configuration `yaml:"reporter"`
 	}
 
 	// Statsd contains the config items for statsd metrics reporter

--- a/docker/config_template_prometheus.yaml
+++ b/docker/config_template_prometheus.yaml
@@ -1,0 +1,84 @@
+log:
+  stdout: true
+  level: "${LOG_LEVEL}"
+
+persistence:
+  defaultStore: cass-default
+  visibilityStore: cass-visibility
+  numHistoryShards: ${NUM_HISTORY_SHARDS}
+  datastores:
+    cass-default:
+      cassandra:
+        hosts: "${CASSANDRA_SEEDS}"
+        keyspace: "${KEYSPACE}"
+        consistency: "${CASSANDRA_CONSISTENCY}"
+    cass-visibility:
+      cassandra:
+        hosts: "${CASSANDRA_SEEDS}"
+        keyspace: "${VISIBILITY_KEYSPACE}"
+        consistency: "${CASSANDRA_CONSISTENCY}"
+
+ringpop:
+  name: cadence
+  bootstrapMode: hosts
+  bootstrapHosts: ${RINGPOP_SEEDS_JSON_ARRAY}
+  maxJoinDuration: 30s
+
+services:
+  frontend:
+    rpc:
+      port: 7933
+      bindOnIP: ${BIND_ON_IP}
+    metrics:
+      prometheus:
+        prefix: "cadence_frontend"
+        reporter:
+          onError: "panic"
+          timerType: "histogram"
+          listenAddress: "127.0.0.1:8000"
+
+  matching:
+    rpc:
+      port: 7935
+      bindOnIP: ${BIND_ON_IP}
+    metrics:
+      prometheus:
+        prefix: "cadence_matching"
+        reporter:
+          onError: "panic"
+          timerType: "histogram"
+          listenAddress: "127.0.0.1:8001"
+
+  history:
+    rpc:
+      port: 7934
+      bindOnIP: ${BIND_ON_IP}
+    metrics:
+      prometheus:
+        prefix: "cadence_history"
+        reporter:
+          onError: "panic"
+          timerType: "histogram"
+          listenAddress: "127.0.0.1:8002"
+
+  worker:
+    rpc:
+      port: 7939
+      bindOnIP: ${BIND_ON_IP}
+    metrics:
+      prometheus:
+        prefix: "cadence_worker"
+        reporter:
+          onError: "panic"
+          timerType: "histogram"
+          listenAddress: "127.0.0.1:8003"
+
+clustersInfo:
+  enableGlobalDomain: false
+  failoverVersionIncrement: 10
+  masterClusterName: "active"
+  currentClusterName: "active"
+  clusterInitialFailoverVersion:
+    active: 0
+  clusterAddress:
+    active: "127.0.0.1:7933"


### PR DESCRIPTION
Hi team,

I made changes to cadence to expose prometheus metrics 
using https://github.com/uber-go/tally/tree/master/prometheus

This resolves #769 

But it does not work as the metric names in the cadence are not compatible with Prometheus query language. https://github.com/uber/cadence/blob/master/common/metrics/defs.go#L1021

Basically Prometheus does not like '-' and '.' in the names.
https://prometheus.io/docs/practices/naming/

There are two options,

1) Rename the metrics.
But this will be disruptive to the existing monitoring rules setup of Cadence within Uber. (I want to know how disruptive it will be?)

2) Rename the metrics on the fly when Prometheus monitoring is on.

Please suggest which one is acceptable.

Thanks,
Harsha
