### PR TITLE
Ignore decision schedule to start timer in passive processing

### DIFF
--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -332,7 +332,7 @@ func (t *timerQueueStandbyProcessorImpl) processDecisionTimeout(timerTask *persi
 
 	// decision schedule to start timer task is a special snowflake.
 	// the schedule to start timer is for sticky decision, which is
-	// not applicable for cross DC
+	// not applicable on the passive cluster
 	if timerTask.TimeoutType == int(workflow.TimeoutTypeScheduleToStart) {
 		return nil
 	}

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -330,6 +330,13 @@ func (t *timerQueueStandbyProcessorImpl) processActivityTimeout(timerTask *persi
 
 func (t *timerQueueStandbyProcessorImpl) processDecisionTimeout(timerTask *persistence.TimerTaskInfo, lastAttempt bool) error {
 
+	// decision schedule to start timer task is a special snowflake.
+	// the schedule to start timer is for sticky decision, which is
+	// not applicable for cross DC
+	if timerTask.TimeoutType == int(workflow.TimeoutTypeScheduleToStart) {
+		return nil
+	}
+
 	var nextEventID *int64
 	postProcessingFn := func() error {
 		return t.fetchHistoryAndVerifyOnce(timerTask, nextEventID, t.processDecisionTimeout)

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -671,6 +671,32 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessDecisionTimeout_Pending() {
 	s.Equal(ErrTaskDiscarded, err)
 }
 
+func (s *timerQueueStandbyProcessorSuite) TestProcessDecisionTimeout_ScheduleToStartTimer() {
+
+	execution := workflow.WorkflowExecution{
+		WorkflowId: common.StringPtr("some random workflow ID"),
+		RunId:      common.StringPtr(uuid.New()),
+	}
+
+	version := int64(4096)
+	decisionScheduleID := int64(16384)
+
+	timerTask := &persistence.TimerTaskInfo{
+		Version:             version,
+		DomainID:            s.domainID,
+		WorkflowID:          execution.GetWorkflowId(),
+		RunID:               execution.GetRunId(),
+		TaskID:              int64(100),
+		TaskType:            persistence.TaskTypeDecisionTimeout,
+		TimeoutType:         int(workflow.TimeoutTypeScheduleToStart),
+		VisibilityTimestamp: time.Now(),
+		EventID:             decisionScheduleID,
+	}
+
+	_, err := s.timerQueueStandbyProcessor.process(timerTask, true)
+	s.Equal(nil, err)
+}
+
 func (s *timerQueueStandbyProcessorSuite) TestProcessDecisionTimeout_Success() {
 
 	execution := workflow.WorkflowExecution{


### PR DESCRIPTION
This is because schedule to start timer for decision is only used by sticky decision, and this sticky decision is only used locally, when failover happen, remote active cluster's corresponding decision is non sticky