### PR TITLE
Fix flaky elasticsearch tests and possible duplicate records in search after

### DIFF
--- a/common/elasticsearch/client.go
+++ b/common/elasticsearch/client.go
@@ -83,6 +83,7 @@ func NewClient(config *Config) (Client, error) {
 	client, err := elastic.NewClient(
 		elastic.SetURL(config.URL.String()),
 		elastic.SetRetrier(elastic.NewBackoffRetrier(elastic.NewExponentialBackoff(128*time.Millisecond, 513*time.Millisecond))),
+		elastic.SetDecoder(&elastic.NumberDecoder{}),
 	)
 	if err != nil {
 		return nil, err

--- a/common/elasticsearch/client.go
+++ b/common/elasticsearch/client.go
@@ -83,7 +83,7 @@ func NewClient(config *Config) (Client, error) {
 	client, err := elastic.NewClient(
 		elastic.SetURL(config.URL.String()),
 		elastic.SetRetrier(elastic.NewBackoffRetrier(elastic.NewExponentialBackoff(128*time.Millisecond, 513*time.Millisecond))),
-		elastic.SetDecoder(&elastic.NumberDecoder{}),
+		elastic.SetDecoder(&elastic.NumberDecoder{}), // critical to ensure decode of int64 won't lose precise
 	)
 	if err != nil {
 		return nil, err

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -338,6 +338,7 @@ func (v *esVisibilityStore) ListWorkflowExecutions(
 	if err != nil {
 		return nil, err
 	}
+	fmt.Printf("vancexu, list get token: %v, %v\n", token.SortValue, token.TieBreaker)
 
 	queryDSL, sortField, err := v.getESQueryDSL(request, token)
 	if err != nil {
@@ -775,6 +776,7 @@ func (v *esVisibilityStore) getListWorkflowExecutionsResponse(searchHits *elasti
 			tieBreaker := sortVals[1].(string)
 
 			nextPageToken, err = v.serializePageToken(&esVisibilityPageToken{SortValue: sortVal, TieBreaker: tieBreaker})
+			fmt.Printf("vancexu: response token: %v, %v\n", sortVal, tieBreaker)
 		}
 		if err != nil {
 			return nil, err

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -338,7 +338,6 @@ func (v *esVisibilityStore) ListWorkflowExecutions(
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("vancexu, list get token: %v, %v\n", token.SortValue, token.TieBreaker)
 
 	queryDSL, sortField, err := v.getESQueryDSL(request, token)
 	if err != nil {
@@ -776,7 +775,6 @@ func (v *esVisibilityStore) getListWorkflowExecutionsResponse(searchHits *elasti
 			tieBreaker := sortVals[1].(string)
 
 			nextPageToken, err = v.serializePageToken(&esVisibilityPageToken{SortValue: sortVal, TieBreaker: tieBreaker})
-			fmt.Printf("vancexu: response token: %v, %v\n", sortVal, tieBreaker)
 		}
 		if err != nil {
 			return nil, err

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -352,12 +352,16 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
 	}
 	s.NotNil(listResp)
 	s.True(len(listResp.GetNextPageToken()) != 0)
+	fmt.Println("vancexu len of listResp: ", len(listResp.GetExecutions()))
+	fmt.Println("vancexu listResp: ", listResp)
 
 	// the last request
 	listRequest.NextPageToken = listResp.GetNextPageToken()
 	resp, err := s.engine.ListWorkflowExecutions(createContext(), listRequest)
 	s.Nil(err)
 	s.Logger.Debug(fmt.Sprintf("last request get executions %s", resp.GetExecutions()))
+	fmt.Println("vancexu len of resp: ", len(resp.GetExecutions()))
+	fmt.Println("vancexu resp: ", resp)
 	s.True(len(resp.GetExecutions()) == 0)
 	s.True(len(resp.GetNextPageToken()) == 0)
 
@@ -533,6 +537,8 @@ func (s *elasticsearchIntegrationSuite) testListWorkflowHelper(numOfWorkflows, p
 		if len(resp.GetExecutions()) == pageSize {
 			openExecutions = resp.GetExecutions()
 			nextPageToken = resp.GetNextPageToken()
+			fmt.Println("vancexu len of listResp: ", len(resp.GetExecutions()))
+			fmt.Println("vancexu listResp: ", resp)
 			break
 		}
 		time.Sleep(waitTimeInMs * time.Millisecond)

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -354,12 +354,14 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
 		}
 		time.Sleep(waitTimeInMs * time.Millisecond)
 	}
+	s.NotNil(listResp)
 	s.True(len(listResp.GetNextPageToken()) != 0)
 
 	// the last request
 	listRequest.NextPageToken = listResp.GetNextPageToken()
 	resp, err := s.engine.ListWorkflowExecutions(createContext(), listRequest)
 	s.Nil(err)
+	s.Logger.Debug(fmt.Sprintf("last request get executions %s", resp.GetExecutions()))
 	s.True(len(resp.GetExecutions()) == 0)
 	s.True(len(resp.GetNextPageToken()) == 0)
 

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -43,8 +43,8 @@ import (
 )
 
 const (
-	numOfRetry   = 50
-	waitTimeInMs = 400
+	numOfRetry        = 50
+	waitTimeInMs      = 400
 	waitForESToSettle = 4 * time.Second // wait es shards for some time ensure data consistent
 )
 
@@ -334,6 +334,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
 		_, err := s.engine.StartWorkflowExecution(createContext(), startRequest)
 		s.Nil(err)
 	}
+
 	time.Sleep(waitForESToSettle)
 
 	var listResp *workflow.ListWorkflowExecutionsResponse
@@ -403,6 +404,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrderBy() {
 		_, err := s.engine.StartWorkflowExecution(createContext(), startRequest)
 		s.Nil(err)
 	}
+
 	time.Sleep(waitForESToSettle)
 
 	desc := "desc"
@@ -514,6 +516,7 @@ func (s *elasticsearchIntegrationSuite) testListWorkflowHelper(numOfWorkflows, p
 		_, err := s.engine.StartWorkflowExecution(createContext(), startRequest)
 		s.Nil(err)
 	}
+
 	time.Sleep(waitForESToSettle)
 
 	var openExecutions []*workflow.WorkflowExecutionInfo

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -17,7 +17,6 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
-//+build esintegration
 
 // to run locally, make sure kafka and es is running,
 // then run cmd `go test -v ./host -run TestElasticsearchIntegrationSuite -tags esintegration`
@@ -183,7 +182,6 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_SearchAttribute() {
 }
 
 func (s *elasticsearchIntegrationSuite) TestListWorkflow_PageToken() {
-	s.T().Skip("fixme: flaky test")
 	id := "es-integration-list-workflow-token-test"
 	wt := "es-integration-list-workflow-token-test-type"
 	tl := "es-integration-list-workflow-token-test-tasklist"
@@ -196,7 +194,6 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_PageToken() {
 }
 
 func (s *elasticsearchIntegrationSuite) TestListWorkflow_SearchAfter() {
-	s.T().Skip("fixme: flaky test")
 	id := "es-integration-list-workflow-searchAfter-test"
 	wt := "es-integration-list-workflow-searchAfter-test-type"
 	tl := "es-integration-list-workflow-searchAfter-test-tasklist"
@@ -315,7 +312,6 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrQuery() {
 
 // To test last page search trigger max window size error
 func (s *elasticsearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
-	s.T().Skip("fixme: flaky test")
 	// set es index index settings
 	indexName := s.testClusterConfig.ESConfig.Indices[common.VisibilityAppName]
 	_, err := s.esClient.IndexPutSettings(indexName).
@@ -536,7 +532,7 @@ func (s *elasticsearchIntegrationSuite) testListWorkflowHelper(numOfWorkflows, p
 		s.Nil(err)
 		if len(resp.GetExecutions()) == pageSize {
 			openExecutions = resp.GetExecutions()
-			nextPageToken = resp.NextPageToken
+			nextPageToken = resp.GetNextPageToken()
 			break
 		}
 		time.Sleep(waitTimeInMs * time.Millisecond)
@@ -561,8 +557,11 @@ func (s *elasticsearchIntegrationSuite) testListWorkflowHelper(numOfWorkflows, p
 		if len(resp.GetExecutions()) == numOfWorkflows-pageSize {
 			inIf = true
 			openExecutions = resp.GetExecutions()
-			nextPageToken = resp.NextPageToken
+			nextPageToken = resp.GetNextPageToken()
 			break
+		} else {
+			fmt.Println("vancexu len of resp: ", len(resp.GetExecutions()))
+			fmt.Println("vancexu resp: ", resp)
 		}
 		time.Sleep(waitTimeInMs * time.Millisecond)
 	}


### PR DESCRIPTION
This PR fixes:
1. Some flaky tests like TestListWorkflow_SearchAfter TestListWorkflow_PageToken and TestListWorkflow_MaxWindowSize.
2. Possible duplicate records when search after. 

2 reasons tests are flaky:
1. say start workflows wid-[1,2,3,4,5,6] then list with page 5, the records of 1st page may not be expected wid-[6,5,4,3,2] but something like wid-[6,4,3,2,1] which leads to 2nd page call get unexpected result. Wait for some time for ES shared to be consistent solve it. 
2. elastic lib decode json int64 myNum to float64 myNum1, when you convert myNum1 to myNum2 int64 through json.Number, myNum2 still not equal to myNum sometimes, this caused duplicate records in 2 pages. This fix is to let elastic lib also use json Number to decode
