### PR TITLE
fatal_log: modify error message for clarity

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -60,11 +60,11 @@ func startHandler(c *cli.Context) {
 	}
 	// cassandra schema version validation
 	if err := cassandra.VerifyCompatibleVersion(cfg.Persistence); err != nil {
-		log.Fatal("Incompatible cassandra versions: ", err)
+		log.Fatal("cassandra schema version compatibility check failed: ", err)
 	}
 	// sql schema version validation
 	if err := sql.VerifyCompatibleVersion(cfg.Persistence); err != nil {
-		log.Fatal("Incompatible sql versions: ", err)
+		log.Fatal("sql schema version compatibility check failed: ", err)
 	}
 
 	var daemons []common.Daemon


### PR DESCRIPTION
Recently, I was debugging a server startup issue and the error message made me believe as though there was a cassandra version incompatibility issue - when in fact, it was simply the schema version compatibility check. This patch fixes fatal message to make sense for the person reading it.