### PR TITLE
Start cadence-server as pid 1 so it can capture and handle shutdown signals.

### DIFF
--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
-set -x
+set -ex
 
-dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
+dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml
+
+exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES


### PR DESCRIPTION
With the current docker setup, the cadence-server runs as a random pid and doesn't properly capture and handle shutdown signals. This is problematic for k8s deployments where deploying new versions is not handled gracefully and the cadence server process has no chance to shutdown properly.

Before:
```
ps
PID   USER     TIME  COMMAND
    1 root      0:00 {start-cadence.s} /bin/bash /start-cadence.sh
    8 root      0:00 dockerize -template /etc/cadence/k8s/config/config_template.yaml:/etc/cadence/config/docker.yaml cadence-server --root /etc/cadence --env docker start --services=frontend
   12 root      2:29 cadence-server --root /etc/cadence --env docker start --services=frontend
   24 root      0:00 bash
   31 root      0:00 ps
```

After:
```
ps
PID   USER     TIME  COMMAND
    1 root      0:11 cadence-server --root /etc/cadence --env docker start --services=frontend
   19 root      0:00 bash
   24 root      0:00 ps
```

And when the container is shutdown by k8s, we can see that in the logs:
```
2020/02/04 18:46:56 Received SIGTERM signal, initiating shutdown.
{"level":"info","ts":"2020-02-04T18:46:56.801Z","msg":"RuntimeMetricsReporter stopped","service":"cadence-frontend","logging-call-at":"runtime.go:175"}
{"level":"info","ts":"2020-02-04T18:46:56.801Z","msg":"frontend stopped","logging-call-at":"service.go:262"}
```
the cadence-server handles the signal and gracefully shuts down. Before k8s would eventually shut the pod down after the `terminationGracePeriod` has passed since nothing was passing the signal onto cadence-server.