### PR TITLE
Fix busy loop in query when GetMutableState failed

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -479,6 +479,8 @@ query_loop:
 						expectedNextEventID = ms.GetNextEventId()
 						continue wait_loop
 					}
+
+					return nil, &workflow.QueryFailedError{Message: err.Error()}
 				}
 			}
 


### PR DESCRIPTION
Fix busy loop in query when GetMutableState failed