### PR TITLE
Refactor workflow execution context & mutable state

### DIFF
--- a/service/history/MockWorkflowExecutionContext.go
+++ b/service/history/MockWorkflowExecutionContext.go
@@ -101,13 +101,13 @@ func (_m *mockWorkflowExecutionContext) clear() {
 	_m.Called()
 }
 
-func (_m *mockWorkflowExecutionContext) createWorkflowExecution(_a0 mutableState, _a1 int64, _a2 bool, _a3 time.Time, _a4 []persistence.Task, _a5 []persistence.Task, _a6 []persistence.Task, _a7 int, _a8 string, _a9 int64) error {
+func (_m *mockWorkflowExecutionContext) createWorkflowExecution(_a0 *persistence.WorkflowSnapshot, _a1 int64, _a2 time.Time, _a3 int, _a4 string, _a5 int64) error {
 
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8, _a9)
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(mutableState, int64, bool, time.Time, []persistence.Task, []persistence.Task, []persistence.Task, int, string, int64) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8, _a9)
+	if rf, ok := ret.Get(0).(func(*persistence.WorkflowSnapshot, int64, time.Time, int, string, int64) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -356,4 +356,44 @@ func (_m *mockWorkflowExecutionContext) updateAsActiveWithNew(_a0 []persistence.
 	}
 
 	return r0
+}
+
+func (_m *mockWorkflowExecutionContext) persistFirstWorkflowEvents(_a0 *persistence.WorkflowEvents) (int64, error) {
+	ret := _m.Called(_a0)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(*persistence.WorkflowEvents) int64); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*persistence.WorkflowEvents) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+func (_m *mockWorkflowExecutionContext) persistNonFirstWorkflowEvents(_a0 *persistence.WorkflowEvents) (int64, error) {
+	ret := _m.Called(_a0)
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func(*persistence.WorkflowEvents) int64); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*persistence.WorkflowEvents) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -720,6 +720,7 @@ func (r *historyReplicator) ApplyReplicationTask(
 		err = r.replicateWorkflowStarted(ctx, context, msBuilder, request.History, sBuilder, logger)
 	default:
 		now := time.Unix(0, lastEvent.GetTimestamp())
+		// TODO remove this set history builder once the update path is re-written
 		msBuilder.SetHistoryBuilder(newHistoryBuilder(msBuilder, r.logger))
 		err = context.replicateWorkflowExecution(request, sBuilder.getTransferTasks(), sBuilder.getTimerTasks(), lastEvent.GetEventId(), now)
 	}

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -752,9 +752,6 @@ func (r *historyReplicator) replicateWorkflowStarted(
 	incomingVersion := firstEvent.GetVersion()
 	lastEvent := history.Events[len(history.Events)-1]
 
-	msBuilder.AddTransferTasks(sBuilder.getTransferTasks()...)
-	msBuilder.AddTimerTasks(sBuilder.getTimerTasks()...)
-
 	now := time.Unix(0, lastEvent.GetTimestamp())
 	newWorkflow, workflowEventsSeq, err := msBuilder.CloseTransactionAsSnapshot(now)
 	if err != nil {

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -2529,10 +2529,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_BrandNew() {
 		EventStoreVersion:    persistence.EventStoreVersionV2,
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -2645,10 +2641,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_ISE() {
 		EventStoreVersion:    persistence.EventStoreVersionV2,
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -2756,10 +2748,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_SameRunID() {
 		EventStoreVersion:    persistence.EventStoreVersionV2,
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -2890,10 +2878,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentComplete_In
 		NonRetriableErrors:   retryPolicy.GetNonRetriableErrorReasons(),
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -3023,10 +3007,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentComplete_In
 		EventStoreVersion:    persistence.EventStoreVersionV2,
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -3156,10 +3136,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentComplete_In
 		EventStoreVersion:    persistence.EventStoreVersionV2,
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -3291,10 +3267,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 	msBuilder.On("GetEventStoreVersion").Return(executionInfo.EventStoreVersion)
 	msBuilder.On("GetCurrentBranch").Return(executionInfo.BranchToken)
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -3453,10 +3425,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 	msBuilder.On("GetEventStoreVersion").Return(executionInfo.EventStoreVersion)
 	msBuilder.On("GetCurrentBranch").Return(executionInfo.BranchToken)
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -3629,10 +3597,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 	msBuilder.On("GetEventStoreVersion").Return(executionInfo.EventStoreVersion)
 	msBuilder.On("GetCurrentBranch").Return(executionInfo.BranchToken)
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -3823,10 +3787,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 		EventStoreVersion:    persistence.EventStoreVersionV2,
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -3974,10 +3934,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 		EventStoreVersion:    persistence.EventStoreVersionV2,
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},
@@ -4142,10 +4098,6 @@ func (s *historyReplicatorSuite) TestReplicateWorkflowStarted_CurrentRunning_Inc
 		NonRetriableErrors:   retryPolicy.GetNonRetriableErrorReasons(),
 	}
 	msBuilder.On("GetExecutionInfo").Return(executionInfo)
-	sBuilder.On("getTransferTasks").Return(transferTasks)
-	sBuilder.On("getTimerTasks").Return(timerTasks)
-	msBuilder.On("AddTransferTasks", transferTasks).Once()
-	msBuilder.On("AddTimerTasks", timerTasks).Once()
 	newWorkflowSnapshot := &persistence.WorkflowSnapshot{
 		ExecutionInfo:    executionInfo,
 		ExecutionStats:   &persistence.ExecutionStats{HistorySize: int64(historySize)},

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -265,6 +265,14 @@ func (w *workflowResetorImpl) buildNewMutableStateForReset(
 		return
 	}
 	newMutableState = newStateBuilder.getMutableState()
+
+	// before this, the mutable state is in replay mode
+	// need to close / flush the mutable state for new changes
+	_, _, retError = newMutableState.CloseTransactionAsSnapshot(w.timeSource.Now())
+	if retError != nil {
+		return
+	}
+
 	newHistorySize = historySize
 
 	retError = w.validateResetWorkflowAfterReplay(newMutableState)


### PR DESCRIPTION
* Cleanup workflow execution creation path, now all create workflow persistence request is generated using mutable state
* Use AddTransferTasks and AddTransferTasks for workflow creation, i.e. mutable state will keep track the transfer / timer tasks
* State builder will set the history builder for events replicated, unifying the management of history events