### PR TITLE
Fix dynamic config GetMapProperty log duplicates

### DIFF
--- a/common/service/dynamicconfig/clientInterface.go
+++ b/common/service/dynamicconfig/clientInterface.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dynamicconfig
+
+import (
+	"time"
+)
+
+// Client allows fetching values from a dynamic configuration system NOTE: This does not have async
+// options right now. In the interest of keeping it minimal, we can add when requirement arises.
+type Client interface {
+	GetValue(name Key, defaultValue interface{}) (interface{}, error)
+	GetValueWithFilters(name Key, filters map[Filter]interface{}, defaultValue interface{}) (interface{}, error)
+
+	GetIntValue(name Key, filters map[Filter]interface{}, defaultValue int) (int, error)
+	GetFloatValue(name Key, filters map[Filter]interface{}, defaultValue float64) (float64, error)
+	GetBoolValue(name Key, filters map[Filter]interface{}, defaultValue bool) (bool, error)
+	GetStringValue(name Key, filters map[Filter]interface{}, defaultValue string) (string, error)
+	GetMapValue(
+		name Key, filters map[Filter]interface{}, defaultValue map[string]interface{},
+	) (map[string]interface{}, error)
+	GetDurationValue(
+		name Key, filters map[Filter]interface{}, defaultValue time.Duration,
+	) (time.Duration, error)
+}

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -22,6 +22,7 @@ package dynamicconfig
 
 import (
 	"fmt"
+	"sort"
 	"sync"
 	"time"
 
@@ -46,7 +47,7 @@ type Collection struct {
 func (c *Collection) logNoValue(key Key, err error) {
 	_, loaded := c.keys.LoadOrStore(key, struct{}{})
 	if !loaded {
-		c.logger.Debug("Failed to fetch key: %s from dynamic config with err: %s", tag.Key(key.String()), tag.Error(err))
+		c.logger.Debug("Failed to fetch key from dynamic config", tag.Key(key.String()), tag.Error(err))
 	}
 }
 
@@ -245,9 +246,30 @@ func (c *Collection) GetMapProperty(key Key, defaultValue map[string]interface{}
 		if err != nil {
 			c.logNoValue(key, err)
 		}
-		c.logValue(key, val, defaultValue)
+		c.logValue(key, mapToString(val), defaultValue)
 		return val
 	}
+}
+
+// mapToString ensure fmt.Print(map) will always be same instead of random order of keys.
+func mapToString(inputMap map[string]interface{}) string {
+	if len(inputMap) == 0 {
+		return ""
+	}
+
+	keys := make([]string, len(inputMap))
+	i := 0
+	for key := range inputMap {
+		keys[i] = key
+		i++
+	}
+	sort.Strings(keys)
+	res := "["
+	for _, key := range keys {
+		res += fmt.Sprintf("%v:%v ", key, inputMap[key])
+	}
+	res = res[:len(res)-1] + "]"
+	return res
 }
 
 // GetStringPropertyFnWithDomainFilter gets property with domain filter and asserts that its domain

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -252,6 +252,7 @@ func (c *Collection) GetMapProperty(key Key, defaultValue map[string]interface{}
 }
 
 // mapToString ensure fmt.Print(map) will always be same instead of random order of keys.
+// Go 1.12+ will fix this then we don't mapToString anymore
 func mapToString(inputMap map[string]interface{}) string {
 	if len(inputMap) == 0 {
 		return ""
@@ -264,7 +265,7 @@ func mapToString(inputMap map[string]interface{}) string {
 		i++
 	}
 	sort.Strings(keys)
-	res := "["
+	res := "map["
 	for _, key := range keys {
 		res += fmt.Sprintf("%v:%v ", key, inputMap[key])
 	}

--- a/common/service/dynamicconfig/config_test.go
+++ b/common/service/dynamicconfig/config_test.go
@@ -230,6 +230,19 @@ func (s *configSuite) TestGetDurationPropertyFilteredByTaskListInfo() {
 	s.Equal(time.Minute, value(domain, taskList, taskType))
 }
 
+func (s *configSuite) TestGetMapProperty() {
+	key := testGetMapPropertyKey
+	val := map[string]interface{}{
+		"testKey": 123,
+	}
+	value := s.cln.GetMapProperty(key, val)
+	s.Equal(val, value())
+	val["testKey"] = "321"
+	s.client.SetValue(key, val)
+	s.Equal(val, value())
+	s.Equal("321", value()["testKey"])
+}
+
 func TestDynamicConfigKeyIsMapped(t *testing.T) {
 	for i := unknownKey; i < lastKeyForTest; i++ {
 		key, ok := keys[i]
@@ -243,4 +256,13 @@ func TestDynamicConfigFilterTypeIsMapped(t *testing.T) {
 	for i := unknownFilter; i < lastFilterTypeForTest; i++ {
 		require.NotEmpty(t, filters[i])
 	}
+}
+
+func TestMapToString(t *testing.T) {
+	require.Equal(t, "", mapToString(nil))
+	m := map[string]interface{}{
+		"k1": 1,
+		"k2": 2,
+	}
+	require.Equal(t, "[k1:1 k2:2]", mapToString(m))
 }

--- a/common/service/dynamicconfig/config_test.go
+++ b/common/service/dynamicconfig/config_test.go
@@ -264,5 +264,5 @@ func TestMapToString(t *testing.T) {
 		"k1": 1,
 		"k2": 2,
 	}
-	require.Equal(t, "[k1:1 k2:2]", mapToString(m))
+	require.Equal(t, "map[k1:1 k2:2]", mapToString(m))
 }

--- a/common/service/dynamicconfig/nopClient.go
+++ b/common/service/dynamicconfig/nopClient.go
@@ -27,24 +27,7 @@ import (
 	"github.com/uber/cadence/common/log"
 )
 
-// Client allows fetching values from a dynamic configuration system NOTE: This does not have async
-// options right now. In the interest of keeping it minimal, we can add when requirement arises.
-type Client interface {
-	GetValue(name Key, defaultValue interface{}) (interface{}, error)
-	GetValueWithFilters(name Key, filters map[Filter]interface{}, defaultValue interface{}) (interface{}, error)
-
-	GetIntValue(name Key, filters map[Filter]interface{}, defaultValue int) (int, error)
-	GetFloatValue(name Key, filters map[Filter]interface{}, defaultValue float64) (float64, error)
-	GetBoolValue(name Key, filters map[Filter]interface{}, defaultValue bool) (bool, error)
-	GetStringValue(name Key, filters map[Filter]interface{}, defaultValue string) (string, error)
-	GetMapValue(
-		name Key, filters map[Filter]interface{}, defaultValue map[string]interface{},
-	) (map[string]interface{}, error)
-	GetDurationValue(
-		name Key, filters map[Filter]interface{}, defaultValue time.Duration,
-	) (time.Duration, error)
-}
-
+// nopClient is a dummy implements of dynamicconfig Client interface, all operations will always return default values.
 type nopClient struct{}
 
 func (mc *nopClient) GetValue(name Key, defaultValue interface{}) (interface{}, error) {


### PR DESCRIPTION
Go 1.11 fmt.Print(map) will generate random string of keys. 
```
func main() {
    m := map[int]int{3: 5, 2: 4, 1: 3}
    fmt.Println(m)

    // In Go 1.12+
    // Output: map[1:3 2:4 3:5]

    // Before Go 1.12 (the order was undefined)
    // map[3:5 2:4 1:3]
}
```
This cause each GetMapProperty of same value will log a message as new value. 

The PR fix this issue, also reorg some files. 