### PR TITLE
Fix zombie workflow continue as new issue since new run may exits

### DIFF
--- a/service/history/nDCTransactionMgr.go
+++ b/service/history/nDCTransactionMgr.go
@@ -117,6 +117,12 @@ type (
 			targetWorkflowEvents *persistence.WorkflowEvents,
 		) error
 
+		checkWorkflowExists(
+			ctx ctx.Context,
+			domainID string,
+			workflowID string,
+			runID string,
+		) (bool, error)
 		getCurrentWorkflowRunID(
 			ctx ctx.Context,
 			domainID string,
@@ -301,6 +307,33 @@ func (r *nDCTransactionMgrImpl) backfillWorkflow(
 		transactionPolicy,
 		nil,
 	)
+}
+
+func (r *nDCTransactionMgrImpl) checkWorkflowExists(
+	ctx ctx.Context,
+	domainID string,
+	workflowID string,
+	runID string,
+) (bool, error) {
+
+	_, err := r.shard.GetExecutionManager().GetWorkflowExecution(
+		&persistence.GetWorkflowExecutionRequest{
+			DomainID: domainID,
+			Execution: shared.WorkflowExecution{
+				WorkflowId: common.StringPtr(workflowID),
+				RunId:      common.StringPtr(runID),
+			},
+		},
+	)
+
+	switch err.(type) {
+	case nil:
+		return true, nil
+	case *shared.EntityNotExistsError:
+		return false, nil
+	default:
+		return false, err
+	}
 }
 
 func (r *nDCTransactionMgrImpl) getCurrentWorkflowRunID(

--- a/service/history/nDCTransactionMgr_mock.go
+++ b/service/history/nDCTransactionMgr_mock.go
@@ -102,6 +102,21 @@ func (mr *MocknDCTransactionMgrMockRecorder) backfillWorkflow(ctx, now, targetWo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "backfillWorkflow", reflect.TypeOf((*MocknDCTransactionMgr)(nil).backfillWorkflow), ctx, now, targetWorkflow, targetWorkflowEvents)
 }
 
+// checkWorkflowExists mocks base method
+func (m *MocknDCTransactionMgr) checkWorkflowExists(ctx context.Context, domainID, workflowID, runID string) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "checkWorkflowExists", ctx, domainID, workflowID, runID)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// checkWorkflowExists indicates an expected call of checkWorkflowExists
+func (mr *MocknDCTransactionMgrMockRecorder) checkWorkflowExists(ctx, domainID, workflowID, runID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "checkWorkflowExists", reflect.TypeOf((*MocknDCTransactionMgr)(nil).checkWorkflowExists), ctx, domainID, workflowID, runID)
+}
+
 // getCurrentWorkflowRunID mocks base method
 func (m *MocknDCTransactionMgr) getCurrentWorkflowRunID(ctx context.Context, domainID, workflowID string) (string, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
* Due to workflow resend, workflow can be applied in different order. This means that logic need to check whether new workflow exists before applying continue as new as zombie