### PR TITLE
Fix visibility data on ES not deleted

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -506,6 +506,8 @@ const (
 	ElasticsearchScanWorkflowExecutionsScope
 	// ElasticsearchCountWorkflowExecutionsScope tracks CountWorkflowExecutions calls made by service to persistence layer
 	ElasticsearchCountWorkflowExecutionsScope
+	// ElasticsearchDeleteWorkflowExecutionsScope tracks DeleteWorkflowExecution calls made by service to persistence layer
+	ElasticsearchDeleteWorkflowExecutionsScope
 
 	// SequentialTaskProcessingScope is used by sequential task processing logic
 	SequentialTaskProcessingScope
@@ -1054,6 +1056,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ElasticsearchListWorkflowExecutionsScope:                   {operation: "ListWorkflowExecutions"},
 		ElasticsearchScanWorkflowExecutionsScope:                   {operation: "ScanWorkflowExecutions"},
 		ElasticsearchCountWorkflowExecutionsScope:                  {operation: "CountWorkflowExecutions"},
+		ElasticsearchDeleteWorkflowExecutionsScope:                 {operation: "DeleteWorkflowExecution"},
 		SequentialTaskProcessingScope:                              {operation: "SequentialTaskProcessing"},
 
 		HistoryArchiverScope: {operation: "HistoryArchiver"},

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -30,7 +30,3 @@ frontend.validSearchAttributes:
 system.minRetentionDays:
 - value: 0
   constraints: {}
-system.enableVisibilityToKafka:
-    - value: true
-system.enableReadVisibilityFromES:
-    - value: true

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -30,3 +30,7 @@ frontend.validSearchAttributes:
 system.minRetentionDays:
 - value: 0
   constraints: {}
+system.enableVisibilityToKafka:
+    - value: true
+system.enableReadVisibilityFromES:
+    - value: true

--- a/docs/visibility-on-elasticsearch.md
+++ b/docs/visibility-on-elasticsearch.md
@@ -36,7 +36,7 @@ To list only open workflows, add `CloseTime = missing` to the end of query.
 ### start workflow with search attributes 
 
 ```
-cadence --do samples-domain workflow start --tl helloWorldGroup --wt main.Workflow --et 60 --dt 10 -i '"vancexu"' -search_attr_key 'CustomIntField | CustomKeywordField | CustomStringField |  CustomBoolField | CustomDatetimeField' -search_attr_value '5 | keyword1 | vancexu test | true | 2019-06-07T16:16:36-08:00'
+cadence --do samples-domain workflow start --tl helloWorldGroup --wt main.Workflow --et 60 --dt 10 -i '"input arg"' -search_attr_key 'CustomIntField | CustomKeywordField | CustomStringField |  CustomBoolField | CustomDatetimeField' -search_attr_value '5 | keyword1 | my test | true | 2019-06-07T16:16:36-08:00'
 ```
 
 Note: start workflow with search attributes but without ES will succeed as normal, but will not be searchable and will not be shown in list result.


### PR DESCRIPTION
A change on metrics client since April 11 breaks delete visibility from ElasticSearch. 
This PR fixed this. 