### PR TITLE
Admin CLI: Delete history before delete execution records in  delete …

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -725,6 +725,8 @@ workflow_state = ? ` +
 		`and visibility_ts = ? ` +
 		`and task_id = ? `
 
+	templateDeleteWorkflowExecutionCurrentRowQuery = templateDeleteWorkflowExecutionMutableStateQuery + " if current_run_id = ? "
+
 	templateDeleteWorkflowExecutionSignalRequestedQuery = `UPDATE executions ` +
 		`SET signal_requested = signal_requested - ? ` +
 		`WHERE shard_id = ? ` +
@@ -904,8 +906,10 @@ type (
 	}
 )
 
+var _ p.ExecutionStore = (*cassandraPersistence)(nil)
+
 //NewWorkflowExecutionPersistenceFromSession returns new ExecutionStore
-func NewWorkflowExecutionPersistenceFromSession(session *gocql.Session, shardID int, logger bark.Logger) p.ExecutionStore {
+func NewWorkflowExecutionPersistenceFromSession(session *gocql.Session, shardID int, logger bark.Logger) *cassandraPersistence {
 	return &cassandraPersistence{cassandraStore: cassandraStore{session: session, logger: logger}, shardID: shardID}
 }
 
@@ -2270,6 +2274,32 @@ func (d *cassandraPersistence) DeleteWorkflowExecution(request *p.DeleteWorkflow
 		}
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("DeleteWorkflowExecution operation failed. Error: %v", err),
+		}
+	}
+
+	return nil
+}
+
+func (d *cassandraPersistence) DeleteWorkflowCurrentRow(request *p.DeleteWorkflowExecutionRequest) error {
+	query := d.session.Query(templateDeleteWorkflowExecutionCurrentRowQuery,
+		d.shardID,
+		rowTypeExecution,
+		request.DomainID,
+		request.WorkflowID,
+		permanentRunID,
+		defaultVisibilityTimestamp,
+		rowTypeExecutionTaskID,
+		request.RunID)
+
+	err := query.Exec()
+	if err != nil {
+		if isThrottlingError(err) {
+			return &workflow.ServiceBusyError{
+				Message: fmt.Sprintf("DeleteWorkflowCurrentRow operation failed. Error: %v", err),
+			}
+		}
+		return &workflow.InternalServiceError{
+			Message: fmt.Sprintf("DeleteWorkflowCurrentRow operation failed. Error: %v", err),
 		}
 	}
 

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -113,13 +113,9 @@ func newAdminWorkflowCommands() []cli.Command {
 					Name:  FlagRunIDWithAlias,
 					Usage: "RunID",
 				},
-				cli.StringFlag{
-					Name:  FlagDomainID,
-					Usage: "DomainID",
-				},
-				cli.IntFlag{
-					Name:  FlagShardID,
-					Usage: "ShardID",
+				cli.BoolFlag{
+					Name:  FlagSkipErrorModeWithAlias,
+					Usage: "skip errors when deleting history",
 				},
 
 				// for cassandra connection
@@ -129,7 +125,8 @@ func newAdminWorkflowCommands() []cli.Command {
 				},
 				cli.IntFlag{
 					Name:  FlagPort,
-					Usage: "cassandra port for the host (default is 9042)",
+					Value: 9042,
+					Usage: "cassandra port for the host",
 				},
 				cli.StringFlag{
 					Name:  FlagUsername,

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -239,15 +239,6 @@ func AdminDeleteWorkflow(c *cli.Context) {
 		WorkflowID: wid,
 		RunID:      rid,
 	}
-	err = exeStore.DeleteWorkflowCurrentRow(req)
-	if err != nil {
-		if skipError {
-			fmt.Println("delete current row failed, ", err)
-		} else {
-			ErrorAndExit("delete current row failed", err)
-		}
-	}
-	fmt.Println("delete current row successfully")
 
 	err = exeStore.DeleteWorkflowExecution(req)
 	if err != nil {
@@ -258,6 +249,16 @@ func AdminDeleteWorkflow(c *cli.Context) {
 		}
 	}
 	fmt.Println("delete mutableState row successfully")
+
+	err = exeStore.DeleteWorkflowCurrentRow(req)
+	if err != nil {
+		if skipError {
+			fmt.Println("delete current row failed, ", err)
+		} else {
+			ErrorAndExit("delete current row failed", err)
+		}
+	}
+	fmt.Println("delete current row successfully")
 }
 
 func readOneRow(query *gocql.Query) (map[string]interface{}, error) {

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -126,6 +126,31 @@ func AdminShowWorkflow(c *cli.Context) {
 
 // AdminDescribeWorkflow describe a new workflow execution for admin
 func AdminDescribeWorkflow(c *cli.Context) {
+
+	resp := describeMutableState(c)
+
+	prettyPrintJSONObject(resp)
+
+	if resp != nil {
+		msStr := resp.GetMutableStateInDatabase()
+		ms := persistence.WorkflowMutableState{}
+		err := json.Unmarshal([]byte(msStr), &ms)
+		if err != nil {
+			ErrorAndExit("json.Unmarshal err", err)
+		}
+		if ms.ExecutionInfo != nil && ms.ExecutionInfo.EventStoreVersion == persistence.EventStoreVersionV2 {
+			branchInfo := shared.HistoryBranch{}
+			thriftrwEncoder := codec.NewThriftRWEncoder()
+			err := thriftrwEncoder.Decode(ms.ExecutionInfo.BranchToken, &branchInfo)
+			if err != nil {
+				ErrorAndExit("thriftrwEncoder.Decode err", err)
+			}
+			prettyPrintJSONObject(branchInfo)
+		}
+	}
+}
+
+func describeMutableState(c *cli.Context) *admin.DescribeWorkflowExecutionResponse {
 	adminClient := cFactory.ServerAdminClient(c)
 
 	domain := getRequiredGlobalOption(c, FlagDomain)
@@ -143,43 +168,65 @@ func AdminDescribeWorkflow(c *cli.Context) {
 		},
 	})
 	if err != nil {
-		ErrorAndExit("Describe workflow execution failed", err)
+		ErrorAndExit("Get workflow mutableState failed", err)
 	}
-
-	prettyPrintJSONObject(resp)
-
-	if resp != nil {
-		msStr := resp.GetMutableStateInDatabase()
-		ms := persistence.WorkflowMutableState{}
-		err = json.Unmarshal([]byte(msStr), &ms)
-		if err != nil {
-			ErrorAndExit("json.Unmarshal err", err)
-		}
-		if ms.ExecutionInfo != nil && ms.ExecutionInfo.EventStoreVersion == persistence.EventStoreVersionV2 {
-			branchInfo := shared.HistoryBranch{}
-			thriftrwEncoder := codec.NewThriftRWEncoder()
-			err := thriftrwEncoder.Decode(ms.ExecutionInfo.BranchToken, &branchInfo)
-			if err != nil {
-				ErrorAndExit("thriftrwEncoder.Decode err", err)
-			}
-			prettyPrintJSONObject(branchInfo)
-		}
-	}
+	return resp
 }
 
 // AdminDeleteWorkflow describe a new workflow execution for admin
 func AdminDeleteWorkflow(c *cli.Context) {
-	domainID := getRequiredOption(c, FlagDomainID)
 	wid := getRequiredOption(c, FlagWorkflowID)
-	rid := getRequiredOption(c, FlagRunID)
-	if !c.IsSet(FlagShardID) {
-		ErrorAndExit("shardID is required", nil)
+	rid := c.String(FlagRunID)
+
+	resp := describeMutableState(c)
+	shardID := resp.GetShardId()
+	msStr := resp.GetMutableStateInDatabase()
+	ms := persistence.WorkflowMutableState{}
+	err := json.Unmarshal([]byte(msStr), &ms)
+	if err != nil {
+		ErrorAndExit("json.Unmarshal err", err)
 	}
-	shardID := c.Int(FlagShardID)
-
+	domainID := ms.ExecutionInfo.DomainID
+	skipError := c.Bool(FlagSkipErrorMode)
 	session := connectToCassandra(c)
+	if ms.ExecutionInfo.EventStoreVersion == persistence.EventStoreVersionV2 {
+		branchInfo := shared.HistoryBranch{}
+		thriftrwEncoder := codec.NewThriftRWEncoder()
+		err := thriftrwEncoder.Decode(ms.ExecutionInfo.BranchToken, &branchInfo)
+		if err != nil {
+			ErrorAndExit("thriftrwEncoder.Decode err", err)
+		}
+		fmt.Println("deleting history events for ...")
+		prettyPrintJSONObject(branchInfo)
+		histV2 := cassp.NewHistoryV2PersistenceFromSession(session, bark.NewNopLogger())
+		err = histV2.DeleteHistoryBranch(&persistence.InternalDeleteHistoryBranchRequest{
+			BranchInfo: branchInfo,
+		})
+		if err != nil {
+			if skipError {
+				fmt.Println("failed to delete history, ", err)
+			} else {
+				ErrorAndExit("DeleteHistoryBranch err", err)
+			}
+		}
+	} else {
+		histV1 := cassp.NewHistoryPersistenceFromSession(session, bark.NewNopLogger())
+		err = histV1.DeleteWorkflowExecutionHistory(&persistence.DeleteWorkflowExecutionHistoryRequest{
+			DomainID: domainID,
+			Execution: shared.WorkflowExecution{
+				WorkflowId: common.StringPtr(wid),
+				RunId:      common.StringPtr(rid),
+			},
+		})
+		if err != nil {
+			if skipError {
+				fmt.Println("failed to delete history, ", err)
+			} else {
+				ErrorAndExit("DeleteWorkflowExecutionHistory err", err)
+			}
+		}
+	}
 
-	var err error
 	permanentRunID := "30000000-0000-f000-f000-000000000001"
 	selectTmpl := "select execution from executions where shard_id = ? and type = 1 and domain_id = ? and workflow_id = ? and run_id = ? "
 	deleteTmpl := "delete from executions where shard_id = ? and type = 1 and domain_id = ? and workflow_id = ? and run_id = ? "
@@ -193,9 +240,9 @@ func AdminDeleteWorkflow(c *cli.Context) {
 		query := session.Query(deleteTmpl, shardID, domainID, wid, permanentRunID)
 		err := query.Exec()
 		if err != nil {
-			ErrorAndExit("delete row failed", err)
+			ErrorAndExit("delete current row failed", err)
 		}
-		fmt.Println("delete row successfully")
+		fmt.Println("delete current row successfully")
 	}
 
 	query = session.Query(selectTmpl, shardID, domainID, wid, rid)
@@ -207,9 +254,9 @@ func AdminDeleteWorkflow(c *cli.Context) {
 		query := session.Query(deleteTmpl, shardID, domainID, wid, rid)
 		err := query.Exec()
 		if err != nil {
-			ErrorAndExit("delete row failed", err)
+			ErrorAndExit("delete mutableState row failed", err)
 		}
-		fmt.Println("delete row successfully")
+		fmt.Println("delete mutableState row successfully")
 	}
 }
 


### PR DESCRIPTION
…command

For https://github.com/uber/cadence/issues/1594

Tested in local:
```
longer@~/gocode/src/github.com/uber/cadence:(delHist)$ ./cadence --do samples-domain adm  wf del -w 'child_workflow:a32d32d3-4a9f-4395-ad4b-883425d25641' -r ae52382d-8d5b-433f-9147-563ea4c92e05 --address 127.0.0.1 --port 9042 --keyspace cadence
deleting history events for ...
{
  "treeID": "ae52382d-8d5b-433f-9147-563ea4c92e05",
  "branchID": "4cd151d5-27e3-4378-8745-b34bd1c18b31"
}
delete current row successfully
delete mutableState row successfully
```