### PR TITLE
Update switch statement to prevent unsupported task type

### DIFF
--- a/common/messaging/kafkaProducer.go
+++ b/common/messaging/kafkaProducer.go
@@ -113,6 +113,12 @@ func (p *kafkaProducer) getKeyForReplicationTask(task *replicator.ReplicationTas
 		// the messaging layer perspective
 		attributes := task.SyncActivityTaskAttributes
 		return sarama.StringEncoder(attributes.GetWorkflowId())
+	case replicator.ReplicationTaskTypeHistoryMetadata,
+		replicator.ReplicationTaskTypeDomain,
+		replicator.ReplicationTaskTypeSyncShardStatus:
+		return nil
+	default:
+		panic("encounter unsupported replication task type")
 	}
 
 	return nil

--- a/common/messaging/kafkaProducer.go
+++ b/common/messaging/kafkaProducer.go
@@ -22,6 +22,7 @@ package messaging
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/Shopify/sarama"
 
@@ -118,7 +119,7 @@ func (p *kafkaProducer) getKeyForReplicationTask(task *replicator.ReplicationTas
 		replicator.ReplicationTaskTypeSyncShardStatus:
 		return nil
 	default:
-		panic("encounter unsupported replication task type")
+		panic(fmt.Sprintf("encounter unsupported replication task type: %v", task.GetTaskType()))
 	}
 
 	return nil


### PR DESCRIPTION
Update switch statement to prevent unsupported task type or newly added type

<!-- Describe what has changed in this PR -->
**What changed?**
Update Kafka producer get key for replication task to handle default case.

<!-- Tell your future self why have you made these changes -->
**Why?**
To prevent newly added replication type not added in the kafka producer

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is to prevent coding issues. This should not impact production.
