### PR TITLE
Fix duplicate messages in kafka causing missed ack

### DIFF
--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -111,6 +111,9 @@ func (p *esProcessorImpl) Stop() {
 
 // Add an ES request, and an map item for kafka message
 func (p *esProcessorImpl) Add(request elastic.BulkableRequest, key string, kafkaMsg messaging.Message) {
+	if p.mapToKafkaMsg.Contains(key) { // handle duplicate delete message
+		p.ackKafkaMsg(key)
+	}
 	p.mapToKafkaMsg.Put(key, kafkaMsg)
 	p.processor.Add(request)
 }

--- a/service/worker/indexer/esProcessor_test.go
+++ b/service/worker/indexer/esProcessor_test.go
@@ -140,6 +140,13 @@ func (s *esProcessorSuite) TestAdd() {
 	s.esProcessor.Add(request, key, mockKafkaMsg)
 	s.Equal(1, s.esProcessor.mapToKafkaMsg.Size())
 	mockKafkaMsg.AssertExpectations(s.T())
+
+	// handle duplicate
+	mockKafkaMsg.On("Ack").Return(nil).Once()
+	s.mockBulkProcessor.On("Add", request).Return().Once()
+	s.esProcessor.Add(request, key, mockKafkaMsg)
+	s.Equal(1, s.esProcessor.mapToKafkaMsg.Size())
+	mockKafkaMsg.AssertExpectations(s.T())
 }
 
 func (s *esProcessorSuite) TestBulkAfterAction() {


### PR DESCRIPTION
For visibility to elasticsearch, the message of deletion type is using docID as key for mapping from kafkaMessage to ES requests. 
Duplicate deletion messages in kafka will caused ESProcessor only ack the latest kafkaMessage given docID, which will caused duplicate message before that acked message skipped being acked. 

This PR check duplicate case, such as d1, d2 comes in partition, when add d2, simply ack d1 and then add d2 as usual.