### PR TITLE
replicator: enforce maxRetryCount per domain

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1430,6 +1430,8 @@ const (
 	MatchingClientForwardedCounter
 	MatchingClientInvalidTaskListName
 
+	ReplicatorTaskDroppedCount
+
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
 
@@ -1746,6 +1748,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		VisibilityArchiveSuccessCount:                             {metricName: "visibility_archiver_archive_success", metricType: Counter},
 		MatchingClientForwardedCounter:                            {metricName: "forwarded", metricType: Counter},
 		MatchingClientInvalidTaskListName:                         {metricName: "invalid_task_list_name", metricType: Counter},
+		ReplicatorTaskDroppedCount:                                {metricName: "replicator_task_dropped", metricType: Counter},
 	},
 	Frontend: {
 		DomainReplicationTaskAckLevel: {metricName: "domain_replication_task_ack_level", metricType: Gauge},

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -69,6 +69,9 @@ type IntPropertyFn func(opts ...FilterOption) int
 // IntPropertyFnWithDomainFilter is a wrapper to get int property from dynamic config with domain as filter
 type IntPropertyFnWithDomainFilter func(domain string) int
 
+// IntPropertyFnWithDomainIDFilter is a wrapper to get int property from dynamic config with domainID as filter
+type IntPropertyFnWithDomainIDFilter func(domainID string) int
+
 // IntPropertyFnWithTaskListInfoFilters is a wrapper to get int property from dynamic config with three filters: domain, taskList, taskType
 type IntPropertyFnWithTaskListInfoFilters func(domain string, taskList string, taskType int) int
 
@@ -139,6 +142,18 @@ func (c *Collection) GetIntProperty(key Key, defaultValue int) IntPropertyFn {
 func (c *Collection) GetIntPropertyFilteredByDomain(key Key, defaultValue int) IntPropertyFnWithDomainFilter {
 	return func(domain string) int {
 		val, err := c.client.GetIntValue(key, getFilterMap(DomainFilter(domain)), defaultValue)
+		if err != nil {
+			c.logNoValue(key, err)
+		}
+		c.logValue(key, val, defaultValue)
+		return val
+	}
+}
+
+// GetIntPropertyFilteredByDomainID gets property with domainID filter and asserts that it's an integer
+func (c *Collection) GetIntPropertyFilteredByDomainID(key Key, defaultValue int) IntPropertyFnWithDomainIDFilter {
+	return func(domainID string) int {
+		val, err := c.client.GetIntValue(key, getFilterMap(DomainIDFilter(domainID)), defaultValue)
 		if err != nil {
 			c.logNoValue(key, err)
 		}

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -600,6 +600,8 @@ const (
 	unknownFilter Filter = iota
 	// DomainName is the domain name
 	DomainName
+	// DomainID the uuid of the domain
+	DomainID
 	// TaskListName is the tasklist name
 	TaskListName
 	// TaskType is the task type (0:Decision, 1:Activity)
@@ -623,6 +625,13 @@ func TaskListFilter(name string) FilterOption {
 func DomainFilter(name string) FilterOption {
 	return func(filterMap map[Filter]interface{}) {
 		filterMap[DomainName] = name
+	}
+}
+
+// DomainIDFilter filters by domain id
+func DomainIDFilter(id string) FilterOption {
+	return func(filterMap map[Filter]interface{}) {
+		filterMap[DomainID] = id
 	}
 }
 

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -47,7 +47,7 @@ type (
 		MaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
 		UpdateAckInterval                  dynamicconfig.DurationPropertyFn
 		UpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
-		MaxRetryCount                      dynamicconfig.IntPropertyFn
+		MaxRetryCount                      dynamicconfig.IntPropertyFnWithDomainIDFilter
 		MetricScope                        int
 	}
 

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -79,7 +79,7 @@ type Config struct {
 	// TimerQueueProcessor settings
 	TimerTaskBatchSize                               dynamicconfig.IntPropertyFn
 	TimerTaskWorkerCount                             dynamicconfig.IntPropertyFn
-	TimerTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
+	TimerTaskMaxRetryCount                           dynamicconfig.IntPropertyFnWithDomainIDFilter
 	TimerProcessorGetFailureRetryCount               dynamicconfig.IntPropertyFn
 	TimerProcessorCompleteTimerFailureRetryCount     dynamicconfig.IntPropertyFn
 	TimerProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
@@ -96,7 +96,7 @@ type Config struct {
 	// TransferQueueProcessor settings
 	TransferTaskBatchSize                               dynamicconfig.IntPropertyFn
 	TransferTaskWorkerCount                             dynamicconfig.IntPropertyFn
-	TransferTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
+	TransferTaskMaxRetryCount                           dynamicconfig.IntPropertyFnWithDomainIDFilter
 	TransferProcessorCompleteTransferFailureRetryCount  dynamicconfig.IntPropertyFn
 	TransferProcessorFailoverMaxPollRPS                 dynamicconfig.IntPropertyFn
 	TransferProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
@@ -110,13 +110,14 @@ type Config struct {
 	// ReplicatorQueueProcessor settings
 	ReplicatorTaskBatchSize                               dynamicconfig.IntPropertyFn
 	ReplicatorTaskWorkerCount                             dynamicconfig.IntPropertyFn
-	ReplicatorTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
+	ReplicatorTaskMaxRetryCount                           dynamicconfig.IntPropertyFnWithDomainIDFilter
 	ReplicatorProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
 	ReplicatorProcessorMaxPollInterval                    dynamicconfig.DurationPropertyFn
 	ReplicatorProcessorMaxPollIntervalJitterCoefficient   dynamicconfig.FloatPropertyFn
 	ReplicatorProcessorUpdateAckInterval                  dynamicconfig.DurationPropertyFn
 	ReplicatorProcessorUpdateAckIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
 	ReplicatorProcessorFetchTasksBatchSize                dynamicconfig.IntPropertyFn
+	ReplicatorSkipTaskProcessing                          dynamicconfig.BoolPropertyFnWithDomainFilter
 
 	// Persistence settings
 	ExecutionMgrNumConns dynamicconfig.IntPropertyFn
@@ -209,7 +210,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		StandbyTaskMissingEventsDiscardDelay:                  dc.GetDurationProperty(dynamicconfig.StandbyTaskMissingEventsDiscardDelay, 25*time.Minute),
 		TimerTaskBatchSize:                                    dc.GetIntProperty(dynamicconfig.TimerTaskBatchSize, 100),
 		TimerTaskWorkerCount:                                  dc.GetIntProperty(dynamicconfig.TimerTaskWorkerCount, 10),
-		TimerTaskMaxRetryCount:                                dc.GetIntProperty(dynamicconfig.TimerTaskMaxRetryCount, 100),
+		TimerTaskMaxRetryCount:                                dc.GetIntPropertyFilteredByDomainID(dynamicconfig.TimerTaskMaxRetryCount, 100),
 		TimerProcessorGetFailureRetryCount:                    dc.GetIntProperty(dynamicconfig.TimerProcessorGetFailureRetryCount, 5),
 		TimerProcessorCompleteTimerFailureRetryCount:          dc.GetIntProperty(dynamicconfig.TimerProcessorCompleteTimerFailureRetryCount, 10),
 		TimerProcessorUpdateAckInterval:                       dc.GetDurationProperty(dynamicconfig.TimerProcessorUpdateAckInterval, 30*time.Second),
@@ -226,7 +227,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		TransferProcessorFailoverMaxPollRPS:                   dc.GetIntProperty(dynamicconfig.TransferProcessorFailoverMaxPollRPS, 1),
 		TransferProcessorMaxPollRPS:                           dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollRPS, 20),
 		TransferTaskWorkerCount:                               dc.GetIntProperty(dynamicconfig.TransferTaskWorkerCount, 10),
-		TransferTaskMaxRetryCount:                             dc.GetIntProperty(dynamicconfig.TransferTaskMaxRetryCount, 100),
+		TransferTaskMaxRetryCount:                             dc.GetIntPropertyFilteredByDomainID(dynamicconfig.TransferTaskMaxRetryCount, 100),
 		TransferProcessorCompleteTransferFailureRetryCount:    dc.GetIntProperty(dynamicconfig.TransferProcessorCompleteTransferFailureRetryCount, 10),
 		TransferProcessorMaxPollInterval:                      dc.GetDurationProperty(dynamicconfig.TransferProcessorMaxPollInterval, 1*time.Minute),
 		TransferProcessorMaxPollIntervalJitterCoefficient:     dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
@@ -236,7 +237,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		TransferProcessorVisibilityArchivalTimeLimit:          dc.GetDurationProperty(dynamicconfig.TransferProcessorVisibilityArchivalTimeLimit, 1*time.Second),
 		ReplicatorTaskBatchSize:                               dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 100),
 		ReplicatorTaskWorkerCount:                             dc.GetIntProperty(dynamicconfig.ReplicatorTaskWorkerCount, 10),
-		ReplicatorTaskMaxRetryCount:                           dc.GetIntProperty(dynamicconfig.ReplicatorTaskMaxRetryCount, 100),
+		ReplicatorTaskMaxRetryCount:                           dc.GetIntPropertyFilteredByDomainID(dynamicconfig.ReplicatorTaskMaxRetryCount, 100),
 		ReplicatorProcessorMaxPollRPS:                         dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxPollRPS, 20),
 		ReplicatorProcessorMaxPollInterval:                    dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorMaxPollInterval, 1*time.Minute),
 		ReplicatorProcessorMaxPollIntervalJitterCoefficient:   dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient, 0.15),

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -131,7 +131,6 @@ func (t *taskProcessor) start() {
 
 func (t *taskProcessor) stop() {
 	close(t.shutdownCh)
-	close(t.tasksCh)
 	if success := common.AwaitWaitGroup(&t.workerWG, time.Minute); !success {
 		t.logger.Warn("Timer queue task processor timedout on shutdown.")
 	}

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -204,7 +204,7 @@ FilterLoop:
 		err := t.handleTaskError(scope, task, notificationChan, err)
 		if err != nil {
 			task.attempt++
-			if task.attempt >= t.config.TimerTaskMaxRetryCount() {
+			if task.attempt >= t.config.TimerTaskMaxRetryCount(task.task.GetDomainID()) {
 				t.metricsClient.RecordTimer(scope, metrics.TaskAttemptTimer, time.Duration(task.attempt))
 				task.logger.Error("Critical error processing timer task, retrying.", tag.Error(err), tag.OperationCritical)
 			}


### PR DESCRIPTION
This patch enforces maxRetryAttempts when processing replication tasks. The config option exist currently but is not used. This patch modifies the config option to be a per domain config and enforces it only within replicator. This patch is needed to mitigate bad state created by some workflows in production. 