### PR TITLE
Fix prometheus metrics emission

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -315,15 +315,42 @@
   version = "v1.0.2"
 
 [[projects]]
-  digest = "1:4142d94383572e74b42352273652c62afec5b23f325222ed09198f46009022d1"
+  digest = "1:2b62d63ca71f89685c4f41373391319f6b67de7c61bbe7fdf2d89526a72fcb42"
   name = "github.com/m3db/prometheus_client_golang"
   packages = [
     "prometheus",
     "prometheus/promhttp",
   ]
   pruneopts = ""
-  revision = "c5b7fccd204277076155f10851dad72b76a49317"
-  version = "v0.8.0"
+  revision = "8ae269d24972b8695572fa6b2e3718b5ea82d6b4"
+
+[[projects]]
+  branch = "master"
+  digest = "1:954b01b825d4edc1b3e838e9faadfb8f70b308b000425d634d72896a81d3ce9f"
+  name = "github.com/m3db/prometheus_client_model"
+  packages = ["go"]
+  pruneopts = ""
+  revision = "8b2299a4bf7d7fc10835527021716d4b4a6e8700"
+
+[[projects]]
+  branch = "master"
+  digest = "1:192c7420ce9083d46de731826d5908a2f571ce1a7be3188428ce388d4f12c16d"
+  name = "github.com/m3db/prometheus_common"
+  packages = [
+    "expfmt",
+    "internal/bitbucket.org/ww/goautoneg",
+    "model",
+  ]
+  pruneopts = ""
+  revision = "25aaa3dff79bb48116615ebe1dea6a494b74ce77"
+
+[[projects]]
+  branch = "master"
+  digest = "1:61df0898746840afc7be5dc2c3eeec83022fab70df11ecee5b16c85e912cf5ed"
+  name = "github.com/m3db/prometheus_procfs"
+  packages = ["."]
+  pruneopts = ""
+  revision = "1878d9fbb537119d24b21ca07effd591627cd160"
 
 [[projects]]
   branch = "master"
@@ -990,6 +1017,7 @@
     "github.com/iancoleman/strcase",
     "github.com/jmoiron/sqlx",
     "github.com/m3db/prometheus_client_golang/prometheus",
+    "github.com/m3db/prometheus_client_golang/prometheus/promhttp",
     "github.com/olekukonko/tablewriter",
     "github.com/olivere/elastic",
     "github.com/pborman/uuid",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -150,3 +150,7 @@ ignored = ["github.com/uber/cadence/.gen"]
 [[constraint]]
   name = "github.com/valyala/fastjson"
   version = "1.4.1"
+
+[[override]]
+  name = "github.com/m3db/prometheus_client_golang"
+  revision = "8ae269d24972b8695572fa6b2e3718b5ea82d6b4"

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -91,15 +91,15 @@ const (
 // Common service base metrics
 const (
 	RestartCount         = "restarts"
-	NumGoRoutinesGauge   = "num-goroutines"
+	NumGoRoutinesGauge   = "num_goroutines"
 	GoMaxProcsGauge      = "gomaxprocs"
-	MemoryAllocatedGauge = "memory.allocated"
-	MemoryHeapGauge      = "memory.heap"
-	MemoryHeapIdleGauge  = "memory.heapidle"
-	MemoryHeapInuseGauge = "memory.heapinuse"
-	MemoryStackGauge     = "memory.stack"
-	NumGCCounter         = "memory.num-gc"
-	GcPauseMsTimer       = "memory.gc-pause-ms"
+	MemoryAllocatedGauge = "memory_allocated"
+	MemoryHeapGauge      = "memory_heap"
+	MemoryHeapIdleGauge  = "memory_heapidle"
+	MemoryHeapInuseGauge = "memory_heapinuse"
+	MemoryStackGauge     = "memory_stack"
+	NumGCCounter         = "memory_num_gc"
+	GcPauseMsTimer       = "memory_gc_pause_ms"
 )
 
 // ServiceMetrics are types for common service base metrics

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -26,9 +26,9 @@ services:
       port: 7933
       bindOnLocalHost: true
     metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "127.0.0.1:8000"
     pprof:
       port: 7936
 
@@ -37,9 +37,9 @@ services:
       port: 7935
       bindOnLocalHost: true
     metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "127.0.0.1:8001"
     pprof:
       port: 7938
 
@@ -48,9 +48,9 @@ services:
       port: 7934
       bindOnLocalHost: true
     metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "127.0.0.1:8002"
     pprof:
       port: 7937
 
@@ -59,9 +59,9 @@ services:
       port: 7939
       bindOnLocalHost: true
     metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
+      prometheus:
+        timerType: "histogram"
+        listenAddress: "127.0.0.1:8003"
     pprof:
       port: 7940
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -28,7 +28,7 @@ services:
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"
-        prefix: "cadence_standby"
+        prefix: "cadence"
     pprof:
       port: 7936
 
@@ -39,7 +39,7 @@ services:
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"
-        prefix: "cadence_standby"
+        prefix: "cadence"
     pprof:
       port: 7938
 
@@ -50,7 +50,7 @@ services:
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"
-        prefix: "cadence_standby"
+        prefix: "cadence"
     pprof:
       port: 7937
 
@@ -61,7 +61,7 @@ services:
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"
-        prefix: "cadence_standby"
+        prefix: "cadence"
     pprof:
       port: 7940
 

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -26,9 +26,9 @@ services:
       port: 7933
       bindOnLocalHost: true
     metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8000"
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence_standby"
     pprof:
       port: 7936
 
@@ -37,9 +37,9 @@ services:
       port: 7935
       bindOnLocalHost: true
     metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8001"
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence_standby"
     pprof:
       port: 7938
 
@@ -48,9 +48,9 @@ services:
       port: 7934
       bindOnLocalHost: true
     metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8002"
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence_standby"
     pprof:
       port: 7937
 
@@ -59,9 +59,9 @@ services:
       port: 7939
       bindOnLocalHost: true
     metrics:
-      prometheus:
-        timerType: "histogram"
-        listenAddress: "127.0.0.1:8003"
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence_standby"
     pprof:
       port: 7940
 


### PR DESCRIPTION
Pin prometheus client to hash as tally depends on that hash and dep sometimes does not honor the hash.. Also, clean up the use of the registry..