### PR TITLE
Add context in history resend

### DIFF
--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -221,9 +221,9 @@ func (c *Collection) GetDurationPropertyFilteredByDomainID(key Key, defaultValue
 	return func(domain string) time.Duration {
 		val, err := c.client.GetDurationValue(key, getFilterMap(DomainIDFilter(domain)), defaultValue)
 		if err != nil {
-			c.logNoValue(key, err)
+			c.logError(key, err)
 		}
-		c.logValue(key, val, defaultValue)
+		c.logValue(key, val, defaultValue, durationCompareEquals)
 		return val
 	}
 }

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -95,6 +95,9 @@ type DurationPropertyFn func(opts ...FilterOption) time.Duration
 // DurationPropertyFnWithDomainFilter is a wrapper to get duration property from dynamic config with domain as filter
 type DurationPropertyFnWithDomainFilter func(domain string) time.Duration
 
+// DurationPropertyFnWithDomainIDFilter is a wrapper to get duration property from dynamic config with domainID as filter
+type DurationPropertyFnWithDomainIDFilter func(domainID string) time.Duration
+
 // DurationPropertyFnWithTaskListInfoFilters is a wrapper to get duration property from dynamic config  with three filters: domain, taskList, taskType
 type DurationPropertyFnWithTaskListInfoFilters func(domain string, taskList string, taskType int) time.Duration
 
@@ -209,6 +212,18 @@ func (c *Collection) GetDurationPropertyFilteredByDomain(key Key, defaultValue t
 			c.logError(key, err)
 		}
 		c.logValue(key, val, defaultValue, durationCompareEquals)
