### PR TITLE
Flush buffer events when workflow close

### DIFF
--- a/host/decision_test.go
+++ b/host/decision_test.go
@@ -350,12 +350,12 @@ func (s *integrationSuite) TestWorkflowTerminationSignalBeforeRegularDecisionSta
 		workflow.EventTypeDecisionTaskScheduled,
 		workflow.EventTypeWorkflowExecutionSignaled,
 		workflow.EventTypeDecisionTaskStarted,
+		workflow.EventTypeDecisionTaskFailed,
 		workflow.EventTypeWorkflowExecutionTerminated,
 	}
 	s.assertHistory(we, expectedHistory)
 }
 
-// TODO signals are left in buffer in this case, which will make reset losing signal
 func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStarted() {
 	id := uuid.New()
 	wt := "interation-workflow-transient-decision-test-type"
@@ -424,6 +424,8 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStar
 		workflow.EventTypeWorkflowExecutionStarted,
 		workflow.EventTypeDecisionTaskScheduled,
 		workflow.EventTypeDecisionTaskStarted,
+		workflow.EventTypeDecisionTaskFailed,
+		workflow.EventTypeWorkflowExecutionSignaled,
 		workflow.EventTypeWorkflowExecutionTerminated,
 	}
 	s.assertHistory(we, expectedHistory)
@@ -615,12 +617,12 @@ func (s *integrationSuite) TestWorkflowTerminationSignalBeforeTransientDecisionS
 		workflow.EventTypeWorkflowExecutionSignaled,
 		workflow.EventTypeDecisionTaskScheduled,
 		workflow.EventTypeDecisionTaskStarted,
+		workflow.EventTypeDecisionTaskFailed,
 		workflow.EventTypeWorkflowExecutionTerminated,
 	}
 	s.assertHistory(we, expectedHistory)
 }
 
-// TODO signals are left in buffer in this case, which will make reset losing signal
 func (s *integrationSuite) TestWorkflowTerminationSignalAfterTransientDecisionStarted() {
 	id := uuid.New()
 	wt := "interation-workflow-transient-decision-test-type"
@@ -717,6 +719,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterTransientDecisionSt
 		workflow.EventTypeDecisionTaskScheduled,
 		workflow.EventTypeDecisionTaskStarted,
 		workflow.EventTypeDecisionTaskFailed,
+		workflow.EventTypeWorkflowExecutionSignaled,
 		workflow.EventTypeWorkflowExecutionTerminated,
 	}
 	s.assertHistory(we, expectedHistory)

--- a/service/history/MockMutableState.go
+++ b/service/history/MockMutableState.go
@@ -902,13 +902,13 @@ func (_m *mockMutableState) AddStartChildWorkflowExecutionInitiatedEvent(_a0 int
 	return r0, r1, r2
 }
 
