### PR TITLE
Wire version histories in persistence layer & fix NDC branch mgr

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -1183,25 +1183,11 @@ func createOrUpdateCurrentExecution(
 	state int,
 	closeStatus int,
 	createRequestID string,
-	replicationState *p.ReplicationState,
+	startVersion int64,
+	lastWriteVersion int64,
 	previousRunID string,
 	previousLastWriteVersion int64,
 ) error {
-
-	startVersion := common.EmptyVersion
-	lastWriteVersion := common.EmptyVersion
-	if replicationState != nil {
-		startVersion = replicationState.StartVersion
-		lastWriteVersion = replicationState.LastWriteVersion
-	} else {
-		// this is to deal with issue that gocql cannot return null value for value inside user defined type
-		// so we cannot know whether the last write version of current workflow record is null or not
-		// since non global domain (request.ReplicationState == null) will not have workflow reset problem
-		// so the CAS on last write version is not necessary
-		if createMode == p.CreateWorkflowModeWorkflowIDReuse {
-			createMode = p.CreateWorkflowModeContinueAsNew
-		}
-	}
 
 	switch createMode {
 	case p.CreateWorkflowModeContinueAsNew:

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -356,6 +356,8 @@ type (
 		ExecutionInfo    *InternalWorkflowExecutionInfo
 		ReplicationState *ReplicationState
 		VersionHistories *DataBlob
+		StartVersion     int64
+		LastWriteVersion int64
 
 		UpsertActivityInfos       []*InternalActivityInfo
 		DeleteActivityInfos       []int64
@@ -384,6 +386,8 @@ type (
 		ExecutionInfo    *InternalWorkflowExecutionInfo
 		ReplicationState *ReplicationState
 		VersionHistories *DataBlob
+		StartVersion     int64
+		LastWriteVersion int64
 
 		ActivityInfos       []*InternalActivityInfo
 		TimerInfos          []*TimerInfo

--- a/common/testing/event_generator.go
+++ b/common/testing/event_generator.go
@@ -575,7 +575,7 @@ func (he HistoryEventVertex) GetData() interface{} {
 	return he.data
 }
 
-// GetData returns the vertex data
+// DeepCopy returns the a deep copy of vertex
 func (he HistoryEventVertex) DeepCopy() Vertex {
 
 	return &HistoryEventVertex{

--- a/service/history/nDCBranchMgr_mock.go
+++ b/service/history/nDCBranchMgr_mock.go
@@ -29,10 +29,9 @@ package history
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	persistence "github.com/uber/cadence/common/persistence"
+	reflect "reflect"
 )
 
 // MocknDCBranchMgr is a mock of nDCBranchMgr interface
@@ -59,16 +58,17 @@ func (m *MocknDCBranchMgr) EXPECT() *MocknDCBranchMgrMockRecorder {
 }
 
 // prepareVersionHistory mocks base method
-func (m *MocknDCBranchMgr) prepareVersionHistory(ctx context.Context, incomingVersionHistory *persistence.VersionHistory) (int, error) {
+func (m *MocknDCBranchMgr) prepareVersionHistory(ctx context.Context, incomingVersionHistory *persistence.VersionHistory, incomingFirstEventID int64) (bool, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "prepareVersionHistory", ctx, incomingVersionHistory)
-	ret0, _ := ret[0].(int)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret := m.ctrl.Call(m, "prepareVersionHistory", ctx, incomingVersionHistory, incomingFirstEventID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // prepareVersionHistory indicates an expected call of prepareVersionHistory
-func (mr *MocknDCBranchMgrMockRecorder) prepareVersionHistory(ctx, incomingVersionHistory interface{}) *gomock.Call {
+func (mr *MocknDCBranchMgrMockRecorder) prepareVersionHistory(ctx, incomingVersionHistory, incomingFirstEventID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "prepareVersionHistory", reflect.TypeOf((*MocknDCBranchMgr)(nil).prepareVersionHistory), ctx, incomingVersionHistory)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "prepareVersionHistory", reflect.TypeOf((*MocknDCBranchMgr)(nil).prepareVersionHistory), ctx, incomingVersionHistory, incomingFirstEventID)
 }


### PR DESCRIPTION
* Add start / last write version to InternalWorkflowSnapshot / InternalWorkflowMutation for 2DC / NDC compatibility
* Remove persistence of branch change in NDC branch manager so NDC transaction manager will handle all case, including zombie workflows
* Optimize NDC branch manager so out of order events will not trigger unnecessary branch creation