### PR TITLE
Auto-Reset : CLI to add/remove bad binary checksum

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -72,6 +72,7 @@ var keys = map[Key]string{
 	FrontendVisibilityMaxPageSize:  "frontend.visibilityMaxPageSize",
 	FrontendVisibilityListMaxQPS:   "frontend.visibilityListMaxQPS",
 	FrontendESVisibilityListMaxQPS: "frontend.esVisibilityListMaxQPS",
+	FrontendMaxBadBinaries:         "frontend.maxBadBinaries",
 	FrontendESIndexMaxResultWindow: "frontend.esIndexMaxResultWindow",
 	FrontendHistoryMaxPageSize:     "frontend.historyMaxPageSize",
 	FrontendRPS:                    "frontend.rps",
@@ -265,6 +266,8 @@ const (
 	MaxDecisionStartToCloseTimeout
 	// EnableClientVersionCheck enables client version check for frontend
 	EnableClientVersionCheck
+	// FrontendMaxBadBinaries is the max number of bad banaries in domain config
+	FrontendMaxBadBinaries
 
 	// key for matching
 

--- a/service/frontend/domainHandler.go
+++ b/service/frontend/domainHandler.go
@@ -431,7 +431,7 @@ func (d *domainHandlerImpl) updateDomain(ctx context.Context,
 		if updatedConfig.BadBinaries != nil {
 			maxLength := d.config.MaxBadBinaries(updateRequest.GetName())
 			// only do merging
-			config.BadBinaries = d.mergeBadBinaries(config.BadBinaries.Binaries, updatedConfig.BadBinaries.Binaries)
+			config.BadBinaries = d.mergeBadBinaries(config.BadBinaries.Binaries, updatedConfig.BadBinaries.Binaries, time.Now().UnixNano())
 			if len(config.BadBinaries.Binaries) > maxLength {
 				return nil, &shared.BadRequestError{
 					Message: fmt.Sprintf("Total resetBinaries cannot exceed the max limit: %v", maxLength),
@@ -639,12 +639,12 @@ func (d *domainHandlerImpl) createResponse(
 	return infoResult, configResult, replicationConfigResult
 }
 
-func (d *domainHandlerImpl) mergeBadBinaries(old map[string]*shared.BadBinaryInfo, new map[string]*shared.BadBinaryInfo) shared.BadBinaries {
+func (d *domainHandlerImpl) mergeBadBinaries(old map[string]*shared.BadBinaryInfo, new map[string]*shared.BadBinaryInfo, createTimeNano int64) shared.BadBinaries {
 	if old == nil {
 		old = map[string]*shared.BadBinaryInfo{}
 	}
 	for k, v := range new {
-		v.CreatedTimeNano = common.Int64Ptr(time.Now().UnixNano())
+		v.CreatedTimeNano = common.Int64Ptr(createTimeNano)
 		old[k] = v
 	}
 	return shared.BadBinaries{

--- a/service/frontend/domainHandler_test.go
+++ b/service/frontend/domainHandler_test.go
@@ -24,6 +24,10 @@ import (
 	"log"
 	"os"
 	"testing"
+	"time"
+
+	"github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
@@ -140,4 +144,80 @@ func (s *domainHandlerSuite) TestMergeDomainData_Nil() {
 		"k0": "v1",
 		"k1": "v2",
 	}, out)
+}
+
+// test merging bad binaries
+
+var nowInt64 = time.Now().UnixNano()
+
+func (s *domainHandlerSuite) TestMergeBadBinaries_Overriding() {
+	out := s.handler.mergeBadBinaries(
+		map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason0")},
+		},
+		map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason2")},
+		}, nowInt64,
+	)
+
+	assert.True(s.T(), out.Equals(&shared.BadBinaries{
+		Binaries: map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason2"), CreatedTimeNano: common.Int64Ptr(nowInt64)},
+		},
+	}))
+}
+
+func (s *domainHandlerSuite) TestMergeBadBinaries_Adding() {
+	out := s.handler.mergeBadBinaries(
+		map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason0")},
+		},
+		map[string]*shared.BadBinaryInfo{
+			"k1": {Reason: common.StringPtr("reason2")},
+		}, nowInt64,
+	)
+
+	expected := &shared.BadBinaries{
+		Binaries: map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason0")},
+			"k1": {Reason: common.StringPtr("reason2"), CreatedTimeNano: common.Int64Ptr(nowInt64)},
+		},
+	}
+	assert.Equal(s.T(), out.String(), expected.String())
+}
+
+func (s *domainHandlerSuite) TestMergeBadBinaries_Merging() {
+	out := s.handler.mergeBadBinaries(
+		map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason0")},
+		},
+		map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason1")},
+			"k1": {Reason: common.StringPtr("reason2")},
+		}, nowInt64,
+	)
+
+	assert.True(s.T(), out.Equals(&shared.BadBinaries{
+		Binaries: map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason1"), CreatedTimeNano: common.Int64Ptr(nowInt64)},
+			"k1": {Reason: common.StringPtr("reason2"), CreatedTimeNano: common.Int64Ptr(nowInt64)},
+		},
+	}))
+}
+
+func (s *domainHandlerSuite) TestMergeBadBinaries_Nil() {
+	out := s.handler.mergeBadBinaries(
+		nil,
+		map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason1")},
+			"k1": {Reason: common.StringPtr("reason2")},
+		}, nowInt64,
+	)
+
+	assert.True(s.T(), out.Equals(&shared.BadBinaries{
+		Binaries: map[string]*shared.BadBinaryInfo{
+			"k0": {Reason: common.StringPtr("reason1"), CreatedTimeNano: common.Int64Ptr(nowInt64)},
+			"k1": {Reason: common.StringPtr("reason2"), CreatedTimeNano: common.Int64Ptr(nowInt64)},
+		},
+	}))
 }

