### PR TITLE
Fix docker for elasticsearch

### DIFF
--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -1,0 +1,34 @@
+frontend.enableClientVersionCheck:
+  - value: true
+system.enableVisibilityToKafka:
+  - value: true
+system.enableReadVisibilityFromES:
+  - value: true
+frontend.validSearchAttributes:
+  - value:
+      DomainID: 1
+      WorkflowID: 1
+      RunID: 1
+      WorkflowType: 1
+      StartTime: 2
+      ExecutionTime: 2
+      CloseTime: 2
+      CloseStatus: 2
+      HistoryLength: 2
+      CustomStringField: 0
+      CustomKeywordField: 1
+      CustomIntField: 2
+      CustomBoolField: 3
+      CustomDoubleField: 4
+      CustomDatetimeField: 5
+      project: 1
+      service: 1
+      environment: 1
+      addon: 1
+      addon-type: 1
+      user: 1
+      CustomDomain: 1
+      Operator: 1
+system.minRetentionDays:
+    - value: 0
+      constraints: {}

--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -31,4 +31,3 @@ frontend.validSearchAttributes:
       Operator: 1
 system.minRetentionDays:
     - value: 0
-      constraints: {}

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,7 +54,7 @@ docker-compose up
 Running cadence service with MySQL
 -----------------------------------------
 
-Run cadence with MySQL instead of cassandra, use following commads:
+Run cadence with MySQL instead of Cassandra, use following commads:
 
 ```
 docker-compose -f docker-compose-mysql.yml up
@@ -62,6 +62,15 @@ docker-compose -f docker-compose-mysql.yml down
 ```
 
 Please note that SQL support is still in active developement and it is not production ready yet.
+
+Running cadence service with ElasticSearch
+-----------------------------------------
+
+Run cadence with ElasticSearch for visibility instead of Cassandra/MySQL
+
+```
+docker-compose -f docker-compose-es.yml up
+``` 
 
 Quickstart for production
 =========================

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -32,9 +32,7 @@ services:
     environment:
       - discovery.type=single-node
   cadence:
-    # TODO https://github.com/uber/cadence/issues/2330
-    # after fixing the ES container, need to use the new image: server:master-auto-setup
-    image: ubercadence/server-es:master
+    image: ubercadence/server:master-auto-setup
     ports:
       - "7933:7933"
       - "7934:7934"


### PR DESCRIPTION
Recent change https://github.com/uber/cadence/pull/2325 didn't include docker setup for elasticsearch. 

This PR fix related issues, so that user can use `ubercadence/server:master-auto-setup` with elasticsearch. 