### PR TITLE
Support read from closed execution v2

### DIFF
--- a/common/persistence/cassandra/cassandraVisibilityPersistenceV2.go
+++ b/common/persistence/cassandra/cassandraVisibilityPersistenceV2.go
@@ -1,0 +1,297 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cassandra
+
+import (
+	"fmt"
+	"github.com/gocql/gocql"
+	"github.com/uber-common/bark"
+	workflow "github.com/uber/cadence/.gen/go/shared"
+	p "github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service/config"
+)
+
+const (
+	templateGetClosedWorkflowExecutionsV2 = `SELECT workflow_id, run_id, start_time, close_time, workflow_type_name, status, history_length ` +
+		`FROM closed_executions_v2 ` +
+		`WHERE domain_id = ? ` +
+		`AND domain_partition IN (?) ` +
+		`AND close_time >= ? ` +
+		`AND close_time <= ? `
+
+	templateGetClosedWorkflowExecutionsByTypeV2 = `SELECT workflow_id, run_id, start_time, close_time, workflow_type_name, status, history_length ` +
+		`FROM closed_executions_v2 ` +
+		`WHERE domain_id = ? ` +
+		`AND domain_partition = ? ` +
+		`AND close_time >= ? ` +
+		`AND close_time <= ? ` +
+		`AND workflow_type_name = ? `
+
+	templateGetClosedWorkflowExecutionsByIDV2 = `SELECT workflow_id, run_id, start_time, close_time, workflow_type_name, status, history_length ` +
+		`FROM closed_executions_v2 ` +
+		`WHERE domain_id = ? ` +
+		`AND domain_partition = ? ` +
+		`AND close_time >= ? ` +
+		`AND close_time <= ? ` +
+		`AND workflow_id = ? `
+
+	templateGetClosedWorkflowExecutionsByStatusV2 = `SELECT workflow_id, run_id, start_time, close_time, workflow_type_name, status, history_length ` +
+		`FROM closed_executions_v2 ` +
+		`WHERE domain_id = ? ` +
+		`AND domain_partition = ? ` +
+		`AND close_time >= ? ` +
+		`AND close_time <= ? ` +
+		`AND status = ? `
+)
+
+type (
+	cassandraVisibilityPersistenceV2 struct {
+		cassandraStore
+		lowConslevel gocql.Consistency
+		persistence  p.VisibilityManager
+	}
+)
+
+// NewVisibilityPersistenceV2 create a wrapper of cassandra visibilityPersistence, with all list closed executions using v2 table
+func NewVisibilityPersistenceV2(persistence p.VisibilityManager, cfg *config.Cassandra, logger bark.Logger) (p.VisibilityManager, error) {
+	cluster := NewCassandraCluster(cfg.Hosts, cfg.Port, cfg.User, cfg.Password, cfg.Datacenter)
+	cluster.Keyspace = cfg.Keyspace
+	cluster.ProtoVersion = cassandraProtoVersion
+	cluster.Consistency = gocql.LocalQuorum
+	cluster.SerialConsistency = gocql.LocalSerial
+	cluster.Timeout = defaultSessionTimeout
+
+	session, err := cluster.CreateSession()
+	if err != nil {
+		return nil, err
+	}
+
+	return &cassandraVisibilityPersistenceV2{
+		cassandraStore: cassandraStore{session: session, logger: logger},
+		lowConslevel:   gocql.One,
+		persistence:    persistence,
+	}, nil
+}
+
+// Close releases the resources held by this object
+func (v *cassandraVisibilityPersistenceV2) Close() {
+	if v.session != nil {
+		v.session.Close()
+	}
+	v.persistence.Close()
+}
+
+func (v *cassandraVisibilityPersistenceV2) GetName() string {
+	return v.persistence.GetName()
+}
+
+func (v *cassandraVisibilityPersistenceV2) RecordWorkflowExecutionStarted(
+	request *p.RecordWorkflowExecutionStartedRequest) error {
+	return v.persistence.RecordWorkflowExecutionStarted(request)
+}
+
+func (v *cassandraVisibilityPersistenceV2) RecordWorkflowExecutionClosed(
+	request *p.RecordWorkflowExecutionClosedRequest) error {
+	return v.persistence.RecordWorkflowExecutionClosed(request)
+}
+
+func (v *cassandraVisibilityPersistenceV2) ListOpenWorkflowExecutions(
+	request *p.ListWorkflowExecutionsRequest) (*p.ListWorkflowExecutionsResponse, error) {
+	return v.persistence.ListOpenWorkflowExecutions(request)
+}
+
+func (v *cassandraVisibilityPersistenceV2) ListOpenWorkflowExecutionsByType(
+	request *p.ListWorkflowExecutionsByTypeRequest) (*p.ListWorkflowExecutionsResponse, error) {
+	return v.persistence.ListOpenWorkflowExecutionsByType(request)
+}
+
+func (v *cassandraVisibilityPersistenceV2) ListOpenWorkflowExecutionsByWorkflowID(
+	request *p.ListWorkflowExecutionsByWorkflowIDRequest) (*p.ListWorkflowExecutionsResponse, error) {
+	return v.persistence.ListOpenWorkflowExecutionsByWorkflowID(request)
+}
+
+func (v *cassandraVisibilityPersistenceV2) GetClosedWorkflowExecution(
+	request *p.GetClosedWorkflowExecutionRequest) (*p.GetClosedWorkflowExecutionResponse, error) {
+	return v.persistence.GetClosedWorkflowExecution(request)
+}
+
+func (v *cassandraVisibilityPersistenceV2) ListClosedWorkflowExecutions(
+	request *p.ListWorkflowExecutionsRequest) (*p.ListWorkflowExecutionsResponse, error) {
+	query := v.session.Query(templateGetClosedWorkflowExecutionsV2,
+		request.DomainUUID,
+		domainPartition,
+		p.UnixNanoToDBTimestamp(request.EarliestStartTime),
+		p.UnixNanoToDBTimestamp(request.LatestStartTime)).Consistency(v.lowConslevel)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	if iter == nil {
+		// TODO: should return a bad request error if the token is invalid
+		return nil, &workflow.InternalServiceError{
+			Message: "ListClosedWorkflowExecutions operation failed.  Not able to create query iterator.",
+		}
+	}
+
+	response := &p.ListWorkflowExecutionsResponse{}
+	response.Executions = make([]*workflow.WorkflowExecutionInfo, 0)
+	wfexecution, has := readClosedWorkflowExecutionRecord(iter)
+	for has {
+		response.Executions = append(response.Executions, wfexecution)
+		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
+	}
+
+	nextPageToken := iter.PageState()
+	response.NextPageToken = make([]byte, len(nextPageToken))
+	copy(response.NextPageToken, nextPageToken)
+	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
+			}
+		}
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
+		}
+	}
+
+	return response, nil
+}
+
+func (v *cassandraVisibilityPersistenceV2) ListClosedWorkflowExecutionsByType(
+	request *p.ListWorkflowExecutionsByTypeRequest) (*p.ListWorkflowExecutionsResponse, error) {
+	query := v.session.Query(templateGetClosedWorkflowExecutionsByTypeV2,
+		request.DomainUUID,
+		domainPartition,
+		p.UnixNanoToDBTimestamp(request.EarliestStartTime),
+		p.UnixNanoToDBTimestamp(request.LatestStartTime),
+		request.WorkflowTypeName).Consistency(v.lowConslevel)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	if iter == nil {
+		// TODO: should return a bad request error if the token is invalid
+		return nil, &workflow.InternalServiceError{
+			Message: "ListClosedWorkflowExecutionsByType operation failed.  Not able to create query iterator.",
+		}
+	}
+
+	response := &p.ListWorkflowExecutionsResponse{}
+	response.Executions = make([]*workflow.WorkflowExecutionInfo, 0)
+	wfexecution, has := readClosedWorkflowExecutionRecord(iter)
+	for has {
+		response.Executions = append(response.Executions, wfexecution)
+		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
+	}
+
+	nextPageToken := iter.PageState()
+	response.NextPageToken = make([]byte, len(nextPageToken))
+	copy(response.NextPageToken, nextPageToken)
+	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
+			}
+		}
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
+		}
+	}
+
+	return response, nil
+}
+
+func (v *cassandraVisibilityPersistenceV2) ListClosedWorkflowExecutionsByWorkflowID(
+	request *p.ListWorkflowExecutionsByWorkflowIDRequest) (*p.ListWorkflowExecutionsResponse, error) {
+	query := v.session.Query(templateGetClosedWorkflowExecutionsByIDV2,
+		request.DomainUUID,
+		domainPartition,
+		p.UnixNanoToDBTimestamp(request.EarliestStartTime),
+		p.UnixNanoToDBTimestamp(request.LatestStartTime),
+		request.WorkflowID).Consistency(v.lowConslevel)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	if iter == nil {
+		// TODO: should return a bad request error if the token is invalid
+		return nil, &workflow.InternalServiceError{
+			Message: "ListClosedWorkflowExecutionsByWorkflowID operation failed.  Not able to create query iterator.",
+		}
+	}
+
+	response := &p.ListWorkflowExecutionsResponse{}
+	response.Executions = make([]*workflow.WorkflowExecutionInfo, 0)
+	wfexecution, has := readClosedWorkflowExecutionRecord(iter)
+	for has {
+		response.Executions = append(response.Executions, wfexecution)
+		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
+	}
+
+	nextPageToken := iter.PageState()
+	response.NextPageToken = make([]byte, len(nextPageToken))
+	copy(response.NextPageToken, nextPageToken)
+	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
+			}
+		}
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
+		}
+	}
+
+	return response, nil
+}
+
+func (v *cassandraVisibilityPersistenceV2) ListClosedWorkflowExecutionsByStatus(
+	request *p.ListClosedWorkflowExecutionsByStatusRequest) (*p.ListWorkflowExecutionsResponse, error) {
+	query := v.session.Query(templateGetClosedWorkflowExecutionsByStatusV2,
+		request.DomainUUID,
+		domainPartition,
+		p.UnixNanoToDBTimestamp(request.EarliestStartTime),
+		p.UnixNanoToDBTimestamp(request.LatestStartTime),
+		request.Status).Consistency(v.lowConslevel)
+	iter := query.PageSize(request.PageSize).PageState(request.NextPageToken).Iter()
+	if iter == nil {
+		// TODO: should return a bad request error if the token is invalid
+		return nil, &workflow.InternalServiceError{
+			Message: "ListClosedWorkflowExecutionsByStatus operation failed.  Not able to create query iterator.",
+		}
+	}
+
+	response := &p.ListWorkflowExecutionsResponse{}
+	response.Executions = make([]*workflow.WorkflowExecutionInfo, 0)
+	wfexecution, has := readClosedWorkflowExecutionRecord(iter)
+	for has {
+		response.Executions = append(response.Executions, wfexecution)
+		wfexecution, has = readClosedWorkflowExecutionRecord(iter)
+	}
+
+	nextPageToken := iter.PageState()
+	response.NextPageToken = make([]byte, len(nextPageToken))
+	copy(response.NextPageToken, nextPageToken)
+	if err := iter.Close(); err != nil {
+		if isThrottlingError(err) {
+			return nil, &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
+			}
+		}
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
+		}
+	}
+
+	return response, nil
+}

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -189,7 +189,7 @@ func (s *TestBase) Setup() {
 		visibilityFactory = pfactory.New(&vCfg, clusterName, nil, log)
 	}
 	// SQL currently doesn't have support for visibility manager
