### PR TITLE
Handle TTL for doc in ElasticSearch

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -63,6 +63,10 @@ const (
 	adminServiceOperationMaxInterval        = 5 * time.Second
 	adminServiceOperationExpirationInterval = 15 * time.Second
 
+	retryKafkaOperationInitialInterval    = 50 * time.Millisecond
+	retryKafkaOperationMaxInterval        = 10 * time.Second
+	retryKafkaOperationExpirationInterval = 30 * time.Second
+
 	// FailureReasonCompleteResultExceedsLimit is failureReason for complete result exceeds limit
 	FailureReasonCompleteResultExceedsLimit = "COMPLETE_RESULT_EXCEEDS_LIMIT"
 	// FailureReasonFailureDetailsExceedsLimit is failureReason for failure details exceeds limit
@@ -153,6 +157,15 @@ func CreateAdminServiceRetryPolicy() backoff.RetryPolicy {
 	return policy
 }
 
+// CreateKafkaOperationRetryPolicy creates a retry policy for kafka operation
+func CreateKafkaOperationRetryPolicy() backoff.RetryPolicy {
+	policy := backoff.NewExponentialRetryPolicy(retryKafkaOperationInitialInterval)
+	policy.SetMaximumInterval(retryKafkaOperationMaxInterval)
+	policy.SetExpirationInterval(retryKafkaOperationExpirationInterval)
+
+	return policy
+}
+
 // IsPersistenceTransientError checks if the error is a transient persistence error
 func IsPersistenceTransientError(err error) bool {
 	switch err.(type) {
@@ -161,6 +174,11 @@ func IsPersistenceTransientError(err error) bool {
 	}
 
 	return false
+}
+
+// IsKafkaTransientError check if the error is a transient kafka error
+func IsKafkaTransientError(err error) bool {
+	return true
 }
 
 // IsServiceTransientError checks if the error is a retryable error.

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -174,7 +174,7 @@ func NewEngineWithShardContext(
 		visibilityProducer = getVisibilityProducer(messagingClient, shard.GetMetricsClient())
 	}
 	txProcessor := newTransferQueueProcessor(shard, historyEngImpl, visibilityMgr, visibilityProducer, matching, historyClient, logger)
-	historyEngImpl.timerProcessor = newTimerQueueProcessor(shard, historyEngImpl, matching, logger)
+	historyEngImpl.timerProcessor = newTimerQueueProcessor(shard, historyEngImpl, matching, visibilityProducer, logger)
 	historyEngImpl.txProcessor = txProcessor
 	shardWrapper.txProcessor = txProcessor
 

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -149,7 +149,7 @@ func (s *engine2Suite) SetupTest() {
 		archivalClient:     s.mockArchivalClient,
 	}
 	h.txProcessor = newTransferQueueProcessor(mockShard, h, s.mockVisibilityMgr, s.mockProducer, s.mockMatchingClient, s.mockHistoryClient, s.logger)
-	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockMatchingClient, s.logger)
+	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockMatchingClient, s.mockProducer, s.logger)
 	s.historyEngine = h
 }
 

--- a/service/history/historyEngine3_eventsv2_test.go
+++ b/service/history/historyEngine3_eventsv2_test.go
@@ -149,7 +149,7 @@ func (s *engine3Suite) SetupTest() {
 		archivalClient:     s.mockArchivalClient,
 	}
 	h.txProcessor = newTransferQueueProcessor(mockShard, h, s.mockVisibilityMgr, s.mockProducer, s.mockMatchingClient, s.mockHistoryClient, s.logger)
-	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockMatchingClient, s.logger)
+	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockMatchingClient, s.mockProducer, s.logger)
 	s.historyEngine = h
 }
 

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -168,7 +168,7 @@ func (s *engineSuite) SetupTest() {
 		archivalClient:       s.mockArchivalClient,
 	}
 	h.txProcessor = newTransferQueueProcessor(shardContextWrapper, h, s.mockVisibilityMgr, s.mockProducer, s.mockMatchingClient, s.mockHistoryClient, s.logger)
