### PR TITLE
dynamic config: disable eventsv2 when using SQL persistence

### DIFF
--- a/common/service/config/persistence.go
+++ b/common/service/config/persistence.go
@@ -22,6 +22,13 @@ package config
 
 import "fmt"
 
+const (
+	// StoreTypeSQL refers to sql based storage as persistence store
+	StoreTypeSQL = "sql"
+	// StoreTypeCassandra refers to cassandra as persistence store
+	StoreTypeCassandra = "cassandra"
+)
+
 // SetMaxQPS sets the MaxQPS value for the given datastore
 func (c *Persistence) SetMaxQPS(key string, qps int) {
 	ds, ok := c.DataStores[key]
@@ -33,6 +40,14 @@ func (c *Persistence) SetMaxQPS(key string, qps int) {
 		return
 	}
 	ds.SQL.MaxQPS = qps
+}
+
+// DefaultStoreType returns the storeType for the default persistence store
+func (c *Persistence) DefaultStoreType() string {
+	if c.DataStores[c.DefaultStore].SQL != nil {
+		return StoreTypeSQL
+	}
+	return StoreTypeCassandra
 }
 
 // Validate validates the persistence config

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -394,7 +394,7 @@ func (c *cadenceImpl) startHistory(rpHosts []string, startWG *sync.WaitGroup, en
 		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, params.Logger))
 		params.DynamicConfig = dynamicconfig.NewNopClient()
 		service := service.New(params)
-		historyConfig := history.NewConfig(dynamicconfig.NewNopCollection(), c.numberOfHistoryShards, c.enableVisibilityToKafka)
+		historyConfig := history.NewConfig(dynamicconfig.NewNopCollection(), c.numberOfHistoryShards, c.enableVisibilityToKafka, config.StoreTypeCassandra)
 		historyConfig.HistoryMgrNumConns = dynamicconfig.GetIntPropertyFn(c.numberOfHistoryShards)
 		historyConfig.ExecutionMgrNumConns = dynamicconfig.GetIntPropertyFn(c.numberOfHistoryShards)
 		historyConfig.EnableEventsV2 = dynamicconfig.GetBoolPropertyFnFilteredByDomain(enableEventsV2)

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/service"
+	cconfig "github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/common/service/dynamicconfig"
 )
 
@@ -511,14 +512,14 @@ func (s *TestShardContext) GetCurrentTime(cluster string) time.Time {
 // NewDynamicConfigForTest return dc for test
 func NewDynamicConfigForTest() *Config {
 	dc := dynamicconfig.NewNopCollection()
-	config := NewConfig(dc, 1, false)
+	config := NewConfig(dc, 1, false, cconfig.StoreTypeCassandra)
 	return config
 }
 
 // NewDynamicConfigForEventsV2Test with enableEventsV2 = true
 func NewDynamicConfigForEventsV2Test() *Config {
 	dc := dynamicconfig.NewNopCollection()
-	config := NewConfig(dc, 1, false)
+	config := NewConfig(dc, 1, false, cconfig.StoreTypeCassandra)
 	config.EnableEventsV2 = dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.EnableEventsV2, true)
 	return config
 }


### PR DESCRIPTION
Recent change to enable eventV2 by default breaks with MySQL based persistence. This patch disables eventsV2 when using SQL based persistence. 