### PR TITLE
Do not emit error metric for GetTags in case blob does not exist

### DIFF
--- a/common/blobstore/metricClient.go
+++ b/common/blobstore/metricClient.go
@@ -76,6 +76,7 @@ func (c *metricClient) GetTags(ctx context.Context, bucket string, key blob.Key)
 	sw.Stop()
 
 	if err != nil {
+		// it is expected to call this API on blobs which do not exist, so emit different metric on ErrBlobNotExists
 		if err != ErrBlobNotExists {
 			c.metricsClient.IncCounter(metrics.BlobstoreClientGetTagsScope, metrics.CadenceClientFailures)
 		} else {

--- a/common/blobstore/metricClient.go
+++ b/common/blobstore/metricClient.go
@@ -75,9 +75,12 @@ func (c *metricClient) GetTags(ctx context.Context, bucket string, key blob.Key)
 	resp, err := c.client.GetTags(ctx, bucket, key)
 	sw.Stop()
 
-	// Do not emit error metric for ErrBlobNotExists because it is expected to call GetTags in order to check existence.
-	if err != nil && err != ErrBlobNotExists {
-		c.metricsClient.IncCounter(metrics.BlobstoreClientGetTagsScope, metrics.CadenceClientFailures)
+	if err != nil {
+		if err != ErrBlobNotExists {
+			c.metricsClient.IncCounter(metrics.BlobstoreClientGetTagsScope, metrics.CadenceClientFailures)
+		} else {
+			c.metricsClient.IncCounter(metrics.BlobstoreClientGetTagsScope, metrics.CadenceErrEntityNotExistsCounter)
+		}
 	}
 	return resp, err
 }

--- a/common/blobstore/metricClient.go
+++ b/common/blobstore/metricClient.go
@@ -75,7 +75,8 @@ func (c *metricClient) GetTags(ctx context.Context, bucket string, key blob.Key)
 	resp, err := c.client.GetTags(ctx, bucket, key)
 	sw.Stop()
 
-	if err != nil {
+	// Do not emit error metric for ErrBlobNotExists because it is expected to call GetTags in order to check existence.
+	if err != nil && err != ErrBlobNotExists {
 		c.metricsClient.IncCounter(metrics.BlobstoreClientGetTagsScope, metrics.CadenceClientFailures)
 	}
 	return resp, err


### PR DESCRIPTION
In archival workflow we call GetTags both to get the tags and to check if blob exists. This is done instead of calling Exists and then GetTags in order to save a blobstore API call. However this means we call GetTags on blobs which we do not know if they exist or not. In the happy path, due to XDC, we expect to call GetTags on blobs which don't exist. Emitting metrics in this case will clutter our metrics.

I do not really like this implementation for two reasons
1. It deviates from our normal metric client pattern
2. It hides errors from being emitted 

An alternative implementation would be to remove the Exists method and instead change the API of GetTags to `GetTags(...) (tags map[string]string, exists bool, err error)` This API felt a little weird to me though. I do not feel strongly about either implementation.  