### PR TITLE
Acquire domain ID & workflow ID lock before creating a new workflow

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -744,6 +744,8 @@ const (
 	HistoryCacheGetAndCreateScope
 	// HistoryCacheGetOrCreateScope is the scope used by history cache
 	HistoryCacheGetOrCreateScope
+	// HistoryCacheGetOrCreateCurrentScope is the scope used by history cache
+	HistoryCacheGetOrCreateCurrentScope
 	// HistoryCacheGetCurrentExecutionScope is the scope used by history cache for getting current execution
 	HistoryCacheGetCurrentExecutionScope
 	// EventsCacheGetEventScope is the scope used by events cache
@@ -1171,6 +1173,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		WorkflowContextScope:                          {operation: "WorkflowContext"},
 		HistoryCacheGetAndCreateScope:                 {operation: "HistoryCacheGetAndCreate", tags: map[string]string{CacheTypeTagName: MutableStateCacheTypeTagValue}},
 		HistoryCacheGetOrCreateScope:                  {operation: "HistoryCacheGetOrCreate", tags: map[string]string{CacheTypeTagName: MutableStateCacheTypeTagValue}},
+		HistoryCacheGetOrCreateCurrentScope:           {operation: "HistoryCacheGetOrCreateCurrent", tags: map[string]string{CacheTypeTagName: MutableStateCacheTypeTagValue}},
 		HistoryCacheGetCurrentExecutionScope:          {operation: "HistoryCacheGetCurrentExecution", tags: map[string]string{CacheTypeTagName: MutableStateCacheTypeTagValue}},
 		EventsCacheGetEventScope:                      {operation: "EventsCacheGetEvent", tags: map[string]string{CacheTypeTagName: EventsCacheTypeTagValue}},
 		EventsCachePutEventScope:                      {operation: "EventsCachePutEvent", tags: map[string]string{CacheTypeTagName: EventsCacheTypeTagValue}},

--- a/service/history/decisionHandler.go
+++ b/service/history/decisionHandler.go
@@ -284,7 +284,7 @@ func (handler *decisionHandlerImpl) handleDecisionTaskCompleted(
 	clientFeatureVersion := call.Header(common.FeatureVersionHeaderName)
 	clientImpl := call.Header(common.ClientImplHeaderName)
 
-	context, release, err := handler.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, workflowExecution)
+	context, release, err := handler.historyCache.getOrCreateWorkflowExecution(ctx, domainID, workflowExecution)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/historyCache.go
+++ b/service/history/historyCache.go
@@ -72,38 +72,65 @@ func newHistoryCache(shard ShardContext) *historyCache {
 	}
 }
 
