### PR TITLE
Improve cross compile functionality on Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 .PHONY: test bins clean cover cover_ci
 PROJECT_ROOT = github.com/uber/cadence
 
-export PATH := $(GOPATH)/bin:$(PATH)
+export PATH := $(shell go env GOPATH)/bin:$(PATH)
+
+ifndef GOOS
+GOOS := $(shell go env GOOS)
+endif
+
+ifndef GOARCH
+GOARCH := $(shell go env GOARCH)
+endif
 
 THRIFT_GENDIR=.gen
 
@@ -97,8 +105,8 @@ GOCOVERPKG_ARG := -coverpkg="$(PROJECT_ROOT)/common/...,$(PROJECT_ROOT)/service/
 
 yarpc-install:
 	GO111MODULE=off go get -u github.com/myitcv/gobin
-	gobin -mod=readonly go.uber.org/thriftrw
-	gobin -mod=readonly go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
+	GOOS= GOARCH= gobin -mod=readonly go.uber.org/thriftrw
+	GOOS= GOARCH= gobin -mod=readonly go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
 
 clean_thrift:
 	rm -rf .gen
@@ -109,15 +117,19 @@ copyright: cmd/tools/copyright/licensegen.go
 	GOOS= GOARCH= go run ./cmd/tools/copyright/licensegen.go --verifyOnly
 
 cadence-cassandra-tool: $(TOOLS_SRC)
+	@echo "compiling cadence-cassandra-tool with OS: $(GOOS), ARCH: $(GOARCH)"
 	go build -i -o cadence-cassandra-tool cmd/tools/cassandra/main.go
 
 cadence-sql-tool: $(TOOLS_SRC)
+	@echo "compiling cadence-sql-tool with OS: $(GOOS), ARCH: $(GOARCH)"
 	go build -i -o cadence-sql-tool cmd/tools/sql/main.go
 
 cadence: $(TOOLS_SRC)
+	@echo "compiling cadence with OS: $(GOOS), ARCH: $(GOARCH)"
 	go build -i -o cadence cmd/tools/cli/main.go
 
 cadence-server: $(ALL_SRC)
+	@echo "compiling cadence-server with OS: $(GOOS), ARCH: $(GOARCH)"
 	go build -ldflags '$(GO_BUILD_LDFLAGS)' -i -o cadence-server cmd/server/cadence.go cmd/server/server.go
 
 bins_nothrift: lint copyright cadence-cassandra-tool cadence-sql-tool cadence cadence-server

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ THRIFTRW_GEN_SRC += $(THRIFT_GENDIR)/go/$1/$1.go
 
 $(THRIFT_GENDIR)/go/$1/$1.go:: $2
 	@mkdir -p $(THRIFT_GENDIR)/go
-	$(GOPATH)/bin/thriftrw --plugin=yarpc --pkg-prefix=$(PROJECT_ROOT)/$(THRIFT_GENDIR)/go/ --out=$(THRIFT_GENDIR)/go $2
+	thriftrw --plugin=yarpc --pkg-prefix=$(PROJECT_ROOT)/$(THRIFT_GENDIR)/go/ --out=$(THRIFT_GENDIR)/go $2
 endef
 
 $(foreach tsrc,$(THRIFTRW_SRCS),$(eval $(call \


### PR DESCRIPTION
* Use default GOOS & GOARCH for gobin thriftrw & thriftrw-plugin-yarpc
* Echo GOOS and GOARCH before compiling binaries.
* Compile with default GOOS & GOARCH:
```
cadence|master⚡ ⇒ make bins
GO111MODULE=off go get -u github.com/myitcv/gobin
GOOS= GOARCH= gobin -mod=readonly go.uber.org/thriftrw
Installed go.uber.org/thriftrw@v1.20.0 to /Users/wenquanxing/gocode/bin/thriftrw
GOOS= GOARCH= gobin -mod=readonly go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
Installed go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc@v1.39.0 to /Users/wenquanxing/gocode/bin/thriftrw-plugin-yarpc
Running linter
GOOS= GOARCH= go run ./cmd/tools/copyright/licensegen.go --verifyOnly
compiling cadence-cassandra-tool with OS: darwin, ARCH: amd64
go build -i -o cadence-cassandra-tool cmd/tools/cassandra/main.go
compiling cadence-sql-tool with OS: darwin, ARCH: amd64
go build -i -o cadence-sql-tool cmd/tools/sql/main.go
compiling cadence with OS: darwin, ARCH: amd64
go build -i -o cadence cmd/tools/cli/main.go
compiling cadence-server with OS: darwin, ARCH: amd64
go build -ldflags '-X github.com/uber/cadence/common/metrics.Revision=1e9e137a -X github.com/uber/cadence/common/metrics.Branch=master -X github.com/uber/cadence/common/metrics.Version=v0.8.1 -X github.com/uber/cadence/common/metrics.BuildDate=2019-09-25-20:23:15 -X github.com/uber/cadence/common/metrics.BuildTimeUnix=1569468195' -i -o cadence-server cmd/server/cadence.go cmd/server/server.go
```
* Compile with GOOS & GOARCH set:
```
cadence|master⚡ ⇒ GOOS=linux GOARCH=amd64 make bins
GO111MODULE=off go get -u github.com/myitcv/gobin
GOOS= GOARCH= gobin -mod=readonly go.uber.org/thriftrw
Installed go.uber.org/thriftrw@v1.20.0 to /Users/wenquanxing/gocode/bin/thriftrw
GOOS= GOARCH= gobin -mod=readonly go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc
Installed go.uber.org/yarpc/encoding/thrift/thriftrw-plugin-yarpc@v1.39.0 to /Users/wenquanxing/gocode/bin/thriftrw-plugin-yarpc
Running linter
GOOS= GOARCH= go run ./cmd/tools/copyright/licensegen.go --verifyOnly
compiling cadence-cassandra-tool with OS: linux, ARCH: amd64
go build -i -o cadence-cassandra-tool cmd/tools/cassandra/main.go
compiling cadence-sql-tool with OS: linux, ARCH: amd64
go build -i -o cadence-sql-tool cmd/tools/sql/main.go
compiling cadence with OS: linux, ARCH: amd64
go build -i -o cadence cmd/tools/cli/main.go
compiling cadence-server with OS: linux, ARCH: amd64
go build -ldflags '-X github.com/uber/cadence/common/metrics.Revision=1e9e137a -X github.com/uber/cadence/common/metrics.Branch=master -X github.com/uber/cadence/common/metrics.Version=v0.8.1 -X github.com/uber/cadence/common/metrics.BuildDate=2019-09-25-20:24:22 -X github.com/uber/cadence/common/metrics.BuildTimeUnix=1569468262' -i -o cadence-server cmd/server/cadence.go cmd/server/server.go
```