### PR TITLE
Add check for total size on respond decision task

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -77,6 +77,8 @@ const (
 	FailureReasonHeartbeatExceedsLimit = "HEARTBEAT_EXCEEDS_LIMIT"
 	// FailureReasonDecisionBlobSizeExceedsLimit is the failureReason for decision blob exceeds size limit
 	FailureReasonDecisionBlobSizeExceedsLimit = "DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
+	// FailureReasonDecisionBlobSizeExceedsLimit is the failureReason for sum decision blob exceeds size limit
+	FailureReasonSumDecisionBlobSizeExceedsLimit = "SUM_DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
 	// TerminateReasonSizeExceedsLimit is reason to terminate workflow when history size or count exceed limit
 	TerminateReasonSizeExceedsLimit = "HISTORY_EXCEEDS_LIMIT"
 )

--- a/common/util.go
+++ b/common/util.go
@@ -77,7 +77,7 @@ const (
 	FailureReasonHeartbeatExceedsLimit = "HEARTBEAT_EXCEEDS_LIMIT"
 	// FailureReasonDecisionBlobSizeExceedsLimit is the failureReason for decision blob exceeds size limit
 	FailureReasonDecisionBlobSizeExceedsLimit = "DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
-	// FailureReasonDecisionBlobSizeExceedsLimit is the failureReason for sum decision blob exceeds size limit
+	// FailureReasonSumDecisionBlobSizeExceedsLimit is the failureReason for sum decision blob exceeds size limit
 	FailureReasonSumDecisionBlobSizeExceedsLimit = "SUM_DECISION_BLOB_SIZE_EXCEEDS_LIMIT"
 	// TerminateReasonSizeExceedsLimit is reason to terminate workflow when history size or count exceed limit
 	TerminateReasonSizeExceedsLimit = "HISTORY_EXCEEDS_LIMIT"

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -137,12 +137,14 @@ type Config struct {
 	NumArchiveSystemWorkflows dynamicconfig.IntPropertyFn
 	ArchiveRequestRPS         dynamicconfig.IntPropertyFn
 
-	BlobSizeLimitError     dynamicconfig.IntPropertyFnWithDomainFilter
-	BlobSizeLimitWarn      dynamicconfig.IntPropertyFnWithDomainFilter
-	HistorySizeLimitError  dynamicconfig.IntPropertyFnWithDomainFilter
-	HistorySizeLimitWarn   dynamicconfig.IntPropertyFnWithDomainFilter
-	HistoryCountLimitError dynamicconfig.IntPropertyFnWithDomainFilter
-	HistoryCountLimitWarn  dynamicconfig.IntPropertyFnWithDomainFilter
+	BlobSizeLimitError      dynamicconfig.IntPropertyFnWithDomainFilter
+	BlobSizeLimitWarn       dynamicconfig.IntPropertyFnWithDomainFilter
+	TotalBlobSizeLimitError dynamicconfig.IntPropertyFnWithDomainFilter
+	TotalBlobSizeLimitWarn  dynamicconfig.IntPropertyFnWithDomainFilter
+	HistorySizeLimitError   dynamicconfig.IntPropertyFnWithDomainFilter
+	HistorySizeLimitWarn    dynamicconfig.IntPropertyFnWithDomainFilter
+	HistoryCountLimitError  dynamicconfig.IntPropertyFnWithDomainFilter
+	HistoryCountLimitWarn   dynamicconfig.IntPropertyFnWithDomainFilter
 
 	ThrottledLogRPS dynamicconfig.IntPropertyFn
 }
@@ -226,12 +228,14 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, enableVisibilit
 		NumArchiveSystemWorkflows: dc.GetIntProperty(dynamicconfig.NumArchiveSystemWorkflows, 1000),
 		ArchiveRequestRPS:         dc.GetIntProperty(dynamicconfig.ArchiveRequestRPS, 300), // should be much smaller than frontend RPS
 
-		BlobSizeLimitError:     dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
-		BlobSizeLimitWarn:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 256*1024),
-		HistorySizeLimitError:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitError, 200*1024*1024),
-		HistorySizeLimitWarn:   dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitWarn, 50*1024*1024),
-		HistoryCountLimitError: dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitError, 200*1024),
-		HistoryCountLimitWarn:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitWarn, 50*1024),
+		BlobSizeLimitError:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
+		BlobSizeLimitWarn:       dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 256*1024),
+		TotalBlobSizeLimitError: dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 2*1024*1024),
+		TotalBlobSizeLimitWarn:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError, 256*1024),
+		HistorySizeLimitError:   dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitError, 200*1024*1024),
+		HistorySizeLimitWarn:    dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitWarn, 50*1024*1024),
+		HistoryCountLimitError:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitError, 200*1024),
+		HistoryCountLimitWarn:   dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitWarn, 50*1024),
 
 		ThrottledLogRPS: dc.GetIntProperty(dynamicconfig.HistoryThrottledLogRPS, 20),
 	}


### PR DESCRIPTION
Questions:
1. Do we really care about each task's individual size or do we only care about the sum? If we only care about the sum size this logic can be simplified.
2. If we do care about the total size and individual sizes separately then what default config values do we want to give to total size? Currently I am using the same defaults for both individual size and total size. 