### PR TITLE
Allow query task for non-active domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ THRIFTRW_SRCS = \
   idl/github.com/uber/cadence/admin.thrift \
 
 PROGS = cadence
-TEST_ARG ?= -race -v -timeout 30m
+TEST_ARG ?= -race -v -timeout 40m
 BUILD := ./build
 TOOLS_CMD_ROOT=./cmd/tools
 INTEG_TEST_ROOT=./host


### PR DESCRIPTION
Cadence matching completely stops dispatching of both DecisionTask
and QueryTask in response to PollForDecisionTask API when domain
is marked as non-active.
We have separated out the task dispatch channel for query and
decisions, as we always want to allow sync match on queries even
if the domain is not active.