### PR TITLE
Panic wrapper for handler

### DIFF
--- a/common/logging/panic.go
+++ b/common/logging/panic.go
@@ -1,0 +1,32 @@
+package logging
+
+import (
+	"fmt"
+	"runtime/debug"
+
+	"github.com/uber-common/bark"
+)
+
+var defaultPanicError = fmt.Errorf("panic object is not error")
+
+// This function is used to capture panic, it will log the panic and also return the error through pointer.
+// If the panic value is not error then a default error is returned
+// We have to use pointer is because in golang: "recover return nil if was not called directly by a deferred function."
+// And we have to set the returned error otherwise our handler will return nil as error which is incorrect
+func CapturePanic(logger bark.Logger, retError *error) {
+	if errPanic := recover(); errPanic != nil {
+		err, ok := errPanic.(error)
+		if !ok {
+			err = defaultPanicError
+		}
+
+		st := string(debug.Stack())
+
+		logger.WithFields(bark.Fields{
+			TagStackTrace: st,
+			TagPanicError: err.Error(),
+		}).Errorf("Panic is captured")
+
+		*retError = err
+	}
+}

--- a/common/logging/panic.go
+++ b/common/logging/panic.go
@@ -27,9 +27,9 @@ import (
 	"github.com/uber-common/bark"
 )
 
-var defaultPanicError = fmt.Errorf("panic object is not error")
+var errDefaultPanic = fmt.Errorf("panic object is not error")
 
-// This function is used to capture panic, it will log the panic and also return the error through pointer.
+// CapturePanic is used to capture panic, it will log the panic and also return the error through pointer.
 // If the panic value is not error then a default error is returned
 // We have to use pointer is because in golang: "recover return nil if was not called directly by a deferred function."
 // And we have to set the returned error otherwise our handler will return nil as error which is incorrect
