### PR TITLE
0.10.3

### DIFF
--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -98,7 +98,6 @@ var (
 // Pre-defined values for TagSysComponent
 var (
 	ComponentTaskList                 = component("tasklist")
-	ComponentHistoryBuilder           = component("history-builder")
 	ComponentHistoryEngine            = component("history-engine")
 	ComponentHistoryCache             = component("history-cache")
 	ComponentEventsCache              = component("events-cache")

--- a/common/quotas/multistageratelimiter.go
+++ b/common/quotas/multistageratelimiter.go
@@ -84,6 +84,13 @@ func (d *MultiStageRateLimiter) Allow(info Info) bool {
 		return false
 	}
 
+	// check whether the reservation is valid now, otherwise
+	// cancel and return right away so we can drop the request
+	if rsv.Delay() != 0 {
+		rsv.Cancel()
+		return false
+	}
+
 	// ensure that the reservation does not break the global rate limit, if it
 	// does, cancel the reservation and do not allow to proceed.
 	if !d.globalLimiter.Allow() {

--- a/host/continueasnew_test.go
+++ b/host/continueasnew_test.go
@@ -33,9 +33,9 @@ import (
 )
 
 func (s *integrationSuite) TestContinueAsNewWorkflow() {
-	id := "interation-continue-as-new-workflow-test"
-	wt := "interation-continue-as-new-workflow-test-type"
-	tl := "interation-continue-as-new-workflow-test-tasklist"
+	id := "integration-continue-as-new-workflow-test"
+	wt := "integration-continue-as-new-workflow-test-type"
+	tl := "integration-continue-as-new-workflow-test-tasklist"
 	identity := "worker1"
 
 	workflowType := &workflow.WorkflowType{}
@@ -139,9 +139,9 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 }
 
 func (s *integrationSuite) TestContinueAsNewWorkflow_Timeout() {
-	id := "interation-continue-as-new-workflow-timeout-test"
-	wt := "interation-continue-as-new-workflow-timeout-test-type"
-	tl := "interation-continue-as-new-workflow-timeout-test-tasklist"
+	id := "integration-continue-as-new-workflow-timeout-test"
+	wt := "integration-continue-as-new-workflow-timeout-test-type"
+	tl := "integration-continue-as-new-workflow-timeout-test-tasklist"
 	identity := "worker1"
 
 	workflowType := &workflow.WorkflowType{}

--- a/host/decision_test.go
+++ b/host/decision_test.go
@@ -32,7 +32,7 @@ import (
 
 func (s *integrationSuite) TestDecisionHeartbeatingWithEmptyResult() {
 	id := uuid.New()
-	wt := "interation-workflow-decision-heartbeating-local-activities"
+	wt := "integration-workflow-decision-heartbeating-local-activities"
 	tl := id
 	identity := "worker1"
 
@@ -139,7 +139,7 @@ func (s *integrationSuite) TestDecisionHeartbeatingWithEmptyResult() {
 
 func (s *integrationSuite) TestDecisionHeartbeatingWithLocalActivitiesResult() {
 	id := uuid.New()
-	wt := "interation-workflow-decision-heartbeating-local-activities"
+	wt := "integration-workflow-decision-heartbeating-local-activities"
 	tl := id
 	identity := "worker1"
 
@@ -283,7 +283,7 @@ func (s *integrationSuite) TestDecisionHeartbeatingWithLocalActivitiesResult() {
 
 func (s *integrationSuite) TestWorkflowTerminationSignalBeforeRegularDecisionStarted() {
 	id := uuid.New()
-	wt := "interation-workflow-transient-decision-test-type"
+	wt := "integration-workflow-transient-decision-test-type"
 	tl := id
 	identity := "worker1"
 
@@ -358,7 +358,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalBeforeRegularDecisionSta
 
 func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStarted() {
 	id := uuid.New()
-	wt := "interation-workflow-transient-decision-test-type"
+	wt := "integration-workflow-transient-decision-test-type"
 	tl := id
 	identity := "worker1"
 
@@ -433,7 +433,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStar
 
 func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStartedAndFailDecision() {
 	id := uuid.New()
-	wt := "interation-workflow-transient-decision-test-type"
+	wt := "integration-workflow-transient-decision-test-type"
 	tl := id
 	identity := "worker1"
 
@@ -520,7 +520,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterRegularDecisionStar
 
 func (s *integrationSuite) TestWorkflowTerminationSignalBeforeTransientDecisionStarted() {
 	id := uuid.New()
-	wt := "interation-workflow-transient-decision-test-type"
+	wt := "integration-workflow-transient-decision-test-type"
 	tl := id
 	identity := "worker1"
 
@@ -625,7 +625,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalBeforeTransientDecisionS
 
 func (s *integrationSuite) TestWorkflowTerminationSignalAfterTransientDecisionStarted() {
 	id := uuid.New()
-	wt := "interation-workflow-transient-decision-test-type"
+	wt := "integration-workflow-transient-decision-test-type"
 	tl := id
 	identity := "worker1"
 
@@ -727,7 +727,7 @@ func (s *integrationSuite) TestWorkflowTerminationSignalAfterTransientDecisionSt
 
 func (s *integrationSuite) TestWorkflowTerminationSignalAfterTransientDecisionStartedAndFailDecision() {
 	id := uuid.New()
-	wt := "interation-workflow-transient-decision-test-type"
+	wt := "integration-workflow-transient-decision-test-type"
 	tl := id
 	identity := "worker1"
 

--- a/host/gethistory_test.go
+++ b/host/gethistory_test.go
@@ -35,9 +35,9 @@ import (
 )
 
 func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
-	workflowID := "interation-get-workflow-history-events-long-poll-test-all"
-	workflowTypeName := "interation-get-workflow-history-events-long-poll-test-all-type"
-	tasklistName := "interation-get-workflow-history-events-long-poll-test-all-tasklist"
+	workflowID := "integration-get-workflow-history-events-long-poll-test-all"
+	workflowTypeName := "integration-get-workflow-history-events-long-poll-test-all-type"
+	tasklistName := "integration-get-workflow-history-events-long-poll-test-all-tasklist"
 	identity := "worker1"
 	activityName := "activity_type1"
 
@@ -203,9 +203,9 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_All() {
 }
 
 func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
-	workflowID := "interation-get-workflow-history-events-long-poll-test-close"
-	workflowTypeName := "interation-get-workflow-history-events-long-poll-test-close-type"
-	tasklistName := "interation-get-workflow-history-events-long-poll-test-close-tasklist"
+	workflowID := "integration-get-workflow-history-events-long-poll-test-close"
+	workflowTypeName := "integration-get-workflow-history-events-long-poll-test-close-type"
+	tasklistName := "integration-get-workflow-history-events-long-poll-test-close-tasklist"
 	identity := "worker1"
 	activityName := "activity_type1"
 
@@ -362,9 +362,9 @@ func (s *integrationSuite) TestGetWorkflowExecutionHistory_Close() {
 }
 
 func (s *integrationSuite) TestGetWorkflowExecutionRawHistory_All() {
-	workflowID := "interation-get-workflow-history-raw-events-all"
-	workflowTypeName := "interation-get-workflow-history-raw-events-all-type"
-	tasklistName := "interation-get-workflow-history-raw-events-all-tasklist"
+	workflowID := "integration-get-workflow-history-raw-events-all"
+	workflowTypeName := "integration-get-workflow-history-raw-events-all-type"
+	tasklistName := "integration-get-workflow-history-raw-events-all-tasklist"
 	identity := "worker1"
 	activityName := "activity_type1"
 

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -278,9 +278,9 @@ StartNewExecutionLoop:
 }
 
 func (s *integrationSuite) TestSequentialWorkflow() {
-	id := "interation-sequential-workflow-test"
-	wt := "interation-sequential-workflow-test-type"
-	tl := "interation-sequential-workflow-test-tasklist"
+	id := "integration-sequential-workflow-test"
+	wt := "integration-sequential-workflow-test-type"
+	tl := "integration-sequential-workflow-test-tasklist"
 	identity := "worker1"
 	activityName := "activity_type1"
 
@@ -388,9 +388,9 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 }
 
 func (s *integrationSuite) TestCompleteDecisionTaskAndCreateNewOne() {
-	id := "interation-complete-decision-create-new-test"
-	wt := "interation-complete-decision-create-new-test-type"
-	tl := "interation-complete-decision-create-new-test-tasklist"
+	id := "integration-complete-decision-create-new-test"
+	wt := "integration-complete-decision-create-new-test-type"
+	tl := "integration-complete-decision-create-new-test-tasklist"
 	identity := "worker1"
 
 	workflowType := &workflow.WorkflowType{}
@@ -859,6 +859,9 @@ func (s *integrationSuite) TestCronWorkflow() {
 	memo := &workflow.Memo{
 		Fields: map[string][]byte{"memoKey": []byte("memoVal")},
 	}
+	searchAttr := &workflow.SearchAttributes{
+		IndexedFields: map[string][]byte{"CustomKeywordField": []byte("1")},
+	}
 
 	request := &workflow.StartWorkflowExecutionRequest{
 		RequestId:                           common.StringPtr(uuid.New()),
@@ -872,6 +875,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 		Identity:                            common.StringPtr(identity),
 		CronSchedule:                        common.StringPtr(cronSchedule), //minimum interval by standard spec is 1m (* * * * *), use non-standard descriptor for short interval for test
 		Memo:                                memo,
+		SearchAttributes:                    searchAttr,
 	}
 
 	startWorkflowTS := time.Now()
@@ -969,6 +973,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	s.Equal("cron-test-error", attributes.GetFailureReason())
 	s.Equal(0, len(attributes.GetLastCompletionResult()))
 	s.Equal(memo, attributes.Memo)
+	s.Equal(searchAttr, attributes.SearchAttributes)
 
 	events = s.getHistory(s.domainName, executions[1])
 	lastEvent = events[len(events)-1]
@@ -978,6 +983,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	s.Equal("", attributes.GetFailureReason())
 	s.Equal("cron-test-result", string(attributes.GetLastCompletionResult()))
 	s.Equal(memo, attributes.Memo)
+	s.Equal(searchAttr, attributes.SearchAttributes)
 
 	events = s.getHistory(s.domainName, executions[2])
 	lastEvent = events[len(events)-1]
@@ -987,6 +993,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	s.Equal("cron-test-error", attributes.GetFailureReason())
 	s.Equal("cron-test-result", string(attributes.GetLastCompletionResult()))
 	s.Equal(memo, attributes.Memo)
+	s.Equal(searchAttr, attributes.SearchAttributes)
 
 	startFilter.LatestTime = common.Int64Ptr(time.Now().UnixNano())
 	var closedExecutions []*workflow.WorkflowExecutionInfo
@@ -1035,6 +1042,108 @@ func (s *integrationSuite) TestCronWorkflow() {
 		s.Equal(int64(0), int64(expectedBackoff-executionTimeDiff)%(targetBackoffDuration.Nanoseconds()/1000000000))
 		lastExecution = executionInfo
 	}
+}
+
+func (s *integrationSuite) TestCronWorkflowTimeout() {
+	id := "integration-wf-cron-timeout-test"
+	wt := "integration-wf-cron-timeout-type"
+	tl := "integration-wf-cron-timeout-tasklist"
+	identity := "worker1"
+	cronSchedule := "@every 3s"
+
+	workflowType := &workflow.WorkflowType{}
+	workflowType.Name = common.StringPtr(wt)
+
+	taskList := &workflow.TaskList{}
+	taskList.Name = common.StringPtr(tl)
+
+	memo := &workflow.Memo{
+		Fields: map[string][]byte{"memoKey": []byte("memoVal")},
+	}
+	searchAttr := &workflow.SearchAttributes{
+		IndexedFields: map[string][]byte{"CustomKeywordField": []byte("1")},
+	}
+
+	request := &workflow.StartWorkflowExecutionRequest{
+		RequestId:                           common.StringPtr(uuid.New()),
+		Domain:                              common.StringPtr(s.domainName),
+		WorkflowId:                          common.StringPtr(id),
+		WorkflowType:                        workflowType,
+		TaskList:                            taskList,
+		Input:                               nil,
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1), // set workflow timeout to 1s
+		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+		Identity:                            common.StringPtr(identity),
+		CronSchedule:                        common.StringPtr(cronSchedule), //minimum interval by standard spec is 1m (* * * * *), use non-standard descriptor for short interval for test
+		Memo:                                memo,
+		SearchAttributes:                    searchAttr,
+	}
+
+	we, err0 := s.engine.StartWorkflowExecution(createContext(), request)
+	s.Nil(err0)
+
+	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(*we.RunId))
+
+	var executions []*workflow.WorkflowExecution
+	dtHandler := func(execution *workflow.WorkflowExecution, wt *workflow.WorkflowType,
+		previousStartedEventID, startedEventID int64, history *workflow.History) ([]byte, []*workflow.Decision, error) {
+
+		executions = append(executions, execution)
+		return nil, []*workflow.Decision{
+			{
+				DecisionType: common.DecisionTypePtr(workflow.DecisionTypeStartTimer),
+
+				StartTimerDecisionAttributes: &workflow.StartTimerDecisionAttributes{
+					TimerId:                   common.StringPtr("timer-id"),
+					StartToFireTimeoutSeconds: common.Int64Ptr(5),
+				},
+			}}, nil
+	}
+
+	poller := &TaskPoller{
+		Engine:          s.engine,
+		Domain:          s.domainName,
+		TaskList:        taskList,
+		Identity:        identity,
+		DecisionHandler: dtHandler,
+		Logger:          s.Logger,
+		T:               s.T(),
+	}
+
+	_, err := poller.PollAndProcessDecisionTask(false, false)
+	s.True(err == nil, err)
+
+	time.Sleep(1 * time.Second) // wait for workflow timeout
+
+	// check when workflow timeout, continueAsNew event contains expected fields
+	events := s.getHistory(s.domainName, executions[0])
+	lastEvent := events[len(events)-1]
+	s.Equal(workflow.EventTypeWorkflowExecutionContinuedAsNew, lastEvent.GetEventType())
+	attributes := lastEvent.WorkflowExecutionContinuedAsNewEventAttributes
+	s.Equal(workflow.ContinueAsNewInitiatorCronSchedule, attributes.GetInitiator())
+	s.Equal("cadenceInternal:Timeout START_TO_CLOSE", attributes.GetFailureReason())
+	s.Equal(memo, attributes.Memo)
+	s.Equal(searchAttr, attributes.SearchAttributes)
+
+	_, err = poller.PollAndProcessDecisionTask(false, false)
+	s.True(err == nil, err)
+
+	// check new run contains expected fields
+	events = s.getHistory(s.domainName, executions[1])
+	firstEvent := events[0]
+	s.Equal(workflow.EventTypeWorkflowExecutionStarted, firstEvent.GetEventType())
+	startAttributes := firstEvent.WorkflowExecutionStartedEventAttributes
+	s.Equal(memo, startAttributes.Memo)
+	s.Equal(searchAttr, startAttributes.SearchAttributes)
+
+	// terminate cron
+	terminateErr := s.engine.TerminateWorkflowExecution(createContext(), &workflow.TerminateWorkflowExecutionRequest{
+		Domain: common.StringPtr(s.domainName),
+		WorkflowExecution: &workflow.WorkflowExecution{
+			WorkflowId: common.StringPtr(id),
+		},
+	})
+	s.NoError(terminateErr)
 }
 
 func (s *integrationSuite) TestSequential_UserTimers() {

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -225,9 +225,9 @@ func (s *integrationSuite) TestSignalWorkflow() {
 }
 
 func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
-	id := "interation-signal-workflow-test-duplicate"
-	wt := "interation-signal-workflow-test-duplicate-type"
-	tl := "interation-signal-workflow-test-duplicate-tasklist"
+	id := "integration-signal-workflow-test-duplicate"
+	wt := "integration-signal-workflow-test-duplicate-type"
+	tl := "integration-signal-workflow-test-duplicate-tasklist"
 	identity := "worker1"
 	activityName := "activity_type1"
 

--- a/service/history/historyBuilder.go
+++ b/service/history/historyBuilder.go
@@ -25,7 +25,6 @@ import (
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -34,7 +33,6 @@ type (
 		transientHistory []*workflow.HistoryEvent
 		history          []*workflow.HistoryEvent
 		msBuilder        mutableState
-		logger           log.Logger
 	}
 )
 
@@ -43,14 +41,12 @@ func newHistoryBuilder(msBuilder mutableState, logger log.Logger) *historyBuilde
 		transientHistory: []*workflow.HistoryEvent{},
 		history:          []*workflow.HistoryEvent{},
 		msBuilder:        msBuilder,
-		logger:           logger.WithTags(tag.ComponentHistoryBuilder),
 	}
 }
 
 func newHistoryBuilderFromEvents(history []*workflow.HistoryEvent, logger log.Logger) *historyBuilder {
 	return &historyBuilder{
 		history: history,
-		logger:  logger.WithTags(tag.ComponentHistoryBuilder),
 	}
 }
 

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1366,6 +1366,16 @@ func (e *mutableStateBuilder) DeleteUserTimer(
 			fmt.Sprintf("Unable to find timer: %v in mutable state", timerID),
 			tag.ErrorTypeInvalidMutableStateAction,
 		)
+
+		// DeleteUserTimer only called by Replicate Timer Cancel and Timer Fired events
+		// Ignore timer double fired issue on domain cb026e4f-a3af-4a5a-8036-6b53f2f8cab5
+		if e.executionInfo != nil && e.executionInfo.DomainID == "cb026e4f-a3af-4a5a-8036-6b53f2f8cab5" {
+
+			e.logger.Warn("passive_timer_double_fire_issue",
+				tag.WorkflowID(e.executionInfo.WorkflowID),
+				tag.WorkflowRunID(e.executionInfo.RunID))
+			return nil
+		}
 		return ErrMissingTimerInfo
 	}
 

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -1366,6 +1366,7 @@ func (e *mutableStateBuilder) DeleteUserTimer(
 			fmt.Sprintf("unable to find timer ID: %v in mutable state", timerID),
 			tag.ErrorTypeInvalidMutableStateAction,
 		)
+		return ErrMissingTimerInfo
 	}
 
 	delete(e.pendingTimerInfoIDs, timerID)

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -749,15 +749,17 @@ func (t *timerQueueActiveProcessorImpl) processWorkflowTimeout(
 	continueAsnewAttributes := &workflow.ContinueAsNewWorkflowExecutionDecisionAttributes{
 		WorkflowType:                        startAttributes.WorkflowType,
 		TaskList:                            startAttributes.TaskList,
-		RetryPolicy:                         startAttributes.RetryPolicy,
 		Input:                               startAttributes.Input,
-		Header:                              startAttributes.Header,
 		ExecutionStartToCloseTimeoutSeconds: startAttributes.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      startAttributes.TaskStartToCloseTimeoutSeconds,
 		BackoffStartIntervalInSeconds:       common.Int32Ptr(int32(backoffInterval.Seconds())),
+		RetryPolicy:                         startAttributes.RetryPolicy,
 		Initiator:                           continueAsNewInitiator.Ptr(),
 		FailureReason:                       common.StringPtr(timeoutReason),
 		CronSchedule:                        common.StringPtr(msBuilder.GetExecutionInfo().CronSchedule),
+		Header:                              startAttributes.Header,
+		Memo:                                startAttributes.Memo,
+		SearchAttributes:                    startAttributes.SearchAttributes,
 	}
 	newMutableState, err := retryWorkflow(
 		msBuilder,


### PR DESCRIPTION
There are two changes that should go in as hot fixes before the holiday freeze. 

1. Logging change to reduce memory pressure on history
2. Bug fix on rate limiter

This diff shows the delta between what is in production now and what we should release. No other changes should go in before the deployment freeze. 