### PR TITLE
Release 0.5.0 in docker compose and fix release instruction

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -73,7 +73,7 @@ Update docker-compose.yml when releasing new version
 1. Build the new docker image and push into docker hub
 ```bash
 docker build . -t ubercadence/server:THE.LATEST.VERSION  --build-arg git_branch=vTHE.LATEST.VERSION 
-docker push ubercadence/server:master
+docker push ubercadence/server:THE.LATEST.VERSION
 ```
 2. Remember to update the docker-compose.yml to use latest version and check in to master
 ```yaml

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   cadence:
-    image: ubercadence/server:0.4.0
+    image: ubercadence/server:0.5.0
     ports:
      - "7933:7933"
      - "7934:7934"


### PR DESCRIPTION
Releasing shouldn't push to master tag. Master tag is supposed to be the latest commit of our master branch.