### PR TITLE
Disable not-well-defined decision cross domain call

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -49,9 +49,6 @@ const (
 	DomainCacheRefreshInterval = 10 * time.Second
 	domainCacheRefreshPageSize = 100
 
-	domainCacheLocked   int32 = 0
-	domainCacheReleased int32 = 1
-
 	domainCacheInitialized int32 = 0
 	domainCacheStarted     int32 = 1
 	domainCacheStopped     int32 = 2
@@ -118,7 +115,13 @@ type (
 )
 
 // NewDomainCache creates a new instance of cache for holding onto domain information to reduce the load on persistence
-func NewDomainCache(metadataMgr persistence.MetadataManager, clusterMetadata cluster.Metadata, metricsClient metrics.Client, logger log.Logger) DomainCache {
+func NewDomainCache(
+	metadataMgr persistence.MetadataManager,
+	clusterMetadata cluster.Metadata,
+	metricsClient metrics.Client,
+	logger log.Logger,
+) DomainCache {
+
 	cache := &domainCache{
 		status:           domainCacheInitialized,
 		shutdownChan:     make(chan struct{}),
@@ -149,12 +152,15 @@ func newDomainCacheEntry(clusterMetadata cluster.Metadata) *DomainCacheEntry {
 	return &DomainCacheEntry{clusterMetadata: clusterMetadata}
 }
 
-// NewDomainCacheEntryWithReplicationForTest returns an entry with test data
-func NewDomainCacheEntryWithReplicationForTest(info *persistence.DomainInfo,
+// NewGlobalDomainCacheEntryForTest returns an entry with test data
+func NewGlobalDomainCacheEntryForTest(
+	info *persistence.DomainInfo,
 	config *persistence.DomainConfig,
 	repConfig *persistence.DomainReplicationConfig,
 	failoverVersion int64,
-	clusterMetadata cluster.Metadata) *DomainCacheEntry {
+	clusterMetadata cluster.Metadata,
+) *DomainCacheEntry {
+
 	return &DomainCacheEntry{
 		info:              info,
 		config:            config,
@@ -165,11 +171,44 @@ func NewDomainCacheEntryWithReplicationForTest(info *persistence.DomainInfo,
 	}
 }
 
-// NewDomainCacheEntryForTest returns an entry with domainInfo
-func NewDomainCacheEntryForTest(info *persistence.DomainInfo, config *persistence.DomainConfig) *DomainCacheEntry {
+// NeLocalDomainCacheEntryForTest returns an entry with test data
+func NewLocalDomainCacheEntryForTest(
+	info *persistence.DomainInfo,
+	config *persistence.DomainConfig,
+	targetCluster string,
+	clusterMetadata cluster.Metadata,
+) *DomainCacheEntry {
+
 	return &DomainCacheEntry{
-		info:   info,
-		config: config,
+		info:           info,
+		config:         config,
+		isGlobalDomain: false,
+		replicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: targetCluster,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: targetCluster}},
+		},
+		failoverVersion: common.EmptyVersion,
+		clusterMetadata: clusterMetadata,
+	}
+}
+
+// NewDomainCacheEntryForTest returns an entry with test data
+func NewDomainCacheEntryForTest(
+	info *persistence.DomainInfo,
+	config *persistence.DomainConfig,
+	isGlobalDomain bool,
+	repConfig *persistence.DomainReplicationConfig,
+	failoverVersion int64,
+	clusterMetadata cluster.Metadata,
+) *DomainCacheEntry {
+
+	return &DomainCacheEntry{
+		info:              info,
+		config:            config,
+		isGlobalDomain:    isGlobalDomain,
+		replicationConfig: repConfig,
+		failoverVersion:   failoverVersion,
+		clusterMetadata:   clusterMetadata,
 	}
 }
 

--- a/service/history/conflictResolver_test.go
+++ b/service/history/conflictResolver_test.go
@@ -302,7 +302,9 @@ func (s *conflictResolverSuite) TestReset() {
 		Execution: execution,
 	}).Return(&persistence.GetWorkflowExecutionResponse{}, nil).Once() // return empty resoonse since we are not testing the load
 	s.mockClusterMetadata.On("IsGlobalDomainEnabled").Return(true)
-	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{}, nil), nil)
+	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{}, nil, "", nil,
+	), nil)
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
 	_, err := s.conflictResolver.reset(prevRunID, prevLastWriteVersion, prevState, createRequestID, nextEventID-1, executionInfo)

