### PR TITLE
Fix NDC events reapplication transaction policy

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2464,7 +2464,7 @@ func (e *historyEngineImpl) ReapplyEvents(
 			//  reset to workflow finish event
 			//  ignore this case for now
 			if !msBuilder.IsWorkflowExecutionRunning() {
-				e.logger.Warn("failed to reapply event to a finished workflow",
+				e.logger.Warn("cannot reapply event to a finished workflow",
 					tag.WorkflowDomainID(domainID),
 					tag.WorkflowID(workflowID),
 				)

--- a/service/history/nDCTransactionMgr.go
+++ b/service/history/nDCTransactionMgr.go
@@ -279,7 +279,7 @@ func (r *nDCTransactionMgrImpl) backfillWorkflow(
 		} else if mode == persistence.UpdateWorkflowModeUpdateCurrent {
 			// case 2
 			transactionPolicy = transactionPolicyActive
-			r.logger.Warn("failed to reapply event to a finished workflow",
+			r.logger.Warn("cannot reapply event to a finished workflow",
 				tag.WorkflowDomainID(targetWorkflowEvents.DomainID),
 				tag.WorkflowID(targetWorkflowEvents.WorkflowID),
 			)

--- a/service/history/nDCTransactionMgr.go
+++ b/service/history/nDCTransactionMgr.go
@@ -227,6 +227,7 @@ func (r *nDCTransactionMgrImpl) backfillWorkflow(
 	}
 
 	mode := persistence.UpdateWorkflowModeUpdateCurrent
+	transactionPolicy := transactionPolicyPassive
 	// since we are not rebuilding the mutable state then we
 	// can trust the result from IsCurrentWorkflowGuaranteed
 	if !targetWorkflow.getMutableState().IsCurrentWorkflowGuaranteed() {
@@ -265,9 +266,9 @@ func (r *nDCTransactionMgrImpl) backfillWorkflow(
 		// target workflow is active && target workflow is current workflow
 		// we need to reapply events here, rather than using reapplyEvents
 		// within workflow execution context, or otherwise deadlock will appear
-
 		if targetWorkflow.getMutableState().IsCurrentWorkflowGuaranteed() {
 			// case 1
+			transactionPolicy = transactionPolicyActive
 			if err := r.eventsReapplier.reapplyEvents(
 				ctx,
 				targetWorkflow.getMutableState(),
@@ -277,11 +278,18 @@ func (r *nDCTransactionMgrImpl) backfillWorkflow(
 			}
 		} else if mode == persistence.UpdateWorkflowModeUpdateCurrent {
 			// case 2
+			transactionPolicy = transactionPolicyActive
 			r.logger.Warn("failed to reapply event to a finished workflow",
 				tag.WorkflowDomainID(targetWorkflowEvents.DomainID),
 				tag.WorkflowID(targetWorkflowEvents.WorkflowID),
 			)
 			r.metricsClient.IncCounter(metrics.HistoryReapplyEventsScope, metrics.EventReapplySkippedCount)
+			// TODO when https://github.com/uber/cadence/issues/2420 is finished
+			//  reset to workflow finish event and reapply to new resetted workflow by using
+			//  transactionPolicyActive, ignore this case for now
+		} else {
+			// target workflow is active but not being pointed by current record
+			// do not need to handle events reapplication here
 		}
 	}
 
@@ -290,7 +298,7 @@ func (r *nDCTransactionMgrImpl) backfillWorkflow(
 		mode,
 		nil,
 		nil,
-		transactionPolicyPassive,
+		transactionPolicy,
 		nil,
 	)
 }

--- a/service/history/nDCTransactionMgrForExistingWorkflow.go
+++ b/service/history/nDCTransactionMgrForExistingWorkflow.go
@@ -314,6 +314,9 @@ func (r *nDCTransactionMgrForExistingWorkflowImpl) suppressCurrentAndUpdateAsCur
 		if err != nil {
 			return err
 		}
+		if err := targetWorkflow.revive(); err != nil {
+			return err
+		}
 	}
 
 	var newContext workflowExecutionContext

--- a/service/history/nDCTransactionMgrForExistingWorkflow_test.go
+++ b/service/history/nDCTransactionMgrForExistingWorkflow_test.go
@@ -216,6 +216,7 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 	currentWorkflowPolicy := transactionPolicyPassive
 	currentMutableState.On("IsWorkflowExecutionRunning").Return(true)
 	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(currentWorkflowPolicy, nil).Times(1)
+	targetWorkflow.EXPECT().revive().Return(nil).Times(1)
 
 	targetContext.On(
 		"conflictResolveWorkflowExecution",
@@ -426,6 +427,7 @@ func (s *nDCTransactionMgrForExistingWorkflowSuite) TestDispatchForExistingWorkf
 	currentWorkflowPolicy := transactionPolicyActive
 	currentMutableState.On("IsWorkflowExecutionRunning").Return(true)
 	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(currentWorkflowPolicy, nil).Times(1)
+	targetWorkflow.EXPECT().revive().Return(nil).Times(1)
 
 	targetContext.On(
 		"conflictResolveWorkflowExecution",

--- a/service/history/nDCTransactionMgrForNewWorkflow.go
+++ b/service/history/nDCTransactionMgrForNewWorkflow.go
@@ -262,6 +262,9 @@ func (r *nDCTransactionMgrForNewWorkflowImpl) suppressCurrentAndCreateAsCurrent(
 	if err != nil {
 		return err
 	}
+	if err := targetWorkflow.revive(); err != nil {
+		return err
+	}
 
 	return currentWorkflow.getContext().updateWorkflowExecutionWithNew(
 		now,

--- a/service/history/nDCTransactionMgrForNewWorkflow_test.go
+++ b/service/history/nDCTransactionMgrForNewWorkflow_test.go
@@ -353,6 +353,7 @@ func (s *nDCTransactionMgrForNewWorkflowSuite) TestDispatchForNewWorkflow_Suppre
 	currentMutableState.On("IsWorkflowExecutionRunning").Return(true)
 	currentWorkflowPolicy := transactionPolicyActive
 	currentWorkflow.EXPECT().suppressWorkflowBy(targetWorkflow).Return(currentWorkflowPolicy, nil).Times(1)
+	targetWorkflow.EXPECT().revive().Return(nil).Times(1)
 
 	currentContext.On(
 		"updateWorkflowExecutionWithNew",

--- a/service/history/nDCWorkflow_mock.go
+++ b/service/history/nDCWorkflow_mock.go
@@ -128,6 +128,20 @@ func (mr *MocknDCWorkflowMockRecorder) happensAfter(that interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "happensAfter", reflect.TypeOf((*MocknDCWorkflow)(nil).happensAfter), that)
 }
 
+// revive mocks base method
+func (m *MocknDCWorkflow) revive() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "revive")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// revive indicates an expected call of revive
+func (mr *MocknDCWorkflowMockRecorder) revive() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "revive", reflect.TypeOf((*MocknDCWorkflow)(nil).revive))
+}
+
 // suppressWorkflowBy mocks base method
 func (m *MocknDCWorkflow) suppressWorkflowBy(incomingWorkflow nDCWorkflow) (transactionPolicy, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
* NDC transaction manager backfill events should use active transaction policy if target workflow is current workflow & target workflow is active
* Fix NDC transaction manager target workflow transient from zombie to non-zombie state
* Add more unit test for NDC transaction manager
* Fix null pointer in history engine reapply events API