### PR TITLE
Fix admin cli missed type in add search attribute

### DIFF
--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -38,7 +38,7 @@ import (
 func AdminAddSearchAttribute(c *cli.Context) {
 	key := getRequiredOption(c, FlagSearchAttributesKey)
 	valType := getRequiredIntOption(c, FlagSearchAttributesType)
-	if valType < 0 || valType >= 5 {
+	if !isValueTypeValid(valType) {
 		ErrorAndExit("Unknown Search Attributes value type.", nil)
 	}
 
@@ -100,4 +100,8 @@ func intValTypeToString(valType int) string {
 	default:
 		return ""
 	}
+}
+
+func isValueTypeValid(valType int) bool {
+	return valType >= 0 && valType <= 5
 }

--- a/tools/cli/adminClusterCommands_test.go
+++ b/tools/cli/adminClusterCommands_test.go
@@ -1,0 +1,62 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cli
+
+import (
+	"testing"
+
+	"github.com/bmizerany/assert"
+)
+
+func TestAdminAddSearchAttribute_isValueTypeValid(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    int
+		expected bool
+	}{
+		{
+			name:     "negative",
+			input:    -1,
+			expected: false,
+		},
+		{
+			name:     "valid",
+			input:    0,
+			expected: true,
+		},
+		{
+			name:     "valid",
+			input:    5,
+			expected: true,
+		},
+		{
+			name:     "unknown",
+			input:    6,
+			expected: false,
+		},
+	}
+
+	for _, testCase := range testCases {
+		assert.Equal(t, testCase.expected, isValueTypeValid(testCase.input))
+	}
+}


### PR DESCRIPTION
Currently adding search attribute with `date` type will falsely return error "unknown type".
This PR fix it.