### PR TITLE
Handle race condition in replication Q

### DIFF
--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -208,7 +208,7 @@ func (p *replicatorQueueProcessorImpl) processHistoryReplicationTask(task *persi
 	}
 
 	replicationTask, err := GenerateReplicationTask(targetClusters, task, p.historyMgr, p.historyV2Mgr, p.metricsClient, p.logger, nil)
-	if err != nil {
+	if err != nil || replicationTask == nil {
 		return err
 	}
 
@@ -232,6 +232,11 @@ func GenerateReplicationTask(targetClusters []string, task *persistence.Replicat
 			task.DomainID, task.WorkflowID, task.RunID, task.FirstEventID, task.NextEventID, task.EventStoreVersion, task.BranchToken)
 		if err != nil {
 			return nil, err
+		}
+		for _, event := range history.Events {
+			if task.Version != event.GetVersion() {
+				return nil, nil
+			}
 		}
 	}
 

--- a/tools/cli/adminKafkaCommands.go
+++ b/tools/cli/adminKafkaCommands.go
@@ -392,7 +392,7 @@ func doRereplicate(shardID int, domainID, wid, rid string, minID, maxID int64, t
 				taskTemplate.NewRunEventStoreVersion = resp.State.ExecutionInfo.EventStoreVersion
 				taskTemplate.NewRunBranchToken = resp.State.ExecutionInfo.GetCurrentBranch()
 			}
-
+			taskTemplate.Version = firstEvent.GetVersion()
 			taskTemplate.FirstEventID = firstEvent.GetEventId()
 			taskTemplate.NextEventID = lastEvent.GetEventId() + 1
 			task, err := history.GenerateReplicationTask(targets, taskTemplate, historyMgr, historyV2Mgr, nil, bark.NewNopLogger(), batch)


### PR DESCRIPTION
It is possible that workflow history got reset and overwrite during conflict rresolution.
Replication Q should handle case if input task version is diffent than history batch.

solves #1169