### PR TITLE
Add archival size metrics

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1334,6 +1334,8 @@ const (
 	ArchiverNonRetryableErrorCount
 	ArchiverSkipUploadCount
 	ArchiverHistoryMutatedCount
+	ArchiverBlobSize
+	ArchiverTotalUploadSize
 	ArchiverRunningDeterministicConstructionCheckCount
 	ArchiverDeterministicConstructionCheckFailedCount
 	ArchiverCouldNotRunDeterministicConstructionCheckCount
@@ -1575,6 +1577,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ArchiverNonRetryableErrorCount:                         {metricName: "archiver_non_retryable_error"},
 		ArchiverSkipUploadCount:                                {metricName: "archiver_skip_upload"},
 		ArchiverHistoryMutatedCount:                            {metricName: "archiver_history_mutated"},
+		ArchiverBlobSize:                                       {metricName: "archiver_blob_size", metricType: Timer},
+		ArchiverTotalUploadSize:                                {metricName: "archiver_total_upload_size", metricType: Timer},
 		ArchiverRunningDeterministicConstructionCheckCount:     {metricName: "archiver_running_deterministic_construction_check"},
 		ArchiverDeterministicConstructionCheckFailedCount:      {metricName: "archiver_deterministic_construction_check_failed"},
 		ArchiverCouldNotRunDeterministicConstructionCheckCount: {metricName: "archiver_could_not_run_deterministic_construction_check"},

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -124,6 +124,7 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 	blobstoreClient := container.Blobstore
 
 	handledLastBlob := false
+	var totalUploadSize int64
 	for pageToken := common.FirstBlobPageToken; !handledLastBlob; pageToken++ {
 		key, err := NewHistoryBlobKey(request.DomainID, request.WorkflowID, request.RunID, request.CloseFailoverVersion, pageToken)
 		if err != nil {
@@ -173,6 +174,9 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 			logger.Error(uploadErrorMsg, tag.ArchivalUploadFailReason(reason), tag.ArchivalBlobKey(key.String()))
 			return cadence.NewCustomError(errConstructBlob, err.Error())
 		}
+		currBlobSize := int64(len(blob.Body))
+		scope.RecordTimer(metrics.ArchiverBlobSize, time.Duration(currBlobSize))
+		totalUploadSize = totalUploadSize + currBlobSize
 		if runConstTest {
 			existingBlob, err := downloadBlob(ctx, blobstoreClient, request.BucketName, key)
 			if err != nil {
@@ -191,8 +195,10 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 			logger.Error(uploadErrorMsg, tag.ArchivalUploadFailReason(errorDetails(err)), tag.ArchivalBlobKey(key.String()), tag.Error(err))
 			return err
 		}
+
 		handledLastBlob = *historyBlob.Header.IsLast
 	}
+	scope.RecordTimer(metrics.ArchiverTotalUploadSize, time.Duration(totalUploadSize))
 	indexBlobKey, err := NewHistoryIndexBlobKey(request.DomainID, request.WorkflowID, request.RunID)
 	if err != nil {
 		logger.Error(uploadErrorMsg, tag.ArchivalUploadFailReason("could not construct index blob key"))

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -195,7 +195,6 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 			logger.Error(uploadErrorMsg, tag.ArchivalUploadFailReason(errorDetails(err)), tag.ArchivalBlobKey(key.String()), tag.Error(err))
 			return err
 		}
-
 		handledLastBlob = *historyBlob.Header.IsLast
 	}
 	scope.RecordTimer(metrics.ArchiverTotalUploadSize, time.Duration(totalUploadSize))

--- a/service/worker/archiver/activities_test.go
+++ b/service/worker/archiver/activities_test.go
@@ -75,6 +75,7 @@ func (s *activitiesSuite) SetupTest() {
 	s.metricsClient = &mmocks.Client{}
 	s.metricsScope = &mmocks.Scope{}
 	s.metricsScope.On("StartTimer", metrics.CadenceLatency).Return(metrics.NewTestStopwatch()).Once()
+	s.metricsScope.On("RecordTimer", mock.Anything, mock.Anything).Maybe()
 }
 
 func (s *activitiesSuite) TearDownTest() {


### PR DESCRIPTION
This will enable us to create a histogram of blob sizes and total history upload sizes.