### PR TITLE
Cancel timer should clear any TimerFired events in buffered events

### DIFF
--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -222,24 +222,6 @@ func (b *historyBuilder) AddTimerFiredEvent(
 	return b.addEventToHistory(event)
 }
 
-func (b *historyBuilder) CheckAndClearTimerFiredEvent(timerID string) bool {
-	// go over all history events. if we find a timer fired event for the given
-	// timerID, clear it
-	timerFiredIdx := -1
-	for idx, event := range b.history {
-		if *event.EventType == workflow.EventTypeTimerFired &&
-			*event.TimerFiredEventAttributes.TimerId == timerID {
-			timerFiredIdx = idx
-			break
-		}
-	}
-	if timerFiredIdx == -1 {
-		return false
-	}
-	b.removeHistoryAtIdx(timerFiredIdx)
-	return true
-}
-
 func (b *historyBuilder) AddActivityTaskCancelRequestedEvent(decisionCompletedEventID int64,
 	activityID string) *workflow.HistoryEvent {
 
@@ -982,16 +964,6 @@ func (b *historyBuilder) newChildWorkflowExecutionTimedOutEvent(domain *string, 
 	historyEvent.ChildWorkflowExecutionTimedOutEventAttributes = attributes
 
 	return historyEvent
-}
-
-func (b *historyBuilder) removeHistoryAtIdx(removeIdx int) {
-	// these are buffered events without actual event IDs, so we do not need to
-	// do anything with the event IDs
-	for idx := removeIdx; idx < len(b.history)-1; idx++ {
-		b.history[idx] = b.history[idx+1]
-	}
-	// truncate last element in the slice
-	b.history = b.history[:len(b.history)-1]
 }
 
 func newDecisionTaskScheduledEventWithInfo(eventID, timestamp int64, taskList string, startToCloseTimeoutSeconds int32,

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1558,6 +1558,10 @@ Update_History_Loop:
 					// since timer builder has a local cached version of timers
 					tBuilder = e.getTimerBuilder(context.getExecution())
 					tBuilder.loadUserTimers(msBuilder)
+
+					// timer deletion is a success, we may have deleted a fired timer in
+					// which case we should reset hasBufferedEvents
+					hasUnhandledEvents = msBuilder.HasBufferedEvents()
 				}
 
 			case workflow.DecisionTypeRecordMarker:

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4490,10 +4490,11 @@ func (s *engineSuite) TestCancelTimer_RespondDecisionTaskCompleted_TimerFired() 
 	s.Nil(err)
 
 	executionBuilder := s.getBuilder(domainID, we)
-	s.Equal(int64(11), executionBuilder.GetExecutionInfo().NextEventID)
+	s.Equal(int64(10), executionBuilder.GetExecutionInfo().NextEventID)
 	s.Equal(int64(7), executionBuilder.GetExecutionInfo().LastProcessedEvent)
 	s.Equal(persistence.WorkflowStateRunning, executionBuilder.GetExecutionInfo().State)
-	s.True(executionBuilder.HasPendingDecisionTask())
+	s.False(executionBuilder.HasPendingDecisionTask())
+	s.False(executionBuilder.HasBufferedEvents())
 }
 
 func (s *engineSuite) TestSignalWorkflowExecution() {

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4422,6 +4422,74 @@ func (s *engineSuite) TestCancelTimer_RespondDecisionTaskCompleted_NoStartTimer(
 	s.False(executionBuilder.HasPendingDecisionTask())
 }
 
+func (s *engineSuite) TestCancelTimer_RespondDecisionTaskCompleted_TimerFired() {
+	domainID := validDomainID
+	we := workflow.WorkflowExecution{
+		WorkflowId: common.StringPtr("wId"),
+		RunId:      common.StringPtr(validRunID),
+	}
+	tl := "testTaskList"
+	taskToken, _ := json.Marshal(&common.TaskToken{
+		WorkflowID: *we.WorkflowId,
+		RunID:      *we.RunId,
+		ScheduleID: 2,
+	})
+	identity := "testIdentity"
+	timerID := "t1"
+
+	msBuilder := newMutableStateBuilderWithEventV2(s.mockClusterMetadata.GetCurrentClusterName(), s.mockHistoryEngine.shard, s.eventsCache,
+		bark.NewLoggerFromLogrus(log.New()), we.GetRunId())
+	// Verify cancel timer with a start event.
+	addWorkflowExecutionStartedEvent(msBuilder, we, "wType", tl, []byte("input"), 100, 100, identity)
+	di := addDecisionTaskScheduledEvent(msBuilder)
+	addDecisionTaskStartedEvent(msBuilder, di.ScheduleID, tl, identity)
+
+	ms := createMutableState(msBuilder)
+	gwmsResponse := &persistence.GetWorkflowExecutionResponse{State: ms}
+
+	decisions := []*workflow.Decision{{
+		DecisionType: common.DecisionTypePtr(workflow.DecisionTypeCancelTimer),
+		CancelTimerDecisionAttributes: &workflow.CancelTimerDecisionAttributes{
+			TimerId: common.StringPtr(timerID),
+		},
+	}}
+
+	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything).Return(gwmsResponse, nil).Once()
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything).Return(&p.AppendHistoryNodesResponse{Size: 0}, nil).Once()
+	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything).Return(&p.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &p.MutableStateUpdateSessionStats{}}, nil).Once()
+
+	s.mockMetadataMgr.On("GetDomain", mock.Anything).Return(
+		&persistence.GetDomainResponse{
+			Info:   &persistence.DomainInfo{ID: domainID},
+			Config: &persistence.DomainConfig{Retention: 1},
+			ReplicationConfig: &persistence.DomainReplicationConfig{
+				ActiveClusterName: cluster.TestCurrentClusterName,
+				Clusters: []*persistence.ClusterReplicationConfig{
+					&persistence.ClusterReplicationConfig{ClusterName: cluster.TestCurrentClusterName},
+				},
+			},
+			TableVersion: persistence.DomainTableVersionV1,
+		},
+		nil,
+	)
+	_, err := s.mockHistoryEngine.RespondDecisionTaskCompleted(context.Background(), &history.RespondDecisionTaskCompletedRequest{
+		DomainUUID: common.StringPtr(domainID),
+		CompleteRequest: &workflow.RespondDecisionTaskCompletedRequest{
+			TaskToken:        taskToken,
+			Decisions:        decisions,
+			ExecutionContext: []byte("context"),
+			Identity:         &identity,
+		},
+	})
+	s.Nil(err)
+
+	executionBuilder := s.getBuilder(domainID, we)
+	s.Equal(int64(6), executionBuilder.GetExecutionInfo().NextEventID)
+	s.Equal(int64(3), executionBuilder.GetExecutionInfo().LastProcessedEvent)
+	s.Equal(persistence.WorkflowStateRunning, executionBuilder.GetExecutionInfo().State)
+	s.False(executionBuilder.HasPendingDecisionTask())
+}
+
 func (s *engineSuite) TestSignalWorkflowExecution() {
 	signalRequest := &history.SignalWorkflowExecutionRequest{}
 	err := s.mockHistoryEngine.SignalWorkflowExecution(context.Background(), signalRequest)

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -527,8 +527,8 @@ func checkAndClearTimerFiredEvent(events []*workflow.HistoryEvent, timerID strin
 	// timerID, clear it
 	timerFiredIdx := -1
 	for idx, event := range events {
-		if *event.EventType == workflow.EventTypeTimerFired &&
-			*event.TimerFiredEventAttributes.TimerId == timerID {
+		if event.GetEventType() == workflow.EventTypeTimerFired &&
+			event.GetTimerFiredEventAttributes().GetTimerId() == timerID {
 			timerFiredIdx = idx
 			break
 		}
@@ -2302,7 +2302,7 @@ func (e *mutableStateBuilder) AddTimerCanceledEvent(
 	identity string,
 ) *workflow.HistoryEvent {
 	var timerStartedID int64
-	timerID := *attributes.TimerId
+	timerID := attributes.GetTimerId()
 	isTimerRunning, ti := e.GetUserTimer(timerID)
 	if !isTimerRunning {
 		// if timer is not running then check if it has fired in the mutable state.
@@ -2314,9 +2314,9 @@ func (e *mutableStateBuilder) AddTimerCanceledEvent(
 				"{IsTimerRunning: %v, timerID: %v}", isTimerRunning, timerID))
 			return nil
 		}
-		timerStartedID = *timerFiredEvent.TimerFiredEventAttributes.StartedEventId
+		timerStartedID = timerFiredEvent.TimerFiredEventAttributes.GetStartedEventId()
 	} else {
-		timerStartedID = ti.StartedID
+		timerStartedID = ti.GetStartedId()
 	}
 
 	// Timer is running.

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -518,6 +518,10 @@ func (e *mutableStateBuilder) checkAndClearTimerFiredEvent(timerID string) *work
 	if timerEvent != nil {
 		return timerEvent
 	}
+	e.updateBufferedEvents, timerEvent = checkAndClearTimerFiredEvent(e.updateBufferedEvents, timerID)
+	if timerEvent != nil {
+		return timerEvent
+	}
 	e.hBuilder.history, timerEvent = checkAndClearTimerFiredEvent(e.hBuilder.history, timerID)
 	return timerEvent
 }
@@ -2316,7 +2320,7 @@ func (e *mutableStateBuilder) AddTimerCanceledEvent(
 		}
 		timerStartedID = timerFiredEvent.TimerFiredEventAttributes.GetStartedEventId()
 	} else {
-		timerStartedID = ti.GetStartedId()
+		timerStartedID = ti.StartedID
 	}
 
 	// Timer is running.

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -287,7 +287,6 @@ func (e *mutableStateBuilder) FlushBufferedEvents() error {
 	var newBufferedEvents []*workflow.HistoryEvent
 	var newCommittedEvents []*workflow.HistoryEvent
 	for _, event := range e.hBuilder.history {
-		fmt.Printf("event type is %v\n", event.EventType)
 		if event.GetEventId() == common.BufferedEventID {
 			newBufferedEvents = append(newBufferedEvents, event)
 		} else {
@@ -457,7 +456,6 @@ func (e *mutableStateBuilder) CloseUpdateSession() (*mutableStateSessionUpdates,
 	if e.updateBufferedEvents != nil {
 		e.bufferedEvents = append(e.bufferedEvents, e.updateBufferedEvents...)
 		e.updateBufferedEvents = nil
-		fmt.Printf("closed session!!!\n")
 	}
 	if len(e.bufferedEvents) > e.config.MaximumBufferedEventsBatch() {
 		return nil, ErrBufferedEventsLimitExceeded
@@ -538,19 +536,7 @@ func checkAndClearTimerFiredEvent(events []*workflow.HistoryEvent, timerID strin
 	if timerFiredIdx == -1 {
 		return events, nil
 	}
-	timerFiredEvent := events[timerFiredIdx]
-	events = removeHistoryAtIdx(events, timerFiredIdx)
-	return events, timerFiredEvent
-}
-
-func removeHistoryAtIdx(events []*workflow.HistoryEvent, removeIdx int) []*workflow.HistoryEvent {
-	// these are buffered events without actual event IDs, so we do not need to
-	// do anything with the event IDs
-	for idx := removeIdx; idx < len(events)-1; idx++ {
-		events[idx] = events[idx+1]
-	}
-	// truncate last element in the slice
-	return events[:len(events)-1]
+	return append(events[:timerFiredIdx], events[timerFiredIdx+1:]...), events[timerFiredIdx]
 }
 
 func convertUpdateActivityInfos(inputs map[*persistence.ActivityInfo]struct{}) []*persistence.ActivityInfo {


### PR DESCRIPTION
While cancelling timer, if the timer does not exist go over buffered events to check if the timer was already fired and clear it, so that the cancel can succeed.

Fixes #1610 