### PR TITLE
Add docker CLI instructions for host address

### DIFF
--- a/docs/08_cli.md
+++ b/docs/08_cli.md
@@ -14,7 +14,12 @@ Example of using the docker image to describe a domain:
 docker run --rm ubercadence/cli:master --domain samples-domain domain describe
 ```
 
-You could use docker image `ubercadence/cli`, by replacing all the following `./cadence ...` with `docker run --rm ubercadence/cli:master --address <HOST_DNS>:7933 ...` . For old versions of docker, HOST_DNS is just 127.0.0.1; for 18.03 onwards, you may have to use host.docker.internal. For more info check https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds  
+You could use docker image `ubercadence/cli`, by replacing all the following `./cadence ...` with `docker run --rm ubercadence/cli:master --address <HOST_DNS>:7933 ...` . 
+
+You may get "connection refused" error for 18.03 onwards versions of docker. You have to use host.docker.internal. For more info check https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds  
+```
+docker run --rm ubercadence/cli:master --address host.docker.internal:7933 --domain samples-domain domain describe
+```
 
 
 To build the CLI tool locally, clone the [Cadence server repo](https://github.com/uber/cadence) and run

--- a/docs/08_cli.md
+++ b/docs/08_cli.md
@@ -14,6 +14,9 @@ Example of using the docker image to describe a domain:
 docker run --rm ubercadence/cli:master --domain samples-domain domain describe
 ```
 
+You could use docker image `ubercadence/cli`, by replacing all the following `./cadence ...` with `docker run --rm ubercadence/cli:master --address <HOST_DNS>:7933 ...` . For old versions of docker, HOST_DNS is just 127.0.0.1; for 18.03 onwards, you may have to use host.docker.internal. For more info check https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds  
+
+
 To build the CLI tool locally, clone the [Cadence server repo](https://github.com/uber/cadence) and run
 `make bins`. This produces an executable called `cadence`. With a local build, the same command to 
 describe a domain would look like this:

--- a/docs/08_cli.md
+++ b/docs/08_cli.md
@@ -14,13 +14,10 @@ Example of using the docker image to describe a domain:
 docker run --rm ubercadence/cli:master --domain samples-domain domain describe
 ```
 
-You could use docker image `ubercadence/cli`, by replacing all the following `./cadence ...` with `docker run --rm ubercadence/cli:master --address <HOST_DNS>:7933 ...` . 
-
 You may get "connection refused" error for 18.03 onwards versions of docker. You have to use host.docker.internal. For more info check https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds  
 ```
 docker run --rm ubercadence/cli:master --address host.docker.internal:7933 --domain samples-domain domain describe
 ```
-
 
 To build the CLI tool locally, clone the [Cadence server repo](https://github.com/uber/cadence) and run
 `make bins`. This produces an executable called `cadence`. With a local build, the same command to 

--- a/docs/08_cli.md
+++ b/docs/08_cli.md
@@ -14,7 +14,8 @@ Example of using the docker image to describe a domain:
 docker run --rm ubercadence/cli:master --domain samples-domain domain describe
 ```
 
-You may get "connection refused" error for 18.03 onwards versions of docker. You have to use host.docker.internal. For more info check https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds  
+On Docker versions 18.03 and later, you may get a "connection refused" error. You can work around this by setting the host to "host.docker.internal" (see [here](https://docs.docker.com/docker-for-mac/networking/#use-cases-and-workarounds) for more info).
+
 ```
 docker run --rm ubercadence/cli:master --address host.docker.internal:7933 --domain samples-domain domain describe
 ```


### PR DESCRIPTION
We had that before but somehow lost it when migrating to a different branch: https://github.com/uber/cadence/pull/1869/files