### PR TITLE
Skeleton of executions scanner

### DIFF
--- a/.gen/go/shared/shared.go
+++ b/.gen/go/shared/shared.go
@@ -1,17 +1,17 @@
 // The MIT License (MIT)
-//
+// 
 // Copyright (c) 2020 Uber Technologies, Inc.
-//
+// 
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-//
+// 
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-//
+// 
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1019,6 +1019,8 @@ const (
 	ArchiverArchivalWorkflowScope
 	// TaskListScavengerScope is scope used by all metrics emitted by worker.tasklist.Scavenger module
 	TaskListScavengerScope
+	// ExecutionsScavengerScope
+	ExecutionsScavengerScope
 	// BatcherScope is scope used by all metrics emitted by worker.Batcher module
 	BatcherScope
 	// HistoryScavengerScope is scope used by all metrics emitted by worker.history.Scavenger module
@@ -1479,6 +1481,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		ArchiverPumpScope:                      {operation: "ArchiverPump"},
 		ArchiverArchivalWorkflowScope:          {operation: "ArchiverArchivalWorkflow"},
 		TaskListScavengerScope:                 {operation: "tasklistscavenger"},
+		ExecutionsScavengerScope:               {operation: "executionsscavenger"},
 		HistoryScavengerScope:                  {operation: "historyscavenger"},
 		BatcherScope:                           {operation: "batcher"},
 		ParentClosePolicyProcessorScope:        {operation: "ParentClosePolicyProcessor"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1834,6 +1834,7 @@ const (
 	TaskListProcessedCount
 	TaskListDeletedCount
 	TaskListOutstandingCount
+	ExecutionsOutstandingCount
 	StartedCount
 	StoppedCount
 	ExecutorTasksDeferredCount
@@ -2168,6 +2169,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskListProcessedCount:                        {metricName: "tasklist_processed", metricType: Gauge},
 		TaskListDeletedCount:                          {metricName: "tasklist_deleted", metricType: Gauge},
 		TaskListOutstandingCount:                      {metricName: "tasklist_outstanding", metricType: Gauge},
+		ExecutionsOutstandingCount:                    {metricName: "executions_outstanding", metricType: Gauge},
 		StartedCount:                                  {metricName: "started", metricType: Counter},
 		StoppedCount:                                  {metricName: "stopped", metricType: Counter},
 		ExecutorTasksDeferredCount:                    {metricName: "executor_deferred", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1019,7 +1019,7 @@ const (
 	ArchiverArchivalWorkflowScope
 	// TaskListScavengerScope is scope used by all metrics emitted by worker.tasklist.Scavenger module
 	TaskListScavengerScope
-	// ExecutionsScavengerScope
+	// ExecutionsScavengerScope is scope used by all metrics emitted by worker.executions.Scavenger module
 	ExecutionsScavengerScope
 	// BatcherScope is scope used by all metrics emitted by worker.Batcher module
 	BatcherScope

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -238,6 +238,9 @@ var keys = map[Key]string{
 	WorkerTimeLimitPerArchivalIteration:             "worker.TimeLimitPerArchivalIteration",
 	WorkerThrottledLogRPS:                           "worker.throttledLogRPS",
 	ScannerPersistenceMaxQPS:                        "worker.scannerPersistenceMaxQPS",
+	TaskListScannerEnabled:                          "worker.taskListScannerEnabled",
+	HistoryScannerEnabled:                           "worker.historyScannerEnabled",
+	ExecutionsScannerEnabled:                        "worker.executionsScannerEnabled",
 }
 
 const (
@@ -601,6 +604,12 @@ const (
 	WorkerThrottledLogRPS
 	// ScannerPersistenceMaxQPS is the maximum rate of persistence calls from worker.Scanner
 	ScannerPersistenceMaxQPS
+	// TaskListScannerEnabled indicates if task list scanner should be started as part of worker.Scanner
+	TaskListScannerEnabled
+	// HistoryScannerEnabled indicates if history scanner should be started as part of worker.Scanner
+	HistoryScannerEnabled
+	// ExecutionsScannerEnabled indicates if executions scanner should be started as part of worker.Scanner
+	ExecutionsScannerEnabled
 	// EnableBatcher decides whether start batcher in our worker
 	EnableBatcher
 	// EnableParentClosePolicyWorker decides whether or not enable system workers for processing parent close policy task

--- a/service/worker/scanner/executions/handler.go
+++ b/service/worker/scanner/executions/handler.go
@@ -1,17 +1,17 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2020 Uber Technologies, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/service/worker/scanner/executions/handler.go
+++ b/service/worker/scanner/executions/handler.go
@@ -1,0 +1,23 @@
+package executions
+
+import "github.com/uber/cadence/service/worker/scanner/executor"
+
+type handlerStatus = executor.TaskStatus
+
+const (
+	handlerStatusDone  = executor.TaskStatusDone
+	handlerStatusErr   = executor.TaskStatusErr
+	handlerStatusDefer = executor.TaskStatusDefer
+)
+
+const scannerTaskListPrefix = "cadence-sys-executions-scanner"
+
+// validateHandler validates a single execution.
+// It operates in two phases: collection step and validation step.
+// During collection step information from persistence is read for this workflow execution.
+// During validation step invariants are asserted over everything that was read.
+// In the future its possible to add a third step here which will additionally take automatic recovery actions if validation failed.
+func (s *Scavenger) validateHandler(key *executionKey) handlerStatus {
+	// TODO: implement this
+	return handlerStatusDone
+}

--- a/service/worker/scanner/executions/handler.go
+++ b/service/worker/scanner/executions/handler.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2020 Uber Technologies, Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package executions
 
 import "github.com/uber/cadence/service/worker/scanner/executor"

--- a/service/worker/scanner/executions/scavenger.go
+++ b/service/worker/scanner/executions/scavenger.go
@@ -1,17 +1,17 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2020 Uber Technologies, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/service/worker/scanner/executions/scavenger.go
+++ b/service/worker/scanner/executions/scavenger.go
@@ -164,7 +164,7 @@ func (s *Scavenger) awaitExecutor() {
 		select {
 		case <-time.After(executorPollInterval):
 			outstanding = s.executor.TaskCount()
-			s.metrics.UpdateGauge(metrics.ExecutionsScavengerScope, metrics.TaskListOutstandingCount, float64(outstanding))
+			s.metrics.UpdateGauge(metrics.ExecutionsScavengerScope, metrics.ExecutionsOutstandingCount, float64(outstanding))
 		case <-s.stopC:
 			return
 		}

--- a/service/worker/scanner/executions/scavenger.go
+++ b/service/worker/scanner/executions/scavenger.go
@@ -1,0 +1,159 @@
+package executions
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	p "github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/service/worker/scanner/executor"
+)
+
+type (
+	// Scavenger is the type that holds the state for executions scavenger daemon
+	Scavenger struct {
+		visibilityQuery string // optionally can be provided to limit the scope of a scan, by default all open executions are scanned
+		visDB           p.VisibilityManager
+		historyDB       p.HistoryManager
+		executor        executor.Executor
+		metrics         metrics.Client
+		logger          log.Logger
+		stats           stats
+		status          int32
+		stopC           chan struct{}
+		stopWG          sync.WaitGroup
+	}
+
+	executionKey struct {
+		domainID   string
+		workflowID string
+		runID      string
+	}
+
+	stats struct {
+		// TODO: include stats here that should be tracked throughout execution of scavenger
+	}
+
+	// executorTask is a runnable task that adheres to the executor.Task interface
+	// for the scavenger, each of this task processes a single workflow execution
+	executorTask struct {
+		executionKey
+		scvg *Scavenger
+	}
+)
+
+var (
+	executionsBatchSize      = 32   // maximum number of executions we process concurrently
+	executionsPageSize       = 1000 // page size of executions read from visibility manager
+	executorPollInterval     = time.Minute
+	executorMaxDeferredTasks = 10000
+)
+
+// NewScavenger returns an instance of executions scavenger daemon
+// The Scavenger can be started by calling the Start() method on the
+// returned object. Calling the Start() method will result in one
+// complete iteration over all of the open workflow executions in the system. For
+// each executions, will attempt to validate the workflow execution and emit metrics/logs on validation failures.
+//
+// The scavenger will retry on all persistence errors infinitely and will only stop under
+// two conditions
+//  - either all executions are processed successfully (or)
+//  - Stop() method is called to stop the scavenger
+func NewScavenger(
+	visibilityQuery string,
+	visDB p.VisibilityManager,
+	historyDB p.HistoryManager,
+	metricsClient metrics.Client,
+	logger log.Logger,
+) *Scavenger {
+	stopC := make(chan struct{})
+	taskExecutor := executor.NewFixedSizePoolExecutor(
+		executionsBatchSize, executorMaxDeferredTasks, metricsClient, metrics.ExecutionsScavengerScope)
+	return &Scavenger{
+		visibilityQuery: visibilityQuery,
+		visDB:           visDB,
+		historyDB:       historyDB,
+		metrics:         metricsClient,
+		logger:          logger,
+		stopC:           stopC,
+		executor:        taskExecutor,
+	}
+}
+
+// Start starts the scavenger
+func (s *Scavenger) Start() {
+	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+	s.logger.Info("Executions scavenger starting")
+	s.stopWG.Add(1)
+	s.executor.Start()
+	go s.run()
+	s.metrics.IncCounter(metrics.ExecutionsScavengerScope, metrics.StartedCount)
+	s.logger.Info("Executions scavenger started")
+}
+
+// Stop stops the scavenger
+func (s *Scavenger) Stop() {
+	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+	s.metrics.IncCounter(metrics.ExecutionsScavengerScope, metrics.StoppedCount)
+	s.logger.Info("Executions scavenger stopping")
+	close(s.stopC)
+	s.executor.Stop()
+	s.stopWG.Wait()
+	s.logger.Info("Executions scavenger stopped")
+}
+
+// Alive returns true if the scavenger is still running
+func (s *Scavenger) Alive() bool {
+	return atomic.LoadInt32(&s.status) == common.DaemonStatusStarted
+}
+
+// run does a single run over all executions and validates them
+func (s *Scavenger) run() {
+	// TODO: implement this
+	// 1. read from visibility manager
+	// 2. create executionTasks
+	// 3. pass them off to the executor to run
+	// 4. wait until the executor is done
+	// 5. emit metrics on the run of scavenger
+}
+
+func (s *Scavenger) awaitExecutor() {
+	outstanding := s.executor.TaskCount()
+	for outstanding > 0 {
+		select {
+		case <-time.After(executorPollInterval):
+			outstanding = s.executor.TaskCount()
+			s.metrics.UpdateGauge(metrics.ExecutionsScavengerScope, metrics.TaskListOutstandingCount, float64(outstanding))
+		case <-s.stopC:
+			return
+		}
+	}
+}
+
+func (s *Scavenger) emitStats() {
+	// TODO: implement this, this will emit metrics after a full run of executor scavenger is finished
+}
+
+// newTask returns a new instance of an executable task which will process a single execution
+func (s *Scavenger) newTask(domainID, workflowID, runID string) executor.Task {
+	return &executorTask{
+		executionKey: executionKey{
+			domainID:   domainID,
+			workflowID: workflowID,
+			runID:      runID,
+		},
+		scvg: s,
+	}
+}
+
+// Run runs the task
+func (t *executorTask) Run() executor.TaskStatus {
+	return t.scvg.validateHandler(&t.executionKey)
+}

--- a/service/worker/scanner/executions/scavenger.go
+++ b/service/worker/scanner/executions/scavenger.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2020 Uber Technologies, Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package executions
 
 import (

--- a/service/worker/scanner/executions/scavenger_test.go
+++ b/service/worker/scanner/executions/scavenger_test.go
@@ -1,0 +1,1 @@
+package executions

--- a/service/worker/scanner/executions/scavenger_test.go
+++ b/service/worker/scanner/executions/scavenger_test.go
@@ -1,1 +1,23 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2020 Uber Technologies, Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package executions

--- a/service/worker/scanner/executions/scavenger_test.go
+++ b/service/worker/scanner/executions/scavenger_test.go
@@ -1,17 +1,17 @@
 // The MIT License (MIT)
-// 
+//
 // Copyright (c) 2020 Uber Technologies, Inc.
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -42,8 +42,13 @@ import (
 const (
 	// scannerStartUpDelay is to let services warm up
 	scannerStartUpDelay = time.Second * 4
-	// fullExecutionsScanDefaultQuery indicates the visibility scanner should scan through all open workflows
-	fullExecutionsScanDefaultQuery = "SELECT * from elasticSearch.executions WHERE state IS open" // TODO: depending on if we go straight to ES or through frontend this query will look different
+)
+
+var (
+	defaultExecutionsScannerParams = ExecutionsScannerWorkflowParams{
+		// fullExecutionsScanDefaultQuery indicates the visibility scanner should scan through all open workflows
+		VisibilityQuery: "SELECT * from elasticSearch.executions WHERE state IS open", // TODO: depending on if we go straight to ES or through frontend this query will look different
+	}
 )
 
 type (
@@ -59,7 +64,7 @@ type (
 		TaskListScannerEnabled dynamicconfig.BoolPropertyFn
 		// HistoryScannerEnabled indicates if history scanner should be started as part of scanner
 		HistoryScannerEnabled dynamicconfig.BoolPropertyFn
-		// ExecutionsScannerEnabled
+		// ExecutionsScannerEnabled indicates if executions scanner should be started as part of scanner
 		ExecutionsScannerEnabled dynamicconfig.BoolPropertyFn
 	}
 
@@ -128,7 +133,7 @@ func (s *Scanner) Start() error {
 	var workerTaskListNames []string
 	if s.context.cfg.ExecutionsScannerEnabled() {
 		workerTaskListNames = append(workerTaskListNames, executionsScannerTaskListName)
-		go s.startWorkflowWithRetry(executionsScannerWFStartOptions, executionsScannerWFTypeName, fullExecutionsScanDefaultQuery)
+		go s.startWorkflowWithRetry(executionsScannerWFStartOptions, executionsScannerWFTypeName, defaultExecutionsScannerParams)
 	}
 
 	if s.context.cfg.Persistence.DefaultStoreType() == config.StoreTypeSQL && s.context.cfg.TaskListScannerEnabled() {

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -30,6 +30,8 @@ import (
 	"go.uber.org/cadence/worker"
 	"go.uber.org/zap"
 
+	"github.com/uber/cadence/service/worker/scanner/executions"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cluster"
@@ -45,7 +47,7 @@ const (
 )
 
 var (
-	defaultExecutionsScannerParams = ExecutionsScannerWorkflowParams{
+	defaultExecutionsScannerParams = executions.ScannerWorkflowParams{
 		// fullExecutionsScanDefaultQuery indicates the visibility scanner should scan through all open workflows
 		VisibilityQuery: "SELECT * from elasticSearch.executions WHERE state IS open", // TODO: depending on if we go straight to ES or through frontend this query will look different
 	}

--- a/service/worker/scanner/tasklist/handler.go
+++ b/service/worker/scanner/tasklist/handler.go
@@ -38,7 +38,7 @@ const (
 	handlerStatusDefer = executor.TaskStatusDefer
 )
 
-const scannerTaskListPrefix = "cadence-sys-scanner"
+const scannerTaskListPrefix = "cadence-sys-tl-scanner"
 
 // deleteHandler handles deletions for a given task list
 // this handler limits the amount of tasks deleted to maxTasksPerJob

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -102,15 +102,6 @@ var (
 	}
 )
 
-type (
-	// ExecutionsScannerWorkflowParams are the parameters passed to the executions scanner workflow
-	ExecutionsScannerWorkflowParams struct {
-		VisibilityQuery string // optionally can be provided to limit the scope of the scan
-
-		// add other fields here such as: bool generateReport, string outputLocation, bool runInDryMode etc...
-	}
-)
-
 func init() {
 	workflow.RegisterWithOptions(TaskListScannerWorkflow, workflow.RegisterOptions{Name: tlScannerWFTypeName})
 	workflow.RegisterWithOptions(HistoryScannerWorkflow, workflow.RegisterOptions{Name: historyScannerWFTypeName})
@@ -145,7 +136,7 @@ func HistoryScannerWorkflow(
 // ExecutionsScannerWorkflow is the workflow that runs the executions scanner background daemon
 func ExecutionsScannerWorkflow(
 	ctx workflow.Context,
-	executionsScannerWorkflowParams ExecutionsScannerWorkflowParams,
+	executionsScannerWorkflowParams executions.ScannerWorkflowParams,
 ) error {
 
 	future := workflow.ExecuteActivity(workflow.WithActivityOptions(ctx, activityOptions), executionsScavengerActivityName, executionsScannerWorkflowParams)
@@ -202,7 +193,7 @@ func TaskListScavengerActivity(
 // ExecutionsScavengerActivity is the activity that runs executions scavenger
 func ExecutionsScavengerActivity(
 	activityCtx context.Context,
-	executionsScannerWorkflowParams ExecutionsScannerWorkflowParams,
+	executionsScannerWorkflowParams executions.ScannerWorkflowParams,
 ) error {
 
 	ctx := activityCtx.Value(scannerContextKey).(scannerContext)

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -54,6 +54,11 @@ const (
 	historyScannerWFTypeName     = "cadence-sys-history-scanner-workflow"
 	historyScannerTaskListName   = "cadence-sys-history-scanner-tasklist-0"
 	historyScavengerActivityName = "cadence-sys-history-scanner-scvg-activity"
+
+	executionsScannerWFID           = "cadence-sys-executions-scanner"
+	executionsScannerWFTypeName     = "cadence-sys-executions-scanner-workflow"
+	executionsScannerTaskListName   = "cadence-sys-executions-scanner-tasklist-0"
+	executionsScavengerActivityName = "cadence-sys-executions-scanner-scvg-activity"
 )
 
 var (

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -127,9 +127,12 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			TimeLimitPerArchivalIteration: dc.GetDurationProperty(dynamicconfig.WorkerTimeLimitPerArchivalIteration, archiver.MaxArchivalIterationTimeout()),
 		},
 		ScannerCfg: &scanner.Config{
-			PersistenceMaxQPS: dc.GetIntProperty(dynamicconfig.ScannerPersistenceMaxQPS, 100),
-			Persistence:       &params.PersistenceConfig,
-			ClusterMetadata:   params.ClusterMetadata,
+			PersistenceMaxQPS:        dc.GetIntProperty(dynamicconfig.ScannerPersistenceMaxQPS, 100),
+			Persistence:              &params.PersistenceConfig,
+			ClusterMetadata:          params.ClusterMetadata,
+			TaskListScannerEnabled:   dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
+			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
+			ExecutionsScannerEnabled: dc.GetBoolProperty(dynamicconfig.ExecutionsScannerEnabled, false),
 		},
 		BatcherCfg: &batcher.Config{
 			AdminOperationToken: dc.GetStringProperty(dynamicconfig.AdminOperationToken, common.DefaultAdminOperationToken),


### PR DESCRIPTION
This diff includes the skeleton of a new system scanner which will go over workflow executions. This scanner is meant to be used to assert system invariants, generate reports and someday could also automatically perform repair actions. 

This code contains all the plumbing needed to actually bootstrap this workflow and run it. This diff does not contain the actual implementation of the validations or unit tests (these will come in follow up diffs). 