+		return val
+	}
+}
+
+// GetDurationPropertyFilteredByDomainID gets property with domainID filter and asserts that it's a duration
+func (c *Collection) GetDurationPropertyFilteredByDomainID(key Key, defaultValue time.Duration) DurationPropertyFnWithDomainIDFilter {
+	return func(domain string) time.Duration {
+		val, err := c.client.GetDurationValue(key, getFilterMap(DomainIDFilter(domain)), defaultValue)
+		if err != nil {
+			c.logNoValue(key, err)
+		}
+		c.logValue(key, val, defaultValue)
 		return val
 	}
 }

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -218,8 +218,8 @@ func (c *Collection) GetDurationPropertyFilteredByDomain(key Key, defaultValue t
 
 // GetDurationPropertyFilteredByDomainID gets property with domainID filter and asserts that it's a duration
 func (c *Collection) GetDurationPropertyFilteredByDomainID(key Key, defaultValue time.Duration) DurationPropertyFnWithDomainIDFilter {
-	return func(domain string) time.Duration {
-		val, err := c.client.GetDurationValue(key, getFilterMap(DomainIDFilter(domain)), defaultValue)
+	return func(domainID string) time.Duration {
+		val, err := c.client.GetDurationValue(key, getFilterMap(DomainIDFilter(domainID)), defaultValue)
 		if err != nil {
 			c.logError(key, err)
 		}

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -687,6 +687,8 @@ const (
 
 	// lastFilterTypeForTest must be the last one in this const group for testing purpose
 	lastFilterTypeForTest
+	// DomainID is the domain id
+	DomainID
 )
 
 // FilterOption is used to provide filters for dynamic config keys
@@ -703,6 +705,13 @@ func TaskListFilter(name string) FilterOption {
 func DomainFilter(name string) FilterOption {
 	return func(filterMap map[Filter]interface{}) {
 		filterMap[DomainName] = name
+	}
+}
+
+// DomainIDFilter filters by domain id
+func DomainIDFilter(name string) FilterOption {
+	return func(filterMap map[Filter]interface{}) {
+		filterMap[DomainID] = name
 	}
 }
 

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -672,6 +672,7 @@ func (f Filter) String() string {
 var filters = []string{
 	"unknownFilter",
 	"domainName",
+	"domainID",
 	"taskListName",
 	"taskType",
 }

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -224,6 +224,7 @@ var keys = map[Key]string{
 	WorkerReplicationTaskMaxRetryCount:              "worker.replicationTaskMaxRetryCount",
 	WorkerReplicationTaskMaxRetryDuration:           "worker.replicationTaskMaxRetryDuration",
 	WorkerReplicationTaskContextDuration:            "worker.replicationTaskContextDuration",
+	WorkerReReplicationContextTimeout:               "worker.workerReReplicationContextTimeout",
 	WorkerIndexerConcurrency:                        "worker.indexerConcurrency",
 	WorkerESProcessorNumOfWorkers:                   "worker.ESProcessorNumOfWorkers",
 	WorkerESProcessorBulkActions:                    "worker.ESProcessorBulkActions",
@@ -578,6 +579,8 @@ const (
 	WorkerReplicationTaskMaxRetryDuration
 	// WorkerReplicationTaskContextDuration is the context timeout for apply replication tasks
 	WorkerReplicationTaskContextDuration
+	// WorkerReReplicationContextTimeout is the context timeout for end to end  re-replication process
+	WorkerReReplicationContextTimeout
 	// WorkerIndexerConcurrency is the max concurrent messages to be processed at any given time
 	WorkerIndexerConcurrency
 	// WorkerESProcessorNumOfWorkers is num of workers for esProcessor

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -681,12 +681,12 @@ const (
 	unknownFilter Filter = iota
 	// DomainName is the domain name
 	DomainName
+	// DomainID is the domain id
+	DomainID
 	// TaskListName is the tasklist name
 	TaskListName
 	// TaskType is the task type (0:Decision, 1:Activity)
 	TaskType
-	// DomainID is the domain id
-	DomainID
 
 	// lastFilterTypeForTest must be the last one in this const group for testing purpose
 	lastFilterTypeForTest

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -684,11 +684,11 @@ const (
 	TaskListName
 	// TaskType is the task type (0:Decision, 1:Activity)
 	TaskType
+	// DomainID is the domain id
+	DomainID
 
 	// lastFilterTypeForTest must be the last one in this const group for testing purpose
 	lastFilterTypeForTest
-	// DomainID is the domain id
-	DomainID
 )
 
 // FilterOption is used to provide filters for dynamic config keys
@@ -709,9 +709,9 @@ func DomainFilter(name string) FilterOption {
 }
 
 // DomainIDFilter filters by domain id
-func DomainIDFilter(name string) FilterOption {
+func DomainIDFilter(domainID string) FilterOption {
 	return func(filterMap map[Filter]interface{}) {
-		filterMap[DomainID] = name
+		filterMap[DomainID] = domainID
 	}
 }
 

--- a/common/xdc/historyRereplicator.go
+++ b/common/xdc/historyRereplicator.go
@@ -22,6 +22,7 @@ package xdc
 
 import (
 	"context"
+	"github.com/uber/cadence/common/service/dynamicconfig"
 	"time"
 
 	"github.com/uber/cadence/.gen/go/admin"
@@ -70,6 +71,7 @@ type (
 		historyReplicationFn historyReplicationFn
 		serializer           persistence.PayloadSerializer
 		replicationTimeout   time.Duration
+		rereplicationTimeout dynamicconfig.DurationPropertyFnWithDomainIDFilter
 		logger               log.Logger
 	}
 
@@ -84,6 +86,7 @@ type (
 		endingNextEventID     int64
 		rereplicator          *HistoryRereplicatorImpl
 		logger                log.Logger
+		ctx                   context.Context
 	}
 )
 
@@ -91,10 +94,19 @@ func newHistoryRereplicationContext(domainID string, workflowID string,
 	beginningRunID string, beginningFirstEventID int64,
 	endingRunID string, endingNextEventID int64,
 	rereplicator *HistoryRereplicatorImpl) *historyRereplicationContext {
+
 	logger := rereplicator.logger.WithTags(
 		tag.WorkflowDomainID(domainID), tag.WorkflowID(workflowID), tag.WorkflowBeginningRunID(beginningRunID),
 		tag.WorkflowBeginningFirstEventID(beginningFirstEventID), tag.WorkflowEndingRunID(endingRunID),
 		tag.WorkflowEndingNextEventID(endingNextEventID))
+
+	ctx := context.Background()
+	var cancel context.CancelFunc
+	timeout := rereplicator.rereplicationTimeout(domainID)
+	if timeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
 	return &historyRereplicationContext{
 		seenEmptyEvents:       false,
 		rpcCalls:              0,
@@ -106,12 +118,20 @@ func newHistoryRereplicationContext(domainID string, workflowID string,
 		endingNextEventID:     endingNextEventID,
 		rereplicator:          rereplicator,
 		logger:                logger,
+		ctx:                   ctx,
 	}
 }
 
 // NewHistoryRereplicator create a new HistoryRereplicatorImpl
-func NewHistoryRereplicator(targetClusterName string, domainCache cache.DomainCache, adminClient a.Client, historyReplicationFn historyReplicationFn,
-	serializer persistence.PayloadSerializer, replicationTimeout time.Duration, logger log.Logger) *HistoryRereplicatorImpl {
+func NewHistoryRereplicator(
+	targetClusterName string,
+	domainCache cache.DomainCache,
+	adminClient a.Client,
+	historyReplicationFn historyReplicationFn,
+	serializer persistence.PayloadSerializer,
+	replicationTimeout time.Duration,
+	rereplicationTimeout dynamicconfig.DurationPropertyFnWithDomainIDFilter,
+	logger log.Logger) *HistoryRereplicatorImpl {
 
 	return &HistoryRereplicatorImpl{
 		targetClusterName:    targetClusterName,
@@ -120,6 +140,7 @@ func NewHistoryRereplicator(targetClusterName string, domainCache cache.DomainCa
 		historyReplicationFn: historyReplicationFn,
 		serializer:           serializer,
 		replicationTimeout:   replicationTimeout,
+		rereplicationTimeout: rereplicationTimeout,
 		logger:               logger,
 	}
 }
@@ -299,7 +320,7 @@ func (c *historyRereplicationContext) sendReplicationRawRequest(request *history
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.rereplicator.replicationTimeout)
+	ctx, cancel := context.WithTimeout(c.ctx, c.rereplicator.replicationTimeout)
 	defer func() {
 		cancel()
 		c.rpcCalls++
@@ -309,7 +330,7 @@ func (c *historyRereplicationContext) sendReplicationRawRequest(request *history
 		return nil
 	}
 
-	logger := c.logger.WithTags(tag.WorkflowEndingRunID(request.WorkflowExecution.GetRunId()))
+	logger := c.logger.WithTags(tag.WorkflowBeginningRunID(c.beginningRunID), tag.WorkflowEndingRunID(request.WorkflowExecution.GetRunId()))
 
 	// sometimes there can be case when the first re-replication call
 	// trigger an history reset and this reset can leave a hole in target
@@ -320,11 +341,11 @@ func (c *historyRereplicationContext) sendReplicationRawRequest(request *history
 		return err
 	}
 	if c.rpcCalls > 0 {
-		logger.Error("encounter RetryTaskError not in first call")
+		logger.Error("encounter RetryTaskError not in first call", tag.Error(retryErr))
 		return err
 	}
 	if retryErr.GetRunId() != c.beginningRunID {
-		logger.Error("encounter RetryTaskError with non expected run ID")
+		logger.Error("encounter RetryTaskError with non expected run ID", tag.Error(retryErr))
 		return err
 	}
 	if retryErr.GetNextEventId() >= c.beginningFirstEventID {
@@ -340,7 +361,7 @@ func (c *historyRereplicationContext) sendReplicationRawRequest(request *history
 	}
 
 	// after the amend of the missing history events after history reset, redo the request
-	ctxAgain, cancelAgain := context.WithTimeout(context.Background(), c.rereplicator.replicationTimeout)
+	ctxAgain, cancelAgain := context.WithTimeout(c.ctx, c.rereplicator.replicationTimeout)
 	defer cancelAgain()
 	return c.rereplicator.historyReplicationFn(ctxAgain, request)
 }
@@ -395,7 +416,7 @@ func (c *historyRereplicationContext) getHistory(
 	}
 	domainName := domainEntry.GetInfo().Name
 
-	ctx, cancel := context.WithTimeout(context.Background(), c.rereplicator.replicationTimeout)
+	ctx, cancel := context.WithTimeout(c.ctx, c.rereplicator.replicationTimeout)
 	defer cancel()
 	response, err := c.rereplicator.adminClient.GetWorkflowExecutionRawHistory(ctx, &admin.GetWorkflowExecutionRawHistoryRequest{
 		Domain: common.StringPtr(domainName),

--- a/common/xdc/historyRereplicator.go
+++ b/common/xdc/historyRereplicator.go
@@ -22,8 +22,9 @@ package xdc
 
 import (
 	"context"
-	"github.com/uber/cadence/common/service/dynamicconfig"
 	"time"
+
+	"github.com/uber/cadence/common/service/dynamicconfig"
 
 	"github.com/uber/cadence/.gen/go/admin"
 	"github.com/uber/cadence/.gen/go/history"

--- a/common/xdc/historyRereplicator.go
+++ b/common/xdc/historyRereplicator.go
@@ -103,7 +103,10 @@ func newHistoryRereplicationContext(domainID string, workflowID string,
 
 	ctx := context.Background()
 	var cancel context.CancelFunc
-	timeout := rereplicator.rereplicationTimeout(domainID)
+	var timeout time.Duration
+	if rereplicator.rereplicationTimeout != nil {
+		timeout = rereplicator.rereplicationTimeout(domainID)
+	}
 	if timeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 	}

--- a/common/xdc/historyRereplicator.go
+++ b/common/xdc/historyRereplicator.go
@@ -428,7 +428,7 @@ func (c *historyRereplicationContext) getHistory(
 
 	ctx, cancel := context.WithTimeout(c.ctx, c.rereplicator.replicationTimeout)
 	defer cancel()
-	defer cancel()
+
 	response, err := c.rereplicator.adminClient.GetWorkflowExecutionRawHistory(ctx, &admin.GetWorkflowExecutionRawHistoryRequest{
 		Domain: common.StringPtr(domainName),
 		Execution: &shared.WorkflowExecution{

--- a/common/xdc/historyRereplicator_test.go
+++ b/common/xdc/historyRereplicator_test.go
@@ -1262,5 +1262,6 @@ func (s *historyRereplicatorSuite) getDummyRereplicationContext() *historyRerepl
 	return &historyRereplicationContext{
 		rereplicator: s.rereplicator,
 		logger:       s.rereplicator.logger,
+		ctx:          context.Background(),
 	}
 }

--- a/common/xdc/historyRereplicator_test.go
+++ b/common/xdc/historyRereplicator_test.go
@@ -117,6 +117,7 @@ func (s *historyRereplicatorSuite) SetupTest() {
 		},
 		persistence.NewPayloadSerializer(),
 		30*time.Second,
+		nil,
 		s.logger,
 	)
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -308,6 +308,7 @@ func NewEngineWithShardContext(
 		},
 		shard.GetService().GetPayloadSerializer(),
 		replicationTimeout,
+		nil,
 		shard.GetLogger(),
 	)
 	replicationTaskExecutor := newReplicationTaskExecutor(

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -101,6 +101,7 @@ func newTimerQueueProcessor(
 				},
 				shard.GetService().GetPayloadSerializer(),
 				historyRereplicationTimeout,
+				nil,
 				logger,
 			)
 			nDCHistoryResender := xdc.NewNDCHistoryResender(

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -104,6 +104,7 @@ func newTransferQueueProcessor(
 				},
 				persistence.NewPayloadSerializer(),
 				historyRereplicationTimeout,
+				nil,
 				logger,
 			)
 			nDCHistoryResender := xdc.NewNDCHistoryResender(

--- a/service/worker/archiver/util_test.go
+++ b/service/worker/archiver/util_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
 	"github.com/uber/cadence/.gen/go/shared"
 )
 

--- a/service/worker/replicator/replicator.go
+++ b/service/worker/replicator/replicator.go
@@ -75,6 +75,7 @@ type (
 		ReplicationTaskMaxRetryCount       dynamicconfig.IntPropertyFn
 		ReplicationTaskMaxRetryDuration    dynamicconfig.DurationPropertyFn
 		ReplicationTaskContextTimeout      dynamicconfig.DurationPropertyFn
+		ReReplicationContextTimeout        dynamicconfig.DurationPropertyFnWithDomainIDFilter
 	}
 )
 
@@ -175,6 +176,7 @@ func (r *Replicator) createKafkaProcessors(currentClusterName string, clusterNam
 		},
 		r.historySerializer,
 		r.config.ReplicationTaskContextTimeout(),
+		r.config.ReReplicationContextTimeout,
 		r.logger,
 	)
 	nDCHistoryReplicator := xdc.NewNDCHistoryResender(

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -116,6 +116,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			ReplicationTaskMaxRetryCount:       dc.GetIntProperty(dynamicconfig.WorkerReplicationTaskMaxRetryCount, 400),
 			ReplicationTaskMaxRetryDuration:    dc.GetDurationProperty(dynamicconfig.WorkerReplicationTaskMaxRetryDuration, 15*time.Minute),
 			ReplicationTaskContextTimeout:      dc.GetDurationProperty(dynamicconfig.WorkerReplicationTaskContextDuration, 30*time.Second),
+			ReReplicationContextTimeout:        dc.GetDurationPropertyFilteredByDomainID(dynamicconfig.WorkerReReplicationContextTimeout, 0*time.Second),
 		},
 		ArchiverConfig: &archiver.Config{
 			ArchiverConcurrency:           dc.GetIntProperty(dynamicconfig.WorkerArchiverConcurrency, 50),


### PR DESCRIPTION
Add context in history resend and be able to config per domain context timeout

<!-- Describe what has changed in this PR -->
**What changed?**
Add e2e resend context timeout

<!-- Tell your future self why have you made these changes -->
**Why?**
Debug some issue with Kafka backlog

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minor risk
