### PR TITLE
Implement batcher CLI As Short Term

### DIFF
--- a/service/worker/batcher/batcher.go
+++ b/service/worker/batcher/batcher.go
@@ -113,7 +113,7 @@ func (s *Batcher) Start() error {
 		BackgroundActivityContext: context.WithValue(context.Background(), batcherContextKey, s),
 		Tracer:                    opentracing.GlobalTracer(),
 	}
-	worker := worker.New(s.svcClient, common.SystemGlobalDomainName, batcherTaskListName, workerOpts)
+	worker := worker.New(s.svcClient, common.SystemGlobalDomainName, BatcherTaskListName, workerOpts)
 	return worker.Start()
 }
 

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -176,6 +176,14 @@ const (
 	FlagResetBadBinaryChecksum            = "reset_bad_binary_checksum"
 	FlagListQuery                         = "query"
 	FlagListQueryWithAlias                = FlagListQuery + ", q"
+	FlagBatchType                         = "batch_type"
+	FlagBatchTypeWithAlias                = FlagBatchType + ", bt"
+	FlagSignalName                        = "signal_name"
+	FlagSignalNameWithAlias               = FlagSignalName + ", sig"
+	FlagRPS                               = "rps"
+	FlagJobID                             = "job_id"
+	FlagJobIDWithAlias                    = FlagJobID + ", jid"
+	FlagYes                               = "yes"
 )
 
 var flagsForExecution = []cli.Flag{

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -23,6 +23,7 @@ package cli
 import (
 	"strings"
 
+	"github.com/uber/cadence/service/worker/batcher"
 	"github.com/urfave/cli"
 )
 
@@ -287,6 +288,11 @@ func newWorkflowCommands() []cli.Command {
 				ResetInBatch(c)
 			},
 		},
+		{
+			Name:        "batch",
+			Usage:       "batch operation on a list of workflows from query.",
+			Subcommands: newBatchCommands(),
+		},
 	}
 }
 
