### PR TITLE
mutable state checksums part#2: persistence changes

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -28,6 +28,7 @@ import (
 
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/checksum"
 	p "github.com/uber/cadence/common/persistence"
 )
 
@@ -55,6 +56,7 @@ func applyWorkflowMutationBatch(
 		versionHistories,
 		cqlNowTimestampMillis,
 		condition,
+		workflowMutation.Checksum,
 	); err != nil {
 		return err
 	}
@@ -170,6 +172,7 @@ func applyWorkflowSnapshotBatchAsReset(
 		versionHistories,
 		cqlNowTimestampMillis,
 		condition,
+		workflowSnapshot.Checksum,
 	); err != nil {
 		return err
 	}
@@ -274,6 +277,7 @@ func applyWorkflowSnapshotBatchAsNew(
 		executionInfo,
 		replicationState,
 		versionHistories,
+		workflowSnapshot.Checksum,
 		cqlNowTimestampMillis,
 	); err != nil {
 		return err
@@ -362,6 +366,7 @@ func createExecution(
 	executionInfo *p.InternalWorkflowExecutionInfo,
 	replicationState *p.ReplicationState,
 	versionHistories *p.DataBlob,
+	checksum checksum.Checksum,
 	cqlNowTimestampMillis int64,
 ) error {
 
@@ -460,7 +465,10 @@ func createExecution(
 			executionInfo.Memo,
 			executionInfo.NextEventID,
 			defaultVisibilityTimestamp,
-			rowTypeExecutionTaskID)
+			rowTypeExecutionTaskID,
+			checksum.Version,
+			checksum.Flavor,
+			checksum.Value)
 	} else if versionHistories != nil {
 		// TODO also need to set the start / current / last write version
 		versionHistoriesData, versionHistoriesEncoding := p.FromDataBlob(versionHistories)
@@ -532,7 +540,10 @@ func createExecution(
 			defaultVisibilityTimestamp,
 			rowTypeExecutionTaskID,
 			versionHistoriesData,
-			versionHistoriesEncoding)
+			versionHistoriesEncoding,
+			checksum.Version,
+			checksum.Flavor,
+			checksum.Value)
 	} else if replicationState != nil {
 		lastReplicationInfo := make(map[string]map[string]interface{})
 		for k, v := range replicationState.LastReplicationInfo {
@@ -610,7 +621,10 @@ func createExecution(
 			lastReplicationInfo,
 			executionInfo.NextEventID,
 			defaultVisibilityTimestamp,
-			rowTypeExecutionTaskID)
+			rowTypeExecutionTaskID,
+			checksum.Version,
+			checksum.Flavor,
+			checksum.Value)
 	} else {
 		return &workflow.InternalServiceError{
 			Message: fmt.Sprintf("Create workflow execution with both version histories and replication state."),
@@ -627,6 +641,7 @@ func updateExecution(
 	versionHistories *p.DataBlob,
 	cqlNowTimestampMillis int64,
 	condition int64,
+	checksum checksum.Checksum,
 ) error {
 
 	// validate workflow state & close status
@@ -717,6 +732,9 @@ func updateExecution(
 			executionInfo.SearchAttributes,
 			executionInfo.Memo,
 			executionInfo.NextEventID,
+			checksum.Version,
+			checksum.Flavor,
+			checksum.Value,
 			shardID,
 			rowTypeExecution,
 			domainID,
@@ -790,6 +808,9 @@ func updateExecution(
 			executionInfo.NextEventID,
 			versionHistoriesData,
 			versionHistoriesEncoding,
+			checksum.Version,
+			checksum.Flavor,
+			checksum.Value,
 			shardID,
 			rowTypeExecution,
 			domainID,
@@ -869,6 +890,9 @@ func updateExecution(
 			replicationState.LastWriteEventID,
 			lastReplicationInfo,
 			executionInfo.NextEventID,
+			checksum.Version,
+			checksum.Flavor,
+			checksum.Value,
 			shardID,
 			rowTypeExecution,
 			domainID,
@@ -2498,6 +2522,24 @@ func createReplicationInfoMap(
 	rInfoMap["last_event_id"] = info.LastEventID
 
 	return rInfoMap
+}
+
+func createChecksum(result map[string]interface{}) checksum.Checksum {
+	if len(result) == 0 {
+		return checksum.Checksum{}
+	}
+	csum := checksum.Checksum{}
+	for k, v := range result {
+		switch k {
+		case "flavor":
+			csum.Flavor = checksum.Flavor(v.(int))
+		case "version":
+			csum.Version = v.(int)
+		case "value":
+			csum.Value = v.([]byte)
+		}
+	}
+	return csum
 }
 
 func isTimeoutError(err error) bool {

--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -2525,10 +2525,10 @@ func createReplicationInfoMap(
 }
 
 func createChecksum(result map[string]interface{}) checksum.Checksum {
-	if len(result) == 0 {
-		return checksum.Checksum{}
-	}
 	csum := checksum.Checksum{}
+	if len(result) == 0 {
+		return csum
+	}
 	for k, v := range result {
 		switch k {
 		case "flavor":

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -76,6 +76,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 			SignalInfos:        response.State.SignalInfos,
 			SignalRequestedIDs: response.State.SignalRequestedIDs,
 			ReplicationState:   response.State.ReplicationState,
+			Checksum:           response.State.Checksum,
 		},
 	}
 
@@ -672,6 +673,7 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 		TimerTasks:       input.TimerTasks,
 
 		Condition: input.Condition,
+		Checksum:  input.Checksum,
 	}, nil
 }
 
@@ -729,6 +731,7 @@ func (m *executionManagerImpl) SerializeWorkflowSnapshot(
 		TimerTasks:       input.TimerTasks,
 
 		Condition: input.Condition,
+		Checksum:  input.Checksum,
 	}, nil
 }
 

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -305,6 +305,7 @@ func (s *TestBase) CreateWorkflowExecutionWithBranchToken(domainID string, workf
 				},
 			},
 			TimerTasks: timerTasks,
+			Checksum:   testWorkflowChecksum,
 		},
 		RangeID: s.ShardInfo.RangeID,
 	})
@@ -367,6 +368,7 @@ func (s *TestBase) CreateWorkflowExecutionWithReplication(domainID string, workf
 			ReplicationState: state,
 			TransferTasks:    transferTasks,
 			ReplicationTasks: replicationTasks,
+			Checksum:         testWorkflowChecksum,
 		},
 		RangeID: s.ShardInfo.RangeID,
 	})
