### PR TITLE
Make persistence config dynamic for system scanner

### DIFF
--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -23,6 +23,8 @@ package client
 import (
 	"sync"
 
+	"github.com/uber/cadence/common/service/dynamicconfig"
+
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
 	p "github.com/uber/cadence/common/persistence"
@@ -138,7 +140,7 @@ func NewFactory(
 		logger:                   logger,
 		clusterName:              clusterName,
 	}
-	limiters := buildRatelimiters(cfg)
+	limiters := buildRateLimiters(cfg)
 	factory.init(clusterName, limiters)
 	return factory
 }
@@ -322,18 +324,18 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 	f.datastores[storeTypeVisibility] = visibilityDataStore
 }
 
-func buildRatelimiters(cfg *config.Persistence) map[string]quotas.Limiter {
+func buildRateLimiters(cfg *config.Persistence) map[string]quotas.Limiter {
 	result := make(map[string]quotas.Limiter, len(cfg.DataStores))
 	for dsName, ds := range cfg.DataStores {
-		qps := 0
+		var qps dynamicconfig.IntPropertyFn
 		if ds.Cassandra != nil {
 			qps = ds.Cassandra.MaxQPS
 		}
 		if ds.SQL != nil {
 			qps = ds.SQL.MaxQPS
 		}
-		if qps > 0 {
-			result[dsName] = quotas.NewSimpleRateLimiter(qps)
+		if qps != nil {
+			result[dsName] = quotas.NewDynamicRateLimiter(func() float64 { return float64(qps()) })
 		}
 	}
 	return result

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -23,8 +23,6 @@ package client
 import (
 	"sync"
 
-	"github.com/uber/cadence/common/service/dynamicconfig"
-
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
 	p "github.com/uber/cadence/common/persistence"
@@ -32,6 +30,7 @@ import (
 	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/quotas"
 	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/service/dynamicconfig"
 )
 
 type (

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -187,7 +187,7 @@ type (
 		// Datacenter is the data center filter arg for cassandra
 		Datacenter string `yaml:"datacenter"`
 		// MaxQPS is the max request rate to this datastore
-		MaxQPS int `yaml:"maxQPS"`
+		MaxQPS dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
 		// MaxConns is the max number of connections to this datastore for a single keyspace
 		MaxConns int `yaml:"maxConns"`
 		// TLS configuration
@@ -211,7 +211,7 @@ type (
 		// ConnectAttributes is a set of key-value attributes to be sent as part of connect data_source_name url
 		ConnectAttributes map[string]string `yaml:"connectAttributes"`
 		// MaxQPS the max request rate on this datastore
-		MaxQPS int `yaml:"maxQPS"`
+		MaxQPS dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
 		// MaxConns the max number of connections to this datastore
 		MaxConns int `yaml:"maxConns"`
 		// MaxIdleConns is the max number of idle connections to this datastore

--- a/common/service/config/persistence.go
+++ b/common/service/config/persistence.go
@@ -20,7 +20,11 @@
 
 package config
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/uber/cadence/common/service/dynamicconfig"
+)
 
 const (
 	// StoreTypeSQL refers to sql based storage as persistence store
@@ -30,7 +34,7 @@ const (
 )
 
 // SetMaxQPS sets the MaxQPS value for the given datastore
-func (c *Persistence) SetMaxQPS(key string, qps int) {
+func (c *Persistence) SetMaxQPS(key string, qps dynamicconfig.IntPropertyFn) {
 	ds, ok := c.DataStores[key]
 	if !ok {
 		return

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -146,7 +146,7 @@ func NewService(
 	serviceConfig := NewConfig(dynamicconfig.NewCollection(params.DynamicConfig, params.Logger), params.PersistenceConfig.NumHistoryShards, isAdvancedVisExistInConfig)
 
 	params.PersistenceConfig.HistoryMaxConns = serviceConfig.HistoryMgrNumConns()
-	params.PersistenceConfig.SetMaxQPS(params.PersistenceConfig.DefaultStore, serviceConfig.PersistenceMaxQPS())
+	params.PersistenceConfig.SetMaxQPS(params.PersistenceConfig.DefaultStore, serviceConfig.PersistenceMaxQPS)
 	params.PersistenceConfig.VisibilityConfig = &config.VisibilityConfig{
 		VisibilityListMaxQPS:            serviceConfig.VisibilityListMaxQPS,
 		EnableSampling:                  serviceConfig.EnableVisibilitySampling,

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -354,7 +354,7 @@ func NewService(
 		params.PersistenceConfig.IsAdvancedVisibilityConfigExist())
 
 	params.PersistenceConfig.HistoryMaxConns = serviceConfig.HistoryMgrNumConns()
-	params.PersistenceConfig.SetMaxQPS(params.PersistenceConfig.DefaultStore, serviceConfig.PersistenceMaxQPS())
+	params.PersistenceConfig.SetMaxQPS(params.PersistenceConfig.DefaultStore, serviceConfig.PersistenceMaxQPS)
 	params.PersistenceConfig.VisibilityConfig = &config.VisibilityConfig{
 		VisibilityOpenMaxQPS:            serviceConfig.VisibilityOpenMaxQPS,
 		VisibilityClosedMaxQPS:          serviceConfig.VisibilityClosedMaxQPS,

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -48,10 +48,7 @@ func NewService(
 ) (resource.Resource, error) {
 
 	serviceConfig := NewConfig(dynamicconfig.NewCollection(params.DynamicConfig, params.Logger))
-	params.PersistenceConfig.SetMaxQPS(
-		params.PersistenceConfig.DefaultStore,
-		serviceConfig.PersistenceMaxQPS(),
-	)
+	params.PersistenceConfig.SetMaxQPS(params.PersistenceConfig.DefaultStore, serviceConfig.PersistenceMaxQPS)
 	serviceResource, err := resource.New(
 		params,
 		common.MatchingServiceName,

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -107,7 +107,6 @@ func New(
 ) *Scanner {
 
 	cfg := params.Config
-	cfg.Persistence.SetMaxQPS(cfg.Persistence.DefaultStore, cfg.PersistenceMaxQPS())
 	zapLogger, err := zap.NewProduction()
 	if err != nil {
 		resource.GetLogger().Fatal("failed to initialize zap logger", tag.Error(err))

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -282,7 +282,7 @@ func initializeMetadataMgr(
 ) persistence.MetadataManager {
 
 	pConfig := serviceConfig.Persistence
-	pConfig.SetMaxQPS(pConfig.DefaultStore, dependencyMaxQPS)
+	pConfig.SetMaxQPS(pConfig.DefaultStore, dynamicconfig.GetIntPropertyFn(dependencyMaxQPS))
 	pConfig.VisibilityConfig = &config.VisibilityConfig{
 		VisibilityListMaxQPS:            dynamicconfig.GetIntPropertyFilteredByDomain(dependencyMaxQPS),
 		EnableSampling:                  dynamicconfig.GetBoolPropertyFn(false), // not used by domain operation


### PR DESCRIPTION
In order to safely implement executions scanner we need the persistence RPS to be controllable through dynamic config. This diff addresses the two issues that had prevented us from doing this:

1. Persistence RPS was not truly dynamic. The dynamic config value was read once when service components booted up and then never read again. I changed this to plumb the dynamic config through everywhere. This is safe because we were never relying on the value in static yaml config.
2. The worker only had one resource.Resource (with one persistence RPS) shared between all features of the worker. This made it impossible to set a persistence RPS for one worker feature and a different RPS for another worker feature. In order to address this I added a new field on worker for the resources for scanner. Before my change we attempted to this by setting the PersistenceMaxRPS in the scanner before we start the scanner, but this wasn't working because the resources (including the rate limited persistence resources) had already been created. 