-// AddTimeoutWorkflowEvent provides a mock function with given fields:
-func (_m *mockMutableState) AddTimeoutWorkflowEvent() (*shared.HistoryEvent, error) {
-	ret := _m.Called()
+// AddTimeoutWorkflowEvent provides a mock function with given fields: _a0
+func (_m *mockMutableState) AddTimeoutWorkflowEvent(_a0 int64) (*shared.HistoryEvent, error) {
+	ret := _m.Called(_a0)
 
 	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func() *shared.HistoryEvent); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(int64) *shared.HistoryEvent); ok {
+		r0 = rf(_a0)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*shared.HistoryEvent)
@@ -916,8 +916,8 @@ func (_m *mockMutableState) AddTimeoutWorkflowEvent() (*shared.HistoryEvent, err
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(int64) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -1118,13 +1118,13 @@ func (_m *mockMutableState) AddWorkflowExecutionStartedEvent(_a0 shared.Workflow
 	return r0, r1
 }
 
-// AddWorkflowExecutionTerminatedEvent provides a mock function with given fields: _a0, _a1, _a2
-func (_m *mockMutableState) AddWorkflowExecutionTerminatedEvent(_a0 string, _a1 []byte, _a2 string) (*shared.HistoryEvent, error) {
-	ret := _m.Called(_a0, _a1, _a2)
+// AddWorkflowExecutionTerminatedEvent provides a mock function with given fields: _a0, _a1, _a2, _a3
+func (_m *mockMutableState) AddWorkflowExecutionTerminatedEvent(_a0 int64, _a1 string, _a2 []byte, _a3 string) (*shared.HistoryEvent, error) {
+	ret := _m.Called(_a0, _a1, _a2, _a3)
 
 	var r0 *shared.HistoryEvent
-	if rf, ok := ret.Get(0).(func(string, []byte, string) *shared.HistoryEvent); ok {
-		r0 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(0).(func(int64, string, []byte, string) *shared.HistoryEvent); ok {
+		r0 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*shared.HistoryEvent)
@@ -1132,8 +1132,8 @@ func (_m *mockMutableState) AddWorkflowExecutionTerminatedEvent(_a0 string, _a1 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string, []byte, string) error); ok {
-		r1 = rf(_a0, _a1, _a2)
+	if rf, ok := ret.Get(1).(func(int64, string, []byte, string) error); ok {
+		r1 = rf(_a0, _a1, _a2, _a3)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/service/history/decisionHandler.go
+++ b/service/history/decisionHandler.go
@@ -531,10 +531,13 @@ Update_History_Loop:
 					return nil, err
 				}
 
-				if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
+				eventBatchFirstEventID := msBuilder.GetNextEventID()
+				if err := terminateWorkflow(
+					msBuilder,
+					eventBatchFirstEventID,
 					common.FailureReasonTransactionSizeExceedsLimit,
 					[]byte(updateErr.Error()),
-					"cadence-history-server",
+					identityHistoryService,
 				); err != nil {
 					return nil, err
 				}

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1851,15 +1851,14 @@ func (e *historyEngineImpl) TerminateWorkflowExecution(
 				return ErrWorkflowCompleted
 			}
 
-			if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
+			eventBatchFirstEventID := msBuilder.GetNextEventID()
+			return terminateWorkflow(
+				msBuilder,
+				eventBatchFirstEventID,
 				request.GetReason(),
 				request.GetDetails(),
 				request.GetIdentity(),
-			); err != nil {
-				return &workflow.InternalServiceError{Message: "Unable to terminate workflow execution."}
-			}
-
-			return nil
+			)
 		})
 }
 

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -40,19 +40,8 @@ import (
 	"github.com/uber/cadence/common/persistence"
 )
 
