### PR TITLE
Adding auto-reset points to visibility record

### DIFF
--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -24,17 +24,18 @@ import "github.com/uber/cadence/.gen/go/shared"
 
 // valid indexed fields on ES
 const (
-	DomainID      = "DomainID"
-	WorkflowID    = "WorkflowID"
-	RunID         = "RunID"
-	WorkflowType  = "WorkflowType"
-	StartTime     = "StartTime"
-	ExecutionTime = "ExecutionTime"
-	CloseTime     = "CloseTime"
-	CloseStatus   = "CloseStatus"
-	HistoryLength = "HistoryLength"
-	Encoding      = "Encoding"
-	KafkaKey      = "KafkaKey"
+	DomainID        = "DomainID"
+	WorkflowID      = "WorkflowID"
+	RunID           = "RunID"
+	WorkflowType    = "WorkflowType"
+	StartTime       = "StartTime"
+	ExecutionTime   = "ExecutionTime"
+	CloseTime       = "CloseTime"
+	CloseStatus     = "CloseStatus"
+	HistoryLength   = "HistoryLength"
+	Encoding        = "Encoding"
+	KafkaKey        = "KafkaKey"
+	BinaryChecksums = "BinaryChecksums"
 
 	CustomStringField    = "CustomStringField"
 	CustomKeywordField   = "CustomKeywordField"
@@ -65,6 +66,7 @@ func createDefaultIndexedKeys() map[string]interface{} {
 		CustomDoubleField:    shared.IndexedValueTypeDouble,
 		CustomDatetimeField:  shared.IndexedValueTypeDatetime,
 		CadenceChangeVersion: shared.IndexedValueTypeKeyword,
+		BinaryChecksums:      shared.IndexedValueTypeKeyword,
 	}
 	for k, v := range systemIndexedKeys {
 		defaultIndexedKeys[k] = v

--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -31,5 +31,6 @@ frontend.validSearchAttributes:
       Operator: 1
       RolloutID: 1
       CadenceChangeVersion: 1
+      BinaryChecksums: 1
 system.minRetentionDays:
     - value: 0

--- a/host/testdata/es_index_template.json
+++ b/host/testdata/es_index_template.json
@@ -45,12 +45,23 @@
         },
         "Attr": {
           "properties": {
+            "CadenceChangeVersion":  { "type": "keyword" },
             "CustomStringField":  { "type": "text" },
             "CustomKeywordField": { "type": "keyword"},
             "CustomIntField": { "type": "long"},
             "CustomBoolField": { "type": "boolean"},
             "CustomDoubleField": { "type": "double"},
-            "CustomDatetimeField": { "type": "date"}
+            "CustomDatetimeField": { "type": "date"},
+            "project": { "type": "keyword"},
+            "service": { "type": "keyword"},
+            "environment": { "type": "keyword"},
+            "addon": { "type": "keyword"},
+            "addon-type": { "type": "keyword"},
+            "user": { "type": "keyword"},
+            "CustomDomain": { "type": "keyword"},
+            "Operator": { "type": "keyword"},
+            "RolloutID": { "type": "keyword"},
+            "BinaryChecksums": { "type": "keyword"}
           }
         }
       }

--- a/schema/elasticsearch/visibility/index_template.json
+++ b/schema/elasticsearch/visibility/index_template.json
@@ -60,7 +60,8 @@
             "user": { "type": "keyword"},
             "CustomDomain": { "type": "keyword"},
             "Operator": { "type": "keyword"},
-            "RolloutID": { "type": "keyword"}
+            "RolloutID": { "type": "keyword"},
+            "BinaryChecksums": { "type": "keyword"}
           }
         }
       }

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -202,7 +202,6 @@ func newMutableStateBuilder(
 		State:              persistence.WorkflowStateCreated,
 		CloseStatus:        persistence.WorkflowCloseStatusNone,
 		LastProcessedEvent: common.EmptyEventID,
-		SearchAttributes:   make(map[string][]byte),
 	}
 	s.hBuilder = newHistoryBuilder(s, logger)
 	s.taskGenerator = newMutableStateTaskGenerator(shard.GetDomainCache(), s.logger, s)
