### PR TITLE
logging: use throttled logger for limits / size violations

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber-common/bark"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/metrics"
@@ -87,7 +88,7 @@ type (
 		cacheByID       *atomic.Value
 		metadataMgr     persistence.MetadataManager
 		clusterMetadata cluster.Metadata
-		timeSource      common.TimeSource
+		timeSource      clock.TimeSource
 		metricsClient   metrics.Client
 		logger          bark.Logger
 
@@ -124,7 +125,7 @@ func NewDomainCache(metadataMgr persistence.MetadataManager, clusterMetadata clu
 		cacheByID:        &atomic.Value{},
 		metadataMgr:      metadataMgr,
 		clusterMetadata:  clusterMetadata,
-		timeSource:       common.NewRealTimeSource(),
+		timeSource:       clock.NewRealTimeSource(),
 		metricsClient:    metricsClient,
 		logger:           logger,
 		prepareCallbacks: make(map[int]PrepareCallbackFn),

--- a/common/clock/time_source.go
+++ b/common/clock/time_source.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package common
+package clock
 
 import "time"
 

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -85,6 +85,7 @@ const (
 	TagScheduleAttempt            = "schedule-attempt"
 	TagCursorTimestamp            = "cursor-timestamp"
 	TagHistorySize                = "history-size"
+	TagHistorySizeBytes           = "history-size-bytes"
 	TagEventCount                 = "event-count"
 	TagESRequest                  = "es-request"
 	TagESKey                      = "es-mapping-key"

--- a/common/logging/throttle.go
+++ b/common/logging/throttle.go
@@ -38,6 +38,8 @@ type throttledLogger struct {
 	}
 }
 
+var _ bark.Logger = (*throttledLogger)(nil)
+
 // NewThrottledLogger returns an implementation of bark logger that throttles the
 // log messages being emitted. The underlying implementation uses a token bucket
 // ratelimiter and stops emitting logs once the bucket runs out of tokens

--- a/common/logging/throttle.go
+++ b/common/logging/throttle.go
@@ -1,0 +1,147 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package logging
+
+import (
+	"github.com/uber-common/bark"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/tokenbucket"
+)
+
+type throttledLogger struct {
+	tb  tokenbucket.TokenBucket
+	log bark.Logger
+}
+
+const throttledLogRPS = 50
+
+// NewThrottledLogger returns an implementation of bark logger that throttles the
+// log messages being emitted. The underlying implementation uses a token bucket
+// ratelimiter and stops emitting logs once the bucket runs out of tokens
+//
+// Fatal/Panic logs are always emitted without any throttling
+func NewThrottledLogger(log bark.Logger) bark.Logger {
+	tb := tokenbucket.New(throttledLogRPS, clock.NewRealTimeSource())
+	return &throttledLogger{tb: tb, log: log}
+}
+
+func (tl *throttledLogger) Debug(args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Debug(args)
+	})
+}
+
+// Log at debug level with fmt.Printf-like formatting
+func (tl *throttledLogger) Debugf(format string, args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Debugf(format, args)
+	})
+}
+
+// Log at info level
+func (tl *throttledLogger) Info(args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Info(args)
+	})
+}
+
+// Log at info level with fmt.Printf-like formatting
+func (tl *throttledLogger) Infof(format string, args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Infof(format, args)
+	})
+}
+
+// Log at warning level
+func (tl *throttledLogger) Warn(args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Warn(args)
+	})
+}
+
+// Log at warning level with fmt.Printf-like formatting
+func (tl *throttledLogger) Warnf(format string, args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Warnf(format, args)
+	})
+}
+
+// Log at error level
+func (tl *throttledLogger) Error(args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Error(args)
+	})
+}
+
+// Log at error level with fmt.Printf-like formatting
+func (tl *throttledLogger) Errorf(format string, args ...interface{}) {
+	tl.rateLimit(func() {
+		tl.log.Error(format, args)
+	})
+}
+
+// Log at fatal level, then terminate process (irrecoverable)
+func (tl *throttledLogger) Fatal(args ...interface{}) {
+	tl.log.Fatal(args)
+}
+
+// Log at fatal level with fmt.Printf-like formatting, then terminate process (irrecoverable)
+func (tl *throttledLogger) Fatalf(format string, args ...interface{}) {
+	tl.log.Fatalf(format, args)
+}
+
+// Log at panic level, then panic (recoverable)
+func (tl *throttledLogger) Panic(args ...interface{}) {
+	tl.log.Panic(args)
+}
+
+// Log at panic level with fmt.Printf-like formatting, then panic (recoverable)
+func (tl *throttledLogger) Panicf(format string, args ...interface{}) {
+	tl.log.Panicf(format, args)
+}
+
+// Return a logger with the specified key-value pair set, to be logged in a subsequent normal logging call
+func (tl *throttledLogger) WithField(key string, value interface{}) bark.Logger {
+	return &throttledLogger{tb: tl.tb, log: tl.log.WithField(key, value)}
+}
+
+// Return a logger with the specified key-value pairs set, to be included in a subsequent normal logging call
+func (tl *throttledLogger) WithFields(keyValues bark.LogFields) bark.Logger {
+	return &throttledLogger{tb: tl.tb, log: tl.log.WithFields(keyValues)}
+}
+
+// Return a logger with the specified error set, to be included in a subsequent normal logging call
+func (tl *throttledLogger) WithError(err error) bark.Logger {
+	return &throttledLogger{tb: tl.tb, log: tl.log.WithError(err)}
+}
+
+// Return map fields associated with this logger, if any (i.e. if this logger was returned from WithField[s])
+// If no fields are set, returns nil
+func (tl *throttledLogger) Fields() bark.Fields {
+	return tl.log.Fields()
+}
+
+func (tl *throttledLogger) rateLimit(f func()) {
+	ok, _ := tl.tb.TryConsume(1)
+	if ok {
+		f()
+	}
+}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1298,6 +1298,7 @@ const (
 const (
 	ReplicatorMessages = iota + NumCommonMetrics
 	ReplicatorFailures
+	ReplicatorMessagesDropped
 	ReplicatorLatency
 	ESProcessorFailures
 	ESProcessorCorruptedData
@@ -1507,6 +1508,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 	Worker: {
 		ReplicatorMessages:                       {metricName: "replicator.messages"},
 		ReplicatorFailures:                       {metricName: "replicator.errors"},
+		ReplicatorMessagesDropped:                {metricName: "replicator.messages.dropped"},
 		ReplicatorLatency:                        {metricName: "replicator.latency"},
 		ESProcessorFailures:                      {metricName: "es-processor.errors"},
 		ESProcessorCorruptedData:                 {metricName: "es-processor.corrupted-data"},

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -23,7 +23,7 @@ package persistence
 import (
 	"github.com/uber-common/bark"
 	workflow "github.com/uber/cadence/.gen/go/shared"
-	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/tokenbucket"
 )
 
 var (
@@ -35,43 +35,43 @@ var (
 
 type (
 	shardRateLimitedPersistenceClient struct {
-		rateLimiter common.TokenBucket
+		rateLimiter tokenbucket.TokenBucket
 		persistence ShardManager
 		logger      bark.Logger
 	}
 
 	workflowExecutionRateLimitedPersistenceClient struct {
-		rateLimiter common.TokenBucket
+		rateLimiter tokenbucket.TokenBucket
 		persistence ExecutionManager
 		logger      bark.Logger
 	}
 
 	taskRateLimitedPersistenceClient struct {
-		rateLimiter common.TokenBucket
+		rateLimiter tokenbucket.TokenBucket
 		persistence TaskManager
 		logger      bark.Logger
 	}
 
 	historyRateLimitedPersistenceClient struct {
-		rateLimiter common.TokenBucket
+		rateLimiter tokenbucket.TokenBucket
 		persistence HistoryManager
 		logger      bark.Logger
 	}
 
 	historyV2RateLimitedPersistenceClient struct {
-		rateLimiter common.TokenBucket
+		rateLimiter tokenbucket.TokenBucket
 		persistence HistoryV2Manager
 		logger      bark.Logger
 	}
 
 	metadataRateLimitedPersistenceClient struct {
-		rateLimiter common.TokenBucket
+		rateLimiter tokenbucket.TokenBucket
 		persistence MetadataManager
 		logger      bark.Logger
 	}
 
 	visibilityRateLimitedPersistenceClient struct {
-		rateLimiter common.TokenBucket
+		rateLimiter tokenbucket.TokenBucket
 		persistence VisibilityManager
 		logger      bark.Logger
 	}
@@ -86,7 +86,7 @@ var _ MetadataManager = (*metadataRateLimitedPersistenceClient)(nil)
 var _ VisibilityManager = (*visibilityRateLimitedPersistenceClient)(nil)
 
 // NewShardPersistenceRateLimitedClient creates a client to manage shards
-func NewShardPersistenceRateLimitedClient(persistence ShardManager, rateLimiter common.TokenBucket, logger bark.Logger) ShardManager {
+func NewShardPersistenceRateLimitedClient(persistence ShardManager, rateLimiter tokenbucket.TokenBucket, logger bark.Logger) ShardManager {
 	return &shardRateLimitedPersistenceClient{
 		persistence: persistence,
 		rateLimiter: rateLimiter,
@@ -95,7 +95,7 @@ func NewShardPersistenceRateLimitedClient(persistence ShardManager, rateLimiter 
 }
 
 // NewWorkflowExecutionPersistenceRateLimitedClient creates a client to manage executions
-func NewWorkflowExecutionPersistenceRateLimitedClient(persistence ExecutionManager, rateLimiter common.TokenBucket, logger bark.Logger) ExecutionManager {
+func NewWorkflowExecutionPersistenceRateLimitedClient(persistence ExecutionManager, rateLimiter tokenbucket.TokenBucket, logger bark.Logger) ExecutionManager {
 	return &workflowExecutionRateLimitedPersistenceClient{
 		persistence: persistence,
 		rateLimiter: rateLimiter,
@@ -104,7 +104,7 @@ func NewWorkflowExecutionPersistenceRateLimitedClient(persistence ExecutionManag
 }
 
 // NewTaskPersistenceRateLimitedClient creates a client to manage tasks
-func NewTaskPersistenceRateLimitedClient(persistence TaskManager, rateLimiter common.TokenBucket, logger bark.Logger) TaskManager {
+func NewTaskPersistenceRateLimitedClient(persistence TaskManager, rateLimiter tokenbucket.TokenBucket, logger bark.Logger) TaskManager {
 	return &taskRateLimitedPersistenceClient{
 		persistence: persistence,
 		rateLimiter: rateLimiter,
@@ -113,7 +113,7 @@ func NewTaskPersistenceRateLimitedClient(persistence TaskManager, rateLimiter co
 }
 
 // NewHistoryPersistenceRateLimitedClient creates a HistoryManager client to manage workflow execution history
-func NewHistoryPersistenceRateLimitedClient(persistence HistoryManager, rateLimiter common.TokenBucket, logger bark.Logger) HistoryManager {
+func NewHistoryPersistenceRateLimitedClient(persistence HistoryManager, rateLimiter tokenbucket.TokenBucket, logger bark.Logger) HistoryManager {
 	return &historyRateLimitedPersistenceClient{
 		persistence: persistence,
 		rateLimiter: rateLimiter,
@@ -122,7 +122,7 @@ func NewHistoryPersistenceRateLimitedClient(persistence HistoryManager, rateLimi
 }
 
 // NewHistoryV2PersistenceRateLimitedClient creates a HistoryManager client to manage workflow execution history
-func NewHistoryV2PersistenceRateLimitedClient(persistence HistoryV2Manager, rateLimiter common.TokenBucket, logger bark.Logger) HistoryV2Manager {
+func NewHistoryV2PersistenceRateLimitedClient(persistence HistoryV2Manager, rateLimiter tokenbucket.TokenBucket, logger bark.Logger) HistoryV2Manager {
 	return &historyV2RateLimitedPersistenceClient{
 		persistence: persistence,
 		rateLimiter: rateLimiter,
@@ -131,7 +131,7 @@ func NewHistoryV2PersistenceRateLimitedClient(persistence HistoryV2Manager, rate
 }
 
 // NewMetadataPersistenceRateLimitedClient creates a MetadataManager client to manage metadata
-func NewMetadataPersistenceRateLimitedClient(persistence MetadataManager, rateLimiter common.TokenBucket, logger bark.Logger) MetadataManager {
+func NewMetadataPersistenceRateLimitedClient(persistence MetadataManager, rateLimiter tokenbucket.TokenBucket, logger bark.Logger) MetadataManager {
 	return &metadataRateLimitedPersistenceClient{
 		persistence: persistence,
 		rateLimiter: rateLimiter,
@@ -140,7 +140,7 @@ func NewMetadataPersistenceRateLimitedClient(persistence MetadataManager, rateLi
 }
 
 // NewVisibilityPersistenceRateLimitedClient creates a client to manage visibility
-func NewVisibilityPersistenceRateLimitedClient(persistence VisibilityManager, rateLimiter common.TokenBucket, logger bark.Logger) VisibilityManager {
+func NewVisibilityPersistenceRateLimitedClient(persistence VisibilityManager, rateLimiter tokenbucket.TokenBucket, logger bark.Logger) VisibilityManager {
 	return &visibilityRateLimitedPersistenceClient{
 		persistence: persistence,
 		rateLimiter: rateLimiter,

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -66,9 +66,6 @@ var keys = map[Key]string{
 	HistoryCountLimitWarn:  "limit.historyCount.warn",
 	MaxIDLengthLimit:       "limit.maxIDLength",
 
-	// common to all services
-	ThrottledLogRPS: "service.throttledLogRPS",
-
 	// frontend settings
 	FrontendPersistenceMaxQPS:      "frontend.persistenceMaxQPS",
 	FrontendVisibilityMaxPageSize:  "frontend.visibilityMaxPageSize",
@@ -79,6 +76,7 @@ var keys = map[Key]string{
 	FrontendHistoryMgrNumConns:     "frontend.historyMgrNumConns",
 	MaxDecisionStartToCloseTimeout: "frontend.maxDecisionStartToCloseTimeout",
 	DisableListVisibilityByFilter:  "frontend.disableListVisibilityByFilter",
+	FrontendThrottledLogRPS:        "frontend.throttledLogRPS",
 
 	// matching settings
 	MatchingRPS:                             "matching.rps",
@@ -93,6 +91,7 @@ var keys = map[Key]string{
 	MatchingOutstandingTaskAppendsThreshold: "matching.outstandingTaskAppendsThreshold",
 	MatchingMaxTaskBatchSize:                "matching.maxTaskBatchSize",
 	MatchingMaxTaskDeleteBatchSize:          "matching.maxTaskDeleteBatchSize",
+	MatchingThrottledLogRPS:                 "matching.throttledLogRPS",
 
 	// history settings
 	HistoryRPS:                                            "history.rps",
@@ -160,6 +159,7 @@ var keys = map[Key]string{
 	EnableEventsV2:                                        "history.enableEventsV2",
 	NumArchiveSystemWorkflows:                             "history.numArchiveSystemWorkflows",
 	EmitShardDiffLog:                                      "history.emitShardDiffLog",
+	HistoryThrottledLogRPS:                                "history.throttledLogRPS",
 
 	WorkerPersistenceMaxQPS:                  "worker.persistenceMaxQPS",
 	WorkerReplicatorConcurrency:              "worker.replicatorConcurrency",
@@ -176,6 +176,7 @@ var keys = map[Key]string{
 	WorkerTargetArchivalBlobSize:             "worker.WorkerTargetArchivalBlobSize",
 	WorkerArchiverConcurrency:                "worker.ArchiverConcurrency",
 	WorkerArchivalsPerIteration:              "worker.ArchivalsPerIteration",
+	WorkerThrottledLogRPS:                    "worker.throttledLogRPS",
 }
 
 const (
@@ -231,11 +232,6 @@ const (
 	// WorkflowType, ActivityType, SignalName, MarkerName, ErrorReason/FailureReason/CancelCause, Identity, RequestID
 	MaxIDLengthLimit
 
-	// common to all services
-
-	// ThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
-	ThrottledLogRPS
-
 	// key for frontend
 
 	// FrontendPersistenceMaxQPS is the max qps frontend host can query DB
@@ -252,6 +248,8 @@ const (
 	FrontendRPS
 	// FrontendHistoryMgrNumConns is for persistence cluster.NumConns
 	FrontendHistoryMgrNumConns
+	// FrontendThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
+	FrontendThrottledLogRPS
 	// MaxDecisionStartToCloseTimeout is max decision timeout in seconds
 	MaxDecisionStartToCloseTimeout
 
@@ -281,6 +279,8 @@ const (
 	MatchingMaxTaskBatchSize
 	// MatchingMaxTaskDeleteBatchSize is the max batch size for range deletion of tasks
 	MatchingMaxTaskDeleteBatchSize
+	// MatchingThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
+	MatchingThrottledLogRPS
 
 	// key for history
 
@@ -414,6 +414,8 @@ const (
 
 	// EnableEventsV2 is whether to use eventsV2
 	EnableEventsV2
+	// HistoryThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
+	HistoryThrottledLogRPS
 
 	// key for worker
 
@@ -447,6 +449,8 @@ const (
 	WorkerArchiverConcurrency
 	// WorkerArchivalsPerIteration controls the number of archivals handled in each iteration of archival workflow
 	WorkerArchivalsPerIteration
+	// WorkerThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
+	WorkerThrottledLogRPS
 
 	// lastKeyForTest must be the last one in this const group for testing purpose
 	lastKeyForTest

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -66,6 +66,9 @@ var keys = map[Key]string{
 	HistoryCountLimitWarn:  "limit.historyCount.warn",
 	MaxIDLengthLimit:       "limit.maxIDLength",
 
+	// common to all services
+	ThrottledLogRPS: "service.throttledLogRPS",
+
 	// frontend settings
 	FrontendPersistenceMaxQPS:      "frontend.persistenceMaxQPS",
 	FrontendVisibilityMaxPageSize:  "frontend.visibilityMaxPageSize",
@@ -227,6 +230,11 @@ const (
 	// MaxIDLengthLimit is the length limit for various IDs, including: Domain, TaskList, WorkflowID, ActivityID, TimerID,
 	// WorkflowType, ActivityType, SignalName, MarkerName, ErrorReason/FailureReason/CancelCause, Identity, RequestID
 	MaxIDLengthLimit
+
+	// common to all services
+
+	// ThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
+	ThrottledLogRPS
 
 	// key for frontend
 

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -58,6 +58,7 @@ type (
 	BootstrapParams struct {
 		Name                string
 		Logger              bark.Logger
+		ThrottledLogger     bark.Logger
 		MetricScope         tally.Scope
 		RingpopFactory      RingpopFactory
 		RPCFactory          common.RPCFactory
@@ -107,8 +108,6 @@ type (
 	}
 )
 
-const defaultThrottledLogRPS = 20
-
 // New instantiates a Service Instance
 // TODO: have a better name for Service.
 func New(params *BootstrapParams) Service {
@@ -116,6 +115,7 @@ func New(params *BootstrapParams) Service {
 		status:                common.DaemonStatusInitialized,
 		sName:                 params.Name,
 		logger:                params.Logger,
+		throttledLogger:       params.ThrottledLogger,
 		rpcFactory:            params.RPCFactory,
 		rpFactory:             params.RingpopFactory,
 		pprofInitializer:      params.PProfInitializer,
@@ -128,8 +128,6 @@ func New(params *BootstrapParams) Service {
 		dynamicCollection:     dynamicconfig.NewCollection(params.DynamicConfig, params.Logger),
 	}
 
-	tlRPS := sVice.dynamicCollection.GetIntProperty(dynamicconfig.ThrottledLogRPS, defaultThrottledLogRPS)
-	sVice.throttledLogger = logging.NewThrottledLogger(params.Logger, tlRPS)
 	sVice.runtimeMetricsReporter = metrics.NewRuntimeMetricsReporter(params.MetricScope, time.Minute, sVice.logger)
 	sVice.dispatcher = sVice.rpcFactory.CreateDispatcher()
 	if sVice.dispatcher == nil {

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -107,6 +107,8 @@ type (
 	}
 )
 
+const defaultThrottledLogRPS = 20
+
 // New instantiates a Service Instance
 // TODO: have a better name for Service.
 func New(params *BootstrapParams) Service {
@@ -114,7 +116,6 @@ func New(params *BootstrapParams) Service {
 		status:                common.DaemonStatusInitialized,
 		sName:                 params.Name,
 		logger:                params.Logger,
-		throttledLogger:       logging.NewThrottledLogger(params.Logger),
 		rpcFactory:            params.RPCFactory,
 		rpFactory:             params.RingpopFactory,
 		pprofInitializer:      params.PProfInitializer,
@@ -126,6 +127,9 @@ func New(params *BootstrapParams) Service {
 		dispatcherProvider:    params.DispatcherProvider,
 		dynamicCollection:     dynamicconfig.NewCollection(params.DynamicConfig, params.Logger),
 	}
+
+	tlRPS := sVice.dynamicCollection.GetIntProperty(dynamicconfig.ThrottledLogRPS, defaultThrottledLogRPS)
+	sVice.throttledLogger = logging.NewThrottledLogger(params.Logger, tlRPS)
 	sVice.runtimeMetricsReporter = metrics.NewRuntimeMetricsReporter(params.MetricScope, time.Minute, sVice.logger)
 	sVice.dispatcher = sVice.rpcFactory.CreateDispatcher()
 	if sVice.dispatcher == nil {

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -96,6 +96,7 @@ type (
 		clientBean             client.Bean
 		numberOfHistoryShards  int
 		logger                 bark.Logger
+		throttledLogger        bark.Logger
 		metricsScope           tally.Scope
 		runtimeMetricsReporter *metrics.RuntimeMetricsReporter
 		metricsClient          metrics.Client
@@ -113,6 +114,7 @@ func New(params *BootstrapParams) Service {
 		status:                common.DaemonStatusInitialized,
 		sName:                 params.Name,
 		logger:                params.Logger,
+		throttledLogger:       logging.NewThrottledLogger(params.Logger),
 		rpcFactory:            params.RPCFactory,
 		rpFactory:             params.RingpopFactory,
 		pprofInitializer:      params.PProfInitializer,
@@ -235,6 +237,10 @@ func (h *serviceImpl) Stop() {
 // GetLogger returns the service logger
 func (h *serviceImpl) GetLogger() bark.Logger {
 	return h.logger
+}
+
+func (h *serviceImpl) GetThrottledLogger() bark.Logger {
+	return h.throttledLogger
 }
 
 func (h *serviceImpl) GetMetricsClient() metrics.Client {

--- a/common/service/serviceTestBase.go
+++ b/common/service/serviceTestBase.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/uber-common/bark"
 
+	"github.com/uber/cadence/common/logging"
 	"go.uber.org/yarpc"
 )
 
@@ -86,6 +87,10 @@ func (s *serviceTestBase) Stop() {
 // GetLogger returns the logger for service
 func (s *serviceTestBase) GetLogger() bark.Logger {
 	return s.logger
+}
+
+func (s *serviceTestBase) GetThrottledLogger() bark.Logger {
+	return logging.NewThrottledLogger(s.logger)
 }
 
 // GetMetricsClient returns the metric client for service

--- a/common/service/serviceTestBase.go
+++ b/common/service/serviceTestBase.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber-common/bark"
 
 	"github.com/uber/cadence/common/logging"
+	"github.com/uber/cadence/common/service/dynamicconfig"
 	"go.uber.org/yarpc"
 )
 
@@ -90,7 +91,7 @@ func (s *serviceTestBase) GetLogger() bark.Logger {
 }
 
 func (s *serviceTestBase) GetThrottledLogger() bark.Logger {
-	return logging.NewThrottledLogger(s.logger)
+	return logging.NewThrottledLogger(s.logger, func(opts ...dynamicconfig.FilterOption) int { return defaultThrottledLogRPS })
 }
 
 // GetMetricsClient returns the metric client for service

--- a/common/service/serviceTestBase.go
+++ b/common/service/serviceTestBase.go
@@ -91,7 +91,7 @@ func (s *serviceTestBase) GetLogger() bark.Logger {
 }
 
 func (s *serviceTestBase) GetThrottledLogger() bark.Logger {
-	return logging.NewThrottledLogger(s.logger, func(opts ...dynamicconfig.FilterOption) int { return defaultThrottledLogRPS })
+	return logging.NewThrottledLogger(s.logger, func(opts ...dynamicconfig.FilterOption) int { return 10 })
 }
 
 // GetMetricsClient returns the metric client for service

--- a/common/service/serviceinterfaces.go
+++ b/common/service/serviceinterfaces.go
@@ -44,6 +44,8 @@ type (
 
 		GetLogger() bark.Logger
 
+		GetThrottledLogger() bark.Logger
+
 		GetMetricsClient() metrics.Client
 
 		GetClientBean() client.Bean

--- a/common/tokenbucket/tb.go
+++ b/common/tokenbucket/tb.go
@@ -18,17 +18,19 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package common
+package tokenbucket
 
 import (
 	"sync"
 	"time"
+
+	"github.com/uber/cadence/common/clock"
 )
 
 type (
-	// TokenBucketFactory is an interface mainly used for injecting mock implementation of TokenBucket for unit testing
-	TokenBucketFactory interface {
-		CreateTokenBucket(rps int, timeSource TimeSource) TokenBucket
+	// Factory is an interface mainly used for injecting mock implementation of TokenBucket for unit testing
+	Factory interface {
+		CreateTokenBucket(rps int, timeSource clock.TimeSource) TokenBucket
 	}
 
 	// TokenBucket is the interface for any implementation of a token bucket rate limiter
@@ -69,7 +71,7 @@ type (
 		overflowTokens         int
 		nextRefillTime         int64
 		nextOverflowRefillTime int64
-		timeSource             TimeSource
+		timeSource             clock.TimeSource
 	}
 
 	priorityTokenBucketImpl struct {
@@ -86,7 +88,7 @@ type (
 		overflowRps            int
 		overflowTokens         int
 		nextOverflowRefillTime int64
-		timeSource             TimeSource
+		timeSource             clock.TimeSource
 	}
 )
 
@@ -95,7 +97,7 @@ const (
 	backoffInterval = int64(10 * time.Millisecond)
 )
 
-// NewTokenBucket creates and returns a
+// New creates and returns a
 // new token bucket rate limiter that
 // replenishes the bucket every 100
 // milliseconds. Thread safe.
@@ -119,7 +121,7 @@ const (
 // BenchmarkTokenBucketParallel-8	10000000	       129 ns/op
 // BenchmarkGolangRateParallel-8 	10000000	       208 ns/op
 //
-func NewTokenBucket(rps int, timeSource TimeSource) TokenBucket {
+func New(rps int, timeSource clock.TimeSource) TokenBucket {
 	tb := new(tokenBucketImpl)
 	tb.timeSource = timeSource
 	tb.fillInterval = int64(time.Millisecond * 100)
@@ -129,8 +131,8 @@ func NewTokenBucket(rps int, timeSource TimeSource) TokenBucket {
 	return tb
 }
 
-// NewTokenBucketFactory creates an instance of factory used for creating TokenBucket instances
-func NewTokenBucketFactory() TokenBucketFactory {
+// NewFactory creates an instance of factory used for creating TokenBucket instances
+func NewFactory() Factory {
 	return &tokenBucketFactoryImpl{}
 }
 
@@ -138,8 +140,8 @@ func NewTokenBucketFactory() TokenBucketFactory {
 // new token bucket rate limiter that
 // repelenishes the bucket every 100
 // milliseconds. Thread safe.
-func (f *tokenBucketFactoryImpl) CreateTokenBucket(rps int, timeSource TimeSource) TokenBucket {
-	return NewTokenBucket(rps, timeSource)
+func (f *tokenBucketFactoryImpl) CreateTokenBucket(rps int, timeSource clock.TimeSource) TokenBucket {
+	return New(rps, timeSource)
 }
 
 func (tb *tokenBucketImpl) TryConsume(count int) (bool, time.Duration) {
@@ -225,7 +227,7 @@ func (tb *tokenBucketImpl) isOverflowRefillDue(now int64) bool {
 // @param rps
 //    Desired rate per second
 //
-func NewPriorityTokenBucket(numOfPriority, rps int, timeSource TimeSource) PriorityTokenBucket {
+func NewPriorityTokenBucket(numOfPriority, rps int, timeSource clock.TimeSource) PriorityTokenBucket {
 	tb := new(priorityTokenBucketImpl)
 	tb.tokens = make([]int, numOfPriority)
 	tb.timeSource = timeSource
@@ -238,7 +240,7 @@ func NewPriorityTokenBucket(numOfPriority, rps int, timeSource TimeSource) Prior
 
 // NewFullPriorityTokenBucket creates and returns a new priority token bucket with all bucket init with full tokens.
 // With all buckets full, get tokens from low priority buckets won't be missed initially, but may caused bursts.
-func NewFullPriorityTokenBucket(numOfPriority, rps int, timeSource TimeSource) PriorityTokenBucket {
+func NewFullPriorityTokenBucket(numOfPriority, rps int, timeSource clock.TimeSource) PriorityTokenBucket {
 	tb := new(priorityTokenBucketImpl)
 	tb.tokens = make([]int, numOfPriority)
 	tb.timeSource = timeSource

--- a/common/tokenbucket/tb_test.go
+++ b/common/tokenbucket/tb_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package common
+package tokenbucket
 
 import (
 	"testing"
@@ -57,7 +57,7 @@ func (ts *mockTimeSource) advance(d time.Duration) {
 
 func (s *TokenBucketSuite) TestRpsEnforced() {
 	ts := &mockTimeSource{currTime: time.Now()}
-	tb := NewTokenBucket(99, ts)
+	tb := New(99, ts)
 	for i := 0; i < 2; i++ {
 		total := 0
 		attempts := 1
@@ -86,7 +86,7 @@ func (s *TokenBucketSuite) TestRpsEnforced() {
 
 func (s *TokenBucketSuite) TestLowRpsEnforced() {
 	ts := &mockTimeSource{currTime: time.Now()}
-	tb := NewTokenBucket(3, ts)
+	tb := New(3, ts)
 
 	total := 0
 	attempts := 1

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
@@ -288,6 +289,7 @@ func (c *cadenceImpl) startFrontend(rpHosts []string, startWG *sync.WaitGroup) {
 	params.DCRedirectionPolicy = config.DCRedirectionPolicy{}
 	params.Name = common.FrontendServiceName
 	params.Logger = c.logger
+	params.ThrottledLogger = logging.NewThrottledLogger(c.logger, func(...dynamicconfig.FilterOption) int { return 10 })
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.FrontendPProfPort())
 	params.RPCFactory = newRPCFactoryImpl(common.FrontendServiceName, c.FrontendAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(common.FrontendServiceName, make(map[string]string))
@@ -345,6 +347,7 @@ func (c *cadenceImpl) startHistory(rpHosts []string, startWG *sync.WaitGroup, en
 		params := new(service.BootstrapParams)
 		params.Name = common.HistoryServiceName
 		params.Logger = c.logger
+		params.ThrottledLogger = logging.NewThrottledLogger(c.logger, func(...dynamicconfig.FilterOption) int { return 10 })
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
 		params.RPCFactory = newRPCFactoryImpl(common.HistoryServiceName, hostport, c.logger)
 		params.MetricScope = tally.NewTestScope(common.HistoryServiceName, make(map[string]string))
@@ -381,6 +384,7 @@ func (c *cadenceImpl) startMatching(rpHosts []string, startWG *sync.WaitGroup) {
 	params := new(service.BootstrapParams)
 	params.Name = common.MatchingServiceName
 	params.Logger = c.logger
+	params.ThrottledLogger = logging.NewThrottledLogger(c.logger, func(...dynamicconfig.FilterOption) int { return 10 })
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.MatchingPProfPort())
 	params.RPCFactory = newRPCFactoryImpl(common.MatchingServiceName, c.MatchingServiceAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(common.MatchingServiceName, make(map[string]string))

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -360,6 +360,7 @@ func (c *cadenceImpl) startHistory(rpHosts []string, startWG *sync.WaitGroup, en
 			DataStores:       map[string]config.DataStore{"test": {Cassandra: &cassandraConfig}},
 		}
 		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, params.Logger))
+		params.DynamicConfig = dynamicconfig.NewNopClient()
 		service := service.New(params)
 		historyConfig := history.NewConfig(dynamicconfig.NewNopCollection(), c.numberOfHistoryShards, c.enableVisibilityToKafka)
 		historyConfig.HistoryMgrNumConns = dynamicconfig.GetIntPropertyFn(c.numberOfHistoryShards)
@@ -394,6 +395,7 @@ func (c *cadenceImpl) startMatching(rpHosts []string, startWG *sync.WaitGroup) {
 		DataStores:       map[string]config.DataStore{"test": {Cassandra: &cassandraConfig}},
 	}
 	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, params.Logger))
+	params.DynamicConfig = dynamicconfig.NewNopClient()
 	service := service.New(params)
 	c.matchingHandler = matching.NewHandler(
 		service, matching.NewConfig(dynamicconfig.NewNopCollection()), c.taskMgr, c.metadataMgr,
@@ -422,6 +424,7 @@ func (c *cadenceImpl) startWorker(rpHosts []string, startWG *sync.WaitGroup) {
 		DataStores:       map[string]config.DataStore{"test": {Cassandra: &cassandraConfig}},
 	}
 	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, params.Logger))
+	params.DynamicConfig = dynamicconfig.NewNopClient()
 	service := service.New(params)
 	service.Start()
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/uber/cadence/.gen/go/cadence/workflowserviceserver"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
@@ -33,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/common/tokenbucket"
 )
 
 // Config represents configuration for cadence-frontend service
@@ -141,7 +143,7 @@ func (s *Service) Start() {
 		visibilityIndexName := params.ESConfig.Indices[common.VisibilityAppName]
 		visibilityFromES = elasticsearch.NewElasticSearchVisibilityManager(params.ESClient, visibilityIndexName, log)
 		// wrap with rate limiter
-		esRateLimiter := common.NewTokenBucket(s.config.PersistenceMaxQPS(), common.NewRealTimeSource())
+		esRateLimiter := tokenbucket.New(s.config.PersistenceMaxQPS(), clock.NewRealTimeSource())
 		visibilityFromES = persistence.NewVisibilityPersistenceRateLimitedClient(visibilityFromES, esRateLimiter, log)
 		// wrap with advanced rate limit for list
 		visibilityConfigForES := &config.VisibilityConfig{

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -47,11 +47,13 @@ import (
 	"github.com/uber/cadence/common/blobstore/blob"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/client"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/tokenbucket"
 	"github.com/uber/cadence/service/worker/archiver"
 	"go.uber.org/yarpc/yarpcerrors"
 )
@@ -72,7 +74,7 @@ type (
 		tokenSerializer   common.TaskTokenSerializer
 		metricsClient     metrics.Client
 		startWG           sync.WaitGroup
-		rateLimiter       common.TokenBucket
+		rateLimiter       tokenbucket.TokenBucket
 		config            *Config
 		domainReplicator  DomainReplicator
 		blobstoreClient   blobstore.Client
@@ -156,7 +158,7 @@ func NewWorkflowHandler(sVice service.Service, config *Config, metadataMgr persi
 		visibilityMgr:    visibilityMgr,
 		tokenSerializer:  common.NewJSONTaskTokenSerializer(),
 		domainCache:      cache.NewDomainCache(metadataMgr, sVice.GetClusterMetadata(), sVice.GetMetricsClient(), sVice.GetLogger()),
-		rateLimiter:      common.NewTokenBucket(config.RPS(), common.NewRealTimeSource()),
+		rateLimiter:      tokenbucket.New(config.RPS(), clock.NewRealTimeSource()),
 		domainReplicator: NewDomainReplicator(kafkaProducer, sVice.GetLogger()),
 		blobstoreClient:  blobstoreClient,
 	}
@@ -965,7 +967,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 
 	if err := common.CheckEventBlobSizeLimit(len(heartbeatRequest.Details), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// heartbeat details exceed size limit, we would fail the activity immediately with explicit error reason
 		failRequest := &gen.RespondActivityTaskFailedRequest{
 			TaskToken: heartbeatRequest.TaskToken,
@@ -1051,7 +1053,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 
 	if err := common.CheckEventBlobSizeLimit(len(heartbeatRequest.Details), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// heartbeat details exceed size limit, we would fail the activity immediately with explicit error reason
 		failRequest := &gen.RespondActivityTaskFailedRequest{
 			TaskToken: token,
@@ -1126,7 +1128,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 
 	if err := common.CheckEventBlobSizeLimit(len(completeRequest.Result), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// result exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
 			TaskToken: completeRequest.TaskToken,
@@ -1214,7 +1216,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 
 	if err := common.CheckEventBlobSizeLimit(len(completeRequest.Result), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// result exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
 			TaskToken: token,
@@ -1288,7 +1290,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 
 	if err := common.CheckEventBlobSizeLimit(len(failedRequest.Details), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// details exceeds blob size limit, we would truncate the details and put a specific error reason
 		failedRequest.Reason = common.StringPtr(common.FailureReasonFailureDetailsExceedsLimit)
 		failedRequest.Details = failedRequest.Details[0:sizeLimitError]
@@ -1363,7 +1365,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 
 	if err := common.CheckEventBlobSizeLimit(len(failedRequest.Details), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// details exceeds blob size limit, we would truncate the details and put a specific error reason
 		failedRequest.Reason = common.StringPtr(common.FailureReasonFailureDetailsExceedsLimit)
 		failedRequest.Details = failedRequest.Details[0:sizeLimitError]
@@ -1427,7 +1429,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 
 	if err := common.CheckEventBlobSizeLimit(len(cancelRequest.Details), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// details exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
 			TaskToken: cancelRequest.TaskToken,
@@ -1514,7 +1516,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 
 	if err := common.CheckEventBlobSizeLimit(len(cancelRequest.Details), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// details exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
 			TaskToken: token,
@@ -1655,7 +1657,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 
 	if err := common.CheckEventBlobSizeLimit(len(failedRequest.Details), sizeLimitWarn, sizeLimitError,
 		taskToken.DomainID, taskToken.WorkflowID, taskToken.RunID,
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		// details exceed, we would just truncate the size for decision task failed as the details is not used anywhere by client code
 		failedRequest.Details = failedRequest.Details[0:sizeLimitError]
 	}
@@ -1820,7 +1822,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	sizeLimitError := wh.config.BlobSizeLimitError(startRequest.GetDomain())
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(startRequest.GetDomain())
 	if err := common.CheckEventBlobSizeLimit(len(startRequest.Input), sizeLimitWarn, sizeLimitError, domainID,
-		startRequest.GetWorkflowId(), "", wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		startRequest.GetWorkflowId(), "", wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		return nil, wh.error(err, scope)
 	}
 
@@ -2058,7 +2060,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(signalRequest.GetDomain())
 	if err := common.CheckEventBlobSizeLimit(len(signalRequest.Input), sizeLimitWarn, sizeLimitError, domainID,
 		signalRequest.GetWorkflowExecution().GetWorkflowId(), signalRequest.GetWorkflowExecution().GetWorkflowId(),
-		wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		return wh.error(err, scope)
 	}
 
@@ -2185,11 +2187,11 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	sizeLimitError := wh.config.BlobSizeLimitError(signalWithStartRequest.GetDomain())
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(signalWithStartRequest.GetDomain())
 	if err := common.CheckEventBlobSizeLimit(len(signalWithStartRequest.SignalInput), sizeLimitWarn, sizeLimitError, domainID,
-		signalWithStartRequest.GetWorkflowId(), "", wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		signalWithStartRequest.GetWorkflowId(), "", wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		return nil, wh.error(err, scope)
 	}
 	if err := common.CheckEventBlobSizeLimit(len(signalWithStartRequest.Input), sizeLimitWarn, sizeLimitError, domainID,
-		signalWithStartRequest.GetWorkflowId(), "", wh.metricsClient, scope, wh.GetLogger()); err != nil {
+		signalWithStartRequest.GetWorkflowId(), "", wh.metricsClient, scope, wh.GetThrottledLogger()); err != nil {
 		return nil, wh.error(err, scope)
 	}
 
@@ -2402,7 +2404,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 					WorkflowID:                    listRequest.ExecutionFilter.GetWorkflowId(),
 				})
 		}
-		logging.LogListOpenWorkflowByFilter(wh.GetLogger(), listRequest.GetDomain(), logging.ListWorkflowFilterByID)
+		logging.LogListOpenWorkflowByFilter(wh.GetThrottledLogger(), listRequest.GetDomain(), logging.ListWorkflowFilterByID)
 	} else if listRequest.TypeFilter != nil {
 		if wh.config.DisableListVisibilityByFilter(domain) {
 			err = errNoPermission
@@ -2412,7 +2414,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 				WorkflowTypeName:              listRequest.TypeFilter.GetName(),
 			})
 		}
-		logging.LogListOpenWorkflowByFilter(wh.GetLogger(), listRequest.GetDomain(), logging.ListWorkflowFilterByType)
+		logging.LogListOpenWorkflowByFilter(wh.GetThrottledLogger(), listRequest.GetDomain(), logging.ListWorkflowFilterByType)
 	} else {
 		persistenceResp, err = wh.visibilityMgr.ListOpenWorkflowExecutions(&baseReq)
 	}
@@ -2803,7 +2805,7 @@ func (wh *WorkflowHandler) getHistory(scope int, domainID string, execution gen.
 		wh.metricsClient.RecordTimer(scope, metrics.HistorySize, time.Duration(size))
 
 		if size > common.GetHistoryWarnSizeLimit {
-			wh.GetLogger().WithFields(bark.Fields{
+			wh.GetThrottledLogger().WithFields(bark.Fields{
 				logging.TagWorkflowExecutionID: execution.GetWorkflowId(),
 				logging.TagWorkflowRunID:       execution.GetRunId(),
 				logging.TagDomainID:            domainID,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1789,7 +1789,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	maxDecisionTimeout := int32(wh.config.MaxDecisionStartToCloseTimeout(startRequest.GetDomain()))
 	// TODO: remove this assignment and logging in future, so that frontend will just return bad request for large decision timeout
 	if startRequest.GetTaskStartToCloseTimeoutSeconds() > startRequest.GetExecutionStartToCloseTimeoutSeconds() {
-		logging.LogDecisionTimeoutLargerThanWorkflowTimeout(wh.Service.GetLogger(),
+		logging.LogDecisionTimeoutLargerThanWorkflowTimeout(wh.Service.GetThrottledLogger(),
 			startRequest.GetTaskStartToCloseTimeoutSeconds(),
 			startRequest.GetDomain(),
 			startRequest.GetWorkflowId(),

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -37,12 +37,14 @@ import (
 	"github.com/uber/cadence/client/public"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/membership"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/tokenbucket"
 	"go.uber.org/yarpc/yarpcerrors"
 )
 
@@ -69,7 +71,7 @@ type (
 		historyEventNotifier  historyEventNotifier
 		publisher             messaging.Producer
 		visibilityProducer    messaging.Producer
-		rateLimiter           common.TokenBucket
+		rateLimiter           tokenbucket.TokenBucket
 		service.Service
 	}
 )
@@ -104,7 +106,7 @@ func NewHandler(sVice service.Service, config *Config, shardManager persistence.
 		visibilityMgr:       visibilityMgr,
 		executionMgrFactory: executionMgrFactory,
 		tokenSerializer:     common.NewJSONTaskTokenSerializer(),
-		rateLimiter:         common.NewTokenBucket(config.RPS(), common.NewRealTimeSource()),
+		rateLimiter:         tokenbucket.New(config.RPS(), clock.NewRealTimeSource()),
 	}
 
 	// prevent us from trying to serve requests before shard controller is started and ready

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -31,6 +31,7 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/logging"
@@ -248,7 +249,7 @@ func (r *historyReplicator) SyncActivity(ctx context.Context, request *h.SyncAct
 	}
 	now := time.Unix(0, eventTime)
 	timerTasks := []persistence.Task{}
-	timeSource := common.NewEventTimeSource()
+	timeSource := clock.NewEventTimeSource()
 	timeSource.Update(now)
 	timerBuilder := newTimerBuilder(r.shard.GetConfig(), r.logger, timeSource)
 	if tt := timerBuilder.GetActivityTimerTaskIfNeeded(msBuilder); tt != nil {
@@ -830,7 +831,7 @@ func (r *historyReplicator) replicateWorkflowStarted(ctx context.Context, contex
 			BranchToken:   msBuilder.GetCurrentBranch(),
 			Events:        history.Events,
 			TransactionID: transactionID,
-		}, msBuilder.GetExecutionInfo().DomainID)
+		}, msBuilder.GetExecutionInfo().DomainID, execution)
 	} else {
 		historySize, err = r.shard.AppendHistoryEvents(&persistence.AppendHistoryEventsRequest{
 			DomainID:          domainID,

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -29,9 +29,11 @@ import (
 
 	"github.com/uber-common/bark"
 	"github.com/uber-go/tally"
+	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
@@ -435,7 +437,8 @@ func (s *TestShardContext) AppendHistoryEvents(request *persistence.AppendHistor
 }
 
 // AppendHistoryV2Events append history V2 events
-func (s *TestShardContext) AppendHistoryV2Events(request *persistence.AppendHistoryNodesRequest, domainID string) (int, error) {
+func (s *TestShardContext) AppendHistoryV2Events(
+	request *persistence.AppendHistoryNodesRequest, domainID string, execution shared.WorkflowExecution) (int, error) {
 	resp, err := s.historyV2Mgr.AppendHistoryNodes(request)
 	return resp.Size, err
 }
@@ -452,6 +455,11 @@ func (s *TestShardContext) GetConfig() *Config {
 
 // GetLogger test implementation
 func (s *TestShardContext) GetLogger() bark.Logger {
+	return s.logger
+}
+
+// GetThrottledLogger returns a throttled logger
+func (s *TestShardContext) GetThrottledLogger() bark.Logger {
 	return s.logger
 }
 
@@ -472,8 +480,8 @@ func (s *TestShardContext) GetRangeID() int64 {
 }
 
 // GetTimeSource test implementation
-func (s *TestShardContext) GetTimeSource() common.TimeSource {
-	return common.NewRealTimeSource()
+func (s *TestShardContext) GetTimeSource() clock.TimeSource {
+	return clock.NewRealTimeSource()
 }
 
 // SetCurrentTime test implementation

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -31,10 +31,12 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/common/tokenbucket"
 )
 
 type (
@@ -59,7 +61,7 @@ type (
 		processor     processor
 		logger        bark.Logger
 		metricsClient metrics.Client
-		rateLimiter   common.TokenBucket // Read rate limiter
+		rateLimiter   tokenbucket.TokenBucket // Read rate limiter
 		ackMgr        queueAckMgr
 		retryPolicy   backoff.RetryPolicy
 
@@ -93,7 +95,7 @@ func newQueueProcessorBase(clusterName string, shard ShardContext, options *Queu
 		shard:                   shard,
 		options:                 options,
 		processor:               processor,
-		rateLimiter:             common.NewTokenBucket(options.MaxPollRPS(), common.NewRealTimeSource()),
+		rateLimiter:             tokenbucket.New(options.MaxPollRPS(), clock.NewRealTimeSource()),
 		workerNotificationChans: workerNotificationChans,
 		status:                  common.DaemonStatusInitialized,
 		notifyCh:                make(chan struct{}, 1),

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/cadence/.gen/go/replicator"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
@@ -309,7 +310,7 @@ func (p *replicatorQueueProcessorImpl) updateAckLevel(ackLevel int64) error {
 
 	// this is a hack, since there is not dedicated ticker on the queue processor
 	// to periodically send out sync shard message, put it here
-	now := common.NewRealTimeSource().Now()
+	now := clock.NewRealTimeSource().Now()
 	if p.lastShardSyncTimestamp.Add(p.shard.GetConfig().ShardSyncMinInterval()).Before(now) {
 		syncStatusTask := &replicator.ReplicationTask{
 			TaskType: replicator.ReplicationTaskType.Ptr(replicator.ReplicationTaskTypeSyncShardStatus),

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
@@ -73,13 +74,14 @@ type (
 		ResetMutableState(request *persistence.ResetMutableStateRequest) error
 		ResetWorkflowExecution(request *persistence.ResetWorkflowExecutionRequest) error
 		AppendHistoryEvents(request *persistence.AppendHistoryEventsRequest) (int, error)
-		AppendHistoryV2Events(request *persistence.AppendHistoryNodesRequest, domainID string) (int, error)
+		AppendHistoryV2Events(request *persistence.AppendHistoryNodesRequest, domainID string, execution shared.WorkflowExecution) (int, error)
 		NotifyNewHistoryEvent(event *historyEventNotification) error
 		GetConfig() *Config
 		GetEventsCache() eventsCache
 		GetLogger() bark.Logger
+		GetThrottledLogger() bark.Logger
 		GetMetricsClient() metrics.Client
-		GetTimeSource() common.TimeSource
+		GetTimeSource() clock.TimeSource
 		SetCurrentTime(cluster string, currentTime time.Time)
 		GetCurrentTime(cluster string) time.Time
 		GetTimerMaxReadLevel(cluster string) time.Time
@@ -102,6 +104,7 @@ type (
 		isClosed         bool
 		config           *Config
 		logger           bark.Logger
+		throttledLogger  bark.Logger
 		metricsClient    metrics.Client
 
 		sync.RWMutex
@@ -122,6 +125,7 @@ var _ ShardContext = (*shardContextImpl)(nil)
 const (
 	logWarnTransferLevelDiff = 3000000 // 3 million
 	logWarnTimerLevelDiff    = time.Duration(30 * time.Minute)
+	historySizeLogThreshold  = 10 * 1024 * 1024
 )
 
 func (s *shardContextImpl) GetShardID() int {
@@ -726,7 +730,8 @@ Reset_Loop:
 	return ErrMaxAttemptsExceeded
 }
 
-func (s *shardContextImpl) AppendHistoryV2Events(request *persistence.AppendHistoryNodesRequest, domainID string) (int, error) {
+func (s *shardContextImpl) AppendHistoryV2Events(
+	request *persistence.AppendHistoryNodesRequest, domainID string, execution shared.WorkflowExecution) (int, error) {
 
 	domainEntry, err := s.domainCache.GetDomainByID(domainID)
 	if err != nil {
@@ -737,6 +742,14 @@ func (s *shardContextImpl) AppendHistoryV2Events(request *persistence.AppendHist
 	size := 0
 	defer func() {
 		s.metricsClient.RecordTimer(metrics.SessionSizeStatsScope, metrics.HistorySize, time.Duration(size))
+		if size >= historySizeLogThreshold {
+			s.throttledLogger.WithFields(bark.Fields{
+				logging.TagDomainID:            domainID,
+				logging.TagWorkflowExecutionID: execution.WorkflowId,
+				logging.TagWorkflowRunID:       execution.RunId,
+				logging.TagHistorySizeBytes:    size,
+			}).Warn("history size threshold breached")
+		}
 	}()
 	resp, err0 := s.historyV2Mgr.AppendHistoryNodes(request)
 	if resp != nil {
@@ -756,6 +769,14 @@ func (s *shardContextImpl) AppendHistoryEvents(request *persistence.AppendHistor
 	size := 0
 	defer func() {
 		s.metricsClient.RecordTimer(metrics.SessionSizeStatsScope, metrics.HistorySize, time.Duration(size))
+		if size >= historySizeLogThreshold {
+			s.throttledLogger.WithFields(bark.Fields{
+				logging.TagDomainID:            request.DomainID,
+				logging.TagWorkflowExecutionID: request.Execution.WorkflowId,
+				logging.TagWorkflowRunID:       request.Execution.RunId,
+				logging.TagHistorySizeBytes:    size,
+			}).Warn("history size threshold breached")
+		}
 	}()
 
 	// No need to lock context here, as we can write concurrently to append history events
@@ -798,6 +819,10 @@ func (s *shardContextImpl) GetEventsCache() eventsCache {
 
 func (s *shardContextImpl) GetLogger() bark.Logger {
 	return s.logger
+}
+
+func (s *shardContextImpl) GetThrottledLogger() bark.Logger {
+	return s.throttledLogger
 }
 
 func (s *shardContextImpl) GetMetricsClient() metrics.Client {
@@ -891,7 +916,7 @@ func (s *shardContextImpl) updateMaxReadLevelLocked(rl int64) {
 
 func (s *shardContextImpl) updateShardInfoLocked() error {
 	var err error
-	now := common.NewRealTimeSource().Now()
+	now := clock.NewRealTimeSource().Now()
 	if s.lastUpdated.Add(s.config.ShardUpdateMinInterval()).After(now) {
 		return nil
 	}
@@ -1014,8 +1039,8 @@ func (s *shardContextImpl) allocateTimerIDsLocked(domainEntry *cache.DomainCache
 	return nil
 }
 
-func (s *shardContextImpl) GetTimeSource() common.TimeSource {
-	return common.NewRealTimeSource()
+func (s *shardContextImpl) GetTimeSource() clock.TimeSource {
+	return clock.NewRealTimeSource()
 }
 
 func (s *shardContextImpl) SetCurrentTime(cluster string, currentTime time.Time) {
@@ -1126,9 +1151,8 @@ func acquireShard(shardItem *historyShardsItem, closeCh chan<- int) (ShardContex
 		standbyClusterCurrentTime: standbyClusterCurrentTime,
 		timerMaxReadLevelMap:      timerMaxReadLevelMap, // use ack to init read level
 	}
-	context.logger = shardItem.logger.WithFields(bark.Fields{
-		logging.TagHistoryShardID: shardItem.shardID,
-	})
+	context.logger = shardItem.logger
+	context.throttledLogger = shardItem.throttledLogger
 	context.eventsCache = newEventsCache(context)
 
 	err1 := context.renewRangeLocked(true)

--- a/service/history/stateBuilder.go
+++ b/service/history/stateBuilder.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/persistence"
 )
@@ -561,7 +562,7 @@ func (b *stateBuilderImpl) getTaskList(msBuilder mutableState) string {
 }
 
 func (b *stateBuilderImpl) getTimerBuilder(event *shared.HistoryEvent) *timerBuilder {
-	timeSource := common.NewEventTimeSource()
+	timeSource := clock.NewEventTimeSource()
 	now := time.Unix(0, event.GetTimestamp())
 	timeSource.Update(now)
 

--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber-common/bark"
 	w "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/persistence"
 )
@@ -71,7 +72,7 @@ type (
 		config                 *Config
 		logger                 bark.Logger
 		localSeqNumGen         SequenceNumberGenerator // This one used to order in-memory list.
-		timeSource             common.TimeSource
+		timeSource             clock.TimeSource
 	}
 
 	// TimerSequenceID - Visibility timer stamp + Sequence Number.
@@ -120,7 +121,7 @@ func (l *localSeqNumGenerator) NextSeq() int64 {
 }
 
 // newTimerBuilder creates a timer builder.
-func newTimerBuilder(config *Config, logger bark.Logger, timeSource common.TimeSource) *timerBuilder {
+func newTimerBuilder(config *Config, logger bark.Logger, timeSource clock.TimeSource) *timerBuilder {
 	return &timerBuilder{
 		userTimers:            timers{},
 		pendingUserTimers:     make(map[string]*persistence.TimerInfo),

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -34,6 +34,7 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
@@ -167,7 +168,7 @@ func (s *timerQueueProcessorSuite) createExecutionWithTimers(domainID string, we
 	timerTasks := []persistence.Task{}
 	timerInfos := []*persistence.TimerInfo{}
 	decisionCompletedID := int64(4)
-	tBuilder := newTimerBuilder(s.ShardContext.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.ShardContext.GetConfig(), s.logger, clock.NewRealTimeSource())
 
 	for _, timeOut := range timeOuts {
 		_, ti := builder.AddTimerStartedEvent(decisionCompletedID,
@@ -338,7 +339,7 @@ func (s *timerQueueProcessorSuite) TestTimerTaskAfterProcessorStart() {
 	processor := s.engineImpl.timerProcessor.(*timerQueueProcessorImpl)
 	processor.Start()
 
-	tBuilder := newTimerBuilder(s.ShardContext.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.ShardContext.GetConfig(), s.logger, clock.NewRealTimeSource())
 	tt := s.addDecisionTimer(domainID, workflowExecution, tBuilder)
 	processor.NotifyNewTimers(cluster.TestCurrentClusterName, s.ShardContext.GetCurrentTime(cluster.TestCurrentClusterName), tt)
 

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber-common/bark"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/messaging"
@@ -458,7 +459,7 @@ func (t *timerQueueStandbyProcessorImpl) getStandbyClusterTime() time.Time {
 }
 
 func (t *timerQueueStandbyProcessorImpl) getTimerBuilder() *timerBuilder {
-	timeSource := common.NewEventTimeSource()
+	timeSource := clock.NewEventTimeSource()
 	now := t.getStandbyClusterTime()
 	timeSource.Update(now)
 	return newTimerBuilder(t.shard.GetConfig(), t.logger, timeSource)

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
@@ -209,7 +210,7 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Pending() 
 	event, timerInfo := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID, int64(timerTimeout.Seconds()))
 	nextEventID := event.GetEventId() + 1
 
-	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, clock.NewRealTimeSource())
 	tBuilder.AddUserTimer(timerInfo, msBuilder)
 	timerTask := &persistence.TimerTaskInfo{
 		Version:             version,
@@ -273,7 +274,7 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Success() 
 	timerTimeout := 2 * time.Second
 	event, timerInfo := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID, int64(timerTimeout.Seconds()))
 
-	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, clock.NewRealTimeSource())
 	tBuilder.AddUserTimer(timerInfo, msBuilder)
 	timerTask := &persistence.TimerTaskInfo{
 		Version:             version,
@@ -334,7 +335,7 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Multiple()
 	timerTimeout2 := 50 * time.Second
 	_, timerInfo2 := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID2, int64(timerTimeout2.Seconds()))
 
-	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, clock.NewRealTimeSource())
 	tBuilder.AddUserTimer(timerInfo1, msBuilder)
 	tBuilder.AddUserTimer(timerInfo2, msBuilder)
 
@@ -397,7 +398,7 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessActivityTimeout_Pending() {
 		int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()))
 	nextEventID := scheduledEvent.GetEventId() + 1
 
-	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, clock.NewRealTimeSource())
 
 	timerTask := &persistence.TimerTaskInfo{
 		Version:             version,
@@ -466,7 +467,7 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessActivityTimeout_Success() {
 		int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()))
 	startedEvent := addActivityTaskStartedEvent(msBuilder, scheduleEvent.GetEventId(), tasklist, identity)
 
-	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, clock.NewRealTimeSource())
 	tBuilder.AddStartToCloseActivityTimeout(timerInfo)
 
 	timerTask := &persistence.TimerTaskInfo{
@@ -541,7 +542,7 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessActivityTimeout_Multiple_Ca
 	activityInfo2.TimerTaskStatus |= TimerTaskStatusCreatedHeartbeat
 	activityInfo2.LastHeartBeatUpdatedTime = time.Now()
 
-	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, common.NewRealTimeSource())
+	tBuilder := newTimerBuilder(s.mockShard.GetConfig(), s.logger, clock.NewRealTimeSource())
 	tBuilder.AddStartToCloseActivityTimeout(timerInfo1)
 	tBuilder.AddScheduleToCloseActivityTimeout(timerInfo2)
 

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -32,9 +32,11 @@ import (
 	gen "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/tokenbucket"
 )
 
 var _ matchingserviceserver.Interface = (*Handler)(nil)
@@ -48,7 +50,7 @@ type Handler struct {
 	metricsClient   metrics.Client
 	startWG         sync.WaitGroup
 	domainCache     cache.DomainCache
-	rateLimiter     common.TokenBucket
+	rateLimiter     tokenbucket.TokenBucket
 	service.Service
 }
 
@@ -63,7 +65,7 @@ func NewHandler(sVice service.Service, config *Config, taskPersistence persisten
 		taskPersistence: taskPersistence,
 		metadataMgr:     metadataMgr,
 		config:          config,
-		rateLimiter:     common.NewTokenBucket(config.RPS(), common.NewRealTimeSource()),
+		rateLimiter:     tokenbucket.New(config.RPS(), clock.NewRealTimeSource()),
 	}
 	// prevent us from trying to serve requests before matching engine is started and ready
 	handler.startWG.Add(1)

--- a/service/worker/replicator/processor.go
+++ b/service/worker/replicator/processor.go
@@ -466,7 +466,7 @@ Loop:
 		}
 	}
 	if !processTask {
-		logger.Warn("Dropping non-targeted history task.")
+		p.metricsClient.IncCounter(metrics.HistoryReplicationTaskScope, metrics.ReplicatorMessagesDropped)
 		return nil
 	}
 


### PR DESCRIPTION
Patch contains the following changes
- New implementation of bark.Logger that throttles the emitted logs
- Noisy logs in frontend now use throttled logger instead of regular logger
- Added new log in shardContext for history-size violations
- To avoid circular dependency, I had to move tokenbucket and timesource into their separate packages. This part of the change is just mechanical