### PR TITLE
clientVersionCheck: disable by default, enable for localhost devel

### DIFF
--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -35,3 +35,7 @@
 #         - false
 #         - key4: true
 #           key5: 2.0
+
+# enable this only for localhost development
+frontend.enableClientVersionCheck:
+  - value: true

--- a/docker/README.md
+++ b/docker/README.md
@@ -80,6 +80,7 @@ docker run -e CASSANDRA_CONSISTENCY=Quorum \            -- Default cassandra con
     -e NUM_HISTORY_SHARDS=1024  \                       -- Number of history shards
     -e SERVICES=history,matching \                      -- Spinup only the provided services
     -e LOG_LEVEL=debug,info \                           -- Logging level
+    -e DYNAMIC_CONFIG_FILE_PATH=config/foo.yaml         -- Dynamic config file to be watched
     ubercadence/server:<tag>
 ```
 

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -97,3 +97,7 @@ archival:
 
 publicClient:
   hostPort: ${BIND_ON_IP}:7933
+
+dynamicConfigClient:
+  filepath: ${DYNAMIC_CONFIG_FILE_PATH}
+  pollInterval: "60s"

--- a/docker/config_template_mysql.yaml
+++ b/docker/config_template_mysql.yaml
@@ -103,3 +103,7 @@ archival:
 
 publicClient:
   hostPort: ${BIND_ON_IP}:7933
+
+dynamicConfigClient:
+  filepath: ${DYNAMIC_CONFIG_FILE_PATH}
+  pollInterval: "60s"

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -26,6 +26,7 @@ services:
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
       - "STATSD_ENDPOINT=statsd:8125"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - mysql
       - statsd

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "STATSD_ENDPOINT=statsd:8125"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
       - cassandra
       - statsd

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -33,7 +33,7 @@ export KEYSPACE="${KEYSPACE:-cadence}"
 export VISIBILITY_KEYSPACE="${VISIBILITY_KEYSPACE:-cadence_visibility}"
 export CASSANDRA_CONSISTENCY="${CASSANDRA_CONSISTENCY:-One}"
 
-#mysql env
+# mysql env
 export DBNAME="${DBNAME:-cadence}"
 export VISIBILITY_DBNAME="${VISIBILITY_DBNAME:-cadence_visibility}"
 export DB_PORT=${DB_PORT:-3306}

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -421,7 +421,7 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]string, startWG *sync.Wai
 	c.adminHandler.RegisterHandler()
 
 	dc := dynamicconfig.NewCollection(params.DynamicConfig, c.logger)
-	frontendConfig := frontend.NewConfig(dc, c.historyConfig.NumHistoryShards, c.workerConfig.EnableIndexer, true)
+	frontendConfig := frontend.NewConfig(dc, c.historyConfig.NumHistoryShards, c.workerConfig.EnableIndexer)
 	c.frontendHandler = frontend.NewWorkflowHandler(
 		c.frontEndService, frontendConfig, c.metadataMgr, c.historyMgr, c.historyV2Mgr,
 		c.visibilityMgr, kafkaProducer, params.BlobstoreClient)

--- a/service/frontend/dcRedirectionHandler_test.go
+++ b/service/frontend/dcRedirectionHandler_test.go
@@ -86,7 +86,7 @@ func (s *dcRedirectionHandlerSuite) SetupTest() {
 	s.domainID = "some random domain ID"
 	s.currentClusterName = cluster.TestCurrentClusterName
 	s.alternativeClusterName = cluster.TestAlternativeClusterName
-	s.config = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNopClient(), s.logger), 0, false, false)
+	s.config = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNopClient(), s.logger), 0, false)
 	s.mockMetadataMgr = &mocks.MetadataManager{}
 
 	s.mockClusterMetadata = &mocks.ClusterMetadata{}

--- a/service/frontend/dcRedirectionPolicy_test.go
+++ b/service/frontend/dcRedirectionPolicy_test.go
@@ -120,7 +120,7 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) SetupTest() {
 	logger, err := loggerimpl.NewDevelopment()
 	s.Nil(err)
 
-	s.mockConfig = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNopClient(), logger), 0, false, false)
+	s.mockConfig = NewConfig(dynamicconfig.NewCollection(dynamicconfig.NewNopClient(), logger), 0, false)
 	s.mockMetadataMgr = &mocks.MetadataManager{}
 	s.mockClusterMetadata = &mocks.ClusterMetadata{}
 	s.mockClusterMetadata.On("IsGlobalDomainEnabled").Return(true)

--- a/service/frontend/domainHandler_GlobalDomainDisabled_test.go
+++ b/service/frontend/domainHandler_GlobalDomainDisabled_test.go
@@ -78,7 +78,7 @@ func (s *domainHandlerGlobalDomainDisabledSuite) TearDownSuite() {
 
 func (s *domainHandlerGlobalDomainDisabledSuite) SetupTest() {
 	logger := loggerimpl.NewNopLogger()
-	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false, false)
+	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false)
 	s.metadataMgr = s.TestBase.MetadataProxy
 	s.mockBlobstoreClient = &mocks.BlobstoreClient{}
 	s.mockProducer = &mocks.KafkaProducer{}

--- a/service/frontend/domainHandler_GlobalDomainEnabled_MasterCluster_test.go
+++ b/service/frontend/domainHandler_GlobalDomainEnabled_MasterCluster_test.go
@@ -80,7 +80,7 @@ func (s *domainHandlerGlobalDomainEnabledMasterClusterSuite) TearDownSuite() {
 
 func (s *domainHandlerGlobalDomainEnabledMasterClusterSuite) SetupTest() {
 	logger := loggerimpl.NewNopLogger()
-	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false, false)
+	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false)
 	s.metadataMgr = s.TestBase.MetadataProxy
 	s.mockBlobstoreClient = &mocks.BlobstoreClient{}
 	s.mockProducer = &mocks.KafkaProducer{}

--- a/service/frontend/domainHandler_GlobalDomainEnabled_NotMasterCluster_test.go
+++ b/service/frontend/domainHandler_GlobalDomainEnabled_NotMasterCluster_test.go
@@ -80,7 +80,7 @@ func (s *domainHandlerGlobalDomainEnabledNotMasterClusterSuite) TearDownSuite() 
 
 func (s *domainHandlerGlobalDomainEnabledNotMasterClusterSuite) SetupTest() {
 	logger := loggerimpl.NewNopLogger()
-	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false, false)
+	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false)
 	s.metadataMgr = s.TestBase.MetadataProxy
 	s.mockBlobstoreClient = &mocks.BlobstoreClient{}
 	s.mockProducer = &mocks.KafkaProducer{}

--- a/service/frontend/domainHandler_test.go
+++ b/service/frontend/domainHandler_test.go
@@ -83,7 +83,7 @@ func (s *domainHandlerCommonSuite) TearDownSuite() {
 
 func (s *domainHandlerCommonSuite) SetupTest() {
 	logger := loggerimpl.NewNopLogger()
-	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false, false)
+	s.config = NewConfig(dc.NewCollection(dc.NewNopClient(), logger), numHistoryShards, false)
 	s.metadataMgr = s.TestBase.MetadataProxy
 	s.mockBlobstoreClient = &mocks.BlobstoreClient{}
 	s.mockProducer = &mocks.KafkaProducer{}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -81,7 +81,7 @@ type Config struct {
 }
 
 // NewConfig returns new service config with default values
-func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableVisibilityToKafka bool, enableClientVersionCheck bool) *Config {
+func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableVisibilityToKafka bool) *Config {
 	return &Config{
 		NumHistoryShards:                    numHistoryShards,
 		PersistenceMaxQPS:                   dc.GetIntProperty(dynamicconfig.FrontendPersistenceMaxQPS, 2000),
@@ -106,7 +106,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableVisibil
 		BlobSizeLimitWarn:                   dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitWarn, 256*1024),
 		ThrottledLogRPS:                     dc.GetIntProperty(dynamicconfig.FrontendThrottledLogRPS, 20),
 		EnableDomainNotActiveAutoForwarding: dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.EnableDomainNotActiveAutoForwarding, false),
-		EnableClientVersionCheck:            dc.GetBoolProperty(dynamicconfig.EnableClientVersionCheck, enableClientVersionCheck),
+		EnableClientVersionCheck:            dc.GetBoolProperty(dynamicconfig.EnableClientVersionCheck, false),
 		ValidSearchAttributes:               dc.GetMapProperty(dynamicconfig.ValidSearchAttributes, definition.GetDefaultIndexedKeys()),
 		SearchAttributesNumberOfKeysLimit:   dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesNumberOfKeysLimit, 20),
 		SearchAttributesSizeOfValueLimit:    dc.GetIntPropertyFilteredByDomain(dynamicconfig.SearchAttributesSizeOfValueLimit, 2*1024),
@@ -123,7 +123,7 @@ type Service struct {
 
 // NewService builds a new cadence-frontend service
 func NewService(params *service.BootstrapParams) common.Daemon {
-	config := NewConfig(dynamicconfig.NewCollection(params.DynamicConfig, params.Logger), params.PersistenceConfig.NumHistoryShards, params.ESConfig.Enable, true)
+	config := NewConfig(dynamicconfig.NewCollection(params.DynamicConfig, params.Logger), params.PersistenceConfig.NumHistoryShards, params.ESConfig.Enable)
 	params.ThrottledLogger = loggerimpl.NewThrottledLogger(params.Logger, config.ThrottledLogRPS)
 	params.UpdateLoggerWithServiceName(common.FrontendServiceName)
 	return &Service{

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1203,7 +1203,7 @@ func (s *workflowHandlerSuite) TestCountWorkflowExecutions() {
 }
 
 func (s *workflowHandlerSuite) newConfig() *Config {
-	return NewConfig(dc.NewCollection(dc.NewNopClient(), s.logger), numHistoryShards, false, false)
+	return NewConfig(dc.NewCollection(dc.NewNopClient(), s.logger), numHistoryShards, false)
 }
 
 func bucketMetadataResponse(owner string, retentionDays int) *blobstore.BucketMetadataResponse {


### PR DESCRIPTION
Frontend started enforcing client feature version checks recently.  The way this works - it checks if the client SDK version is compatible with the current server version and if not, rejects requests from the client. However, this is broken for the case when cadence-server is rolled back, say, due to a bug. In this case, customers who are using new versions of SDK (which is incompatible with rolled back version of server) will see all requests fail. This isn't ideal since the incompatibility we talk about here is only certain new features which the customer may or may not be using. 

This patch disables the client version check by default. The original intention of the version check is to force customers who are testing against localhost to upgrade to latest client sdk version. To meet that goal, this patch enables version check just for the docker container we vend for testing.