### PR TITLE
Check correct configuration field when validating visibility store

### DIFF
--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -313,7 +313,7 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 	visibilityCfg := f.config.DataStores[f.config.VisibilityStore]
 	visibilityDataStore := Datastore{ratelimit: limiters[f.config.VisibilityStore]}
 	switch {
-	case defaultCfg.Cassandra != nil:
+	case visibilityCfg.Cassandra != nil:
 		visibilityDataStore.factory = cassandra.NewFactory(*visibilityCfg.Cassandra, clusterName, f.logger)
 	case visibilityCfg.SQL != nil:
 		visibilityDataStore.factory = sql.NewFactory(*visibilityCfg.SQL, clusterName, f.logger)


### PR DESCRIPTION
Previously we were validating wrong configuration field during factory initialization.
This change fixes that and checks visibility config for the visibility factory.

Without this change it is impossible to use docstore as a default storage and cassandra as a visibility gateway.

Note that abstract datastore is currently not supported for visibility and may be added in future.