### PR TITLE
Bugfix: conflict resolution termination version should be local last write version.

### DIFF
--- a/service/history/MockMutableState.go
+++ b/service/history/MockMutableState.go
@@ -1057,13 +1057,13 @@ func (_m *mockMutableState) AddWorkflowExecutionStartedEvent(_a0 shared.Workflow
 	return r0, r1
 }
 
-// AddWorkflowExecutionTerminatedEvent provides a mock function with given fields: _a0
-func (_m *mockMutableState) AddWorkflowExecutionTerminatedEvent(_a0 *shared.TerminateWorkflowExecutionRequest) (*shared.HistoryEvent, error) {
-	ret := _m.Called(_a0)
+// AddWorkflowExecutionTerminatedEvent provides a mock function with given fields: _a0, _a1, _a2
+func (_m *mockMutableState) AddWorkflowExecutionTerminatedEvent(_a0 string, _a1 []byte, _a2 string) (*shared.HistoryEvent, error) {
+	ret := _m.Called(_a0, _a1, _a2)
 
 	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func(*shared.TerminateWorkflowExecutionRequest) *shared.HistoryEvent); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(string, []byte, string) *shared.HistoryEvent); ok {
+		r0 = rf(_a0, _a1, _a2)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*shared.HistoryEvent)
@@ -1071,8 +1071,8 @@ func (_m *mockMutableState) AddWorkflowExecutionTerminatedEvent(_a0 *shared.Term
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*shared.TerminateWorkflowExecutionRequest) error); ok {
-		r1 = rf(_a0)
+	if rf, ok := ret.Get(1).(func(string, []byte, string) error); ok {
+		r1 = rf(_a0, _a1, _a2)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/service/history/decisionHandler.go
+++ b/service/history/decisionHandler.go
@@ -533,11 +533,11 @@ Update_History_Loop:
 					return nil, err
 				}
 
-				_, err := msBuilder.AddWorkflowExecutionTerminatedEvent(&workflow.TerminateWorkflowExecutionRequest{
-					Reason:   common.StringPtr(common.FailureReasonTransactionSizeExceedsLimit),
-					Identity: common.StringPtr("cadence-history-server"),
-					Details:  []byte(updateErr.Error()),
-				})
+				_, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
+					common.FailureReasonTransactionSizeExceedsLimit,
+					[]byte(updateErr.Error()),
+					"cadence-history-server",
+				)
 				if err != nil {
 					return nil, err
 				}

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -183,9 +183,11 @@ func (b *historyBuilder) AddTimeoutWorkflowEvent() *workflow.HistoryEvent {
 }
 
 func (b *historyBuilder) AddWorkflowExecutionTerminatedEvent(
-	request *workflow.TerminateWorkflowExecutionRequest) *workflow.HistoryEvent {
-	event := b.newWorkflowExecutionTerminatedEvent(request)
-
+	reason string,
+	details []byte,
+	identity string,
+) *workflow.HistoryEvent {
+	event := b.newWorkflowExecutionTerminatedEvent(reason, details, identity)
 	return b.addEventToHistory(event)
 }
 
