### PR TITLE
Add support for domain tags in metrics

### DIFF
--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -147,6 +147,12 @@ func (m *ClientImpl) Tagged(tags map[string]string) Client {
 	return NewClient(scope, m.serviceIdx)
 }
 
+// Scope return a new internal metrics scope that can be used to add additional
+// information to the metrics emitted
+func (m *ClientImpl) Scope(scopeIdx int) Scope {
+	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs)
+}
+
 func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {
 	defs := make(map[int]metricDefinition)
 	for idx, def := range MetricDefs[Common] {

--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -141,16 +141,10 @@ func (m *ClientImpl) UpdateGauge(scopeIdx int, gaugeIdx int, value float64) {
 	m.childScopes[scopeIdx].Gauge(oldName).Update(value)
 }
 
-// Tagged returns a client that adds the given tags to all metrics
-func (m *ClientImpl) Tagged(tags map[string]string) Client {
-	scope := m.parentScope.Tagged(tags)
-	return NewClient(scope, m.serviceIdx)
-}
-
 // Scope return a new internal metrics scope that can be used to add additional
 // information to the metrics emitted
-func (m *ClientImpl) Scope(scopeIdx int) Scope {
-	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs)
+func (m *ClientImpl) Scope(scopeIdx int, tags ...Tag) Scope {
+	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs).Tagged(tags...)
 }
 
 func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -48,9 +48,20 @@ type (
 
 	// Scope is an interface for metrics
 	Scope interface {
-		Counter(id int) tally.Counter
-		Gauge(id int) tally.Gauge
-		Timer(id int) tally.Timer
+		// IncCounter increments a counter metric
+		IncCounter(counter int)
+		// AddCounter adds delta to the counter metric
+		AddCounter(counter int, delta int64)
+		// StartTimer starts a timer for the given
+		// metric name. Time will be recorded when stopwatch is stopped.
+		StartTimer(timer int) tally.Stopwatch
+		// RecordTimer starts a timer for the given
+		// metric name
+		RecordTimer(timer int, d time.Duration)
+		// UpdateGauge reports Gauge type absolute value metric
+		UpdateGauge(gauge int, value float64)
+		// Tagged return an internal scope that can be used to add additional
+		// information to metrics
 		Tagged(tags ...Tag) Scope
 	}
 )

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -22,6 +22,8 @@ package metrics
 
 import (
 	"time"
+
+	"github.com/uber-go/tally"
 )
 
 type (
@@ -39,10 +41,16 @@ type (
 		RecordTimer(scope int, timer int, d time.Duration)
 		// UpdateGauge reports Gauge type absolute value metric
 		UpdateGauge(scope int, gauge int, value float64)
-		// Tagged returns a client that adds the given tags to all metrics
-		Tagged(tags map[string]string) Client
 		// Scope return an internal scope that can be used to add additional
 		// information to metrics
-		Scope(scope int) Scope
+		Scope(scope int, tags ...Tag) Scope
+	}
+
+	// Scope is an interface for metrics
+	Scope interface {
+		Counter(id int) tally.Counter
+		Gauge(id int) tally.Gauge
+		Timer(id int) tally.Timer
+		Tagged(tags ...Tag) Scope
 	}
 )

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -41,5 +41,8 @@ type (
 		UpdateGauge(scope int, gauge int, value float64)
 		// Tagged returns a client that adds the given tags to all metrics
 		Tagged(tags map[string]string) Client
+		// Scope return an internal scope that can be used to add additional
+		// information to metrics
+		Scope(scope int) Scope
 	}
 )

--- a/common/metrics/metrics_scope.go
+++ b/common/metrics/metrics_scope.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 import "github.com/uber-go/tally"

--- a/common/metrics/metrics_scope.go
+++ b/common/metrics/metrics_scope.go
@@ -1,0 +1,71 @@
+package metrics
+
+import "github.com/uber-go/tally"
+
+const domainTag = "domain"
+
+// Tag is an interface to define metrics tags
+type Tag interface {
+	Key() string
+	Value() string
+}
+
+// Scope is an interface for metrics
+type Scope interface {
+	Counter(id int) tally.Counter
+	Gauge(id int) tally.Gauge
+	Timer(id int) tally.Timer
+	Tagged(tags ...Tag) Scope
+}
+
+type metricsScope struct {
+	scope tally.Scope
+	defs  map[int]metricDefinition
+}
+
+func newMetricsScope(scope tally.Scope, defs map[int]metricDefinition) Scope {
+	return &metricsScope{scope, defs}
+}
+
+func (m *metricsScope) Counter(id int) tally.Counter {
+	name := string(m.defs[id].metricName)
+	return m.scope.Counter(name)
+}
+
+func (m *metricsScope) Gauge(id int) tally.Gauge {
+	name := string(m.defs[id].metricName)
+	return m.scope.Gauge(name)
+}
+
+func (m *metricsScope) Timer(id int) tally.Timer {
+	name := string(m.defs[id].metricName)
+	return m.scope.Timer(name)
+}
+
+func (m *metricsScope) Tagged(tags ...Tag) Scope {
+	tagMap := make(map[string]string, len(tags))
+	for _, tag := range tags {
+		tagMap[tag.Key()] = tag.Value()
+	}
+	return newMetricsScope(m.scope.Tagged(tagMap), m.defs)
+}
+
+// DomainTag wraps a domain tag
+type DomainTag struct {
+	value string
+}
+
+// NewDomainTag returns a new domain tag
+func NewDomainTag(value string) DomainTag {
+	return DomainTag{value}
+}
+
+// Key returns the key of the domain tag
+func (d DomainTag) Key() string {
+	return domainTag
+}
+
+// Value returns the value of a domain tag
+func (d DomainTag) Value() string {
+	return d.value
+}

