### PR TITLE
Fix between and on customized fields

### DIFF
--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -489,7 +489,9 @@ func (v *esVisibilityStore) getESQueryDSL(request *p.ListWorkflowExecutionsReque
 		dsl.Set(dslFieldFrom, fastjson.MustParse(strconv.Itoa(token.From)))
 	}
 
-	return dsl.String(), sortField, nil
+	dslStr := cleanDSL(dsl.String())
+
+	return dslStr, sortField, nil
 }
 
 func getSQLFromListRequest(request *p.ListWorkflowExecutionsRequestV2) string {
@@ -986,4 +988,12 @@ func timeProcessFunc(obj *fastjson.Object, key string, value *fastjson.Value) er
 		obj.Set(key, fastjson.MustParse(fmt.Sprintf(`"%v"`, parsedTime.UnixNano())))
 		return nil
 	})
+}
+
+// elasticsql may transfer `Attr.Name` to "`Attr.Name`" instead of "Attr.Name" in dsl in some operator like "between and"
+// this function is used to clean up
+func cleanDSL(input string) string {
+	var re = regexp.MustCompile("(`)(Attr.\\w+)(`)")
+	result := re.ReplaceAllString(input, `$2`)
+	return result
 }


### PR DESCRIPTION
This PR fix bug on in elasticsql `between and`.

Usually we expect
sql:  select * from dummy where **\`Attr.CustomIntField\`** = 1 limit 10
queryDSL:  {"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"2b8344db-0ed6-47a4-92fd-bdeb6ead93e3"}}},{"bool":{"must":[{"match_phrase":{"**Attr.CustomIntField**":{"query":"1"}}}]}}]}},"from":0,"size":10,"sort":[{"StartTime":"desc"},{"RunID":"desc"}]}
Note Attr.CustomIntField back stick is removed in dsl

While in `between and`
sql:  select * from dummy where **\`Attr.CustomIntField\`** between 1 and 5 limit 10
queryDSL:  {"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"2b8344db-0ed6-47a4-92fd-bdeb6ead93e3"}}},{"bool":{"must":[{"range":{"**\`Attr.CustomIntField\`**":{"from":"1","to":"5"}}}]}}]}},"from":0,"size":10,"sort":[{"StartTime":"desc"},{"RunID":"desc"}]}
DSL contains back sticks leads to column not known by ES

