### PR TITLE
Using latest version of goveralls for code coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ cover: $(COVER_ROOT)/cover.out
 	go tool cover -html=$(COVER_ROOT)/cover.out;
 
 cover_ci: $(COVER_ROOT)/cover.out
-	goveralls -coverprofile=$(COVER_ROOT)/cover.out -service=buildkite -debug || echo Coveralls failed;
+	goveralls -coverprofile=$(COVER_ROOT)/cover.out -service=buildkite || echo Coveralls failed;
 
 lint:
 	@echo Running linter

--- a/Makefile
+++ b/Makefile
@@ -202,7 +202,7 @@ cover: $(COVER_ROOT)/cover.out
 	go tool cover -html=$(COVER_ROOT)/cover.out;
 
 cover_ci: $(COVER_ROOT)/cover.out
-	goveralls -coverprofile=$(COVER_ROOT)/cover.out -service=buildkite || echo Coveralls failed;
+	goveralls -coverprofile=$(COVER_ROOT)/cover.out -service=buildkite -debug || echo Coveralls failed;
 
 lint:
 	@echo Running linter

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -25,7 +25,7 @@ RUN go get -u github.com/golang/dep/cmd/dep
 RUN go get -u github.com/Masterminds/glide
 RUN go get -u golang.org/x/lint/golint
 RUN go get github.com/axw/gocov/gocov
-RUN go get github.com/mattn/goveralls
+RUN go get github.com/dmetzgar/goveralls
 RUN go get golang.org/x/tools/cmd/cover
 
 # https://github.com/docker-library/golang/blob/c1baf037d71331eb0b8d4c70cff4c29cf124c5e0/1.4/Dockerfile

--- a/scripts/buildkite/gocov.sh
+++ b/scripts/buildkite/gocov.sh
@@ -3,7 +3,7 @@
 set -ex
 
 # fetch codecov reporting tool
-go get github.com/mattn/goveralls
+go get github.com/dmetzgar/goveralls
 
 # download cover files from all the tests
 mkdir -p build/coverage


### PR DESCRIPTION
The repo for [goveralls](https://github.com/mattn/goveralls) hasn't had a release since 2017. `go get` was pulling the latest release and wasn't getting the buildkite environment info. So I created a [fork](https://github.com/dmetzgar/goveralls) and a new release with the latest code. I'm open to better suggestions.