--- a/common/metrics/mocks/Client.go
+++ b/common/metrics/mocks/Client.go
@@ -81,3 +81,17 @@ func (_m *Client) Tagged(tags map[string]string) metrics.Client {
 func (_m *Client) UpdateGauge(scope int, gauge int, value float64) {
 	_m.Called(scope, gauge, value)
 }
+
+// Scope provides a mock function with given fields: scope
+func (_m *Client) Scope(scope int) metrics.Scope {
+	ret := _m.Called(scope)
+
+	var r0 metrics.Scope
+	if rf, ok := ret.Get(0).(func(int) metrics.Scope); ok {
+		r0 = rf(scope)
+	} else {
+		r0 = ret.Get(0).(metrics.Scope)
+	}
+
+	return r0
+}

--- a/common/metrics/mocks/Client.go
+++ b/common/metrics/mocks/Client.go
@@ -61,34 +61,18 @@ func (_m *Client) StartTimer(scope int, timer int) metrics.Stopwatch {
 	return r0
 }
 
-// Tagged provides a mock function with given fields: tags
-func (_m *Client) Tagged(tags map[string]string) metrics.Client {
-	ret := _m.Called(tags)
-
-	var r0 metrics.Client
-	if rf, ok := ret.Get(0).(func(map[string]string) metrics.Client); ok {
-		r0 = rf(tags)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(metrics.Client)
-		}
-	}
-
-	return r0
-}
-
 // UpdateGauge provides a mock function with given fields: scope, gauge, value
 func (_m *Client) UpdateGauge(scope int, gauge int, value float64) {
 	_m.Called(scope, gauge, value)
 }
 
 // Scope provides a mock function with given fields: scope
