### PR TITLE
Remove unnecessary user timer API in timer builder

### DIFF
--- a/service/history/decisionTaskHandler.go
+++ b/service/history/decisionTaskHandler.go
@@ -311,10 +311,9 @@ func (handler *decisionTaskHandlerImpl) handleDecisionStartTimer(
 		return err
 	}
 
-	_, ti, err := handler.mutableState.AddTimerStartedEvent(handler.decisionTaskCompletedID, attr)
+	_, _, err := handler.mutableState.AddTimerStartedEvent(handler.decisionTaskCompletedID, attr)
 	switch err.(type) {
 	case nil:
-		handler.timerBuilder.AddUserTimer(ti, handler.mutableState)
 		return nil
 	case *workflow.BadRequestError:
 		return handler.handlerFailDecision(

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1311,7 +1311,6 @@ func (e *mutableStateBuilder) getDecisionInfo() *decisionInfo {
 	if e.IsStickyTaskListEnabled() {
 		taskList = e.executionInfo.StickyTaskList
 	}
-
 	return &decisionInfo{
 		Version:                    e.executionInfo.DecisionVersion,
 		ScheduleID:                 e.executionInfo.DecisionScheduleID,

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1311,6 +1311,7 @@ func (e *mutableStateBuilder) getDecisionInfo() *decisionInfo {
 	if e.IsStickyTaskListEnabled() {
 		taskList = e.executionInfo.StickyTaskList
 	}
+
 	return &decisionInfo{
 		Version:                    e.executionInfo.DecisionVersion,
 		ScheduleID:                 e.executionInfo.DecisionScheduleID,

--- a/service/history/stateBuilder.go
+++ b/service/history/stateBuilder.go
@@ -716,7 +716,6 @@ func (b *stateBuilderImpl) scheduleUserTimerTask(
 	msBuilder mutableState,
 ) persistence.Task {
 	timerBuilder := b.getTimerBuilder(event)
-	timerBuilder.AddUserTimer(ti, msBuilder)
 	return timerBuilder.GetUserTimerTaskIfNeeded(msBuilder)
 }
 

--- a/service/history/timerBuilder.go
+++ b/service/history/timerBuilder.go
@@ -167,19 +167,6 @@ func (tb *timerBuilder) AddActivityTimeoutTask(scheduleID int64,
 	return timeOutTask
 }
 
-// AddUserTimer - Adds an user timeout request.
-func (tb *timerBuilder) AddUserTimer(ti *persistence.TimerInfo, msBuilder mutableState) {
-	if !tb.isLoadedUserTimers {
-		tb.loadUserTimers(msBuilder)
-	}
-	seqNum := tb.localSeqNumGen.NextSeq()
-	timer := &timerDetails{
-		TimerSequenceID: TimerSequenceID{VisibilityTimestamp: ti.ExpiryTime, TaskID: seqNum},
-		TimerID:         ti.TimerID,
-		TaskCreated:     ti.TaskID == TimerTaskStatusCreated}
-	tb.insertTimer(timer)
-}
-
 // GetUserTimerTaskIfNeeded - if we need create a timer task for the user timers
 func (tb *timerBuilder) GetUserTimerTaskIfNeeded(msBuilder mutableState) persistence.Task {
 	if !tb.isLoadedUserTimers {

--- a/service/history/timerBuilder_test.go
+++ b/service/history/timerBuilder_test.go
@@ -97,7 +97,6 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderSingleUserTimer() {
 	})
 	s.Nil(err)
 
-	tb.AddUserTimer(ti1, msb)
 	t1 := tb.GetUserTimerTaskIfNeeded(msb)
 
 	s.NotNil(t1)
@@ -130,14 +129,12 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 		StartToFireTimeoutSeconds: common.Int64Ptr(1),
 	})
 	s.Nil(err)
-	tb.AddUserTimer(tiBefore, msb)
 
-	_, tiAfter, err := msb.AddTimerStartedEvent(int64(3), &workflow.StartTimerDecisionAttributes{
+	_, _, err = msb.AddTimerStartedEvent(int64(3), &workflow.StartTimerDecisionAttributes{
 		TimerId:                   common.StringPtr("tid-after"),
 		StartToFireTimeoutSeconds: common.Int64Ptr(15),
 	})
 	s.Nil(err)
-	tb.AddUserTimer(tiAfter, msb)
 
 	t1 := tb.GetUserTimerTaskIfNeeded(msb)
 	s.NotNil(t1)
@@ -154,12 +151,11 @@ func (s *timerBuilderProcessorSuite) TestTimerBuilderMulitpleUserTimer() {
 		TimerInfos:    timerInfos,
 	})
 
-	_, ti3, err := msb.AddTimerStartedEvent(int64(3), &workflow.StartTimerDecisionAttributes{
+	_, _, err = msb.AddTimerStartedEvent(int64(3), &workflow.StartTimerDecisionAttributes{
 		TimerId:                   common.StringPtr("tid-after"),
 		StartToFireTimeoutSeconds: common.Int64Ptr(15),
 	})
 	s.Nil(err)
-	tb.AddUserTimer(ti3, msb)
 
 	t1 = tb.GetUserTimerTaskIfNeeded(msb)
 	s.NotNil(t1)

--- a/service/history/timerQueueProcessor_test.go
+++ b/service/history/timerQueueProcessor_test.go
@@ -199,7 +199,6 @@ func (s *timerQueueProcessorSuite) createExecutionWithTimers(domainID string, we
 			})
 		s.Nil(err)
 		timerInfos = append(timerInfos, ti)
-		tBuilder.AddUserTimer(ti, builder)
 	}
 
 	if t := tBuilder.GetUserTimerTaskIfNeeded(builder); t != nil {
@@ -249,10 +248,9 @@ func (s *timerQueueProcessorSuite) addUserTimer(domainID string, we workflow.Wor
 	condition := state.ExecutionInfo.NextEventID
 
 	// create a user timer
-	_, ti, err := builder.AddTimerStartedEvent(common.EmptyEventID,
+	_, _, err = builder.AddTimerStartedEvent(common.EmptyEventID,
 		&workflow.StartTimerDecisionAttributes{TimerId: common.StringPtr(timerID), StartToFireTimeoutSeconds: common.Int64Ptr(1)})
 	s.Nil(err)
-	tb.AddUserTimer(ti, builder)
 	t := tb.GetUserTimerTaskIfNeeded(builder)
 	s.NotNil(t)
 	timerTasks := []persistence.Task{t}
@@ -962,8 +960,6 @@ func (s *timerQueueProcessorSuite) TestTimerUserTimers_SameExpiry() {
 		&workflow.StartTimerDecisionAttributes{TimerId: common.StringPtr("tid2"), StartToFireTimeoutSeconds: common.Int64Ptr(1)})
 	s.Nil(err)
 
-	tBuilder.AddUserTimer(ti, builder)
-	tBuilder.AddUserTimer(ti2, builder)
 	t := tBuilder.GetUserTimerTaskIfNeeded(builder)
 	timerTasks = append(timerTasks, t)
 

--- a/service/history/timerQueueStandbyProcessor_test.go
+++ b/service/history/timerQueueStandbyProcessor_test.go
@@ -215,11 +215,10 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Pending() 
 
 	timerID := "timer"
 	timerTimeout := 2 * time.Second
-	event, timerInfo := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID, int64(timerTimeout.Seconds()))
+	event, _ = addTimerStartedEvent(msBuilder, event.GetEventId(), timerID, int64(timerTimeout.Seconds()))
 	nextEventID := event.GetEventId() + 1
 
 	tBuilder := newTimerBuilder(clock.NewRealTimeSource())
-	tBuilder.AddUserTimer(timerInfo, msBuilder)
 	timerTask := &persistence.TimerTaskInfo{
 		Version:             version,
 		DomainID:            s.domainID,
@@ -280,10 +279,9 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Success() 
 
 	timerID := "timer"
 	timerTimeout := 2 * time.Second
-	event, timerInfo := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID, int64(timerTimeout.Seconds()))
+	_, _ = addTimerStartedEvent(msBuilder, event.GetEventId(), timerID, int64(timerTimeout.Seconds()))
 
 	tBuilder := newTimerBuilder(clock.NewRealTimeSource())
-	tBuilder.AddUserTimer(timerInfo, msBuilder)
 	timerTask := &persistence.TimerTaskInfo{
 		Version:             version,
 		DomainID:            s.domainID,
@@ -337,15 +335,13 @@ func (s *timerQueueStandbyProcessorSuite) TestProcessExpiredUserTimer_Multiple()
 
 	timerID1 := "timer-1"
 	timerTimeout1 := 2 * time.Second
-	timerEvent1, timerInfo1 := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID1, int64(timerTimeout1.Seconds()))
+	timerEvent1, _ := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID1, int64(timerTimeout1.Seconds()))
 
 	timerID2 := "timer-2"
 	timerTimeout2 := 50 * time.Second
-	_, timerInfo2 := addTimerStartedEvent(msBuilder, event.GetEventId(), timerID2, int64(timerTimeout2.Seconds()))
+	_, _ = addTimerStartedEvent(msBuilder, event.GetEventId(), timerID2, int64(timerTimeout2.Seconds()))
 
 	tBuilder := newTimerBuilder(clock.NewRealTimeSource())
-	tBuilder.AddUserTimer(timerInfo1, msBuilder)
-	tBuilder.AddUserTimer(timerInfo2, msBuilder)
 
 	timerTask := &persistence.TimerTaskInfo{
 		Version:             version,


### PR DESCRIPTION
* Remove AddUserTimer in timerBuilder
* User timer generation is handled by closeTransactionHandleActivityUserTimerTasks in mutableState

solve #1046