### PR TITLE
sql: add support for workflow retry params

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1496,7 +1496,7 @@ func (d *cassandraPersistence) GetWorkflowExecution(request *p.GetWorkflowExecut
 	activityInfos := make(map[int64]*p.InternalActivityInfo)
 	aMap := result["activity_map"].(map[int64]map[string]interface{})
 	for key, value := range aMap {
-		info := createActivityInfo(value)
+		info := createActivityInfo(request.DomainID, value)
 		activityInfos[key] = info
 	}
 	state.ActivitInfos = activityInfos
@@ -3819,7 +3819,7 @@ func createReplicationTaskInfo(result map[string]interface{}) *p.ReplicationTask
 	return info
 }
 
-func createActivityInfo(result map[string]interface{}) *p.InternalActivityInfo {
+func createActivityInfo(domainID string, result map[string]interface{}) *p.InternalActivityInfo {
 	info := &p.InternalActivityInfo{}
 	var sharedEncoding common.EncodingType
 	var scheduledEventData, startedEventData []byte
@@ -3887,6 +3887,7 @@ func createActivityInfo(result map[string]interface{}) *p.InternalActivityInfo {
 			sharedEncoding = common.EncodingType(v.(string))
 		}
 	}
+	info.DomainID = domainID
 	info.ScheduledEvent = p.NewDataBlob(scheduledEventData, sharedEncoding)
 	info.StartedEvent = p.NewDataBlob(startedEventData, sharedEncoding)
 

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -32,6 +32,10 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
+	"math"
+
+	"math/rand"
+
 	gen "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cluster"
@@ -97,7 +101,6 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionBrandNew() {
 
 	_, err := s.ExecutionManager.CreateWorkflowExecution(req)
 	s.Nil(err)
-
 	_, err = s.ExecutionManager.CreateWorkflowExecution(req)
 	s.NotNil(err)
 	alreadyStartedErr, ok := err.(*p.WorkflowExecutionAlreadyStartedError)
@@ -442,63 +445,107 @@ func (s *ExecutionManagerSuite) TestPersistenceStartWorkflowWithReplicationState
 
 // TestGetWorkflow test
 func (s *ExecutionManagerSuite) TestGetWorkflow() {
-	domainID := "8f27f02b-ce22-4fd9-941b-65e1131b0bb5"
-	workflowExecution := gen.WorkflowExecution{
-		WorkflowId: common.StringPtr("get-workflow-test"),
-		RunId:      common.StringPtr("918e7b1d-bfa4-4fe0-86cb-604858f90ce4"),
-	}
-	task0, err0 := s.ExecutionManager.CreateWorkflowExecution(&p.CreateWorkflowExecutionRequest{
-		RequestID:            uuid.New(),
-		DomainID:             domainID,
-		Execution:            workflowExecution,
-		TaskList:             "queue1",
-		WorkflowTypeName:     "wType",
-		WorkflowTimeout:      20,
-		DecisionTimeoutValue: 13,
-		ExecutionContext:     nil,
-		NextEventID:          3,
-		LastProcessedEvent:   0,
-		RangeID:              s.ShardInfo.RangeID,
-		TransferTasks: []p.Task{
-			&p.DecisionTask{
-				TaskID:              s.GetNextSequenceNumber(),
-				DomainID:            domainID,
-				TaskList:            "queue1",
-				ScheduleID:          2,
-				VisibilityTimestamp: time.Now(),
+	createReq := &p.CreateWorkflowExecutionRequest{
+		RequestID: uuid.New(),
+		DomainID:  uuid.New(),
+		Execution: gen.WorkflowExecution{
+			WorkflowId: common.StringPtr("get-workflow-test"),
+			RunId:      common.StringPtr(uuid.New()),
+		},
+		ParentDomainID: uuid.New(),
+		ParentExecution: &gen.WorkflowExecution{
+			WorkflowId: common.StringPtr("get-workflow-test-parent"),
+			RunId:      common.StringPtr(uuid.New()),
+		},
+		InitiatedID:                 rand.Int63(),
+		TaskList:                    "get-wf-test-tasklist",
+		WorkflowTypeName:            "code.uber.internal/test/workflow",
+		WorkflowTimeout:             rand.Int31(),
+		DecisionTimeoutValue:        rand.Int31(),
+		ExecutionContext:            []byte("test-execution-context"),
+		NextEventID:                 rand.Int63(),
+		LastProcessedEvent:          int64(rand.Int31()),
+		SignalCount:                 rand.Int31(),
+		HistorySize:                 int64(rand.Int31()),
+		DecisionVersion:             int64(rand.Int31()),
+		DecisionScheduleID:          int64(rand.Int31()),
+		DecisionStartedID:           int64(rand.Int31()),
+		DecisionStartToCloseTimeout: rand.Int31(),
+		CreateWorkflowMode:          p.CreateWorkflowModeBrandNew,
+		ReplicationState: &p.ReplicationState{
+			CurrentVersion:   int64(rand.Int31()),
+			StartVersion:     int64(rand.Int31()),
+			LastWriteVersion: int64(rand.Int31()),
+			LastWriteEventID: int64(rand.Int31()),
+			LastReplicationInfo: map[string]*p.ReplicationInfo{
+				"r2": &p.ReplicationInfo{Version: math.MaxInt32, LastEventID: math.MaxInt32},
 			},
 		},
-		TimerTasks:                  nil,
-		DecisionScheduleID:          2,
-		DecisionStartedID:           common.EmptyEventID,
-		DecisionStartToCloseTimeout: 1,
-		SignalCount:                 9,
-	})
-	s.NoError(err0)
-	s.NotNil(task0, "Expected non empty task identifier.")
+		Attempt:            rand.Int31(),
+		HasRetryPolicy:     true,
+		InitialInterval:    rand.Int31(),
+		BackoffCoefficient: 7.78,
+		MaximumInterval:    rand.Int31(),
+		ExpirationTime:     time.Now(),
+		MaximumAttempts:    rand.Int31(),
+		NonRetriableErrors: []string{"badRequestError", "accessDeniedError"},
+		CronSchedule:       "* * * * *",
+		ExpirationSeconds:  rand.Int31(),
+	}
 
-	state, err1 := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
-	s.NoError(err1)
+	createResp, err := s.ExecutionManager.CreateWorkflowExecution(createReq)
+	s.NoError(err)
+	s.NotNil(createResp, "Expected non empty task identifier.")
+
+	state, err := s.GetWorkflowExecutionInfo(createReq.DomainID, createReq.Execution)
+	s.NoError(err)
 	info := state.ExecutionInfo
 	s.NotNil(info, "Valid Workflow response expected.")
-	s.NotNil(info, "Valid Workflow info expected.")
-	s.Equal(domainID, info.DomainID)
-	s.Equal("get-workflow-test", info.WorkflowID)
-	s.Equal("918e7b1d-bfa4-4fe0-86cb-604858f90ce4", info.RunID)
-	s.Equal("queue1", info.TaskList)
-	s.Equal("wType", info.WorkflowTypeName)
-	s.Equal(int32(20), info.WorkflowTimeout)
-	s.Equal(int32(13), info.DecisionTimeoutValue)
-	s.Equal([]byte(nil), info.ExecutionContext)
+	s.Equal(createReq.RequestID, info.CreateRequestID)
+	s.Equal(createReq.DomainID, info.DomainID)
+	s.Equal(*createReq.Execution.WorkflowId, info.WorkflowID)
+	s.Equal(*createReq.Execution.RunId, info.RunID)
+	s.Equal(createReq.ParentDomainID, info.ParentDomainID)
+	s.Equal(*createReq.ParentExecution.WorkflowId, info.ParentWorkflowID)
+	s.Equal(*createReq.ParentExecution.RunId, info.ParentRunID)
+	s.Equal(createReq.InitiatedID, info.InitiatedID)
+	s.Equal(createReq.TaskList, info.TaskList)
+	s.Equal(createReq.WorkflowTypeName, info.WorkflowTypeName)
+	s.Equal(createReq.WorkflowTimeout, info.WorkflowTimeout)
+	s.Equal(createReq.DecisionTimeoutValue, info.DecisionTimeoutValue)
+	s.Equal(createReq.ExecutionContext, info.ExecutionContext)
 	s.Equal(p.WorkflowStateCreated, info.State)
-	s.Equal(int64(3), info.NextEventID)
-	s.Equal(int64(0), info.LastProcessedEvent)
+	s.Equal(createReq.NextEventID, info.NextEventID)
+	s.Equal(createReq.LastProcessedEvent, info.LastProcessedEvent)
 	s.Equal(true, validateTimeRange(info.LastUpdatedTimestamp, time.Hour))
-	s.Equal(int64(2), info.DecisionScheduleID)
-	s.Equal(common.EmptyEventID, info.DecisionStartedID)
-	s.Equal(int32(1), info.DecisionTimeout)
-	s.Equal(int32(9), info.SignalCount)
-	log.Infof("Workflow execution last updated: %v", info.LastUpdatedTimestamp)
+	s.Equal(createReq.DecisionVersion, info.DecisionVersion)
+	s.Equal(createReq.DecisionScheduleID, info.DecisionScheduleID)
+	s.Equal(createReq.DecisionStartedID, info.DecisionStartedID)
+	s.Equal(createReq.DecisionStartToCloseTimeout, info.DecisionTimeout)
+	s.Equal(createReq.SignalCount, info.SignalCount)
+	s.Equal(createReq.HistorySize, info.HistorySize)
+	s.Equal(createReq.Attempt, info.Attempt)
+	s.Equal(createReq.HasRetryPolicy, info.HasRetryPolicy)
+	s.Equal(createReq.InitialInterval, info.InitialInterval)
+	s.Equal(createReq.BackoffCoefficient, info.BackoffCoefficient)
+	s.Equal(createReq.MaximumAttempts, info.MaximumAttempts)
+	s.Equal(createReq.MaximumInterval, info.MaximumInterval)
+	s.Equal(createReq.ExpirationSeconds, info.ExpirationSeconds)
+	s.EqualTimes(createReq.ExpirationTime, info.ExpirationTime)
+	s.Equal(createReq.CronSchedule, info.CronSchedule)
+	s.Equal(createReq.NonRetriableErrors, info.NonRetriableErrors)
+
+	s.Equal(createReq.ReplicationState.LastWriteEventID, state.ReplicationState.LastWriteEventID)
+	s.Equal(createReq.ReplicationState.LastWriteVersion, state.ReplicationState.LastWriteVersion)
+	s.Equal(createReq.ReplicationState.StartVersion, state.ReplicationState.StartVersion)
+	s.Equal(createReq.ReplicationState.CurrentVersion, state.ReplicationState.CurrentVersion)
+	s.NotNil(state.ReplicationState.LastReplicationInfo)
+	for k, v := range createReq.ReplicationState.LastReplicationInfo {
+		v1, ok := state.ReplicationState.LastReplicationInfo[k]
+		s.True(ok)
+		s.Equal(v.Version, v1.Version)
+		s.Equal(v.LastEventID, v1.LastEventID)
+	}
 }
 
 // TestUpdateWorkflow test
@@ -557,6 +604,15 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	updatedInfo.ClientFeatureVersion = "random client feature version"
 	updatedInfo.ClientImpl = "random client impl"
 	updatedInfo.SignalCount = 9
+	updatedInfo.HistorySize = math.MaxInt64
+	updatedInfo.InitialInterval = math.MaxInt32
+	updatedInfo.BackoffCoefficient = 4.45
+	updatedInfo.MaximumInterval = math.MaxInt32
+	updatedInfo.MaximumAttempts = math.MaxInt32
+	updatedInfo.ExpirationSeconds = math.MaxInt32
+	updatedInfo.ExpirationTime = time.Now()
+	updatedInfo.NonRetriableErrors = []string{"accessDenied", "badRequest"}
+
 	err2 := s.UpdateWorkflowExecution(updatedInfo, []int64{int64(4)}, nil, int64(3), nil, nil, nil, nil, nil, nil)
 	s.NoError(err2)
 
@@ -589,6 +645,14 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	s.Equal(updatedInfo.ClientFeatureVersion, info1.ClientFeatureVersion)
 	s.Equal(updatedInfo.ClientImpl, info1.ClientImpl)
 	s.Equal(updatedInfo.SignalCount, info1.SignalCount)
+	s.EqualValues(updatedInfo.HistorySize, info1.HistorySize)
+	s.Equal(updatedInfo.InitialInterval, info1.InitialInterval)
+	s.Equal(updatedInfo.BackoffCoefficient, info1.BackoffCoefficient)
+	s.Equal(updatedInfo.MaximumInterval, info1.MaximumInterval)
+	s.Equal(updatedInfo.MaximumAttempts, info1.MaximumAttempts)
+	s.Equal(updatedInfo.ExpirationSeconds, info1.ExpirationSeconds)
+	s.EqualTimes(updatedInfo.ExpirationTime, info1.ExpirationTime)
+	s.Equal(updatedInfo.NonRetriableErrors, info1.NonRetriableErrors)
 
 	log.Infof("Workflow execution last updated: %v", info1.LastUpdatedTimestamp)
 
@@ -621,6 +685,14 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	s.Equal(int64(123), info2.DecisionAttempt)
 	s.Equal(int64(321), info2.DecisionTimestamp)
 	s.Equal(updatedInfo.SignalCount, info2.SignalCount)
+	s.EqualValues(updatedInfo.HistorySize, info2.HistorySize)
+	s.Equal(updatedInfo.InitialInterval, info2.InitialInterval)
+	s.Equal(updatedInfo.BackoffCoefficient, info2.BackoffCoefficient)
+	s.Equal(updatedInfo.MaximumInterval, info2.MaximumInterval)
+	s.Equal(updatedInfo.MaximumAttempts, info2.MaximumAttempts)
+	s.Equal(updatedInfo.ExpirationSeconds, info2.ExpirationSeconds)
+	s.EqualTimes(updatedInfo.ExpirationTime, info2.ExpirationTime)
+	s.Equal(updatedInfo.NonRetriableErrors, info2.NonRetriableErrors)
 
 	log.Infof("Workflow execution last updated: %v", info2.LastUpdatedTimestamp)
 
@@ -652,6 +724,14 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	s.Equal(int64(123), info3.DecisionAttempt)
 	s.Equal(int64(321), info3.DecisionTimestamp)
 	s.Equal(updatedInfo.SignalCount, info2.SignalCount)
+	s.EqualValues(updatedInfo.HistorySize, info2.HistorySize)
+	s.Equal(updatedInfo.InitialInterval, info2.InitialInterval)
+	s.Equal(updatedInfo.BackoffCoefficient, info2.BackoffCoefficient)
+	s.Equal(updatedInfo.MaximumInterval, info2.MaximumInterval)
+	s.Equal(updatedInfo.MaximumAttempts, info2.MaximumAttempts)
+	s.Equal(updatedInfo.ExpirationSeconds, info2.ExpirationSeconds)
+	s.EqualTimes(updatedInfo.ExpirationTime, info2.ExpirationTime)
+	s.Equal(updatedInfo.NonRetriableErrors, info2.NonRetriableErrors)
 
 	log.Infof("Workflow execution last updated: %v", info3.LastUpdatedTimestamp)
 
@@ -684,6 +764,14 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflow() {
 	s.Equal(int64(123), info4.DecisionAttempt)
 	s.Equal(int64(321), info4.DecisionTimestamp)
 	s.Equal(updatedInfo.SignalCount, info2.SignalCount)
+	s.EqualValues(updatedInfo.HistorySize, info2.HistorySize)
+	s.Equal(updatedInfo.InitialInterval, info2.InitialInterval)
+	s.Equal(updatedInfo.BackoffCoefficient, info2.BackoffCoefficient)
+	s.Equal(updatedInfo.MaximumInterval, info2.MaximumInterval)
+	s.Equal(updatedInfo.MaximumAttempts, info2.MaximumAttempts)
+	s.Equal(updatedInfo.ExpirationSeconds, info2.ExpirationSeconds)
+	s.EqualTimes(updatedInfo.ExpirationTime, info2.ExpirationTime)
+	s.Equal(updatedInfo.NonRetriableErrors, info2.NonRetriableErrors)
 
 	log.Infof("Workflow execution last updated: %v", info4.LastUpdatedTimestamp)
 }
@@ -1354,7 +1442,10 @@ func (s *ExecutionManagerSuite) TestTimerTasksComplete() {
 		RunId:      common.StringPtr("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"),
 	}
 
-	task0, err0 := s.CreateWorkflowExecution(domainID, workflowExecution, "taskList", "wType", 20, 13, nil, 3, 0, 2, nil)
+	now := time.Now()
+	initialTasks := []p.Task{&p.DecisionTimeoutTask{now.Add(1 * time.Second), 1, 2, 3, int(gen.TimeoutTypeStartToClose), 11}}
+
+	task0, err0 := s.CreateWorkflowExecution(domainID, workflowExecution, "taskList", "wType", 20, 13, nil, 3, 0, 2, initialTasks)
 	s.NoError(err0)
 	s.NotNil(task0, "Expected non empty task identifier.")
 
@@ -1366,9 +1457,7 @@ func (s *ExecutionManagerSuite) TestTimerTasksComplete() {
 	updatedInfo := copyWorkflowExecutionInfo(info0)
 	updatedInfo.NextEventID = int64(5)
 	updatedInfo.LastProcessedEvent = int64(2)
-	now := time.Now()
 	tasks := []p.Task{
-		&p.DecisionTimeoutTask{now.Add(1 * time.Second), 1, 2, 3, int(gen.TimeoutTypeStartToClose), 11},
 		&p.WorkflowTimeoutTask{now.Add(2 * time.Second), 2, 12},
 		&p.DeleteHistoryEventTask{now.Add(2 * time.Second), 3, 13},
 		&p.ActivityTimeoutTask{now.Add(3 * time.Second), 4, int(gen.TimeoutTypeStartToClose), 7, 0, 14},
@@ -1380,7 +1469,7 @@ func (s *ExecutionManagerSuite) TestTimerTasksComplete() {
 	timerTasks, err1 := s.GetTimerIndexTasks(1, true) // use page size one to force pagination
 	s.NoError(err1)
 	s.NotNil(timerTasks, "expected valid list of tasks.")
-	s.Equal(len(tasks), len(timerTasks))
+	s.Equal(len(tasks)+len(initialTasks), len(timerTasks))
 	s.Equal(p.TaskTypeDecisionTimeout, timerTasks[0].TaskType)
 	s.Equal(p.TaskTypeWorkflowTimeout, timerTasks[1].TaskType)
 	s.Equal(p.TaskTypeDeleteHistoryEvent, timerTasks[2].TaskType)
@@ -1493,6 +1582,9 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 		ScheduledEventBatchID:    1,
 		ScheduledEvent:           &gen.HistoryEvent{EventId: int64Ptr(1)},
 		ScheduledTime:            currentTime,
+		ActivityID:               uuid.New(),
+		RequestID:                uuid.New(),
+		Details:                  []byte(uuid.New()),
 		StartedID:                2,
 		StartedEvent:             &gen.HistoryEvent{EventId: int64Ptr(2)},
 		StartedTime:              currentTime,
@@ -1502,6 +1594,19 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 		HeartbeatTimeout:         4,
 		LastHeartBeatUpdatedTime: currentTime,
 		TimerTaskStatus:          1,
+		CancelRequested:          true,
+		CancelRequestID:          math.MaxInt64,
+		Attempt:                  math.MaxInt32,
+		DomainID:                 domainID,
+		StartedIdentity:          uuid.New(),
+		TaskList:                 uuid.New(),
+		HasRetryPolicy:           true,
+		InitialInterval:          math.MaxInt32,
+		MaximumInterval:          math.MaxInt32,
+		MaximumAttempts:          math.MaxInt32,
+		BackoffCoefficient:       5.55,
+		ExpirationTime:           currentTime,
+		NonRetriableErrors:       []string{"accessDenied", "badRequest"},
 	}}
 	err2 := s.UpdateWorkflowExecution(updatedInfo, []int64{int64(4)}, nil, int64(3), nil, nil, activityInfos, nil, nil, nil)
 	s.NoError(err2)
@@ -1519,6 +1624,9 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 	s.Equal(int64(1), ai.ScheduledEventBatchID)
 	s.Equal(int64(1), *ai.ScheduledEvent.EventId)
 	s.EqualTimes(currentTime, ai.ScheduledTime)
+	s.Equal(activityInfos[0].ActivityID, ai.ActivityID)
+	s.Equal(activityInfos[0].RequestID, ai.RequestID)
+	s.Equal(activityInfos[0].Details, ai.Details)
 	s.Equal(int64(2), ai.StartedID)
 	s.Equal(int64(2), *ai.StartedEvent.EventId)
 	s.EqualTimes(currentTime, ai.StartedTime)
@@ -1528,6 +1636,19 @@ func (s *ExecutionManagerSuite) TestWorkflowMutableStateActivities() {
 	s.Equal(int32(4), ai.HeartbeatTimeout)
 	s.EqualTimes(currentTime, ai.LastHeartBeatUpdatedTime)
 	s.Equal(int32(1), ai.TimerTaskStatus)
+	s.Equal(activityInfos[0].CancelRequested, ai.CancelRequested)
+	s.Equal(activityInfos[0].CancelRequestID, ai.CancelRequestID)
+	s.Equal(activityInfos[0].Attempt, ai.Attempt)
+	s.Equal(activityInfos[0].DomainID, ai.DomainID)
+	s.Equal(activityInfos[0].StartedIdentity, ai.StartedIdentity)
+	s.Equal(activityInfos[0].TaskList, ai.TaskList)
+	s.Equal(activityInfos[0].HasRetryPolicy, ai.HasRetryPolicy)
+	s.Equal(activityInfos[0].InitialInterval, ai.InitialInterval)
+	s.Equal(activityInfos[0].MaximumInterval, ai.MaximumInterval)
+	s.Equal(activityInfos[0].MaximumAttempts, ai.MaximumAttempts)
+	s.Equal(activityInfos[0].BackoffCoefficient, ai.BackoffCoefficient)
+	s.EqualTimes(activityInfos[0].ExpirationTime, ai.ExpirationTime)
+	s.Equal(activityInfos[0].NonRetriableErrors, ai.NonRetriableErrors)
 
 	err2 = s.UpdateWorkflowExecution(updatedInfo, nil, nil, int64(5), nil, nil, nil, []int64{1}, nil, nil)
 	s.NoError(err2)

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -22,6 +22,8 @@ package persistencetests
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -31,10 +33,6 @@ import (
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
-
-	"math"
-
-	"math/rand"
 
 	gen "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"

--- a/common/persistence/sql/storage/mysql/execution.go
+++ b/common/persistence/sql/storage/mysql/execution.go
@@ -55,8 +55,19 @@ client_library_version,
 client_feature_version,
 client_impl,
 signal_count,
+history_size,
 completion_event_encoding,
-cron_schedule`
+cron_schedule,
+has_retry_policy,
+attempt,
+initial_interval,
+backoff_coefficient,
+maximum_interval,
+maximum_attempts,
+expiration_seconds,
+expiration_time,
+non_retryable_errors
+`
 
 	executionsColumnsTags = `:shard_id,
 :domain_id,
@@ -86,8 +97,18 @@ cron_schedule`
 :client_feature_version,
 :client_impl,
 :signal_count,
+:history_size,
 :completion_event_encoding,
-:cron_schedule`
+:cron_schedule,
+:has_retry_policy,
+:attempt,
+:initial_interval,
+:backoff_coefficient,
+:maximum_interval,
+:maximum_attempts,
+:expiration_seconds,
+:expiration_time,
+:non_retryable_errors`
 
 	executionsBlobColumns = `completion_event,
 execution_context`
@@ -173,7 +194,19 @@ current_version = :current_version,
 last_write_version = :last_write_version,
 last_write_event_id = :last_write_event_id,
 last_replication_info = :last_replication_info,
-signal_count = :signal_count
+signal_count = :signal_count,
+history_size = :history_size,
+cron_schedule = :cron_schedule,
+has_retry_policy = :has_retry_policy,
+attempt = :attempt,
+initial_interval = :initial_interval,
+backoff_coefficient = :backoff_coefficient,
+maximum_interval = :maximum_interval,
+maximum_attempts = :maximum_attempts,
+expiration_seconds = :expiration_seconds,
+expiration_time = :expiration_time,
+non_retryable_errors = :non_retryable_errors
+
 WHERE
 shard_id = :shard_id AND
 domain_id = :domain_id AND
@@ -369,6 +402,7 @@ shard_id=? AND domain_id=? AND workflow_id=? AND run_id=?`
 func (mdb *DB) InsertIntoExecutions(row *sqldb.ExecutionsRow) (sql.Result, error) {
 	row.StartTime = mdb.converter.ToMySQLDateTime(row.StartTime)
 	row.LastUpdatedTime = mdb.converter.ToMySQLDateTime(row.LastUpdatedTime)
+	row.ExpirationTime = mdb.converter.ToMySQLDateTime(row.ExpirationTime)
 	return mdb.conn.NamedExec(createExecutionQry, row)
 }
 
@@ -376,6 +410,7 @@ func (mdb *DB) InsertIntoExecutions(row *sqldb.ExecutionsRow) (sql.Result, error
 func (mdb *DB) UpdateExecutions(row *sqldb.ExecutionsRow) (sql.Result, error) {
 	row.StartTime = mdb.converter.ToMySQLDateTime(row.StartTime)
 	row.LastUpdatedTime = mdb.converter.ToMySQLDateTime(row.LastUpdatedTime)
+	row.ExpirationTime = mdb.converter.ToMySQLDateTime(row.ExpirationTime)
 	return mdb.conn.NamedExec(updateExecutionQry, row)
 }
 
@@ -388,6 +423,7 @@ func (mdb *DB) SelectFromExecutions(filter *sqldb.ExecutionsFilter) (*sqldb.Exec
 	}
 	row.StartTime = mdb.converter.FromMySQLDateTime(row.StartTime)
 	row.LastUpdatedTime = mdb.converter.FromMySQLDateTime(row.LastUpdatedTime)
+	row.ExpirationTime = mdb.converter.FromMySQLDateTime(row.ExpirationTime)
 	return &row, err
 }
 

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -156,7 +156,17 @@ type (
 		ClientFeatureVersion         string
 		ClientImpl                   string
 		SignalCount                  int
+		HistorySize                  int64
 		CronSchedule                 string
+		HasRetryPolicy               bool
+		Attempt                      int
+		InitialInterval              int
+		BackoffCoefficient           float64
+		MaximumInterval              int
+		MaximumAttempts              int
+		ExpirationSeconds            int
+		ExpirationTime               time.Time
+		NonRetryableErrors           []byte
 	}
 
 	// ExecutionsFilter contains the column names within domain table that

--- a/schema/mysql/v56/cadence/schema.sql
+++ b/schema/mysql/v56/cadence/schema.sql
@@ -110,8 +110,17 @@ CREATE TABLE executions(
 	client_feature_version VARCHAR(255) NOT NULL, -- 4.
 	client_impl VARCHAR(255) NOT NULL, -- 5.
 	signal_count INT NOT NULL,
+	history_size BIGINT NOT NULL,
 	cron_schedule VARCHAR(255),
-	-- TODO: fix sql to support workflow retry. https://github.com/uber/cadence/issues/1339
+	has_retry_policy BOOLEAN NOT NULL,-- If there is a retry policy
+	attempt INT NOT NULL,
+  initial_interval INT NOT NULL,    -- initial retry interval, in seconds
+  backoff_coefficient DOUBLE NOT NULL,
+  maximum_interval INT NOT NULL,    -- max retry interval in seconds
+  maximum_attempts INT NOT NULL,    -- max number of attempts including initial non-retry attempt
+  expiration_seconds INT NOT NULL,
+  expiration_time DATETIME(6) NOT NULL, -- retry expiration time
+  non_retryable_errors BLOB,
 	PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
 );
 

--- a/schema/mysql/v57/cadence/schema.sql
+++ b/schema/mysql/v57/cadence/schema.sql
@@ -110,8 +110,17 @@ CREATE TABLE executions(
 	client_feature_version VARCHAR(255) NOT NULL, -- 4.
 	client_impl VARCHAR(255) NOT NULL, -- 5.
 	signal_count INT NOT NULL,
+	history_size BIGINT NOT NULL,
 	cron_schedule VARCHAR(255),
-	-- TODO: fix sql to support workflow retry. https://github.com/uber/cadence/issues/1339
+	has_retry_policy BOOLEAN NOT NULL,-- If there is a retry policy
+	attempt INT NOT NULL,
+  initial_interval INT NOT NULL,    -- initial retry interval, in seconds
+  backoff_coefficient DOUBLE NOT NULL,
+  maximum_interval INT NOT NULL,    -- max retry interval in seconds
+  maximum_attempts INT NOT NULL,    -- max number of attempts including initial non-retry attempt
+  expiration_seconds INT NOT NULL,
+  expiration_time DATETIME(6) NOT NULL, -- retry expiration time
+  non_retryable_errors BLOB,
 	PRIMARY KEY (shard_id, domain_id, workflow_id, run_id)
 );
 


### PR DESCRIPTION
- Fixes #1339
- Also contains improvements to test coverage and related fixes

Note to Reviewer:
The 'executions' table at this point has close to 50 columns. We could consider storing the mutable state as a blob in MySQL - however the pros/cons of doing so are not very clear at this time. So, I have decided to tackle this problem independently after getting some data on the performance implications of such a change.

Pros/Cons to having too many columns are below. The I/O cost is likely to be the same with both blob and wide rows

- Cons
  - CPU cost on the MySQL server to do conversions to/from blobs obtained from InnoDB
  - Mutable state (executions) is something we expect to add/deprecate columns frequently. In a sharded mysql cluster,  schema changes may be hard i.e. all storage shards must agree on the new schema despite operating independently - this may or may not add operational complexity

- Pros
  - Allows for joins on non-primary key fields - but we likely don't need this flexibility