### PR TITLE
Revert commits for adding debug metrics and logging

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1493,10 +1493,6 @@ const (
 	TaskBatchCompleteCounter
 	TaskProcessingLatency
 	TaskQueueLatency
-	ActivityTimeoutLatencyInMemory
-	ActivityTimeoutLatencyUpdateExecution
-	ActivityTimeoutLatencyLoadMutableState
-	ActivityTimeoutLatencyGetExecutionContext
 
 	AckLevelUpdateCounter
 	AckLevelUpdateFailedCounter
@@ -1827,10 +1823,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskNotActiveCounter:                              {metricName: "task_errors_not_active_counter", metricType: Counter},
 		TaskLimitExceededCounter:                          {metricName: "task_errors_limit_exceeded_counter", metricType: Counter},
 		TaskProcessingLatency:                             {metricName: "task_latency_processing", metricType: Timer},
-		ActivityTimeoutLatencyInMemory:                    {metricName: "activity_timeout_latency_in_memory", metricType: Timer},
-		ActivityTimeoutLatencyUpdateExecution:             {metricName: "activity_timeout_latency_update_execution", metricType: Timer},
-		ActivityTimeoutLatencyLoadMutableState:            {metricName: "activity_timeout_latency_load_mutable_state", metricType: Timer},
-		ActivityTimeoutLatencyGetExecutionContext:         {metricName: "activity_timeout_latency_get_execution_context", metricType: Timer},
 		TaskQueueLatency:                                  {metricName: "task_latency_queue", metricType: Timer},
 		TaskBatchCompleteCounter:                          {metricName: "task_batch_complete_counter", metricType: Counter},
 		AckLevelUpdateCounter:                             {metricName: "ack_level_update", metricType: Counter},


### PR DESCRIPTION
Revert "Update metrics and add logging for activity timeout task (#3030)"
Revert "Add metrics for profiling activity timeout task latency (#3026)"
Revert "check if timer expired first"
