### PR TITLE
Update Makefile on sync submodule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ test: bins
 
 release: go-generate test
 
-# need to run xdc tests with race detector off because of ringpop bug causing data race issue
+# need to run xdc tests with race detector off because of ringpop bug causing data race issues
 test_xdc: bins
 	@rm -f test
 	@rm -f test.log

--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,7 @@ test: bins
 
 release: go-generate test
 
-# need to run xdc tests with race detector off because of ringpop bug causing data race issues
+# need to run xdc tests with race detector off because of ringpop bug causing data race issue
 test_xdc: bins
 	@rm -f test
 	@rm -f test.log

--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ INTEG_NDC_SQL_COVER_FILE   := $(COVER_ROOT)/integ_ndc_sql_cover.out
 #   Packages are specified as import paths.
 GOCOVERPKG_ARG := -coverpkg="$(PROJECT_ROOT)/common/...,$(PROJECT_ROOT)/service/...,$(PROJECT_ROOT)/client/...,$(PROJECT_ROOT)/tools/..."
 
-git-submodules:
-	git submodule update --init --recursive
+sync-submodules:
+	git submodule update --init --recursive --remote
 
 yarpc-install:
 	GO111MODULE=off go get -u github.com/myitcv/gobin
@@ -116,7 +116,7 @@ yarpc-install:
 clean_thrift:
 	rm -rf .gen
 
-thriftc: yarpc-install git-submodules $(THRIFTRW_GEN_SRC) copyright
+thriftc: yarpc-install $(THRIFTRW_GEN_SRC) copyright
 
 copyright: cmd/tools/copyright/licensegen.go
 	GOOS= GOARCH= go run ./cmd/tools/copyright/licensegen.go --verifyOnly


### PR DESCRIPTION
As submodule currently does not support pin to commit, this creates problems when merging master to a local developing branch. If the commit in master might point to the new commit in submodule idl. But the local branch tracks the old commit. 

The change removing the command of sync submodule and only two cases should run make sync-submodules:
1. Merge master
2. Current changes in the local branch require IDL changes

The buildkite should be fine as it do git clone every time and it should get the latest commit in master branch.