### PR TITLE
Not retry on reset bad request

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1208,6 +1208,7 @@ const (
 	FailedDecisionsCounter
 	StaleMutableStateCounter
 	AutoResetPointsLimitExceededCounter
+	AutoResetPointCorruptionCounter
 	ConcurrencyUpdateFailureCounter
 	CadenceErrEventAlreadyStartedCounter
 	CadenceErrShardOwnershipLostCounter
@@ -1451,6 +1452,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		FailedDecisionsCounter:                       {metricName: "failed_decisions", metricType: Counter},
 		StaleMutableStateCounter:                     {metricName: "stale_mutable_state", metricType: Counter},
 		AutoResetPointsLimitExceededCounter:          {metricName: "auto_reset_points_exceed_limit", metricType: Counter},
+		AutoResetPointCorruptionCounter:              {metricName: "auto_reset_point_corruption", metricType: Counter},
 		ConcurrencyUpdateFailureCounter:              {metricName: "concurrency_update_failure", metricType: Counter},
 		CadenceErrShardOwnershipLostCounter:          {metricName: "cadence_errors_shard_ownership_lost", metricType: Counter},
 		CadenceErrEventAlreadyStartedCounter:         {metricName: "cadence_errors_event_already_started", metricType: Counter},

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -998,8 +998,8 @@ func (t *transferQueueActiveProcessorImpl) processResetWorkflow(task *persistenc
 			logger.Error("Auto-Reset workflow failed and not retryable. The reset point is corrupted.", tag.Error(err))
 			return nil
 		}
-		logger.Error("Auto-Reset workflow failed", tag.Error(err))
 		// log this error and retry
+		logger.Error("Auto-Reset workflow failed", tag.Error(err))
 		return err
 	}
 	logger.Info("Auto-Reset workflow finished", tag.WorkflowResetNewRunID(resp.GetRunId()))

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -991,7 +991,15 @@ func (t *transferQueueActiveProcessorImpl) processResetWorkflow(task *persistenc
 		RequestId:             common.StringPtr(uuid.New()),
 	}, baseContext, baseMutableState, currContext, currMutableState)
 	if err != nil {
+		if _, ok := err.(*workflow.BadRequestError); ok {
+			// This means the reset point is corrupted and not retry able.
+			// There must be a bug in our system that we must fix.(for example, history is not the same in active/passive)
+			t.metricsClient.IncCounter(metrics.TransferQueueProcessorScope, metrics.AutoResetPointCorruptionCounter)
+			logger.Error("Auto-Reset workflow failed and not retryable. The reset point is corrupted.", tag.Error(err))
+			return nil
+		}
 		logger.Error("Auto-Reset workflow failed", tag.Error(err))
+		// log this error and retry
 		return err
 	}
 	logger.Info("Auto-Reset workflow finished", tag.WorkflowResetNewRunID(resp.GetRunId()))

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -545,6 +545,7 @@ func (w *workflowResetorImpl) replayHistoryEvents(decisionFinishEventID int64, r
 		for _, batch := range readResp.History {
 			history := batch.Events
 			firstEvent := history[0]
+			lastEvent := history[len(history)-1]
 
 			// for saving received signals only
 			if firstEvent.GetEventId() >= decisionFinishEventID {
@@ -588,7 +589,7 @@ func (w *workflowResetorImpl) replayHistoryEvents(decisionFinishEventID int64, r
 			}
 
 			// avoid replay this event in stateBuilder which will run into NPE if WF doesn't enable XDC
-			if firstEvent.GetEventType() == workflow.EventTypeWorkflowExecutionContinuedAsNew {
+			if lastEvent.GetEventType() == workflow.EventTypeWorkflowExecutionContinuedAsNew {
 				retError = &workflow.BadRequestError{
 					Message: fmt.Sprintf("wrong DecisionFinishEventId, cannot replay history to continueAsNew"),
 				}


### PR DESCRIPTION
If for any reason the reset task failed and we know it is not retryable we should skip the task to unblock transfer Queue.

That corruption usually means critical bug in our system. We should set up alert on the metric