### PR TITLE
Correctly emit workflow execution stats

### DIFF
--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -776,9 +776,12 @@ func (s *shardContextImpl) AppendHistoryEvents(request *persistence.AppendHistor
 	defer func() {
 		// N.B. - Dual emit here makes sense so that we can see aggregate timer stats across all
 		// domains along with the individual domains stats
-		s.metricsClient.RecordTimer(metrics.SessionSizeStatsScope, metrics.HistorySize, time.Duration(size))
+		allDomainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainAllTag())
+		allDomainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
 		if domainEntry != nil && domainEntry.GetInfo() != nil {
-			s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(domainEntry.GetInfo().Name)).RecordTimer(metrics.HistorySize, time.Duration(size))
+			domainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(
+				domainEntry.GetInfo().Name))
+			domainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
 		}
 		if size >= historySizeLogThreshold {
 			s.throttledLogger.Warn("history size threshold breached",


### PR DESCRIPTION
Workflow execution stats were incorrectly emitted under persistence
scope instead of execution stats scope.

Session state metric was not tagged correctly for all domains
scope.