### PR TITLE
Use cron workflow for history scanner workflow

### DIFF
--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -83,6 +83,7 @@ var (
 		TaskList:                     historyScannerTaskListName,
 		ExecutionStartToCloseTimeout: infiniteDuration,
 		WorkflowIDReusePolicy:        cclient.WorkflowIDReusePolicyAllowDuplicate,
+		CronSchedule:                 "0 */12 * * *",
 	}
 )
 


### PR DESCRIPTION
Same as tasklist scanner, we should use cron scheduler for scanner workflow to make sure they are continue with new run after first run finishes.