### PR TITLE
CLI bugfix to reset using reset_type option

### DIFF
--- a/tools/cli/commands.go
+++ b/tools/cli/commands.go
@@ -1337,7 +1337,7 @@ func ResetWorkflow(c *cli.Context) {
 	if !ok && eventID <= 0 {
 		ErrorAndExit("Must specify valid eventID or valid resetType", nil)
 	}
-	if ok {
+	if ok && len(extraForResetType) > 0 {
 		getRequiredOption(c, extraForResetType)
 	}
 


### PR DESCRIPTION
When reset_type of FirstDecisionCompleted, LastDecisionCompleted or
LastContinuedAsNew is provided we should not check for other
required options.