### PR TITLE
Add Integration test for history size limit

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -79,8 +79,8 @@ const (
 	FailureReasonHeartbeatExceedsLimit = "HEARTBEAT_EXCEEDS_LIMIT"
 	// FailureReasonDecisionBlobSizeExceedsLimit is the failureReason for decision blob exceeds size limit
 	FailureReasonDecisionBlobSizeExceedsLimit = "DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
-	// TerminateReasonSizeExceedsLimit is reason to terminate workflow when history size exceed limit
-	TerminateReasonSizeExceedsLimit = "HISTORY_SIZE_EXCEEDS_LIMIT"
+	// TerminateReasonSizeExceedsLimit is reason to terminate workflow when history size or count exceed limit
+	TerminateReasonSizeExceedsLimit = "HISTORY_EXCEEDS_LIMIT"
 )
 
 var (

--- a/host/integration_cross_dc_domain_test.go
+++ b/host/integration_cross_dc_domain_test.go
@@ -99,6 +99,10 @@ func (s *integrationCrossDCSuite) setupTest(enableGlobalDomain bool, isMasterClu
 		ClusterInfo: config.ClustersInfo{
 			EnableGlobalDomain: enableGlobalDomain,
 		},
+		HistoryConfig: &HistoryConfig{
+			NumHistoryHosts:  1,
+			NumHistoryShards: 1,
+		},
 	}, s.logger)
 	s.Require().NoError(err)
 	s.testCluster = c

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -118,7 +118,7 @@ func (s *IntegrationBase) setupLogger() {
 	s.Logger = bark.NewLoggerFromLogrus(logger)
 }
 
