### PR TITLE
queueProcessor: fix write on closed chan panic

### DIFF
--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -130,7 +130,6 @@ func (t *taskProcessor) start() {
 
 func (t *taskProcessor) stop() {
 	close(t.shutdownCh)
-	close(t.tasksCh)
 	if success := common.AwaitWaitGroup(&t.workerWG, time.Minute); !success {
 		t.logger.Warn("Timer queue task processor timedout on shutdown.")
 	}


### PR DESCRIPTION
This patch is already released as a hotfix in production. Merging the fix to master.