### PR TITLE
Eat operation not support error for change version on DB

### DIFF
--- a/common/persistence/cassandra/cassandraVisibilityPersistence.go
+++ b/common/persistence/cassandra/cassandraVisibilityPersistence.go
@@ -328,7 +328,9 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionClosed(
 
 func (v *cassandraVisibilityPersistence) UpsertWorkflowExecution(
 	request *p.InternalUpsertWorkflowExecutionRequest) error {
-
+	if p.IsNopUpsertWorkflowRequest(request) {
+		return nil
+	}
 	return p.NewOperationNotSupportErrorForVis()
 }
 

--- a/common/persistence/persistence-tests/visibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/visibilityPersistenceTest.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/cadence/common/definition"
+
 	"github.com/pborman/uuid"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
@@ -666,6 +668,50 @@ func (s *VisibilityPersistenceSuite) TestDelete() {
 		})
 		s.Nil(err5)
 		s.Equal(remaining, len(resp.Executions))
+	}
+}
+
+func (s *VisibilityPersistenceSuite) TestUpsertWorkflowExecution() {
+	tests := []struct {
+		request  *p.UpsertWorkflowExecutionRequest
+		expected error
+	}{
+		{
+			request: &p.UpsertWorkflowExecutionRequest{
+				DomainUUID:         "",
+				Domain:             "",
+				Execution:          gen.WorkflowExecution{},
+				WorkflowTypeName:   "",
+				StartTimestamp:     0,
+				ExecutionTimestamp: 0,
+				WorkflowTimeout:    0,
+				TaskID:             0,
+				Memo:               nil,
+				SearchAttributes: map[string][]byte{
+					definition.CadenceChangeVersion: []byte("dummy"),
+				},
+			},
+			expected: nil,
+		},
+		{
+			request: &p.UpsertWorkflowExecutionRequest{
+				DomainUUID:         "",
+				Domain:             "",
+				Execution:          gen.WorkflowExecution{},
+				WorkflowTypeName:   "",
+				StartTimestamp:     0,
+				ExecutionTimestamp: 0,
+				WorkflowTimeout:    0,
+				TaskID:             0,
+				Memo:               nil,
+				SearchAttributes:   nil,
+			},
+			expected: p.NewOperationNotSupportErrorForVis(),
+		},
+	}
+
+	for _, test := range tests {
+		s.Equal(test.expected, s.VisibilityMgr.UpsertWorkflowExecution(test.request))
 	}
 }
 

--- a/common/persistence/sql/sqlVisibilityStore.go
+++ b/common/persistence/sql/sqlVisibilityStore.go
@@ -103,6 +103,9 @@ func (s *sqlVisibilityStore) RecordWorkflowExecutionClosed(request *p.InternalRe
 }
 
 func (s *sqlVisibilityStore) UpsertWorkflowExecution(request *p.InternalUpsertWorkflowExecutionRequest) error {
+	if p.IsNopUpsertWorkflowRequest(request) {
+		return nil
+	}
 	return p.NewOperationNotSupportErrorForVis()
 }
 

--- a/common/persistence/visibilityInterfaces.go
+++ b/common/persistence/visibilityInterfaces.go
@@ -22,6 +22,7 @@ package persistence
 
 import (
 	s "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common/definition"
 )
 
 // Interfaces for the Visibility Store.
@@ -188,4 +189,10 @@ type (
 // NewOperationNotSupportErrorForVis create error for operation not support in visibility
 func NewOperationNotSupportErrorForVis() error {
 	return &s.BadRequestError{Message: "Operation not support. Please use on ElasticSearch"}
+}
+
+// IsNopUpsertWorkflowRequest return whether upsert request should be no-op
+func IsNopUpsertWorkflowRequest(request *InternalUpsertWorkflowExecutionRequest) bool {
+	_, exist := request.SearchAttributes[definition.CadenceChangeVersion]
+	return exist
 }

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -1682,7 +1682,7 @@ func doReset(c *cli.Context, domain, wid, rid string, params batchResetParamsTyp
 
 	if params.dryRun {
 		fmt.Printf("dry run to reset wid: %v, rid:%v to baseRunID:%v, eventID:%v \n", wid, rid, resetBaseRunID, decisionFinishID)
-	}else{
+	} else {
 		resp2, err := frontendClient.ResetWorkflowExecution(ctx, &shared.ResetWorkflowExecutionRequest{
 			Domain: common.StringPtr(domain),
 			WorkflowExecution: &shared.WorkflowExecution{


### PR DESCRIPTION
Currently workflow.getVersion will always add an UpsertWorkflowSearchAttributes event for searchable change version. While without visibility on Elasticsearch, cadence server will failed when process transfer task with error: "Operation not support. Please use on ElasticSearch". 

This PR change the error to an no-op for searchable change version. 