### PR TITLE
config/rpc: support binding on user specified ip addr

### DIFF
--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -77,6 +77,10 @@ type (
 		Port int `yaml:"port"`
 		// BindOnLocalHost is true if localhost is the bind address
 		BindOnLocalHost bool `yaml:"bindOnLocalHost"`
+		// BindOnIP can be used to bind service on specific ip (eg. `0.0.0.0`) -
+		// check net.ParseIP for supported syntax, only IPv4 is supported,
+		// mutually exclusive with `BindOnLocalHost` option
+		BindOnIP string `yaml:"bindOnIP"`
 		// DisableLogging disables all logging for rpc
 		DisableLogging bool `yaml:"disableLogging"`
 		// LogLevel is the desired log level

--- a/common/service/config/rpc.go
+++ b/common/service/config/rpc.go
@@ -87,7 +87,7 @@ func (d *RPCFactory) CreateDispatcherForOutbound(
 
 func (d *RPCFactory) getListenIP() net.IP {
 	if d.config.BindOnLocalHost && len(d.config.BindOnIP) > 0 {
-		d.logger.Fatalf("ListenIP failed, BindOnLocalHost and BindOnIP are mutually exclussive")
+		d.logger.Fatalf("ListenIP failed, bindOnLocalHost and bindOnIP are mutually exclussive")
 	}
 
 	if d.config.BindOnLocalHost {
@@ -99,7 +99,7 @@ func (d *RPCFactory) getListenIP() net.IP {
 		if ip != nil && ip.To4() != nil {
 			return ip.To4()
 		}
-		d.logger.Fatalf("ListenIP failed, unable to parse %q or it is not IPv4 address", d.config.BindOnIP)
+		d.logger.Fatalf("ListenIP failed, unable to parse bindOnIP value %q or it is not IPv4 address", d.config.BindOnIP)
 	}
 	ip, err := ListenIP()
 	if err != nil {

--- a/common/service/config/rpc.go
+++ b/common/service/config/rpc.go
@@ -95,7 +95,7 @@ func (d *RPCFactory) getListenIP() net.IP {
 	}
 
 	if len(d.config.BindOnIP) > 0 {
-		ip = net.ParseIP(d.config.BindOnIP)
+		ip := net.ParseIP(d.config.BindOnIP)
 		if ip != nil && ip.To4() != nil {
 			return ip.To4()
 		}

--- a/common/service/config/rpc.go
+++ b/common/service/config/rpc.go
@@ -86,8 +86,20 @@ func (d *RPCFactory) CreateDispatcherForOutbound(
 }
 
 func (d *RPCFactory) getListenIP() net.IP {
+	if d.config.BindOnLocalHost && len(d.config.BindOnIP) > 0 {
+		d.logger.Fatalf("ListenIP failed, BindOnLocalHost and BindOnIP are mutually exclussive")
+	}
+
 	if d.config.BindOnLocalHost {
 		return net.IPv4(127, 0, 0, 1)
+	}
+
+	if len(d.config.BindOnIP) > 0 {
+		ip = net.ParseIP(d.config.BindOnIP)
+		if ip != nil && ip.To4() != nil {
+			return ip.To4
+		}
+		d.logger.Fatalf("ListenIP failed, unable to parse %q or it is not IPv4 address", d.config.BindOnIP)
 	}
 	ip, err := ListenIP()
 	if err != nil {

--- a/common/service/config/rpc.go
+++ b/common/service/config/rpc.go
@@ -97,7 +97,7 @@ func (d *RPCFactory) getListenIP() net.IP {
 	if len(d.config.BindOnIP) > 0 {
 		ip = net.ParseIP(d.config.BindOnIP)
 		if ip != nil && ip.To4() != nil {
-			return ip.To4
+			return ip.To4()
 		}
 		d.logger.Fatalf("ListenIP failed, unable to parse %q or it is not IPv4 address", d.config.BindOnIP)
 	}

--- a/common/service/config/rpc.go
+++ b/common/service/config/rpc.go
@@ -87,7 +87,7 @@ func (d *RPCFactory) CreateDispatcherForOutbound(
 
 func (d *RPCFactory) getListenIP() net.IP {
 	if d.config.BindOnLocalHost && len(d.config.BindOnIP) > 0 {
-		d.logger.Fatalf("ListenIP failed, bindOnLocalHost and bindOnIP are mutually exclussive")
+		d.logger.Fatalf("ListenIP failed, bindOnLocalHost and bindOnIP are mutually exclusive")
 	}
 
 	if d.config.BindOnLocalHost {

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -29,6 +29,7 @@ services:
     rpc:
       port: 7933
       bindOnLocalHost: ${BIND_ON_LOCALHOST}
+      bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:
         hostPort: "${STATSD_ENDPOINT}"
@@ -38,6 +39,7 @@ services:
     rpc:
       port: 7935
       bindOnLocalHost: ${BIND_ON_LOCALHOST}
+      bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:
         hostPort: "${STATSD_ENDPOINT}"
@@ -47,6 +49,7 @@ services:
     rpc:
       port: 7934
       bindOnLocalHost: ${BIND_ON_LOCALHOST}
+      bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:
         hostPort: "${STATSD_ENDPOINT}"
@@ -56,6 +59,7 @@ services:
     rpc:
       port: 7939
       bindOnLocalHost: ${BIND_ON_LOCALHOST}
+      bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:
         hostPort: "${STATSD_ENDPOINT}"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -28,7 +28,6 @@ services:
   frontend:
     rpc:
       port: 7933
-      bindOnLocalHost: ${BIND_ON_LOCALHOST}
       bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:
@@ -38,7 +37,6 @@ services:
   matching:
     rpc:
       port: 7935
-      bindOnLocalHost: ${BIND_ON_LOCALHOST}
       bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:
@@ -48,7 +46,6 @@ services:
   history:
     rpc:
       port: 7934
-      bindOnLocalHost: ${BIND_ON_LOCALHOST}
       bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:
@@ -58,7 +55,6 @@ services:
   worker:
     rpc:
       port: 7939
-      bindOnLocalHost: ${BIND_ON_LOCALHOST}
       bindOnIP: ${BIND_ON_IP}
     metrics:
       statsd:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -55,11 +55,19 @@ init_env() {
 
     export HOST_IP=`hostname --ip-address`
 
-    if [ "$BIND_ON_LOCALHOST" == true ]; then
-            export HOST_IP="127.0.0.1"
-    else
-        export BIND_ON_LOCALHOST=false
+    if [ "$BIND_ON_LOCALHOST" == true ] || [ "$BIND_ON_IP" == "127.0.0.1" ]; then
+        export BIND_ON_IP="127.0.0.1"
+        export HOST_IP="127.0.0.1"
+    elif [ -z "$BIND_ON_IP" ]; then
+        # not binding to localhost and bind_on_ip is empty - use default host ip addr
+        export BIND_ON_IP=$HOST_IP
+    elif [ "$BIND_ON_IP" != "0.0.0.0" ]; then
+        # binding to a user specified addr, make sure HOST_IP also uses the same addr
+        export HOST_IP=$BIND_ON_IP
     fi
+
+    // this env variable is deprecated
+    export BIND_ON_LOCALHOST=false
 
     if [ -z "$KEYSPACE" ]; then
         export KEYSPACE="cadence"


### PR DESCRIPTION
This patch does the following:
 - Adds support to have cadence server bind on user provided ip address (bind_on_ip)
 - Deprecates bind_on_localhost since bind_on_ip is a super set of bind_on_localhost
 - Modifies docker startup script to add support for bind_on_ip

See discussion here #1285