### PR TITLE
Fix int overflow in list api time filter

### DIFF
--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -686,9 +686,16 @@ func (v *esVisibilityStore) getSearchResult(request *p.ListWorkflowExecutionsReq
 		rangeQuery = elastic.NewRangeQuery(es.CloseTime)
 	}
 	// ElasticSearch v6 is unable to precisely compare time, have to manually add resolution 1ms to time range.
+	// Also has to use string instead of int64 to avoid data conversion issue,
+	// 9223372036854775807 to 9223372036854776000 (long overflow)
+	if request.LatestStartTime > math.MaxInt64-oneMilliSecondInNano { // prevent latestTime overflow
+		request.LatestStartTime = math.MaxInt64 - oneMilliSecondInNano
+	}
+	earliestTimeStr := strconv.FormatInt(request.EarliestStartTime-oneMilliSecondInNano, 10)
+	latestTimeStr := strconv.FormatInt(request.LatestStartTime+oneMilliSecondInNano, 10)
 	rangeQuery = rangeQuery.
-		Gte(request.EarliestStartTime - oneMilliSecondInNano).
-		Lte(request.LatestStartTime + oneMilliSecondInNano)
+		Gte(earliestTimeStr).
+		Lte(latestTimeStr)
 
 	boolQuery := elastic.NewBoolQuery().Must(matchDomainQuery).Filter(rangeQuery)
 	if matchQuery != nil {

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -691,6 +691,9 @@ func (v *esVisibilityStore) getSearchResult(request *p.ListWorkflowExecutionsReq
 	if request.LatestStartTime > math.MaxInt64-oneMilliSecondInNano { // prevent latestTime overflow
 		request.LatestStartTime = math.MaxInt64 - oneMilliSecondInNano
 	}
+	if request.EarliestStartTime < math.MinInt64+oneMilliSecondInNano { // prevent earliestTime overflow
+		request.EarliestStartTime = math.MinInt64 + oneMilliSecondInNano
+	}
 	earliestTimeStr := strconv.FormatInt(request.EarliestStartTime-oneMilliSecondInNano, 10)
 	latestTimeStr := strconv.FormatInt(request.LatestStartTime+oneMilliSecondInNano, 10)
 	rangeQuery = rangeQuery.

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2214,6 +2214,10 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(ctx context.Context,
 		return nil, wh.error(&gen.BadRequestError{Message: "LatestTime in StartTimeFilter is required"}, scope)
 	}
 
+	if listRequest.StartTimeFilter.GetEarliestTime() > listRequest.StartTimeFilter.GetLatestTime() {
+		return nil, wh.error(&gen.BadRequestError{Message: "EarliestTime in StartTimeFilter should not be larger than LatestTime"}, scope)
+	}
+
 	if listRequest.ExecutionFilter != nil && listRequest.TypeFilter != nil {
 		return nil, wh.error(&gen.BadRequestError{
 			Message: "Only one of ExecutionFilter or TypeFilter is allowed"}, scope)
@@ -2315,6 +2319,10 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(ctx context.Context,
 
 	if listRequest.StartTimeFilter.LatestTime == nil {
 		return nil, wh.error(&gen.BadRequestError{Message: "LatestTime in StartTimeFilter is required"}, scope)
+	}
+
+	if listRequest.StartTimeFilter.GetEarliestTime() > listRequest.StartTimeFilter.GetLatestTime() {
+		return nil, wh.error(&gen.BadRequestError{Message: "EarliestTime in StartTimeFilter should not be larger than LatestTime"}, scope)
 	}
 
 	filterCount := 0


### PR DESCRIPTION
Currently when user use MaxInt64 in StartTimeFilter of ListOpenWorkflowExecutions ... APIs against ES, it will return no results because int overflow and ES not able to handle correctly process MaxInt64.

This PR fixed this issue.