-	s.VisibilityMgr, err = visibilityFactory.NewVisibilityManager(false)
+	s.VisibilityMgr, err = visibilityFactory.NewVisibilityManager()
 	if err != nil {
 		s.fatalOnError("NewVisibilityManager", err)
 	}

--- a/common/persistence/persistence-tests/visibilitySamplingClient_test.go
+++ b/common/persistence/persistence-tests/visibilitySamplingClient_test.go
@@ -65,7 +65,7 @@ func (s *VisibilitySamplingSuite) SetupTest() {
 	s.Assertions = require.New(s.T()) // Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 
 	s.persistence = &mocks.VisibilityManager{}
-	config := &c.SamplingConfig{
+	config := &c.VisibilityConfig{
 		VisibilityOpenMaxQPS:   dynamicconfig.GetIntPropertyFilteredByDomain(1),
 		VisibilityClosedMaxQPS: dynamicconfig.GetIntPropertyFilteredByDomain(10),
 		VisibilityListMaxQPS:   dynamicconfig.GetIntPropertyFilteredByDomain(1),

--- a/common/persistence/visibilitySamplingClient.go
+++ b/common/persistence/visibilitySamplingClient.go
@@ -43,7 +43,7 @@ type visibilitySamplingClient struct {
 	rateLimitersForClosed *domainToBucketMap
 	rateLimitersForList   *domainToBucketMap
 	persistence           VisibilityManager
-	config                *config.SamplingConfig
+	config                *config.VisibilityConfig
 	metricClient          metrics.Client
 	logger                bark.Logger
 }
@@ -51,7 +51,7 @@ type visibilitySamplingClient struct {
 var _ VisibilityManager = (*visibilitySamplingClient)(nil)
 
 // NewVisibilitySamplingClient creates a client to manage visibility with sampling
-func NewVisibilitySamplingClient(persistence VisibilityManager, config *config.SamplingConfig, metricClient metrics.Client, logger bark.Logger) VisibilityManager {
+func NewVisibilitySamplingClient(persistence VisibilityManager, config *config.VisibilityConfig, metricClient metrics.Client, logger bark.Logger) VisibilityManager {
 	return &visibilitySamplingClient{
 		persistence:           persistence,
 		rateLimitersForOpen:   newDomainToBucketMap(),

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -113,8 +113,8 @@ type (
 		NumHistoryShards int `yaml:"numHistoryShards" validate:"nonzero"`
 		// DataStores contains the configuration for all datastores
 		DataStores map[string]DataStore `yaml:"datastores"`
-		// SamplingConfig is config for visibility sampling
-		SamplingConfig SamplingConfig
+		// VisibilityConfig is config for visibility sampling
+		VisibilityConfig *VisibilityConfig
 	}
 
 	// DataStore is the configuration for a single datastore
@@ -125,8 +125,12 @@ type (
 		SQL *SQL `yaml:"sql"`
 	}
 
-	// SamplingConfig is config for visibility sampling
-	SamplingConfig struct {
+	// VisibilityConfig is config for visibility sampling
+	VisibilityConfig struct {
+		// EnableSampling for visibility
+		EnableSampling dynamicconfig.BoolPropertyFn
+		// EnableReadFromClosedExecutionV2 read closed from v2 table
+		EnableReadFromClosedExecutionV2 dynamicconfig.BoolPropertyFn
 		// VisibilityOpenMaxQPS max QPS for record open workflows
 		VisibilityOpenMaxQPS dynamicconfig.IntPropertyFnWithDomainFilter
 		// VisibilityClosedMaxQPS max QPS for record closed workflows

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -48,12 +48,13 @@ var keys = map[Key]string{
 	testGetBoolPropertyFilteredByTaskListInfoKey:     "testGetBoolPropertyFilteredByTaskListInfoKey",
 
 	// system settings
-	EnableGlobalDomain:         "system.enableGlobalDomain",
-	EnableNewKafkaClient:       "system.enableNewKafkaClient",
-	EnableVisibilitySampling:   "system.enableVisibilitySampling",
-	EnableVisibilityToKafka:    "system.enableVisibilityToKafka",
-	EnableReadVisibilityFromES: "system.enableReadVisibilityFromES",
-	EnableArchival:             "system.enableArchival",
+	EnableGlobalDomain:              "system.enableGlobalDomain",
+	EnableNewKafkaClient:            "system.enableNewKafkaClient",
+	EnableVisibilitySampling:        "system.enableVisibilitySampling",
+	EnableReadFromClosedExecutionV2: "system.enableReadFromClosedExecutionV2",
+	EnableVisibilityToKafka:         "system.enableVisibilityToKafka",
+	EnableReadVisibilityFromES:      "system.enableReadVisibilityFromES",
+	EnableArchival:                  "system.enableArchival",
 
 	// size limit
 	BlobSizeLimitError:     "limit.blobSize.error",
@@ -189,6 +190,8 @@ const (
 	EnableNewKafkaClient
 	// EnableVisibilitySampling is key for enable visibility sampling
 	EnableVisibilitySampling
+	// EnableReadFromClosedExecutionV2 is key for enable read from cadence_visibility.closed_executions_v2
+	EnableReadFromClosedExecutionV2
 	// EnableVisibilityToKafka is key for enable kafka
 	EnableVisibilityToKafka
 	// EnableReadVisibilityFromES is key for enable read from elastic search
@@ -263,9 +266,9 @@ const (
 	HistoryRPS
 	// HistoryPersistenceMaxQPS is the max qps history host can query DB
 	HistoryPersistenceMaxQPS
-	// HistoryVisibilityOpenMaxQPS is max qps one history host can query visibility open_executions
+	// HistoryVisibilityOpenMaxQPS is max qps one history host can write visibility open_executions
 	HistoryVisibilityOpenMaxQPS
-	// HistoryVisibilityClosedMaxQPS is max qps one history host can query visibility closed_executions
+	// HistoryVisibilityClosedMaxQPS is max qps one history host can write visibility closed_executions
 	HistoryVisibilityClosedMaxQPS
 	// HistoryLongPollExpirationInterval is the long poll expiration interval in the history service
 	HistoryLongPollExpirationInterval

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	persistencefactory "github.com/uber/cadence/common/persistence/persistence-factory"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/common/service/dynamicconfig"
 )
 
@@ -35,13 +36,14 @@ import (
 type Config struct {
 	NumberOfShards int
 
-	RPS                      dynamicconfig.IntPropertyFn
-	MaxIDLengthLimit         dynamicconfig.IntPropertyFn
-	PersistenceMaxQPS        dynamicconfig.IntPropertyFn
-	EnableVisibilitySampling dynamicconfig.BoolPropertyFn
-	VisibilityOpenMaxQPS     dynamicconfig.IntPropertyFnWithDomainFilter
-	VisibilityClosedMaxQPS   dynamicconfig.IntPropertyFnWithDomainFilter
-	EnableVisibilityToKafka  dynamicconfig.BoolPropertyFn
+	RPS                             dynamicconfig.IntPropertyFn
+	MaxIDLengthLimit                dynamicconfig.IntPropertyFn
+	PersistenceMaxQPS               dynamicconfig.IntPropertyFn
+	EnableVisibilitySampling        dynamicconfig.BoolPropertyFn
+	EnableReadFromClosedExecutionV2 dynamicconfig.BoolPropertyFn
+	VisibilityOpenMaxQPS            dynamicconfig.IntPropertyFnWithDomainFilter
+	VisibilityClosedMaxQPS          dynamicconfig.IntPropertyFnWithDomainFilter
+	EnableVisibilityToKafka         dynamicconfig.BoolPropertyFn
 
 	// HistoryCache settings
 	// Change of these configs require shard restart
@@ -145,6 +147,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, enableVisibilit
 		MaxIDLengthLimit:                                      dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		PersistenceMaxQPS:                                     dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 9000),
 		EnableVisibilitySampling:                              dc.GetBoolProperty(dynamicconfig.EnableVisibilitySampling, true),
+		EnableReadFromClosedExecutionV2:                       dc.GetBoolProperty(dynamicconfig.EnableReadFromClosedExecutionV2, false),
 		VisibilityOpenMaxQPS:                                  dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryVisibilityOpenMaxQPS, 300),
 		VisibilityClosedMaxQPS:                                dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryVisibilityClosedMaxQPS, 300),
 		EnableVisibilityToKafka:                               dc.GetBoolProperty(dynamicconfig.EnableVisibilityToKafka, enableVisibilityToKafka),
@@ -260,8 +263,12 @@ func (s *Service) Start() {
 	pConfig := params.PersistenceConfig
 	pConfig.HistoryMaxConns = s.config.HistoryMgrNumConns()
 	pConfig.SetMaxQPS(pConfig.DefaultStore, s.config.PersistenceMaxQPS())
-	pConfig.SamplingConfig.VisibilityOpenMaxQPS = s.config.VisibilityOpenMaxQPS
-	pConfig.SamplingConfig.VisibilityClosedMaxQPS = s.config.VisibilityClosedMaxQPS
+	pConfig.VisibilityConfig = &config.VisibilityConfig{
+		VisibilityOpenMaxQPS:            s.config.VisibilityOpenMaxQPS,
+		VisibilityClosedMaxQPS:          s.config.VisibilityClosedMaxQPS,
+		EnableSampling:                  s.config.EnableVisibilitySampling,
+		EnableReadFromClosedExecutionV2: s.config.EnableReadFromClosedExecutionV2,
+	}
 	pFactory := persistencefactory.New(&pConfig, params.ClusterMetadata.GetCurrentClusterName(), s.metricsClient, log)
 
 	shardMgr, err := pFactory.NewShardManager()
@@ -274,7 +281,7 @@ func (s *Service) Start() {
 		log.Fatalf("failed to create metadata manager: %v", err)
 	}
 
-	visibility, err := pFactory.NewVisibilityManager(s.config.EnableVisibilitySampling())
+	visibility, err := pFactory.NewVisibilityManager()
 	if err != nil {
 		log.Fatalf("failed to create visibility manager: %v", err)
 	}


### PR DESCRIPTION
Add EnableReadFromClosedExecutionV2 to support reading from cadence_visibility.closed_execution_v2 table. 
Note: 
1. This change is only for cassandra. Currently SQL read closed execution is still sort by startTime instead of closeTime. 
2. There is no backward compatible solution to rename `ListClosedWorkflowExecutionsRequest` property `StartTimeFilter` to reflect this behavior. So leave it there as a mental trick for user who turn on read from v2.
