### PR TITLE
Add admin CLI tool to refill message to ElasticSearch

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -592,6 +592,10 @@ func newAdminElasticSearchCommands() []cli.Command {
 					Usage: "URL of ElasticSearch cluster",
 				},
 				cli.StringFlag{
+					Name:  FlagMuttleyDestinationWithAlias,
+					Usage: "Optional muttely destination to ElasticSearch cluster",
+				},
+				cli.StringFlag{
 					Name:  FlagIndex,
 					Usage: "ElasticSearch target index",
 				},

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -565,3 +565,44 @@ clusters:
 		},
 	}
 }
+
+func newAdminElasticSearchCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:    "catIndex",
+			Aliases: []string{"cind"},
+			Usage:   "Cat Indices on ElasticSearch",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagURL,
+					Usage: "URL of ElasticSearch cluster",
+				},
+			},
+			Action: func(c *cli.Context) {
+				AdminCatIndices(c)
+			},
+		},
+		{
+			Name:    "index",
+			Aliases: []string{"ind"},
+			Usage:   "Index docs on ElasticSearch",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagURL,
+					Usage: "URL of ElasticSearch cluster",
+				},
+				cli.StringFlag{
+					Name:  FlagIndex,
+					Usage: "ElasticSearch target index",
+				},
+				cli.StringFlag{
+					Name:  FlagInputFileWithAlias,
+					Usage: "Input file of indexer.Message in json format, separated by newline",
+				},
+			},
+			Action: func(c *cli.Context) {
+				AdminIndex(c)
+			},
+		},
+	}
+}

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -599,6 +599,11 @@ func newAdminElasticSearchCommands() []cli.Command {
 					Name:  FlagInputFileWithAlias,
 					Usage: "Input file of indexer.Message in json format, separated by newline",
 				},
+				cli.IntFlag{
+					Name:  FlagBatchSizeWithAlias,
+					Usage: "Optional batch size of actions for bulk operations",
+					Value: 1000,
+				},
 			},
 			Action: func(c *cli.Context) {
 				AdminIndex(c)

--- a/tools/cli/adminElasticSearchCommands.go
+++ b/tools/cli/adminElasticSearchCommands.go
@@ -62,6 +62,7 @@ func getESClient(c *cli.Context) *elastic.Client {
 	return esClient
 }
 
+// AdminCatIndices cat indices for ES cluster
 func AdminCatIndices(c *cli.Context) {
 	esClient := getESClient(c)
 
@@ -90,6 +91,7 @@ func AdminCatIndices(c *cli.Context) {
 	table.Render()
 }
 
+// AdminIndex used to bulk insert message from kafka parse
 func AdminIndex(c *cli.Context) {
 	esClient := getESClient(c)
 	indexName := getRequiredOption(c, FlagIndex)

--- a/tools/cli/adminElasticSearchCommands.go
+++ b/tools/cli/adminElasticSearchCommands.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"context"
+	"github.com/olekukonko/tablewriter"
+	"github.com/olivere/elastic"
+	"github.com/urfave/cli"
+	"os"
+	"strconv"
+	"time"
+)
+
+func newESClient(url string) (*elastic.Client, error) {
+	client, err := elastic.NewClient(
+		elastic.SetURL(url),
+		elastic.SetRetrier(elastic.NewBackoffRetrier(elastic.NewExponentialBackoff(128*time.Millisecond, 513*time.Millisecond))),
+	)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
+}
+
+func AdminCatIndices(c *cli.Context) {
+	esClient, err := newESClient(c.String(FlagURL))
+	if err != nil {
+		ErrorAndExit("Unable to create ElasticSearch client", err)
+	}
+	ctx := context.Background()
+	resp, err := esClient.CatIndices().Do(ctx)
+	if err != nil {
+		ErrorAndExit("Unable to cat indices", err)
+	}
+
+	table := tablewriter.NewWriter(os.Stdout)
+	header := []string{"health", "status", "index", "pri", "rep", "docs.count", "docs.deleted", "store.size", "pri.store.size"}
+	table.SetHeader(header)
+	for _, row := range resp {
+		data := make([]string, len(header))
+		data[0] = row.Health
+		data[1] = row.Status
+		data[2] = row.Index
+		data[3] = strconv.Itoa(row.Pri)
+		data[4] = strconv.Itoa(row.Rep)
+		data[5] = strconv.Itoa(row.DocsCount)
+		data[6] = strconv.Itoa(row.DocsDeleted)
+		data[7] = row.StoreSize
+		data[8] = row.PriStoreSize
+		table.Append(data)
+	}
+	table.Render()
+}
+
+func AdminIndex(c *cli.Context) {
+
+}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -95,6 +95,12 @@ func NewCliApp() *cli.App {
 					Usage:       "Run admin operation on domain",
 					Subcommands: newAdminDomainCommands(),
 				},
+				{
+					Name:        "elasticsearch",
+					Aliases:     []string{"es"},
+					Usage:       "Run admin operation on ElasticSearch",
+					Subcommands: newAdminElasticSearchCommands(),
+				},
 			},
 		},
 	}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -25,7 +25,7 @@ import "github.com/urfave/cli"
 const (
 	// Version is the controlled version string. It should be updated every time
 	// before we release a new version.
-	Version = "0.5.8"
+	Version = "0.5.9"
 )
 
 // NewCliApp instantiates a new instance of the CLI application.

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -136,6 +136,8 @@ const (
 	FlagMessageTypeWithAlias        = FlagMessageType + ", mt"
 	FlagURL                         = "url"
 	FlagIndex                       = "index"
+	FlagBatchSize                   = "batch_size"
+	FlagBatchSizeWithAlias          = FlagBatchSize + ", bs"
 )
 
 var flagsForExecution = []cli.Flag{

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -135,6 +135,8 @@ const (
 	FlagMessageType                 = "message_type"
 	FlagMessageTypeWithAlias        = FlagMessageType + ", mt"
 	FlagURL                         = "url"
+	FlagMuttleyDestination          = "muttely_destination"
+	FlagMuttleyDestinationWithAlias = FlagMuttleyDestination + ", muttley"
 	FlagIndex                       = "index"
 	FlagBatchSize                   = "batch_size"
 	FlagBatchSizeWithAlias          = FlagBatchSize + ", bs"

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -134,6 +134,8 @@ const (
 	FlagHeadersModeWithAlias        = FlagHeadersMode + ", he"
 	FlagMessageType                 = "message_type"
 	FlagMessageTypeWithAlias        = FlagMessageType + ", mt"
+	FlagURL                         = "url"
+	FlagIndex                       = "index"
 )
 
 var flagsForExecution = []cli.Flag{


### PR DESCRIPTION
This PR add 2 new commands to operate elasticsearch.
1. For list cluster indices info (to test connection)
2. For refill message got from kafka when necessary

This also increase CLI version to 0.5.9