@@ -677,12 +679,12 @@ func (b *historyBuilder) newWorkflowExecutionSignaledEvent(
 }
 
 func (b *historyBuilder) newWorkflowExecutionTerminatedEvent(
-	request *workflow.TerminateWorkflowExecutionRequest) *workflow.HistoryEvent {
+	reason string, details []byte, identity string) *workflow.HistoryEvent {
 	historyEvent := b.msBuilder.CreateNewHistoryEvent(workflow.EventTypeWorkflowExecutionTerminated)
 	attributes := &workflow.WorkflowExecutionTerminatedEventAttributes{}
-	attributes.Reason = common.StringPtr(common.StringDefault(request.Reason))
-	attributes.Details = request.Details
-	attributes.Identity = common.StringPtr(common.StringDefault(request.Identity))
+	attributes.Reason = common.StringPtr(reason)
+	attributes.Details = details
+	attributes.Identity = common.StringPtr(identity)
 	historyEvent.WorkflowExecutionTerminatedEventAttributes = attributes
 
 	return historyEvent

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1580,7 +1580,11 @@ func (e *historyEngineImpl) TerminateWorkflowExecution(ctx ctx.Context, terminat
 				return nil, ErrWorkflowCompleted
 			}
 
-			if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(request); err != nil {
+			if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
+				request.GetReason(),
+				request.GetDetails(),
+				request.GetIdentity(),
+			); err != nil {
 				return nil, &workflow.InternalServiceError{Message: "Unable to terminate workflow execution."}
 			}
 

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -853,6 +853,7 @@ func (r *historyReplicator) conflictResolutionTerminateCurrentRunningIfNotSelf(
 	// remote run 1's version trigger a conflict resolution trying to force terminate run 2R
 	// conflict resolution should only force terminate workflow if that workflow has lower last write version
 	if incomingVersion <= currentLastWriteVetsion {
+		logger.Info("Conflict resolution current workflow has equal or higher version.")
 		return "", 0, 0, nil
 	}
 
@@ -958,7 +959,7 @@ func (r *historyReplicator) terminateWorkflow(
 			msBuilder.UpdateReplicationStateVersion(currentLastWriteVersion, true)
 			if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
 				workflowTerminationReason,
-				nil,
+				[]byte(fmt.Sprintf("terminated by version: %v", incomingVersion)),
 				workflowTerminationIdentity,
 			); err != nil {
 				return nil, &workflow.InternalServiceError{Message: "Unable to terminate workflow execution."}

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -428,16 +428,11 @@ func (r *historyReplicator) ApplyOtherEventsMissingMutableState(ctx ctx.Context,
 	}
 	if currentLastWriteVersion < lastEvent.GetVersion() {
 		if currentStillRunning {
-			err = r.terminateWorkflow(ctx, domainID, workflowID, currentRunID, lastEvent.GetVersion(), lastEvent.GetTimestamp(), logger)
+			_, err = r.terminateWorkflow(ctx, domainID, workflowID, currentRunID, lastEvent.GetVersion(), logger)
 			if err != nil {
-				if _, ok := err.(*shared.EntityNotExistsError); !ok {
-					return err
-				}
-				// if workflow is completed just when the call is made, will get EntityNotExistsError
-				// we are not sure whether the workflow to be terminated ends with continue as new or not
-				// so when encounter EntityNotExistsError, just continue to execute, if err occurs,
-				// there will be retry on the worker level
+				return err
 			}
+
 		}
 		if request.GetResetWorkflow() {
 			return r.resetor.ApplyResetEvent(ctx, request, domainID, workflowID, currentRunID)
@@ -758,7 +753,11 @@ func (r *historyReplicator) replicateWorkflowStarted(ctx ctx.Context, context wo
 		return nil
 	}
 	if currentLastWriteVersion == incomingVersion {
-		_, currentMutableState, currentRelease, err := r.getCurrentWorkflowMutableState(ctx, domainID, execution.GetWorkflowId())
+		_, currentMutableState, currentRelease, err := r.getCurrentWorkflowMutableState(
+			ctx,
+			domainID,
+			execution.GetWorkflowId(),
+		)
 		if err != nil {
 			return err
 		}
@@ -770,7 +769,13 @@ func (r *historyReplicator) replicateWorkflowStarted(ctx ctx.Context, context wo
 		if executionInfo.LastEventTaskID < currentLastEventTaskID {
 			return nil
 		}
-		return newRetryTaskErrorWithHint(ErrRetryExistingWorkflowMsg, domainID, execution.GetWorkflowId(), currentRunID, currentNextEventID)
+		return newRetryTaskErrorWithHint(
+			ErrRetryExistingWorkflowMsg,
+			domainID,
+			execution.GetWorkflowId(),
+			currentRunID,
+			currentNextEventID,
+		)
 	}
 
 	// currentStartVersion < incomingVersion && current workflow still running
@@ -780,8 +785,14 @@ func (r *historyReplicator) replicateWorkflowStarted(ctx ctx.Context, context wo
 	// start the new workflow from the request
 
 	// same workflow ID, same shard
-	incomingTimestamp := lastEvent.GetTimestamp()
-	err = r.terminateWorkflow(ctx, domainID, executionInfo.WorkflowID, currentRunID, incomingVersion, incomingTimestamp, logger)
+	currentLastWriteVersion, err = r.terminateWorkflow(
+		ctx,
+		domainID,
+		executionInfo.WorkflowID,
+		currentRunID,
+		incomingVersion,
+		logger,
+	)
 	if err != nil {
 		if _, ok := err.(*shared.EntityNotExistsError); !ok {
 			return err
@@ -793,7 +804,7 @@ func (r *historyReplicator) replicateWorkflowStarted(ctx ctx.Context, context wo
 	}
 	createMode = persistence.CreateWorkflowModeWorkflowIDReuse
 	prevRunID = currentRunID
-	prevLastWriteVersion = incomingVersion
+	prevLastWriteVersion = currentLastWriteVersion
 	return context.createWorkflowExecution(
 		msBuilder, sourceCluster, createReplicationTask, now, transferTasks, replicationTasks, timerTasks,
 		createMode, prevRunID, prevLastWriteVersion,
@@ -854,12 +865,19 @@ func (r *historyReplicator) conflictResolutionTerminateCurrentRunningIfNotSelf(
 
 	// need to terminate the current workflow
 	// same workflow ID, same shard
-	err = r.terminateWorkflow(ctx, domainID, workflowID, currentRunID, incomingVersion, incomingTimestamp, logger)
+	currentLastWriteVetsion, err = r.terminateWorkflow(
+		ctx,
+		domainID,
+		workflowID,
+		currentRunID,
+		incomingVersion,
+		logger,
+	)
 	if err != nil {
 		logError(logger, "Conflict resolution err terminating current workflow.", err)
 		return "", 0, 0, err
 	}
-	return currentRunID, incomingVersion, persistence.WorkflowStateCompleted, nil
+	return currentRunID, currentLastWriteVetsion, persistence.WorkflowStateCompleted, nil
 }
 
 // func (r *historyReplicator) getCurrentWorkflowInfo(domainID string, workflowID string) (runID string, lastWriteVersion int64, closeStatus int, retError error) {
@@ -884,58 +902,84 @@ func (r *historyReplicator) getCurrentWorkflowMutableState(ctx ctx.Context, doma
 	return context, msBuilder, release, nil
 }
 
-func (r *historyReplicator) terminateWorkflow(ctx ctx.Context, domainID string, workflowID string,
-	runID string, incomingVersion int64, incomingTimestamp int64, logger log.Logger) (retError error) {
+func (r *historyReplicator) terminateWorkflow(
+	ctx ctx.Context,
+	domainID string,
+	workflowID string,
+	runID string,
+	incomingVersion int64,
+	logger log.Logger,
+) (int64, error) {
 
+	// same workflow ID, same shard
 	execution := shared.WorkflowExecution{
 		WorkflowId: common.StringPtr(workflowID),
 		RunId:      common.StringPtr(runID),
 	}
-	context, release, err := r.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+	var currentLastWriteVersion int64
+	err := r.historyEngine.updateWorkflowExecution(ctx, domainID, execution, true, false,
+		func(msBuilder mutableState, tBuilder *timerBuilder) ([]persistence.Task, error) {
+
+			// compare the current last write version first
+			// since this function has assumption that
+			// incomingVersion <= currentLastWriteVersion
+			// if assumption is broken (race condition), then retry
+			currentLastWriteVersion = msBuilder.GetLastWriteVersion()
+			if incomingVersion <= currentLastWriteVersion {
+				return nil, newRetryTaskErrorWithHint(
+					ErrRetryExistingWorkflowMsg,
+					domainID,
+					workflowID,
+					runID,
+					msBuilder.GetNextEventID(),
+				)
+			}
+
+			if !msBuilder.IsWorkflowExecutionRunning() {
+				return nil, ErrWorkflowCompleted
+			}
+
+			// incomingVersion > currentLastWriteVersion
+
+			// need to check if able to force terminate the workflow, by using last write version
+			// if last write version indicates not from current cluster, need to fetch from remote
+			sourceCluster := r.clusterMetadata.ClusterNameForFailoverVersion(currentLastWriteVersion)
+			if sourceCluster != r.clusterMetadata.GetCurrentClusterName() {
+				return nil, newRetryTaskErrorWithHint(
+					ErrRetryExistingWorkflowMsg,
+					domainID,
+					workflowID,
+					runID,
+					msBuilder.GetNextEventID(),
+				)
+			}
+
+			// setting the current version to be the last write version
+			msBuilder.UpdateReplicationStateVersion(currentLastWriteVersion, true)
+			if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
+				workflowTerminationReason,
+				nil,
+				workflowTerminationIdentity,
+			); err != nil {
+				return nil, &workflow.InternalServiceError{Message: "Unable to terminate workflow execution."}
+			}
+
+			return nil, nil
+		})
+
 	if err != nil {
-		return err
+		if _, ok := err.(*workflow.EntityNotExistsError); !ok {
+			return 0, err
+		}
+		err = nil
 	}
-	defer func() { release(retError) }()
-
-	msBuilder, err := context.loadWorkflowExecution()
-	if err != nil {
-		return err
-	}
-	if !msBuilder.IsWorkflowExecutionRunning() {
-		return nil
-	}
-
-	nextEventID := msBuilder.GetNextEventID()
-	sourceCluster := r.clusterMetadata.ClusterNameForFailoverVersion(incomingVersion)
-	terminationEvent := &shared.HistoryEvent{
-		EventId:   common.Int64Ptr(nextEventID),
-		Timestamp: common.Int64Ptr(incomingTimestamp),
-		Version:   common.Int64Ptr(incomingVersion),
-		// TaskId is default to 0 since this event is not generated by remote
-		EventType: shared.EventTypeWorkflowExecutionTerminated.Ptr(),
-		WorkflowExecutionTerminatedEventAttributes: &shared.WorkflowExecutionTerminatedEventAttributes{
-			Reason:   common.StringPtr(workflowTerminationReason),
-			Identity: common.StringPtr(workflowTerminationIdentity),
-			Details:  nil,
-		},
-	}
-	history := &shared.History{Events: []*shared.HistoryEvent{terminationEvent}}
-
-	req := &h.ReplicateEventsRequest{
-		SourceCluster:     common.StringPtr(sourceCluster),
-		DomainUUID:        common.StringPtr(domainID),
-		WorkflowExecution: &execution,
-		FirstEventId:      common.Int64Ptr(nextEventID),
-		NextEventId:       common.Int64Ptr(nextEventID + 1),
-		Version:           common.Int64Ptr(incomingVersion),
-		History:           history,
-		NewRunHistory:     nil,
-	}
-	return r.ApplyReplicationTask(ctx, context, msBuilder, req, logger)
+	return currentLastWriteVersion, nil
 }
 
-func (r *historyReplicator) getLatestCheckpoint(replicationInfoRemote map[string]*workflow.ReplicationInfo,
-	replicationInfoLocal map[string]*persistence.ReplicationInfo) (int64, int64) {
+func (r *historyReplicator) getLatestCheckpoint(
+	replicationInfoRemote map[string]*workflow.ReplicationInfo,
+	replicationInfoLocal map[string]*persistence.ReplicationInfo,
+) (int64, int64) {
 
 	// this only applies to 2 data center case
 

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -868,20 +868,23 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsMissingMutableState_Incomin
 		},
 	}
 
-	clusterName := cluster.TestAlternativeClusterName
-	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", version).Return(clusterName)
+	sourceClusterName := cluster.TestAlternativeClusterName
+	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", version).Return(sourceClusterName)
+	currentClusterName := cluster.TestCurrentClusterName
+	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentVersion).Return(currentClusterName)
 
 	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(
 		&persistence.GetDomainResponse{
 			Info:   &persistence.DomainInfo{ID: domainID, Name: domainName},
 			Config: &persistence.DomainConfig{Retention: 1},
 			ReplicationConfig: &persistence.DomainReplicationConfig{
-				ActiveClusterName: clusterName,
+				ActiveClusterName: sourceClusterName,
 				Clusters: []*persistence.ClusterReplicationConfig{
-					{ClusterName: clusterName},
+					{ClusterName: sourceClusterName},
+					{ClusterName: currentClusterName},
 				},
 			},
-			FailoverVersion: currentVersion,
+			FailoverVersion: version,
 			IsGlobalDomain:  true,
 			TableVersion:    persistence.DomainTableVersionV1,
 		}, nil,
@@ -899,6 +902,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsMissingMutableState_Incomin
 		WorkflowId: common.StringPtr(workflowID),
 		RunId:      common.StringPtr(currentRunID),
 	}
+	contextCurrent.On("getExecution").Return(currentExecution)
 	contextCurrentCacheKey := definition.NewWorkflowIdentifier(domainID, currentExecution.GetWorkflowId(), currentExecution.GetRunId())
 	s.historyReplicator.historyCache.PutIfNotExist(contextCurrentCacheKey, contextCurrent)
 
@@ -906,14 +910,9 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsMissingMutableState_Incomin
 		RunID: currentRunID,
 	})
 	msBuilderCurrent.On("GetLastWriteVersion").Return(currentVersion)
-	msBuilderCurrent.On("GetReplicationState").Return(&persistence.ReplicationState{
-		LastWriteVersion: currentVersion,
-		LastWriteEventID: currentNextEventID - 1,
-	})
 	msBuilderCurrent.On("GetNextEventID").Return(currentNextEventID)
 	msBuilderCurrent.On("IsWorkflowExecutionRunning").Return(true) // this is used to update the version on mutable state
-	msBuilderCurrent.On("UpdateReplicationStateVersion", version, true).Once()
-	msBuilderCurrent.On("UpdateReplicationStateLastEventID", clusterName, version, currentNextEventID).Once()
+	msBuilderCurrent.On("UpdateReplicationStateVersion", currentVersion, true).Once()
 
 	s.mockExecutionMgr.On("GetCurrentExecution", &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
@@ -923,38 +922,10 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsMissingMutableState_Incomin
 		CloseStatus: persistence.WorkflowCloseStatusNone,
 	}, nil)
 
-	terminationEvent := &shared.HistoryEvent{
-		EventId:   common.Int64Ptr(currentNextEventID),
-		Timestamp: common.Int64Ptr(now),
-		Version:   common.Int64Ptr(version),
-		EventType: shared.EventTypeWorkflowExecutionTerminated.Ptr(),
-		WorkflowExecutionTerminatedEventAttributes: &shared.WorkflowExecutionTerminatedEventAttributes{
-			Reason:   common.StringPtr(workflowTerminationReason),
-			Identity: common.StringPtr(workflowTerminationIdentity),
-			Details:  nil,
-		},
-	}
-	terminateRequest := &h.ReplicateEventsRequest{
-		SourceCluster: common.StringPtr(clusterName),
-		DomainUUID:    common.StringPtr(domainID),
-		WorkflowExecution: &shared.WorkflowExecution{
-			WorkflowId: common.StringPtr(workflowID),
-			RunId:      common.StringPtr(currentRunID),
-		},
-		FirstEventId:  common.Int64Ptr(currentNextEventID),
-		NextEventId:   common.Int64Ptr(currentNextEventID + 1),
-		Version:       common.Int64Ptr(version),
-		History:       &shared.History{Events: []*shared.HistoryEvent{terminationEvent}},
-		NewRunHistory: nil,
-	}
-
-	msBuilderCurrent.On("ReplicateWorkflowExecutionTerminatedEvent", currentNextEventID, mock.MatchedBy(func(input *shared.HistoryEvent) bool {
-		return reflect.DeepEqual(terminationEvent, input)
-	})).Return(nil)
-	contextCurrent.On("replicateWorkflowExecution", terminateRequest, mock.Anything, mock.Anything, currentNextEventID, mock.Anything, mock.Anything).Return(nil).Once()
-	s.mockTxProcessor.On("NotifyNewTask", clusterName, mock.Anything)
-	s.mockTimerProcessor.On("NotifyNewTimers", clusterName, mock.Anything, mock.Anything)
-	msBuilderCurrent.On("ClearStickyness").Once()
+	msBuilderCurrent.On("AddWorkflowExecutionTerminatedEvent",
+		workflowTerminationReason, []byte(nil), workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
+	contextCurrent.On("updateWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	s.mockTimerProcessor.On("NotifyNewTimers", currentClusterName, mock.Anything, mock.Anything)
 
 	err := s.historyReplicator.ApplyOtherEventsMissingMutableState(ctx.Background(), domainID, workflowID, runID, req, s.logger)
 	s.Equal(newRetryTaskErrorWithHint(ErrWorkflowNotFoundMsg, domainID, workflowID, runID, common.FirstEventID), err)
@@ -3248,7 +3219,7 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 			TimerTasks:                  timerTasks,
 			CreateWorkflowMode:          persistence.CreateWorkflowModeWorkflowIDReuse,
 			PreviousRunID:               currentRunID,
-			PreviousLastWriteVersion:    version,
+			PreviousLastWriteVersion:    currentVersion,
 			ReplicationState:            replicationState,
 			EventStoreVersion:           persistence.EventStoreVersionV2,
 			CronSchedule:                cronSchedule,
@@ -3262,6 +3233,25 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 		}, input)
 	})).Return(&persistence.CreateWorkflowExecutionResponse{}, nil).Once()
 
+	// this mocks are for the terminate current workflow operation
+	domainVersion := int64(4081)
+	domainName := "some random domain name"
+	s.mockMetadataMgr.On("GetDomain", &persistence.GetDomainRequest{ID: domainID}).Return(
+		&persistence.GetDomainResponse{
+			Info:   &persistence.DomainInfo{ID: domainID, Name: domainName},
+			Config: &persistence.DomainConfig{Retention: 1},
+			ReplicationConfig: &persistence.DomainReplicationConfig{
+				ActiveClusterName: cluster.TestCurrentClusterName,
+				Clusters: []*persistence.ClusterReplicationConfig{
+					{ClusterName: cluster.TestCurrentClusterName},
+				},
+			},
+			FailoverVersion: domainVersion, // this does not matter
+			IsGlobalDomain:  true,
+			TableVersion:    persistence.DomainTableVersionV1,
+		}, nil,
+	).Once()
+
 	contextCurrent := &mockWorkflowExecutionContext{}
 	defer contextCurrent.AssertExpectations(s.T())
 	contextCurrent.On("lock", mock.Anything).Return(nil)
@@ -3269,22 +3259,27 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 	msBuilderCurrent := &mockMutableState{}
 	defer msBuilderCurrent.AssertExpectations(s.T())
 
-	contextCurrent.On("loadWorkflowExecution").Return(msBuilderCurrent, nil).Once()
+	contextCurrent.On("loadWorkflowExecution").Return(msBuilderCurrent, nil)
 	currentExecution := &shared.WorkflowExecution{
 		WorkflowId: common.StringPtr(workflowID),
 		RunId:      common.StringPtr(currentRunID),
 	}
+	contextCurrent.On("getExecution").Return(currentExecution)
 	contextCurrentCacheKey := definition.NewWorkflowIdentifier(domainID, currentExecution.GetWorkflowId(), currentExecution.GetRunId())
 	s.historyReplicator.historyCache.PutIfNotExist(contextCurrentCacheKey, contextCurrent)
-	msBuilderCurrent.On("IsWorkflowExecutionRunning").Return(false)
-	s.mockMetadataMgr.On("GetDomain", mock.Anything).Return(&persistence.GetDomainResponse{
-		Info:              &persistence.DomainInfo{ID: domainID, Name: "domain name"},
-		TableVersion:      p.DomainTableVersionV1,
-		Config:            &p.DomainConfig{},
-		ReplicationConfig: &p.DomainReplicationConfig{},
-	}, nil)
 
-	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", version).Return(cluster.TestCurrentClusterName)
+	msBuilderCurrent.On("GetLastWriteVersion").Return(currentVersion)
+	msBuilderCurrent.On("IsWorkflowExecutionRunning").Return(true) // this is used to update the version on mutable state
+	msBuilderCurrent.On("UpdateReplicationStateVersion", currentVersion, true).Once()
+
+	currentClusterName := cluster.TestCurrentClusterName
+	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentVersion).Return(currentClusterName)
+
+	msBuilderCurrent.On("AddWorkflowExecutionTerminatedEvent",
+		workflowTerminationReason, []byte(nil), workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
+	contextCurrent.On("updateWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	s.mockTimerProcessor.On("NotifyNewTimers", currentClusterName, mock.Anything, mock.Anything)
+
 	err := s.historyReplicator.replicateWorkflowStarted(ctx.Background(), context, msBuilder, sourceCluster, history,
 		sBuilder, s.logger)
 	s.Nil(err)
@@ -3415,18 +3410,17 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateCurrentRunningIf
 		WorkflowId: common.StringPtr(workflowID),
 		RunId:      common.StringPtr(currentRunID),
 	}
+	contextCurrent.On("getExecution").Return(currentExecution)
 	contextCurrentCacheKey := definition.NewWorkflowIdentifier(domainID, currentExecution.GetWorkflowId(), currentExecution.GetRunId())
 	s.historyReplicator.historyCache.PutIfNotExist(contextCurrentCacheKey, contextCurrent)
 
-	currentNextEventID := int64(999)
-	msBuilderCurrent.On("GetReplicationState").Return(&persistence.ReplicationState{})
-	msBuilderCurrent.On("GetExecutionInfo").Return(&persistence.WorkflowExecutionInfo{
-		CloseStatus: persistence.WorkflowCloseStatusNone,
-	})
-	msBuilderCurrent.On("GetNextEventID").Return(currentNextEventID)
+	currentVersion := incomingVersion - 10
+	currentCluster := cluster.TestCurrentClusterName
+	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentVersion).Return(currentCluster)
+
+	msBuilderCurrent.On("GetLastWriteVersion").Return(currentVersion)
 	msBuilderCurrent.On("IsWorkflowExecutionRunning").Return(true) // this is used to update the version on mutable state
-	msBuilderCurrent.On("UpdateReplicationStateVersion", incomingVersion, true).Once()
-	msBuilderCurrent.On("UpdateReplicationStateLastEventID", incomingCluster, incomingVersion, currentNextEventID).Once()
+	msBuilderCurrent.On("UpdateReplicationStateVersion", currentVersion, true).Once()
 
 	s.mockExecutionMgr.On("GetCurrentExecution", &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
@@ -3435,43 +3429,18 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateCurrentRunningIf
 		RunID:            currentRunID,
 		State:            persistence.WorkflowStateRunning,
 		CloseStatus:      persistence.WorkflowCloseStatusNone,
-		LastWriteVersion: incomingVersion - 10,
+		LastWriteVersion: currentVersion,
 	}, nil)
 
-	terminationEvent := &shared.HistoryEvent{
-		EventId:   common.Int64Ptr(currentNextEventID),
-		Timestamp: common.Int64Ptr(incomingTimestamp),
-		Version:   common.Int64Ptr(incomingVersion),
-		EventType: shared.EventTypeWorkflowExecutionTerminated.Ptr(),
-		WorkflowExecutionTerminatedEventAttributes: &shared.WorkflowExecutionTerminatedEventAttributes{
-			Reason:   common.StringPtr(workflowTerminationReason),
-			Identity: common.StringPtr(workflowTerminationIdentity),
-			Details:  nil,
-		},
-	}
-	terminateRequest := &h.ReplicateEventsRequest{
-		SourceCluster:     common.StringPtr(incomingCluster),
-		DomainUUID:        common.StringPtr(domainID),
-		WorkflowExecution: currentExecution,
-		FirstEventId:      common.Int64Ptr(currentNextEventID),
-		NextEventId:       common.Int64Ptr(currentNextEventID + 1),
-		Version:           common.Int64Ptr(incomingVersion),
-		History:           &shared.History{Events: []*shared.HistoryEvent{terminationEvent}},
-		NewRunHistory:     nil,
-	}
-
-	msBuilderCurrent.On("ReplicateWorkflowExecutionTerminatedEvent", int64(999), mock.MatchedBy(func(input *shared.HistoryEvent) bool {
-		return reflect.DeepEqual(terminationEvent, input)
-	})).Return(nil)
-	contextCurrent.On("replicateWorkflowExecution", terminateRequest, mock.Anything, mock.Anything, currentNextEventID, mock.Anything, mock.Anything).Return(nil).Once()
-	s.mockTxProcessor.On("NotifyNewTask", incomingCluster, mock.Anything)
-	s.mockTimerProcessor.On("NotifyNewTimers", incomingCluster, mock.Anything, mock.Anything)
-	msBuilderCurrent.On("ClearStickyness").Once()
+	msBuilderCurrent.On("AddWorkflowExecutionTerminatedEvent",
+		workflowTerminationReason, []byte(nil), workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
+	contextCurrent.On("updateWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
+	s.mockTimerProcessor.On("NotifyNewTimers", currentCluster, mock.Anything, mock.Anything)
 
 	prevRunID, prevLastWriteVersion, prevState, err := s.historyReplicator.conflictResolutionTerminateCurrentRunningIfNotSelf(ctx.Background(), msBuilderTarget, incomingVersion, incomingTimestamp, s.logger)
 	s.Nil(err)
 	s.Equal(currentRunID, prevRunID)
-	s.Equal(incomingVersion, prevLastWriteVersion)
+	s.Equal(currentVersion, prevLastWriteVersion)
 	s.Equal(persistence.WorkflowStateCompleted, prevState)
 }
 

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -923,7 +923,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsMissingMutableState_Incomin
 	}, nil)
 
 	msBuilderCurrent.On("AddWorkflowExecutionTerminatedEvent",
-		workflowTerminationReason, []byte(nil), workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
+		workflowTerminationReason, mock.Anything, workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
 	contextCurrent.On("updateWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	s.mockTimerProcessor.On("NotifyNewTimers", currentClusterName, mock.Anything, mock.Anything)
 
@@ -3276,7 +3276,7 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentVersion).Return(currentClusterName)
 
 	msBuilderCurrent.On("AddWorkflowExecutionTerminatedEvent",
-		workflowTerminationReason, []byte(nil), workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
+		workflowTerminationReason, mock.Anything, workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
 	contextCurrent.On("updateWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	s.mockTimerProcessor.On("NotifyNewTimers", currentClusterName, mock.Anything, mock.Anything)
 
@@ -3433,7 +3433,7 @@ func (s *historyReplicatorSuite) TestConflictResolutionTerminateCurrentRunningIf
 	}, nil)
 
 	msBuilderCurrent.On("AddWorkflowExecutionTerminatedEvent",
-		workflowTerminationReason, []byte(nil), workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
+		workflowTerminationReason, mock.Anything, workflowTerminationIdentity).Return(&workflow.HistoryEvent{}, nil)
 	contextCurrent.On("updateWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 	s.mockTimerProcessor.On("NotifyNewTimers", currentCluster, mock.Anything, mock.Anything)
 

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -88,7 +88,7 @@ type (
 		AddWorkflowExecutionCanceledEvent(int64, *workflow.CancelWorkflowExecutionDecisionAttributes) (*workflow.HistoryEvent, error)
 		AddWorkflowExecutionSignaled(signalName string, input []byte, identity string) (*workflow.HistoryEvent, error)
 		AddWorkflowExecutionStartedEvent(workflow.WorkflowExecution, *h.StartWorkflowExecutionRequest) (*workflow.HistoryEvent, error)
-		AddWorkflowExecutionTerminatedEvent(*workflow.TerminateWorkflowExecutionRequest) (*workflow.HistoryEvent, error)
+		AddWorkflowExecutionTerminatedEvent(reason string, details []byte, identity string) (*workflow.HistoryEvent, error)
 		ClearStickyness()
 		CloseUpdateSession() (*mutableStateSessionUpdates, error)
 		CheckResettable() error

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2928,7 +2928,7 @@ func (e *mutableStateBuilder) AddRecordMarkerEvent(
 }
 
 func (e *mutableStateBuilder) AddWorkflowExecutionTerminatedEvent(
-	request *workflow.TerminateWorkflowExecutionRequest,
+	reason string, details []byte, identity string,
 ) (*workflow.HistoryEvent, error) {
 
 	opTag := tag.WorkflowActionWorkflowTerminated
@@ -2936,7 +2936,7 @@ func (e *mutableStateBuilder) AddWorkflowExecutionTerminatedEvent(
 		return nil, err
 	}
 
-	event := e.hBuilder.AddWorkflowExecutionTerminatedEvent(request)
+	event := e.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity)
 	if err := e.ReplicateWorkflowExecutionTerminatedEvent(event.GetEventId(), event); err != nil {
 		return nil, err
 	}

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -693,10 +693,13 @@ func (c *workflowExecutionContextImpl) update(transferTasks []persistence.Task, 
 					return err1
 				}
 
-				c.msBuilder.AddWorkflowExecutionTerminatedEvent(&workflow.TerminateWorkflowExecutionRequest{
-					Reason:   common.StringPtr(common.TerminateReasonSizeExceedsLimit),
-					Identity: common.StringPtr("cadence-history-server"),
-				})
+				if _, err = c.msBuilder.AddWorkflowExecutionTerminatedEvent(
+					common.TerminateReasonSizeExceedsLimit,
+					nil,
+					"cadence-history-server",
+				); err != nil {
+					return err
+				}
 
 				updates, err = c.msBuilder.CloseUpdateSession()
 				if err != nil {

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -347,11 +347,13 @@ func (w *workflowResetorImpl) terminateIfCurrIsRunning(
 
 	if currMutableState.IsWorkflowExecutionRunning() {
 		terminateCurr = true
-		currMutableState.AddWorkflowExecutionTerminatedEvent(&workflow.TerminateWorkflowExecutionRequest{
-			Reason:   common.StringPtr(reason),
-			Details:  nil,
-			Identity: common.StringPtr(identityHistoryService),
-		})
+		if _, retError = currMutableState.AddWorkflowExecutionTerminatedEvent(
+			reason,
+			nil,
+			identityHistoryService,
+		); retError != nil {
+			return
+		}
 		closeTask, cleanupTask, retError = w.eng.getWorkflowHistoryCleanupTasks(
 			currMutableState.GetExecutionInfo().DomainID,
 			currMutableState.GetExecutionInfo().WorkflowID,


### PR DESCRIPTION
Change conflict resolution force termination logic to generate termination event with
local cluster's version.
If use incoming version (existing logic), then it is possible that a workflow will
have different history between 2 clusters and the end event can be with same version,
this will break the contract that only apply an event if history before are the same.

Case showing the issue: consider same domain ID, workflow ID
```
T = 0, A is active,
        Cluster A, Run 1        |       Cluster B, Run 1
        EID: 1, V: 1            |       EID: 1, V: 1
        ...                     |       ...
        EID: 5, V: 1            |       EID: 5, V: 1
        EID: 7, V: 1            |
Failover ------------------------------------------------
                                |       EID: 6, V: 10
                                |       EID: 9, V: 10
                                |       Run 1 finished
                                |       Run 2 started
        Run 2 terminate Run 1   |       EID: 1, V: 10
        EID: 8, V: 10           |
                                |
        Run 2 replicated        |
        EID: 1, V: 10           |
```