### PR TITLE
Fix read visibility from elasticsearch resolution issue on time range

### DIFF
--- a/common/persistence/elasticsearchVisibility_test.go
+++ b/common/persistence/elasticsearchVisibility_test.go
@@ -322,9 +322,12 @@ func (s *ESVisibilitySuite) TestGetSearchResult() {
 	matchDomainQuery := elastic.NewMatchQuery(es.DomainID, request.DomainUUID)
 	existClosedStatusQuery := elastic.NewExistsQuery(es.CloseStatus)
 
+	earliestTime := request.EarliestStartTime - oneMilliSecondInNano
+	lastestTime := request.LatestStartTime + oneMilliSecondInNano
+
 	// test for open
 	isOpen := true
-	rangeQuery := elastic.NewRangeQuery(es.StartTime).Gte(request.EarliestStartTime).Lte(request.LatestStartTime)
+	rangeQuery := elastic.NewRangeQuery(es.StartTime).Gte(earliestTime).Lte(lastestTime)
 	boolQuery := elastic.NewBoolQuery().Must(matchDomainQuery).Filter(rangeQuery).MustNot(existClosedStatusQuery)
 	params := &es.SearchParameters{
 		Index:    testIndex,
@@ -338,7 +341,7 @@ func (s *ESVisibilitySuite) TestGetSearchResult() {
 
 	// test for closed
 	isOpen = false
-	rangeQuery = elastic.NewRangeQuery(es.CloseTime).Gte(request.EarliestStartTime).Lte(request.LatestStartTime)
+	rangeQuery = elastic.NewRangeQuery(es.CloseTime).Gte(earliestTime).Lte(lastestTime)
 	boolQuery = elastic.NewBoolQuery().Must(matchDomainQuery).Filter(rangeQuery).Must(existClosedStatusQuery)
 	params.Query = boolQuery
 	params.Sorter = []elastic.Sorter{elastic.NewFieldSort(es.CloseTime).Desc()}


### PR DESCRIPTION
ElasticSearch v6 is unable to precisely compare time in nanosecond, for example when search with time range [t1,t2] inclusive using lte and gte, records with timestamp t1 or t2 will not show in search result. 
This PR manually add resolution 1ms to time range to address above issue. 

This RP also include some small fix and refactor including:
1. Fix a bug of incorrectly override of es enable config
2. Remove duplicate code in kafka client. 