### PR TITLE
matching_scalable_tasklist: bug fixes

### DIFF
--- a/service/matching/forwarder.go
+++ b/service/matching/forwarder.go
@@ -148,6 +148,7 @@ func (fwdr *Forwarder) ForwardTask(ctx context.Context, task *internalTask) erro
 			},
 			ScheduleId:                    &task.event.ScheduleID,
 			ScheduleToStartTimeoutSeconds: &task.event.ScheduleToStartTimeout,
+			Source:                        &task.source,
 			ForwardedFrom:                 &fwdr.taskListID.name,
 		})
 	case persistence.TaskListTypeActivity:
@@ -161,6 +162,7 @@ func (fwdr *Forwarder) ForwardTask(ctx context.Context, task *internalTask) erro
 			},
 			ScheduleId:                    &task.event.ScheduleID,
 			ScheduleToStartTimeoutSeconds: &task.event.ScheduleToStartTimeout,
+			Source:                        &task.source,
 			ForwardedFrom:                 &fwdr.taskListID.name,
 		})
 	default:

--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -72,7 +72,7 @@ func (t *ForwarderTestSuite) TearDownTest() {
 }
 
 func (t *ForwarderTestSuite) TestForwardTaskError() {
-	task := newInternalTask(&persistence.TaskInfo{}, nil, "", false)
+	task := newInternalTask(&persistence.TaskInfo{}, nil, gen.TaskSourceHistory, "", false)
 	t.Equal(errNoParent, t.fwdr.ForwardTask(context.Background(), task))
 
 	t.usingTasklistPartition(persistence.TaskListTypeActivity)
@@ -91,7 +91,7 @@ func (t *ForwarderTestSuite) TestForwardDecisionTask() {
 	).Return(nil).Times(1)
 
 	taskInfo := t.newTaskInfo()
-	task := newInternalTask(taskInfo, nil, "", false)
+	task := newInternalTask(taskInfo, nil, gen.TaskSourceHistory, "", false)
 	t.NoError(t.fwdr.ForwardTask(context.Background(), task))
 	t.NotNil(request)
 	t.Equal(t.taskList.Parent(20), request.TaskList.GetName())
@@ -115,7 +115,7 @@ func (t *ForwarderTestSuite) TestForwardActivityTask() {
 	).Return(nil).Times(1)
 
 	taskInfo := t.newTaskInfo()
-	task := newInternalTask(taskInfo, nil, "", false)
+	task := newInternalTask(taskInfo, nil, gen.TaskSourceHistory, "", false)
 	t.NoError(t.fwdr.ForwardTask(context.Background(), task))
 	t.NotNil(request)
 	t.Equal(t.taskList.Parent(20), request.TaskList.GetName())
@@ -135,7 +135,7 @@ func (t *ForwarderTestSuite) TestForwardTaskRateExceeded() {
 	rps := 2
 	t.client.EXPECT().AddActivityTask(gomock.Any(), gomock.Any()).Return(nil).Times(rps)
 	taskInfo := t.newTaskInfo()
-	task := newInternalTask(taskInfo, nil, "", false)
+	task := newInternalTask(taskInfo, nil, gen.TaskSourceHistory, "", false)
 	for i := 0; i < rps; i++ {
 		t.NoError(t.fwdr.ForwardTask(context.Background(), task))
 	}

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -158,8 +158,12 @@ func (tm *TaskMatcher) offerOrTimeout(ctx context.Context, task *internalTask) (
 	select {
 	case tm.taskC <- task: // poller picked up the task
 		if task.responseC != nil {
-			err := <-task.responseC
-			return true, err
+			select {
+			case err := <-task.responseC:
+				return true, err
+			case <-ctx.Done():
+				return false, nil
+			}
 		}
 		return false, nil
 	case <-ctx.Done():

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -25,10 +25,10 @@ import (
 	"errors"
 	"time"
 
-	"github.com/uber/cadence/.gen/go/shared"
-
 	"golang.org/x/time/rate"
 
+	"github.com/uber/cadence/.gen/go/matching"
+	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/quotas"
 )
@@ -79,9 +79,27 @@ func newTaskMatcher(config *taskListConfig, fwdr *Forwarder, scopeFunc func() me
 // If the task is successfully matched with a consumer, this
 // method will return true and no error. If the task is matched
 // but consumer returned error, then this method will return
-// true and error message. Both regular tasks and query tasks
-// should use this method to match with a consumer. Likewise, sync matches
-// and non-sync matches both should use this method.
+// true and error message. This method should not be used for query
+// task. This method should ONLY be used for sync match.
+//
+// When a local poller is not available and forwarding to a parent
+// task list partition is possible, this method will attempt forwarding
+// to the parent partition.
+//
+// Cases when this method will block:
+//
+// Ratelimit:
+// When a ratelimit is token is not available, this method might block
+// waiting for a token until the provided context timeout. Rate limits are
+// not enforced for forwarded tasks from child partition.
+//
+// Forwarded tasks that originated from db backlog:
+// When this method is called with a task that is forwarded from a
+// remote partition and if (1) this task list is root (2) task
+// was from db backlog - this method will block until context timeout
+// trying to match with a poller. The caller is expected to set the
+// correct context timeout.
+//
 // returns error when:
 //  - ratelimit is exceeded (does not apply to query task)
 //  - context deadline is exceeded
@@ -108,7 +126,7 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, err
 		return false, nil
 	default:
 		// no poller waiting for tasks, try forwarding this task to the
-		// root partition if available
+		// root partition if possible
 		select {
 		case token := <-tm.fwdrAddReqTokenC():
 			if err := tm.fwdr.ForwardTask(ctx, task); err == nil {
@@ -118,6 +136,13 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, err
 			}
 			token.release()
 		default:
+			if !tm.isForwardingAllowed() && // we are the root partition and forwarding is not possible
+				task.source == matching.TaskSourceDbBacklog && // task was from backlog (stored in db)
+				task.isForwarded() { // task came from a child partition
+				// a forwarded backlog task from a child partition, block trying
+				// to match with a poller until ctx timeout
+				return tm.offerOrTimeout(ctx, task)
+			}
 		}
 
 		if rsv != nil {
@@ -125,6 +150,19 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, err
 			// return it since we did not really do any work
 			rsv.Cancel()
 		}
+		return false, nil
+	}
+}
+
+func (tm *TaskMatcher) offerOrTimeout(ctx context.Context, task *internalTask) (bool, error) {
+	select {
+	case tm.taskC <- task: // poller picked up the task
+		if task.responseC != nil {
+			err := <-task.responseC
+			return true, err
+		}
+		return false, nil
+	case <-ctx.Done():
 		return false, nil
 	}
 }
@@ -209,6 +247,10 @@ forLoop:
 				continue forLoop
 			}
 			cancel()
+			// at this point, we forwarded the task to a parent partition which
+			// in turn dispatched the task to a poller. Make sure we delete the
+			// task from the database
+			task.finish(nil)
 			return nil
 		case <-ctx.Done():
 			return ctx.Err()
@@ -374,4 +416,8 @@ func (tm *TaskMatcher) ratelimit(ctx context.Context) (*rate.Reservation, error)
 
 	time.Sleep(rsv.Delay())
 	return rsv, nil
+}
+
+func (tm *TaskMatcher) isForwardingAllowed() bool {
+	return tm.fwdr != nil
 }

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -89,7 +89,7 @@ func newTaskMatcher(config *taskListConfig, fwdr *Forwarder, scopeFunc func() me
 // Cases when this method will block:
 //
 // Ratelimit:
-// When a ratelimit is token is not available, this method might block
+// When a ratelimit token is not available, this method might block
 // waiting for a token until the provided context timeout. Rate limits are
 // not enforced for forwarded tasks from child partition.
 //

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -244,6 +244,7 @@ func (e *matchingEngineImpl) AddDecisionTask(ctx context.Context, addRequest *m.
 	return tlMgr.AddTask(ctx, addTaskParams{
 		execution:     addRequest.Execution,
 		taskInfo:      taskInfo,
+		source:        addRequest.GetSource(),
 		forwardedFrom: addRequest.GetForwardedFrom(),
 	})
 }
@@ -282,6 +283,7 @@ func (e *matchingEngineImpl) AddActivityTask(ctx context.Context, addRequest *m.
 	return tlMgr.AddTask(ctx, addTaskParams{
 		execution:     addRequest.Execution,
 		taskInfo:      taskInfo,
+		source:        addRequest.GetSource(),
 		forwardedFrom: addRequest.GetForwardedFrom(),
 	})
 }

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -368,18 +368,27 @@ func (s *matchingEngineSuite) PollForTasksEmptyResultTest(callContext context.Co
 }
 
 func (s *matchingEngineSuite) TestAddActivityTasks() {
-	s.AddTasksTest(persistence.TaskListTypeActivity)
+	s.AddTasksTest(persistence.TaskListTypeActivity, false)
 }
 
 func (s *matchingEngineSuite) TestAddDecisionTasks() {
-	s.AddTasksTest(persistence.TaskListTypeDecision)
+	s.AddTasksTest(persistence.TaskListTypeDecision, false)
 }
 
-func (s *matchingEngineSuite) AddTasksTest(taskType int) {
+func (s *matchingEngineSuite) TestAddActivityTasksForwarded() {
+	s.AddTasksTest(persistence.TaskListTypeActivity, true)
+}
+
+func (s *matchingEngineSuite) TestAddDecisionTasksForwarded() {
+	s.AddTasksTest(persistence.TaskListTypeDecision, true)
+}
+
+func (s *matchingEngineSuite) AddTasksTest(taskType int, isForwarded bool) {
 	s.matchingEngine.config.RangeSize = 300 // override to low number for the test
 
 	domainID := "domainId"
 	tl := "makeToast"
+	forwardedFrom := "/__cadence_sys/makeToast/1"
 
 	taskList := &workflow.TaskList{}
 	taskList.Name = &tl
@@ -402,7 +411,9 @@ func (s *matchingEngineSuite) AddTasksTest(taskType int) {
 				TaskList:                      taskList,
 				ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
 			}
-
+			if isForwarded {
+				addRequest.ForwardedFrom = &forwardedFrom
+			}
 			_, err = s.matchingEngine.AddActivityTask(context.Background(), &addRequest)
 		} else {
 			addRequest := matching.AddDecisionTaskRequest{
@@ -412,12 +423,26 @@ func (s *matchingEngineSuite) AddTasksTest(taskType int) {
 				TaskList:                      taskList,
 				ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
 			}
-
+			if isForwarded {
+				addRequest.ForwardedFrom = &forwardedFrom
+			}
 			_, err = s.matchingEngine.AddDecisionTask(context.Background(), &addRequest)
 		}
-		s.NoError(err)
+
+		switch isForwarded {
+		case false:
+			s.NoError(err)
+		case true:
+			s.Equal(errRemoteSyncMatchFailed, err)
+		}
 	}
-	s.EqualValues(taskCount, s.taskManager.getTaskCount(newTestTaskListID(domainID, tl, taskType)))
+
+	switch isForwarded {
+	case false:
+		s.EqualValues(taskCount, s.taskManager.getTaskCount(newTestTaskListID(domainID, tl, taskType)))
+	case true:
+		s.EqualValues(0, s.taskManager.getTaskCount(newTestTaskListID(domainID, tl, taskType)))
+	}
 }
 
 func (s *matchingEngineSuite) TestTaskWriterShutdown() {

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -51,6 +51,7 @@ type (
 		query            *queryTaskInfo   // non-nil for a query task that's locally sync matched
 		started          *startedTaskInfo // non-nil for a task received from a parent partition which is already started
 		domainName       string
+		source           m.TaskSource
 		forwardedFrom    string     // name of the child partition this task is forwarded from (empty if not forwarded)
 		responseC        chan error // non-nil only where there is a caller waiting for response (sync-match)
 		backlogCountHint int64
@@ -60,6 +61,7 @@ type (
 func newInternalTask(
 	info *persistence.TaskInfo,
 	completionFunc func(*persistence.TaskInfo, error),
+	source m.TaskSource,
 	forwardedFrom string,
 	forSyncMatch bool,
 ) *internalTask {
@@ -68,6 +70,7 @@ func newInternalTask(
 			TaskInfo:       info,
 			completionFunc: completionFunc,
 		},
+		source:        source,
 		forwardedFrom: forwardedFrom,
 	}
 	if forSyncMatch {
@@ -85,7 +88,8 @@ func newInternalQueryTask(
 			taskID:  taskID,
 			request: request,
 		},
-		responseC: make(chan error, 1),
+		forwardedFrom: request.GetForwardedFrom(),
+		responseC:     make(chan error, 1),
 	}
 }
 

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -23,6 +23,7 @@ package matching
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -115,6 +116,8 @@ const (
 )
 
 var _ taskListManager = (*taskListManagerImpl)(nil)
+
+var errRemoteSyncMatchFailed = errors.New("remote sync match failed")
 
 func newTaskListManager(
 	e *matchingEngineImpl,
@@ -219,9 +222,13 @@ func (c *taskListManagerImpl) AddTask(ctx context.Context, params addTaskParams)
 			return &persistence.CreateTasksResponse{}, err
 		}
 
-		r, err := c.taskWriter.appendTask(params.execution, params.taskInfo)
-		syncMatch = false
-		return r, err
+		if params.forwardedFrom != "" {
+			// forwarded from child partition - only do sync match
+			// child partition will persist the task when sync match fails
+			return &persistence.CreateTasksResponse{}, errRemoteSyncMatchFailed
+		}
+
+		return c.taskWriter.appendTask(params.execution, params.taskInfo)
 	})
 	if err == nil {
 		c.taskReader.Signal()

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -25,6 +25,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/uber/cadence/.gen/go/matching"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -92,7 +93,7 @@ dispatchLoop:
 			if !ok { // Task list getTasks pump is shutdown
 				break dispatchLoop
 			}
-			task := newInternalTask(taskInfo, tr.tlMgr.completeTask, "", false)
+			task := newInternalTask(taskInfo, tr.tlMgr.completeTask, matching.TaskSourceDbBacklog, "", false)
 			for {
 				err := tr.tlMgr.DispatchTask(tr.cancelCtx, task)
 				if err == nil {


### PR DESCRIPTION
This patch fixes multiple problems with the scalable task list implementation:

**Problem#1:**  Tasks can be persisted twice, once at the child partition and once at the root partition
Currently, the parent partition is missing the necessary check to not persist a task when it's forwarded from a child partition (for remote sync match). This leads to tasks being persisted and processed twice.

Solution: Added check with AddTask() to not persist the task when forwardedFrom is true

**Problem#2:** ACK levels can get stuck for child partitions. Following is the scenario that leads to this problem:
  - Child partition receives a task, there is no poller and so persists the task to db
  - Child partition taskReader reads backlog from db and attempts to match against a poller
  - Child partition forwards the task to parent for remote sync match
  - Task is remote sync matched and child partition receives success
  - Child partition fails to delete the task from db / mark the task as completed

Solution: ACK the task even in the case of remote sync match

**Problem#3:** The impact of this problem could be increased task dispatch latency when there is backlog and insufficient number of pollers. Following is the scenario:

  - Child partition taskReader reads backlog from db and attempts to match against a poller
  - Child partition forwards the task to parent for remote sync match after local sync match fails
  - The call to the parent has a context timeout of 2s with the intention that the call will block on the parent partition for up to 2s trying to remote sync match. 
 - Parent partition overrides the context timeout from 2s to 200ms because sync matches typically are non-blocking.
- Child partition spends the remained 1.5s trying to do local sync match before it makes another attempt at remote sync match.

Solution: Add logic within the parent partition to allow sync match to block for this scenario.