-func (_m *Client) Scope(scope int) metrics.Scope {
-	ret := _m.Called(scope)
+func (_m *Client) Scope(scope int, tags ...metrics.Tag) metrics.Scope {
+	ret := _m.Called(scope, tags)
 
 	var r0 metrics.Scope
-	if rf, ok := ret.Get(0).(func(int) metrics.Scope); ok {
-		r0 = rf(scope)
+	if rf, ok := ret.Get(0).(func(int, ...metrics.Tag) metrics.Scope); ok {
+		r0 = rf(scope, tags...)
 	} else {
 		r0 = ret.Get(0).(metrics.Scope)
 	}

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -20,7 +20,11 @@
 
 package metrics
 
-import "github.com/uber-go/tally"
+import (
+	"time"
+
+	"github.com/uber-go/tally"
+)
 
 type metricsScope struct {
 	scope tally.Scope
@@ -31,19 +35,29 @@ func newMetricsScope(scope tally.Scope, defs map[int]metricDefinition) Scope {
 	return &metricsScope{scope, defs}
 }
 
-func (m *metricsScope) Counter(id int) tally.Counter {
+func (m *metricsScope) IncCounter(id int) {
 	name := string(m.defs[id].metricName)
-	return m.scope.Counter(name)
+	m.scope.Counter(name).Inc(1)
 }
 
-func (m *metricsScope) Gauge(id int) tally.Gauge {
+func (m *metricsScope) AddCounter(id int, delta int64) {
 	name := string(m.defs[id].metricName)
-	return m.scope.Gauge(name)
+	m.scope.Counter(name).Inc(delta)
 }
 
-func (m *metricsScope) Timer(id int) tally.Timer {
+func (m *metricsScope) UpdateGauge(id int, value float64) {
 	name := string(m.defs[id].metricName)
-	return m.scope.Timer(name)
+	m.scope.Gauge(name).Update(value)
+}
+
+func (m *metricsScope) StartTimer(id int) tally.Stopwatch {
+	name := string(m.defs[id].metricName)
+	return m.scope.Timer(name).Start()
+}
+
+func (m *metricsScope) RecordTimer(id int, d time.Duration) {
+	name := string(m.defs[id].metricName)
+	m.scope.Timer(name).Record(d)
 }
 
 func (m *metricsScope) Tagged(tags ...Tag) Scope {

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -22,22 +22,6 @@ package metrics
 
 import "github.com/uber-go/tally"
 
-const domainTag = "domain"
-
-// Tag is an interface to define metrics tags
-type Tag interface {
-	Key() string
-	Value() string
-}
-
-// Scope is an interface for metrics
-type Scope interface {
-	Counter(id int) tally.Counter
-	Gauge(id int) tally.Gauge
-	Timer(id int) tally.Timer
-	Tagged(tags ...Tag) Scope
-}
-
 type metricsScope struct {
 	scope tally.Scope
 	defs  map[int]metricDefinition
@@ -68,24 +52,4 @@ func (m *metricsScope) Tagged(tags ...Tag) Scope {
 		tagMap[tag.Key()] = tag.Value()
 	}
 	return newMetricsScope(m.scope.Tagged(tagMap), m.defs)
-}
-
-// DomainTag wraps a domain tag
-type DomainTag struct {
-	value string
-}
-
-// NewDomainTag returns a new domain tag
-func NewDomainTag(value string) DomainTag {
-	return DomainTag{value}
-}
-
-// Key returns the key of the domain tag
-func (d DomainTag) Key() string {
-	return domainTag
-}
-
-// Value returns the value of a domain tag
-func (d DomainTag) Value() string {
-	return d.value
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -1,0 +1,29 @@
+package metrics
+
+const domainTag = "domain"
+
+// Tag is an interface to define metrics tags
+type Tag interface {
+	Key() string
+	Value() string
+}
+
+// DomainTag wraps a domain tag
+type DomainTag struct {
+	value string
+}
+
+// NewDomainTag returns a new domain tag
+func NewDomainTag(value string) DomainTag {
+	return DomainTag{value}
+}
+
+// Key returns the key of the domain tag
+func (d DomainTag) Key() string {
+	return domainTag
+}
+
+// Value returns the value of a domain tag
+func (d DomainTag) Value() string {
+	return d.value
+}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -1,3 +1,23 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package metrics
 
 const domainTag = "domain"

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -20,7 +20,7 @@
 
 package metrics
 
-const domainTag = "domain"
+const domain = "domain"
 
 // Tag is an interface to define metrics tags
 type Tag interface {
@@ -28,22 +28,21 @@ type Tag interface {
 	Value() string
 }
 
-// DomainTag wraps a domain tag
-type DomainTag struct {
+type domainTag struct {
 	value string
 }
 
-// NewDomainTag returns a new domain tag
-func NewDomainTag(value string) DomainTag {
-	return DomainTag{value}
+// DomainTag returns a new domain tag
+func DomainTag(value string) Tag {
+	return domainTag{value}
 }
 
 // Key returns the key of the domain tag
-func (d DomainTag) Key() string {
-	return domainTag
+func (d domainTag) Key() string {
+	return domain
 }
 
 // Value returns the value of a domain tag
-func (d DomainTag) Value() string {
+func (d domainTag) Value() string {
 	return d.value
 }

--- a/service/worker/archiver/replay_metrics_client.go
+++ b/service/worker/archiver/replay_metrics_client.go
@@ -80,6 +80,11 @@ func (r *replayMetricsClient) UpdateGauge(scope int, gauge int, value float64) {
 	r.client.UpdateGauge(scope, gauge, value)
 }
 
+// Scope returns a client that adds the given tags to all metrics
+func (r *replayMetricsClient) Scope(scope int) metrics.Scope {
+	return r.client.Scope(scope)
+}
+
 // Tagged returns a client that adds the given tags to all metrics
 func (r *replayMetricsClient) Tagged(tags map[string]string) metrics.Client {
 	return &replayMetricsClient{

--- a/service/worker/archiver/replay_metrics_client.go
+++ b/service/worker/archiver/replay_metrics_client.go
@@ -81,16 +81,8 @@ func (r *replayMetricsClient) UpdateGauge(scope int, gauge int, value float64) {
 }
 
 // Scope returns a client that adds the given tags to all metrics
-func (r *replayMetricsClient) Scope(scope int) metrics.Scope {
-	return r.client.Scope(scope)
-}
-
-// Tagged returns a client that adds the given tags to all metrics
-func (r *replayMetricsClient) Tagged(tags map[string]string) metrics.Client {
-	return &replayMetricsClient{
-		client: r.client.Tagged(tags),
-		ctx:    r.ctx,
-	}
+func (r *replayMetricsClient) Scope(scope int, tags ...metrics.Tag) metrics.Scope {
+	return r.client.Scope(scope, tags...)
 }
 
 type nopStopwatchRecorder struct{}


### PR DESCRIPTION
Creating an internal scope structure that allows adding pre-defined tags to metrics. Presently Domain is the one allowed tag.