-	h.timerProcessor = newTimerQueueProcessor(shardContextWrapper, h, s.mockMatchingClient, s.logger)
+	h.timerProcessor = newTimerQueueProcessor(shardContextWrapper, h, s.mockMatchingClient, s.mockProducer, s.logger)
 	h.historyEventNotifier.Start()
 	shardContextWrapper.txProcessor = h.txProcessor
 	s.mockHistoryEngine = h

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -166,7 +166,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, enableVisibilit
 		TimerProcessorMaxPollRPS:                              dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollRPS, 20),
 		TimerProcessorMaxPollInterval:                         dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxPollInterval, 5*time.Minute),
 		TimerProcessorMaxPollIntervalJitterCoefficient:        dc.GetFloat64Property(dynamicconfig.TimerProcessorMaxPollIntervalJitterCoefficient, 0.15),
-		TimerProcessorMaxTimeShift:                            dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxPollInterval, 1*time.Second),
+		TimerProcessorMaxTimeShift:                            dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxTimeShift, 1*time.Second),
 		TransferTaskBatchSize:                                 dc.GetIntProperty(dynamicconfig.TransferTaskBatchSize, 100),
 		TransferProcessorFailoverMaxPollRPS:                   dc.GetIntProperty(dynamicconfig.TransferProcessorFailoverMaxPollRPS, 1),
 		TransferProcessorMaxPollRPS:                           dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollRPS, 20),

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -937,6 +937,9 @@ func (s *shardContextImpl) emitShardInfoMetricsLogsLocked() {
 	s.metricsClient.RecordTimer(metrics.ShardInfoScope, metrics.ShardInfoTimerFailoverInProgressTimer, time.Duration(timerFailoverInProgress))
 }
 
