### PR TITLE
Consistent query bug fixes

### DIFF
--- a/common/client/versionChecker.go
+++ b/common/client/versionChecker.go
@@ -40,11 +40,11 @@ const (
 	CLI = "cli"
 
 	// SupportedGoSDKVersion indicates the highest go sdk version server will accept requests from
-	SupportedGoSDKVersion = "1.4.0"
+	SupportedGoSDKVersion = "1.5.0"
 	// SupportedJavaSDKVersion indicates the highest java sdk version server will accept requests from
-	SupportedJavaSDKVersion = "1.4.0"
+	SupportedJavaSDKVersion = "1.5.0"
 	// SupportedCLIVersion indicates the highest cli version server will accept requests from
-	SupportedCLIVersion = "1.4.0"
+	SupportedCLIVersion = "1.5.0"
 
 	// GoWorkerStickyQueryVersion indicates the minimum client version of go worker which supports StickyQuery
 	GoWorkerStickyQueryVersion = "1.0.0"

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -4,3 +4,6 @@ frontend.enableClientVersionCheck:
 system.minRetentionDays:
 - value: 0
   constraints: {}
+history.EnableConsistentQueryByDomain:
+  - value: true
+    constrains: {}

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -3116,7 +3116,7 @@ func (wh *WorkflowHandler) getDefaultScope(scope int) metrics.Scope {
 	return wh.GetMetricsClient().Scope(scope).Tagged(metrics.DomainUnknownTag())
 }
 
-func frontendInternalServiceError(fmtStr string, args... interface{}) error{
+func frontendInternalServiceError(fmtStr string, args ...interface{}) error {
 	// NOTE: For internal error, we can't return thrift error from cadence-frontend.
 	// Because in uber internal metrics, thrift errors are counted as user errors.
 	return fmt.Errorf(fmtStr, args...)

--- a/service/history/decisionHandler_test.go
+++ b/service/history/decisionHandler_test.go
@@ -81,21 +81,28 @@ func (s *DecisionHandlerSuite) TearDownTest() {
 
 func (s *DecisionHandlerSuite) TestHandleBufferedQueries_ClientNotSupports() {
 	s.assertQueryCounts(s.queryRegistry, 10, 0, 0, 0)
-	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, "0.0.0", nil, false, testGlobalDomainEntry)
+	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, "0.0.0", nil, false, testGlobalDomainEntry, false)
 	s.assertQueryCounts(s.queryRegistry, 0, 0, 0, 10)
+}
+
+func (s *DecisionHandlerSuite) TestHandleBufferedQueries_HeartbeatDecision() {
+	s.assertQueryCounts(s.queryRegistry, 10, 0, 0, 0)
+	queryResults := s.constructQueryResults(s.queryRegistry.getBufferedIDs()[0:5], 10)
+	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, client.GoWorkerConsistentQueryVersion, queryResults, false, testGlobalDomainEntry, true)
+	s.assertQueryCounts(s.queryRegistry, 10, 0, 0, 0)
 }
 
 func (s *DecisionHandlerSuite) TestHandleBufferedQueries_NewDecisionTask() {
 	s.assertQueryCounts(s.queryRegistry, 10, 0, 0, 0)
 	queryResults := s.constructQueryResults(s.queryRegistry.getBufferedIDs()[0:5], 10)
-	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, client.GoWorkerConsistentQueryVersion, queryResults, true, testGlobalDomainEntry)
+	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, client.GoWorkerConsistentQueryVersion, queryResults, true, testGlobalDomainEntry, false)
 	s.assertQueryCounts(s.queryRegistry, 5, 5, 0, 0)
 }
 
 func (s *DecisionHandlerSuite) TestHandleBufferedQueries_NoNewDecisionTask() {
 	s.assertQueryCounts(s.queryRegistry, 10, 0, 0, 0)
 	queryResults := s.constructQueryResults(s.queryRegistry.getBufferedIDs()[0:5], 10)
-	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, client.GoWorkerConsistentQueryVersion, queryResults, false, testGlobalDomainEntry)
+	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, client.GoWorkerConsistentQueryVersion, queryResults, false, testGlobalDomainEntry, false)
 	s.assertQueryCounts(s.queryRegistry, 0, 5, 5, 0)
 }
 
@@ -107,7 +114,7 @@ func (s *DecisionHandlerSuite) TestHandleBufferedQueries_QueryTooLarge() {
 	for k, v := range largeQueryResults {
 		queryResults[k] = v
 	}
-	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, client.GoWorkerConsistentQueryVersion, queryResults, false, testGlobalDomainEntry)
+	s.decisionHandler.handleBufferedQueries(s.mockMutableState, client.GoSDK, client.GoWorkerConsistentQueryVersion, queryResults, false, testGlobalDomainEntry, false)
 	s.assertQueryCounts(s.queryRegistry, 0, 5, 0, 5)
 }
 

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -175,7 +175,7 @@ var (
 	// ErrEventsAterWorkflowFinish is the error indicating server error trying to write events after workflow finish event
 	ErrEventsAterWorkflowFinish = &workflow.InternalServiceError{Message: "error validating last event being workflow finish event"}
 	// ErrQueryEnteredInvalidState is error indicating query entered invalid state
-	ErrQueryEnteredInvalidState = &workflow.InternalServiceError{Message: "query entered invalid state, this should be impossible"}
+	ErrQueryEnteredInvalidState = &workflow.BadRequestError{Message: "query entered invalid state, this should be impossible"}
 	// ErrQueryWorkflowBeforeFirstDecision is error indicating that query was attempted before first decision task completed
 	ErrQueryWorkflowBeforeFirstDecision = &workflow.BadRequestError{Message: "workflow must handle at least one decision task before it can be queried"}
 	// ErrConsistentQueryNotEnabled is error indicating that consistent query was requested but either cluster or domain does not enable consistent query
@@ -1002,7 +1002,6 @@ func (e *historyEngineImpl) queryDirectlyThroughMatching(
 func (e *historyEngineImpl) getMutableState(
 	ctx ctx.Context,
 	domainID string,
-
 	execution workflow.WorkflowExecution,
 ) (retResp *h.GetMutableStateResponse, retError error) {
 


### PR DESCRIPTION
- BadRequest error needs to be returned if query enters invalid state or client is not supported this ensures client side does not keep retrying queries forever. 
- We must not unblock or answer queries if the decision is a heartbeat decision because that can violate consistency of query. 