### PR TITLE
Increment readLevel when skipping over expired tasks

### DIFF
--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -88,6 +88,37 @@ func TestDeliverBufferTasks_NoPollers(t *testing.T) {
 	wg.Wait()
 }
 
+func TestReadLevelForAllExpiredTasksInBatch(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	tlm := createTestTaskListManager(controller)
+	tlm.db.rangeID = int64(1)
+	tlm.db.ackLevel = int64(0)
+	tlm.taskAckManager.setAckLevel(tlm.db.ackLevel)
+	tlm.taskAckManager.setReadLevel(tlm.db.ackLevel)
+	require.Equal(t, int64(0), tlm.taskAckManager.getAckLevel())
+	require.Equal(t, int64(0), tlm.taskAckManager.getReadLevel())
+
+	// Add all expired tasks
+	tasks := []*persistence.TaskInfo{
+		&persistence.TaskInfo{
+			TaskID:      11,
+			Expiry:      time.Now().Add(-time.Minute),
+			CreatedTime: time.Now().Add(-time.Hour),
+		},
+		&persistence.TaskInfo{
+			TaskID:      12,
+			Expiry:      time.Now().Add(-time.Minute),
+			CreatedTime: time.Now().Add(-time.Hour),
+		},
+	}
+
+	require.True(t, tlm.taskReader.addTasksToBuffer(tasks, time.Now(), time.NewTimer(time.Minute)))
+	require.Equal(t, int64(0), tlm.taskAckManager.getAckLevel())
+	require.Equal(t, int64(12), tlm.taskAckManager.getReadLevel())
+}
+
 func createTestTaskListManager(controller *gomock.Controller) *taskListManagerImpl {
 	return createTestTaskListManagerWithConfig(controller, defaultTestConfig())
 }

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -239,6 +239,9 @@ func (tr *taskReader) addTasksToBuffer(
 	for _, t := range tasks {
 		if tr.isTaskExpired(t, now) {
 			tr.scope().IncCounter(metrics.ExpiredTasksCounter)
+			// Also increment readLevel for expired tasks otherwise it could result in
+			// looping over the same tasks if all tasks read in the batch are expired
+			tr.tlMgr.taskAckManager.setReadLevel(t.TaskID)
 			continue
 		}
 		if !tr.addSingleTaskToBuffer(t, lastWriteTime, idleTimer) {


### PR DESCRIPTION
TaskReader has to logic to skip over expired tasks instead of
adding it to AckManager to prevent dispatch.  This results in
taskReader to get stuck in all tasks read from the database are
expired as it results in readLevel to not move at all.

This change also increments the readLevel when skipping expired
tasks to prevent taskReader to spin on expired tasks.