-var (
-	errNoHistoryFound = errors.NewInternalFailureError("no history events found")
-
-	workflowTerminationReason   = "Terminate Workflow Due To Version Conflict."
-	workflowTerminationIdentity = "worker-service"
-
-	workflowResetReason = "Reset Workflow Due To Events Re-application."
-)
-
 type (
 	conflictResolverProvider func(context workflowExecutionContext, logger log.Logger) conflictResolver
-	stateBuilderProvider     func(msBuilder mutableState, logger log.Logger) stateBuilder
-	mutableStateProvider     func(domainEntry *cache.DomainCacheEntry, logger log.Logger) mutableState
 
 	historyReplicator struct {
 		shard             ShardContext

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -1092,7 +1092,9 @@ func (r *historyReplicator) terminateWorkflow(
 
 			// setting the current version to be the last write version
 			msBuilder.UpdateReplicationStateVersion(currentLastWriteVersion, true)
+			eventBatchFirstEventID := msBuilder.GetNextEventID()
 			if _, err := msBuilder.AddWorkflowExecutionTerminatedEvent(
+				eventBatchFirstEventID,
 				workflowTerminationReason,
 				[]byte(fmt.Sprintf("terminated by version: %v", incomingVersion)),
 				workflowTerminationIdentity,

--- a/service/history/mutableState.go
+++ b/service/history/mutableState.go
@@ -95,7 +95,7 @@ type (
 		AddSignalRequested(requestID string)
 		AddStartChildWorkflowExecutionFailedEvent(int64, workflow.ChildWorkflowExecutionFailedCause, *workflow.StartChildWorkflowExecutionInitiatedEventAttributes) (*workflow.HistoryEvent, error)
 		AddStartChildWorkflowExecutionInitiatedEvent(int64, string, *workflow.StartChildWorkflowExecutionDecisionAttributes) (*workflow.HistoryEvent, *persistence.ChildExecutionInfo, error)
-		AddTimeoutWorkflowEvent() (*workflow.HistoryEvent, error)
+		AddTimeoutWorkflowEvent(int64) (*workflow.HistoryEvent, error)
 		AddTimerCanceledEvent(int64, *workflow.CancelTimerDecisionAttributes, string) (*workflow.HistoryEvent, error)
 		AddTimerFiredEvent(int64, string) (*workflow.HistoryEvent, error)
 		AddTimerStartedEvent(int64, *workflow.StartTimerDecisionAttributes) (*workflow.HistoryEvent, *persistence.TimerInfo, error)
@@ -104,7 +104,7 @@ type (
 		AddWorkflowExecutionCanceledEvent(int64, *workflow.CancelWorkflowExecutionDecisionAttributes) (*workflow.HistoryEvent, error)
 		AddWorkflowExecutionSignaled(signalName string, input []byte, identity string) (*workflow.HistoryEvent, error)
 		AddWorkflowExecutionStartedEvent(workflow.WorkflowExecution, *h.StartWorkflowExecutionRequest) (*workflow.HistoryEvent, error)
-		AddWorkflowExecutionTerminatedEvent(reason string, details []byte, identity string) (*workflow.HistoryEvent, error)
+		AddWorkflowExecutionTerminatedEvent(firstEventID int64, reason string, details []byte, identity string) (*workflow.HistoryEvent, error)
 		ClearStickyness()
 		CheckResettable() error
 		CopyToPersistence() *persistence.WorkflowMutableState

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2447,7 +2447,10 @@ func (e *mutableStateBuilder) AddTimeoutWorkflowEvent(
 	}
 
 	event := e.hBuilder.AddTimeoutWorkflowEvent()
-	if err := e.ReplicateWorkflowExecutionTimedoutEvent(event.GetEventId(), event); err != nil {
+	if err := e.ReplicateWorkflowExecutionTimedoutEvent(
+		firstEventID,
+		event,
+	); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -3039,7 +3042,10 @@ func (e *mutableStateBuilder) AddWorkflowExecutionTerminatedEvent(
 	}
 
 	event := e.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity)
-	if err := e.ReplicateWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
+	if err := e.ReplicateWorkflowExecutionTerminatedEvent(
+		firstEventID,
+		event,
+	); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2437,7 +2437,9 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionFailedEvent(
 	return nil
 }
 
-func (e *mutableStateBuilder) AddTimeoutWorkflowEvent() (*workflow.HistoryEvent, error) {
+func (e *mutableStateBuilder) AddTimeoutWorkflowEvent(
+	firstEventID int64,
+) (*workflow.HistoryEvent, error) {
 
 	opTag := tag.WorkflowActionWorkflowTimeout
 	if err := e.checkMutability(opTag); err != nil {
@@ -3025,6 +3027,7 @@ func (e *mutableStateBuilder) AddRecordMarkerEvent(
 }
 
 func (e *mutableStateBuilder) AddWorkflowExecutionTerminatedEvent(
+	firstEventID int64,
 	reason string,
 	details []byte,
 	identity string,
@@ -3036,7 +3039,7 @@ func (e *mutableStateBuilder) AddWorkflowExecutionTerminatedEvent(
 	}
 
 	event := e.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity)
-	if err := e.ReplicateWorkflowExecutionTerminatedEvent(event.GetEventId(), event); err != nil {
+	if err := e.ReplicateWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -2447,10 +2447,7 @@ func (e *mutableStateBuilder) AddTimeoutWorkflowEvent(
 	}
 
 	event := e.hBuilder.AddTimeoutWorkflowEvent()
-	if err := e.ReplicateWorkflowExecutionTimedoutEvent(
-		firstEventID,
-		event,
-	); err != nil {
+	if err := e.ReplicateWorkflowExecutionTimedoutEvent(firstEventID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation
@@ -3042,10 +3039,7 @@ func (e *mutableStateBuilder) AddWorkflowExecutionTerminatedEvent(
 	}
 
 	event := e.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity)
-	if err := e.ReplicateWorkflowExecutionTerminatedEvent(
-		firstEventID,
-		event,
-	); err != nil {
+	if err := e.ReplicateWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
 		return nil, err
 	}
 	// TODO merge active & passive task generation

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -38,7 +38,22 @@ import (
 	"github.com/uber/cadence/common/persistence"
 )
 
+var (
+	workflowTerminationReason   = "Terminate Workflow Due To Version Conflict."
+	workflowTerminationIdentity = "worker-service"
+	workflowResetReason         = "Reset Workflow Due To Events Re-application."
+)
+
 type (
+	stateBuilderProvider func(
+		msBuilder mutableState,
+		logger log.Logger) stateBuilder
+
+	mutableStateProvider func(
+		domainEntry *cache.DomainCacheEntry,
+		logger log.Logger,
+	) mutableState
+
 	nDCBranchMgrProvider func(
 		context workflowExecutionContext,
 		mutableState mutableState,

--- a/service/history/nDCWorkflow.go
+++ b/service/history/nDCWorkflow.go
@@ -258,6 +258,7 @@ func (r *nDCWorkflowImpl) terminateWorkflow(
 	incomingLastWriteVersion int64,
 ) error {
 
+	eventBatchFirstEventID := r.getMutableState().GetNextEventID()
 	if err := r.failDecision(lastWriteVersion); err != nil {
 		return err
 	}
@@ -268,6 +269,7 @@ func (r *nDCWorkflowImpl) terminateWorkflow(
 	}
 
 	_, err := r.mutableState.AddWorkflowExecutionTerminatedEvent(
+		eventBatchFirstEventID,
 		workflowTerminationReason,
 		[]byte(fmt.Sprintf("terminated by version: %v", incomingLastWriteVersion)),
 		workflowTerminationIdentity,

--- a/service/history/nDCWorkflow_test.go
+++ b/service/history/nDCWorkflow_test.go
@@ -274,6 +274,7 @@ func (s *nDCWorkflowSuite) TestSuppressWorkflowBy_Terminate() {
 			persistence.NewVersionHistoryItem(lastEventID, lastEventVersion),
 		},
 	))
+	s.mockMutableState.On("GetNextEventID").Return(lastEventID + 1)
 	s.mockMutableState.On("GetVersionHistories").Return(versionHistories)
 	s.mockMutableState.On("GetExecutionInfo").Return(&persistence.WorkflowExecutionInfo{
 		DomainID:        s.domainID,
@@ -344,7 +345,9 @@ func (s *nDCWorkflowSuite) TestSuppressWorkflowBy_Terminate() {
 	).Return(&shared.HistoryEvent{}, nil).Times(1)
 	s.mockMutableState.On("FlushBufferedEvents").Return(nil).Times(1)
 
-	s.mockMutableState.On("AddWorkflowExecutionTerminatedEvent", mock.Anything, mock.Anything, mock.Anything).Return(&shared.HistoryEvent{}, nil)
+	s.mockMutableState.On("AddWorkflowExecutionTerminatedEvent",
+		lastEventID+1, workflowTerminationReason, mock.Anything, workflowTerminationIdentity,
+	).Return(&shared.HistoryEvent{}, nil)
 
 	// if workflow is in zombie or finished state, keep as is
 	s.mockMutableState.On("IsWorkflowExecutionRunning").Return(false).Once()

--- a/service/history/workflowExecutionUtil.go
+++ b/service/history/workflowExecutionUtil.go
@@ -22,6 +22,7 @@ package history
 
 import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
 )
 
 func failDecision(
@@ -63,4 +64,81 @@ func scheduleDecision(
 		return &workflow.InternalServiceError{Message: "Failed to add decision scheduled event."}
 	}
 	return nil
+}
+
+func retryWorkflow(
+	mutableState mutableState,
+	eventBatchFirstEventID int64,
+	parentDomainName string,
+	continueAsNewAttributes *workflow.ContinueAsNewWorkflowExecutionDecisionAttributes,
+) (mutableState, error) {
+
+	if decision, ok := mutableState.GetInFlightDecision(); ok {
+		if err := failDecision(
+			mutableState,
+			decision,
+			workflow.DecisionTaskFailedCauseForceCloseDecision,
+		); err != nil {
+			return nil, err
+		}
+	}
+
+	_, newMutableState, err := mutableState.AddContinueAsNewEvent(
+		eventBatchFirstEventID,
+		common.EmptyEventID,
+		parentDomainName,
+		continueAsNewAttributes,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return newMutableState, nil
+}
+
+func timeoutWorkflow(
+	mutableState mutableState,
+	eventBatchFirstEventID int64,
+) error {
+
+	if decision, ok := mutableState.GetInFlightDecision(); ok {
+		if err := failDecision(
+			mutableState,
+			decision,
+			workflow.DecisionTaskFailedCauseForceCloseDecision,
+		); err != nil {
+			return err
+		}
+	}
+
+	_, err := mutableState.AddTimeoutWorkflowEvent(
+		eventBatchFirstEventID,
+	)
+	return err
+}
+
+func terminateWorkflow(
+	mutableState mutableState,
+	eventBatchFirstEventID int64,
+	terminateReason string,
+	terminateDetails []byte,
+	terminateIdentity string,
+) error {
+
+	if decision, ok := mutableState.GetInFlightDecision(); ok {
+		if err := failDecision(
+			mutableState,
+			decision,
+			workflow.DecisionTaskFailedCauseForceCloseDecision,
+		); err != nil {
+			return err
+		}
+	}
+
+	_, err := mutableState.AddWorkflowExecutionTerminatedEvent(
+		eventBatchFirstEventID,
+		terminateReason,
+		terminateDetails,
+		terminateIdentity,
+	)
+	return err
 }

--- a/service/history/workflowResetor.go
+++ b/service/history/workflowResetor.go
@@ -376,7 +376,9 @@ func (w *workflowResetorImpl) terminateIfCurrIsRunning(
 
 	if currMutableState.IsWorkflowExecutionRunning() {
 		terminateCurr = true
+		eventBatchFirstEventID := currMutableState.GetNextEventID()
 		if _, retError = currMutableState.AddWorkflowExecutionTerminatedEvent(
+			eventBatchFirstEventID,
 			reason,
 			nil,
 			identityHistoryService,

--- a/service/history/workflowResetter.go
+++ b/service/history/workflowResetter.go
@@ -436,22 +436,14 @@ func (r *workflowResetterImpl) terminateWorkflow(
 	terminateReason string,
 ) error {
 
-	if decision, ok := mutableState.GetInFlightDecision(); ok {
-		if err := failDecision(
-			mutableState,
-			decision,
-			shared.DecisionTaskFailedCauseForceCloseDecision,
-		); err != nil {
-			return err
-		}
-	}
-
-	_, err := mutableState.AddWorkflowExecutionTerminatedEvent(
+	eventBatchFirstEventID := mutableState.GetNextEventID()
+	return terminateWorkflow(
+		mutableState,
+		eventBatchFirstEventID,
 		terminateReason,
 		nil,
 		identityHistoryService,
 	)
-	return err
 }
 
 func (r *workflowResetterImpl) reapplyContinueAsNewWorkflowEvents(

--- a/service/history/workflowResetter_test.go
+++ b/service/history/workflowResetter_test.go
@@ -354,11 +354,13 @@ func (s *workflowResetterSuite) TestTerminateWorkflow() {
 		ScheduleID: 1234,
 		StartedID:  5678,
 	}
+	nextEventID := int64(666)
 	terminateReason := "some random terminate reason"
 
 	mutableState := &mockMutableState{}
 	defer mutableState.AssertExpectations(s.T())
 
+	mutableState.On("GetNextEventID").Return(nextEventID)
 	mutableState.On("GetInFlightDecision").Return(decision, true).Times(1)
 	mutableState.On("AddDecisionTaskFailedEvent",
 		decision.ScheduleID,
@@ -373,6 +375,7 @@ func (s *workflowResetterSuite) TestTerminateWorkflow() {
 	).Return(&shared.HistoryEvent{}, nil).Times(1)
 	mutableState.On("FlushBufferedEvents").Return(nil).Once()
 	mutableState.On("AddWorkflowExecutionTerminatedEvent",
+		nextEventID,
 		terminateReason,
 		([]byte)(nil),
 		identityHistoryService,


### PR DESCRIPTION
* Fail in flight decision & flush buffered events when workflow is timed out, terminated or retried (by continue as new)
* Update mutable state AddTimeoutWorkflowEvent / AddWorkflowExecutionTerminatedEvent accordingly