### PR TITLE
Admin command for visibility into membership info for the cluster

### DIFF
--- a/.gen/go/admin/admin.go
+++ b/.gen/go/admin/admin.go
@@ -325,6 +325,196 @@ func (v *AddSearchAttributeRequest) IsSetSecurityToken() bool {
 	return v != nil && v.SecurityToken != nil
 }
 
+type DescribeClusterResponse struct {
+	SupportedClientVersions *shared.SupportedClientVersions `json:"supportedClientVersions,omitempty"`
+	MembershipInfo          *MembershipInfo                 `json:"membershipInfo,omitempty"`
+}
+
+// ToWire translates a DescribeClusterResponse struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *DescribeClusterResponse) ToWire() (wire.Value, error) {
+	var (
+		fields [2]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.SupportedClientVersions != nil {
+		w, err = v.SupportedClientVersions.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 10, Value: w}
+		i++
+	}
+	if v.MembershipInfo != nil {
+		w, err = v.MembershipInfo.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 20, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _SupportedClientVersions_Read(w wire.Value) (*shared.SupportedClientVersions, error) {
+	var v shared.SupportedClientVersions
+	err := v.FromWire(w)
+	return &v, err
+}
+
+func _MembershipInfo_Read(w wire.Value) (*MembershipInfo, error) {
+	var v MembershipInfo
+	err := v.FromWire(w)
+	return &v, err
+}
+
+// FromWire deserializes a DescribeClusterResponse struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a DescribeClusterResponse struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v DescribeClusterResponse
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *DescribeClusterResponse) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 10:
+			if field.Value.Type() == wire.TStruct {
+				v.SupportedClientVersions, err = _SupportedClientVersions_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 20:
+			if field.Value.Type() == wire.TStruct {
+				v.MembershipInfo, err = _MembershipInfo_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a DescribeClusterResponse
+// struct.
+func (v *DescribeClusterResponse) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [2]string
+	i := 0
+	if v.SupportedClientVersions != nil {
+		fields[i] = fmt.Sprintf("SupportedClientVersions: %v", v.SupportedClientVersions)
+		i++
+	}
+	if v.MembershipInfo != nil {
+		fields[i] = fmt.Sprintf("MembershipInfo: %v", v.MembershipInfo)
+		i++
+	}
+
+	return fmt.Sprintf("DescribeClusterResponse{%v}", strings.Join(fields[:i], ", "))
+}
+
+// Equals returns true if all the fields of this DescribeClusterResponse match the
+// provided DescribeClusterResponse.
+//
+// This function performs a deep comparison.
+func (v *DescribeClusterResponse) Equals(rhs *DescribeClusterResponse) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !((v.SupportedClientVersions == nil && rhs.SupportedClientVersions == nil) || (v.SupportedClientVersions != nil && rhs.SupportedClientVersions != nil && v.SupportedClientVersions.Equals(rhs.SupportedClientVersions))) {
+		return false
+	}
+	if !((v.MembershipInfo == nil && rhs.MembershipInfo == nil) || (v.MembershipInfo != nil && rhs.MembershipInfo != nil && v.MembershipInfo.Equals(rhs.MembershipInfo))) {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of DescribeClusterResponse.
+func (v *DescribeClusterResponse) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.SupportedClientVersions != nil {
+		err = multierr.Append(err, enc.AddObject("supportedClientVersions", v.SupportedClientVersions))
+	}
+	if v.MembershipInfo != nil {
+		err = multierr.Append(err, enc.AddObject("membershipInfo", v.MembershipInfo))
+	}
+	return err
+}
+
+// GetSupportedClientVersions returns the value of SupportedClientVersions if it is set or its
+// zero value if it is unset.
+func (v *DescribeClusterResponse) GetSupportedClientVersions() (o *shared.SupportedClientVersions) {
+	if v != nil && v.SupportedClientVersions != nil {
+		return v.SupportedClientVersions
+	}
+
+	return
+}
+
+// IsSetSupportedClientVersions returns true if SupportedClientVersions is not nil.
+func (v *DescribeClusterResponse) IsSetSupportedClientVersions() bool {
+	return v != nil && v.SupportedClientVersions != nil
+}
+
+// GetMembershipInfo returns the value of MembershipInfo if it is set or its
+// zero value if it is unset.
+func (v *DescribeClusterResponse) GetMembershipInfo() (o *MembershipInfo) {
+	if v != nil && v.MembershipInfo != nil {
+		return v.MembershipInfo
+	}
+
+	return
+}
+
+// IsSetMembershipInfo returns true if MembershipInfo is not nil.
+func (v *DescribeClusterResponse) IsSetMembershipInfo() bool {
+	return v != nil && v.MembershipInfo != nil
+}
+
 type DescribeWorkflowExecutionRequest struct {
 	Domain    *string                   `json:"domain,omitempty"`
 	Execution *shared.WorkflowExecution `json:"execution,omitempty"`
@@ -2268,19 +2458,829 @@ func (v *GetWorkflowExecutionRawHistoryV2Response) IsSetVersionHistory() bool {
 	return v != nil && v.VersionHistory != nil
 }
 
+type HostInfo struct {
+	Identity *string `json:"Identity,omitempty"`
+}
+
+// ToWire translates a HostInfo struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *HostInfo) ToWire() (wire.Value, error) {
+	var (
+		fields [1]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.Identity != nil {
+		w, err = wire.NewValueString(*(v.Identity)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 10, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+// FromWire deserializes a HostInfo struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a HostInfo struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v HostInfo
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *HostInfo) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 10:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.Identity = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a HostInfo
+// struct.
+func (v *HostInfo) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [1]string
+	i := 0
+	if v.Identity != nil {
+		fields[i] = fmt.Sprintf("Identity: %v", *(v.Identity))
+		i++
+	}
+
+	return fmt.Sprintf("HostInfo{%v}", strings.Join(fields[:i], ", "))
+}
+
+// Equals returns true if all the fields of this HostInfo match the
+// provided HostInfo.
+//
+// This function performs a deep comparison.
+func (v *HostInfo) Equals(rhs *HostInfo) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !_String_EqualsPtr(v.Identity, rhs.Identity) {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of HostInfo.
+func (v *HostInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.Identity != nil {
+		enc.AddString("Identity", *v.Identity)
+	}
+	return err
+}
+
+// GetIdentity returns the value of Identity if it is set or its
+// zero value if it is unset.
+func (v *HostInfo) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+
+	return
+}
+
+// IsSetIdentity returns true if Identity is not nil.
+func (v *HostInfo) IsSetIdentity() bool {
+	return v != nil && v.Identity != nil
+}
+
+type MembershipInfo struct {
+	CurrentHost      *HostInfo   `json:"currentHost,omitempty"`
+	ReachableMembers []string    `json:"reachableMembers,omitempty"`
+	Rings            []*RingInfo `json:"rings,omitempty"`
+}
+
+type _List_String_ValueList []string
+
+func (v _List_String_ValueList) ForEach(f func(wire.Value) error) error {
+	for _, x := range v {
+		w, err := wire.NewValueString(x), error(nil)
+		if err != nil {
+			return err
+		}
+		err = f(w)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_String_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_String_ValueList) ValueType() wire.Type {
+	return wire.TBinary
+}
+
+func (_List_String_ValueList) Close() {}
+
+type _List_RingInfo_ValueList []*RingInfo
+
+func (v _List_RingInfo_ValueList) ForEach(f func(wire.Value) error) error {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
+		w, err := x.ToWire()
+		if err != nil {
+			return err
+		}
+		err = f(w)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_RingInfo_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_RingInfo_ValueList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_List_RingInfo_ValueList) Close() {}
+
+// ToWire translates a MembershipInfo struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *MembershipInfo) ToWire() (wire.Value, error) {
+	var (
+		fields [3]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.CurrentHost != nil {
+		w, err = v.CurrentHost.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 10, Value: w}
+		i++
+	}
+	if v.ReachableMembers != nil {
+		w, err = wire.NewValueList(_List_String_ValueList(v.ReachableMembers)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 20, Value: w}
+		i++
+	}
+	if v.Rings != nil {
+		w, err = wire.NewValueList(_List_RingInfo_ValueList(v.Rings)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 30, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _HostInfo_Read(w wire.Value) (*HostInfo, error) {
+	var v HostInfo
+	err := v.FromWire(w)
+	return &v, err
+}
+
+func _List_String_Read(l wire.ValueList) ([]string, error) {
+	if l.ValueType() != wire.TBinary {
+		return nil, nil
+	}
+
+	o := make([]string, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
+		i, err := x.GetString(), error(nil)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Close()
+	return o, err
+}
+
+func _RingInfo_Read(w wire.Value) (*RingInfo, error) {
+	var v RingInfo
+	err := v.FromWire(w)
+	return &v, err
+}
+
+func _List_RingInfo_Read(l wire.ValueList) ([]*RingInfo, error) {
+	if l.ValueType() != wire.TStruct {
+		return nil, nil
+	}
+
+	o := make([]*RingInfo, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
+		i, err := _RingInfo_Read(x)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Close()
+	return o, err
+}
+
+// FromWire deserializes a MembershipInfo struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a MembershipInfo struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v MembershipInfo
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *MembershipInfo) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 10:
+			if field.Value.Type() == wire.TStruct {
+				v.CurrentHost, err = _HostInfo_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 20:
+			if field.Value.Type() == wire.TList {
+				v.ReachableMembers, err = _List_String_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+
+			}
+		case 30:
+			if field.Value.Type() == wire.TList {
+				v.Rings, err = _List_RingInfo_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a MembershipInfo
+// struct.
+func (v *MembershipInfo) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [3]string
+	i := 0
+	if v.CurrentHost != nil {
+		fields[i] = fmt.Sprintf("CurrentHost: %v", v.CurrentHost)
+		i++
+	}
+	if v.ReachableMembers != nil {
+		fields[i] = fmt.Sprintf("ReachableMembers: %v", v.ReachableMembers)
+		i++
+	}
+	if v.Rings != nil {
+		fields[i] = fmt.Sprintf("Rings: %v", v.Rings)
+		i++
+	}
+
+	return fmt.Sprintf("MembershipInfo{%v}", strings.Join(fields[:i], ", "))
+}
+
+func _List_String_Equals(lhs, rhs []string) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for i, lv := range lhs {
+		rv := rhs[i]
+		if !(lv == rv) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func _List_RingInfo_Equals(lhs, rhs []*RingInfo) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for i, lv := range lhs {
+		rv := rhs[i]
+		if !lv.Equals(rv) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Equals returns true if all the fields of this MembershipInfo match the
+// provided MembershipInfo.
+//
+// This function performs a deep comparison.
+func (v *MembershipInfo) Equals(rhs *MembershipInfo) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !((v.CurrentHost == nil && rhs.CurrentHost == nil) || (v.CurrentHost != nil && rhs.CurrentHost != nil && v.CurrentHost.Equals(rhs.CurrentHost))) {
+		return false
+	}
+	if !((v.ReachableMembers == nil && rhs.ReachableMembers == nil) || (v.ReachableMembers != nil && rhs.ReachableMembers != nil && _List_String_Equals(v.ReachableMembers, rhs.ReachableMembers))) {
+		return false
+	}
+	if !((v.Rings == nil && rhs.Rings == nil) || (v.Rings != nil && rhs.Rings != nil && _List_RingInfo_Equals(v.Rings, rhs.Rings))) {
+		return false
+	}
+
+	return true
+}
+
+type _List_String_Zapper []string
+
+// MarshalLogArray implements zapcore.ArrayMarshaler, enabling
+// fast logging of _List_String_Zapper.
+func (l _List_String_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err error) {
+	for _, v := range l {
+		enc.AppendString(v)
+	}
+	return err
+}
+
+type _List_RingInfo_Zapper []*RingInfo
+
+// MarshalLogArray implements zapcore.ArrayMarshaler, enabling
+// fast logging of _List_RingInfo_Zapper.
+func (l _List_RingInfo_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err error) {
+	for _, v := range l {
+		err = multierr.Append(err, enc.AppendObject(v))
+	}
+	return err
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of MembershipInfo.
+func (v *MembershipInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.CurrentHost != nil {
+		err = multierr.Append(err, enc.AddObject("currentHost", v.CurrentHost))
+	}
+	if v.ReachableMembers != nil {
+		err = multierr.Append(err, enc.AddArray("reachableMembers", (_List_String_Zapper)(v.ReachableMembers)))
+	}
+	if v.Rings != nil {
+		err = multierr.Append(err, enc.AddArray("rings", (_List_RingInfo_Zapper)(v.Rings)))
+	}
+	return err
+}
+
+// GetCurrentHost returns the value of CurrentHost if it is set or its
+// zero value if it is unset.
+func (v *MembershipInfo) GetCurrentHost() (o *HostInfo) {
+	if v != nil && v.CurrentHost != nil {
+		return v.CurrentHost
+	}
+
+	return
+}
+
+// IsSetCurrentHost returns true if CurrentHost is not nil.
+func (v *MembershipInfo) IsSetCurrentHost() bool {
+	return v != nil && v.CurrentHost != nil
+}
+
+// GetReachableMembers returns the value of ReachableMembers if it is set or its
+// zero value if it is unset.
+func (v *MembershipInfo) GetReachableMembers() (o []string) {
+	if v != nil && v.ReachableMembers != nil {
+		return v.ReachableMembers
+	}
+
+	return
+}
+
+// IsSetReachableMembers returns true if ReachableMembers is not nil.
+func (v *MembershipInfo) IsSetReachableMembers() bool {
+	return v != nil && v.ReachableMembers != nil
+}
+
+// GetRings returns the value of Rings if it is set or its
+// zero value if it is unset.
+func (v *MembershipInfo) GetRings() (o []*RingInfo) {
+	if v != nil && v.Rings != nil {
+		return v.Rings
+	}
+
+	return
+}
+
+// IsSetRings returns true if Rings is not nil.
+func (v *MembershipInfo) IsSetRings() bool {
+	return v != nil && v.Rings != nil
+}
+
+type RingInfo struct {
+	Role        *string     `json:"role,omitempty"`
+	ServerCount *int32      `json:"serverCount,omitempty"`
+	Servers     []*HostInfo `json:"servers,omitempty"`
+}
+
+type _List_HostInfo_ValueList []*HostInfo
+
+func (v _List_HostInfo_ValueList) ForEach(f func(wire.Value) error) error {
+	for i, x := range v {
+		if x == nil {
+			return fmt.Errorf("invalid [%v]: value is nil", i)
+		}
+		w, err := x.ToWire()
+		if err != nil {
+			return err
+		}
+		err = f(w)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (v _List_HostInfo_ValueList) Size() int {
+	return len(v)
+}
+
+func (_List_HostInfo_ValueList) ValueType() wire.Type {
+	return wire.TStruct
+}
+
+func (_List_HostInfo_ValueList) Close() {}
+
+// ToWire translates a RingInfo struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *RingInfo) ToWire() (wire.Value, error) {
+	var (
+		fields [3]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.Role != nil {
+		w, err = wire.NewValueString(*(v.Role)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 10, Value: w}
+		i++
+	}
+	if v.ServerCount != nil {
+		w, err = wire.NewValueI32(*(v.ServerCount)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 20, Value: w}
+		i++
+	}
+	if v.Servers != nil {
+		w, err = wire.NewValueList(_List_HostInfo_ValueList(v.Servers)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 30, Value: w}
+		i++
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _List_HostInfo_Read(l wire.ValueList) ([]*HostInfo, error) {
+	if l.ValueType() != wire.TStruct {
+		return nil, nil
+	}
+
+	o := make([]*HostInfo, 0, l.Size())
+	err := l.ForEach(func(x wire.Value) error {
+		i, err := _HostInfo_Read(x)
+		if err != nil {
+			return err
+		}
+		o = append(o, i)
+		return nil
+	})
+	l.Close()
+	return o, err
+}
+
+// FromWire deserializes a RingInfo struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a RingInfo struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v RingInfo
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *RingInfo) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 10:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.Role = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 20:
+			if field.Value.Type() == wire.TI32 {
+				var x int32
+				x, err = field.Value.GetI32(), error(nil)
+				v.ServerCount = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 30:
+			if field.Value.Type() == wire.TList {
+				v.Servers, err = _List_HostInfo_Read(field.Value.GetList())
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a RingInfo
+// struct.
+func (v *RingInfo) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [3]string
+	i := 0
+	if v.Role != nil {
+		fields[i] = fmt.Sprintf("Role: %v", *(v.Role))
+		i++
+	}
+	if v.ServerCount != nil {
+		fields[i] = fmt.Sprintf("ServerCount: %v", *(v.ServerCount))
+		i++
+	}
+	if v.Servers != nil {
+		fields[i] = fmt.Sprintf("Servers: %v", v.Servers)
+		i++
+	}
+
+	return fmt.Sprintf("RingInfo{%v}", strings.Join(fields[:i], ", "))
+}
+
+func _List_HostInfo_Equals(lhs, rhs []*HostInfo) bool {
+	if len(lhs) != len(rhs) {
+		return false
+	}
+
+	for i, lv := range lhs {
+		rv := rhs[i]
+		if !lv.Equals(rv) {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Equals returns true if all the fields of this RingInfo match the
+// provided RingInfo.
+//
+// This function performs a deep comparison.
+func (v *RingInfo) Equals(rhs *RingInfo) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !_String_EqualsPtr(v.Role, rhs.Role) {
+		return false
+	}
+	if !_I32_EqualsPtr(v.ServerCount, rhs.ServerCount) {
+		return false
+	}
+	if !((v.Servers == nil && rhs.Servers == nil) || (v.Servers != nil && rhs.Servers != nil && _List_HostInfo_Equals(v.Servers, rhs.Servers))) {
+		return false
+	}
+
+	return true
+}
+
+type _List_HostInfo_Zapper []*HostInfo
+
+// MarshalLogArray implements zapcore.ArrayMarshaler, enabling
+// fast logging of _List_HostInfo_Zapper.
+func (l _List_HostInfo_Zapper) MarshalLogArray(enc zapcore.ArrayEncoder) (err error) {
+	for _, v := range l {
+		err = multierr.Append(err, enc.AppendObject(v))
+	}
+	return err
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of RingInfo.
+func (v *RingInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.Role != nil {
+		enc.AddString("role", *v.Role)
+	}
+	if v.ServerCount != nil {
+		enc.AddInt32("serverCount", *v.ServerCount)
+	}
+	if v.Servers != nil {
+		err = multierr.Append(err, enc.AddArray("servers", (_List_HostInfo_Zapper)(v.Servers)))
+	}
+	return err
+}
+
+// GetRole returns the value of Role if it is set or its
+// zero value if it is unset.
+func (v *RingInfo) GetRole() (o string) {
+	if v != nil && v.Role != nil {
+		return *v.Role
+	}
+
+	return
+}
+
+// IsSetRole returns true if Role is not nil.
+func (v *RingInfo) IsSetRole() bool {
+	return v != nil && v.Role != nil
+}
+
+// GetServerCount returns the value of ServerCount if it is set or its
+// zero value if it is unset.
+func (v *RingInfo) GetServerCount() (o int32) {
+	if v != nil && v.ServerCount != nil {
+		return *v.ServerCount
+	}
+
+	return
+}
+
+// IsSetServerCount returns true if ServerCount is not nil.
+func (v *RingInfo) IsSetServerCount() bool {
+	return v != nil && v.ServerCount != nil
+}
+
+// GetServers returns the value of Servers if it is set or its
+// zero value if it is unset.
+func (v *RingInfo) GetServers() (o []*HostInfo) {
+	if v != nil && v.Servers != nil {
+		return v.Servers
+	}
+
+	return
+}
+
+// IsSetServers returns true if Servers is not nil.
+func (v *RingInfo) IsSetServers() bool {
+	return v != nil && v.Servers != nil
+}
+
 // ThriftModule represents the IDL file used to generate this package.
 var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "admin",
 	Package:  "github.com/uber/cadence/.gen/go/admin",
 	FilePath: "admin.thrift",
-	SHA1:     "d0cb30b14168816c9370a19deb75662809e045b7",
+	SHA1:     "d0f3cef4de0041c4951e862a88c7f44c81f15482",
 	Includes: []*thriftreflect.ThriftModule{
 		shared.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence.admin\n\ninclude \"shared.thrift\"\n\n/**\n* AdminService provides advanced APIs for debugging and analysis with admin privillege\n**/\nservice AdminService {\n  /**\n  * DescribeWorkflowExecution returns information about the internal states of workflow execution.\n  **/\n  DescribeWorkflowExecutionResponse DescribeWorkflowExecution(1: DescribeWorkflowExecutionRequest request)\n    throws (\n      1: shared.BadRequestError         badRequestError,\n      2: shared.InternalServiceError    internalServiceError,\n      3: shared.EntityNotExistsError    entityNotExistError,\n      4: shared.AccessDeniedError       accessDeniedError,\n    )\n\n  /**\n  * DescribeHistoryHost returns information about the internal states of a history host\n  **/\n  shared.DescribeHistoryHostResponse DescribeHistoryHost(1: shared.DescribeHistoryHostRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void CloseShard(1: shared.CloseShardRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void RemoveTask(1: shared.RemoveTaskRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  **/\n  GetWorkflowExecutionRawHistoryResponse GetWorkflowExecutionRawHistory(1: GetWorkflowExecutionRawHistoryRequest getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  * StartEventId defines the beginning of the event to fetch. The first event is inclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\n  GetWorkflowExecutionRawHistoryV2Response GetWorkflowExecutionRawHistoryV2(1: GetWorkflowExecutionRawHistoryV2Request getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * AddSearchAttribute whitelist search attribute in request.\n  **/\n  void AddSearchAttribute(1: AddSearchAttributeRequest request)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.ServiceBusyError serviceBusyError,\n    )\n}\n\nstruct DescribeWorkflowExecutionRequest {\n  10: optional string                       domain\n  20: optional shared.WorkflowExecution     execution\n}\n\nstruct DescribeWorkflowExecutionResponse {\n  10: optional string shardId\n  20: optional string historyAddr\n  40: optional string mutableStateInCache\n  50: optional string mutableStateInDatabase\n}\n\nstruct GetWorkflowExecutionRawHistoryRequest {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") firstEventId\n  40: optional i64 (js.type = \"Long\") nextEventId\n  50: optional i32 maximumPageSize\n  60: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryResponse {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional map<string, shared.ReplicationInfo> replicationInfo\n  40: optional i32 eventStoreVersion\n}\n\n/**\n  * StartEventId defines the beginning of the event to fetch. The first event is exclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\nstruct GetWorkflowExecutionRawHistoryV2Request {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") startEventId\n  40: optional i64 (js.type = \"Long\") startEventVersion\n  50: optional i64 (js.type = \"Long\") endEventId\n  60: optional i64 (js.type = \"Long\") endEventVersion\n  70: optional i32 maximumPageSize\n  80: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryV2Response {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional shared.VersionHistory versionHistory\n}\n\nstruct AddSearchAttributeRequest {\n  10: optional map<string, shared.IndexedValueType> searchAttribute\n  20: optional string securityToken\n}\n"
+const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence.admin\n\ninclude \"shared.thrift\"\n\n/**\n* AdminService provides advanced APIs for debugging and analysis with admin privillege\n**/\nservice AdminService {\n  /**\n  * DescribeWorkflowExecution returns information about the internal states of workflow execution.\n  **/\n  DescribeWorkflowExecutionResponse DescribeWorkflowExecution(1: DescribeWorkflowExecutionRequest request)\n    throws (\n      1: shared.BadRequestError         badRequestError,\n      2: shared.InternalServiceError    internalServiceError,\n      3: shared.EntityNotExistsError    entityNotExistError,\n      4: shared.AccessDeniedError       accessDeniedError,\n    )\n\n  /**\n  * DescribeHistoryHost returns information about the internal states of a history host\n  **/\n  shared.DescribeHistoryHostResponse DescribeHistoryHost(1: shared.DescribeHistoryHostRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void CloseShard(1: shared.CloseShardRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void RemoveTask(1: shared.RemoveTaskRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  **/\n  GetWorkflowExecutionRawHistoryResponse GetWorkflowExecutionRawHistory(1: GetWorkflowExecutionRawHistoryRequest getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  * StartEventId defines the beginning of the event to fetch. The first event is inclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\n  GetWorkflowExecutionRawHistoryV2Response GetWorkflowExecutionRawHistoryV2(1: GetWorkflowExecutionRawHistoryV2Request getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * AddSearchAttribute whitelist search attribute in request.\n  **/\n  void AddSearchAttribute(1: AddSearchAttributeRequest request)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * DescribeCluster returns information about cadence cluster\n  **/\n  DescribeClusterResponse DescribeCluster()\n    throws (\n      1: shared.InternalServiceError internalServiceError,\n      2: shared.ServiceBusyError serviceBusyError,\n    )\n}\n\nstruct DescribeWorkflowExecutionRequest {\n  10: optional string                       domain\n  20: optional shared.WorkflowExecution     execution\n}\n\nstruct DescribeWorkflowExecutionResponse {\n  10: optional string shardId\n  20: optional string historyAddr\n  40: optional string mutableStateInCache\n  50: optional string mutableStateInDatabase\n}\n\nstruct GetWorkflowExecutionRawHistoryRequest {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") firstEventId\n  40: optional i64 (js.type = \"Long\") nextEventId\n  50: optional i32 maximumPageSize\n  60: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryResponse {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional map<string, shared.ReplicationInfo> replicationInfo\n  40: optional i32 eventStoreVersion\n}\n\n/**\n  * StartEventId defines the beginning of the event to fetch. The first event is exclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\nstruct GetWorkflowExecutionRawHistoryV2Request {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") startEventId\n  40: optional i64 (js.type = \"Long\") startEventVersion\n  50: optional i64 (js.type = \"Long\") endEventId\n  60: optional i64 (js.type = \"Long\") endEventVersion\n  70: optional i32 maximumPageSize\n  80: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryV2Response {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional shared.VersionHistory versionHistory\n}\n\nstruct AddSearchAttributeRequest {\n  10: optional map<string, shared.IndexedValueType> searchAttribute\n  20: optional string securityToken\n}\n\nstruct HostInfo {\n  10: optional string Identity\n}\n\nstruct RingInfo {\n  10: optional string role\n  20: optional i32 serverCount\n  30: optional list<HostInfo> servers\n}\n\nstruct MembershipInfo {\n  10: optional HostInfo currentHost\n  20: optional list<string> reachableMembers\n  30: optional list<RingInfo> rings\n}\n\nstruct DescribeClusterResponse {\n  10: optional shared.SupportedClientVersions supportedClientVersions\n  20: optional MembershipInfo membershipInfo\n}\n"
 
 // AdminService_AddSearchAttribute_Args represents the arguments for the AdminService.AddSearchAttribute function.
 //
@@ -3357,6 +4357,479 @@ func (v *AdminService_CloseShard_Result) MethodName() string {
 //
 // This will always be Reply for this struct.
 func (v *AdminService_CloseShard_Result) EnvelopeType() wire.EnvelopeType {
+	return wire.Reply
+}
+
+// AdminService_DescribeCluster_Args represents the arguments for the AdminService.DescribeCluster function.
+//
+// The arguments for DescribeCluster are sent and received over the wire as this struct.
+type AdminService_DescribeCluster_Args struct {
+}
+
+// ToWire translates a AdminService_DescribeCluster_Args struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *AdminService_DescribeCluster_Args) ToWire() (wire.Value, error) {
+	var (
+		fields [0]wire.Field
+		i      int = 0
+	)
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+// FromWire deserializes a AdminService_DescribeCluster_Args struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a AdminService_DescribeCluster_Args struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v AdminService_DescribeCluster_Args
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *AdminService_DescribeCluster_Args) FromWire(w wire.Value) error {
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		}
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a AdminService_DescribeCluster_Args
+// struct.
+func (v *AdminService_DescribeCluster_Args) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [0]string
+	i := 0
+
+	return fmt.Sprintf("AdminService_DescribeCluster_Args{%v}", strings.Join(fields[:i], ", "))
+}
+
+// Equals returns true if all the fields of this AdminService_DescribeCluster_Args match the
+// provided AdminService_DescribeCluster_Args.
+//
+// This function performs a deep comparison.
+func (v *AdminService_DescribeCluster_Args) Equals(rhs *AdminService_DescribeCluster_Args) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of AdminService_DescribeCluster_Args.
+func (v *AdminService_DescribeCluster_Args) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	return err
+}
+
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the arguments.
+//
+// This will always be "DescribeCluster" for this struct.
+func (v *AdminService_DescribeCluster_Args) MethodName() string {
+	return "DescribeCluster"
+}
+
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Call for this struct.
+func (v *AdminService_DescribeCluster_Args) EnvelopeType() wire.EnvelopeType {
+	return wire.Call
+}
+
+// AdminService_DescribeCluster_Helper provides functions that aid in handling the
+// parameters and return values of the AdminService.DescribeCluster
+// function.
+var AdminService_DescribeCluster_Helper = struct {
+	// Args accepts the parameters of DescribeCluster in-order and returns
+	// the arguments struct for the function.
+	Args func() *AdminService_DescribeCluster_Args
+
+	// IsException returns true if the given error can be thrown
+	// by DescribeCluster.
+	//
+	// An error can be thrown by DescribeCluster only if the
+	// corresponding exception type was mentioned in the 'throws'
+	// section for it in the Thrift file.
+	IsException func(error) bool
+
+	// WrapResponse returns the result struct for DescribeCluster
+	// given its return value and error.
+	//
+	// This allows mapping values and errors returned by
+	// DescribeCluster into a serializable result struct.
+	// WrapResponse returns a non-nil error if the provided
+	// error cannot be thrown by DescribeCluster
+	//
+	//   value, err := DescribeCluster(args)
+	//   result, err := AdminService_DescribeCluster_Helper.WrapResponse(value, err)
+	//   if err != nil {
+	//     return fmt.Errorf("unexpected error from DescribeCluster: %v", err)
+	//   }
+	//   serialize(result)
+	WrapResponse func(*DescribeClusterResponse, error) (*AdminService_DescribeCluster_Result, error)
+
+	// UnwrapResponse takes the result struct for DescribeCluster
+	// and returns the value or error returned by it.
+	//
+	// The error is non-nil only if DescribeCluster threw an
+	// exception.
+	//
+	//   result := deserialize(bytes)
+	//   value, err := AdminService_DescribeCluster_Helper.UnwrapResponse(result)
+	UnwrapResponse func(*AdminService_DescribeCluster_Result) (*DescribeClusterResponse, error)
+}{}
+
+func init() {
+	AdminService_DescribeCluster_Helper.Args = func() *AdminService_DescribeCluster_Args {
+		return &AdminService_DescribeCluster_Args{}
+	}
+
+	AdminService_DescribeCluster_Helper.IsException = func(err error) bool {
+		switch err.(type) {
+		case *shared.InternalServiceError:
+			return true
+		case *shared.ServiceBusyError:
+			return true
+		default:
+			return false
+		}
+	}
+
+	AdminService_DescribeCluster_Helper.WrapResponse = func(success *DescribeClusterResponse, err error) (*AdminService_DescribeCluster_Result, error) {
+		if err == nil {
+			return &AdminService_DescribeCluster_Result{Success: success}, nil
+		}
+
+		switch e := err.(type) {
+		case *shared.InternalServiceError:
+			if e == nil {
+				return nil, errors.New("WrapResponse received non-nil error type with nil value for AdminService_DescribeCluster_Result.InternalServiceError")
+			}
+			return &AdminService_DescribeCluster_Result{InternalServiceError: e}, nil
+		case *shared.ServiceBusyError:
+			if e == nil {
+				return nil, errors.New("WrapResponse received non-nil error type with nil value for AdminService_DescribeCluster_Result.ServiceBusyError")
+			}
+			return &AdminService_DescribeCluster_Result{ServiceBusyError: e}, nil
+		}
+
+		return nil, err
+	}
+	AdminService_DescribeCluster_Helper.UnwrapResponse = func(result *AdminService_DescribeCluster_Result) (success *DescribeClusterResponse, err error) {
+		if result.InternalServiceError != nil {
+			err = result.InternalServiceError
+			return
+		}
+		if result.ServiceBusyError != nil {
+			err = result.ServiceBusyError
+			return
+		}
+
+		if result.Success != nil {
+			success = result.Success
+			return
+		}
+
+		err = errors.New("expected a non-void result")
+		return
+	}
+
+}
+
+// AdminService_DescribeCluster_Result represents the result of a AdminService.DescribeCluster function call.
+//
+// The result of a DescribeCluster execution is sent and received over the wire as this struct.
+//
+// Success is set only if the function did not throw an exception.
+type AdminService_DescribeCluster_Result struct {
+	// Value returned by DescribeCluster after a successful execution.
+	Success              *DescribeClusterResponse     `json:"success,omitempty"`
+	InternalServiceError *shared.InternalServiceError `json:"internalServiceError,omitempty"`
+	ServiceBusyError     *shared.ServiceBusyError     `json:"serviceBusyError,omitempty"`
+}
+
+// ToWire translates a AdminService_DescribeCluster_Result struct into a Thrift-level intermediate
+// representation. This intermediate representation may be serialized
+// into bytes using a ThriftRW protocol implementation.
+//
+// An error is returned if the struct or any of its fields failed to
+// validate.
+//
+//   x, err := v.ToWire()
+//   if err != nil {
+//     return err
+//   }
+//
+//   if err := binaryProtocol.Encode(x, writer); err != nil {
+//     return err
+//   }
+func (v *AdminService_DescribeCluster_Result) ToWire() (wire.Value, error) {
+	var (
+		fields [3]wire.Field
+		i      int = 0
+		w      wire.Value
+		err    error
+	)
+
+	if v.Success != nil {
+		w, err = v.Success.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 0, Value: w}
+		i++
+	}
+	if v.InternalServiceError != nil {
+		w, err = v.InternalServiceError.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 1, Value: w}
+		i++
+	}
+	if v.ServiceBusyError != nil {
+		w, err = v.ServiceBusyError.ToWire()
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 2, Value: w}
+		i++
+	}
+
+	if i != 1 {
+		return wire.Value{}, fmt.Errorf("AdminService_DescribeCluster_Result should have exactly one field: got %v fields", i)
+	}
+
+	return wire.NewValueStruct(wire.Struct{Fields: fields[:i]}), nil
+}
+
+func _DescribeClusterResponse_Read(w wire.Value) (*DescribeClusterResponse, error) {
+	var v DescribeClusterResponse
+	err := v.FromWire(w)
+	return &v, err
+}
+
+// FromWire deserializes a AdminService_DescribeCluster_Result struct from its Thrift-level
+// representation. The Thrift-level representation may be obtained
+// from a ThriftRW protocol implementation.
+//
+// An error is returned if we were unable to build a AdminService_DescribeCluster_Result struct
+// from the provided intermediate representation.
+//
+//   x, err := binaryProtocol.Decode(reader, wire.TStruct)
+//   if err != nil {
+//     return nil, err
+//   }
+//
+//   var v AdminService_DescribeCluster_Result
+//   if err := v.FromWire(x); err != nil {
+//     return nil, err
+//   }
+//   return &v, nil
+func (v *AdminService_DescribeCluster_Result) FromWire(w wire.Value) error {
+	var err error
+
+	for _, field := range w.GetStruct().Fields {
+		switch field.ID {
+		case 0:
+			if field.Value.Type() == wire.TStruct {
+				v.Success, err = _DescribeClusterResponse_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 1:
+			if field.Value.Type() == wire.TStruct {
+				v.InternalServiceError, err = _InternalServiceError_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 2:
+			if field.Value.Type() == wire.TStruct {
+				v.ServiceBusyError, err = _ServiceBusyError_Read(field.Value)
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+	}
+
+	count := 0
+	if v.Success != nil {
+		count++
+	}
+	if v.InternalServiceError != nil {
+		count++
+	}
+	if v.ServiceBusyError != nil {
+		count++
+	}
+	if count != 1 {
+		return fmt.Errorf("AdminService_DescribeCluster_Result should have exactly one field: got %v fields", count)
+	}
+
+	return nil
+}
+
+// String returns a readable string representation of a AdminService_DescribeCluster_Result
+// struct.
+func (v *AdminService_DescribeCluster_Result) String() string {
+	if v == nil {
+		return "<nil>"
+	}
+
+	var fields [3]string
+	i := 0
+	if v.Success != nil {
+		fields[i] = fmt.Sprintf("Success: %v", v.Success)
+		i++
+	}
+	if v.InternalServiceError != nil {
+		fields[i] = fmt.Sprintf("InternalServiceError: %v", v.InternalServiceError)
+		i++
+	}
+	if v.ServiceBusyError != nil {
+		fields[i] = fmt.Sprintf("ServiceBusyError: %v", v.ServiceBusyError)
+		i++
+	}
+
+	return fmt.Sprintf("AdminService_DescribeCluster_Result{%v}", strings.Join(fields[:i], ", "))
+}
+
+// Equals returns true if all the fields of this AdminService_DescribeCluster_Result match the
+// provided AdminService_DescribeCluster_Result.
+//
+// This function performs a deep comparison.
+func (v *AdminService_DescribeCluster_Result) Equals(rhs *AdminService_DescribeCluster_Result) bool {
+	if v == nil {
+		return rhs == nil
+	} else if rhs == nil {
+		return false
+	}
+	if !((v.Success == nil && rhs.Success == nil) || (v.Success != nil && rhs.Success != nil && v.Success.Equals(rhs.Success))) {
+		return false
+	}
+	if !((v.InternalServiceError == nil && rhs.InternalServiceError == nil) || (v.InternalServiceError != nil && rhs.InternalServiceError != nil && v.InternalServiceError.Equals(rhs.InternalServiceError))) {
+		return false
+	}
+	if !((v.ServiceBusyError == nil && rhs.ServiceBusyError == nil) || (v.ServiceBusyError != nil && rhs.ServiceBusyError != nil && v.ServiceBusyError.Equals(rhs.ServiceBusyError))) {
+		return false
+	}
+
+	return true
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, enabling
+// fast logging of AdminService_DescribeCluster_Result.
+func (v *AdminService_DescribeCluster_Result) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
+	if v == nil {
+		return nil
+	}
+	if v.Success != nil {
+		err = multierr.Append(err, enc.AddObject("success", v.Success))
+	}
+	if v.InternalServiceError != nil {
+		err = multierr.Append(err, enc.AddObject("internalServiceError", v.InternalServiceError))
+	}
+	if v.ServiceBusyError != nil {
+		err = multierr.Append(err, enc.AddObject("serviceBusyError", v.ServiceBusyError))
+	}
+	return err
+}
+
+// GetSuccess returns the value of Success if it is set or its
+// zero value if it is unset.
+func (v *AdminService_DescribeCluster_Result) GetSuccess() (o *DescribeClusterResponse) {
+	if v != nil && v.Success != nil {
+		return v.Success
+	}
+
+	return
+}
+
+// IsSetSuccess returns true if Success is not nil.
+func (v *AdminService_DescribeCluster_Result) IsSetSuccess() bool {
+	return v != nil && v.Success != nil
+}
+
+// GetInternalServiceError returns the value of InternalServiceError if it is set or its
+// zero value if it is unset.
+func (v *AdminService_DescribeCluster_Result) GetInternalServiceError() (o *shared.InternalServiceError) {
+	if v != nil && v.InternalServiceError != nil {
+		return v.InternalServiceError
+	}
+
+	return
+}
+
+// IsSetInternalServiceError returns true if InternalServiceError is not nil.
+func (v *AdminService_DescribeCluster_Result) IsSetInternalServiceError() bool {
+	return v != nil && v.InternalServiceError != nil
+}
+
+// GetServiceBusyError returns the value of ServiceBusyError if it is set or its
+// zero value if it is unset.
+func (v *AdminService_DescribeCluster_Result) GetServiceBusyError() (o *shared.ServiceBusyError) {
+	if v != nil && v.ServiceBusyError != nil {
+		return v.ServiceBusyError
+	}
+
+	return
+}
+
+// IsSetServiceBusyError returns true if ServiceBusyError is not nil.
+func (v *AdminService_DescribeCluster_Result) IsSetServiceBusyError() bool {
+	return v != nil && v.ServiceBusyError != nil
+}
+
+// MethodName returns the name of the Thrift function as specified in
+// the IDL, for which this struct represent the result.
+//
+// This will always be "DescribeCluster" for this struct.
+func (v *AdminService_DescribeCluster_Result) MethodName() string {
+	return "DescribeCluster"
+}
+
+// EnvelopeType returns the kind of value inside this struct.
+//
+// This will always be Reply for this struct.
+func (v *AdminService_DescribeCluster_Result) EnvelopeType() wire.EnvelopeType {
 	return wire.Reply
 }
 

--- a/.gen/go/admin/admin.go
+++ b/.gen/go/admin/admin.go
@@ -2973,8 +2973,8 @@ func (v *MembershipInfo) IsSetRings() bool {
 
 type RingInfo struct {
 	Role        *string     `json:"role,omitempty"`
-	ServerCount *int32      `json:"serverCount,omitempty"`
-	Servers     []*HostInfo `json:"servers,omitempty"`
+	MemberCount *int32      `json:"memberCount,omitempty"`
+	Members     []*HostInfo `json:"members,omitempty"`
 }
 
 type _List_HostInfo_ValueList []*HostInfo
@@ -3037,16 +3037,16 @@ func (v *RingInfo) ToWire() (wire.Value, error) {
 		fields[i] = wire.Field{ID: 10, Value: w}
 		i++
 	}
-	if v.ServerCount != nil {
-		w, err = wire.NewValueI32(*(v.ServerCount)), error(nil)
+	if v.MemberCount != nil {
+		w, err = wire.NewValueI32(*(v.MemberCount)), error(nil)
 		if err != nil {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 20, Value: w}
 		i++
 	}
-	if v.Servers != nil {
-		w, err = wire.NewValueList(_List_HostInfo_ValueList(v.Servers)), error(nil)
+	if v.Members != nil {
+		w, err = wire.NewValueList(_List_HostInfo_ValueList(v.Members)), error(nil)
 		if err != nil {
 			return w, err
 		}
@@ -3111,7 +3111,7 @@ func (v *RingInfo) FromWire(w wire.Value) error {
 			if field.Value.Type() == wire.TI32 {
 				var x int32
 				x, err = field.Value.GetI32(), error(nil)
-				v.ServerCount = &x
+				v.MemberCount = &x
 				if err != nil {
 					return err
 				}
@@ -3119,7 +3119,7 @@ func (v *RingInfo) FromWire(w wire.Value) error {
 			}
 		case 30:
 			if field.Value.Type() == wire.TList {
-				v.Servers, err = _List_HostInfo_Read(field.Value.GetList())
+				v.Members, err = _List_HostInfo_Read(field.Value.GetList())
 				if err != nil {
 					return err
 				}
@@ -3144,12 +3144,12 @@ func (v *RingInfo) String() string {
 		fields[i] = fmt.Sprintf("Role: %v", *(v.Role))
 		i++
 	}
-	if v.ServerCount != nil {
-		fields[i] = fmt.Sprintf("ServerCount: %v", *(v.ServerCount))
+	if v.MemberCount != nil {
+		fields[i] = fmt.Sprintf("MemberCount: %v", *(v.MemberCount))
 		i++
 	}
-	if v.Servers != nil {
-		fields[i] = fmt.Sprintf("Servers: %v", v.Servers)
+	if v.Members != nil {
+		fields[i] = fmt.Sprintf("Members: %v", v.Members)
 		i++
 	}
 
@@ -3184,10 +3184,10 @@ func (v *RingInfo) Equals(rhs *RingInfo) bool {
 	if !_String_EqualsPtr(v.Role, rhs.Role) {
 		return false
 	}
-	if !_I32_EqualsPtr(v.ServerCount, rhs.ServerCount) {
+	if !_I32_EqualsPtr(v.MemberCount, rhs.MemberCount) {
 		return false
 	}
-	if !((v.Servers == nil && rhs.Servers == nil) || (v.Servers != nil && rhs.Servers != nil && _List_HostInfo_Equals(v.Servers, rhs.Servers))) {
+	if !((v.Members == nil && rhs.Members == nil) || (v.Members != nil && rhs.Members != nil && _List_HostInfo_Equals(v.Members, rhs.Members))) {
 		return false
 	}
 
@@ -3214,11 +3214,11 @@ func (v *RingInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	if v.Role != nil {
 		enc.AddString("role", *v.Role)
 	}
-	if v.ServerCount != nil {
-		enc.AddInt32("serverCount", *v.ServerCount)
+	if v.MemberCount != nil {
+		enc.AddInt32("memberCount", *v.MemberCount)
 	}
-	if v.Servers != nil {
-		err = multierr.Append(err, enc.AddArray("servers", (_List_HostInfo_Zapper)(v.Servers)))
+	if v.Members != nil {
+		err = multierr.Append(err, enc.AddArray("members", (_List_HostInfo_Zapper)(v.Members)))
 	}
 	return err
 }
@@ -3238,34 +3238,34 @@ func (v *RingInfo) IsSetRole() bool {
 	return v != nil && v.Role != nil
 }
 
-// GetServerCount returns the value of ServerCount if it is set or its
+// GetMemberCount returns the value of MemberCount if it is set or its
 // zero value if it is unset.
-func (v *RingInfo) GetServerCount() (o int32) {
-	if v != nil && v.ServerCount != nil {
-		return *v.ServerCount
+func (v *RingInfo) GetMemberCount() (o int32) {
+	if v != nil && v.MemberCount != nil {
+		return *v.MemberCount
 	}
 
 	return
 }
 
-// IsSetServerCount returns true if ServerCount is not nil.
-func (v *RingInfo) IsSetServerCount() bool {
-	return v != nil && v.ServerCount != nil
+// IsSetMemberCount returns true if MemberCount is not nil.
+func (v *RingInfo) IsSetMemberCount() bool {
+	return v != nil && v.MemberCount != nil
 }
 
-// GetServers returns the value of Servers if it is set or its
+// GetMembers returns the value of Members if it is set or its
 // zero value if it is unset.
-func (v *RingInfo) GetServers() (o []*HostInfo) {
-	if v != nil && v.Servers != nil {
-		return v.Servers
+func (v *RingInfo) GetMembers() (o []*HostInfo) {
+	if v != nil && v.Members != nil {
+		return v.Members
 	}
 
 	return
 }
 
-// IsSetServers returns true if Servers is not nil.
-func (v *RingInfo) IsSetServers() bool {
-	return v != nil && v.Servers != nil
+// IsSetMembers returns true if Members is not nil.
+func (v *RingInfo) IsSetMembers() bool {
+	return v != nil && v.Members != nil
 }
 
 // ThriftModule represents the IDL file used to generate this package.
@@ -3273,14 +3273,14 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "admin",
 	Package:  "github.com/uber/cadence/.gen/go/admin",
 	FilePath: "admin.thrift",
-	SHA1:     "d0f3cef4de0041c4951e862a88c7f44c81f15482",
+	SHA1:     "c1f0f309c4be6dace7e0e8b6c419a63f83d8bece",
 	Includes: []*thriftreflect.ThriftModule{
 		shared.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence.admin\n\ninclude \"shared.thrift\"\n\n/**\n* AdminService provides advanced APIs for debugging and analysis with admin privillege\n**/\nservice AdminService {\n  /**\n  * DescribeWorkflowExecution returns information about the internal states of workflow execution.\n  **/\n  DescribeWorkflowExecutionResponse DescribeWorkflowExecution(1: DescribeWorkflowExecutionRequest request)\n    throws (\n      1: shared.BadRequestError         badRequestError,\n      2: shared.InternalServiceError    internalServiceError,\n      3: shared.EntityNotExistsError    entityNotExistError,\n      4: shared.AccessDeniedError       accessDeniedError,\n    )\n\n  /**\n  * DescribeHistoryHost returns information about the internal states of a history host\n  **/\n  shared.DescribeHistoryHostResponse DescribeHistoryHost(1: shared.DescribeHistoryHostRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void CloseShard(1: shared.CloseShardRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void RemoveTask(1: shared.RemoveTaskRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  **/\n  GetWorkflowExecutionRawHistoryResponse GetWorkflowExecutionRawHistory(1: GetWorkflowExecutionRawHistoryRequest getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  * StartEventId defines the beginning of the event to fetch. The first event is inclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\n  GetWorkflowExecutionRawHistoryV2Response GetWorkflowExecutionRawHistoryV2(1: GetWorkflowExecutionRawHistoryV2Request getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * AddSearchAttribute whitelist search attribute in request.\n  **/\n  void AddSearchAttribute(1: AddSearchAttributeRequest request)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * DescribeCluster returns information about cadence cluster\n  **/\n  DescribeClusterResponse DescribeCluster()\n    throws (\n      1: shared.InternalServiceError internalServiceError,\n      2: shared.ServiceBusyError serviceBusyError,\n    )\n}\n\nstruct DescribeWorkflowExecutionRequest {\n  10: optional string                       domain\n  20: optional shared.WorkflowExecution     execution\n}\n\nstruct DescribeWorkflowExecutionResponse {\n  10: optional string shardId\n  20: optional string historyAddr\n  40: optional string mutableStateInCache\n  50: optional string mutableStateInDatabase\n}\n\nstruct GetWorkflowExecutionRawHistoryRequest {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") firstEventId\n  40: optional i64 (js.type = \"Long\") nextEventId\n  50: optional i32 maximumPageSize\n  60: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryResponse {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional map<string, shared.ReplicationInfo> replicationInfo\n  40: optional i32 eventStoreVersion\n}\n\n/**\n  * StartEventId defines the beginning of the event to fetch. The first event is exclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\nstruct GetWorkflowExecutionRawHistoryV2Request {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") startEventId\n  40: optional i64 (js.type = \"Long\") startEventVersion\n  50: optional i64 (js.type = \"Long\") endEventId\n  60: optional i64 (js.type = \"Long\") endEventVersion\n  70: optional i32 maximumPageSize\n  80: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryV2Response {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional shared.VersionHistory versionHistory\n}\n\nstruct AddSearchAttributeRequest {\n  10: optional map<string, shared.IndexedValueType> searchAttribute\n  20: optional string securityToken\n}\n\nstruct HostInfo {\n  10: optional string Identity\n}\n\nstruct RingInfo {\n  10: optional string role\n  20: optional i32 serverCount\n  30: optional list<HostInfo> servers\n}\n\nstruct MembershipInfo {\n  10: optional HostInfo currentHost\n  20: optional list<string> reachableMembers\n  30: optional list<RingInfo> rings\n}\n\nstruct DescribeClusterResponse {\n  10: optional shared.SupportedClientVersions supportedClientVersions\n  20: optional MembershipInfo membershipInfo\n}\n"
+const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence.admin\n\ninclude \"shared.thrift\"\n\n/**\n* AdminService provides advanced APIs for debugging and analysis with admin privillege\n**/\nservice AdminService {\n  /**\n  * DescribeWorkflowExecution returns information about the internal states of workflow execution.\n  **/\n  DescribeWorkflowExecutionResponse DescribeWorkflowExecution(1: DescribeWorkflowExecutionRequest request)\n    throws (\n      1: shared.BadRequestError         badRequestError,\n      2: shared.InternalServiceError    internalServiceError,\n      3: shared.EntityNotExistsError    entityNotExistError,\n      4: shared.AccessDeniedError       accessDeniedError,\n    )\n\n  /**\n  * DescribeHistoryHost returns information about the internal states of a history host\n  **/\n  shared.DescribeHistoryHostResponse DescribeHistoryHost(1: shared.DescribeHistoryHostRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void CloseShard(1: shared.CloseShardRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n  void RemoveTask(1: shared.RemoveTaskRequest request)\n    throws (\n      1: shared.BadRequestError       badRequestError,\n      2: shared.InternalServiceError  internalServiceError,\n      3: shared.AccessDeniedError     accessDeniedError,\n    )\n\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  **/\n  GetWorkflowExecutionRawHistoryResponse GetWorkflowExecutionRawHistory(1: GetWorkflowExecutionRawHistoryRequest getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * Returns the raw history of specified workflow execution.  It fails with 'EntityNotExistError' if speficied workflow\n  * execution in unknown to the service.\n  * StartEventId defines the beginning of the event to fetch. The first event is inclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\n  GetWorkflowExecutionRawHistoryV2Response GetWorkflowExecutionRawHistoryV2(1: GetWorkflowExecutionRawHistoryV2Request getRequest)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.EntityNotExistsError entityNotExistError,\n      4: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * AddSearchAttribute whitelist search attribute in request.\n  **/\n  void AddSearchAttribute(1: AddSearchAttributeRequest request)\n    throws (\n      1: shared.BadRequestError badRequestError,\n      2: shared.InternalServiceError internalServiceError,\n      3: shared.ServiceBusyError serviceBusyError,\n    )\n\n  /**\n  * DescribeCluster returns information about cadence cluster\n  **/\n  DescribeClusterResponse DescribeCluster()\n    throws (\n      1: shared.InternalServiceError internalServiceError,\n      2: shared.ServiceBusyError serviceBusyError,\n    )\n}\n\nstruct DescribeWorkflowExecutionRequest {\n  10: optional string                       domain\n  20: optional shared.WorkflowExecution     execution\n}\n\nstruct DescribeWorkflowExecutionResponse {\n  10: optional string shardId\n  20: optional string historyAddr\n  40: optional string mutableStateInCache\n  50: optional string mutableStateInDatabase\n}\n\nstruct GetWorkflowExecutionRawHistoryRequest {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") firstEventId\n  40: optional i64 (js.type = \"Long\") nextEventId\n  50: optional i32 maximumPageSize\n  60: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryResponse {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional map<string, shared.ReplicationInfo> replicationInfo\n  40: optional i32 eventStoreVersion\n}\n\n/**\n  * StartEventId defines the beginning of the event to fetch. The first event is exclusive.\n  * EndEventId and EndEventVersion defines the end of the event to fetch. The end event is exclusive.\n  **/\nstruct GetWorkflowExecutionRawHistoryV2Request {\n  10: optional string domain\n  20: optional shared.WorkflowExecution execution\n  30: optional i64 (js.type = \"Long\") startEventId\n  40: optional i64 (js.type = \"Long\") startEventVersion\n  50: optional i64 (js.type = \"Long\") endEventId\n  60: optional i64 (js.type = \"Long\") endEventVersion\n  70: optional i32 maximumPageSize\n  80: optional binary nextPageToken\n}\n\nstruct GetWorkflowExecutionRawHistoryV2Response {\n  10: optional binary nextPageToken\n  20: optional list<shared.DataBlob> historyBatches\n  30: optional shared.VersionHistory versionHistory\n}\n\nstruct AddSearchAttributeRequest {\n  10: optional map<string, shared.IndexedValueType> searchAttribute\n  20: optional string securityToken\n}\n\nstruct HostInfo {\n  10: optional string Identity\n}\n\nstruct RingInfo {\n  10: optional string role\n  20: optional i32 memberCount\n  30: optional list<HostInfo> members\n}\n\nstruct MembershipInfo {\n  10: optional HostInfo currentHost\n  20: optional list<string> reachableMembers\n  30: optional list<RingInfo> rings\n}\n\nstruct DescribeClusterResponse {\n  10: optional shared.SupportedClientVersions supportedClientVersions\n  20: optional MembershipInfo membershipInfo\n}\n"
 
 // AdminService_AddSearchAttribute_Args represents the arguments for the AdminService.AddSearchAttribute function.
 //

--- a/.gen/go/admin/adminserviceclient/client.go
+++ b/.gen/go/admin/adminserviceclient/client.go
@@ -50,6 +50,11 @@ type Interface interface {
 		opts ...yarpc.CallOption,
 	) error
 
+	DescribeCluster(
+		ctx context.Context,
+		opts ...yarpc.CallOption,
+	) (*admin.DescribeClusterResponse, error)
+
 	DescribeHistoryHost(
 		ctx context.Context,
 		Request *shared.DescribeHistoryHostRequest,
@@ -148,6 +153,28 @@ func (c client) CloseShard(
 	}
 
 	err = admin.AdminService_CloseShard_Helper.UnwrapResponse(&result)
+	return
+}
+
+func (c client) DescribeCluster(
+	ctx context.Context,
+	opts ...yarpc.CallOption,
+) (success *admin.DescribeClusterResponse, err error) {
+
+	args := admin.AdminService_DescribeCluster_Helper.Args()
+
+	var body wire.Value
+	body, err = c.c.Call(ctx, args, opts...)
+	if err != nil {
+		return
+	}
+
+	var result admin.AdminService_DescribeCluster_Result
+	if err = result.FromWire(body); err != nil {
+		return
+	}
+
+	success, err = admin.AdminService_DescribeCluster_Helper.UnwrapResponse(&result)
 	return
 }
 

--- a/.gen/go/admin/adminservicetest/client.go
+++ b/.gen/go/admin/adminservicetest/client.go
@@ -127,6 +127,37 @@ func (mr *_MockClientRecorder) CloseShard(
 	return mr.mock.ctrl.RecordCall(mr.mock, "CloseShard", args...)
 }
 
+// DescribeCluster responds to a DescribeCluster call based on the mock expectations. This
+// call will fail if the mock does not expect this call. Use EXPECT to expect
+// a call to this function.
+//
+// 	client.EXPECT().DescribeCluster(gomock.Any(), ...).Return(...)
+// 	... := client.DescribeCluster(...)
+func (m *MockClient) DescribeCluster(
+	ctx context.Context,
+	opts ...yarpc.CallOption,
+) (success *admin.DescribeClusterResponse, err error) {
+
+	args := []interface{}{ctx}
+	for _, o := range opts {
+		args = append(args, o)
+	}
+	i := 0
+	ret := m.ctrl.Call(m, "DescribeCluster", args...)
+	success, _ = ret[i].(*admin.DescribeClusterResponse)
+	i++
+	err, _ = ret[i].(error)
+	return
+}
+
+func (mr *_MockClientRecorder) DescribeCluster(
+	ctx interface{},
+	opts ...interface{},
+) *gomock.Call {
+	args := append([]interface{}{ctx}, opts...)
+	return mr.mock.ctrl.RecordCall(mr.mock, "DescribeCluster", args...)
+}
+
 // DescribeHistoryHost responds to a DescribeHistoryHost call based on the mock expectations. This
 // call will fail if the mock does not expect this call. Use EXPECT to expect
 // a call to this function.

--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -168,6 +168,21 @@ func (c *clientImpl) GetWorkflowExecutionRawHistoryV2(
 	return client.GetWorkflowExecutionRawHistoryV2(ctx, request, opts...)
 }
 
+func (c *clientImpl) DescribeCluster(
+	ctx context.Context,
+	opts ...yarpc.CallOption,
+) (*admin.DescribeClusterResponse, error) {
+
+	opts = common.AggregateYarpcOptions(ctx, opts...)
+	client, err := c.getRandomClient()
+	if err != nil {
+		return nil, err
+	}
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return client.DescribeCluster(ctx, opts...)
+}
+
 func (c *clientImpl) createContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		return context.WithTimeout(context.Background(), c.timeout)

--- a/client/admin/metricClient.go
+++ b/client/admin/metricClient.go
@@ -170,3 +170,20 @@ func (c *metricClient) GetWorkflowExecutionRawHistoryV2(
 	}
 	return resp, err
 }
+
+func (c *metricClient) DescribeCluster(
+	ctx context.Context,
+	opts ...yarpc.CallOption,
+) (*admin.DescribeClusterResponse, error) {
+
+	c.metricsClient.IncCounter(metrics.AdminClientDescribeClusterScope, metrics.CadenceClientRequests)
+
+	sw := c.metricsClient.StartTimer(metrics.AdminClientDescribeClusterScope, metrics.CadenceClientLatency)
+	resp, err := c.client.DescribeCluster(ctx, opts...)
+	sw.Stop()
+
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.AdminClientDescribeClusterScope, metrics.CadenceClientFailures)
+	}
+	return resp, err
+}

--- a/client/admin/retryableClient.go
+++ b/client/admin/retryableClient.go
@@ -152,3 +152,18 @@ func (c *retryableClient) GetWorkflowExecutionRawHistoryV2(
 	err := backoff.Retry(op, c.policy, c.isRetryable)
 	return resp, err
 }
+
+func (c *retryableClient) DescribeCluster(
+	ctx context.Context,
+	opts ...yarpc.CallOption,
+) (*admin.DescribeClusterResponse, error) {
+
+	var resp *admin.DescribeClusterResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.DescribeCluster(ctx, opts...)
+		return err
+	}
+	err := backoff.Retry(op, c.policy, c.isRetryable)
+	return resp, err
+}

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//go:generate mockgen -copyright_file ../../LICENSE -package $GOPACKAGE -source $GOFILE -destination interface_mock.go
+//go:generate mockgen -copyright_file ../../LICENSE -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go
 
 package membership
 
@@ -64,6 +64,8 @@ type (
 		AddListener(service string, name string, notifyChannel chan<- *ChangedEvent) error
 		// RemoveListener removes a listener for this service.
 		RemoveListener(service string, name string) error
+		// GetReachableMembers returns addresses of all members of the ring
+		GetReachableMembers() ([]string, error)
 	}
 
 	// ServiceResolver provides membership information for a specific cadence service.
@@ -77,5 +79,9 @@ type (
 		AddListener(name string, notifyChannel chan<- *ChangedEvent) error
 		// RemoveListener removes a listener for this service.
 		RemoveListener(name string) error
+		// ServerCount returns host count in hashring for any particular role
+		ServerCount() int
+		// Servers returns all host addresses in hashring for any particular role
+		Servers() []*HostInfo
 	}
 )

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -79,9 +79,9 @@ type (
 		AddListener(name string, notifyChannel chan<- *ChangedEvent) error
 		// RemoveListener removes a listener for this service.
 		RemoveListener(name string) error
-		// ServerCount returns host count in hashring for any particular role
-		ServerCount() int
-		// Servers returns all host addresses in hashring for any particular role
-		Servers() []*HostInfo
+		// MemberCount returns host count in hashring for any particular role
+		MemberCount() int
+		// Members returns all host addresses in hashring for any particular role
+		Members() []*HostInfo
 	}
 )

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -234,30 +234,30 @@ func (mr *MockServiceResolverMockRecorder) RemoveListener(name interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockServiceResolver)(nil).RemoveListener), name)
 }
 
-// ServerCount mocks base method
-func (m *MockServiceResolver) ServerCount() int {
+// MemberCount mocks base method
+func (m *MockServiceResolver) MemberCount() int {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ServerCount")
+	ret := m.ctrl.Call(m, "MemberCount")
 	ret0, _ := ret[0].(int)
 	return ret0
 }
 
-// ServerCount indicates an expected call of ServerCount
-func (mr *MockServiceResolverMockRecorder) ServerCount() *gomock.Call {
+// MemberCount indicates an expected call of MemberCount
+func (mr *MockServiceResolverMockRecorder) MemberCount() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerCount", reflect.TypeOf((*MockServiceResolver)(nil).ServerCount))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MemberCount", reflect.TypeOf((*MockServiceResolver)(nil).MemberCount))
 }
 
-// Servers mocks base method
-func (m *MockServiceResolver) Servers() []*HostInfo {
+// Members mocks base method
+func (m *MockServiceResolver) Members() []*HostInfo {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Servers")
+	ret := m.ctrl.Call(m, "Members")
 	ret0, _ := ret[0].([]*HostInfo)
 	return ret0
 }
 
-// Servers indicates an expected call of Servers
-func (mr *MockServiceResolverMockRecorder) Servers() *gomock.Call {
+// Members indicates an expected call of Members
+func (mr *MockServiceResolverMockRecorder) Members() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Servers", reflect.TypeOf((*MockServiceResolver)(nil).Servers))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Members", reflect.TypeOf((*MockServiceResolver)(nil).Members))
 }

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -153,6 +153,21 @@ func (mr *MockMonitorMockRecorder) RemoveListener(service, name interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockMonitor)(nil).RemoveListener), service, name)
 }
 
+// GetReachableMembers mocks base method
+func (m *MockMonitor) GetReachableMembers() ([]string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetReachableMembers")
+	ret0, _ := ret[0].([]string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetReachableMembers indicates an expected call of GetReachableMembers
+func (mr *MockMonitorMockRecorder) GetReachableMembers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReachableMembers", reflect.TypeOf((*MockMonitor)(nil).GetReachableMembers))
+}
+
 // MockServiceResolver is a mock of ServiceResolver interface
 type MockServiceResolver struct {
 	ctrl     *gomock.Controller
@@ -217,4 +232,32 @@ func (m *MockServiceResolver) RemoveListener(name string) error {
 func (mr *MockServiceResolverMockRecorder) RemoveListener(name interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveListener", reflect.TypeOf((*MockServiceResolver)(nil).RemoveListener), name)
+}
+
+// ServerCount mocks base method
+func (m *MockServiceResolver) ServerCount() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ServerCount")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// ServerCount indicates an expected call of ServerCount
+func (mr *MockServiceResolverMockRecorder) ServerCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ServerCount", reflect.TypeOf((*MockServiceResolver)(nil).ServerCount))
+}
+
+// Servers mocks base method
+func (m *MockServiceResolver) Servers() []*HostInfo {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Servers")
+	ret0, _ := ret[0].([]*HostInfo)
+	return ret0
+}
+
+// Servers indicates an expected call of Servers
+func (mr *MockServiceResolverMockRecorder) Servers() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Servers", reflect.TypeOf((*MockServiceResolver)(nil).Servers))
 }

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -146,3 +146,7 @@ func (rpo *ringpopMonitor) RemoveListener(service string, name string) error {
 	}
 	return ring.RemoveListener(name)
 }
+
+func (rpo *ringpopMonitor) GetReachableMembers() ([]string, error) {
+	return rpo.rp.GetReachableMembers()
+}

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -173,11 +173,11 @@ func (r *ringpopServiceResolver) RemoveListener(
 	return nil
 }
 
-func (r *ringpopServiceResolver) ServerCount() int {
+func (r *ringpopServiceResolver) MemberCount() int {
 	return r.ring.ServerCount()
 }
 
-func (r *ringpopServiceResolver) Servers() []*HostInfo {
+func (r *ringpopServiceResolver) Members() []*HostInfo {
 	var servers []*HostInfo
 	for _, s := range r.ring.Servers() {
 		servers = append(servers, NewHostInfo(s, r.getLabelsMap()))

--- a/common/membership/rpServiceResolver.go
+++ b/common/membership/rpServiceResolver.go
@@ -173,6 +173,19 @@ func (r *ringpopServiceResolver) RemoveListener(
 	return nil
 }
 
+func (r *ringpopServiceResolver) ServerCount() int {
+	return r.ring.ServerCount()
+}
+
+func (r *ringpopServiceResolver) Servers() []*HostInfo {
+	var servers []*HostInfo
+	for _, s := range r.ring.Servers() {
+		servers = append(servers, NewHostInfo(s, r.getLabelsMap()))
+	}
+
+	return servers
+}
+
 // HandleEvent handles updates from ringpop
 func (r *ringpopServiceResolver) HandleEvent(
 	event events.Event,

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -419,6 +419,8 @@ const (
 	AdminClientGetWorkflowExecutionRawHistoryScope
 	// AdminClientGetWorkflowExecutionRawHistoryV2Scope tracks RPC calls to admin service
 	AdminClientGetWorkflowExecutionRawHistoryV2Scope
+	// AdminClientDescribeClusterScope tracks RPC calls to admin service
+	AdminClientDescribeClusterScope
 	// DCRedirectionDeprecateDomainScope tracks RPC calls for dc redirection
 	DCRedirectionDeprecateDomainScope
 	// DCRedirectionDescribeDomainScope tracks RPC calls for dc redirection
@@ -1112,6 +1114,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		AdminClientDescribeWorkflowExecutionScope:           {operation: "AdminClientDescribeWorkflowExecution", tags: map[string]string{CadenceRoleTagName: AdminRoleTagValue}},
 		AdminClientGetWorkflowExecutionRawHistoryScope:      {operation: "AdminClientGetWorkflowExecutionRawHistory", tags: map[string]string{CadenceRoleTagName: AdminRoleTagValue}},
 		AdminClientGetWorkflowExecutionRawHistoryV2Scope:    {operation: "AdminClientGetWorkflowExecutionRawHistoryV2", tags: map[string]string{CadenceRoleTagName: AdminRoleTagValue}},
+		AdminClientDescribeClusterScope:                     {operation: "AdminClientDescribeCluster", tags: map[string]string{CadenceRoleTagName: AdminRoleTagValue}},
 		AdminClientCloseShardScope:                          {operation: "AdminClientCloseShard", tags: map[string]string{CadenceRoleTagName: AdminRoleTagValue}},
 		DCRedirectionDeprecateDomainScope:                   {operation: "DCRedirectionDeprecateDomain", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeDomainScope:                    {operation: "DCRedirectionDescribeDomain", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},

--- a/common/mocks/ServiceResolver.go
+++ b/common/mocks/ServiceResolver.go
@@ -79,4 +79,32 @@ func (_m *ServiceResolver) RemoveListener(name string) error {
 	return r0
 }
 
+// ServerCount is am mock implementation
+func (_m *ServiceResolver) ServerCount() int {
+	ret := _m.Called()
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func() int); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	return r0
+}
+
+// Servers is am mock implementation
+func (_m *ServiceResolver) Servers() []*membership.HostInfo {
+	ret := _m.Called()
+
+	var r0 []*membership.HostInfo
+	if rf, ok := ret.Get(0).(func() []*membership.HostInfo); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).([]*membership.HostInfo)
+	}
+
+	return r0
+}
+
 var _ membership.ServiceResolver = (*ServiceResolver)(nil)

--- a/common/mocks/ServiceResolver.go
+++ b/common/mocks/ServiceResolver.go
@@ -79,8 +79,8 @@ func (_m *ServiceResolver) RemoveListener(name string) error {
 	return r0
 }
 
-// ServerCount is am mock implementation
-func (_m *ServiceResolver) ServerCount() int {
+// MemberCount is am mock implementation
+func (_m *ServiceResolver) MemberCount() int {
 	ret := _m.Called()
 
 	var r0 int
@@ -93,8 +93,8 @@ func (_m *ServiceResolver) ServerCount() int {
 	return r0
 }
 
-// Servers is am mock implementation
-func (_m *ServiceResolver) Servers() []*membership.HostInfo {
+// Members is am mock implementation
+func (_m *ServiceResolver) Members() []*membership.HostInfo {
 	ret := _m.Called()
 
 	var r0 []*membership.HostInfo

--- a/host/simpleMonitor.go
+++ b/host/simpleMonitor.go
@@ -70,3 +70,7 @@ func (s *simpleMonitor) AddListener(service string, name string, notifyChannel c
 func (s *simpleMonitor) RemoveListener(service string, name string) error {
 	return nil
 }
+
+func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
+	return nil, nil
+}

--- a/host/simpleServiceResolver.go
+++ b/host/simpleServiceResolver.go
@@ -54,3 +54,11 @@ func (s *simpleResolver) AddListener(name string, notifyChannel chan<- *membersh
 func (s *simpleResolver) RemoveListener(name string) error {
 	return nil
 }
+
+func (s *simpleResolver) ServerCount() int {
+	return len(s.hosts)
+}
+
+func (s *simpleResolver) Servers() []*membership.HostInfo {
+	return s.hosts
+}

--- a/host/simpleServiceResolver.go
+++ b/host/simpleServiceResolver.go
@@ -55,10 +55,10 @@ func (s *simpleResolver) RemoveListener(name string) error {
 	return nil
 }
 
-func (s *simpleResolver) ServerCount() int {
+func (s *simpleResolver) MemberCount() int {
 	return len(s.hosts)
 }
 
-func (s *simpleResolver) Servers() []*membership.HostInfo {
+func (s *simpleResolver) Members() []*membership.HostInfo {
 	return s.hosts
 }

--- a/idl/github.com/uber/cadence/admin.thrift
+++ b/idl/github.com/uber/cadence/admin.thrift
@@ -168,8 +168,8 @@ struct HostInfo {
 
 struct RingInfo {
   10: optional string role
-  20: optional i32 serverCount
-  30: optional list<HostInfo> servers
+  20: optional i32 memberCount
+  30: optional list<HostInfo> members
 }
 
 struct MembershipInfo {

--- a/idl/github.com/uber/cadence/admin.thrift
+++ b/idl/github.com/uber/cadence/admin.thrift
@@ -97,6 +97,15 @@ service AdminService {
       2: shared.InternalServiceError internalServiceError,
       3: shared.ServiceBusyError serviceBusyError,
     )
+
+  /**
+  * DescribeCluster returns information about cadence cluster
+  **/
+  DescribeClusterResponse DescribeCluster()
+    throws (
+      1: shared.InternalServiceError internalServiceError,
+      2: shared.ServiceBusyError serviceBusyError,
+    )
 }
 
 struct DescribeWorkflowExecutionRequest {
@@ -151,4 +160,25 @@ struct GetWorkflowExecutionRawHistoryV2Response {
 struct AddSearchAttributeRequest {
   10: optional map<string, shared.IndexedValueType> searchAttribute
   20: optional string securityToken
+}
+
+struct HostInfo {
+  10: optional string Identity
+}
+
+struct RingInfo {
+  10: optional string role
+  20: optional i32 serverCount
+  30: optional list<HostInfo> servers
+}
+
+struct MembershipInfo {
+  10: optional HostInfo currentHost
+  20: optional list<string> reachableMembers
+  30: optional list<RingInfo> rings
+}
+
+struct DescribeClusterResponse {
+  10: optional shared.SupportedClientVersions supportedClientVersions
+  20: optional MembershipInfo membershipInfo
 }

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -39,6 +39,7 @@ import (
 	hist "github.com/uber/cadence/.gen/go/history"
 	gen "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -540,6 +541,66 @@ func (adh *AdminHandler) GetWorkflowExecutionRawHistoryV2(
 	}
 
 	return result, nil
+}
+
+// DescribeCluster return information about cadence deployment
+func (adh *AdminHandler) DescribeCluster(
+	ctx context.Context,
+) (resp *admin.DescribeClusterResponse, retError error) {
+
+	defer log.CapturePanic(adh.GetLogger(), &retError)
+	scope := metrics.AdminGetWorkflowExecutionRawHistoryV2Scope
+	sw := adh.startRequestProfile(scope)
+	defer sw.Stop()
+
+	membershipInfo := &admin.MembershipInfo{}
+	if monitor := adh.GetMembershipMonitor(); monitor != nil {
+		currentHost, err := monitor.WhoAmI()
+		if err != nil {
+			return nil, adh.error(err, scope)
+		}
+
+		membershipInfo.CurrentHost = &admin.HostInfo{
+			Identity: common.StringPtr(currentHost.Identity()),
+		}
+
+		members, err := monitor.GetReachableMembers()
+		if err != nil {
+			return nil, adh.error(err, scope)
+		}
+
+		membershipInfo.ReachableMembers = members
+
+		var rings []*admin.RingInfo
+		for _, role := range []string{common.FrontendServiceName, common.HistoryServiceName, common.MatchingServiceName, common.WorkerServiceName} {
+			resolver, err := monitor.GetResolver(role)
+			if err != nil {
+				return nil, adh.error(err, scope)
+			}
+
+			var servers []*admin.HostInfo
+			for _, server := range resolver.Servers() {
+				servers = append(servers, &admin.HostInfo{
+					Identity: common.StringPtr(server.Identity()),
+				})
+			}
+
+			rings = append(rings, &admin.RingInfo{
+				Role:        common.StringPtr(role),
+				ServerCount: common.Int32Ptr(int32(resolver.ServerCount())),
+				Servers:     servers,
+			})
+		}
+		membershipInfo.Rings = rings
+	}
+
+	return &admin.DescribeClusterResponse{
+		SupportedClientVersions: &gen.SupportedClientVersions{
+			GoSdk:   common.StringPtr(client.SupportedGoSDKVersion),
+			JavaSdk: common.StringPtr(client.SupportedJavaSDKVersion),
+		},
+		MembershipInfo: membershipInfo,
+	}, nil
 }
 
 func (adh *AdminHandler) validateGetWorkflowExecutionRawHistoryV2Request(

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -579,7 +579,7 @@ func (adh *AdminHandler) DescribeCluster(
 			}
 
 			var servers []*admin.HostInfo
-			for _, server := range resolver.Servers() {
+			for _, server := range resolver.Members() {
 				servers = append(servers, &admin.HostInfo{
 					Identity: common.StringPtr(server.Identity()),
 				})
@@ -587,8 +587,8 @@ func (adh *AdminHandler) DescribeCluster(
 
 			rings = append(rings, &admin.RingInfo{
 				Role:        common.StringPtr(role),
-				ServerCount: common.Int32Ptr(int32(resolver.ServerCount())),
-				Servers:     servers,
+				MemberCount: common.Int32Ptr(int32(resolver.MemberCount())),
+				Members:     servers,
 			})
 		}
 		membershipInfo.Rings = rings

--- a/service/frontend/dcRedirectionHandler_test.go
+++ b/service/frontend/dcRedirectionHandler_test.go
@@ -810,9 +810,9 @@ func (s *dcRedirectionHandlerSuite) TestListTaskListPartitions() {
 
 	req := &shared.ListTaskListPartitionsRequest{
 		Domain: common.StringPtr(s.domainName),
-		TaskList:&shared.TaskList{
-			Name:common.StringPtr("test_tesk_list"),
-			Kind:common.TaskListKindPtr(0),
+		TaskList: &shared.TaskList{
+			Name: common.StringPtr("test_tesk_list"),
+			Kind: common.TaskListKindPtr(0),
 		},
 	}
 	resp, err := s.handler.ListTaskListPartitions(context.Background(), req)

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -785,5 +785,13 @@ func newAdminClusterCommands() []cli.Command {
 				AdminAddSearchAttribute(c)
 			},
 		},
+		{
+			Name:    "describe",
+			Aliases: []string{"d"},
+			Usage:   "Describe cluster information",
+			Action: func(c *cli.Context) {
+				AdminDescribeCluster(c)
+			},
+		},
 	}
 }

--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -69,6 +69,19 @@ func AdminAddSearchAttribute(c *cli.Context) {
 	fmt.Println("Success")
 }
 
+func AdminDescribeCluster(c *cli.Context) {
+	adminClient := cFactory.ServerAdminClient(c)
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+	response, err := adminClient.DescribeCluster(ctx)
+	if err != nil {
+		ErrorAndExit("Operation DescribeCluster failed.", err)
+	}
+
+	prettyPrintJSONObject(response)
+}
+
 func intValTypeToString(valType int) string {
 	switch valType {
 	case 0:

--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -69,6 +69,7 @@ func AdminAddSearchAttribute(c *cli.Context) {
 	fmt.Println("Success")
 }
 
+// AdminDescribeCluster is used to dump information about the cluster
 func AdminDescribeCluster(c *cli.Context) {
 	adminClient := cFactory.ServerAdminClient(c)
 


### PR DESCRIPTION
Added new admin API DescribeCluster which exposes all membership
information for the cluster.
Updated Membership contract to expose GetReachableMembers API on
Monitor interface and ServerCount and Servers API on
ServerResolver interface which is used for implementing the
DescribeCluster admin handler.
CLI changes to add new admin cluster command to describe cluster.

```
cadence admin cluster d
{
  "supportedClientVersions": {
    "goSdk": "1.5.0",
    "javaSdk": "1.5.0"
  },
  "membershipInfo": {
    "currentHost": {
      "Identity": "127.0.0.1:7933"
    },
    "reachableMembers": [
      "127.0.0.1:7935",
      "127.0.0.1:7939",
      "127.0.0.1:7933",
      "127.0.0.1:7934"
    ],
    "rings": [
      {
        "role": "cadence-frontend",
        "serverCount": 1,
        "servers": [
          {
            "Identity": "127.0.0.1:7933"
          }
        ]
      },
      {
        "role": "cadence-history",
        "serverCount": 1,
        "servers": [
          {
            "Identity": "127.0.0.1:7934"
          }
        ]
      },
      {
        "role": "cadence-matching",
        "serverCount": 1,
        "servers": [
          {
            "Identity": "127.0.0.1:7935"
          }
        ]
      },
      {
        "role": "cadence-worker",
        "serverCount": 1,
        "servers": [
          {
            "Identity": "127.0.0.1:7939"
          }
        ]
      }
    ]
  }
}
```