--- a/service/history/conflictResovlverV2_test.go
+++ b/service/history/conflictResovlverV2_test.go
@@ -246,7 +246,9 @@ func (s *conflictResolverV2Suite) TestReset() {
 		Execution: execution,
 	}).Return(&persistence.GetWorkflowExecutionResponse{}, nil).Once() // return empty resoonse since we are not testing the load
 	s.mockClusterMetadata.On("IsGlobalDomainEnabled").Return(true)
-	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{}, nil), nil)
+	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{}, nil, "", nil,
+	), nil)
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	s.mockHistoryV2Mgr.On("ReadHistoryBranchByBatch", mock.Anything).Return(&persistence.ReadHistoryBranchByBatchResponse{
 		History:          history,

--- a/service/history/decisionChecker.go
+++ b/service/history/decisionChecker.go
@@ -110,9 +110,18 @@ func (c *decisionBlobSizeChecker) failWorkflowIfBlobSizeExceedsLimit(
 }
 
 func (v *decisionAttrValidator) validateActivityScheduleAttributes(
+	domainID string,
+	targetDomainID string,
 	attributes *workflow.ScheduleActivityTaskDecisionAttributes,
 	wfTimeout int32,
 ) error {
+
+	if err := v.validateCrossDomainCall(
+		domainID,
+		targetDomainID,
+	); err != nil {
+		return err
+	}
 
 	if attributes == nil {
 		return &workflow.BadRequestError{Message: "ScheduleActivityTaskDecisionAttributes is not set on decision."}
@@ -305,8 +314,17 @@ func (v *decisionAttrValidator) validateCancelWorkflowExecutionAttributes(
 }
 
 func (v *decisionAttrValidator) validateCancelExternalWorkflowExecutionAttributes(
+	domainID string,
+	targetDomainID string,
 	attributes *workflow.RequestCancelExternalWorkflowExecutionDecisionAttributes,
 ) error {
+
+	if err := v.validateCrossDomainCall(
+		domainID,
+		targetDomainID,
+	); err != nil {
+		return err
+	}
 
 	if attributes == nil {
 		return &workflow.BadRequestError{Message: "RequestCancelExternalWorkflowExecutionDecisionAttributes is not set on decision."}
@@ -329,8 +347,17 @@ func (v *decisionAttrValidator) validateCancelExternalWorkflowExecutionAttribute
 }
 
 func (v *decisionAttrValidator) validateSignalExternalWorkflowExecutionAttributes(
+	domainID string,
+	targetDomainID string,
 	attributes *workflow.SignalExternalWorkflowExecutionDecisionAttributes,
 ) error {
+
+	if err := v.validateCrossDomainCall(
+		domainID,
+		targetDomainID,
+	); err != nil {
+		return err
+	}
 
 	if attributes == nil {
 		return &workflow.BadRequestError{Message: "SignalExternalWorkflowExecutionDecisionAttributes is not set on decision."}
@@ -363,8 +390,8 @@ func (v *decisionAttrValidator) validateSignalExternalWorkflowExecutionAttribute
 }
 
 func (v *decisionAttrValidator) validateContinueAsNewWorkflowExecutionAttributes(
-	executionInfo *persistence.WorkflowExecutionInfo,
 	attributes *workflow.ContinueAsNewWorkflowExecutionDecisionAttributes,
+	executionInfo *persistence.WorkflowExecutionInfo,
 ) error {
 
 	if attributes == nil {
@@ -401,9 +428,18 @@ func (v *decisionAttrValidator) validateContinueAsNewWorkflowExecutionAttributes
 }
 
 func (v *decisionAttrValidator) validateStartChildExecutionAttributes(
-	parentInfo *persistence.WorkflowExecutionInfo,
+	domainID string,
+	targetDomainID string,
 	attributes *workflow.StartChildWorkflowExecutionDecisionAttributes,
+	parentInfo *persistence.WorkflowExecutionInfo,
 ) error {
+
+	if err := v.validateCrossDomainCall(
+		domainID,
+		targetDomainID,
+	); err != nil {
+		return err
+	}
 
 	if attributes == nil {
 		return &workflow.BadRequestError{Message: "StartChildWorkflowExecutionDecisionAttributes is not set on decision."}

--- a/service/history/decisionChecker_test.go
+++ b/service/history/decisionChecker_test.go
@@ -26,11 +26,16 @@ import (
 	"github.com/stretchr/testify/suite"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/persistence"
 )
 
 type (
 	decisionAttrValidatorSuite struct {
 		suite.Suite
+
+		mockDomainCache *cache.DomainCacheMock
 
 		maxIDLengthLimit int
 		validator        *decisionAttrValidator
@@ -50,8 +55,12 @@ func (s *decisionAttrValidatorSuite) TearDownSuite() {
 }
 
 func (s *decisionAttrValidatorSuite) SetupTest() {
+	s.mockDomainCache = &cache.DomainCacheMock{}
 	s.maxIDLengthLimit = 1000
-	s.validator = newDecisionAttrValidator(s.maxIDLengthLimit)
+	s.validator = newDecisionAttrValidator(
+		s.mockDomainCache,
+		s.maxIDLengthLimit,
+	)
 }
 
 func (s *decisionAttrValidatorSuite) TearDownTest() {
@@ -84,5 +93,375 @@ func (s *decisionAttrValidatorSuite) TestValidateSignalExternalWorkflowExecution
 
 	attributes.Input = []byte("test input")
 	err = s.validator.validateSignalExternalWorkflowExecutionAttributes(attributes)
+	s.Nil(err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_LocalToLocal() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+	targetDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.Nil(err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_LocalToEffectiveLocal_SameCluster() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestCurrentClusterName}},
+		},
+		1234,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.Nil(err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_LocalToEffectiveLocal_DiffCluster() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestAlternativeClusterName}},
+		},
+		1234,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_LocalToGlobal() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		1234,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_EffectiveLocalToLocal_SameCluster() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestCurrentClusterName}},
+		},
+		1234,
+		nil,
+	)
+	targetDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.Nil(err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_EffectiveLocalToLocal_DiffCluster() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestAlternativeClusterName}},
+		},
+		1234,
+		nil,
+	)
+	targetDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_EffectiveLocalToEffectiveLocal_SameCluster() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestCurrentClusterName}},
+		},
+		1234,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestCurrentClusterName}},
+		},
+		5678,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.Nil(err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_EffectiveLocalToEffectiveLocal_DiffCluster() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestCurrentClusterName}},
+		},
+		1234,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters:          []*persistence.ClusterReplicationConfig{{ClusterName: cluster.TestAlternativeClusterName}},
+		},
+		5678,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_EffectiveLocalToGlobal() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+			},
+		},
+		5678,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		1234,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_GlobalToLocal() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		1234,
+		nil,
+	)
+	targetDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		cluster.TestCurrentClusterName,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_GlobalToEffectiveLocal() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		5678,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+			},
+		},
+		1234,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_GlobalToGlobal_DiffDomain() {
+	domainID := "some random domain ID"
+	targetDomainID := "some random target domain ID"
+	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: domainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestAlternativeClusterName},
+				{ClusterName: cluster.TestCurrentClusterName},
+			},
+		},
+		1234,
+		nil,
+	)
+	targetDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: targetDomainID},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		1234,
+		nil,
+	)
+
+	s.mockDomainCache.On("GetDomainByID", domainID).Return(domainEntry, nil)
+	s.mockDomainCache.On("GetDomainByID", targetDomainID).Return(targetDomainEntry, nil)
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
+	s.IsType(&workflow.BadRequestError{}, err)
+}
+
+func (s *decisionAttrValidatorSuite) TestValidateCrossDomainCall_GlobalToGlobal_SameDomain() {
+	domainID := "some random domain ID"
+	targetDomainID := domainID
+
+	err := s.validator.validateCrossDomainCall(domainID, targetDomainID)
 	s.Nil(err)
 }

