### PR TITLE
Cross dc domain archival config

### DIFF
--- a/service/frontend/domainReplicationTaskHandler.go
+++ b/service/frontend/domainReplicationTaskHandler.go
@@ -91,6 +91,8 @@ func (domainReplicator *domainReplicatorImpl) HandleTransmissionTask(domainOpera
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(config.Retention),
 			EmitMetric:                             common.BoolPtr(config.EmitMetric),
+			ArchivalBucketName:                     common.StringPtr(config.ArchivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(config.ArchivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(replicationConfig.ActiveClusterName),

--- a/service/frontend/domainReplicationTaskHandler_test.go
+++ b/service/frontend/domainReplicationTaskHandler_test.go
@@ -82,6 +82,8 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_Is
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -105,8 +107,10 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_Is
 		Data:        data,
 	}
 	config := &p.DomainConfig{
-		Retention:  retention,
-		EmitMetric: emitMetric,
+		Retention:      retention,
+		EmitMetric:     emitMetric,
+		ArchivalBucket: archivalBucket,
+		ArchivalStatus: archivalStatus,
 	}
 	replicationConfig := &p.DomainReplicationConfig{
 		ActiveClusterName: clusterActive,
@@ -129,6 +133,8 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_Is
 			Config: &shared.DomainConfiguration{
 				WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 				EmitMetric:                             common.BoolPtr(emitMetric),
+				ArchivalBucketName:                     common.StringPtr(archivalBucket),
+				ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 			},
 			ReplicationConfig: &shared.DomainReplicationConfiguration{
 				ActiveClusterName: common.StringPtr(clusterActive),
@@ -151,6 +157,8 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_No
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -174,8 +182,10 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_No
 		Data:        data,
 	}
 	config := &p.DomainConfig{
-		Retention:  retention,
-		EmitMetric: emitMetric,
+		Retention:      retention,
+		EmitMetric:     emitMetric,
+		ArchivalBucket: archivalBucket,
+		ArchivalStatus: archivalStatus,
 	}
 	replicationConfig := &p.DomainReplicationConfig{
 		ActiveClusterName: clusterActive,
@@ -197,6 +207,8 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_UpdateDomainTask_IsGl
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -220,8 +232,10 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_UpdateDomainTask_IsGl
 		Data:        data,
 	}
 	config := &p.DomainConfig{
-		Retention:  retention,
-		EmitMetric: emitMetric,
+		Retention:      retention,
+		EmitMetric:     emitMetric,
+		ArchivalBucket: archivalBucket,
+		ArchivalStatus: archivalStatus,
 	}
 	replicationConfig := &p.DomainReplicationConfig{
 		ActiveClusterName: clusterActive,
@@ -244,6 +258,8 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_UpdateDomainTask_IsGl
 			Config: &shared.DomainConfiguration{
 				WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 				EmitMetric:                             common.BoolPtr(emitMetric),
+				ArchivalBucketName:                     common.StringPtr(archivalBucket),
+				ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 			},
 			ReplicationConfig: &shared.DomainReplicationConfiguration{
 				ActiveClusterName: common.StringPtr(clusterActive),
@@ -266,6 +282,8 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_UpdateDomainTask_NotG
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -289,8 +307,10 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_UpdateDomainTask_NotG
 		Data:        data,
 	}
 	config := &p.DomainConfig{
-		Retention:  retention,
-		EmitMetric: emitMetric,
+		Retention:      retention,
+		EmitMetric:     emitMetric,
+		ArchivalBucket: archivalBucket,
+		ArchivalStatus: archivalStatus,
 	}
 	replicationConfig := &p.DomainReplicationConfig{
 		ActiveClusterName: clusterActive,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2991,12 +2991,13 @@ func (wh *WorkflowHandler) createDomainResponse(info *persistence.DomainInfo, co
 	if configResult.GetArchivalStatus() != gen.ArchivalStatusNeverEnabled {
 		bucketName := config.ArchivalBucket
 		configResult.ArchivalBucketName = common.StringPtr(bucketName)
-		metadata, err := wh.blobstoreClient.BucketMetadata(context.Background(), bucketName)
 
-		// TODO: handle error correctly once there is a working implementation of blobstore
-		if err == nil {
-			configResult.ArchivalRetentionPeriodInDays = common.Int32Ptr(int32(metadata.RetentionDays))
-			configResult.ArchivalBucketOwner = common.StringPtr(metadata.Owner)
+		if wh.Service.GetClusterMetadata().IsArchivalEnabled() {
+			metadata, err := wh.blobstoreClient.BucketMetadata(context.Background(), bucketName)
+			if err == nil {
+				configResult.ArchivalRetentionPeriodInDays = common.Int32Ptr(int32(metadata.RetentionDays))
+				configResult.ArchivalBucketOwner = common.StringPtr(metadata.Owner)
+			}
 		}
 	}
 

--- a/service/worker/replicator/domainReplicationTaskHandler.go
+++ b/service/worker/replicator/domainReplicationTaskHandler.go
@@ -101,8 +101,10 @@ func (domainReplicator *domainReplicatorImpl) handleDomainCreationReplicationTas
 			Data:        task.Info.Data,
 		},
 		Config: &persistence.DomainConfig{
-			Retention:  task.Config.GetWorkflowExecutionRetentionPeriodInDays(),
-			EmitMetric: task.Config.GetEmitMetric(),
+			Retention:      task.Config.GetWorkflowExecutionRetentionPeriodInDays(),
+			EmitMetric:     task.Config.GetEmitMetric(),
+			ArchivalBucket: task.Config.GetArchivalBucketName(),
+			ArchivalStatus: task.Config.GetArchivalStatus(),
 		},
 		ReplicationConfig: &persistence.DomainReplicationConfig{
 			ActiveClusterName: task.ReplicationConfig.GetActiveClusterName(),
@@ -168,8 +170,10 @@ func (domainReplicator *domainReplicatorImpl) handleDomainUpdateReplicationTask(
 			Data:        task.Info.Data,
 		}
 		request.Config = &persistence.DomainConfig{
-			Retention:  task.Config.GetWorkflowExecutionRetentionPeriodInDays(),
-			EmitMetric: task.Config.GetEmitMetric(),
+			Retention:      task.Config.GetWorkflowExecutionRetentionPeriodInDays(),
+			EmitMetric:     task.Config.GetEmitMetric(),
+			ArchivalBucket: task.Config.GetArchivalBucketName(),
+			ArchivalStatus: task.Config.GetArchivalStatus(),
 		}
 		request.ReplicationConfig.Clusters = domainReplicator.convertClusterReplicationConfigFromThrift(task.ReplicationConfig.Clusters)
 		request.ConfigVersion = task.GetConfigVersion()

--- a/service/worker/replicator/domainReplicationTaskHandler_test.go
+++ b/service/worker/replicator/domainReplicationTaskHandler_test.go
@@ -83,6 +83,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_RegisterDomainTask() {
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -109,6 +111,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_RegisterDomainTask() {
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 			EmitMetric:                             common.BoolPtr(emitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(clusterActive),
@@ -135,6 +139,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_RegisterDomainTask() {
 	s.Equal(data, resp.Info.Data)
 	s.Equal(retention, resp.Config.Retention)
 	s.Equal(emitMetric, resp.Config.EmitMetric)
+	s.Equal(archivalBucket, resp.Config.ArchivalBucket)
+	s.Equal(archivalStatus, resp.Config.ArchivalStatus)
 	s.Equal(clusterActive, resp.ReplicationConfig.ActiveClusterName)
 	s.Equal(s.domainReplicator.convertClusterReplicationConfigFromThrift(clusters), resp.ReplicationConfig.Clusters)
 	s.Equal(configVersion, resp.ConfigVersion)
@@ -152,6 +158,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_DomainN
 	ownerEmail := "some random test owner"
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(12)
@@ -179,6 +187,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_DomainN
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 			EmitMetric:                             common.BoolPtr(emitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(clusterActive),
@@ -205,6 +215,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_DomainN
 	s.Equal(domainData, resp.Info.Data)
 	s.Equal(retention, resp.Config.Retention)
 	s.Equal(emitMetric, resp.Config.EmitMetric)
+	s.Equal(archivalBucket, resp.Config.ArchivalBucket)
+	s.Equal(archivalStatus, resp.Config.ArchivalStatus)
 	s.Equal(clusterActive, resp.ReplicationConfig.ActiveClusterName)
 	s.Equal(s.domainReplicator.convertClusterReplicationConfigFromThrift(clusters), resp.ReplicationConfig.Clusters)
 	s.Equal(configVersion, resp.ConfigVersion)
@@ -223,6 +235,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -249,6 +263,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 			EmitMetric:                             common.BoolPtr(emitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(clusterActive),
@@ -269,6 +285,7 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 	updatedData := map[string]string{"k": "v1"}
 	updateRetention := int32(122)
 	updateEmitMetric := true
+	updateArchivalStatus := shared.ArchivalStatusDisabled
 	updateClusterActive := "other random active cluster name"
 	updateClusterStandby := "other random standby cluster name"
 	updateConfigVersion := configVersion + 1
@@ -294,6 +311,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(updateRetention),
 			EmitMetric:                             common.BoolPtr(updateEmitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(updateArchivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(updateClusterActive),
@@ -318,6 +337,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 	s.Equal(updatedData, resp.Info.Data)
 	s.Equal(updateRetention, resp.Config.Retention)
 	s.Equal(updateEmitMetric, resp.Config.EmitMetric)
+	s.Equal(archivalBucket, resp.Config.ArchivalBucket)
+	s.Equal(updateArchivalStatus, resp.Config.ArchivalStatus)
 	s.Equal(updateClusterActive, resp.ReplicationConfig.ActiveClusterName)
 	s.Equal(s.domainReplicator.convertClusterReplicationConfigFromThrift(updateClusters), resp.ReplicationConfig.Clusters)
 	s.Equal(updateConfigVersion, resp.ConfigVersion)
@@ -336,6 +357,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := ""
+	archivalStatus := shared.ArchivalStatusNeverEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -362,6 +385,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 			EmitMetric:                             common.BoolPtr(emitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(clusterActive),
@@ -382,6 +407,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 	updateData := map[string]string{"k": "v2"}
 	updateRetention := int32(122)
 	updateEmitMetric := true
+	updateArchivalBucket := "some random archival bucket name"
+	updateArchivalStatus := shared.ArchivalStatusEnabled
 	updateClusterActive := "other random active cluster name"
 	updateClusterStandby := "other random standby cluster name"
 	updateConfigVersion := configVersion + 1
@@ -407,6 +434,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(updateRetention),
 			EmitMetric:                             common.BoolPtr(updateEmitMetric),
+			ArchivalBucketName:                     common.StringPtr(updateArchivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(updateArchivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(updateClusterActive),
@@ -431,6 +460,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_UpdateC
 	s.Equal(updateData, resp.Info.Data)
 	s.Equal(updateRetention, resp.Config.Retention)
 	s.Equal(updateEmitMetric, resp.Config.EmitMetric)
+	s.Equal(updateArchivalBucket, resp.Config.ArchivalBucket)
+	s.Equal(updateArchivalStatus, resp.Config.ArchivalStatus)
 	s.Equal(clusterActive, resp.ReplicationConfig.ActiveClusterName)
 	s.Equal(s.domainReplicator.convertClusterReplicationConfigFromThrift(updateClusters), resp.ReplicationConfig.Clusters)
 	s.Equal(updateConfigVersion, resp.ConfigVersion)
@@ -449,6 +480,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -475,6 +508,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 			EmitMetric:                             common.BoolPtr(emitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(clusterActive),
@@ -520,6 +555,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(updateRetention),
 			EmitMetric:                             common.BoolPtr(updateEmitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(updateClusterActive),
@@ -544,6 +581,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 	s.Equal(data, resp.Info.Data)
 	s.Equal(retention, resp.Config.Retention)
 	s.Equal(emitMetric, resp.Config.EmitMetric)
+	s.Equal(archivalBucket, resp.Config.ArchivalBucket)
+	s.Equal(archivalStatus, resp.Config.ArchivalStatus)
 	s.Equal(updateClusterActive, resp.ReplicationConfig.ActiveClusterName)
 	s.Equal(s.domainReplicator.convertClusterReplicationConfigFromThrift(clusters), resp.ReplicationConfig.Clusters)
 	s.Equal(configVersion, resp.ConfigVersion)
@@ -562,6 +601,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 	data := map[string]string{"k": "v"}
 	retention := int32(10)
 	emitMetric := true
+	archivalBucket := "some random archival bucket name"
+	archivalStatus := shared.ArchivalStatusEnabled
 	clusterActive := "some random active cluster name"
 	clusterStandby := "some random standby cluster name"
 	configVersion := int64(0)
@@ -588,6 +629,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retention),
 			EmitMetric:                             common.BoolPtr(emitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(clusterActive),
@@ -635,6 +678,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 		Config: &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(updateRetention),
 			EmitMetric:                             common.BoolPtr(updateEmitMetric),
+			ArchivalBucketName:                     common.StringPtr(archivalBucket),
+			ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(updateClusterActive),
@@ -656,6 +701,8 @@ func (s *domainReplicatorSuite) TestHandleReceivingTask_UpdateDomainTask_NoUpdat
 	s.Equal(data, resp.Info.Data)
 	s.Equal(retention, resp.Config.Retention)
 	s.Equal(emitMetric, resp.Config.EmitMetric)
+	s.Equal(archivalBucket, resp.Config.ArchivalBucket)
+	s.Equal(archivalStatus, resp.Config.ArchivalStatus)
 	s.Equal(clusterActive, resp.ReplicationConfig.ActiveClusterName)
 	s.Equal(s.domainReplicator.convertClusterReplicationConfigFromThrift(clusters), resp.ReplicationConfig.Clusters)
 	s.Equal(configVersion, resp.ConfigVersion)

--- a/tools/cli/adminDomainCommands.go
+++ b/tools/cli/adminDomainCommands.go
@@ -284,7 +284,6 @@ func AdminDescribeDomain(c *cli.Context) {
 		ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domain), err)
 	}
 
-	archivalStatus := resp.Configuration.GetArchivalStatus()
 	var formatStr = "Name: %v\nDescription: %v\nOwnerEmail: %v\nDomainData: %v\nStatus: %v\nRetentionInDays: %v\n" +
 		"EmitMetrics: %v\nActiveClusterName: %v\nClusters: %v\nArchivalStatus: %v\n"
 	descValues := []interface{}{
@@ -297,14 +296,20 @@ func AdminDescribeDomain(c *cli.Context) {
 		resp.Configuration.GetEmitMetric(),
 		resp.ReplicationConfiguration.GetActiveClusterName(),
 		serverClustersToString(resp.ReplicationConfiguration.Clusters),
-		archivalStatus.String(),
+		resp.Configuration.GetArchivalStatus().String(),
 	}
-	if archivalStatus != shared.ArchivalStatusNeverEnabled {
-		formatStr = formatStr + "BucketName: %v\nArchivalRetentionInDays: %v\nBucketOwner: %v\n"
-		descValues = append(descValues,
-			resp.Configuration.GetArchivalBucketName(),
-			fmt.Sprintf("%v", resp.Configuration.GetArchivalRetentionPeriodInDays()),
-			resp.Configuration.GetArchivalBucketOwner())
+
+	if resp.Configuration.ArchivalBucketName != nil {
+		formatStr = formatStr + "BucketName: %v\n"
+		descValues = append(descValues, resp.Configuration.GetArchivalBucketName())
+	}
+	if resp.Configuration.ArchivalRetentionPeriodInDays != nil {
+		formatStr = formatStr + "ArchivalRetentionInDays: %v\n"
+		descValues = append(descValues, resp.Configuration.GetArchivalRetentionPeriodInDays())
+	}
+	if resp.Configuration.ArchivalBucketOwner != nil {
+		formatStr = formatStr + "BucketOwner: %v\n"
+		descValues = append(descValues, resp.Configuration.GetArchivalBucketOwner())
 	}
 	fmt.Printf(formatStr, descValues...)
 }


### PR DESCRIPTION
- Introduces assertion that any archival config put into database is valid. This validation is mostly for clarity and sanity, it should never fail.
- Add domain archival config to replication logic. Before it was not being plumbed through.