@@ -37,7 +37,7 @@ func CapturePanic(logger bark.Logger, retError *error) {
 	if errPanic := recover(); errPanic != nil {
 		err, ok := errPanic.(error)
 		if !ok {
-			err = defaultPanicError
+			err = errDefaultPanic
 		}
 
 		st := string(debug.Stack())

--- a/common/logging/panic.go
+++ b/common/logging/panic.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package logging
 
 import (

--- a/common/logging/tags.go
+++ b/common/logging/tags.go
@@ -28,6 +28,10 @@ const TagHostname = "hostname"
 
 // Tags
 const (
+	// system tags
+	TagStackTrace = "cadence-stack-trace"
+	TagPanicError = "cadence-panic-error"
+
 	// workflow logging tags
 	TagWorkflowEventID            = "wf-event-id"
 	TagWorkflowComponent          = "wf-component"

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -105,7 +105,8 @@ func (adh *AdminHandler) Stop() {
 }
 
 // DescribeWorkflowExecution returns information about the specified workflow execution.
-func (adh *AdminHandler) DescribeWorkflowExecution(ctx context.Context, request *admin.DescribeWorkflowExecutionRequest) (*admin.DescribeWorkflowExecutionResponse, error) {
+func (adh *AdminHandler) DescribeWorkflowExecution(ctx context.Context, request *admin.DescribeWorkflowExecutionRequest) (resp *admin.DescribeWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(adh.GetLogger(), &retError)
 	scope := metrics.AdminDescribeWorkflowExecutionScope
 	if request == nil {
 		return nil, adh.error(errRequestNotSet, scope)
@@ -127,7 +128,7 @@ func (adh *AdminHandler) DescribeWorkflowExecution(ctx context.Context, request 
 	domainID, err := adh.domainCache.GetDomainID(request.GetDomain())
 
 	historyAddr := historyHost.GetAddress()
-	resp, err := adh.history.DescribeMutableState(ctx, &hist.DescribeMutableStateRequest{
+	resp2, err := adh.history.DescribeMutableState(ctx, &hist.DescribeMutableStateRequest{
 		DomainUUID: &domainID,
 		Execution:  request.Execution,
 	})
@@ -137,13 +138,14 @@ func (adh *AdminHandler) DescribeWorkflowExecution(ctx context.Context, request 
 	return &admin.DescribeWorkflowExecutionResponse{
 		ShardId:                common.StringPtr(shardIDForOutput),
 		HistoryAddr:            common.StringPtr(historyAddr),
-		MutableStateInDatabase: resp.MutableStateInDatabase,
-		MutableStateInCache:    resp.MutableStateInCache,
+		MutableStateInDatabase: resp2.MutableStateInDatabase,
+		MutableStateInCache:    resp2.MutableStateInCache,
 	}, err
 }
 
 // DescribeHistoryHost returns information about the internal states of a history host
-func (adh *AdminHandler) DescribeHistoryHost(ctx context.Context, request *gen.DescribeHistoryHostRequest) (*gen.DescribeHistoryHostResponse, error) {
+func (adh *AdminHandler) DescribeHistoryHost(ctx context.Context, request *gen.DescribeHistoryHostRequest) (resp *gen.DescribeHistoryHostResponse, retError error) {
+	defer logging.CapturePanic(adh.GetLogger(), &retError)
 	scope := metrics.AdminDescribeHistoryHostScope
 	if request == nil || (request.ShardIdForHost == nil && request.ExecutionForHost == nil && request.HostAddress == nil) {
 		return nil, adh.error(errRequestNotSet, scope)
@@ -161,7 +163,8 @@ func (adh *AdminHandler) DescribeHistoryHost(ctx context.Context, request *gen.D
 
 // GetWorkflowExecutionRawHistory - retrieves the history of workflow execution
 func (adh *AdminHandler) GetWorkflowExecutionRawHistory(
-	ctx context.Context, request *admin.GetWorkflowExecutionRawHistoryRequest) (*admin.GetWorkflowExecutionRawHistoryResponse, error) {
+	ctx context.Context, request *admin.GetWorkflowExecutionRawHistoryRequest) (resp *admin.GetWorkflowExecutionRawHistoryResponse, retError error) {
+	defer logging.CapturePanic(adh.GetLogger(), &retError)
 
 	scope := metrics.AdminGetWorkflowExecutionRawHistoryScope
 	sw := adh.startRequestProfile(scope)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -220,7 +220,8 @@ func (wh *WorkflowHandler) checkPermission(securityToken *string, scope int) err
 // entity within Cadence, used as a container for all resources like workflow executions, tasklists, etc.  Domain
 // acts as a sandbox and provides isolation for all resources within the domain.  All resources belongs to exactly one
 // domain.
-func (wh *WorkflowHandler) RegisterDomain(ctx context.Context, registerRequest *gen.RegisterDomainRequest) error {
+func (wh *WorkflowHandler) RegisterDomain(ctx context.Context, registerRequest *gen.RegisterDomainRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 	scope := metrics.FrontendRegisterDomainScope
 	sw := wh.startRequestProfile(scope)
 	defer sw.Stop()
@@ -348,7 +349,8 @@ func (wh *WorkflowHandler) RegisterDomain(ctx context.Context, registerRequest *
 
 // ListDomains returns the information and configuration for a registered domain.
 func (wh *WorkflowHandler) ListDomains(ctx context.Context,
-	listRequest *gen.ListDomainsRequest) (*gen.ListDomainsResponse, error) {
+	listRequest *gen.ListDomainsRequest) (response *gen.ListDomainsResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 	scope := metrics.FrontendListDomainsScope
 	sw := wh.startRequestProfile(scope)
 	defer sw.Stop()
@@ -381,7 +383,7 @@ func (wh *WorkflowHandler) ListDomains(ctx context.Context,
 		domains = append(domains, desc)
 	}
 
-	response := &gen.ListDomainsResponse{
+	response = &gen.ListDomainsResponse{
 		Domains:       domains,
 		NextPageToken: resp.NextPageToken,
 	}
@@ -391,8 +393,8 @@ func (wh *WorkflowHandler) ListDomains(ctx context.Context,
 
 // DescribeDomain returns the information and configuration for a registered domain.
 func (wh *WorkflowHandler) DescribeDomain(ctx context.Context,
-	describeRequest *gen.DescribeDomainRequest) (*gen.DescribeDomainResponse, error) {
-
+	describeRequest *gen.DescribeDomainRequest) (response *gen.DescribeDomainResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 	scope := metrics.FrontendDescribeDomainScope
 	sw := wh.startRequestProfile(scope)
 	defer sw.Stop()
@@ -411,7 +413,7 @@ func (wh *WorkflowHandler) DescribeDomain(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	response := &gen.DescribeDomainResponse{
+	response = &gen.DescribeDomainResponse{
 		IsGlobalDomain:  common.BoolPtr(resp.IsGlobalDomain),
 		FailoverVersion: common.Int64Ptr(resp.FailoverVersion),
 	}
@@ -423,7 +425,8 @@ func (wh *WorkflowHandler) DescribeDomain(ctx context.Context,
 
 // UpdateDomain is used to update the information and configuration for a registered domain.
 func (wh *WorkflowHandler) UpdateDomain(ctx context.Context,
-	updateRequest *gen.UpdateDomainRequest) (*gen.UpdateDomainResponse, error) {
+	updateRequest *gen.UpdateDomainRequest) (resp *gen.UpdateDomainResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendUpdateDomainScope
 	sw := wh.startRequestProfile(scope)
@@ -676,7 +679,8 @@ func (wh *WorkflowHandler) mergeDomainData(old map[string]string, new map[string
 // DeprecateDomain us used to update status of a registered domain to DEPRECATED.  Once the domain is deprecated
 // it cannot be used to start new workflow executions.  Existing workflow executions will continue to run on
 // deprecated domains.
-func (wh *WorkflowHandler) DeprecateDomain(ctx context.Context, deprecateRequest *gen.DeprecateDomainRequest) error {
+func (wh *WorkflowHandler) DeprecateDomain(ctx context.Context, deprecateRequest *gen.DeprecateDomainRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendDeprecateDomainScope
 	sw := wh.startRequestProfile(scope)
@@ -749,7 +753,8 @@ func (wh *WorkflowHandler) DeprecateDomain(ctx context.Context, deprecateRequest
 // PollForActivityTask - Poll for an activity task.
 func (wh *WorkflowHandler) PollForActivityTask(
 	ctx context.Context,
-	pollRequest *gen.PollForActivityTaskRequest) (*gen.PollForActivityTaskResponse, error) {
+	pollRequest *gen.PollForActivityTaskRequest) (resp *gen.PollForActivityTaskResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	callTime := time.Now()
 
@@ -791,7 +796,6 @@ func (wh *WorkflowHandler) PollForActivityTask(
 	}
 
 	pollerID := uuid.New()
-	var resp *gen.PollForActivityTaskResponse
 	op := func() error {
 		var err error
 		resp, err = wh.matching.PollForActivityTask(ctx, &m.PollForActivityTaskRequest{
@@ -826,7 +830,8 @@ func (wh *WorkflowHandler) PollForActivityTask(
 // PollForDecisionTask - Poll for a decision task.
 func (wh *WorkflowHandler) PollForDecisionTask(
 	ctx context.Context,
-	pollRequest *gen.PollForDecisionTaskRequest) (*gen.PollForDecisionTaskResponse, error) {
+	pollRequest *gen.PollForDecisionTaskRequest) (resp *gen.PollForDecisionTaskResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	callTime := time.Now()
 
@@ -905,7 +910,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 	}
 
 	eventStoreVersion := matchingResp.GetEventStoreVersion()
-	resp, err := wh.createPollForDecisionTaskResponse(ctx, scope, domainID, matchingResp, eventStoreVersion, matchingResp.GetBranchToken())
+	resp, err = wh.createPollForDecisionTaskResponse(ctx, scope, domainID, matchingResp, eventStoreVersion, matchingResp.GetBranchToken())
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -941,6 +946,7 @@ func (wh *WorkflowHandler) cancelOutstandingPoll(ctx context.Context, err error,
 func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 	ctx context.Context,
 	heartbeatRequest *gen.RecordActivityTaskHeartbeatRequest) (resp *gen.RecordActivityTaskHeartbeatResponse, err error) {
+	defer logging.CapturePanic(wh.GetLogger(), &err)
 
 	scope := metrics.FrontendRecordActivityTaskHeartbeatScope
 	sw := wh.startRequestProfile(scope)
@@ -1008,6 +1014,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 	ctx context.Context,
 	heartbeatRequest *gen.RecordActivityTaskHeartbeatByIDRequest) (resp *gen.RecordActivityTaskHeartbeatResponse, err error) {
+	defer logging.CapturePanic(wh.GetLogger(), &err)
 
 	scope := metrics.FrontendRecordActivityTaskHeartbeatByIDScope
 	sw := wh.startRequestProfile(scope)
@@ -1099,7 +1106,8 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 // RespondActivityTaskCompleted - response to an activity task
 func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	ctx context.Context,
-	completeRequest *gen.RespondActivityTaskCompletedRequest) error {
+	completeRequest *gen.RespondActivityTaskCompletedRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondActivityTaskCompletedScope
 	sw := wh.startRequestProfile(scope)
@@ -1167,7 +1175,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 // RespondActivityTaskCompletedByID - response to an activity task
 func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 	ctx context.Context,
-	completeRequest *gen.RespondActivityTaskCompletedByIDRequest) error {
+	completeRequest *gen.RespondActivityTaskCompletedByIDRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondActivityTaskCompletedByIDScope
 	sw := wh.startRequestProfile(scope)
@@ -1261,7 +1270,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 // RespondActivityTaskFailed - response to an activity task failure
 func (wh *WorkflowHandler) RespondActivityTaskFailed(
 	ctx context.Context,
-	failedRequest *gen.RespondActivityTaskFailedRequest) error {
+	failedRequest *gen.RespondActivityTaskFailedRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondActivityTaskFailedScope
 	sw := wh.startRequestProfile(scope)
@@ -1317,7 +1327,8 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 // RespondActivityTaskFailedByID - response to an activity task failure
 func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 	ctx context.Context,
-	failedRequest *gen.RespondActivityTaskFailedByIDRequest) error {
+	failedRequest *gen.RespondActivityTaskFailedByIDRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondActivityTaskFailedByIDScope
 	sw := wh.startRequestProfile(scope)
@@ -1399,7 +1410,8 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 // RespondActivityTaskCanceled - called to cancel an activity task
 func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 	ctx context.Context,
-	cancelRequest *gen.RespondActivityTaskCanceledRequest) error {
+	cancelRequest *gen.RespondActivityTaskCanceledRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondActivityTaskCanceledScope
 	sw := wh.startRequestProfile(scope)
@@ -1468,7 +1480,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 // RespondActivityTaskCanceledByID - called to cancel an activity task
 func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 	ctx context.Context,
-	cancelRequest *gen.RespondActivityTaskCanceledByIDRequest) error {
+	cancelRequest *gen.RespondActivityTaskCanceledByIDRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondActivityTaskCanceledScope
 	sw := wh.startRequestProfile(scope)
@@ -1561,7 +1574,8 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 // RespondDecisionTaskCompleted - response to a decision task
 func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 	ctx context.Context,
-	completeRequest *gen.RespondDecisionTaskCompletedRequest) (*gen.RespondDecisionTaskCompletedResponse, error) {
+	completeRequest *gen.RespondDecisionTaskCompletedRequest) (resp *gen.RespondDecisionTaskCompletedResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondDecisionTaskCompletedScope
 	sw := wh.startRequestProfile(scope)
@@ -1627,7 +1641,8 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 // RespondDecisionTaskFailed - failed response to a decision task
 func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 	ctx context.Context,
-	failedRequest *gen.RespondDecisionTaskFailedRequest) error {
+	failedRequest *gen.RespondDecisionTaskFailedRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondDecisionTaskFailedScope
 	sw := wh.startRequestProfile(scope)
@@ -1683,7 +1698,8 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 // RespondQueryTaskCompleted - response to a query task
 func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 	ctx context.Context,
-	completeRequest *gen.RespondQueryTaskCompletedRequest) error {
+	completeRequest *gen.RespondQueryTaskCompletedRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRespondQueryTaskCompletedScope
 	sw := wh.startRequestProfile(scope)
@@ -1724,7 +1740,8 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 // StartWorkflowExecution - Creates a new workflow execution
 func (wh *WorkflowHandler) StartWorkflowExecution(
 	ctx context.Context,
-	startRequest *gen.StartWorkflowExecutionRequest) (*gen.StartWorkflowExecutionResponse, error) {
+	startRequest *gen.StartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendStartWorkflowExecutionScope
 	sw := wh.startRequestProfile(scope)
@@ -1836,7 +1853,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 
 	wh.Service.GetLogger().Debugf("Start workflow execution request domainID: %v", domainID)
 
-	resp, err := wh.history.StartWorkflowExecution(ctx, common.CreateHistoryStartWorkflowRequest(domainID, startRequest))
+	resp, err = wh.history.StartWorkflowExecution(ctx, common.CreateHistoryStartWorkflowRequest(domainID, startRequest))
 
 	if err != nil {
 		return nil, wh.error(err, scope)
@@ -1847,7 +1864,8 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 // GetWorkflowExecutionHistory - retrieves the history of workflow execution
 func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 	ctx context.Context,
-	getRequest *gen.GetWorkflowExecutionHistoryRequest) (*gen.GetWorkflowExecutionHistoryResponse, error) {
+	getRequest *gen.GetWorkflowExecutionHistoryRequest) (resp *gen.GetWorkflowExecutionHistoryResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendGetWorkflowExecutionHistoryScope
 	sw := wh.startRequestProfile(scope)
@@ -2025,7 +2043,8 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 // SignalWorkflowExecution is used to send a signal event to running workflow execution.  This results in
 // WorkflowExecutionSignaled event recorded in the history and a decision task being created for the execution.
 func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
-	signalRequest *gen.SignalWorkflowExecutionRequest) error {
+	signalRequest *gen.SignalWorkflowExecutionRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendSignalWorkflowExecutionScope
 	sw := wh.startRequestProfile(scope)
@@ -2093,7 +2112,8 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 // If workflow is not running or not found, this results in WorkflowExecutionStarted and WorkflowExecutionSignaled
 // event recorded in history, and a decision task being created for the execution
 func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
-	signalWithStartRequest *gen.SignalWithStartWorkflowExecutionRequest) (*gen.StartWorkflowExecutionResponse, error) {
+	signalWithStartRequest *gen.SignalWithStartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendSignalWithStartWorkflowExecutionScope
 	sw := wh.startRequestProfile(scope)
@@ -2207,7 +2227,6 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	var resp *gen.StartWorkflowExecutionResponse
 	op := func() error {
 		var err error
 		resp, err = wh.history.SignalWithStartWorkflowExecution(ctx, &h.SignalWithStartWorkflowExecutionRequest{
@@ -2228,7 +2247,8 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 // TerminateWorkflowExecution terminates an existing workflow execution by recording WorkflowExecutionTerminated event
 // in the history and immediately terminating the execution instance.
 func (wh *WorkflowHandler) TerminateWorkflowExecution(ctx context.Context,
-	terminateRequest *gen.TerminateWorkflowExecutionRequest) error {
+	terminateRequest *gen.TerminateWorkflowExecutionRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendTerminateWorkflowExecutionScope
 	sw := wh.startRequestProfile(scope)
@@ -2269,7 +2289,8 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(ctx context.Context,
 // ResetWorkflowExecution reset an existing workflow execution to the nextFirstEventID
 // in the history and immediately terminating the current execution instance.
 func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context,
-	resetRequest *gen.ResetWorkflowExecutionRequest) (*gen.ResetWorkflowExecutionResponse, error) {
+	resetRequest *gen.ResetWorkflowExecutionRequest) (resp *gen.ResetWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendResetWorkflowExecutionScope
 	sw := wh.startRequestProfile(scope)
@@ -2296,7 +2317,6 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	var resp *gen.ResetWorkflowExecutionResponse
 	resp, err = wh.history.ResetWorkflowExecution(ctx, &h.ResetWorkflowExecutionRequest{
 		DomainUUID:   common.StringPtr(domainID),
 		ResetRequest: resetRequest,
@@ -2311,7 +2331,8 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context,
 // RequestCancelWorkflowExecution - requests to cancel a workflow execution
 func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 	ctx context.Context,
-	cancelRequest *gen.RequestCancelWorkflowExecutionRequest) error {
+	cancelRequest *gen.RequestCancelWorkflowExecutionRequest) (retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendRequestCancelWorkflowExecutionScope
 	sw := wh.startRequestProfile(scope)
@@ -2351,7 +2372,8 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 
 // ListOpenWorkflowExecutions - retrieves info for open workflow executions in a domain
 func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
-	listRequest *gen.ListOpenWorkflowExecutionsRequest) (*gen.ListOpenWorkflowExecutionsResponse, error) {
+	listRequest *gen.ListOpenWorkflowExecutionsRequest) (resp *gen.ListOpenWorkflowExecutionsResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendListOpenWorkflowExecutionsScope
 	sw := wh.startRequestProfile(scope)
@@ -2435,7 +2457,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	resp := &gen.ListOpenWorkflowExecutionsResponse{}
+	resp = &gen.ListOpenWorkflowExecutionsResponse{}
 	resp.Executions = persistenceResp.Executions
 	resp.NextPageToken = persistenceResp.NextPageToken
 	return resp, nil
@@ -2443,7 +2465,8 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 
 // ListClosedWorkflowExecutions - retrieves info for closed workflow executions in a domain
 func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
-	listRequest *gen.ListClosedWorkflowExecutionsRequest) (*gen.ListClosedWorkflowExecutionsResponse, error) {
+	listRequest *gen.ListClosedWorkflowExecutionsRequest) (resp *gen.ListClosedWorkflowExecutionsResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendListClosedWorkflowExecutionsScope
 	sw := wh.startRequestProfile(scope)
@@ -2548,14 +2571,16 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	resp := &gen.ListClosedWorkflowExecutionsResponse{}
+	resp = &gen.ListClosedWorkflowExecutionsResponse{}
 	resp.Executions = persistenceResp.Executions
 	resp.NextPageToken = persistenceResp.NextPageToken
 	return resp, nil
 }
 
 // ResetStickyTaskList reset the volatile information in mutable state of a given workflow.
-func (wh *WorkflowHandler) ResetStickyTaskList(ctx context.Context, resetRequest *gen.ResetStickyTaskListRequest) (*gen.ResetStickyTaskListResponse, error) {
+func (wh *WorkflowHandler) ResetStickyTaskList(ctx context.Context, resetRequest *gen.ResetStickyTaskListRequest) (resp *gen.ResetStickyTaskListResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
+
 	scope := metrics.FrontendResetStickyTaskListScope
 	sw := wh.startRequestProfile(scope)
 	defer sw.Stop()
@@ -2589,7 +2614,8 @@ func (wh *WorkflowHandler) ResetStickyTaskList(ctx context.Context, resetRequest
 
 // QueryWorkflow returns query result for a specified workflow execution
 func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
-	queryRequest *gen.QueryWorkflowRequest) (*gen.QueryWorkflowResponse, error) {
+	queryRequest *gen.QueryWorkflowRequest) (resp *gen.QueryWorkflowResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendQueryWorkflowScope
 	sw := wh.startRequestProfile(scope)
@@ -2688,7 +2714,8 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
 }
 
 // DescribeWorkflowExecution returns information about the specified workflow execution.
-func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, request *gen.DescribeWorkflowExecutionRequest) (*gen.DescribeWorkflowExecutionResponse, error) {
+func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, request *gen.DescribeWorkflowExecutionRequest) (resp *gen.DescribeWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendDescribeWorkflowExecutionScope
 	sw := wh.startRequestProfile(scope)
@@ -2729,7 +2756,8 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 // DescribeTaskList returns information about the target tasklist, right now this API returns the
 // pollers which polled this tasklist in last few minutes. If includeTaskListStatus field is true,
 // it will also return status of tasklist's ackManager (readLevel, ackLevel, backlogCountHint and taskIDBlock).
-func (wh *WorkflowHandler) DescribeTaskList(ctx context.Context, request *gen.DescribeTaskListRequest) (*gen.DescribeTaskListResponse, error) {
+func (wh *WorkflowHandler) DescribeTaskList(ctx context.Context, request *gen.DescribeTaskListRequest) (resp *gen.DescribeTaskListResponse, retError error) {
+	defer logging.CapturePanic(wh.GetLogger(), &retError)
 
 	scope := metrics.FrontendDescribeTaskListScope
 	sw := wh.startRequestProfile(scope)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -204,7 +204,8 @@ func (h *Handler) Health(ctx context.Context) (*health.HealthStatus, error) {
 
 // RecordActivityTaskHeartbeat - Record Activity Task Heart beat.
 func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context,
-	wrappedRequest *hist.RecordActivityTaskHeartbeatRequest) (*gen.RecordActivityTaskHeartbeatResponse, error) {
+	wrappedRequest *hist.RecordActivityTaskHeartbeatRequest) (resp *gen.RecordActivityTaskHeartbeatResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRecordActivityTaskHeartbeatScope
@@ -249,7 +250,8 @@ func (h *Handler) RecordActivityTaskHeartbeat(ctx context.Context,
 
 // RecordActivityTaskStarted - Record Activity Task started.
 func (h *Handler) RecordActivityTaskStarted(ctx context.Context,
-	recordRequest *hist.RecordActivityTaskStartedRequest) (*hist.RecordActivityTaskStartedResponse, error) {
+	recordRequest *hist.RecordActivityTaskStartedRequest) (resp *hist.RecordActivityTaskStartedResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRecordActivityTaskStartedScope
@@ -283,7 +285,8 @@ func (h *Handler) RecordActivityTaskStarted(ctx context.Context,
 
 // RecordDecisionTaskStarted - Record Decision Task started.
 func (h *Handler) RecordDecisionTaskStarted(ctx context.Context,
-	recordRequest *hist.RecordDecisionTaskStartedRequest) (*hist.RecordDecisionTaskStartedResponse, error) {
+	recordRequest *hist.RecordDecisionTaskStartedRequest) (resp *hist.RecordDecisionTaskStartedResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 	h.Service.GetLogger().Debugf("RecordDecisionTaskStarted. DomainID: %v, WorkflowID: %v, RunID: %v, ScheduleID: %v",
 		recordRequest.GetDomainUUID(),
@@ -331,7 +334,8 @@ func (h *Handler) RecordDecisionTaskStarted(ctx context.Context,
 
 // RespondActivityTaskCompleted - records completion of an activity task
 func (h *Handler) RespondActivityTaskCompleted(ctx context.Context,
-	wrappedRequest *hist.RespondActivityTaskCompletedRequest) error {
+	wrappedRequest *hist.RespondActivityTaskCompletedRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRespondActivityTaskCompletedScope
@@ -376,7 +380,8 @@ func (h *Handler) RespondActivityTaskCompleted(ctx context.Context,
 
 // RespondActivityTaskFailed - records failure of an activity task
 func (h *Handler) RespondActivityTaskFailed(ctx context.Context,
-	wrappedRequest *hist.RespondActivityTaskFailedRequest) error {
+	wrappedRequest *hist.RespondActivityTaskFailedRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRespondActivityTaskFailedScope
@@ -421,7 +426,8 @@ func (h *Handler) RespondActivityTaskFailed(ctx context.Context,
 
 // RespondActivityTaskCanceled - records failure of an activity task
 func (h *Handler) RespondActivityTaskCanceled(ctx context.Context,
-	wrappedRequest *hist.RespondActivityTaskCanceledRequest) error {
+	wrappedRequest *hist.RespondActivityTaskCanceledRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRespondActivityTaskCanceledScope
@@ -466,7 +472,8 @@ func (h *Handler) RespondActivityTaskCanceled(ctx context.Context,
 
 // RespondDecisionTaskCompleted - records completion of a decision task
 func (h *Handler) RespondDecisionTaskCompleted(ctx context.Context,
-	wrappedRequest *hist.RespondDecisionTaskCompletedRequest) (*hist.RespondDecisionTaskCompletedResponse, error) {
+	wrappedRequest *hist.RespondDecisionTaskCompletedRequest) (resp *hist.RespondDecisionTaskCompletedResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRespondDecisionTaskCompletedScope
@@ -517,7 +524,8 @@ func (h *Handler) RespondDecisionTaskCompleted(ctx context.Context,
 
 // RespondDecisionTaskFailed - failed response to decision task
 func (h *Handler) RespondDecisionTaskFailed(ctx context.Context,
-	wrappedRequest *hist.RespondDecisionTaskFailedRequest) error {
+	wrappedRequest *hist.RespondDecisionTaskFailedRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRespondDecisionTaskFailedScope
@@ -568,7 +576,8 @@ func (h *Handler) RespondDecisionTaskFailed(ctx context.Context,
 
 // StartWorkflowExecution - creates a new workflow execution
 func (h *Handler) StartWorkflowExecution(ctx context.Context,
-	wrappedRequest *hist.StartWorkflowExecutionRequest) (*gen.StartWorkflowExecutionResponse, error) {
+	wrappedRequest *hist.StartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryStartWorkflowExecutionScope
@@ -602,7 +611,8 @@ func (h *Handler) StartWorkflowExecution(ctx context.Context,
 
 // DescribeHistoryHost returns information about the internal states of a history host
 func (h *Handler) DescribeHistoryHost(ctx context.Context,
-	request *gen.DescribeHistoryHostRequest) (*gen.DescribeHistoryHostResponse, error) {
+	request *gen.DescribeHistoryHostRequest) (resp *gen.DescribeHistoryHostResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	numOfItemsInCacheByID, numOfItemsInCacheByName := h.domainCache.GetCacheSize()
@@ -623,7 +633,7 @@ func (h *Handler) DescribeHistoryHost(ctx context.Context,
 		status += "not stopping"
 	}
 
-	resp := &gen.DescribeHistoryHostResponse{
+	resp = &gen.DescribeHistoryHostResponse{
 		NumberOfShards: common.Int32Ptr(int32(h.controller.numShards())),
 		ShardIDs:       h.controller.shardIDs(),
 		DomainCache: &gen.DomainCacheInfo{
@@ -638,7 +648,8 @@ func (h *Handler) DescribeHistoryHost(ctx context.Context,
 
 // DescribeMutableState - returns the internal analysis of workflow execution state
 func (h *Handler) DescribeMutableState(ctx context.Context,
-	request *hist.DescribeMutableStateRequest) (*hist.DescribeMutableStateResponse, error) {
+	request *hist.DescribeMutableStateRequest) (resp *hist.DescribeMutableStateResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRecordActivityTaskHeartbeatScope
@@ -667,7 +678,8 @@ func (h *Handler) DescribeMutableState(ctx context.Context,
 
 // GetMutableState - returns the id of the next event in the execution's history
 func (h *Handler) GetMutableState(ctx context.Context,
-	getRequest *hist.GetMutableStateRequest) (*hist.GetMutableStateResponse, error) {
+	getRequest *hist.GetMutableStateRequest) (resp *hist.GetMutableStateResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryGetMutableStateScope
@@ -699,7 +711,8 @@ func (h *Handler) GetMutableState(ctx context.Context,
 }
 
 // DescribeWorkflowExecution returns information about the specified workflow execution.
-func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *hist.DescribeWorkflowExecutionRequest) (*gen.DescribeWorkflowExecutionResponse, error) {
+func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *hist.DescribeWorkflowExecutionRequest) (resp *gen.DescribeWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryDescribeWorkflowExecutionScope
@@ -732,7 +745,8 @@ func (h *Handler) DescribeWorkflowExecution(ctx context.Context, request *hist.D
 
 // RequestCancelWorkflowExecution - requests cancellation of a workflow
 func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context,
-	request *hist.RequestCancelWorkflowExecutionRequest) error {
+	request *hist.RequestCancelWorkflowExecutionRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRequestCancelWorkflowExecutionScope
@@ -773,7 +787,8 @@ func (h *Handler) RequestCancelWorkflowExecution(ctx context.Context,
 // SignalWorkflowExecution is used to send a signal event to running workflow execution.  This results in
 // WorkflowExecutionSignaled event recorded in the history and a decision task being created for the execution.
 func (h *Handler) SignalWorkflowExecution(ctx context.Context,
-	wrappedRequest *hist.SignalWorkflowExecutionRequest) error {
+	wrappedRequest *hist.SignalWorkflowExecutionRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistorySignalWorkflowExecutionScope
@@ -811,7 +826,8 @@ func (h *Handler) SignalWorkflowExecution(ctx context.Context,
 // If workflow is not running or not found, this results in WorkflowExecutionStarted and WorkflowExecutionSignaled
 // event recorded in history, and a decision task being created for the execution
 func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context,
-	wrappedRequest *hist.SignalWithStartWorkflowExecutionRequest) (*gen.StartWorkflowExecutionResponse, error) {
+	wrappedRequest *hist.SignalWithStartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistorySignalWithStartWorkflowExecutionScope
@@ -846,7 +862,8 @@ func (h *Handler) SignalWithStartWorkflowExecution(ctx context.Context,
 // RemoveSignalMutableState is used to remove a signal request ID that was previously recorded.  This is currently
 // used to clean execution info when signal decision finished.
 func (h *Handler) RemoveSignalMutableState(ctx context.Context,
-	wrappedRequest *hist.RemoveSignalMutableStateRequest) error {
+	wrappedRequest *hist.RemoveSignalMutableStateRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRemoveSignalMutableStateScope
@@ -881,7 +898,8 @@ func (h *Handler) RemoveSignalMutableState(ctx context.Context,
 // TerminateWorkflowExecution terminates an existing workflow execution by recording WorkflowExecutionTerminated event
 // in the history and immediately terminating the execution instance.
 func (h *Handler) TerminateWorkflowExecution(ctx context.Context,
-	wrappedRequest *hist.TerminateWorkflowExecutionRequest) error {
+	wrappedRequest *hist.TerminateWorkflowExecutionRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryTerminateWorkflowExecutionScope
@@ -916,7 +934,8 @@ func (h *Handler) TerminateWorkflowExecution(ctx context.Context,
 // ResetWorkflowExecution reset an existing workflow execution
 // in the history and immediately terminating the execution instance.
 func (h *Handler) ResetWorkflowExecution(ctx context.Context,
-	wrappedRequest *hist.ResetWorkflowExecutionRequest) (*gen.ResetWorkflowExecutionResponse, error) {
+	wrappedRequest *hist.ResetWorkflowExecutionRequest) (resp *gen.ResetWorkflowExecutionResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryResetWorkflowExecutionScope
@@ -952,7 +971,8 @@ func (h *Handler) ResetWorkflowExecution(ctx context.Context,
 // used by transfer queue processor during the processing of StartChildWorkflowExecution task, where it first starts
 // child execution without creating the decision task and then calls this API after updating the mutable state of
 // parent execution.
-func (h *Handler) ScheduleDecisionTask(ctx context.Context, request *hist.ScheduleDecisionTaskRequest) error {
+func (h *Handler) ScheduleDecisionTask(ctx context.Context, request *hist.ScheduleDecisionTaskRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryScheduleDecisionTaskScope
@@ -990,7 +1010,8 @@ func (h *Handler) ScheduleDecisionTask(ctx context.Context, request *hist.Schedu
 
 // RecordChildExecutionCompleted is used for reporting the completion of child workflow execution to parent.
 // This is mainly called by transfer queue processor during the processing of DeleteExecution task.
-func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *hist.RecordChildExecutionCompletedRequest) error {
+func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *hist.RecordChildExecutionCompletedRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryRecordChildExecutionCompletedScope
@@ -1033,7 +1054,8 @@ func (h *Handler) RecordChildExecutionCompleted(ctx context.Context, request *hi
 // 3. ClientLibraryVersion
 // 4. ClientFeatureVersion
 // 5. ClientImpl
-func (h *Handler) ResetStickyTaskList(ctx context.Context, resetRequest *hist.ResetStickyTaskListRequest) (*hist.ResetStickyTaskListResponse, error) {
+func (h *Handler) ResetStickyTaskList(ctx context.Context, resetRequest *hist.ResetStickyTaskListRequest) (resp *hist.ResetStickyTaskListResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryResetStickyTaskListScope
@@ -1056,7 +1078,7 @@ func (h *Handler) ResetStickyTaskList(ctx context.Context, resetRequest *hist.Re
 		return nil, h.error(err, scope, domainID, workflowID)
 	}
 
-	resp, err := engine.ResetStickyTaskList(ctx, resetRequest)
+	resp, err = engine.ResetStickyTaskList(ctx, resetRequest)
 	if err != nil {
 		return nil, h.error(err, scope, domainID, workflowID)
 	}
@@ -1065,7 +1087,8 @@ func (h *Handler) ResetStickyTaskList(ctx context.Context, resetRequest *hist.Re
 }
 
 // ReplicateEvents is called by processor to replicate history events for passive domains
-func (h *Handler) ReplicateEvents(ctx context.Context, replicateRequest *hist.ReplicateEventsRequest) error {
+func (h *Handler) ReplicateEvents(ctx context.Context, replicateRequest *hist.ReplicateEventsRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryReplicateEventsScope
@@ -1098,7 +1121,8 @@ func (h *Handler) ReplicateEvents(ctx context.Context, replicateRequest *hist.Re
 }
 
 // ReplicateRawEvents is called by processor to replicate history raw events for passive domains
-func (h *Handler) ReplicateRawEvents(ctx context.Context, replicateRequest *hist.ReplicateRawEventsRequest) error {
+func (h *Handler) ReplicateRawEvents(ctx context.Context, replicateRequest *hist.ReplicateRawEventsRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistoryReplicateRawEventsScope
@@ -1131,7 +1155,8 @@ func (h *Handler) ReplicateRawEvents(ctx context.Context, replicateRequest *hist
 }
 
 // SyncShardStatus is called by processor to sync history shard information from another cluster
-func (h *Handler) SyncShardStatus(ctx context.Context, syncShardStatusRequest *hist.SyncShardStatusRequest) error {
+func (h *Handler) SyncShardStatus(ctx context.Context, syncShardStatusRequest *hist.SyncShardStatusRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistorySyncShardStatusScope
@@ -1170,7 +1195,8 @@ func (h *Handler) SyncShardStatus(ctx context.Context, syncShardStatusRequest *h
 }
 
 // SyncActivity is called by processor to sync activity
-func (h *Handler) SyncActivity(ctx context.Context, syncActivityRequest *hist.SyncActivityRequest) error {
+func (h *Handler) SyncActivity(ctx context.Context, syncActivityRequest *hist.SyncActivityRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope := metrics.HistorySyncActivityScope

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/logging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
@@ -114,7 +115,8 @@ func (h *Handler) startRequestProfile(api string, scope int) tally.Stopwatch {
 }
 
 // AddActivityTask - adds an activity task.
-func (h *Handler) AddActivityTask(ctx context.Context, addRequest *m.AddActivityTaskRequest) error {
+func (h *Handler) AddActivityTask(ctx context.Context, addRequest *m.AddActivityTaskRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	startT := time.Now()
 	scope := metrics.MatchingAddActivityTaskScope
 	sw := h.startRequestProfile("AddActivityTask", scope)
@@ -133,7 +135,8 @@ func (h *Handler) AddActivityTask(ctx context.Context, addRequest *m.AddActivity
 }
 
 // AddDecisionTask - adds a decision task.
-func (h *Handler) AddDecisionTask(ctx context.Context, addRequest *m.AddDecisionTaskRequest) error {
+func (h *Handler) AddDecisionTask(ctx context.Context, addRequest *m.AddDecisionTaskRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	startT := time.Now()
 	scope := metrics.MatchingAddDecisionTaskScope
 	sw := h.startRequestProfile("AddDecisionTask", scope)
@@ -152,7 +155,8 @@ func (h *Handler) AddDecisionTask(ctx context.Context, addRequest *m.AddDecision
 
 // PollForActivityTask - long poll for an activity task.
 func (h *Handler) PollForActivityTask(ctx context.Context,
-	pollRequest *m.PollForActivityTaskRequest) (*gen.PollForActivityTaskResponse, error) {
+	pollRequest *m.PollForActivityTaskRequest) (resp *gen.PollForActivityTaskResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 
 	scope := metrics.MatchingPollForActivityTaskScope
 	sw := h.startRequestProfile("PollForActivityTask", scope)
@@ -172,7 +176,8 @@ func (h *Handler) PollForActivityTask(ctx context.Context,
 
 // PollForDecisionTask - long poll for a decision task.
 func (h *Handler) PollForDecisionTask(ctx context.Context,
-	pollRequest *m.PollForDecisionTaskRequest) (*m.PollForDecisionTaskResponse, error) {
+	pollRequest *m.PollForDecisionTaskRequest) (resp *m.PollForDecisionTaskResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 
 	scope := metrics.MatchingPollForDecisionTaskScope
 	sw := h.startRequestProfile("PollForDecisionTask", scope)
@@ -192,7 +197,8 @@ func (h *Handler) PollForDecisionTask(ctx context.Context,
 
 // QueryWorkflow queries a given workflow synchronously and return the query result.
 func (h *Handler) QueryWorkflow(ctx context.Context,
-	queryRequest *m.QueryWorkflowRequest) (*gen.QueryWorkflowResponse, error) {
+	queryRequest *m.QueryWorkflowRequest) (resp *gen.QueryWorkflowResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	scope := metrics.MatchingQueryWorkflowScope
 	sw := h.startRequestProfile("QueryWorkflow", scope)
 	defer sw.Stop()
@@ -206,7 +212,8 @@ func (h *Handler) QueryWorkflow(ctx context.Context,
 }
 
 // RespondQueryTaskCompleted responds a query task completed
-func (h *Handler) RespondQueryTaskCompleted(ctx context.Context, request *m.RespondQueryTaskCompletedRequest) error {
+func (h *Handler) RespondQueryTaskCompleted(ctx context.Context, request *m.RespondQueryTaskCompletedRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	scope := metrics.MatchingRespondQueryTaskCompletedScope
 	sw := h.startRequestProfile("RespondQueryTaskCompleted", scope)
 	defer sw.Stop()
@@ -220,7 +227,8 @@ func (h *Handler) RespondQueryTaskCompleted(ctx context.Context, request *m.Resp
 
 // CancelOutstandingPoll is used to cancel outstanding pollers
 func (h *Handler) CancelOutstandingPoll(ctx context.Context,
-	request *m.CancelOutstandingPollRequest) error {
+	request *m.CancelOutstandingPollRequest) (retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	scope := metrics.MatchingCancelOutstandingPollScope
 	sw := h.startRequestProfile("CancelOutstandingPoll", scope)
 	defer sw.Stop()
@@ -235,7 +243,8 @@ func (h *Handler) CancelOutstandingPoll(ctx context.Context,
 // DescribeTaskList returns information about the target tasklist, right now this API returns the
 // pollers which polled this tasklist in last few minutes. If includeTaskListStatus field is true,
 // it will also return status of tasklist's ackManager (readLevel, ackLevel, backlogCountHint and taskIDBlock).
-func (h *Handler) DescribeTaskList(ctx context.Context, request *m.DescribeTaskListRequest) (*gen.DescribeTaskListResponse, error) {
+func (h *Handler) DescribeTaskList(ctx context.Context, request *m.DescribeTaskListRequest) (resp *gen.DescribeTaskListResponse, retError error) {
+	defer logging.CapturePanic(h.GetLogger(), &retError)
 	scope := metrics.MatchingDescribeTaskListScope
 	sw := h.startRequestProfile("DescribeTaskList", scope)
 	defer sw.Stop()


### PR DESCRIPTION
Done for history only. If looks OK then I will add to frontend/match as well.

For https://github.com/uber/cadence/issues/1438

Tested locally(forcing NPE by changing code):
```
ERRO[2019-03-21T15:34:08-07:00] Panic is captured                             Service=cadence-history cadence-panic-error="runtime error: invalid memory address or nil pointer dereference" cadence-stack-trace="goroutine 9315 [running]:\nruntime/debug.Stack(0x203f640, 0x202fbc0, 0x31204a0)\n\t/usr/local/Cellar/go/1.12/libexec/src/runtime/debug/stack.go:24 +0x9d\ngithub.com/uber/cadence/common/logging.CapturePanic(0x24ce780, 0xc000412aa0, 0xc0022befe0)\n\t/Users/longer/gocode/src/github.com/uber/cadence/common/logging/panic.go:43 +0x78\npanic(0x202fbc0, 0x31204a0)\n\t/usr/local/Cellar/go/1.12/libexec/src/runtime/panic.go:522 +0x1b5\ngithub.com/uber/cadence/.gen/go/shared.(*WorkflowExecution).GetWorkflowId(...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/.gen/go/shared/types.go:40040\ngithub.com/uber/cadence/service/history.(*Handler).DescribeMutableState(0xc001a54000, 0x24b6440, 0xc002276270, 0xc001ce78c0, 0x0, 0x0, 0x0)\n\t/Users/longer/gocode/src/github.com/uber/cadence/service/history/handler.go:667 +0x1b7\ngithub.com/uber/cadence/.gen/go/history/historyserviceserver.handler.DescribeMutableState(0x24d2e00, 0xc001a54000, 0x24b6440, 0xc002276270, 0xc, 0x0, 0x0, 0x0, 0x0, 0xc002a6f7a0, ...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/.gen/go/history/historyserviceserver/server.go:499 +0xd8\ngithub.com/uber/cadence/vendor/go.uber.org/yarpc/encoding/thrift.thriftUnaryHandler.Handle(0xc001a4c0e0, 0x24b77c0, 0x3153148, 0x1074000, 0x24b6440, 0xc0022761b0, 0xc001a80000, 0x24adb80, 0xc0027f0020, 0x0, ...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/go.uber.org/yarpc/encoding/thrift/inbound.go:60 +0x1c5\ngithub.com/uber/cadence/vendor/go.uber.org/yarpc/internal/observability.(*Middleware).Handle(0xc0003d4380, 0x24b6440, 0xc0022761b0, 0xc001a80000, 0x3769938, 0xc002a6f620, 0x2489320, 0xc001a4c420, 0x60, 0xc002a746e8)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/go.uber.org/yarpc/internal/observability/middleware.go:74 +0x164\ngithub.com/uber/cadence/vendor/go.uber.org/yarpc/api/middleware.unaryHandlerWithMiddleware.Handle(...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/go.uber.org/yarpc/api/middleware/inbound.go:71\ngithub.com/uber/cadence/vendor/go.uber.org/yarpc/api/transport.InvokeUnaryHandler(0x24b6440, 0xc0022761b0, 0xbf1d2238040f6dc0, 0x2b9aa459a, 0x3135840, 0xc001a80000, 0x3769938, 0xc002a6f620, 0x2489240, 0xc001a4c760, ...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/go.uber.org/yarpc/api/transport/handler_invoker.go:70 +0xef\ngithub.com/uber/cadence/vendor/go.uber.org/yarpc/transport/tchannel.handler.callHandler(0xc0017afd10, 0x6262008, 0xc000cd2fc0, 0x24ae440, 0x3152d00, 0x0, 0xc0004f81e0, 0x22d30f8, 0x24b6440, 0xc0022761b0, ...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/go.uber.org/yarpc/transport/tchannel/handler.go:213 +0x938\ngithub.com/uber/cadence/vendor/go.uber.org/yarpc/transport/tchannel.handler.handle(0xc0017afd10, 0x6262008, 0xc000cd2fc0, 0x24ae440, 0x3152d00, 0x0, 0xc0004f81e0, 0x22d30f8, 0x24b7580, 0xc001d21ca0, ...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/go.uber.org/yarpc/transport/tchannel/handler.go:116 +0x1c4\ngithub.com/uber/cadence/vendor/go.uber.org/yarpc/transport/tchannel.handler.Handle(...)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/go.uber.org/yarpc/transport/tchannel/handler.go:106\ngithub.com/uber/cadence/vendor/github.com/uber/tchannel-go.channelHandler.Handle(0xc000cf8000, 0x24b7580, 0xc001d21ca0, 0xc000cc6fc0)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/github.com/uber/tchannel-go/handlers.go:126 +0x8d\ngithub.com/uber/cadence/vendor/github.com/uber/tchannel-go.(*Connection).dispatchInbound(0xc001cb8000, 0x1900000005, 0xc000cc6fc0, 0xc002c74180)\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/github.com/uber/tchannel-go/inbound.go:200 +0x362\ncreated by github.com/uber/cadence/vendor/github.com/uber/tchannel-go.(*Connection).handleCallReq\n\t/Users/longer/gocode/src/github.com/uber/cadence/vendor/github.com/uber/tchannel-go/inbound.go:131 +0xe47\n"
```