### PR TITLE
Refactor reset mutable state path

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -140,8 +140,8 @@ const (
 	PersistenceGetWorkflowExecutionScope
 	// PersistenceUpdateWorkflowExecutionScope tracks UpdateWorkflowExecution calls made by service to persistence layer
 	PersistenceUpdateWorkflowExecutionScope
-	// PersistenceResetMutableStateScope tracks ResetMutableState calls made by service to persistence layer
-	PersistenceResetMutableStateScope
+	// PersistenceConflictResolveWorkflowExecutionScope tracks ConflictResolveWorkflowExecution calls made by service to persistence layer
+	PersistenceConflictResolveWorkflowExecutionScope
 	// PersistenceResetWorkflowExecutionScope tracks ResetWorkflowExecution calls made by service to persistence layer
 	PersistenceResetWorkflowExecutionScope
 	// PersistenceDeleteWorkflowExecutionScope tracks DeleteWorkflowExecution calls made by service to persistence layer
@@ -877,7 +877,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceCreateWorkflowExecutionScope:                  {operation: "CreateWorkflowExecution"},
 		PersistenceGetWorkflowExecutionScope:                     {operation: "GetWorkflowExecution"},
 		PersistenceUpdateWorkflowExecutionScope:                  {operation: "UpdateWorkflowExecution"},
-		PersistenceResetMutableStateScope:                        {operation: "ResetMutableState"},
+		PersistenceConflictResolveWorkflowExecutionScope:         {operation: "ConflictResolveWorkflowExecution"},
 		PersistenceResetWorkflowExecutionScope:                   {operation: "ResetWorkflowExecution"},
 		PersistenceDeleteWorkflowExecutionScope:                  {operation: "DeleteWorkflowExecution"},
 		PersistenceDeleteCurrentWorkflowExecutionScope:           {operation: "DeleteCurrentWorkflowExecution"},

--- a/common/mocks/ExecutionManager.go
+++ b/common/mocks/ExecutionManager.go
@@ -125,12 +125,12 @@ func (_m *ExecutionManager) UpdateWorkflowExecution(request *persistence.UpdateW
 	return r0, r1
 }
 
-// ResetMutableState provides a mock function with given fields: request
-func (_m *ExecutionManager) ResetMutableState(request *persistence.ResetMutableStateRequest) error {
+// ConflictResolveWorkflowExecution provides a mock function with given fields: request
+func (_m *ExecutionManager) ConflictResolveWorkflowExecution(request *persistence.ConflictResolveWorkflowExecutionRequest) error {
 	ret := _m.Called(request)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*persistence.ResetMutableStateRequest) error); ok {
+	if rf, ok := ret.Get(0).(func(*persistence.ConflictResolveWorkflowExecutionRequest) error); ok {
 		r0 = rf(request)
 	} else {
 		r0 = ret.Error(0)

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1143,10 +1143,10 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 					}
 				}
 
-				if prevRunID := previous["current_run_id"].(gocql.UUID).String(); prevRunID != executionInfo.RunID {
+				if prevRunID := previous["current_run_id"].(gocql.UUID).String(); prevRunID != request.PreviousRunID {
 					// currentRunID on previous run has been changed, return to caller to handle
-					msg := fmt.Sprintf("Workflow execution creation condition failed by mismatch runID. WorkflowId: %v, CurrentRunID: %v, columns: (%v)",
-						executionInfo.WorkflowID, executionInfo.RunID, strings.Join(columns, ","))
+					msg := fmt.Sprintf("Workflow execution creation condition failed by mismatch runID. WorkflowId: %v, Expected Current RunID: %v, Actual Current RunID: %v",
+						executionInfo.WorkflowID, request.PreviousRunID, prevRunID)
 					return nil, &p.CurrentWorkflowConditionFailedError{Msg: msg}
 				}
 

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1515,7 +1515,7 @@ func (d *cassandraPersistence) ResetWorkflowExecution(request *p.InternalResetWo
 	return nil
 }
 
-func (d *cassandraPersistence) ResetMutableState(request *p.InternalResetMutableStateRequest) error {
+func (d *cassandraPersistence) ConflictResolveWorkflowExecution(request *p.InternalConflictResolveWorkflowExecutionRequest) error {
 	batch := d.session.NewBatch(gocql.LoggedBatch)
 
 	resetWorkflow := request.ResetWorkflowSnapshot
@@ -1576,14 +1576,14 @@ func (d *cassandraPersistence) ResetMutableState(request *p.InternalResetMutable
 		if isTimeoutError(err) {
 			// Write may have succeeded, but we don't know
 			// return this info to the caller so they have the option of trying to find out by executing a read
-			return &p.TimeoutError{Msg: fmt.Sprintf("ResetMutableState timed out. Error: %v", err)}
+			return &p.TimeoutError{Msg: fmt.Sprintf("ConflictResolveWorkflowExecution timed out. Error: %v", err)}
 		} else if isThrottlingError(err) {
 			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ResetMutableState operation failed. Error: %v", err),
+				Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Error: %v", err),
 			}
 		}
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Error: %v", err),
 		}
 	}
 

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1152,7 +1152,7 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 
 				msg := fmt.Sprintf("Workflow execution creation condition failed. WorkflowId: %v, CurrentRunID: %v, columns: (%v)",
 					executionInfo.WorkflowID, executionInfo.RunID, strings.Join(columns, ","))
-				return nil, &p.ConditionFailedError{Msg: msg}
+				return nil, &p.CurrentWorkflowConditionFailedError{Msg: msg}
 			}
 
 			previous = make(map[string]interface{})

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -726,8 +726,8 @@ type (
 		Encoding common.EncodingType // optional binary encoding type
 	}
 
-	// ResetMutableStateRequest is used to reset workflow execution state for a single run
-	ResetMutableStateRequest struct {
+	// ConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for a single run
+	ConflictResolveWorkflowExecutionRequest struct {
 		RangeID int64
 
 		// previous workflow information
@@ -1379,7 +1379,7 @@ type (
 		CreateWorkflowExecution(request *CreateWorkflowExecutionRequest) (*CreateWorkflowExecutionResponse, error)
 		GetWorkflowExecution(request *GetWorkflowExecutionRequest) (*GetWorkflowExecutionResponse, error)
 		UpdateWorkflowExecution(request *UpdateWorkflowExecutionRequest) (*UpdateWorkflowExecutionResponse, error)
-		ResetMutableState(request *ResetMutableStateRequest) error
+		ConflictResolveWorkflowExecution(request *ConflictResolveWorkflowExecutionRequest) error
 		ResetWorkflowExecution(request *ResetWorkflowExecutionRequest) error
 		DeleteWorkflowExecution(request *DeleteWorkflowExecutionRequest) error
 		DeleteCurrentWorkflowExecution(request *DeleteCurrentWorkflowExecutionRequest) error

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -485,8 +485,8 @@ func (m *executionManagerImpl) SerializeExecutionInfo(
 	}, nil
 }
 
-func (m *executionManagerImpl) ResetMutableState(
-	request *ResetMutableStateRequest,
+func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
+	request *ConflictResolveWorkflowExecutionRequest,
 ) error {
 
 	serializedResetWorkflowSnapshot, err := m.SerializeWorkflowSnapshot(&request.ResetWorkflowSnapshot, request.Encoding)
@@ -501,7 +501,7 @@ func (m *executionManagerImpl) ResetMutableState(
 		}
 	}
 
-	newRequest := &InternalResetMutableStateRequest{
+	newRequest := &InternalConflictResolveWorkflowExecutionRequest{
 		RangeID: request.RangeID,
 
 		PrevRunID:            request.PrevRunID,
@@ -512,7 +512,7 @@ func (m *executionManagerImpl) ResetMutableState(
 
 		CurrentWorkflowMutation: serializedCurrentWorkflowMutation,
 	}
-	return m.persistence.ResetMutableState(newRequest)
+	return m.persistence.ConflictResolveWorkflowExecution(newRequest)
 }
 
 func (m *executionManagerImpl) ResetWorkflowExecution(

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -2939,8 +2939,8 @@ func (s *ExecutionManagerSuite) TestUpdateAndClearBufferedEvents() {
 	s.Equal(0, stats3.BufferedEventsSize)
 }
 
-// TestResetMutableStateCurrentIsSelf test
-func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
+// TestConflictResolveWorkflowExecutionCurrentIsSelf test
+func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsSelf() {
 	domainID := "4ca1faac-1a3a-47af-8e51-fdaa2b3d45b9"
 	workflowExecution := gen.WorkflowExecution{
 		WorkflowId: common.StringPtr("test-reset-mutable-state-test-current-is-self"),
@@ -3314,7 +3314,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 		StartVersion:   int64(8780),
 	}
 
-	err3 := s.ResetMutableState(
+	err3 := s.ConflictResolveWorkflowExecution(
 		workflowExecution.GetRunId(), state1.ReplicationState.LastWriteVersion, state1.ExecutionInfo.State,
 		updatedInfo1, updatedStats1, rState, int64(5), resetActivityInfos, resetTimerInfos,
 		resetChildExecutionInfos, resetRequestCancelInfos, resetSignalInfos, nil)
@@ -3410,8 +3410,8 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsSelf() {
 
 }
 
-// TestResetMutableStateCurrentIsNotSelf test
-func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsNotSelf() {
+// TestConflictResolveWorkflowExecutionCurrentIsNotSelf test
+func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionCurrentIsNotSelf() {
 	domainID := "4ca1faac-1a3a-47af-8e51-fdaa2b3d45b9"
 	workflowID := "test-reset-mutable-state-test-current-is-not-self"
 
@@ -3488,7 +3488,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsNotSelf() {
 		CurrentVersion: int64(8789),
 		StartVersion:   int64(8780),
 	}
-	err = s.ResetMutableState(
+	err = s.ConflictResolveWorkflowExecution(
 		currentRunID, currentState.LastWriteVersion, currentInfo.State,
 		resetExecutionInfo, resetStats, rState, continueAsNewInfo.NextEventID, resetActivityInfos, resetTimerInfos,
 		resetChildExecutionInfos, resetRequestCancelInfos, resetSignalInfos, nil)
@@ -3522,7 +3522,7 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsNotSelf() {
 	currentInfo = copyWorkflowExecutionInfo(state.ExecutionInfo)
 	currentState = copyReplicationState(state.ReplicationState)
 
-	err = s.ResetMutableState(
+	err = s.ConflictResolveWorkflowExecution(
 		workflowExecutionCurrent2.GetRunId(), currentState.LastWriteVersion, currentInfo.State,
 		resetExecutionInfo, resetStats, rState, continueAsNewInfo.NextEventID, resetActivityInfos, resetTimerInfos,
 		resetChildExecutionInfos, resetRequestCancelInfos, resetSignalInfos, nil)
@@ -3533,8 +3533,8 @@ func (s *ExecutionManagerSuite) TestResetMutableStateCurrentIsNotSelf() {
 	s.Equal(workflowExecutionReset.GetRunId(), runID)
 }
 
-// TestResetMutableStateMismatch test
-func (s *ExecutionManagerSuite) TestResetMutableStateMismatch() {
+// TestConflictResolveWorkflowExecutionMismatch test
+func (s *ExecutionManagerSuite) TestConflictResolveWorkflowExecutionMismatch() {
 	domainID := "4ca1faac-1a3a-47af-8e51-fdaa2b3d45b9"
 	workflowID := "test-reset-mutable-state-test-mismatch"
 
@@ -3622,21 +3622,21 @@ func (s *ExecutionManagerSuite) TestResetMutableStateMismatch() {
 	}
 
 	wrongPrevRunID := uuid.New()
-	err = s.ResetMutableState(
+	err = s.ConflictResolveWorkflowExecution(
 		wrongPrevRunID, currentState.LastWriteVersion, currentInfo.State,
 		resetExecutionInfo, resetStats, rState, continueAsNewInfo.NextEventID, resetActivityInfos, resetTimerInfos,
 		resetChildExecutionInfos, resetRequestCancelInfos, resetSignalInfos, nil)
 	s.NotNil(err)
 
 	wrongLastWriteVersion := currentState.LastWriteVersion + 1
-	err = s.ResetMutableState(
+	err = s.ConflictResolveWorkflowExecution(
 		workflowExecutionCurrent.GetRunId(), wrongLastWriteVersion, currentInfo.State,
 		resetExecutionInfo, resetStats, rState, continueAsNewInfo.NextEventID, resetActivityInfos, resetTimerInfos,
 		resetChildExecutionInfos, resetRequestCancelInfos, resetSignalInfos, nil)
 	s.NotNil(err)
 
 	wrongState := currentInfo.State + 1
-	err = s.ResetMutableState(
+	err = s.ConflictResolveWorkflowExecution(
 		workflowExecutionCurrent.GetRunId(), currentState.LastWriteVersion, wrongState,
 		resetExecutionInfo, resetStats, rState, continueAsNewInfo.NextEventID, resetActivityInfos, resetTimerInfos,
 		resetChildExecutionInfos, resetRequestCancelInfos, resetSignalInfos, nil)

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -903,12 +903,12 @@ func (s *TestBase) UpdateAllMutableState(updatedMutableState *p.WorkflowMutableS
 	return err
 }
 
-// ResetMutableState is  utility method to reset mutable state
-func (s *TestBase) ResetMutableState(prevRunID string, prevLastWriteVersion int64, prevState int,
+// ConflictResolveWorkflowExecution is  utility method to reset mutable state
+func (s *TestBase) ConflictResolveWorkflowExecution(prevRunID string, prevLastWriteVersion int64, prevState int,
 	info *p.WorkflowExecutionInfo, stats *p.ExecutionStats, replicationState *p.ReplicationState, nextEventID int64,
 	activityInfos []*p.ActivityInfo, timerInfos []*p.TimerInfo, childExecutionInfos []*p.ChildExecutionInfo,
 	requestCancelInfos []*p.RequestCancelInfo, signalInfos []*p.SignalInfo, ids []string) error {
-	return s.ExecutionManager.ResetMutableState(&p.ResetMutableStateRequest{
+	return s.ExecutionManager.ConflictResolveWorkflowExecution(&p.ConflictResolveWorkflowExecutionRequest{
 		RangeID:              s.ShardInfo.RangeID,
 		PrevRunID:            prevRunID,
 		PrevLastWriteVersion: prevLastWriteVersion,

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -61,7 +61,7 @@ type (
 		//The below three APIs are related to serialization/deserialization
 		GetWorkflowExecution(request *GetWorkflowExecutionRequest) (*InternalGetWorkflowExecutionResponse, error)
 		UpdateWorkflowExecution(request *InternalUpdateWorkflowExecutionRequest) error
-		ResetMutableState(request *InternalResetMutableStateRequest) error
+		ConflictResolveWorkflowExecution(request *InternalConflictResolveWorkflowExecutionRequest) error
 		ResetWorkflowExecution(request *InternalResetWorkflowExecutionRequest) error
 
 		CreateWorkflowExecution(request *InternalCreateWorkflowExecutionRequest) (*CreateWorkflowExecutionResponse, error)
@@ -300,8 +300,8 @@ type (
 		NewWorkflowSnapshot *InternalWorkflowSnapshot
 	}
 
-	// InternalResetMutableStateRequest is used to reset workflow execution state for Persistence Interface
-	InternalResetMutableStateRequest struct {
+	// InternalConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for Persistence Interface
+	InternalConflictResolveWorkflowExecutionRequest struct {
 		RangeID int64
 
 		// previous workflow information

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -260,15 +260,15 @@ func (p *workflowExecutionPersistenceClient) UpdateWorkflowExecution(request *Up
 	return resp, err
 }
 
-func (p *workflowExecutionPersistenceClient) ResetMutableState(request *ResetMutableStateRequest) error {
-	p.metricClient.IncCounter(metrics.PersistenceResetMutableStateScope, metrics.PersistenceRequests)
+func (p *workflowExecutionPersistenceClient) ConflictResolveWorkflowExecution(request *ConflictResolveWorkflowExecutionRequest) error {
+	p.metricClient.IncCounter(metrics.PersistenceConflictResolveWorkflowExecutionScope, metrics.PersistenceRequests)
 
-	sw := p.metricClient.StartTimer(metrics.PersistenceResetMutableStateScope, metrics.PersistenceLatency)
-	err := p.persistence.ResetMutableState(request)
+	sw := p.metricClient.StartTimer(metrics.PersistenceConflictResolveWorkflowExecutionScope, metrics.PersistenceLatency)
+	err := p.persistence.ConflictResolveWorkflowExecution(request)
 	sw.Stop()
 
 	if err != nil {
-		p.updateErrorMetric(metrics.PersistenceResetMutableStateScope, err)
+		p.updateErrorMetric(metrics.PersistenceConflictResolveWorkflowExecutionScope, err)
 	}
 
 	return err

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -218,12 +218,12 @@ func (p *workflowExecutionRateLimitedPersistenceClient) UpdateWorkflowExecution(
 	return resp, err
 }
 
-func (p *workflowExecutionRateLimitedPersistenceClient) ResetMutableState(request *ResetMutableStateRequest) error {
+func (p *workflowExecutionRateLimitedPersistenceClient) ConflictResolveWorkflowExecution(request *ConflictResolveWorkflowExecutionRequest) error {
 	if ok, _ := p.rateLimiter.TryConsume(1); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
-	err := p.persistence.ResetMutableState(request)
+	err := p.persistence.ConflictResolveWorkflowExecution(request)
 	return err
 }
 

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -584,18 +584,18 @@ func (m *sqlExecutionManager) resetWorkflowExecutionTx(
 	return applyWorkflowSnapshotTxAsNew(tx, m.shardID, &request.NewWorkflowSnapshot)
 }
 
-func (m *sqlExecutionManager) ResetMutableState(
-	request *p.InternalResetMutableStateRequest,
+func (m *sqlExecutionManager) ConflictResolveWorkflowExecution(
+	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
 
-	return m.txExecuteShardLocked("ResetMutableState", request.RangeID, func(tx sqldb.Tx) error {
+	return m.txExecuteShardLocked("ConflictResolveWorkflowExecution", request.RangeID, func(tx sqldb.Tx) error {
 		return m.resetMutableStateTx(tx, request)
 	})
 }
 
 func (m *sqlExecutionManager) resetMutableStateTx(
 	tx sqldb.Tx,
-	request *p.InternalResetMutableStateRequest,
+	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
 
 	resetWorkflow := request.ResetWorkflowSnapshot
@@ -624,7 +624,7 @@ func (m *sqlExecutionManager) resetMutableStateTx(
 		replicationState.StartVersion,
 		replicationState.LastWriteVersion); err != nil {
 		return &workflow.InternalServiceError{Message: fmt.Sprintf(
-			"ResetMutableState. Failed to comare and swap the current record. Error: %v",
+			"ConflictResolveWorkflowExecution. Failed to comare and swap the current record. Error: %v",
 			err,
 		)}
 	}

--- a/common/persistence/sql/sqlExecutionManagerUtil.go
+++ b/common/persistence/sql/sqlExecutionManagerUtil.go
@@ -202,7 +202,7 @@ func applyWorkflowSnapshotTxAsReset(
 			return err
 		default:
 			return &workflow.InternalServiceError{
-				Message: fmt.Sprintf("ResetMutableState operation failed. Failed to lock executions row. Error: %v", err),
+				Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to lock executions row. Error: %v", err),
 			}
 		}
 	}
@@ -212,7 +212,7 @@ func applyWorkflowSnapshotTxAsReset(
 		replicationState,
 		shardID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to update executions row. Erorr: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to update executions row. Erorr: %v", err),
 		}
 	}
 
@@ -233,7 +233,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to clear activity info map. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to clear activity info map. Error: %v", err),
 		}
 	}
 
@@ -245,7 +245,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to insert into activity info map after clearing. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to insert into activity info map after clearing. Error: %v", err),
 		}
 	}
 
@@ -255,7 +255,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to clear timer info map. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to clear timer info map. Error: %v", err),
 		}
 	}
 
@@ -267,7 +267,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to insert into timer info map after clearing. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to insert into timer info map after clearing. Error: %v", err),
 		}
 	}
 
@@ -277,7 +277,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to clear child execution info map. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to clear child execution info map. Error: %v", err),
 		}
 	}
 
@@ -289,7 +289,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to insert into activity info map after clearing. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to insert into activity info map after clearing. Error: %v", err),
 		}
 	}
 
@@ -299,7 +299,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to clear request cancel info map. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to clear request cancel info map. Error: %v", err),
 		}
 	}
 
@@ -311,7 +311,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to insert into request cancel info map after clearing. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to insert into request cancel info map after clearing. Error: %v", err),
 		}
 	}
 
@@ -321,7 +321,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to clear signal info map. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to clear signal info map. Error: %v", err),
 		}
 	}
 
@@ -333,7 +333,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID); err != nil {
 		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetMutableState operation failed. Failed to insert into signal info map after clearing. Error: %v", err),
+			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Failed to insert into signal info map after clearing. Error: %v", err),
 		}
 	}
 

--- a/service/history/MockConflictResolver.go
+++ b/service/history/MockConflictResolver.go
@@ -33,12 +33,12 @@ type mockConflictResolver struct {
 var _ conflictResolver = (*mockConflictResolver)(nil)
 
 // reset is mock implementation for reset of conflictResolver
-func (_m *mockConflictResolver) reset(_a0 string, _a1 int64, _a2 int, _a3 string, _a4 int64, _a5 *persistence.WorkflowExecutionInfo) (mutableState, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
+func (_m *mockConflictResolver) reset(_a0 string, _a1 int64, _a2 int, _a3 string, _a4 int64, _a5 *persistence.WorkflowExecutionInfo, _a6 int64) (mutableState, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 
 	var r0 mutableState
-	if rf, ok := ret.Get(0).(func(string, int64, int, string, int64, *persistence.WorkflowExecutionInfo) mutableState); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(0).(func(string, int64, int, string, int64, *persistence.WorkflowExecutionInfo, int64) mutableState); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(mutableState)
@@ -46,8 +46,8 @@ func (_m *mockConflictResolver) reset(_a0 string, _a1 int64, _a2 int, _a3 string
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(string, int64, int, string, int64, *persistence.WorkflowExecutionInfo, int64) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/service/history/MockMutableState.go
+++ b/service/history/MockMutableState.go
@@ -2632,22 +2632,6 @@ func (_m *mockMutableState) ReplicateWorkflowExecutionTimedoutEvent(_a0 int64, _
 	return r0
 }
 
-// ResetSnapshot provides a mock function with given fields: _a0, _a1, _a2
-func (_m *mockMutableState) ResetSnapshot(_a0 string, _a1 int64, _a2 int, _a3 []persistence.Task, _a4 []persistence.Task, _a5 []persistence.Task) *persistence.ResetMutableStateRequest {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
-
-	var r0 *persistence.ResetMutableStateRequest
-	if rf, ok := ret.Get(0).(func(string, int64, int, []persistence.Task, []persistence.Task, []persistence.Task) *persistence.ResetMutableStateRequest); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*persistence.ResetMutableStateRequest)
-		}
-	}
-
-	return r0
-}
-
 // SetHistoryBuilder provides a mock function with given fields: hBuilder
 func (_m *mockMutableState) SetHistoryBuilder(hBuilder *historyBuilder) {
 	_m.Called(hBuilder)
@@ -2748,6 +2732,25 @@ func (_m *mockMutableState) GetTimerTasks() []persistence.Task {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]persistence.Task)
 		}
+	}
+
+	return r0
+}
+
+// SetUpdateCondition provides a mock function with given fields:
+func (_m *mockMutableState) SetUpdateCondition(_a0 int64) {
+	_m.Called(_a0)
+}
+
+// GetUpdateCondition provides a mock function with given fields:
+func (_m *mockMutableState) GetUpdateCondition() int64 {
+	ret := _m.Called()
+
+	var r0 int64
+	if rf, ok := ret.Get(0).(func() int64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int64)
 	}
 
 	return r0

--- a/service/history/MockWorkflowExecutionContext.go
+++ b/service/history/MockWorkflowExecutionContext.go
@@ -165,12 +165,12 @@ func (_m *mockWorkflowExecutionContext) loadExecutionStats() (*persistence.Execu
 	return r0, r1
 }
 
-func (_m *mockWorkflowExecutionContext) resetMutableState(_a0 string, _a1 int64, _a2 int, _a3 []persistence.Task, _a4 []persistence.Task, _a5 []persistence.Task, _a6 mutableState, _a7 int64) (mutableState, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
+func (_m *mockWorkflowExecutionContext) conflictResolveWorkflowExecution(_a0 time.Time, _a1 string, _a2 int64, _a3 int, _a4 mutableState, _a5 int64) (mutableState, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
 
 	var r0 mutableState
-	if rf, ok := ret.Get(0).(func(string, int64, int, []persistence.Task, []persistence.Task, []persistence.Task, mutableState, int64) mutableState); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
+	if rf, ok := ret.Get(0).(func(time.Time, string, int64, int, mutableState, int64) mutableState); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(mutableState)
@@ -178,8 +178,8 @@ func (_m *mockWorkflowExecutionContext) resetMutableState(_a0 string, _a1 int64,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, int64, int, []persistence.Task, []persistence.Task, []persistence.Task, mutableState, int64) error); ok {
-		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
+	if rf, ok := ret.Get(1).(func(time.Time, string, int64, int, mutableState, int64) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/service/history/conflictResolver.go
+++ b/service/history/conflictResolver.go
@@ -161,8 +161,10 @@ func (r *conflictResolverImpl) reset(
 	}
 
 	resetMutableStateBuilder.SetUpdateCondition(updateCondition)
-	// whenever a reset of mutable state is done, we need to sync the workflow search attribute
-	resetMutableStateBuilder.AddTransferTasks(&persistence.UpsertWorkflowSearchAttributesTask{})
+	if r.shard.GetConfig().EnableVisibilityToKafka() {
+		// whenever a reset of mutable state is done, we need to sync the workflow search attribute
+		resetMutableStateBuilder.AddTransferTasks(&persistence.UpsertWorkflowSearchAttributesTask{})
+	}
 
 	r.logger.Info("All events applied for execution.", tag.WorkflowResetNextEventID(resetMutableStateBuilder.GetNextEventID()))
 	msBuilder, err := r.context.conflictResolveWorkflowExecution(

--- a/service/history/conflictResolver.go
+++ b/service/history/conflictResolver.go
@@ -39,6 +39,7 @@ type (
 			requestID string,
 			replayEventID int64,
 			info *persistence.WorkflowExecutionInfo,
+			updateCondition int64,
 		) (mutableState, error)
 	}
 
@@ -72,6 +73,7 @@ func (r *conflictResolverImpl) reset(
 	requestID string,
 	replayEventID int64,
 	info *persistence.WorkflowExecutionInfo,
+	updateCondition int64,
 ) (mutableState, error) {
 
 	domainID := r.context.getDomainID()
@@ -84,16 +86,14 @@ func (r *conflictResolverImpl) reset(
 	var nextPageToken []byte
 	var resetMutableStateBuilder *mutableStateBuilder
 	var sBuilder stateBuilder
-	var lastEvent *shared.HistoryEvent
 	var history []*shared.HistoryEvent
 	var totalSize int64
-	var lastFirstEventID int64
 	var err error
 
 	eventsToApply := replayNextEventID - common.FirstEventID
 	for hasMore := true; hasMore; hasMore = len(nextPageToken) > 0 {
 		var size int
-		history, size, lastFirstEventID, nextPageToken, err = r.getHistory(domainID, execution, common.FirstEventID, replayNextEventID, nextPageToken, eventStoreVersion, branchToken)
+		history, size, _, nextPageToken, err = r.getHistory(domainID, execution, common.FirstEventID, replayNextEventID, nextPageToken, eventStoreVersion, branchToken)
 		if err != nil {
 			r.logError("Conflict resolution err getting history.", err)
 			return nil, err
@@ -113,7 +113,6 @@ func (r *conflictResolverImpl) reset(
 		}
 
 		firstEvent := history[0]
-		lastEvent = history[len(history)-1]
 		if firstEvent.GetEventId() == common.FirstEventID {
 			resetMutableStateBuilder = newMutableStateBuilderWithReplicationState(
 				r.shard,
@@ -135,30 +134,42 @@ func (r *conflictResolverImpl) reset(
 			r.logError("Conflict resolution err applying events.", err)
 			return nil, err
 		}
-		resetMutableStateBuilder.executionInfo.SetLastFirstEventID(lastFirstEventID)
 		totalSize += int64(size)
+	}
+
+	if resetMutableStateBuilder == nil {
+		return nil, &shared.BadRequestError{
+			Message: "unable to create reset mutable state",
+		}
 	}
 
 	// reset branchToken to the original one(it has been set to a wrong branchToken in applyEvents for startEvent)
 	resetMutableStateBuilder.executionInfo.BranchToken = branchToken
-	// similarly, in case of resetWF, the runID in startEvent is incorrect
-	resetMutableStateBuilder.executionInfo.RunID = info.RunID
-	// Applying events to mutableState does not move the nextEventID.  Explicitly set nextEventID to new value
-	resetMutableStateBuilder.executionInfo.SetNextEventID(replayNextEventID)
+
 	resetMutableStateBuilder.executionInfo.StartTimestamp = startTime
 	// the last updated time is not important here, since this should be updated with event time afterwards
 	resetMutableStateBuilder.executionInfo.LastUpdatedTimestamp = startTime
 
-	resetMutableStateBuilder.UpdateReplicationStateLastEventID(lastEvent.GetVersion(), replayEventID)
+	// close the rebuild transaction on reset mutable state, since we do not want oo write the
+	// events used in the replay to be persisted again
+	_, _, err = resetMutableStateBuilder.CloseTransactionAsSnapshot(
+		startTime,
+		transactionPolicyPassive,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	resetMutableStateBuilder.SetUpdateCondition(updateCondition)
+	// whenever a reset of mutable state is done, we need to sync the workflow search attribute
+	resetMutableStateBuilder.AddTransferTasks(&persistence.UpsertWorkflowSearchAttributesTask{})
 
 	r.logger.Info("All events applied for execution.", tag.WorkflowResetNextEventID(resetMutableStateBuilder.GetNextEventID()))
-	msBuilder, err := r.context.resetMutableState(
+	msBuilder, err := r.context.conflictResolveWorkflowExecution(
+		startTime,
 		prevRunID,
 		prevLastWriteVersion,
 		prevState,
-		nil,
-		nil,
-		nil,
 		resetMutableStateBuilder,
 		totalSize,
 	)

--- a/service/history/conflictResolver_test.go
+++ b/service/history/conflictResolver_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/service/dynamicconfig"
 )
 
 type (
@@ -197,6 +198,8 @@ func (s *conflictResolverSuite) TestGetHistory() {
 }
 
 func (s *conflictResolverSuite) TestReset() {
+	s.mockShard.config.EnableVisibilityToKafka = dynamicconfig.GetBoolPropertyFn(true)
+
 	prevRunID := uuid.New()
 	prevLastWriteVersion := int64(123)
 	prevState := persistence.WorkflowStateRunning

--- a/service/history/conflictResolver_test.go
+++ b/service/history/conflictResolver_test.go
@@ -200,15 +200,20 @@ func (s *conflictResolverSuite) TestReset() {
 	prevRunID := uuid.New()
 	prevLastWriteVersion := int64(123)
 	prevState := persistence.WorkflowStateRunning
+
 	sourceCluster := cluster.TestAlternativeClusterName
 	startTime := time.Now()
+	version := int64(12)
+
 	domainID := s.mockContext.domainID
 	execution := s.mockContext.workflowExecution
 	nextEventID := int64(2)
+	branchToken := []byte("some random branch token")
+	eventStoreVersion := int32(persistence.EventStoreVersionV2)
 
 	event1 := &shared.HistoryEvent{
 		EventId: common.Int64Ptr(1),
-		Version: common.Int64Ptr(12),
+		Version: common.Int64Ptr(version),
 		WorkflowExecutionStartedEventAttributes: &shared.WorkflowExecutionStartedEventAttributes{
 			WorkflowType:                        &shared.WorkflowType{Name: common.StringPtr("some random workflow type")},
 			TaskList:                            &shared.TaskList{Name: common.StringPtr("some random workflow type")},
@@ -224,15 +229,15 @@ func (s *conflictResolverSuite) TestReset() {
 	}
 
 	historySize := int64(1234567)
-	s.mockHistoryMgr.On("GetWorkflowExecutionHistory", &persistence.GetWorkflowExecutionHistoryRequest{
-		DomainID:      domainID,
-		Execution:     execution,
-		FirstEventID:  common.FirstEventID,
-		NextEventID:   nextEventID,
+	s.mockHistoryV2Mgr.On("ReadHistoryBranch", &persistence.ReadHistoryBranchRequest{
+		BranchToken:   branchToken,
+		MinEventID:    common.FirstEventID,
+		MaxEventID:    nextEventID,
 		PageSize:      defaultHistoryPageSize,
 		NextPageToken: nil,
-	}).Return(&persistence.GetWorkflowExecutionHistoryResponse{
-		History:          &shared.History{Events: []*shared.HistoryEvent{event1, event2}},
+		ShardID:       common.IntPtr(s.mockShard.GetShardID()),
+	}).Return(&persistence.ReadHistoryBranchResponse{
+		HistoryEvents:    []*shared.HistoryEvent{event1, event2},
 		NextPageToken:    nil,
 		LastFirstEventID: event1.GetEventId(),
 		Size:             int(historySize),
@@ -268,45 +273,57 @@ func (s *conflictResolverSuite) TestReset() {
 		DecisionAttempt:          0,
 		DecisionStartedTimestamp: 0,
 		CreateRequestID:          createRequestID,
+		BranchToken:              branchToken,
+		EventStoreVersion:        eventStoreVersion,
 	}
 	// this is only a shallow test, meaning
 	// the mutable state only has the minimal information
 	// so we can test the conflict resolver
-	s.mockExecutionMgr.On("ResetMutableState", &persistence.ResetMutableStateRequest{
-		RangeID:              s.mockShard.shardInfo.RangeID,
-		PrevRunID:            prevRunID,
-		PrevLastWriteVersion: prevLastWriteVersion,
-		PrevState:            prevState,
-		ResetWorkflowSnapshot: persistence.WorkflowSnapshot{
-			ExecutionInfo: executionInfo,
-			ExecutionStats: &persistence.ExecutionStats{
-				HistorySize: historySize,
-			},
-			ReplicationState: &persistence.ReplicationState{
-				CurrentVersion:   event1.GetVersion(),
-				StartVersion:     event1.GetVersion(),
-				LastWriteVersion: event1.GetVersion(),
-				LastWriteEventID: event1.GetEventId(),
-				LastReplicationInfo: map[string]*persistence.ReplicationInfo{
-					sourceCluster: &persistence.ReplicationInfo{
-						Version:     event1.GetVersion(),
-						LastEventID: event1.GetEventId(),
+	s.mockExecutionMgr.On("ConflictResolveWorkflowExecution", mock.MatchedBy(func(input *persistence.ConflictResolveWorkflowExecutionRequest) bool {
+		transferTasks := input.ResetWorkflowSnapshot.TransferTasks
+		if len(transferTasks) != 1 {
+			return false
+		}
+		s.IsType(&persistence.UpsertWorkflowSearchAttributesTask{}, transferTasks[0])
+		input.ResetWorkflowSnapshot.TransferTasks = nil
+
+		s.Equal(&persistence.ConflictResolveWorkflowExecutionRequest{
+			RangeID:              s.mockShard.shardInfo.RangeID,
+			PrevRunID:            prevRunID,
+			PrevLastWriteVersion: prevLastWriteVersion,
+			PrevState:            prevState,
+			ResetWorkflowSnapshot: persistence.WorkflowSnapshot{
+				ExecutionInfo: executionInfo,
+				ExecutionStats: &persistence.ExecutionStats{
+					HistorySize: historySize,
+				},
+				ReplicationState: &persistence.ReplicationState{
+					CurrentVersion:   event1.GetVersion(),
+					StartVersion:     event1.GetVersion(),
+					LastWriteVersion: event1.GetVersion(),
+					LastWriteEventID: event1.GetEventId(),
+					LastReplicationInfo: map[string]*persistence.ReplicationInfo{
+						sourceCluster: &persistence.ReplicationInfo{
+							Version:     event1.GetVersion(),
+							LastEventID: event1.GetEventId(),
+						},
 					},
 				},
+				ActivityInfos:       []*persistence.ActivityInfo{},
+				TimerInfos:          []*persistence.TimerInfo{},
+				ChildExecutionInfos: []*persistence.ChildExecutionInfo{},
+				RequestCancelInfos:  []*persistence.RequestCancelInfo{},
+				SignalInfos:         []*persistence.SignalInfo{},
+				SignalRequestedIDs:  []string{},
+				TransferTasks:       nil,
+				ReplicationTasks:    nil,
+				TimerTasks:          nil,
+				Condition:           s.mockContext.updateCondition,
 			},
-			ActivityInfos:       []*persistence.ActivityInfo{},
-			TimerInfos:          []*persistence.TimerInfo{},
-			ChildExecutionInfos: []*persistence.ChildExecutionInfo{},
-			RequestCancelInfos:  []*persistence.RequestCancelInfo{},
-			SignalInfos:         []*persistence.SignalInfo{},
-			SignalRequestedIDs:  []string{},
-			ReplicationTasks:    nil,
-			TransferTasks:       nil,
-			TimerTasks:          nil,
-			Condition:           s.mockContext.updateCondition,
-		},
-		Encoding: common.EncodingType(s.mockShard.GetConfig().EventEncodingType(domainID)),
-	}).Return(nil).Once()
+			Encoding: common.EncodingType(s.mockShard.GetConfig().EventEncodingType(domainID)),
+		}, input)
+		return true
+	})).Return(nil).Once()
 	s.mockExecutionMgr.On("GetWorkflowExecution", &persistence.GetWorkflowExecutionRequest{
 		DomainID:  domainID,
 		Execution: execution,
@@ -323,6 +340,6 @@ func (s *conflictResolverSuite) TestReset() {
 	), nil)
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 
-	_, err := s.conflictResolver.reset(prevRunID, prevLastWriteVersion, prevState, createRequestID, nextEventID-1, executionInfo)
+	_, err := s.conflictResolver.reset(prevRunID, prevLastWriteVersion, prevState, createRequestID, nextEventID-1, executionInfo, s.mockContext.updateCondition)
 	s.Nil(err)
 }

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -1163,6 +1163,7 @@ func (r *historyReplicator) resetMutableState(
 		uuid.New(),
 		lastEventID,
 		msBuilder.GetExecutionInfo(),
+		msBuilder.GetUpdateCondition(),
 	)
 	logger.Info("Completed Resetting of workflow execution.")
 	if err != nil {

--- a/service/history/historyReplicator_test.go
+++ b/service/history/historyReplicator_test.go
@@ -1960,6 +1960,8 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	currentReplicationInfoLastEventID := currentLastEventID - 11
 	incomingVersion := currentLastWriteVersion + 10
 
+	updateCondition := int64(1394)
+
 	incomingActiveCluster := cluster.TestAlternativeClusterName
 	prevActiveCluster := cluster.TestCurrentClusterName
 	context := &mockWorkflowExecutionContext{}
@@ -1995,6 +1997,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	msBuilderIn.On("GetExecutionInfo").Return(exeInfo)
 	msBuilderIn.On("IsWorkflowExecutionRunning").Return(currentState != persistence.WorkflowStateCompleted)
 	msBuilderIn.On("GetLastWriteVersion").Return(currentLastWriteVersion)
+	msBuilderIn.On("GetUpdateCondition").Return(updateCondition)
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentLastWriteVersion).Return(prevActiveCluster)
 
 	mockConflictResolver := &mockConflictResolver{}
@@ -2004,7 +2007,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	msBuilderMid := &mockMutableState{}
 	msBuilderMid.On("GetNextEventID").Return(int64(12345)) // this is used by log
 	mockConflictResolver.On("reset",
-		runID, currentLastWriteVersion, currentState, mock.Anything, currentReplicationInfoLastEventID, exeInfo,
+		runID, currentLastWriteVersion, currentState, mock.Anything, currentReplicationInfoLastEventID, exeInfo, updateCondition,
 	).Return(msBuilderMid, nil)
 	msBuilderOut, err := s.historyReplicator.ApplyOtherEventsVersionChecking(ctx.Background(), context, msBuilderIn, request, s.logger)
 	s.Equal(msBuilderMid, msBuilderOut)
@@ -2021,6 +2024,8 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	incomingVersion := currentLastWriteVersion + 10
 	incomingReplicationInfoLastWriteVersion := currentReplicationInfoLastWriteVersion - 10
 	incomingReplicationInfoLastEventID := currentReplicationInfoLastEventID - 20
+
+	updateCondition := int64(1394)
 
 	incomingActiveCluster := cluster.TestAlternativeClusterName
 	prevActiveCluster := cluster.TestCurrentClusterName
@@ -2062,6 +2067,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	msBuilderIn.On("GetExecutionInfo").Return(exeInfo)
 	msBuilderIn.On("IsWorkflowExecutionRunning").Return(currentState != persistence.WorkflowStateCompleted)
 	msBuilderIn.On("GetLastWriteVersion").Return(currentLastWriteVersion)
+	msBuilderIn.On("GetUpdateCondition").Return(updateCondition)
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentLastWriteVersion).Return(prevActiveCluster)
 
 	mockConflictResolver := &mockConflictResolver{}
@@ -2071,7 +2077,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	msBuilderMid := &mockMutableState{}
 	msBuilderMid.On("GetNextEventID").Return(int64(12345)) // this is used by log
 	mockConflictResolver.On("reset",
-		runID, currentLastWriteVersion, currentState, mock.Anything, currentReplicationInfoLastEventID, exeInfo,
+		runID, currentLastWriteVersion, currentState, mock.Anything, currentReplicationInfoLastEventID, exeInfo, updateCondition,
 	).Return(msBuilderMid, nil)
 	msBuilderOut, err := s.historyReplicator.ApplyOtherEventsVersionChecking(ctx.Background(), context, msBuilderIn, request, s.logger)
 	s.Equal(msBuilderMid, msBuilderOut)
@@ -2123,6 +2129,8 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	incomingReplicationInfoLastWriteVersion := currentLastWriteVersion
 	incomingReplicationInfoLastEventID := currentLastEventID - 10
 
+	updateCondition := int64(1394)
+
 	prevActiveCluster := cluster.TestCurrentClusterName
 	context := &mockWorkflowExecutionContext{}
 	defer context.AssertExpectations(s.T())
@@ -2157,6 +2165,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	msBuilderIn.On("GetExecutionInfo").Return(exeInfo)
 	msBuilderIn.On("IsWorkflowExecutionRunning").Return(currentState != persistence.WorkflowStateCompleted)
 	msBuilderIn.On("GetLastWriteVersion").Return(currentLastWriteVersion)
+	msBuilderIn.On("GetUpdateCondition").Return(updateCondition)
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentLastWriteVersion).Return(prevActiveCluster)
 
 	mockConflictResolver := &mockConflictResolver{}
@@ -2166,7 +2175,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	msBuilderMid := &mockMutableState{}
 	msBuilderMid.On("GetNextEventID").Return(int64(12345)) // this is used by log
 	mockConflictResolver.On("reset",
-		runID, currentLastWriteVersion, currentState, mock.Anything, incomingReplicationInfoLastEventID, exeInfo,
+		runID, currentLastWriteVersion, currentState, mock.Anything, incomingReplicationInfoLastEventID, exeInfo, updateCondition,
 	).Return(msBuilderMid, nil)
 	msBuilderOut, err := s.historyReplicator.ApplyOtherEventsVersionChecking(ctx.Background(), context, msBuilderIn, request, s.logger)
 	s.Equal(msBuilderMid, msBuilderOut)
@@ -2267,6 +2276,8 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	decisionTasklist := "some random decision tasklist"
 	decisionStickyTasklist := "some random decision sticky tasklist"
 
+	updateCondition := int64(1394)
+
 	prevActiveCluster := cluster.TestCurrentClusterName
 	context := &mockWorkflowExecutionContext{}
 	defer context.AssertExpectations(s.T())
@@ -2343,6 +2354,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	}).Once()
 	msBuilderIn.On("IsWorkflowExecutionRunning").Return(currentState != persistence.WorkflowStateCompleted)
 	msBuilderIn.On("GetLastWriteVersion").Return(currentLastWriteVersion)
+	msBuilderIn.On("GetUpdateCondition").Return(updateCondition)
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", currentLastWriteVersion).Return(prevActiveCluster)
 
 	mockConflictResolver := &mockConflictResolver{}
@@ -2352,7 +2364,7 @@ func (s *historyReplicatorSuite) TestApplyOtherEventsVersionChecking_IncomingGre
 	msBuilderMid := &mockMutableState{}
 	msBuilderMid.On("GetNextEventID").Return(int64(12345)) // this is used by log
 	mockConflictResolver.On("reset",
-		runID, currentLastWriteVersion, currentState, mock.Anything, incomingReplicationInfoLastEventID, exeInfo,
+		runID, currentLastWriteVersion, currentState, mock.Anything, incomingReplicationInfoLastEventID, exeInfo, updateCondition,
 	).Return(msBuilderMid, nil)
 	msBuilderOut, err := s.historyReplicator.ApplyOtherEventsVersionChecking(ctx.Background(), context, msBuilderIn, request, s.logger)
 	s.Equal(msBuilderMid, msBuilderOut)

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -427,9 +427,9 @@ func (s *TestShardContext) GetTimerMaxReadLevel(cluster string) time.Time {
 	return s.timerMaxReadLevelMap[cluster]
 }
 
-// ResetMutableState test implementation
-func (s *TestShardContext) ResetMutableState(request *persistence.ResetMutableStateRequest) error {
-	return s.executionMgr.ResetMutableState(request)
+// ConflictResolveWorkflowExecution test implementation
+func (s *TestShardContext) ConflictResolveWorkflowExecution(request *persistence.ConflictResolveWorkflowExecutionRequest) error {
+	return s.executionMgr.ConflictResolveWorkflowExecution(request)
 }
 
 // ResetWorkflowExecution test implementation

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -189,7 +189,6 @@ type (
 		ReplicateWorkflowExecutionStartedEvent(*cache.DomainCacheEntry, *string, workflow.WorkflowExecution, string, *workflow.HistoryEvent) error
 		ReplicateWorkflowExecutionTerminatedEvent(int64, *workflow.HistoryEvent) error
 		ReplicateWorkflowExecutionTimedoutEvent(int64, *workflow.HistoryEvent) error
-		ResetSnapshot(string, int64, int, []persistence.Task, []persistence.Task, []persistence.Task) *persistence.ResetMutableStateRequest
 		SetHistoryBuilder(hBuilder *historyBuilder)
 		SetHistoryTree(treeID string) error
 		UpdateActivity(*persistence.ActivityInfo) error
@@ -204,6 +203,8 @@ type (
 		AddTimerTasks(timerTasks ...persistence.Task)
 		GetTransferTasks() []persistence.Task
 		GetTimerTasks() []persistence.Task
+		SetUpdateCondition(int64)
+		GetUpdateCondition() int64
 
 		CloseTransactionAsMutation(now time.Time, transactionPolicy transactionPolicy) (*persistence.WorkflowMutation, []*persistence.WorkflowEvents, error)
 		CloseTransactionAsSnapshot(now time.Time, transactionPolicy transactionPolicy) (*persistence.WorkflowSnapshot, []*persistence.WorkflowEvents, error)

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -644,7 +644,7 @@ func (e *mutableStateBuilder) shouldBufferEvent(eventType workflow.EventType) bo
 		workflow.EventTypeActivityTaskScheduled,
 		workflow.EventTypeActivityTaskCancelRequested,
 		workflow.EventTypeTimerStarted,
-		// DecisionTypeCancelTimer is an excption. This decision will be mapped
+		// DecisionTypeCancelTimer is an exception. This decision will be mapped
 		// to either workflow.EventTypeTimerCanceled, or workflow.EventTypeCancelTimerFailed.
 		// So both should not be buffered. Ref: historyEngine, search for "workflow.DecisionTypeCancelTimer"
 		workflow.EventTypeTimerCanceled,

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -261,66 +261,6 @@ func (e *mutableStateBuilder) GetReplicationState() *persistence.ReplicationStat
 	return e.replicationState
 }
 
-func (e *mutableStateBuilder) ResetSnapshot(
-	prevRunID string,
-	prevLastWriteVersion int64,
-	prevState int,
-	replicationTasks []persistence.Task,
-	transferTasks []persistence.Task,
-	timerTasks []persistence.Task,
-) *persistence.ResetMutableStateRequest {
-	// Clear any cached stats before loading mutable state to force recompute on next call to GetStats
-
-	insertActivities := make([]*persistence.ActivityInfo, 0, len(e.pendingActivityInfoIDs))
-	for _, info := range e.pendingActivityInfoIDs {
-		insertActivities = append(insertActivities, info)
-	}
-
-	insertTimers := make([]*persistence.TimerInfo, 0, len(e.pendingTimerInfoIDs))
-	for _, info := range e.pendingTimerInfoIDs {
-		insertTimers = append(insertTimers, info)
-	}
-
-	insertChildExecutions := make([]*persistence.ChildExecutionInfo, 0, len(e.pendingChildExecutionInfoIDs))
-	for _, info := range e.pendingChildExecutionInfoIDs {
-		insertChildExecutions = append(insertChildExecutions, info)
-	}
-
-	insertRequestCancels := make([]*persistence.RequestCancelInfo, 0, len(e.pendingRequestCancelInfoIDs))
-	for _, info := range e.pendingRequestCancelInfoIDs {
-		insertRequestCancels = append(insertRequestCancels, info)
-	}
-
-	insertSignals := make([]*persistence.SignalInfo, 0, len(e.pendingSignalInfoIDs))
-	for _, info := range e.pendingSignalInfoIDs {
-		insertSignals = append(insertSignals, info)
-	}
-
-	insertSignalRequested := make([]string, 0, len(e.pendingSignalRequestedIDs))
-	for id := range e.pendingSignalRequestedIDs {
-		insertSignalRequested = append(insertSignalRequested, id)
-	}
-
-	return &persistence.ResetMutableStateRequest{
-		PrevRunID:            prevRunID,
-		PrevLastWriteVersion: prevLastWriteVersion,
-		PrevState:            prevState,
-		ResetWorkflowSnapshot: persistence.WorkflowSnapshot{
-			ExecutionInfo:       e.executionInfo,
-			ReplicationState:    e.replicationState,
-			ActivityInfos:       insertActivities,
-			TimerInfos:          insertTimers,
-			ChildExecutionInfos: insertChildExecutions,
-			RequestCancelInfos:  insertRequestCancels,
-			SignalInfos:         insertSignals,
-			SignalRequestedIDs:  insertSignalRequested,
-			ReplicationTasks:    replicationTasks,
-			TransferTasks:       transferTasks,
-			TimerTasks:          timerTasks,
-		},
-	}
-}
-
 func (e *mutableStateBuilder) FlushBufferedEvents() error {
 	// put new events into 2 buckets:
 	//  1) if the event was added while there was in-flight decision, then put it in buffered bucket
@@ -3454,6 +3394,14 @@ func (e *mutableStateBuilder) AddTimerTasks(
 
 func (e *mutableStateBuilder) GetTimerTasks() []persistence.Task {
 	return e.insertTimerTasks
+}
+
+func (e *mutableStateBuilder) SetUpdateCondition(condition int64) {
+	e.condition = condition
+}
+
+func (e *mutableStateBuilder) GetUpdateCondition() int64 {
+	return e.condition
 }
 
 func (e *mutableStateBuilder) CloseTransactionAsMutation(

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -4079,15 +4079,6 @@ func (s *resetorSuite) TestApplyReset() {
 		},
 	}
 
-	appendV2Req := &p.AppendHistoryNodesRequest{
-		IsNewBranch:   false,
-		Info:          "",
-		BranchToken:   newBranchToken,
-		Events:        historyAfterReset.Events,
-		TransactionID: 1,
-		Encoding:      common.EncodingType(s.config.EventEncodingType(domainID)),
-		ShardID:       common.IntPtr(s.shardID),
-	}
 	appendV2Resp := &p.AppendHistoryNodesResponse{
 		Size: 200,
 	}
@@ -4107,7 +4098,7 @@ func (s *resetorSuite) TestApplyReset() {
 	s.mockHistoryV2Mgr.On("ForkHistoryBranch", forkReq).Return(forkResp, nil).Once()
 	s.mockHistoryV2Mgr.On("CompleteForkBranch", completeReq).Return(nil).Once()
 	s.mockHistoryV2Mgr.On("CompleteForkBranch", completeReqErr).Return(nil).Maybe()
-	s.mockHistoryV2Mgr.On("AppendHistoryNodes", appendV2Req).Return(appendV2Resp, nil).Once()
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything).Return(appendV2Resp, nil).Once()
 	s.mockExecutionMgr.On("ResetWorkflowExecution", mock.Anything).Return(nil).Once()
 	err := s.resetor.ApplyResetEvent(context.Background(), request, domainID, wid, currRunID)
 	s.Nil(err)
@@ -4138,6 +4129,8 @@ func (s *resetorSuite) TestApplyReset() {
 	s.Equal(int64(32), appendReq.Events[2].GetEventId())
 	s.Equal(int64(33), appendReq.Events[3].GetEventId())
 	s.Equal(int64(34), appendReq.Events[4].GetEventId())
+
+	s.Equal(common.EncodingType(s.config.EventEncodingType(domainID)), appendReq.Encoding)
 
 	// verify executionManager request
 	calls = s.mockExecutionMgr.Calls


### PR DESCRIPTION
* Remove redundant code in conflict resolver
* Rename ResetMutableState to ConflictResolveWorkflowExecution
* When appending history events to DB, set transaction ID in shard context, instead of within workflow execution context
* Remove ResetSnapshot in favor of CloseTransactionAsSnapshot
* When doing conflict resolution on workflow execution, also schedule a transfer task to sync workflow search attributes