### PR TITLE
Allow empty active cluster when register domain

### DIFF
--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -83,6 +83,7 @@ func RegisterDomain(c *cli.Context) {
 	if c.IsSet(FlagActiveClusterName) {
 		activeClusterName = common.StringPtr(c.String(FlagActiveClusterName))
 	}
+
 	var clusters []*shared.ClusterReplicationConfiguration
 	if c.IsSet(FlagClusters) {
 		clusterStr := c.String(FlagClusters)

--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -79,9 +79,9 @@ func RegisterDomain(c *cli.Context) {
 		}
 	}
 
-	var activeClusterName string
+	var activeClusterName *string
 	if c.IsSet(FlagActiveClusterName) {
-		activeClusterName = c.String(FlagActiveClusterName)
+		activeClusterName = common.StringPtr(c.String(FlagActiveClusterName))
 	}
 	var clusters []*shared.ClusterReplicationConfiguration
 	if c.IsSet(FlagClusters) {
@@ -104,7 +104,7 @@ func RegisterDomain(c *cli.Context) {
 		WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(int32(retentionDays)),
 		EmitMetric:                             common.BoolPtr(emitMetric),
 		Clusters:                               clusters,
-		ActiveClusterName:                      common.StringPtr(activeClusterName),
+		ActiveClusterName:                      activeClusterName,
 		SecurityToken:                          common.StringPtr(securityToken),
 		ArchivalStatus:                         archivalStatus(c),
 		ArchivalBucketName:                     common.StringPtr(c.String(FlagArchivalBucketName)),


### PR DESCRIPTION
```
cadence|master⚡ ⇒ ./cadence --address 127.0.0.1:7933 --do canary-test domain register --oe cadence-dev@uber.com --desc 'canary cross dc test domain' --rd 7 --em true                      
Domain canary-test successfully registered.
cadence|master⚡ ⇒ ./cadence --address 127.0.0.1:7933 --do canary-test domain describe
Name: canary-test
UUID: a7aaa025-f702-4a15-af7c-afe39434a566
Description: canary cross dc test domain
OwnerEmail: cadence-dev@uber.com
DomainData: map[]
Status: REGISTERED
RetentionInDays: 7
EmitMetrics: true
ActiveClusterName: active
Clusters: active
ArchivalStatus: DISABLED
Bad binaries to reset:
```