### PR TITLE
Add buffered events version change protection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,8 @@ THRIFTRW_SRCS = \
   idl/github.com/uber/cadence/sqlblobs.thrift \
 
 PROGS = cadence
-TEST_ARG ?= -race -v -timeout 40m
+TEST_TIMEOUT = 15m
+TEST_ARG ?= -race -v -timeout $(TEST_TIMEOUT)
 BUILD := ./build
 TOOLS_CMD_ROOT=./cmd/tools
 INTEG_TEST_ROOT=./host
@@ -46,8 +47,6 @@ endif
 ifdef TEST_TAG
 override TEST_TAG := -tags $(TEST_TAG)
 endif
-
-TEST_TIMEOUT = 15m
 
 define thriftrwrule
 THRIFTRW_GEN_SRC += $(THRIFT_GENDIR)/go/$1/$1.go
@@ -165,7 +164,7 @@ cover_profile: clean bins_nothrift
 	@echo Running package tests:
 	@for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
-		go test -timeout $(TEST_TIMEOUT) "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
+		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
 		cat $(BUILD)/"$$dir"/coverage.out | grep -v "^mode: \w\+" >> $(UNIT_COVER_FILE); \
 	done;
 
@@ -176,7 +175,7 @@ cover_integration_profile: clean bins_nothrift
 
 	@echo Running integration test with $(PERSISTENCE_TYPE) and eventsV2 $(EVENTSV2)
 	@mkdir -p $(BUILD)/$(INTEG_TEST_DIR)
-	@time go test -timeout $(TEST_TIMEOUT) $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) -eventsV2=$(EVENTSV2) -persistenceType=$(PERSISTENCE_TYPE) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
+	@time go test $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) -eventsV2=$(EVENTSV2) -persistenceType=$(PERSISTENCE_TYPE) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
 	@cat $(BUILD)/$(INTEG_TEST_DIR)/coverage.out | grep -v "^mode: \w\+" >> $(INTEG_COVER_FILE)
 
 cover_xdc_profile: clean bins_nothrift

