### PR TITLE
Optimize parent close policy system workflow

### DIFF
--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -1567,6 +1567,10 @@ func (t *transferQueueActiveProcessorImpl) processParentClosePolicy(
 			})
 		}
 
+		if len(executions) == 0{
+			return nil
+		}
+
 		request := parentclosepolicy.Request{
 			DomainUUID: domainID,
 			DomainName: domainName,


### PR DESCRIPTION
Do not trigger system workflow if all the children are to abandon.