-func (c *historyCache) getOrCreateWorkflowExecution(domainID string,
-	execution workflow.WorkflowExecution) (workflowExecutionContext, releaseWorkflowExecutionFunc, error) {
-	return c.getOrCreateWorkflowExecutionWithTimeout(context.Background(), domainID, execution)
-}
+func (c *historyCache) getOrCreatCurrentWorkflowExecution(
+	ctx context.Context,
+	domainID string,
+	workflowID string,
+) (workflowExecutionContext, releaseWorkflowExecutionFunc, error) {
 
-func (c *historyCache) validateWorkflowExecutionInfo(domainID string, execution *workflow.WorkflowExecution) error {
-	if execution.GetWorkflowId() == "" {
-		return &workflow.BadRequestError{Message: "Can't load workflow execution.  WorkflowId not set."}
+	// using empty run ID as current workflow run ID
+	runID := ""
+	execution := workflow.WorkflowExecution{
+		WorkflowId: common.StringPtr(workflowID),
+		RunId:      common.StringPtr(runID),
 	}
 
-	// RunID is not provided, lets try to retrieve the RunID for current active execution
-	if execution.GetRunId() == "" {
-		response, err := c.getCurrentExecutionWithRetry(&persistence.GetCurrentExecutionRequest{
-			DomainID:   domainID,
-			WorkflowID: execution.GetWorkflowId(),
-		})
+	// Test hook for disabling the cache
+	if c.disabled {
+		return newWorkflowExecutionContext(
+			domainID,
+			execution,
+			c.shard,
+			c.executionManager,
+			c.logger,
+		), func(error) {}, nil
+	}
 
+	key := definition.NewWorkflowIdentifier(domainID, workflowID, runID)
+	workflowCtx, cacheHit := c.Get(key).(workflowExecutionContext)
+	if !cacheHit {
+		c.metricsClient.IncCounter(metrics.HistoryCacheGetOrCreateScope, metrics.CacheMissCounter)
+		// Let's create the workflow execution workflowCtx
+		workflowCtx = newWorkflowExecutionContext(domainID, execution, c.shard, c.executionManager, c.logger)
+		elem, err := c.PutIfNotExist(key, workflowCtx)
 		if err != nil {
-			return err
+			c.metricsClient.IncCounter(metrics.HistoryCacheGetOrCreateScope, metrics.CacheFailures)
+			return nil, nil, err
 		}
-
-		execution.RunId = common.StringPtr(response.RunID)
-	} else if uuid.Parse(execution.GetRunId()) == nil { // immediately return if invalid runID
-		return &workflow.BadRequestError{Message: "RunID is not valid UUID."}
+		workflowCtx = elem.(workflowExecutionContext)
 	}
-	return nil
+
+	// This will create a closure on every request.
+	// Consider revisiting this if it causes too much GC activity
+	releaseFunc := c.makeReleaseFunc(key, cacheNotReleased, workflowCtx, true)
+
+	if err := workflowCtx.lock(ctx); err != nil {
+		// ctx is done before lock can be acquired
+		c.Release(key)
+		c.metricsClient.IncCounter(metrics.HistoryCacheGetOrCreateScope, metrics.CacheFailures)
+		c.metricsClient.IncCounter(metrics.HistoryCacheGetOrCreateScope, metrics.AcquireLockFailedCounter)
+		return nil, nil, err
+	}
+	return workflowCtx, releaseFunc, nil
 }
 
 // For analyzing mutableState, we have to try get workflowExecutionContext from cache and also load from database
-func (c *historyCache) getAndCreateWorkflowExecutionWithTimeout(ctx context.Context, domainID string,
-	execution workflow.WorkflowExecution) (workflowExecutionContext, workflowExecutionContext,
-	releaseWorkflowExecutionFunc, bool, error) {
+func (c *historyCache) getAndCreateWorkflowExecution(
+	ctx context.Context,
+	domainID string,
+	execution workflow.WorkflowExecution,
+) (workflowExecutionContext, workflowExecutionContext, releaseWorkflowExecutionFunc, bool, error) {
+
 	c.metricsClient.IncCounter(metrics.HistoryCacheGetAndCreateScope, metrics.CacheRequests)
 	sw := c.metricsClient.StartTimer(metrics.HistoryCacheGetAndCreateScope, metrics.CacheLatency)
 	defer sw.Stop()
@@ -125,7 +152,7 @@ func (c *historyCache) getAndCreateWorkflowExecutionWithTimeout(ctx context.Cont
 			c.metricsClient.IncCounter(metrics.HistoryCacheGetAndCreateScope, metrics.AcquireLockFailedCounter)
 			return nil, nil, nil, false, err
 		}
-		releaseFunc = c.makeReleaseFunc(key, cacheNotReleased, contextFromCache)
+		releaseFunc = c.makeReleaseFunc(key, cacheNotReleased, contextFromCache, false)
 	} else {
 		c.metricsClient.IncCounter(metrics.HistoryCacheGetAndCreateScope, metrics.CacheMissCounter)
 	}
@@ -135,11 +162,22 @@ func (c *historyCache) getAndCreateWorkflowExecutionWithTimeout(ctx context.Cont
 	return contextFromCache, contextFromDB, releaseFunc, cacheHit, nil
 }
 
-func (c *historyCache) getOrCreateWorkflowExecutionWithTimeout(ctx context.Context, domainID string,
-	execution workflow.WorkflowExecution) (workflowExecutionContext, releaseWorkflowExecutionFunc, error) {
+func (c *historyCache) getOrCreateWorkflowExecutionForBackground(
+	domainID string,
+	execution workflow.WorkflowExecution,
+) (workflowExecutionContext, releaseWorkflowExecutionFunc, error) {
+
+	return c.getOrCreateWorkflowExecution(context.Background(), domainID, execution)
+}
+
+func (c *historyCache) getOrCreateWorkflowExecution(
+	ctx context.Context,
+	domainID string,
+	execution workflow.WorkflowExecution,
+) (workflowExecutionContext, releaseWorkflowExecutionFunc, error) {
+
 	c.metricsClient.IncCounter(metrics.HistoryCacheGetOrCreateScope, metrics.CacheRequests)
 	sw := c.metricsClient.StartTimer(metrics.HistoryCacheGetOrCreateScope, metrics.CacheLatency)
-
 	defer sw.Stop()
 
 	if err := c.validateWorkflowExecutionInfo(domainID, &execution); err != nil {
@@ -168,7 +206,7 @@ func (c *historyCache) getOrCreateWorkflowExecutionWithTimeout(ctx context.Conte
 
 	// This will create a closure on every request.
 	// Consider revisiting this if it causes too much GC activity
-	releaseFunc := c.makeReleaseFunc(key, cacheNotReleased, workflowCtx)
+	releaseFunc := c.makeReleaseFunc(key, cacheNotReleased, workflowCtx, false)
 
 	if err := workflowCtx.lock(ctx); err != nil {
 		// ctx is done before lock can be acquired
@@ -180,10 +218,43 @@ func (c *historyCache) getOrCreateWorkflowExecutionWithTimeout(ctx context.Conte
 	return workflowCtx, releaseFunc, nil
 }
 
-func (c *historyCache) makeReleaseFunc(key definition.WorkflowIdentifier, status int32, context workflowExecutionContext) func(error) {
+func (c *historyCache) validateWorkflowExecutionInfo(
+	domainID string,
+	execution *workflow.WorkflowExecution,
+) error {
+
+	if execution.GetWorkflowId() == "" {
+		return &workflow.BadRequestError{Message: "Can't load workflow execution.  WorkflowId not set."}
+	}
+
+	// RunID is not provided, lets try to retrieve the RunID for current active execution
+	if execution.GetRunId() == "" {
+		response, err := c.getCurrentExecutionWithRetry(&persistence.GetCurrentExecutionRequest{
+			DomainID:   domainID,
+			WorkflowID: execution.GetWorkflowId(),
+		})
+
+		if err != nil {
+			return err
+		}
+
+		execution.RunId = common.StringPtr(response.RunID)
+	} else if uuid.Parse(execution.GetRunId()) == nil { // immediately return if invalid runID
+		return &workflow.BadRequestError{Message: "RunID is not valid UUID."}
+	}
+	return nil
+}
+
+func (c *historyCache) makeReleaseFunc(
+	key definition.WorkflowIdentifier,
+	status int32,
+	context workflowExecutionContext,
+	forceClearCache bool,
+) func(error) {
+
 	return func(err error) {
 		if atomic.CompareAndSwapInt32(&status, cacheNotReleased, cacheReleased) {
-			if err != nil {
+			if err != nil || forceClearCache {
 				// TODO see issue #668, there are certain type or errors which can bypass the clear
 				context.clear()
 			}
@@ -194,7 +265,9 @@ func (c *historyCache) makeReleaseFunc(key definition.WorkflowIdentifier, status
 }
 
 func (c *historyCache) getCurrentExecutionWithRetry(
-	request *persistence.GetCurrentExecutionRequest) (*persistence.GetCurrentExecutionResponse, error) {
+	request *persistence.GetCurrentExecutionRequest,
+) (*persistence.GetCurrentExecutionResponse, error) {
+
 	c.metricsClient.IncCounter(metrics.HistoryCacheGetCurrentExecutionScope, metrics.CacheRequests)
 	sw := c.metricsClient.StartTimer(metrics.HistoryCacheGetCurrentExecutionScope, metrics.CacheLatency)
 	defer sw.Stop()

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -388,7 +388,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 
 	workflowID := request.GetWorkflowId()
 	// grab the current context as a lock, nothing more
-	_, currentRelease, err := e.historyCache.getOrCreatCurrentWorkflowExecution(
+	_, currentRelease, err := e.historyCache.getOrCreateCurrentWorkflowExecution(
 		ctx,
 		domainID,
 		workflowID,
@@ -1474,7 +1474,7 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(
 
 	workflowID := request.GetWorkflowId()
 	// grab the current context as a lock, nothing more
-	_, currentRelease, err := e.historyCache.getOrCreatCurrentWorkflowExecution(
+	_, currentRelease, err := e.historyCache.getOrCreateCurrentWorkflowExecution(
 		ctx,
 		domainID,
 		workflowID,

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -305,7 +305,11 @@ func (e *historyEngineImpl) registerDomainFailoverCallback() {
 	)
 }
 
-func (e *historyEngineImpl) createMutableState(clusterMetadata cluster.Metadata, domainEntry *cache.DomainCacheEntry) mutableState {
+func (e *historyEngineImpl) createMutableState(
+	clusterMetadata cluster.Metadata,
+	domainEntry *cache.DomainCacheEntry,
+) mutableState {
+
 	var msBuilder mutableState
 	if clusterMetadata.IsGlobalDomainEnabled() && domainEntry.IsGlobalDomain() {
 		// all workflows within a global domain should have replication state, no matter whether it will be replicated to multiple
@@ -329,8 +333,14 @@ func (e *historyEngineImpl) createMutableState(clusterMetadata cluster.Metadata,
 	return msBuilder
 }
 
-func (e *historyEngineImpl) generateFirstDecisionTask(domainID string, msBuilder mutableState, parentInfo *h.ParentExecutionInfo,
-	taskListName string, cronBackoffSeconds int32) ([]persistence.Task, *decisionInfo, error) {
+func (e *historyEngineImpl) generateFirstDecisionTask(
+	domainID string,
+	msBuilder mutableState,
+	parentInfo *h.ParentExecutionInfo,
+	taskListName string,
+	cronBackoffSeconds int32,
+) ([]persistence.Task, *decisionInfo, error) {
+
 	di := &decisionInfo{
 		TaskList:        taskListName,
 		Version:         common.EmptyVersion,
@@ -376,8 +386,20 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 		return
 	}
 
+	workflowID := request.GetWorkflowId()
+	// grab the current context as a lock, nothing more
+	_, currentRelease, err := e.historyCache.getOrCreatCurrentWorkflowExecution(
+		ctx,
+		domainID,
+		workflowID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { currentRelease(retError) }()
+
 	execution := workflow.WorkflowExecution{
-		WorkflowId: request.WorkflowId,
+		WorkflowId: common.StringPtr(workflowID),
 		RunId:      common.StringPtr(uuid.New()),
 	}
 	clusterMetadata := e.shard.GetService().GetClusterMetadata()
@@ -388,7 +410,7 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 	}
 	if eventStoreVersion == persistence.EventStoreVersionV2 {
 		// NOTE: except for fork(reset), we use runID as treeID for simplicity
-		if retError = msBuilder.SetHistoryTree(*execution.RunId); retError != nil {
+		if retError = msBuilder.SetHistoryTree(execution.GetRunId()); retError != nil {
 			return
 		}
 	}
@@ -497,8 +519,10 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 }
 
 // GetMutableState retrieves the mutable state of the workflow execution
-func (e *historyEngineImpl) GetMutableState(ctx ctx.Context,
-	request *h.GetMutableStateRequest) (*h.GetMutableStateResponse, error) {
+func (e *historyEngineImpl) GetMutableState(
+	ctx ctx.Context,
+	request *h.GetMutableStateRequest,
+) (*h.GetMutableStateResponse, error) {
 
 	domainID, err := validateDomainUUID(request.DomainUUID)
 	if err != nil {
@@ -569,10 +593,13 @@ func (e *historyEngineImpl) GetMutableState(ctx ctx.Context,
 	return response, nil
 }
 
-func (e *historyEngineImpl) getMutableState(ctx ctx.Context,
-	domainID string, execution workflow.WorkflowExecution) (retResp *h.GetMutableStateResponse, retError error) {
+func (e *historyEngineImpl) getMutableState(
+	ctx ctx.Context,
+	domainID string,
+	execution workflow.WorkflowExecution,
+) (retResp *h.GetMutableStateResponse, retError error) {
 
-	context, release, retError := e.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+	context, release, retError := e.historyCache.getOrCreateWorkflowExecution(ctx, domainID, execution)
 	if retError != nil {
 		return
 	}
@@ -616,8 +643,10 @@ func (e *historyEngineImpl) getMutableState(ctx ctx.Context,
 	return
 }
 
-func (e *historyEngineImpl) DescribeMutableState(ctx ctx.Context,
-	request *h.DescribeMutableStateRequest) (retResp *h.DescribeMutableStateResponse, retError error) {
+func (e *historyEngineImpl) DescribeMutableState(
+	ctx ctx.Context,
+	request *h.DescribeMutableStateRequest,
+) (retResp *h.DescribeMutableStateResponse, retError error) {
 
 	domainID, err := validateDomainUUID(request.DomainUUID)
 	if err != nil {
@@ -629,7 +658,7 @@ func (e *historyEngineImpl) DescribeMutableState(ctx ctx.Context,
 		RunId:      request.Execution.RunId,
 	}
 
-	cacheCtx, dbCtx, release, cacheHit, err := e.historyCache.getAndCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+	cacheCtx, dbCtx, release, cacheHit, err := e.historyCache.getAndCreateWorkflowExecution(ctx, domainID, execution)
 	if err != nil {
 		return nil, err
 	}
@@ -664,7 +693,11 @@ func (e *historyEngineImpl) toMutableStateJSON(msb mutableState) (*string, error
 // 3. ClientLibraryVersion
 // 4. ClientFeatureVersion
 // 5. ClientImpl
-func (e *historyEngineImpl) ResetStickyTaskList(ctx ctx.Context, resetRequest *h.ResetStickyTaskListRequest) (*h.ResetStickyTaskListResponse, error) {
+func (e *historyEngineImpl) ResetStickyTaskList(
+	ctx ctx.Context,
+	resetRequest *h.ResetStickyTaskListRequest,
+) (*h.ResetStickyTaskListResponse, error) {
+
 	domainID, err := validateDomainUUID(resetRequest.DomainUUID)
 	if err != nil {
 		return nil, err
@@ -687,8 +720,11 @@ func (e *historyEngineImpl) ResetStickyTaskList(ctx ctx.Context, resetRequest *h
 }
 
 // DescribeWorkflowExecution returns information about the specified workflow execution.
-func (e *historyEngineImpl) DescribeWorkflowExecution(ctx ctx.Context,
-	request *h.DescribeWorkflowExecutionRequest) (retResp *workflow.DescribeWorkflowExecutionResponse, retError error) {
+func (e *historyEngineImpl) DescribeWorkflowExecution(
+	ctx ctx.Context,
+	request *h.DescribeWorkflowExecutionRequest,
+) (retResp *workflow.DescribeWorkflowExecutionResponse, retError error) {
+
 	domainID, err := validateDomainUUID(request.DomainUUID)
 	if err != nil {
 		return nil, err
@@ -696,7 +732,7 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(ctx ctx.Context,
 
 	execution := *request.Request.Execution
 
-	context, release, err0 := e.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+	context, release, err0 := e.historyCache.getOrCreateWorkflowExecution(ctx, domainID, execution)
 	if err0 != nil {
 		return nil, err0
 	}
@@ -798,8 +834,10 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(ctx ctx.Context,
 	return result, nil
 }
 
-func (e *historyEngineImpl) RecordActivityTaskStarted(ctx ctx.Context,
-	request *h.RecordActivityTaskStartedRequest) (*h.RecordActivityTaskStartedResponse, error) {
+func (e *historyEngineImpl) RecordActivityTaskStarted(
+	ctx ctx.Context,
+	request *h.RecordActivityTaskStartedRequest,
+) (*h.RecordActivityTaskStartedResponse, error) {
 
 	domainEntry, err := e.getActiveDomainEntry(request.DomainUUID)
 	if err != nil {
@@ -926,7 +964,10 @@ func (e *historyEngineImpl) RespondDecisionTaskFailed(
 }
 
 // RespondActivityTaskCompleted completes an activity task.
-func (e *historyEngineImpl) RespondActivityTaskCompleted(ctx ctx.Context, req *h.RespondActivityTaskCompletedRequest) error {
+func (e *historyEngineImpl) RespondActivityTaskCompleted(
+	ctx ctx.Context,
+	req *h.RespondActivityTaskCompletedRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(req.DomainUUID)
 	if err != nil {
@@ -981,7 +1022,10 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(ctx ctx.Context, req *h
 }
 
 // RespondActivityTaskFailed completes an activity task failure.
-func (e *historyEngineImpl) RespondActivityTaskFailed(ctx ctx.Context, req *h.RespondActivityTaskFailedRequest) error {
+func (e *historyEngineImpl) RespondActivityTaskFailed(
+	ctx ctx.Context,
+	req *h.RespondActivityTaskFailedRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(req.DomainUUID)
 	if err != nil {
@@ -1046,7 +1090,10 @@ func (e *historyEngineImpl) RespondActivityTaskFailed(ctx ctx.Context, req *h.Re
 }
 
 // RespondActivityTaskCanceled completes an activity task failure.
-func (e *historyEngineImpl) RespondActivityTaskCanceled(ctx ctx.Context, req *h.RespondActivityTaskCanceledRequest) error {
+func (e *historyEngineImpl) RespondActivityTaskCanceled(
+	ctx ctx.Context,
+	req *h.RespondActivityTaskCanceledRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(req.DomainUUID)
 	if err != nil {
@@ -1111,8 +1158,10 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(ctx ctx.Context, req *h.
 // This method can be used for two purposes.
 // - For reporting liveness of the activity.
 // - For reporting progress of the activity, this can be done even if the liveness is not configured.
-func (e *historyEngineImpl) RecordActivityTaskHeartbeat(ctx ctx.Context,
-	req *h.RecordActivityTaskHeartbeatRequest) (*workflow.RecordActivityTaskHeartbeatResponse, error) {
+func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
+	ctx ctx.Context,
+	req *h.RecordActivityTaskHeartbeatRequest,
+) (*workflow.RecordActivityTaskHeartbeatResponse, error) {
 
 	domainEntry, err := e.getActiveDomainEntry(req.DomainUUID)
 	if err != nil {
@@ -1181,8 +1230,10 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(ctx ctx.Context,
 }
 
 // RequestCancelWorkflowExecution records request cancellation event for workflow execution
-func (e *historyEngineImpl) RequestCancelWorkflowExecution(ctx ctx.Context,
-	req *h.RequestCancelWorkflowExecutionRequest) error {
+func (e *historyEngineImpl) RequestCancelWorkflowExecution(
+	ctx ctx.Context,
+	req *h.RequestCancelWorkflowExecutionRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(req.DomainUUID)
 	if err != nil {
@@ -1236,7 +1287,10 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(ctx ctx.Context,
 		})
 }
 
-func (e *historyEngineImpl) SignalWorkflowExecution(ctx ctx.Context, signalRequest *h.SignalWorkflowExecutionRequest) error {
+func (e *historyEngineImpl) SignalWorkflowExecution(
+	ctx ctx.Context,
+	signalRequest *h.SignalWorkflowExecutionRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(signalRequest.DomainUUID)
 	if err != nil {
@@ -1306,8 +1360,10 @@ func (e *historyEngineImpl) SignalWorkflowExecution(ctx ctx.Context, signalReque
 	})
 }
 
-func (e *historyEngineImpl) SignalWithStartWorkflowExecution(ctx ctx.Context, signalWithStartRequest *h.SignalWithStartWorkflowExecutionRequest) (
-	retResp *workflow.StartWorkflowExecutionResponse, retError error) {
+func (e *historyEngineImpl) SignalWithStartWorkflowExecution(
+	ctx ctx.Context,
+	signalWithStartRequest *h.SignalWithStartWorkflowExecutionRequest,
+) (retResp *workflow.StartWorkflowExecutionResponse, retError error) {
 
 	domainEntry, retError := e.getActiveDomainEntry(signalWithStartRequest.DomainUUID)
 	if retError != nil {
@@ -1323,7 +1379,7 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(ctx ctx.Context, si
 	var prevMutableState mutableState
 	attempt := 0
 
-	context, release, err0 := e.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+	context, release, err0 := e.historyCache.getOrCreateWorkflowExecution(ctx, domainID, execution)
 
 	if err0 == nil {
 		defer func() { release(retError) }()
@@ -1416,8 +1472,20 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(ctx ctx.Context, si
 		return
 	}
 
+	workflowID := request.GetWorkflowId()
+	// grab the current context as a lock, nothing more
+	_, currentRelease, err := e.historyCache.getOrCreatCurrentWorkflowExecution(
+		ctx,
+		domainID,
+		workflowID,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { currentRelease(retError) }()
+
 	execution = workflow.WorkflowExecution{
-		WorkflowId: request.WorkflowId,
+		WorkflowId: common.StringPtr(workflowID),
 		RunId:      common.StringPtr(uuid.New()),
 	}
 
@@ -1455,7 +1523,7 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(ctx ctx.Context, si
 	// Generate first decision task event.
 	taskList := request.TaskList.GetName()
 	// Add WF start event
-	_, err := msBuilder.AddWorkflowExecutionStartedEvent(execution, startRequest)
+	_, err = msBuilder.AddWorkflowExecutionStartedEvent(execution, startRequest)
 	if err != nil {
 		return nil, &workflow.InternalServiceError{Message: "Failed to add workflow execution started event."}
 	}
@@ -1535,7 +1603,10 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(ctx ctx.Context, si
 }
 
 // RemoveSignalMutableState remove the signal request id in signal_requested for deduplicate
-func (e *historyEngineImpl) RemoveSignalMutableState(ctx ctx.Context, request *h.RemoveSignalMutableStateRequest) error {
+func (e *historyEngineImpl) RemoveSignalMutableState(
+	ctx ctx.Context,
+	request *h.RemoveSignalMutableStateRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(request.DomainUUID)
 	if err != nil {
@@ -1560,7 +1631,10 @@ func (e *historyEngineImpl) RemoveSignalMutableState(ctx ctx.Context, request *h
 		})
 }
 
-func (e *historyEngineImpl) TerminateWorkflowExecution(ctx ctx.Context, terminateRequest *h.TerminateWorkflowExecutionRequest) error {
+func (e *historyEngineImpl) TerminateWorkflowExecution(
+	ctx ctx.Context,
+	terminateRequest *h.TerminateWorkflowExecutionRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(terminateRequest.DomainUUID)
 	if err != nil {
@@ -1593,7 +1667,10 @@ func (e *historyEngineImpl) TerminateWorkflowExecution(ctx ctx.Context, terminat
 }
 
 // RecordChildExecutionCompleted records the completion of child execution into parent execution history
-func (e *historyEngineImpl) RecordChildExecutionCompleted(ctx ctx.Context, completionRequest *h.RecordChildExecutionCompletedRequest) error {
+func (e *historyEngineImpl) RecordChildExecutionCompleted(
+	ctx ctx.Context,
+	completionRequest *h.RecordChildExecutionCompletedRequest,
+) error {
 
 	domainEntry, err := e.getActiveDomainEntry(completionRequest.DomainUUID)
 	if err != nil {
@@ -1645,15 +1722,27 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(ctx ctx.Context, compl
 		})
 }
 
-func (e *historyEngineImpl) ReplicateEvents(ctx ctx.Context, replicateRequest *h.ReplicateEventsRequest) error {
+func (e *historyEngineImpl) ReplicateEvents(
+	ctx ctx.Context,
+	replicateRequest *h.ReplicateEventsRequest,
+) error {
+
 	return e.replicator.ApplyEvents(ctx, replicateRequest)
 }
 
-func (e *historyEngineImpl) ReplicateRawEvents(ctx ctx.Context, replicateRequest *h.ReplicateRawEventsRequest) error {
+func (e *historyEngineImpl) ReplicateRawEvents(
+	ctx ctx.Context,
+	replicateRequest *h.ReplicateRawEventsRequest,
+) error {
+
 	return e.replicator.ApplyRawEvents(ctx, replicateRequest)
 }
 
-func (e *historyEngineImpl) SyncShardStatus(ctx ctx.Context, request *h.SyncShardStatusRequest) error {
+func (e *historyEngineImpl) SyncShardStatus(
+	ctx ctx.Context,
+	request *h.SyncShardStatusRequest,
+) error {
+
 	clusterName := request.GetSourceCluster()
 	now := time.Unix(0, request.GetTimestamp())
 
@@ -1667,12 +1756,18 @@ func (e *historyEngineImpl) SyncShardStatus(ctx ctx.Context, request *h.SyncShar
 	return nil
 }
 
-func (e *historyEngineImpl) SyncActivity(ctx ctx.Context, request *h.SyncActivityRequest) (retError error) {
+func (e *historyEngineImpl) SyncActivity(
+	ctx ctx.Context,
+	request *h.SyncActivityRequest,
+) (retError error) {
+
 	return e.replicator.SyncActivity(ctx, request)
 }
 
-func (e *historyEngineImpl) ResetWorkflowExecution(ctx ctx.Context,
-	resetRequest *h.ResetWorkflowExecutionRequest) (response *workflow.ResetWorkflowExecutionResponse, retError error) {
+func (e *historyEngineImpl) ResetWorkflowExecution(
+	ctx ctx.Context,
+	resetRequest *h.ResetWorkflowExecutionRequest,
+) (response *workflow.ResetWorkflowExecutionResponse, retError error) {
 
 	domainEntry, retError := e.getActiveDomainEntry(resetRequest.DomainUUID)
 	if retError != nil {
@@ -1698,7 +1793,7 @@ func (e *historyEngineImpl) ResetWorkflowExecution(ctx ctx.Context,
 		RunId:      request.WorkflowExecution.RunId,
 	}
 
-	baseContext, baseRelease, retError := e.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, baseExecution)
+	baseContext, baseRelease, retError := e.historyCache.getOrCreateWorkflowExecution(ctx, domainID, baseExecution)
 	if retError != nil {
 		return
 	}
@@ -1731,7 +1826,7 @@ func (e *historyEngineImpl) ResetWorkflowExecution(ctx ctx.Context,
 			RunId:      common.StringPtr(resp.RunID),
 		}
 		var currRelease func(err error)
-		currContext, currRelease, retError = e.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, currExecution)
+		currContext, currRelease, retError = e.historyCache.getOrCreateWorkflowExecution(ctx, domainID, currExecution)
 		if retError != nil {
 			return
 		}
@@ -1757,7 +1852,10 @@ func (e *historyEngineImpl) ResetWorkflowExecution(ctx ctx.Context,
 	return e.resetor.ResetWorkflowExecution(ctx, request, baseContext, baseMutableState, currContext, currMutableState)
 }
 
-func (e *historyEngineImpl) DeleteExecutionFromVisibility(task *persistence.TimerTaskInfo) error {
+func (e *historyEngineImpl) DeleteExecutionFromVisibility(
+	task *persistence.TimerTaskInfo,
+) error {
+
 	request := &persistence.VisibilityDeleteWorkflowExecutionRequest{
 		DomainID:   task.DomainID,
 		WorkflowID: task.WorkflowID,
@@ -1775,9 +1873,14 @@ type updateWorkflowAction struct {
 	transferTasks  []persistence.Task
 }
 
-func (e *historyEngineImpl) updateWorkflowExecutionWithAction(ctx ctx.Context, domainID string, execution workflow.WorkflowExecution,
-	action func(builder mutableState, tBuilder *timerBuilder) (*updateWorkflowAction, error)) (retError error) {
-	context, release, err0 := e.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+func (e *historyEngineImpl) updateWorkflowExecutionWithAction(
+	ctx ctx.Context,
+	domainID string,
+	execution workflow.WorkflowExecution,
+	action func(builder mutableState, tBuilder *timerBuilder) (*updateWorkflowAction, error),
+) (retError error) {
+
+	context, release, err0 := e.historyCache.getOrCreateWorkflowExecution(ctx, domainID, execution)
 	if err0 != nil {
 		return err0
 	}
@@ -1862,9 +1965,15 @@ Update_History_Loop:
 	return ErrMaxAttemptsExceeded
 }
 
-func (e *historyEngineImpl) updateWorkflowExecution(ctx ctx.Context, domainID string, execution workflow.WorkflowExecution,
-	createDeletionTask, createDecisionTask bool,
-	action func(builder mutableState, tBuilder *timerBuilder) ([]persistence.Task, error)) error {
+func (e *historyEngineImpl) updateWorkflowExecution(
+	ctx ctx.Context,
+	domainID string,
+	execution workflow.WorkflowExecution,
+	createDeletionTask bool,
+	createDecisionTask bool,
+	action func(builder mutableState, tBuilder *timerBuilder) ([]persistence.Task, error),
+) error {
+
 	return e.updateWorkflowExecutionWithAction(ctx, domainID, execution,
 		func(builder mutableState, tBuilder *timerBuilder) (*updateWorkflowAction, error) {
 			timerTasks, err := action(builder, tBuilder)
@@ -1906,7 +2015,11 @@ func getWorkflowHistoryCleanupTasksFromShard(
 	return &persistence.CloseExecutionTask{}, deleteTask, nil
 }
 
-func createDeleteHistoryEventTimerTask(tBuilder *timerBuilder, retentionInDays int32) *persistence.DeleteHistoryEventTask {
+func createDeleteHistoryEventTimerTask(
+	tBuilder *timerBuilder,
+	retentionInDays int32,
+) *persistence.DeleteHistoryEventTask {
+
 	retention := time.Duration(retentionInDays) * time.Hour * 24
 	if tBuilder != nil {
 		return tBuilder.createDeleteHistoryEventTimerTask(retention)
@@ -1917,7 +2030,13 @@ func createDeleteHistoryEventTimerTask(tBuilder *timerBuilder, retentionInDays i
 	}
 }
 
-func (e *historyEngineImpl) deleteEvents(domainID string, execution workflow.WorkflowExecution, eventStoreVersion int32, branchToken []byte) {
+func (e *historyEngineImpl) deleteEvents(
+	domainID string,
+	execution workflow.WorkflowExecution,
+	eventStoreVersion int32,
+	branchToken []byte,
+) {
+
 	// We created the history events but failed to create workflow execution, so cleanup the history which could cause
 	// us to leak history events which are never cleaned up. Cleaning up the events is absolutely safe here as they
 	// are always created for a unique run_id which is not visible beyond this call yet.
@@ -1935,8 +2054,15 @@ func (e *historyEngineImpl) deleteEvents(domainID string, execution workflow.Wor
 	}
 }
 
-func (e *historyEngineImpl) failDecision(context workflowExecutionContext, scheduleID, startedID int64,
-	cause workflow.DecisionTaskFailedCause, details []byte, request *workflow.RespondDecisionTaskCompletedRequest) (mutableState, error) {
+func (e *historyEngineImpl) failDecision(
+	context workflowExecutionContext,
+	scheduleID int64,
+	startedID int64,
+	cause workflow.DecisionTaskFailedCause,
+	details []byte,
+	request *workflow.RespondDecisionTaskCompletedRequest,
+) (mutableState, error) {
+
 	// Clear any updates we have accumulated so far
 	context.clear()
 
@@ -1956,12 +2082,18 @@ func (e *historyEngineImpl) failDecision(context workflowExecutionContext, sched
 	return msBuilder, nil
 }
 
-func (e *historyEngineImpl) getTimerBuilder(we *workflow.WorkflowExecution) *timerBuilder {
+func (e *historyEngineImpl) getTimerBuilder(
+	we *workflow.WorkflowExecution,
+) *timerBuilder {
+
 	log := e.logger.WithTags(tag.WorkflowID(we.GetWorkflowId()), tag.WorkflowRunID(we.GetRunId()))
 	return newTimerBuilder(e.shard.GetConfig(), log, clock.NewRealTimeSource())
 }
 
-func (s *shardContextWrapper) UpdateWorkflowExecution(request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error) {
+func (s *shardContextWrapper) UpdateWorkflowExecution(
+	request *persistence.UpdateWorkflowExecutionRequest,
+) (*persistence.UpdateWorkflowExecutionResponse, error) {
+
 	resp, err := s.ShardContext.UpdateWorkflowExecution(request)
 	if err == nil {
 		s.txProcessor.NotifyNewTask(s.currentClusterName, request.TransferTasks)
@@ -1972,8 +2104,10 @@ func (s *shardContextWrapper) UpdateWorkflowExecution(request *persistence.Updat
 	return resp, err
 }
 
-func (s *shardContextWrapper) CreateWorkflowExecution(request *persistence.CreateWorkflowExecutionRequest) (
-	*persistence.CreateWorkflowExecutionResponse, error) {
+func (s *shardContextWrapper) CreateWorkflowExecution(
+	request *persistence.CreateWorkflowExecutionRequest,
+) (*persistence.CreateWorkflowExecutionResponse, error) {
+
 	resp, err := s.ShardContext.CreateWorkflowExecution(request)
 	if err == nil {
 		s.txProcessor.NotifyNewTask(s.currentClusterName, request.TransferTasks)
@@ -1984,13 +2118,20 @@ func (s *shardContextWrapper) CreateWorkflowExecution(request *persistence.Creat
 	return resp, err
 }
 
-func (s *shardContextWrapper) NotifyNewHistoryEvent(event *historyEventNotification) error {
+func (s *shardContextWrapper) NotifyNewHistoryEvent(
+	event *historyEventNotification,
+) error {
+
 	s.historyEventNotifier.NotifyNewHistoryEvent(event)
 	err := s.ShardContext.NotifyNewHistoryEvent(event)
 	return err
 }
 
-func validateStartWorkflowExecutionRequest(request *workflow.StartWorkflowExecutionRequest, maxIDLengthLimit int) error {
+func validateStartWorkflowExecutionRequest(
+	request *workflow.StartWorkflowExecutionRequest,
+	maxIDLengthLimit int,
+) error {
+
 	if len(request.GetRequestId()) == 0 {
 		return &workflow.BadRequestError{Message: "Missing request ID."}
 	}
@@ -2022,7 +2163,10 @@ func validateStartWorkflowExecutionRequest(request *workflow.StartWorkflowExecut
 	return common.ValidateRetryPolicy(request.RetryPolicy)
 }
 
-func validateDomainUUID(domainUUID *string) (string, error) {
+func validateDomainUUID(
+	domainUUID *string,
+) (string, error) {
+
 	if domainUUID == nil {
 		return "", &workflow.BadRequestError{Message: "Missing domain UUID."}
 	} else if uuid.Parse(*domainUUID) == nil {
@@ -2031,11 +2175,18 @@ func validateDomainUUID(domainUUID *string) (string, error) {
 	return *domainUUID, nil
 }
 
-func (e *historyEngineImpl) getActiveDomainEntry(domainUUID *string) (*cache.DomainCacheEntry, error) {
+func (e *historyEngineImpl) getActiveDomainEntry(
+	domainUUID *string,
+) (*cache.DomainCacheEntry, error) {
+
 	return getActiveDomainEntryFromShard(e.shard, domainUUID)
 }
 
-func getActiveDomainEntryFromShard(shard ShardContext, domainUUID *string) (*cache.DomainCacheEntry, error) {
+func getActiveDomainEntryFromShard(
+	shard ShardContext,
+	domainUUID *string,
+) (*cache.DomainCacheEntry, error) {
+
 	domainID, err := validateDomainUUID(domainUUID)
 	if err != nil {
 		return nil, err
@@ -2051,7 +2202,11 @@ func getActiveDomainEntryFromShard(shard ShardContext, domainUUID *string) (*cac
 	return domainEntry, nil
 }
 
-func getScheduleID(activityID string, msBuilder mutableState) (int64, error) {
+func getScheduleID(
+	activityID string,
+	msBuilder mutableState,
+) (int64, error) {
+
 	if activityID == "" {
 		return 0, &workflow.BadRequestError{Message: "Neither ActivityID nor ScheduleID is provided"}
 	}
@@ -2062,8 +2217,11 @@ func getScheduleID(activityID string, msBuilder mutableState) (int64, error) {
 	return scheduleID, nil
 }
 
-func getStartRequest(domainID string,
-	request *workflow.SignalWithStartWorkflowExecutionRequest) *h.StartWorkflowExecutionRequest {
+func getStartRequest(
+	domainID string,
+	request *workflow.SignalWithStartWorkflowExecutionRequest,
+) *h.StartWorkflowExecutionRequest {
+
 	req := &workflow.StartWorkflowExecutionRequest{
 		Domain:                              request.Domain,
 		WorkflowId:                          request.WorkflowId,
@@ -2086,7 +2244,12 @@ func getStartRequest(domainID string,
 	return startRequest
 }
 
-func setTaskInfo(version int64, timestamp time.Time, transferTasks []persistence.Task, timerTasks []persistence.Task) {
+func setTaskInfo(
+	version int64,
+	timestamp time.Time,
+	transferTasks []persistence.Task,
+	timerTasks []persistence.Task,
+) {
 	// set both the task version, as well as the timestamp on the transfer tasks
 	for _, task := range transferTasks {
 		task.SetVersion(version)
@@ -2098,8 +2261,12 @@ func setTaskInfo(version int64, timestamp time.Time, transferTasks []persistence
 }
 
 // for startWorkflowExecution & signalWithStart to handle workflow reuse policy
-func (e *historyEngineImpl) applyWorkflowIDReusePolicyForSigWithStart(prevExecutionInfo *persistence.WorkflowExecutionInfo,
-	domainID string, execution workflow.WorkflowExecution, wfIDReusePolicy workflow.WorkflowIdReusePolicy) error {
+func (e *historyEngineImpl) applyWorkflowIDReusePolicyForSigWithStart(
+	prevExecutionInfo *persistence.WorkflowExecutionInfo,
+	domainID string,
+	execution workflow.WorkflowExecution,
+	wfIDReusePolicy workflow.WorkflowIdReusePolicy,
+) error {
 
 	prevStartRequestID := prevExecutionInfo.CreateRequestID
 	prevRunID := prevExecutionInfo.RunID
@@ -2110,8 +2277,15 @@ func (e *historyEngineImpl) applyWorkflowIDReusePolicyForSigWithStart(prevExecut
 
 }
 
-func (e *historyEngineImpl) applyWorkflowIDReusePolicyHelper(prevStartRequestID, prevRunID string, prevState, prevCloseState int,
-	domainID string, execution workflow.WorkflowExecution, wfIDReusePolicy workflow.WorkflowIdReusePolicy) error {
+func (e *historyEngineImpl) applyWorkflowIDReusePolicyHelper(
+	prevStartRequestID,
+	prevRunID string,
+	prevState int,
+	prevCloseState int,
+	domainID string,
+	execution workflow.WorkflowExecution,
+	wfIDReusePolicy workflow.WorkflowIdReusePolicy,
+) error {
 
 	// here we know there is some information about the prev workflow, i.e. either running right now
 	// or has history check if the this workflow is finished

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -1744,7 +1744,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_WorkflowAlread
 }
 
 func (s *engine2Suite) getBuilder(domainID string, we workflow.WorkflowExecution) mutableState {
-	context, release, err := s.historyEngine.historyCache.getOrCreateWorkflowExecution(domainID, we)
+	context, release, err := s.historyEngine.historyCache.getOrCreateWorkflowExecutionForBackground(domainID, we)
 	if err != nil {
 		return nil
 	}

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -4807,7 +4807,7 @@ func (s *engineSuite) TestRemoveSignalMutableState() {
 }
 
 func (s *engineSuite) getBuilder(domainID string, we workflow.WorkflowExecution) mutableState {
-	context, release, err := s.mockHistoryEngine.historyCache.getOrCreateWorkflowExecution(domainID, we)
+	context, release, err := s.mockHistoryEngine.historyCache.getOrCreateWorkflowExecutionForBackground(domainID, we)
 	if err != nil {
 		return nil
 	}

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -153,7 +153,7 @@ func (r *historyReplicator) SyncActivity(ctx ctx.Context, request *h.SyncActivit
 		RunId:      request.RunId,
 	}
 
-	context, release, err := r.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+	context, release, err := r.historyCache.getOrCreateWorkflowExecution(ctx, domainID, execution)
 	if err != nil {
 		// for get workflow execution context, with valid run id
 		// err will not be of type EntityNotExistsError
@@ -344,7 +344,7 @@ func (r *historyReplicator) ApplyEvents(ctx ctx.Context, request *h.ReplicateEve
 	}
 
 	execution := *request.WorkflowExecution
-	context, release, err := r.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, execution)
+	context, release, err := r.historyCache.getOrCreateWorkflowExecution(ctx, domainID, execution)
 	if err != nil {
 		// for get workflow execution context, with valid run id
 		// err will not be of type EntityNotExistsError
@@ -885,7 +885,7 @@ func (r *historyReplicator) conflictResolutionTerminateCurrentRunningIfNotSelf(
 func (r *historyReplicator) getCurrentWorkflowMutableState(ctx ctx.Context, domainID string,
 	workflowID string) (workflowExecutionContext, mutableState, releaseWorkflowExecutionFunc, error) {
 	// we need to check the current workflow execution
-	context, release, err := r.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx,
+	context, release, err := r.historyCache.getOrCreateWorkflowExecution(ctx,
 		domainID,
 		// only use the workflow ID, to get the current running one
 		shared.WorkflowExecution{WorkflowId: common.StringPtr(workflowID)},

--- a/service/history/historyReplicatorV2.go
+++ b/service/history/historyReplicatorV2.go
@@ -110,7 +110,7 @@ func (r *historyReplicatorV2) ApplyEvents(ctx ctx.Context, request *h.ReplicateE
 		return err
 	}
 
-	context, release, err := r.historyCache.getOrCreateWorkflowExecutionWithTimeout(
+	context, release, err := r.historyCache.getOrCreateWorkflowExecution(
 		ctx,
 		task.domainID,
 		task.execution,
@@ -446,7 +446,7 @@ func (r *historyReplicatorV2) getCurrentWorkflowMutableState(ctx ctx.Context, do
 	// TODO refactor for case if context is already current workflow
 
 	// we need to check the current workflow execution
-	context, release, err := r.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx,
+	context, release, err := r.historyCache.getOrCreateWorkflowExecution(ctx,
 		domainID,
 		// only use the workflow ID, to get the current running one
 		shared.WorkflowExecution{WorkflowId: common.StringPtr(workflowID)},

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -183,7 +183,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_WorkflowClosed() {
 	workflowID := "some random workflow ID"
 	runID := uuid.New()
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -218,7 +218,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_IncomingScheduleIDLarger_Incom
 	lastWriteVersion := version + 100
 	nextEventID := scheduleID - 10
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -278,7 +278,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_IncomingScheduleIDLarger_Incom
 	lastWriteVersion := version - 100
 	nextEventID := scheduleID - 10
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -338,7 +338,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_ActivityCompleted() {
 	lastWriteVersion := version
 	nextEventID := scheduleID + 10
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -398,7 +398,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_ActivityRunning_LocalActivityV
 	lastWriteVersion := version + 10
 	nextEventID := scheduleID + 10
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -465,7 +465,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_ActivityRunning_Update_SameVer
 
 	nextEventID := scheduleID + 10
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -545,7 +545,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_ActivityRunning_Update_SameVer
 
 	nextEventID := scheduleID + 10
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -625,7 +625,7 @@ func (s *historyReplicatorSuite) TestSyncActivity_ActivityRunning_Update_LargerV
 
 	nextEventID := scheduleID + 10
 
-	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecution(
+	context, release, err := s.historyReplicator.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -152,7 +152,7 @@ func (p *replicatorQueueProcessorImpl) processSyncActivityTask(task *persistence
 		WorkflowId: common.StringPtr(task.WorkflowID),
 		RunId:      common.StringPtr(task.RunID),
 	}
-	context, release, err := p.historyCache.getOrCreateWorkflowExecution(domainID, execution)
+	context, release, err := p.historyCache.getOrCreateWorkflowExecutionForBackground(domainID, execution)
 	if err != nil {
 		return err
 	}

--- a/service/history/replicatorQueueProcessor_test.go
+++ b/service/history/replicatorQueueProcessor_test.go
@@ -164,7 +164,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowCompleted() {
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
 
-	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecution(
+	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -205,7 +205,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityCompleted() {
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
 
-	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecution(
+	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -265,7 +265,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRetry() {
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
 
-	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecution(
+	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),
@@ -359,7 +359,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRunning() {
 	}
 	s.mockExecutionMgr.On("CompleteReplicationTask", &persistence.CompleteReplicationTaskRequest{TaskID: taskID}).Return(nil).Once()
 
-	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecution(
+	context, release, _ := s.replicatorQueueProcessor.historyCache.getOrCreateWorkflowExecutionForBackground(
 		domainID,
 		shared.WorkflowExecution{
 			WorkflowId: common.StringPtr(workflowID),

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -254,7 +254,7 @@ func (t *timerQueueActiveProcessorImpl) process(timerTask *persistence.TimerTask
 }
 
 func (t *timerQueueActiveProcessorImpl) processExpiredUserTimer(task *persistence.TimerTaskInfo) (retError error) {
-	context, release, err0 := t.cache.getOrCreateWorkflowExecution(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
+	context, release, err0 := t.cache.getOrCreateWorkflowExecutionForBackground(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
 	if err0 != nil {
 		return err0
 	}
@@ -319,7 +319,7 @@ Update_History_Loop:
 
 func (t *timerQueueActiveProcessorImpl) processActivityTimeout(timerTask *persistence.TimerTaskInfo) (retError error) {
 
-	context, release, err0 := t.cache.getOrCreateWorkflowExecution(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(timerTask))
+	context, release, err0 := t.cache.getOrCreateWorkflowExecutionForBackground(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(timerTask))
 	if err0 != nil {
 		return err0
 	}
@@ -480,7 +480,7 @@ Update_History_Loop:
 
 func (t *timerQueueActiveProcessorImpl) processDecisionTimeout(task *persistence.TimerTaskInfo) (retError error) {
 
-	context, release, err0 := t.cache.getOrCreateWorkflowExecution(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
+	context, release, err0 := t.cache.getOrCreateWorkflowExecutionForBackground(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
 	if err0 != nil {
 		return err0
 	}
@@ -552,7 +552,7 @@ Update_History_Loop:
 
 func (t *timerQueueActiveProcessorImpl) processWorkflowBackoffTimer(task *persistence.TimerTaskInfo) (retError error) {
 
-	context, release, err0 := t.cache.getOrCreateWorkflowExecution(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
+	context, release, err0 := t.cache.getOrCreateWorkflowExecutionForBackground(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
 	if err0 != nil {
 		return err0
 	}
@@ -594,7 +594,7 @@ Update_History_Loop:
 func (t *timerQueueActiveProcessorImpl) processActivityRetryTimer(task *persistence.TimerTaskInfo) error {
 
 	processFn := func() error {
-		context, release, err0 := t.cache.getOrCreateWorkflowExecution(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
+		context, release, err0 := t.cache.getOrCreateWorkflowExecutionForBackground(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task))
 		defer release(nil)
 		if err0 != nil {
 			return err0
@@ -680,7 +680,7 @@ func (t *timerQueueActiveProcessorImpl) processActivityRetryTimer(task *persiste
 func (t *timerQueueActiveProcessorImpl) processWorkflowTimeout(task *persistence.TimerTaskInfo) (retError error) {
 
 	domainID, workflowExecution := t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(task)
-	context, release, err0 := t.cache.getOrCreateWorkflowExecution(domainID, workflowExecution)
+	context, release, err0 := t.cache.getOrCreateWorkflowExecutionForBackground(domainID, workflowExecution)
 	if err0 != nil {
 		return err0
 	}

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -563,7 +563,7 @@ func (t *timerQueueProcessorBase) getDomainIDAndWorkflowExecution(task *persiste
 
 func (t *timerQueueProcessorBase) processDeleteHistoryEvent(task *persistence.TimerTaskInfo) (retError error) {
 
-	context, release, err := t.cache.getOrCreateWorkflowExecution(t.getDomainIDAndWorkflowExecution(task))
+	context, release, err := t.cache.getOrCreateWorkflowExecutionForBackground(t.getDomainIDAndWorkflowExecution(task))
 	if err != nil {
 		return err
 	}

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -463,7 +463,7 @@ func (t *timerQueueStandbyProcessorImpl) getTimerBuilder() *timerBuilder {
 
 func (t *timerQueueStandbyProcessorImpl) processTimer(timerTask *persistence.TimerTaskInfo,
 	action func(workflowExecutionContext, mutableState) error, postAction func() error) (retError error) {
-	context, release, err := t.cache.getOrCreateWorkflowExecution(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(timerTask))
+	context, release, err := t.cache.getOrCreateWorkflowExecutionForBackground(t.timerQueueProcessorBase.getDomainIDAndWorkflowExecution(timerTask))
 	if err != nil {
 		return err
 	}

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -265,7 +265,7 @@ func (t *transferQueueActiveProcessorImpl) processActivityTask(task *persistence
 		WorkflowId: common.StringPtr(task.WorkflowID),
 		RunId:      common.StringPtr(task.RunID)}
 
-	context, release, err := t.cache.getOrCreateWorkflowExecution(task.DomainID, execution)
+	context, release, err := t.cache.getOrCreateWorkflowExecutionForBackground(task.DomainID, execution)
 	if err != nil {
 		return err
 	}
@@ -309,7 +309,7 @@ func (t *transferQueueActiveProcessorImpl) processDecisionTask(task *persistence
 	}
 
 	// get workflow timeout
-	context, release, err := t.cache.getOrCreateWorkflowExecution(task.DomainID, execution)
+	context, release, err := t.cache.getOrCreateWorkflowExecutionForBackground(task.DomainID, execution)
 	if err != nil {
 		return err
 	}
@@ -366,7 +366,7 @@ func (t *transferQueueActiveProcessorImpl) processCloseExecution(task *persisten
 		RunId:      common.StringPtr(task.RunID),
 	}
 
-	context, release, err := t.cache.getOrCreateWorkflowExecution(domainID, execution)
+	context, release, err := t.cache.getOrCreateWorkflowExecutionForBackground(domainID, execution)
 	if err != nil {
 		return err
 	}
@@ -464,7 +464,7 @@ func (t *transferQueueActiveProcessorImpl) processCancelExecution(task *persiste
 
 	var context workflowExecutionContext
 	var release releaseWorkflowExecutionFunc
-	context, release, err = t.cache.getOrCreateWorkflowExecution(domainID, execution)
+	context, release, err = t.cache.getOrCreateWorkflowExecutionForBackground(domainID, execution)
 	if err != nil {
 		return err
 	}
@@ -582,7 +582,7 @@ func (t *transferQueueActiveProcessorImpl) processSignalExecution(task *persiste
 
 	var context workflowExecutionContext
 	var release releaseWorkflowExecutionFunc
-	context, release, err = t.cache.getOrCreateWorkflowExecution(domainID, execution)
+	context, release, err = t.cache.getOrCreateWorkflowExecutionForBackground(domainID, execution)
 	if err != nil {
 		return err
 	}
@@ -711,7 +711,7 @@ func (t *transferQueueActiveProcessorImpl) processStartChildExecution(task *pers
 
 	var context workflowExecutionContext
 	var release releaseWorkflowExecutionFunc
-	context, release, err = t.cache.getOrCreateWorkflowExecution(domainID, execution)
+	context, release, err = t.cache.getOrCreateWorkflowExecutionForBackground(domainID, execution)
 	if err != nil {
 		return err
 	}
@@ -846,7 +846,7 @@ func (t *transferQueueActiveProcessorImpl) processRecordWorkflowStarted(task *pe
 	}
 
 	// get workflow timeout
-	context, release, err := t.cache.getOrCreateWorkflowExecution(task.DomainID, execution)
+	context, release, err := t.cache.getOrCreateWorkflowExecutionForBackground(task.DomainID, execution)
 	if err != nil {
 		return err
 	}
@@ -899,7 +899,7 @@ func (t *transferQueueActiveProcessorImpl) processResetWorkflow(task *persistenc
 		tag.WorkflowRunID(execution.GetRunId()),
 	)
 	// get workflow timeout
-	currContext, currRelease, err := t.cache.getOrCreateWorkflowExecution(task.DomainID, execution)
+	currContext, currRelease, err := t.cache.getOrCreateWorkflowExecutionForBackground(task.DomainID, execution)
 	if err != nil {
 		return err
 	}
@@ -968,7 +968,7 @@ func (t *transferQueueActiveProcessorImpl) processResetWorkflow(task *persistenc
 			RunId:      common.StringPtr(resetPt.GetRunId()),
 		}
 		var baseRelease func(err error)
-		baseContext, baseRelease, err = t.cache.getOrCreateWorkflowExecution(task.DomainID, baseExecution)
+		baseContext, baseRelease, err = t.cache.getOrCreateWorkflowExecutionForBackground(task.DomainID, baseExecution)
 		if err != nil {
 			return err
 		}

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -459,7 +459,7 @@ func (t *transferQueueStandbyProcessorImpl) processRecordWorkflowStarted(transfe
 
 func (t *transferQueueStandbyProcessorImpl) processTransfer(processTaskIfClosed bool, transferTask *persistence.TransferTaskInfo,
 	action func(mutableState) error, postAction func() error) (retError error) {
-	context, release, err := t.cache.getOrCreateWorkflowExecution(t.getDomainIDAndWorkflowExecution(transferTask))
+	context, release, err := t.cache.getOrCreateWorkflowExecutionForBackground(t.getDomainIDAndWorkflowExecution(transferTask))
 	if err != nil {
 		return err
 	}

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -448,7 +448,7 @@ func (w *workflowResetorImpl) replayReceivedSignals(
 				WorkflowId: common.StringPtr(newMutableState.GetExecutionInfo().WorkflowID),
 				RunId:      common.StringPtr(continueRunID),
 			}
-			continueContext, continueRelease, err := w.eng.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, newMutableState.GetExecutionInfo().DomainID, continueExe)
+			continueContext, continueRelease, err := w.eng.historyCache.getOrCreateWorkflowExecution(ctx, newMutableState.GetExecutionInfo().DomainID, continueExe)
 			if err != nil {
 				return err
 			}
@@ -715,7 +715,7 @@ func (w *workflowResetorImpl) ApplyResetEvent(
 		RunId:      common.StringPtr(resetAttr.GetBaseRunId()),
 	}
 
-	baseContext, baseRelease, baseErr := w.eng.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, baseExecution)
+	baseContext, baseRelease, baseErr := w.eng.historyCache.getOrCreateWorkflowExecution(ctx, domainID, baseExecution)
 	if baseErr != nil {
 		return baseErr
 	}
@@ -739,7 +739,7 @@ func (w *workflowResetorImpl) ApplyResetEvent(
 			RunId:      common.StringPtr(currentRunID),
 		}
 		var currErr error
-		currContext, currRelease, currErr = w.eng.historyCache.getOrCreateWorkflowExecutionWithTimeout(ctx, domainID, currExecution)
+		currContext, currRelease, currErr = w.eng.historyCache.getOrCreateWorkflowExecution(ctx, domainID, currExecution)
 		if currErr != nil {
 			return currErr
 		}


### PR DESCRIPTION
* Add getOrCreatCurrentWorkflowExecution for current workflow execution lock
* Start workflow execution / signal with start workflow execution, before creating the workflow, will lock on current workflow execution, i.e. run ID being ""
* Rename getOrCreateWorkflowExecutionWithTimeout -> getOrCreateWorkflowExecution
* Rename getOrCreateWorkflowExecution -> getOrCreateWorkflowExecutionForBackground
* Reformat workflow execution context