### PR TITLE
Support for abstract datastore in persistence tests

### DIFF
--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -225,8 +225,8 @@ type (
 	CustomDatastoreConfig struct {
 		// Name of the custom datastore
 		Name string `yaml:"name"`
-		// ConnectAttributes is a set of key-value attributes that can be used by AbstractDatastoreFactory implementation
-		ConnectAttributes map[string]string `yaml:"connectAttributes"`
+		// Options is a set of key-value attributes that can be used by AbstractDatastoreFactory implementation
+		Options map[string]string `yaml:"options"`
 	}
 
 	// Replicator describes the configuration of replicator


### PR DESCRIPTION
This change:

- Adds AbstractDatastoreFactory to the TestBase
- Makes logger public so it can be set outside of the package
- Adds/renames couple fields in the CustomDatastoreConfig