### PR TITLE
Set default event store version to v2 in apply events

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1745,10 +1745,6 @@ func (e *historyEngineImpl) ReplicateEvents(
 	replicateRequest *h.ReplicateEventsRequest,
 ) error {
 
-	// This is to make new release after event v1 deprecation forward-compatible
-	replicateRequest.EventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
-	replicateRequest.NewRunEventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
-
 	return e.replicator.ApplyEvents(ctx, replicateRequest)
 }
 
@@ -1756,10 +1752,6 @@ func (e *historyEngineImpl) ReplicateRawEvents(
 	ctx ctx.Context,
 	replicateRequest *h.ReplicateRawEventsRequest,
 ) error {
-
-	// This is to make new release after event v1 deprecation forward-compatible
-	replicateRequest.EventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
-	replicateRequest.NewRunEventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
 
 	return e.replicator.ApplyRawEvents(ctx, replicateRequest)
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1745,6 +1745,10 @@ func (e *historyEngineImpl) ReplicateEvents(
 	replicateRequest *h.ReplicateEventsRequest,
 ) error {
 
+	// This is to make new release after event v1 deprecation forward-compatible
+	replicateRequest.EventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
+	replicateRequest.NewRunEventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
+
 	return e.replicator.ApplyEvents(ctx, replicateRequest)
 }
 
@@ -1752,6 +1756,10 @@ func (e *historyEngineImpl) ReplicateRawEvents(
 	ctx ctx.Context,
 	replicateRequest *h.ReplicateRawEventsRequest,
 ) error {
+
+	// This is to make new release after event v1 deprecation forward-compatible
+	replicateRequest.EventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
+	replicateRequest.NewRunEventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
 
 	return e.replicator.ApplyRawEvents(ctx, replicateRequest)
 }

--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -375,6 +375,11 @@ func (r *historyReplicator) ApplyEvents(
 		r.metricsClient.IncCounter(metrics.ReplicateHistoryEventsScope, metrics.EmptyReplicationEventsCounter)
 		return nil
 	}
+
+	// This is to make new release after event v1 deprecation forward-compatible
+	request.EventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
+	request.NewRunEventStoreVersion = common.Int32Ptr(persistence.EventStoreVersionV2)
+
 	domainID, err := validateDomainUUID(request.DomainUUID)
 	if err != nil {
 		return err


### PR DESCRIPTION
Set default event store version to v2 in apply events. This change is needed before service upgrade to 0.10