### PR TITLE
Treat WorkflowExecutionAlreadyStartedError as non-transient error

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -198,6 +198,8 @@ func IsServiceNonRetryableError(err error) bool {
 		return true
 	case *workflow.DomainNotActiveError:
 		return true
+	case *workflow.WorkflowExecutionAlreadyStartedError:
+		return true
 	case *workflow.CancellationAlreadyRequestedError:
 		return true
 	case *yarpcerrors.Status:

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -22,6 +22,7 @@ package host
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"strconv"
 	"strings"
@@ -1421,7 +1422,8 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 		Identity:                            common.StringPtr(identity),
 		WorkflowIdReusePolicy:               &wfIDReusePolicy,
 	}
-	resp, err := s.engine.SignalWithStartWorkflowExecution(createContext(), sRequest)
+	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+	resp, err := s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
 	s.Nil(resp)
 	s.Error(err)
 	errMsg := err.(*workflow.WorkflowExecutionAlreadyStartedError).GetMessage()
@@ -1429,7 +1431,8 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 
 	// test policy WorkflowIdReusePolicyAllowDuplicateFailedOnly
 	wfIDReusePolicy = workflow.WorkflowIdReusePolicyAllowDuplicateFailedOnly
-	resp, err = s.engine.SignalWithStartWorkflowExecution(createContext(), sRequest)
+	ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+	resp, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
 	s.Nil(resp)
 	s.Error(err)
 	errMsg = err.(*workflow.WorkflowExecutionAlreadyStartedError).GetMessage()
@@ -1437,7 +1440,8 @@ func (s *integrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 
 	// test policy WorkflowIdReusePolicyAllowDuplicate
 	wfIDReusePolicy = workflow.WorkflowIdReusePolicyAllowDuplicate
-	resp, err = s.engine.SignalWithStartWorkflowExecution(createContext(), sRequest)
+	ctx, _ = context.WithTimeout(context.Background(), 5*time.Second)
+	resp, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
 	s.Nil(err)
 	s.NotEmpty(resp.GetRunId())
 


### PR DESCRIPTION
Setting the WorkflowIDReusePolicy to
'WorkflowIDReusePolicyAllowDuplicateFailedOnly' or
'WorkflowIDReusePolicyRejectDuplicate' results in
'WorkflowExecutionAlreadyStartedError' on StartWorkflowExecution or
SignalWithStartWorkflowExecution. Since this error is treated as
retryable error it results in frontend to keep on retrying the call
until timeout.

fixes #1811 