### PR TITLE
Fix typos in 05_queries.md

### DIFF
--- a/docs/03_concepts/05_queries.md
+++ b/docs/03_concepts/05_queries.md
@@ -2,9 +2,9 @@
 
 Workflow code is stateful with the Cadence framework preserving it over various software and hardware failures. The state is constantly mutated during workflow execution. To expose this internal state to the external world Cadence provides a synchronous query feature. From the workflow implementer point of view the query is exposed as a synchronous callback that is invoked by external entities. Multiple such callbacks can be provided per workflow type exposing different information to different external systems.
 
-To execute a query an external client calls a synchronous Cadence API providing _domian, workflowID, query name_ and optional _query arguments_.
+To execute a query an external client calls a synchronous Cadence API providing _domain, workflowID, query name_ and optional _query arguments_.
 
-Query callbacks must be read-only not mutatating the workflow state in any way. The other limitation is that the query callback cannot contain any blocking code. Both above limitations rule out ability to invoke activities from the query handlers.
+Query callbacks must be read-only not mutating the workflow state in any way. The other limitation is that the query callback cannot contain any blocking code. Both above limitations rule out ability to invoke activities from the query handlers.
 
 Cadence team is currently working on implementing _update_ feature that would be similar to query in the way it is invoked, but would support workflow state mutation and local activity invocations.
 


### PR DESCRIPTION
Found some typos when browsing in Synchronous Query docs.