### PR TITLE
Release strict assertion for UpdateCurrentWorkflowByPass for marking workflow as corrupted state

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1914,7 +1914,7 @@ func (d *cassandraPersistence) assertNotCurrentExecution(
 		DomainID:   domainID,
 		WorkflowID: workflowID,
 	}); err != nil {
-		if err == gocql.ErrNotFound{
+		if _, ok := err.(*workflow.EntityNotExistsError); ok{
 			// allow bypassing no current record
 			return nil
 		}

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1914,6 +1914,10 @@ func (d *cassandraPersistence) assertNotCurrentExecution(
 		DomainID:   domainID,
 		WorkflowID: workflowID,
 	}); err != nil {
+		if err == gocql.ErrNotFound{
+			// allow bypassing no current record
+			return nil
+		}
 		return err
 	} else if resp.RunID == runID {
 		return &p.ConditionFailedError{

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -100,6 +100,7 @@ const (
 	WorkflowStateCompleted
 	WorkflowStateZombie
 	WorkflowStateVoid
+	WorkflowStateCorrupted
 )
 
 // Workflow execution close status

--- a/common/persistence/operationModeValidator.go
+++ b/common/persistence/operationModeValidator.go
@@ -322,7 +322,8 @@ func checkWorkflowState(state int) error {
 	case WorkflowStateCreated,
 		WorkflowStateRunning,
 		WorkflowStateZombie,
-		WorkflowStateCompleted:
+		WorkflowStateCompleted,
+		WorkflowStateCorrupted:
 		return nil
 	default:
 		return &workflow.InternalServiceError{

--- a/common/persistence/sql/sqlExecutionManagerUtil.go
+++ b/common/persistence/sql/sqlExecutionManagerUtil.go
@@ -1030,11 +1030,6 @@ func assertNotCurrentExecution(
 	workflowID string,
 	runID sqlplugin.UUID,
 ) error {
-
-	assertFn := func(currentRow *sqlplugin.CurrentExecutionsRow) error {
-		return assertRunIDMismatch(runID, currentRow.RunID)
-	}
-
 	currentRow, err := tx.LockCurrentExecutions(&sqlplugin.CurrentExecutionsFilter{
 		ShardID:    int64(shardID),
 		DomainID:   domainID,
@@ -1049,7 +1044,7 @@ func assertNotCurrentExecution(
 			Message: fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err),
 		}
 	}
-	return assertFn(currentRow)
+	return assertRunIDMismatch(runID, currentRow.RunID)
 }
 
 func assertRunIDAndUpdateCurrentExecution(

--- a/common/persistence/workflowStateCloseStatusValidator.go
+++ b/common/persistence/workflowStateCloseStatusValidator.go
@@ -32,6 +32,7 @@ var (
 		WorkflowStateRunning:   {},
 		WorkflowStateCompleted: {},
 		WorkflowStateZombie:    {},
+		WorkflowStateCorrupted: {},
 	}
 
 	validWorkflowCloseStatuses = map[int]struct{}{

--- a/service/history/mutableStateBuilder.go
+++ b/service/history/mutableStateBuilder.go
@@ -789,6 +789,8 @@ func (e *mutableStateBuilder) IsCurrentWorkflowGuaranteed() bool {
 		return false
 	case persistence.WorkflowStateZombie:
 		return false
+	case persistence.WorkflowStateCorrupted:
+		return false
 	default:
 		panic(fmt.Sprintf("unknown workflow state: %v", e.executionInfo.State))
 	}
@@ -1520,6 +1522,8 @@ func (e *mutableStateBuilder) IsWorkflowExecutionRunning() bool {
 	case persistence.WorkflowStateCompleted:
 		return false
 	case persistence.WorkflowStateZombie:
+		return false
+	case persistence.WorkflowStateCorrupted:
 		return false
 	default:
 		panic(fmt.Sprintf("unknown workflow state: %v", e.executionInfo.State))


### PR DESCRIPTION
This is a pre step for implementing a scanner to mark workflow as corrupted and then eventually delete it. 