### PR TITLE
Fix doc typos.

### DIFF
--- a/docs/02_use_cases/02_orchestration.md
+++ b/docs/02_use_cases/02_orchestration.md
@@ -1,6 +1,6 @@
 # Microservice Orchestration and Saga
 
-It is common that some business processes are is implemented as multiple microservice calls.
+It is common that some business processes are implemented as multiple microservice calls.
 And the implementation must guarantee that all of the calls must eventually succeed even with the occurrence of prolonged downstream service failures.
 In some cases, instead of trying to complete the process by retrying for a long time, compensation rollback logic should be executed.
 [Saga Pattern](https://microservices.io/patterns/data/saga.html) is one way to standardize on compensation APIs.

--- a/docs/02_use_cases/06_batch_job.md
+++ b/docs/02_use_cases/06_batch_job.md
@@ -3,5 +3,5 @@
 A lot of batch jobs are not pure data manipulation programs. For those, the existing big data frameworks are the best fit.
 But if processing a record requires external API calls that might fail and potentially take a long time, Cadence might be preferable.
 
-One of our internal Uber customers uses Cadence for end of month statement generation. Each statement requires calls to multiple
+One of our internal Uber customer uses Cadence for end of month statement generation. Each statement requires calls to multiple
 microservices and some statements can be really large. Cadence was chosen because it provides hard guarantees around durability of the financial data and seamlessly deals with long running operations, retries, and intermittent failures.

--- a/docs/03_concepts/07_task_lists.md
+++ b/docs/03_concepts/07_task_lists.md
@@ -7,8 +7,8 @@ Instead of calling the worker directly, an intermediate queue is used. So the se
 queue and a worker receives the task using a long poll request. 
 Cadence calls this queue used to dispatch activity tasks an *activity task list*.
 
-Similarly, when a workflow needs to handle an external event, a decision task is created. *
-A Decision task list* is used to deliver it to the workflow worker (also called _decider_).
+Similarly, when a workflow needs to handle an external event, a decision task is created.
+*A Decision task list* is used to deliver it to the workflow worker (also called _decider_).
 
 While Cadence task lists are queues, they have some differences from commonly used queuing technologies. 
 The main one is that they do not require explicit registration and are created on demand. The number of task lists

--- a/docs/07_goclient/02_create_workflows.md
+++ b/docs/07_goclient/02_create_workflows.md
@@ -49,7 +49,7 @@ func SimpleWorkflow(ctx workflow.Context, value string) error {
     if err := future.Get(ctx, &result); err != nil {
         return err
     }
-    workflow.GetLogger(ctx).Info(“Done”, zap.String(“result”, result))
+    workflow.GetLogger(ctx).Info("Done", zap.String("result", result))
     return nil
 }
 ```

--- a/docs/07_goclient/index.md
+++ b/docs/07_goclient/index.md
@@ -6,7 +6,7 @@ Go client attempts to follow Go language conventions. The conversion of a Go pro
 
 Cadence requires determinism of the workflow code. It supports deterministic execution of the multithreaded code and constructs like `select` that are non-deterministic by Go design. The Cadence solution is to provide corresponding constructs in the form of interfaces that have similar capability but support deterministic execution.
 
-For example, instead of native Go channels, workflow code must use the `workflow.Channel` interface. Instead of `select`, the Selector interface must be used.
+For example, instead of native Go channels, workflow code must use the `workflow.Channel` interface. Instead of `select`, the `workflow.Selector` interface must be used.
 
 For more information, see [Creating Workflows](02_create_workflows#]).
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,8 +2,8 @@
 
 A large number of use cases span beyond a single request-reply, require tracking
 of a complex state, respond to asynchronous events, and communicate to external unreliable dependencies.
-The usual approach to building such an applications is a hodgepodge of stateless services,
-databases, cron jobs and queuing systems. This negatively impacts the developer productivity as most of the code is
+The usual approach to building such applications is a hodgepodge of stateless services,
+databases, cron jobs, and queuing systems. This negatively impacts the developer productivity as most of the code is
 dedicated to plumbing, obscuring the actual business logic behind a myriad of low-level details. Such systems frequently have availability problems as it is hard to keep all the components healthy.
 
 The Cadence solution is a [_fault-oblivious stateful_ programming model](03_concepts/01_workflows) that obscures most of the complexities of building scalable distributed applications. In essence, Cadence provides a durable virtual memory that is not


### PR DESCRIPTION
I recently read all docs (besides Java client) and found few typos/markup errors. I think I saw more of them and will create another PR for the rest.