@@ -420,6 +422,7 @@ func (s *TestBase) CreateWorkflowExecutionManyTasks(domainID string, workflowExe
 			},
 			ExecutionStats: &p.ExecutionStats{},
 			TransferTasks:  transferTasks,
+			Checksum:       testWorkflowChecksum,
 		},
 		RangeID: s.ShardInfo.RangeID,
 	})
@@ -772,6 +775,7 @@ func (s *TestBase) UpdateWorkflowExecutionWithReplication(updatedInfo *p.Workflo
 			TimerTasks:       timerTasks,
 
 			Condition: condition,
+			Checksum:  testWorkflowChecksum,
 		},
 		Encoding: pickRandomEncoding(),
 	})
@@ -940,6 +944,7 @@ func (s *TestBase) ConflictResolveWorkflowExecution(prevRunID string, prevLastWr
 			RequestCancelInfos:  requestCancelInfos,
 			SignalInfos:         signalInfos,
 			SignalRequestedIDs:  ids,
+			Checksum:            testWorkflowChecksum,
 		},
 		Encoding: pickRandomEncoding(),
 	})

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -24,10 +24,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/uber/cadence/common/checksum"
-
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/checksum"
 )
 
 type (
@@ -246,7 +245,8 @@ type (
 		SignalInfos         map[int64]*SignalInfo
 		SignalRequestedIDs  map[string]struct{}
 		BufferedEvents      []*DataBlob
-		Checksum            checksum.Checksum
+
+		Checksum checksum.Checksum
 	}
 
 	// InternalActivityInfo details  for Persistence Interface
@@ -383,7 +383,8 @@ type (
 		ReplicationTasks []Task
 
 		Condition int64
-		Checksum  checksum.Checksum
+
+		Checksum checksum.Checksum
 	}
 
 	// InternalWorkflowSnapshot is used as generic workflow execution state snapshot for Persistence Interface
@@ -406,7 +407,8 @@ type (
 		ReplicationTasks []Task
 
 		Condition int64
-		Checksum  checksum.Checksum
+
+		Checksum checksum.Checksum
 	}
 
 	// InternalAppendHistoryEventsRequest is used to append new events to workflow execution history  for Persistence Interface

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -24,6 +24,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/uber/cadence/common/checksum"
+
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 )
@@ -244,6 +246,7 @@ type (
 		SignalInfos         map[int64]*SignalInfo
 		SignalRequestedIDs  map[string]struct{}
 		BufferedEvents      []*DataBlob
+		Checksum            checksum.Checksum
 	}
 
 	// InternalActivityInfo details  for Persistence Interface
@@ -380,6 +383,7 @@ type (
 		ReplicationTasks []Task
 
 		Condition int64
+		Checksum  checksum.Checksum
 	}
 
 	// InternalWorkflowSnapshot is used as generic workflow execution state snapshot for Persistence Interface
@@ -402,6 +406,7 @@ type (
 		ReplicationTasks []Task
 
 		Condition int64
+		Checksum  checksum.Checksum
 	}
 
 	// InternalAppendHistoryEventsRequest is used to append new events to workflow execution history  for Persistence Interface

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -302,6 +302,12 @@ CREATE TYPE branch_range (
   end_node_id bigint, -- exclusive node_id to represent the stopping point for this range
 );
 
+CREATE TYPE checksum (
+  version int,  -- version of the payload used to generate checksum
+  flavor  int,  -- type of checksum e.g crc32OverThrift
+  value   blob, -- checksum bytes
+);
+
 CREATE TABLE executions (
   shard_id                       int,
   type                           int, -- enum RowType { Shard, Execution, TransferTask, TimerTask, ReplicationTask}
@@ -331,6 +337,7 @@ CREATE TABLE executions (
   workflow_state                 int,
   version_histories              blob, -- the metadata of history branching
   version_histories_encoding     text,
+  checksum                       frozen<checksum>,
   PRIMARY KEY  (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id)
 ) WITH COMPACTION = {
     'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'

--- a/schema/cassandra/cadence/versioned/v0.24/checksum.cql
+++ b/schema/cassandra/cadence/versioned/v0.24/checksum.cql
@@ -1,0 +1,2 @@
+CREATE TYPE checksum (version int, flavor int, value blob);
+ALTER TABLE executions ADD checksum frozen<checksum>;

--- a/schema/cassandra/cadence/versioned/v0.24/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.24/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.24",
+  "MinCompatibleVersion": "0.23",
+  "Description": "Added checksum to executions table",
+  "SchemaUpdateCqlFiles": [
+    "checksum.cql"
+  ]
+}

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -23,7 +23,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.23"
+const Version = "0.24"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.4"


### PR DESCRIPTION
This patch contains the cassandra persistence changes to support mutable state checksums. This is a follow up to #2941 