### PR TITLE
Handle edge case when doing history re-replication from standby side.

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -88,6 +88,7 @@ var keys = map[Key]string{
 
 	// history settings
 	EnableSyncActivityHeartbeat:                           "history.enableSyncActivityHeartbeat",
+	EnableHistoryRereplication:                            "history.enableHistoryRereplication",
 	HistoryRPS:                                            "history.rps",
 	HistoryPersistenceMaxQPS:                              "history.persistenceMaxQPS",
 	HistoryVisibilityOpenMaxQPS:                           "history.historyVisibilityOpenMaxQPS",
@@ -150,9 +151,10 @@ var keys = map[Key]string{
 	EnableEventsV2:                                        "history.enableEventsV2",
 	NumSystemWorkflows:                                    "history.numSystemWorkflows",
 
-	WorkerPersistenceMaxQPS:       "worker.persistenceMaxQPS",
-	WorkerReplicatorConcurrency:   "worker.replicatorConcurrency",
-	WorkerReplicationTaskMaxRetry: "worker.replicationTaskMaxRetry",
+	WorkerPersistenceMaxQPS:          "worker.persistenceMaxQPS",
+	WorkerReplicatorConcurrency:      "worker.replicatorConcurrency",
+	WorkerReplicatorBufferRetryCount: "worker.replicatorBufferRetryCount",
+	WorkerReplicationTaskMaxRetry:    "worker.replicationTaskMaxRetry",
 }
 
 const (
@@ -246,6 +248,8 @@ const (
 
 	// EnableSyncActivityHeartbeat whether enable sending out sync activity heartbeat replication task
 	EnableSyncActivityHeartbeat
+	// EnableHistoryRereplication whether enable history re-replication
+	EnableHistoryRereplication
 	// HistoryRPS is request rate per second for each history host
 	HistoryRPS
 	// HistoryPersistenceMaxQPS is the max qps history host can query DB
@@ -370,12 +374,15 @@ const (
 
 	// EnableEventsV2 is whether to use eventsV2
 	EnableEventsV2
-	// key for histoworkerry
+
+	// key for history worker
 
 	// WorkerPersistenceMaxQPS is the max qps worker host can query DB
 	WorkerPersistenceMaxQPS
 	// WorkerReplicatorConcurrency is the max concurrenct tasks to be processed at any given time
 	WorkerReplicatorConcurrency
+	// WorkerReplicatorBufferRetryCount is the retry attempt when encounter retry error
+	WorkerReplicatorBufferRetryCount
 	// WorkerReplicationTaskMaxRetry is the max retry for any task
 	WorkerReplicationTaskMaxRetry
 

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -277,6 +277,16 @@ func (adh *AdminHandler) GetWorkflowExecutionRawHistory(
 		pageSize,
 	)
 	if err != nil {
+		if _, ok := err.(*gen.EntityNotExistsError); ok {
+			// when no events can be returned from DB, DB layer will return
+			// EntityNotExistsError, this API shall return empty response
+			return &admin.GetWorkflowExecutionRawHistoryResponse{
+				HistoryBatches:    []*gen.DataBlob{},
+				ReplicationInfo:   token.ReplicationInfo,
+				EventStoreVersion: common.Int32Ptr(token.EventStoreVersion),
+				NextPageToken:     nil, // no further pagination
+			}, nil
+		}
 		return nil, err
 	}
 

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -75,6 +75,8 @@ var (
 	ErrRetrySyncActivity = &shared.RetryTaskError{Message: "retry on applying sync activity"}
 	// ErrRetryBufferEventsMsg is returned when events are arriving out of order, should retry, or specify force apply
 	ErrRetryBufferEventsMsg = "retry on applying buffer events"
+	// ErrRetryEmptyEventsMsg is returned when events size is 0
+	ErrRetryEmptyEventsMsg = "retry on applying empty events"
 	// ErrWorkflowNotFoundMsg is returned when workflow not found
 	ErrWorkflowNotFoundMsg = "retry on workflow not found"
 	// ErrRetryExistingWorkflowMsg is returned when events are arriving out of order, and there is another workflow with same version running

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -35,6 +35,7 @@ type Config struct {
 	NumberOfShards int
 
 	EnableSyncActivityHeartbeat dynamicconfig.BoolPropertyFn
+	EnableHistoryRereplication  dynamicconfig.BoolPropertyFn
 	RPS                         dynamicconfig.IntPropertyFn
 	MaxIDLengthLimit            dynamicconfig.IntPropertyFn
 	PersistenceMaxQPS           dynamicconfig.IntPropertyFn
@@ -136,6 +137,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int) *Config {
 	return &Config{
 		NumberOfShards:                                        numberOfShards,
 		EnableSyncActivityHeartbeat:                           dc.GetBoolProperty(dynamicconfig.EnableSyncActivityHeartbeat, false),
+		EnableHistoryRereplication:                            dc.GetBoolProperty(dynamicconfig.EnableHistoryRereplication, false),
 		RPS:                                                   dc.GetIntProperty(dynamicconfig.HistoryRPS, 3000),
 		MaxIDLengthLimit:                                      dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		PersistenceMaxQPS:                                     dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 9000),

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -74,6 +74,7 @@ func newTimerQueueProcessor(shard ShardContext, historyService *historyEngineImp
 	for clusterName := range shard.GetService().GetClusterMetadata().GetAllClusterFailoverVersions() {
 		if clusterName != shard.GetService().GetClusterMetadata().GetCurrentClusterName() {
 			historyRereplicator := xdc.NewHistoryRereplicator(
+				currentClusterName,
 				shard.GetDomainCache(),
 				shard.GetService().GetClientBean().GetRemoteAdminClient(clusterName),
 				func(ctx context.Context, request *h.ReplicateRawEventsRequest) error {

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -506,6 +506,10 @@ func (t *timerQueueStandbyProcessorImpl) fetchHistoryAndVerifyOnce(timerTask *pe
 }
 
 func (t *timerQueueStandbyProcessorImpl) fetchHistoryFromRemote(timerTask *persistence.TimerTaskInfo, nextEventID int64) error {
+	if !t.shard.GetConfig().EnableHistoryRereplication() {
+		return nil
+	}
+
 	err := t.historyRereplicator.SendMultiWorkflowHistory(
 		timerTask.DomainID, timerTask.WorkflowID,
 		timerTask.RunID, nextEventID,

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/service/dynamicconfig"
 	"github.com/uber/cadence/common/xdc"
 )
 
@@ -119,6 +120,8 @@ func (s *timerQueueStandbyProcessorSuite) SetupTest() {
 	s.mockClientBean = &client.MockClientBean{}
 	s.mockService = service.NewTestService(s.mockClusterMetadata, s.mockMessagingClient, metricsClient, s.mockClientBean, s.logger)
 
+	config := NewDynamicConfigForTest()
+	config.EnableHistoryRereplication = dynamicconfig.GetBoolPropertyFn(true)
 	s.mockShard = &shardContextImpl{
 		service:                   s.mockService,
 		shardInfo:                 &persistence.ShardInfo{ShardID: shardID, RangeID: 1, TransferAckLevel: 0},
@@ -128,7 +131,7 @@ func (s *timerQueueStandbyProcessorSuite) SetupTest() {
 		historyMgr:                s.mockHistoryMgr,
 		maxTransferSequenceNumber: 100000,
 		closeCh:                   make(chan int, 100),
-		config:                    NewDynamicConfigForTest(),
+		config:                    config,
 		logger:                    s.logger,
 		domainCache:               cache.NewDomainCache(s.mockMetadataMgr, s.mockClusterMetadata, metricsClient, s.logger),
 		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -79,6 +79,7 @@ func newTransferQueueProcessor(shard ShardContext, historyService *historyEngine
 	for clusterName := range shard.GetService().GetClusterMetadata().GetAllClusterFailoverVersions() {
 		if clusterName != currentClusterName {
 			historyRereplicator := xdc.NewHistoryRereplicator(
+				currentClusterName,
 				shard.GetDomainCache(),
 				shard.GetService().GetClientBean().GetRemoteAdminClient(clusterName),
 				func(ctx context.Context, request *h.ReplicateRawEventsRequest) error {

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -471,6 +471,9 @@ func (t *transferQueueStandbyProcessorImpl) fetchHistoryAndVerifyOnce(transferTa
 }
 
 func (t *transferQueueStandbyProcessorImpl) fetchHistoryFromRemote(transferTask *persistence.TransferTaskInfo, nextEventID int64) error {
+	if !t.shard.GetConfig().EnableHistoryRereplication() {
+		return nil
+	}
 	err := t.historyRereplicator.SendMultiWorkflowHistory(
 		transferTask.DomainID, transferTask.WorkflowID,
 		transferTask.RunID, nextEventID,

--- a/service/history/transferQueueStandbyProcessor_test.go
+++ b/service/history/transferQueueStandbyProcessor_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/service/dynamicconfig"
 	"github.com/uber/cadence/common/xdc"
 )
 
@@ -121,6 +122,8 @@ func (s *transferQueueStandbyProcessorSuite) SetupTest() {
 	s.mockClientBean = &client.MockClientBean{}
 	s.mockService = service.NewTestService(s.mockClusterMetadata, s.mockMessagingClient, metricsClient, s.mockClientBean, s.logger)
 
+	config := NewDynamicConfigForTest()
+	config.EnableHistoryRereplication = dynamicconfig.GetBoolPropertyFn(true)
 	s.mockShard = &shardContextImpl{
 		service:                   s.mockService,
 		shardInfo:                 &persistence.ShardInfo{ShardID: shardID, RangeID: 1, TransferAckLevel: 0},
@@ -130,7 +133,7 @@ func (s *transferQueueStandbyProcessorSuite) SetupTest() {
 		historyMgr:                s.mockHistoryMgr,
 		maxTransferSequenceNumber: 100000,
 		closeCh:                   make(chan int, 100),
-		config:                    NewDynamicConfigForTest(),
+		config:                    config,
 		logger:                    s.logger,
 		domainCache:               cache.NewDomainCache(s.mockMetadataMgr, s.mockClusterMetadata, metricsClient, s.logger),
 		metricsClient:             metrics.NewClient(tally.NoopScope, metrics.History),

--- a/service/worker/replicator/processor.go
+++ b/service/worker/replicator/processor.go
@@ -413,6 +413,10 @@ func (p *replicationTaskProcessor) handleActivityTask(task *replicator.Replicati
 	err = p.historyClient.SyncActivity(ctx, req)
 	cancel()
 
+	if !p.config.EnableHistoryRereplication() {
+		return err
+	}
+
 	retryErr, ok := err.(*shared.RetryTaskError)
 	if !ok {
 		return err
@@ -473,7 +477,7 @@ Loop:
 	}
 
 RetryLoop:
-	for i := 0; i < p.config.ReplicatorBufferRetryCount; i++ {
+	for i := 0; i < p.config.ReplicatorBufferRetryCount(); i++ {
 		ctx, cancel := context.WithTimeout(context.Background(), replicationTimeout)
 		err = p.historyClient.ReplicateEvents(ctx, req)
 		cancel()
@@ -498,6 +502,10 @@ RetryLoop:
 	ctx, cancel := context.WithTimeout(context.Background(), replicationTimeout)
 	err = p.historyClient.ReplicateEvents(ctx, req)
 	cancel()
+
+	if !p.config.EnableHistoryRereplication() {
+		return err
+	}
 
 	retryErr, ok := err.(*shared.RetryTaskError)
 	if !ok {

--- a/service/worker/replicator/replicator.go
+++ b/service/worker/replicator/replicator.go
@@ -117,6 +117,7 @@ func (r *Replicator) Start() error {
 				logging.TagConsumerName:      consumerName,
 			})
 			historyRereplicator := xdc.NewHistoryRereplicator(
+				currentClusterName,
 				r.domainCache,
 				adminClient,
 				func(ctx context.Context, request *h.ReplicateRawEventsRequest) error {

--- a/service/worker/replicator/replicator.go
+++ b/service/worker/replicator/replicator.go
@@ -61,9 +61,11 @@ type (
 
 	// Config contains all the replication config for worker
 	Config struct {
+		EnableHistoryRereplication dynamicconfig.BoolPropertyFn
+
 		PersistenceMaxQPS          dynamicconfig.IntPropertyFn
 		ReplicatorConcurrency      dynamicconfig.IntPropertyFn
-		ReplicatorBufferRetryCount int
+		ReplicatorBufferRetryCount dynamicconfig.IntPropertyFn
 		ReplicationTaskMaxRetry    dynamicconfig.IntPropertyFn
 	}
 )

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -82,9 +82,10 @@ func NewService(params *service.BootstrapParams) common.Daemon {
 func NewConfig(dc *dynamicconfig.Collection) *Config {
 	return &Config{
 		ReplicationCfg: &replicator.Config{
+			EnableHistoryRereplication: dc.GetBoolProperty(dynamicconfig.EnableHistoryRereplication, false),
 			PersistenceMaxQPS:          dc.GetIntProperty(dynamicconfig.WorkerPersistenceMaxQPS, 500),
 			ReplicatorConcurrency:      dc.GetIntProperty(dynamicconfig.WorkerReplicatorConcurrency, 1000),
-			ReplicatorBufferRetryCount: 8,
+			ReplicatorBufferRetryCount: dc.GetIntProperty(dynamicconfig.WorkerReplicatorBufferRetryCount, 8),
 			ReplicationTaskMaxRetry:    dc.GetIntProperty(dynamicconfig.WorkerReplicationTaskMaxRetry, 50),
 		},
 		SysWorkflowCfg: &sysworkflow.Config{},


### PR DESCRIPTION
* History re-replication triggered by standby, can have longer (stale) history, causing source cluster returning empty event blobs, history re-replication logic will use the replication info to determine the beginning event ID for resend history.