### PR TITLE
Switch to using readWriteMutex for lockableQueryMap

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -60,7 +60,7 @@ type (
 	// RespondQueryTaskCompleted() or through an internal service error causing cadence to be unable to dispatch
 	// query task to workflow worker.
 	lockableQueryTaskMap struct {
-		sync.Mutex
+		sync.RWMutex
 		queryTaskMap map[string]chan *queryResult
 	}
 
@@ -829,8 +829,8 @@ func (m *lockableQueryTaskMap) put(key string, value chan *queryResult) {
 }
 
 func (m *lockableQueryTaskMap) get(key string) (chan *queryResult, bool) {
-	m.Lock()
-	defer m.Unlock()
+	m.RLock()
+	defer m.RUnlock()
 	result, ok := m.queryTaskMap[key]
 	return result, ok
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Switch to using readWriteMutex for lockableQueryMap

<!-- Tell your future self why have you made these changes -->
Reduce latency of respondQueryTaskCompleted due to lock contention

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
N/A


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Nothing

