### PR TITLE
Adds prometheus config to config_template.yml

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -89,6 +89,7 @@ services:
         {{- else if .Env.PROMETHEUS_ENDPOINT }}
         metrics:
             prometheus:
+                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 
@@ -104,6 +105,7 @@ services:
         {{- else if .Env.PROMETHEUS_ENDPOINT }}
         metrics:
             prometheus:
+                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 
@@ -119,6 +121,7 @@ services:
         {{- else if .Env.PROMETHEUS_ENDPOINT }}
         metrics:
             prometheus:
+                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 
@@ -134,6 +137,7 @@ services:
         {{- else if .Env.PROMETHEUS_ENDPOINT }}
         metrics:
             prometheus:
+                timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -86,6 +86,10 @@ services:
             statsd:
                 hostPort: {{ .Env.STATSD_ENDPOINT }}
                 prefix: "cadence-frontend"
+        {{- else if .Env.PROMETHEUS_ENDPOINT }}
+        metrics:
+            prometheus:
+                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 
     matching:
@@ -97,6 +101,10 @@ services:
             statsd:
                 hostPort: {{ .Env.STATSD_ENDPOINT }}
                 prefix: "cadence-matching"
+        {{- else if .Env.PROMETHEUS_ENDPOINT }}
+        metrics:
+            prometheus:
+                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 
     history:
@@ -108,6 +116,10 @@ services:
             statsd:
                 hostPort: {{ .Env.STATSD_ENDPOINT }}
                 prefix: "cadence-history"
+        {{- else if .Env.PROMETHEUS_ENDPOINT }}
+        metrics:
+            prometheus:
+                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 
     worker:
@@ -119,6 +131,10 @@ services:
             statsd:
                 hostPort: {{ .Env.STATSD_ENDPOINT }}
                 prefix: "cadence-worker"
+        {{- else if .Env.PROMETHEUS_ENDPOINT }}
+        metrics:
+            prometheus:
+                listenAddress: {{ .Env.PROMETHEUS_ENDPOINT }}
         {{- end }}
 
 clusterMetadata:


### PR DESCRIPTION
Doesn't have `timerType` specified because it will cause error when
reporting histogram metrics