-// GetTestClusterConfig returns test cluster config
+// GetTestClusterConfig return test cluster config
 func GetTestClusterConfig(configFile string) (*TestClusterConfig, error) {
 	environment.SetupEnv()
 

--- a/host/sizelimit_test.go
+++ b/host/sizelimit_test.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package host
+
+import (
+	"bytes"
+	"encoding/binary"
+	"flag"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	workflow "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
+	"strconv"
+	"testing"
+	"time"
+)
+
+type sizeLimitIntegrationSuite struct {
+	// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
+	// not merely log an error
+	*require.Assertions
+	IntegrationBase
+}
+
+// This cluster use customized threshold for history config
+func (s *sizeLimitIntegrationSuite) SetupSuite() {
+	s.setupSuite("testdata/integration_sizelimit_cluster.yaml")
+}
+
+func (s *sizeLimitIntegrationSuite) TearDownSuite() {
+	s.tearDownSuite()
+}
+
+func (s *sizeLimitIntegrationSuite) SetupTest() {
+	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
+	s.Assertions = require.New(s.T())
+}
+
+func TestSizeLimitIntegrationSuite(t *testing.T) {
+	flag.Parse()
+	suite.Run(t, new(sizeLimitIntegrationSuite))
+}
+
+func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
+	id := "integration-terminate-workflow-by-size-limit-test"
+	wt := "integration-terminate-workflow-by-size-limit-test-type"
+	tl := "integration-terminate-workflow-by-size-limit-test-tasklist"
+	identity := "worker1"
+	activityName := "activity_type1"
+
+	workflowType := &workflow.WorkflowType{}
+	workflowType.Name = common.StringPtr(wt)
+
+	taskList := &workflow.TaskList{}
+	taskList.Name = common.StringPtr(tl)
+
+	request := &workflow.StartWorkflowExecutionRequest{
+		RequestId:                           common.StringPtr(uuid.New()),
+		Domain:                              common.StringPtr(s.domainName),
+		WorkflowId:                          common.StringPtr(id),
+		WorkflowType:                        workflowType,
+		TaskList:                            taskList,
+		Input:                               nil,
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(100),
+		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Identity:                            common.StringPtr(identity),
+	}
+
+	we, err0 := s.engine.StartWorkflowExecution(createContext(), request)
+	s.Nil(err0)
+
+	s.Logger.Infof("StartWorkflowExecution: response: %v \n", *we.RunId)
+
+	activityCount := int32(4)
+	activityCounter := int32(0)
+	dtHandler := func(execution *workflow.WorkflowExecution, wt *workflow.WorkflowType,
+		previousStartedEventID, startedEventID int64, history *workflow.History) ([]byte, []*workflow.Decision, error) {
+		if activityCounter < activityCount {
+			activityCounter++
+			buf := new(bytes.Buffer)
+			s.Nil(binary.Write(buf, binary.LittleEndian, activityCounter))
+
+			return []byte(strconv.Itoa(int(activityCounter))), []*workflow.Decision{{
+				DecisionType: common.DecisionTypePtr(workflow.DecisionTypeScheduleActivityTask),
+				ScheduleActivityTaskDecisionAttributes: &workflow.ScheduleActivityTaskDecisionAttributes{
+					ActivityId:                    common.StringPtr(strconv.Itoa(int(activityCounter))),
+					ActivityType:                  &workflow.ActivityType{Name: common.StringPtr(activityName)},
+					TaskList:                      &workflow.TaskList{Name: &tl},
+					Input:                         buf.Bytes(),
+					ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
+					ScheduleToStartTimeoutSeconds: common.Int32Ptr(10),
+					StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
+					HeartbeatTimeoutSeconds:       common.Int32Ptr(5),
+				},
+			}}, nil
+		}
+
+		return []byte(strconv.Itoa(int(activityCounter))), []*workflow.Decision{{
+			DecisionType: common.DecisionTypePtr(workflow.DecisionTypeCompleteWorkflowExecution),
+			CompleteWorkflowExecutionDecisionAttributes: &workflow.CompleteWorkflowExecutionDecisionAttributes{
+				Result: []byte("Done."),
+			},
+		}}, nil
+	}
+
+	atHandler := func(execution *workflow.WorkflowExecution, activityType *workflow.ActivityType,
+		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
+
+		return []byte("Activity Result."), false, nil
+	}
+
+	poller := &TaskPoller{
+		Engine:          s.engine,
+		Domain:          s.domainName,
+		TaskList:        taskList,
+		Identity:        identity,
+		DecisionHandler: dtHandler,
+		ActivityHandler: atHandler,
+		Logger:          s.Logger,
+		T:               s.T(),
+	}
+
+	for i := int32(0); i < activityCount-1; i++ {
+		_, err := poller.PollAndProcessDecisionTask(false, false)
+		s.Logger.Infof("PollAndProcessDecisionTask: %v", err)
+		s.Nil(err)
+
+		err = poller.PollAndProcessActivityTask(false)
+		s.Logger.Infof("PollAndProcessActivityTask: %v", err)
+		s.Nil(err)
+	}
+
+	// process this decision will trigger history exceed limit error
+	_, err := poller.PollAndProcessDecisionTask(false, false)
+	s.Logger.Infof("PollAndProcessDecisionTask: %v", err)
+	s.NotNil(err)
+	s.Equal(&workflow.EntityNotExistsError{Message: "Workflow execution already completed."}, err)
+
+	// verify last event is terminated event
+	historyResponse, err := s.engine.GetWorkflowExecutionHistory(createContext(), &workflow.GetWorkflowExecutionHistoryRequest{
+		Domain: common.StringPtr(s.domainName),
+		Execution: &workflow.WorkflowExecution{
+			WorkflowId: common.StringPtr(id),
+			RunId:      common.StringPtr(we.GetRunId()),
+		},
+	})
+	s.Nil(err)
+	history := historyResponse.History
+	lastEvent := history.Events[len(history.Events)-1]
+	s.Equal(workflow.EventTypeWorkflowExecutionTerminated, lastEvent.GetEventType())
+	terminateEventAttributes := lastEvent.WorkflowExecutionTerminatedEventAttributes
+	s.Equal(common.TerminateReasonSizeExceedsLimit, terminateEventAttributes.GetReason())
+	s.Equal("cadence-history-server", terminateEventAttributes.GetIdentity())
+
+	// verify visibility is correctly processed from open to close
+	isCloseCorrect := false
+	for i := 0; i < 10; i++ {
+		resp, err1 := s.engine.ListClosedWorkflowExecutions(createContext(), &workflow.ListClosedWorkflowExecutionsRequest{
+			Domain:          common.StringPtr(s.domainName),
+			MaximumPageSize: common.Int32Ptr(100),
+			StartTimeFilter: &workflow.StartTimeFilter{
+				EarliestTime: common.Int64Ptr(0),
+				LatestTime:   common.Int64Ptr(time.Now().UnixNano()),
+			},
+			ExecutionFilter: &workflow.WorkflowExecutionFilter{
+				WorkflowId: common.StringPtr(id),
+			},
+		})
+		s.Nil(err1)
+		if len(resp.Executions) == 1 {
+			isCloseCorrect = true
+			break
+		}
+		s.Logger.Info("Closed WorkflowExecution is not yet visible")
+		time.Sleep(100 * time.Millisecond)
+	}
+	s.True(isCloseCorrect)
+}

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -54,8 +54,6 @@ type (
 		EnableArchival        bool
 		IsMasterCluster       bool
 		ClusterNo             int
-		NumHistoryShards      int
-		NumHistoryHosts       int
 		ClusterInfo           config.ClustersInfo
 		MessagingClientConfig *MessagingClientConfig
 		Persistence           persistencetests.TestBaseOptions
@@ -92,11 +90,11 @@ func NewCluster(options *TestClusterConfig, logger bark.Logger) (*TestCluster, e
 	options.Persistence.ClusterMetadata = clusterMetadata
 	testBase := persistencetests.NewTestBase(&options.Persistence)
 	testBase.Setup()
-	setupShards(testBase, options.NumHistoryShards, logger)
+	setupShards(testBase, options.HistoryConfig.NumHistoryShards, logger)
 	blobstore := setupBlobstore(logger)
 
 	pConfig := testBase.Config()
-	pConfig.NumHistoryShards = options.NumHistoryShards
+	pConfig.NumHistoryShards = options.HistoryConfig.NumHistoryShards
 	cadenceParams := &CadenceParams{
 		ClusterMetadata:               clusterMetadata,
 		PersistenceConfig:             pConfig,
@@ -110,8 +108,6 @@ func NewCluster(options *TestClusterConfig, logger bark.Logger) (*TestCluster, e
 		ExecutionMgrFactory:           testBase.ExecutionMgrFactory,
 		TaskMgr:                       testBase.TaskMgr,
 		VisibilityMgr:                 testBase.VisibilityMgr,
-		NumberOfHistoryShards:         options.NumHistoryShards,
-		NumberOfHistoryHosts:          options.NumHistoryHosts,
 		Logger:                        logger,
 		ClusterNo:                     options.ClusterNo,
 		EnableWorker:                  options.EnableWorker,

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -59,6 +59,7 @@ type (
 		ClusterInfo           config.ClustersInfo
 		MessagingClientConfig *MessagingClientConfig
 		Persistence           persistencetests.TestBaseOptions
+		HistoryConfig         *HistoryConfig
 	}
 
 	// MessagingClientConfig is the config for messaging config
@@ -118,6 +119,7 @@ func NewCluster(options *TestClusterConfig, logger bark.Logger) (*TestCluster, e
 		EnableVisibilityToKafka:       false,
 		EnableReadHistoryFromArchival: options.EnableArchival,
 		Blobstore:                     blobstore.client,
+		HistoryConfig:                 options.HistoryConfig,
 	}
 	cluster := NewCadence(cadenceParams)
 	if err := cluster.Start(); err != nil {

--- a/host/testdata/clientintegrationtestcluster.yaml
+++ b/host/testdata/clientintegrationtestcluster.yaml
@@ -2,7 +2,8 @@ enableworker: false
 enableeventsv2: false
 enablearchival: false
 clusterno: 0
-numhistoryshards: 4
-numhistoryhosts: 1
 messagingclientconfig:
   usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1

--- a/host/testdata/integration_sizelimit_cluster.yaml
+++ b/host/testdata/integration_sizelimit_cluster.yaml
@@ -2,7 +2,7 @@ persistoptions:
   enableglobaldomain: false
   ismastercluster: false
   enablearchival: true
-enableworker: true
+enableworker: false
 enableeventsv2: false
 enablearchival: false
 clusterno: 0

--- a/host/testdata/integration_sizelimit_cluster.yaml
+++ b/host/testdata/integration_sizelimit_cluster.yaml
@@ -6,10 +6,10 @@ enableworker: true
 enableeventsv2: false
 enablearchival: false
 clusterno: 0
-numhistoryshards: 4
-numhistoryhosts: 1
 messagingclientconfig:
   usemock: true
 historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
   historycountlimiterror: 20
   historycountlimitwarn: 10

--- a/host/testdata/integration_sizelimit_cluster.yaml
+++ b/host/testdata/integration_sizelimit_cluster.yaml
@@ -1,0 +1,15 @@
+persistoptions:
+  enableglobaldomain: false
+  ismastercluster: false
+  enablearchival: true
+enableworker: true
+enableeventsv2: false
+enablearchival: false
+clusterno: 0
+numhistoryshards: 4
+numhistoryhosts: 1
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  historycountlimiterror: 20
+  historycountlimitwarn: 10

--- a/host/testdata/integration_sizelimit_cluster.yaml
+++ b/host/testdata/integration_sizelimit_cluster.yaml
@@ -1,7 +1,3 @@
-persistoptions:
-  enableglobaldomain: false
-  ismastercluster: false
-  enablearchival: true
 enableworker: false
 enableeventsv2: false
 enablearchival: false

--- a/host/testdata/integrationtestcluster.yaml
+++ b/host/testdata/integrationtestcluster.yaml
@@ -2,7 +2,8 @@ enableworker: true
 enableeventsv2: false
 enablearchival: true
 clusterno: 0
-numhistoryshards: 4
-numhistoryhosts: 1
 messagingclientconfig:
   usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1

--- a/hostxdc/testdata/integrationtestclusters.yaml
+++ b/hostxdc/testdata/integrationtestclusters.yaml
@@ -20,8 +20,9 @@
   enableeventsv2: false
   enablearchival: false
   clusterno: 0
-  numhistoryshards: 1
-  numhistoryhosts: 1
+  historyconfig:
+    numhistoryshards: 1
+    numhistoryhosts: 1
   messagingclientconfig:
     usemock: false
     kafkaconfig:
@@ -74,8 +75,9 @@
   enableeventsv2: false
   enablearchival: false
   clusterno: 1
-  numhistoryshards: 1
-  numhistoryhosts: 1
+  historyconfig:
+    numhistoryshards: 1
+    numhistoryhosts: 1
   messagingclientconfig:
     usemock: false
     kafkaconfig:

--- a/hostxdc/testdata/integrationtestclusters.yaml
+++ b/hostxdc/testdata/integrationtestclusters.yaml
@@ -18,7 +18,6 @@
   enablearchival: false
   enableworker: true
   enableeventsv2: false
-  enablearchival: false
   clusterno: 0
   historyconfig:
     numhistoryshards: 1
@@ -73,7 +72,6 @@
   enablearchival: false
   enableworker: true
   enableeventsv2: false
-  enablearchival: false
   clusterno: 1
   historyconfig:
     numhistoryshards: 1


### PR DESCRIPTION
This PR includes an integration test for history size limit case. 
Because we need setup cluster with smaller limit config, this also include a new parameter `HistoryConfig` in Integration Test config. 

(We could do more refactor to move some config nobs to HistoryConfig to make code looks cleaner, if needed)