### PR TITLE
sql: make visibility APIs do upsert instead of insert/update

### DIFF
--- a/common/persistence/sql/sqlVisibilityStore.go
+++ b/common/persistence/sql/sqlVisibilityStore.go
@@ -61,47 +61,37 @@ func NewSQLVisibilityStore(cfg config.SQL, logger bark.Logger) (p.VisibilityMana
 }
 
 func (s *sqlVisibilityStore) RecordWorkflowExecutionStarted(request *p.RecordWorkflowExecutionStartedRequest) error {
-	result, err := s.db.InsertIntoVisibility(&sqldb.VisibilityRow{
+	_, err := s.db.InsertIntoVisibility(&sqldb.VisibilityRow{
 		DomainID:         request.DomainUUID,
 		WorkflowID:       *request.Execution.WorkflowId,
 		RunID:            *request.Execution.RunId,
 		StartTime:        time.Unix(0, request.StartTimestamp),
 		WorkflowTypeName: request.WorkflowTypeName,
 	})
-	if err != nil {
-		return err
-	}
-	noRowsAffected, err := result.RowsAffected()
-	if err != nil {
-		return fmt.Errorf("RecordWorkflowExecutionStarted rowsAffected error: %v", err)
-	}
-	if noRowsAffected != 1 {
-		return fmt.Errorf("RecordWorkflowExecutionStarted %v rows updated instead of one", noRowsAffected)
-	}
-	return nil
+	return err
 }
 
 func (s *sqlVisibilityStore) RecordWorkflowExecutionClosed(request *p.RecordWorkflowExecutionClosedRequest) error {
 	closeTime := time.Unix(0, request.CloseTimestamp)
-	result, err := s.db.UpdateVisibility(&sqldb.VisibilityRow{
-		CloseTime:     &closeTime,
-		CloseStatus:   common.Int32Ptr(int32(request.Status)),
-		HistoryLength: &request.HistoryLength,
-		DomainID:      request.DomainUUID,
-		RunID:         *request.Execution.RunId,
+	result, err := s.db.ReplaceIntoVisibility(&sqldb.VisibilityRow{
+		DomainID:         request.DomainUUID,
+		WorkflowID:       *request.Execution.WorkflowId,
+		RunID:            *request.Execution.RunId,
+		StartTime:        time.Unix(0, request.StartTimestamp),
+		WorkflowTypeName: request.WorkflowTypeName,
+		CloseTime:        &closeTime,
+		CloseStatus:      common.Int32Ptr(int32(request.Status)),
+		HistoryLength:    &request.HistoryLength,
 	})
 	if err != nil {
 		return err
 	}
 	noRowsAffected, err := result.RowsAffected()
 	if err != nil {
-		return fmt.Errorf("RecordWorkflowExecutionStarted rowsAffected error: %v", err)
+		return fmt.Errorf("RecordWorkflowExecutionClosed rowsAffected error: %v", err)
 	}
-	if noRowsAffected != 1 {
-		// TODO:this should never happen since we always create the record before setting it to closed
-		// However, its ideal to provide same semantics as cassandra API here i.e. always upsert old
-		// record and return success
-		return nil
+	if noRowsAffected > 2 { // either adds a new row or deletes old row and adds new row
+		return fmt.Errorf("RecordWorkflowExecutionClosed unexpected numRows (%v) updated", noRowsAffected)
 	}
 	return nil
 }

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -739,8 +739,11 @@ type (
 		// - multiple rows - {shardID, domainID, workflowID, runID}
 		DeleteFromSignalsRequestedSets(filter *SignalsRequestedSetsFilter) (sql.Result, error)
 
+		// InsertIntoVisibility inserts a row into visibility table. If a row already exist,
+		// no changes will be made by this API
 		InsertIntoVisibility(row *VisibilityRow) (sql.Result, error)
-		UpdateVisibility(row *VisibilityRow) (sql.Result, error)
+		// ReplaceIntoVisibility deletes old row (if it exist) and inserts new row into visibility table
+		ReplaceIntoVisibility(row *VisibilityRow) (sql.Result, error)
 		// SelectFromVisibility returns one or more rows from visibility table
 		// Required filter params:
 		// - getClosedWorkflowExecution - retrieves single row - {domainID, runID, closed=true}


### PR DESCRIPTION
Currently, the SQL visibility APIs are not idempotent. They throw an error when row already exist. This creates a problem when are duplicate calls and/or calls out of order. This patch modifies the SQL APIs to use "insert ignore" and "replace into" instead of "insert" and "update". This will give the semantics that the caller expects

As part of this change, the tests are also updated to validate that persistence returns exactly what was stored. New tests are also added for duplicate and out of order processing