### PR TITLE
matching: refactor taskListManager to separate out individual components

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -322,6 +322,14 @@ func MinInt64(a, b int64) int64 {
 	return b
 }
 
+// MaxInt64 returns the greater of two given int64
+func MaxInt64(a, b int64) int64 {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 // MinInt32 return smaller one of two inputs int32
 func MinInt32(a, b int32) int32 {
 	if a < b {

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"time"
+
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/service/dynamicconfig"
+)
+
+type (
+	// Config represents configuration for cadence-matching service
+	Config struct {
+		PersistenceMaxQPS dynamicconfig.IntPropertyFn
+		EnableSyncMatch   dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
+		RPS               dynamicconfig.IntPropertyFn
+
+		// taskListManager configuration
+		RangeSize                 int64
+		GetTasksBatchSize         dynamicconfig.IntPropertyFnWithTaskListInfoFilters
+		UpdateAckInterval         dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
+		IdleTasklistCheckInterval dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
+		MaxTasklistIdleTime       dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
+		// Time to hold a poll request before returning an empty response if there are no tasks
+		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
+		MinTaskThrottlingBurstSize dynamicconfig.IntPropertyFnWithTaskListInfoFilters
+		MaxTaskDeleteBatchSize     dynamicconfig.IntPropertyFnWithTaskListInfoFilters
+
+		// taskWriter configuration
+		OutstandingTaskAppendsThreshold dynamicconfig.IntPropertyFnWithTaskListInfoFilters
+		MaxTaskBatchSize                dynamicconfig.IntPropertyFnWithTaskListInfoFilters
+
+		ThrottledLogRPS dynamicconfig.IntPropertyFn
+	}
+
+	taskListConfig struct {
+		EnableSyncMatch func() bool
+		// Time to hold a poll request before returning an empty response if there are no tasks
+		LongPollExpirationInterval func() time.Duration
+		RangeSize                  int64
+		GetTasksBatchSize          func() int
+		UpdateAckInterval          func() time.Duration
+		IdleTasklistCheckInterval  func() time.Duration
+		MaxTasklistIdleTime        func() time.Duration
+		MinTaskThrottlingBurstSize func() int
+		MaxTaskDeleteBatchSize     func() int
+		// taskWriter configuration
+		OutstandingTaskAppendsThreshold func() int
+		MaxTaskBatchSize                func() int
+	}
+)
+
+// NewConfig returns new service config with default values
+func NewConfig(dc *dynamicconfig.Collection) *Config {
+	return &Config{
+		PersistenceMaxQPS:               dc.GetIntProperty(dynamicconfig.MatchingPersistenceMaxQPS, 3000),
+		EnableSyncMatch:                 dc.GetBoolPropertyFilteredByTaskListInfo(dynamicconfig.MatchingEnableSyncMatch, true),
+		RPS:                             dc.GetIntProperty(dynamicconfig.MatchingRPS, 1200),
+		RangeSize:                       100000,
+		GetTasksBatchSize:               dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingGetTasksBatchSize, 1000),
+		UpdateAckInterval:               dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingUpdateAckInterval, 1*time.Minute),
+		IdleTasklistCheckInterval:       dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingIdleTasklistCheckInterval, 5*time.Minute),
+		MaxTasklistIdleTime:             dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MaxTasklistIdleTime, 5*time.Minute),
+		LongPollExpirationInterval:      dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingLongPollExpirationInterval, time.Minute),
+		MinTaskThrottlingBurstSize:      dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingMinTaskThrottlingBurstSize, 1),
+		MaxTaskDeleteBatchSize:          dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingMaxTaskDeleteBatchSize, 100),
+		OutstandingTaskAppendsThreshold: dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingOutstandingTaskAppendsThreshold, 250),
+		MaxTaskBatchSize:                dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingMaxTaskBatchSize, 100),
+		ThrottledLogRPS:                 dc.GetIntProperty(dynamicconfig.MatchingThrottledLogRPS, 20),
+	}
+}
+
+func newTaskListConfig(id *taskListID, config *Config, domainCache cache.DomainCache) (*taskListConfig, error) {
+	domainEntry, err := domainCache.GetDomainByID(id.domainID)
+	if err != nil {
+		return nil, err
+	}
+
+	domain := domainEntry.GetInfo().Name
+	taskListName := id.taskListName
+	taskType := id.taskType
+	return &taskListConfig{
+		RangeSize: config.RangeSize,
+		GetTasksBatchSize: func() int {
+			return config.GetTasksBatchSize(domain, taskListName, taskType)
+		},
+		UpdateAckInterval: func() time.Duration {
+			return config.UpdateAckInterval(domain, taskListName, taskType)
+		},
+		IdleTasklistCheckInterval: func() time.Duration {
+			return config.IdleTasklistCheckInterval(domain, taskListName, taskType)
+		},
+		MaxTasklistIdleTime: func() time.Duration {
+			return config.MaxTasklistIdleTime(domain, taskListName, taskType)
+		},
+		MinTaskThrottlingBurstSize: func() int {
+			return config.MinTaskThrottlingBurstSize(domain, taskListName, taskType)
+		},
+		EnableSyncMatch: func() bool {
+			return config.EnableSyncMatch(domain, taskListName, taskType)
+		},
+		LongPollExpirationInterval: func() time.Duration {
+			return config.LongPollExpirationInterval(domain, taskListName, taskType)
+		},
+		MaxTaskDeleteBatchSize: func() int {
+			return config.MaxTaskDeleteBatchSize(domain, taskListName, taskType)
+		},
+		OutstandingTaskAppendsThreshold: func() int {
+			return config.OutstandingTaskAppendsThreshold(domain, taskListName, taskType)
+		},
+		MaxTaskBatchSize: func() int {
+			return config.MaxTaskBatchSize(domain, taskListName, taskType)
+		},
+	}, nil
+}

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -129,7 +129,7 @@ func (h *Handler) AddActivityTask(ctx context.Context, addRequest *m.AddActivity
 		return h.handleErr(errMatchingHostThrottle, scope)
 	}
 
-	syncMatch, err := h.engine.AddActivityTask(addRequest)
+	syncMatch, err := h.engine.AddActivityTask(ctx, addRequest)
 	if syncMatch {
 		h.metricsClient.RecordTimer(scope, metrics.SyncMatchLatency, time.Since(startT))
 	}
@@ -149,7 +149,7 @@ func (h *Handler) AddDecisionTask(ctx context.Context, addRequest *m.AddDecision
 		return h.handleErr(errMatchingHostThrottle, scope)
 	}
 
