### PR TITLE
doc: fix new worker sample code

### DIFF
--- a/docs/07_goclient/01_workers.md
+++ b/docs/07_goclient/01_workers.md
@@ -70,7 +70,7 @@ func startWorker(logger *zap.Logger, service workflowserviceclient.Interface) {
 		MetricsScope: tally.NewTestScope(TaskListName, map[string]string{}),
 	}
 
-	worker := worker.NewWorker(
+	worker := worker.New(
 		service,
 		Domain,
 		TaskListName,


### PR DESCRIPTION
Fixing worker creation code in docs: `worker.NewWorker` => `worker.New`