### PR TITLE
Clean up legacy batcher code

### DIFF
--- a/service/worker/batcher/batcher.go
+++ b/service/worker/batcher/batcher.go
@@ -22,7 +22,7 @@ package batcher
 
 import (
 	"context"
-	
+
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
 	"github.com/uber/cadence/client"


### PR DESCRIPTION
We switched to local domains and left some legacy code to clean up: https://github.com/uber/cadence/issues/2309
