### PR TITLE
Fix list visibility from ES last page token is not empty

### DIFF
--- a/common/persistence/elasticsearch/elasticsearchVisibility.go
+++ b/common/persistence/elasticsearch/elasticsearchVisibility.go
@@ -324,6 +324,10 @@ func (v *esVisibilityManager) getListWorkflowExecutionsResponse(searchHits *elas
 	actualHits := searchHits.Hits
 	numOfActualHits := len(actualHits)
 
+	if numOfActualHits == 0 {
+		return response, nil
+	}
+
 	nextPageToken, err := v.serializePageToken(&esVisibilityPageToken{From: token.From + numOfActualHits})
 	if err != nil {
 		return nil, err

--- a/common/persistence/elasticsearch/elasticsearchVisibility.go
+++ b/common/persistence/elasticsearch/elasticsearchVisibility.go
@@ -105,7 +105,7 @@ func (v *esVisibilityManager) ListOpenWorkflowExecutions(
 		}
 	}
 
-	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen)
+	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen, request.PageSize)
 }
 
 func (v *esVisibilityManager) ListClosedWorkflowExecutions(
@@ -124,7 +124,7 @@ func (v *esVisibilityManager) ListClosedWorkflowExecutions(
 		}
 	}
 
-	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen)
+	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen, request.PageSize)
 }
 
 func (v *esVisibilityManager) ListOpenWorkflowExecutionsByType(
@@ -144,7 +144,7 @@ func (v *esVisibilityManager) ListOpenWorkflowExecutionsByType(
 		}
 	}
 
-	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen)
+	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen, request.PageSize)
 }
 
 func (v *esVisibilityManager) ListClosedWorkflowExecutionsByType(
@@ -164,7 +164,7 @@ func (v *esVisibilityManager) ListClosedWorkflowExecutionsByType(
 		}
 	}
 
-	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen)
+	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen, request.PageSize)
 }
 
 func (v *esVisibilityManager) ListOpenWorkflowExecutionsByWorkflowID(
@@ -184,7 +184,7 @@ func (v *esVisibilityManager) ListOpenWorkflowExecutionsByWorkflowID(
 		}
 	}
 
-	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen)
+	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen, request.PageSize)
 }
 
 func (v *esVisibilityManager) ListClosedWorkflowExecutionsByWorkflowID(
@@ -204,7 +204,7 @@ func (v *esVisibilityManager) ListClosedWorkflowExecutionsByWorkflowID(
 		}
 	}
 
-	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen)
+	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen, request.PageSize)
 }
 
 func (v *esVisibilityManager) ListClosedWorkflowExecutionsByStatus(
@@ -224,7 +224,7 @@ func (v *esVisibilityManager) ListClosedWorkflowExecutionsByStatus(
 		}
 	}
 
-	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen)
+	return v.getListWorkflowExecutionsResponse(searchResult.Hits, token, isOpen, request.PageSize)
 }
 
 func (v *esVisibilityManager) GetClosedWorkflowExecution(
@@ -318,22 +318,20 @@ func (v *esVisibilityManager) getSearchResult(request *p.ListWorkflowExecutionsR
 }
 
 func (v *esVisibilityManager) getListWorkflowExecutionsResponse(searchHits *elastic.SearchHits,
-	token *esVisibilityPageToken, isOpen bool) (*p.ListWorkflowExecutionsResponse, error) {
+	token *esVisibilityPageToken, isOpen bool, pageSize int) (*p.ListWorkflowExecutionsResponse, error) {
 
 	response := &p.ListWorkflowExecutionsResponse{}
 	actualHits := searchHits.Hits
 	numOfActualHits := len(actualHits)
 
-	if numOfActualHits == 0 {
-		return response, nil
+	if numOfActualHits == pageSize {
+		nextPageToken, err := v.serializePageToken(&esVisibilityPageToken{From: token.From + numOfActualHits})
+		if err != nil {
+			return nil, err
+		}
+		response.NextPageToken = make([]byte, len(nextPageToken))
+		copy(response.NextPageToken, nextPageToken)
 	}
-
-	nextPageToken, err := v.serializePageToken(&esVisibilityPageToken{From: token.From + numOfActualHits})
-	if err != nil {
-		return nil, err
-	}
-	response.NextPageToken = make([]byte, len(nextPageToken))
-	copy(response.NextPageToken, nextPageToken)
 
 	response.Executions = make([]*workflow.WorkflowExecutionInfo, 0)
 	for i := 0; i < numOfActualHits; i++ {

--- a/common/persistence/elasticsearch/elasticsearchVisibility_test.go
+++ b/common/persistence/elasticsearch/elasticsearchVisibility_test.go
@@ -363,7 +363,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 
 	// test for empty hits
 	searchHits := &elastic.SearchHits{}
-	resp, err := s.visibilityMgr.getListWorkflowExecutionsResponse(searchHits, token, isOpen)
+	resp, err := s.visibilityMgr.getListWorkflowExecutionsResponse(searchHits, token, isOpen, 1)
 	s.NoError(err)
 	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(0, len(resp.Executions))
@@ -383,10 +383,16 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 		Source: source,
 	}
 	searchHits.Hits = []*elastic.SearchHit{searchHit}
-	resp, err = s.visibilityMgr.getListWorkflowExecutionsResponse(searchHits, token, isOpen)
+	resp, err = s.visibilityMgr.getListWorkflowExecutionsResponse(searchHits, token, isOpen, 1)
 	s.NoError(err)
 	serializedToken, _ := s.visibilityMgr.serializePageToken(&esVisibilityPageToken{From: 1})
 	s.Equal(serializedToken, resp.NextPageToken)
+	s.Equal(1, len(resp.Executions))
+
+	// test for last page hits
+	resp, err = s.visibilityMgr.getListWorkflowExecutionsResponse(searchHits, token, isOpen, 2)
+	s.NoError(err)
+	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(1, len(resp.Executions))
 }
 

--- a/common/persistence/elasticsearch/elasticsearchVisibility_test.go
+++ b/common/persistence/elasticsearch/elasticsearchVisibility_test.go
@@ -360,13 +360,12 @@ func (s *ESVisibilitySuite) TestGetSearchResult() {
 func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	isOpen := true
 	token := &esVisibilityPageToken{From: 0}
-	serializedToken, _ := s.visibilityMgr.serializePageToken(token)
 
 	// test for empty hits
 	searchHits := &elastic.SearchHits{}
 	resp, err := s.visibilityMgr.getListWorkflowExecutionsResponse(searchHits, token, isOpen)
 	s.NoError(err)
-	s.Equal(serializedToken, resp.NextPageToken)
+	s.Equal(0, len(resp.NextPageToken))
 	s.Equal(0, len(resp.Executions))
 
 	// test for one hits
@@ -386,7 +385,7 @@ func (s *ESVisibilitySuite) TestGetListWorkflowExecutionsResponse() {
 	searchHits.Hits = []*elastic.SearchHit{searchHit}
 	resp, err = s.visibilityMgr.getListWorkflowExecutionsResponse(searchHits, token, isOpen)
 	s.NoError(err)
-	serializedToken, _ = s.visibilityMgr.serializePageToken(&esVisibilityPageToken{From: 1})
+	serializedToken, _ := s.visibilityMgr.serializePageToken(&esVisibilityPageToken{From: 1})
 	s.Equal(serializedToken, resp.NextPageToken)
 	s.Equal(1, len(resp.Executions))
 }


### PR DESCRIPTION
Currently it last page token in response is same as previous request's pageToken, which caused a breaking change to list APIs. 

This PR fix the issue. It returns empty token. 