### PR TITLE
Fix replication task nil bug

### DIFF
--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -171,12 +171,8 @@ func (p *replicatorQueueProcessorImpl) queueShutdown() error {
 
 func (p *replicatorQueueProcessorImpl) processSyncActivityTask(task *persistence.ReplicationTaskInfo) error {
 	replicationTask, err := p.generateSyncActivityTask(ctx.Background(), task)
-	if err != nil {
+	if err != nil || replicationTask == nil {
 		return err
-	}
-
-	if replicationTask == nil {
-		return nil
 	}
 
 	return p.replicator.Publish(replicationTask)
@@ -185,7 +181,7 @@ func (p *replicatorQueueProcessorImpl) processSyncActivityTask(task *persistence
 func (p *replicatorQueueProcessorImpl) processHistoryReplicationTask(task *persistence.ReplicationTaskInfo) error {
 
 	replicationTask, err := p.toReplicationTask(ctx.Background(), task)
-	if err != nil {
+	if err != nil || replicationTask == nil {
 		return err
 	}
 

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -169,7 +169,10 @@ func (p *replicatorQueueProcessorImpl) queueShutdown() error {
 	return nil
 }
 
-func (p *replicatorQueueProcessorImpl) processSyncActivityTask(task *persistence.ReplicationTaskInfo) error {
+func (p *replicatorQueueProcessorImpl) processSyncActivityTask(
+	task *persistence.ReplicationTaskInfo,
+) error {
+
 	replicationTask, err := p.generateSyncActivityTask(ctx.Background(), task)
 	if err != nil || replicationTask == nil {
 		return err
@@ -178,7 +181,9 @@ func (p *replicatorQueueProcessorImpl) processSyncActivityTask(task *persistence
 	return p.replicator.Publish(replicationTask)
 }
 
-func (p *replicatorQueueProcessorImpl) processHistoryReplicationTask(task *persistence.ReplicationTaskInfo) error {
+func (p *replicatorQueueProcessorImpl) processHistoryReplicationTask(
+	task *persistence.ReplicationTaskInfo,
+) error {
 
 	replicationTask, err := p.toReplicationTask(ctx.Background(), task)
 	if err != nil || replicationTask == nil {


### PR DESCRIPTION
Replication task generator will return nil if the version is mismatch. We should return if the task is nil.