### PR TITLE
Workflow retry incorrectly set attempt on start event of new run

### DIFF
--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2405,7 +2405,7 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionContinuedAsNewEvent(sour
 
 	if continueAsNewAttributes.GetInitiator() == workflow.ContinueAsNewInitiatorRetryPolicy {
 		// retry
-		continueAsNew.Attempt = continueAsNew.Attempt + 1
+		continueAsNew.Attempt = startedAttributes.GetAttempt()
 		continueAsNew.ExpirationTime = e.executionInfo.ExpirationTime
 	} else {
 		// by cron or decider


### PR DESCRIPTION
Workflow execution with retry policy does not update attempt on
new run and always sets it to 1.  This results in retry policy to
never fail the execution based on attempt.  Fixing the mutablestate
update to use correct value for attempt from the new start
attributes.
Also added integration tests to validate attemp on start attributes
and also test bailout using attempt or non-retryable errors from
the policy.

fixes #1485 