### PR TITLE
sql: some minor improvements

### DIFF
--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -213,6 +213,7 @@ func (m *sqlTaskManager) GetTasks(request *persistence.GetTasksRequest) (*persis
 		TaskType:     int64(request.TaskType),
 		MinTaskID:    &request.ReadLevel,
 		MaxTaskID:    &request.MaxReadLevel,
+		PageSize:     &request.BatchSize,
 	})
 	if err != nil {
 		return nil, &workflow.InternalServiceError{

--- a/common/persistence/sql/storage/mysql/task.go
+++ b/common/persistence/sql/storage/mysql/task.go
@@ -58,7 +58,7 @@ task_type = :task_type
 
 	getTaskQry = `SELECT workflow_id, run_id, schedule_id, task_id ` +
 		`FROM tasks ` +
-		`WHERE domain_id = ? AND task_list_name = ? AND task_type = ? AND task_id > ? AND task_id <= ?`
+		`WHERE domain_id = ? AND task_list_name = ? AND task_type = ? AND task_id > ? AND task_id <= ? LIMIT ?`
 
 	createTaskQry = `INSERT INTO ` +
 		`tasks(domain_id, workflow_id, run_id, schedule_id, task_list_name, task_type, task_id, expiry_ts) ` +
@@ -81,7 +81,7 @@ func (mdb *DB) SelectFromTasks(filter *sqldb.TasksFilter) ([]sqldb.TasksRow, err
 	var err error
 	var rows []sqldb.TasksRow
 	err = mdb.conn.Select(&rows, getTaskQry, filter.DomainID,
-		filter.TaskListName, filter.TaskType, *filter.MinTaskID, *filter.MaxTaskID)
+		filter.TaskListName, filter.TaskType, *filter.MinTaskID, *filter.MaxTaskID, *filter.PageSize)
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -229,6 +229,7 @@ type (
 		TaskID       *int64
 		MinTaskID    *int64
 		MaxTaskID    *int64
+		PageSize     *int
 	}
 
 	// TaskListsRow represents a row in task_lists table
@@ -565,7 +566,11 @@ type (
 		WriteLockShards(filter *ShardsFilter) (int, error)
 
 		InsertIntoTasks(rows []TasksRow) (sql.Result, error)
+		// SelectFromTasks retrieves one or more rows from the tasks table
+		// Required filter params - {domainID, tasklistName, taskType, minTaskID, maxTaskID, pageSize}
 		SelectFromTasks(filter *TasksFilter) ([]TasksRow, error)
+		// DeleteFromTasks deletes a row from tasks table
+		// Required filter params - {domainID, tasklistName, taskType, taskID}
 		DeleteFromTasks(filter *TasksFilter) (sql.Result, error)
 
 		InsertIntoTaskLists(row *TaskListsRow) (sql.Result, error)

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -137,12 +137,12 @@ func updateActivityInfos(tx sqldb.Tx,
 	return nil
 }
 
-func getActivityInfoMap(tx sqldb.Tx,
+func getActivityInfoMap(db sqldb.Interface,
 	shardID int,
 	domainID,
 	workflowID,
 	runID string) (map[int64]*persistence.InternalActivityInfo, error) {
-	rows, err := tx.SelectFromActivityInfoMaps(&sqldb.ActivityInfoMapsFilter{
+	rows, err := db.SelectFromActivityInfoMaps(&sqldb.ActivityInfoMapsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -279,12 +279,12 @@ func updateTimerInfos(tx sqldb.Tx,
 	return nil
 }
 
-func getTimerInfoMap(tx sqldb.Tx,
+func getTimerInfoMap(db sqldb.Interface,
 	shardID int,
 	domainID,
 	workflowID,
 	runID string) (map[string]*persistence.TimerInfo, error) {
-	rows, err := tx.SelectFromTimerInfoMaps(&sqldb.TimerInfoMapsFilter{
+	rows, err := db.SelectFromTimerInfoMaps(&sqldb.TimerInfoMapsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -378,12 +378,12 @@ func updateChildExecutionInfos(tx sqldb.Tx,
 	return nil
 }
 
-func getChildExecutionInfoMap(tx sqldb.Tx,
+func getChildExecutionInfoMap(db sqldb.Interface,
 	shardID int,
 	domainID,
 	workflowID,
 	runID string) (map[int64]*persistence.InternalChildExecutionInfo, error) {
-	rows, err := tx.SelectFromChildExecutionInfoMaps(&sqldb.ChildExecutionInfoMapsFilter{
+	rows, err := db.SelectFromChildExecutionInfoMaps(&sqldb.ChildExecutionInfoMapsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -490,12 +490,12 @@ func updateRequestCancelInfos(tx sqldb.Tx,
 	return nil
 }
 
-func getRequestCancelInfoMap(tx sqldb.Tx,
+func getRequestCancelInfoMap(db sqldb.Interface,
 	shardID int,
 	domainID,
 	workflowID,
 	runID string) (map[int64]*persistence.RequestCancelInfo, error) {
-	rows, err := tx.SelectFromRequestCancelInfoMaps(&sqldb.RequestCancelInfoMapsFilter{
+	rows, err := db.SelectFromRequestCancelInfoMaps(&sqldb.RequestCancelInfoMapsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -592,12 +592,12 @@ func updateSignalInfos(tx sqldb.Tx,
 	return nil
 }
 
-func getSignalInfoMap(tx sqldb.Tx,
+func getSignalInfoMap(db sqldb.Interface,
 	shardID int,
 	domainID,
 	workflowID,
 	runID string) (map[int64]*persistence.SignalInfo, error) {
-	rows, err := tx.SelectFromSignalInfoMaps(&sqldb.SignalInfoMapsFilter{
+	rows, err := db.SelectFromSignalInfoMaps(&sqldb.SignalInfoMapsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -700,12 +700,12 @@ func updateBufferedReplicationTasks(tx sqldb.Tx,
 	return nil
 }
 
-func getBufferedReplicationTasks(tx sqldb.Tx,
+func getBufferedReplicationTasks(db sqldb.Interface,
 	shardID int,
 	domainID,
 	workflowID,
 	runID string) (map[int64]*persistence.InternalBufferedReplicationTask, error) {
-	rows, err := tx.SelectFromBufferedReplicationTasks(&sqldb.BufferedReplicationTaskMapsFilter{
+	rows, err := db.SelectFromBufferedReplicationTasks(&sqldb.BufferedReplicationTaskMapsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: workflowID,

--- a/common/persistence/sql/workflowStateNonMaps.go
+++ b/common/persistence/sql/workflowStateNonMaps.go
@@ -68,12 +68,12 @@ func updateSignalsRequested(tx sqldb.Tx,
 	return nil
 }
 
-func getSignalsRequested(tx sqldb.Tx,
+func getSignalsRequested(db sqldb.Interface,
 	shardID int,
 	domainID,
 	workflowID,
 	runID string) (map[string]struct{}, error) {
-	rows, err := tx.SelectFromSignalsRequestedSets(&sqldb.SignalsRequestedSetsFilter{
+	rows, err := db.SelectFromSignalsRequestedSets(&sqldb.SignalsRequestedSetsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
 		WorkflowID: workflowID,

--- a/schema/mysql/v56/cadence/schema.sql
+++ b/schema/mysql/v56/cadence/schema.sql
@@ -205,8 +205,8 @@ CREATE TABLE events (
 	run_id         VARCHAR(64) NOT NULL,
 	first_event_id BIGINT NOT NULL,
 	batch_version  BIGINT,
-	range_id       INT NOT NULL,
-	tx_id          INT NOT NULL,
+	range_id       BIGINT NOT NULL,
+	tx_id          BIGINT NOT NULL,
 	data MEDIUMBLOB NOT NULL,
 	data_encoding  VARCHAR(64) NOT NULL,
 	PRIMARY KEY (domain_id, workflow_id, run_id, first_event_id)

--- a/schema/mysql/v57/cadence/schema.sql
+++ b/schema/mysql/v57/cadence/schema.sql
@@ -204,9 +204,9 @@ CREATE TABLE events (
 	run_id         VARCHAR(64) NOT NULL,
 	first_event_id BIGINT NOT NULL,
 	batch_version  BIGINT,
-	range_id       INT NOT NULL,
-	tx_id          INT NOT NULL,
-	data BLOB      NOT NULL,
+	range_id       BIGINT NOT NULL,
+	tx_id          BIGINT NOT NULL,
+	data MEDIUMBLOB  NOT NULL,
 	data_encoding  VARCHAR(64) NOT NULL,
 	PRIMARY KEY (domain_id, workflow_id, run_id, first_event_id)
 );


### PR DESCRIPTION
This patch contains the following changes
 - getWorkflowExecution: Remove un-necessary write lock. Application level locks already guard against concurrent access
 - getTasks: Support reading tasks in batches / pages
 - Schema: Make history events use MEDIUMBLOB instead of BLOB