### PR TITLE
Batch terminating workflow

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1084,6 +1084,7 @@
     "github.com/m3db/prometheus_client_golang/prometheus",
     "github.com/olekukonko/tablewriter",
     "github.com/olivere/elastic",
+    "github.com/opentracing/opentracing-go",
     "github.com/pborman/uuid",
     "github.com/robfig/cron",
     "github.com/sirupsen/logrus",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -987,7 +987,7 @@
     "internal/semver",
   ]
   pruneopts = ""
-  revision = "38ae2c8f64122bd595b7f93f968a6686cd27bb5a"
+  revision = "7e72c71c505fa4ee8da98520d2b0673ba2eefe56"
 
 [[projects]]
   digest = "1:47f391ee443f578f01168347818cb234ed819521e49e4d2c8dd2fb80d48ee41a"

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -987,7 +987,7 @@
     "internal/semver",
   ]
   pruneopts = ""
-  revision = "7e72c71c505fa4ee8da98520d2b0673ba2eefe56"
+  revision = "38ae2c8f64122bd595b7f93f968a6686cd27bb5a"
 
 [[projects]]
   digest = "1:47f391ee443f578f01168347818cb234ed819521e49e4d2c8dd2fb80d48ee41a"

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -841,6 +841,8 @@ const (
 	ArchiverArchivalWorkflowScope
 	// TaskListScavengerScope is scope used by all metrics emitted by worker.tasklist.Scavenger module
 	TaskListScavengerScope
+	// BatcherScope is scope used by all metrics emitted by worker.Batcher module
+	BatcherScope
 
 	NumWorkerScopes
 )
@@ -1225,6 +1227,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ArchiverPumpScope:                   {operation: "ArchiverPump"},
 		ArchiverArchivalWorkflowScope:       {operation: "ArchiverArchivalWorkflow"},
 		TaskListScavengerScope:              {operation: "tasklistscavenger"},
+		BatcherScope:                        {operation: "batcher"},
 	},
 	// Blobstore Scope Names
 	Blobstore: {
@@ -1499,6 +1502,8 @@ const (
 	StoppedCount
 	ExecutorTasksDeferredCount
 	ExecutorTasksDroppedCount
+	BatcherProcessorSuccess
+	BatcherProcessorFailures
 	NumWorkerMetrics
 )
 
@@ -1747,6 +1752,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		StoppedCount:                                           {metricName: "stopped", metricType: Counter},
 		ExecutorTasksDeferredCount:                             {metricName: "executor_deferred", metricType: Counter},
 		ExecutorTasksDroppedCount:                              {metricName: "executor_dropped", metricType: Counter},
+		BatcherProcessorSuccess:                                {metricName: "batcher_processor_requests", metricType: Counter},
+		BatcherProcessorFailures:                               {metricName: "batcher_processor_errors", metricType: Counter},
 	},
 }
 

--- a/service/worker/batcher/batcher.go
+++ b/service/worker/batcher/batcher.go
@@ -108,7 +108,7 @@ func (s *Batcher) Start() error {
 		MetricsScope:              s.tallyScope,
 		BackgroundActivityContext: context.WithValue(context.Background(), batcherContextKey, s),
 	}
-	worker := worker.New(s.svcClient, common.SystemLocalDomainName, batcherTaskListName, workerOpts)
+	worker := worker.New(s.svcClient, common.SystemGlobalDomainName, batcherTaskListName, workerOpts)
 	return worker.Start()
 }
 
@@ -135,8 +135,8 @@ func (s *Batcher) createGlobalSystemDomainIfNotExists() error {
 		return nil
 	}
 
-	if s.cfg.ClusterMetadata.IsMasterCluster() && !s.cfg.ClusterMetadata.IsGlobalDomainEnabled() {
-		return fmt.Errorf("not master cluster, retry on describe domain only")
+	if s.cfg.ClusterMetadata.IsGlobalDomainEnabled() && !s.cfg.ClusterMetadata.IsMasterCluster() {
+		return fmt.Errorf("not master of the global cluster, retry on describe domain only")
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), rpcTimeout)

--- a/service/worker/batcher/batcher.go
+++ b/service/worker/batcher/batcher.go
@@ -71,19 +71,14 @@ type (
 		TallyScope tally.Scope
 	}
 
-	// batcherContext is the context object that get's
-	// passed around within the scanner workflows / activities
-	batcherContext struct {
+	// Batcher is the background sub-system that execute workflow for batch operations
+	// It is also the context object that get's passed around within the scanner workflows / activities
+	Batcher struct {
 		cfg           Config
 		svcClient     workflowserviceclient.Interface
 		metricsClient metrics.Client
 		tallyScope    tally.Scope
 		logger        log.Logger
-	}
-
-	// Batcher is the background sub-system that execute workflow for batch operations
-	Batcher struct {
-		context batcherContext
 	}
 )
 