--- a/service/frontend/domainReplicationTaskHandler.go
+++ b/service/frontend/domainReplicationTaskHandler.go
@@ -22,6 +22,7 @@ package frontend
 
 import (
 	"errors"
+
 	"github.com/uber/cadence/.gen/go/replicator"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
@@ -91,6 +92,7 @@ func (domainReplicator *domainReplicatorImpl) HandleTransmissionTask(domainOpera
 			EmitMetric:                             common.BoolPtr(config.EmitMetric),
 			ArchivalBucketName:                     common.StringPtr(config.ArchivalBucket),
 			ArchivalStatus:                         common.ArchivalStatusPtr(config.ArchivalStatus),
+			BadBinaries:                            &config.BadBinaries,
 		},
 		ReplicationConfig: &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(replicationConfig.ActiveClusterName),

--- a/service/frontend/domainReplicationTaskHandler_test.go
+++ b/service/frontend/domainReplicationTaskHandler_test.go
@@ -104,6 +104,7 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_Is
 		EmitMetric:     emitMetric,
 		ArchivalBucket: archivalBucket,
 		ArchivalStatus: archivalStatus,
+		BadBinaries:    shared.BadBinaries{},
 	}
 	replicationConfig := &p.DomainReplicationConfig{
 		ActiveClusterName: clusterActive,
@@ -128,6 +129,7 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_Is
 				EmitMetric:                             common.BoolPtr(emitMetric),
 				ArchivalBucketName:                     common.StringPtr(archivalBucket),
 				ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
+				BadBinaries:                            &shared.BadBinaries{},
 			},
 			ReplicationConfig: &shared.DomainReplicationConfiguration{
 				ActiveClusterName: common.StringPtr(clusterActive),
@@ -179,6 +181,7 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_RegisterDomainTask_No
 		EmitMetric:     emitMetric,
 		ArchivalBucket: archivalBucket,
 		ArchivalStatus: archivalStatus,
+		BadBinaries:    shared.BadBinaries{},
 	}
 	replicationConfig := &p.DomainReplicationConfig{
 		ActiveClusterName: clusterActive,
@@ -229,6 +232,7 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_UpdateDomainTask_IsGl
 		EmitMetric:     emitMetric,
 		ArchivalBucket: archivalBucket,
 		ArchivalStatus: archivalStatus,
+		BadBinaries:    shared.BadBinaries{},
 	}
 	replicationConfig := &p.DomainReplicationConfig{
 		ActiveClusterName: clusterActive,
@@ -253,6 +257,7 @@ func (s *domainReplicatorSuite) TestHandleTransmissionTask_UpdateDomainTask_IsGl
 				EmitMetric:                             common.BoolPtr(emitMetric),
 				ArchivalBucketName:                     common.StringPtr(archivalBucket),
 				ArchivalStatus:                         common.ArchivalStatusPtr(archivalStatus),
+				BadBinaries:                            &shared.BadBinaries{},
 			},
 			ReplicationConfig: &shared.DomainReplicationConfiguration{
 				ActiveClusterName: common.StringPtr(clusterActive),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -56,6 +56,7 @@ type Config struct {
 	HistoryMgrNumConns dynamicconfig.IntPropertyFn
 
 	MaxDecisionStartToCloseTimeout dynamicconfig.IntPropertyFnWithDomainFilter
+	MaxBadBinaries                 dynamicconfig.IntPropertyFnWithDomainFilter
 
 	// security protection settings
 	EnableAdminProtection         dynamicconfig.BoolPropertyFn
@@ -90,6 +91,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableVisibil
 		MaxIDLengthLimit:                    dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		HistoryMgrNumConns:                  dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
 		MaxDecisionStartToCloseTimeout:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaxDecisionStartToCloseTimeout, 600),
+		MaxBadBinaries:                      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries, 10),
 		EnableAdminProtection:               dc.GetBoolProperty(dynamicconfig.EnableAdminProtection, false),
 		AdminOperationToken:                 dc.GetStringProperty(dynamicconfig.AdminOperationToken, "CadenceTeamONLY"),
 		DisableListVisibilityByFilter:       dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.DisableListVisibilityByFilter, false),

