### PR TITLE
Add support for custom MySQL TLS configuration

### DIFF
--- a/common/auth/tls.go
+++ b/common/auth/tls.go
@@ -21,7 +21,7 @@
 package auth
 
 type (
-	// TLS describe TLS configuration (for Kafka, Cassandra)
+	// TLS describe TLS configuration (for Kafka, Cassandra, MySQL)
 	TLS struct {
 		Enabled bool `yaml:"enabled"`
 

--- a/common/persistence/sql/factory.go
+++ b/common/persistence/sql/factory.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/sql/storage"
+	"github.com/uber/cadence/common/persistence/sql/storage/mysql"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
 	"github.com/uber/cadence/common/service/config"
 )
@@ -142,11 +143,11 @@ func (c *dbConn) get() (sqldb.Interface, error) {
 	c.Lock()
 	defer c.Unlock()
 	if c.refCnt == 0 {
-		conn, err := storage.NewSQLDB(c.cfg)
+		db, err := storage.NewSQLDB(c.cfg)
 		if err != nil {
 			return nil, err
 		}
-		c.Interface = conn
+		c.Interface = mysql.NewDB(db, nil)
 	}
 	c.refCnt++
 	return c, nil

--- a/common/persistence/sql/sqlVisibilityStore.go
+++ b/common/persistence/sql/sqlVisibilityStore.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/sql/storage"
+	"github.com/uber/cadence/common/persistence/sql/storage/mysql"
 	"github.com/uber/cadence/common/persistence/sql/storage/sqldb"
 	"github.com/uber/cadence/common/service/config"
 )
@@ -54,7 +55,7 @@ func NewSQLVisibilityStore(cfg config.SQL, logger log.Logger) (p.VisibilityStore
 	}
 	return &sqlVisibilityStore{
 		sqlStore: sqlStore{
-			db:     db,
+			db:     mysql.NewDB(db, nil),
 			logger: logger,
 		},
 	}, nil

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -219,6 +219,8 @@ type (
 		// NumShards is the number of storage shards to use for tables
 		// in a sharded sql database. The default value for this param is 1
 		NumShards int `yaml:"nShards"`
+		// TLS configuration
+		TLS *auth.TLS `yaml:"tls"`
 	}
 
 	// Replicator describes the configuration of replicator

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -138,6 +138,9 @@ const (
 	// CLIFlagQuiet is the cli flag for quiet mode
 	CLIFlagQuiet = CLIOptQuiet + ", q"
 
+	// CLIFlagConnectAttributesTxIsolation controls the transaction isolation version for mysql
+	CLIFlagConnectAttributesTxIsolation = "tx-isolation"
+
 	// CLIFlagEnableTLS enables cassandra client TLS
 	CLIFlagEnableTLS = "tls"
 	// CLIFlagTLSCertFile is the optional tls cert file (tls must be enabled)

--- a/tools/sql-extensions/mysql/conn_test.go
+++ b/tools/sql-extensions/mysql/conn_test.go
@@ -21,12 +21,13 @@
 package mysql
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/environment"
 	"github.com/uber/cadence/tools/common/schema/test"
 	"github.com/uber/cadence/tools/sql"
@@ -70,13 +71,12 @@ func (s *SQLConnTestSuite) TestParseCQLFile() {
 }
 
 func (s *SQLConnTestSuite) TestSQLConn() {
-	conn, err := sql.NewConnection(&sql.ConnectParams{
-		Host:       environment.GetMySQLAddress(),
-		Port:       environment.GetMySQLPort(),
-		User:       testUser,
-		Password:   testPassword,
-		DriverName: driverName,
-		Database:   s.DBName,
+	conn, err := sql.NewConnection(&config.SQL{
+		ConnectAddr:  fmt.Sprintf("%v:%v", environment.GetMySQLAddress(), environment.GetMySQLPort()),
+		User:         testUser,
+		Password:     testPassword,
+		DriverName:   driverName,
+		DatabaseName: s.DBName,
 	})
 	s.Nil(err)
 	s.RunCreateTest(conn)
@@ -86,13 +86,12 @@ func (s *SQLConnTestSuite) TestSQLConn() {
 }
 
 func newTestConn(database string) (*sql.Connection, error) {
-	return sql.NewConnection(&sql.ConnectParams{
-		Host:       environment.GetMySQLAddress(),
-		Port:       environment.GetMySQLPort(),
-		User:       testUser,
-		Password:   testPassword,
-		DriverName: driverName,
-		Database:   database,
+	return sql.NewConnection(&config.SQL{
+		ConnectAddr:  fmt.Sprintf("%v:%v", environment.GetMySQLAddress(), environment.GetMySQLPort()),
+		User:         testUser,
+		Password:     testPassword,
+		DriverName:   driverName,
+		DatabaseName: database,
 	})
 }
 

--- a/tools/sql-extensions/mysql/driver.go
+++ b/tools/sql-extensions/mysql/driver.go
@@ -21,13 +21,11 @@
 package mysql
 
 import (
-	"fmt"
-
 	_ "github.com/go-sql-driver/mysql" // needed to load the mysql driver
-
 	"github.com/iancoleman/strcase"
 	"github.com/jmoiron/sqlx"
-
+	"github.com/uber/cadence/common/persistence/sql/storage"
+	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/tools/sql"
 )
 
@@ -80,8 +78,8 @@ func (d *driver) GetDriverName() string {
 	return driverName
 }
 
-func (d *driver) CreateDBConnection(driverName, host string, port int, user string, passwd string, database string) (*sqlx.DB, error) {
-	db, err := sqlx.Connect(driverName, fmt.Sprintf(dataSourceNameMySQL, user, passwd, "tcp", host, port, database))
+func (d *driver) CreateDBConnection(cfg *config.SQL) (*sqlx.DB, error) {
+	db, err := storage.NewSQLDB(cfg)
 
 	if err != nil {
 		return nil, err

--- a/tools/sql-extensions/mysql/handler_test.go
+++ b/tools/sql-extensions/mysql/handler_test.go
@@ -21,11 +21,12 @@
 package mysql
 
 import (
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-
+	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/environment"
 	"github.com/uber/cadence/tools/common/schema"
 	"github.com/uber/cadence/tools/sql"
@@ -46,17 +47,17 @@ func (s *HandlerTestSuite) SetupTest() {
 	s.Assertions = require.New(s.T()) // Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
 }
 
-func (s *HandlerTestSuite) TestValidateConnectParams() {
-	p := new(sql.ConnectParams)
-	s.NotNil(sql.ValidateConnectParams(p, false))
-	s.NotNil(sql.ValidateConnectParams(p, true))
+func (s *HandlerTestSuite) TestValidateConnectConfig() {
+	cfg := new(config.SQL)
+	s.NotNil(sql.ValidateConnectConfig(cfg, false))
+	s.NotNil(sql.ValidateConnectConfig(cfg, true))
 
-	p.Host = environment.GetMySQLAddress()
-	s.NotNil(sql.ValidateConnectParams(p, false))
-	s.Nil(sql.ValidateConnectParams(p, true))
-	s.Equal(schema.DryrunDBName, p.Database)
+	cfg.ConnectAddr = environment.GetMySQLAddress() + ":" + strconv.Itoa(environment.GetMySQLPort())
+	s.NotNil(sql.ValidateConnectConfig(cfg, false))
+	s.Nil(sql.ValidateConnectConfig(cfg, true))
+	s.Equal(schema.DryrunDBName, cfg.DatabaseName)
 
-	p.Database = "foobar"
-	s.Nil(sql.ValidateConnectParams(p, false))
-	s.Nil(sql.ValidateConnectParams(p, true))
+	cfg.DatabaseName = "foobar"
+	s.Nil(sql.ValidateConnectConfig(cfg, false))
+	s.Nil(sql.ValidateConnectConfig(cfg, true))
 }

--- a/tools/sql-extensions/postgres/driver.go
+++ b/tools/sql-extensions/postgres/driver.go
@@ -21,13 +21,11 @@
 package postgres
 
 import (
-	"fmt"
-
-	_ "github.com/lib/pq" // needed to load the postgres driver
-
 	"github.com/iancoleman/strcase"
 	"github.com/jmoiron/sqlx"
-
+	_ "github.com/lib/pq" // needed to load the postgres driver
+	"github.com/uber/cadence/common/persistence/sql/storage"
+	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/tools/sql"
 )
 
@@ -83,11 +81,8 @@ func (d *driver) GetDriverName() string {
 	return driverName
 }
 
-func (d *driver) CreateDBConnection(driverName, host string, port int, user string, passwd string, database string) (*sqlx.DB, error) {
-	if database == "" {
-		database = "postgres"
-	}
-	db, err := sqlx.Connect(driverName, fmt.Sprintf(dataSourceNamePostgres, user, passwd, host, port, database))
+func (d *driver) CreateDBConnection(cfg *config.SQL) (*sqlx.DB, error) {
+	db, err := storage.NewSQLDB(cfg)
 
 	if err != nil {
 		return nil, err

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -90,9 +90,34 @@ func BuildCLIOptions() *cli.App {
 			Usage:  "name of the sql driver",
 			EnvVar: "SQL_DRIVER",
 		},
+		cli.StringFlag{
+			Name:   schema.CLIFlagConnectAttributesTxIsolation,
+			Usage:  "tx-isolation version",
+			EnvVar: "CONNECT_ATTRIBUTES_TX_ISOLATION",
+		},
 		cli.BoolFlag{
 			Name:  schema.CLIFlagQuiet,
 			Usage: "Don't set exit status to 1 on error",
+		},
+		cli.BoolFlag{
+			Name:  schema.CLIFlagEnableTLS,
+			Usage: "enable TLS over sql connection",
+		},
+		cli.StringFlag{
+			Name:  schema.CLIFlagTLSCertFile,
+			Usage: "sql tls client cert path (tls must be enabled)",
+		},
+		cli.StringFlag{
+			Name:  schema.CLIFlagTLSKeyFile,
+			Usage: "sql tls client key path (tls must be enabled)",
+		},
+		cli.StringFlag{
+			Name:  schema.CLIFlagTLSCaFile,
+			Usage: "sql tls client ca path (tls must be enabled)",
+		},
+		cli.BoolFlag{
+			Name:  schema.CLIFlagTLSEnableHostVerification,
+			Usage: "sql tls verify hostname and server cert (tls must be enabled)",
 		},
 	}
 


### PR DESCRIPTION
This is an attempt to add support for TLS MySQL (we use RDS/Aurora and require TLS support) using the recently added TLS support for Cassandra. In the process it reuses the config in persistence for use in tools and removes ConnectParams. 

Feedback is welcome!