-	syncMatch, err := h.engine.AddDecisionTask(addRequest)
+	syncMatch, err := h.engine.AddDecisionTask(ctx, addRequest)
 	if syncMatch {
 		h.metricsClient.RecordTimer(scope, metrics.SyncMatchLatency, time.Since(startT))
 	}

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/metrics"
+	"golang.org/x/time/rate"
+)
+
+// TaskMatcher matches a task producer with a task consumer
+// Producers are usually rpc calls from history or taskReader
+// that drains backlog from db. Consumers are the task list pollers
+type TaskMatcher struct {
+	// synchronous task channel to match producer/consumer
+	taskC chan *internalTask
+	// synchronous task channel to match query task - the reason to have
+	// separate channel for this is because there are cases when consumers
+	// are interested in queryTasks but not others. Example is when domain is
+	// not active in a cluster
+	queryTaskC chan *internalTask
+	// ratelimiter that limits the rate at which tasks can be dispatched to consumers
+	limiter *rateLimiter
+	// domain metric scope
+	scope func() metrics.Scope
+}
+
+const (
+	_defaultTaskDispatchRPS    = 100000.0
+	_defaultTaskDispatchRPSTTL = 60 * time.Second
+	// maxRateLimitWaitTime is the max amount of time that we are willing to wait for a
+	// ratelimit token to be available in future
+	maxRateLimitWaitTime = int64(200 * time.Millisecond)
+)
+
+var errTasklistThrottled = errors.New("cannot add to tasklist, limit exceeded")
+
+// newTaskMatcher returns an task matcher instance. The returned instance can be
+// used by task producers and consumers to find a match. Both sync matches and non-sync
+// matches should use this implementation
+func newTaskMatcher(config *taskListConfig, scopeFunc func() metrics.Scope) *TaskMatcher {
+	dPtr := _defaultTaskDispatchRPS
+	limiter := newRateLimiter(&dPtr, _defaultTaskDispatchRPSTTL, config.MinTaskThrottlingBurstSize())
+	return &TaskMatcher{
+		limiter:    limiter,
+		scope:      scopeFunc,
+		taskC:      make(chan *internalTask),
+		queryTaskC: make(chan *internalTask),
+	}
+}
+
+// Offer offers a task to a potential consumer (poller)
+// If the task is successfully matched with a consumer, this
+// method will return true and no error. If the task is matched
+// but consumer returned error, then this method will return
+// true and error message. Both regular tasks and query tasks
+// should use this method to match with a consumer. Likewise, sync matches
+// and non-sync matches both should use this method.
+// returns error when:
+//  - ratelimit is exceeded (does not apply to query task)
+//  - context deadline is exceeded
+//  - task is matched and consumer returns error in response channel
+func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, error) {
+	if task.isQuery() {
+		select {
+		case tm.queryTaskC <- task:
+			<-task.syncResponseCh
+			return true, nil
+		case <-ctx.Done():
+			return false, ctx.Err()
+		}
+	}
+
+	rsv, err := tm.ratelimit(ctx)
+	if err != nil {
+		tm.scope().IncCounter(metrics.SyncThrottleCounter)
+		return false, err
+	}
+
+	select {
+	case tm.taskC <- task: // poller picked up the task
+		if task.syncResponseCh != nil {
+			// if there is a response channel, block until resp is received
+			// and return error if the response contains error
+			err = <-task.syncResponseCh
+			return true, err
+		}
+		return false, err
+	default: // no poller waiting for tasks
+		if rsv != nil {
+			// there was a ratelimit token we consumed
+			// return it since we did not really do any work
+			rsv.Cancel()
+		}
+		return false, nil
+	}
+}
+
+// MustOffer blocks until a consumer is found to handle this task
+// Returns error only when context is canceled or the ratelimit is set to zero (allow nothing)
+// The passed in context MUST NOT have a deadline associated with it
+func (tm *TaskMatcher) MustOffer(ctx context.Context, task *internalTask) error {
+	if _, err := tm.ratelimit(ctx); err != nil {
+		return err
+	}
+	select {
+	case tm.taskC <- task:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// Poll blocks until a task is found or context deadline is exceeded
+// On success, the returned task could be a query task or a regular task
+// Returns ErrNoTasks when context deadline is exceeded
+func (tm *TaskMatcher) Poll(ctx context.Context) (*internalTask, error) {
+	select {
+	case task := <-tm.taskC:
+		if task.syncResponseCh != nil {
+			tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
+		}
+		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		return task, nil
+	case task := <-tm.queryTaskC:
+		tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
+		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		return task, nil
+	case <-ctx.Done():
+		tm.scope().IncCounter(metrics.PollTimeoutCounter)
+		return nil, ErrNoTasks
+	}
+}
+
+// PollForQuery blocks until a *query* task is found or context deadline is exceeded
+// Returns ErrNoTasks when context deadline is exceeded
+func (tm *TaskMatcher) PollForQuery(ctx context.Context) (*internalTask, error) {
+	select {
+	case task := <-tm.queryTaskC:
+		tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
+		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		return task, nil
+	case <-ctx.Done():
+		tm.scope().IncCounter(metrics.PollTimeoutCounter)
+		return nil, ErrNoTasks
+	}
+}
+
+// UpdateRatelimit updates the task dispatch rate
+func (tm *TaskMatcher) UpdateRatelimit(rps *float64) {
+	tm.limiter.UpdateMaxDispatch(rps)
+}
+
+// Rate returns the current rate at which tasks are dispatched
+func (tm *TaskMatcher) Rate() float64 {
+	return tm.limiter.Limit()
+}
+
+func (tm *TaskMatcher) ratelimit(ctx context.Context) (*rate.Reservation, error) {
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		if err := tm.limiter.Wait(ctx); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	}
+
+	// how long can we wait for a ratelimit token to be available in future
+	timeout := time.Duration(common.MinInt64(int64(deadline.Sub(time.Now())), maxRateLimitWaitTime))
+
+	rsv := tm.limiter.Reserve()
+	// If we have to wait too long for reservation, give up and return
+	if !rsv.OK() || rsv.Delay() > timeout {
+		if rsv.OK() { // if we were indeed given a reservation, return it before we bail out
+			rsv.Cancel()
+		}
+		return nil, errTasklistThrottled
+	}
+
+	time.Sleep(rsv.Delay())
+	return rsv, nil
+}

--- a/service/matching/matchingEngineInterfaces.go
+++ b/service/matching/matchingEngineInterfaces.go
@@ -31,8 +31,8 @@ type (
 	// Engine exposes interfaces for clients to poll for activity and decision tasks.
 	Engine interface {
 		Stop()
-		AddDecisionTask(addRequest *m.AddDecisionTaskRequest) (syncMatch bool, err error)
-		AddActivityTask(addRequest *m.AddActivityTaskRequest) (syncMatch bool, err error)
+		AddDecisionTask(ctx context.Context, addRequest *m.AddDecisionTaskRequest) (syncMatch bool, err error)
+		AddActivityTask(ctx context.Context, addRequest *m.AddActivityTaskRequest) (syncMatch bool, err error)
 		PollForDecisionTask(ctx context.Context, request *m.PollForDecisionTaskRequest) (*m.PollForDecisionTaskResponse, error)
 		PollForActivityTask(ctx context.Context, request *m.PollForActivityTaskRequest) (*workflow.PollForActivityTaskResponse, error)
 		QueryWorkflow(ctx context.Context, request *m.QueryWorkflowRequest) (*workflow.QueryWorkflowResponse, error)

--- a/service/matching/ratelimiter.go
+++ b/service/matching/ratelimiter.go
@@ -99,6 +99,11 @@ func (rl *rateLimiter) Reserve() *rate.Reservation {
 	return limiter.Reserve()
 }
 
+func (rl *rateLimiter) Allow() bool {
+	limiter := rl.globalLimiter.Load().(*rate.Limiter)
+	return limiter.Allow()
+}
+
 // Limit returns the current rate per second limit for this ratelimiter
 func (rl *rateLimiter) Limit() float64 {
 	if rl.maxDispatchPerSecond != nil {

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -21,8 +21,6 @@
 package matching
 
 import (
-	"time"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/log/tag"
@@ -30,50 +28,6 @@ import (
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/service/dynamicconfig"
 )
-
-// Config represents configuration for cadence-matching service
-type Config struct {
-	PersistenceMaxQPS dynamicconfig.IntPropertyFn
-	EnableSyncMatch   dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
-	RPS               dynamicconfig.IntPropertyFn
-
-	// taskListManager configuration
-	RangeSize                 int64
-	GetTasksBatchSize         dynamicconfig.IntPropertyFnWithTaskListInfoFilters
-	UpdateAckInterval         dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
-	IdleTasklistCheckInterval dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
-	MaxTasklistIdleTime       dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
-	// Time to hold a poll request before returning an empty response if there are no tasks
-	LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
-	MinTaskThrottlingBurstSize dynamicconfig.IntPropertyFnWithTaskListInfoFilters
-	MaxTaskDeleteBatchSize     dynamicconfig.IntPropertyFnWithTaskListInfoFilters
-
-	// taskWriter configuration
-	OutstandingTaskAppendsThreshold dynamicconfig.IntPropertyFnWithTaskListInfoFilters
-	MaxTaskBatchSize                dynamicconfig.IntPropertyFnWithTaskListInfoFilters
-
-	ThrottledLogRPS dynamicconfig.IntPropertyFn
-}
-
-// NewConfig returns new service config with default values
-func NewConfig(dc *dynamicconfig.Collection) *Config {
-	return &Config{
-		PersistenceMaxQPS:               dc.GetIntProperty(dynamicconfig.MatchingPersistenceMaxQPS, 3000),
-		EnableSyncMatch:                 dc.GetBoolPropertyFilteredByTaskListInfo(dynamicconfig.MatchingEnableSyncMatch, true),
-		RPS:                             dc.GetIntProperty(dynamicconfig.MatchingRPS, 1200),
-		RangeSize:                       100000,
-		GetTasksBatchSize:               dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingGetTasksBatchSize, 1000),
-		UpdateAckInterval:               dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingUpdateAckInterval, 1*time.Minute),
-		IdleTasklistCheckInterval:       dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingIdleTasklistCheckInterval, 5*time.Minute),
-		MaxTasklistIdleTime:             dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MaxTasklistIdleTime, 5*time.Minute),
-		LongPollExpirationInterval:      dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.MatchingLongPollExpirationInterval, time.Minute),
-		MinTaskThrottlingBurstSize:      dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingMinTaskThrottlingBurstSize, 1),
-		MaxTaskDeleteBatchSize:          dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingMaxTaskDeleteBatchSize, 100),
-		OutstandingTaskAppendsThreshold: dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingOutstandingTaskAppendsThreshold, 250),
-		MaxTaskBatchSize:                dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingMaxTaskBatchSize, 100),
-		ThrottledLogRPS:                 dc.GetIntProperty(dynamicconfig.MatchingThrottledLogRPS, 20),
-	}
-}
 
 // Service represents the cadence-matching service
 type Service struct {

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -1,0 +1,93 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	m "github.com/uber/cadence/.gen/go/matching"
+	s "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common/persistence"
+)
+
+type (
+	queryTaskInfo struct {
+		taskID       string
+		queryRequest *m.QueryWorkflowRequest
+	}
+	// internalTask represents an activity, decision or query task
+	// holds task specific info and additional metadata
+	internalTask struct {
+		info              *persistence.TaskInfo
+		syncResponseCh    chan error
+		workflowExecution s.WorkflowExecution
+		queryInfo         *queryTaskInfo
+		backlogCountHint  int64
+		domainName        string
+		completionFunc    func(*internalTask, error)
+	}
+)
+
+func newInternalTask(
+	info *persistence.TaskInfo,
+	completionFunc func(*internalTask, error),
+	forSyncMatch bool,
+) *internalTask {
+	task := &internalTask{
+		info:           info,
+		completionFunc: completionFunc,
+		workflowExecution: s.WorkflowExecution{
+			WorkflowId: &info.WorkflowID,
+			RunId:      &info.RunID,
+		},
+	}
+	if forSyncMatch {
+		task.syncResponseCh = make(chan error, 1)
+	}
+	return task
+}
+
+func newInternalQueryTask(
+	queryInfo *queryTaskInfo,
+	completionFunc func(*internalTask, error),
+) *internalTask {
+	return &internalTask{
+		info: &persistence.TaskInfo{
+			DomainID:   queryInfo.queryRequest.GetDomainUUID(),
+			WorkflowID: queryInfo.queryRequest.QueryRequest.Execution.GetWorkflowId(),
+			RunID:      queryInfo.queryRequest.QueryRequest.Execution.GetRunId(),
+		},
+		completionFunc:    completionFunc,
+		queryInfo:         queryInfo,
+		workflowExecution: *queryInfo.queryRequest.QueryRequest.GetExecution(),
+		syncResponseCh:    make(chan error, 1),
+	}
+}
+
+// isQuery returns true if the underlying task is a query task
+func (task *internalTask) isQuery() bool {
+	return task.queryInfo != nil
+}
+
+// finish marks a task as finished. Should be called after a poller picks up a task
+// and marks it as started. If the task is unable to marked as started, then this
+// method should be called with a non-nil error argument.
+func (task *internalTask) finish(err error) {
+	task.completionFunc(task, err)
+}

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -23,14 +23,11 @@ package matching
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
-	h "github.com/uber/cadence/.gen/go/history"
-	m "github.com/uber/cadence/.gen/go/matching"
 	s "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -42,110 +39,61 @@ import (
 )
 
 const (
-	done time.Duration = -1
-
 	// Time budget for empty task to propagate through the function stack and be returned to
 	// pollForActivityTask or pollForDecisionTask handler.
 	returnEmptyTaskTimeBudget time.Duration = time.Second
 )
 