--- a/service/worker/replicator/domainReplicationTaskHandler.go
+++ b/service/worker/replicator/domainReplicationTaskHandler.go
@@ -180,6 +180,9 @@ func (domainReplicator *domainReplicatorImpl) handleDomainUpdateReplicationTask(
 			ArchivalBucket: task.Config.GetArchivalBucketName(),
 			ArchivalStatus: task.Config.GetArchivalStatus(),
 		}
+		if task.Config.GetBadBinaries() != nil {
+			request.Config.BadBinaries = *task.Config.GetBadBinaries()
+		}
 		request.ReplicationConfig.Clusters = domainReplicator.convertClusterReplicationConfigFromThrift(task.ReplicationConfig.Clusters)
 		request.ConfigVersion = task.GetConfigVersion()
 	}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -25,7 +25,7 @@ import "github.com/urfave/cli"
 const (
 	// Version is the controlled version string. It should be updated every time
 	// before we release a new version.
-	Version = "0.5.11"
+	Version = "0.6.0"
 )
 
 // NewCliApp instantiates a new instance of the CLI application.

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -125,44 +125,21 @@ func (s *cliAppSuite) TestAppCommands() {
 }
 
 func (s *cliAppSuite) TestDomainRegister() {
-	s.clientFrontendClient.EXPECT().RegisterDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil)
+	s.serverFrontendClient.EXPECT().RegisterDomain(gomock.Any(), gomock.Any()).Return(nil)
 	err := s.app.Run([]string{"", "--do", domainName, "domain", "register"})
 	s.Nil(err)
 }
 
 func (s *cliAppSuite) TestDomainRegister_DomainExist() {
-	s.clientFrontendClient.EXPECT().RegisterDomain(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.DomainAlreadyExistsError{})
+	s.serverFrontendClient.EXPECT().RegisterDomain(gomock.Any(), gomock.Any()).Return(&shared.DomainAlreadyExistsError{})
 	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "register"})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestDomainRegister_Failed() {
-	s.clientFrontendClient.EXPECT().RegisterDomain(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.BadRequestError{"fake error"})
+	s.serverFrontendClient.EXPECT().RegisterDomain(gomock.Any(), gomock.Any()).Return(&shared.BadRequestError{"fake error"})
 	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "register"})
 	s.Equal(1, errorCode)
