### PR TITLE
Matching use non retry matching client

### DIFF
--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -71,7 +71,7 @@ func NewHandler(
 		engine: NewEngine(
 			resource.GetTaskManager(),
 			resource.GetHistoryClient(),
-			resource.GetMatchingClient(),
+			resource.GetMatchingRawClient(),
 			config,
 			resource.GetLogger(),
 			resource.GetMetricsClient(),

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -71,7 +71,7 @@ func NewHandler(
 		engine: NewEngine(
 			resource.GetTaskManager(),
 			resource.GetHistoryClient(),
-			resource.GetMatchingRawClient(),
+			resource.GetMatchingRawClient(), // Use non retry client inside matching
 			config,
 			resource.GetLogger(),
 			resource.GetMetricsClient(),


### PR DESCRIPTION
The matching engine only use the matching client for forwarding request. The caller does not care if the client returns error in this case. If the client return error, the matching can handle the task locally. 