### PR TITLE
Add RolloutID to default search attributes

### DIFF
--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -26,6 +26,7 @@ frontend.validSearchAttributes:
     user: 1
     CustomDomain: 1
     Operator: 1
+    RolloutID: 1
   constraints: {}
 system.minRetentionDays:
 - value: 0

--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -29,5 +29,6 @@ frontend.validSearchAttributes:
       user: 1
       CustomDomain: 1
       Operator: 1
+      RolloutID: 1
 system.minRetentionDays:
     - value: 0


### PR DESCRIPTION
Currently for local test search attributes, user need to wait an interval (10s+) for dynamic config take effect. 
To make it easier for dev console team integration test, add their key to default list. 

