### PR TITLE
Make archival dynamic config require restart

### DIFF
--- a/cmd/server/server.go
+++ b/cmd/server/server.go
@@ -143,15 +143,14 @@ func (s *server) startService() common.Daemon {
 	}
 	params.ClusterMetadata = cluster.NewMetadata(
 		params.Logger,
-		params.MetricsClient,
 		dc.GetBoolProperty(dynamicconfig.EnableGlobalDomain, clusterMetadata.EnableGlobalDomain),
 		clusterMetadata.FailoverVersionIncrement,
 		clusterMetadata.MasterClusterName,
 		clusterMetadata.CurrentClusterName,
 		clusterMetadata.ClusterInformation,
-		archivalStatus,
+		archivalStatus(),
 		s.cfg.Archival.DefaultBucket,
-		enableReadFromArchival,
+		enableReadFromArchival(),
 	)
 	params.DispatcherProvider = client.NewIPYarpcDispatcherProvider()
 	params.ESConfig = &s.cfg.ElasticSearch

--- a/common/cluster/metadataTestBase.go
+++ b/common/cluster/metadataTestBase.go
@@ -23,7 +23,6 @@ package cluster
 import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log/loggerimpl"
-	"github.com/uber/cadence/common/metrics/mocks"
 	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/common/service/dynamicconfig"
 )
@@ -93,28 +92,26 @@ func GetTestClusterMetadata(enableGlobalDomain bool, isMasterCluster bool, enabl
 	if enableGlobalDomain {
 		return NewMetadata(
 			loggerimpl.NewNopLogger(),
-			&mocks.Client{},
 			dynamicconfig.GetBoolPropertyFn(true),
 			TestFailoverVersionIncrement,
 			masterClusterName,
 			TestCurrentClusterName,
 			TestAllClusterInfo,
-			dynamicconfig.GetStringPropertyFn(archivalStatus),
+			archivalStatus,
 			clusterDefaultBucket,
-			dynamicconfig.GetBoolPropertyFn(enableArchival),
+			enableArchival,
 		)
 	}
 
 	return NewMetadata(
 		loggerimpl.NewNopLogger(),
-		&mocks.Client{},
 		dynamicconfig.GetBoolPropertyFn(false),
 		TestFailoverVersionIncrement,
 		TestCurrentClusterName,
 		TestCurrentClusterName,
 		TestSingleDCClusterInfo,
-		dynamicconfig.GetStringPropertyFn(archivalStatus),
+		archivalStatus,
 		clusterDefaultBucket,
-		dynamicconfig.GetBoolPropertyFn(enableArchival),
+		enableArchival,
 	)
 }

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -34,11 +34,10 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/messaging"
-	metricsmocks "github.com/uber/cadence/common/metrics/mocks"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	pes "github.com/uber/cadence/common/persistence/elasticsearch"
-	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/common/service/dynamicconfig"
 	"go.uber.org/zap"
@@ -94,15 +93,14 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 	if !options.IsMasterCluster && options.ClusterMetadata.MasterClusterName != "" { // xdc cluster metadata setup
 		clusterMetadata = cluster.NewMetadata(
 			logger,
-			&metricsmocks.Client{},
 			dynamicconfig.GetBoolPropertyFn(options.ClusterMetadata.EnableGlobalDomain),
 			options.ClusterMetadata.FailoverVersionIncrement,
 			options.ClusterMetadata.MasterClusterName,
 			options.ClusterMetadata.CurrentClusterName,
 			options.ClusterMetadata.ClusterInformation,
-			dynamicconfig.GetStringPropertyFn("disabled"),
+			"disabled",
 			"",
-			dynamicconfig.GetBoolPropertyFn(false),
+			false,
 		)
 	}
 


### PR DESCRIPTION
This diff corrects a bug that makes it unsafe to enable archival. 

When the cluster starts up it reads dynamic config to determine if it should create a blobstore. If dynamic config says archival is disabled then blobstore is set to nil. Once blobstore client is set to nil it is never set again. However everytime a domain is updated or registered we read the current dynamic config value for archival cluster status. If that status is now set to enabled we will access blobstore client. But that client is nil, so we will get a NPE. This issues results in no safe way to enable archival for the cluster.

The fix is to read the dynamic config once on startup and then never read it again, use this single value for initializing blobstore as well as determining if archival is enabled in other places in code. This has the downside of making the dynamic config require a cluster restart to take effect. 