@@ -1934,6 +1933,9 @@ func (e *mutableStateBuilder) addBinaryCheckSumIfNotExists(
 	bytes, err := json.Marshal(recentBinaryChecksums)
 	if err != nil {
 		return err
+	}
+	if exeInfo.SearchAttributes == nil {
+		exeInfo.SearchAttributes = make(map[string][]byte)
 	}
 	exeInfo.SearchAttributes[definition.BinaryChecksums] = bytes
 	if e.shard.GetConfig().AdvancedVisibilityWritingMode() != common.AdvancedVisibilityWritingModeOff {

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -21,6 +21,7 @@
 package history
 
 import (
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -33,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -200,6 +202,7 @@ func newMutableStateBuilder(
 		State:              persistence.WorkflowStateCreated,
 		CloseStatus:        persistence.WorkflowCloseStatusNone,
 		LastProcessedEvent: common.EmptyEventID,
+		SearchAttributes:   make(map[string][]byte),
 	}
 	s.hBuilder = newHistoryBuilder(s, logger)
 	s.taskGenerator = newMutableStateTaskGenerator(shard.GetDomainCache(), s.logger, s)
@@ -1880,10 +1883,10 @@ func (e *mutableStateBuilder) CreateTransientDecisionEvents(
 func (e *mutableStateBuilder) addBinaryCheckSumIfNotExists(
 	event *workflow.HistoryEvent,
 	maxResetPoints int,
-) {
+) error {
 	binChecksum := event.GetDecisionTaskCompletedEventAttributes().GetBinaryChecksum()
 	if len(binChecksum) == 0 {
-		return
+		return nil
 	}
 	exeInfo := e.executionInfo
 	var currResetPoints []*workflow.ResetPointInfo
@@ -1893,17 +1896,24 @@ func (e *mutableStateBuilder) addBinaryCheckSumIfNotExists(
 		currResetPoints = make([]*workflow.ResetPointInfo, 0, 1)
 	}
 
+	// List of all recent binary checksums associated with the workflow.
+	var recentBinaryChecksums []string
+
 	for _, rp := range currResetPoints {
+		recentBinaryChecksums = append(recentBinaryChecksums, rp.GetBinaryChecksum())
 		if rp.GetBinaryChecksum() == binChecksum {
 			// this checksum already exists
-			return
+			return nil
 		}
 	}
 
 	if len(currResetPoints) == maxResetPoints {
-		// if exceeding the max limit, do rotation by taking the oldest one out
+		// If exceeding the max limit, do rotation by taking the oldest one out.
 		currResetPoints = currResetPoints[1:]
+		recentBinaryChecksums = recentBinaryChecksums[1:]
 	}
+	// Adding current version of the binary checksum.
+	recentBinaryChecksums = append(recentBinaryChecksums, binChecksum)
 
 	resettable := true
 	err := e.CheckResettable()
@@ -1921,6 +1931,15 @@ func (e *mutableStateBuilder) addBinaryCheckSumIfNotExists(
 	exeInfo.AutoResetPoints = &workflow.ResetPoints{
 		Points: currResetPoints,
 	}
+	bytes, err := json.Marshal(recentBinaryChecksums)
+	if err != nil {
+		return err
+	}
+	exeInfo.SearchAttributes[definition.BinaryChecksums] = bytes
+	if e.shard.GetConfig().AdvancedVisibilityWritingMode() != common.AdvancedVisibilityWritingModeOff {
+		return e.taskGenerator.generateWorkflowSearchAttrTasks(e.unixNanoToTime(event.GetTimestamp()))
+	}
+	return nil
 }
 
 // TODO: we will release the restriction when reset API allow those pending


### PR DESCRIPTION
This change:
* Introduces binary checksums into ElasticSearch by saving them in the mutableStateBuilder into the search attributes and adding a corresponding transfer task to upsert search attributes.
* Adds BinaryChecksums as a new indexed field in the elasticsearch.
* Whitelists this new property on the client side.