-}
-
-var describeDomainResponse = &shared.DescribeDomainResponse{
-	DomainInfo: &shared.DomainInfo{
-		Name:        common.StringPtr("test-domain"),
-		Description: common.StringPtr("a test domain"),
-		OwnerEmail:  common.StringPtr("test@uber.com"),
-	},
-	Configuration: &shared.DomainConfiguration{
-		WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(3),
-		EmitMetric:                             common.BoolPtr(true),
-	},
-	ReplicationConfiguration: &shared.DomainReplicationConfiguration{
-		ActiveClusterName: common.StringPtr("active"),
-		Clusters: []*shared.ClusterReplicationConfiguration{
-			{
-				ClusterName: common.StringPtr("active"),
-			},
-			{
-				ClusterName: common.StringPtr("standby"),
-			},
-		},
-	},
 }
 
 var describeDomainResponseServer = &serverShared.DescribeDomainResponse{
@@ -189,9 +166,9 @@ var describeDomainResponseServer = &serverShared.DescribeDomainResponse{
 }
 
 func (s *cliAppSuite) TestDomainUpdate() {
-	resp := describeDomainResponse
-	s.clientFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(resp, nil).Times(2)
-	s.clientFrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, nil).Times(2)
+	resp := describeDomainResponseServer
+	s.serverFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(resp, nil).Times(2)
+	s.serverFrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any()).Return(nil, nil).Times(2)
 	err := s.app.Run([]string{"", "--do", domainName, "domain", "update"})
 	s.Nil(err)
 	err = s.app.Run([]string{"", "--do", domainName, "domain", "update", "--desc", "another desc", "--oe", "another@uber.com", "--rd", "1", "--em", "f"})
