### PR TITLE
Add --datacenter option to cadence-cassandra-tool

### DIFF
--- a/tools/cassandra/README.md
+++ b/tools/cassandra/README.md
@@ -13,7 +13,7 @@ make install-schema
 - You should see an executable `cadence-cassandra-tool`
 
 ### Do one time database creation and schema setup for a new cluster
-This uses Cassandra's SimpleStratagey for replication. For production, we recommend using a replication factor of 3 with NetworkTopologyStrategy.
+This uses Cassandra's SimpleStratagey for replication. For production, we recommend also passing the `--datacenter` option (which uses NetworkTopologyStrategy), and using a replication factor of 3.
 
 ```
 cadence-cassandra-tool --ep $CASSANDRA_SEEDS create -k $KEYSPACE --rf $RF

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -179,6 +179,7 @@ func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 	config.Password = cli.GlobalString(schema.CLIOptPassword)
 	config.Timeout = cli.GlobalInt(schema.CLIOptTimeout)
 	config.Keyspace = cli.GlobalString(schema.CLIOptKeyspace)
+	config.datacenter = cli.String(schema.CLIOptDatacenter)
 	config.numReplicas = cli.Int(schema.CLIOptReplicationFactor)
 
 	if cli.GlobalBool(schema.CLIFlagEnableTLS) {

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -189,6 +189,10 @@ func buildCLIOptions() *cli.App {
 					Name:  schema.CLIFlagKeyspace,
 					Usage: "name of the Keyspace",
 				},
+				cli.StringFlag{
+					Name:  schema.CLIFlagDatacenter,
+					Usage: "datacenter for the Keyspace (if provided, uses NetworkTopologyStrategy instead of SimpleStrategy)",
+				},
 				cli.IntFlag{
 					Name:  schema.CLIFlagReplicationFactor,
 					Value: 1,

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -98,6 +98,8 @@ const (
 	CLIOptDryrun = "dryrun"
 	// CLIOptSchemaDir is the cli option for schema directory
 	CLIOptSchemaDir = "schema-dir"
+	// CLIOptDatacenter is the cli option for datacenter
+	CLIOptDatacenter = "datacenter"
 	// CLIOptReplicationFactor is the cli option for replication factor
 	CLIOptReplicationFactor = "replication-factor"
 	// CLIOptQuiet is the cli option for quiet mode
@@ -133,6 +135,8 @@ const (
 	CLIFlagDryrun = CLIOptDryrun + ", y"
 	// CLIFlagSchemaDir is the cli flag for schema directory
 	CLIFlagSchemaDir = CLIOptSchemaDir + ", d"
+	// CLIFlagDatacenter is the cli flag for datacenter
+	CLIFlagDatacenter = CLIOptDatacenter + ", dc"
 	// CLIFlagReplicationFactor is the cli flag for replication factor
 	CLIFlagReplicationFactor = CLIOptReplicationFactor + ", rf"
 	// CLIFlagQuiet is the cli flag for quiet mode


### PR DESCRIPTION
If passed, the tool will create the keyspace using NetworkTopologyStrategy instead of SimpleStrategy.