### PR TITLE
Cleanup PersistenceTestCluster interface

### DIFF
--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -90,13 +90,9 @@ type (
 
 	// PersistenceTestCluster exposes management operations on a database
 	PersistenceTestCluster interface {
-		DatabaseName() string
 		SetupTestDatabase()
 		TearDownTestDatabase()
-		DropDatabase()
 		Config() config.Persistence
-		LoadSchema(fileNames []string, schemaDir string)
-		LoadVisibilitySchema(fileNames []string, schemaDir string)
 	}
 
 	// TestTransferTaskIDGenerator helper


### PR DESCRIPTION
This change removes methods that are not generic enough and are only used in the internal implementation details.

Methods being deleted are never used through the interface and are only referenced from within other methods of the same interface.