### PR TITLE
Use correct context inside of croutine and do not close channel

### DIFF
--- a/service/worker/archiver/archiver.go
+++ b/service/worker/archiver/archiver.go
@@ -80,7 +80,7 @@ func (a *archiver) Start() {
 				handleRequest(ctx, a.logger, a.metricsClient, request)
 				handledHashes = append(handledHashes, hashArchiveRequest(request))
 			}
-			a.resultCh.Send(a.ctx, handledHashes)
+			a.resultCh.Send(ctx, handledHashes)
 			a.metricsClient.IncCounter(metrics.ArchiverScope, metrics.ArchiverCoroutineStoppedCount)
 		})
 	}
@@ -95,7 +95,6 @@ func (a *archiver) Finished() []uint64 {
 		a.resultCh.Receive(a.ctx, &subResult)
 		handledHashes = append(handledHashes, subResult...)
 	}
-	a.resultCh.Close()
 	a.metricsClient.IncCounter(metrics.ArchiverScope, metrics.ArchiverStoppedCount)
 	return handledHashes
 }

--- a/service/worker/archiver/workflow.go
+++ b/service/worker/archiver/workflow.go
@@ -99,7 +99,7 @@ func archivalWorkflowHelper(
 		}
 		pumpResult.UnhandledCarryover = append(pumpResult.UnhandledCarryover, request)
 	}
-	signalCh.Close()
+	logger.Info("archival system workflow continue as new")
 	ctx = workflow.WithExecutionStartToCloseTimeout(ctx, workflowStartToCloseTimeout)
 	ctx = workflow.WithWorkflowTaskStartToCloseTimeout(ctx, workflowTaskStartToCloseTimeout)
 	return workflow.NewContinueAsNewError(ctx, archivalWorkflowFnName, pumpResult.UnhandledCarryover)


### PR DESCRIPTION
Closing channel results in a panic. There is a ticket open to address this issue: https://github.com/uber-go/cadence-client/issues/710. As long as this bug exists simply not closing the channel is fine.