### PR TITLE
Add filter to not reapply event with the same version

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2904,8 +2904,13 @@ func (e *historyEngineImpl) ReapplyEvents(
 				return nil, err
 			}
 			for _, event := range reapplyEvents {
+				if event.GetVersion() == lastWriteVersion {
+					// The reapply is from the same cluster. Ignoring.
+					continue
+				}
 				dedupResource := definition.NewEventReappliedID(runID, event.GetEventId(), event.GetVersion())
-				if event.GetVersion() == lastWriteVersion || mutableState.IsResourceDuplicated(dedupResource) {
+				if mutableState.IsResourceDuplicated(dedupResource) {
+					// already apply the signal
 					continue
 				}
 				toReapplyEvents = append(toReapplyEvents, event)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
During NDC event reapplication, add a filter to not apply event with the same version as the current workflow last write version. 

<!-- Tell your future self why have you made these changes -->
**Why?**
If the reapply event with the same version, it means the event is from the same cluster and no failover happened during this time. It means the event is already applied in the current cluster and there is no need to reapply this event.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Reapply events with version A to the current workflow with version A. The events should not show in history.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the worst case, the event will not reapply to the current branch.
