### PR TITLE
Fix archival handled requests not match pumped requests

### DIFF
--- a/service/worker/archiver/util.go
+++ b/service/worker/archiver/util.go
@@ -22,7 +22,7 @@ package archiver
 
 import (
 	"bytes"
-	"encoding/gob"
+	"encoding/json"
 	"time"
 
 	"github.com/dgryski/go-farm"
@@ -39,7 +39,9 @@ func MaxArchivalIterationTimeout() time.Duration {
 
 func hash(i interface{}) uint64 {
 	var b bytes.Buffer
-	gob.NewEncoder(&b).Encode(i) //nolint:errcheck
+	// please make sure encoder is deterministic (especially when encoding map objects)
+	// use json not gob here as json will sort map keys, while gob is non-deterministic
+	json.NewEncoder(&b).Encode(i) //nolint:errcheck
 	return farm.Fingerprint64(b.Bytes())
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use json instead of gob when hashing archival requests

<!-- Tell your future self why have you made these changes -->
**Why?**
gob is non-deterministic when encoding map objects

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No, this fixes a sanity check itself.
