### PR TITLE
Add initial support for custom SQL TLS configuration

### DIFF
--- a/common/auth/tls.go
+++ b/common/auth/tls.go
@@ -21,7 +21,7 @@
 package auth
 
 type (
-	// TLS describe TLS configuration (for Kafka, Cassandra)
+	// TLS describe TLS configuration (for Kafka, Cassandra, SQL)
 	TLS struct {
 		Enabled bool `yaml:"enabled"`
 

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -219,6 +219,8 @@ type (
 		// NumShards is the number of storage shards to use for tables
 		// in a sharded sql database. The default value for this param is 1
 		NumShards int `yaml:"nShards"`
+		// TLS is the configuration for TLS connections
+		TLS *auth.TLS `yaml:"tls"`
 	}
 
 	// Replicator describes the configuration of replicator

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -84,6 +84,8 @@ const (
 	CLIOptDatabase = "database"
 	// CLIOptPluginName is the cli option for plugin name
 	CLIOptPluginName = "plugin"
+	// CLIOptConnectAttributes is the cli option for connect attributes (key/values via a url query string)
+	CLIOptConnectAttributes = "connect-attributes"
 	// CLIOptVersion is the cli option for version
 	CLIOptVersion = "version"
 	// CLIOptSchemaFile is the cli option for schema file
@@ -119,6 +121,8 @@ const (
 	CLIFlagDatabase = CLIOptDatabase + ", db"
 	// CLIFlagPluginName is the cli flag for plugin name
 	CLIFlagPluginName = CLIOptPluginName + ", pl"
+	// CLIFlagConnectAttributes allows arbitrary connect attributes
+	CLIFlagConnectAttributes = CLIOptConnectAttributes + ", ca"
 	// CLIFlagVersion is the cli flag for version
 	CLIFlagVersion = CLIOptVersion + ", v"
 	// CLIFlagSchemaFile is the cli flag for schema file

--- a/tools/sql/clitest/connTest.go
+++ b/tools/sql/clitest/connTest.go
@@ -21,9 +21,12 @@
 package clitest
 
 import (
-	"github.com/stretchr/testify/require"
+	"net"
+	"strconv"
 
+	"github.com/stretchr/testify/require"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/environment"
 	"github.com/uber/cadence/tools/common/schema/test"
 	"github.com/uber/cadence/tools/sql"
@@ -79,13 +82,15 @@ func (s *SQLConnTestSuite) TestParseCQLFile() {
 // TODO refactor the whole package to support testing against Postgres
 // https://github.com/uber/cadence/issues/2856
 func (s *SQLConnTestSuite) TestSQLConn() {
-	conn, err := sql.NewConnection(&sql.ConnectParams{
-		Host:       environment.GetMySQLAddress(),
-		Port:       environment.GetMySQLPort(),
-		User:       testUser,
-		Password:   testPassword,
-		PluginName: s.pluginName,
-		Database:   s.DBName,
+	conn, err := sql.NewConnection(&config.SQL{
+		ConnectAddr: net.JoinHostPort(
+			environment.GetMySQLAddress(),
+			strconv.Itoa(environment.GetMySQLPort()),
+		),
+		User:         testUser,
+		Password:     testPassword,
+		PluginName:   s.pluginName,
+		DatabaseName: s.DBName,
 	})
 	s.Nil(err)
 	s.RunCreateTest(conn)
@@ -95,13 +100,15 @@ func (s *SQLConnTestSuite) TestSQLConn() {
 }
 
 func newTestConn(database, pluginName string) (*sql.Connection, error) {
-	return sql.NewConnection(&sql.ConnectParams{
-		Host:       environment.GetMySQLAddress(),
-		Port:       environment.GetMySQLPort(),
-		User:       testUser,
-		Password:   testPassword,
-		PluginName: pluginName,
-		Database:   database,
+	return sql.NewConnection(&config.SQL{
+		ConnectAddr: net.JoinHostPort(
+			environment.GetMySQLAddress(),
+			strconv.Itoa(environment.GetMySQLPort()),
+		),
+		User:         testUser,
+		Password:     testPassword,
+		PluginName:   pluginName,
+		DatabaseName: database,
 	})
 }
 

--- a/tools/sql/conn.go
+++ b/tools/sql/conn.go
@@ -21,8 +21,6 @@
 package sql
 
 import (
-	"fmt"
-
 	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 	"github.com/uber/cadence/common/service/config"
@@ -30,16 +28,6 @@ import (
 )
 
 type (
-	// ConnectParams is the connection param
-	ConnectParams struct {
-		Host       string
-		Port       int
-		User       string
-		Password   string
-		Database   string
-		PluginName string
-	}
-
 	// Connection is the connection to database
 	Connection struct {
 		dbName  string
@@ -50,22 +38,15 @@ type (
 var _ schema.DB = (*Connection)(nil)
 
 // NewConnection creates a new connection to database
-func NewConnection(params *ConnectParams) (*Connection, error) {
-
-	db, err := sql.NewSQLAdminDB(&config.SQL{
-		PluginName:   params.PluginName,
-		User:         params.User,
-		Password:     params.Password,
-		DatabaseName: params.Database,
-		ConnectAddr:  fmt.Sprintf("%v:%v", params.Host, params.Port),
-	})
+func NewConnection(cfg *config.SQL) (*Connection, error) {
+	db, err := sql.NewSQLAdminDB(cfg)
 	if err != nil {
 		return nil, err
 	}
 
 	return &Connection{
 		adminDb: db,
-		dbName:  params.Database,
+		dbName:  cfg.DatabaseName,
 	}, nil
 }
 

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -23,11 +23,12 @@ package sql
 import (
 	"fmt"
 	"log"
-	"strconv"
-	"strings"
+	"net"
+	"net/url"
 
 	"github.com/urfave/cli"
 
+	"github.com/uber/cadence/common/auth"
 	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/schema/mysql"
 	"github.com/uber/cadence/tools/common/schema"
@@ -61,32 +62,8 @@ func CheckCompatibleVersion(
 	cfg config.SQL,
 	expectedVersion string,
 ) error {
-	var host string
-	var port int
-	if strings.Contains(cfg.ConnectAddr, ":") {
-		ss := strings.Split(cfg.ConnectAddr, ":")
-		if len(ss) != 2 {
-			panic("invalid connect address, it must be in host:port format")
-		}
-		var err error
-		host = ss[0]
-		port, err = strconv.Atoi(ss[1])
-		if err != nil {
-			panic("invalid port number:" + ss[1])
-		}
-	} else {
-		host = cfg.ConnectAddr
-		port = defaultSQLPort
-	}
+	connection, err := NewConnection(&cfg)
 
-	connection, err := NewConnection(&ConnectParams{
-		Host:       host,
-		Port:       port,
-		User:       cfg.User,
-		Password:   cfg.Password,
-		PluginName: cfg.PluginName,
-		Database:   cfg.DatabaseName,
-	})
 	if err != nil {
 		return fmt.Errorf("unable to create SQL connection: %v", err.Error())
 	}
@@ -99,11 +76,11 @@ func CheckCompatibleVersion(
 // using the given command line arguments
 // as input
 func setupSchema(cli *cli.Context) error {
-	params, err := parseConnectParams(cli)
+	cfg, err := parseConnectConfig(cli)
 	if err != nil {
 		return handleErr(schema.NewConfigError(err.Error()))
 	}
-	conn, err := NewConnection(params)
+	conn, err := NewConnection(cfg)
 	if err != nil {
 		return handleErr(err)
 	}
@@ -117,18 +94,17 @@ func setupSchema(cli *cli.Context) error {
 // updateSchema executes the updateSchemaTask
 // using the given command lien args as input
 func updateSchema(cli *cli.Context) error {
-	params, err := parseConnectParams(cli)
+	cfg, err := parseConnectConfig(cli)
 	if err != nil {
 		return handleErr(schema.NewConfigError(err.Error()))
 	}
-	if params.Database == schema.DryrunDBName {
-		p := *params
-		if err := doCreateDatabase(p, p.Database); err != nil {
+	if cfg.DatabaseName == schema.DryrunDBName {
+		if err := doCreateDatabase(cfg, cfg.DatabaseName); err != nil {
 			return handleErr(fmt.Errorf("error creating dryrun database: %v", err))
 		}
-		defer doDropDatabase(p, p.Database)
+		defer doDropDatabase(cfg, cfg.DatabaseName)
 	}
-	conn, err := NewConnection(params)
+	conn, err := NewConnection(cfg)
 	if err != nil {
 		return handleErr(err)
 	}
@@ -141,7 +117,7 @@ func updateSchema(cli *cli.Context) error {
 
 // createDatabase creates a sql database
 func createDatabase(cli *cli.Context) error {
-	params, err := parseConnectParams(cli)
+	cfg, err := parseConnectConfig(cli)
 	if err != nil {
 		return handleErr(schema.NewConfigError(err.Error()))
 	}
@@ -149,16 +125,16 @@ func createDatabase(cli *cli.Context) error {
 	if database == "" {
 		return handleErr(schema.NewConfigError("missing " + flag(schema.CLIOptDatabase) + " argument "))
 	}
-	err = doCreateDatabase(*params, database)
+	err = doCreateDatabase(cfg, database)
 	if err != nil {
 		return handleErr(fmt.Errorf("error creating database:%v", err))
 	}
 	return nil
 }
 
-func doCreateDatabase(p ConnectParams, name string) error {
-	p.Database = ""
-	conn, err := NewConnection(&p)
+func doCreateDatabase(cfg *config.SQL, name string) error {
+	cfg.DatabaseName = ""
+	conn, err := NewConnection(cfg)
 	if err != nil {
 		return err
 	}
@@ -166,9 +142,9 @@ func doCreateDatabase(p ConnectParams, name string) error {
 	return conn.CreateDatabase(name)
 }
 
-func doDropDatabase(p ConnectParams, name string) {
-	p.Database = ""
-	conn, err := NewConnection(&p)
+func doDropDatabase(cfg *config.SQL, name string) {
+	cfg.DatabaseName = ""
+	conn, err := NewConnection(cfg)
 	if err != nil {
 		logErr(err)
 		return
@@ -180,31 +156,80 @@ func doDropDatabase(p ConnectParams, name string) {
 	conn.Close()
 }
 
-func parseConnectParams(cli *cli.Context) (*ConnectParams, error) {
-	params := new(ConnectParams)
-	params.Host = cli.GlobalString(schema.CLIOptEndpoint)
-	params.Port = cli.GlobalInt(schema.CLIOptPort)
-	params.User = cli.GlobalString(schema.CLIOptUser)
-	params.Password = cli.GlobalString(schema.CLIOptPassword)
-	params.Database = cli.GlobalString(schema.CLIOptDatabase)
-	params.PluginName = cli.GlobalString(schema.CLIOptPluginName)
+func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
+	cfg := new(config.SQL)
+
+	host := cli.GlobalString(schema.CLIOptEndpoint)
+	port := cli.GlobalInt(schema.CLIOptPort)
+	cfg.ConnectAddr = fmt.Sprintf("%s:%v", host, port)
+	cfg.User = cli.GlobalString(schema.CLIOptUser)
+	cfg.Password = cli.GlobalString(schema.CLIOptPassword)
+	cfg.DatabaseName = cli.GlobalString(schema.CLIOptDatabase)
+	cfg.PluginName = cli.GlobalString(schema.CLIOptPluginName)
 	isDryRun := cli.Bool(schema.CLIOptDryrun)
-	if err := ValidateConnectParams(params, isDryRun); err != nil {
+
+	if cfg.ConnectAttributes == nil {
+		cfg.ConnectAttributes = map[string]string{}
+	}
+	connectAttributesQueryString := cli.GlobalString(schema.CLIOptConnectAttributes)
+	if connectAttributesQueryString != "" {
+		values, err := url.ParseQuery(connectAttributesQueryString)
+		if err != nil {
+			return nil, fmt.Errorf("invalid connect attributes: %v", err)
+		}
+		for key, vals := range values {
+			// check to ensure only one value is provider per key
+			if len(vals) > 1 {
+				return nil, fmt.Errorf("invalid connect attribute %v, only 1 value allowed: %v", key, vals)
+			}
+			cfg.ConnectAttributes[key] = vals[0]
+		}
+	}
+
+	if cli.GlobalBool(schema.CLIFlagEnableTLS) {
+		cfg.TLS = &auth.TLS{
+			Enabled:                true,
+			CertFile:               cli.GlobalString(schema.CLIFlagTLSCertFile),
+			KeyFile:                cli.GlobalString(schema.CLIFlagTLSKeyFile),
+			CaFile:                 cli.GlobalString(schema.CLIFlagTLSCaFile),
+			EnableHostVerification: cli.GlobalBool(schema.CLIFlagTLSEnableHostVerification),
+		}
+	}
+
+	if err := ValidateConnectConfig(cfg, isDryRun); err != nil {
 		return nil, err
 	}
-	return params, nil
+
+	return cfg, nil
 }
 
-// ValidateConnectParams validates params
-func ValidateConnectParams(params *ConnectParams, isDryRun bool) error {
-	if len(params.Host) == 0 {
+// ValidateConnectConfig validates params
+func ValidateConnectConfig(cfg *config.SQL, isDryRun bool) error {
+	host, _, err := net.SplitHostPort(cfg.ConnectAddr)
+	if err != nil {
+		return schema.NewConfigError("invalid host and port " + cfg.ConnectAddr)
+	}
+	if len(host) == 0 {
 		return schema.NewConfigError("missing sql endpoint argument " + flag(schema.CLIOptEndpoint))
 	}
-	if params.Database == "" {
+	if cfg.DatabaseName == "" {
 		if !isDryRun {
-			return schema.NewConfigError("missing " + flag(schema.CLIOptDatabase) + " argument ")
+			return schema.NewConfigError("missing " + flag(schema.CLIOptDatabase) + " argument")
 		}
-		params.Database = schema.DryrunDBName
+		cfg.DatabaseName = schema.DryrunDBName
+	}
+	if cfg.TLS != nil && cfg.TLS.Enabled {
+		enabledCaFile := cfg.TLS.CaFile != ""
+		enabledCertFile := cfg.TLS.CertFile != ""
+		enabledKeyFile := cfg.TLS.KeyFile != ""
+
+		if (enabledCertFile && !enabledKeyFile) || (!enabledCertFile && enabledKeyFile) {
+			return schema.NewConfigError("must have both CertFile and KeyFile set")
+		}
+
+		if !enabledCaFile && !enabledCertFile && !enabledKeyFile {
+			return schema.NewConfigError("must provide tls certs to use")
+		}
 	}
 	return nil
 }

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -94,6 +94,36 @@ func BuildCLIOptions() *cli.App {
 			Name:  schema.CLIFlagQuiet,
 			Usage: "Don't set exit status to 1 on error",
 		},
+		cli.StringFlag{
+			Name:   schema.CLIFlagConnectAttributes,
+			Usage:  "sql connect attributes",
+			EnvVar: "SQL_CONNECT_ATTRIBUTES",
+		},
+		cli.BoolFlag{
+			Name:   schema.CLIFlagEnableTLS,
+			Usage:  "enable TLS over sql connection",
+			EnvVar: "SQL_TLS",
+		},
+		cli.StringFlag{
+			Name:   schema.CLIFlagTLSCertFile,
+			Usage:  "sql tls client cert path (tls must be enabled)",
+			EnvVar: "SQL_TLS_CERT_FILE",
+		},
+		cli.StringFlag{
+			Name:   schema.CLIFlagTLSKeyFile,
+			Usage:  "sql tls client key path (tls must be enabled)",
+			EnvVar: "SQL_TLS_KEY_FILE",
+		},
+		cli.StringFlag{
+			Name:   schema.CLIFlagTLSCaFile,
+			Usage:  "sql tls client ca file (tls must be enabled)",
+			EnvVar: "SQL_TLS_CA_FILE",
+		},
+		cli.BoolFlag{
+			Name:   schema.CLIFlagTLSEnableHostVerification,
+			Usage:  "sql tls verify hostname and server cert (tls must be enabled)",
+			EnvVar: "SQL_TLS_ENABLE_HOST_VERIFICATION",
+		},
 	}
 
 	app.Commands = []cli.Command{


### PR DESCRIPTION
This is an attempt to add support for TLS MySQL (we use RDS/Aurora and require TLS support) using the recently added TLS support for Cassandra. In the process it reuses the config in persistence for use in tools and removes ConnectParams.

For the cli you can use env:
```
SQL_TLS=1 SQL_TLS_CA_FILE=./my-ca-file.pem SQL_CONNECT_ATTRIBUTES="tx_isolation=READ-COMMITTED" ./cadence-sql-tool ...
```
or command flags:
```
./cadence-sql-tool ... --tls --tls-ca-file ./my-ca-file.pem --plugin mysql --connect-attributes "tx_isolation=READ-COMMITTED" create ...
```

And `tls:` can now be used in config.yaml for running `cadence-server`

Feedback is welcome!

_Closing previous attempt, which was before major refactor related to postgres support:
https://github.com/uber/cadence/pull/2841_
