### PR TITLE
Fix missing search attributes in default schema

### DIFF
--- a/schema/elasticsearch/visibility/index_template.json
+++ b/schema/elasticsearch/visibility/index_template.json
@@ -56,7 +56,10 @@
             "environment": { "type": "keyword"},
             "addon": { "type": "keyword"},
             "addon-type": { "type": "keyword"},
-            "user": { "type": "keyword"}
+            "user": { "type": "keyword"},
+            "CustomDomain": { "type": "keyword"},
+            "Operator": { "type": "keyword"},
+            "RolloutID": { "type": "keyword"}
           }
         }
       }


### PR DESCRIPTION
This caused some keys not able to be queried using local docker. 