### PR TITLE
Use gobin, instead of go get vendor for thriftrw & thriftrw-plugin-yarpc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 *.iml
 *.cov
 *.html
+.gobincache/
 .tmp/
 .vscode/
 /vendor

--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,6 @@ COVER_ROOT                 := $(BUILD)/coverage
 UNIT_COVER_FILE            := $(COVER_ROOT)/unit_cover.out
 INTEG_COVER_FILE           := $(COVER_ROOT)/integ_$(PERSISTENCE_TYPE)$(EV2_TEST)_cover.out
 INTEG_XDC_COVER_FILE       := $(COVER_ROOT)/integ_xdc_$(PERSISTENCE_TYPE)_cover.out
-
 INTEG_CASS_COVER_FILE      := $(COVER_ROOT)/integ_cassandra_cover.out
 INTEG_CASS_EV2_COVER_FILE  := $(COVER_ROOT)/integ_cassandra_ev2_cover.out
 INTEG_XDC_CASS_COVER_FILE  := $(COVER_ROOT)/integ_xdc_cassandra_cover.out

--- a/Makefile
+++ b/Makefile
@@ -97,9 +97,9 @@ INTEG_XDC_SQL_COVER_FILE   := $(COVER_ROOT)/integ_xdc_sql_cover.out
 GOCOVERPKG_ARG := -coverpkg="$(PROJECT_ROOT)/common/...,$(PROJECT_ROOT)/service/...,$(PROJECT_ROOT)/client/...,$(PROJECT_ROOT)/tools/..."
 
 yarpc-install:
-	go mod vendor
-	go get './vendor/go.uber.org/thriftrw'
-	go get './vendor/go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc'
+	GO111MODULE=off go get -u github.com/myitcv/gobin
+	gobin -mod=readonly go.uber.org/thriftrw
+	gobin -mod=readonly go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
 
 clean_thrift:
 	rm -rf .gen


### PR DESCRIPTION
* Use gobin since go@1.13 disabled go get ./vendor/*
Ref: [link](https://github.com/golang/go/blame/b9edee32e15eb2ea66fe96563088520fff6f2535/src/cmd/go/testdata/script/mod_dot.txt#L8)