--- a/service/history/decisionHandler.go
+++ b/service/history/decisionHandler.go
@@ -375,7 +375,10 @@ Update_History_Loop:
 			failMessage = fmt.Sprintf("binary %v is already marked as bad deployment", binChecksum)
 		} else {
 
-			decisionAttrValidator := newDecisionAttrValidator(handler.config.MaxIDLengthLimit())
+			decisionAttrValidator := newDecisionAttrValidator(
+				handler.domainCache,
+				handler.config.MaxIDLengthLimit(),
+			)
 			decisionBlobSizeChecker := newDecisionBlobSizeChecker(
 				handler.config.BlobSizeLimitWarn(domainEntry.GetInfo().Name),
 				handler.config.BlobSizeLimitError(domainEntry.GetInfo().Name),

--- a/service/history/decisionTaskHandler.go
+++ b/service/history/decisionTaskHandler.go
@@ -194,14 +194,11 @@ func (handler *decisionTaskHandlerImpl) handleDecisionScheduleActivity(
 
 	if err := handler.validateDecisionAttr(
 		func() error {
-			if err := handler.attrValidator.validateCrossDomainCall(
+			return handler.attrValidator.validateActivityScheduleAttributes(
 				domainID,
 				targetDomainID,
-			); err != nil {
-				return err
-			}
-			return handler.attrValidator.validateActivityScheduleAttributes(
-				attr, executionInfo.WorkflowTimeout,
+				attr,
+				executionInfo.WorkflowTimeout,
 			)
 		},
 		workflow.DecisionTaskFailedCauseBadScheduleActivityAttributes,
@@ -581,13 +578,11 @@ func (handler *decisionTaskHandlerImpl) handleDecisionRequestCancelExternalWorkf
 
 	if err := handler.validateDecisionAttr(
 		func() error {
-			if err := handler.attrValidator.validateCrossDomainCall(
+			return handler.attrValidator.validateCancelExternalWorkflowExecutionAttributes(
 				domainID,
 				targetDomainID,
-			); err != nil {
-				return err
-			}
-			return handler.attrValidator.validateCancelExternalWorkflowExecutionAttributes(attr)
+				attr,
+			)
 		},
 		workflow.DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes,
 	); err != nil || handler.stopProcessing {
@@ -661,7 +656,8 @@ func (handler *decisionTaskHandlerImpl) handleDecisionContinueAsNewWorkflow(
 	if err := handler.validateDecisionAttr(
 		func() error {
 			return handler.attrValidator.validateContinueAsNewWorkflowExecutionAttributes(
-				executionInfo, attr,
+				attr,
+				executionInfo,
 			)
 		},
 		workflow.DecisionTaskFailedCauseBadContinueAsNewAttributes,
@@ -743,14 +739,11 @@ func (handler *decisionTaskHandlerImpl) handleDecisionStartChildWorkflow(
 
 	if err := handler.validateDecisionAttr(
 		func() error {
-			if err := handler.attrValidator.validateCrossDomainCall(
+			return handler.attrValidator.validateStartChildExecutionAttributes(
 				domainID,
 				targetDomainID,
-			); err != nil {
-				return err
-			}
-			return handler.attrValidator.validateStartChildExecutionAttributes(
-				executionInfo, attr,
+				attr,
+				executionInfo,
 			)
 		},
 		workflow.DecisionTaskFailedCauseBadStartChildExecutionAttributes,
@@ -806,13 +799,11 @@ func (handler *decisionTaskHandlerImpl) handleDecisionSignalExternalWorkflow(
 
 	if err := handler.validateDecisionAttr(
 		func() error {
-			if err := handler.attrValidator.validateCrossDomainCall(
+			return handler.attrValidator.validateSignalExternalWorkflowExecutionAttributes(
 				domainID,
 				targetDomainID,
-			); err != nil {
-				return err
-			}
-			return handler.attrValidator.validateSignalExternalWorkflowExecutionAttributes(attr)
+				attr,
+			)
 		},
 		workflow.DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes,
 	); err != nil || handler.stopProcessing {

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -116,7 +116,9 @@ func (s *engine2Suite) SetupTest() {
 	s.mockClusterMetadata.On("GetAllClusterInfo").Return(cluster.TestSingleDCClusterInfo)
 	s.mockClusterMetadata.On("IsGlobalDomainEnabled").Return(false)
 	s.mockDomainCache = &cache.DomainCacheMock{}
-	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{}), nil)
+	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewLocalDomainCacheEntryForTest(
+		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{}, "", nil,
+	), nil)
 	s.mockEventsCache = &MockEventsCache{}
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
 		mock.Anything).Return()

--- a/service/history/historyEngine3_eventsv2_test.go
+++ b/service/history/historyEngine3_eventsv2_test.go
@@ -167,7 +167,9 @@ func (s *engine3Suite) TearDownTest() {
 }
 
 func (s *engine3Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
-	testDomainEntry := cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1})
+	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 
@@ -251,7 +253,9 @@ func (s *engine3Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 }
 
 func (s *engine3Suite) TestStartWorkflowExecution_BrandNew() {
-	testDomainEntry := cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1})
+	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 
@@ -296,7 +300,9 @@ func (s *engine3Suite) TestStartWorkflowExecution_BrandNew() {
 }
 
 func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
-	testDomainEntry := cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1})
+	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 
@@ -352,7 +358,9 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 }
 
 func (s *engine3Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
-	testDomainEntry := cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1})
+	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -181,7 +181,9 @@ func (s *resetorSuite) TearDownTest() {
 }
 
 func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
-	testDomainEntry := cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1})
+	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Once()
@@ -873,7 +875,9 @@ func (s *resetorSuite) assertActivityIDs(ids []string, timers []*p.ActivityInfo)
 }
 
 func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCancel() {
-	testDomainEntry := cache.NewDomainCacheEntryForTest(&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1})
+	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
+		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return().Once()
@@ -1445,7 +1449,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", beforeResetVersion).Return("standby")
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return("active")
 
-	testDomainEntry := cache.NewDomainCacheEntryWithReplicationForTest(
+	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
 		&p.DomainInfo{ID: validDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{
@@ -2168,7 +2172,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", beforeResetVersion).Return("active")
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return("standby")
 
-	testDomainEntry := cache.NewDomainCacheEntryWithReplicationForTest(
+	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
 		&p.DomainInfo{ID: validDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{
@@ -2774,7 +2778,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", beforeResetVersion).Return("standby")
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return("active")
 
-	testDomainEntry := cache.NewDomainCacheEntryWithReplicationForTest(
+	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
 		&p.DomainInfo{ID: validDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{
@@ -3480,7 +3484,7 @@ func (s *resetorSuite) TestApplyReset() {
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", beforeResetVersion).Return("standby")
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return("active")
 
-	testDomainEntry := cache.NewDomainCacheEntryWithReplicationForTest(
+	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
 		&p.DomainInfo{ID: validDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{


### PR DESCRIPTION
* Local domain to local domain cross domain call is still valid
* Local domain to global domain cross domain call is disabled
* Global domain to itself cross domain call is still valid
* Global domain to local domain cross domain call is disabled
* Global domain to other global domain cross domain call is disabled
* Affected decisions are
  * ScheduleActivity
  * CancelExternalWorkflowExecution
  * SignalExternalWorkflowExecution
  * StartChildExecution

solve #2042 