-// NOTE: Is this good enough for stress tests?
-const (
-	_defaultTaskDispatchRPS    = 100000.0
-	_defaultTaskDispatchRPSTTL = 60 * time.Second
-)
-
-var errAddTasklistThrottled = errors.New("cannot add to tasklist, limit exceeded")
-
 type (
+	addTaskParams struct {
+		execution *s.WorkflowExecution
+		taskInfo  *persistence.TaskInfo
+	}
+
 	taskListManager interface {
 		Start() error
 		Stop()
-		AddTask(execution *s.WorkflowExecution, taskInfo *persistence.TaskInfo) (syncMatch bool, err error)
-		GetTaskContext(ctx context.Context, maxDispatchPerSecond *float64) (*taskContext, error)
-		SyncMatchQueryTask(ctx context.Context, queryTask *queryTaskInfo) error
+		// AddTask adds a task to the task list. This method will first attempt a synchronous
+		// match with a poller. When that fails, task will be written to database and later
+		// asynchronously matched with a poller
+		AddTask(ctx context.Context, params addTaskParams) (syncMatch bool, err error)
+		// GetTask blocks waiting for a task Returns error when context deadline is exceeded
+		// maxDispatchPerSecond is the max rate at which tasks are allowed to be dispatched
+		// from this task list to pollers
+		GetTask(ctx context.Context, maxDispatchPerSecond *float64) (*internalTask, error)
+		// DispatchTask dispatches a task to a poller. When there are no pollers to pick
+		// up the task, this method will return error. Task will not be persisted to db
+		DispatchTask(ctx context.Context, task *internalTask) error
+		// DispatchQueryTask dispatches a query task to a poller. When there are no pollers
+		// to pick up the task, this method will return error. Task will not be persisted to
+		// db and no ratelimits are applied for this call
+		DispatchQueryTask(ctx context.Context, queryTask *queryTaskInfo) error
 		CancelPoller(pollerID string)
 		GetAllPollerInfo() []*s.PollerInfo
+		// DescribeTaskList returns information about the target tasklist
 		DescribeTaskList(includeTaskListStatus bool) *s.DescribeTaskListResponse
 		String() string
 	}
 
-	taskListConfig struct {
-		EnableSyncMatch func() bool
-		// Time to hold a poll request before returning an empty response if there are no tasks
-		LongPollExpirationInterval func() time.Duration
-		RangeSize                  int64
-		GetTasksBatchSize          func() int
-		UpdateAckInterval          func() time.Duration
-		IdleTasklistCheckInterval  func() time.Duration
-		MaxTasklistIdleTime        func() time.Duration
-		MinTaskThrottlingBurstSize func() int
-		MaxTaskDeleteBatchSize     func() int
-		// taskWriter configuration
-		OutstandingTaskAppendsThreshold func() int
-		MaxTaskBatchSize                func() int
-	}
-
-	// Contains information needed for current task transition from queue to Workflow execution history.
-	taskContext struct {
-		tlMgr             *taskListManagerImpl
-		info              *persistence.TaskInfo
-		syncResponseCh    chan<- *syncMatchResponse
-		workflowExecution s.WorkflowExecution
-		queryTaskInfo     *queryTaskInfo
-		backlogCountHint  int64
-		domainName        string
-	}
-
-	queryTaskInfo struct {
-		taskID       string
-		queryRequest *m.QueryWorkflowRequest
-	}
-
 	// Single task list in memory state
 	taskListManagerImpl struct {
-		domainCache      cache.DomainCache
 		taskListID       *taskListID
+		taskListKind     int // sticky taskList has different process in persistence
+		config           *taskListConfig
+		db               *taskListDB
+		engine           *matchingEngineImpl
+		taskWriter       *taskWriter
+		taskReader       *taskReader // reads tasks from db and async matches it with poller
+		taskGC           *taskGC
+		taskAckManager   ackManager   // tracks ackLevel for delivered messages
+		matcher          *TaskMatcher // for matching a task producer with a poller
+		domainCache      cache.DomainCache
 		logger           log.Logger
 		metricsClient    metrics.Client
 		domainNameValue  atomic.Value
 		domainScopeValue atomic.Value // domain tagged metric scope
-		engine           *matchingEngineImpl
-		config           *taskListConfig
-
 		// pollerHistory stores poller which poll from this tasklist in last few minutes
 		pollerHistory *pollerHistory
-
-		taskWriter *taskWriter
-		taskBuffer chan *persistence.TaskInfo // tasks loaded from persistence
-		// tasksForPoll is used to deliver tasks to pollers.
-		// It must to be unbuffered. addTask publishes to it asynchronously and expects publish to succeed
-		// only if there is waiting poll that consumes from it. Tasks in taskBuffer will blocking-add to
-		// this channel
-		tasksForPoll chan *getTaskResult
-		// queryTasksForPoll is used for delivering query tasks to pollers.
-		// It must be unbuffered as query tasks are always Sync Matched.  We use a separate channel for query tasks because
-		// unlike activity/decision tasks, query tasks are enabled for dispatch on both active and standby clusters
-		queryTasksForPoll chan *getTaskResult
-		notifyCh          chan struct{} // Used as signal to notify pump of new tasks
-		// Note: We need two shutdown channels so we can stop task pump independently of the deliverBuffer
-		// loop in getTasksPump in unit tests
-		shutdownCh              chan struct{}  // Delivers stop to the pump that populates taskBuffer
-		deliverBufferShutdownCh chan struct{}  // Delivers stop to the pump that populates taskBuffer
-		startWG                 sync.WaitGroup // ensures that background processes do not start until setup is ready
-		stopped                 int32
-		// The cancel objects are to cancel the ratelimiter Wait in deliverBufferTasksLoop. The ideal
-		// approach is to use request-scoped contexts and use a unique one for each call to Wait. However
-		// in order to cancel it on shutdown, we need a new goroutine for each call that would wait on
-		// the shutdown channel. To optimize on efficiency, we instead create one and tag it on the struct
-		// so the cancel can be called directly on shutdown.
-		cancelCtx  context.Context
-		cancelFunc context.CancelFunc
-
-		db             *taskListDB
-		taskAckManager ackManager // tracks ackLevel for delivered messages
-		taskGC         *taskGC
-
 		// outstandingPollsMap is needed to keep track of all outstanding pollers for a
 		// particular tasklist.  PollerID generated by frontend is used as the key and
 		// CancelFunc is the value.  This is used to cancel the context to unblock any
@@ -153,130 +101,56 @@ type (
 		// prevent tasks being dispatched to zombie pollers.
 		outstandingPollsLock sync.Mutex
 		outstandingPollsMap  map[string]context.CancelFunc
-		// Rate limiter for task dispatch
-		rateLimiter *rateLimiter
 
-		taskListKind int // sticky taskList has different process in persistence
-	}
-
-	// getTaskResult contains task info and optional channel to notify createTask caller
-	// that task is successfully started and returned to a poller
-	getTaskResult struct {
-		task      *persistence.TaskInfo
-		C         chan *syncMatchResponse
-		queryTask *queryTaskInfo
-		syncMatch bool
-	}
-
-	// syncMatchResponse result of sync match delivered to a createTask caller
-	syncMatchResponse struct {
-		response *persistence.CreateTasksResponse
-		err      error
+		shutdownCh chan struct{}  // Delivers stop to the pump that populates taskBuffer
+		startWG    sync.WaitGroup // ensures that background processes do not start until setup is ready
+		stopped    int32
 	}
 )
 
-func newTaskListConfig(id *taskListID, config *Config, domainCache cache.DomainCache) (*taskListConfig, error) {
-	domainEntry, err := domainCache.GetDomainByID(id.domainID)
-	if err != nil {
-		return nil, err
-	}
-
-	domain := domainEntry.GetInfo().Name
-	taskListName := id.taskListName
-	taskType := id.taskType
-	return &taskListConfig{
-		RangeSize: config.RangeSize,
-		GetTasksBatchSize: func() int {
-			return config.GetTasksBatchSize(domain, taskListName, taskType)
-		},
-		UpdateAckInterval: func() time.Duration {
-			return config.UpdateAckInterval(domain, taskListName, taskType)
-		},
-		IdleTasklistCheckInterval: func() time.Duration {
-			return config.IdleTasklistCheckInterval(domain, taskListName, taskType)
-		},
-		MaxTasklistIdleTime: func() time.Duration {
-			return config.MaxTasklistIdleTime(domain, taskListName, taskType)
-		},
-		MinTaskThrottlingBurstSize: func() int {
-			return config.MinTaskThrottlingBurstSize(domain, taskListName, taskType)
-		},
-		EnableSyncMatch: func() bool {
-			return config.EnableSyncMatch(domain, taskListName, taskType)
-		},
-		LongPollExpirationInterval: func() time.Duration {
-			return config.LongPollExpirationInterval(domain, taskListName, taskType)
-		},
-		MaxTaskDeleteBatchSize: func() int {
-			return config.MaxTaskDeleteBatchSize(domain, taskListName, taskType)
-		},
-		OutstandingTaskAppendsThreshold: func() int {
-			return config.OutstandingTaskAppendsThreshold(domain, taskListName, taskType)
-		},
-		MaxTaskBatchSize: func() int {
-			return config.MaxTaskBatchSize(domain, taskListName, taskType)
-		},
-	}, nil
-}
+var _ taskListManager = (*taskListManagerImpl)(nil)
 
 func newTaskListManager(
-	e *matchingEngineImpl, taskList *taskListID, taskListKind *s.TaskListKind, config *Config,
+	e *matchingEngineImpl,
+	taskList *taskListID,
+	taskListKind *s.TaskListKind,
+	config *Config,
 ) (taskListManager, error) {
-	dPtr := _defaultTaskDispatchRPS
+
 	taskListConfig, err := newTaskListConfig(taskList, config, e.domainCache)
 	if err != nil {
 		return nil, err
 	}
-	rl := newRateLimiter(
-		&dPtr, _defaultTaskDispatchRPSTTL, taskListConfig.MinTaskThrottlingBurstSize(),
-	)
-	return newTaskListManagerWithRateLimiter(
-		e, taskList, taskListKind, e.domainCache, taskListConfig, rl,
-	), nil
-}
 
-func newTaskListManagerWithRateLimiter(
-	e *matchingEngineImpl, taskList *taskListID, taskListKind *s.TaskListKind,
-	domainCache cache.DomainCache, config *taskListConfig, rl *rateLimiter,
-) taskListManager {
-	// To perform one db operation if there are no pollers
-	taskBufferSize := config.GetTasksBatchSize() - 1
-	ctx, cancel := context.WithCancel(context.Background())
 	if taskListKind == nil {
 		taskListKind = common.TaskListKindPtr(s.TaskListKindNormal)
 	}
 
 	db := newTaskListDB(e.taskManager, taskList.domainID, taskList.taskListName, taskList.taskType, int(*taskListKind), e.logger)
 	tlMgr := &taskListManagerImpl{
-		domainCache:             domainCache,
-		metricsClient:           e.metricsClient,
-		engine:                  e,
-		taskBuffer:              make(chan *persistence.TaskInfo, taskBufferSize),
-		notifyCh:                make(chan struct{}, 1),
-		shutdownCh:              make(chan struct{}),
-		deliverBufferShutdownCh: make(chan struct{}),
-		cancelCtx:               ctx,
-		cancelFunc:              cancel,
-		taskListID:              taskList,
+		domainCache:   e.domainCache,
+		metricsClient: e.metricsClient,
+		engine:        e,
+		shutdownCh:    make(chan struct{}),
+		taskListID:    taskList,
 		logger: e.logger.WithTags(tag.WorkflowTaskListName(taskList.taskListName),
 			tag.WorkflowTaskListType(taskList.taskType)),
 		db:                  db,
 		taskAckManager:      newAckManager(e.logger),
-		taskGC:              newTaskGC(db, config),
-		tasksForPoll:        make(chan *getTaskResult),
-		queryTasksForPoll:   make(chan *getTaskResult),
-		config:              config,
+		taskGC:              newTaskGC(db, taskListConfig),
+		config:              taskListConfig,
 		pollerHistory:       newPollerHistory(),
 		outstandingPollsMap: make(map[string]context.CancelFunc),
-		rateLimiter:         rl,
 		taskListKind:        int(*taskListKind),
 	}
 	tlMgr.domainNameValue.Store("")
 	tlMgr.domainScopeValue.Store(e.metricsClient.Scope(metrics.MatchingTaskListMgrScope, metrics.DomainUnknownTag()))
 	tlMgr.tryInitDomainNameAndScope()
 	tlMgr.taskWriter = newTaskWriter(tlMgr)
+	tlMgr.taskReader = newTaskReader(tlMgr)
+	tlMgr.matcher = newTaskMatcher(taskListConfig, tlMgr.domainScope)
 	tlMgr.startWG.Add(1)
-	return tlMgr
+	return tlMgr, nil
 }
 
 // Starts reading pump for the given task list.
@@ -293,8 +167,7 @@ func (c *taskListManagerImpl) Start() error {
 
 	c.taskAckManager.setAckLevel(state.ackLevel)
 	c.taskWriter.Start(c.rangeIDToTaskIDBlock(state.rangeID))
-	c.signalNewTask()
-	go c.getTasksPump()
+	c.taskReader.Start()
 
 	return nil
 }
@@ -304,117 +177,87 @@ func (c *taskListManagerImpl) Stop() {
 	if !atomic.CompareAndSwapInt32(&c.stopped, 0, 1) {
 		return
 	}
-	close(c.deliverBufferShutdownCh)
-	c.cancelFunc()
 	close(c.shutdownCh)
 	c.taskWriter.Stop()
+	c.taskReader.Stop()
 	c.engine.removeTaskListManager(c.taskListID)
 	c.engine.removeTaskListManager(c.taskListID)
 	c.logger.Info("", tag.LifeCycleStopped)
 }
 
-func (c *taskListManagerImpl) AddTask(execution *s.WorkflowExecution, taskInfo *persistence.TaskInfo) (syncMatch bool, err error) {
+// AddTask adds a task to the task list. This method will first attempt a synchronous
+// match with a poller. When there are no pollers or if ratelimit is exceeded, task will
+// be written to database and later asynchronously matched with a poller
+func (c *taskListManagerImpl) AddTask(ctx context.Context, params addTaskParams) (bool, error) {
 	c.startWG.Wait()
-	_, err = c.executeWithRetry(func() (interface{}, error) {
+	var syncMatch bool
+	_, err := c.executeWithRetry(func() (interface{}, error) {
 
-		domainEntry, err := c.domainCache.GetDomainByID(taskInfo.DomainID)
+		domainEntry, err := c.domainCache.GetDomainByID(params.taskInfo.DomainID)
 		if err != nil {
 			return nil, err
 		}
+
 		if domainEntry.GetDomainNotActiveErr() != nil {
-			// domain not active, do not do sync match
-			r, err := c.taskWriter.appendTask(execution, taskInfo)
+			r, err := c.taskWriter.appendTask(params.execution, params.taskInfo)
 			syncMatch = false
 			return r, err
 		}
 
-		r, err := c.trySyncMatch(taskInfo)
-		if (err != nil && err != errAddTasklistThrottled) || r != nil {
+		ok, err := c.matcher.Offer(ctx, newInternalTask(params.taskInfo, c.completeTask, true))
+		if ok {
 			syncMatch = true
-			return r, err
+			return &persistence.CreateTasksResponse{}, err
 		}
-		r, err = c.taskWriter.appendTask(execution, taskInfo)
+
+		r, err := c.taskWriter.appendTask(params.execution, params.taskInfo)
 		syncMatch = false
 		return r, err
 	})
 	if err == nil {
-		c.signalNewTask()
+		c.taskReader.Signal()
 	}
 	return syncMatch, err
 }
 
-func (c *taskListManagerImpl) SyncMatchQueryTask(ctx context.Context, queryTask *queryTaskInfo) error {
-	c.startWG.Wait()
-
-	domainID := queryTask.queryRequest.GetDomainUUID()
-	we := queryTask.queryRequest.QueryRequest.Execution
-	taskInfo := &persistence.TaskInfo{
-		DomainID:   domainID,
-		RunID:      we.GetRunId(),
-		WorkflowID: we.GetWorkflowId(),
-	}
-
-	request := &getTaskResult{task: taskInfo, C: make(chan *syncMatchResponse, 1), queryTask: queryTask}
-	select {
-	case c.queryTasksForPoll <- request:
-		<-request.C
-		return nil
-	case <-ctx.Done():
-		return &s.QueryFailedError{Message: "timeout: no workflow worker polling for given tasklist"}
-	}
+// DispatchTask dispatches a task to a poller. When there are no pollers to pick
+// up the task or if rate limit is exceeded, this method will return error. Task
+// *will not* be persisted to db
+func (c *taskListManagerImpl) DispatchTask(ctx context.Context, task *internalTask) error {
+	return c.matcher.MustOffer(ctx, task)
 }
 
-// Loads a task from DB or from sync match and wraps it in a task context
-func (c *taskListManagerImpl) GetTaskContext(
+// DispatchQueryTask dispatches a query task to a poller. When there are no pollers
+// to pick up the task, this method will return error. Task will not be persisted to
+// db and no ratelimits will be applied for this call
+func (c *taskListManagerImpl) DispatchQueryTask(ctx context.Context, queryTask *queryTaskInfo) error {
+	c.startWG.Wait()
+	task := newInternalQueryTask(queryTask, c.completeTask)
+	_, err := c.matcher.Offer(ctx, task)
+	if err == context.DeadlineExceeded {
+		return &s.QueryFailedError{Message: "timeout: no workflow worker polling for given tasklist"}
+	}
+	return err
+}
+
+// GetTask blocks waiting for a task.
+// Returns error when context deadline is exceeded
+// maxDispatchPerSecond is the max rate at which tasks are allowed
+// to be dispatched from this task list to pollers
+func (c *taskListManagerImpl) GetTask(
 	ctx context.Context,
 	maxDispatchPerSecond *float64,
-) (*taskContext, error) {
-	result, err := c.getTask(ctx, maxDispatchPerSecond)
+) (*internalTask, error) {
+	task, err := c.getTask(ctx, maxDispatchPerSecond)
 	if err != nil {
 		return nil, err
 	}
-	task := result.task
-	workflowExecution := s.WorkflowExecution{
-		WorkflowId: common.StringPtr(task.WorkflowID),
-		RunId:      common.StringPtr(task.RunID),
-	}
-
-	tCtx := &taskContext{
-		info:              task,
-		workflowExecution: workflowExecution,
-		tlMgr:             c,
-		syncResponseCh:    result.C,         // nil if task is loaded from persistence
-		queryTaskInfo:     result.queryTask, // non-nil for query task
-		backlogCountHint:  c.taskAckManager.getBacklogCountHint(),
-		domainName:        c.domainName(),
-	}
-	return tCtx, nil
+	task.domainName = c.domainName()
+	task.backlogCountHint = c.taskAckManager.getBacklogCountHint()
+	return task, nil
 }
 
-func (c *taskListManagerImpl) persistAckLevel() error {
-	return c.db.UpdateState(c.taskAckManager.getAckLevel())
-}
-
-func (c *taskListManagerImpl) getAckLevel() (ackLevel int64) {
-	return c.taskAckManager.getAckLevel()
-}
-
-func (c *taskListManagerImpl) getTaskListKind() int {
-	// there is no need to lock here,
-	// since c.taskListKind is assigned when taskListManager been created and never changed.
-	return c.taskListKind
-}
-
-// completeTaskPoll should be called after task poll is done even if append has failed.
-// There is no correspondent initiateTaskPoll as append is initiated in getTasksPump
-func (c *taskListManagerImpl) completeTaskPoll(taskID int64) int64 {
-	ackLevel := c.taskAckManager.completeTask(taskID)
-	c.taskGC.Run(ackLevel)
-	return ackLevel
-}
-
-// Loads task from taskBuffer (which is populated from persistence) or from sync match to add task call
-func (c *taskListManagerImpl) getTask(ctx context.Context, maxDispatchPerSecond *float64) (*getTaskResult, error) {
+func (c *taskListManagerImpl) getTask(ctx context.Context, maxDispatchPerSecond *float64) (*internalTask, error) {
 	childCtxTimeout := c.config.LongPollExpirationInterval()
 	if deadline, ok := ctx.Deadline(); ok {
 		// We need to set a shorter timeout than the original ctx; otherwise, by the time ctx deadline is
@@ -449,14 +292,9 @@ func (c *taskListManagerImpl) getTask(ctx context.Context, maxDispatchPerSecond 
 		c.pollerHistory.updatePollerInfo(pollerIdentity(identity), maxDispatchPerSecond)
 	}
 
-	var tasksForPoll chan *getTaskResult
 	domainEntry, err := c.domainCache.GetDomainByID(c.taskListID.domainID)
 	if err != nil {
 		return nil, err
-	}
-	if domainEntry.GetDomainNotActiveErr() == nil {
-		// domain active
-		tasksForPoll = c.tasksForPoll
 	}
 
 	// the desired global rate limit for the task list comes from the
@@ -464,25 +302,18 @@ func (c *taskListManagerImpl) getTask(ctx context.Context, maxDispatchPerSecond 
 	// one rateLimiter for this entire task list and as we get polls,
 	// we update the ratelimiter rps if it has changed from the last
 	// value. Last poller wins if different pollers provide different values
-	c.rateLimiter.UpdateMaxDispatch(maxDispatchPerSecond)
+	c.matcher.UpdateRatelimit(maxDispatchPerSecond)
 
-	select {
-	case result := <-tasksForPoll:
-		if result.syncMatch {
-			c.domainScope().IncCounter(metrics.PollSuccessWithSyncCounter)
-		}
-		c.domainScope().IncCounter(metrics.PollSuccessCounter)
-		return result, nil
-	case result := <-c.queryTasksForPoll:
-		if result.syncMatch {
-			c.domainScope().IncCounter(metrics.PollSuccessWithSyncCounter)
-		}
-		c.domainScope().IncCounter(metrics.PollSuccessCounter)
-		return result, nil
-	case <-childCtx.Done():
-		c.domainScope().IncCounter(metrics.PollTimeoutCounter)
-		return nil, ErrNoTasks
+	if domainEntry.GetDomainNotActiveErr() != nil {
+		return c.matcher.PollForQuery(childCtx)
 	}
+
+	return c.matcher.Poll(childCtx)
+}
+
+// GetAllPollerInfo returns all pollers that polled from this tasklist in last few minutes
+func (c *taskListManagerImpl) GetAllPollerInfo() []*s.PollerInfo {
+	return c.pollerHistory.getAllPollerInfo()
 }
 
 func (c *taskListManagerImpl) CancelPoller(pollerID string) {
@@ -493,6 +324,89 @@ func (c *taskListManagerImpl) CancelPoller(pollerID string) {
 	if ok && cancel != nil {
 		cancel()
 	}
+}
+
+// DescribeTaskList returns information about the target tasklist, right now this API returns the
+// pollers which polled this tasklist in last few minutes and status of tasklist's ackManager
+// (readLevel, ackLevel, backlogCountHint and taskIDBlock).
+func (c *taskListManagerImpl) DescribeTaskList(includeTaskListStatus bool) *s.DescribeTaskListResponse {
+	response := &s.DescribeTaskListResponse{Pollers: c.GetAllPollerInfo()}
+	if !includeTaskListStatus {
+		return response
+	}
+
+	taskIDBlock := c.rangeIDToTaskIDBlock(c.db.RangeID())
+	response.TaskListStatus = &s.TaskListStatus{
+		ReadLevel:        common.Int64Ptr(c.taskAckManager.getReadLevel()),
+		AckLevel:         common.Int64Ptr(c.taskAckManager.getAckLevel()),
+		BacklogCountHint: common.Int64Ptr(c.taskAckManager.getBacklogCountHint()),
+		RatePerSecond:    common.Float64Ptr(c.matcher.Rate()),
+		TaskIDBlock: &s.TaskIDBlock{
+			StartID: common.Int64Ptr(taskIDBlock.start),
+			EndID:   common.Int64Ptr(taskIDBlock.end),
+		},
+	}
+
+	return response
+}
+
+func (c *taskListManagerImpl) String() string {
+	buf := new(bytes.Buffer)
+	if c.taskListID.taskType == persistence.TaskListTypeActivity {
+		buf.WriteString("Activity")
+	} else {
+		buf.WriteString("Decision")
+	}
+	rangeID := c.db.RangeID()
+	fmt.Fprintf(buf, " task list %v\n", c.taskListID.taskListName)
+	fmt.Fprintf(buf, "RangeID=%v\n", rangeID)
+	fmt.Fprintf(buf, "TaskIDBlock=%+v\n", c.rangeIDToTaskIDBlock(rangeID))
+	fmt.Fprintf(buf, "AckLevel=%v\n", c.taskAckManager.ackLevel)
+	fmt.Fprintf(buf, "MaxReadLevel=%v\n", c.taskAckManager.getReadLevel())
+
+	return buf.String()
+}
+
+// completeTask marks a task as processed. If this task was synchronously matched, a notification
+// is sent in the syncMatch response channel to be picked by addTask goroutine. If this task was
+// created by taskReader (i.e. backlog from db):
+//   - it is deleted from the database when err is nil
+//   - new task is created and current task is deleted when err is not nil
+func (c *taskListManagerImpl) completeTask(task *internalTask, err error) {
+	if task.syncResponseCh != nil {
+		// It is OK to succeed task creation as it was already completed
+		task.syncResponseCh <- err
+		return
+	}
+
+	if err != nil {
+		// failed to start the task.
+		// We cannot just remove it from persistence because then it will be lost.
+		// We handle this by writing the task back to persistence with a higher taskID.
+		// This will allow subsequent tasks to make progress, and hopefully by the time this task is picked-up
+		// again the underlying reason for failing to start will be resolved.
+		// Note that RecordTaskStarted only fails after retrying for a long time, so a single task will not be
+		// re-written to persistence frequently.
+		_, err = c.executeWithRetry(func() (interface{}, error) {
+			return c.taskWriter.appendTask(&task.workflowExecution, task.info)
+		})
+
+		if err != nil {
+			// OK, we also failed to write to persistence.
+			// This should only happen in very extreme cases where persistence is completely down.
+			// We still can't lose the old task so we just unload the entire task list
+			c.logger.Error("Persistent store operation failure",
+				tag.StoreOperationStopTaskList,
+				tag.Error(err),
+				tag.WorkflowTaskListName(c.taskListID.taskListName),
+				tag.WorkflowTaskListType(c.taskListID.taskType))
+			c.Stop()
+			return
+		}
+		c.taskReader.Signal()
+	}
+	ackLevel := c.taskAckManager.completeTask(task.info.TaskID)
+	c.taskGC.Run(ackLevel)
 }
 
 func (c *taskListManagerImpl) renewLeaseWithRetry() (taskListState, error) {
@@ -531,82 +445,14 @@ func (c *taskListManagerImpl) allocTaskIDBlock(prevBlockEnd int64) (taskIDBlock,
 	return c.rangeIDToTaskIDBlock(state.rangeID), nil
 }
 
-func (c *taskListManagerImpl) String() string {
-	buf := new(bytes.Buffer)
-	if c.taskListID.taskType == persistence.TaskListTypeActivity {
-		buf.WriteString("Activity")
-	} else {
-		buf.WriteString("Decision")
-	}
-	rangeID := c.db.RangeID()
-	fmt.Fprintf(buf, " task list %v\n", c.taskListID.taskListName)
-	fmt.Fprintf(buf, "RangeID=%v\n", rangeID)
-	fmt.Fprintf(buf, "TaskIDBlock=%+v\n", c.rangeIDToTaskIDBlock(rangeID))
-	fmt.Fprintf(buf, "AckLevel=%v\n", c.taskAckManager.ackLevel)
-	fmt.Fprintf(buf, "MaxReadLevel=%v\n", c.taskAckManager.getReadLevel())
-
-	return buf.String()
+func (c *taskListManagerImpl) getAckLevel() (ackLevel int64) {
+	return c.taskAckManager.getAckLevel()
 }
 
-// getAllPollerInfo return poller which poll from this tasklist in last few minutes
-func (c *taskListManagerImpl) GetAllPollerInfo() []*s.PollerInfo {
-	return c.pollerHistory.getAllPollerInfo()
-}
-
-// DescribeTaskList returns information about the target tasklist, right now this API returns the
-// pollers which polled this tasklist in last few minutes and status of tasklist's ackManager
-// (readLevel, ackLevel, backlogCountHint and taskIDBlock).
-func (c *taskListManagerImpl) DescribeTaskList(includeTaskListStatus bool) *s.DescribeTaskListResponse {
-	response := &s.DescribeTaskListResponse{Pollers: c.GetAllPollerInfo()}
-	if !includeTaskListStatus {
-		return response
-	}
-
-	taskIDBlock := c.rangeIDToTaskIDBlock(c.db.RangeID())
-	response.TaskListStatus = &s.TaskListStatus{
-		ReadLevel:        common.Int64Ptr(c.taskAckManager.getReadLevel()),
-		AckLevel:         common.Int64Ptr(c.taskAckManager.getAckLevel()),
-		BacklogCountHint: common.Int64Ptr(c.taskAckManager.getBacklogCountHint()),
-		RatePerSecond:    common.Float64Ptr(c.rateLimiter.Limit()),
-		TaskIDBlock: &s.TaskIDBlock{
-			StartID: common.Int64Ptr(taskIDBlock.start),
-			EndID:   common.Int64Ptr(taskIDBlock.end),
-		},
-	}
-
-	return response
-}
-
-// Tries to match task to a poller that is already waiting on getTask.
-// When this method returns non nil response without error it is guaranteed that the task is started
-// and sent to a poller. So it not necessary to persist it.
-// Returns (nil, nil) if there is no waiting poller which indicates that task has to be persisted.
-func (c *taskListManagerImpl) trySyncMatch(task *persistence.TaskInfo) (*persistence.CreateTasksResponse, error) {
-	if !c.config.EnableSyncMatch() {
-		return nil, nil
-	}
-	// Request from the point of view of Add(Activity|Decision)Task operation.
-	// But it is getTask result from the point of view of a poll operation.
-	request := &getTaskResult{task: task, C: make(chan *syncMatchResponse, 1), syncMatch: true}
-
-	rsv := c.rateLimiter.Reserve()
-	// If we have to wait too long for reservation, better to store in task buffer and handle later.
-	if !rsv.OK() || rsv.Delay() > time.Second {
-		if rsv.OK() { // if we were indeed given a reservation, return it before we bail out
-			rsv.Cancel()
-		}
-		c.domainScope().IncCounter(metrics.SyncThrottleCounter)
-		return nil, errAddTasklistThrottled
-	}
-	time.Sleep(rsv.Delay())
-	select {
-	case c.tasksForPoll <- request: // poller goroutine picked up the task
-		r := <-request.C
-		return r.response, r.err
-	default: // no poller waiting for tasks
-		rsv.Cancel()
-		return nil, nil
-	}
+func (c *taskListManagerImpl) getTaskListKind() int {
+	// there is no need to lock here,
+	// since c.taskListKind is assigned when taskListManager been created and never changed.
+	return c.taskListKind
 }
 
 // Retry operation on transient error. On rangeID update by another process calls c.Stop().
@@ -635,97 +481,8 @@ func (c *taskListManagerImpl) executeWithRetry(
 	return
 }
 
-func (c *taskListManagerImpl) signalNewTask() {
-	var event struct{}
-	select {
-	case c.notifyCh <- event:
-	default: // channel already has an event, don't block
-	}
-}
-
-func (c *taskContext) RecordDecisionTaskStartedWithRetry(ctx context.Context,
-	request *h.RecordDecisionTaskStartedRequest) (resp *h.RecordDecisionTaskStartedResponse, err error) {
-	op := func() error {
-		var err error
-		resp, err = c.tlMgr.engine.historyService.RecordDecisionTaskStarted(ctx, request)
-		return err
-	}
-	err = backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {
-		switch err.(type) {
-		case *s.EntityNotExistsError, *h.EventAlreadyStartedError:
-			return false
-		}
-		return true
-	})
-	return
-}
-
-func (c *taskContext) RecordActivityTaskStartedWithRetry(ctx context.Context,
-	request *h.RecordActivityTaskStartedRequest) (resp *h.RecordActivityTaskStartedResponse, err error) {
-	op := func() error {
-		var err error
-		resp, err = c.tlMgr.engine.historyService.RecordActivityTaskStarted(ctx, request)
-		return err
-	}
-	err = backoff.Retry(op, historyServiceOperationRetryPolicy, func(err error) bool {
-		switch err.(type) {
-		case *s.EntityNotExistsError, *h.EventAlreadyStartedError:
-			return false
-		}
-		return true
-	})
-	return
-}
-
-// If poll received task from addTask directly the addTask goroutine is notified about start task result.
-// If poll received task from persistence then task is deleted from it if no error was reported.
-func (c *taskContext) completeTask(err error) {
-	tlMgr := c.tlMgr
-	tlMgr.logger.Debug(fmt.Sprintf("completeTask task taskList=%v, taskID=%v, err=%v",
-		tlMgr.taskListID.taskListName, c.info.TaskID, err))
-	if c.syncResponseCh != nil {
-		// It is OK to succeed task creation as it was already completed
-		c.syncResponseCh <- &syncMatchResponse{
-			response: &persistence.CreateTasksResponse{}, err: err}
-		return
-	}
-
-	if err != nil {
-		// failed to start the task.
-		// We cannot just remove it from persistence because then it will be lost.
-		// We handle this by writing the task back to persistence with a higher taskID.
-		// This will allow subsequent tasks to make progress, and hopefully by the time this task is picked-up
-		// again the underlying reason for failing to start will be resolved.
-		// Note that RecordTaskStarted only fails after retrying for a long time, so a single task will not be
-		// re-written to persistence frequently.
-		_, err = tlMgr.executeWithRetry(func() (interface{}, error) {
-			return tlMgr.taskWriter.appendTask(&c.workflowExecution, c.info)
-		})
-
-		if err != nil {
-			// OK, we also failed to write to persistence.
-			// This should only happen in very extreme cases where persistence is completely down.
-			// We still can't lose the old task so we just unload the entire task list
-			tlMgr.logger.Error("Persistent store operation failure",
-				tag.StoreOperationStopTaskList,
-				tag.Error(err),
-				tag.WorkflowTaskListName(tlMgr.taskListID.taskListName),
-				tag.WorkflowTaskListType(tlMgr.taskListID.taskType))
-			tlMgr.Stop()
-			return
-		}
-		tlMgr.signalNewTask()
-	}
-
-	tlMgr.completeTaskPoll(c.info.TaskID)
-}
-
 func createServiceBusyError(msg string) *s.ServiceBusyError {
 	return &s.ServiceBusyError{Message: msg}
-}
-
-func (c *taskListManagerImpl) isTaskAddedRecently(lastAddTime time.Time) bool {
-	return time.Now().Sub(lastAddTime) <= c.config.MaxTasklistIdleTime()
 }
 
 func (c *taskListManagerImpl) domainScope() metrics.Scope {

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -22,10 +22,10 @@ package matching
 
 import (
 	"context"
-	"fmt"
 	"runtime"
 	"time"
 
+	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
@@ -33,103 +33,145 @@ import (
 
 var epochStartTime = time.Unix(0, 0)
 
-func (c *taskListManagerImpl) deliverBufferTasksForPoll() {
-deliverBufferTasksLoop:
+type (
+	taskReader struct {
+		taskBuffer chan *persistence.TaskInfo // tasks loaded from persistence
+		notifyC    chan struct{}              // Used as signal to notify pump of new tasks
+		tlMgr      *taskListManagerImpl
+		// The cancel objects are to cancel the ratelimiter Wait in dispatchBufferedTasks. The ideal
+		// approach is to use request-scoped contexts and use a unique one for each call to Wait. However
+		// in order to cancel it on shutdown, we need a new goroutine for each call that would wait on
+		// the shutdown channel. To optimize on efficiency, we instead create one and tag it on the struct
+		// so the cancel can be called directly on shutdown.
+		cancelCtx  context.Context
+		cancelFunc context.CancelFunc
+		// separate shutdownC needed for dispatchTasks go routine to allow
+		// getTasksPump to be stopped without stopping dispatchTasks in unit tests
+		dispatcherShutdownC chan struct{}
+	}
+)
+
+func newTaskReader(tlMgr *taskListManagerImpl) *taskReader {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &taskReader{
+		tlMgr:               tlMgr,
+		cancelCtx:           ctx,
+		cancelFunc:          cancel,
+		taskBuffer:          make(chan *persistence.TaskInfo, tlMgr.config.GetTasksBatchSize()-1),
+		notifyC:             make(chan struct{}, 1),
+		dispatcherShutdownC: make(chan struct{}),
+	}
+}
+
+func (tr *taskReader) Start() {
+	tr.Signal()
+	go tr.dispatchBufferedTasks()
+	go tr.getTasksPump()
+}
+
+func (tr *taskReader) Stop() {
+	tr.cancelFunc()
+	close(tr.dispatcherShutdownC)
+}
+
+func (tr *taskReader) Signal() {
+	var event struct{}
+	select {
+	case tr.notifyC <- event:
+	default: // channel already has an event, don't block
+	}
+}
+
+func (tr *taskReader) dispatchBufferedTasks() {
+dispatchLoop:
 	for {
-		err := c.rateLimiter.Wait(c.cancelCtx)
-		if err != nil {
-			if err == context.Canceled {
-				c.logger.Info("Tasklist manager context is cancelled, shutting down")
-				break deliverBufferTasksLoop
-			}
-			c.logger.Debug(fmt.Sprintf(
-				"Unable to add buffer task, rate limit failed, domainId: %s, tasklist: %s, error: %s",
-				c.taskListID.domainID, c.taskListID.taskListName, err.Error()),
-			)
-			c.domainScope().IncCounter(metrics.BufferThrottleCounter)
-			// This is to prevent busy looping when throttling is set to 0
-			runtime.Gosched()
-			continue
-		}
 		select {
-		case task, ok := <-c.taskBuffer:
+		case taskInfo, ok := <-tr.taskBuffer:
 			if !ok { // Task list getTasks pump is shutdown
-				break deliverBufferTasksLoop
+				break dispatchLoop
 			}
-			select {
-			case c.tasksForPoll <- &getTaskResult{task: task}:
-			case <-c.deliverBufferShutdownCh:
-				break deliverBufferTasksLoop
+			task := newInternalTask(taskInfo, tr.tlMgr.completeTask, false)
+			for {
+				err := tr.tlMgr.DispatchTask(tr.cancelCtx, task)
+				if err == nil {
+					break
+				}
+				if err == context.Canceled {
+					tr.tlMgr.logger.Info("Tasklist manager context is cancelled, shutting down")
+					break dispatchLoop
+				}
+				// this should never happen unless there is a bug - don't drop the task
+				tr.scope().IncCounter(metrics.BufferThrottleCounter)
+				tr.logger().Error("taskReader: unexpected error dispatching task", tag.Error(err))
+				runtime.Gosched()
 			}
-		case <-c.deliverBufferShutdownCh:
-			break deliverBufferTasksLoop
+		case <-tr.dispatcherShutdownC:
+			break dispatchLoop
 		}
 	}
 }
 
-func (c *taskListManagerImpl) getTasksPump() {
-	defer close(c.taskBuffer)
-	c.startWG.Wait()
+func (tr *taskReader) getTasksPump() {
+	tr.tlMgr.startWG.Wait()
+	defer close(tr.taskBuffer)
 
-	go c.deliverBufferTasksForPoll()
-	updateAckTimer := time.NewTimer(c.config.UpdateAckInterval())
-	checkIdleTaskListTimer := time.NewTimer(c.config.IdleTasklistCheckInterval())
+	updateAckTimer := time.NewTimer(tr.tlMgr.config.UpdateAckInterval())
+	checkIdleTaskListTimer := time.NewTimer(tr.tlMgr.config.IdleTasklistCheckInterval())
 	lastTimeWriteTask := time.Time{}
 getTasksPumpLoop:
 	for {
 		select {
-		case <-c.shutdownCh:
+		case <-tr.tlMgr.shutdownCh:
 			break getTasksPumpLoop
-		case <-c.notifyCh:
+		case <-tr.notifyC:
 			{
 				lastTimeWriteTask = time.Now()
 
-				tasks, readLevel, isReadBatchDone, err := c.getTaskBatch()
+				tasks, readLevel, isReadBatchDone, err := tr.getTaskBatch()
 				if err != nil {
-					c.signalNewTask() // re-enqueue the event
+					tr.Signal() // re-enqueue the event
 					// TODO: Should we ever stop retrying on db errors?
 					continue getTasksPumpLoop
 				}
 
 				if len(tasks) == 0 {
-					c.taskAckManager.setReadLevel(readLevel)
+					tr.tlMgr.taskAckManager.setReadLevel(readLevel)
 					if !isReadBatchDone {
-						c.signalNewTask()
+						tr.Signal()
 					}
 					continue getTasksPumpLoop
 				}
 
-				if !c.addTasksToBuffer(tasks, lastTimeWriteTask, checkIdleTaskListTimer) {
+				if !tr.addTasksToBuffer(tasks, lastTimeWriteTask, checkIdleTaskListTimer) {
 					break getTasksPumpLoop
 				}
 				// There maybe more tasks. We yield now, but signal pump to check again later.
-				c.signalNewTask()
+				tr.Signal()
 			}
 		case <-updateAckTimer.C:
 			{
-				err := c.persistAckLevel()
-				//var err error
+				err := tr.persistAckLevel()
 				if err != nil {
 					if _, ok := err.(*persistence.ConditionFailedError); ok {
 						// This indicates the task list may have moved to another host.
-						c.Stop()
+						tr.tlMgr.Stop()
 					} else {
-						c.logger.Error("Persistent store operation failure",
+						tr.logger().Error("Persistent store operation failure",
 							tag.StoreOperationUpdateTaskList,
 							tag.Error(err))
 					}
 					// keep going as saving ack is not critical
 				}
-				c.signalNewTask() // periodically signal pump to check persistence for tasks
-				updateAckTimer = time.NewTimer(c.config.UpdateAckInterval())
+				tr.Signal() // periodically signal pump to check persistence for tasks
+				updateAckTimer = time.NewTimer(tr.tlMgr.config.UpdateAckInterval())
 			}
 		case <-checkIdleTaskListTimer.C:
 			{
-				if c.isIdle(lastTimeWriteTask) {
-					c.handleIdleTimeout()
+				if tr.isIdle(lastTimeWriteTask) {
+					tr.handleIdleTimeout()
 					break getTasksPumpLoop
 				}
-				checkIdleTaskListTimer = time.NewTimer(c.config.IdleTasklistCheckInterval())
+				checkIdleTaskListTimer = time.NewTimer(tr.tlMgr.config.IdleTasklistCheckInterval())
 			}
 		}
 	}
@@ -138,9 +180,9 @@ getTasksPumpLoop:
 	checkIdleTaskListTimer.Stop()
 }
 
-func (c *taskListManagerImpl) getTaskBatchWithRange(readLevel int64, maxReadLevel int64) ([]*persistence.TaskInfo, error) {
-	response, err := c.executeWithRetry(func() (interface{}, error) {
-		return c.db.GetTasks(readLevel, maxReadLevel, c.config.GetTasksBatchSize())
+func (tr *taskReader) getTaskBatchWithRange(readLevel int64, maxReadLevel int64) ([]*persistence.TaskInfo, error) {
+	response, err := tr.tlMgr.executeWithRetry(func() (interface{}, error) {
+		return tr.tlMgr.db.GetTasks(readLevel, maxReadLevel, tr.tlMgr.config.GetTasksBatchSize())
 	})
 	if err != nil {
 		return nil, err
@@ -151,18 +193,18 @@ func (c *taskListManagerImpl) getTaskBatchWithRange(readLevel int64, maxReadLeve
 // Returns a batch of tasks from persistence starting form current read level.
 // Also return a number that can be used to update readLevel
 // Also return a bool to indicate whether read is finished
-func (c *taskListManagerImpl) getTaskBatch() ([]*persistence.TaskInfo, int64, bool, error) {
+func (tr *taskReader) getTaskBatch() ([]*persistence.TaskInfo, int64, bool, error) {
 	var tasks []*persistence.TaskInfo
-	readLevel := c.taskAckManager.getReadLevel()
-	maxReadLevel := c.taskWriter.GetMaxReadLevel()
+	readLevel := tr.tlMgr.taskAckManager.getReadLevel()
+	maxReadLevel := tr.tlMgr.taskWriter.GetMaxReadLevel()
 
 	// counter i is used to break and let caller check whether tasklist is still alive and need resume read.
 	for i := 0; i < 10 && readLevel < maxReadLevel; i++ {
-		upper := readLevel + c.config.RangeSize
+		upper := readLevel + tr.tlMgr.config.RangeSize
 		if upper > maxReadLevel {
 			upper = maxReadLevel
 		}
-		tasks, err := c.getTaskBatchWithRange(readLevel, upper)
+		tasks, err := tr.getTaskBatchWithRange(readLevel, upper)
 		if err != nil {
 			return nil, readLevel, true, err
 		}
@@ -175,49 +217,65 @@ func (c *taskListManagerImpl) getTaskBatch() ([]*persistence.TaskInfo, int64, bo
 	return tasks, readLevel, readLevel == maxReadLevel, nil // caller will update readLevel when no task grabbed
 }
 
-func (c *taskListManagerImpl) isTaskExpired(t *persistence.TaskInfo, now time.Time) bool {
+func (tr *taskReader) isTaskExpired(t *persistence.TaskInfo, now time.Time) bool {
 	return t.Expiry.After(epochStartTime) && time.Now().After(t.Expiry)
 }
 
-func (c *taskListManagerImpl) isIdle(lastWriteTime time.Time) bool {
-	return !c.isTaskAddedRecently(lastWriteTime) && len(c.GetAllPollerInfo()) == 0
+func (tr *taskReader) isIdle(lastWriteTime time.Time) bool {
+	return !tr.isTaskAddedRecently(lastWriteTime) && len(tr.tlMgr.GetAllPollerInfo()) == 0
 }
 
-func (c *taskListManagerImpl) handleIdleTimeout() {
-	c.persistAckLevel()
-	c.taskGC.RunNow(c.taskAckManager.getAckLevel())
-	c.Stop()
+func (tr *taskReader) handleIdleTimeout() {
+	tr.persistAckLevel()
+	tr.tlMgr.taskGC.RunNow(tr.tlMgr.taskAckManager.getAckLevel())
+	tr.tlMgr.Stop()
 }
 
-func (c *taskListManagerImpl) addTasksToBuffer(
+func (tr *taskReader) addTasksToBuffer(
 	tasks []*persistence.TaskInfo, lastWriteTime time.Time, idleTimer *time.Timer) bool {
 	now := time.Now()
 	for _, t := range tasks {
-		if c.isTaskExpired(t, now) {
-			c.domainScope().IncCounter(metrics.ExpiredTasksCounter)
+		if tr.isTaskExpired(t, now) {
+			tr.scope().IncCounter(metrics.ExpiredTasksCounter)
 			continue
 		}
-		if !c.addSingleTaskToBuffer(t, lastWriteTime, idleTimer) {
+		if !tr.addSingleTaskToBuffer(t, lastWriteTime, idleTimer) {
 			return false // we are shutting down the task list
 		}
 	}
 	return true
 }
 
-func (c *taskListManagerImpl) addSingleTaskToBuffer(
+func (tr *taskReader) addSingleTaskToBuffer(
 	task *persistence.TaskInfo, lastWriteTime time.Time, idleTimer *time.Timer) bool {
-	c.taskAckManager.addTask(task.TaskID)
+	tr.tlMgr.taskAckManager.addTask(task.TaskID)
 	for {
 		select {
-		case c.taskBuffer <- task:
+		case tr.taskBuffer <- task:
 			return true
 		case <-idleTimer.C:
-			if c.isIdle(lastWriteTime) {
-				c.handleIdleTimeout()
+			if tr.isIdle(lastWriteTime) {
+				tr.handleIdleTimeout()
 				return false
 			}
-		case <-c.shutdownCh:
+		case <-tr.tlMgr.shutdownCh:
 			return false
 		}
 	}
+}
+
+func (tr *taskReader) persistAckLevel() error {
+	return tr.tlMgr.db.UpdateState(tr.tlMgr.taskAckManager.getAckLevel())
+}
+
+func (tr *taskReader) isTaskAddedRecently(lastAddTime time.Time) bool {
+	return time.Now().Sub(lastAddTime) <= tr.tlMgr.config.MaxTasklistIdleTime()
+}
+
+func (tr *taskReader) logger() log.Logger {
+	return tr.tlMgr.logger
+}
+
+func (tr *taskReader) scope() metrics.Scope {
+	return tr.tlMgr.domainScope()
 }

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -57,9 +57,11 @@ func newTaskReader(tlMgr *taskListManagerImpl) *taskReader {
 		tlMgr:               tlMgr,
 		cancelCtx:           ctx,
 		cancelFunc:          cancel,
-		taskBuffer:          make(chan *persistence.TaskInfo, tlMgr.config.GetTasksBatchSize()-1),
 		notifyC:             make(chan struct{}, 1),
 		dispatcherShutdownC: make(chan struct{}),
+		// we always dequeue the head of the buffer and try to dispatch it to a poller
+		// so allocate one less than desired target buffer size
+		taskBuffer: make(chan *persistence.TaskInfo, tlMgr.config.GetTasksBatchSize()-1),
 	}
 }
 


### PR DESCRIPTION
First step towards #2098. This patch separates out individual components within taskListManager into their own class / files. Most important parts are:

- the piece of code that matches a task producer with a task consumer is separated out into a new class called TaskMatcher
- taskReader used to acquire a ratelimit token, read a task from db and then block infinitely until a poller arrives. This meant ratelimit not being honored in certain cases. This behavior is now fixed. This is the only behavior change in this PR.  

Other things:
- taskListManager.AddTask() now takes a context param (previously never honored the context)
- taskContext is replaced with internalTask. The RecordXXXStarted() methods are removed from the taskContext since they don't really belong there
- taskReader is moved into its own class - but it still takes taskListManager as a param because of the tight coupling. I tried to break this but there are optimizations that necessitate access to internal state of taskListManager. So this part of refactoring is purely for readability - from a encapsulation perspective, it doesn't buy anything
- All configs are moved to one file