### PR TITLE
sql: allow configuration of connection pool settings

### DIFF
--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -29,9 +29,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	p "github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/sql/storage"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
-	"github.com/uber/cadence/common/service/config"
 )
 
 type sqlHistoryManager struct {
@@ -40,11 +38,7 @@ type sqlHistoryManager struct {
 }
 
 // newHistoryPersistence creates an instance of HistoryManager
-func newHistoryPersistence(cfg config.SQL, logger log.Logger) (p.HistoryStore, error) {
-	var db, err = storage.NewSQLDB(&cfg)
-	if err != nil {
-		return nil, err
-	}
+func newHistoryPersistence(db sqldb.Interface, logger log.Logger) (p.HistoryStore, error) {
 	return &sqlHistoryManager{
 		sqlStore: sqlStore{
 			db:     db,

--- a/common/persistence/sql/sqlHistoryV2Manager.go
+++ b/common/persistence/sql/sqlHistoryV2Manager.go
@@ -32,9 +32,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	p "github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/sql/storage"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
-	"github.com/uber/cadence/common/service/config"
 )
 
 type sqlHistoryV2Manager struct {
@@ -42,12 +40,8 @@ type sqlHistoryV2Manager struct {
 	shardID int
 }
 
-// newHistoryPersistence creates an instance of HistoryManager
-func newHistoryV2Persistence(cfg config.SQL, logger log.Logger) (p.HistoryV2Store, error) {
-	var db, err = storage.NewSQLDB(&cfg)
-	if err != nil {
-		return nil, err
-	}
+// newHistoryV2Persistence creates an instance of HistoryManager
+func newHistoryV2Persistence(db sqldb.Interface, logger log.Logger) (p.HistoryV2Store, error) {
 	return &sqlHistoryV2Manager{
 		sqlStore: sqlStore{
 			db:     db,

--- a/common/persistence/sql/sqlMetadataManagerV2.go
+++ b/common/persistence/sql/sqlMetadataManagerV2.go
@@ -30,9 +30,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/sql/storage"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
-	"github.com/uber/cadence/common/service/config"
 )
 
 type sqlMetadataManagerV2 struct {
@@ -41,12 +39,8 @@ type sqlMetadataManagerV2 struct {
 }
 
 // newMetadataPersistenceV2 creates an instance of sqlMetadataManagerV2
-func newMetadataPersistenceV2(cfg config.SQL, currentClusterName string,
+func newMetadataPersistenceV2(db sqldb.Interface, currentClusterName string,
 	logger log.Logger) (persistence.MetadataManager, error) {
-	var db, err = storage.NewSQLDB(&cfg)
-	if err != nil {
-		return nil, err
-	}
 	return &sqlMetadataManagerV2{
 		sqlStore: sqlStore{
 			db:     db,

--- a/common/persistence/sql/sqlShardManager.go
+++ b/common/persistence/sql/sqlShardManager.go
@@ -30,9 +30,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/sql/storage"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
-	"github.com/uber/cadence/common/service/config"
 )
 
 type sqlShardManager struct {
@@ -41,11 +39,7 @@ type sqlShardManager struct {
 }
 
 // newShardPersistence creates an instance of ShardManager
-func newShardPersistence(cfg config.SQL, currentClusterName string, log log.Logger) (persistence.ShardManager, error) {
-	var db, err = storage.NewSQLDB(&cfg)
-	if err != nil {
-		return nil, err
-	}
+func newShardPersistence(db sqldb.Interface, currentClusterName string, log log.Logger) (persistence.ShardManager, error) {
 	return &sqlShardManager{
 		sqlStore: sqlStore{
 			db:     db,

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -32,9 +32,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/sql/storage"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
-	"github.com/uber/cadence/common/service/config"
 )
 
 type sqlTaskManager struct {
@@ -47,17 +45,13 @@ var (
 )
 
 // newTaskPersistence creates a new instance of TaskManager
-func newTaskPersistence(cfg config.SQL, log log.Logger) (persistence.TaskManager, error) {
-	var db, err = storage.NewSQLDB(&cfg)
-	if err != nil {
-		return nil, err
-	}
+func newTaskPersistence(db sqldb.Interface, nShards int, log log.Logger) (persistence.TaskManager, error) {
 	return &sqlTaskManager{
 		sqlStore: sqlStore{
 			db:     db,
 			logger: log,
 		},
-		nShards: cfg.NumShards,
+		nShards: nShards,
 	}, nil
 }
 

--- a/common/persistence/sql/storage/store.go
+++ b/common/persistence/sql/storage/store.go
@@ -55,6 +55,15 @@ func NewSQLDB(cfg *config.SQL) (sqldb.Interface, error) {
 	if err != nil {
 		return nil, err
 	}
+	if cfg.MaxConns > 0 {
+		db.SetMaxOpenConns(cfg.MaxConns)
+	}
+	if cfg.MaxIdleConns > 0 {
+		db.SetMaxIdleConns(cfg.MaxIdleConns)
+	}
+	if cfg.MaxConnLifetime > 0 {
+		db.SetConnMaxLifetime(cfg.MaxConnLifetime)
+	}
 	// Maps struct names in CamelCase to snake without need for db struct tags.
 	db.MapperFunc(strcase.ToSnake)
 	return mysql.NewDB(db, nil), nil

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -192,6 +192,10 @@ type (
 		MaxQPS int `yaml:"maxQPS"`
 		// MaxConns the max number of connections to this datastore
 		MaxConns int `yaml:"maxConns"`
+		// MaxIdleConns is the max number of idle connections to this datastore
+		MaxIdleConns int `yaml:"maxIdleConns"`
+		// MaxConnLifetime is the maximum time a connection can be alive
+		MaxConnLifetime time.Duration `yaml:"maxConnLifetime"`
 		// NumShards is the number of storage shards to use for tables
 		// in a sharded sql database. The default value for this param is 1
 		NumShards int `yaml:"nShards"`


### PR DESCRIPTION
This patch exposes sql connection pool settings to config yaml. Some refactoring of the persistence factory was needed to achieve this. One behavior difference is introduced (for SQL only) as part of this diff. Previously, we use a separate connection pool (sqlx.DB object) for each type of persistence manager (taskMgr, executionMgr etc). This makes connection pool settings like maxConns difficult unless we also expose separate settings for each one of the managers. On the other hand, for MySQL, there is no clear advantage to maintaining separate connection pools today. There could be some benefits wrt priority (i.e. execution manager gets more maxConns than taskMgr), but this is best enforced at higher layers (quotas & ratelimiting). So, this patch puts all managers under one connection pool.