@@ -353,6 +359,96 @@ func newActivityCommands() []cli.Command {
 			},
 			Action: func(c *cli.Context) {
 				FailActivity(c)
+			},
+		},
+	}
+}
+
+func newBatchCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:    "describe",
+			Aliases: []string{"desc"},
+			Usage:   "Describe a batch operation job",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagJobIDWithAlias,
+					Usage: "Batch Job ID",
+				},
+			},
+			Action: func(c *cli.Context) {
+				DescribeBatchJob(c)
+			},
+		},
+		{
+			Name:  "terminate",
+			Usage: "terminate a batch operation job",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagJobIDWithAlias,
+					Usage: "Batch Job ID",
+				},
+				cli.StringFlag{
+					Name:  FlagReasonWithAlias,
+					Usage: "Reason to stop this batch job",
+				},
+			},
+			Action: func(c *cli.Context) {
+				TerminateBatchJob(c)
+			},
+		},
+		{
+			Name:    "list",
+			Aliases: []string{"l"},
+			Usage:   "Describe a batch operation job",
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  FlagPageSizeWithAlias,
+					Value: 30,
+					Usage: "Result page size",
+				},
+			},
+			Action: func(c *cli.Context) {
+				ListBatchJobs(c)
+			},
+		},
+		{
+			Name:  "start",
+			Usage: "Start a batch operation job",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagListQueryWithAlias,
+					Usage: "Query to get workflows for being executed this batch operation",
+				},
+				cli.StringFlag{
+					Name:  FlagReasonWithAlias,
+					Usage: "Reason to run this batch job",
+				},
+				cli.StringFlag{
+					Name:  FlagBatchTypeWithAlias,
+					Usage: "Types supported: " + strings.Join(batcher.AllBatchTypes, ","),
+				},
+				//below are optional
+				cli.StringFlag{
+					Name:  FlagSignalNameWithAlias,
+					Usage: "Required for batch signal",
+				},
+				cli.StringFlag{
+					Name:  FlagInputWithAlias,
+					Usage: "Optional input of signal",
+				},
+				cli.IntFlag{
+					Name:  FlagRPS,
+					Value: batcher.DefaultRPS,
+					Usage: "RPS of processing",
+				},
+				cli.BoolFlag{
+					Name:  FlagYes,
+					Usage: "Optional flag to disable confirmation prompt",
+				},
+			},
+			Action: func(c *cli.Context) {
+				StartBatchJob(c)
 			},
 		},
 	}

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -1,0 +1,215 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/service/worker/batcher"
+	"github.com/urfave/cli"
+	"go.uber.org/cadence/.gen/go/shared"
+	cclient "go.uber.org/cadence/client"
+)
+
+// TerminateBatchJob stops abatch job
+func TerminateBatchJob(c *cli.Context) {
+	jobID := getRequiredOption(c, FlagJobID)
+	reason := getRequiredOption(c, FlagReason)
+	svcClient := cFactory.ClientFrontendClient(c)
+	client := cclient.NewClient(svcClient, common.SystemGlobalDomainName, &cclient.Options{})
+	tcCtx, cancel := newContext(c)
+	defer cancel()
+	err := client.TerminateWorkflow(tcCtx, jobID, "", reason, nil)
+	if err != nil {
+		ErrorAndExit("Failed to terminate batch job", err)
+	}
+	output := map[string]interface{}{
+		"msg": "batch job is terminated",
+	}
+	prettyPrintJSONObject(output)
+}
+
+// DescribeBatchJob describe the status of the batch job
+func DescribeBatchJob(c *cli.Context) {
+	jobID := getRequiredOption(c, FlagJobID)
+
+	svcClient := cFactory.ClientFrontendClient(c)
+	client := cclient.NewClient(svcClient, common.SystemGlobalDomainName, &cclient.Options{})
+	tcCtx, cancel := newContext(c)
+	defer cancel()
+	wf, err := client.DescribeWorkflowExecution(tcCtx, jobID, "")
+	if err != nil {
+		ErrorAndExit("Failed to describe batch job", err)
+	}
+
+	output := map[string]interface{}{}
+	if wf.WorkflowExecutionInfo.CloseStatus != nil {
+		if wf.WorkflowExecutionInfo.GetCloseStatus() != shared.WorkflowExecutionCloseStatusCompleted {
+			output["msg"] = "batch job stopped status: " + wf.WorkflowExecutionInfo.GetCloseStatus().String()
+		} else {
+			output["msg"] = "batch job is finished successfully"
+		}
+	} else {
+		output["msg"] = "batch job is running"
+		if len(wf.PendingActivities) > 0 {
+			hbdBinary := wf.PendingActivities[0].HeartbeatDetails
+			hbd := batcher.HeartBeatDetails{}
+			err := json.Unmarshal(hbdBinary, &hbd)
+			if err != nil {
+				ErrorAndExit("Failed to describe batch job", err)
+			}
+			output["progress"] = hbd
+		}
+	}
+	prettyPrintJSONObject(output)
+}
+
+// ListBatchJobs list the started batch jobs
+func ListBatchJobs(c *cli.Context) {
+	domain := getRequiredGlobalOption(c, FlagDomain)
+	pageSize := c.Int(FlagPageSize)
+	svcClient := cFactory.ClientFrontendClient(c)
+	client := cclient.NewClient(svcClient, common.SystemGlobalDomainName, &cclient.Options{})
+	tcCtx, cancel := newContext(c)
+	defer cancel()
+	resp, err := client.ListWorkflow(tcCtx, &shared.ListWorkflowExecutionsRequest{
+		Domain:   common.StringPtr(common.SystemGlobalDomainName),
+		PageSize: common.Int32Ptr(int32(pageSize)),
+		Query:    common.StringPtr(fmt.Sprintf("CustomDomain = '%v'", domain)),
+	})
+	if err != nil {
+		ErrorAndExit("Failed to list batch jobs", err)
+	}
+	output := make([]interface{}, 0, len(resp.Executions))
+	for _, wf := range resp.Executions {
+		job := map[string]string{
+			"jobID":     wf.Execution.GetWorkflowId(),
+			"startTime": convertTime(wf.GetStartTime(), false),
+			"reason":    string(wf.Memo.Fields["Reason"]),
+			"operator":  string(wf.SearchAttributes.IndexedFields["Operator"]),
+		}
+
+		if wf.CloseStatus != nil {
+			job["status"] = wf.CloseStatus.String()
+			job["closeTime"] = convertTime(wf.GetCloseTime(), false)
+		} else {
+			job["status"] = "RUNNING"
+		}
+
+		output = append(output, job)
+	}
+	prettyPrintJSONObject(output)
+}
+
+// DescribeBatchJob describe the status of the batch job
+func StartBatchJob(c *cli.Context) {
+	domain := getRequiredGlobalOption(c, FlagDomain)
+	query := getRequiredOption(c, FlagListQuery)
+	reason := getRequiredOption(c, FlagReason)
+	batchType := getRequiredOption(c, FlagBatchType)
+	if !validateBatchType(batchType) {
+		ErrorAndExit("batchType is not valid, supported:"+strings.Join(batcher.AllBatchTypes, ","), nil)
+	}
+	operator := getCurrentUserFromEnv()
+	var sigName, sigVal string
+	if batchType == batcher.BatchTypeSignal {
+		sigName = getRequiredOption(c, FlagSignalName)
+		sigVal = getRequiredOption(c, FlagInput)
+	}
+	rps := c.Int(FlagRPS)
+
+	svcClient := cFactory.ClientFrontendClient(c)
+	client := cclient.NewClient(svcClient, common.SystemGlobalDomainName, &cclient.Options{})
+	tcCtx, cancel := newContext(c)
+	defer cancel()
+	resp, err := client.CountWorkflow(tcCtx, &shared.CountWorkflowExecutionsRequest{
+		Domain: common.StringPtr(domain),
+		Query:  common.StringPtr(query),
+	})
+	if err != nil {
+		ErrorAndExit("Failed to count impacting workflows for starting a batch job", err)
+	}
+	fmt.Printf("This batch job will be operating on %v workflows.\n", resp.GetCount())
+	if !c.Bool(FlagYes) {
+		reader := bufio.NewReader(os.Stdin)
+		for {
+			fmt.Print("Please confirm[Yes/No]:")
+			text, err := reader.ReadString('\n')
+			if err != nil {
+				ErrorAndExit("Failed to  get confirmation for starting a batch job", err)
+			}
+			if strings.EqualFold(strings.TrimSpace(text), "yes") {
+				break
+			} else {
+				fmt.Println("Batch job is not started")
+				return
+			}
+		}
+
+	}
+	tcCtx, cancel = newContext(c)
+	defer cancel()
+	options := cclient.StartWorkflowOptions{
+		TaskList:                     batcher.BatcherTaskListName,
+		ExecutionStartToCloseTimeout: batcher.InfiniteDuration,
+		Memo: map[string]interface{}{
+			"Reason": reason,
+		},
+		SearchAttributes: map[string]interface{}{
+			"CustomDomain": domain,
+			"Operator":     operator,
+		},
+	}
+	params := batcher.BatchParams{
+		DomainName: domain,
+		Query:      query,
+		Reason:     reason,
+		BatchType:  batchType,
+		SignalParams: batcher.SignalParams{
+			SignalName: sigName,
+			Input:      sigVal,
+		},
+		RPS: rps,
+	}
+	wf, err := client.StartWorkflow(tcCtx, options, batcher.BatchWFTypeName, params)
+	if err != nil {
+		ErrorAndExit("Failed to start batch job", err)
+	}
+	output := map[string]interface{}{
+		"msg":   "batch job is started",
+		"jobID": wf.ID,
+	}
+	prettyPrintJSONObject(output)
+}
+
+func validateBatchType(bt string) bool {
+	for _, b := range batcher.AllBatchTypes {
+		if b == bt {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
We will re-implement it with service API after https://github.com/uber/cadence/pull/2220 is released.

Tested locally:
```
longer@~/gocode/src/github.com/uber/cadence:(batch-cli)$ ./cadence --do samples-domain wf batch start --query "WorkflowType='main.SampleParentWorkflow'" --reason "test" --bt signal --sig testname --input haha
This batch job will be operating on 5 workflows.
Please confirm[Yes/No]:yes
{
  "jobID": "8e131345-60a3-4bbc-b2a8-37d81d6f5f02",
  "msg": "batch job is started"
}

longer@~/gocode/src/github.com/uber/cadence:(batch-cli)$ ./cadence --do samples-domain wf batch list -ps 2
[
  {
    "closeTime": "2019-07-18T15:14:06-07:00",
    "jobID": "8e131345-60a3-4bbc-b2a8-37d81d6f5f02",
    "operator": "\"longer\"",
    "reason": "\"test\"\n",
    "startTime": "2019-07-18T15:14:06-07:00",
    "status": "COMPLETED"
  },
  {
    "closeTime": "2019-07-18T15:11:46-07:00",
    "jobID": "5e9d0692-3f57-4dac-9b2f-1d68f3fedf9e",
    "operator": "\"longer\"",
    "reason": "\"test\"\n",
    "startTime": "2019-07-18T15:11:45-07:00",
    "status": "COMPLETED"
  }
]

longer@~/gocode/src/github.com/uber/cadence:(batch-cli)$ ./cadence --do samples-domain wf batch desc -jid 8e131345-60a3-4bbc-b2a8-37d81d6f5f02
{
  "msg": "batch job is finished successfully"
}


```