### PR TITLE
Use separate task processor per queue

### DIFF
--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -57,7 +57,6 @@ func newTimerQueueActiveProcessor(
 	historyService *historyEngineImpl,
 	matchingClient matching.Client,
 	taskAllocator taskAllocator,
-	taskProcessor *taskProcessor,
 	logger log.Logger,
 ) *timerQueueActiveProcessorImpl {
 
@@ -105,7 +104,6 @@ func newTimerQueueActiveProcessor(
 			historyService,
 			timerQueueAckMgr,
 			timerGate,
-			taskProcessor,
 			shard.GetConfig().TimerProcessorMaxPollRPS,
 			logger,
 		),
@@ -124,7 +122,6 @@ func newTimerQueueFailoverProcessor(
 	maxLevel time.Time,
 	matchingClient matching.Client,
 	taskAllocator taskAllocator,
-	taskProcessor *taskProcessor,
 	logger log.Logger,
 ) (func(ackLevel TimerSequenceID) error, *timerQueueActiveProcessorImpl) {
 
@@ -193,7 +190,6 @@ func newTimerQueueFailoverProcessor(
 			historyService,
 			timerQueueAckMgr,
 			timerGate,
-			taskProcessor,
 			shard.GetConfig().TimerProcessorFailoverMaxPollRPS,
 			logger,
 		),

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -189,17 +189,11 @@ func (s *timerQueueProcessor2Suite) SetupTest() {
 	s.mockShard.SetEngine(h)
 	s.mockHistoryEngine = h
 	s.clusterName = cluster.TestCurrentClusterName
-	options := taskProcessorOptions{
-		queueSize:   s.mockShard.GetConfig().TimerTaskBatchSize() * s.mockShard.GetConfig().TimerTaskWorkerCount(),
-		workerCount: s.mockShard.GetConfig().TimerTaskWorkerCount(),
-	}
-	s.taskProcessor = newTaskProcessor(options, s.mockShard, h.historyCache, s.logger)
 	s.timerQueueActiveProcessor = newTimerQueueActiveProcessor(
 		s.mockShard,
 		h,
 		s.mockMatchingClient,
 		newTaskAllocator(s.mockShard),
-		s.taskProcessor,
 		s.logger,
 	)
 

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -79,7 +79,6 @@ type (
 		domainEntry               *cache.DomainCacheEntry
 		clusterName               string
 		timerQueueActiveProcessor *timerQueueActiveProcessorImpl
-		taskProcessor             *taskProcessor
 	}
 )
 
@@ -217,13 +216,11 @@ func (s *timerQueueProcessor2Suite) TearDownTest() {
 }
 
 func (s *timerQueueProcessor2Suite) startProcessor() {
-	s.taskProcessor.start()
 	s.timerQueueActiveProcessor.Start()
 }
 
 func (s *timerQueueProcessor2Suite) stopProcessor() {
 	s.timerQueueActiveProcessor.Stop()
-	s.taskProcessor.stop()
 }
 
 func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -68,7 +68,6 @@ type (
 		timeSource       clock.TimeSource
 		rateLimiter      quotas.Limiter
 		retryPolicy      backoff.RetryPolicy
-		processor        *taskProcessor
 		lastPollTime     time.Time
 		taskProcessor    *taskProcessor
 
@@ -111,7 +110,7 @@ func newTimerQueueProcessorBase(
 		timeSource:       shard.GetTimeSource(),
 		newTimerCh:       make(chan struct{}, 1),
 		lastPollTime:     time.Time{},
-		processor:        taskProcessor,
+		taskProcessor:    taskProcessor,
 		rateLimiter: quotas.NewDynamicRateLimiter(
 			func() float64 {
 				return float64(maxPollRPS())
@@ -348,7 +347,7 @@ func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*persistence.TimerT
 	}
 
 	for _, task := range timerTasks {
-		if shutdown := t.processor.addTask(
+		if shutdown := t.taskProcessor.addTask(
 			&taskInfo{
 				processor: t.timerProcessor,
 				task:      task,
@@ -372,7 +371,7 @@ func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*persistence.TimerT
 }
 
 func (t *timerQueueProcessorBase) retryTasks() {
-	t.processor.retryTasks()
+	t.taskProcessor.retryTasks()
 }
 
 func (t *timerQueueProcessorBase) complete(timerTask *persistence.TimerTaskInfo) {

--- a/service/history/timerQueueProcessorBase_test.go
+++ b/service/history/timerQueueProcessorBase_test.go
@@ -125,17 +125,12 @@ func (s *timerQueueProcessorBaseSuite) SetupTest() {
 		archivalClient: s.mockArchivalClient,
 	}
 
-	options := taskProcessorOptions{
-		queueSize:   s.mockShard.GetConfig().TimerTaskBatchSize() * s.mockShard.GetConfig().TimerTaskWorkerCount(),
-		workerCount: s.mockShard.GetConfig().TimerTaskWorkerCount(),
-	}
 	s.timerQueueProcessor = newTimerQueueProcessorBase(
 		s.scope,
 		s.mockShard,
 		h,
 		s.mockQueueAckMgr,
 		NewLocalTimerGate(clock.NewRealTimeSource()),
-		newTaskProcessor(options, s.mockShard, h.historyCache, s.logger),
 		dynamicconfig.GetIntPropertyFn(10),
 		s.logger,
 	)

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -60,7 +60,6 @@ func newTimerQueueStandbyProcessor(
 	historyService *historyEngineImpl,
 	clusterName string,
 	taskAllocator taskAllocator,
-	taskProcessor *taskProcessor,
 	historyRereplicator xdc.HistoryRereplicator,
 	logger log.Logger,
 ) *timerQueueStandbyProcessorImpl {
@@ -108,7 +107,6 @@ func newTimerQueueStandbyProcessor(
 			historyService,
 			timerQueueAckMgr,
 			timerGate,
-			taskProcessor,
 			shard.GetConfig().TimerProcessorMaxPollRPS,
 			logger,
 		),

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -166,16 +166,11 @@ func (s *timerQueueStandbyProcessorSuite) SetupTest() {
 	s.mockShard.SetEngine(h)
 	s.mockHistoryEngine = h
 	s.clusterName = cluster.TestAlternativeClusterName
-	options := taskProcessorOptions{
-		queueSize:   s.mockShard.GetConfig().TimerTaskBatchSize() * s.mockShard.GetConfig().TimerTaskWorkerCount(),
-		workerCount: s.mockShard.GetConfig().TimerTaskWorkerCount(),
-	}
 	s.timerQueueStandbyProcessor = newTimerQueueStandbyProcessor(
 		s.mockShard,
 		h,
 		s.clusterName,
 		newTaskAllocator(s.mockShard),
-		newTaskProcessor(options, s.mockShard, h.historyCache, s.logger),
 		s.mockHistoryRereplicator,
 		s.logger,
 	)

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -65,7 +65,6 @@ func newTransferQueueActiveProcessor(
 	matchingClient matching.Client,
 	historyClient history.Client,
 	taskAllocator taskAllocator,
-	taskProcessor *taskProcessor,
 	logger log.Logger,
 ) *transferQueueActiveProcessorImpl {
 
@@ -112,12 +111,19 @@ func newTransferQueueActiveProcessor(
 		cache:              historyService.historyCache,
 		transferTaskFilter: transferTaskFilter,
 		transferQueueProcessorBase: newTransferQueueProcessorBase(
-			shard, options, visibilityMgr, matchingClient, maxReadAckLevel, updateTransferAckLevel, transferQueueShutdown, logger,
+			shard,
+			options,
+			 visibilityMgr,
+				matchingClient,
+				 maxReadAckLevel,
+					updateTransferAckLevel,
+					 transferQueueShutdown,
+					  logger,
 		),
 	}
 
 	queueAckMgr := newQueueAckMgr(shard, options, processor, shard.GetTransferClusterAckLevel(currentClusterName), logger)
-	queueProcessorBase := newQueueProcessorBase(currentClusterName, shard, options, processor, queueAckMgr, taskProcessor, logger)
+	queueProcessorBase := newQueueProcessorBase(currentClusterName, shard, options, processor, queueAckMgr, historyService.historyCache, logger)
 	processor.queueAckMgr = queueAckMgr
 	processor.queueProcessorBase = queueProcessorBase
 
@@ -135,7 +141,6 @@ func newTransferQueueFailoverProcessor(
 	minLevel int64,
 	maxLevel int64,
 	taskAllocator taskAllocator,
-	taskProcessor *taskProcessor,
 	logger log.Logger,
 ) (func(ackLevel int64) error, *transferQueueActiveProcessorImpl) {
 
@@ -203,7 +208,7 @@ func newTransferQueueFailoverProcessor(
 	}
 
 	queueAckMgr := newQueueFailoverAckMgr(shard, options, processor, minLevel, logger)
-	queueProcessorBase := newQueueProcessorBase(currentClusterName, shard, options, processor, queueAckMgr, taskProcessor, logger)
+	queueProcessorBase := newQueueProcessorBase(currentClusterName, shard, options, processor, queueAckMgr, historyService.historyCache, logger)
 	processor.queueAckMgr = queueAckMgr
 	processor.queueProcessorBase = queueProcessorBase
 	return updateTransferAckLevel, processor

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -113,12 +113,12 @@ func newTransferQueueActiveProcessor(
 		transferQueueProcessorBase: newTransferQueueProcessorBase(
 			shard,
 			options,
-			 visibilityMgr,
-				matchingClient,
-				 maxReadAckLevel,
-					updateTransferAckLevel,
-					 transferQueueShutdown,
-					  logger,
+			visibilityMgr,
+			matchingClient,
+			maxReadAckLevel,
+			updateTransferAckLevel,
+			transferQueueShutdown,
+			logger,
 		),
 	}
 

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -177,10 +177,6 @@ func (s *transferQueueActiveProcessorSuite) SetupTest() {
 	s.mockShard.SetEngine(h)
 	s.mockHistoryEngine = h
 	s.mockQueueAckMgr = &MockQueueAckMgr{}
-	options := taskProcessorOptions{
-		queueSize:   s.mockShard.GetConfig().TransferTaskBatchSize(),
-		workerCount: s.mockShard.GetConfig().TransferTaskWorkerCount(),
-	}
 	s.transferQueueActiveProcessor = newTransferQueueActiveProcessor(
 		s.mockShard,
 		h,
@@ -188,7 +184,6 @@ func (s *transferQueueActiveProcessorSuite) SetupTest() {
 		s.mockMatchingClient,
 		s.mockHistoryClient,
 		newTaskAllocator(s.mockShard),
-		newTaskProcessor(options, s.mockShard, h.historyCache, s.logger),
 		s.logger,
 	)
 	s.transferQueueActiveProcessor.queueAckMgr = s.mockQueueAckMgr

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -57,7 +57,6 @@ func newTransferQueueStandbyProcessor(
 	matchingClient matching.Client,
 	taskAllocator taskAllocator,
 	historyRereplicator xdc.HistoryRereplicator,
-	taskProcessor *taskProcessor,
 	logger log.Logger,
 ) *transferQueueStandbyProcessorImpl {
 
@@ -103,14 +102,20 @@ func newTransferQueueStandbyProcessor(
 		logger:             logger,
 		metricsClient:      historyService.metricsClient,
 		transferQueueProcessorBase: newTransferQueueProcessorBase(
-			shard, options, visibilityMgr, matchingClient,
-			maxReadAckLevel, updateClusterAckLevel, transferQueueShutdown, logger,
+			shard,
+			options,
+			visibilityMgr,
+			matchingClient,
+			maxReadAckLevel,
+			updateClusterAckLevel,
+			transferQueueShutdown,
+			logger,
 		),
 		historyRereplicator: historyRereplicator,
 	}
 
 	queueAckMgr := newQueueAckMgr(shard, options, processor, shard.GetTransferClusterAckLevel(clusterName), logger)
-	queueProcessorBase := newQueueProcessorBase(clusterName, shard, options, processor, queueAckMgr, taskProcessor, logger)
+	queueProcessorBase := newQueueProcessorBase(clusterName, shard, options, processor, queueAckMgr, historyService.historyCache, logger)
 	processor.queueAckMgr = queueAckMgr
 	processor.queueProcessorBase = queueProcessorBase
 

--- a/service/history/transferQueueStandbyProcessor_test.go
+++ b/service/history/transferQueueStandbyProcessor_test.go
@@ -172,10 +172,6 @@ func (s *transferQueueStandbyProcessorSuite) SetupTest() {
 	s.mockShard.SetEngine(h)
 	s.mockHistoryEngine = h
 	s.clusterName = cluster.TestAlternativeClusterName
-	options := taskProcessorOptions{
-		queueSize:   s.mockShard.GetConfig().TransferTaskBatchSize(),
-		workerCount: s.mockShard.GetConfig().TransferTaskWorkerCount(),
-	}
 	s.transferQueueStandbyProcessor = newTransferQueueStandbyProcessor(
 		s.clusterName,
 		s.mockShard,
@@ -184,7 +180,6 @@ func (s *transferQueueStandbyProcessorSuite) SetupTest() {
 		s.mockMatchingClient,
 		newTaskAllocator(s.mockShard),
 		s.mockHistoryRereplicator,
-		newTaskProcessor(options, s.mockShard, h.historyCache, s.logger),
 		s.logger,
 	)
 	s.mockQueueAckMgr = &MockQueueAckMgr{}


### PR DESCRIPTION
Keep the refactoring but undo previous change to use same task processor across all types of queues.