### PR TITLE
schema-tool: do not error when schema is already up-to-date

### DIFF
--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -44,6 +44,10 @@ func (s *UpdateTaskTestSuite) SetupSuite() {
 
 func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
 
+	emptyDir, err := ioutil.TempDir("", "update_schema_test_empty")
+	s.Nil(err)
+	defer os.RemoveAll(emptyDir)
+
 	tmpDir, err := ioutil.TempDir("", "update_schema_test")
 	s.Nil(err)
 	defer os.RemoveAll(tmpDir)
@@ -57,6 +61,16 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
 	s.NotNil(err)
 	_, err = readSchemaDir(tmpDir, "0.5", "10.3")
 	s.NotNil(err)
+	_, err = readSchemaDir(tmpDir, "1.5", "1.5")
+	s.NotNil(err)
+	_, err = readSchemaDir(tmpDir, "1.5", "0.5")
+	s.NotNil(err)
+	_, err = readSchemaDir(tmpDir, "10.3", "")
+	s.NotNil(err)
+	_, err = readSchemaDir(emptyDir, "11.0", "")
+	s.NotNil(err)
+	_, err = readSchemaDir(emptyDir, "10.1", "")
+	s.NotNil(err)
 
 	ans, err := readSchemaDir(tmpDir, "0.4", "10.2")
 	s.Nil(err)
@@ -65,6 +79,10 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
 	ans, err = readSchemaDir(tmpDir, "0.5", "3.5")
 	s.Nil(err)
 	s.Equal([]string{"v1.5", "v2.5", "v3.5"}, ans)
+
+	ans, err = readSchemaDir(tmpDir, "10.2", "")
+	s.Nil(err)
+	s.Equal(0, len(ans))
 }
 
 func (s *UpdateTaskTestSuite) TestReadManifest() {

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -45,11 +45,11 @@ func (s *UpdateTaskTestSuite) SetupSuite() {
 func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
 
 	emptyDir, err := ioutil.TempDir("", "update_schema_test_empty")
-	s.Nil(err)
+	s.NoError(err)
 	defer os.RemoveAll(emptyDir)
 
 	tmpDir, err := ioutil.TempDir("", "update_schema_test")
-	s.Nil(err)
+	s.NoError(err)
 	defer os.RemoveAll(tmpDir)
 
 	subDirs := []string{"v0.5", "v1.5", "v2.5", "v3.5", "v10.2", "abc", "2.0", "3.0"}
@@ -58,30 +58,30 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDir() {
 	}
 
 	_, err = readSchemaDir(tmpDir, "11.0", "11.2")
-	s.NotNil(err)
+	s.Error(err)
 	_, err = readSchemaDir(tmpDir, "0.5", "10.3")
-	s.NotNil(err)
+	s.Error(err)
 	_, err = readSchemaDir(tmpDir, "1.5", "1.5")
-	s.NotNil(err)
+	s.Error(err)
 	_, err = readSchemaDir(tmpDir, "1.5", "0.5")
-	s.NotNil(err)
+	s.Error(err)
 	_, err = readSchemaDir(tmpDir, "10.3", "")
-	s.NotNil(err)
+	s.Error(err)
 	_, err = readSchemaDir(emptyDir, "11.0", "")
-	s.NotNil(err)
+	s.Error(err)
 	_, err = readSchemaDir(emptyDir, "10.1", "")
-	s.NotNil(err)
+	s.Error(err)
 
 	ans, err := readSchemaDir(tmpDir, "0.4", "10.2")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal([]string{"v0.5", "v1.5", "v2.5", "v3.5", "v10.2"}, ans)
 
 	ans, err = readSchemaDir(tmpDir, "0.5", "3.5")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal([]string{"v1.5", "v2.5", "v3.5"}, ans)
 
 	ans, err = readSchemaDir(tmpDir, "10.2", "")
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(0, len(ans))
 }
 
@@ -150,10 +150,10 @@ func (s *UpdateTaskTestSuite) runReadManifestTest(dir, input, currVer, minVer, d
 
 	m, err := readManifest(dir)
 	if isErr {
-		s.NotNil(err)
+		s.Error(err)
 		return
 	}
-	s.Nil(err)
+	s.NoError(err)
 	s.Equal(currVer, m.CurrVersion)
 	s.Equal(minVer, m.MinCompatibleVersion)
 	s.Equal(desc, m.Description)


### PR DESCRIPTION
Fixes https://github.com/uber/cadence/issues/2087