### PR TITLE
persistence: API changes to support tasklist cleanup

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -170,8 +170,8 @@ const (
 	PersistenceGetTasksScope
 	// PersistenceCompleteTaskScope tracks CompleteTask calls made by service to persistence layer
 	PersistenceCompleteTaskScope
-	// PersistenceRangeCompleteTaskScope is the metric scope for persistence.TaskManager.RangeCompleteTask API
-	PersistenceRangeCompleteTaskScope
+	// PersistenceCompleteTasksLessThanScope is the metric scope for persistence.TaskManager.PersistenceCompleteTasksLessThan API
+	PersistenceCompleteTasksLessThanScope
 	// PersistenceLeaseTaskListScope tracks LeaseTaskList calls made by service to persistence layer
 	PersistenceLeaseTaskListScope
 	// PersistenceUpdateTaskListScope tracks PersistenceUpdateTaskListScope calls made by service to persistence layer
@@ -798,7 +798,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceCreateTaskScope:                               {operation: "CreateTask", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceGetTasksScope:                                 {operation: "GetTasks", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceCompleteTaskScope:                             {operation: "CompleteTask", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
-		PersistenceRangeCompleteTaskScope:                        {operation: "RangeCompleteTask", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
+		PersistenceCompleteTasksLessThanScope:                    {operation: "CompleteTasksLessThan", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceLeaseTaskListScope:                            {operation: "LeaseTaskList", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceUpdateTaskListScope:                           {operation: "UpdateTaskList", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceListTaskListScope:                             {operation: "ListTaskList", tags: map[string]string{ShardTagName: NoneShardsTagValue}},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -170,10 +170,16 @@ const (
 	PersistenceGetTasksScope
 	// PersistenceCompleteTaskScope tracks CompleteTask calls made by service to persistence layer
 	PersistenceCompleteTaskScope
+	// PersistenceRangeCompleteTaskScope is the metric scope for persistence.TaskManager.RangeCompleteTask API
+	PersistenceRangeCompleteTaskScope
 	// PersistenceLeaseTaskListScope tracks LeaseTaskList calls made by service to persistence layer
 	PersistenceLeaseTaskListScope
 	// PersistenceUpdateTaskListScope tracks PersistenceUpdateTaskListScope calls made by service to persistence layer
 	PersistenceUpdateTaskListScope
+	// PersistenceListTaskListScope is the metric scope for persistence.TaskManager.ListTaskList API
+	PersistenceListTaskListScope
+	// PersistenceDeleteTaskListScope is the metric scope for persistence.TaskManager.DeleteTaskList API
+	PersistenceDeleteTaskListScope
 	// PersistenceAppendHistoryEventsScope tracks AppendHistoryEvents calls made by service to persistence layer
 	PersistenceAppendHistoryEventsScope
 	// PersistenceGetWorkflowExecutionHistoryScope tracks GetWorkflowExecutionHistory calls made by service to persistence layer
@@ -792,8 +798,11 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceCreateTaskScope:                               {operation: "CreateTask", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceGetTasksScope:                                 {operation: "GetTasks", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceCompleteTaskScope:                             {operation: "CompleteTask", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
+		PersistenceRangeCompleteTaskScope:                        {operation: "RangeCompleteTask", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceLeaseTaskListScope:                            {operation: "LeaseTaskList", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceUpdateTaskListScope:                           {operation: "UpdateTaskList", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
+		PersistenceListTaskListScope:                             {operation: "ListTaskList", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
+		PersistenceDeleteTaskListScope:                           {operation: "DeleteTaskList", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceAppendHistoryEventsScope:                      {operation: "AppendHistoryEvents", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceGetWorkflowExecutionHistoryScope:              {operation: "GetWorkflowExecutionHistory", tags: map[string]string{ShardTagName: NoneShardsTagValue}},
 		PersistenceDeleteWorkflowExecutionHistoryScope:           {operation: "DeleteWorkflowExecutionHistory", tags: map[string]string{ShardTagName: NoneShardsTagValue}},

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -321,7 +321,8 @@ const (
 		`name: ?, ` +
 		`type: ?, ` +
 		`ack_level: ?, ` +
-		`kind: ? ` +
+		`kind: ?, ` +
+		`last_updated: ? ` +
 		`}`
 
 	templateTaskType = `{` +
@@ -827,6 +828,14 @@ workflow_state = ? ` +
 		`and type = ? ` +
 		`and task_id = ?`
 
+	templateRangeCompleteTaskQuery = `DELETE FROM tasks ` +
+		`WHERE domain_id = ? ` +
+		`AND task_list_name = ? ` +
+		`AND task_list_type = ? ` +
+		`AND type = ? ` +
+		`AND task_id >= ? ` +
+		`AND task_id <= ? `
+
 	templateGetTaskList = `SELECT ` +
 		`range_id, ` +
 		`task_list ` +
@@ -866,6 +875,14 @@ workflow_state = ? ` +
 		`range_id, ` +
 		`task_list ` +
 		`) VALUES (?, ?, ?, ?, ?, ?, ` + templateTaskListType + `) USING TTL ?`
+
+	templateDeleteTaskListQuery = `DELETE FROM tasks ` +
+		`WHERE domain_id = ? ` +
+		`AND task_list_name = ? ` +
+		`AND task_list_type = ? ` +
+		`AND type = ? ` +
+		`AND task_id = ? ` +
+		`IF range_id = ?`
 )
 
 var (
@@ -2516,6 +2533,7 @@ func (d *cassandraPersistence) LeaseTaskList(request *p.LeaseTaskListRequest) (*
 			Message: fmt.Sprintf("LeaseTaskList requires non empty task list"),
 		}
 	}
+	now := time.Now()
 	query := d.session.Query(templateGetTaskList,
 		request.DomainID,
 		request.TaskList,
@@ -2540,6 +2558,7 @@ func (d *cassandraPersistence) LeaseTaskList(request *p.LeaseTaskListRequest) (*
 				request.TaskType,
 				0,
 				request.TaskListKind,
+				now,
 			)
 		} else if isThrottlingError(err) {
 			return nil, &workflow.ServiceBusyError{
@@ -2562,6 +2581,7 @@ func (d *cassandraPersistence) LeaseTaskList(request *p.LeaseTaskListRequest) (*
 			request.TaskType,
 			ackLevel,
 			taskListKind,
+			now,
 			request.DomainID,
 			&request.TaskList,
 			request.TaskType,
@@ -2588,7 +2608,15 @@ func (d *cassandraPersistence) LeaseTaskList(request *p.LeaseTaskListRequest) (*
 			Msg: fmt.Sprintf("LeaseTaskList failed to apply. db rangeID %v", previousRangeID),
 		}
 	}
-	tli := &p.TaskListInfo{DomainID: request.DomainID, Name: request.TaskList, TaskType: request.TaskType, RangeID: rangeID + 1, AckLevel: ackLevel, Kind: request.TaskListKind}
+	tli := &p.TaskListInfo{
+		DomainID:    request.DomainID,
+		Name:        request.TaskList,
+		TaskType:    request.TaskType,
+		RangeID:     rangeID + 1,
+		AckLevel:    ackLevel,
+		Kind:        request.TaskListKind,
+		LastUpdated: now,
+	}
 	return &p.LeaseTaskListResponse{TaskListInfo: tli}, nil
 }
 
@@ -2609,6 +2637,7 @@ func (d *cassandraPersistence) UpdateTaskList(request *p.UpdateTaskListRequest) 
 			tli.TaskType,
 			tli.AckLevel,
 			tli.Kind,
+			time.Now(),
 			stickyTaskListTTL,
 		)
 		err := query.Exec()
@@ -2632,6 +2661,7 @@ func (d *cassandraPersistence) UpdateTaskList(request *p.UpdateTaskListRequest) 
 		tli.TaskType,
 		tli.AckLevel,
 		tli.Kind,
+		time.Now(),
 		tli.DomainID,
 		&tli.Name,
 		tli.TaskType,
@@ -2666,6 +2696,35 @@ func (d *cassandraPersistence) UpdateTaskList(request *p.UpdateTaskListRequest) 
 	}
 
 	return &p.UpdateTaskListResponse{}, nil
+}
+
+func (d *cassandraPersistence) ListTaskList(request *p.ListTaskListRequest) (*p.ListTaskListResponse, error) {
+	return nil, &workflow.InternalServiceError{
+		Message: fmt.Sprintf("unsupported operation"),
+	}
+}
+
+func (d *cassandraPersistence) DeleteTaskList(request *p.DeleteTaskListRequest) error {
+	query := d.session.Query(templateDeleteTaskListQuery,
+		request.DomainID, request.TaskListName, request.TaskListType, rowTypeTaskList, taskListTaskID, request.RangeID)
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("DeleteTaskList operation failed. Error: %v", err),
+			}
+		}
+		return &workflow.InternalServiceError{
+			Message: fmt.Sprintf("DeleteTaskList operation failed. Error: %v", err),
+		}
+	}
+	if !applied {
+		return &p.ConditionFailedError{
+			Msg: fmt.Sprintf("DeleteTaskList operation failed: expected_range_id=%v but found %+v", request.RangeID, previous),
+		}
+	}
+	return nil
 }
 
 // From TaskManager interface
@@ -2713,6 +2772,7 @@ func (d *cassandraPersistence) CreateTasks(request *p.CreateTasksRequest) (*p.Cr
 		taskListType,
 		ackLevel,
 		taskListKind,
+		time.Now(),
 		domainID,
 		taskList,
 		taskListType,
@@ -2815,6 +2875,23 @@ func (d *cassandraPersistence) CompleteTask(request *p.CompleteTaskRequest) erro
 		}
 	}
 
+	return nil
+}
+
+func (d *cassandraPersistence) RangeCompleteTask(request *p.RangeCompleteTaskRequest) error {
+	query := d.session.Query(templateRangeCompleteTaskQuery,
+		request.DomainID, request.TaskListName, request.TaskType, rowTypeTask, request.MinTaskID, request.MaxTaskID)
+	err := query.Exec()
+	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("RangeCompleteTask operation failed. Error: %v", err),
+			}
+		}
+		return &workflow.InternalServiceError{
+			Message: fmt.Sprintf("RangeCompleteTask operation failed. Error: %v", err),
+		}
+	}
 	return nil
 }
 

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -333,12 +333,14 @@ type (
 
 	// TaskListInfo describes a state of a task list implementation.
 	TaskListInfo struct {
-		DomainID string
-		Name     string
-		TaskType int
-		RangeID  int64
-		AckLevel int64
-		Kind     int
+		DomainID    string
+		Name        string
+		TaskType    int
+		RangeID     int64
+		AckLevel    int64
+		Kind        int
+		Expiry      time.Time
+		LastUpdated time.Time
 	}
 
 	// TaskInfo describes either activity or decision task
@@ -895,6 +897,26 @@ type (
 	UpdateTaskListResponse struct {
 	}
 
+	// ListTaskListRequest contains the request params needed to invoke ListTaskList API
+	ListTaskListRequest struct {
+		PageSize  int
+		PageToken []byte
+	}
+
+	// ListTaskListResponse is the response from ListTaskList API
+	ListTaskListResponse struct {
+		Items         []TaskListInfo
+		NextPageToken []byte
+	}
+
+	// DeleteTaskListRequest contains the request params needed to invoke DeleteTaskList API
+	DeleteTaskListRequest struct {
+		DomainID     string
+		TaskListName string
+		TaskListType int
+		RangeID      int64
+	}
+
 	// CreateTasksRequest is used to create a new task for a workflow exectution
 	CreateTasksRequest struct {
 		TaskListInfo *TaskListInfo
@@ -932,6 +954,15 @@ type (
 	CompleteTaskRequest struct {
 		TaskList *TaskListInfo
 		TaskID   int64
+	}
+
+	// RangeCompleteTaskRequest contains the request params needed to invoke RangeCompleteTask API
+	RangeCompleteTaskRequest struct {
+		DomainID     string
+		TaskListName string
+		TaskType     int
+		MinTaskID    int64
+		MaxTaskID    int64
 	}
 
 	// GetTimerIndexTasksRequest is the request for GetTimerIndexTasks
@@ -1352,9 +1383,12 @@ type (
 		GetName() string
 		LeaseTaskList(request *LeaseTaskListRequest) (*LeaseTaskListResponse, error)
 		UpdateTaskList(request *UpdateTaskListRequest) (*UpdateTaskListResponse, error)
+		ListTaskList(request *ListTaskListRequest) (*ListTaskListResponse, error)
+		DeleteTaskList(request *DeleteTaskListRequest) error
 		CreateTasks(request *CreateTasksRequest) (*CreateTasksResponse, error)
 		GetTasks(request *GetTasksRequest) (*GetTasksResponse, error)
 		CompleteTask(request *CompleteTaskRequest) error
+		RangeCompleteTask(request *RangeCompleteTaskRequest) error
 	}
 
 	// HistoryManager is used to manage Workflow Execution HistoryEventBatch

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -21,6 +21,7 @@
 package persistencetests
 
 import (
+	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -152,10 +153,67 @@ func (s *MatchingPersistenceSuite) TestCompleteDecisionTask() {
 	}
 }
 
+func (s *MatchingPersistenceSuite) TestRangeCompleteTasks() {
+	domainID := uuid.New()
+	taskList := "range-complete-task-tl0"
+	wfExec := gen.WorkflowExecution{
+		WorkflowId: common.StringPtr("range-complete-task-test"),
+		RunId:      common.StringPtr(uuid.New()),
+	}
+	_, err := s.CreateActivityTasks(domainID, wfExec, map[int64]string{
+		10: taskList,
+		20: taskList,
+		30: taskList,
+		40: taskList,
+		50: taskList,
+	})
+	s.NoError(err)
+
+	resp, err := s.GetTasks(domainID, taskList, p.TaskListTypeActivity, 10)
+	s.NoError(err)
+	s.NotNil(resp.Tasks)
+	s.Equal(5, len(resp.Tasks), "getTasks returned wrong number of tasks")
+
+	tasks := resp.Tasks
+
+	testCases := []struct {
+		input  [2]int64
+		output []int64
+	}{
+		{
+			input:  [2]int64{tasks[0].TaskID, tasks[0].TaskID},
+			output: []int64{tasks[1].TaskID, tasks[2].TaskID, tasks[3].TaskID, tasks[4].TaskID},
+		},
+		{
+			input:  [2]int64{tasks[1].TaskID, tasks[2].TaskID},
+			output: []int64{tasks[3].TaskID, tasks[4].TaskID},
+		},
+		{
+			input:  [2]int64{tasks[3].TaskID, tasks[4].TaskID},
+			output: []int64{},
+		},
+	}
+
+	req := &p.RangeCompleteTaskRequest{DomainID: domainID, TaskListName: taskList, TaskType: p.TaskListTypeActivity}
+
+	for _, tc := range testCases {
+		req.MaxTaskID = tc.input[0]
+		req.MaxTaskID = tc.input[1]
+		s.NoError(s.TaskMgr.RangeCompleteTask(req))
+		resp, err := s.GetTasks(domainID, taskList, p.TaskListTypeActivity, 10)
+		s.NoError(err)
+		s.Equal(len(tc.output), len(resp.Tasks), "rangeCompleteTask deleted wrong set of tasks")
+		for i := range tc.output {
+			s.Equal(tc.output[i], resp.Tasks[i].TaskID)
+		}
+	}
+}
+
 // TestLeaseAndUpdateTaskList test
 func (s *MatchingPersistenceSuite) TestLeaseAndUpdateTaskList() {
 	domainID := "00136543-72ad-4615-b7e9-44bca9775b45"
 	taskList := "aaaaaaa"
+	leaseTime := time.Now()
 	response, err := s.TaskMgr.LeaseTaskList(&p.LeaseTaskListRequest{
 		DomainID: domainID,
 		TaskList: taskList,
@@ -165,7 +223,9 @@ func (s *MatchingPersistenceSuite) TestLeaseAndUpdateTaskList() {
 	tli := response.TaskListInfo
 	s.EqualValues(1, tli.RangeID)
 	s.EqualValues(0, tli.AckLevel)
+	s.True(tli.LastUpdated.After(leaseTime) || tli.LastUpdated.Equal(leaseTime))
 
+	leaseTime = time.Now()
 	response, err = s.TaskMgr.LeaseTaskList(&p.LeaseTaskListRequest{
 		DomainID: domainID,
 		TaskList: taskList,
@@ -175,6 +235,7 @@ func (s *MatchingPersistenceSuite) TestLeaseAndUpdateTaskList() {
 	tli = response.TaskListInfo
 	s.EqualValues(2, tli.RangeID)
 	s.EqualValues(0, tli.AckLevel)
+	s.True(tli.LastUpdated.After(leaseTime) || tli.LastUpdated.Equal(leaseTime))
 
 	taskListInfo := &p.TaskListInfo{
 		DomainID: domainID,
@@ -224,4 +285,127 @@ func (s *MatchingPersistenceSuite) TestLeaseAndUpdateTaskListSticky() {
 		TaskListInfo: taskListInfo,
 	})
 	s.NoError(err) // because update with ttl doesn't check rangeID
+}
+
+func (s *MatchingPersistenceSuite) deleteAllTaskList() {
+	var nextPageToken []byte
+	for {
+		resp, err := s.TaskMgr.ListTaskList(&p.ListTaskListRequest{PageSize: 10, PageToken: nextPageToken})
+		s.NoError(err)
+		for _, it := range resp.Items {
+			err = s.TaskMgr.DeleteTaskList(&p.DeleteTaskListRequest{
+				DomainID:     it.DomainID,
+				TaskListName: it.Name,
+				TaskListType: it.TaskType,
+				RangeID:      it.RangeID,
+			})
+			s.NoError(err)
+		}
+		nextPageToken = resp.NextPageToken
+		if nextPageToken == nil {
+			break
+		}
+	}
+}
+
+func (s *MatchingPersistenceSuite) TestListWithOneTaskList() {
+	if s.TaskMgr.GetName() == "cassandra" {
+		s.T().Skip("ListTaskList API is currently not supported in cassandra")
+	}
+	s.deleteAllTaskList()
+	resp, err := s.TaskMgr.ListTaskList(&p.ListTaskListRequest{PageSize: 10})
+	s.NoError(err)
+	s.Nil(resp.NextPageToken)
+	s.Equal(0, len(resp.Items))
+
+	rangeID := int64(0)
+	ackLevel := int64(0)
+	domainID := uuid.New()
+	for i := 0; i < 10; i++ {
+		rangeID++
+		updatedTime := time.Now()
+		_, err := s.TaskMgr.LeaseTaskList(&p.LeaseTaskListRequest{
+			DomainID:     domainID,
+			TaskList:     "list-task-list-test-tl0",
+			TaskType:     p.TaskListTypeActivity,
+			TaskListKind: p.TaskListKindSticky,
+		})
+		s.NoError(err)
+
+		resp, err := s.TaskMgr.ListTaskList(&p.ListTaskListRequest{PageSize: 10})
+		s.NoError(err)
+
+		s.Equal(1, len(resp.Items))
+		s.Equal(domainID, resp.Items[0].DomainID)
+		s.Equal("list-task-list-test-tl0", resp.Items[0].Name)
+		s.Equal(p.TaskListTypeActivity, resp.Items[0].TaskType)
+		s.Equal(p.TaskListKindSticky, resp.Items[0].Kind)
+		s.Equal(rangeID, resp.Items[0].RangeID)
+		s.Equal(ackLevel, resp.Items[0].AckLevel)
+		s.True(resp.Items[0].LastUpdated.After(updatedTime) || resp.Items[0].LastUpdated.Equal(updatedTime))
+
+		ackLevel++
+		updatedTime = time.Now()
+		_, err = s.TaskMgr.UpdateTaskList(&p.UpdateTaskListRequest{
+			TaskListInfo: &p.TaskListInfo{
+				DomainID: domainID,
+				Name:     "list-task-list-test-tl0",
+				TaskType: p.TaskListTypeActivity,
+				RangeID:  rangeID,
+				AckLevel: ackLevel,
+				Kind:     p.TaskListKindSticky,
+			},
+		})
+		s.NoError(err)
+
+		resp, err = s.TaskMgr.ListTaskList(&p.ListTaskListRequest{PageSize: 10})
+		s.NoError(err)
+		s.Equal(1, len(resp.Items))
+		s.True(resp.Items[0].LastUpdated.After(updatedTime) || resp.Items[0].LastUpdated.Equal(updatedTime))
+	}
+	s.deleteAllTaskList()
+}
+
+func (s *MatchingPersistenceSuite) TestListWithMultipleTaskList() {
+	if s.TaskMgr.GetName() == "cassandra" {
+		s.T().Skip("ListTaskList API is currently not supported in cassandra")
+	}
+	s.deleteAllTaskList()
+	domainID := uuid.New()
+	tlNames := make(map[string]struct{})
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("test-list-with-multiple-%v", i)
+		_, err := s.TaskMgr.LeaseTaskList(&p.LeaseTaskListRequest{
+			DomainID:     domainID,
+			TaskList:     name,
+			TaskType:     p.TaskListTypeActivity,
+			TaskListKind: p.TaskListKindNormal,
+		})
+		s.NoError(err)
+		tlNames[name] = struct{}{}
+		listedNames := make(map[string]struct{})
+		var nextPageToken []byte
+		for {
+			resp, err := s.TaskMgr.ListTaskList(&p.ListTaskListRequest{PageSize: 10, PageToken: nextPageToken})
+			s.NoError(err)
+			for _, it := range resp.Items {
+				s.Equal(domainID, it.DomainID)
+				s.Equal(p.TaskListTypeActivity, it.TaskType)
+				s.Equal(p.TaskListKindNormal, it.Kind)
+				_, ok := listedNames[it.Name]
+				s.False(ok, "list API returns duplicate entries - have: %+v got:%v", listedNames, it.Name)
+				listedNames[it.Name] = struct{}{}
+			}
+			nextPageToken = resp.NextPageToken
+			if nextPageToken == nil {
+				break
+			}
+		}
+		s.Equal(tlNames, listedNames, "list API returned wrong set of task list names")
+	}
+	s.deleteAllTaskList()
+	resp, err := s.TaskMgr.ListTaskList(&p.ListTaskListRequest{PageSize: 10})
+	s.NoError(err)
+	s.Nil(resp.NextPageToken)
+	s.Equal(0, len(resp.Items))
 }

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -509,6 +509,17 @@ func (p *taskPersistenceClient) CompleteTask(request *CompleteTaskRequest) error
 	return err
 }
 
+func (p *taskPersistenceClient) RangeCompleteTask(request *RangeCompleteTaskRequest) error {
+	p.metricClient.IncCounter(metrics.PersistenceRangeCompleteTaskScope, metrics.PersistenceRequests)
+	sw := p.metricClient.StartTimer(metrics.PersistenceRangeCompleteTaskScope, metrics.PersistenceLatency)
+	err := p.persistence.RangeCompleteTask(request)
+	sw.Stop()
+	if err != nil {
+		p.updateErrorMetric(metrics.PersistenceRangeCompleteTaskScope, err)
+	}
+	return err
+}
+
 func (p *taskPersistenceClient) LeaseTaskList(request *LeaseTaskListRequest) (*LeaseTaskListResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceLeaseTaskListScope, metrics.PersistenceRequests)
 
@@ -521,6 +532,28 @@ func (p *taskPersistenceClient) LeaseTaskList(request *LeaseTaskListRequest) (*L
 	}
 
 	return response, err
+}
+
+func (p *taskPersistenceClient) ListTaskList(request *ListTaskListRequest) (*ListTaskListResponse, error) {
+	p.metricClient.IncCounter(metrics.PersistenceListTaskListScope, metrics.PersistenceRequests)
+	sw := p.metricClient.StartTimer(metrics.PersistenceListTaskListScope, metrics.PersistenceLatency)
+	response, err := p.persistence.ListTaskList(request)
+	sw.Stop()
+	if err != nil {
+		p.updateErrorMetric(metrics.PersistenceListTaskListScope, err)
+	}
+	return response, err
+}
+
+func (p *taskPersistenceClient) DeleteTaskList(request *DeleteTaskListRequest) error {
+	p.metricClient.IncCounter(metrics.PersistenceDeleteTaskListScope, metrics.PersistenceRequests)
+	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteTaskListScope, metrics.PersistenceLatency)
+	err := p.persistence.DeleteTaskList(request)
+	sw.Stop()
+	if err != nil {
+		p.updateErrorMetric(metrics.PersistenceDeleteTaskListScope, err)
+	}
+	return err
 }
 
 func (p *taskPersistenceClient) UpdateTaskList(request *UpdateTaskListRequest) (*UpdateTaskListResponse, error) {

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -509,15 +509,15 @@ func (p *taskPersistenceClient) CompleteTask(request *CompleteTaskRequest) error
 	return err
 }
 
-func (p *taskPersistenceClient) RangeCompleteTask(request *RangeCompleteTaskRequest) error {
-	p.metricClient.IncCounter(metrics.PersistenceRangeCompleteTaskScope, metrics.PersistenceRequests)
-	sw := p.metricClient.StartTimer(metrics.PersistenceRangeCompleteTaskScope, metrics.PersistenceLatency)
-	err := p.persistence.RangeCompleteTask(request)
+func (p *taskPersistenceClient) CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error) {
+	p.metricClient.IncCounter(metrics.PersistenceCompleteTasksLessThanScope, metrics.PersistenceRequests)
+	sw := p.metricClient.StartTimer(metrics.PersistenceCompleteTasksLessThanScope, metrics.PersistenceLatency)
+	result, err := p.persistence.CompleteTasksLessThan(request)
 	sw.Stop()
 	if err != nil {
-		p.updateErrorMetric(metrics.PersistenceRangeCompleteTaskScope, err)
+		p.updateErrorMetric(metrics.PersistenceCompleteTasksLessThanScope, err)
 	}
-	return err
+	return result, err
 }
 
 func (p *taskPersistenceClient) LeaseTaskList(request *LeaseTaskListRequest) (*LeaseTaskListResponse, error) {

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -370,11 +370,11 @@ func (p *taskRateLimitedPersistenceClient) CompleteTask(request *CompleteTaskReq
 	return err
 }
 
-func (p *taskRateLimitedPersistenceClient) RangeCompleteTask(request *RangeCompleteTaskRequest) error {
+func (p *taskRateLimitedPersistenceClient) CompleteTasksLessThan(request *CompleteTasksLessThanRequest) (int, error) {
 	if ok, _ := p.rateLimiter.TryConsume(1); !ok {
-		return ErrPersistenceLimitExceeded
+		return 0, ErrPersistenceLimitExceeded
 	}
-	return p.persistence.RangeCompleteTask(request)
+	return p.persistence.CompleteTasksLessThan(request)
 }
 
 func (p *taskRateLimitedPersistenceClient) LeaseTaskList(request *LeaseTaskListRequest) (*LeaseTaskListResponse, error) {

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -370,6 +370,13 @@ func (p *taskRateLimitedPersistenceClient) CompleteTask(request *CompleteTaskReq
 	return err
 }
 
+func (p *taskRateLimitedPersistenceClient) RangeCompleteTask(request *RangeCompleteTaskRequest) error {
+	if ok, _ := p.rateLimiter.TryConsume(1); !ok {
+		return ErrPersistenceLimitExceeded
+	}
+	return p.persistence.RangeCompleteTask(request)
+}
+
 func (p *taskRateLimitedPersistenceClient) LeaseTaskList(request *LeaseTaskListRequest) (*LeaseTaskListResponse, error) {
 	if ok, _ := p.rateLimiter.TryConsume(1); !ok {
 		return nil, ErrPersistenceLimitExceeded
@@ -386,6 +393,20 @@ func (p *taskRateLimitedPersistenceClient) UpdateTaskList(request *UpdateTaskLis
 
 	response, err := p.persistence.UpdateTaskList(request)
 	return response, err
+}
+
+func (p *taskRateLimitedPersistenceClient) ListTaskList(request *ListTaskListRequest) (*ListTaskListResponse, error) {
+	if ok, _ := p.rateLimiter.TryConsume(1); !ok {
+		return nil, ErrPersistenceLimitExceeded
+	}
+	return p.persistence.ListTaskList(request)
+}
+
+func (p *taskRateLimitedPersistenceClient) DeleteTaskList(request *DeleteTaskListRequest) error {
+	if ok, _ := p.rateLimiter.TryConsume(1); !ok {
+		return ErrPersistenceLimitExceeded
+	}
+	return p.persistence.DeleteTaskList(request)
 }
 
 func (p *taskRateLimitedPersistenceClient) Close() {

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -69,6 +69,7 @@ func NewTestCluster(port int, dbName string, schemaDir string, driverName string
 		ConnectProtocol: "tcp",
 		DriverName:      driverName,
 		DatabaseName:    dbName,
+		NumShards:       4,
 	}
 	return &result
 }

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -236,7 +236,7 @@ func (m *sqlTaskManager) ListTaskList(request *persistence.ListTaskListRequest) 
 
 	var nextPageToken []byte
 	switch {
-	case len(rows) == request.PageSize:
+	case len(rows) >= request.PageSize:
 		lastRow := &rows[request.PageSize-1]
 		nextPageToken, err = gobSerialize(&taskListPageToken{
 			ShardID:  pageToken.ShardID,
@@ -246,10 +246,6 @@ func (m *sqlTaskManager) ListTaskList(request *persistence.ListTaskListRequest) 
 		})
 	case pageToken.ShardID+1 < m.nShards:
 		nextPageToken, err = gobSerialize(&taskListPageToken{ShardID: pageToken.ShardID + 1, TaskType: math.MinInt16})
-	default:
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("invalid state: request:%+v, pageToken=%+v, len(rows)=%v", request, pageToken, len(rows)),
-		}
 	}
 
 	if err != nil {

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -28,7 +28,11 @@ import (
 	"database/sql"
 	"time"
 
+	"math"
+
+	"github.com/dgryski/go-farm"
 	workflow "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/sql/storage"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
@@ -37,7 +41,12 @@ import (
 
 type sqlTaskManager struct {
 	sqlStore
+	nShards int
 }
+
+var (
+	minUUID = "00000000-0000-0000-0000-000000000000"
+)
 
 // newTaskPersistence creates a new instance of TaskManager
 func newTaskPersistence(cfg config.SQL, log bark.Logger) (persistence.TaskManager, error) {
@@ -50,28 +59,34 @@ func newTaskPersistence(cfg config.SQL, log bark.Logger) (persistence.TaskManage
 			db:     db,
 			logger: log,
 		},
+		nShards: cfg.NumShards,
 	}, nil
 }
 
 func (m *sqlTaskManager) LeaseTaskList(request *persistence.LeaseTaskListRequest) (*persistence.LeaseTaskListResponse, error) {
 	var rangeID int64
 	var ackLevel int64
+	shardID := m.shardID(request.DomainID, request.TaskList)
 	domainID := sqldb.MustParseUUID(request.DomainID)
-	row, err := m.db.SelectFromTaskLists(&sqldb.TaskListsFilter{
-		DomainID: domainID,
-		Name:     request.TaskList,
-		TaskType: int64(request.TaskType)})
+	rows, err := m.db.SelectFromTaskLists(&sqldb.TaskListsFilter{
+		ShardID:  shardID,
+		DomainID: &domainID,
+		Name:     &request.TaskList,
+		TaskType: common.Int64Ptr(int64(request.TaskType))})
 	if err != nil {
 		if err == sql.ErrNoRows {
-			row = &sqldb.TaskListsRow{
-				DomainID: domainID,
-				Name:     request.TaskList,
-				TaskType: int64(request.TaskType),
-				AckLevel: ackLevel,
-				Kind:     int64(request.TaskListKind),
-				ExpiryTs: time.Time{},
+			row := sqldb.TaskListsRow{
+				ShardID:     shardID,
+				DomainID:    domainID,
+				Name:        request.TaskList,
+				TaskType:    int64(request.TaskType),
+				AckLevel:    ackLevel,
+				Kind:        int64(request.TaskListKind),
+				ExpiryTs:    time.Time{},
+				LastUpdated: time.Now(),
 			}
-			if _, err := m.db.InsertIntoTaskLists(row); err != nil {
+			rows = []sqldb.TaskListsRow{row}
+			if _, err := m.db.InsertIntoTaskLists(&row); err != nil {
 				return nil, &workflow.InternalServiceError{
 					Message: fmt.Sprintf("LeaseTaskList operation failed. Failed to make task list %v of type %v. Error: %v", request.TaskList, request.TaskType, err),
 				}
@@ -83,6 +98,7 @@ func (m *sqlTaskManager) LeaseTaskList(request *persistence.LeaseTaskListRequest
 		}
 	}
 
+	row := rows[0]
 	var resp *persistence.LeaseTaskListResponse
 	err = m.txExecute("LeaseTaskList", func(tx sqldb.Tx) error {
 		rangeID = row.RangeID
@@ -90,18 +106,21 @@ func (m *sqlTaskManager) LeaseTaskList(request *persistence.LeaseTaskListRequest
 		// We need to separately check the condition and do the
 		// update because we want to throw different error codes.
 		// Since we need to do things separately (in a transaction), we need to take a lock.
-		err1 := lockTaskList(tx, domainID, request.TaskList, request.TaskType, rangeID)
+		err1 := lockTaskList(tx, shardID, domainID, request.TaskList, request.TaskType, rangeID)
 		if err1 != nil {
 			return err1
 		}
+		now := time.Now()
 		result, err1 := tx.UpdateTaskLists(&sqldb.TaskListsRow{
-			DomainID: row.DomainID,
-			RangeID:  row.RangeID + 1,
-			Name:     row.Name,
-			TaskType: row.TaskType,
-			AckLevel: row.AckLevel,
-			Kind:     row.Kind,
-			ExpiryTs: row.ExpiryTs,
+			ShardID:     shardID,
+			DomainID:    row.DomainID,
+			RangeID:     row.RangeID + 1,
+			Name:        row.Name,
+			TaskType:    row.TaskType,
+			AckLevel:    row.AckLevel,
+			Kind:        row.Kind,
+			ExpiryTs:    row.ExpiryTs,
+			LastUpdated: now,
 		})
 		if err1 != nil {
 			return err1
@@ -114,12 +133,13 @@ func (m *sqlTaskManager) LeaseTaskList(request *persistence.LeaseTaskListRequest
 			return fmt.Errorf("%v rows affected instead of 1", rowsAffected)
 		}
 		resp = &persistence.LeaseTaskListResponse{TaskListInfo: &persistence.TaskListInfo{
-			DomainID: request.DomainID,
-			Name:     request.TaskList,
-			TaskType: request.TaskType,
-			RangeID:  rangeID + 1,
-			AckLevel: ackLevel,
-			Kind:     request.TaskListKind,
+			DomainID:    request.DomainID,
+			Name:        request.TaskList,
+			TaskType:    request.TaskType,
+			RangeID:     rangeID + 1,
+			AckLevel:    ackLevel,
+			Kind:        request.TaskListKind,
+			LastUpdated: now,
 		}}
 		return nil
 	})
@@ -127,16 +147,19 @@ func (m *sqlTaskManager) LeaseTaskList(request *persistence.LeaseTaskListRequest
 }
 
 func (m *sqlTaskManager) UpdateTaskList(request *persistence.UpdateTaskListRequest) (*persistence.UpdateTaskListResponse, error) {
+	shardID := m.shardID(request.TaskListInfo.DomainID, request.TaskListInfo.Name)
 	domainID := sqldb.MustParseUUID(request.TaskListInfo.DomainID)
 	if request.TaskListInfo.Kind == persistence.TaskListKindSticky {
 		if _, err := m.db.ReplaceIntoTaskLists(&sqldb.TaskListsRow{
-			DomainID: domainID,
-			RangeID:  request.TaskListInfo.RangeID,
-			Name:     request.TaskListInfo.Name,
-			TaskType: int64(request.TaskListInfo.TaskType),
-			AckLevel: request.TaskListInfo.AckLevel,
-			Kind:     int64(request.TaskListInfo.Kind),
-			ExpiryTs: stickyTaskListTTL(),
+			ShardID:     shardID,
+			DomainID:    domainID,
+			RangeID:     request.TaskListInfo.RangeID,
+			Name:        request.TaskListInfo.Name,
+			TaskType:    int64(request.TaskListInfo.TaskType),
+			AckLevel:    request.TaskListInfo.AckLevel,
+			Kind:        int64(request.TaskListInfo.Kind),
+			ExpiryTs:    stickyTaskListTTL(),
+			LastUpdated: time.Now(),
 		}); err != nil {
 			return nil, &workflow.InternalServiceError{
 				Message: fmt.Sprintf("UpdateTaskList operation failed. Failed to make sticky task list. Error: %v", err),
@@ -146,18 +169,20 @@ func (m *sqlTaskManager) UpdateTaskList(request *persistence.UpdateTaskListReque
 	var resp *persistence.UpdateTaskListResponse
 	err := m.txExecute("UpdateTaskList", func(tx sqldb.Tx) error {
 		err1 := lockTaskList(
-			tx, domainID, request.TaskListInfo.Name, request.TaskListInfo.TaskType, request.TaskListInfo.RangeID)
+			tx, shardID, domainID, request.TaskListInfo.Name, request.TaskListInfo.TaskType, request.TaskListInfo.RangeID)
 		if err1 != nil {
 			return err1
 		}
 		result, err1 := tx.UpdateTaskLists(&sqldb.TaskListsRow{
-			DomainID: domainID,
-			RangeID:  request.TaskListInfo.RangeID,
-			Name:     request.TaskListInfo.Name,
-			TaskType: int64(request.TaskListInfo.TaskType),
-			AckLevel: request.TaskListInfo.AckLevel,
-			Kind:     int64(request.TaskListInfo.Kind),
-			ExpiryTs: time.Time{},
+			ShardID:     shardID,
+			DomainID:    domainID,
+			RangeID:     request.TaskListInfo.RangeID,
+			Name:        request.TaskListInfo.Name,
+			TaskType:    int64(request.TaskListInfo.TaskType),
+			AckLevel:    request.TaskListInfo.AckLevel,
+			Kind:        int64(request.TaskListInfo.Kind),
+			ExpiryTs:    time.Time{},
+			LastUpdated: time.Now(),
 		})
 		if err1 != nil {
 			return err1
@@ -173,6 +198,103 @@ func (m *sqlTaskManager) UpdateTaskList(request *persistence.UpdateTaskListReque
 		return nil
 	})
 	return resp, err
+}
+
+type taskListPageToken struct {
+	ShardID  int
+	DomainID string
+	Name     string
+	TaskType int64
+}
+
+func (m *sqlTaskManager) ListTaskList(request *persistence.ListTaskListRequest) (*persistence.ListTaskListResponse, error) {
+	pageToken := taskListPageToken{TaskType: math.MinInt16, DomainID: minUUID}
+	if request.PageToken != nil {
+		if err := gobDeserialize(request.PageToken, &pageToken); err != nil {
+			return nil, &workflow.InternalServiceError{Message: fmt.Sprintf("error deserializing page token: %v", err)}
+		}
+	}
+	var err error
+	var rows []sqldb.TaskListsRow
+	domainID := sqldb.MustParseUUID(pageToken.DomainID)
+	for pageToken.ShardID < m.nShards {
+		rows, err = m.db.SelectFromTaskLists(&sqldb.TaskListsFilter{
+			ShardID:             pageToken.ShardID,
+			DomainIDGreaterThan: &domainID,
+			NameGreaterThan:     &pageToken.Name,
+			TaskTypeGreaterThan: &pageToken.TaskType,
+			PageSize:            &request.PageSize,
+		})
+		if err != nil {
+			return nil, &workflow.InternalServiceError{Message: err.Error()}
+		}
+		if len(rows) > 0 {
+			break
+		}
+		pageToken = taskListPageToken{ShardID: pageToken.ShardID + 1, TaskType: math.MinInt16, DomainID: minUUID}
+	}
+
+	var nextPageToken []byte
+	switch {
+	case len(rows) == request.PageSize:
+		lastRow := &rows[request.PageSize-1]
+		nextPageToken, err = gobSerialize(&taskListPageToken{
+			ShardID:  pageToken.ShardID,
+			DomainID: lastRow.DomainID.String(),
+			Name:     lastRow.Name,
+			TaskType: lastRow.TaskType,
+		})
+	case pageToken.ShardID+1 < m.nShards:
+		nextPageToken, err = gobSerialize(&taskListPageToken{ShardID: pageToken.ShardID + 1, TaskType: math.MinInt16})
+	default:
+		return nil, &workflow.InternalServiceError{
+			Message: fmt.Sprintf("invalid state: request:%+v, pageToken=%+v, len(rows)=%v", request, pageToken, len(rows)),
+		}
+	}
+
+	if err != nil {
+		return nil, &workflow.InternalServiceError{Message: fmt.Sprintf("error serializing nextPageToken:%v", err)}
+	}
+
+	resp := &persistence.ListTaskListResponse{
+		Items:         make([]persistence.TaskListInfo, len(rows)),
+		NextPageToken: nextPageToken,
+	}
+
+	for i := range rows {
+		resp.Items[i].DomainID = rows[i].DomainID.String()
+		resp.Items[i].Name = rows[i].Name
+		resp.Items[i].TaskType = int(rows[i].TaskType)
+		resp.Items[i].RangeID = rows[i].RangeID
+		resp.Items[i].Kind = int(rows[i].Kind)
+		resp.Items[i].AckLevel = rows[i].AckLevel
+		resp.Items[i].Expiry = rows[i].ExpiryTs
+		resp.Items[i].LastUpdated = rows[i].LastUpdated
+	}
+
+	return resp, nil
+}
+
+func (m *sqlTaskManager) DeleteTaskList(request *persistence.DeleteTaskListRequest) error {
+	domainID := sqldb.MustParseUUID(request.DomainID)
+	result, err := m.db.DeleteFromTaskLists(&sqldb.TaskListsFilter{
+		ShardID:  m.shardID(request.DomainID, request.TaskListName),
+		DomainID: &domainID,
+		Name:     &request.TaskListName,
+		TaskType: common.Int64Ptr(int64(request.TaskListType)),
+		RangeID:  &request.RangeID,
+	})
+	if err != nil {
+		return &workflow.InternalServiceError{Message: err.Error()}
+	}
+	nRows, err := result.RowsAffected()
+	if err != nil {
+		return &workflow.InternalServiceError{Message: fmt.Sprintf("rowsAffected returned error:%v", err)}
+	}
+	if nRows != 1 {
+		return &workflow.InternalServiceError{Message: fmt.Sprintf("delete failed: %v rows affected instead of 1", nRows)}
+	}
+	return nil
 }
 
 func (m *sqlTaskManager) CreateTasks(request *persistence.CreateTasksRequest) (*persistence.CreateTasksResponse, error) {
@@ -200,6 +322,7 @@ func (m *sqlTaskManager) CreateTasks(request *persistence.CreateTasksRequest) (*
 		}
 		// Lock task list before committing.
 		err1 := lockTaskList(tx,
+			m.shardID(request.TaskListInfo.DomainID, request.TaskListInfo.Name),
 			sqldb.MustParseUUID(request.TaskListInfo.DomainID),
 			request.TaskListInfo.Name,
 			request.TaskListInfo.TaskType, request.TaskListInfo.RangeID)
@@ -241,7 +364,6 @@ func (m *sqlTaskManager) GetTasks(request *persistence.GetTasksRequest) (*persis
 	return &persistence.GetTasksResponse{Tasks: tasks}, nil
 }
 
-// Deprecated
 func (m *sqlTaskManager) CompleteTask(request *persistence.CompleteTaskRequest) error {
 	taskID := request.TaskID
 	taskList := request.TaskList
@@ -256,8 +378,28 @@ func (m *sqlTaskManager) CompleteTask(request *persistence.CompleteTaskRequest) 
 	return nil
 }
 
-func lockTaskList(tx sqldb.Tx, domainID sqldb.UUID, name string, taskListType int, oldRangeID int64) error {
-	rangeID, err := tx.LockTaskLists(&sqldb.TaskListsFilter{DomainID: domainID, Name: name, TaskType: int64(taskListType)})
+func (m *sqlTaskManager) RangeCompleteTask(request *persistence.RangeCompleteTaskRequest) error {
+	_, err := m.db.DeleteFromTasks(&sqldb.TasksFilter{
+		DomainID:     sqldb.MustParseUUID(request.DomainID),
+		TaskListName: request.TaskListName,
+		TaskType:     int64(request.TaskType),
+		MinTaskID:    &request.MinTaskID,
+		MaxTaskID:    &request.MaxTaskID,
+	})
+	if err != nil {
+		return &workflow.InternalServiceError{Message: err.Error()}
+	}
+	return nil
+}
+
+func (m *sqlTaskManager) shardID(domainID string, name string) int {
+	id := farm.Hash32([]byte(domainID+"_"+name)) % uint32(m.nShards)
+	return int(id)
+}
+
+func lockTaskList(tx sqldb.Tx, shardID int, domainID sqldb.UUID, name string, taskListType int, oldRangeID int64) error {
+	rangeID, err := tx.LockTaskLists(&sqldb.TaskListsFilter{
+		ShardID: shardID, DomainID: &domainID, Name: &name, TaskType: common.Int64Ptr(int64(taskListType))})
 	if err != nil {
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("Failed to lock task list. Error: %v", err),

--- a/common/persistence/sql/storage/mysql/task.go
+++ b/common/persistence/sql/storage/mysql/task.go
@@ -23,12 +23,14 @@ package mysql
 import (
 	"database/sql"
 
+	"fmt"
+
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
 )
 
 const (
-	taskListCreatePart = `INTO task_lists(domain_id, range_id, name, task_type, ack_level, kind, expiry_ts) ` +
-		`VALUES (:domain_id, :range_id, :name, :task_type, :ack_level, :kind, :expiry_ts)`
+	taskListCreatePart = `INTO task_lists(shard_id, domain_id, range_id, name, task_type, ack_level, kind, expiry_ts, last_updated) ` +
+		`VALUES (:shard_id, :domain_id, :range_id, :name, :task_type, :ack_level, :kind, :expiry_ts, :last_updated)`
 
 	// (default range ID: initialRangeID == 1)
 	createTaskListQry = `INSERT ` + taskListCreatePart
@@ -36,25 +38,31 @@ const (
 	replaceTaskListQry = `REPLACE ` + taskListCreatePart
 
 	updateTaskListQry = `UPDATE task_lists SET
-domain_id = :domain_id,
 range_id = :range_id,
-name = :name,
 task_type = :task_type,
 ack_level = :ack_level,
 kind = :kind,
-expiry_ts = :expiry_ts
+expiry_ts = :expiry_ts,
+last_updated = :last_updated
 WHERE
+shard_id = :shard_id AND
 domain_id = :domain_id AND
 name = :name AND
 task_type = :task_type
 `
 
-	getTaskListQry = `SELECT domain_id, range_id, name, task_type, ack_level, kind, expiry_ts ` +
+	listTaskListQry = `SELECT domain_id, range_id, name, task_type, ack_level, kind, expiry_ts, last_updated ` +
 		`FROM task_lists ` +
-		`WHERE domain_id = ? AND name = ? AND task_type = ?`
+		`WHERE shard_id = ? AND domain_id > ? AND name > ? AND task_type > ? LIMIT ?`
+
+	getTaskListQry = `SELECT domain_id, range_id, name, task_type, ack_level, kind, expiry_ts, last_updated ` +
+		`FROM task_lists ` +
+		`WHERE shard_id = ? AND domain_id = ? AND name = ? AND task_type = ?`
+
+	deleteTaskListQry = `DELETE FROM task_lists WHERE shard_id=? AND domain_id=? AND name=? AND task_type=? AND range_id=?`
 
 	lockTaskListQry = `SELECT range_id FROM task_lists ` +
-		`WHERE domain_id = ? AND name = ? AND task_type = ? FOR UPDATE`
+		`WHERE shard_id = ? AND domain_id = ? AND name = ? AND task_type = ? FOR UPDATE`
 
 	getTaskQry = `SELECT workflow_id, run_id, schedule_id, task_id ` +
 		`FROM tasks ` +
@@ -66,6 +74,9 @@ task_type = :task_type
 
 	deleteTaskQry = `DELETE FROM tasks ` +
 		`WHERE domain_id = ? AND task_list_name = ? AND task_type = ? AND task_id = ?`
+
+	rangeDeleteTaskQry = `DELETE FROM tasks ` +
+		`WHERE domain_id = ? AND task_list_name = ? AND task_type = ? AND task_id >= ? AND task_id <= ?`
 )
 
 // InsertIntoTasks inserts one or more rows into tasks table
@@ -93,6 +104,10 @@ func (mdb *DB) SelectFromTasks(filter *sqldb.TasksFilter) ([]sqldb.TasksRow, err
 
 // DeleteFromTasks deletes one or more rows from tasks table
 func (mdb *DB) DeleteFromTasks(filter *sqldb.TasksFilter) (sql.Result, error) {
+	if filter.MinTaskID != nil && filter.MaxTaskID != nil {
+		return mdb.conn.Exec(rangeDeleteTaskQry,
+			filter.DomainID, filter.TaskListName, filter.TaskType, *filter.MinTaskID, *filter.MaxTaskID)
+	}
 	return mdb.conn.Exec(deleteTaskQry, filter.DomainID, filter.TaskListName, filter.TaskType, *filter.TaskID)
 }
 
@@ -115,25 +130,51 @@ func (mdb *DB) UpdateTaskLists(row *sqldb.TaskListsRow) (sql.Result, error) {
 }
 
 // SelectFromTaskLists reads one or more rows from task_lists table
-func (mdb *DB) SelectFromTaskLists(filter *sqldb.TaskListsFilter) (*sqldb.TaskListsRow, error) {
+func (mdb *DB) SelectFromTaskLists(filter *sqldb.TaskListsFilter) ([]sqldb.TaskListsRow, error) {
+	switch {
+	case filter.DomainID != nil && filter.Name != nil && filter.TaskType != nil:
+		return mdb.selectFromTaskLists(filter)
+	case filter.DomainIDGreaterThan != nil && filter.NameGreaterThan != nil && filter.TaskTypeGreaterThan != nil && filter.PageSize != nil:
+		return mdb.rangeSelectFromTaskLists(filter)
+	default:
+		return nil, fmt.Errorf("invalid set of query filter params")
+	}
+}
+
+func (mdb *DB) selectFromTaskLists(filter *sqldb.TaskListsFilter) ([]sqldb.TaskListsRow, error) {
 	var err error
 	var row sqldb.TaskListsRow
-	err = mdb.conn.Get(&row, getTaskListQry, filter.DomainID, filter.Name, filter.TaskType)
+	err = mdb.conn.Get(&row, getTaskListQry, filter.ShardID, *filter.DomainID, *filter.Name, *filter.TaskType)
 	if err != nil {
 		return nil, err
 	}
 	row.ExpiryTs = mdb.converter.FromMySQLDateTime(row.ExpiryTs)
-	return &row, err
+	return []sqldb.TaskListsRow{row}, err
+}
+
+func (mdb *DB) rangeSelectFromTaskLists(filter *sqldb.TaskListsFilter) ([]sqldb.TaskListsRow, error) {
+	var err error
+	var rows []sqldb.TaskListsRow
+	err = mdb.conn.Select(&rows, listTaskListQry,
+		filter.ShardID, *filter.DomainIDGreaterThan, *filter.NameGreaterThan, *filter.TaskTypeGreaterThan, *filter.PageSize)
+	if err != nil {
+		return nil, err
+	}
+	for i := range rows {
+		rows[i].ShardID = filter.ShardID
+		rows[i].ExpiryTs = mdb.converter.FromMySQLDateTime(rows[i].ExpiryTs)
+	}
+	return rows, nil
 }
 
 // DeleteFromTaskLists deletes a row from task_lists table
 func (mdb *DB) DeleteFromTaskLists(filter *sqldb.TaskListsFilter) (sql.Result, error) {
-	return mdb.conn.Exec(deleteTaskQry, filter.DomainID, filter.Name, filter.TaskType)
+	return mdb.conn.Exec(deleteTaskListQry, filter.ShardID, *filter.DomainID, *filter.Name, *filter.TaskType, *filter.RangeID)
 }
 
 // LockTaskLists locks a row in task_lists table
 func (mdb *DB) LockTaskLists(filter *sqldb.TaskListsFilter) (int64, error) {
 	var rangeID int64
-	err := mdb.conn.Get(&rangeID, lockTaskListQry, filter.DomainID, filter.Name, filter.TaskType)
+	err := mdb.conn.Get(&rangeID, lockTaskListQry, filter.ShardID, *filter.DomainID, *filter.Name, *filter.TaskType)
 	return rangeID, err
 }

--- a/common/persistence/sql/storage/mysql/task.go
+++ b/common/persistence/sql/storage/mysql/task.go
@@ -53,7 +53,7 @@ task_type = :task_type
 
 	listTaskListQry = `SELECT domain_id, range_id, name, task_type, ack_level, kind, expiry_ts, last_updated ` +
 		`FROM task_lists ` +
-		`WHERE shard_id = ? AND domain_id > ? AND name > ? AND task_type > ? LIMIT ?`
+		`WHERE shard_id = ? AND domain_id > ? AND name > ? AND task_type > ? ORDER BY domain_id,name,task_type LIMIT ?`
 
 	getTaskListQry = `SELECT domain_id, range_id, name, task_type, ack_level, kind, expiry_ts, last_updated ` +
 		`FROM task_lists ` +

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -245,21 +245,29 @@ type (
 
 	// TaskListsRow represents a row in task_lists table
 	TaskListsRow struct {
-		DomainID UUID
-		Name     string
-		TaskType int64
-		RangeID  int64
-		AckLevel int64
-		Kind     int64
-		ExpiryTs time.Time
+		ShardID     int
+		DomainID    UUID
+		Name        string
+		TaskType    int64
+		RangeID     int64
+		AckLevel    int64
+		Kind        int64
+		LastUpdated time.Time
+		ExpiryTs    time.Time
 	}
 
 	// TaskListsFilter contains the column names within domain table that
 	// can be used to filter results through a WHERE clause
 	TaskListsFilter struct {
-		DomainID UUID
-		Name     string
-		TaskType int64
+		ShardID             int
+		DomainID            *UUID
+		Name                *string
+		TaskType            *int64
+		DomainIDGreaterThan *UUID
+		NameGreaterThan     *string
+		TaskTypeGreaterThan *int64
+		RangeID             *int64
+		PageSize            *int
 	}
 
 	// ReplicationTasksRow represents a row in replication_tasks table
@@ -581,13 +589,19 @@ type (
 		// Required filter params - {domainID, tasklistName, taskType, minTaskID, maxTaskID, pageSize}
 		SelectFromTasks(filter *TasksFilter) ([]TasksRow, error)
 		// DeleteFromTasks deletes a row from tasks table
-		// Required filter params - {domainID, tasklistName, taskType, taskID}
+		// Required filter params:
+		//  to delete single row - {domainID, tasklistName, taskType, taskID}
+		//  to delete multiple rows - {domainID, tasklistName, taskType, minTaskID, maxTaskID}
 		DeleteFromTasks(filter *TasksFilter) (sql.Result, error)
 
 		InsertIntoTaskLists(row *TaskListsRow) (sql.Result, error)
 		ReplaceIntoTaskLists(row *TaskListsRow) (sql.Result, error)
 		UpdateTaskLists(row *TaskListsRow) (sql.Result, error)
-		SelectFromTaskLists(filter *TaskListsFilter) (*TaskListsRow, error)
+		// SelectFromTaskLists returns one or more rows from task_lists table
+		// Required Filter params:
+		//  to read a single row: {shardID, domainID, name, taskType}
+		//  to range read multiple rows: {shardID, domainIDGreaterThan, nameGreaterThan, taskTypeGreaterThan, pageSize}
+		SelectFromTaskLists(filter *TaskListsFilter) ([]TaskListsRow, error)
 		DeleteFromTaskLists(filter *TaskListsFilter) (sql.Result, error)
 		LockTaskLists(filter *TaskListsFilter) (int64, error)
 

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -234,13 +234,15 @@ type (
 	// TasksFilter contains the column names within domain table that
 	// can be used to filter results through a WHERE clause
 	TasksFilter struct {
-		DomainID     UUID
-		TaskListName string
-		TaskType     int64
-		TaskID       *int64
-		MinTaskID    *int64
-		MaxTaskID    *int64
-		PageSize     *int
+		DomainID             UUID
+		TaskListName         string
+		TaskType             int64
+		TaskID               *int64
+		MinTaskID            *int64
+		MaxTaskID            *int64
+		TaskIDLessThanEquals *int64
+		Limit                *int
+		PageSize             *int
 	}
 
 	// TaskListsRow represents a row in task_lists table
@@ -590,8 +592,11 @@ type (
 		SelectFromTasks(filter *TasksFilter) ([]TasksRow, error)
 		// DeleteFromTasks deletes a row from tasks table
 		// Required filter params:
-		//  to delete single row - {domainID, tasklistName, taskType, taskID}
-		//  to delete multiple rows - {domainID, tasklistName, taskType, minTaskID, maxTaskID}
+		//  to delete single row
+		//     - {domainID, tasklistName, taskType, taskID}
+		//  to delete multiple rows
+		//    - {domainID, tasklistName, taskType, taskIDLessThanEquals, limit }
+		//    - this will delete upto limit number of tasks less than or equal to the given task id
 		DeleteFromTasks(filter *TasksFilter) (sql.Result, error)
 
 		InsertIntoTaskLists(row *TaskListsRow) (sql.Result, error)

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -22,8 +22,9 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/uber/cadence/common/blobstore/filestore"
 	"time"
+
+	"github.com/uber/cadence/common/blobstore/filestore"
 
 	"github.com/uber-go/tally/m3"
 	"github.com/uber/cadence/common/elasticsearch"
@@ -183,6 +184,9 @@ type (
 		MaxQPS int `yaml:"maxQPS"`
 		// MaxConns the max number of connections to this datastore
 		MaxConns int `yaml:"maxConns"`
+		// NumShards is the number of storage shards to use for tables
+		// in a sharded sql database. The default value for this param is 1
+		NumShards int `yaml:"nShards"`
 	}
 
 	// Replicator describes the configuration of replicator

--- a/common/service/config/persistence.go
+++ b/common/service/config/persistence.go
@@ -41,13 +41,16 @@ func (c *Persistence) Validate() error {
 	for _, st := range stores {
 		ds, ok := c.DataStores[st]
 		if !ok {
-			return fmt.Errorf("persistence: missing config for datastore %v", st)
+			return fmt.Errorf("persistence config: missing config for datastore %v", st)
 		}
 		if ds.SQL == nil && ds.Cassandra == nil {
-			return fmt.Errorf("persistence: datastore %v: must provide config for one of cassandra or sql stores", st)
+			return fmt.Errorf("persistence config: datastore %v: must provide config for one of cassandra or sql stores", st)
 		}
 		if ds.SQL != nil && ds.Cassandra != nil {
-			return fmt.Errorf("persistce: datastore %v: only one of SQL or cassandra can be specified", st)
+			return fmt.Errorf("persistence config: datastore %v: only one of SQL or cassandra can be specified", st)
+		}
+		if ds.SQL != nil && ds.SQL.NumShards == 0 {
+			ds.SQL.NumShards = 1
 		}
 	}
 	return nil

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -226,6 +226,7 @@ CREATE TYPE task_list (
   type             int, -- enum TaskRowType {ActivityTask, DecisionTask}
   ack_level        bigint, -- task_id of the last acknowledged message
   kind             int, -- enum TaskListKind {Normal, Sticky}
+  last_updated     timestamp
 );
 
 CREATE TYPE domain (

--- a/schema/cassandra/cadence/versioned/v0.14/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.14/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.14",
+  "MinCompatibleVersion": "0.14",
+  "Description": "Added params to tasklist type to enable task_list deletions",
+  "SchemaUpdateCqlFiles": [
+    "task_list.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.14/task_list.cql
+++ b/schema/cassandra/cadence/versioned/v0.14/task_list.cql
@@ -1,0 +1,1 @@
+ALTER TYPE task_list ADD last_updated timestamp;

--- a/schema/mysql/v56/cadence/schema.sql
+++ b/schema/mysql/v56/cadence/schema.sql
@@ -153,7 +153,6 @@ CREATE TABLE buffered_events (
 CREATE INDEX buffered_events_by_events_ids ON buffered_events(shard_id, domain_id, workflow_id, run_id);
 
 CREATE TABLE tasks (
-  shard_id INT NOT NULL DEFAULT 0,
   domain_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
@@ -162,10 +161,11 @@ CREATE TABLE tasks (
   task_type TINYINT NOT NULL, -- {Activity, Decision}
   task_id BIGINT NOT NULL,
   expiry_ts DATETIME(6) NOT NULL,
-  PRIMARY KEY (shard_id, domain_id, task_list_name, task_type, task_id)
+  PRIMARY KEY (domain_id, task_list_name, task_type, task_id)
 );
 
 CREATE TABLE task_lists (
+  shard_id INT NOT NULL,
 	domain_id BINARY(16) NOT NULL,
 	range_id BIGINT NOT NULL,
 	name VARCHAR(255) NOT NULL,
@@ -173,7 +173,8 @@ CREATE TABLE task_lists (
 	ack_level BIGINT NOT NULL DEFAULT 0,
 	kind TINYINT NOT NULL, -- {Normal, Sticky}
 	expiry_ts DATETIME(6) NOT NULL,
-	PRIMARY KEY (domain_id, name, task_type)
+	last_updated DATETIME(6) NOT NULL,
+	PRIMARY KEY (shard_id, domain_id, name, task_type)
 );
 
 CREATE TABLE replication_tasks (

--- a/schema/mysql/v57/cadence/schema.sql
+++ b/schema/mysql/v57/cadence/schema.sql
@@ -153,7 +153,6 @@ CREATE TABLE buffered_events (
 CREATE INDEX buffered_events_by_events_ids ON buffered_events(shard_id, domain_id, workflow_id, run_id);
 
 CREATE TABLE tasks (
-  shard_id INT NOT NULL DEFAULT 0,
   domain_id BINARY(16) NOT NULL,
   workflow_id VARCHAR(255) NOT NULL,
   run_id BINARY(16) NOT NULL,
@@ -162,10 +161,11 @@ CREATE TABLE tasks (
   task_type TINYINT NOT NULL, -- {Activity, Decision}
   task_id BIGINT NOT NULL,
   expiry_ts DATETIME(6) NOT NULL,
-  PRIMARY KEY (shard_id, domain_id, task_list_name, task_type, task_id)
+  PRIMARY KEY (domain_id, task_list_name, task_type, task_id)
 );
 
 CREATE TABLE task_lists (
+  shard_id INT NOT NULL,
 	domain_id BINARY(16) NOT NULL,
 	range_id BIGINT NOT NULL,
 	name VARCHAR(255) NOT NULL,
@@ -173,7 +173,8 @@ CREATE TABLE task_lists (
 	ack_level BIGINT NOT NULL DEFAULT 0,
 	kind TINYINT NOT NULL, -- {Normal, Sticky}
 	expiry_ts DATETIME(6) NOT NULL,
-	PRIMARY KEY (domain_id, name, task_type)
+	last_updated DATETIME(6) NOT NULL,
+	PRIMARY KEY (shard_id, domain_id, name, task_type)
 );
 
 CREATE TABLE replication_tasks (

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1636,6 +1636,33 @@ func (m *testTaskManager) CompleteTask(request *persistence.CompleteTaskRequest)
 	return nil
 }
 
+func (m *testTaskManager) RangeCompleteTask(request *persistence.RangeCompleteTaskRequest) error {
+	tlm := m.getTaskListManager(newTaskListID(request.DomainID, request.TaskListName, request.TaskType))
+	tlm.Lock()
+	defer tlm.Unlock()
+	keys := tlm.tasks.Keys()
+	for _, key := range keys {
+		id := key.(int64)
+		if id >= request.MinTaskID && id <= request.MaxTaskID {
+			tlm.tasks.Remove(id)
+		}
+	}
+	return nil
+}
+
+func (m *testTaskManager) ListTaskList(
+	request *persistence.ListTaskListRequest) (*persistence.ListTaskListResponse, error) {
+	return nil, fmt.Errorf("unsupported operation")
+}
+
+func (m *testTaskManager) DeleteTaskList(request *persistence.DeleteTaskListRequest) error {
+	m.Lock()
+	defer m.Unlock()
+	key := newTaskListID(request.DomainID, request.TaskListName, request.TaskListType)
+	delete(m.taskLists, *key)
+	return nil
+}
+
 // CreateTask provides a mock function with given fields: request
 func (m *testTaskManager) CreateTasks(request *persistence.CreateTasksRequest) (*persistence.CreateTasksResponse, error) {
 	domainID := request.TaskListInfo.DomainID

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1636,18 +1636,18 @@ func (m *testTaskManager) CompleteTask(request *persistence.CompleteTaskRequest)
 	return nil
 }
 
-func (m *testTaskManager) RangeCompleteTask(request *persistence.RangeCompleteTaskRequest) error {
+func (m *testTaskManager) CompleteTasksLessThan(request *persistence.CompleteTasksLessThanRequest) (int, error) {
 	tlm := m.getTaskListManager(newTaskListID(request.DomainID, request.TaskListName, request.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
 	keys := tlm.tasks.Keys()
 	for _, key := range keys {
 		id := key.(int64)
-		if id >= request.MinTaskID && id <= request.MaxTaskID {
+		if id <= request.TaskID {
 			tlm.tasks.Remove(id)
 		}
 	}
-	return nil
+	return persistence.UnknownNumRowsAffected, nil
 }
 
 func (m *testTaskManager) ListTaskList(

--- a/tools/cassandra/updateTask_test.go
+++ b/tools/cassandra/updateTask_test.go
@@ -130,7 +130,7 @@ func (s *UpdateSchemaTestSuite) TestDryrun() {
 	s.Nil(err)
 	// update the version to the latest
 	s.log.Infof("Ver: %v", ver)
-	s.Equal(0, cmpVersion(ver, "0.13"))
+	s.Equal(0, cmpVersion(ver, "0.14"))
 
 	dropAllTablesTypes(client)
 }


### PR DESCRIPTION
This patch contains the persistence API changes needed to support task list cleanup (deletion of expired tasks and deletion of unused task_lists). Cassandra currently supports deletion of tasks through TTL while MySQL doesn't support this at all. Both Cassandra and MySQL stores don't support deletion of expired/idle task_lists today. This PR is primarily geared towards adding support for MySQL, but when possible, the corresponding changes are also made to cassandra.

**New APIs Introduced**

1. ListTaskList: Paginated API to get a list of all task lists across all storage shards
2. DeleteTaskList: Deletes a given task list
3. RangeCompleteTasks: Deleting a range of tasks within a task list

**ListTaskList: Implementation Notes**

MySQL: This PR introduces a "shardID" column to the task_list table. The shardID here is purely a store concept and is not exposed to the upper layers of the application. ShardID is introduced so that task_list data can be partitioned across different storage shards for a sharded MySQL DB. ShardID also enables listing task_lists table shard by shard with pagination. The total number of shards is made configurable with the default value being 1 i.e. non-sharded mysql instance. If the underlying store supports this kind of multi-shard "select * from table" query seamlessly, shardID is redundant. 

Cassandra: This API is currently impossible to support for cassandra because of the way the tasks table is partitioned