@@ -91,13 +86,11 @@ type (
 func New(params *BootstrapParams) *Batcher {
 	cfg := params.Config
 	return &Batcher{
-		context: batcherContext{
-			cfg:           cfg,
-			svcClient:     params.ServiceClient,
-			metricsClient: params.MetricsClient,
-			tallyScope:    params.TallyScope,
-			logger:        params.Logger.WithTags(tag.ComponentBatcher),
-		},
+		cfg:           cfg,
+		svcClient:     params.ServiceClient,
+		metricsClient: params.MetricsClient,
+		tallyScope:    params.TallyScope,
+		logger:        params.Logger.WithTags(tag.ComponentBatcher),
 	}
 }
 
@@ -112,10 +105,10 @@ func (s *Batcher) Start() error {
 
 	// start worker for batch operation workflows
 	workerOpts := worker.Options{
-		MetricsScope:              s.context.tallyScope,
-		BackgroundActivityContext: context.WithValue(context.Background(), batcherContextKey, s.context),
+		MetricsScope:              s.tallyScope,
+		BackgroundActivityContext: context.WithValue(context.Background(), batcherContextKey, s),
 	}
-	worker := worker.New(s.context.svcClient, common.SystemLocalDomainName, batcherTaskListName, workerOpts)
+	worker := worker.New(s.svcClient, common.SystemLocalDomainName, batcherTaskListName, workerOpts)
 	return worker.Start()
 }
 
@@ -132,28 +125,28 @@ func (s *Batcher) createGlobalSystemDomainIfNotExistsWithRetry() error {
 
 func (s *Batcher) createGlobalSystemDomainIfNotExists() error {
 	ctx, cancel := context.WithTimeout(context.Background(), rpcTimeout)
-	_, err := s.context.svcClient.DescribeDomain(ctx, &shared.DescribeDomainRequest{
+	_, err := s.svcClient.DescribeDomain(ctx, &shared.DescribeDomainRequest{
 		Name: common.StringPtr(common.SystemGlobalDomainName),
 	})
 	cancel()
 
 	if err == nil {
-		s.context.logger.Info("Global system domain already exists", tag.WorkflowDomainName(common.SystemGlobalDomainName))
+		s.logger.Info("Global system domain already exists", tag.WorkflowDomainName(common.SystemGlobalDomainName))
 		return nil
 	}
 
-	if s.context.cfg.ClusterMetadata.IsMasterCluster() && !s.context.cfg.ClusterMetadata.IsGlobalDomainEnabled() {
+	if s.cfg.ClusterMetadata.IsMasterCluster() && !s.cfg.ClusterMetadata.IsGlobalDomainEnabled() {
 		return fmt.Errorf("not master cluster, retry on describe domain only")
 	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), rpcTimeout)
-	err = s.context.svcClient.RegisterDomain(ctx, s.getDomainCreationRequest())
+	err = s.svcClient.RegisterDomain(ctx, s.getDomainCreationRequest())
 	cancel()
 	if err != nil {
-		s.context.logger.Error("Error creating global system domain", tag.Error(err))
+		s.logger.Error("Error creating global system domain", tag.Error(err))
 		return err
 	}
-	s.context.logger.Info("Domain created successfully")
+	s.logger.Info("Domain created successfully")
 	return nil
 }
 
@@ -162,15 +155,15 @@ func (s *Batcher) getDomainCreationRequest() *shared.RegisterDomainRequest {
 		Name:                                   common.StringPtr(common.SystemGlobalDomainName),
 		WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(common.SystemDomainRetentionDays),
 		EmitMetric:                             common.BoolPtr(true),
-		SecurityToken:                          common.StringPtr(s.context.cfg.AdminOperationToken()),
+		SecurityToken:                          common.StringPtr(s.cfg.AdminOperationToken()),
 		IsGlobalDomain:                         common.BoolPtr(false),
 	}
 
-	if s.context.cfg.ClusterMetadata.IsGlobalDomainEnabled() {
+	if s.cfg.ClusterMetadata.IsGlobalDomainEnabled() {
 		req.IsGlobalDomain = common.BoolPtr(true)
-		req.ActiveClusterName = common.StringPtr(s.context.cfg.ClusterMetadata.GetMasterClusterName())
+		req.ActiveClusterName = common.StringPtr(s.cfg.ClusterMetadata.GetMasterClusterName())
 		var clusters []*shared.ClusterReplicationConfiguration
-		for name, c := range s.context.cfg.ClusterMetadata.GetAllClusterInfo() {
+		for name, c := range s.cfg.ClusterMetadata.GetAllClusterInfo() {
 			if !c.Enabled {
 				continue
 			}

--- a/service/worker/batcher/batcher.go
+++ b/service/worker/batcher/batcher.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -107,6 +108,7 @@ func (s *Batcher) Start() error {
 	workerOpts := worker.Options{
 		MetricsScope:              s.tallyScope,
 		BackgroundActivityContext: context.WithValue(context.Background(), batcherContextKey, s),
+		Tracer:                    opentracing.GlobalTracer(),
 	}
 	worker := worker.New(s.svcClient, common.SystemGlobalDomainName, batcherTaskListName, workerOpts)
 	return worker.Start()

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -219,6 +219,10 @@ func BatchActivity(ctx context.Context, batchParams BatchParams) error {
 		if err != nil {
 			return err
 		}
+		batchCount := len(resp.Executions)
+		if batchCount <= 0 {
+			break
+		}
 
 		// send all tasks
 		for _, wf := range resp.Executions {
@@ -228,7 +232,6 @@ func BatchActivity(ctx context.Context, batchParams BatchParams) error {
 				hbd:       hbd,
 			}
 		}
-		batchCount := len(resp.Executions)
 
 		succCount := 0
 		errCount := 0

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -322,6 +322,7 @@ func processTerminate(ctx context.Context, limiter *rate.Limiter, task taskDetai
 			return err
 		}
 		if len(resp.PendingChildren) > 0 {
+			getActivityLogger(ctx).Info("Found more child workflows to terminate", tag.Number(int64(len(resp.PendingChildren))))
 			for _, ch := range resp.PendingChildren {
 				wfs = append(wfs, shared.WorkflowExecution{
 					WorkflowId: ch.WorkflowID,

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -62,6 +62,8 @@ type (
 	// TerminateParams is the parameters for terminating workflow
 	TerminateParams struct {
 		// this indicates whether to terminate children workflow. Default to true.
+		// TODO https://github.com/uber/cadence/issues/2159
+		// Ideally default should be childPolicy of the workflow. But it's currently totally broken.
 		TerminateChildren *bool
 	}
 

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -54,6 +54,7 @@ const (
 )
 
 const (
+	// BatchTypeTerminate is batch type for terminating workflows
 	BatchTypeTerminate = "terminate"
 )
 
@@ -177,6 +178,7 @@ func setDefaultParams(params BatchParams) (BatchParams, error) {
 	}
 }
 
+// BatchActivity is activity for processing batch operation
 func BatchActivity(ctx context.Context, batchParams BatchParams) error {
 	batcher := ctx.Value(batcherContextKey).(*Batcher)
 

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -61,12 +61,6 @@ const (
 )
 
 type (
-	ResetParams struct {
-		ResetType         string
-		BadBinaryChecksum string
-		SkipIfOpen        bool
-	}
-
 	BatchParams struct {
 		// Target domain to execute batch operation
 		DomainName string
@@ -76,8 +70,6 @@ type (
 		Reason string
 		// Supporting: reset,terminate
 		BatchType string
-		// Detailed param for reset batch type
-		ResetParams ResetParams
 
 		// Below are all optional
 
@@ -144,6 +136,9 @@ func BatchWorkflow(ctx workflow.Context, batchParams BatchParams) error {
 }
 
 func setDefaultParams(params BatchParams) (BatchParams, error) {
+	if params.BatchType == "" || params.Reason == "" || params.DomainName == "" || params.QueryCondition == "" {
+		return BatchParams{}, fmt.Errorf("must provide required parameters: BatchType/Reason/DomainName/QueryCondition")
+	}
 	if params.RPS <= 0 {
 		params.RPS = defaultRPS
 	}

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -303,7 +303,6 @@ func processOneTerminateTask(ctx context.Context, limiter *rate.Limiter, task ta
 			}
 		}
 		wfs = wfs[1:]
-		getActivityLogger(ctx).Info("terminated wf:", tag.WorkflowID(wf.GetWorkflowId()), tag.WorkflowRunID(wf.GetRunId()))
 		newCtx, cancel = context.WithDeadline(ctx, time.Now().Add(rpcTimeout))
 		resp, err := batcher.svcClient.DescribeWorkflowExecution(newCtx, &shared.DescribeWorkflowExecutionRequest{
 			Domain:    common.StringPtr(param.DomainName),

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -278,6 +278,7 @@ func BatchActivity(ctx context.Context, batchParams BatchParams) (HeartBeatDetai
 }
 
 func countWorkflowsWithRetry(ctx context.Context, svcClient workflowserviceclient.Interface, batchParams BatchParams) (*shared.CountWorkflowExecutionsResponse, error) {
+	batcher := ctx.Value(batcherContextKey).(*Batcher)
 	var resp *shared.CountWorkflowExecutionsResponse
 	policy := backoff.NewExponentialRetryPolicy(rpcTimeout)
 	policy.SetMaximumInterval(batchParams.ActivityHeartBeatTimeout)
@@ -290,7 +291,6 @@ func countWorkflowsWithRetry(ctx context.Context, svcClient workflowserviceclien
 			Query:  common.StringPtr(batchParams.Query),
 		})
 		if err != nil {
-			batcher := ctx.Value(batcherContextKey).(*Batcher)
 			batcher.metricsClient.IncCounter(metrics.BatcherScope, metrics.BatcherProcessorFailures)
 			getActivityLogger(ctx).Error("Failed to countWorkflowsWithRetry for batch operation task", tag.Error(err))
 		}
@@ -302,7 +302,9 @@ func countWorkflowsWithRetry(ctx context.Context, svcClient workflowserviceclien
 
 	return resp, err
 }
+
 func scanWorkflowsWithRetry(ctx context.Context, svcClient workflowserviceclient.Interface, pageToken []byte, batchParams BatchParams) (*shared.ListWorkflowExecutionsResponse, error) {
+	batcher := ctx.Value(batcherContextKey).(*Batcher)
 	var resp *shared.ListWorkflowExecutionsResponse
 	policy := backoff.NewExponentialRetryPolicy(rpcTimeout)
 	policy.SetMaximumInterval(batchParams.ActivityHeartBeatTimeout)
@@ -316,7 +318,6 @@ func scanWorkflowsWithRetry(ctx context.Context, svcClient workflowserviceclient
 			Query:         common.StringPtr(batchParams.Query),
 		})
 		if err != nil {
-			batcher := ctx.Value(batcherContextKey).(*Batcher)
 			batcher.metricsClient.IncCounter(metrics.BatcherScope, metrics.BatcherProcessorFailures)
 			getActivityLogger(ctx).Error("Failed to scanWorkflowsWithRetry for batch operation task", tag.Error(err))
 		}

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -22,30 +22,43 @@ package batcher
 
 import (
 	"context"
-	"fmt"
-	"github.com/uber/cadence/.gen/go/shared"
+	"sync/atomic"
 	"time"
 
+	"github.com/uber/cadence/common/log"
+
+	"golang.org/x/time/rate"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/log/tag"
 	"go.uber.org/cadence"
+	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/activity"
 	"go.uber.org/cadence/workflow"
 )
 
 const (
-	batcherContextKey          = "batcherContext"
-	batcherTaskListName        = "cadence-sys-batcher-tasklist"
-	batchWFTypeName            = "cadence-sys-batch-workflow"
-	batchResetActivityName     = "cadence-sys-batch-reset-activity"
-	batchTerminateActivityName = "cadence-sys-batch-terminate-activity"
+	batcherContextKey   = "batcherContext"
+	batcherTaskListName = "cadence-sys-batcher-tasklist"
+	batchWFTypeName     = "cadence-sys-batch-workflow"
+	batchActivityName   = "cadence-sys-batch-activity"
 
-	infiniteDuration        = 20 * 365 * 24 * time.Hour
-	batchActivityHBInterval = 10 * time.Second
+	infiniteDuration = 20 * 365 * 24 * time.Hour
+	pageSize         = 1000
+
+	// below are default values for BatchParams
+
+	defaultRPS                      = 50
+	defaultConcurrency              = 5
+	defaultAttemptsOnRetryableError = 50
+	// this number is based on above default values in the worst case:
+	//  pageSize * defaultAttemptsOnRetryableError / defaultRPS  = 1000s = 16.6 Min
+	defaultActivityHeartBeatTimeout = 20 * time.Minute
 )
 
 const (
-	BatchTypeResetUnknown = iota
-	BatchTypeTerminate
-	BatchTypeReset
+	BatchTypeTerminate = "reset"
+	BatchTypeReset     = "terminate"
 )
 
 type (
@@ -55,9 +68,42 @@ type (
 	}
 
 	BatchParams struct {
+		// Target domain to execute batch operation
+		DomainName string
+		// To query the target workflows for processing
 		QueryCondition string
-		BatchType      int
-		ResetParams    ResetParams
+		// Supporting: reset,terminate
+		BatchType string
+		// Detailed param for reset batch type
+		ResetParams ResetParams
+
+		// Below are all optional
+
+		// RPS of processing. Default to defaultRPS
+		RPS int
+		// Number of goroutines running in parallel to process
+		Concurrency int
+		// Number of attempts for each workflow to process in case of retryable error before giving up
+		AttemptsOnRetryableError int
+		ActivityHeartBeatTimeout time.Duration
+	}
+
+	HeartBeatDetails struct {
+		PageToken   []byte
+		CurrentPage int
+		// This is just an estimation for visibility
+		TotalEstimate int64
+		// Number of workflows processed successfully
+		SuccessCount int32
+		// Number of workflows skipped due to some errors that are safe to skip, like EntityNotExtits.
+		SkipCount int32
+		// Number of workflows that give up due to errors.
+		ErrorCount int32
+	}
+
+	taskDetail struct {
+		execution shared.WorkflowExecution
+		attempts  int
 	}
 )
 
@@ -72,38 +118,192 @@ var (
 	batchActivityOptions = workflow.ActivityOptions{
 		ScheduleToStartTimeout: 5 * time.Minute,
 		StartToCloseTimeout:    infiniteDuration,
-		HeartbeatTimeout:       5 * time.Minute,
 		RetryPolicy:            &batchActivityRetryPolicy,
 	}
 )
 
 func init() {
 	workflow.RegisterWithOptions(BatchWorkflow, workflow.RegisterOptions{Name: batchWFTypeName})
-	activity.RegisterWithOptions(BatchResetActivity, activity.RegisterOptions{Name: batchResetActivityName})
-	activity.RegisterWithOptions(BatchTerminateActivity, activity.RegisterOptions{Name: batchTerminateActivityName})
+	activity.RegisterWithOptions(BatchActivity, activity.RegisterOptions{Name: batchActivityName})
 }
 
 // BatchWorkflow is the workflow that runs a batch job of resetting workflows
 func BatchWorkflow(ctx workflow.Context, batchParams BatchParams) error {
-	var future workflow.Future
-	switch batchParams.BatchType {
-	case BatchTypeReset:
-		future = workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, batchActivityOptions), batchResetActivityName, batchParams.QueryCondition, batchParams.ResetParams)
-	case BatchTypeTerminate:
-		future = workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, batchActivityOptions), batchTerminateActivityName, batchParams.QueryCondition)
-	default:
-		return fmt.Errorf("Unsupported operation: %v", batchParams.BatchType)
+	batchParams = setDefaultParams(batchParams)
+	batchActivityOptions.HeartbeatTimeout = batchParams.ActivityHeartBeatTimeout
+	opt := workflow.WithActivityOptions(ctx, batchActivityOptions)
+	return workflow.ExecuteActivity(opt, batchActivityName, batchParams).Get(ctx, nil)
+}
+
+func setDefaultParams(params BatchParams) BatchParams {
+	if params.RPS <= 0 {
+		params.RPS = defaultRPS
+	}
+	if params.Concurrency <= 0 {
+		params.Concurrency = defaultConcurrency
+	}
+	if params.AttemptsOnRetryableError <= 0 {
+		params.AttemptsOnRetryableError = defaultAttemptsOnRetryableError
+	}
+	if params.ActivityHeartBeatTimeout <= 0 {
+		params.ActivityHeartBeatTimeout = defaultActivityHeartBeatTimeout
+	}
+	return params
+}
+
+func BatchActivity(ctx context.Context, batchParams BatchParams) error {
+	batcher := ctx.Value(batcherContextKey).(Batcher)
+
+	hbd := HeartBeatDetails{}
+	startOver := true
+	if activity.HasHeartbeatDetails(ctx) {
+		if err := activity.GetHeartbeatDetails(ctx, &hbd); err == nil {
+			startOver = false
+		} else {
+			//TODO error metrics
+			getActivityLogger(ctx).Error("Failed to recover from last heartbeat, start over from beginning", tag.Error(err))
+		}
 	}
 
-	return future.Get(ctx, nil)
-}
+	if startOver {
+		resp, err := batcher.svcClient.CountWorkflowExecutions(ctx, &shared.CountWorkflowExecutionsRequest{
+			Domain: common.StringPtr(batchParams.DomainName),
+			Query:  common.StringPtr(batchParams.QueryCondition),
+		})
+		if err != nil {
+			return err
+		}
+		hbd.TotalEstimate = resp.GetCount()
+	}
+	rateLimiter := rate.NewLimiter(rate.Limit(batchParams.RPS), 0)
+	taskCh := make(chan taskDetail, pageSize)
+	var succCount, skipCount, errCount int32
+	for i := 0; i < batchParams.Concurrency; i++ {
+		go startTaskProcessor(ctx, batchParams, taskCh, rateLimiter, &succCount, &skipCount, &errCount)
+	}
 
-func BatchResetActivity(aCtx context.Context, queryCondition string, params ResetParams) error {
-	ctx := aCtx.Value(batcherContextKey).(batcherContext)
-	resp, err := ctx.svcClient.ListWorkflowExecutions(aCtx, &shared.ListWorkflowExecutionsRequest{})
+	for {
+		resp, err := batcher.svcClient.ListWorkflowExecutions(ctx, &shared.ListWorkflowExecutionsRequest{
+			PageSize:      common.Int32Ptr(int32(pageSize)),
+			Domain:        common.StringPtr(batchParams.DomainName),
+			NextPageToken: hbd.PageToken,
+			Query:         common.StringPtr(batchParams.QueryCondition),
+		})
+		if err != nil {
+			return err
+		}
+
+		// send all tasks
+		for _, wf := range resp.Executions {
+			taskCh <- taskDetail{
+				execution: *wf.Execution,
+				attempts:  0,
+			}
+		}
+		batchCount := len(resp.Executions)
+
+		// clear all counters
+		atomic.StoreInt32(&succCount, 0)
+		atomic.StoreInt32(&skipCount, 0)
+		atomic.StoreInt32(&errCount, 0)
+
+		// wait for counters indicate this batch is done
+	Loop:
+		for {
+			select {
+			case <-time.Tick(time.Second):
+				if int32(batchCount) == atomic.LoadInt32(&succCount)+atomic.LoadInt32(&skipCount)+atomic.LoadInt32(&errCount) {
+					break Loop
+				}
+			case <-ctx.Done():
+				// Need to return in case of cancellation, otherwise we may leak this goroutine
+				// TODO need to check if should we return cancellation error or it doesn't matter
+				return nil
+			}
+		}
+
+		hbd.CurrentPage++
+		hbd.PageToken = resp.NextPageToken
+		hbd.SuccessCount += atomic.LoadInt32(&succCount)
+		hbd.SkipCount += atomic.LoadInt32(&skipCount)
+		hbd.ErrorCount += atomic.LoadInt32(&errCount)
+		activity.RecordHeartbeat(ctx, hbd)
+
+		if len(hbd.PageToken) == 0 {
+			break
+		}
+	}
+
 	return nil
 }
 
-func BatchTerminateActivity(aCtx context.Context, queryCondition string) error {
+func startTaskProcessor(
+	ctx context.Context, batchParams BatchParams, taskCh chan taskDetail,
+	limiter *rate.Limiter, doneCount, skipCount, errCount *int32) {
+	batcher := ctx.Value(batcherContextKey).(Batcher)
+
+	for {
+		select {
+		case task := <-taskCh:
+			if isDone(ctx) {
+				return
+			}
+			var err error
+
+			switch batchParams.BatchType {
+			case BatchTypeTerminate:
+				err = processTerminate(ctx, batcher, limiter, task)
+			case BatchTypeReset:
+				err = processReset(ctx, batcher, limiter, task, batchParams.ResetParams)
+			}
+			if err != nil {
+				_, ok := err.(*shared.EntityNotExistsError)
+				if ok {
+					atomic.AddInt32(skipCount, 1)
+				} else {
+					getActivityLogger(ctx).Error("Failed to process task", tag.Error(err))
+					// put back to the channel if less than attemptsOnError
+					task.attempts++
+					if task.attempts >= batchParams.AttemptsOnRetryableError {
+						atomic.AddInt32(errCount, 1)
+					} else {
+						taskCh <- task
+					}
+				}
+			} else {
+				atomic.AddInt32(doneCount, 1)
+			}
+		}
+	}
+}
+
+func processTerminate(ctx context.Context, batcher Batcher, limiter *rate.Limiter, task taskDetail) error {
+	//TODO
 	return nil
+}
+
+func processReset(ctx context.Context, batcher Batcher, limiter *rate.Limiter, task taskDetail, param ResetParams) error {
+	err := limiter.Wait(ctx)
+	if err != nil {
+		getActivityLogger(ctx).Error("Failed to wait for rateLimiter", tag.Error(err))
+	}
+}
+
+func isDone(ctx context.Context) bool {
+	select {
+	case <-ctx.Done():
+		return true
+	default:
+		return false
+	}
+}
+
+func getActivityLogger(ctx context.Context) log.Logger {
+	batcher := ctx.Value(batcherContextKey).(Batcher)
+	wfInfo := activity.GetInfo(ctx)
+	return batcher.logger.WithTags(
+		tag.WorkflowID(wfInfo.WorkflowExecution.ID),
+		tag.WorkflowRunID(wfInfo.WorkflowExecution.RunID),
+		tag.WorkflowDomainName(wfInfo.WorkflowDomain),
+	)
 }

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -292,7 +292,7 @@ func startTaskProcessor(
 	}
 }
 
-func processOneTerminateTask(ctx context.Context, limiter *rate.Limiter, task taskDetail, param BatchParams) error {
+func processOneTerminateTask(ctx context.Context, limiter *rate.Limiter, task taskDetail, batchParams BatchParams) error {
 	batcher := ctx.Value(batcherContextKey).(*Batcher)
 
 	wfs := []shared.WorkflowExecution{task.execution}
@@ -306,9 +306,9 @@ func processOneTerminateTask(ctx context.Context, limiter *rate.Limiter, task ta
 
 		newCtx, cancel := context.WithDeadline(ctx, time.Now().Add(rpcTimeout))
 		err = batcher.svcClient.TerminateWorkflowExecution(newCtx, &shared.TerminateWorkflowExecutionRequest{
-			Domain:            common.StringPtr(param.DomainName),
+			Domain:            common.StringPtr(batchParams.DomainName),
 			WorkflowExecution: &wf,
-			Reason:            common.StringPtr(param.Reason),
+			Reason:            common.StringPtr(batchParams.Reason),
 			Identity:          common.StringPtr(batchWFTypeName),
 		})
 		cancel()
@@ -321,7 +321,7 @@ func processOneTerminateTask(ctx context.Context, limiter *rate.Limiter, task ta
 		wfs = wfs[1:]
 		newCtx, cancel = context.WithDeadline(ctx, time.Now().Add(rpcTimeout))
 		resp, err := batcher.svcClient.DescribeWorkflowExecution(newCtx, &shared.DescribeWorkflowExecutionRequest{
-			Domain:    common.StringPtr(param.DomainName),
+			Domain:    common.StringPtr(batchParams.DomainName),
 			Execution: &wf,
 		})
 		cancel()

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -45,7 +45,6 @@ const (
 	pageSize         = 1000
 
 	// below are default values for BatchParams
-
 	defaultRPS                      = 50
 	defaultConcurrency              = 5
 	defaultAttemptsOnRetryableError = 50

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -41,8 +41,9 @@ const (
 )
 
 const (
-	BatchTypeReset = iota
+	BatchTypeResetUnknown = iota
 	BatchTypeTerminate
+	BatchTypeReset
 )
 
 type (

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -20,7 +20,71 @@
 
 package batcher
 
-const (
-	batcherContextKey   = "batcherContext"
-	batcherTaskListName = "cadence-sys-batcher-tasklist"
+import (
+	"context"
+	"time"
+
+	"go.uber.org/cadence"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/workflow"
 )
+
+const (
+	batcherContextKey          = "batcherContext"
+	batcherTaskListName        = "cadence-sys-batcher-tasklist"
+	batchWFTypeName            = "cadence-sys-batch-workflow"
+	batchResetActivityName     = "cadence-sys-batch-reset-activity"
+	batchTerminateActivityName = "cadence-sys-batch-terminate-activity"
+
+	infiniteDuration        = 20 * 365 * 24 * time.Hour
+	batchActivityHBInterval = 10 * time.Second
+)
+
+const (
+	BatchTypeReset = iota
+	BatchTypeTerminate
+)
+
+type (
+	ResetParams struct {
+		ResetType         string
+		BadBinaryChecksum string
+	}
+
+	BatchParams struct {
+		QueryCondition string
+		BatchType      int
+		ResetParams    ResetParams
+	}
+)
+
+var (
+	batchActivityRetryPolicy = cadence.RetryPolicy{
+		InitialInterval:    10 * time.Second,
+		BackoffCoefficient: 1.7,
+		MaximumInterval:    5 * time.Minute,
+		ExpirationInterval: infiniteDuration,
+	}
+
+	batchActivityOptions = workflow.ActivityOptions{
+		ScheduleToStartTimeout: 5 * time.Minute,
+		StartToCloseTimeout:    infiniteDuration,
+		HeartbeatTimeout:       5 * time.Minute,
+		RetryPolicy:            &batchActivityRetryPolicy,
+	}
+)
+
+func init() {
+	workflow.RegisterWithOptions(BatchWorkflow, workflow.RegisterOptions{Name: batchWFTypeName})
+	activity.RegisterWithOptions(BatchResetActivity, activity.RegisterOptions{Name: batchResetActivityName})
+}
+
+// BatchWorkflow is the workflow that runs a batch job of resetting workflows
+func BatchWorkflow(ctx workflow.Context, batchParams BatchParams) error {
+	future := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, batchActivityOptions), batchResetActivityName)
+	return future.Get(ctx, nil)
+}
+
+func BatchResetActivity(aCtx context.Context) error {
+	return nil
+}

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -272,6 +272,8 @@ func startTaskProcessor(
 
 	for {
 		select {
+		case <-ctx.Done():
+			return
 		case task := <-taskCh:
 			if isDone(ctx) {
 				return

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -204,6 +204,11 @@ func BatchActivity(ctx context.Context, batchParams BatchParams) error {
 			return err
 		}
 
+		// clear all counters
+		atomic.StoreInt32(&succCount, 0)
+		atomic.StoreInt32(&skipCount, 0)
+		atomic.StoreInt32(&errCount, 0)
+
 		// send all tasks
 		for _, wf := range resp.Executions {
 			taskCh <- taskDetail{
@@ -213,11 +218,6 @@ func BatchActivity(ctx context.Context, batchParams BatchParams) error {
 			}
 		}
 		batchCount := len(resp.Executions)
-
-		// clear all counters
-		atomic.StoreInt32(&succCount, 0)
-		atomic.StoreInt32(&skipCount, 0)
-		atomic.StoreInt32(&errCount, 0)
 
 		// wait for counters indicate this batch is done
 	Loop:

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -398,7 +398,7 @@ func processTerminateTask(ctx context.Context, limiter *rate.Limiter, task taskD
 		})
 		cancel()
 		if err != nil {
-			// // EntityNotExistsError means wf is deleted
+			// EntityNotExistsError means wf is deleted
 			_, ok := err.(*shared.EntityNotExistsError)
 			if !ok {
 				return err

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -266,7 +266,7 @@ func startTaskProcessor(
 
 			switch batchParams.BatchType {
 			case BatchTypeTerminate:
-				err = processTerminate(ctx, limiter, task, batchParams)
+				err = processOneTerminateTask(ctx, limiter, task, batchParams)
 			}
 			if err != nil {
 				_, ok := err.(*shared.EntityNotExistsError)
@@ -289,7 +289,7 @@ func startTaskProcessor(
 	}
 }
 
-func processTerminate(ctx context.Context, limiter *rate.Limiter, task taskDetail, param BatchParams) error {
+func processOneTerminateTask(ctx context.Context, limiter *rate.Limiter, task taskDetail, param BatchParams) error {
 	batcher := ctx.Value(batcherContextKey).(Batcher)
 
 	wfs := []shared.WorkflowExecution{task.execution}

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -150,7 +150,7 @@ func (s *Service) Start() {
 	scannerEnabled := s.config.ScannerCfg.Persistence.DefaultStoreType() == config.StoreTypeSQL
 	batcherEnabled := s.config.EnableBatcher()
 
-	if replicatorEnabled || archiverEnabled || scannerEnabled {
+	if replicatorEnabled || archiverEnabled || scannerEnabled || batcherEnabled {
 		pConfig := s.params.PersistenceConfig
 		pConfig.SetMaxQPS(pConfig.DefaultStore, s.config.ReplicationCfg.PersistenceMaxQPS())
 		pFactory := persistencefactory.New(&pConfig, s.params.ClusterMetadata.GetCurrentClusterName(), s.metricsClient, s.logger)


### PR DESCRIPTION
Tested locally:
start wf and child wfs:
```
longer@~/gocode/src/github.com/uber/cadence:(batch-term)$ cadence --do samples-domain wf list --query "WorkflowType='main.SampleParentWorkflow' and CloseTime=missing order by CloseTime ASC" -ps 100
        WORKFLOW TYPE       |                     WORKFLOW ID                     |                RUN ID                | START TIME | EXECUTION TIME | END TIME
  main.SampleParentWorkflow | parentworkflow_952970e3-f223-48a8-8e2d-5db9d5871663 | ffd9bb6d-140a-45da-be12-52b4e31e873c | 17:26:51   | 17:26:51       | 16:00:00
  main.SampleParentWorkflow | parentworkflow_efe85202-f1a7-4c17-9a2f-dcb7e35c3b2c | f5e41f08-bd4b-425f-a9d8-6c1347824a6d | 17:27:02   | 17:27:02       | 16:00:00
  main.SampleParentWorkflow | parentworkflow_4dc12065-cc8d-4e42-8da7-18a3aeee187d | ede21ac0-8465-480d-8c25-50da1dbe2dbe | 17:26:54   | 17:26:54       | 16:00:00
  main.SampleParentWorkflow | parentworkflow_e25501b5-c859-462e-a517-eb050dc22b26 | e94eda6e-e1bf-416b-8779-2bf4ed48d876 | 17:27:05   | 17:27:05       | 16:00:00
  main.SampleParentWorkflow | parentworkflow_68bb29ea-eb36-4b4d-985e-18d3275f290b | e4c70df5-3d3a-4879-9fec-cde5656e2d9d | 17:27:02   | 17:27:02       | 16:00:00
  main.SampleParentWorkflow | parentworkflow_73d2b47d-a47c-45e0-816d-110ed03a5ac0 | e235d9dd-ee76-4712-93df-d843dc7821dd | 17:27:02   | 17:27:02       | 16:00:00
...
...
...
...
```

Start batch terminate wf
```
longer@~/gocode/src/github.com/uber/cadence:(batch-term)$ cadence --do cadence-system-global wf start -w "test-batch-14" -wt cadence-sys-batch-workflow -et 100000 -dt 100 -i "{\"DomainName\":\"samples-domain\",\"Query\":\"WorkflowType='main.SampleParentWorkflow' and CloseTime=missing\",\"Reason\":\"test-reason\",\"BatchType\":\"terminate\",\"TerminateParams\":{\"TerminateChildren\":true}}" --tl cadence-sys-batcher-tasklist
Started Workflow Id: test-batch-14, run Id: c56ceeeb-655d-46f6-9d00-e693f4acf638
```

target wf terminated:
```
longer@~/gocode/src/github.com/uber/cadence:(batch-term)$ cadence --do samples-domain wf list --query "WorkflowType='main.SampleParentWorkflow' and CloseTime=missing order by CloseTime ASC" -ps 100
  WORKFLOW TYPE | WORKFLOW ID | RUN ID | START TIME | EXECUTION TIME | END TIME
longer@~/gocode/src/github.com/uber/cadence:(batch-term)$ cadence --do samples-domain wf list --open
  WORKFLOW TYPE | WORKFLOW ID | RUN ID | START TIME | EXECUTION TIME
```



Also tested heartbeat:
```
  "PendingActivities": [
    {
      "ActivityID": "0",
      "ActivityType": {
        "name": "cadence-sys-batch-activity"
      },
      "State": "STARTED",
      "LastStartedTimestamp": "2019-07-02T17:27:16-07:00",
      "HeartbeatDetails": "{\"PageToken\":\"eyJGcm9tIjowLCJTb3J0VmFsdWUiOm51bGwsIlRpZUJyZWFrZXIiOiIiLCJTY3JvbGxJRCI6IkRuRjFaWEo1VkdobGJrWmxkR05vQlFBQUFBQUFBQUhtRmpOU1pFNXRXREJvVkhsNVZuSjVTME5HUm0xQ1prRUFBQUFBQUFBQjV4WXpVbVJPYlZnd2FGUjVlVlp5ZVV0RFJrWnRRbVpCQUFBQUFBQUFBZWdXTTFKa1RtMVlNR2hVZVhsV2NubExRMFpHYlVKbVFRQUFBQUFBQUFIcEZqTlNaRTV0V0RCb1ZIbDVWbko1UzBOR1JtMUNaa0VBQUFBQUFBQUI2aFl6VW1ST2JWZ3dhRlI1ZVZaeWVVdERSa1p0UW1aQiJ9\",\"CurrentPage\":18,\"TotalEstimate\":39,\"SuccessCount\":36,\"ErrorCount\":0}\n",
      "LastHeartbeatTimestamp": "2019-07-02T17:27:30-07:00",
      "Attempt": 0,
      "ExpirationTimestamp": "2039-06-27T16:27:16-08:00"
    }
  ]
```