### PR TITLE
Add metrics for archival request counts

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1335,7 +1335,9 @@ const (
 	ArchiverCoroutineStoppedCount
 	ArchiverHandleRequestLatency
 	ArchiverUploadWithRetriesLatency
+	ArchiverUploadWithRetriesCount
 	ArchiverDeleteWithRetriesLatency
+	ArchiverDeleteWithRetriesCount
 	ArchiverUploadFailedAllRetriesCount
 	ArchiverUploadSuccessCount
 	ArchiverDeleteLocalFailedAllRetriesCount
@@ -1571,7 +1573,9 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ArchiverCoroutineStoppedCount:                          {metricName: "archiver_coroutine_stopped"},
 		ArchiverHandleRequestLatency:                           {metricName: "archiver_handle_request_latency"},
 		ArchiverUploadWithRetriesLatency:                       {metricName: "archiver_upload_with_retries_latency"},
+		ArchiverUploadWithRetriesCount:                         {metricName: "archiver_upload_with_retries"},
 		ArchiverDeleteWithRetriesLatency:                       {metricName: "archiver_delete_with_retries_latency"},
+		ArchiverDeleteWithRetriesCount:                         {metricName: "archiver_delete_with_retries"},
 		ArchiverUploadFailedAllRetriesCount:                    {metricName: "archiver_upload_failed_all_retries"},
 		ArchiverUploadSuccessCount:                             {metricName: "archiver_upload_success"},
 		ArchiverDeleteLocalFailedAllRetriesCount:               {metricName: "archiver_delete_local_failed_all_retries"},

--- a/service/worker/archiver/archiver_test.go
+++ b/service/worker/archiver/archiver_test.go
@@ -62,6 +62,9 @@ func (s *archiverSuite) SetupSuite() {
 func (s *archiverSuite) SetupTest() {
 	archiverTestMetrics = &mmocks.Client{}
 	archiverTestMetrics.On("StartTimer", mock.Anything, mock.Anything).Return(tally.NewStopwatch(time.Now(), &nopStopwatchRecorder{}))
+	archiverTestMetrics.On("IncCounter", metrics.ArchiverScope, metrics.CadenceRequests)
+	archiverTestMetrics.On("IncCounter", metrics.ArchiverScope, metrics.ArchiverUploadWithRetriesCount)
+	archiverTestMetrics.On("IncCounter", metrics.ArchiverScope, metrics.ArchiverDeleteWithRetriesCount)
 	archiverTestLogger = &log.MockLogger{}
 	archiverTestLogger.On("WithTags", mock.Anything).Return(archiverTestLogger)
 }
@@ -72,6 +75,7 @@ func (s *archiverSuite) TearDownTest() {
 }
 
 func (s *archiverSuite) TestHandleRequest_UploadFails_NonRetryableError() {
+
 	archiverTestMetrics.On("IncCounter", metrics.ArchiverScope, metrics.ArchiverUploadFailedAllRetriesCount).Once()
 	archiverTestMetrics.On("IncCounter", metrics.ArchiverScope, metrics.ArchiverDeleteLocalSuccessCount).Once()
 	archiverTestLogger.On("Error", mock.Anything, mock.Anything).Once()


### PR DESCRIPTION
These metrics enable us to produce availability graphs for archival.