### PR TITLE
Reset CLI: show reset points, reset by type

### DIFF
--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -1594,7 +1594,7 @@ func getFirstDecisionCompletedID(domain, wid, rid string, ctx context.Context, f
 		for _, e := range resp.GetHistory().GetEvents() {
 			if e.GetEventType() == shared.EventTypeDecisionTaskCompleted {
 				decisionFinishID = e.GetEventId()
-				return
+				return resetBaseRunID, decisionFinishID, nil
 			}
 		}
 		if len(resp.NextPageToken) != 0 {

--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -1571,6 +1571,9 @@ func getLastDecisionCompletedID(domain, wid, rid string, ctx context.Context, fr
 			break
 		}
 	}
+	if decisionFinishID == 0 {
+		return "", 0, printErrorAndReturn("Get DecisionFinishID failed", fmt.Errorf("no DecisionFinishID"))
+	}
 	return
 }
 
@@ -1603,10 +1606,13 @@ func getFirstDecisionCompletedID(domain, wid, rid string, ctx context.Context, f
 			break
 		}
 	}
+	if decisionFinishID == 0 {
+		return "", 0, printErrorAndReturn("Get DecisionFinishID failed", fmt.Errorf("no DecisionFinishID"))
+	}
 	return
 }
 
-func getLastContinueAsNewID(domain, wid, rid string, ctx context.Context, frontendClient workflowserviceclient.Interface) (resetBaseRunID string, lastDecisionFinishID int64, err error) {
+func getLastContinueAsNewID(domain, wid, rid string, ctx context.Context, frontendClient workflowserviceclient.Interface) (resetBaseRunID string, decisionFinishID int64, err error) {
 	// get first event
 	req := &shared.GetWorkflowExecutionHistoryRequest{
 		Domain: common.StringPtr(domain),
@@ -1643,7 +1649,7 @@ func getLastContinueAsNewID(domain, wid, rid string, ctx context.Context, fronte
 		}
 		for _, e := range resp.GetHistory().GetEvents() {
 			if e.GetEventType() == shared.EventTypeDecisionTaskCompleted {
-				lastDecisionFinishID = e.GetEventId()
+				decisionFinishID = e.GetEventId()
 			}
 		}
 		if len(resp.NextPageToken) != 0 {
@@ -1651,6 +1657,9 @@ func getLastContinueAsNewID(domain, wid, rid string, ctx context.Context, fronte
 		} else {
 			break
 		}
+	}
+	if decisionFinishID == 0 {
+		return "", 0, printErrorAndReturn("Get DecisionFinishID failed", fmt.Errorf("no DecisionFinishID"))
 	}
 	return
 }

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -159,6 +159,7 @@ const (
 	FlagAddBadBinary                = "add_bad_binary"
 	FlagRemoveBadBinary             = "remove_bad_binary"
 	FlagResetType                   = "reset_type"
+	FlagResetPointsOnly             = "reset_points_only"
 )
 
 var flagsForExecution = []cli.Flag{
@@ -206,6 +207,10 @@ func getFlagsForShowID() []cli.Flag {
 			Name:  FlagMaxFieldLengthWithAlias,
 			Usage: "Maximum length for each attribute field",
 			Value: defaultMaxFieldLength,
+		},
+		cli.BoolFlag{
+			Name:  FlagResetPointsOnly,
+			Usage: "Only show events that are eligible for reset",
 		},
 	}
 }

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -199,7 +199,7 @@ func newWorkflowCommands() []cli.Command {
 		{
 			Name:    "reset",
 			Aliases: []string{"rs"},
-			Usage:   "reset the workflow",
+			Usage:   "reset the workflow, by eventID or resetType.",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagWorkflowIDWithAlias,
@@ -216,6 +216,10 @@ func newWorkflowCommands() []cli.Command {
 				cli.StringFlag{
 					Name:  FlagReason,
 					Usage: "reason to do the reset",
+				},
+				cli.StringFlag{
+					Name:  FlagResetType,
+					Usage: "where to reset. Support one of these: LastDecisionCompleted,LastContinuedAsNew",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -20,7 +20,11 @@
 
 package cli
 
-import "github.com/urfave/cli"
+import (
+	"strings"
+
+	"github.com/urfave/cli"
+)
 
 func newWorkflowCommands() []cli.Command {
 	return []cli.Command{
@@ -199,7 +203,7 @@ func newWorkflowCommands() []cli.Command {
 		{
 			Name:    "reset",
 			Aliases: []string{"rs"},
-			Usage:   "reset the workflow, by eventID or resetType.",
+			Usage:   "reset the workflow, by either eventID or resetType.",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagWorkflowIDWithAlias,
@@ -219,7 +223,7 @@ func newWorkflowCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  FlagResetType,
-					Usage: "where to reset. Support one of these: LastDecisionCompleted,LastContinuedAsNew",
+					Usage: "where to reset. Support one of these: " + strings.Join(mapKeysToArray(resetTypesMap), ","),
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -228,7 +232,7 @@ func newWorkflowCommands() []cli.Command {
 		},
 		{
 			Name:  "reset-batch",
-			Usage: "reset workflow in batch",
+			Usage: "reset workflow in batch by resetType: " + strings.Join(mapKeysToArray(resetTypesMap), ","),
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagInputFileWithAlias,
@@ -258,7 +262,7 @@ func newWorkflowCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  FlagResetType,
-					Usage: "How to reset, currently support: LastDecisionCompleted,LastContinuedAsNew",
+					Usage: "where to reset. Support one of these: " + strings.Join(mapKeysToArray(resetTypesMap), ","),
 				},
 			},
 			Action: func(c *cli.Context) {


### PR DESCRIPTION
https://github.com/uber/cadence/issues/1755

Show:
```
longer@~/gocode/src/github.com/uber/cadence:(reset-types)$ ./cadence --do samples-domain wf show -w cron_26b2745d-9cfc-4573-98be-b30d36fa4888 --reset_points_only
   4  DecisionTaskCompleted  {ExecutionContext:[],
                             ScheduledEventId:2, StartedEventId:3,
                             Identity:7459@longer-C02V60N3HTDG@cronGroup,
                             BinaryChecksum:d7ad67a57f53a54483c2f7e518a10473}
   9  DecisionTaskCompleted  {ExecutionContext:[],
                             ScheduledEventId:7, StartedEventId:8,
                             Identity:7459@longer-C02V60N3HTDG@cronGroup,
                             BinaryChecksum:d7ad67a57f53a54483c2f7e518a10473}
  15  DecisionTaskCompleted  {ExecutionContext:[],
                             ScheduledEventId:13, StartedEventId:14,
                             Identity:7459@longer-C02V60N3HTDG@cronGroup,
                             BinaryChecksum:d7ad67a57f53a54483c2f7e518a10473}
  20  DecisionTaskCompleted  {ExecutionContext:[],
                             ScheduledEventId:18, StartedEventId:19,
                             Identity:7459@longer-C02V60N3HTDG@cronGroup,
                             BinaryChecksum:d7ad67a57f53a54483c2f7e518a10473}
  26  DecisionTaskCompleted  {ExecutionContext:[],
                             ScheduledEventId:24, StartedEventId:25,
                             Identity:7459@longer-C02V60N3HTDG@cronGroup,
                             BinaryChecksum:d7ad67a57f53a54483c2f7e518a10473}
  31  DecisionTaskCompleted  {ExecutionContext:[],
                             ScheduledEventId:29, StartedEventId:30,
..
...
```

Reset:
```
longer@~/gocode/src/github.com/uber/cadence:(reset-types)$ ./cadence --do samples-domain wf reset -w cron_26b2745d-9cfc-4573-98be-b30d36fa4888 --reset_type FirstDecisionCompleted -r 993a4504-7f7a-4be4-83cc-6b5a0fb6f3ed --reason test
switch FirstDecisionCompleted
{
  "runId": "6c43b2d6-e7be-41aa-8721-bfa646740459"
}
longer@~/gocode/src/github.com/uber/cadence:(reset-types)$ ./cadence --do samples-domain wf show -w cron_26b2745d-9cfc-4573-98be-b30d36fa4888
  1  WorkflowExecutionStarted  {WorkflowType:{Name:main.SampleCronWorkflow},
                                TaskList:{Name:cronGroup},
                                Input:[{"JobCount":960,"ScheduleInterval":1000000000}],
                                ExecutionStartToCloseTimeoutSeconds:1200,
                                TaskStartToCloseTimeoutSeconds:60,
                                ContinuedExecutionRunId:64aafb3d-91f9-49b1-8a13-b18b0cd2d32b,
                                ContinuedFailureDetails:[], LastCompletionResult:[],
                                Attempt:0}
  2  DecisionTaskScheduled     {TaskList:{Name:cronGroup},
                                StartToCloseTimeoutSeconds:60,
                                Attempt:0}
  3  DecisionTaskStarted       {ScheduledEventId:2,
                                Identity:7281@longer-C02V60N3HTDG@cronGroup,
                                RequestId:4e58accd-5bd7-4cec-939b-ff2bbd816c9c}
  4  DecisionTaskFailed        {EventId:4, Timestamp:1556819733731686000,
                                EventType:DecisionTaskFailed,
                                Version:-24, TaskId:16777234,
                                DecisionTaskFailedEventAttributes:{ScheduledEventId:2,
                                StartedEventId:3, Cause:RESET_WORKFLOW,
                                Details:[], Identity:history-service,
                                Reason:longer:test,
                                BaseRunId:993a4504-7f7a-4be4-83cc-6b5a0fb6f3ed,
                                NewRunId:63108088-1bfe-4ec4-9360-b9fbebdf4baa,
                                ForkEventVersion:-24}}
  5  DecisionTaskScheduled     {TaskList:{Name:cronGroup},
                                StartToCloseTimeoutSeconds:60,
                                Attempt:0}
```

```
longer@~/gocode/src/github.com/uber/cadence:(reset-types)$ ./cadence --do samples-domain wf reset -w cron_26b2745d-9cfc-4573-98be-b30d36fa4888 --reset_type FirstDecisionCompleted -r 63108088-1bfe-4ec4-9360-b9fbebdf4baa --reason test reset
switch FirstDecisionCompleted
Get DecisionFinishID failed
Error: getResetEventIDByType failed
Error Details: no DecisionFinishID
('export CADENCE_CLI_SHOW_STACKS=1' to see stack traces)
longer@~/gocode/src/github.com/uber/cadence:(reset-types)$
```