### PR TITLE
Fix losing signal when closing workflow with in-flight decision

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1126,6 +1126,8 @@ func failInFlightDecisionToClearBufferedEvents(msBuilder mutableState) error {
 		if event == nil {
 			return &workflow.InternalServiceError{Message: "Failed to add decision failed event."}
 		}
+
+		return msBuilder.FlushBufferedEvents()
 	}
 	return nil
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1099,7 +1099,7 @@ func (c *decisionBlobSizeChecker) failWorkflowIfBlobSizeExceedsLimit(blob []byte
 		return false, nil
 	}
 
-	err = failInFlightDecisionToCollectSignals(c.msBuilder)
+	err = failInFlightDecisionToClearBufferedEvents(c.msBuilder)
 	if err != nil {
 		return false, err
 	}
@@ -1117,7 +1117,7 @@ func (c *decisionBlobSizeChecker) failWorkflowIfBlobSizeExceedsLimit(blob []byte
 }
 
 // Before closing workflow, if there is a in-flight decision, fail the decision first. So that we don't close the workflow with buffered events
-func failInFlightDecisionToCollectSignals(msBuilder mutableState) error {
+func failInFlightDecisionToClearBufferedEvents(msBuilder mutableState) error {
 	if msBuilder.HasInFlightDecisionTask() {
 		di, _ := msBuilder.GetInFlightDecisionTask()
 
@@ -2504,7 +2504,7 @@ func (e *historyEngineImpl) TerminateWorkflowExecution(ctx context.Context, term
 				return nil, ErrWorkflowCompleted
 			}
 
-			err := failInFlightDecisionToCollectSignals(msBuilder)
+			err := failInFlightDecisionToClearBufferedEvents(msBuilder)
 			if err != nil {
 				return nil, err
 			}

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -29,6 +29,10 @@ import (
 	"github.com/uber/cadence/common/persistence"
 )
 
+const (
+	decisionFailureForBuffered = "FailDecisionToClearBufferedEvents"
+)
+
 type (
 	// TODO: This should be part of persistence layer
 	decisionInfo struct {

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -715,6 +715,11 @@ Update_History_Loop:
 			}
 		}
 
+		err = failInFlightDecisionToCollectSignals(msBuilder)
+		if err != nil {
+			return err
+		}
+
 		timeoutReason := getTimeoutErrorReason(workflow.TimeoutTypeStartToClose)
 		backoffInterval := msBuilder.GetRetryBackoffDuration(timeoutReason)
 		continueAsNewInitiator := workflow.ContinueAsNewInitiatorRetryPolicy

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -715,7 +715,7 @@ Update_History_Loop:
 			}
 		}
 
-		err = failInFlightDecisionToCollectSignals(msBuilder)
+		err = failInFlightDecisionToClearBufferedEvents(msBuilder)
 		if err != nil {
 			return err
 		}

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -531,7 +531,7 @@ func (c *workflowExecutionContextImpl) update(transferTasks []persistence.Task, 
 					return err1
 				}
 
-				err = failInFlightDecisionToCollectSignals(c.msBuilder)
+				err = failInFlightDecisionToClearBufferedEvents(c.msBuilder)
 				if err != nil {
 					return err
 				}

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -531,15 +531,9 @@ func (c *workflowExecutionContextImpl) update(transferTasks []persistence.Task, 
 					return err1
 				}
 
-				// If there is a in-flight decision, fail the decision first. So that we don't close the workflow with buffered events
-				if c.msBuilder.HasInFlightDecisionTask() {
-					di, _ := c.msBuilder.GetInFlightDecisionTask()
-
-					event := c.msBuilder.AddDecisionTaskFailedEvent(di.ScheduleID, di.StartedID, workflow.DecisionTaskFailedCauseResetWorkflow, nil,
-						identityHistoryService, decisionFailureForBuffered, "", "", 0)
-					if event == nil {
-						return &workflow.InternalServiceError{Message: "Failed to add decision failed event."}
-					}
+				err = failInFlightDecisionToCollectSignals(c.msBuilder)
+				if err != nil {
+					return err
 				}
 
 				c.msBuilder.AddWorkflowExecutionTerminatedEvent(&workflow.TerminateWorkflowExecutionRequest{

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -394,7 +394,7 @@ func (w *workflowResetorImpl) terminateIfCurrIsRunning(currMutableState mutableS
 	if currMutableState.IsWorkflowExecutionRunning() {
 		terminateCurr = true
 
-		retError = failInFlightDecisionToCollectSignals(currMutableState)
+		retError = failInFlightDecisionToClearBufferedEvents(currMutableState)
 		if retError != nil {
 			return
 		}


### PR DESCRIPTION
Initially I wanted to centralize it in update() in WFContext. However it won't work for XDC because XDC requires no more events after WF closed.