### PR TITLE
Adding json tags for ShardInfo struct to reuse for docstore

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -242,21 +242,21 @@ type (
 
 	// ShardInfo describes a shard
 	ShardInfo struct {
-		ShardID                   int
-		Owner                     string
-		RangeID                   int64
-		StolenSinceRenew          int
-		UpdatedAt                 time.Time
-		ReplicationAckLevel       int64
-		ReplicationDLQAckLevel    map[string]int64
-		TransferAckLevel          int64
-		TimerAckLevel             time.Time
-		ClusterTransferAckLevel   map[string]int64
-		ClusterTimerAckLevel      map[string]time.Time
-		TransferFailoverLevels    map[string]TransferFailoverLevel // uuid -> TransferFailoverLevel
-		TimerFailoverLevels       map[string]TimerFailoverLevel    // uuid -> TimerFailoverLevel
-		ClusterReplicationLevel   map[string]int64                 // cluster -> last replicated taskID
-		DomainNotificationVersion int64
+		ShardID                   int                              `json:"shard_id"`
+		Owner                     string                           `json:"owner"`
+		RangeID                   int64                            `json:"range_id"`
+		StolenSinceRenew          int                              `json:"stolen_since_renew"`
+		UpdatedAt                 time.Time                        `json:"updated_at"`
+		ReplicationAckLevel       int64                            `json:"replication_ack_level"`
+		ReplicationDLQAckLevel    map[string]int64                 `json:"replication_dlq_ack_level"`
+		TransferAckLevel          int64                            `json:"transfer_ack_level"`
+		TimerAckLevel             time.Time                        `json:"timer_ack_level"`
+		ClusterTransferAckLevel   map[string]int64                 `json:"cluster_transfer_ack_level"`
+		ClusterTimerAckLevel      map[string]time.Time             `json:"cluster_timer_ack_level"`
+		TransferFailoverLevels    map[string]TransferFailoverLevel `json:"transfer_failover_levels"`
+		TimerFailoverLevels       map[string]TimerFailoverLevel    `json:"timer_failover_levels"`
+		ClusterReplicationLevel   map[string]int64                 `json:"cluster_replication_level"`
+		DomainNotificationVersion int64                            `json:"domain_notification_version"`
 	}
 
 	// TransferFailoverLevel contains corresponding start / end level

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -253,8 +253,8 @@ type (
 		TimerAckLevel             time.Time                        `json:"timer_ack_level"`
 		ClusterTransferAckLevel   map[string]int64                 `json:"cluster_transfer_ack_level"`
 		ClusterTimerAckLevel      map[string]time.Time             `json:"cluster_timer_ack_level"`
-		TransferFailoverLevels    map[string]TransferFailoverLevel `json:"transfer_failover_levels"`
-		TimerFailoverLevels       map[string]TimerFailoverLevel    `json:"timer_failover_levels"`
+		TransferFailoverLevels    map[string]TransferFailoverLevel  // uuid -> TransferFailoverLevel
+		TimerFailoverLevels       map[string]TimerFailoverLevel     // uuid -> TimerFailoverLevel
 		ClusterReplicationLevel   map[string]int64                 `json:"cluster_replication_level"`
 		DomainNotificationVersion int64                            `json:"domain_notification_version"`
 	}

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -253,8 +253,8 @@ type (
 		TimerAckLevel             time.Time                        `json:"timer_ack_level"`
 		ClusterTransferAckLevel   map[string]int64                 `json:"cluster_transfer_ack_level"`
 		ClusterTimerAckLevel      map[string]time.Time             `json:"cluster_timer_ack_level"`
-		TransferFailoverLevels    map[string]TransferFailoverLevel  // uuid -> TransferFailoverLevel
-		TimerFailoverLevels       map[string]TimerFailoverLevel     // uuid -> TimerFailoverLevel
+		TransferFailoverLevels    map[string]TransferFailoverLevel // uuid -> TransferFailoverLevel
+		TimerFailoverLevels       map[string]TimerFailoverLevel    // uuid -> TimerFailoverLevel
 		ClusterReplicationLevel   map[string]int64                 `json:"cluster_replication_level"`
 		DomainNotificationVersion int64                            `json:"domain_notification_version"`
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added json tag for ShardInfo for docstore shardManager implementation. TimerFailoverLevels and TransferFailoverLevels are not used as these are not persisted.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

