### PR TITLE
Add ability to cache scopes

### DIFF
--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -41,8 +41,7 @@ type (
 		RecordTimer(scope int, timer int, d time.Duration)
 		// UpdateGauge reports Gauge type absolute value metric
 		UpdateGauge(scope int, gauge int, value float64)
-		// Scope return an internal scope that can be used to add additional
-		// information to metrics
+		// Scope return an internal scope that can be used to add additional information to metrics
 		Scope(scope int, tags ...Tag) Scope
 	}
 


### PR DESCRIPTION
This adds the ability in our metricsClient to cache scopes. We have seen that scope construction contributes significantly to GC time. 

This code turns on caching for all metrics scopes with no config to disable. This was done this way as a first pass because it produces the simplest API, we should discuss further if we need to enable or disable this feature in different places in code. 