### PR TITLE
Update CLI documentation for local dev quickstart

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -17,7 +17,7 @@ View Cadence-Web at localhost:8088
 Use Cadence-CLI with `docker run --network=host --rm ubercadence/cli:master`
 
 For example to register new domain 'test-domain' with 1 retention day
-`docker run --network=host --rm ubercadence/cli:master --do test-domain domain register -rd 1`
+`docker run --network=host --rm ubercadence/cli:master --do test-domain domain register -rd 1 --global_domain false`
 
 
 Using a pre-built image


### PR DESCRIPTION
https://github.com/uber/cadence/blob/master/docker/README.md contains instruction for CLI usage
```
For example to register new domain 'test-domain' with 1 retention day
`docker run --network=host --rm ubercadence/cli:master --do test-domain domain register -rd 1`
```
which fails with the following message
```
Error: Option global_domain must be provided.
```

I suppose that it worth adding `--global_domain false` to documentation.