@@ -199,23 +176,23 @@ func (s *cliAppSuite) TestDomainUpdate() {
 }
 
 func (s *cliAppSuite) TestDomainUpdate_DomainNotExist() {
-	resp := describeDomainResponse
-	s.clientFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(resp, nil)
-	s.clientFrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, &shared.EntityNotExistsError{})
+	resp := describeDomainResponseServer
+	s.serverFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(resp, nil)
+	s.serverFrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any()).Return(nil, &shared.EntityNotExistsError{})
 	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "update"})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestDomainUpdate_ActiveClusterFlagNotSet_DomainNotExist() {
-	s.clientFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, &shared.EntityNotExistsError{})
+	s.serverFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(nil, &shared.EntityNotExistsError{})
 	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "update"})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestDomainUpdate_Failed() {
-	resp := describeDomainResponse
-	s.clientFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), callOptions...).Return(resp, nil)
-	s.clientFrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any(), callOptions...).Return(nil, &shared.BadRequestError{"faked error"})
+	resp := describeDomainResponseServer
+	s.serverFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).Return(resp, nil)
+	s.serverFrontendClient.EXPECT().UpdateDomain(gomock.Any(), gomock.Any()).Return(nil, &shared.BadRequestError{"faked error"})
 	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "update"})
 	s.Equal(1, errorCode)
 }

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -130,7 +130,7 @@ func ErrorAndExit(msg string, err error) {
 
 // RegisterDomain register a domain
 func RegisterDomain(c *cli.Context) {
-	domainClient := getDomainClient(c)
+	frontendClient := cFactory.ServerFrontendClient(c)
 	domain := getRequiredGlobalOption(c, FlagDomain)
 
 	description := c.String(FlagDescription)
@@ -169,20 +169,20 @@ func RegisterDomain(c *cli.Context) {
 	if c.IsSet(FlagActiveClusterName) {
 		activeClusterName = c.String(FlagActiveClusterName)
 	}
-	var clusters []*s.ClusterReplicationConfiguration
+	var clusters []*shared.ClusterReplicationConfiguration
 	if c.IsSet(FlagClusters) {
 		clusterStr := c.String(FlagClusters)
-		clusters = append(clusters, &s.ClusterReplicationConfiguration{
+		clusters = append(clusters, &shared.ClusterReplicationConfiguration{
 			ClusterName: common.StringPtr(clusterStr),
 		})
 		for _, clusterStr := range c.Args() {
-			clusters = append(clusters, &s.ClusterReplicationConfiguration{
+			clusters = append(clusters, &shared.ClusterReplicationConfiguration{
 				ClusterName: common.StringPtr(clusterStr),
 			})
 		}
 	}
 
-	request := &s.RegisterDomainRequest{
+	request := &shared.RegisterDomainRequest{
 		Name:                                   common.StringPtr(domain),
 		Description:                            common.StringPtr(description),
 		OwnerEmail:                             common.StringPtr(ownerEmail),
@@ -198,7 +198,7 @@ func RegisterDomain(c *cli.Context) {
 
 	ctx, cancel := newContext(c)
 	defer cancel()
-	err = domainClient.Register(ctx, request)
+	err = frontendClient.RegisterDomain(ctx, request)
 	if err != nil {
 		if _, ok := err.(*s.DomainAlreadyExistsError); !ok {
 			ErrorAndExit("Register Domain operation failed.", err)
@@ -212,27 +212,29 @@ func RegisterDomain(c *cli.Context) {
 
 // UpdateDomain updates a domain
 func UpdateDomain(c *cli.Context) {
-	domainClient := getDomainClient(c)
+	frontendClient := cFactory.ServerFrontendClient(c)
 	domain := getRequiredGlobalOption(c, FlagDomain)
 
-	var updateRequest *s.UpdateDomainRequest
+	var updateRequest *shared.UpdateDomainRequest
 	ctx, cancel := newContext(c)
 	defer cancel()
 
 	if c.IsSet(FlagActiveClusterName) {
 		activeCluster := c.String(FlagActiveClusterName)
 		fmt.Printf("Will set active cluster name to: %s, other flag will be omitted.\n", activeCluster)
-		replicationConfig := &s.DomainReplicationConfiguration{
+		replicationConfig := &shared.DomainReplicationConfiguration{
 			ActiveClusterName: common.StringPtr(activeCluster),
 		}
-		updateRequest = &s.UpdateDomainRequest{
+		updateRequest = &shared.UpdateDomainRequest{
 			Name:                     common.StringPtr(domain),
 			ReplicationConfiguration: replicationConfig,
 		}
 	} else {
-		resp, err := domainClient.Describe(ctx, domain)
+		resp, err := frontendClient.DescribeDomain(ctx, &shared.DescribeDomainRequest{
+			Name: common.StringPtr(domain),
+		})
 		if err != nil {
-			if _, ok := err.(*s.EntityNotExistsError); !ok {
+			if _, ok := err.(*shared.EntityNotExistsError); !ok {
 				ErrorAndExit("Operation UpdateDomain failed.", err)
 			} else {
 				ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domain), err)
@@ -244,7 +246,7 @@ func UpdateDomain(c *cli.Context) {
 		ownerEmail := resp.DomainInfo.GetOwnerEmail()
 		retentionDays := resp.Configuration.GetWorkflowExecutionRetentionPeriodInDays()
 		emitMetric := resp.Configuration.GetEmitMetric()
-		var clusters []*s.ClusterReplicationConfiguration
+		var clusters []*shared.ClusterReplicationConfiguration
 
 		if c.IsSet(FlagDescription) {
 			description = c.String(FlagDescription)
@@ -271,41 +273,66 @@ func UpdateDomain(c *cli.Context) {
 		}
 		if c.IsSet(FlagClusters) {
 			clusterStr := c.String(FlagClusters)
-			clusters = append(clusters, &s.ClusterReplicationConfiguration{
+			clusters = append(clusters, &shared.ClusterReplicationConfiguration{
 				ClusterName: common.StringPtr(clusterStr),
 			})
 			for _, clusterStr := range c.Args() {
-				clusters = append(clusters, &s.ClusterReplicationConfiguration{
+				clusters = append(clusters, &shared.ClusterReplicationConfiguration{
 					ClusterName: common.StringPtr(clusterStr),
 				})
 			}
 		}
 
-		updateInfo := &s.UpdateDomainInfo{
+		var binBinaries *shared.BadBinaries
+		if c.IsSet(FlagAddBadBinary) {
+			if !c.IsSet(FlagReason) {
+				ErrorAndExit("Must provide a reason.", nil)
+			}
+			binChecksum := c.String(FlagAddBadBinary)
+			reason := c.String(FlagReason)
+			operator := getCurrentUserFromEnv()
+			binBinaries = &shared.BadBinaries{
+				Binaries: map[string]*shared.BadBinaryInfo{
+					binChecksum: {
+						Reason:   common.StringPtr(reason),
+						Operator: common.StringPtr(operator),
+					},
+				},
+			}
+		}
+
+		var badBinaryToDelete *string
+		if c.IsSet(FlagRemoveBadBinary) {
+			badBinaryToDelete = common.StringPtr(c.String(FlagAddBadBinary))
+		}
+
+		updateInfo := &shared.UpdateDomainInfo{
 			Description: common.StringPtr(description),
 			OwnerEmail:  common.StringPtr(ownerEmail),
 			Data:        domainData,
 		}
-		updateConfig := &s.DomainConfiguration{
+		updateConfig := &shared.DomainConfiguration{
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(int32(retentionDays)),
 			EmitMetric:                             common.BoolPtr(emitMetric),
 			ArchivalStatus:                         archivalStatus(c),
 			ArchivalBucketName:                     common.StringPtr(c.String(FlagArchivalBucketName)),
+			BadBinaries:                            binBinaries,
 		}
-		replicationConfig := &s.DomainReplicationConfiguration{
+		replicationConfig := &shared.DomainReplicationConfiguration{
 			Clusters: clusters,
 		}
-		updateRequest = &s.UpdateDomainRequest{
+		updateRequest = &shared.UpdateDomainRequest{
 			Name:                     common.StringPtr(domain),
 			UpdatedInfo:              updateInfo,
 			Configuration:            updateConfig,
 			ReplicationConfiguration: replicationConfig,
+			DeleteBadBinary:          badBinaryToDelete,
 		}
 	}
 
 	securityToken := c.String(FlagSecurityToken)
 	updateRequest.SecurityToken = common.StringPtr(securityToken)
-	err := domainClient.Update(ctx, updateRequest)
+	_, err := frontendClient.UpdateDomain(ctx, updateRequest)
 	if err != nil {
 		if _, ok := err.(*s.EntityNotExistsError); !ok {
 			ErrorAndExit("Operation UpdateDomain failed.", err)
@@ -315,6 +342,20 @@ func UpdateDomain(c *cli.Context) {
 	} else {
 		fmt.Printf("Domain %s successfully updated.\n", domain)
 	}
+}
+
+func getCurrentUserFromEnv() string {
+	varNames := []string{
+		"USER",
+		"LOGNAME",
+		"HOME",
+	}
+	for _, n := range varNames {
+		if len(os.Getenv(n)) > 0 {
+			return os.Getenv(n)
+		}
+	}
+	return "unkown"
 }
 
 // DescribeDomain updates a domain
@@ -1323,10 +1364,6 @@ func ObserveHistoryWithID(c *cli.Context) {
 	printWorkflowProgress(c, wid, rid)
 }
 
-func getDomainClient(c *cli.Context) client.DomainClient {
-	return client.NewDomainClient(cFactory.ClientFrontendClient(c), &client.Options{})
-}
-
 func getWorkflowClient(c *cli.Context) client.Client {
 	domain := getRequiredGlobalOption(c, FlagDomain)
 	return client.NewClient(cFactory.ClientFrontendClient(c), domain, &client.Options{})
@@ -1595,13 +1632,13 @@ func getWorkflowIDReusePolicy(value int) *s.WorkflowIdReusePolicy {
 	return nil
 }
 
-func archivalStatus(c *cli.Context) *s.ArchivalStatus {
+func archivalStatus(c *cli.Context) *shared.ArchivalStatus {
 	if c.IsSet(FlagArchivalStatus) {
 		switch c.String(FlagArchivalStatus) {
 		case "disabled":
-			return common.ClientArchivalStatusPtr(s.ArchivalStatusDisabled)
+			common.ArchivalStatusPtr(shared.ArchivalStatusDisabled)
 		case "enabled":
-			return common.ClientArchivalStatusPtr(s.ArchivalStatusEnabled)
+			return common.ArchivalStatusPtr(shared.ArchivalStatusEnabled)
 		default:
 			ErrorAndExit(fmt.Sprintf("Option %s format is invalid.", FlagArchivalStatus), errors.New("invalid status, valid values are \"disabled\" and \"enabled\""))
 		}

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -68,6 +68,12 @@ const (
 	showErrorStackEnv    = `CADENCE_CLI_SHOW_STACKS`
 )
 
+var envKeysForUserName = []string{
+	"USER",
+	"LOGNAME",
+	"HOME",
+}
+
 type jsonType int
 
 const (
@@ -345,12 +351,7 @@ func UpdateDomain(c *cli.Context) {
 }
 
 func getCurrentUserFromEnv() string {
-	varNames := []string{
-		"USER",
-		"LOGNAME",
-		"HOME",
-	}
-	for _, n := range varNames {
+	for _, n := range envKeysForUserName {
 		if len(os.Getenv(n)) > 0 {
 			return os.Getenv(n)
 		}

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -303,7 +303,7 @@ func UpdateDomain(c *cli.Context) {
 
 		var badBinaryToDelete *string
 		if c.IsSet(FlagRemoveBadBinary) {
-			badBinaryToDelete = common.StringPtr(c.String(FlagAddBadBinary))
+			badBinaryToDelete = common.StringPtr(c.String(FlagRemoveBadBinary))
 		}
 
 		updateInfo := &shared.UpdateDomainInfo{

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -371,6 +371,24 @@ func DescribeDomain(c *cli.Context) {
 		descValues = append(descValues, resp.Configuration.GetArchivalBucketOwner())
 	}
 	fmt.Printf(formatStr, descValues...)
+	if resp.Configuration.BadBinaries != nil {
+		fmt.Println("Bad binaries to reset:")
+		table := tablewriter.NewWriter(os.Stdout)
+		table.SetBorder(true)
+		table.SetColumnSeparator("|")
+		header := []string{"Binary Checksum", "Operator", "Start Time", "Reason"}
+		headerColor := []tablewriter.Colors{tableHeaderBlue, tableHeaderBlue, tableHeaderBlue, tableHeaderBlue}
+		table.SetHeader(header)
+		table.SetHeaderColor(headerColor...)
+		for cs, bin := range resp.Configuration.BadBinaries.Binaries {
+			row := []string{cs}
+			row = append(row, bin.GetOperator())
+			row = append(row, time.Unix(0, bin.GetCreatedTimeNano()).String())
+			row = append(row, bin.GetReason())
+			table.Append(row)
+		}
+		table.Render()
+	}
 }
 
 // ShowHistory shows the history of given workflow execution based on workflowID and runID.

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -1636,7 +1636,7 @@ func archivalStatus(c *cli.Context) *shared.ArchivalStatus {
 	if c.IsSet(FlagArchivalStatus) {
 		switch c.String(FlagArchivalStatus) {
 		case "disabled":
-			common.ArchivalStatusPtr(shared.ArchivalStatusDisabled)
+			return common.ArchivalStatusPtr(shared.ArchivalStatusDisabled)
 		case "enabled":
 			return common.ArchivalStatusPtr(shared.ArchivalStatusEnabled)
 		default:

--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -159,6 +159,18 @@ func newDomainCommands() []cli.Command {
 					Name:  FlagArchivalBucketNameWithAlias,
 					Usage: "Optionally specify bucket (cannot be changed after first time archival is enabled)",
 				},
+				cli.StringFlag{
+					Name:  FlagAddBadBinary,
+					Usage: "Binary checksum to add for resetting workflow",
+				},
+				cli.StringFlag{
+					Name:  FlagRemoveBadBinary,
+					Usage: "Binary checksum to remove for resetting workflow",
+				},
+				cli.StringFlag{
+					Name:  FlagReason,
+					Usage: "Reason for the operation",
+				},
 			},
 			Action: func(c *cli.Context) {
 				UpdateDomain(c)

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -152,6 +152,8 @@ const (
 	FlagMemoKey                     = "memo_key"
 	FlagMemo                        = "memo"
 	FlagMemoFile                    = "memo_file"
+	FlagAddBadBinary                = "add_bad_binary"
+	FlagRemoveBadBinary             = "remove_bad_binary"
 )
 
 var flagsForExecution = []cli.Flag{


### PR DESCRIPTION
Tested locally:
```
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d update --add_bad_binary testbinary4 --reason "haha2"
Domain testdm successfully updated.
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d update --add_bad_binary testbinary5 --reason "haha2"
Domain testdm successfully updated.
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d update --add_bad_binary testbinary6 --reason "haha2"
Domain testdm successfully updated.
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d update --add_bad_binary testbinary1 --reason "haha2"
Domain testdm successfully updated.
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d desc
Name: testdm
Description: test
OwnerEmail:
DomainData: map[]
Status: REGISTERED
RetentionInDays: 10
EmitMetrics: true
ActiveClusterName: active
Clusters: active
ArchivalStatus: DISABLED
Bad binaries to reset:
+-----------------+----------+--------------------------------+--------+
| BINARY CHECKSUM | OPERATOR |           START TIME           | REASON |
+-----------------+----------+--------------------------------+--------+
| testbinary1     | longer   | 2019-04-29 17:34:52.707705     | haha2  |
|                 |          | -0700 PDT                      |        |
| testbinary6     | longer   | 2019-04-29 17:34:48.786401     | haha2  |
|                 |          | -0700 PDT                      |        |
| testbinary4     | longer   | 2019-04-29 17:34:41.972265     | haha2  |
|                 |          | -0700 PDT                      |        |
| testbinary5     | longer   | 2019-04-29 17:34:45.574244     | haha2  |
|                 |          | -0700 PDT                      |        |
+-----------------+----------+--------------------------------+--------+
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d update --remove_bad_binary testbinary2
Error: Operation UpdateDomain failed.
Error Details: BadRequestError{Message: Bad binary checksum doesn't exists.}
('export CADENCE_CLI_SHOW_STACKS=1' to see stack traces)
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d update --remove_bad_binary testbinary4
Domain testdm successfully updated.
longer@~/gocode/src/github.com/uber/cadence:(auto-reset-4)$ ./cadence --do testdm d desc
Name: testdm
Description: test
OwnerEmail:
DomainData: map[]
Status: REGISTERED
RetentionInDays: 10
EmitMetrics: true
ActiveClusterName: active
Clusters: active
ArchivalStatus: DISABLED
Bad binaries to reset:
+-----------------+----------+--------------------------------+--------+
| BINARY CHECKSUM | OPERATOR |           START TIME           | REASON |
+-----------------+----------+--------------------------------+--------+
| testbinary1     | longer   | 2019-04-29 17:34:52.707705     | haha2  |
|                 |          | -0700 PDT                      |        |
| testbinary6     | longer   | 2019-04-29 17:34:48.786401     | haha2  |
|                 |          | -0700 PDT                      |        |
| testbinary5     | longer   | 2019-04-29 17:34:45.574244     | haha2  |
|                 |          | -0700 PDT                      |        |
+-----------------+----------+--------------------------------+--------+
```