### PR TITLE
Reset: not rely on timeout for cleanup history

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,7 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b h1:AP/Y7sqYicnjGDfD5VcY4CIfh1hRXBUavxrvELjTiOE=
 github.com/bmizerany/perks v0.0.0-20141205001514-d9a9656a3a4b/go.mod h1:ac9efd0D1fsDb3EJvhqgXRbFx7bs2wqZ10HQPeU8U/Q=
+github.com/bsm/sarama-cluster v2.1.13+incompatible h1:bqU3gMJbWZVxLZ9PGWVKP05yOmFXUlfw61RBwuE3PYU=
 github.com/bsm/sarama-cluster v2.1.13+incompatible/go.mod h1:r7ao+4tTNXvWm+VRpRJchr2kQhqxgmAp2iEX5W96gMM=
 github.com/cactus/go-statsd-client v3.1.1+incompatible h1:p97okCU2aaeSxQ6KzMdGEwQkiGBMys71/J0XWoirbJY=
 github.com/cactus/go-statsd-client v3.1.1+incompatible/go.mod h1:cMRcwZDklk7hXp+Law83urTHUiHMzCev/r4JMYr/zU0=

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -111,7 +111,7 @@ func (w *workflowResetorImpl) ResetWorkflowExecution(
 		if newMutableState != nil && len(newMutableState.GetExecutionInfo().GetCurrentBranch()) > 0 {
 			w.eng.historyV2Mgr.CompleteForkBranch(&persistence.CompleteForkBranchRequest{
 				BranchToken: newMutableState.GetExecutionInfo().GetCurrentBranch(),
-				Success:     retError == nil || persistence.IsTimeoutError(retError),
+				Success:     true,
 				ShardID:     common.IntPtr(w.eng.shard.GetShardID()),
 			})
 		}
@@ -778,7 +778,7 @@ func (w *workflowResetorImpl) ApplyResetEvent(
 	defer func() {
 		w.eng.historyV2Mgr.CompleteForkBranch(&persistence.CompleteForkBranchRequest{
 			BranchToken: newMsBuilder.GetExecutionInfo().GetCurrentBranch(),
-			Success:     retError == nil || persistence.IsTimeoutError(retError),
+			Success:     true,
 			ShardID:     shardID,
 		})
 	}()

--- a/service/history/workflowResetor_test.go
+++ b/service/history/workflowResetor_test.go
@@ -757,7 +757,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_NoReplication() {
 	}
 	completeReqErr := &p.CompleteForkBranchRequest{
 		BranchToken: newBranchToken,
-		Success:     false,
+		Success:     true,
 		ShardID:     common.IntPtr(s.shardID),
 	}
 
@@ -2063,7 +2063,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_WithTerminatingCur
 	}
 	completeReqErr := &p.CompleteForkBranchRequest{
 		BranchToken: newBranchToken,
-		Success:     false,
+		Success:     true,
 		ShardID:     common.IntPtr(s.shardID),
 	}
 
@@ -2781,7 +2781,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NotActive() {
 
 	completeReqErr := &p.CompleteForkBranchRequest{
 		BranchToken: newBranchToken,
-		Success:     false,
+		Success:     true,
 		ShardID:     common.IntPtr(s.shardID),
 	}
 
@@ -3396,7 +3396,7 @@ func (s *resetorSuite) TestResetWorkflowExecution_Replication_NoTerminatingCurre
 	}
 	completeReqErr := &p.CompleteForkBranchRequest{
 		BranchToken: newBranchToken,
-		Success:     false,
+		Success:     true,
 		ShardID:     common.IntPtr(s.shardID),
 	}
 
@@ -4026,7 +4026,7 @@ func (s *resetorSuite) TestApplyReset() {
 	}
 	completeReqErr := &p.CompleteForkBranchRequest{
 		BranchToken: newBranchToken,
-		Success:     false,
+		Success:     true,
 		ShardID:     common.IntPtr(s.shardID),
 	}
 


### PR DESCRIPTION
As a safer way, we have implemented history scanner to cleanup in background job