### PR TITLE
ContinueAsNew should track the workflow previous run for NDC enabled

### DIFF
--- a/service/history/historyReplicator.go
+++ b/service/history/historyReplicator.go
@@ -284,6 +284,11 @@ func (r *historyReplicator) ApplyEvents(
 				request.WorkflowExecution.GetRunId(), request, logger)
 		}
 
+		// Sanity check to make only 2DC mutable state here
+		if msBuilder.GetReplicationState() == nil {
+			return &workflow.InternalServiceError{Message: "The mutable state does not support 2DC."}
+		}
+
 		logger.WithTags(tag.CurrentVersion(msBuilder.GetReplicationState().LastWriteVersion))
 		msBuilder, err = r.ApplyOtherEventsVersionChecking(ctx, context, msBuilder, request, logger)
 		if err != nil || msBuilder == nil {

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -3246,10 +3246,11 @@ func (e *mutableStateBuilder) AddContinueAsNewEvent(
 	}
 	firstRunID := currentStartEvent.GetWorkflowExecutionStartedEventAttributes().GetFirstExecutionRunId()
 
+	domainName := e.domainEntry.GetInfo().Name
 	domainID := e.domainEntry.GetInfo().ID
 	var newStateBuilder *mutableStateBuilder
 	// If a workflow is ndc enabled, the continue as new should be ndc enabled.
-	if e.GetVersionHistories() != nil {
+	if e.config.EnableNDC(domainName) || e.GetVersionHistories() != nil {
 		newStateBuilder = newMutableStateBuilderWithVersionHistories(
 			e.shard,
 			e.shard.GetEventsCache(),

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -3246,10 +3246,10 @@ func (e *mutableStateBuilder) AddContinueAsNewEvent(
 	}
 	firstRunID := currentStartEvent.GetWorkflowExecutionStartedEventAttributes().GetFirstExecutionRunId()
 
-	domainName := e.domainEntry.GetInfo().Name
 	domainID := e.domainEntry.GetInfo().ID
 	var newStateBuilder *mutableStateBuilder
-	if e.config.EnableNDC(domainName) {
+	// If a workflow is ndc enabled, the continue as new should be ndc enabled.
+	if e.GetVersionHistories() != nil {
 		newStateBuilder = newMutableStateBuilderWithVersionHistories(
 			e.shard,
 			e.shard.GetEventsCache(),

--- a/service/history/nDCHistoryReplicator.go
+++ b/service/history/nDCHistoryReplicator.go
@@ -232,6 +232,11 @@ func (r *nDCHistoryReplicatorImpl) applyEvents(
 		mutableState, err := context.loadWorkflowExecution()
 		switch err.(type) {
 		case nil:
+			// Sanity check to make only 3DC mutable state here
+			if mutableState.GetVersionHistories() == nil {
+				return &shared.InternalServiceError{Message: "The mutable state does not support 3DC."}
+			}
+
 			doContinue, branchIndex, err := r.applyNonStartEventsPrepareBranch(ctx, context, mutableState, task)
 			if err != nil {
 				return err


### PR DESCRIPTION
ContinueAsNew should track the workflow previous run for NDC enabled