### PR TITLE
CLI: add missing memo in describe workflow

### DIFF
--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -862,6 +862,7 @@ type workflowExecutionInfo struct {
 	HistoryLength    *int64
 	ParentDomainID   *string
 	ParentExecution  *shared.WorkflowExecution
+	Memo             *shared.Memo
 	SearchAttributes map[string]interface{}
 	AutoResetPoints  *shared.ResetPoints
 }
@@ -896,6 +897,7 @@ func convertDescribeWorkflowExecutionResponse(resp *shared.DescribeWorkflowExecu
 		HistoryLength:    info.HistoryLength,
 		ParentDomainID:   info.ParentDomainId,
 		ParentExecution:  info.ParentExecution,
+		Memo:             info.Memo,
 		SearchAttributes: convertSearchAttributesToMapOfInterface(info.SearchAttributes, wfClient, c),
 		AutoResetPoints:  info.AutoResetPoints,
 	}


### PR DESCRIPTION
Currently only `cadence --do <domain> wf desc -w <wid> -praw` will output memo, but basic `wf desc` doesn't print memo.

This PR print it even though we cannot decode memo.