### PR TITLE
Build: use Go v1.13.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGET=server
 ARG GOPROXY
 
 # Build tcheck binary
-FROM golang:1.13.0-alpine AS tcheck
+FROM golang:1.13.3-alpine AS tcheck
 
 RUN apk add --update --no-cache ca-certificates git curl
 
@@ -25,7 +25,7 @@ RUN go install
 
 
 # Build Cadence binaries
-FROM golang:1.13.0-alpine AS builder
+FROM golang:1.13.3-alpine AS builder
 
 RUN apk add --update --no-cache ca-certificates make git curl mercurial bzr
 

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.0
+FROM golang:1.13.3
 
 # Tried to set Python to ignore warnings due to the instructions at this link:
 # https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation


### PR DESCRIPTION
See [Go v1.13.3 - release notes](https://golang.org/doc/devel/release.html#go1.13).