+// NOTE: allocateTimerIDsLocked should always been called after assigning taskID for transferTasks when assigning taskID together,
+// because Cadence Indexer assume timer taskID of deleteWorkflowExecution is larger than transfer taskID of closeWorkflowExecution
+// for a given workflow.
 func (s *shardContextImpl) allocateTimerIDsLocked(timerTasks []persistence.Task, domainID, workflowID string) error {
 	// assign IDs for the timer tasks. They need to be assigned under shard lock.
 	clusterMetadata := s.GetService().GetClusterMetadata()

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -150,7 +150,7 @@ func (s *timerQueueProcessor2Suite) SetupTest() {
 		metricsClient:      s.mockShard.GetMetricsClient(),
 	}
 	h.txProcessor = newTransferQueueProcessor(s.mockShard, h, s.mockVisibilityMgr, s.mockProducer, s.mockMatchingClient, &mocks.HistoryClient{}, s.logger)
-	h.timerProcessor = newTimerQueueProcessor(s.mockShard, h, s.mockMatchingClient, s.logger)
+	h.timerProcessor = newTimerQueueProcessor(s.mockShard, h, s.mockMatchingClient, s.mockProducer, s.logger)
 	s.mockHistoryEngine = h
 }
 

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -28,11 +28,13 @@ import (
 	"time"
 
 	"github.com/uber-common/bark"
+	"github.com/uber/cadence/.gen/go/indexer"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/logging"
+	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service/dynamicconfig"
@@ -50,25 +52,26 @@ var (
 
 type (
 	timerQueueProcessorBase struct {
-		scope            int
-		shard            ShardContext
-		historyService   *historyEngineImpl
-		cache            *historyCache
-		executionManager persistence.ExecutionManager
-		status           int32
-		shutdownWG       sync.WaitGroup
-		shutdownCh       chan struct{}
-		tasksCh          chan *persistence.TimerTaskInfo
-		config           *Config
-		logger           bark.Logger
-		metricsClient    metrics.Client
-		timerFiredCount  uint64
-		timerProcessor   timerProcessor
-		timerQueueAckMgr timerQueueAckMgr
-		timerGate        TimerGate
-		rateLimiter      common.TokenBucket
-		startDelay       dynamicconfig.DurationPropertyFn
-		retryPolicy      backoff.RetryPolicy
+		scope              int
+		shard              ShardContext
+		historyService     *historyEngineImpl
+		cache              *historyCache
+		executionManager   persistence.ExecutionManager
+		status             int32
+		shutdownWG         sync.WaitGroup
+		shutdownCh         chan struct{}
+		tasksCh            chan *persistence.TimerTaskInfo
+		config             *Config
+		logger             bark.Logger
+		metricsClient      metrics.Client
+		timerFiredCount    uint64
+		timerProcessor     timerProcessor
+		timerQueueAckMgr   timerQueueAckMgr
+		timerGate          TimerGate
+		rateLimiter        common.TokenBucket
+		startDelay         dynamicconfig.DurationPropertyFn
+		retryPolicy        backoff.RetryPolicy
+		visibilityProducer messaging.Producer
 
 		// worker coroutines notification
 		workerNotificationChans []chan struct{}
@@ -86,7 +89,9 @@ type (
 
 func newTimerQueueProcessorBase(scope int, shard ShardContext, historyService *historyEngineImpl,
 	timerQueueAckMgr timerQueueAckMgr, timerGate TimerGate, maxPollRPS dynamicconfig.IntPropertyFn,
-	startDelay dynamicconfig.DurationPropertyFn, logger bark.Logger) *timerQueueProcessorBase {
+	startDelay dynamicconfig.DurationPropertyFn, visibilityProducer messaging.Producer,
+	logger bark.Logger) *timerQueueProcessorBase {
+
 	log := logger.WithFields(bark.Fields{
 		logging.TagWorkflowComponent: logging.TagValueTimerQueueComponent,
 	})
@@ -118,6 +123,7 @@ func newTimerQueueProcessorBase(scope int, shard ShardContext, historyService *h
 		rateLimiter:             common.NewTokenBucket(maxPollRPS(), common.NewRealTimeSource()),
 		startDelay:              startDelay,
 		retryPolicy:             common.CreatePersistanceRetryPolicy(),
+		visibilityProducer:      visibilityProducer,
 	}
 
 	return base
@@ -569,7 +575,7 @@ func (t *timerQueueProcessorBase) processDeleteHistoryEvent(task *persistence.Ti
 		return err
 	}
 
-	return t.deleteWorkflowVisibility()
+	return t.deleteWorkflowVisibility(task)
 }
 
 func (t *timerQueueProcessorBase) deleteWorkflowExecution(task *persistence.TimerTaskInfo) error {
@@ -606,9 +612,29 @@ func (t *timerQueueProcessorBase) deleteWorkflowHistory(task *persistence.TimerT
 	return backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 }
 
-func (t *timerQueueProcessorBase) deleteWorkflowVisibility() error {
-	// TODO
-	return nil
+func (t *timerQueueProcessorBase) deleteWorkflowVisibility(task *persistence.TimerTaskInfo) error {
+	if t.visibilityProducer == nil {
+		return nil
+	}
+
+	msg := getVisibilityMessageForDeletion(task.DomainID, task.WorkflowID, task.RunID, task.GetTaskID())
+	op := func() error {
+		return t.visibilityProducer.Publish(msg)
+	}
+
+	return backoff.Retry(op, kafkaOperationRetryPolicy, common.IsKafkaTransientError)
+}
+
+func getVisibilityMessageForDeletion(domainID, workflowID, runID string, docVersion int64) *indexer.Message {
+	msgType := indexer.MessageTypeDelete
+	msg := &indexer.Message{
+		MessageType: &msgType,
+		DomainID:    common.StringPtr(domainID),
+		WorkflowID:  common.StringPtr(workflowID),
+		RunID:       common.StringPtr(runID),
+		Version:     common.Int64Ptr(docVersion),
+	}
+	return msg
 }
 
 func (t *timerQueueProcessorBase) getTimerTaskType(taskType int) string {

--- a/service/history/timerQueueProcessorBase_test.go
+++ b/service/history/timerQueueProcessorBase_test.go
@@ -55,6 +55,7 @@ type (
 		mockProcessor       *MockTimerProcessor
 		mockQueueAckMgr     *MockTimerQueueAckMgr
 		mockClientBean      *client.MockClientBean
+		mockProducer        messaging.Producer
 
 		scope            int
 		notificationChan chan struct{}
@@ -105,6 +106,7 @@ func (s *timerQueueProcessorBaseSuite) SetupTest() {
 		metricsClient:             metricsClient,
 		standbyClusterCurrentTime: make(map[string]time.Time),
 	}
+	s.mockProducer = &mocks.KafkaProducer{}
 
 	s.scope = 0
 	s.notificationChan = make(chan struct{})
@@ -121,6 +123,7 @@ func (s *timerQueueProcessorBaseSuite) SetupTest() {
 		NewLocalTimerGate(),
 		dynamicconfig.GetIntPropertyFn(10),
 		dynamicconfig.GetDurationPropertyFn(0*time.Second),
+		s.mockProducer,
 		s.logger,
 	)
 	s.timerQueueProcessor.timerProcessor = s.mockProcessor

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -103,7 +103,7 @@ func (s *timerQueueProcessorSuite) SetupTest() {
 	s.engineImpl.txProcessor = newTransferQueueProcessor(
 		s.ShardContext, s.engineImpl, s.mockVisibilityMgr, &mocks.KafkaProducer{}, &mocks.MatchingClient{}, &mocks.HistoryClient{}, s.logger,
 	)
-	s.engineImpl.timerProcessor = newTimerQueueProcessor(s.ShardContext, s.engineImpl, s.mockMatchingClient, s.logger)
+	s.engineImpl.timerProcessor = newTimerQueueProcessor(s.ShardContext, s.engineImpl, s.mockMatchingClient, &mocks.KafkaProducer{}, s.logger)
 }
 
 func (s *timerQueueProcessorSuite) TearDownTest() {

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/logging"
+	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 )
@@ -57,7 +58,9 @@ type (
 )
 
 func newTimerQueueStandbyProcessor(shard ShardContext, historyService *historyEngineImpl, clusterName string,
-	taskAllocator taskAllocator, historyRereplicator xdc.HistoryRereplicator, logger bark.Logger) *timerQueueStandbyProcessorImpl {
+	taskAllocator taskAllocator, historyRereplicator xdc.HistoryRereplicator, visibilityProducer messaging.Producer,
+	logger bark.Logger) *timerQueueStandbyProcessorImpl {
+
 	timeNow := func() time.Time {
 		return shard.GetCurrentTime(clusterName)
 	}
@@ -101,6 +104,7 @@ func newTimerQueueStandbyProcessor(shard ShardContext, historyService *historyEn
 			timerGate,
 			shard.GetConfig().TimerProcessorMaxPollRPS,
 			shard.GetConfig().TimerProcessorStartDelay,
+			visibilityProducer,
 			logger,
 		),
 		timerQueueAckMgr:    timerQueueAckMgr,

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -152,7 +152,7 @@ func (s *timerQueueStandbyProcessorSuite) SetupTest() {
 	}
 	s.mockHistoryEngine = h
 	s.clusterName = cluster.TestAlternativeClusterName
-	s.timerQueueStandbyProcessor = newTimerQueueStandbyProcessor(s.mockShard, h, s.clusterName, newTaskAllocator(s.mockShard), s.mockHistoryRereplicator, s.logger)
+	s.timerQueueStandbyProcessor = newTimerQueueStandbyProcessor(s.mockShard, h, s.clusterName, newTaskAllocator(s.mockShard), s.mockHistoryRereplicator, s.mockProducer, s.logger)
 	s.mocktimerQueueAckMgr = &MockTimerQueueAckMgr{}
 	s.timerQueueStandbyProcessor.timerQueueAckMgr = s.mocktimerQueueAckMgr
 }

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -319,13 +319,12 @@ func (t *transferQueueActiveProcessorImpl) processDecisionTask(task *persistence
 		tasklist.Kind = common.TaskListKindPtr(workflow.TaskListKindSticky)
 		decisionTimeout = executionInfo.StickyScheduleToStartTimeout
 	}
-	nextEventID := executionInfo.NextEventID
 
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
 	if task.ScheduleID <= common.FirstEventID+2 || task.RecordVisibility {
-		err = t.recordWorkflowStarted(task.DomainID, execution, wfTypeName, startTimestamp.UnixNano(), workflowTimeout, nextEventID)
+		err = t.recordWorkflowStarted(task.DomainID, execution, wfTypeName, startTimestamp.UnixNano(), workflowTimeout, task.GetTaskID())
 		if err != nil {
 			return err
 		}
@@ -386,7 +385,7 @@ func (t *transferQueueActiveProcessorImpl) processCloseExecution(task *persisten
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
 	err = t.recordWorkflowClosed(
-		domainID, execution, workflowTypeName, workflowStartTimestamp, workflowCloseTimestamp, workflowCloseStatus, workflowHistoryLength, executionInfo.NextEventID,
+		domainID, execution, workflowTypeName, workflowStartTimestamp, workflowCloseTimestamp, workflowCloseStatus, workflowHistoryLength, task.GetTaskID(),
 	)
 	if err != nil {
 		return err

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -213,7 +213,7 @@ func (t *transferQueueStandbyProcessorImpl) processDecisionTask(transferTask *pe
 
 		if !isPending {
 			if markWorkflowAsOpen {
-				err := t.recordWorkflowStarted(transferTask.DomainID, execution, wfTypeName, startTimestamp.UnixNano(), workflowTimeout, executionInfo.NextEventID)
+				err := t.recordWorkflowStarted(transferTask.DomainID, execution, wfTypeName, startTimestamp.UnixNano(), workflowTimeout, transferTask.GetTaskID())
 				if err != nil {
 					return err
 				}
@@ -229,7 +229,7 @@ func (t *transferQueueStandbyProcessorImpl) processDecisionTask(transferTask *pe
 		}
 
 		if markWorkflowAsOpen {
-			err = t.recordWorkflowStarted(transferTask.DomainID, execution, wfTypeName, startTimestamp.UnixNano(), workflowTimeout, executionInfo.NextEventID)
+			err = t.recordWorkflowStarted(transferTask.DomainID, execution, wfTypeName, startTimestamp.UnixNano(), workflowTimeout, transferTask.GetTaskID())
 		}
 
 		now := t.shard.GetCurrentTime(t.clusterName)
@@ -289,7 +289,7 @@ func (t *transferQueueStandbyProcessorImpl) processCloseExecution(transferTask *
 		// since event replication should be done by active cluster
 
 		return t.recordWorkflowClosed(
-			transferTask.DomainID, execution, workflowTypeName, workflowStartTimestamp, workflowCloseTimestamp, workflowCloseStatus, workflowHistoryLength, executionInfo.NextEventID,
+			transferTask.DomainID, execution, workflowTypeName, workflowStartTimestamp, workflowCloseTimestamp, workflowCloseStatus, workflowHistoryLength, transferTask.GetTaskID(),
 		)
 	}, standbyTaskPostActionNoOp) // no op post action, since the entire workflow is finished
 }

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -83,9 +83,11 @@ type (
 	}
 )
 
+var _ workflowExecutionContext = (*workflowExecutionContextImpl)(nil)
+
 var (
-	persistenceOperationRetryPolicy                          = common.CreatePersistanceRetryPolicy()
-	_                               workflowExecutionContext = (*workflowExecutionContextImpl)(nil)
+	persistenceOperationRetryPolicy = common.CreatePersistanceRetryPolicy()
+	kafkaOperationRetryPolicy       = common.CreateKafkaOperationRetryPolicy()
 )
 
 func newWorkflowExecutionContext(domainID string, execution workflow.WorkflowExecution, shard ShardContext,

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -157,7 +157,7 @@ func (s *resetorSuite) SetupTest() {
 		archivalClient:     s.mockArchivalClient,
 	}
 	h.txProcessor = newTransferQueueProcessor(mockShard, h, s.mockVisibilityMgr, s.mockProducer, s.mockMatchingClient, s.mockHistoryClient, s.logger)
-	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockMatchingClient, s.logger)
+	h.timerProcessor = newTimerQueueProcessor(mockShard, h, s.mockMatchingClient, s.mockProducer, s.logger)
 	repl := newHistoryReplicator(mockShard, h, historyCache, s.mockDomainCache, s.mockHistoryMgr, s.mockHistoryV2Mgr, s.logger)
 	s.resetor = newWorkflowResetor(h, repl)
 	h.resetor = s.resetor


### PR DESCRIPTION
This PR includes:
1. cadence send delete event from to kafka, in timer task process; indexer consume from kafka and send delete requests to ElasticSearch
2. change doc version to use taskID, to avoid possible issues around crossDC
3. clean/refactor some code