### PR TITLE
sql: delete current_executions row as part of workflow deletion

### DIFF
--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -821,7 +821,7 @@ func (s *ExecutionManagerSuite) TestDeleteWorkflow() {
 // TestDeleteCurrentWorkflow test
 func (s *ExecutionManagerSuite) TestDeleteCurrentWorkflow() {
 	if s.ExecutionManager.GetName() != "cassandra" {
-		s.T().Skip("SQL doesn't support retention yet")
+		s.T().Skip("this test is only applicable for cassandra (uses TTL based deletes)")
 	}
 	finishedCurrentExecutionRetentionTTL := int32(3) // 3 seconds
 	domainID := "54d15308-e20e-4b91-a00f-a518a3892790"
@@ -862,6 +862,60 @@ func (s *ExecutionManagerSuite) TestDeleteCurrentWorkflow() {
 	// execution record should still be there
 	info0, err2 = s.GetWorkflowExecutionInfo(domainID, workflowExecution)
 	s.NoError(err2)
+}
+
+// TestUpdateDeleteWorkflow verifies that an update workflow (with FinishExecution set to true)
+// followed by DeleteWorkflowExecution  clears all state associated with the workflow. The
+// reason for having this test is because cassandra deletes current_executions row with TTL
+// as part of the UpdateWFExecution API whereas SQL deletes current_executions entry as part of
+// timer task / DeleteWorkflowExecution API - so, an update followed by delete should clear
+// all state in both sql/cassandra
+func (s *ExecutionManagerSuite) TestUpdateDeleteWorkflow() {
+	finishedCurrentExecutionRetentionTTL := int32(2)
+	domainID := "54d15308-e20e-4b91-a00f-a518a3892790"
+	workflowExecution := gen.WorkflowExecution{
+		WorkflowId: common.StringPtr("update-delete-workflow-test"),
+		RunId:      common.StringPtr("6cae4054-6ba7-46d3-8755-e3c2db6f74ea"),
+	}
+
+	task0, err0 := s.CreateWorkflowExecution(domainID, workflowExecution, "queue1", "wType", 20, 13, nil, 3, 0, 2, nil)
+	s.NoError(err0)
+	s.NotNil(task0, "Expected non empty task identifier.")
+
+	runID0, err1 := s.GetCurrentWorkflowRunID(domainID, *workflowExecution.WorkflowId)
+	s.NoError(err1)
+	s.Equal(*workflowExecution.RunId, runID0)
+
+	info0, err2 := s.GetWorkflowExecutionInfo(domainID, workflowExecution)
+	s.NoError(err2)
+
+	updatedInfo1 := copyWorkflowExecutionInfo(info0.ExecutionInfo)
+	updatedInfo1.NextEventID = int64(6)
+	updatedInfo1.LastProcessedEvent = int64(2)
+	err3 := s.UpdateWorkflowExecutionAndFinish(updatedInfo1, int64(3), finishedCurrentExecutionRetentionTTL)
+	s.NoError(err3)
+
+	runID4, err4 := s.GetCurrentWorkflowRunID(domainID, *workflowExecution.WorkflowId)
+	s.NoError(err4)
+	s.Equal(*workflowExecution.RunId, runID4)
+
+	// simulate a timer_task deleting execution after retention
+	err5 := s.DeleteWorkflowExecution(info0.ExecutionInfo)
+	s.NoError(err5)
+
+	time.Sleep(time.Duration(finishedCurrentExecutionRetentionTTL*2) * time.Second)
+
+	runID0, err1 = s.GetCurrentWorkflowRunID(domainID, *workflowExecution.WorkflowId)
+	s.Error(err1)
+	s.Empty(runID0)
+	_, ok := err1.(*gen.EntityNotExistsError)
+	s.True(ok)
+
+	// execution record should still be there
+	info0, err2 = s.GetWorkflowExecutionInfo(domainID, workflowExecution)
+	s.Error(err2)
+	_, ok = err2.(*gen.EntityNotExistsError)
+	s.True(ok)
 }
 
 // TestGetCurrentWorkflow test
@@ -983,14 +1037,14 @@ func (s *ExecutionManagerSuite) TestTransferTasksThroughUpdate() {
 	s.Equal(p.TransferTaskTypeCloseExecution, task3.TaskType)
 	s.Equal("", task3.TargetRunID)
 
-	err8 := s.DeleteWorkflowExecution(info1)
+	err8 := s.CompleteTransferTask(task3.TaskID)
 	s.NoError(err8)
 
-	err9 := s.CompleteTransferTask(task3.TaskID)
-	s.NoError(err9)
+	_, err9 := s.CreateWorkflowExecution(domainID, newExecution, "queue1", "wType", 20, 13, nil, 3, 0, 2, nil)
+	s.Error(err9, "Error expected.")
 
-	_, err10 := s.CreateWorkflowExecution(domainID, newExecution, "queue1", "wType", 20, 13, nil, 3, 0, 2, nil)
-	s.Error(err10, "Error expected.")
+	err10 := s.DeleteWorkflowExecution(info1)
+	s.NoError(err10)
 }
 
 // TestCancelTransferTaskTasks test

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1041,7 +1041,7 @@ func (s *ExecutionManagerSuite) TestTransferTasksThroughUpdate() {
 	s.NoError(err8)
 
 	_, err9 := s.CreateWorkflowExecution(domainID, newExecution, "queue1", "wType", 20, 13, nil, 3, 0, 2, nil)
-	s.Error(err9, "Error expected.")
+	s.Error(err9, "createWFExecution (brand_new) must fail when there is a previous instance of workflow state already in DB")
 
 	err10 := s.DeleteWorkflowExecution(info1)
 	s.NoError(err10)

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -844,6 +844,10 @@ func (m *sqlExecutionManager) DeleteWorkflowExecution(request *p.DeleteWorkflowE
 		}); err != nil {
 			return err
 		}
+		// its possible for a new run of the same workflow to have started after the run we are deleting
+		// here was finished. In that case, current_executions table will have the same workflowID but different
+		// runID. The following code will delete the row from current_executions if and only if the runID is
+		// same as the one we are trying to delete here
 		_, err := tx.DeleteFromCurrentExecutions(&sqldb.CurrentExecutionsFilter{
 			ShardID:    int64(m.shardID),
 			DomainID:   domainID,

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -197,6 +197,7 @@ type (
 		ShardID    int64
 		DomainID   UUID
 		WorkflowID string
+		RunID      UUID
 	}
 
 	// BufferedEventsRow represents a row in buffered_events table
@@ -606,7 +607,11 @@ type (
 
 		InsertIntoCurrentExecutions(row *CurrentExecutionsRow) (sql.Result, error)
 		UpdateCurrentExecutions(row *CurrentExecutionsRow) (sql.Result, error)
+		// SelectFromCurrentExecutions returns one or more rows from current_executions table
+		// Required params - {shardID, domainID, workflowID}
 		SelectFromCurrentExecutions(filter *CurrentExecutionsFilter) (*CurrentExecutionsRow, error)
+		// DeleteFromCurrentExecutions performa a conditinal delete of a row in current_executions table
+		// Required params - {shardID, domainID, workflowID, runID}
 		DeleteFromCurrentExecutions(filter *CurrentExecutionsFilter) (sql.Result, error)
 		LockCurrentExecutions(filter *CurrentExecutionsFilter) (UUID, error)
 

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -610,7 +610,10 @@ type (
 		// SelectFromCurrentExecutions returns one or more rows from current_executions table
 		// Required params - {shardID, domainID, workflowID}
 		SelectFromCurrentExecutions(filter *CurrentExecutionsFilter) (*CurrentExecutionsRow, error)
-		// DeleteFromCurrentExecutions performa a conditinal delete of a row in current_executions table
+		// DeleteFromCurrentExecutions deletes a single row that matches the filter criteria
+		// If a row exist, that row will be deleted and this method will return success
+		// If there is no row matching the filter criteria, this method will still return success
+		// Callers can check the output of Result.RowsAffected() to see if a row was deleted or not
 		// Required params - {shardID, domainID, workflowID, runID}
 		DeleteFromCurrentExecutions(filter *CurrentExecutionsFilter) (sql.Result, error)
 		LockCurrentExecutions(filter *CurrentExecutionsFilter) (UUID, error)


### PR DESCRIPTION
Problem:
As of today, we don't delete rows from current_executions table even after workflow retention expires. This is because, historically, we relied on cassandra's TTL mechanism to delete this record. Since SQL does not have a TTL equivalent, this patch contains a change to cleanup current_executions state after workflow retention. 

Fix: We currently have a timer_task that fires after retention to delete history/mutable state. This handler calls the persistence DeleteWFExecution API. This patch changes the behavior of this API (for SQL) to delete both mutable state and current_executions entry in a single transaction. The current_executions delete is a conditional delete because its possible for a new run to have started.

Fixes parts of #1436. 

Note to Reviewer:
One thing I don't like about this change is that - the behavior of DeleteWFExecution is different for SQL and Cassandra. This is because TTL is still the best way to delete the current_executions row for cassandra and it makes sense to leave the existing behavior as such. This behavior difference is transparent to rest of cadence. However, persistence layer implementations need to be aware that - 
  (1) if store supports TTL, its best for delete to happen in UpdateWorkflowExecution using TTL
  (2) if store doesn't support TTL, the delete needs to happen in DeleteWFExecution

I added a unit test that creates a workflow, updates it (completion) and then calls deleteWFExecution. After this, the test verifies all state is deleted. 