### PR TITLE
Fix visibility producer init process 

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -105,8 +105,8 @@ kafka:
       cluster: test
   applications:
     visibility:
-      topic: cadence-visibility
-      dlq-topic: cadence-visibility-dlq
+      topic: cadence-visibility-dev
+      dlq-topic: cadence-visibility-dev-dlq
 
 elasticsearch:
   enable: false
@@ -114,5 +114,5 @@ elasticsearch:
     scheme: "http"
     host: "127.0.0.1:9200"
   indices:
-    visibility: visibility-dev
+    visibility: cadence-visibility-dev
 

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -138,7 +138,7 @@ func NewEngineWithShardContext(
 	frontendClient frontend.Client,
 	historyEventNotifier historyEventNotifier,
 	publisher messaging.Producer,
-	messagingClient messaging.Client,
+	visibilityProducer messaging.Producer,
 	config *Config,
 ) Engine {
 	currentClusterName := shard.GetService().GetClusterMetadata().GetCurrentClusterName()
@@ -169,10 +169,7 @@ func NewEngineWithShardContext(
 		config:               config,
 		archivalClient:       sysworkflow.NewArchivalClient(frontendClient, shard.GetConfig().NumSysWorkflows),
 	}
-	var visibilityProducer messaging.Producer
-	if config.EnableVisibilityToKafka() {
-		visibilityProducer = getVisibilityProducer(messagingClient, shard.GetMetricsClient())
-	}
+
 	txProcessor := newTransferQueueProcessor(shard, historyEngImpl, visibilityMgr, visibilityProducer, matching, historyClient, logger)
 	historyEngImpl.timerProcessor = newTimerQueueProcessor(shard, historyEngImpl, matching, visibilityProducer, logger)
 	historyEngImpl.txProcessor = txProcessor
@@ -3327,18 +3324,4 @@ func getWorkflowAlreadyStartedError(errMsg string, createRequestID string, workf
 		StartRequestId: common.StringPtr(fmt.Sprintf("%v", createRequestID)),
 		RunId:          common.StringPtr(fmt.Sprintf("%v", runID)),
 	}
-}
-
-func getVisibilityProducer(messagingClient messaging.Client, metricsClient metrics.Client) messaging.Producer {
-	if messagingClient == nil {
-		return nil
-	}
-	visibilityProducer, err := messagingClient.NewProducer(common.VisibilityAppName)
-	if err != nil {
-		panic(err)
-	}
-	if metricsClient != nil {
-		visibilityProducer = messaging.NewMetricProducer(visibilityProducer, metricsClient)
-	}
-	return visibilityProducer
 }

--- a/service/worker/indexer/indexer.go
+++ b/service/worker/indexer/indexer.go
@@ -78,7 +78,7 @@ func NewIndexer(config *Config, client messaging.Client, esClient *elastic.Clien
 // Start indexer
 func (x Indexer) Start() error {
 	visibilityApp := common.VisibilityAppName
-	visConsumerName := getConsumerName(visibilityApp)
+	visConsumerName := getConsumerName(x.visibilityIndexName)
 	x.visibilityProcessor = newIndexProcessor(visibilityApp, visConsumerName, x.kafkaClient, x.esClient,
 		visibilityProcessorName, x.visibilityIndexName, x.config, x.logger, x.metricsClient)
 	return x.visibilityProcessor.Start()


### PR DESCRIPTION
Currently each shard will create a visibility producer, which will lead to kafka "peer reset" error when load is large.
This PR fix this by moving visibility producer initialization process to history handler, which is host level.
This PR also include:

a fix on metrics client being wrapped twice.
a fix on consumer name.