### PR TITLE
Add instance ID to runtime metrics

### DIFF
--- a/common/metrics/runtime.go
+++ b/common/metrics/runtime.go
@@ -44,7 +44,7 @@ func NewRuntimeMetricsReporter(
 	scope tally.Scope,
 	reportInterval time.Duration,
 	logger log.Logger,
-	instance string,
+	instanceID string,
 ) *RuntimeMetricsReporter {
 	var memstats runtime.MemStats
 	runtime.ReadMemStats(&memstats)
@@ -55,8 +55,8 @@ func NewRuntimeMetricsReporter(
 		lastNumGC:      memstats.NumGC,
 		quit:           make(chan struct{}),
 	}
-	if len(instance) > 0 {
-		rReporter.scope = scope.Tagged(map[string]string{instanceTag: instance})
+	if len(instanceID) > 0 {
+		rReporter.scope = scope.Tagged(map[string]string{instance: instanceID})
 	}
 	return rReporter
 }

--- a/common/metrics/runtime.go
+++ b/common/metrics/runtime.go
@@ -40,7 +40,12 @@ type RuntimeMetricsReporter struct {
 }
 
 // NewRuntimeMetricsReporter Creates a new RuntimeMetricsReporter.
-func NewRuntimeMetricsReporter(scope tally.Scope, reportInterval time.Duration, logger log.Logger) *RuntimeMetricsReporter {
+func NewRuntimeMetricsReporter(
+	scope tally.Scope,
+	reportInterval time.Duration,
+	logger log.Logger,
+	instance string,
+) *RuntimeMetricsReporter {
 	var memstats runtime.MemStats
 	runtime.ReadMemStats(&memstats)
 	rReporter := &RuntimeMetricsReporter{
@@ -49,6 +54,9 @@ func NewRuntimeMetricsReporter(scope tally.Scope, reportInterval time.Duration, 
 		logger:         logger,
 		lastNumGC:      memstats.NumGC,
 		quit:           make(chan struct{}),
+	}
+	if len(instance) > 0 {
+		rReporter.scope = scope.Tagged(map[string]string{instanceTag: instance})
 	}
 	return rReporter
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -21,7 +21,8 @@
 package metrics
 
 const (
-	domain         = "domain"
+	instanceTag    = "instance"
+	domainTag      = "domain"
 	domainAllValue = "all"
 )
 
@@ -31,38 +32,38 @@ type Tag interface {
 	Value() string
 }
 
-type domainTag struct {
+type _domainTag struct {
 	value string
 }
 
-type domainAllTag struct{}
-
 // DomainTag returns a new domain tag
 func DomainTag(value string) Tag {
-	return domainTag{value}
+	return _domainTag{value}
 }
 
 // Key returns the key of the domain tag
-func (d domainTag) Key() string {
-	return domain
+func (d _domainTag) Key() string {
+	return domainTag
 }
 
 // Value returns the value of a domain tag
-func (d domainTag) Value() string {
+func (d _domainTag) Value() string {
 	return d.value
 }
 
+type _domainAllTag struct{}
+
 // DomainAllTag returns a new domain all tag-value
 func DomainAllTag() Tag {
-	return domainAllTag{}
+	return _domainAllTag{}
 }
 
 // Key returns the key of the domain all tag
-func (d domainAllTag) Key() string {
-	return domain
+func (d _domainAllTag) Key() string {
+	return domainTag
 }
 
 // Value returns the value of the domain all tag
-func (d domainAllTag) Value() string {
+func (d _domainAllTag) Value() string {
 	return domainAllValue
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -21,8 +21,8 @@
 package metrics
 
 const (
-	instanceTag    = "instance"
-	domainTag      = "domain"
+	instance       = "instance"
+	domain         = "domain"
 	domainAllValue = "all"
 )
 
@@ -32,38 +32,57 @@ type Tag interface {
 	Value() string
 }
 
-type _domainTag struct {
+type domainTag struct {
 	value string
 }
 
 // DomainTag returns a new domain tag
 func DomainTag(value string) Tag {
-	return _domainTag{value}
+	return domainTag{value}
 }
 
 // Key returns the key of the domain tag
-func (d _domainTag) Key() string {
-	return domainTag
+func (d domainTag) Key() string {
+	return domain
 }
 
 // Value returns the value of a domain tag
-func (d _domainTag) Value() string {
+func (d domainTag) Value() string {
 	return d.value
 }
 
-type _domainAllTag struct{}
+type domainAllTag struct{}
 
 // DomainAllTag returns a new domain all tag-value
 func DomainAllTag() Tag {
-	return _domainAllTag{}
+	return domainAllTag{}
 }
 
 // Key returns the key of the domain all tag
-func (d _domainAllTag) Key() string {
-	return domainTag
+func (d domainAllTag) Key() string {
+	return domain
 }
 
 // Value returns the value of the domain all tag
-func (d _domainAllTag) Value() string {
+func (d domainAllTag) Value() string {
 	return domainAllValue
+}
+
+type instanceTag struct {
+	value string
+}
+
+// InstanceTag returns a new instance tag
+func InstanceTag(value string) Tag {
+	return instanceTag{value}
+}
+
+// Key returns the key of the instance tag
+func (i instanceTag) Key() string {
+	return instance
+}
+
+// Value returns the value of a instance tag
+func (i instanceTag) Value() string {
+	return i.value
 }

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -56,6 +56,7 @@ type (
 	// needed to bootstrap a service
 	BootstrapParams struct {
 		Name            string
+		InstanceID      string
 		Logger          log.Logger
 		ThrottledLogger log.Logger
 
@@ -132,7 +133,7 @@ func New(params *BootstrapParams) Service {
 		dynamicCollection:     dynamicconfig.NewCollection(params.DynamicConfig, params.Logger),
 	}
 
-	sVice.runtimeMetricsReporter = metrics.NewRuntimeMetricsReporter(params.MetricScope, time.Minute, sVice.GetLogger())
+	sVice.runtimeMetricsReporter = metrics.NewRuntimeMetricsReporter(params.MetricScope, time.Minute, sVice.GetLogger(), params.InstanceID)
 	sVice.dispatcher = sVice.rpcFactory.CreateDispatcher()
 	if sVice.dispatcher == nil {
 		sVice.logger.Fatal("Unable to create yarpc dispatcher")


### PR DESCRIPTION
- Support for adding instance tag to runtime metrics.
- Currently not used in default cadence server