### PR TITLE
Clear stickyness when it is not being used when scheduling decision

### DIFF
--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1383,6 +1383,13 @@ func (e *mutableStateBuilder) AddDecisionTaskScheduledEventAsHeartbeat(
 	taskList := e.executionInfo.TaskList
 	if e.IsStickyTaskListEnabled() {
 		taskList = e.executionInfo.StickyTaskList
+	} else {
+		// It can be because stickyness has expired due to StickyTTL config
+		// In that case we need to clear stickyness so that the LastUpdateTimestamp is not corrupted.
+		// In other cases, clearing stickyness shouldn't hurt anything.
+		// TODO: https://github.com/uber/cadence/issues/2357:
+		//  if we can use a new field(LastDecisionUpdateTimestamp), then we could get rid of it.
+		e.ClearStickyness()
 	}
 	startToCloseTimeoutSeconds := e.executionInfo.DecisionTimeoutValue
 

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -155,6 +155,7 @@ type Config struct {
 
 	// Decision settings
 	// StickyTTL is to expire a sticky tasklist if no update more than this duration
+	// TODO https://github.com/uber/cadence/issues/2357
 	StickyTTL dynamicconfig.DurationPropertyFnWithDomainFilter
 	// DecisionHeartbeatTimeout is to timeout behavior of: RespondDecisionTaskComplete with ForceCreateNewDecisionTask == true without any decisions
 	// So that decision will be scheduled to another worker(by clear stickyness)


### PR DESCRIPTION
Related to https://github.com/uber/cadence/issues/2357