### PR TITLE
Fix replicate WorkflowStart to include cron and retry

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1283,6 +1283,7 @@ Update_History_Loop:
 						BackoffStartIntervalInSeconds:       common.Int32Ptr(int32(cronBackoff.Seconds())),
 						Initiator:                           workflow.ContinueAsNewInitiatorCronSchedule.Ptr(),
 						LastCompletionResult:                attributes.Result,
+						CronSchedule:                        startAttributes.CronSchedule,
 					}
 
 					if _, continueAsNewBuilder, err = msBuilder.AddContinueAsNewEvent(completedID, domainEntry, startAttributes.GetParentWorkflowDomain(), continueAsnewAttributes, eventStoreVersion); err != nil {
@@ -1356,6 +1357,7 @@ Update_History_Loop:
 						FailureReason:                       failedAttributes.Reason,
 						FailureDetails:                      failedAttributes.Details,
 						LastCompletionResult:                startAttributes.LastCompletionResult,
+						CronSchedule:                        startAttributes.CronSchedule,
 					}
 
 					if _, continueAsNewBuilder, err = msBuilder.AddContinueAsNewEvent(completedID, domainEntry, startAttributes.GetParentWorkflowDomain(), continueAsnewAttributes, eventStoreVersion); err != nil {

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1310,6 +1310,22 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(domainID st
 	if event.ParentInitiatedEventId != nil {
 		e.executionInfo.InitiatedID = event.GetParentInitiatedEventId()
 	}
+
+	if event.RetryPolicy != nil {
+		e.executionInfo.HasRetryPolicy = true
+		e.executionInfo.InitialInterval = event.RetryPolicy.GetInitialIntervalInSeconds()
+		e.executionInfo.BackoffCoefficient = event.RetryPolicy.GetBackoffCoefficient()
+		e.executionInfo.MaximumInterval = event.RetryPolicy.GetMaximumIntervalInSeconds()
+		e.executionInfo.MaximumAttempts = event.RetryPolicy.GetMaximumAttempts()
+		e.executionInfo.NonRetriableErrors = event.RetryPolicy.NonRetriableErrorReasons
+		if event.RetryPolicy.GetExpirationIntervalInSeconds() > 0 && event.GetExpirationTimestamp() > 0 {
+			e.executionInfo.ExpirationTime = time.Unix(0, event.GetExpirationTimestamp())
+		}
+	}
+
+	if event.CronSchedule != nil {
+		e.executionInfo.CronSchedule = event.GetCronSchedule()
+	}
 }
 
 func (e *mutableStateBuilder) AddDecisionTaskScheduledEvent() *decisionInfo {
@@ -2367,16 +2383,20 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionContinuedAsNewEvent(sour
 		PreviousRunID:        prevRunID,
 		ReplicationState:     newStateBuilder.GetReplicationState(),
 		HasRetryPolicy:       startedAttributes.RetryPolicy != nil,
-		InitialInterval:      e.executionInfo.InitialInterval,
-		BackoffCoefficient:   e.executionInfo.BackoffCoefficient,
-		MaximumInterval:      e.executionInfo.MaximumInterval,
-		MaximumAttempts:      e.executionInfo.MaximumAttempts,
-		NonRetriableErrors:   e.executionInfo.NonRetriableErrors,
+		CronSchedule:         startedAttributes.GetCronSchedule(),
 		EventStoreVersion:    newStateBuilder.GetEventStoreVersion(),
 		BranchToken:          newStateBuilder.GetCurrentBranch(),
-		CronSchedule:         e.executionInfo.CronSchedule,
-		ExpirationSeconds:    e.executionInfo.ExpirationSeconds,
 	}
+
+	if continueAsNew.HasRetryPolicy {
+		continueAsNew.InitialInterval = startedAttributes.RetryPolicy.GetInitialIntervalInSeconds()
+		continueAsNew.BackoffCoefficient = startedAttributes.RetryPolicy.GetBackoffCoefficient()
+		continueAsNew.MaximumInterval = startedAttributes.RetryPolicy.GetMaximumIntervalInSeconds()
+		continueAsNew.MaximumAttempts = startedAttributes.RetryPolicy.GetMaximumAttempts()
+		continueAsNew.ExpirationSeconds = startedAttributes.RetryPolicy.GetExpirationIntervalInSeconds()
+		continueAsNew.NonRetriableErrors = startedAttributes.RetryPolicy.NonRetriableErrorReasons
+	}
+
 	if continueAsNewAttributes.GetInitiator() == workflow.ContinueAsNewInitiatorRetryPolicy {
 		// retry
 		continueAsNew.Attempt = continueAsNew.Attempt + 1

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1217,6 +1217,7 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(d
 		ExecutionStartToCloseTimeoutSeconds: attributes.ExecutionStartToCloseTimeoutSeconds,
 		Input:                               attributes.Input,
 		RetryPolicy:                         attributes.RetryPolicy,
+		CronSchedule:                        attributes.CronSchedule,
 	}
 
 	req := &h.StartWorkflowExecutionRequest{


### PR DESCRIPTION
replicate cron schedule for workflow start event, also update replicate ContinueAsNew event to use info from the event instead of from current mutable state.