### PR TITLE
Fix Dockerfile COPY error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR /cadence
 ENV GOFLAGS="-mod=readonly"
 
 # Copy go mod dependencies and build cache
-COPY go.* .
+COPY go.* ./
 RUN go mod download
 
 COPY . .


### PR DESCRIPTION
Before this change I was getting the following error:

```
$ docker build .
Sending build context to Docker daemon   43.9MB
Step 1/44 : ARG TARGET=server
Step 2/44 : ARG GOPROXY
Step 3/44 : FROM golang:1.12.7-alpine AS builder
 ---> 6b21b4c6e7a3
Step 4/44 : RUN apk add --update --no-cache ca-certificates make git curl mercurial bzr
 ---> Using cache
 ---> ff5a2f6aa592
Step 5/44 : WORKDIR /cadence
 ---> Using cache
 ---> 5f377831b7e4
Step 6/44 : ENV GOFLAGS="-mod=readonly"
 ---> Using cache
 ---> 825e571711a3
Step 7/44 : COPY go.* .
When using COPY with more than one source file, the destination must be a directory and end with a /
```
This appears to have fixed the error