### PR TITLE
Add connectAttributes to docker/config_template.yml

### DIFF
--- a/common/persistence/sql/storage/store.go
+++ b/common/persistence/sql/storage/store.go
@@ -88,7 +88,15 @@ func buildDSNAttrs(cfg *config.SQL) string {
 	// only override isolation level if not specified
 	if !hasAttr(attrs, isolationLevelAttrName) &&
 		!hasAttr(attrs, isolationLevelAttrNameLegacy) {
-		attrs[isolationLevelAttrName] = defaultIsolationLevel
+
+		var attrName string
+		if cfg.TransactionIsolationAttrName == "" {
+			attrName = isolationLevelAttrName
+		} else {
+			attrName = cfg.TransactionIsolationAttrName
+		}
+
+		attrs[attrName] = defaultIsolationLevel
 	}
 
 	// these attrs are always overriden

--- a/common/persistence/sql/storage/store_test.go
+++ b/common/persistence/sql/storage/store_test.go
@@ -108,6 +108,19 @@ func (s *StoreTestSuite) TestBuildDSN() {
 			outIsolationVal: "'repeatable-read'",
 			outURLPath:      "test:pass@tcp(192.168.0.1:3306)/db1?",
 		},
+		{
+			in: config.SQL{
+				User:                         "test",
+				Password:                     "pass",
+				ConnectProtocol:              "tcp",
+				ConnectAddr:                  "192.168.0.1:3306",
+				DatabaseName:                 "db1",
+				TransactionIsolationAttrName: "tx_isolation",
+			},
+			outIsolationKey: "tx_isolation",
+			outIsolationVal: "'READ-COMMITTED'",
+			outURLPath:      "test:pass@tcp(192.168.0.1:3306)/db1?",
+		},
 	}
 
 	for _, tc := range testCases {

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -216,6 +216,10 @@ type (
 		// NumShards is the number of storage shards to use for tables
 		// in a sharded sql database. The default value for this param is 1
 		NumShards int `yaml:"nShards"`
+		// Name to use for the transaction isolation level connection attribute.
+		// Defaults to "transaction_isolation".
+		// This is ignored if "transaction_isolation" or "tx_isolation" is included in "ConnectAttributes"
+		TransactionIsolationAttrName string `yaml:"transactionIsolationAttrName"`
 	}
 
 	// Replicator describes the configuration of replicator

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -33,6 +33,7 @@ persistence:
                 user: {{ default .Env.MYSQL_USER "" }}
                 password: {{ default .Env.MYSQL_PWD "" }}
                 connectAttributes: {{ default .Env.MYSQL_CONNECT_ATTRS "{}" }}
+                transactionIsolationAttrName: {{ default .Env.MYSQL_TX_ISOLATION_ATTR_NAME "" }}
         visibility:
             sql:
                 driverName: "mysql"
@@ -42,6 +43,7 @@ persistence:
                 user: {{ default .Env.MYSQL_USER "" }}
                 password: {{ default .Env.MYSQL_PWD "" }}
                 connectAttributes: {{ default .Env.MYSQL_CONNECT_ATTRS "{}" }}
+                transactionIsolationAttrName: {{ default .Env.MYSQL_TX_ISOLATION_ATTR_NAME "" }}
         {{- end }}
         {{- if eq $es "true" }}
         es-visibility:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -32,6 +32,7 @@ persistence:
                 connectProtocol: "tcp"
                 user: {{ default .Env.MYSQL_USER "" }}
                 password: {{ default .Env.MYSQL_PWD "" }}
+                connectAttributes: {{ default .Env.MYSQL_CONNECT_ATTRS "{}" }}
         visibility:
             sql:
                 driverName: "mysql"
@@ -40,6 +41,7 @@ persistence:
                 connectProtocol: "tcp"
                 user: {{ default .Env.MYSQL_USER "" }}
                 password: {{ default .Env.MYSQL_PWD "" }}
+                connectAttributes: {{ default .Env.MYSQL_CONNECT_ATTRS "{}" }}
         {{- end }}
         {{- if eq $es "true" }}
         es-visibility:


### PR DESCRIPTION
This allows MySQL connection attributes to be set via environment variables passed to `docker run`.

**This expects the environment variable to be a JSON encoded string**. Kind of ugly, but I'm not sure of a better way around this. Doing some of comma separated key value pair thing feels.. fragile. Any better ideas?

Also, I'm not very familiar with `cadence` - any good ways to add tests for this config template?