### PR TITLE
Change how domain scopes are created for front end handler metrics

### DIFF
--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -104,7 +104,7 @@ func (m *ClientImpl) UpdateGauge(scopeIdx int, gaugeIdx int, value float64) {
 // Scope return a new internal metrics scope that can be used to add additional
 // information to the metrics emitted
 func (m *ClientImpl) Scope(scopeIdx int, tags ...Tag) Scope {
-	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs).Tagged(tags...)
+	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs, false).Tagged(tags...)
 }
 
 func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -54,7 +54,7 @@ type (
 		AddCounter(counter int, delta int64)
 		// StartTimer starts a timer for the given
 		// metric name. Time will be recorded when stopwatch is stopped.
-		StartTimer(timer int) tally.Stopwatch
+		StartTimer(timer int) Stopwatch
 		// RecordTimer starts a timer for the given
 		// metric name
 		RecordTimer(timer int, d time.Duration)

--- a/common/metrics/mocks/Scope.go
+++ b/common/metrics/mocks/Scope.go
@@ -24,7 +24,6 @@ import (
 	time "time"
 
 	mock "github.com/stretchr/testify/mock"
-	tally "github.com/uber-go/tally"
 	metrics "github.com/uber/cadence/common/metrics"
 )
 
@@ -49,14 +48,14 @@ func (_m *Scope) RecordTimer(timer int, d time.Duration) {
 }
 
 // StartTimer provides a mock function with given fields: timer
-func (_m *Scope) StartTimer(timer int) tally.Stopwatch {
+func (_m *Scope) StartTimer(timer int) metrics.Stopwatch {
 	ret := _m.Called(timer)
 
-	var r0 tally.Stopwatch
-	if rf, ok := ret.Get(0).(func(int) tally.Stopwatch); ok {
+	var r0 metrics.Stopwatch
+	if rf, ok := ret.Get(0).(func(int) metrics.Stopwatch); ok {
 		r0 = rf(timer)
 	} else {
-		r0 = ret.Get(0).(tally.Stopwatch)
+		r0 = ret.Get(0).(metrics.Stopwatch)
 	}
 
 	return r0

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -27,17 +27,18 @@ import (
 )
 
 type metricsScope struct {
-	scope tally.Scope
-	defs  map[int]metricDefinition
+	scope    tally.Scope
+	defs     map[int]metricDefinition
+	isDomain bool
 }
 
-func newMetricsScope(scope tally.Scope, defs map[int]metricDefinition) Scope {
-	return &metricsScope{scope, defs}
+func newMetricsScope(scope tally.Scope, defs map[int]metricDefinition, isDomain bool) Scope {
+	return &metricsScope{scope, defs, isDomain}
 }
 
 // NoopScope returns a noop scope of metrics
 func NoopScope(serviceIdx ServiceIdx) Scope {
-	return &metricsScope{tally.NoopScope, getMetricDefs(serviceIdx)}
+	return &metricsScope{tally.NoopScope, getMetricDefs(serviceIdx), false}
 }
 
 func (m *metricsScope) IncCounter(id int) {
@@ -55,20 +56,32 @@ func (m *metricsScope) UpdateGauge(id int, value float64) {
 	m.scope.Gauge(name).Update(value)
 }
 
-func (m *metricsScope) StartTimer(id int) tally.Stopwatch {
+func (m *metricsScope) StartTimer(id int) Stopwatch {
 	name := string(m.defs[id].metricName)
-	return m.scope.Timer(name).Start()
+	timer := m.scope.Timer(name)
+	if m.isDomain {
+		timerAll := m.scope.Tagged(map[string]string{domain: domainAllValue}).Timer(name)
+		return NewStopwatch(timer, timerAll)
+	}
+	return NewStopwatch(timer)
 }
 
 func (m *metricsScope) RecordTimer(id int, d time.Duration) {
 	name := string(m.defs[id].metricName)
 	m.scope.Timer(name).Record(d)
+	if m.isDomain {
+		m.scope.Tagged(map[string]string{domain: domainAllValue}).Timer(name).Record(d)
+	}
 }
 
 func (m *metricsScope) Tagged(tags ...Tag) Scope {
+	isDomain := false
 	tagMap := make(map[string]string, len(tags))
 	for _, tag := range tags {
+		if tag.Key() == domain {
+			isDomain = true
+		}
 		tagMap[tag.Key()] = tag.Value()
 	}
-	return newMetricsScope(m.scope.Tagged(tagMap), m.defs)
+	return newMetricsScope(m.scope.Tagged(tagMap), m.defs, isDomain)
 }

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -78,10 +78,14 @@ func (m *metricsScope) Tagged(tags ...Tag) Scope {
 	isDomain := false
 	tagMap := make(map[string]string, len(tags))
 	for _, tag := range tags {
-		if tag.Key() == domain {
+		if isDomainTag(tag) {
 			isDomain = true
 		}
 		tagMap[tag.Key()] = tag.Value()
 	}
 	return newMetricsScope(m.scope.Tagged(tagMap), m.defs, isDomain)
+}
+
+func isDomainTag(tag Tag) bool {
+	return tag.Key() == domain && tag.Value() != domainAllValue
 }

--- a/common/metrics/stopwatch.go
+++ b/common/metrics/stopwatch.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package metrics
+
+import (
+	"time"
+
+	"github.com/uber-go/tally"
+)
+
+// Stopwatch is a helper for simpler tracking of elapsed time, use the
+// Stop() method to report time elapsed since its created back to the
+// timer or histogram.
+type Stopwatch struct {
+	start  time.Time
+	timers []tally.Timer
+}
+
+// NewStopwatch creates a new immutable stopwatch for recording the start
+// time to a stopwatch reporter.
+func NewStopwatch(timers ...tally.Timer) Stopwatch {
+	return Stopwatch{time.Now(), timers}
+}
+
+// NewTestStopwatch returns a new test stopwatch
+func NewTestStopwatch() Stopwatch {
+	return Stopwatch{time.Now(), []tally.Timer{}}
+}
+
+// Stop reports time elapsed since the stopwatch start to the recorder.
+func (sw Stopwatch) Stop() {
+	d := time.Now().Sub(sw.start)
+	for _, timer := range sw.timers {
+		timer.Record(d)
+	}
+}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -45,8 +45,12 @@ type domainTag struct {
 }
 
 // DomainTag returns a new domain tag. For timers, this also ensures that we
-// dual emit the metric with the all tag.
+// dual emit the metric with the all tag. If a blank domain is provided then
+// this converts that to an unknown domain.
 func DomainTag(value string) Tag {
+	if len(value) == 0 {
+		value = domainUnknownValue
+	}
 	return domainTag{value}
 }
 
@@ -60,26 +64,9 @@ func (d domainTag) Value() string {
 	return d.value
 }
 
-type domainAllTag struct{}
-
-// DomainAllTag returns a new domain all tag-value
-func DomainAllTag() Tag {
-	return domainAllTag{}
-}
-
-// Key returns the key of the domain all tag
-func (d domainAllTag) Key() string {
-	return domain
-}
-
-// Value returns the value of the domain all tag
-func (d domainAllTag) Value() string {
-	return domainAllValue
-}
-
 type domainUnknownTag struct{}
 
-// DomainAllTag returns a new domain:unknown tag-value
+// DomainUnknownTag returns a new domain:unknown tag-value
 func DomainUnknownTag() Tag {
 	return domainUnknownTag{}
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -44,7 +44,8 @@ type domainTag struct {
 	value string
 }
 
-// DomainTag returns a new domain tag
+// DomainTag returns a new domain tag. For timers, this also ensures that we
+// dual emit the metric with the all tag.
 func DomainTag(value string) Tag {
 	return domainTag{value}
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -98,6 +98,10 @@ type (
 		BlobstorePageToken   int
 		CloseFailoverVersion int64
 	}
+
+	domainGetter interface {
+		GetDomain() string
+	}
 )
 
 var (
@@ -322,7 +326,7 @@ func (wh *WorkflowHandler) PollForActivityTask(
 
 	callTime := time.Now()
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForActivityTaskScope, pollRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForActivityTaskScope, pollRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -401,7 +405,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 
 	callTime := time.Now()
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForDecisionTaskScope, pollRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForDecisionTaskScope, pollRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -1468,7 +1472,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	startRequest *gen.StartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendStartWorkflowExecutionScope, startRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendStartWorkflowExecutionScope, startRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -1611,7 +1615,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 	getRequest *gen.GetWorkflowExecutionHistoryRequest) (resp *gen.GetWorkflowExecutionHistoryResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendGetWorkflowExecutionHistoryScope, getRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendGetWorkflowExecutionHistoryScope, getRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -1813,7 +1817,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 	signalRequest *gen.SignalWorkflowExecutionRequest) (retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendSignalWorkflowExecutionScope, signalRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendSignalWorkflowExecutionScope, signalRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -1892,7 +1896,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	signalWithStartRequest *gen.SignalWithStartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendSignalWithStartWorkflowExecutionScope, signalWithStartRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendSignalWithStartWorkflowExecutionScope, signalWithStartRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2050,7 +2054,7 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(ctx context.Context,
 	terminateRequest *gen.TerminateWorkflowExecutionRequest) (retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendTerminateWorkflowExecutionScope, terminateRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendTerminateWorkflowExecutionScope, terminateRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2095,7 +2099,7 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context,
 	resetRequest *gen.ResetWorkflowExecutionRequest) (resp *gen.ResetWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetWorkflowExecutionScope, resetRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetWorkflowExecutionScope, resetRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2140,7 +2144,7 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 	cancelRequest *gen.RequestCancelWorkflowExecutionRequest) (retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRequestCancelWorkflowExecutionScope, cancelRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRequestCancelWorkflowExecutionScope, cancelRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2184,7 +2188,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 	listRequest *gen.ListOpenWorkflowExecutionsRequest) (resp *gen.ListOpenWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListOpenWorkflowExecutionsScope, listRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListOpenWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2282,7 +2286,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
 	listRequest *gen.ListClosedWorkflowExecutionsRequest) (resp *gen.ListClosedWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListClosedWorkflowExecutionsScope, listRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListClosedWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2398,7 +2402,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
 func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, listRequest *gen.ListWorkflowExecutionsRequest) (resp *gen.ListWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListWorkflowExecutionsScope, listRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2453,7 +2457,7 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, listReque
 func (wh *WorkflowHandler) ScanWorkflowExecutions(ctx context.Context, listRequest *gen.ListWorkflowExecutionsRequest) (resp *gen.ListWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendScanWorkflowExecutionsScope, listRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendScanWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2508,7 +2512,7 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(ctx context.Context, listReque
 func (wh *WorkflowHandler) CountWorkflowExecutions(ctx context.Context, countRequest *gen.CountWorkflowExecutionsRequest) (resp *gen.CountWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendCountWorkflowExecutionsScope, countRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendCountWorkflowExecutionsScope, countRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2575,7 +2579,7 @@ func (wh *WorkflowHandler) GetSearchAttributes(ctx context.Context) (resp *gen.G
 func (wh *WorkflowHandler) ResetStickyTaskList(ctx context.Context, resetRequest *gen.ResetStickyTaskListRequest) (resp *gen.ResetStickyTaskListResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetStickyTaskListScope, resetRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetStickyTaskListScope, resetRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2617,7 +2621,7 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
 	queryRequest *gen.QueryWorkflowRequest) (resp *gen.QueryWorkflowResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendQueryWorkflowScope, queryRequest.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendQueryWorkflowScope, queryRequest)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2719,7 +2723,7 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
 func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, request *gen.DescribeWorkflowExecutionRequest) (resp *gen.DescribeWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeWorkflowExecutionScope, request.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeWorkflowExecutionScope, request)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2764,7 +2768,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 func (wh *WorkflowHandler) DescribeTaskList(ctx context.Context, request *gen.DescribeTaskListRequest) (resp *gen.DescribeTaskListResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeTaskListScope, request.Domain)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeTaskListScope, request)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2907,12 +2911,12 @@ func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, metric
 }
 
 // startRequestProfileWithDomain initiates recording of request metrics and returns a domain tagged scope
-func (wh *WorkflowHandler) startRequestProfileWithDomain(scope int, domain *string) (metrics.Scope, metrics.Stopwatch) {
+func (wh *WorkflowHandler) startRequestProfileWithDomain(scope int, d domainGetter) (metrics.Scope, metrics.Stopwatch) {
 	wh.startWG.Wait()
 
 	var metricsScope metrics.Scope
-	if domain != nil && len(*domain) > 0 {
-		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainTag(*domain))
+	if d != nil && len(d.GetDomain()) > 0 {
+		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainTag(d.GetDomain()))
 	} else {
 		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainAllTag())
 	}

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2900,9 +2900,9 @@ func (wh *WorkflowHandler) getLoggerForTask(taskToken []byte) log.Logger {
 func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, metrics.Stopwatch) {
 	wh.startWG.Wait()
 
-	metricsScope := wh.metricsClient.Scope(scope)
+	metricsScope := wh.metricsClient.Scope(scope).Tagged(metrics.DomainUnknownTag())
 	// timer should be emitted with the all tag
-	sw := metricsScope.Tagged(metrics.DomainAllTag()).StartTimer(metrics.CadenceLatency)
+	sw := metricsScope.StartTimer(metrics.CadenceLatency)
 	metricsScope.IncCounter(metrics.CadenceRequests)
 	return metricsScope, sw
 }
@@ -2912,10 +2912,10 @@ func (wh *WorkflowHandler) startRequestProfileWithDomain(scope int, d domainGett
 	wh.startWG.Wait()
 
 	var metricsScope metrics.Scope
-	if d != nil && len(d.GetDomain()) > 0 {
+	if d != nil {
 		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainTag(d.GetDomain()))
 	} else {
-		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainAllTag())
+		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainUnknownTag())
 	}
 	sw := metricsScope.StartTimer(metrics.CadenceLatency)
 	metricsScope.IncCounter(metrics.CadenceRequests)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2899,8 +2899,9 @@ func (wh *WorkflowHandler) getLoggerForTask(taskToken []byte) log.Logger {
 func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, metrics.Stopwatch) {
 	wh.startWG.Wait()
 
-	metricsScope := wh.metricsClient.Scope(scope).Tagged(metrics.DomainAllTag())
-	sw := metricsScope.StartTimer(metrics.CadenceLatency)
+	metricsScope := wh.metricsClient.Scope(scope)
+	// timer should be emitted with the all tag
+	sw := metricsScope.Tagged(metrics.DomainAllTag()).StartTimer(metrics.CadenceLatency)
 	metricsScope.IncCounter(metrics.CadenceRequests)
 	return metricsScope, sw
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -323,7 +323,7 @@ func (wh *WorkflowHandler) PollForActivityTask(
 
 	callTime := time.Now()
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendPollForActivityTaskScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForActivityTaskScope, pollRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -362,9 +362,6 @@ func (wh *WorkflowHandler) PollForActivityTask(
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
-
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(pollRequest.GetDomain()))
 
 	pollerID := uuid.New()
 	op := func() error {
@@ -405,7 +402,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 
 	callTime := time.Now()
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendPollForDecisionTaskScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForDecisionTaskScope, pollRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -446,9 +443,6 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 		return nil, wh.error(err, scope)
 	}
 	domainID := domainEntry.GetInfo().ID
-
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(domainName))
 
 	wh.Service.GetLogger().Debug("Poll for decision.", tag.WorkflowDomainName(domainName), tag.WorkflowDomainID(domainID))
 	if err := wh.checkBadBinary(domainEntry, pollRequest.GetBinaryChecksum()); err != nil {
@@ -1475,7 +1469,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	startRequest *gen.StartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendStartWorkflowExecutionScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendStartWorkflowExecutionScope, startRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -1618,7 +1612,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 	getRequest *gen.GetWorkflowExecutionHistoryRequest) (resp *gen.GetWorkflowExecutionHistoryResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendGetWorkflowExecutionHistoryScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendGetWorkflowExecutionHistoryScope, getRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -1822,7 +1816,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 	signalRequest *gen.SignalWorkflowExecutionRequest) (retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendSignalWorkflowExecutionScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendSignalWorkflowExecutionScope, signalRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -1904,7 +1898,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 	signalWithStartRequest *gen.SignalWithStartWorkflowExecutionRequest) (resp *gen.StartWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendSignalWithStartWorkflowExecutionScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendSignalWithStartWorkflowExecutionScope, signalWithStartRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2065,7 +2059,7 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(ctx context.Context,
 	terminateRequest *gen.TerminateWorkflowExecutionRequest) (retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendTerminateWorkflowExecutionScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendTerminateWorkflowExecutionScope, terminateRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2113,7 +2107,7 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context,
 	resetRequest *gen.ResetWorkflowExecutionRequest) (resp *gen.ResetWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendResetWorkflowExecutionScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetWorkflowExecutionScope, resetRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2161,7 +2155,7 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 	cancelRequest *gen.RequestCancelWorkflowExecutionRequest) (retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendRequestCancelWorkflowExecutionScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRequestCancelWorkflowExecutionScope, cancelRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2208,7 +2202,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 	listRequest *gen.ListOpenWorkflowExecutionsRequest) (resp *gen.ListOpenWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendListOpenWorkflowExecutionsScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListOpenWorkflowExecutionsScope, listRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2309,7 +2303,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
 	listRequest *gen.ListClosedWorkflowExecutionsRequest) (resp *gen.ListClosedWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendListClosedWorkflowExecutionsScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListClosedWorkflowExecutionsScope, listRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2428,7 +2422,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
 func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, listRequest *gen.ListWorkflowExecutionsRequest) (resp *gen.ListWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendListWorkflowExecutionsScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListWorkflowExecutionsScope, listRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2486,7 +2480,7 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, listReque
 func (wh *WorkflowHandler) ScanWorkflowExecutions(ctx context.Context, listRequest *gen.ListWorkflowExecutionsRequest) (resp *gen.ListWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendScanWorkflowExecutionsScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendScanWorkflowExecutionsScope, listRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2544,7 +2538,7 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(ctx context.Context, listReque
 func (wh *WorkflowHandler) CountWorkflowExecutions(ctx context.Context, countRequest *gen.CountWorkflowExecutionsRequest) (resp *gen.CountWorkflowExecutionsResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendCountWorkflowExecutionsScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendCountWorkflowExecutionsScope, countRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2614,7 +2608,7 @@ func (wh *WorkflowHandler) GetSearchAttributes(ctx context.Context) (resp *gen.G
 func (wh *WorkflowHandler) ResetStickyTaskList(ctx context.Context, resetRequest *gen.ResetStickyTaskListRequest) (resp *gen.ResetStickyTaskListResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendResetStickyTaskListScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetStickyTaskListScope, resetRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2656,7 +2650,7 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
 	queryRequest *gen.QueryWorkflowRequest) (resp *gen.QueryWorkflowResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendQueryWorkflowScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendQueryWorkflowScope, queryRequest.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2761,7 +2755,7 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
 func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, request *gen.DescribeWorkflowExecutionRequest) (resp *gen.DescribeWorkflowExecutionResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendDescribeWorkflowExecutionScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeWorkflowExecutionScope, request.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2809,7 +2803,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 func (wh *WorkflowHandler) DescribeTaskList(ctx context.Context, request *gen.DescribeTaskListRequest) (resp *gen.DescribeTaskListResponse, retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
-	scope, sw := wh.startRequestProfile(metrics.FrontendDescribeTaskListScope)
+	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeTaskListScope, request.Domain)
 	defer sw.Stop()
 
 	if err := wh.versionChecker.checkClientVersion(ctx); err != nil {
@@ -2948,6 +2942,21 @@ func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, tally.
 	wh.startWG.Wait()
 
 	metricsScope := wh.metricsClient.Scope(scope)
+	sw := metricsScope.StartTimer(metrics.CadenceLatency)
+	metricsScope.IncCounter(metrics.CadenceRequests)
+	return metricsScope, sw
+}
+
+// startRequestProfileWithDomain initiates recording of request metrics and returns a domain tagged scope
+func (wh *WorkflowHandler) startRequestProfileWithDomain(scope int, domain *string) (metrics.Scope, tally.Stopwatch) {
+	wh.startWG.Wait()
+
+	var metricsScope metrics.Scope
+	if domain != nil && len(*domain) > 0 {
+		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainTag(*domain))
+	} else {
+		metricsScope = wh.metricsClient.Scope(scope)
+	}
 	sw := metricsScope.StartTimer(metrics.CadenceLatency)
 	metricsScope.IncCounter(metrics.CadenceRequests)
 	return metricsScope, sw

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2864,9 +2864,6 @@ func (wh *WorkflowHandler) getHistory(
 	}
 
 	if len(historyEvents) > 0 {
-		// N.B. - Dual emit is required here so that we can see aggregate timer stats across all
-		// domains along with the individual domains stats
-		scope.Tagged(metrics.DomainAllTag()).RecordTimer(metrics.HistorySize, time.Duration(size))
 		scope.RecordTimer(metrics.HistorySize, time.Duration(size))
 
 		if size > common.GetHistoryWarnSizeLimit {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1644,8 +1644,6 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 		return nil, wh.error(err, scope)
 	}
 
-	scope = scope.Tagged(metrics.DomainTag(getRequest.GetDomain()))
-
 	// force limit page size if exceed
 	if getRequest.GetMaximumPageSize() > common.GetHistoryMaxPageSize {
 		wh.GetThrottledLogger().Warn("GetHistory page size is larger than threshold",
@@ -1860,9 +1858,6 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(ctx context.Context,
 		return wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(signalRequest.GetDomain()))
-
 	sizeLimitError := wh.config.BlobSizeLimitError(signalRequest.GetDomain())
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(signalRequest.GetDomain())
 	if err := common.CheckEventBlobSizeLimit(
@@ -2005,9 +2000,6 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(domainName))
-
 	sizeLimitError := wh.config.BlobSizeLimitError(domainName)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainName)
 	if err := common.CheckEventBlobSizeLimit(
@@ -2087,9 +2079,6 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(ctx context.Context,
 		return wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(terminateRequest.GetDomain()))
-
 	err = wh.history.TerminateWorkflowExecution(ctx, &h.TerminateWorkflowExecutionRequest{
 		DomainUUID:       common.StringPtr(domainID),
 		TerminateRequest: terminateRequest,
@@ -2135,9 +2124,6 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(resetRequest.GetDomain()))
-
 	resp, err = wh.history.ResetWorkflowExecution(ctx, &h.ResetWorkflowExecutionRequest{
 		DomainUUID:   common.StringPtr(domainID),
 		ResetRequest: resetRequest,
@@ -2182,9 +2168,6 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 	if err != nil {
 		return wh.error(err, scope)
 	}
-
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(cancelRequest.GetDomain()))
 
 	err = wh.history.RequestCancelWorkflowExecution(ctx, &h.RequestCancelWorkflowExecutionRequest{
 		DomainUUID:    common.StringPtr(domainID),
@@ -2247,9 +2230,6 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
-
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(domain))
 
 	baseReq := persistence.ListWorkflowExecutionsRequest{
 		DomainUUID:        domainID,
@@ -2357,9 +2337,6 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(domain))
-
 	baseReq := persistence.ListWorkflowExecutionsRequest{
 		DomainUUID:        domainID,
 		Domain:            domain,
@@ -2455,9 +2432,6 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(ctx context.Context, listReque
 		return nil, wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(domain))
-
 	req := &persistence.ListWorkflowExecutionsRequestV2{
 		DomainUUID:    domainID,
 		Domain:        domain,
@@ -2513,9 +2487,6 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(ctx context.Context, listReque
 		return nil, wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(domain))
-
 	req := &persistence.ListWorkflowExecutionsRequestV2{
 		DomainUUID:    domainID,
 		Domain:        domain,
@@ -2566,9 +2537,6 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(ctx context.Context, countReq
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
-
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(domain))
 
 	req := &persistence.CountWorkflowExecutionsRequest{
 		DomainUUID: domainID,
@@ -2682,9 +2650,6 @@ func (wh *WorkflowHandler) QueryWorkflow(ctx context.Context,
 		return nil, wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(queryRequest.GetDomain()))
-
 	matchingRequest := &m.QueryWorkflowRequest{
 		DomainUUID:   common.StringPtr(domainID),
 		QueryRequest: queryRequest,
@@ -2778,9 +2743,6 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(ctx context.Context, reques
 		return nil, wh.error(err, scope)
 	}
 
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(request.GetDomain()))
-
 	if err := wh.validateExecutionAndEmitMetrics(request.Execution, scope); err != nil {
 		return nil, err
 	}
@@ -2825,9 +2787,6 @@ func (wh *WorkflowHandler) DescribeTaskList(ctx context.Context, request *gen.De
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
-
-	// add domain tag to scope, so further metrics will have the domain tag
-	scope = scope.Tagged(metrics.DomainTag(request.GetDomain()))
 
 	if err := wh.validateTaskList(request.TaskList, scope); err != nil {
 		return nil, err

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2899,7 +2899,7 @@ func (wh *WorkflowHandler) getLoggerForTask(taskToken []byte) log.Logger {
 func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, metrics.Stopwatch) {
 	wh.startWG.Wait()
 
-	metricsScope := wh.metricsClient.Scope(scope)
+	metricsScope := wh.metricsClient.Scope(scope).Tagged(metrics.DomainAllTag())
 	sw := metricsScope.StartTimer(metrics.CadenceLatency)
 	metricsScope.IncCounter(metrics.CadenceRequests)
 	return metricsScope, sw
@@ -2913,7 +2913,7 @@ func (wh *WorkflowHandler) startRequestProfileWithDomain(scope int, domain *stri
 	if domain != nil && len(*domain) > 0 {
 		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainTag(*domain))
 	} else {
-		metricsScope = wh.metricsClient.Scope(scope)
+		metricsScope = wh.metricsClient.Scope(scope).Tagged(metrics.DomainAllTag())
 	}
 	sw := metricsScope.StartTimer(metrics.CadenceLatency)
 	metricsScope.IncCounter(metrics.CadenceRequests)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber-go/tally"
 	"github.com/uber/cadence/.gen/go/cadence/workflowserviceserver"
 	"github.com/uber/cadence/.gen/go/health"
 	"github.com/uber/cadence/.gen/go/health/metaserver"
@@ -2897,7 +2896,7 @@ func (wh *WorkflowHandler) getLoggerForTask(taskToken []byte) log.Logger {
 }
 
 // startRequestProfile initiates recording of request metrics
-func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, tally.Stopwatch) {
+func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, metrics.Stopwatch) {
 	wh.startWG.Wait()
 
 	metricsScope := wh.metricsClient.Scope(scope)
@@ -2907,7 +2906,7 @@ func (wh *WorkflowHandler) startRequestProfile(scope int) (metrics.Scope, tally.
 }
 
 // startRequestProfileWithDomain initiates recording of request metrics and returns a domain tagged scope
-func (wh *WorkflowHandler) startRequestProfileWithDomain(scope int, domain *string) (metrics.Scope, tally.Stopwatch) {
+func (wh *WorkflowHandler) startRequestProfileWithDomain(scope int, domain *string) (metrics.Scope, metrics.Stopwatch) {
 	wh.startWG.Wait()
 
 	var metricsScope metrics.Scope

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -774,15 +774,14 @@ func (s *shardContextImpl) AppendHistoryEvents(request *persistence.AppendHistor
 
 	size := 0
 	defer func() {
-		// N.B. - Dual emit here makes sense so that we can see aggregate timer stats across all
-		// domains along with the individual domains stats
-		allDomainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainAllTag())
-		allDomainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
 		if domainEntry != nil && domainEntry.GetInfo() != nil {
-			domainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(
-				domainEntry.GetInfo().Name))
+			domainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(domainEntry.GetInfo().Name))
 			domainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
+		} else {
+			allDomainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainAllTag())
+			allDomainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
 		}
+
 		if size >= historySizeLogThreshold {
 			s.throttledLogger.Warn("history size threshold breached",
 				tag.WorkflowID(request.Execution.GetWorkflowId()),

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -774,13 +774,12 @@ func (s *shardContextImpl) AppendHistoryEvents(request *persistence.AppendHistor
 
 	size := 0
 	defer func() {
+		domain := ""
 		if domainEntry != nil && domainEntry.GetInfo() != nil {
-			domainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(domainEntry.GetInfo().Name))
-			domainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
-		} else {
-			allDomainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainAllTag())
-			allDomainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
+			domain = domainEntry.GetInfo().Name
 		}
+		domainSizeScope := s.metricsClient.Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(domain))
+		domainSizeScope.RecordTimer(metrics.HistorySize, time.Duration(size))
 
 		if size >= historySizeLogThreshold {
 			s.throttledLogger.Warn("history size threshold breached",

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -625,8 +625,9 @@ func (e *matchingEngineImpl) createPollForDecisionTaskResponse(context *taskCont
 			scope := e.metricsClient.Scope(metrics.MatchingPollForDecisionTaskScope)
 			if len(context.domainName) != 0 {
 				scope.Tagged(metrics.DomainTag(context.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
+			} else {
+				scope.Tagged(metrics.DomainAllTag()).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
 			}
-			scope.Tagged(metrics.DomainAllTag()).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
 		}
 	}
 
@@ -655,8 +656,9 @@ func (e *matchingEngineImpl) createPollForActivityTaskResponse(context *taskCont
 		scope := e.metricsClient.Scope(metrics.MatchingPollForActivityTaskScope)
 		if len(context.domainName) != 0 {
 			scope.Tagged(metrics.DomainTag(context.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
+		} else {
+			scope.Tagged(metrics.DomainAllTag()).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
 		}
-		scope.Tagged(metrics.DomainAllTag()).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
 	}
 
 	response := &workflow.PollForActivityTaskResponse{}

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -623,11 +623,7 @@ func (e *matchingEngineImpl) createPollForDecisionTaskResponse(context *taskCont
 		token, _ = e.tokenSerializer.Serialize(taskoken)
 		if context.syncResponseCh == nil {
 			scope := e.metricsClient.Scope(metrics.MatchingPollForDecisionTaskScope)
-			if len(context.domainName) != 0 {
-				scope.Tagged(metrics.DomainTag(context.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
-			} else {
-				scope.Tagged(metrics.DomainAllTag()).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
-			}
+			scope.Tagged(metrics.DomainTag(context.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
 		}
 	}
 
@@ -654,11 +650,7 @@ func (e *matchingEngineImpl) createPollForActivityTaskResponse(context *taskCont
 	}
 	if context.syncResponseCh == nil {
 		scope := e.metricsClient.Scope(metrics.MatchingPollForActivityTaskScope)
-		if len(context.domainName) != 0 {
-			scope.Tagged(metrics.DomainTag(context.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
-		} else {
-			scope.Tagged(metrics.DomainAllTag()).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
-		}
+		scope.Tagged(metrics.DomainTag(context.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.CreatedTime))
 	}
 
 	response := &workflow.PollForActivityTaskResponse{}

--- a/service/worker/archiver/activities_test.go
+++ b/service/worker/archiver/activities_test.go
@@ -25,11 +25,9 @@ import (
 	"errors"
 	"strconv"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"github.com/uber-go/tally"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/blobstore"
@@ -76,7 +74,7 @@ func (s *activitiesSuite) SetupTest() {
 	s.logger = loggerimpl.NewLogger(zapLogger)
 	s.metricsClient = &mmocks.Client{}
 	s.metricsScope = &mmocks.Scope{}
-	s.metricsScope.On("StartTimer", metrics.CadenceLatency).Return(tally.NewStopwatch(time.Now(), &nopStopwatchRecorder{})).Once()
+	s.metricsScope.On("StartTimer", metrics.CadenceLatency).Return(metrics.NewTestStopwatch()).Once()
 }
 
 func (s *activitiesSuite) TearDownTest() {

--- a/service/worker/archiver/replay_metrics_client.go
+++ b/service/worker/archiver/replay_metrics_client.go
@@ -118,9 +118,9 @@ func (r *replayMetricsScope) AddCounter(counter int, delta int64) {
 }
 
 // StartTimer starts a timer for the given metric name. Time will be recorded when stopwatch is stopped.
-func (r *replayMetricsScope) StartTimer(timer int) tally.Stopwatch {
+func (r *replayMetricsScope) StartTimer(timer int) metrics.Stopwatch {
 	if workflow.IsReplaying(r.ctx) {
-		return nopStopwatch()
+		return metrics.NewTestStopwatch()
 	}
 	return r.scope.StartTimer(timer)
 }


### PR DESCRIPTION
- create startRequestProfileWithDomain method and use in places where domain name is passed in
- create domainGetter interface so we can retrieve domain from request body
- update timer logic to dual emit to all internally if domain tag is used
- create an internal stopwatch with same methods as tally.Stopwatch to assist with the above.