### PR TITLE
Add config option to add prefix to emitted metrics

### DIFF
--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -292,8 +292,8 @@ type (
 		// Tags is the set of key-value pairs to be reported
 		// as part of every metric
 		Tags map[string]string `yaml:"tags"`
-		// Prefixes all outgoing metrics with the provided string
-		Prefix string
+		// Prefix sets the prefix to all outgoing metrics
+		Prefix string `yaml:"prefix"`
 	}
 
 	// Statsd contains the config items for statsd metrics reporter

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -292,6 +292,8 @@ type (
 		// Tags is the set of key-value pairs to be reported
 		// as part of every metric
 		Tags map[string]string `yaml:"tags"`
+		// Prefixes all outgoing metrics with the provided string
+		Prefix string
 	}
 
 	// Statsd contains the config items for statsd metrics reporter

--- a/common/service/config/metrics.go
+++ b/common/service/config/metrics.go
@@ -92,6 +92,7 @@ func (c *Metrics) newM3Scope(logger log.Logger) tally.Scope {
 	scopeOpts := tally.ScopeOptions{
 		Tags:           c.Tags,
 		CachedReporter: reporter,
+		Prefix:         c.Prefix,
 	}
 	scope, _ := tally.NewRootScope(scopeOpts, time.Second)
 	return scope
@@ -114,6 +115,7 @@ func (c *Metrics) newStatsdScope(logger log.Logger) tally.Scope {
 	scopeOpts := tally.ScopeOptions{
 		Tags:     c.Tags,
 		Reporter: reporter,
+		Prefix:   c.Prefix,
 	}
 	scope, _ := tally.NewRootScope(scopeOpts, time.Second)
 	return scope
@@ -138,6 +140,7 @@ func (c *Metrics) newPrometheusScope(logger log.Logger) tally.Scope {
 		CachedReporter:  reporter,
 		Separator:       prometheus.DefaultSeparator,
 		SanitizeOptions: &sanitizeOptions,
+		Prefix:          c.Prefix,
 	}
 	scope, _ := tally.NewRootScope(scopeOpts, time.Second)
 	return scope


### PR DESCRIPTION
This becomes useful when two different cadence clusters need to emit metrics to the same metrics backend, or even just improves visibility into the cadence metrics since some are prefixed with cadence and others are not.

I've tested this out on the prometheus and it works as expected. My assumption is that it should work with the other metric types, but i'm not too familiar with tally and how its integration works with them. 
The good news is that unless someone specifies prefix, the behavior doesn't change.