--- a/common/persistence/operationModeValidator.go
+++ b/common/persistence/operationModeValidator.go
@@ -135,6 +135,7 @@ func ValidateConflictResolveWorkflowModeState(
 	switch mode {
 	case ConflictResolveWorkflowModeUpdateCurrent:
 		// it is ok that currentWorkflowMutation is null, for 2 DC
+		// Note: current workflow mutation can be in zombie state, for the update
 		if resetWorkflowState == WorkflowStateZombie ||
 			(newWorkflowState != nil && *newWorkflowState == WorkflowStateZombie) {
 			return &workflow.InternalServiceError{

--- a/common/persistence/operationModeValidator.go
+++ b/common/persistence/operationModeValidator.go
@@ -136,8 +136,7 @@ func ValidateConflictResolveWorkflowModeState(
 	case ConflictResolveWorkflowModeUpdateCurrent:
 		// it is ok that currentWorkflowMutation is null, for 2 DC
 		if resetWorkflowState == WorkflowStateZombie ||
-			(newWorkflowState != nil && *newWorkflowState == WorkflowStateZombie) ||
-			(currentWorkflowState != nil && *currentWorkflowState == WorkflowStateZombie) {
+			(newWorkflowState != nil && *newWorkflowState == WorkflowStateZombie) {
 			return &workflow.InternalServiceError{
 				Message: fmt.Sprintf(
 					"Invalid workflow conflict resolve mode %v, state: %v",

--- a/common/persistence/operationModeValidator.go
+++ b/common/persistence/operationModeValidator.go
@@ -142,7 +142,7 @@ func ValidateConflictResolveWorkflowModeState(
 				Message: fmt.Sprintf(
 					"Invalid workflow conflict resolve mode %v, state: %v",
 					mode,
-					*currentWorkflowState,
+					currentWorkflowState,
 				),
 			}
 		}

--- a/common/persistence/operationModeValidator.go
+++ b/common/persistence/operationModeValidator.go
@@ -142,7 +142,7 @@ func ValidateConflictResolveWorkflowModeState(
 				Message: fmt.Sprintf(
 					"Invalid workflow conflict resolve mode %v, state: %v",
 					mode,
-					currentWorkflowState,
+					*currentWorkflowState,
 				),
 			}
 		}

--- a/common/persistence/versionHistory.go
+++ b/common/persistence/versionHistory.go
@@ -319,6 +319,11 @@ func (v *VersionHistory) GetLastItem() (*VersionHistoryItem, error) {
 	return v.items[len(v.items)-1].Duplicate(), nil
 }
 
+// IsEmpty indicate whether version history is empty
+func (v *VersionHistory) IsEmpty() bool {
+	return len(v.items) == 0
+}
+
 // Equals test if this version history and input version history are the same
 func (v *VersionHistory) Equals(input *VersionHistory) bool {
 

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -240,7 +240,7 @@ func (s *IntegrationBase) registerArchivalDomain() error {
 			},
 		},
 		IsGlobalDomain:  false,
-		FailoverVersion: 0,
+		FailoverVersion: common.EmptyVersion,
 	}
 	response, err := s.testCluster.testBase.MetadataProxy.CreateDomain(domainRequest)
 

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -733,6 +733,7 @@ func (c *cadenceImpl) createSystemDomain() error {
 			VisibilityArchivalStatus: shared.ArchivalStatusDisabled,
 		},
 		ReplicationConfig: &persistence.DomainReplicationConfig{},
+		FailoverVersion:   common.EmptyVersion,
 	})
 	if err != nil {
 		if _, ok := err.(*shared.DomainAlreadyExistsError); ok {

--- a/service/history/MockMutableState.go
+++ b/service/history/MockMutableState.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/mock"
+
 	h "github.com/uber/cadence/.gen/go/history"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/cache"
@@ -400,13 +401,13 @@ func (_m *mockMutableState) AddCompletedWorkflowEvent(_a0 int64, _a1 *shared.Com
 	return r0, r1
 }
 
-// AddContinueAsNewEvent provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4, _a5
-func (_m *mockMutableState) AddContinueAsNewEvent(_a0 int64, _a1 int64, _a2 *cache.DomainCacheEntry, _a3 string, _a4 *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, _a5 int32) (*shared.HistoryEvent, mutableState, error) {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5)
+// AddContinueAsNewEvent provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4
+func (_m *mockMutableState) AddContinueAsNewEvent(_a0 int64, _a1 int64, _a2 string, _a3 *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, _a4 int32) (*shared.HistoryEvent, mutableState, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4)
 
 	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func(int64, int64, *cache.DomainCacheEntry, string, *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, int32) *shared.HistoryEvent); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(0).(func(int64, int64, string, *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, int32) *shared.HistoryEvent); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*shared.HistoryEvent)
@@ -414,8 +415,8 @@ func (_m *mockMutableState) AddContinueAsNewEvent(_a0 int64, _a1 int64, _a2 *cac
 	}
 
 	var r1 mutableState
-	if rf, ok := ret.Get(1).(func(int64, int64, *cache.DomainCacheEntry, string, *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, int32) mutableState); ok {
-		r1 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(1).(func(int64, int64, string, *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, int32) mutableState); ok {
+		r1 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(mutableState)
@@ -423,8 +424,8 @@ func (_m *mockMutableState) AddContinueAsNewEvent(_a0 int64, _a1 int64, _a2 *cac
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(int64, int64, *cache.DomainCacheEntry, string, *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, int32) error); ok {
-		r2 = rf(_a0, _a1, _a2, _a3, _a4, _a5)
+	if rf, ok := ret.Get(2).(func(int64, int64, string, *shared.ContinueAsNewWorkflowExecutionDecisionAttributes, int32) error); ok {
+		r2 = rf(_a0, _a1, _a2, _a3, _a4)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -1095,12 +1096,12 @@ func (_m *mockMutableState) AddWorkflowExecutionSignaled(signalName string, inpu
 }
 
 // AddWorkflowExecutionStartedEvent provides a mock function with given fields: _a0, _a1
-func (_m *mockMutableState) AddWorkflowExecutionStartedEvent(_a0 *cache.DomainCacheEntry, _a1 shared.WorkflowExecution, _a2 *h.StartWorkflowExecutionRequest) (*shared.HistoryEvent, error) {
-	ret := _m.Called(_a0, _a1, _a2)
+func (_m *mockMutableState) AddWorkflowExecutionStartedEvent(_a0 shared.WorkflowExecution, _a1 *h.StartWorkflowExecutionRequest) (*shared.HistoryEvent, error) {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func(*cache.DomainCacheEntry, shared.WorkflowExecution, *h.StartWorkflowExecutionRequest) *shared.HistoryEvent); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(shared.WorkflowExecution, *h.StartWorkflowExecutionRequest) *shared.HistoryEvent); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*shared.HistoryEvent)
@@ -1108,8 +1109,8 @@ func (_m *mockMutableState) AddWorkflowExecutionStartedEvent(_a0 *cache.DomainCa
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*cache.DomainCacheEntry, shared.WorkflowExecution, *h.StartWorkflowExecutionRequest) error); ok {
-		r1 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(1).(func(shared.WorkflowExecution, *h.StartWorkflowExecutionRequest) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1527,14 +1528,16 @@ func (_m *mockMutableState) GetCurrentVersion() int64 {
 }
 
 // GetDomainName provides a mock function with given fields:
-func (_m *mockMutableState) GetDomainName() string {
+func (_m *mockMutableState) GetDomainEntry() *cache.DomainCacheEntry {
 	ret := _m.Called()
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
+	var r0 *cache.DomainCacheEntry
+	if rf, ok := ret.Get(0).(func() *cache.DomainCacheEntry); ok {
 		r0 = rf()
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*cache.DomainCacheEntry)
+		}
 	}
 
 	return r0
@@ -2746,13 +2749,13 @@ func (_m *mockMutableState) ReplicateWorkflowExecutionSignaled(_a0 *shared.Histo
 	return r0
 }
 
-// ReplicateWorkflowExecutionStartedEvent provides a mock function with given fields: _a0, _a1, _a2, _a3, _a4
-func (_m *mockMutableState) ReplicateWorkflowExecutionStartedEvent(_a0 *cache.DomainCacheEntry, _a1 *string, _a2 shared.WorkflowExecution, _a3 string, _a4 *shared.HistoryEvent) error {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4)
+// ReplicateWorkflowExecutionStartedEvent provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *mockMutableState) ReplicateWorkflowExecutionStartedEvent(_a0 *string, _a1 shared.WorkflowExecution, _a2 string, _a3 *shared.HistoryEvent) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*cache.DomainCacheEntry, *string, shared.WorkflowExecution, string, *shared.HistoryEvent) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4)
+	if rf, ok := ret.Get(0).(func(*string, shared.WorkflowExecution, string, *shared.HistoryEvent) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -2859,11 +2862,6 @@ func (_m *mockMutableState) UpdateDecision(_a0 *decisionInfo) {
 	_m.Called(_a0)
 }
 
-// UpdateReplicationPolicy provides a mock function with given fields: _a0
-func (_m *mockMutableState) UpdateReplicationPolicy(_a0 cache.ReplicationPolicy) {
-	_m.Called(_a0)
-}
-
 // UpdateReplicationStateLastEventID provides a mock function with given fields: _a0, _a1
 func (_m *mockMutableState) UpdateReplicationStateLastEventID(_a0 int64, _a1 int64) {
 	_m.Called(_a0, _a1)
@@ -2879,9 +2877,18 @@ func (_m *mockMutableState) UpdateUserTimer(_a0 string, _a1 *persistence.TimerIn
 	_m.Called(_a0, _a1)
 }
 
-// UpdateUserTimer provides a mock function with given fields: _a0, _a1
-func (_m *mockMutableState) UpdateCurrentVersion(_a0 int64, _a1 bool) {
-	_m.Called(_a0, _a1)
+// UpdateCurrentVersion provides a mock function with given fields: _a0, _a1
+func (_m *mockMutableState) UpdateCurrentVersion(_a0 int64, _a1 bool) error {
+	ret := _m.Called(_a0, _a1)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int64, bool) error); ok {
+		r0 = rf(_a0, _a1)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // UpdateWorkflowStateCloseStatus provides a mock function with given fields: _a0, _a1
@@ -2925,6 +2932,27 @@ func (_m *mockMutableState) GetUpdateCondition() int64 {
 	}
 
 	return r0
+}
+
+// CloseTransactionAsMutation provides a mock function with given fields: _a0, _a1
+func (_m *mockMutableState) StartTransaction(_a0 *cache.DomainCacheEntry) (bool, error) {
+	ret := _m.Called(_a0)
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(*cache.DomainCacheEntry) bool); ok {
+		r0 = rf(_a0)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(*cache.DomainCacheEntry) error); ok {
+		r1 = rf(_a0)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // CloseTransactionAsMutation provides a mock function with given fields: _a0, _a1

--- a/service/history/MockWorkflowExecutionContext.go
+++ b/service/history/MockWorkflowExecutionContext.go
@@ -179,12 +179,12 @@ func (_m *mockWorkflowExecutionContext) loadExecutionStats() (*persistence.Execu
 	return r0, r1
 }
 
-func (_m *mockWorkflowExecutionContext) conflictResolveWorkflowExecution(_a0 time.Time, _a1 persistence.ConflictResolveWorkflowMode, _a2 mutableState, _a3 workflowExecutionContext, _a4 mutableState, _a5 workflowExecutionContext, _a6 mutableState, _a7 *persistence.CurrentWorkflowCAS) error {
-	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
+func (_m *mockWorkflowExecutionContext) conflictResolveWorkflowExecution(_a0 time.Time, _a1 persistence.ConflictResolveWorkflowMode, _a2 mutableState, _a3 workflowExecutionContext, _a4 mutableState, _a5 workflowExecutionContext, _a6 mutableState, _a7 *transactionPolicy, _a8 *persistence.CurrentWorkflowCAS) error {
+	ret := _m.Called(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(time.Time, persistence.ConflictResolveWorkflowMode, mutableState, workflowExecutionContext, mutableState, workflowExecutionContext, mutableState, *persistence.CurrentWorkflowCAS) error); ok {
-		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7)
+	if rf, ok := ret.Get(0).(func(time.Time, persistence.ConflictResolveWorkflowMode, mutableState, workflowExecutionContext, mutableState, workflowExecutionContext, mutableState, *transactionPolicy, *persistence.CurrentWorkflowCAS) error); ok {
+		r0 = rf(_a0, _a1, _a2, _a3, _a4, _a5, _a6, _a7, _a8)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/service/history/conflictResolver_test.go
+++ b/service/history/conflictResolver_test.go
@@ -136,9 +136,9 @@ func (s *conflictResolverSuite) SetupTest() {
 	}
 	s.mockShard.SetEngine(h)
 
-	s.mockContext = newWorkflowExecutionContext(validDomainID, shared.WorkflowExecution{
+	s.mockContext = newWorkflowExecutionContext(testDomainID, shared.WorkflowExecution{
 		WorkflowId: common.StringPtr("some random workflow ID"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}, s.mockShard, s.mockExecutionMgr, s.logger)
 	s.conflictResolver = newConflictResolver(s.mockShard, s.mockContext, s.mockHistoryMgr, s.mockHistoryV2Mgr, s.logger)
 

--- a/service/history/decisionChecker_test.go
+++ b/service/history/decisionChecker_test.go
@@ -115,7 +115,7 @@ func (s *decisionAttrValidatorSuite) TestValidateSignalExternalWorkflowExecution
 	attributes.Execution.RunId = common.StringPtr("run-id")
 	err = s.validator.validateSignalExternalWorkflowExecutionAttributes(s.testDomainID, s.testTargetDomainID, attributes)
 	s.EqualError(err, "BadRequestError{Message: Invalid RunId set on decision.}")
-	attributes.Execution.RunId = common.StringPtr(validRunID)
+	attributes.Execution.RunId = common.StringPtr(testRunID)
 
 	attributes.SignalName = common.StringPtr("my signal name")
 	err = s.validator.validateSignalExternalWorkflowExecutionAttributes(s.testDomainID, s.testTargetDomainID, attributes)

--- a/service/history/decisionTaskHandler.go
+++ b/service/history/decisionTaskHandler.go
@@ -705,7 +705,6 @@ func (handler *decisionTaskHandlerImpl) handleDecisionContinueAsNewWorkflow(
 	_, newStateBuilder, err := handler.mutableState.AddContinueAsNewEvent(
 		handler.decisionTaskCompletedID,
 		handler.decisionTaskCompletedID,
-		handler.domainEntry,
 		parentDomainName,
 		attr,
 		handler.eventStoreVersion,
@@ -919,7 +918,6 @@ func (handler *decisionTaskHandlerImpl) retryCronContinueAsNew(
 	_, newStateBuilder, err := handler.mutableState.AddContinueAsNewEvent(
 		handler.decisionTaskCompletedID,
 		handler.decisionTaskCompletedID,
-		handler.domainEntry,
 		attr.GetParentWorkflowDomain(),
 		continueAsNewAttributes,
 		handler.eventStoreVersion,

--- a/service/history/historyBuilder_test.go
+++ b/service/history/historyBuilder_test.go
@@ -67,7 +67,7 @@ func (s *historyBuilderSuite) SetupTest() {
 	s.mockDomainCache = &cache.DomainCacheMock{}
 	// Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 	s.Assertions = require.New(s.T())
-	s.domainID = validDomainID
+	s.domainID = testDomainID
 	s.domainEntry = cache.NewLocalDomainCacheEntryForTest(&persistence.DomainInfo{ID: s.domainID}, &persistence.DomainConfig{}, "", nil)
 	s.mockShard = &shardContextImpl{
 		shardInfo:                 &persistence.ShardInfo{ShardID: 0, RangeID: 1, TransferAckLevel: 0},
@@ -81,7 +81,7 @@ func (s *historyBuilderSuite) SetupTest() {
 	}
 	s.mockEventsCache = &MockEventsCache{}
 	s.msBuilder = newMutableStateBuilder(s.mockShard, s.mockEventsCache,
-		s.logger, "")
+		s.logger, testLocalDomainEntry)
 	s.builder = newHistoryBuilder(s.msBuilder, s.logger)
 
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(s.domainEntry, nil).Maybe()
@@ -258,7 +258,6 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowStartFailures() {
 	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
 
 	_, err := s.msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		we,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -712,8 +711,8 @@ func (s *historyBuilderSuite) addWorkflowExecutionStartedEvent(we workflow.Workf
 	}
 
 	event, err := s.msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
-		we, &history.StartWorkflowExecutionRequest{
+		we,
+		&history.StartWorkflowExecutionRequest{
 			DomainUUID:   common.StringPtr(s.domainID),
 			StartRequest: request,
 		},

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -361,9 +361,7 @@ func (e *historyEngineImpl) createMutableState(
 			e.shard,
 			e.shard.GetEventsCache(),
 			e.logger,
-			domainEntry.GetFailoverVersion(),
-			domainEntry.GetReplicationPolicy(),
-			domainEntry.GetInfo().Name,
+			domainEntry,
 		)
 	} else if domainEntry.IsGlobalDomain() {
 		// 2DC XDC protocol
@@ -373,16 +371,14 @@ func (e *historyEngineImpl) createMutableState(
 			e.shard,
 			e.shard.GetEventsCache(),
 			e.logger,
-			domainEntry.GetFailoverVersion(),
-			domainEntry.GetReplicationPolicy(),
-			domainEntry.GetInfo().Name,
+			domainEntry,
 		)
 	} else {
 		newMutableState = newMutableStateBuilder(
 			e.shard,
 			e.shard.GetEventsCache(),
 			e.logger,
-			domainEntry.GetInfo().Name,
+			domainEntry,
 		)
 	}
 
@@ -453,7 +449,6 @@ func (e *historyEngineImpl) StartWorkflowExecution(
 	}
 
 	startEvent, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		domainEntry,
 		execution,
 		startRequest,
 	)
@@ -1647,7 +1642,6 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(
 
 	// Add WF start event
 	startEvent, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		domainEntry,
 		execution,
 		startRequest,
 	)

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -125,7 +125,7 @@ func (s *engine2Suite) SetupTest() {
 
 	s.mockDomainCache = &cache.DomainCacheMock{}
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(cache.NewLocalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{}, "", nil,
+		&p.DomainInfo{ID: testDomainID}, &p.DomainConfig{}, "", nil,
 	), nil)
 	s.mockEventsCache = &MockEventsCache{}
 	s.mockEventsCache.On("putEvent", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything,
@@ -201,10 +201,10 @@ func (s *engine2Suite) TearDownTest() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyExpired() {
-	domainID := validDomainID
+	domainID := testDomainID
 	we := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 	tl := "testTaskList"
 	stickyTl := "stickyTaskList"
@@ -283,10 +283,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyExpired() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
-	domainID := validDomainID
+	domainID := testDomainID
 	we := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 	tl := "testTaskList"
 	stickyTl := "stickyTaskList"
@@ -368,10 +368,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedIfNoExecution() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := &workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -412,10 +412,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfNoExecution() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedIfGetExecutionFailed() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := &workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -456,10 +456,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfGetExecutionFailed() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedIfTaskAlreadyStarted() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -504,10 +504,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfTaskAlreadyStarted() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedIfTaskAlreadyCompleted() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -555,10 +555,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfTaskAlreadyCompleted() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedConflictOnUpdate() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -617,10 +617,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedConflictOnUpdate() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskRetrySameRequest() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	tl := "testTaskList"
@@ -676,10 +676,10 @@ func (s *engine2Suite) TestRecordDecisionTaskRetrySameRequest() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskRetryDifferentRequest() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	tl := "testTaskList"
@@ -734,10 +734,10 @@ func (s *engine2Suite) TestRecordDecisionTaskRetryDifferentRequest() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskStartedMaxAttemptsExceeded() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	tl := "testTaskList"
@@ -790,10 +790,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedMaxAttemptsExceeded() {
 }
 
 func (s *engine2Suite) TestRecordDecisionTaskSuccess() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	tl := "testTaskList"
@@ -844,10 +844,10 @@ func (s *engine2Suite) TestRecordDecisionTaskSuccess() {
 }
 
 func (s *engine2Suite) TestRecordActivityTaskStartedIfNoExecution() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := &workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -891,10 +891,10 @@ func (s *engine2Suite) TestRecordActivityTaskStartedIfNoExecution() {
 }
 
 func (s *engine2Suite) TestRecordActivityTaskStartedSuccess() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -953,10 +953,10 @@ func (s *engine2Suite) TestRecordActivityTaskStartedSuccess() {
 }
 
 func (s *engine2Suite) TestRequestCancelWorkflowExecutionSuccess() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -1003,10 +1003,10 @@ func (s *engine2Suite) TestRequestCancelWorkflowExecutionSuccess() {
 }
 
 func (s *engine2Suite) TestRequestCancelWorkflowExecutionFail() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	identity := "testIdentity"
@@ -1066,10 +1066,10 @@ func (s *engine2Suite) printHistory(builder mutableState) string {
 }
 
 func (s *engine2Suite) TestRespondDecisionTaskCompletedRecordMarkerDecision() {
-	domainID := validDomainID
+	domainID := testDomainID
 	we := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 	tl := "testTaskList"
 	taskToken, _ := json.Marshal(&common.TaskToken{
@@ -1136,7 +1136,7 @@ func (s *engine2Suite) TestRespondDecisionTaskCompletedRecordMarkerDecision() {
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_BrandNew() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "workflowID"
 	workflowType := "workflowType"
 	taskList := "testTaskList"
@@ -1177,7 +1177,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew() {
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_StillRunning_Dedup() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "workflowID"
 	runID := "runID"
 	workflowType := "workflowType"
@@ -1228,7 +1228,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_StillRunning_Dedup() {
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_StillRunning_NonDeDup() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "workflowID"
 	runID := "runID"
 	workflowType := "workflowType"
@@ -1280,7 +1280,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_StillRunning_NonDeDup() {
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevSuccess() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "workflowID"
 	runID := "runID"
 	workflowType := "workflowType"
@@ -1365,7 +1365,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevSuccess() {
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevFail() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "workflowID"
 	workflowType := "workflowType"
 	taskList := "testTaskList"
@@ -1465,9 +1465,9 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
-	runID := validRunID
+	runID := testRunID
 	identity := "testIdentity"
 	signalName := "my signal name"
 	input := []byte("test input")
@@ -1519,7 +1519,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
 	workflowType := "workflowType"
 	taskList := "testTaskList"
@@ -1574,7 +1574,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_CreateTimeout() {
 	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
 	workflowType := "workflowType"
 	taskList := "testTaskList"
@@ -1629,9 +1629,9 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
-	runID := validRunID
+	runID := testRunID
 	workflowType := "workflowType"
 	taskList := "testTaskList"
 	identity := "testIdentity"
@@ -1687,9 +1687,9 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 }
 
 func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateRequests() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
-	runID := validRunID
+	runID := testRunID
 	workflowType := "workflowType"
 	taskList := "testTaskList"
 	identity := "testIdentity"
@@ -1753,9 +1753,9 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateReque
 }
 
 func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_WorkflowAlreadyStarted() {
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
-	runID := validRunID
+	runID := testRunID
 	workflowType := "workflowType"
 	taskList := "testTaskList"
 	identity := "testIdentity"

--- a/service/history/historyEngine3_eventsv2_test.go
+++ b/service/history/historyEngine3_eventsv2_test.go
@@ -196,15 +196,15 @@ func (s *engine3Suite) TearDownTest() {
 
 func (s *engine3Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+		&p.DomainInfo{ID: testDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
 	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 
-	domainID := validDomainID
+	domainID := testDomainID
 	we := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 	tl := "testTaskList"
 	stickyTl := "stickyTaskList"
@@ -285,12 +285,12 @@ func (s *engine3Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 
 func (s *engine3Suite) TestStartWorkflowExecution_BrandNew() {
 	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+		&p.DomainInfo{ID: testDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
 	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
 
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "workflowID"
 	workflowType := "workflowType"
 	taskList := "testTaskList"
@@ -332,7 +332,7 @@ func (s *engine3Suite) TestStartWorkflowExecution_BrandNew() {
 
 func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+		&p.DomainInfo{ID: testDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
 	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
@@ -341,9 +341,9 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
-	runID := validRunID
+	runID := testRunID
 	identity := "testIdentity"
 	signalName := "my signal name"
 	input := []byte("test input")
@@ -392,7 +392,7 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_JustSignal() {
 
 func (s *engine3Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+		&p.DomainInfo{ID: testDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
 	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
@@ -401,7 +401,7 @@ func (s *engine3Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
 	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	workflowID := "wId"
 	workflowType := "workflowType"
 	taskList := "testTaskList"

--- a/service/history/historyTestBase.go
+++ b/service/history/historyTestBase.go
@@ -53,7 +53,7 @@ var (
 	testDomainEmitMetric         = true
 	testDomainActiveClusterName  = cluster.TestCurrentClusterName
 	testDomainStandbyClusterName = cluster.TestAlternativeClusterName
-	testDomainIsGlobalDomain     = true
+	testDomainIsGlobalDomain     = false
 	testDomainAllClusters        = []*persistence.ClusterReplicationConfig{
 		{ClusterName: testDomainActiveClusterName},
 		{ClusterName: testDomainStandbyClusterName},
@@ -575,6 +575,10 @@ func (s *TestBase) SetupWorkflowStore() {
 // SetupDomains setup the domains used for testing
 func (s *TestBase) SetupDomains() {
 	// create the domains which are active / standby
+	version := int64(0)
+	if !testDomainIsGlobalDomain {
+		version = common.EmptyVersion
+	}
 	createDomainRequest := &persistence.CreateDomainRequest{
 		Info: &persistence.DomainInfo{
 			ID:     testDomainActiveID,
@@ -589,7 +593,8 @@ func (s *TestBase) SetupDomains() {
 			ActiveClusterName: testDomainActiveClusterName,
 			Clusters:          testDomainAllClusters,
 		},
-		IsGlobalDomain: testDomainIsGlobalDomain,
+		IsGlobalDomain:  testDomainIsGlobalDomain,
+		FailoverVersion: version,
 	}
 	s.MetadataManager.CreateDomain(createDomainRequest)
 	createDomainRequest.Info.ID = testDomainStandbyID

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -111,8 +111,9 @@ type (
 		stateInDB int
 		// indicates the next event ID in DB, for conditional update
 		nextEventIDInDB int64
-		// indicate whether can do replication
-		replicationPolicy cache.ReplicationPolicy
+		// domain entry contains a snapshot of domain
+		// NOTE: do not use the failover version inside, use currentVersion above
+		domainEntry *cache.DomainCacheEntry
 
 		insertTransferTasks    []persistence.Task
 		insertReplicationTasks []persistence.Task
@@ -127,7 +128,6 @@ type (
 		config          *Config
 		timeSource      clock.TimeSource
 		logger          log.Logger
-		domainName      string
 	}
 )
 
@@ -137,7 +137,7 @@ func newMutableStateBuilder(
 	shard ShardContext,
 	eventsCache eventsCache,
 	logger log.Logger,
-	domainName string,
+	domainEntry *cache.DomainCacheEntry,
 ) *mutableStateBuilder {
 	s := &mutableStateBuilder{
 		updateActivityInfos:             make(map[*persistence.ActivityInfo]struct{}),
@@ -166,10 +166,11 @@ func newMutableStateBuilder(
 		pendingSignalRequestedIDs: make(map[string]struct{}),
 		deleteSignalRequestedID:   "",
 
-		currentVersion:        common.EmptyVersion,
+		currentVersion:        domainEntry.GetFailoverVersion(),
 		hasBufferedEventsInDB: false,
 		stateInDB:             persistence.WorkflowStateVoid,
 		nextEventIDInDB:       0,
+		domainEntry:           domainEntry,
 
 		shard:           shard,
 		clusterMetadata: shard.GetClusterMetadata(),
@@ -177,7 +178,6 @@ func newMutableStateBuilder(
 		config:          shard.GetConfig(),
 		timeSource:      shard.GetTimeSource(),
 		logger:          logger,
-		domainName:      domainName,
 	}
 	s.executionInfo = &persistence.WorkflowExecutionInfo{
 		DecisionVersion:    common.EmptyVersion,
@@ -202,20 +202,16 @@ func newMutableStateBuilderWithReplicationState(
 	shard ShardContext,
 	eventsCache eventsCache,
 	logger log.Logger,
-	version int64,
-	replicationPolicy cache.ReplicationPolicy,
-	domainName string,
+	domainEntry *cache.DomainCacheEntry,
 ) *mutableStateBuilder {
-	s := newMutableStateBuilder(shard, eventsCache, logger, domainName)
+	s := newMutableStateBuilder(shard, eventsCache, logger, domainEntry)
 	s.replicationState = &persistence.ReplicationState{
-		StartVersion:        version,
-		CurrentVersion:      version,
+		StartVersion:        s.currentVersion,
+		CurrentVersion:      s.currentVersion,
 		LastWriteVersion:    common.EmptyVersion,
 		LastWriteEventID:    common.EmptyEventID,
 		LastReplicationInfo: make(map[string]*persistence.ReplicationInfo),
 	}
-	s.currentVersion = version
-	s.replicationPolicy = replicationPolicy
 	return s
 }
 
@@ -223,15 +219,11 @@ func newMutableStateBuilderWithVersionHistories(
 	shard ShardContext,
 	eventsCache eventsCache,
 	logger log.Logger,
-	version int64,
-	replicationPolicy cache.ReplicationPolicy,
-	domainName string,
+	domainEntry *cache.DomainCacheEntry,
 ) *mutableStateBuilder {
 
-	s := newMutableStateBuilder(shard, eventsCache, logger, domainName)
+	s := newMutableStateBuilder(shard, eventsCache, logger, domainEntry)
 	s.versionHistories = persistence.NewVersionHistories(&persistence.VersionHistory{})
-	s.currentVersion = version
-	s.replicationPolicy = replicationPolicy
 	return s
 }
 
@@ -431,26 +423,47 @@ func (e *mutableStateBuilder) FlushBufferedEvents() error {
 func (e *mutableStateBuilder) UpdateCurrentVersion(
 	version int64,
 	forceUpdate bool,
-) {
+) error {
+
+	if !e.IsWorkflowExecutionRunning() {
+		return nil
+	}
 
 	if e.replicationState != nil {
 		e.UpdateReplicationStateVersion(version, forceUpdate)
-		return
+		return nil
 	}
 
 	if e.versionHistories != nil {
+		versionHistory, err := e.versionHistories.GetCurrentVersionHistory()
+		if err != nil {
+			return err
+		}
+
+		if !versionHistory.IsEmpty() {
+			// this make sure current version >= last write version
+			versionHistoryItem, err := versionHistory.GetLastItem()
+			if err != nil {
+				return err
+			}
+			e.currentVersion = versionHistoryItem.GetVersion()
+		}
 		if version > e.currentVersion || forceUpdate {
 			e.currentVersion = version
 		}
-		return
+
+		return nil
 	}
 
 	if version != common.EmptyVersion {
-		e.logger.Error(
-			"cannot update current version of local domain workflow to version other than empty version",
-		)
+		err := &workflow.InternalServiceError{
+			Message: "cannot update current version of local domain workflow to version other than empty version",
+		}
+		e.logger.Error(err.Error())
+		return err
 	}
 	e.currentVersion = common.EmptyVersion
+	return nil
 }
 
 func (e *mutableStateBuilder) GetCurrentVersion() int64 {
@@ -507,13 +520,6 @@ func (e *mutableStateBuilder) GetLastWriteVersion() (int64, error) {
 	}
 
 	return common.EmptyVersion, nil
-}
-
-func (e *mutableStateBuilder) UpdateReplicationPolicy(
-	replicationPolicy cache.ReplicationPolicy,
-) {
-
-	e.replicationPolicy = replicationPolicy
 }
 
 // TODO nDC deprecate once replication state is deprecated
@@ -765,15 +771,15 @@ func (e *mutableStateBuilder) IsCurrentWorkflowGuaranteed() bool {
 	}
 }
 
-func (e *mutableStateBuilder) GetDomainName() string {
-	return e.domainName
+func (e *mutableStateBuilder) GetDomainEntry() *cache.DomainCacheEntry {
+	return e.domainEntry
 }
 
 func (e *mutableStateBuilder) IsStickyTaskListEnabled() bool {
 	if e.executionInfo.StickyTaskList == "" {
 		return false
 	}
-	ttl := e.config.StickyTTL(e.domainName)
+	ttl := e.config.StickyTTL(e.GetDomainEntry().GetInfo().Name)
 	if e.timeSource.Now().After(e.executionInfo.LastUpdatedTimestamp.Add(ttl)) {
 		return false
 	}
@@ -1447,7 +1453,6 @@ func (e *mutableStateBuilder) DeleteSignalRequested(
 }
 
 func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
-	domainEntry *cache.DomainCacheEntry,
 	parentExecutionInfo *h.ParentExecutionInfo,
 	execution workflow.WorkflowExecution,
 	previousExecutionState mutableState,
@@ -1478,7 +1483,7 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
 
 	createRequest := &workflow.StartWorkflowExecutionRequest{
 		RequestId:                           common.StringPtr(uuid.New()),
-		Domain:                              common.StringPtr(domainEntry.GetInfo().Name),
+		Domain:                              common.StringPtr(e.domainEntry.GetInfo().Name),
 		WorkflowId:                          execution.WorkflowId,
 		TaskList:                            tl,
 		WorkflowType:                        wType,
@@ -1493,7 +1498,7 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
 	}
 
 	req := &h.StartWorkflowExecutionRequest{
-		DomainUUID:                      common.StringPtr(domainEntry.GetInfo().ID),
+		DomainUUID:                      common.StringPtr(e.domainEntry.GetInfo().ID),
 		StartRequest:                    createRequest,
 		ParentExecutionInfo:             parentExecutionInfo,
 		LastCompletionResult:            attributes.LastCompletionResult,
@@ -1527,7 +1532,6 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
 
 	event := e.hBuilder.AddWorkflowExecutionStartedEvent(req, previousExecutionInfo, firstRunID, execution.GetRunId())
 	if err := e.ReplicateWorkflowExecutionStartedEvent(
-		domainEntry,
 		parentDomainID,
 		execution,
 		createRequest.GetRequestId(),
@@ -1566,7 +1570,6 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
 }
 
 func (e *mutableStateBuilder) AddWorkflowExecutionStartedEvent(
-	domainEntry *cache.DomainCacheEntry,
 	execution workflow.WorkflowExecution,
 	startRequest *h.StartWorkflowExecutionRequest,
 ) (*workflow.HistoryEvent, error) {
@@ -1592,7 +1595,6 @@ func (e *mutableStateBuilder) AddWorkflowExecutionStartedEvent(
 		parentDomainID = startRequest.ParentExecutionInfo.DomainUUID
 	}
 	if err := e.ReplicateWorkflowExecutionStartedEvent(
-		domainEntry,
 		parentDomainID,
 		execution,
 		request.GetRequestId(),
@@ -1616,7 +1618,6 @@ func (e *mutableStateBuilder) AddWorkflowExecutionStartedEvent(
 }
 
 func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(
-	domainEntry *cache.DomainCacheEntry,
 	parentDomainID *string,
 	execution workflow.WorkflowExecution,
 	requestID string,
@@ -1625,7 +1626,7 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(
 
 	event := startEvent.WorkflowExecutionStartedEventAttributes
 	e.executionInfo.CreateRequestID = requestID
-	e.executionInfo.DomainID = domainEntry.GetInfo().ID
+	e.executionInfo.DomainID = e.domainEntry.GetInfo().ID
 	e.executionInfo.WorkflowID = execution.GetWorkflowId()
 	e.executionInfo.RunID = execution.GetRunId()
 	e.executionInfo.TaskList = event.TaskList.GetName()
@@ -1681,7 +1682,7 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(
 		event.GetPrevAutoResetPoints(),
 		event.GetContinuedExecutionRunId(),
 		startEvent.GetTimestamp(),
-		domainEntry.GetRetentionDays(e.executionInfo.WorkflowID),
+		e.domainEntry.GetRetentionDays(e.executionInfo.WorkflowID),
 	)
 
 	if event.Memo != nil {
@@ -3058,7 +3059,6 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionSignaled(
 func (e *mutableStateBuilder) AddContinueAsNewEvent(
 	firstEventID int64,
 	decisionCompletedEventID int64,
-	domainEntry *cache.DomainCacheEntry,
 	parentDomainName string,
 	attributes *workflow.ContinueAsNewWorkflowExecutionDecisionAttributes,
 	eventStoreVersion int32,
@@ -3097,19 +3097,18 @@ func (e *mutableStateBuilder) AddContinueAsNewEvent(
 	}
 	firstRunID := currentStartEvent.GetWorkflowExecutionStartedEventAttributes().GetFirstExecutionRunId()
 
-	domainName := domainEntry.GetInfo().Name
+	domainName := e.domainEntry.GetInfo().Name
+	domainID := e.domainEntry.GetInfo().ID
 	var newStateBuilder *mutableStateBuilder
 	if e.config.EnableEventsV2(domainName) && e.config.EnableNDC(domainName) {
 		newStateBuilder = newMutableStateBuilderWithVersionHistories(
 			e.shard,
 			e.shard.GetEventsCache(),
 			e.logger,
-			domainEntry.GetFailoverVersion(),
-			domainEntry.GetReplicationPolicy(),
-			domainEntry.GetInfo().Name,
+			e.domainEntry,
 		)
 	} else {
-		if domainEntry.IsGlobalDomain() {
+		if e.domainEntry.IsGlobalDomain() {
 			// all workflows within a global domain should have replication state,
 			// no matter whether it will be replicated to multiple
 			// target clusters or not, for 2DC case
@@ -3117,18 +3116,14 @@ func (e *mutableStateBuilder) AddContinueAsNewEvent(
 				e.shard,
 				e.eventsCache,
 				e.logger,
-				e.GetCurrentVersion(),
-				e.replicationPolicy,
-				e.domainName,
+				e.domainEntry,
 			)
 		} else {
-			newStateBuilder = newMutableStateBuilder(e.shard, e.eventsCache, e.logger, e.domainName)
+			newStateBuilder = newMutableStateBuilder(e.shard, e.eventsCache, e.logger, e.domainEntry)
 		}
 	}
 
-	domainID := domainEntry.GetInfo().ID
 	if _, err = newStateBuilder.addWorkflowExecutionStartedEventForContinueAsNew(
-		domainEntry,
 		parentInfo,
 		newExecution,
 		e,
@@ -3676,12 +3671,29 @@ func (e *mutableStateBuilder) UpdateWorkflowStateCloseStatus(
 	return e.executionInfo.UpdateWorkflowStateCloseStatus(state, closeStatus)
 }
 
+func (e *mutableStateBuilder) StartTransaction(
+	domainEntry *cache.DomainCacheEntry,
+) (bool, error) {
+
+	e.domainEntry = domainEntry
+	if err := e.UpdateCurrentVersion(domainEntry.GetFailoverVersion(), false); err != nil {
+		return false, err
+	}
+
+	flushBeforeReady, err := e.startTransactionHandleDecisionFailover()
+	if err != nil {
+		return false, err
+	}
+
+	return flushBeforeReady, nil
+}
+
 func (e *mutableStateBuilder) CloseTransactionAsMutation(
 	now time.Time,
 	transactionPolicy transactionPolicy,
 ) (*persistence.WorkflowMutation, []*persistence.WorkflowEvents, error) {
 
-	if err := e.prepareTransaction(
+	if err := e.prepareCloseTransaction(
 		now,
 		transactionPolicy,
 	); err != nil {
@@ -3747,7 +3759,7 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 	transactionPolicy transactionPolicy,
 ) (*persistence.WorkflowSnapshot, []*persistence.WorkflowEvents, error) {
 
-	if err := e.prepareTransaction(
+	if err := e.prepareCloseTransaction(
 		now,
 		transactionPolicy,
 	); err != nil {
@@ -3812,39 +3824,12 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 	return workflowSnapshot, workflowEventsSeq, nil
 }
 
-func (e *mutableStateBuilder) closeTransactionHandleActivityUserTimerTasks(
-	now time.Time,
-	transactionPolicy transactionPolicy,
-) error {
-
-	if transactionPolicy == transactionPolicyPassive ||
-		!e.IsWorkflowExecutionRunning() {
-		return nil
-	}
-
-	if err := e.taskGenerator.generateActivityTimerTasks(
-		e.unixNanoToTime(now.UnixNano()),
-	); err != nil {
-		return err
-	}
-
-	return e.taskGenerator.generateUserTimerTasks(
-		e.unixNanoToTime(now.UnixNano()),
-	)
-}
-
-func (e *mutableStateBuilder) prepareTransaction(
+func (e *mutableStateBuilder) prepareCloseTransaction(
 	now time.Time,
 	transactionPolicy transactionPolicy,
 ) error {
 
 	if err := e.closeTransactionWithPolicyCheck(
-		transactionPolicy,
-	); err != nil {
-		return err
-	}
-
-	if err := e.closeTransactionHandleDecisionFailover(
 		transactionPolicy,
 	); err != nil {
 		return err
@@ -4085,7 +4070,7 @@ func (e *mutableStateBuilder) updateWithLastWriteEvent(
 
 func (e *mutableStateBuilder) canReplicateEvents() bool {
 	return (e.GetReplicationState() != nil || e.GetVersionHistories() != nil) &&
-		e.replicationPolicy == cache.ReplicationPolicyMultiCluster
+		e.domainEntry.GetReplicationPolicy() == cache.ReplicationPolicyMultiCluster
 }
 
 // validateNoEventsAfterWorkflowFinish perform check on history event batch
@@ -4132,12 +4117,58 @@ func (e *mutableStateBuilder) validateNoEventsAfterWorkflowFinish(
 	}
 }
 
+func (e *mutableStateBuilder) startTransactionHandleDecisionFailover() (bool, error) {
+
+	if !e.IsWorkflowExecutionRunning() ||
+		!e.canReplicateEvents() {
+		return false, nil
+	}
+
+	// Handling mutable state turn from standby to active, while having a decision on the fly
+	decision, ok := e.GetInFlightDecision()
+	if !ok || decision.Version >= e.GetCurrentVersion() {
+		// no pending decision, no buffered events
+		// or decision has higher / equal version
+		return false, nil
+	}
+
+	lastWriteVersion, err := e.GetLastWriteVersion()
+	if err != nil {
+		return false, err
+	}
+	if lastWriteVersion != decision.Version {
+		return false, &workflow.InternalServiceError{Message: fmt.Sprintf(
+			"mutableStateBuilder encounter mismatch version, decision: %v, last write version %v",
+			decision.Version,
+			lastWriteVersion,
+		)}
+	}
+	if err := e.UpdateCurrentVersion(lastWriteVersion, true); err != nil {
+		return false, err
+	}
+
+	// we have a decision on the fly with a lower version, fail it
+	if err := failDecision(
+		e,
+		decision,
+		workflow.DecisionTaskFailedCauseFailoverCloseDecision,
+	); err != nil {
+		return false, err
+	}
+
+	err = scheduleDecision(e)
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (e *mutableStateBuilder) closeTransactionWithPolicyCheck(
 	transactionPolicy transactionPolicy,
 ) error {
 
 	if transactionPolicy == transactionPolicyPassive ||
-		e.GetReplicationState() == nil {
+		!e.canReplicateEvents() {
 		return nil
 	}
 
@@ -4147,36 +4178,6 @@ func (e *mutableStateBuilder) closeTransactionWithPolicyCheck(
 	if activeCluster != currentCluster {
 		domainID := e.GetExecutionInfo().DomainID
 		return errors.NewDomainNotActiveError(domainID, currentCluster, activeCluster)
-	}
-	return nil
-}
-
-func (e *mutableStateBuilder) closeTransactionHandleDecisionFailover(
-	transactionPolicy transactionPolicy,
-) error {
-
-	if transactionPolicy == transactionPolicyPassive ||
-		!e.IsWorkflowExecutionRunning() ||
-		e.GetReplicationState() == nil {
-		return nil
-	}
-
-	// Handling mutable state turn from standby to active, while having a decision on the fly
-	decision, ok := e.GetInFlightDecision()
-	if ok && decision.Version < e.GetCurrentVersion() {
-		// we have a decision on the fly with a lower version, fail it
-		if err := failDecision(
-			e,
-			decision,
-			workflow.DecisionTaskFailedCauseFailoverCloseDecision,
-		); err != nil {
-			return err
-		}
-
-		err := scheduleDecision(e)
-		if err != nil {
-			return err
-		}
 	}
 	return nil
 }
@@ -4256,6 +4257,27 @@ func (e *mutableStateBuilder) closeTransactionHandleWorkflowReset(
 		)
 	}
 	return nil
+}
+
+func (e *mutableStateBuilder) closeTransactionHandleActivityUserTimerTasks(
+	now time.Time,
+	transactionPolicy transactionPolicy,
+) error {
+
+	if transactionPolicy == transactionPolicyPassive ||
+		!e.IsWorkflowExecutionRunning() {
+		return nil
+	}
+
+	if err := e.taskGenerator.generateActivityTimerTasks(
+		e.unixNanoToTime(now.UnixNano()),
+	); err != nil {
+		return err
+	}
+
+	return e.taskGenerator.generateUserTimerTasks(
+		e.unixNanoToTime(now.UnixNano()),
+	)
 }
 
 func (e *mutableStateBuilder) checkMutability(

--- a/service/history/mutableStateBuilder_test.go
+++ b/service/history/mutableStateBuilder_test.go
@@ -26,10 +26,10 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
+
 	"github.com/uber/cadence/.gen/go/shared"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/loggerimpl"
@@ -72,7 +72,7 @@ func (s *mutableStateSuite) SetupTest() {
 	}
 	s.mockEventsCache = &MockEventsCache{}
 	s.msBuilder = newMutableStateBuilder(s.mockShard, s.mockEventsCache,
-		s.logger, "")
+		s.logger, testLocalDomainEntry)
 }
 
 func (s *mutableStateSuite) TearDownTest() {
@@ -230,10 +230,10 @@ OtherEventsLoop:
 }
 
 func (s *mutableStateSuite) TestReorderEvents() {
-	domainID := validDomainID
+	domainID := testDomainID
 	we := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("wId"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 	tl := "testTaskList"
 	activityID := "activity_id"
@@ -388,7 +388,7 @@ func (s *mutableStateSuite) TestMergeMapOfByteArray() {
 }
 
 func (s *mutableStateSuite) prepareTransientDecisionCompletionFirstBatchReplicated(version int64, runID string) (*shared.HistoryEvent, *shared.HistoryEvent) {
-	domainID := validDomainID
+	domainID := testDomainID
 	execution := shared.WorkflowExecution{
 		WorkflowId: common.StringPtr("some random workflow ID"),
 		RunId:      common.StringPtr(runID),
@@ -457,7 +457,6 @@ func (s *mutableStateSuite) prepareTransientDecisionCompletionFirstBatchReplicat
 	s.mockEventsCache.On("putEvent", domainID, execution.GetWorkflowId(), execution.GetRunId(),
 		workflowStartEvent.GetEventId(), workflowStartEvent).Return(nil).Once()
 	err := s.msBuilder.ReplicateWorkflowExecutionStartedEvent(
-		cache.NewLocalDomainCacheEntryForTest(&persistence.DomainInfo{ID: domainID}, &persistence.DomainConfig{}, "", nil),
 		nil,
 		execution,
 		uuid.New(),

--- a/service/history/nDCBranchMgr_test.go
+++ b/service/history/nDCBranchMgr_test.go
@@ -24,7 +24,6 @@ import (
 	ctx "context"
 	"testing"
 
-	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
@@ -61,9 +60,7 @@ type (
 		workflowID  string
 		runID       string
 
-		controller         *gomock.Controller
-		mockTransactionMgr *MocknDCTransactionMgr
-		nDCBranchMgr       *nDCBranchMgrImpl
+		nDCBranchMgr *nDCBranchMgrImpl
 	}
 )
 
@@ -95,9 +92,6 @@ func (s *nDCBranchMgrSuite) SetupTest() {
 	}
 	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
 
-	s.controller = gomock.NewController(s.T())
-	s.mockTransactionMgr = NewMocknDCTransactionMgr(s.controller)
-
 	s.domainID = uuid.New()
 	s.workflowID = "some random workflow ID"
 	s.runID = uuid.New()
@@ -105,7 +99,7 @@ func (s *nDCBranchMgrSuite) SetupTest() {
 	s.mockMutableState = &mockMutableState{}
 	s.branchIndex = 0
 	s.nDCBranchMgr = newNDCBranchMgr(
-		s.mockShard, s.mockTransactionMgr, s.mockContext, s.mockMutableState, s.logger,
+		s.mockShard, s.mockContext, s.mockMutableState, s.logger,
 	)
 }
 
@@ -113,7 +107,6 @@ func (s *nDCBranchMgrSuite) TearDownTest() {
 	s.mockHistoryV2Mgr.AssertExpectations(s.T())
 	s.mockContext.AssertExpectations(s.T())
 	s.mockMutableState.AssertExpectations(s.T())
-	s.controller.Finish()
 }
 
 func (s *nDCBranchMgrSuite) TestCreateNewBranch() {
@@ -219,11 +212,9 @@ func (s *nDCBranchMgrSuite) TestFlushBufferedEvents() {
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", lastWriteVersion).Return(cluster.TestCurrentClusterName)
 	s.mockClusterMetadata.On("GetCurrentClusterName").Return(cluster.TestCurrentClusterName)
 
-	ctx := ctx.Background()
+	s.mockContext.On("updateWorkflowExecutionAsActive", mock.Anything).Return(nil).Times(1)
 
-	s.mockTransactionMgr.EXPECT().updateWorkflow(
-		ctx, gomock.Any(), false, gomock.Any(), nil,
-	).Return(nil).Times(1)
+	ctx := ctx.Background()
 
 	_, _, err = s.nDCBranchMgr.flushBufferedEvents(ctx, incomingVersionHistory)
 }

--- a/service/history/nDCBranchMgr_test.go
+++ b/service/history/nDCBranchMgr_test.go
@@ -195,7 +195,7 @@ func (s *nDCBranchMgrSuite) TestFlushBufferedEvents() {
 	s.mockMutableState.On("GetVersionHistories").Return(versionHistories).Maybe()
 	s.mockMutableState.On("HasBufferedEvents").Return(true).Times(2)
 	s.mockMutableState.On("IsWorkflowExecutionRunning").Return(true).Times(1)
-	s.mockMutableState.On("UpdateCurrentVersion", lastWriteVersion, true).Times(1)
+	s.mockMutableState.On("UpdateCurrentVersion", lastWriteVersion, true).Return(nil).Times(1)
 	decisionInfo := &decisionInfo{
 		ScheduleID: 1234,
 		StartedID:  2345,

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -137,19 +137,14 @@ func newNDCHistoryReplicator(
 			return newStateBuilder(shard, msBuilder, logger)
 		},
 		newMutableState: func(
-			version int64,
-			domainName string,
+			domainEntry *cache.DomainCacheEntry,
 			logger log.Logger,
 		) mutableState {
 			return newMutableStateBuilderWithVersionHistories(
 				shard,
 				shard.GetEventsCache(),
 				logger,
-				version,
-				// if can see replication task, meaning that domain is
-				// global domain with > 1 target clusters
-				cache.ReplicationPolicyMultiCluster,
-				domainName,
+				domainEntry,
 			)
 		},
 	}
@@ -252,12 +247,16 @@ func (r *nDCHistoryReplicatorImpl) applyStartEvents(
 	task nDCReplicationTask,
 ) (retError error) {
 
+	domainEntry, err := r.domainCache.GetDomainByID(task.getDomainID())
+	if err != nil {
+		return err
+	}
 	requestID := uuid.New() // requestID used for start workflow execution request.  This is not on the history event.
-	mutableState := r.newMutableState(task.getVersion(), context.getDomainName(), task.getLogger())
+	mutableState := r.newMutableState(domainEntry, task.getLogger())
 	stateBuilder := r.newStateBuilder(mutableState, task.getLogger())
 
 	// use state builder for workflow mutable state mutation
-	_, _, _, err := stateBuilder.applyEvents(
+	_, _, _, err = stateBuilder.applyEvents(
 		task.getDomainID(),
 		requestID,
 		*task.getExecution(),

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -111,7 +111,7 @@ func newNDCHistoryReplicator(
 			mutableState mutableState,
 			logger log.Logger,
 		) nDCBranchMgr {
-			return newNDCBranchMgr(shard, transactionMgr, context, mutableState, logger)
+			return newNDCBranchMgr(shard, context, mutableState, logger)
 		},
 		newConflictResolver: func(
 			context workflowExecutionContext,

--- a/service/history/nDCStateRebuilder.go
+++ b/service/history/nDCStateRebuilder.go
@@ -119,8 +119,7 @@ func (r *nDCStateRebuilderImpl) rebuild(
 	}
 	firstEventBatch := batch.(*shared.History).Events
 	rebuiltMutableState, stateBuilder := r.initializeBuilders(
-		firstEventBatch[0].GetVersion(),
-		domainEntry.GetInfo().Name,
+		domainEntry,
 	)
 	if err := r.applyEvents(targetWorkflowIdentifier, stateBuilder, firstEventBatch, requestID); err != nil {
 		return nil, 0, err
@@ -161,18 +160,13 @@ func (r *nDCStateRebuilderImpl) rebuild(
 }
 
 func (r *nDCStateRebuilderImpl) initializeBuilders(
-	version int64,
-	domainName string,
+	domainEntry *cache.DomainCacheEntry,
 ) (mutableState, stateBuilder) {
 	resetMutableStateBuilder := newMutableStateBuilderWithVersionHistories(
 		r.shard,
 		r.shard.GetEventsCache(),
 		r.logger,
-		version,
-		// if can see replication task, meaning that domain is
-		// global domain with > 1 target clusters
-		cache.ReplicationPolicyMultiCluster,
-		domainName,
+		domainEntry,
 	)
 	resetMutableStateBuilder.executionInfo.EventStoreVersion = nDCProtocolVersion
 	stateBuilder := newStateBuilder(r.shard, resetMutableStateBuilder, r.logger)

--- a/service/history/nDCStateRebuilder_test.go
+++ b/service/history/nDCStateRebuilder_test.go
@@ -102,8 +102,6 @@ func (s *nDCStateRebuilderSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockTaskRefresher = NewMockmutableStateTaskRefresher(s.controller)
 
-	s.domainID = uuid.New()
-	s.domainName = "some random domain name"
 	s.workflowID = "some random workflow ID"
 	s.runID = uuid.New()
 	s.nDCStateRebuilder = newNDCStateRebuilder(
@@ -116,12 +114,11 @@ func (s *nDCStateRebuilderSuite) TearDownTest() {
 	s.mockHistoryV2Mgr.AssertExpectations(s.T())
 	s.mockDomainCache.AssertExpectations(s.T())
 	s.mockEventsCache.AssertExpectations(s.T())
-	s.controller.Finish()
+	// s.controller.Finish()
 }
 
 func (s *nDCStateRebuilderSuite) TestInitializeBuilders() {
-	version := int64(123)
-	mutableState, stateBuilder := s.nDCStateRebuilder.initializeBuilders(version, s.domainName)
+	mutableState, stateBuilder := s.nDCStateRebuilder.initializeBuilders(testGlobalDomainEntry)
 	s.NotNil(mutableState)
 	s.NotNil(stateBuilder)
 	s.NotNil(mutableState.GetVersionHistories())

--- a/service/history/nDCTransactionMgrForExistingWorkflow_test.go
+++ b/service/history/nDCTransactionMgrForExistingWorkflow_test.go
@@ -213,8 +213,9 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 	s.mockTransactionMgr.EXPECT().loadNDCWorkflow(ctx, domainID, workflowID, currentRunID).Return(currentWorkflow, nil).Times(1)
 
 	targetWorkflow.EXPECT().happensAfter(currentWorkflow).Return(true, nil)
+	currentWorkflowPolicy := transactionPolicyPassive
 	currentMutableState.On("IsWorkflowExecutionRunning").Return(true)
-	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(nil).Times(1)
+	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(currentWorkflowPolicy, nil).Times(1)
 
 	targetContext.On(
 		"conflictResolveWorkflowExecution",
@@ -225,6 +226,7 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 		newMutableState,
 		currentContext,
 		currentMutableState,
+		currentWorkflowPolicy.ptr(),
 		(*persistence.CurrentWorkflowCAS)(nil),
 	).Return(nil).Once()
 
@@ -288,8 +290,8 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 	s.mockTransactionMgr.EXPECT().loadNDCWorkflow(ctx, domainID, workflowID, currentRunID).Return(currentWorkflow, nil).Times(1)
 
 	targetWorkflow.EXPECT().happensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(nil).Times(1)
-	newWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(nil).Times(1)
+	targetWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(transactionPolicyPassive, nil).Times(1)
+	newWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(transactionPolicyPassive, nil).Times(1)
 
 	targetContext.On(
 		"updateWorkflowExecutionWithNew",
@@ -357,6 +359,7 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 		newMutableState,
 		(workflowExecutionContext)(nil),
 		(mutableState)(nil),
+		(*transactionPolicy)(nil),
 		(*persistence.CurrentWorkflowCAS)(nil),
 	).Return(nil).Once()
 
@@ -420,8 +423,9 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 	s.mockTransactionMgr.EXPECT().loadNDCWorkflow(ctx, domainID, workflowID, currentRunID).Return(currentWorkflow, nil).Times(1)
 
 	targetWorkflow.EXPECT().happensAfter(currentWorkflow).Return(true, nil)
+	currentWorkflowPolicy := transactionPolicyActive
 	currentMutableState.On("IsWorkflowExecutionRunning").Return(true)
-	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(nil).Times(1)
+	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(currentWorkflowPolicy, nil).Times(1)
 
 	targetContext.On(
 		"conflictResolveWorkflowExecution",
@@ -432,6 +436,7 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 		newMutableState,
 		currentContext,
 		currentMutableState,
+		currentWorkflowPolicy.ptr(),
 		(*persistence.CurrentWorkflowCAS)(nil),
 	).Return(nil).Once()
 
@@ -494,8 +499,8 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 	s.mockTransactionMgr.EXPECT().loadNDCWorkflow(ctx, domainID, workflowID, currentRunID).Return(currentWorkflow, nil).Times(1)
 
 	targetWorkflow.EXPECT().happensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(nil).Times(1)
-	newWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(nil).Times(1)
+	targetWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(transactionPolicyPassive, nil).Times(1)
+	newWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(transactionPolicyPassive, nil).Times(1)
 
 	targetContext.On(
 		"conflictResolveWorkflowExecution",
@@ -506,6 +511,7 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 		newMutableState,
 		(workflowExecutionContext)(nil),
 		(mutableState)(nil),
+		(*transactionPolicy)(nil),
 		(*persistence.CurrentWorkflowCAS)(nil),
 	).Return(nil).Once()
 

--- a/service/history/nDCTransactionMgrForNewWorkflow_test.go
+++ b/service/history/nDCTransactionMgrForNewWorkflow_test.go
@@ -281,7 +281,7 @@ func (s *nDCTransactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_Create
 	s.mockTransactionMgr.EXPECT().loadNDCWorkflow(ctx, domainID, workflowID, currentRunID).Return(currentWorkflow, nil).Times(1)
 
 	targetWorkflow.EXPECT().happensAfter(currentWorkflow).Return(false, nil)
-	targetWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(nil).Times(1)
+	targetWorkflow.EXPECT().suppressWorkflowBy(currentWorkflow).Return(transactionPolicyPassive, nil).Times(1)
 
 	targetContext.On(
 		"persistFirstWorkflowEvents", targetWorkflowEventsSeq[0],
@@ -345,7 +345,8 @@ func (s *nDCTransactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_Suppre
 
 	targetWorkflow.EXPECT().happensAfter(currentWorkflow).Return(true, nil)
 	currentMutableState.On("IsWorkflowExecutionRunning").Return(true)
-	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(nil).Times(1)
+	currentWorkflowPolicy := transactionPolicyActive
+	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(currentWorkflowPolicy, nil).Times(1)
 
 	currentContext.On(
 		"updateWorkflowExecutionWithNew",
@@ -353,7 +354,7 @@ func (s *nDCTransactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_Suppre
 		persistence.UpdateWorkflowModeUpdateCurrent,
 		targetContext,
 		targetMutableState,
-		transactionPolicyActive,
+		currentWorkflowPolicy,
 		transactionPolicyPassive.ptr(),
 	).Return(nil).Once()
 

--- a/service/history/nDCWorkflow_mock.go
+++ b/service/history/nDCWorkflow_mock.go
@@ -129,11 +129,12 @@ func (mr *MocknDCWorkflowMockRecorder) happensAfter(that interface{}) *gomock.Ca
 }
 
 // suppressWorkflowBy mocks base method
-func (m *MocknDCWorkflow) suppressWorkflowBy(incomingWorkflow nDCWorkflow) error {
+func (m *MocknDCWorkflow) suppressWorkflowBy(incomingWorkflow nDCWorkflow) (transactionPolicy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "suppressWorkflowBy", incomingWorkflow)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(transactionPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // suppressWorkflowBy indicates an expected call of suppressWorkflowBy

--- a/service/history/timerBuilder_test.go
+++ b/service/history/timerBuilder_test.go
@@ -86,7 +86,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderSingleUserTimer() {
 	tb := newTimerBuilder(&mockTimeSource{currTime: time.Now()})
 
 	// Add one timer.
-	msb := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, "")
+	msb := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, testLocalDomainEntry)
 	msb.Load(&persistence.WorkflowMutableState{
 		ExecutionInfo: &persistence.WorkflowExecutionInfo{NextEventID: int64(201)},
 		TimerInfos:    make(map[string]*persistence.TimerInfo),
@@ -119,7 +119,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 	// Add two timers. (before and after)
 	tp := &persistence.TimerInfo{TimerID: "tid1", StartedID: 201, TaskID: 101, ExpiryTime: time.Now().Add(10 * time.Second)}
 	timerInfos := map[string]*persistence.TimerInfo{"tid1": tp}
-	msb := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, "")
+	msb := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, testLocalDomainEntry)
 	msb.Load(&persistence.WorkflowMutableState{
 		ExecutionInfo: &persistence.WorkflowExecutionInfo{NextEventID: int64(202)},
 		TimerInfos:    timerInfos,
@@ -148,7 +148,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 	tb = newTimerBuilder(&mockTimeSource{currTime: time.Now()})
 	tp2 := &persistence.TimerInfo{TimerID: "tid1", StartedID: 201, TaskID: TimerTaskStatusNone, ExpiryTime: time.Now().Add(10 * time.Second)}
 	timerInfos = map[string]*persistence.TimerInfo{"tid1": tp2}
-	msb = newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, "")
+	msb = newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, testLocalDomainEntry)
 	msb.Load(&persistence.WorkflowMutableState{
 		ExecutionInfo: &persistence.WorkflowExecutionInfo{NextEventID: int64(203)},
 		TimerInfos:    timerInfos,
@@ -176,7 +176,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 func (s *timerBuilderProcessorSuite) TestTimerBuilderDuplicateTimerID() {
 	tp := &persistence.TimerInfo{TimerID: "tid-exist", StartedID: 201, TaskID: 101, ExpiryTime: time.Now().Add(10 * time.Second)}
 	timerInfos := map[string]*persistence.TimerInfo{"tid-exist": tp}
-	msb := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, "")
+	msb := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, testLocalDomainEntry)
 	msb.Load(&persistence.WorkflowMutableState{
 		ExecutionInfo: &persistence.WorkflowExecutionInfo{NextEventID: int64(203)},
 		TimerInfos:    timerInfos,
@@ -192,7 +192,7 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderDuplicateTimerID() {
 
 func (s *timerBuilderProcessorSuite) TestTimerBuilder_GetActivityTimer() {
 	// ScheduleToStart being more than HB.
-	builder := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, "")
+	builder := newMutableStateBuilder(s.mockShard, s.mockEventsCache, s.logger, testLocalDomainEntry)
 	ase, ai, err := builder.AddActivityTaskScheduledEvent(common.EmptyEventID,
 		&workflow.ScheduleActivityTaskDecisionAttributes{
 			ActivityId:                    common.StringPtr("test-id"),

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -763,7 +763,6 @@ func (t *timerQueueActiveProcessorImpl) processWorkflowTimeout(
 	_, newMutableState, err := msBuilder.AddContinueAsNewEvent(
 		msBuilder.GetNextEventID(),
 		common.EmptyEventID,
-		domainEntry,
 		startAttributes.GetParentWorkflowDomain(),
 		continueAsnewAttributes,
 		eventStoreVersion,

--- a/service/history/timerQueueProcessor2_test.go
+++ b/service/history/timerQueueProcessor2_test.go
@@ -226,7 +226,7 @@ func (s *timerQueueProcessor2Suite) stopProcessor() {
 
 func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
 	we := workflow.WorkflowExecution{WorkflowId: common.StringPtr("timer-update-timesout-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "user-timer-update-times-out"
 
@@ -240,7 +240,6 @@ func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
 		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 	}
 	_, _ = builder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		we,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID:   common.StringPtr(s.domainID),
@@ -259,7 +258,7 @@ func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
 	timerTask := &persistence.TimerTaskInfo{
 		DomainID:   s.domainID,
 		WorkflowID: "wid",
-		RunID:      validRunID,
+		RunID:      testRunID,
 		TaskID:     taskID,
 		TaskType:   persistence.TaskTypeDecisionTimeout, TimeoutType: int(workflow.TimeoutTypeStartToClose),
 		VisibilityTimestamp: mockTS.Now(),
@@ -302,7 +301,7 @@ func (s *timerQueueProcessor2Suite) TestTimerUpdateTimesOut() {
 
 func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 	we := workflow.WorkflowExecution{WorkflowId: common.StringPtr("workflow-timesout-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 	taskList := "task-workflow-times-out"
 
 	builder := newMutableStateBuilderWithEventV2(s.mockShard, s.mockEventsCache, s.logger, we.GetRunId())
@@ -315,7 +314,6 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 	}
 	_, _ = builder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		we,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID:   common.StringPtr(s.domainID),
@@ -334,7 +332,7 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 	timerTask := &persistence.TimerTaskInfo{
 		DomainID:            s.domainID,
 		WorkflowID:          "wid",
-		RunID:               validRunID,
+		RunID:               testRunID,
 		TaskID:              taskID,
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
 		VisibilityTimestamp: mockTS.Now(),
@@ -378,7 +376,7 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout() {
 
 func (s *timerQueueProcessor2Suite) TestWorkflowTimeout_Cron() {
 	we := workflow.WorkflowExecution{WorkflowId: common.StringPtr("workflow-timesout-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 	taskList := "task-workflow-times-out"
 	schedule := "@every 30s"
 
@@ -393,7 +391,6 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout_Cron() {
 		CronSchedule:                        &schedule,
 	}
 	_, _ = builder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		we,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID:   common.StringPtr(s.domainID),
@@ -412,7 +409,7 @@ func (s *timerQueueProcessor2Suite) TestWorkflowTimeout_Cron() {
 	timerTask := &persistence.TimerTaskInfo{
 		DomainID:            s.domainID,
 		WorkflowID:          "wid",
-		RunID:               validRunID,
+		RunID:               testRunID,
 		TaskID:              taskID,
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
 		VisibilityTimestamp: mockTS.Now(),

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -305,7 +305,7 @@ func (s *timerQueueProcessorSuite) TestSingleTimerTask() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("single-timer-test"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 	taskList := "single-timer-queue"
 	identity := "testIdentity"
@@ -328,7 +328,7 @@ func (s *timerQueueProcessorSuite) TestSingleTimerTask() {
 func (s *timerQueueProcessorSuite) TestManyTimerTasks() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("multiple-timer-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "multiple-timer-queue"
 	identity := "testIdentity"
@@ -351,7 +351,7 @@ func (s *timerQueueProcessorSuite) TestManyTimerTasks() {
 func (s *timerQueueProcessorSuite) TestTimerTaskAfterProcessorStart() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("After-timer-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "After-timer-queue"
 	identity := "testIdentity"
@@ -432,7 +432,7 @@ func (s *timerQueueProcessorSuite) updateHistoryAndTimers(ms mutableState, timer
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithOutStart() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-SCHEDULE_TO_START-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 
@@ -477,7 +477,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithOutS
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithStart() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-SCHEDULE_TO_START-Started-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 
@@ -525,7 +525,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_WithStar
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_MoreThanStartToClose() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-SCHEDULE_TO_START-more-than-start2close"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 
@@ -572,7 +572,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToStart_MoreThan
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_WithStart() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-START_TO_CLOSE-Started-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 
@@ -619,7 +619,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_WithStart()
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_CompletedActivity() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-START_TO_CLOSE-Completed-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 	s.createExecutionWithTimers(domainID, workflowExecution, taskList, "identity", []int32{})
@@ -671,7 +671,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskStartToClose_CompletedAc
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_JustScheduled() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-SCHEDULE_TO_CLOSE-Scheduled-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 	s.createExecutionWithTimers(domainID, workflowExecution, taskList, "identity", []int32{})
@@ -716,7 +716,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_JustSche
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Started() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-SCHEDULE_TO_CLOSE-Started-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 	s.createExecutionWithTimers(domainID, workflowExecution, taskList, "identity", []int32{})
@@ -764,7 +764,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Started(
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Completed() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-SCHEDULE_TO_CLOSE-Completed-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 	s.createExecutionWithTimers(domainID, workflowExecution, taskList, "identity", []int32{})
@@ -817,7 +817,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTaskScheduleToClose_Complete
 func (s *timerQueueProcessorSuite) TestTimerActivityTaskHeartBeat_JustStarted() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("activity-timer-hb-started-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "activity-timer-queue"
 
@@ -842,7 +842,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTask_SameExpiry() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{
 		WorkflowId: common.StringPtr("activity-timer-same-expiry-test"),
-		RunId:      common.StringPtr(validRunID),
+		RunId:      common.StringPtr(testRunID),
 	}
 
 	taskList := "activity-timer-queue"
@@ -911,7 +911,7 @@ func (s *timerQueueProcessorSuite) TestTimerActivityTask_SameExpiry() {
 func (s *timerQueueProcessorSuite) TestTimerUserTimers() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("user-timer-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "user-timer-queue"
 	s.createExecutionWithTimers(domainID, workflowExecution, taskList, "identity", []int32{})
@@ -934,7 +934,7 @@ func (s *timerQueueProcessorSuite) TestTimerUserTimers() {
 func (s *timerQueueProcessorSuite) TestTimerUserTimers_SameExpiry() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("user-timer-same-expiry-test"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "user-timer-same-expiry-queue"
 	s.createExecutionWithTimers(domainID, workflowExecution, taskList, "identity", []int32{})
@@ -990,7 +990,7 @@ func (s *timerQueueProcessorSuite) TestTimerUserTimers_SameExpiry() {
 func (s *timerQueueProcessorSuite) TestTimersOnClosedWorkflow() {
 	domainID := testDomainActiveID
 	workflowExecution := workflow.WorkflowExecution{WorkflowId: common.StringPtr("closed-workflow-test-decision-timer"),
-		RunId: common.StringPtr(validRunID)}
+		RunId: common.StringPtr(testRunID)}
 
 	taskList := "closed-workflow-queue"
 	s.createExecutionWithTimers(domainID, workflowExecution, taskList, "identity", []int32{})

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
+
 	"github.com/uber/cadence/.gen/go/history"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client"
@@ -175,7 +176,7 @@ func (s *timerQueueStandbyProcessorSuite) SetupTest() {
 		s.logger,
 	)
 
-	s.domainID = validDomainID
+	s.domainID = testDomainID
 	s.domainEntry = cache.NewLocalDomainCacheEntryForTest(&persistence.DomainInfo{ID: s.domainID}, &persistence.DomainConfig{}, "", nil)
 }
 
@@ -209,7 +210,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Pending() 
 		execution.GetRunId(),
 	)
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -275,7 +275,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Success() 
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -333,7 +332,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Multiple()
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -397,7 +395,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessActivityTimeout_Pending() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -466,7 +463,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessActivityTimeout_Success() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -533,7 +529,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessActivityTimeout_Multiple_Ca
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -651,7 +646,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessDecisionTimeout_Pending() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -735,7 +729,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessDecisionTimeout_Success() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -785,7 +778,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessWorkflowBackoffTimer_Pendin
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	event, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -838,7 +830,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessWorkflowBackoffTimer_Succes
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -883,7 +874,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessWorkflowTimeout_Pending() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -942,7 +932,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessWorkflowTimeout_Success() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -992,7 +981,6 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessRetryTimeout() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -23,6 +23,7 @@ package history
 import (
 	ctx "context"
 	"fmt"
+
 	"github.com/pborman/uuid"
 
 	h "github.com/uber/cadence/.gen/go/history"
@@ -473,7 +474,7 @@ func (t *transferQueueActiveProcessorImpl) processCloseExecution(
 	workflowExecutionTimestamp := getWorkflowExecutionTimestamp(msBuilder, startEvent)
 	visibilityMemo := getWorkflowMemo(executionInfo.Memo)
 	searchAttr := executionInfo.SearchAttributes
-	domainName := msBuilder.GetDomainName()
+	domainName := msBuilder.GetDomainEntry().GetInfo().Name
 	children := msBuilder.GetPendingChildExecutionInfos()
 
 	// release the context lock since we no longer need mutable state builder and

--- a/service/history/transferQueueActiveProcessor_test.go
+++ b/service/history/transferQueueActiveProcessor_test.go
@@ -119,7 +119,7 @@ func (s *transferQueueActiveProcessorSuite) SetupTest() {
 	s.version = int64(4096)
 	// ack manager will use the domain information
 	s.mockMetadataMgr.On("GetDomain", mock.Anything).Return(&persistence.GetDomainResponse{
-		Info: &persistence.DomainInfo{ID: validDomainID},
+		Info: &persistence.DomainInfo{ID: testDomainID},
 		Config: &persistence.DomainConfig{
 			Retention:                1,
 			VisibilityArchivalStatus: workflow.ArchivalStatusEnabled,
@@ -213,7 +213,7 @@ func (s *transferQueueActiveProcessorSuite) SetupTest() {
 	s.mockParentClosePolicyClient = &parentclosepolicy.ClientMock{}
 	s.transferQueueActiveProcessor.parentClosePolicyClient = s.mockParentClosePolicyClient
 
-	s.domainID = validDomainID
+	s.domainID = testDomainID
 	s.domainEntry = cache.NewLocalDomainCacheEntryForTest(&persistence.DomainInfo{ID: s.domainID}, &persistence.DomainConfig{}, "", nil)
 }
 
@@ -244,7 +244,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Success() {
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -302,7 +301,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessActivityTask_Duplication(
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -362,7 +360,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_FirstDecisio
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -411,7 +408,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_NonFirstDeci
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -468,7 +464,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_Sticky_NonFi
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -529,7 +524,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_DecisionNotS
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -588,7 +582,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessDecisionTask_Duplication(
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -647,7 +640,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_HasParent(
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -715,7 +707,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent()
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -773,7 +764,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent_H
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -913,7 +903,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCloseExecution_NoParent_H
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1016,7 +1005,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Success()
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1080,7 +1068,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Failure()
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1146,7 +1133,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessCancelExecution_Duplicati
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1213,7 +1199,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Success()
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1292,7 +1277,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Failure()
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1362,7 +1346,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessSignalExecution_Duplicati
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1429,7 +1412,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1531,7 +1513,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Failu
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1626,7 +1607,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Succe
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1723,7 +1703,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessStartChildExecution_Dupli
 
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1810,7 +1789,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessRecordWorkflowStartedTask
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 
 	event, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1862,7 +1840,6 @@ func (s *transferQueueActiveProcessorSuite) TestProcessUpsertWorkflowSearchAttri
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, s.version, execution.GetRunId())
 
 	event, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),

--- a/service/history/transferQueueStandbyProcessor_test.go
+++ b/service/history/transferQueueStandbyProcessor_test.go
@@ -204,7 +204,7 @@ func (s *transferQueueStandbyProcessorSuite) SetupTest() {
 	s.mockQueueAckMgr = &MockQueueAckMgr{}
 	s.transferQueueStandbyProcessor.queueAckMgr = s.mockQueueAckMgr
 
-	s.domainID = validDomainID
+	s.domainID = testDomainID
 	s.domainEntry = cache.NewLocalDomainCacheEntryForTest(&persistence.DomainInfo{ID: s.domainID}, &persistence.DomainConfig{}, "", nil)
 }
 
@@ -235,7 +235,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Pending() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -291,7 +290,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Pending_Pus
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -348,7 +346,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessActivityTask_Success() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -405,7 +402,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Pending() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -453,7 +449,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Pending_Pus
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -503,7 +498,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Success_Fir
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -553,7 +547,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessDecisionTask_Success_Non
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -609,7 +602,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCloseExecution() {
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -675,7 +667,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCancelExecution_Pending(
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -747,7 +738,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessCancelExecution_Success(
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -812,7 +802,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessSignalExecution_Pending(
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -886,7 +875,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessSignalExecution_Success(
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -950,7 +938,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessStartChildExecution_Pend
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1022,7 +1009,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessStartChildExecution_Succ
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	_, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1082,7 +1068,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessRecordWorkflowStartedTas
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	event, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),
@@ -1144,7 +1129,6 @@ func (s *transferQueueStandbyProcessorSuite) TestProcessUpsertWorkflowSearchAttr
 	version := int64(4096)
 	msBuilder := newMutableStateBuilderWithReplicationStateWithEventV2(s.mockShard, s.mockShard.GetEventsCache(), s.logger, version, execution.GetRunId())
 	event, err := msBuilder.AddWorkflowExecutionStartedEvent(
-		s.domainEntry,
 		execution,
 		&history.StartWorkflowExecutionRequest{
 			DomainUUID: common.StringPtr(s.domainID),

--- a/service/history/workflowExecutionContext.go
+++ b/service/history/workflowExecutionContext.go
@@ -76,6 +76,7 @@ type (
 			newMutableState mutableState,
 			currentContext workflowExecutionContext,
 			currentMutableState mutableState,
+			currentTransactionPolicy *transactionPolicy,
 			workflowCAS *persistence.CurrentWorkflowCAS,
 		) error
 		updateWorkflowExecutionAsActive(
@@ -228,72 +229,65 @@ func (c *workflowExecutionContextImpl) loadExecutionStats() (*persistence.Execut
 }
 
 func (c *workflowExecutionContextImpl) loadWorkflowExecution() (mutableState, error) {
-	err := c.loadWorkflowExecutionInternal()
-	if err != nil {
-		return nil, err
-	}
-	err = c.updateVersion()
-	if err != nil {
-		return nil, err
-	}
-	return c.msBuilder, nil
-}
 
-func (c *workflowExecutionContextImpl) loadWorkflowExecutionInternal() error {
+	domainEntry, err := c.shard.GetDomainCache().GetDomainByID(c.domainID)
+	if err != nil {
+		return nil, err
+	}
+
 	if c.msBuilder != nil {
-		return nil
-	}
-
-	response, err := c.getWorkflowExecutionWithRetry(&persistence.GetWorkflowExecutionRequest{
-		DomainID:  c.domainID,
-		Execution: c.workflowExecution,
-	})
-	if err != nil {
-		return err
-	}
-
-	c.msBuilder = newMutableStateBuilder(
-		c.shard,
-		c.shard.GetEventsCache(),
-		c.logger,
-		c.getDomainName(),
-	)
-	c.msBuilder.Load(response.State)
-	c.stats = response.State.ExecutionStats
-	c.updateCondition = response.State.ExecutionInfo.NextEventID
-
-	// finally emit execution and session stats
-	emitWorkflowExecutionStats(
-		c.metricsClient,
-		c.getDomainName(),
-		response.MutableStateStats,
-		c.stats.HistorySize,
-	)
-	return nil
-}
-
-func (c *workflowExecutionContextImpl) updateVersion() error {
-	if c.msBuilder.GetReplicationState() != nil || c.msBuilder.GetVersionHistories() != nil {
-		if !c.msBuilder.IsWorkflowExecutionRunning() {
-			// we should not update the version on mutable state when the workflow is finished
-			return nil
-		}
-		// Support for global domains is enabled and we are performing an update for global domain
-		domainEntry, err := c.shard.GetDomainCache().GetDomainByID(c.domainID)
+		flushBeforeReady, err := c.msBuilder.StartTransaction(domainEntry)
 		if err != nil {
-			return err
+			return nil, err
+		}
+		if !flushBeforeReady {
+			return c.msBuilder, nil
 		}
 
-		if c.msBuilder.GetReplicationState() != nil {
-			c.msBuilder.UpdateReplicationStateVersion(domainEntry.GetFailoverVersion(), false)
-		} else if c.msBuilder.GetVersionHistories() != nil {
-			c.msBuilder.UpdateCurrentVersion(domainEntry.GetFailoverVersion(), false)
+		if err = c.updateWorkflowExecutionAsActive(
+			c.shard.GetTimeSource().Now(),
+		); err != nil {
+			return nil, err
+		}
+	} else {
+		response, err := c.getWorkflowExecutionWithRetry(&persistence.GetWorkflowExecutionRequest{
+			DomainID:  c.domainID,
+			Execution: c.workflowExecution,
+		})
+		if err != nil {
+			return nil, err
 		}
 
-		// this is a hack, only create replication task if have # target cluster > 1, for more see #868
-		c.msBuilder.UpdateReplicationPolicy(domainEntry.GetReplicationPolicy())
+		c.msBuilder = newMutableStateBuilder(
+			c.shard,
+			c.shard.GetEventsCache(),
+			c.logger,
+			domainEntry,
+		)
+		c.msBuilder.Load(response.State)
+		c.stats = response.State.ExecutionStats
+		c.updateCondition = response.State.ExecutionInfo.NextEventID
+
+		// finally emit execution and session stats
+		emitWorkflowExecutionStats(
+			c.metricsClient,
+			c.getDomainName(),
+			response.MutableStateStats,
+			c.stats.HistorySize,
+		)
 	}
-	return nil
+
+	flushBeforeReady, err := c.msBuilder.StartTransaction(domainEntry)
+	if err != nil {
+		return nil, err
+	}
+	if flushBeforeReady {
+		return nil, &workflow.InternalServiceError{
+			Message: "workflowExecutionContext counter flushBeforeReady status after loading mutable state from DB",
+		}
+	}
+
+	return c.msBuilder, nil
 }
 
 func (c *workflowExecutionContextImpl) createWorkflowExecution(
@@ -339,6 +333,7 @@ func (c *workflowExecutionContextImpl) conflictResolveWorkflowExecution(
 	newMutableState mutableState,
 	currentContext workflowExecutionContext,
 	currentMutableState mutableState,
+	currentTransactionPolicy *transactionPolicy,
 	workflowCAS *persistence.CurrentWorkflowCAS,
 ) (retError error) {
 
@@ -397,7 +392,7 @@ func (c *workflowExecutionContextImpl) conflictResolveWorkflowExecution(
 	}
 
 	var currentWorkflow *persistence.WorkflowMutation
-	if currentContext != nil && currentMutableState != nil {
+	if currentContext != nil && currentMutableState != nil && currentTransactionPolicy != nil {
 
 		defer func() {
 			if retError != nil {
@@ -407,7 +402,7 @@ func (c *workflowExecutionContextImpl) conflictResolveWorkflowExecution(
 
 		currentWorkflow, workflowEventsSeq, err = currentMutableState.CloseTransactionAsMutation(
 			now,
-			transactionPolicyActive, // current workflow must be closed as active
+			*currentTransactionPolicy,
 		)
 		if err != nil {
 			return err

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -201,7 +201,7 @@ func (s *resetorSuite) TearDownTest() {
 
 func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+		&p.DomainInfo{ID: testDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
 	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
@@ -211,7 +211,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 	_, err := s.historyEngine.ResetWorkflowExecution(context.Background(), request)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	request.DomainUUID = &domainID
 	request.ResetRequest = &workflow.ResetWorkflowExecutionRequest{}
 	_, err = s.historyEngine.ResetWorkflowExecution(context.Background(), request)
@@ -256,14 +256,17 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 	signalName2 := "sig2"
 	forkBranchToken := []byte("forkBranchToken")
 	forkExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:          domainID,
-		WorkflowID:        wid,
-		WorkflowTypeName:  wfType,
-		TaskList:          taskListName,
-		RunID:             forkRunID,
-		EventStoreVersion: p.EventStoreVersionV2,
-		BranchToken:       forkBranchToken,
-		NextEventID:       34,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              forkRunID,
+		EventStoreVersion:  p.EventStoreVersionV2,
+		BranchToken:        forkBranchToken,
+		NextEventID:        34,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	forkGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{
 		ExecutionInfo:  forkExeInfo,
@@ -278,12 +281,15 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 		},
 	}
 	currExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:         domainID,
-		WorkflowID:       wid,
-		WorkflowTypeName: wfType,
-		TaskList:         taskListName,
-		RunID:            currRunID,
-		NextEventID:      common.FirstEventID,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              currRunID,
+		NextEventID:        common.FirstEventID,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	compareCurrExeInfo := copyWorkflowExecutionInfo(currExeInfo)
 	currGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{
@@ -897,7 +903,7 @@ func (s *resetorSuite) assertActivityIDs(ids []string, timers []*p.ActivityInfo)
 
 func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCancel() {
 	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
+		&p.DomainInfo{ID: testDomainID}, &p.DomainConfig{Retention: 1}, "", nil,
 	)
 	s.mockDomainCache.On("GetDomainByID", mock.Anything).Return(testDomainEntry, nil)
 	s.mockDomainCache.On("GetDomain", mock.Anything).Return(testDomainEntry, nil)
@@ -907,7 +913,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCance
 	_, err := s.historyEngine.ResetWorkflowExecution(context.Background(), request)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	request.DomainUUID = &domainID
 	request.ResetRequest = &workflow.ResetWorkflowExecutionRequest{}
 	_, err = s.historyEngine.ResetWorkflowExecution(context.Background(), request)
@@ -955,14 +961,17 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCance
 	}
 	forkBranchToken := []byte("forkBranchToken")
 	forkExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:          domainID,
-		WorkflowID:        wid,
-		WorkflowTypeName:  wfType,
-		TaskList:          taskListName,
-		RunID:             forkRunID,
-		EventStoreVersion: p.EventStoreVersionV2,
-		BranchToken:       forkBranchToken,
-		NextEventID:       35,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              forkRunID,
+		EventStoreVersion:  p.EventStoreVersionV2,
+		BranchToken:        forkBranchToken,
+		NextEventID:        35,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	forkGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{
 		ExecutionInfo:  forkExeInfo,
@@ -977,12 +986,15 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication_WithRequestCance
 		},
 	}
 	currExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:         domainID,
-		WorkflowID:       wid,
-		WorkflowTypeName: wfType,
-		TaskList:         taskListName,
-		RunID:            currRunID,
-		NextEventID:      common.FirstEventID,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              currRunID,
+		NextEventID:        common.FirstEventID,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	currGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{
 		ExecutionInfo:  currExeInfo,
@@ -1473,7 +1485,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return("active")
 
 	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID},
+		&p.DomainInfo{ID: testDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{
 			ActiveClusterName: "active",
@@ -1497,7 +1509,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 	_, err := s.historyEngine.ResetWorkflowExecution(context.Background(), request)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	request.DomainUUID = &domainID
 	request.ResetRequest = &workflow.ResetWorkflowExecutionRequest{}
 	_, err = s.historyEngine.ResetWorkflowExecution(context.Background(), request)
@@ -1544,14 +1556,17 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 
 	forkBranchToken := []byte("forkBranchToken")
 	forkExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:          domainID,
-		WorkflowID:        wid,
-		WorkflowTypeName:  wfType,
-		TaskList:          taskListName,
-		RunID:             forkRunID,
-		EventStoreVersion: p.EventStoreVersionV2,
-		BranchToken:       forkBranchToken,
-		NextEventID:       35,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              forkRunID,
+		EventStoreVersion:  p.EventStoreVersionV2,
+		BranchToken:        forkBranchToken,
+		NextEventID:        35,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 
 	forkRepState := &p.ReplicationState{
@@ -1575,12 +1590,15 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 		},
 	}
 	currExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:         domainID,
-		WorkflowID:       wid,
-		WorkflowTypeName: wfType,
-		TaskList:         taskListName,
-		RunID:            currRunID,
-		NextEventID:      common.FirstEventID,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              currRunID,
+		NextEventID:        common.FirstEventID,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	compareCurrExeInfo := copyWorkflowExecutionInfo(currExeInfo)
 	currGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{
@@ -2197,7 +2215,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return("standby")
 
 	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID},
+		&p.DomainInfo{ID: testDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{
 			ActiveClusterName: "active",
@@ -2221,7 +2239,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 	_, err := s.historyEngine.ResetWorkflowExecution(context.Background(), request)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	request.DomainUUID = &domainID
 	request.ResetRequest = &workflow.ResetWorkflowExecutionRequest{}
 	_, err = s.historyEngine.ResetWorkflowExecution(context.Background(), request)
@@ -2268,14 +2286,17 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 
 	forkBranchToken := []byte("forkBranchToken")
 	forkExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:          domainID,
-		WorkflowID:        wid,
-		WorkflowTypeName:  wfType,
-		TaskList:          taskListName,
-		RunID:             forkRunID,
-		EventStoreVersion: p.EventStoreVersionV2,
-		BranchToken:       forkBranchToken,
-		NextEventID:       35,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              forkRunID,
+		EventStoreVersion:  p.EventStoreVersionV2,
+		BranchToken:        forkBranchToken,
+		NextEventID:        35,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 
 	forkRepState := &p.ReplicationState{
@@ -2299,12 +2320,15 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 		},
 	}
 	currExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:         domainID,
-		WorkflowID:       wid,
-		WorkflowTypeName: wfType,
-		TaskList:         taskListName,
-		RunID:            currRunID,
-		NextEventID:      common.FirstEventID,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              currRunID,
+		NextEventID:        common.FirstEventID,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	currGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{
 		ExecutionInfo:    currExeInfo,
@@ -2805,7 +2829,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return("active")
 
 	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID},
+		&p.DomainInfo{ID: testDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{
 			ActiveClusterName: "active",
@@ -2829,7 +2853,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 	_, err := s.historyEngine.ResetWorkflowExecution(context.Background(), request)
 	s.EqualError(err, "BadRequestError{Message: Missing domain UUID.}")
 
-	domainID := validDomainID
+	domainID := testDomainID
 	request.DomainUUID = &domainID
 	request.ResetRequest = &workflow.ResetWorkflowExecutionRequest{}
 	_, err = s.historyEngine.ResetWorkflowExecution(context.Background(), request)
@@ -2876,14 +2900,17 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 
 	forkBranchToken := []byte("forkBranchToken")
 	forkExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:          domainID,
-		WorkflowID:        wid,
-		WorkflowTypeName:  wfType,
-		TaskList:          taskListName,
-		RunID:             forkRunID,
-		EventStoreVersion: p.EventStoreVersionV2,
-		BranchToken:       forkBranchToken,
-		NextEventID:       35,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              forkRunID,
+		EventStoreVersion:  p.EventStoreVersionV2,
+		BranchToken:        forkBranchToken,
+		NextEventID:        35,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 
 	forkRepState := &p.ReplicationState{
@@ -2907,13 +2934,16 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 		},
 	}
 	currExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:         domainID,
-		WorkflowID:       wid,
-		WorkflowTypeName: wfType,
-		TaskList:         taskListName,
-		RunID:            currRunID,
-		NextEventID:      common.FirstEventID,
-		State:            p.WorkflowStateCompleted,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              currRunID,
+		NextEventID:        common.FirstEventID,
+		State:              p.WorkflowStateCompleted,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	compareCurrExeInfo := copyWorkflowExecutionInfo(currExeInfo)
 	currGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{
@@ -3504,14 +3534,14 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 }
 
 func (s *resetorSuite) TestApplyReset() {
-	domainID := validDomainID
+	domainID := testDomainID
 	beforeResetVersion := int64(100)
 	afterResetVersion := int64(101)
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", beforeResetVersion).Return(cluster.TestAlternativeClusterName)
 	s.mockClusterMetadata.On("ClusterNameForFailoverVersion", afterResetVersion).Return(cluster.TestCurrentClusterName)
 
 	testDomainEntry := cache.NewGlobalDomainCacheEntryForTest(
-		&p.DomainInfo{ID: validDomainID},
+		&p.DomainInfo{ID: testDomainID},
 		&p.DomainConfig{Retention: 1},
 		&p.DomainReplicationConfig{
 			ActiveClusterName: cluster.TestAlternativeClusterName,
@@ -3562,14 +3592,17 @@ func (s *resetorSuite) TestApplyReset() {
 
 	forkBranchToken := []byte("forkBranchToken")
 	forkExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:          domainID,
-		WorkflowID:        wid,
-		WorkflowTypeName:  wfType,
-		TaskList:          taskListName,
-		RunID:             forkRunID,
-		EventStoreVersion: p.EventStoreVersionV2,
-		BranchToken:       forkBranchToken,
-		NextEventID:       35,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              forkRunID,
+		EventStoreVersion:  p.EventStoreVersionV2,
+		BranchToken:        forkBranchToken,
+		NextEventID:        35,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 
 	forkRepState := &p.ReplicationState{
@@ -3593,13 +3626,16 @@ func (s *resetorSuite) TestApplyReset() {
 		},
 	}
 	currExeInfo := &p.WorkflowExecutionInfo{
-		DomainID:         domainID,
-		WorkflowID:       wid,
-		WorkflowTypeName: wfType,
-		TaskList:         taskListName,
-		RunID:            currRunID,
-		NextEventID:      common.FirstEventID,
-		State:            p.WorkflowStateCompleted,
+		DomainID:           domainID,
+		WorkflowID:         wid,
+		WorkflowTypeName:   wfType,
+		TaskList:           taskListName,
+		RunID:              currRunID,
+		NextEventID:        common.FirstEventID,
+		State:              p.WorkflowStateCompleted,
+		DecisionVersion:    common.EmptyVersion,
+		DecisionScheduleID: common.EmptyEventID,
+		DecisionStartedID:  common.EmptyEventID,
 	}
 	compareCurrExeInfo := copyWorkflowExecutionInfo(currExeInfo)
 	currGwmsResponse := &p.GetWorkflowExecutionResponse{State: &p.WorkflowMutableState{


### PR DESCRIPTION
* When mutable state is initialized, a copy of domain cache entry is passed in, instead of domain name for ease of use
* Update some tests, use mocked domain cache entry, instead of mock metadata manager
* Add additional return parameter: transaction policy for nDCWorkflow suppressWorkflowBy API
* Allow current workflow to be set as zombie during conflicting resolution
* Fix issue that NDC branch manager should flush buffer as active
* When mutable state is initialized, buffered events version checking will be triggered, handing 4 cases of version changes, decision will be failed and persisted to DB before passing mutable state to caller.
   * active -> passive => fail decision & flush buffer using last write version
   * active -> active => fail decision & flush buffer using last write version
   * passive -> active => fail decision using current version, no buffered events
   * passive -> passive => no buffered events, since always passive, nothing to be done