### PR TITLE
persistenceTestBase: re-expose dbport/schemaDir options 

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceTest.go
+++ b/common/persistence/cassandra/cassandraPersistenceTest.go
@@ -48,15 +48,21 @@ type TestCluster struct {
 }
 
 // NewTestCluster returns a new cassandra test cluster
-func NewTestCluster(keyspace string) *TestCluster {
+func NewTestCluster(keyspace string, port int, schemaDir string) *TestCluster {
 	var result TestCluster
 	result.keyspace = keyspace
-	result.schemaDir = testSchemaDir
+	if port == 0 {
+		port = environment.GetCassandraPort()
+	}
+	if schemaDir == "" {
+		schemaDir = testSchemaDir
+	}
+	result.schemaDir = schemaDir
 	result.cfg = config.Cassandra{
 		User:     testUser,
 		Password: testPassword,
 		Hosts:    environment.GetCassandraAddress(),
-		Port:     environment.GetCassandraPort(),
+		Port:     port,
 		MaxConns: 2,
 		Keyspace: keyspace,
 	}

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -52,7 +52,9 @@ type (
 	// TestBaseOptions options to configure workflow test base.
 	TestBaseOptions struct {
 		DBName          string
+		DBPort          int              `yaml:"-"`
 		StoreType       string           `yaml:"-"`
+		SchemaDir       string           `yaml:"-"`
 		ClusterMetadata cluster.Metadata `yaml:"-"`
 	}
 
@@ -105,7 +107,7 @@ func NewTestBaseWithCassandra(options *TestBaseOptions) TestBase {
 	if options.DBName == "" {
 		options.DBName = "test_" + GenerateRandomDBName(10)
 	}
-	testCluster := cassandra.NewTestCluster(options.DBName)
+	testCluster := cassandra.NewTestCluster(options.DBName, options.DBPort, options.SchemaDir)
 	return newTestBase(options, testCluster)
 }
 
@@ -114,7 +116,7 @@ func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
 	if options.DBName == "" {
 		options.DBName = GenerateRandomDBName(10)
 	}
-	testCluster := sql.NewTestCluster(options.DBName)
+	testCluster := sql.NewTestCluster(options.DBName, options.DBPort, options.SchemaDir)
 	return newTestBase(options, testCluster)
 }
 

--- a/common/persistence/sql/sqlPersistenceTest.go
+++ b/common/persistence/sql/sqlPersistenceTest.go
@@ -34,11 +34,9 @@ import (
 )
 
 const (
-	testWorkflowClusterHosts = "127.0.0.1"
-	testPort                 = 3306
-	testUser                 = "uber"
-	testPassword             = "uber"
-	testSchemaDir            = "schema/mysql/v57"
+	testUser      = "uber"
+	testPassword  = "uber"
+	testSchemaDir = "schema/mysql/v57"
 )
 
 // TestCluster allows executing cassandra operations in testing.
@@ -50,14 +48,20 @@ type TestCluster struct {
 }
 
 // NewTestCluster returns a new SQL test cluster
-func NewTestCluster(dbName string) *TestCluster {
+func NewTestCluster(dbName string, port int, schemaDir string) *TestCluster {
 	var result TestCluster
 	result.dbName = dbName
-	result.schemaDir = testSchemaDir
+	if port == 0 {
+		port = environment.GetMySQLPort()
+	}
+	if schemaDir == "" {
+		schemaDir = testSchemaDir
+	}
+	result.schemaDir = schemaDir
 	result.cfg = config.SQL{
 		User:            testUser,
 		Password:        testPassword,
-		ConnectAddr:     fmt.Sprintf("%v:%v", environment.GetMySQLAddress(), environment.GetMySQLPort()),
+		ConnectAddr:     fmt.Sprintf("%v:%v", environment.GetMySQLAddress(), port),
 		ConnectProtocol: "tcp",
 		DriverName:      defaultDriverName,
 		DatabaseName:    dbName,


### PR DESCRIPTION
A previous patch removed these options think they weren't used at all. However, it looks like UBER internal integration environment relies on these options. This patch simply adds the options back. 