### PR TITLE
Fix race for handling duplicate kafka message

### DIFF
--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -112,7 +112,8 @@ func (p *esProcessorImpl) Stop() {
 // Add an ES request, and an map item for kafka message
 func (p *esProcessorImpl) Add(request elastic.BulkableRequest, key string, kafkaMsg messaging.Message) {
 	if p.mapToKafkaMsg.Contains(key) { // handle duplicate delete message
-		p.ackKafkaMsg(key)
+		kafkaMsg.Ack()
+		return
 	}
 	p.mapToKafkaMsg.Put(key, kafkaMsg)
 	p.processor.Add(request)

--- a/service/worker/indexer/esProcessor_test.go
+++ b/service/worker/indexer/esProcessor_test.go
@@ -143,7 +143,6 @@ func (s *esProcessorSuite) TestAdd() {
 
 	// handle duplicate
 	mockKafkaMsg.On("Ack").Return(nil).Once()
-	s.mockBulkProcessor.On("Add", request).Return().Once()
 	s.esProcessor.Add(request, key, mockKafkaMsg)
 	s.Equal(1, s.esProcessor.mapToKafkaMsg.Size())
 	mockKafkaMsg.AssertExpectations(s.T())


### PR DESCRIPTION
Currently, when handle duplicate delete message in kafka, there is a race condition which will cause message being acked twice. 
This fix just ack the new message instead of old message.