### PR TITLE
matching: make taskListID and taskListName partition aware

### DIFF
--- a/service/history/decisionChecker.go
+++ b/service/history/decisionChecker.go
@@ -22,7 +22,6 @@ package history
 
 import (
 	"fmt"
-
 	"strings"
 
 	"github.com/pborman/uuid"
@@ -61,7 +60,9 @@ type (
 	}
 )
 
-const reservedTaskListPrefix = "/__cadence_sys/"
+const (
+	reservedTaskListPrefix = "/__cadence_sys/"
+)
 
 func newDecisionAttrValidator(
 	domainCache cache.DomainCache,
@@ -195,7 +196,8 @@ func (v *decisionAttrValidator) validateActivityScheduleAttributes(
 		return &workflow.BadRequestError{Message: "ScheduleActivityTaskDecisionAttributes is not set on decision."}
 	}
 
-	if _, err := v.validatedTaskList(attributes.TaskList, ""); err != nil {
+	defaultTaskListName := ""
+	if _, err := v.validatedTaskList(attributes.TaskList, defaultTaskListName); err != nil {
 		return err
 	}
 

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -96,7 +96,7 @@ func newTaskListConfig(id *taskListID, config *Config, domainCache cache.DomainC
 	}
 
 	domain := domainEntry.GetInfo().Name
-	taskListName := id.taskListName
+	taskListName := id.name
 	taskType := id.taskType
 	return &taskListConfig{
 		RangeSize: config.RangeSize,

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -307,7 +307,7 @@ func (s *matchingEngineSuite) PollForTasksEmptyResultTest(callContext context.Co
 	taskList := &workflow.TaskList{}
 	taskList.Name = &tl
 	var taskListType workflow.TaskListType
-	tlID := newTaskListID(domainID, tl, taskType)
+	tlID := newTestTaskListID(domainID, tl, taskType)
 	//const rangeID = 123
 	const pollCount = 10
 	for i := 0; i < pollCount; i++ {
@@ -408,12 +408,7 @@ func (s *matchingEngineSuite) AddTasksTest(taskType int) {
 		}
 		s.NoError(err)
 	}
-	s.EqualValues(taskCount, s.taskManager.getTaskCount(&taskListID{
-		domainID:     domainID,
-		taskListName: tl,
-		taskType:     taskType,
-	}))
-
+	s.EqualValues(taskCount, s.taskManager.getTaskCount(newTestTaskListID(domainID, tl, taskType)))
 }
 
 func (s *matchingEngineSuite) TestTaskWriterShutdown() {
@@ -429,11 +424,7 @@ func (s *matchingEngineSuite) TestTaskWriterShutdown() {
 	workflowID := "workflow1"
 	execution := workflow.WorkflowExecution{RunId: &runID, WorkflowId: &workflowID}
 
-	tlID := &taskListID{
-		domainID:     domainID,
-		taskListName: tl,
-		taskType:     persistence.TaskListTypeActivity,
-	}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 	tlKind := common.TaskListKindPtr(workflow.TaskListKindNormal)
 	tlm, err := s.matchingEngine.getTaskListManager(tlID, tlKind)
 	s.Nil(err)
@@ -477,7 +468,7 @@ func (s *matchingEngineSuite) TestAddThenConsumeActivities() {
 
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 	s.taskManager.getTaskListManager(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
@@ -589,7 +580,7 @@ func (s *matchingEngineSuite) TestSyncMatchActivities() {
 
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 	tlKind := common.TaskListKindPtr(workflow.TaskListKindNormal)
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 	// So we can get snapshots
@@ -788,7 +779,7 @@ func (s *matchingEngineSuite) concurrentPublishConsumeActivities(
 	var scheduleID int64 = 123
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 	tlKind := common.TaskListKindPtr(workflow.TaskListKindNormal)
 	dispatchTTL := time.Nanosecond
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
@@ -939,7 +930,7 @@ func (s *matchingEngineSuite) TestConcurrentPublishConsumeDecisions() {
 
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeDecision}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeDecision)
 	s.taskManager.getTaskListManager(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
@@ -1085,7 +1076,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesActivitiesRangeStealing() {
 
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 	s.taskManager.getTaskListManager(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
@@ -1240,7 +1231,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesDecisionsRangeStealing() {
 
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeDecision}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeDecision)
 	s.taskManager.getTaskListManager(tlID).rangeID = initialRangeID
 	s.matchingEngine.config.RangeSize = rangeSize // override to low number for the test
 
@@ -1377,7 +1368,7 @@ func (s *matchingEngineSuite) TestAddTaskAfterStartFailure() {
 
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 	tlKind := common.TaskListKindPtr(workflow.TaskListKindNormal)
 
 	taskList := &workflow.TaskList{}
@@ -1421,7 +1412,7 @@ func (s *matchingEngineSuite) TestTaskListManagerGetTaskBatch() {
 
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 
 	taskList := &workflow.TaskList{}
 	taskList.Name = &tl
@@ -1515,7 +1506,7 @@ func (s *matchingEngineSuite) TestTaskListManagerGetTaskBatch() {
 func (s *matchingEngineSuite) TestTaskListManagerGetTaskBatch_ReadBatchDone() {
 	domainID := "domainId"
 	tl := "makeToast"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 	tlNormal := workflow.TaskListKindNormal
 
 	const rangeSize = 10
@@ -1551,7 +1542,7 @@ func (s *matchingEngineSuite) TestTaskExpiryAndCompletion() {
 
 	domainID := uuid.New()
 	tl := "task-expiry-completion-tl0"
-	tlID := &taskListID{domainID: domainID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(domainID, tl, persistence.TaskListTypeActivity)
 
 	taskList := &workflow.TaskList{}
 	taskList.Name = &tl
@@ -1760,9 +1751,17 @@ func newTestTaskListManager() *testTaskListManager {
 	return &testTaskListManager{tasks: treemap.NewWith(Int64Comparator)}
 }
 
+func newTestTaskListID(domainID string, name string, taskType int) *taskListID {
+	result, err := newTaskListID(domainID, name, taskType)
+	if err != nil {
+		panic(fmt.Sprintf("newTaskListID failed with error %v", err))
+	}
+	return result
+}
+
 // LeaseTaskList provides a mock function with given fields: request
 func (m *testTaskManager) LeaseTaskList(request *persistence.LeaseTaskListRequest) (*persistence.LeaseTaskListResponse, error) {
-	tlm := m.getTaskListManager(newTaskListID(request.DomainID, request.TaskList, request.TaskType))
+	tlm := m.getTaskListManager(newTestTaskListID(request.DomainID, request.TaskList, request.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
 	tlm.rangeID++
@@ -1785,7 +1784,7 @@ func (m *testTaskManager) UpdateTaskList(request *persistence.UpdateTaskListRequ
 	m.logger.Debug(fmt.Sprintf("UpdateTaskList taskListInfo=%v, ackLevel=%v", request.TaskListInfo, request.TaskListInfo.AckLevel))
 
 	tli := request.TaskListInfo
-	tlm := m.getTaskListManager(newTaskListID(tli.DomainID, tli.Name, tli.TaskType))
+	tlm := m.getTaskListManager(newTestTaskListID(tli.DomainID, tli.Name, tli.TaskType))
 
 	tlm.Lock()
 	defer tlm.Unlock()
@@ -1806,7 +1805,7 @@ func (m *testTaskManager) CompleteTask(request *persistence.CompleteTaskRequest)
 	}
 
 	tli := request.TaskList
-	tlm := m.getTaskListManager(newTaskListID(tli.DomainID, tli.Name, tli.TaskType))
+	tlm := m.getTaskListManager(newTestTaskListID(tli.DomainID, tli.Name, tli.TaskType))
 
 	tlm.Lock()
 	defer tlm.Unlock()
@@ -1816,7 +1815,7 @@ func (m *testTaskManager) CompleteTask(request *persistence.CompleteTaskRequest)
 }
 
 func (m *testTaskManager) CompleteTasksLessThan(request *persistence.CompleteTasksLessThanRequest) (int, error) {
-	tlm := m.getTaskListManager(newTaskListID(request.DomainID, request.TaskListName, request.TaskType))
+	tlm := m.getTaskListManager(newTestTaskListID(request.DomainID, request.TaskListName, request.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
 	keys := tlm.tasks.Keys()
@@ -1837,7 +1836,7 @@ func (m *testTaskManager) ListTaskList(
 func (m *testTaskManager) DeleteTaskList(request *persistence.DeleteTaskListRequest) error {
 	m.Lock()
 	defer m.Unlock()
-	key := newTaskListID(request.DomainID, request.TaskListName, request.TaskListType)
+	key := newTestTaskListID(request.DomainID, request.TaskListName, request.TaskListType)
 	delete(m.taskLists, *key)
 	return nil
 }
@@ -1849,7 +1848,7 @@ func (m *testTaskManager) CreateTasks(request *persistence.CreateTasksRequest) (
 	taskType := request.TaskListInfo.TaskType
 	rangeID := request.TaskListInfo.RangeID
 
-	tlm := m.getTaskListManager(newTaskListID(domainID, taskList, taskType))
+	tlm := m.getTaskListManager(newTestTaskListID(domainID, taskList, taskType))
 	tlm.Lock()
 	defer tlm.Unlock()
 
@@ -1899,7 +1898,7 @@ func (m *testTaskManager) CreateTasks(request *persistence.CreateTasksRequest) (
 func (m *testTaskManager) GetTasks(request *persistence.GetTasksRequest) (*persistence.GetTasksResponse, error) {
 	m.logger.Debug(fmt.Sprintf("testTaskManager.GetTasks readLevel=%v, maxReadLevel=%v", request.ReadLevel, request.MaxReadLevel))
 
-	tlm := m.getTaskListManager(newTaskListID(request.DomainID, request.TaskList, request.TaskType))
+	tlm := m.getTaskListManager(newTestTaskListID(request.DomainID, request.TaskList, request.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
 	var tasks []*persistence.TaskInfo
@@ -1947,7 +1946,7 @@ func (m *testTaskManager) String() string {
 		} else {
 			result += "Decision"
 		}
-		result += " task list " + id.taskListName
+		result += " task list " + id.name
 		result += "\n"
 		result += fmt.Sprintf("AckLevel=%v\n", tl.ackLevel)
 		result += fmt.Sprintf("CreateTaskCount=%v\n", tl.createTaskCount)

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -131,14 +131,14 @@ func newTaskListManager(
 		taskListKind = common.TaskListKindPtr(s.TaskListKindNormal)
 	}
 
-	db := newTaskListDB(e.taskManager, taskList.domainID, taskList.taskListName, taskList.taskType, int(*taskListKind), e.logger)
+	db := newTaskListDB(e.taskManager, taskList.domainID, taskList.name, taskList.taskType, int(*taskListKind), e.logger)
 	tlMgr := &taskListManagerImpl{
 		domainCache:   e.domainCache,
 		metricsClient: e.metricsClient,
 		engine:        e,
 		shutdownCh:    make(chan struct{}),
 		taskListID:    taskList,
-		logger: e.logger.WithTags(tag.WorkflowTaskListName(taskList.taskListName),
+		logger: e.logger.WithTags(tag.WorkflowTaskListName(taskList.name),
 			tag.WorkflowTaskListType(taskList.taskType)),
 		db:                  db,
 		taskAckManager:      newAckManager(e.logger),
@@ -354,7 +354,7 @@ func (c *taskListManagerImpl) String() string {
 		buf.WriteString("Decision")
 	}
 	rangeID := c.db.RangeID()
-	fmt.Fprintf(buf, " task list %v\n", c.taskListID.taskListName)
+	fmt.Fprintf(buf, " task list %v\n", c.taskListID.name)
 	fmt.Fprintf(buf, "RangeID=%v\n", rangeID)
 	fmt.Fprintf(buf, "TaskIDBlock=%+v\n", c.rangeIDToTaskIDBlock(rangeID))
 	fmt.Fprintf(buf, "AckLevel=%v\n", c.taskAckManager.ackLevel)
@@ -394,7 +394,7 @@ func (c *taskListManagerImpl) completeTask(task *internalTask, err error) {
 			c.logger.Error("Persistent store operation failure",
 				tag.StoreOperationStopTaskList,
 				tag.Error(err),
-				tag.WorkflowTaskListName(c.taskListID.taskListName),
+				tag.WorkflowTaskListName(c.taskListID.name),
 				tag.WorkflowTaskListType(c.taskListID.taskType))
 			c.Stop()
 			return

--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -108,7 +108,7 @@ func createTestTaskListManagerWithConfig(cfg *Config) *taskListManagerImpl {
 	)
 	tl := "tl"
 	dID := "domain"
-	tlID := &taskListID{domainID: dID, taskListName: tl, taskType: persistence.TaskListTypeActivity}
+	tlID := newTestTaskListID(dID, tl, persistence.TaskListTypeActivity)
 	tlKind := common.TaskListKindPtr(workflow.TaskListKindNormal)
 	tlMgr, err := newTaskListManager(me, tlID, tlKind, cfg)
 	if err != nil {

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -176,7 +176,7 @@ writerLoop:
 					w.logger.Error("Persistent store operation failure",
 						tag.StoreOperationCreateTask,
 						tag.Error(err),
-						tag.WorkflowTaskListName(w.taskListID.taskListName),
+						tag.WorkflowTaskListName(w.taskListID.name),
 						tag.WorkflowTaskListType(w.taskListID.taskType),
 						tag.Number(taskIDs[0]),
 						tag.NextNumber(taskIDs[batchSize-1]),

--- a/service/matching/tasklist.go
+++ b/service/matching/tasklist.go
@@ -1,0 +1,150 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/uber/cadence/common/persistence"
+)
+
+type (
+	// taskListID is the key that uniquely identifies a task list
+	taskListID struct {
+		qualifiedTaskListName
+		domainID string
+		taskType int
+	}
+	// qualifiedTaskListName refers to the fully qualified task list name
+	qualifiedTaskListName struct {
+		name      string // internal name of the tasks list
+		baseName  string // original name of the task list as specified by user
+		partition int    // partitionID of task list
+	}
+)
+
+const (
+	// taskListPartitionPrefix is the required naming prefix for any task list partition other than partition 0
+	taskListPartitionPrefix = "/__cadence_sys/"
+)
+
+// newTaskListName returns a fully qualified task list name.
+// Fully qualified names contain additional metadata about task list
+// derived from their given name. The additional metadata only makes sense
+// when a task list has more than one partition. When there is more than
+// one partition for a user specified task list, each of the
+// individual partitions have an internal name of the form
+//
+//     /__cadence_sys/[original-name]/[partitionID]
+//
+// The name of the root partition is always the same as the user specified name. Rest of
+// the partitions follow the naming convention above. In addition, the task lists partitions
+// logically form a N-ary tree where N is configurable dynamically. The tree formation is an
+// optimization to allow for partitioned task lists to dispatch tasks with low latency when
+// throughput is low - See https://github.com/uber/cadence/issues/2098
+//
+// Returns error if the given name is non-compliant with the required format
+// for task list names
+func newTaskListName(name string) (qualifiedTaskListName, error) {
+	tn := qualifiedTaskListName{
+		name:     name,
+		baseName: name,
+	}
+	if err := tn.init(); err != nil {
+		return qualifiedTaskListName{}, err
+	}
+	return tn, nil
+}
+
+// IsRoot returns true if this task list is a root partition
+func (tn *qualifiedTaskListName) IsRoot() bool {
+	return tn.partition == 0
+}
+
+// Parent returns the name of the parent task list
+// input:
+//   degree: Number of children at each level of the tree
+// Returns empty string if this task list is the root
+func (tn *qualifiedTaskListName) Parent(degree int) string {
+	if tn.IsRoot() {
+		return ""
+	}
+	pid := (tn.partition+degree-1)/degree - 1
+	return tn.mkName(pid)
+}
+
+func (tn *qualifiedTaskListName) mkName(partition int) string {
+	if partition == 0 {
+		return tn.baseName
+	}
+	return fmt.Sprintf("%v%v/%v", taskListPartitionPrefix, tn.baseName, partition)
+}
+
+func (tn *qualifiedTaskListName) init() error {
+	if !strings.HasPrefix(tn.name, taskListPartitionPrefix) {
+		return nil
+	}
+
+	suffixOff := strings.LastIndex(tn.name, "/")
+	if suffixOff <= len(taskListPartitionPrefix) {
+		return fmt.Errorf("invalid partitioned task list name %v", tn.name)
+	}
+
+	p, err := strconv.Atoi(tn.name[suffixOff+1:])
+	if err != nil || p <= 0 {
+		return fmt.Errorf("invalid partitioned task list name %v", tn.name)
+	}
+
+	tn.partition = p
+	tn.baseName = tn.name[len(taskListPartitionPrefix):suffixOff]
+	return nil
+}
+
+// newTaskListID returns taskListID which uniquely identfies as task list
+func newTaskListID(domainID, taskListName string, taskType int) (*taskListID, error) {
+	name, err := newTaskListName(taskListName)
+	if err != nil {
+		return nil, err
+	}
+	return &taskListID{
+		qualifiedTaskListName: name,
+		domainID:              domainID,
+		taskType:              taskType,
+	}, nil
+}
+
+func (tid *taskListID) String() string {
+	var b bytes.Buffer
+	b.WriteString("[")
+	b.WriteString("name=")
+	b.WriteString(tid.name)
+	b.WriteString("type=")
+	if tid.taskType == persistence.TaskListTypeActivity {
+		b.WriteString("activity")
+	} else {
+		b.WriteString("decision")
+	}
+	b.WriteString("]")
+	return b.String()
+}

--- a/service/matching/tasklist.go
+++ b/service/matching/tasklist.go
@@ -87,7 +87,7 @@ func (tn *qualifiedTaskListName) IsRoot() bool {
 //   degree: Number of children at each level of the tree
 // Returns empty string if this task list is the root
 func (tn *qualifiedTaskListName) Parent(degree int) string {
-	if tn.IsRoot() {
+	if tn.IsRoot() || degree == 0 {
 		return ""
 	}
 	pid := (tn.partition+degree-1)/degree - 1

--- a/service/matching/tasklist_test.go
+++ b/service/matching/tasklist_test.go
@@ -63,7 +63,13 @@ func TestTaskListParentName(t *testing.T) {
 		degree int
 		output string
 	}{
-		/* binary tree */
+		/* unexpected input */
+		{"list0", 0, ""},
+		/* 1-ary tree */
+		{"list0", 1, ""},
+		{"/__cadence_sys/list0/1", 1, "list0"},
+		{"/__cadence_sys/list0/2", 1, "/__cadence_sys/list0/1"},
+		/* 2-ary tree */
 		{"list0", 2, ""},
 		{"/__cadence_sys/list0/1", 2, "list0"},
 		{"/__cadence_sys/list0/2", 2, "list0"},

--- a/service/matching/tasklist_test.go
+++ b/service/matching/tasklist_test.go
@@ -1,0 +1,110 @@
+// Copyright (c) 2019 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidTaskListNames(t *testing.T) {
+	testCases := []struct {
+		input     string
+		baseName  string
+		partition int
+	}{
+		{"0", "0", 0},
+		{"list0", "list0", 0},
+		{"/list0", "/list0", 0},
+		{"/list0/", "/list0/", 0},
+		{"__cadence_sys/list0", "__cadence_sys/list0", 0},
+		{"__cadence_sys/list0/", "__cadence_sys/list0/", 0},
+		{"/__cadence_sys_list0", "/__cadence_sys_list0", 0},
+		{"/__cadence_sys/list0/1", "list0", 1},
+		{"/__cadence_sys//list0//41", "/list0/", 41},
+		{"/__cadence_sys//__cadence_sys/sys/0/41", "/__cadence_sys/sys/0", 41},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.input, func(t *testing.T) {
+			tn, err := newTaskListName(tc.input)
+			require.NoError(t, err)
+			require.Equal(t, tc.partition, tn.partition)
+			require.Equal(t, tc.partition == 0, tn.IsRoot())
+			require.Equal(t, tc.baseName, tn.baseName)
+			require.Equal(t, tc.input, tn.name)
+		})
+	}
+}
+
+func TestTaskListParentName(t *testing.T) {
+	testCases := []struct {
+		name   string
+		degree int
+		output string
+	}{
+		/* binary tree */
+		{"list0", 2, ""},
+		{"/__cadence_sys/list0/1", 2, "list0"},
+		{"/__cadence_sys/list0/2", 2, "list0"},
+		{"/__cadence_sys/list0/3", 2, "/__cadence_sys/list0/1"},
+		{"/__cadence_sys/list0/4", 2, "/__cadence_sys/list0/1"},
+		{"/__cadence_sys/list0/5", 2, "/__cadence_sys/list0/2"},
+		{"/__cadence_sys/list0/6", 2, "/__cadence_sys/list0/2"},
+		/* 3-ary tree */
+		{"/__cadence_sys/list0/1", 3, "list0"},
+		{"/__cadence_sys/list0/2", 3, "list0"},
+		{"/__cadence_sys/list0/3", 3, "list0"},
+		{"/__cadence_sys/list0/4", 3, "/__cadence_sys/list0/1"},
+		{"/__cadence_sys/list0/5", 3, "/__cadence_sys/list0/1"},
+		{"/__cadence_sys/list0/6", 3, "/__cadence_sys/list0/1"},
+		{"/__cadence_sys/list0/7", 3, "/__cadence_sys/list0/2"},
+		{"/__cadence_sys/list0/10", 3, "/__cadence_sys/list0/3"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name+"#"+strconv.Itoa(tc.degree), func(t *testing.T) {
+			tn, err := newTaskListName(tc.name)
+			require.NoError(t, err)
+			require.Equal(t, tc.output, tn.Parent(tc.degree))
+		})
+	}
+}
+
+func TestInvalidTasklistNames(t *testing.T) {
+	inputs := []string{
+		"/__cadence_sys/",
+		"/__cadence_sys/0",
+		"/__cadence_sys//1",
+		"/__cadence_sys//0",
+		"/__cadence_sys/list0",
+		"/__cadence_sys/list0/0",
+		"/__cadence_sys/list0/-1",
+	}
+	for _, name := range inputs {
+		t.Run(name, func(t *testing.T) {
+			_, err := newTaskListName(name)
+			require.Error(t, err)
+		})
+	}
+}


### PR DESCRIPTION
This patch does 3 things:
 - makes taskListID type partition aware
-  introduces new type "qualifiedTaskListName" to represent internal task list names with metadata
- adds validation to prohibit tasklist names with reserved prefix

Related to #2098
