### PR TITLE
Support GetWorkflowExecutionHistory API from archival

### DIFF
--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -220,7 +220,10 @@ func (c *lru) Release(key interface{}) {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	elt := c.byKey[key]
+	elt, ok := c.byKey[key]
+	if !ok {
+		return
+	}
 	entry := elt.Value.(*entryImpl)
 	entry.refCount--
 }

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -102,7 +102,7 @@ const (
 	TagValueIndexerProcessorComponent         = "indexer-processor"
 	TagValueIndexerESProcessorComponent       = "indexer-es-processor"
 	TagValueESVisibilityManager               = "es-visibility-manager"
-	TagValueArchivalSystemWorkflowComponent   = "archival-system-workflow"
+	TagValueArchiveSystemWorkflowComponent    = "archive-system-workflow"
 
 	// TagHistoryBuilderAction values
 	TagValueActionWorkflowStarted                 = "add-workflowexecution-started-event"
@@ -169,7 +169,7 @@ const (
 	TagArchiveRequestWorkflowID          = "archive-request-workflow-id"
 	TagArchiveRequestRunID               = "archive-request-run-id"
 	TagArchiveRequestEventStoreVersion   = "archive-request-event-store-version"
-	TagArchiveRequestLastFirstEventID    = "archive-request-last-first-event-id"
+	TagArchiveRequestNextEventID         = "archive-request-next-event-id"
 	TagNumberOfSignalsUntilContinueAsNew = "number-of-signals-until-continue-as-new"
 	TagBucket                            = "bucket"
 	TagFileBlobstoreBlobPath             = "file-blobstore-blob-path"

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -755,8 +755,8 @@ const (
 	ESProcessorScope
 	// IndexProcessorScope is scope used by all metric emitted by index processor
 	IndexProcessorScope
-	// SystemWorkflowScope is scope used by all metrics emitted by SystemWorkflow
-	SystemWorkflowScope
+	// ArchiveSystemWorkflowScope is scope used by all metrics emitted by ArchiveSystemWorkflow
+	ArchiveSystemWorkflowScope
 	// ArchivalUploadActivity is scope used by all metrics emitted by ArchivalUploadActivity
 	ArchivalUploadActivityScope
 	// ArchivalDeleteHistoryActivity is scope used by all metrics emitted by ArchivalDeleteHistoryActivity
@@ -1086,7 +1086,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		SyncActivityTaskScope:              {operation: "SyncActivityTask"},
 		ESProcessorScope:                   {operation: "ESProcessor"},
 		IndexProcessorScope:                {operation: "IndexProcessor"},
-		SystemWorkflowScope:                {operation: "SystemWorkflow"},
+		ArchiveSystemWorkflowScope:         {operation: "ArchiveSystemWorkflow"},
 		ArchivalUploadActivityScope:        {operation: "ArchivalUploadActivity"},
 		ArchivalDeleteHistoryActivityScope: {operation: "ArchivalDeleteHistoryActivity"},
 		HistoryBlobIteratorScope:           {operation: "HistoryBlobIterator"},

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -153,7 +153,7 @@ var keys = map[Key]string{
 	EnableAdminProtection:                                 "history.enableAdminProtection",
 	AdminOperationToken:                                   "history.adminOperationToken",
 	EnableEventsV2:                                        "history.enableEventsV2",
-	NumSystemWorkflows:                                    "history.numSystemWorkflows",
+	NumArchiveSystemWorkflows:                             "history.numArchiveSystemWorkflows",
 
 	WorkerPersistenceMaxQPS:                  "worker.persistenceMaxQPS",
 	WorkerReplicatorConcurrency:              "worker.replicatorConcurrency",
@@ -385,8 +385,8 @@ const (
 	ShardSyncMinInterval
 	// DefaultEventEncoding is the encoding type for history events
 	DefaultEventEncoding
-	// NumSystemWorkflows is key for number of system workflows running in total
-	NumSystemWorkflows
+	// NumArchiveSystemWorkflows is key for number of archive system workflows running in total
+	NumArchiveSystemWorkflows
 
 	// EnableAdminProtection is whether to enable admin checking
 	EnableAdminProtection

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -25,7 +25,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"go.uber.org/cadence/.gen/go/shared"
 	"sync"
 	"time"
 
@@ -38,6 +37,7 @@ import (
 	h "github.com/uber/cadence/.gen/go/history"
 	m "github.com/uber/cadence/.gen/go/matching"
 	"github.com/uber/cadence/.gen/go/replicator"
+	"github.com/uber/cadence/.gen/go/shared"
 	gen "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
@@ -3132,7 +3132,7 @@ func (wh *WorkflowHandler) historyArchived(ctx context.Context, request *gen.Get
 	}
 	getMutableStateRequest := &h.GetMutableStateRequest{
 		DomainUUID: common.StringPtr(domainID),
-		Execution: request.Execution,
+		Execution:  request.Execution,
 	}
 	_, err := wh.history.GetMutableState(ctx, getMutableStateRequest)
 	if err == nil {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -28,8 +28,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/uber/cadence/common/blobstore/blob"
-	"github.com/uber/cadence/service/worker/sysworkflow"
 	"github.com/pborman/uuid"
 	"github.com/uber-common/bark"
 	"github.com/uber-go/tally"
@@ -45,6 +43,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/blobstore"
+	"github.com/uber/cadence/common/blobstore/blob"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/logging"
@@ -52,6 +51,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/service/worker/sysworkflow"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -25,11 +25,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/uber/cadence/common/blobstore/blob"
-	"github.com/uber/cadence/service/worker/sysworkflow"
 	"sync"
 	"time"
 
+	"github.com/uber/cadence/common/blobstore/blob"
+	"github.com/uber/cadence/service/worker/sysworkflow"
 	"github.com/pborman/uuid"
 	"github.com/uber-common/bark"
 	"github.com/uber-go/tally"

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -3182,12 +3182,11 @@ func (wh *WorkflowHandler) getArchivedHistory(
 			return nil, wh.error(err, scope)
 		}
 	}
-	if *historyBlob.Header.NextPageToken == common.LastBlobNextPageToken {
+	token = &getHistoryContinuationTokenArchival{
+		BlobstorePageToken: *historyBlob.Header.NextPageToken,
+	}
+	if token.BlobstorePageToken == common.LastBlobNextPageToken {
 		token = nil
-	} else {
-		token = &getHistoryContinuationTokenArchival{
-			BlobstorePageToken: *historyBlob.Header.NextPageToken,
-		}
 	}
 	nextToken, err := serializeHistoryTokenArchival(token)
 	if err != nil {

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -22,6 +22,7 @@ package frontend
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"log"
 	"os"
@@ -34,10 +35,13 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-common/bark"
 	"github.com/uber-go/tally"
+
+	"github.com/uber/cadence/.gen/go/history"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/blobstore"
+	"github.com/uber/cadence/common/blobstore/blob"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
@@ -45,6 +49,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	cs "github.com/uber/cadence/common/service"
 	dc "github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/service/worker/sysworkflow"
 )
 
 type (
@@ -960,6 +965,203 @@ func (s *workflowHandlerSuite) TestUpdateDomain_Success_ArchivalNeverEnabledToEn
 	assert.Equal(s.T(), "custom-bucket", result.GetConfiguration().GetArchivalBucketName())
 }
 
+func (s *workflowHandlerSuite) TestHistoryArchived() {
+	wh := &WorkflowHandler{}
+	getHistoryRequest := &shared.GetWorkflowExecutionHistoryRequest{}
+	s.False(wh.historyArchived(context.Background(), getHistoryRequest, "test-domain"))
+
+	getHistoryRequest = &shared.GetWorkflowExecutionHistoryRequest{
+		Execution: &shared.WorkflowExecution{},
+	}
+	s.False(wh.historyArchived(context.Background(), getHistoryRequest, "test-domain"))
+
+	mockHistoryClient := &mocks.HistoryClient{}
+	mockHistoryClient.On("DescribeMutableState", mock.Anything, mock.Anything).Return(nil, errors.New("error getting mutable state")).Once()
+	wh = &WorkflowHandler{
+		history: mockHistoryClient,
+	}
+	getHistoryRequest = &shared.GetWorkflowExecutionHistoryRequest{
+		Execution: &shared.WorkflowExecution{
+			WorkflowId: common.StringPtr("test-workflow-id"),
+			RunId:      common.StringPtr("test-run-id"),
+		},
+	}
+	s.True(wh.historyArchived(context.Background(), getHistoryRequest, "test-domain"))
+	mockHistoryClient.AssertCalled(s.T(), "DescribeMutableState", mock.Anything, mock.Anything)
+
+	describeMutableStateResponse := &history.DescribeMutableStateResponse{}
+	mockHistoryClient.On("DescribeMutableState", mock.Anything, mock.Anything).Return(describeMutableStateResponse, nil).Once()
+	wh = &WorkflowHandler{
+		history: mockHistoryClient,
+	}
+	getHistoryRequest = &shared.GetWorkflowExecutionHistoryRequest{
+		Execution: &shared.WorkflowExecution{
+			WorkflowId: common.StringPtr("test-workflow-id"),
+			RunId:      common.StringPtr("test-run-id"),
+		},
+	}
+	s.True(wh.historyArchived(context.Background(), getHistoryRequest, "test-domain"))
+	mockHistoryClient.AssertCalled(s.T(), "DescribeMutableState", mock.Anything, mock.Anything)
+
+	describeMutableStateResponse = &history.DescribeMutableStateResponse{
+		MutableStateInDatabase: common.StringPtr("some mutable state in database"),
+	}
+	mockHistoryClient.On("DescribeMutableState", mock.Anything, mock.Anything).Return(describeMutableStateResponse, nil).Once()
+	wh = &WorkflowHandler{
+		history: mockHistoryClient,
+	}
+	getHistoryRequest = &shared.GetWorkflowExecutionHistoryRequest{
+		Execution: &shared.WorkflowExecution{
+			WorkflowId: common.StringPtr("test-workflow-id"),
+			RunId:      common.StringPtr("test-run-id"),
+		},
+	}
+	s.False(wh.historyArchived(context.Background(), getHistoryRequest, "test-domain"))
+	mockHistoryClient.AssertCalled(s.T(), "DescribeMutableState", mock.Anything, mock.Anything)
+}
+
+func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_DomainCacheEntryError() {
+	config := s.newConfig()
+	mMetadataManager := &mocks.MetadataManager{}
+	mMetadataManager.On("GetDomain", mock.Anything).Return(nil, errors.New("error getting domain"))
+	wh := s.getWorkflowHandlerWithParams(s.mockService, config, mMetadataManager, s.mockBlobstoreClient)
+	wh.metricsClient = wh.Service.GetMetricsClient()
+	wh.startWG.Done()
+	resp, err := wh.getArchivedHistory(context.Background(), getHistoryRequest(nil), "test-domain-id", 0)
+	s.Nil(resp)
+	s.Error(err)
+}
+
+func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_ArchivalBucketEmpty() {
+	config := s.newConfig()
+	mMetadataManager := &mocks.MetadataManager{}
+	mMetadataManager.On("GetDomain", mock.Anything).Return(persistenceGetDomainResponse("", shared.ArchivalStatusNeverEnabled), nil)
+	clusterMetadata := &mocks.ClusterMetadata{}
+	clusterMetadata.On("IsGlobalDomainEnabled").Return(false)
+	mService := cs.NewTestService(clusterMetadata, s.mockMessagingClient, s.mockMetricClient, s.mockClientBean, s.logger)
+	wh := s.getWorkflowHandlerWithParams(mService, config, mMetadataManager, s.mockBlobstoreClient)
+	wh.metricsClient = wh.Service.GetMetricsClient()
+	wh.startWG.Done()
+	resp, err := wh.getArchivedHistory(context.Background(), getHistoryRequest(nil), "test-domain-id", 0)
+	s.Nil(resp)
+	s.Error(err)
+}
+
+func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_InvalidPageToken() {
+	config := s.newConfig()
+	mMetadataManager := &mocks.MetadataManager{}
+	mMetadataManager.On("GetDomain", mock.Anything).Return(persistenceGetDomainResponse("test-bucket", shared.ArchivalStatusEnabled), nil)
+	clusterMetadata := &mocks.ClusterMetadata{}
+	clusterMetadata.On("IsGlobalDomainEnabled").Return(false)
+	mService := cs.NewTestService(clusterMetadata, s.mockMessagingClient, s.mockMetricClient, s.mockClientBean, s.logger)
+	wh := s.getWorkflowHandlerWithParams(mService, config, mMetadataManager, s.mockBlobstoreClient)
+	wh.metricsClient = wh.Service.GetMetricsClient()
+	wh.startWG.Done()
+	resp, err := wh.getArchivedHistory(context.Background(), getHistoryRequest([]byte{3, 4, 5, 1}), "test-domain-id", 0)
+	s.Nil(resp)
+	s.Error(err)
+	s.Equal(errInvalidNextPageToken, err)
+}
+
+func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_InvalidBlobKey() {
+	config := s.newConfig()
+	mMetadataManager := &mocks.MetadataManager{}
+	mMetadataManager.On("GetDomain", mock.Anything).Return(persistenceGetDomainResponse("test-bucket", shared.ArchivalStatusEnabled), nil)
+	clusterMetadata := &mocks.ClusterMetadata{}
+	clusterMetadata.On("IsGlobalDomainEnabled").Return(false)
+	mService := cs.NewTestService(clusterMetadata, s.mockMessagingClient, s.mockMetricClient, s.mockClientBean, s.logger)
+	wh := s.getWorkflowHandlerWithParams(mService, config, mMetadataManager, s.mockBlobstoreClient)
+	wh.metricsClient = wh.Service.GetMetricsClient()
+	wh.startWG.Done()
+	getHistoryRequest := getHistoryRequest(nil)
+	getHistoryRequest.Execution.WorkflowId = common.StringPtr("")
+	resp, err := wh.getArchivedHistory(context.Background(), getHistoryRequest, "test-domain-id", 0)
+	s.Nil(resp)
+	s.Error(err)
+}
+
+func (s *workflowHandlerSuite) TestGetArchivedHistory_Failure_FailedToDownload() {
+	config := s.newConfig()
+	mMetadataManager := &mocks.MetadataManager{}
+	mMetadataManager.On("GetDomain", mock.Anything).Return(persistenceGetDomainResponse("test-bucket", shared.ArchivalStatusEnabled), nil)
+	clusterMetadata := &mocks.ClusterMetadata{}
+	clusterMetadata.On("IsGlobalDomainEnabled").Return(false)
+	mService := cs.NewTestService(clusterMetadata, s.mockMessagingClient, s.mockMetricClient, s.mockClientBean, s.logger)
+	mBlobstore := &mocks.BlobstoreClient{}
+	mBlobstore.On("Download", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("failed to download blob"))
+	wh := s.getWorkflowHandlerWithParams(mService, config, mMetadataManager, mBlobstore)
+	wh.metricsClient = wh.Service.GetMetricsClient()
+	wh.startWG.Done()
+	resp, err := wh.getArchivedHistory(context.Background(), getHistoryRequest(nil), "test-domain-id", 0)
+	s.Nil(resp)
+	s.Error(err)
+}
+
+func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
+	config := s.newConfig()
+	mMetadataManager := &mocks.MetadataManager{}
+	mMetadataManager.On("GetDomain", mock.Anything).Return(persistenceGetDomainResponse("test-bucket", shared.ArchivalStatusEnabled), nil)
+	clusterMetadata := &mocks.ClusterMetadata{}
+	clusterMetadata.On("IsGlobalDomainEnabled").Return(false)
+	mService := cs.NewTestService(clusterMetadata, s.mockMessagingClient, s.mockMetricClient, s.mockClientBean, s.logger)
+	mBlobstore := &mocks.BlobstoreClient{}
+	unwrappedBlob := &sysworkflow.HistoryBlob{
+		Header: &sysworkflow.HistoryBlobHeader{
+			CurrentPageToken: common.IntPtr(common.FirstBlobPageToken),
+			NextPageToken:    common.IntPtr(common.FirstBlobPageToken + 1),
+		},
+		Body: &shared.History{},
+	}
+	bytes, err := json.Marshal(unwrappedBlob)
+	s.NoError(err)
+	historyBlob, err := blob.Wrap(blob.NewBlob(bytes, map[string]string{}), blob.JSONEncoded())
+	s.NoError(err)
+	mBlobstore.On("Download", mock.Anything, mock.Anything, mock.Anything).Return(historyBlob, nil)
+	wh := s.getWorkflowHandlerWithParams(mService, config, mMetadataManager, mBlobstore)
+	wh.metricsClient = wh.Service.GetMetricsClient()
+	wh.startWG.Done()
+	resp, err := wh.getArchivedHistory(context.Background(), getHistoryRequest(nil), "test-domain-id", 0)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.NotNil(resp.History)
+	expectedNextPageToken := &getHistoryContinuationTokenArchival{
+		BlobstorePageToken: 2,
+	}
+	expectedSerializedNextPageToken, err := serializeHistoryTokenArchival(expectedNextPageToken)
+	s.NoError(err)
+	s.Equal(expectedSerializedNextPageToken, resp.NextPageToken)
+}
+
+func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetLastPage() {
+	config := s.newConfig()
+	mMetadataManager := &mocks.MetadataManager{}
+	mMetadataManager.On("GetDomain", mock.Anything).Return(persistenceGetDomainResponse("test-bucket", shared.ArchivalStatusEnabled), nil)
+	clusterMetadata := &mocks.ClusterMetadata{}
+	clusterMetadata.On("IsGlobalDomainEnabled").Return(false)
+	mService := cs.NewTestService(clusterMetadata, s.mockMessagingClient, s.mockMetricClient, s.mockClientBean, s.logger)
+	mBlobstore := &mocks.BlobstoreClient{}
+	unwrappedBlob := &sysworkflow.HistoryBlob{
+		Header: &sysworkflow.HistoryBlobHeader{
+			CurrentPageToken: common.IntPtr(5),
+			NextPageToken:    common.IntPtr(common.LastBlobNextPageToken),
+		},
+		Body: &shared.History{},
+	}
+	bytes, err := json.Marshal(unwrappedBlob)
+	s.NoError(err)
+	historyBlob, err := blob.Wrap(blob.NewBlob(bytes, map[string]string{}), blob.JSONEncoded())
+	s.NoError(err)
+	mBlobstore.On("Download", mock.Anything, mock.Anything, mock.Anything).Return(historyBlob, nil)
+	wh := s.getWorkflowHandlerWithParams(mService, config, mMetadataManager, mBlobstore)
+	wh.metricsClient = wh.Service.GetMetricsClient()
+	wh.startWG.Done()
+	resp, err := wh.getArchivedHistory(context.Background(), getHistoryRequest(nil), "test-domain-id", 0)
+	s.NoError(err)
+	s.NotNil(resp)
+	s.NotNil(resp.History)
+	s.Nil(resp.NextPageToken)
+}
+
 func (s *workflowHandlerSuite) newConfig() *Config {
 	return NewConfig(dc.NewCollection(dc.NewNopClient(), s.logger), false)
 }
@@ -1039,5 +1241,15 @@ func registerDomainRequest(archivalStatus *shared.ArchivalStatus, bucketName *st
 		SecurityToken:      common.StringPtr("token"),
 		ArchivalStatus:     archivalStatus,
 		ArchivalBucketName: bucketName,
+	}
+}
+
+func getHistoryRequest(nextPageToken []byte) *shared.GetWorkflowExecutionHistoryRequest {
+	return &shared.GetWorkflowExecutionHistoryRequest{
+		Execution: &shared.WorkflowExecution{
+			WorkflowId: common.StringPtr("test-workflow-id"),
+			RunId:      common.StringPtr("test-run-id"),
+		},
+		NextPageToken: nextPageToken,
 	}
 }

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -32,7 +32,6 @@ import (
 	hist "github.com/uber/cadence/.gen/go/history"
 	"github.com/uber/cadence/.gen/go/history/historyserviceserver"
 	gen "github.com/uber/cadence/.gen/go/shared"
-	"github.com/uber/cadence/client/frontend"
 	hc "github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/client/public"
@@ -60,7 +59,6 @@ type (
 		domainCache           cache.DomainCache
 		historyServiceClient  hc.Client
 		matchingServiceClient matching.Client
-		frontendServiceClient frontend.Client
 		publicClient          public.Client
 		hServiceResolver      membership.ServiceResolver
 		controller            *shardController
@@ -129,12 +127,6 @@ func (h *Handler) Start() error {
 	h.historyServiceClient = hc.NewRetryableClient(
 		h.GetClientBean().GetHistoryClient(),
 		common.CreateHistoryServiceRetryPolicy(),
-		common.IsWhitelistServiceTransientError,
-	)
-
-	h.frontendServiceClient = frontend.NewRetryableClient(
-		h.GetClientBean().GetFrontendClient(),
-		common.CreateFrontendServiceRetryPolicy(),
 		common.IsWhitelistServiceTransientError,
 	)
 

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -167,7 +167,7 @@ func NewEngineWithShardContext(
 		metricsClient:        shard.GetMetricsClient(),
 		historyEventNotifier: historyEventNotifier,
 		config:               config,
-		archivalClient:       sysworkflow.NewArchivalClient(publicClient, shard.GetConfig().NumSysWorkflows),
+		archivalClient:       sysworkflow.NewArchivalClient(publicClient, shard.GetConfig().NumArchiveSystemWorkflows),
 	}
 
 	txProcessor := newTransferQueueProcessor(shard, historyEngImpl, visibilityMgr, visibilityProducer, matching, historyClient, logger)

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -129,7 +129,7 @@ type Config struct {
 	// whether or not using eventsV2
 	EnableEventsV2 dynamicconfig.BoolPropertyFnWithDomainFilter
 
-	NumSysWorkflows dynamicconfig.IntPropertyFn
+	NumArchiveSystemWorkflows dynamicconfig.IntPropertyFn
 
 	BlobSizeLimitError     dynamicconfig.IntPropertyFnWithDomainFilter
 	BlobSizeLimitWarn      dynamicconfig.IntPropertyFnWithDomainFilter
@@ -209,7 +209,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, enableVisibilit
 		EventEncodingType:          dc.GetStringPropertyFnWithDomainFilter(dynamicconfig.DefaultEventEncoding, string(common.EncodingTypeJSON)),
 		EnableEventsV2:             dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.EnableEventsV2, false),
 
-		NumSysWorkflows: dc.GetIntProperty(dynamicconfig.NumSystemWorkflows, 1000),
+		NumArchiveSystemWorkflows: dc.GetIntProperty(dynamicconfig.NumArchiveSystemWorkflows, 1000),
 
 		BlobSizeLimitError:     dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
 		BlobSizeLimitWarn:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 256*1024),

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -22,6 +22,7 @@ package history
 
 import (
 	"errors"
+	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/service/worker/sysworkflow"
 	"math"
 	"sync"
@@ -632,6 +633,8 @@ func (t *timerQueueProcessorBase) processArchiveHistoryEvent(task *persistence.T
 		NextEventID:          msBuilder.GetNextEventID(),
 		CloseFailoverVersion: msBuilder.GetLastWriteVersion(),
 	}
+	key := definition.NewWorkflowIdentifier(task.DomainID, task.WorkflowID, task.RunID)
+	t.cache.Delete(key)
 	err = t.deleteWorkflowExecution(task)
 	if err != nil {
 		return err

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -636,6 +636,8 @@ func (t *timerQueueProcessorBase) processArchiveHistoryEvent(task *persistence.T
 	if err != nil {
 		return err
 	}
+	// calling clear here to force accesses of mutable state to read database
+	// if this is not called then callers will get mutable state even though its been removed from database
 	context.clear()
 	if err := t.historyService.archivalClient.Archive(req); err != nil {
 		t.logger.WithFields(bark.Fields{

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -623,21 +623,19 @@ func (t *timerQueueProcessorBase) processArchiveHistoryEvent(task *persistence.T
 	} else if !ok {
 		return nil
 	}
-
 	req := &sysworkflow.ArchiveRequest{
 		DomainID:             task.DomainID,
 		WorkflowID:           task.WorkflowID,
 		RunID:                task.RunID,
 		EventStoreVersion:    msBuilder.GetEventStoreVersion(),
 		BranchToken:          msBuilder.GetCurrentBranch(),
-		LastFirstEventID:     msBuilder.GetLastFirstEventID(),
+		NextEventID:          msBuilder.GetNextEventID(),
 		CloseFailoverVersion: msBuilder.GetLastWriteVersion(),
 	}
 	err = t.deleteWorkflowExecution(task)
 	if err != nil {
 		return err
 	}
-
 	if err := t.historyService.archivalClient.Archive(req); err != nil {
 		t.logger.WithFields(bark.Fields{
 			logging.TagHistoryShardID:      t.shard.GetShardID(),

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -22,7 +22,6 @@ package history
 
 import (
 	"errors"
-	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/service/worker/sysworkflow"
 	"math"
 	"sync"
@@ -633,12 +632,11 @@ func (t *timerQueueProcessorBase) processArchiveHistoryEvent(task *persistence.T
 		NextEventID:          msBuilder.GetNextEventID(),
 		CloseFailoverVersion: msBuilder.GetLastWriteVersion(),
 	}
-	key := definition.NewWorkflowIdentifier(task.DomainID, task.WorkflowID, task.RunID)
-	t.cache.Delete(key)
 	err = t.deleteWorkflowExecution(task)
 	if err != nil {
 		return err
 	}
+	context.clear()
 	if err := t.historyService.archivalClient.Archive(req); err != nil {
 		t.logger.WithFields(bark.Fields{
 			logging.TagHistoryShardID:      t.shard.GetShardID(),

--- a/service/worker/sysworkflow/archival_client.go
+++ b/service/worker/sysworkflow/archival_client.go
@@ -37,7 +37,7 @@ type (
 		RunID                string
 		EventStoreVersion    int32
 		BranchToken          []byte
-		LastFirstEventID     int64
+		NextEventID          int64
 		CloseFailoverVersion int64
 	}
 

--- a/service/worker/sysworkflow/history_blob_iterator.go
+++ b/service/worker/sysworkflow/history_blob_iterator.go
@@ -61,7 +61,7 @@ type (
 		runID                string
 		eventStoreVersion    int32
 		branchToken          []byte
-		lastFirstEventID     int64
+		nextEventID          int64
 		config               *Config
 		domain               string
 		clusterName          string
@@ -97,7 +97,7 @@ func NewHistoryBlobIterator(
 		runID:                request.RunID,
 		eventStoreVersion:    request.EventStoreVersion,
 		branchToken:          request.BranchToken,
-		lastFirstEventID:     request.LastFirstEventID,
+		nextEventID:          request.NextEventID,
 		config:               container.Config,
 		domain:               domainName,
 		clusterName:          clusterName,
@@ -196,7 +196,7 @@ func (i *historyBlobIterator) readHistory(pageToken []byte) ([]*shared.HistoryEv
 		req := &persistence.ReadHistoryBranchRequest{
 			BranchToken:   i.branchToken,
 			MinEventID:    common.FirstEventID,
-			MaxEventID:    i.lastFirstEventID,
+			MaxEventID:    i.nextEventID,
 			PageSize:      i.config.HistoryPageSize(i.domain),
 			NextPageToken: pageToken,
 		}
@@ -209,7 +209,7 @@ func (i *historyBlobIterator) readHistory(pageToken []byte) ([]*shared.HistoryEv
 			RunId:      common.StringPtr(i.runID),
 		},
 		FirstEventID:  common.FirstEventID,
-		NextEventID:   i.lastFirstEventID,
+		NextEventID:   i.nextEventID,
 		PageSize:      i.config.HistoryPageSize(i.domain),
 		NextPageToken: pageToken,
 	}

--- a/service/worker/sysworkflow/history_blob_iterator.go
+++ b/service/worker/sysworkflow/history_blob_iterator.go
@@ -22,7 +22,6 @@ package sysworkflow
 
 import (
 	"errors"
-	"strconv"
 	"time"
 
 	"github.com/uber-common/bark"
@@ -134,8 +133,8 @@ func (i *historyBlobIterator) Next() (*HistoryBlob, error) {
 		DomainID:             &i.domainID,
 		WorkflowID:           &i.workflowID,
 		RunID:                &i.runID,
-		CurrentPageToken:     common.StringPtr(strconv.Itoa(i.blobPageToken)),
-		NextPageToken:        common.StringPtr(strconv.Itoa(common.LastBlobNextPageToken)),
+		CurrentPageToken:     common.IntPtr(i.blobPageToken),
+		NextPageToken:        common.IntPtr(common.LastBlobNextPageToken),
 		FirstFailoverVersion: firstEvent.Version,
 		LastFailoverVersion:  lastEvent.Version,
 		FirstEventID:         firstEvent.EventId,
@@ -147,7 +146,7 @@ func (i *historyBlobIterator) Next() (*HistoryBlob, error) {
 	}
 	if i.HasNext() {
 		i.blobPageToken++
-		header.NextPageToken = common.StringPtr(strconv.Itoa(i.blobPageToken))
+		header.NextPageToken = common.IntPtr(i.blobPageToken)
 	}
 	return &HistoryBlob{
 		Header: header,

--- a/service/worker/sysworkflow/history_blob_iterator_test.go
+++ b/service/worker/sysworkflow/history_blob_iterator_test.go
@@ -41,7 +41,7 @@ const (
 	testDomainID                      = "test-domain-id"
 	testWorkflowID                    = "test-workflow-id"
 	testRunID                         = "test-run-id"
-	testLastFirstEventID              = 1800
+	testNextEventID                   = 1800
 	testDomain                        = "test-domain"
 	testClusterName                   = "test-cluster-name"
 	testCloseFailoverVersion          = 100
@@ -475,7 +475,7 @@ func (s *HistoryBlobIteratorSuite) constructMockHistoryManager(returnErrorOnPage
 				RunId:      common.StringPtr(testRunID),
 			},
 			FirstEventID:  common.FirstEventID,
-			NextEventID:   testLastFirstEventID,
+			NextEventID:   testNextEventID,
 			PageSize:      testDefaultPersistencePageSize,
 			NextPageToken: pageToken,
 		}
@@ -547,7 +547,7 @@ func (s *HistoryBlobIteratorSuite) constructTestHistoryBlobIterator(
 		RunID:                testRunID,
 		EventStoreVersion:    int32(eventStoreVersion),
 		BranchToken:          testBranchToken,
-		LastFirstEventID:     testLastFirstEventID,
+		NextEventID:          testNextEventID,
 		CloseFailoverVersion: testCloseFailoverVersion,
 	}
 	container := &SysWorkerContainer{

--- a/service/worker/sysworkflow/history_blob_iterator_test.go
+++ b/service/worker/sysworkflow/history_blob_iterator_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service/dynamicconfig"
-	"strconv"
 	"testing"
 )
 
@@ -344,8 +343,8 @@ func (s *HistoryBlobIteratorSuite) TestNext_Fail_IteratorDepleted() {
 	}
 	s.assertStateMatches(expectedIteratorState, itr)
 	s.NotNil(blob)
-	s.Equal(strconv.Itoa(common.FirstBlobPageToken), *blob.Header.CurrentPageToken)
-	s.Equal(strconv.Itoa(common.LastBlobNextPageToken), *blob.Header.NextPageToken)
+	s.Equal(common.FirstBlobPageToken, *blob.Header.CurrentPageToken)
+	s.Equal(common.LastBlobNextPageToken, *blob.Header.NextPageToken)
 	s.Equal(int64(1), *blob.Header.FirstFailoverVersion)
 	s.Equal(int64(5), *blob.Header.LastFailoverVersion)
 	s.Equal(int64(1), *blob.Header.FirstEventID)
@@ -396,8 +395,8 @@ func (s *HistoryBlobIteratorSuite) TestNext_Fail_ReturnErrOnSecondCallToNext() {
 	}
 	s.assertStateMatches(expectedIteratorState, itr)
 	s.NotNil(blob)
-	s.Equal(strconv.Itoa(common.FirstBlobPageToken), *blob.Header.CurrentPageToken)
-	s.Equal(strconv.Itoa(common.FirstBlobPageToken+1), *blob.Header.NextPageToken)
+	s.Equal(common.FirstBlobPageToken, *blob.Header.CurrentPageToken)
+	s.Equal(common.FirstBlobPageToken+1, *blob.Header.NextPageToken)
 	s.Equal(int64(1), *blob.Header.FirstFailoverVersion)
 	s.Equal(int64(2), *blob.Header.LastFailoverVersion)
 	s.Equal(int64(1), *blob.Header.FirstEventID)
@@ -440,11 +439,11 @@ func (s *HistoryBlobIteratorSuite) TestNext_Success_TenCallsToNext() {
 		s.NotNil(blob)
 		s.Equal(common.FirstEventID+int64(i*100), *blob.Header.FirstEventID)
 		s.Equal(int64(100+(i*100)), *blob.Header.LastEventID)
-		s.Equal(strconv.Itoa(i+1), *blob.Header.CurrentPageToken)
+		s.Equal(i+1, *blob.Header.CurrentPageToken)
 		if i == 9 {
-			s.Equal(strconv.Itoa(common.LastBlobNextPageToken), *blob.Header.NextPageToken)
+			s.Equal(common.LastBlobNextPageToken, *blob.Header.NextPageToken)
 		} else {
-			s.Equal(strconv.Itoa(i+2), *blob.Header.NextPageToken)
+			s.Equal(i+2, *blob.Header.NextPageToken)
 		}
 		s.Equal(int64(100), *blob.Header.EventCount)
 		if i < 9 {

--- a/service/worker/sysworkflow/system_workflow.go
+++ b/service/worker/sysworkflow/system_workflow.go
@@ -60,9 +60,10 @@ func ArchiveSystemWorkflow(ctx workflow.Context, carryoverRequests []ArchiveRequ
 		logging.TagWorkflowRunID:       sysWorkflowInfo.WorkflowExecution.RunID,
 	}), ctx, false)
 	logger.Info("started system workflow")
+
 	metricsClient := NewReplayMetricsClient(globalMetricsClient, ctx)
-	metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerWorkflowStarted)
-	sw := metricsClient.StartTimer(metrics.SystemWorkflowScope, metrics.SysWorkerContinueAsNewLatency)
+	metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerWorkflowStarted)
+	sw := metricsClient.StartTimer(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerContinueAsNewLatency)
 	requestsHandled := 0
 
 	// step 1: start workers to process archival requests in parallel
@@ -92,7 +93,7 @@ func ArchiveSystemWorkflow(ctx workflow.Context, carryoverRequests []ArchiveRequ
 		if more := ch.Receive(ctx, &request); !more {
 			break
 		}
-		metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerReceivedSignal)
+		metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerReceivedSignal)
 		requestsHandled++
 		workQueue.Send(ctx, request)
 	}
@@ -109,14 +110,14 @@ func ArchiveSystemWorkflow(ctx workflow.Context, carryoverRequests []ArchiveRequ
 		if ok := ch.ReceiveAsync(&request); !ok {
 			break
 		}
-		metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerReceivedSignal)
+		metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerReceivedSignal)
 		co = append(co, request)
 	}
 
 	// step 6: schedule new run
 	ctx = workflow.WithExecutionStartToCloseTimeout(ctx, workflowStartToCloseTimeout)
 	ctx = workflow.WithWorkflowTaskStartToCloseTimeout(ctx, decisionTaskStartToCloseTimeout)
-	metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerContinueAsNew)
+	metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerContinueAsNew)
 	sw.Stop()
 	logger.WithFields(bark.Fields{
 		logging.TagNumberOfSignalsUntilContinueAsNew: requestsHandled,
@@ -157,11 +158,11 @@ func handleRequest(request ArchiveRequest, ctx workflow.Context, logger bark.Log
 			logging.TagArchiveRequestWorkflowID:        request.WorkflowID,
 			logging.TagArchiveRequestRunID:             request.RunID,
 			logging.TagArchiveRequestEventStoreVersion: request.EventStoreVersion,
-			logging.TagArchiveRequestLastFirstEventID:  request.LastFirstEventID,
+			logging.TagArchiveRequestNextEventID:       request.NextEventID,
 		}).Error("ArchivalUploadActivity encountered non-retryable error")
-		metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerArchivalUploadActivityNonRetryableFailures)
+		metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerArchivalUploadActivityNonRetryableFailures)
 	} else {
-		metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerArchivalUploadSuccessful)
+		metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerArchivalUploadSuccessful)
 	}
 	lao := workflow.LocalActivityOptions{
 		ScheduleToCloseTimeout: 10 * time.Second,
@@ -178,7 +179,7 @@ func handleRequest(request ArchiveRequest, ctx workflow.Context, logger bark.Log
 	}
 	err := workflow.ExecuteLocalActivity(workflow.WithLocalActivityOptions(ctx, lao), ArchivalDeleteHistoryActivity, request).Get(ctx, nil)
 	if err == nil {
-		metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerArchivalDeleteHistorySuccessful)
+		metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerArchivalDeleteHistorySuccessful)
 		return
 	}
 	logger.WithFields(bark.Fields{
@@ -187,7 +188,7 @@ func handleRequest(request ArchiveRequest, ctx workflow.Context, logger bark.Log
 		logging.TagArchiveRequestWorkflowID:        request.WorkflowID,
 		logging.TagArchiveRequestRunID:             request.RunID,
 		logging.TagArchiveRequestEventStoreVersion: request.EventStoreVersion,
-		logging.TagArchiveRequestLastFirstEventID:  request.LastFirstEventID,
+		logging.TagArchiveRequestNextEventID:       request.NextEventID,
 	}).Warn("ArchivalDeleteHistoryActivity could not be completed as a local activity, attempting to run as normal activity")
 	deleteActOpts := workflow.ActivityOptions{
 		ScheduleToStartTimeout: time.Minute,
@@ -214,11 +215,11 @@ func handleRequest(request ArchiveRequest, ctx workflow.Context, logger bark.Log
 			logging.TagArchiveRequestWorkflowID:        request.WorkflowID,
 			logging.TagArchiveRequestRunID:             request.RunID,
 			logging.TagArchiveRequestEventStoreVersion: request.EventStoreVersion,
-			logging.TagArchiveRequestLastFirstEventID:  request.LastFirstEventID,
+			logging.TagArchiveRequestNextEventID:       request.NextEventID,
 		}).Error("ArchivalDeleteHistoryActivity encountered non-retryable error")
-		metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerArchivalDeleteHistoryActivityNonRetryableFailures)
+		metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerArchivalDeleteHistoryActivityNonRetryableFailures)
 	} else {
-		metricsClient.IncCounter(metrics.SystemWorkflowScope, metrics.SysWorkerArchivalDeleteHistorySuccessful)
+		metricsClient.IncCounter(metrics.ArchiveSystemWorkflowScope, metrics.SysWorkerArchivalDeleteHistorySuccessful)
 	}
 }
 
@@ -241,7 +242,7 @@ func ArchivalUploadActivity(ctx context.Context, request ArchiveRequest) error {
 		logging.TagArchiveRequestWorkflowID:        request.WorkflowID,
 		logging.TagArchiveRequestRunID:             request.RunID,
 		logging.TagArchiveRequestEventStoreVersion: request.EventStoreVersion,
-		logging.TagArchiveRequestLastFirstEventID:  request.LastFirstEventID,
+		logging.TagArchiveRequestNextEventID:       request.NextEventID,
 	})
 	metricsClient := container.MetricsClient
 	domainCache := container.DomainCache
@@ -336,7 +337,7 @@ func ArchivalDeleteHistoryActivity(ctx context.Context, request ArchiveRequest) 
 		logging.TagArchiveRequestWorkflowID:        request.WorkflowID,
 		logging.TagArchiveRequestRunID:             request.RunID,
 		logging.TagArchiveRequestEventStoreVersion: request.EventStoreVersion,
-		logging.TagArchiveRequestLastFirstEventID:  request.LastFirstEventID,
+		logging.TagArchiveRequestNextEventID:       request.NextEventID,
 	})
 	metricsClient := container.MetricsClient
 	if request.EventStoreVersion == persistence.EventStoreVersionV2 {

--- a/service/worker/sysworkflow/sysworker.go
+++ b/service/worker/sysworkflow/sysworker.go
@@ -86,7 +86,7 @@ func init() {
 // NewSysWorker returns a new SysWorker
 func NewSysWorker(container *SysWorkerContainer) SysWorker {
 	logger := container.Logger.WithFields(bark.Fields{
-		logging.TagWorkflowComponent: logging.TagValueArchivalSystemWorkflowComponent,
+		logging.TagWorkflowComponent: logging.TagValueArchiveSystemWorkflowComponent,
 	})
 	globalLogger = logger
 	globalMetricsClient = container.MetricsClient

--- a/service/worker/sysworkflow/util.go
+++ b/service/worker/sysworkflow/util.go
@@ -23,12 +23,14 @@ package sysworkflow
 import (
 	"encoding/json"
 	"fmt"
+	"strconv"
+	"strings"
+
 	"github.com/dgryski/go-farm"
+
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/blobstore/blob"
-	"strconv"
-	"strings"
 )
 
 type (

--- a/service/worker/sysworkflow/util.go
+++ b/service/worker/sysworkflow/util.go
@@ -22,7 +22,6 @@ package sysworkflow
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"github.com/dgryski/go-farm"
 	"github.com/uber/cadence/.gen/go/shared"
@@ -58,13 +57,17 @@ type (
 	}
 )
 
+var (
+	errInvalidKeyInput = &shared.BadRequestError{Message: "invalid input to construct history blob key"}
+)
+
 // NewHistoryBlobKey returns a key for history blob
 func NewHistoryBlobKey(domainID, workflowID, runID string, pageToken int) (blob.Key, error) {
 	if len(domainID) == 0 || len(workflowID) == 0 || len(runID) == 0 {
-		return nil, errors.New("all inputs required to be non-empty")
+		return nil, errInvalidKeyInput
 	}
 	if pageToken < common.FirstBlobPageToken {
-		return nil, errors.New("pageToken is lower than first page")
+		return nil, errInvalidKeyInput
 	}
 	domainIDHash := fmt.Sprintf("%v", farm.Fingerprint64([]byte(domainID)))
 	workflowIDHash := fmt.Sprintf("%v", farm.Fingerprint64([]byte(workflowID)))

--- a/service/worker/sysworkflow/util.go
+++ b/service/worker/sysworkflow/util.go
@@ -26,7 +26,9 @@ import (
 	"fmt"
 	"github.com/dgryski/go-farm"
 	"github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/blobstore/blob"
+	"strconv"
 	"strings"
 )
 
@@ -37,8 +39,8 @@ type (
 		DomainID             *string `json:"domain_id,omitempty"`
 		WorkflowID           *string `json:"workflow_id,omitempty"`
 		RunID                *string `json:"run_id,omitempty"`
-		CurrentPageToken     *string `json:"current_page_token,omitempty"`
-		NextPageToken        *string `json:"next_page_token,omitempty"`
+		CurrentPageToken     *int    `json:"current_page_token,omitempty"`
+		NextPageToken        *int    `json:"next_page_token,omitempty"`
 		FirstFailoverVersion *int64  `json:"first_failover_version,omitempty"`
 		LastFailoverVersion  *int64  `json:"last_failover_version,omitempty"`
 		FirstEventID         *int64  `json:"first_event_id,omitempty"`
@@ -57,15 +59,23 @@ type (
 )
 
 // NewHistoryBlobKey returns a key for history blob
-func NewHistoryBlobKey(domainID, workflowID, runID, pageToken string) (blob.Key, error) {
-	if len(domainID) == 0 || len(workflowID) == 0 || len(runID) == 0 || len(pageToken) == 0 {
+func NewHistoryBlobKey(domainID, workflowID, runID string, pageToken int) (blob.Key, error) {
+	if len(domainID) == 0 || len(workflowID) == 0 || len(runID) == 0 {
 		return nil, errors.New("all inputs required to be non-empty")
+	}
+	if pageToken < common.FirstBlobPageToken {
+		return nil, errors.New("pageToken is lower than first page")
 	}
 	domainIDHash := fmt.Sprintf("%v", farm.Fingerprint64([]byte(domainID)))
 	workflowIDHash := fmt.Sprintf("%v", farm.Fingerprint64([]byte(workflowID)))
 	runIDHash := fmt.Sprintf("%v", farm.Fingerprint64([]byte(runID)))
 	combinedHash := strings.Join([]string{domainIDHash, workflowIDHash, runIDHash}, "")
-	return blob.NewKey(historyBlobKeyExt, combinedHash, pageToken)
+	return blob.NewKey(historyBlobKeyExt, combinedHash, StringPageToken(pageToken))
+}
+
+// StringPageToken converts input blob page token to string form
+func StringPageToken(pageToken int) string {
+	return strconv.Itoa(pageToken)
 }
 
 // ConvertHeaderToTags converts header into metadata tags for blob

--- a/service/worker/sysworkflow/util_test.go
+++ b/service/worker/sysworkflow/util_test.go
@@ -45,7 +45,7 @@ func (s *UtilSuite) TestNewHistoryBlobKey() {
 		domainID       string
 		workflowID     string
 		runID          string
-		pageToken      string
+		pageToken      int
 		expectError    bool
 		expectBuiltKey string
 	}{
@@ -57,9 +57,16 @@ func (s *UtilSuite) TestNewHistoryBlobKey() {
 			domainID:       "testDomainID",
 			workflowID:     "testWorkflowID",
 			runID:          "testRunID",
-			pageToken:      "testPageToken",
+			pageToken:      common.FirstBlobPageToken,
 			expectError:    false,
-			expectBuiltKey: "17971674567288329890367046253745284795510285995943906173973_testPageToken.history",
+			expectBuiltKey: "17971674567288329890367046253745284795510285995943906173973_1.history",
+		},
+		{
+			domainID:    "testDomainID",
+			workflowID:  "testWorkflowID",
+			runID:       "testRunID",
+			pageToken:   -1,
+			expectError: true,
 		},
 	}
 


### PR DESCRIPTION
This diff does the following:

- Adds support to frontend to get archived histories & unit tests.
- Changed name of from SystemWorkflow to ArchiveSystemWorkflow and change all related naming.
- Fix bug in archival signal: use NextEventID instead of LastFirstEventID. 
- Make history blob metadata for page tokens be simple ints instead of strings.

This diff does not support getting history from archival unless domainID, workflowID AND runID are given. Supporting the API without giving runID will be left as a task until after indices are being archived.