### PR TITLE
New history event v2 store ReadRawHistoryBranch API

### DIFF
--- a/common/mocks/HistoryV2Manager.go
+++ b/common/mocks/HistoryV2Manager.go
@@ -103,6 +103,26 @@ func (_m *HistoryV2Manager) ReadHistoryBranchByBatch(request *persistence.ReadHi
 	return r0, r1
 }
 
+// ReadRawHistoryBranch provides a mock function with given fields: request
+func (_m *HistoryV2Manager) ReadRawHistoryBranch(request *persistence.ReadHistoryBranchRequest) (*persistence.ReadRawHistoryBranchResponse, error) {
+	ret := _m.Called(request)
+	var r0 *persistence.ReadRawHistoryBranchResponse
+	if rf, ok := ret.Get(0).(func(*persistence.ReadHistoryBranchRequest) *persistence.ReadRawHistoryBranchResponse); ok {
+		r0 = rf(request)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*persistence.ReadRawHistoryBranchResponse)
+		}
+	}
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*persistence.ReadHistoryBranchRequest) error); ok {
+		r1 = rf(request)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
 // ForkHistoryBranch provides a mock function with given fields: request
 func (_m *HistoryV2Manager) ForkHistoryBranch(request *persistence.ForkHistoryBranchRequest) (*persistence.ForkHistoryBranchResponse, error) {
 	ret := _m.Called(request)

--- a/common/persistence/cassandra/cassandraHistoryV2Persistence.go
+++ b/common/persistence/cassandra/cassandraHistoryV2Persistence.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/gocql/gocql"
+
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
@@ -65,13 +66,20 @@ type (
 )
 
 // NewHistoryV2PersistenceFromSession returns new HistoryV2Store
-func NewHistoryV2PersistenceFromSession(session *gocql.Session, logger log.Logger) p.HistoryV2Store {
+func NewHistoryV2PersistenceFromSession(
+	session *gocql.Session,
+	logger log.Logger,
+) p.HistoryV2Store {
+
 	return &cassandraHistoryV2Persistence{cassandraStore: cassandraStore{session: session, logger: logger}}
 }
 
 // newHistoryPersistence is used to create an instance of HistoryManager implementation
-func newHistoryV2Persistence(cfg config.Cassandra, logger log.Logger) (p.HistoryV2Store,
-	error) {
+func newHistoryV2Persistence(
+	cfg config.Cassandra,
+	logger log.Logger,
+) (p.HistoryV2Store, error) {
+
 	cluster := NewCassandraCluster(cfg.Hosts, cfg.Port, cfg.User, cfg.Password, cfg.Datacenter)
 	cluster.Keyspace = cfg.Keyspace
 	cluster.ProtoVersion = cassandraProtoVersion
@@ -89,7 +97,11 @@ func newHistoryV2Persistence(cfg config.Cassandra, logger log.Logger) (p.History
 	return &cassandraHistoryV2Persistence{cassandraStore: cassandraStore{session: session, logger: logger}}, nil
 }
 
-func convertCommonErrors(operation string, err error) error {
+func convertCommonErrors(
+	operation string,
+	err error,
+) error {
+
 	if err == gocql.ErrNotFound {
 		return &workflow.EntityNotExistsError{
 			Message: fmt.Sprintf("%v failed. Error: %v ", operation, err),
@@ -108,7 +120,10 @@ func convertCommonErrors(operation string, err error) error {
 
 // AppendHistoryNodes upsert a batch of events as a single node to a history branch
 // Note that it's not allowed to append above the branch's ancestors' nodes, which means nodeID >= ForkNodeID
-func (h *cassandraHistoryV2Persistence) AppendHistoryNodes(request *p.InternalAppendHistoryNodesRequest) error {
+func (h *cassandraHistoryV2Persistence) AppendHistoryNodes(
+	request *p.InternalAppendHistoryNodesRequest,
+) error {
+
 	branchInfo := request.BranchInfo
 	beginNodeID := p.GetBeginNodeID(branchInfo)
 
@@ -149,12 +164,17 @@ func (h *cassandraHistoryV2Persistence) AppendHistoryNodes(request *p.InternalAp
 
 // ReadHistoryBranch returns history node data for a branch
 // NOTE: For branch that has ancestors, we need to query Cassandra multiple times, because it doesn't support OR/UNION operator
-func (h *cassandraHistoryV2Persistence) ReadHistoryBranch(request *p.InternalReadHistoryBranchRequest) (*p.InternalReadHistoryBranchResponse, error) {
+func (h *cassandraHistoryV2Persistence) ReadHistoryBranch(
+	request *p.InternalReadHistoryBranchRequest,
+) (*p.InternalReadHistoryBranchResponse, error) {
+
 	treeID := request.TreeID
 	branchID := request.BranchID
 
-	query := h.session.Query(v2templateReadData,
-		treeID, branchID, request.MinNodeID, request.MaxNodeID)
+	lastNodeID := request.LastNodeID
+	lastTxnID := request.LastTransactionID
+
+	query := h.session.Query(v2templateReadData, treeID, branchID, request.MinNodeID, request.MaxNodeID)
 
 	iter := query.PageSize(int(request.PageSize)).PageState(request.NextPageToken).Iter()
 	if iter == nil {
@@ -165,27 +185,42 @@ func (h *cassandraHistoryV2Persistence) ReadHistoryBranch(request *p.InternalRea
 	pagingToken := iter.PageState()
 
 	history := make([]*p.DataBlob, 0, int(request.PageSize))
-	lastNodeID := int64(-1)
-	lastTxnID := int64(-1)
+
 	eventBlob := &p.DataBlob{}
 	nodeID := int64(0)
 	txnID := int64(0)
 
 	for iter.Scan(&nodeID, &txnID, &eventBlob.Data, &eventBlob.Encoding) {
-		if nodeID == lastNodeID {
-			if txnID < lastTxnID {
-				// skip the nodes with smaller txn_id
-				continue
-			} else {
-				return nil, &workflow.InternalServiceError{
-					Message: fmt.Sprintf("corrupted data, same nodeID must have smaller txnID"),
-				}
-			}
+		if txnID < lastTxnID {
+			// assuming that business logic layer is correct and transaction ID only increase
+			// thus, valid event batch will come with increasing transaction ID
+
+			// event batches with smaller node ID
+			//  -> should not be possible since records are already sorted
+			// event batches with same node ID
+			//  -> batch with higher transaction ID is valid
+			// event batches with larger node ID
+			//  -> batch with lower transaction ID is invalid (happens before)
+			//  -> batch with higher transaction ID is valid
+			continue
 		}
-		lastTxnID = txnID
-		lastNodeID = nodeID
-		history = append(history, eventBlob)
-		eventBlob = &p.DataBlob{}
+
+		switch {
+		case nodeID < lastNodeID:
+			return nil, &workflow.InternalServiceError{
+				Message: fmt.Sprintf("corrupted data, nodeID cannot decrease"),
+			}
+		case nodeID == lastNodeID:
+			return nil, &workflow.InternalServiceError{
+				Message: fmt.Sprintf("corrupted data, same nodeID must have smaller txnID"),
+			}
+		default: // row.NodeID > lastNodeID:
+			// NOTE: when row.nodeID > lastNodeID, we expect the one with largest txnID comes first
+			lastTxnID = txnID
+			lastNodeID = nodeID
+			history = append(history, eventBlob)
+			eventBlob = &p.DataBlob{}
+		}
 	}
 
 	if err := iter.Close(); err != nil {
@@ -194,12 +229,12 @@ func (h *cassandraHistoryV2Persistence) ReadHistoryBranch(request *p.InternalRea
 		}
 	}
 
-	response := &p.InternalReadHistoryBranchResponse{
-		History:       history,
-		NextPageToken: pagingToken,
-	}
-
-	return response, nil
+	return &p.InternalReadHistoryBranchResponse{
+		History:           history,
+		NextPageToken:     pagingToken,
+		LastNodeID:        lastNodeID,
+		LastTransactionID: lastTxnID,
+	}, nil
 }
 
 // ForkHistoryBranch forks a new branch from an existing branch
@@ -246,7 +281,10 @@ func (h *cassandraHistoryV2Persistence) ReadHistoryBranch(request *p.InternalRea
 //       \
 //       8[8,9]
 //
-func (h *cassandraHistoryV2Persistence) ForkHistoryBranch(request *p.InternalForkHistoryBranchRequest) (*p.InternalForkHistoryBranchResponse, error) {
+func (h *cassandraHistoryV2Persistence) ForkHistoryBranch(
+	request *p.InternalForkHistoryBranchRequest,
+) (*p.InternalForkHistoryBranchResponse, error) {
+
 	forkB := request.ForkBranchInfo
 	treeID := *forkB.TreeID
 	newAncestors := make([]*workflow.HistoryBranchRange, 0, len(forkB.Ancestors)+1)
@@ -304,7 +342,10 @@ func (h *cassandraHistoryV2Persistence) ForkHistoryBranch(request *p.InternalFor
 }
 
 // UpdateHistoryBranch update a branch
-func (h *cassandraHistoryV2Persistence) CompleteForkBranch(request *p.InternalCompleteForkBranchRequest) error {
+func (h *cassandraHistoryV2Persistence) CompleteForkBranch(
+	request *p.InternalCompleteForkBranchRequest,
+) error {
+
 	branch := request.BranchInfo
 	treeID := *branch.TreeID
 	branchID := *branch.BranchID
@@ -332,7 +373,10 @@ func (h *cassandraHistoryV2Persistence) CompleteForkBranch(request *p.InternalCo
 }
 
 // DeleteHistoryBranch removes a branch
-func (h *cassandraHistoryV2Persistence) DeleteHistoryBranch(request *p.InternalDeleteHistoryBranchRequest) error {
+func (h *cassandraHistoryV2Persistence) DeleteHistoryBranch(
+	request *p.InternalDeleteHistoryBranchRequest,
+) error {
+
 	branch := request.BranchInfo
 	treeID := *branch.TreeID
 	brsToDelete := branch.Ancestors
@@ -393,14 +437,23 @@ func (h *cassandraHistoryV2Persistence) DeleteHistoryBranch(request *p.InternalD
 	return nil
 }
 
-func (h *cassandraHistoryV2Persistence) deleteBranchRangeNodes(batch *gocql.Batch, treeID, branchID string, beginNodeID int64) {
+func (h *cassandraHistoryV2Persistence) deleteBranchRangeNodes(
+	batch *gocql.Batch,
+	treeID string,
+	branchID string,
+	beginNodeID int64,
+) {
+
 	batch.Query(v2templateRangeDeleteData,
 		treeID,
 		branchID,
 		beginNodeID)
 }
 
-func (h *cassandraHistoryV2Persistence) GetAllHistoryTreeBranches(request *p.GetAllHistoryTreeBranchesRequest) (*p.GetAllHistoryTreeBranchesResponse, error) {
+func (h *cassandraHistoryV2Persistence) GetAllHistoryTreeBranches(
+	request *p.GetAllHistoryTreeBranchesRequest,
+) (*p.GetAllHistoryTreeBranchesResponse, error) {
+
 	query := h.session.Query(v2templateScanAllTreeBranches)
 
 	iter := query.PageSize(int(request.PageSize)).PageState(request.NextPageToken).Iter()
@@ -442,7 +495,10 @@ func (h *cassandraHistoryV2Persistence) GetAllHistoryTreeBranches(request *p.Get
 }
 
 // GetHistoryTree returns all branch information of a tree
-func (h *cassandraHistoryV2Persistence) GetHistoryTree(request *p.GetHistoryTreeRequest) (*p.GetHistoryTreeResponse, error) {
+func (h *cassandraHistoryV2Persistence) GetHistoryTree(
+	request *p.GetHistoryTreeRequest,
+) (*p.GetHistoryTreeResponse, error) {
+
 	treeID := request.TreeID
 
 	query := h.session.Query(v2templateReadAllBranches, treeID)
@@ -509,7 +565,10 @@ func (h *cassandraHistoryV2Persistence) GetHistoryTree(request *p.GetHistoryTree
 	}, nil
 }
 
-func (h *cassandraHistoryV2Persistence) parseBranchAncestors(ancestors []map[string]interface{}) []*workflow.HistoryBranchRange {
+func (h *cassandraHistoryV2Persistence) parseBranchAncestors(
+	ancestors []map[string]interface{},
+) []*workflow.HistoryBranchRange {
+
 	ans := make([]*workflow.HistoryBranchRange, 0, len(ancestors))
 	for _, e := range ancestors {
 		an := &workflow.HistoryBranchRange{}

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -1014,7 +1014,7 @@ type (
 	}
 
 	// AppendHistoryEventsRequest is used to append new events to workflow execution history
-	//Deprecated: use v2 API-AppendHistoryNodes() instead
+	// Deprecated: use v2 API-AppendHistoryNodes() instead
 	AppendHistoryEventsRequest struct {
 		DomainID          string
 		Execution         workflow.WorkflowExecution
@@ -1028,7 +1028,7 @@ type (
 	}
 
 	// GetWorkflowExecutionHistoryRequest is used to retrieve history of a workflow execution
-	//Deprecated: use v2 API-AppendHistoryNodes() instead
+	// Deprecated: use v2 API-AppendHistoryNodes() instead
 	GetWorkflowExecutionHistoryRequest struct {
 		DomainID  string
 		Execution workflow.WorkflowExecution
@@ -1069,7 +1069,7 @@ type (
 	}
 
 	// DeleteWorkflowExecutionHistoryRequest is used to delete workflow execution history
-	//Deprecated: use v2 API-AppendHistoryNodes() instead
+	// Deprecated: use v2 API-AppendHistoryNodes() instead
 	DeleteWorkflowExecutionHistoryRequest struct {
 		DomainID  string
 		Execution workflow.WorkflowExecution
@@ -1230,7 +1230,7 @@ type (
 		DeleteRequestCancelInfoCount int
 	}
 
-	//UpdateWorkflowExecutionResponse is response for UpdateWorkflowExecutionRequest
+	// UpdateWorkflowExecutionResponse is response for UpdateWorkflowExecutionRequest
 	UpdateWorkflowExecutionResponse struct {
 		MutableStateUpdateSessionStats *MutableStateUpdateSessionStats
 	}
@@ -1302,6 +1302,18 @@ type (
 		Size int
 		// the first_event_id of last loaded batch
 		LastFirstEventID int64
+	}
+
+	// ReadRawHistoryBranchResponse is the response to ReadHistoryBranchRequest
+	ReadRawHistoryBranchResponse struct {
+		// HistoryEventBlobs history event blobs
+		HistoryEventBlobs []*DataBlob
+		// Token to read next page if there are more events beyond page size.
+		// Use this to set NextPageToken on ReadHistoryBranchRequest to read the next page.
+		// Empty means we have reached the last page, not need to continue
+		NextPageToken []byte
+		// Size of history read from store
+		Size int
 	}
 
 	// ForkHistoryBranchRequest is used to fork a history branch
@@ -1471,14 +1483,14 @@ type (
 		Closeable
 		GetName() string
 
-		//Deprecated: use v2 API-AppendHistoryNodes() instead
+		// Deprecated: use v2 API-AppendHistoryNodes() instead
 		AppendHistoryEvents(request *AppendHistoryEventsRequest) (*AppendHistoryEventsResponse, error)
 		// GetWorkflowExecutionHistory retrieves the paginated list of history events for given execution
-		//Deprecated: use v2 API-ReadHistoryBranch() instead
+		// Deprecated: use v2 API-ReadHistoryBranch() instead
 		GetWorkflowExecutionHistory(request *GetWorkflowExecutionHistoryRequest) (*GetWorkflowExecutionHistoryResponse, error)
-		//Deprecated: use v2 API-ReadHistoryBranchByBatch() instead
+		// Deprecated: use v2 API-ReadHistoryBranchByBatch() instead
 		GetWorkflowExecutionHistoryByBatch(request *GetWorkflowExecutionHistoryRequest) (*GetWorkflowExecutionHistoryByBatchResponse, error)
-		//Deprecated: use v2 API-DeleteHistoryBranch instead
+		// Deprecated: use v2 API-DeleteHistoryBranch instead
 		DeleteWorkflowExecutionHistory(request *DeleteWorkflowExecutionHistoryRequest) error
 	}
 
@@ -1497,6 +1509,9 @@ type (
 		ReadHistoryBranch(request *ReadHistoryBranchRequest) (*ReadHistoryBranchResponse, error)
 		// ReadHistoryBranchByBatch returns history node data for a branch ByBatch
 		ReadHistoryBranchByBatch(request *ReadHistoryBranchRequest) (*ReadHistoryBranchByBatchResponse, error)
+		// ReadRawHistoryBranch returns history node raw data for a branch ByBatch
+		// NOTE: this API should only be used by 3+DC
+		ReadRawHistoryBranch(request *ReadHistoryBranchRequest) (*ReadRawHistoryBranchResponse, error)
 		// ForkHistoryBranch forks a new branch from a old branch
 		ForkHistoryBranch(request *ForkHistoryBranchRequest) (*ForkHistoryBranchResponse, error)
 		// CompleteForkBranch will complete the forking process after update mutableState, this is to help preventing data leakage

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -32,6 +32,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
 	gen "github.com/uber/cadence/.gen/go/shared"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
@@ -113,9 +114,9 @@ func (s *HistoryV2PersistenceSuite) TestGenUUIDs() {
 	s.Equal(concurrency, cnt)
 }
 
-//TestScanAllTrees test
+// TestScanAllTrees test
 func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
-	//TODO https://github.com/uber/cadence/issues/2458
+	// TODO https://github.com/uber/cadence/issues/2458
 	if s.HistoryV2Mgr.GetName() != "cassandra" {
 		return
 	}
@@ -169,43 +170,43 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 	s.Equal(0, len(trees))
 }
 
-//TestReadBranchByPagination test
+// TestReadBranchByPagination test
 func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	treeID := uuid.New()
 	bi, err := s.newHistoryBranch(treeID)
 	s.Nil(err)
 
 	historyW := &workflow.History{}
-	events := s.genRandomEvents([]int64{1, 2, 3}, 1)
+	events := s.genRandomEvents([]int64{1, 2, 3}, 0)
 	err = s.appendNewBranchAndFirstNode(bi, events, 1, "branchInfo")
 	s.Nil(err)
 	historyW.Events = events
 
-	events = s.genRandomEvents([]int64{4}, 1)
-	err = s.appendNewNode(bi, events, 1)
-	s.Nil(err)
-	historyW.Events = append(historyW.Events, events...)
-
-	events = s.genRandomEvents([]int64{5, 6, 7, 8}, 1)
-	err = s.appendNewNode(bi, events, 1)
-	s.Nil(err)
-	historyW.Events = append(historyW.Events, events...)
-
-	// stale event batch
-	events = s.genRandomEvents([]int64{6, 7, 8}, 0)
-	err = s.appendNewNode(bi, events, 1)
-	s.Nil(err)
-	// stale event batch
-	events = s.genRandomEvents([]int64{6, 7, 8}, 0)
+	events = s.genRandomEvents([]int64{4}, 0)
 	err = s.appendNewNode(bi, events, 2)
 	s.Nil(err)
+	historyW.Events = append(historyW.Events, events...)
+
+	events = s.genRandomEvents([]int64{5, 6, 7, 8}, 4)
+	err = s.appendNewNode(bi, events, 6)
+	s.Nil(err)
+	historyW.Events = append(historyW.Events, events...)
+
 	// stale event batch
 	events = s.genRandomEvents([]int64{6, 7, 8}, 1)
 	err = s.appendNewNode(bi, events, 3)
 	s.Nil(err)
+	// stale event batch
+	events = s.genRandomEvents([]int64{6, 7, 8}, 2)
+	err = s.appendNewNode(bi, events, 4)
+	s.Nil(err)
+	// stale event batch
+	events = s.genRandomEvents([]int64{6, 7, 8}, 3)
+	err = s.appendNewNode(bi, events, 5)
+	s.Nil(err)
 
-	events = s.genRandomEvents([]int64{9}, 1)
-	err = s.appendNewNode(bi, events, 1)
+	events = s.genRandomEvents([]int64{9}, 4)
+	err = s.appendNewNode(bi, events, 7)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
@@ -224,53 +225,53 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	s.Equal(4, len(resp.HistoryEvents))
 	s.Equal(int64(6), resp.HistoryEvents[0].GetEventId())
 
-	events = s.genRandomEvents([]int64{10}, 1)
-	err = s.appendNewNode(bi, events, 1)
+	events = s.genRandomEvents([]int64{10}, 4)
+	err = s.appendNewNode(bi, events, 8)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
-	events = s.genRandomEvents([]int64{11}, 1)
-	err = s.appendNewNode(bi, events, 1)
+	events = s.genRandomEvents([]int64{11}, 4)
+	err = s.appendNewNode(bi, events, 9)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
-	events = s.genRandomEvents([]int64{12}, 1)
-	err = s.appendNewNode(bi, events, 1)
+	events = s.genRandomEvents([]int64{12}, 4)
+	err = s.appendNewNode(bi, events, 10)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
-	events = s.genRandomEvents([]int64{13, 14, 15}, 1)
-	err = s.appendNewNode(bi, events, 1)
+	events = s.genRandomEvents([]int64{13, 14, 15}, 4)
+	err = s.appendNewNode(bi, events, 11)
 	s.Nil(err)
 	// we don't append this batch because we will fork from 13
-	//historyW.Events = append(historyW.Events, events...)
+	// historyW.Events = append(historyW.Events, events...)
 
 	// fork from here
 	bi2, err := s.fork(bi, 13)
 	s.Nil(err)
 	s.completeFork(bi2, true)
 
-	events = s.genRandomEvents([]int64{13}, 1)
-	err = s.appendNewNode(bi2, events, 1)
+	events = s.genRandomEvents([]int64{13}, 4)
+	err = s.appendNewNode(bi2, events, 12)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
-	events = s.genRandomEvents([]int64{14}, 1)
-	err = s.appendNewNode(bi2, events, 1)
+	events = s.genRandomEvents([]int64{14}, 4)
+	err = s.appendNewNode(bi2, events, 13)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
-	events = s.genRandomEvents([]int64{15, 16, 17}, 1)
-	err = s.appendNewNode(bi2, events, 1)
+	events = s.genRandomEvents([]int64{15, 16, 17}, 4)
+	err = s.appendNewNode(bi2, events, 14)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
-	events = s.genRandomEvents([]int64{18, 19, 20}, 1)
-	err = s.appendNewNode(bi2, events, 1)
+	events = s.genRandomEvents([]int64{18, 19, 20}, 4)
+	err = s.appendNewNode(bi2, events, 15)
 	s.Nil(err)
 	historyW.Events = append(historyW.Events, events...)
 
-	//read branch to verify
+	// read branch to verify
 	historyR := &workflow.History{}
 
 	req = &p.ReadHistoryBranchRequest{
@@ -281,25 +282,34 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 		NextPageToken: nil,
 		ShardID:       common.IntPtr(s.ShardInfo.ShardID),
 	}
+
 	// first page
 	resp, err = s.HistoryV2Mgr.ReadHistoryBranch(req)
 	s.Nil(err)
+
 	s.Equal(8, len(resp.HistoryEvents))
 	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
 	req.NextPageToken = resp.NextPageToken
 
 	// this page is all stale batches
+	// doe to difference in Cassandra / MySQL pagination
+	// the stale event batch may get returned
 	resp, err = s.HistoryV2Mgr.ReadHistoryBranch(req)
 	s.Nil(err)
-	s.Equal(0, len(resp.HistoryEvents))
 	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
 	req.NextPageToken = resp.NextPageToken
-	// second page
-	resp, err = s.HistoryV2Mgr.ReadHistoryBranch(req)
-	s.Nil(err)
-	s.Equal(3, len(resp.HistoryEvents))
-	historyR.Events = append(historyR.Events, resp.HistoryEvents...)
-	req.NextPageToken = resp.NextPageToken
+	if len(resp.HistoryEvents) == 0 {
+		// second page
+		resp, err = s.HistoryV2Mgr.ReadHistoryBranch(req)
+		s.Nil(err)
+		s.Equal(3, len(resp.HistoryEvents))
+		historyR.Events = append(historyR.Events, resp.HistoryEvents...)
+		req.NextPageToken = resp.NextPageToken
+	} else if len(resp.HistoryEvents) == 3 {
+		// no op
+	} else {
+		s.Fail("should either return 0 (Cassandra) or 3 (MySQL) events")
+	}
 
 	// 3rd page, since we fork from nodeID=13, we can only see one batch of 12 here
 	resp, err = s.HistoryV2Mgr.ReadHistoryBranch(req)
@@ -350,7 +360,7 @@ func (s *HistoryV2PersistenceSuite) TestReadBranchByPagination() {
 	s.Equal(0, len(branches))
 }
 
-//TestConcurrentlyCreateAndAppendBranches test
+// TestConcurrentlyCreateAndAppendBranches test
 func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 	treeID := uuid.New()
 	wg := sync.WaitGroup{}
@@ -373,21 +383,21 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 			historyW.Events = events
 
 			events = s.genRandomEvents([]int64{4}, 1)
-			err = s.appendNewNode(bi, events, 1)
+			err = s.appendNewNode(bi, events, 2)
 			s.Nil(err)
 			historyW.Events = append(historyW.Events, events...)
 
 			events = s.genRandomEvents([]int64{5, 6, 7, 8}, 1)
-			err = s.appendNewNode(bi, events, 1)
+			err = s.appendNewNode(bi, events, 3)
 			s.Nil(err)
 			historyW.Events = append(historyW.Events, events...)
 
 			events = s.genRandomEvents([]int64{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20}, 1)
-			err = s.appendNewNode(bi, events, 1)
+			err = s.appendNewNode(bi, events, 2000)
 			s.Nil(err)
 			historyW.Events = append(historyW.Events, events...)
 
-			//read branch to verify
+			// read branch to verify
 			historyR := &workflow.History{}
 			events = s.read(bi, 1, 21)
 			s.Equal(20, len(events))
@@ -418,9 +428,9 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 			events = s.read(branch, 1, 25)
 			s.Equal(20, len(events))
 
-			// override with greater txn_id but greater version
+			// override with greatest txn_id and greater version
 			events = s.genRandomEvents([]int64{5}, 2)
-			err = s.appendNewNode(branch, events, 2)
+			err = s.appendNewNode(branch, events, 1000)
 			s.Nil(err)
 
 			// read to verify override success
@@ -429,7 +439,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 
 			// override with even larger txn_id and same version
 			events = s.genRandomEvents([]int64{5, 6}, 1)
-			err = s.appendNewNode(branch, events, 3)
+			err = s.appendNewNode(branch, events, 1001)
 			s.Nil(err)
 
 			// read to verify override success, at this point history is corrupted, missing 7/8, so we should only see 6 events
@@ -442,13 +452,13 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyCreateAndAppendBranches() {
 
 			// override more with larger txn_id, this would fix the corrupted hole so that we cna get 20 events again
 			events = s.genRandomEvents([]int64{7, 8}, 1)
-			err = s.appendNewNode(branch, events, 2)
+			err = s.appendNewNode(branch, events, 1002)
 			s.Nil(err)
 			// read to verify override
 			events = s.read(branch, 1, 25)
 			s.Equal(20, len(events))
 			events = s.genRandomEvents([]int64{9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23}, 1)
-			err = s.appendNewNode(branch, events, 2)
+			err = s.appendNewNode(branch, events, 2001)
 			s.Nil(err)
 			events = s.read(branch, 1, 25)
 			s.Equal(23, len(events))
@@ -496,7 +506,18 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 	s.Equal(1, len(branches))
 	mbrID := *branches[0].BranchID
 
-	err = s.appendOneByOne(masterBr, events[1:], 1)
+	txn := int64(1)
+	getTxnLock := sync.Mutex{}
+	reserveTxn := func(count int) int64 {
+		getTxnLock.Lock()
+		defer getTxnLock.Unlock()
+
+		ret := txn
+		txn += int64(count)
+		return ret
+	}
+
+	err = s.appendOneByOne(masterBr, events[1:], reserveTxn(len(events[1:])))
 	s.Nil(err)
 	events = s.read(masterBr, 1, int64(concurrency)+2)
 	s.Nil(err)
@@ -509,6 +530,7 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 		wg.Add(1)
 		go func(idx int) {
 			defer wg.Done()
+
 			forkNodeID := rand.Int63n(int64(concurrency)) + 2
 			level1ID.Store(idx, forkNodeID)
 
@@ -516,9 +538,9 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 			s.Nil(err)
 			level1Br.Store(idx, bi)
 
-			//cannot append to ancestors
+			// cannot append to ancestors
 			events := s.genRandomEvents([]int64{forkNodeID - 1}, 1)
-			err = s.appendNewNode(bi, events, 1)
+			err = s.appendNewNode(bi, events, reserveTxn(1))
 			_, ok := err.(*p.InvalidPersistenceRequestError)
 			s.Equal(true, ok)
 
@@ -529,10 +551,10 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 			}
 			events = s.genRandomEvents(eids, 1)
 
-			err = s.appendNewNode(bi, events[0:1], 1)
+			err = s.appendNewNode(bi, events[0:1], reserveTxn(1))
 			s.Nil(err)
 
-			err = s.appendOneByOne(bi, events[1:], 1)
+			err = s.appendOneByOne(bi, events[1:], reserveTxn(len(events[1:])))
 			s.Nil(err)
 
 			events = s.read(bi, 1, int64(concurrency)*2+2)
@@ -582,9 +604,9 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 				eids = append(eids, i)
 			}
 			events := s.genRandomEvents(eids, 1)
-			err = s.appendNewNode(bi, events[0:1], 1)
+			err = s.appendNewNode(bi, events[0:1], reserveTxn(1))
 			s.Nil(err)
-			err = s.appendOneByOne(bi, events[1:], 1)
+			err = s.appendOneByOne(bi, events[1:], reserveTxn(len(events[1:])))
 			s.Nil(err)
 			events = s.read(bi, 1, int64(concurrency)*3+2)
 			s.Nil(err)
@@ -592,19 +614,19 @@ func (s *HistoryV2PersistenceSuite) TestConcurrentlyForkAndAppendBranches() {
 
 			// try override last event
 			events = s.genRandomEvents([]int64{int64(concurrency)*3 + 1}, 1)
-			err = s.appendNewNode(bi, events, 2)
+			err = s.appendNewNode(bi, events, reserveTxn(1))
 			s.Nil(err)
 			events = s.read(bi, 1, int64(concurrency)*3+2)
 			s.Nil(err)
 			s.Equal((concurrency)*3+1, len(events))
 
-			//test fork and newBranch concurrently
+			// test fork and newBranch concurrently
 			bi, err = s.newHistoryBranch(treeID)
 			s.Nil(err)
 			level2Br.Store(concurrency+idx, bi)
 
 			events = s.genRandomEvents([]int64{1}, 1)
-			err = s.appendNewBranchAndFirstNode(bi, events, 0, "newbr")
+			err = s.appendNewBranchAndFirstNode(bi, events, reserveTxn(1), "newbr")
 			s.Nil(err)
 
 		}(i)
@@ -771,8 +793,8 @@ func (s *HistoryV2PersistenceSuite) readWithError(branch []byte, minID, maxID in
 }
 
 func (s *HistoryV2PersistenceSuite) appendOneByOne(branch []byte, events []*workflow.HistoryEvent, txnID int64) error {
-	for _, e := range events {
-		err := s.append(branch, []*workflow.HistoryEvent{e}, txnID, false, "")
+	for index, e := range events {
+		err := s.append(branch, []*workflow.HistoryEvent{e}, txnID+int64(index), false, "")
 		if err != nil {
 			return err
 		}

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -493,6 +493,10 @@ type (
 		PageSize int
 		// Pagination token
 		NextPageToken []byte
+		// LastNodeID is the last known node ID attached to a history node
+		LastNodeID int64
+		// LastTransactionID is the last known transaction ID attached to a history node
+		LastTransactionID int64
 		// Used in sharded data stores to identify which shard to use
 		ShardID int
 	}
@@ -513,6 +517,10 @@ type (
 		History []*DataBlob
 		// Pagination token
 		NextPageToken []byte
+		// LastNodeID is the last known node ID attached to a history node
+		LastNodeID int64
+		// LastTransactionID is the last known transaction ID attached to a history node
+		LastTransactionID int64
 	}
 
 	// VisibilityWorkflowExecutionInfo is visibility info for internal response

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -1103,6 +1103,18 @@ func (p *historyV2PersistenceClient) ReadHistoryBranchByBatch(request *ReadHisto
 	return response, err
 }
 
+// ReadRawHistoryBranch returns history node raw data for a branch ByBatch
+func (p *historyV2PersistenceClient) ReadRawHistoryBranch(request *ReadHistoryBranchRequest) (*ReadRawHistoryBranchResponse, error) {
+	p.metricClient.IncCounter(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceRequests)
+	sw := p.metricClient.StartTimer(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceLatency)
+	response, err := p.persistence.ReadRawHistoryBranch(request)
+	sw.Stop()
+	if err != nil {
+		p.updateErrorMetric(metrics.PersistenceReadHistoryBranchScope, err)
+	}
+	return response, err
+}
+
 // ForkHistoryBranch forks a new branch from a old branch
 func (p *historyV2PersistenceClient) ForkHistoryBranch(request *ForkHistoryBranchRequest) (*ForkHistoryBranchResponse, error) {
 	p.metricClient.IncCounter(metrics.PersistenceForkHistoryBranchScope, metrics.PersistenceRequests)

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -715,6 +715,15 @@ func (p *historyV2RateLimitedPersistenceClient) ReadHistoryBranchByBatch(request
 	return response, err
 }
 
+// ReadHistoryBranchByBatch returns history node data for a branch
+func (p *historyV2RateLimitedPersistenceClient) ReadRawHistoryBranch(request *ReadHistoryBranchRequest) (*ReadRawHistoryBranchResponse, error) {
+	if ok := p.rateLimiter.Allow(); !ok {
+		return nil, ErrPersistenceLimitExceeded
+	}
+	response, err := p.persistence.ReadRawHistoryBranch(request)
+	return response, err
+}
+
 // ForkHistoryBranch forks a new branch from a old branch
 func (p *historyV2RateLimitedPersistenceClient) ForkHistoryBranch(request *ForkHistoryBranchRequest) (*ForkHistoryBranchResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {

--- a/common/persistence/sql/sqlHistoryV2Manager.go
+++ b/common/persistence/sql/sqlHistoryV2Manager.go
@@ -41,7 +41,11 @@ type sqlHistoryV2Manager struct {
 }
 
 // newHistoryV2Persistence creates an instance of HistoryManager
-func newHistoryV2Persistence(db sqldb.Interface, logger log.Logger) (p.HistoryV2Store, error) {
+func newHistoryV2Persistence(
+	db sqldb.Interface,
+	logger log.Logger,
+) (p.HistoryV2Store, error) {
+
 	return &sqlHistoryV2Manager{
 		sqlStore: sqlStore{
 			db:     db,
@@ -50,7 +54,10 @@ func newHistoryV2Persistence(db sqldb.Interface, logger log.Logger) (p.HistoryV2
 	}, nil
 }
 
-func (m *sqlHistoryV2Manager) serializeAncestors(ans []*shared.HistoryBranchRange) ([]byte, error) {
+func (m *sqlHistoryV2Manager) serializeAncestors(
+	ans []*shared.HistoryBranchRange,
+) ([]byte, error) {
+
 	ancestors, err := json.Marshal(ans)
 	if err != nil {
 		return nil, err
@@ -58,7 +65,10 @@ func (m *sqlHistoryV2Manager) serializeAncestors(ans []*shared.HistoryBranchRang
 	return ancestors, nil
 }
 
-func (m *sqlHistoryV2Manager) deserializeAncestors(jsonStr []byte) ([]*shared.HistoryBranchRange, error) {
+func (m *sqlHistoryV2Manager) deserializeAncestors(
+	jsonStr []byte,
+) ([]*shared.HistoryBranchRange, error) {
+
 	var ans []*shared.HistoryBranchRange
 	err := json.Unmarshal(jsonStr, &ans)
 	if err != nil {
@@ -68,7 +78,10 @@ func (m *sqlHistoryV2Manager) deserializeAncestors(jsonStr []byte) ([]*shared.Hi
 }
 
 // AppendHistoryNodes add(or override) a node to a history branch
-func (m *sqlHistoryV2Manager) AppendHistoryNodes(request *p.InternalAppendHistoryNodesRequest) error {
+func (m *sqlHistoryV2Manager) AppendHistoryNodes(
+	request *p.InternalAppendHistoryNodesRequest,
+) error {
+
 	branchInfo := request.BranchInfo
 	beginNodeID := p.GetBeginNodeID(branchInfo)
 
@@ -152,12 +165,21 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(request *p.InternalAppendHistor
 }
 
 // ReadHistoryBranch returns history node data for a branch
-func (m *sqlHistoryV2Manager) ReadHistoryBranch(request *p.InternalReadHistoryBranchRequest) (*p.InternalReadHistoryBranchResponse, error) {
+func (m *sqlHistoryV2Manager) ReadHistoryBranch(
+	request *p.InternalReadHistoryBranchRequest,
+) (*p.InternalReadHistoryBranchResponse, error) {
+
 	minNodeID := request.MinNodeID
+	maxNodeID := request.MaxNodeID
+
+	lastNodeID := request.LastNodeID
+	lastTxnID := request.LastTransactionID
 
 	if request.NextPageToken != nil && len(request.NextPageToken) > 0 {
 		var lastNodeID int64
 		var err error
+		// TODO the inner pagination token can be replaced by a dummy token
+		//  since lastNodeID & lastTxnID are both provided
 		if lastNodeID, err = deserializePageToken(request.NextPageToken); err != nil {
 			return nil, &shared.InternalServiceError{
 				Message: fmt.Sprintf("invalid next page token %v", request.NextPageToken)}
@@ -169,7 +191,8 @@ func (m *sqlHistoryV2Manager) ReadHistoryBranch(request *p.InternalReadHistoryBr
 		TreeID:    sqldb.MustParseUUID(request.TreeID),
 		BranchID:  sqldb.MustParseUUID(request.BranchID),
 		MinNodeID: &minNodeID,
-		MaxNodeID: &request.MaxNodeID,
+		MaxNodeID: &maxNodeID,
+		MinTxnID:  &lastTxnID,
 		PageSize:  &request.PageSize,
 		ShardID:   request.ShardID,
 	}
@@ -180,26 +203,34 @@ func (m *sqlHistoryV2Manager) ReadHistoryBranch(request *p.InternalReadHistoryBr
 	}
 
 	history := make([]*p.DataBlob, 0, int(request.PageSize))
-	lastNodeID := int64(-1)
-	lastTxnID := int64(-1)
 	eventBlob := &p.DataBlob{}
 
 	for _, row := range rows {
 		eventBlob.Data = row.Data
 		eventBlob.Encoding = common.EncodingType(row.DataEncoding)
+
+		if *row.TxnID < lastTxnID {
+			// assuming that business logic layer is correct and transaction ID only increase
+			// thus, valid event batch will come with increasing transaction ID
+
+			// event batches with smaller node ID
+			//  -> should not be possible since records are already sorted
+			// event batches with same node ID
+			//  -> batch with higher transaction ID is valid
+			// event batches with larger node ID
+			//  -> batch with lower transaction ID is invalid (happens before)
+			//  -> batch with higher transaction ID is valid
+			continue
+		}
+
 		switch {
 		case row.NodeID < lastNodeID:
 			return nil, &shared.InternalServiceError{
 				Message: fmt.Sprintf("corrupted data, nodeID cannot decrease"),
 			}
 		case row.NodeID == lastNodeID:
-			if *row.TxnID < lastTxnID {
-				// skip the nodes with smaller txn_id
-				continue
-			} else {
-				return nil, &shared.InternalServiceError{
-					Message: fmt.Sprintf("corrupted data, same nodeID must have smaller txnID"),
-				}
+			return nil, &shared.InternalServiceError{
+				Message: fmt.Sprintf("corrupted data, same nodeID must have smaller txnID"),
 			}
 		default: // row.NodeID > lastNodeID:
 			// NOTE: when row.nodeID > lastNodeID, we expect the one with largest txnID comes first
@@ -214,12 +245,13 @@ func (m *sqlHistoryV2Manager) ReadHistoryBranch(request *p.InternalReadHistoryBr
 	if len(rows) >= request.PageSize {
 		pagingToken = serializePageToken(lastNodeID)
 	}
-	response := &p.InternalReadHistoryBranchResponse{
-		History:       history,
-		NextPageToken: pagingToken,
-	}
 
-	return response, nil
+	return &p.InternalReadHistoryBranchResponse{
+		History:           history,
+		NextPageToken:     pagingToken,
+		LastNodeID:        lastNodeID,
+		LastTransactionID: lastTxnID,
+	}, nil
 }
 
 // ForkHistoryBranch forks a new branch from an existing branch
@@ -266,7 +298,10 @@ func (m *sqlHistoryV2Manager) ReadHistoryBranch(request *p.InternalReadHistoryBr
 //       \
 //       8[8,9]
 //
-func (m *sqlHistoryV2Manager) ForkHistoryBranch(request *p.InternalForkHistoryBranchRequest) (*p.InternalForkHistoryBranchResponse, error) {
+func (m *sqlHistoryV2Manager) ForkHistoryBranch(
+	request *p.InternalForkHistoryBranchRequest,
+) (*p.InternalForkHistoryBranchResponse, error) {
+
 	forkB := request.ForkBranchInfo
 	treeID := *forkB.TreeID
 	newAncestors := make([]*shared.HistoryBranchRange, 0, len(forkB.Ancestors)+1)
@@ -337,7 +372,10 @@ func (m *sqlHistoryV2Manager) ForkHistoryBranch(request *p.InternalForkHistoryBr
 }
 
 // DeleteHistoryBranch removes a branch
-func (m *sqlHistoryV2Manager) DeleteHistoryBranch(request *p.InternalDeleteHistoryBranchRequest) error {
+func (m *sqlHistoryV2Manager) DeleteHistoryBranch(
+	request *p.InternalDeleteHistoryBranchRequest,
+) error {
+
 	branch := request.BranchInfo
 	treeID := *branch.TreeID
 	brsToDelete := branch.Ancestors
@@ -419,7 +457,10 @@ func (m *sqlHistoryV2Manager) DeleteHistoryBranch(request *p.InternalDeleteHisto
 }
 
 // UpdateHistoryBranch update a branch
-func (m *sqlHistoryV2Manager) CompleteForkBranch(request *p.InternalCompleteForkBranchRequest) error {
+func (m *sqlHistoryV2Manager) CompleteForkBranch(
+	request *p.InternalCompleteForkBranchRequest,
+) error {
+
 	branch := request.BranchInfo
 	treeID := sqldb.MustParseUUID(*branch.TreeID)
 	branchID := sqldb.MustParseUUID(*branch.BranchID)
@@ -477,14 +518,20 @@ func (m *sqlHistoryV2Manager) CompleteForkBranch(request *p.InternalCompleteFork
 	})
 }
 
-func (m *sqlHistoryV2Manager) GetAllHistoryTreeBranches(request *p.GetAllHistoryTreeBranchesRequest) (*p.GetAllHistoryTreeBranchesResponse, error) {
+func (m *sqlHistoryV2Manager) GetAllHistoryTreeBranches(
+	request *p.GetAllHistoryTreeBranchesRequest,
+) (*p.GetAllHistoryTreeBranchesResponse, error) {
+
 	// TODO https://github.com/uber/cadence/issues/2458
 	// Implement it when we need
 	panic("not implemented yet")
 }
 
 // GetHistoryTree returns all branch information of a tree
-func (m *sqlHistoryV2Manager) GetHistoryTree(request *p.GetHistoryTreeRequest) (*p.GetHistoryTreeResponse, error) {
+func (m *sqlHistoryV2Manager) GetHistoryTree(
+	request *p.GetHistoryTreeRequest,
+) (*p.GetHistoryTreeResponse, error) {
+
 	treeID := sqldb.MustParseUUID(request.TreeID)
 	branches := make([]*shared.HistoryBranch, 0)
 	forkingBranches := make([]p.HistoryBranchDetail, 0)

--- a/common/persistence/sql/storage/mysql/eventsV2.go
+++ b/common/persistence/sql/storage/mysql/eventsV2.go
@@ -33,7 +33,7 @@ const (
 		`VALUES (:shard_id, :tree_id, :branch_id, :node_id, :txn_id, :data, :data_encoding) `
 
 	getHistoryNodesQry = `SELECT node_id, txn_id, data, data_encoding FROM history_node ` +
-		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? and node_id < ? ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
+		`WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? and node_id < ? and txn_id < ? ORDER BY shard_id, tree_id, branch_id, node_id, txn_id LIMIT ? `
 
 	deleteHistoryNodesQry = `DELETE FROM history_node WHERE shard_id = ? AND tree_id = ? AND branch_id = ? AND node_id >= ? `
 
@@ -62,7 +62,7 @@ func (mdb *DB) InsertIntoHistoryNode(row *sqldb.HistoryNodeRow) (sql.Result, err
 func (mdb *DB) SelectFromHistoryNode(filter *sqldb.HistoryNodeFilter) ([]sqldb.HistoryNodeRow, error) {
 	var rows []sqldb.HistoryNodeRow
 	err := mdb.conn.Select(&rows, getHistoryNodesQry,
-		filter.ShardID, filter.TreeID, filter.BranchID, *filter.MinNodeID, *filter.MaxNodeID, *filter.PageSize)
+		filter.ShardID, filter.TreeID, filter.BranchID, *filter.MinNodeID, *filter.MaxNodeID, -*filter.MinTxnID, *filter.PageSize)
 	// NOTE: since we let txn_id multiple by -1 when inserting, we have to revert it back here
 	for _, row := range rows {
 		*row.TxnID *= -1

--- a/common/persistence/sql/storage/sqldb/interfaces.go
+++ b/common/persistence/sql/storage/sqldb/interfaces.go
@@ -278,7 +278,9 @@ type (
 		MinNodeID *int64
 		// Exclusive
 		MaxNodeID *int64
-		PageSize  *int
+		// Exclusive
+		MinTxnID *int64
+		PageSize *int
 	}
 
 	// HistoryTreeRow represents a row in history_tree table


### PR DESCRIPTION
* New ReadRawHistoryBranch API which returns history batch event data blob as is
* Fix an issue which can lead to endless pagination in ReadHistoryBranch on MySQL 
* Fix history event V2 related tests
* Note: this should only be used by NDC workflows (until fully tested).