### PR TITLE
Share dockerize command between cadence-server and cadence-auto-setup Dockerfile targets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -60,6 +60,7 @@ COPY --from=builder /cadence/schema /etc/cadence/schema
 COPY docker/entrypoint.sh /docker-entrypoint.sh
 COPY config/dynamicconfig /etc/cadence/config/dynamicconfig
 COPY docker/config_template.yaml /etc/cadence/config
+COPY docker/start-cadence.sh /start-cadence.sh
 
 WORKDIR /etc/cadence
 
@@ -67,7 +68,7 @@ ENV SERVICES="history,matching,frontend,worker"
 
 EXPOSE 7933 7934 7935 7939
 ENTRYPOINT ["/docker-entrypoint.sh"]
-CMD dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
+CMD /start-cadence.sh
 
 
 # All-in-one Cadence server

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -106,4 +106,4 @@ if [ "$SKIP_SCHEMA_SETUP" != true ]; then
     setup_schema
 fi
 
-dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
+bash /start-cadence.sh


### PR DESCRIPTION
Both `Dockerfile` and `docker/start.sh` were executing the same `dockerize` command. This change makes it so both places call the same script.

This also makes it easier to wrap this startup script when overriding CMD with `docker run`. In my case, due to how my Kubernetes infrastructure is set up, I cannot pass database credentials in as environment variables, which is how the dockerize command expects them. Database credentials are only available via files that get mounted at runtime, so I need to wrap the startup script with something that grabs those credentials from a file and sets them as environment variables.

I'm not hip to all the coolest Docker idioms and tricks. Please check me on this.