### PR TITLE
frontend.PollForDecisionTask: add validation to verify history is complete

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1368,6 +1368,7 @@ const (
 	CadenceErrRetryTaskCounter
 	CadenceErrBadBinaryCounter
 	CadenceErrClientVersionNotSupportedCounter
+	CadenceErrIncompleteHistoryCounter
 	PersistenceRequests
 	PersistenceFailures
 	PersistenceLatency
@@ -1437,7 +1438,6 @@ const (
 
 	MatchingClientForwardedCounter
 	MatchingClientInvalidTaskListName
-	CadenceErrIncompleteHistoryCounter
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -1707,6 +1707,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		CadenceErrRetryTaskCounter:                          {metricName: "cadence_errors_retry_task", metricType: Counter},
 		CadenceErrBadBinaryCounter:                          {metricName: "cadence_errors_bad_binary", metricType: Counter},
 		CadenceErrClientVersionNotSupportedCounter:          {metricName: "cadence_errors_client_version_not_supported", metricType: Counter},
+		CadenceErrIncompleteHistoryCounter:                  {metricName: "cadence_errors_incomplete_history", metricType: Counter},
 		PersistenceRequests:                                 {metricName: "persistence_requests", metricType: Counter},
 		PersistenceFailures:                                 {metricName: "persistence_errors", metricType: Counter},
 		PersistenceLatency:                                  {metricName: "persistence_latency", metricType: Timer},
@@ -1764,7 +1765,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		VisibilityArchiveSuccessCount:                             {metricName: "visibility_archiver_archive_success", metricType: Counter},
 		MatchingClientForwardedCounter:                            {metricName: "forwarded", metricType: Counter},
 		MatchingClientInvalidTaskListName:                         {metricName: "invalid_task_list_name", metricType: Counter},
-		CadenceErrIncompleteHistoryCounter:                        {metricName: "cadence_errors_incomplete_history", metricType: Counter},
 	},
 	Frontend: {
 		DomainReplicationTaskAckLevel: {metricName: "domain_replication_task_ack_level", metricType: Gauge},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1437,6 +1437,7 @@ const (
 
 	MatchingClientForwardedCounter
 	MatchingClientInvalidTaskListName
+	CadenceErrIncompleteHistoryCounter
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -1763,6 +1764,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		VisibilityArchiveSuccessCount:                             {metricName: "visibility_archiver_archive_success", metricType: Counter},
 		MatchingClientForwardedCounter:                            {metricName: "forwarded", metricType: Counter},
 		MatchingClientInvalidTaskListName:                         {metricName: "invalid_task_list_name", metricType: Counter},
+		CadenceErrIncompleteHistoryCounter:                        {metricName: "cadence_errors_incomplete_history", metricType: Counter},
 	},
 	Frontend: {
 		DomainReplicationTaskAckLevel: {metricName: "domain_replication_task_ack_level", metricType: Gauge},

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -560,7 +560,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 
 	for i := 0; i < 8; i++ {
 		dropDecisionTask := (i%2 == 0)
-		s.Logger.Info("Calling Decision Task: %d", tag.Counter(i))
+		s.Logger.Info("Calling Decision Task", tag.Counter(i))
 		var err error
 		if dropDecisionTask {
 			_, err = poller.PollAndProcessDecisionTask(true, true)
@@ -579,7 +579,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 			history := historyResponse.History
 			common.PrettyPrintHistory(history, s.Logger)
 		}
-		s.True(err == nil || err == matching.ErrNoTasks, "Error", tag.Error(err))
+		s.True(err == nil || err == matching.ErrNoTasks, "%v", err)
 		if !dropDecisionTask {
 			s.Logger.Info("Calling Activity Task: %d", tag.Counter(i))
 			err = poller.PollAndProcessActivityTask(i%4 == 0)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -3221,6 +3221,12 @@ func (wh *WorkflowHandler) createPollForDecisionTaskResponse(
 
 		if err := verifyHistoryIsComplete(history, firstEventID, nextEventID-1); err != nil {
 			scope.IncCounter(metrics.CadenceErrIncompleteHistoryCounter)
+			wh.GetLogger().Error("PollForDecisionTask: incomplete history",
+				tag.WorkflowDomainID(domainID),
+				tag.WorkflowDomainName(domain.GetInfo().Name),
+				tag.WorkflowID(matchingResp.WorkflowExecution.GetWorkflowId()),
+				tag.WorkflowRunID(matchingResp.WorkflowExecution.GetRunId()),
+				tag.Error(err))
 			return nil, err
 		}
 
@@ -3283,11 +3289,12 @@ func verifyHistoryIsComplete(
 	}
 
 	return fmt.Errorf(
-		"incomplete history: expected events [%v-%v] but got events [%v-%v]",
+		"incomplete history: expected events [%v-%v] but got events [%v-%v] of length %v",
 		expectedFirstEventID,
 		expectedLastEventID,
 		firstEventID,
-		lastEventID)
+		lastEventID,
+		nEvents)
 }
 
 func deserializeHistoryToken(bytes []byte) (*getHistoryContinuationToken, error) {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -3219,7 +3219,7 @@ func (wh *WorkflowHandler) createPollForDecisionTaskResponse(
 			return nil, err
 		}
 
-		if err := verifyHistoryIsComplete(history, firstEventID, nextEventID); err != nil {
+		if err := verifyHistoryIsComplete(history, firstEventID, nextEventID-1); err != nil {
 			scope.IncCounter(metrics.CadenceErrIncompleteHistoryCounter)
 			return nil, err
 		}
@@ -3262,7 +3262,8 @@ func (wh *WorkflowHandler) createPollForDecisionTaskResponse(
 func verifyHistoryIsComplete(
 	history *gen.History,
 	expectedFirstEventID int64,
-	expectedLastEventID int64) error {
+	expectedLastEventID int64,
+) error {
 
 	firstEventID := int64(-1)
 	lastEventID := int64(-1)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -3219,7 +3219,7 @@ func (wh *WorkflowHandler) createPollForDecisionTaskResponse(
 			return nil, err
 		}
 
-		if err := verifyHistoryIsComplete(history, firstEventID, nextEventID-1); err != nil {
+		if err := verifyHistoryIsComplete(history, firstEventID, matchingResp.GetStartedEventId()); err != nil {
 			scope.IncCounter(metrics.CadenceErrIncompleteHistoryCounter)
 			wh.GetLogger().Error("PollForDecisionTask: incomplete history",
 				tag.WorkflowDomainID(domainID),


### PR DESCRIPTION
This patch adds validation logic within frontend::PollForDecisionTask API to make sure the history we send to the worker is complete. When this validation fails, we fail the API call and emit a metric. Purpose of this change is to find out if these types of errors do occur in production (to explain some of the odd behavior we see). 