### PR TITLE
First pass at graceful shutdown handlers

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -90,6 +90,7 @@ var keys = map[Key]string{
 	FrontendRPS:                           "frontend.rps",
 	FrontendDomainRPS:                     "frontend.domainrps",
 	FrontendHistoryMgrNumConns:            "frontend.historyMgrNumConns",
+	FrontendShutdownDrainDuration:         "frontend.shutdownDrainDuration",
 	DisableListVisibilityByFilter:         "frontend.disableListVisibilityByFilter",
 	FrontendThrottledLogRPS:               "frontend.throttledLogRPS",
 	EnableClientVersionCheck:              "frontend.enableClientVersionCheck",
@@ -122,6 +123,7 @@ var keys = map[Key]string{
 	MatchingForwarderMaxOutstandingTasks:    "matching.forwarderMaxOutstandingTasks",
 	MatchingForwarderMaxRatePerSecond:       "matching.forwarderMaxRatePerSecond",
 	MatchingForwarderMaxChildrenPerNode:     "matching.forwarderMaxChildrenPerNode",
+	MatchingShutdownDrainDuration:           "matching.shutdownDrainDuration",
 
 	// history settings
 	HistoryRPS:                                             "history.rps",
@@ -133,6 +135,7 @@ var keys = map[Key]string{
 	HistoryMaxAutoResetPoints:                              "history.historyMaxAutoResetPoints",
 	HistoryCacheMaxSize:                                    "history.cacheMaxSize",
 	HistoryCacheTTL:                                        "history.cacheTTL",
+	HistoryShutdownDrainDuration:                           "history.shutdownDrainDuration",
 	EventsCacheInitialSize:                                 "history.eventsCacheInitialSize",
 	EventsCacheMaxSize:                                     "history.eventsCacheMaxSize",
 	EventsCacheTTL:                                         "history.eventsCacheTTL",

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -348,6 +348,8 @@ const (
 	FrontendHistoryMgrNumConns
 	// FrontendThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
 	FrontendThrottledLogRPS
+	// FrontendShutdownDrainDuration is the duration of traffic drain during shutdown
+	FrontendShutdownDrainDuration
 	// EnableClientVersionCheck enables client version check for frontend
 	EnableClientVersionCheck
 
@@ -410,6 +412,8 @@ const (
 	MatchingForwarderMaxRatePerSecond
 	// MatchingForwarderMaxChildrenPerNode is the max number of children per node in the task list partition tree
 	MatchingForwarderMaxChildrenPerNode
+	// MatchingShutdownDrainDuration is the duration of traffic drain during shutdown
+	MatchingShutdownDrainDuration
 
 	// key for history
 
@@ -429,6 +433,8 @@ const (
 	HistoryCacheMaxSize
 	// HistoryCacheTTL is TTL of history cache
 	HistoryCacheTTL
+	// HistoryShutdownDrainDuration is the duration of traffic drain during shutdown
+	HistoryShutdownDrainDuration
 	// EventsCacheInitialSize is initial size of events cache
 	EventsCacheInitialSize
 	// EventsCacheMaxSize is max size of events cache

--- a/common/util.go
+++ b/common/util.go
@@ -361,6 +361,22 @@ func MaxInt(a, b int) int {
 	return b
 }
 
+// MinDuration returns the smaller of two given time duration
+func MinDuration(a, b time.Duration) time.Duration {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// MaxDuration returns the greater of two given time durations
+func MaxDuration(a, b time.Duration) time.Duration {
+	if a > b {
+		return a
+	}
+	return b
+}
+
 // SortInt64Slice sorts the given int64 slice.
 // Sort is not guaranteed to be stable.
 func SortInt64Slice(slice []int64) {

--- a/service/frontend/accessControlledHandler.go
+++ b/service/frontend/accessControlledHandler.go
@@ -41,14 +41,14 @@ var errUnauthorized = &shared.BadRequestError{Message: "Request unauthorized."}
 type AccessControlledWorkflowHandler struct {
 	resource.Resource
 
-	frontendHandler workflowserviceserver.Interface
+	frontendHandler ServerHandler
 	authorizer      authorization.Authorizer
 
 	startFn func()
 	stopFn  func()
 }
 
-var _ workflowserviceserver.Interface = (*AccessControlledWorkflowHandler)(nil)
+var _ ServerHandler = (*AccessControlledWorkflowHandler)(nil)
 
 // NewAccessControlledHandlerImpl creates frontend handler with authentication support
 func NewAccessControlledHandlerImpl(wfHandler *DCRedirectionHandlerImpl, authorizer authorization.Authorizer) *AccessControlledWorkflowHandler {
@@ -60,8 +60,6 @@ func NewAccessControlledHandlerImpl(wfHandler *DCRedirectionHandlerImpl, authori
 		Resource:        wfHandler.Resource,
 		frontendHandler: wfHandler,
 		authorizer:      authorizer,
-		startFn:         func() { wfHandler.Start() },
-		stopFn:          func() { wfHandler.Stop() },
 	}
 }
 
@@ -73,6 +71,12 @@ func (a *AccessControlledWorkflowHandler) RegisterHandler() {
 	a.GetDispatcher().Register(metaserver.New(a))
 }
 
+// UpdateHealthStatus sets the health status for this rpc handler.
+// This health status will be used within the rpc health check handler
+func (a *AccessControlledWorkflowHandler) UpdateHealthStatus(status HealthStatus) {
+	a.frontendHandler.UpdateHealthStatus(status)
+}
+
 // Health callback for for health check
 func (a *AccessControlledWorkflowHandler) Health(ctx context.Context) (*health.HealthStatus, error) {
 	hs := &health.HealthStatus{Ok: true, Msg: common.StringPtr("auth is good")}
@@ -81,12 +85,12 @@ func (a *AccessControlledWorkflowHandler) Health(ctx context.Context) (*health.H
 
 // Start starts the handler
 func (a *AccessControlledWorkflowHandler) Start() {
-	a.startFn()
+	a.frontendHandler.Start()
 }
 
 // Stop stops the handler
 func (a *AccessControlledWorkflowHandler) Stop() {
-	a.stopFn()
+	a.frontendHandler.Stop()
 }
 
 // CountWorkflowExecutions API call

--- a/service/frontend/accessControlledHandler.go
+++ b/service/frontend/accessControlledHandler.go
@@ -43,9 +43,6 @@ type AccessControlledWorkflowHandler struct {
 
 	frontendHandler ServerHandler
 	authorizer      authorization.Authorizer
-
-	startFn func()
-	stopFn  func()
 }
 
 var _ ServerHandler = (*AccessControlledWorkflowHandler)(nil)

--- a/service/frontend/accessControlledHandler.go
+++ b/service/frontend/accessControlledHandler.go
@@ -29,7 +29,6 @@ import (
 	"github.com/uber/cadence/.gen/go/health"
 	"github.com/uber/cadence/.gen/go/health/metaserver"
 	"github.com/uber/cadence/.gen/go/shared"
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/resource"
 )
 
@@ -76,8 +75,7 @@ func (a *AccessControlledWorkflowHandler) UpdateHealthStatus(status HealthStatus
 
 // Health callback for for health check
 func (a *AccessControlledWorkflowHandler) Health(ctx context.Context) (*health.HealthStatus, error) {
-	hs := &health.HealthStatus{Ok: true, Msg: common.StringPtr("auth is good")}
-	return hs, nil
+	return a.frontendHandler.Health(ctx)
 }
 
 // Start starts the handler

--- a/service/frontend/dcRedirectionHandler.go
+++ b/service/frontend/dcRedirectionHandler.go
@@ -35,7 +35,7 @@ import (
 	"github.com/uber/cadence/common/service/config"
 )
 
-var _ workflowserviceserver.Interface = (*DCRedirectionHandlerImpl)(nil)
+var _ ServerHandler = (*DCRedirectionHandlerImpl)(nil)
 
 type (
 	// DCRedirectionHandlerImpl is simple wrapper over frontend service, doing redirection based on policy
@@ -46,7 +46,7 @@ type (
 		config             *Config
 		redirectionPolicy  DCRedirectionPolicy
 		tokenSerializer    common.TaskTokenSerializer
-		frontendHandler    workflowserviceserver.Interface
+		frontendHandler    ServerHandler
 
 		startFn func()
 		stopFn  func()
@@ -72,8 +72,6 @@ func NewDCRedirectionHandler(
 		redirectionPolicy:  dcRedirectionPolicy,
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		frontendHandler:    wfHandler,
-		startFn:            func() { wfHandler.Start() },
-		stopFn:             func() { wfHandler.Stop() },
 	}
 }
 
@@ -85,18 +83,23 @@ func (handler *DCRedirectionHandlerImpl) RegisterHandler() {
 
 // Start starts the handler
 func (handler *DCRedirectionHandlerImpl) Start() {
-	handler.startFn()
+	handler.frontendHandler.Start()
 }
 
 // Stop stops the handler
 func (handler *DCRedirectionHandlerImpl) Stop() {
-	handler.stopFn()
+	handler.frontendHandler.Stop()
+}
+
+// UpdateHealthStatus sets the health status for this rpc handler.
+// This health status will be used within the rpc health check handler
+func (handler *DCRedirectionHandlerImpl) UpdateHealthStatus(status HealthStatus) {
+	handler.frontendHandler.UpdateHealthStatus(status)
 }
 
 // Health is for health check
 func (handler *DCRedirectionHandlerImpl) Health(ctx context.Context) (*health.HealthStatus, error) {
-	hs := &health.HealthStatus{Ok: true, Msg: common.StringPtr("dc redirection good")}
-	return hs, nil
+	return handler.frontendHandler.Health(ctx)
 }
 
 // Domain APIs, domain APIs does not require redirection

--- a/service/frontend/dcRedirectionHandler.go
+++ b/service/frontend/dcRedirectionHandler.go
@@ -47,9 +47,6 @@ type (
 		redirectionPolicy  DCRedirectionPolicy
 		tokenSerializer    common.TaskTokenSerializer
 		frontendHandler    ServerHandler
-
-		startFn func()
-		stopFn  func()
 	}
 )
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -59,13 +60,32 @@ const (
 	defaultLastMessageID                 = -1
 )
 
-var _ workflowserviceserver.Interface = (*WorkflowHandler)(nil)
+const (
+	// HealthStatusOK is used when this node is healthy and rpc requests are allowed
+	HealthStatusOK HealthStatus = iota
+	// HealthStatusShuttingDown is used when the rpc handler is shutting down
+	HealthStatusShuttingDown
+)
+
+var _ ServerHandler = (*WorkflowHandler)(nil)
 
 type (
+	// ServerHandler is the interface for the frontend rpc handler
+	ServerHandler interface {
+		common.Daemon
+		workflowserviceserver.Interface
+		// Health is the health check method for this rpc handler
+		Health(ctx context.Context) (*health.HealthStatus, error)
+		// UpdateHealthStatus sets the health status for this rpc handler.
+		// This health status will be used within the rpc health check handler
+		UpdateHealthStatus(status HealthStatus)
+	}
 	// WorkflowHandler - Thrift handler interface for workflow service
 	WorkflowHandler struct {
 		resource.Resource
 
+		shuttingDown              int32
+		healthStatus              int32
 		tokenSerializer           common.TaskTokenSerializer
 		rateLimiter               quotas.Policy
 		config                    *Config
@@ -89,6 +109,9 @@ type (
 	domainGetter interface {
 		GetDomain() string
 	}
+
+	// HealthStatus is an enum that refers to the rpc handler health status
+	HealthStatus int32
 )
 
 var (
@@ -116,6 +139,7 @@ var (
 	errClusterNameNotSet                          = &gen.BadRequestError{Message: "Cluster name is not set."}
 	errEmptyReplicationInfo                       = &gen.BadRequestError{Message: "Replication task info is not set."}
 	errEmptyQueueType                             = &gen.BadRequestError{Message: "Queue type is not set."}
+	errShuttingDown                               = &gen.InternalServiceError{Message: "Shutting down"}
 
 	// err for archival
 	errHistoryNotFound = &gen.BadRequestError{Message: "Requested workflow history not found, may have passed retention period."}
@@ -185,13 +209,27 @@ func (wh *WorkflowHandler) Start() {
 
 // Stop stops the handler
 func (wh *WorkflowHandler) Stop() {
+	atomic.StoreInt32(&wh.shuttingDown, 1)
+}
+
+// UpdateHealthStatus sets the health status for this rpc handler.
+// This health status will be used within the rpc health check handler
+func (wh *WorkflowHandler) UpdateHealthStatus(status HealthStatus) {
+	atomic.StoreInt32(&wh.healthStatus, int32(status))
+}
+
+func (wh *WorkflowHandler) isShuttingDown() bool {
+	return atomic.LoadInt32(&wh.shuttingDown) != 0
 }
 
 // Health is for health check
 func (wh *WorkflowHandler) Health(ctx context.Context) (*health.HealthStatus, error) {
-	wh.GetLogger().Debug("Frontend health check endpoint reached.")
-	hs := &health.HealthStatus{Ok: true, Msg: common.StringPtr("frontend good")}
-	return hs, nil
+	status := HealthStatus(atomic.LoadInt32(&wh.healthStatus))
+	msg := status.String()
+	return &health.HealthStatus{
+		Ok:  status == HealthStatusOK,
+		Msg: &msg,
+	}, nil
 }
 
 // RegisterDomain creates a new domain which can be used as a container for all resources.  Domain is a top level
@@ -203,6 +241,10 @@ func (wh *WorkflowHandler) RegisterDomain(ctx context.Context, registerRequest *
 
 	scope, sw := wh.startRequestProfile(metrics.FrontendRegisterDomainScope)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return wh.error(err, scope)
@@ -241,6 +283,10 @@ func (wh *WorkflowHandler) ListDomains(
 	scope, sw := wh.startRequestProfile(metrics.FrontendListDomainsScope)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -265,6 +311,10 @@ func (wh *WorkflowHandler) DescribeDomain(
 
 	scope, sw := wh.startRequestProfile(metrics.FrontendDescribeDomainScope)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -294,6 +344,10 @@ func (wh *WorkflowHandler) UpdateDomain(
 
 	scope, sw := wh.startRequestProfile(metrics.FrontendUpdateDomainScope)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -330,6 +384,10 @@ func (wh *WorkflowHandler) DeprecateDomain(ctx context.Context, deprecateRequest
 	scope, sw := wh.startRequestProfile(metrics.FrontendDeprecateDomainScope)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return wh.error(err, scope)
 	}
@@ -364,6 +422,10 @@ func (wh *WorkflowHandler) PollForActivityTask(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForActivityTaskScope, pollRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -445,6 +507,10 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendPollForDecisionTaskScope, pollRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope, tagsForErrorLog...)
@@ -617,6 +683,10 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 	)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	sizeLimitError := wh.config.BlobSizeLimitError(domainEntry.GetInfo().Name)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainEntry.GetInfo().Name)
 
@@ -667,6 +737,10 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRecordActivityTaskHeartbeatByIDScope, heartbeatRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -811,6 +885,10 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	sizeLimitError := wh.config.BlobSizeLimitError(domainEntry.GetInfo().Name)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainEntry.GetInfo().Name)
 
@@ -860,6 +938,10 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRespondActivityTaskCompletedByIDScope, completeRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return wh.error(err, scope)
@@ -1003,6 +1085,10 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 	)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	if len(failedRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
@@ -1044,6 +1130,10 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRespondActivityTaskFailedByIDScope, failedRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return wh.error(err, scope)
@@ -1175,6 +1265,10 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 	)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	if len(cancelRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
@@ -1228,6 +1322,10 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRespondActivityTaskCanceledScope, cancelRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return wh.error(err, scope)
@@ -1370,6 +1468,10 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 	)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	histResp, err := wh.GetHistoryClient().RespondDecisionTaskCompleted(ctx, &h.RespondDecisionTaskCompletedRequest{
 		DomainUUID:      common.StringPtr(taskToken.DomainID),
 		CompleteRequest: completeRequest},
@@ -1451,6 +1553,10 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 	)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	if len(failedRequest.GetIdentity()) > wh.config.MaxIDLengthLimit() {
 		return wh.error(errIdentityTooLong, scope)
 	}
@@ -1525,6 +1631,10 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 	)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	sizeLimitError := wh.config.BlobSizeLimitError(domainEntry.GetInfo().Name)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainEntry.GetInfo().Name)
 
@@ -1575,6 +1685,10 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendStartWorkflowExecutionScope, startRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -1695,6 +1809,10 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendGetWorkflowExecutionHistoryScope, getRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -2030,6 +2148,10 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendSignalWithStartWorkflowExecutionScope, signalWithStartRequest)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2166,6 +2288,10 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendTerminateWorkflowExecutionScope, terminateRequest)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return wh.error(err, scope)
 	}
@@ -2213,6 +2339,10 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetWorkflowExecutionScope, resetRequest)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2259,6 +2389,10 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendRequestCancelWorkflowExecutionScope, cancelRequest)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return wh.error(err, scope)
 	}
@@ -2304,6 +2438,10 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListOpenWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -2414,6 +2552,10 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListArchivedWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2501,6 +2643,10 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListClosedWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -2630,6 +2776,10 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2692,6 +2842,10 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendScanWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -2756,6 +2910,10 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendCountWorkflowExecutionsScope, countRequest)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2805,6 +2963,10 @@ func (wh *WorkflowHandler) GetSearchAttributes(ctx context.Context) (resp *gen.G
 	scope, sw := wh.startRequestProfile(metrics.FrontendGetSearchAttributesScope)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2825,6 +2987,10 @@ func (wh *WorkflowHandler) ResetStickyTaskList(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendResetStickyTaskListScope, resetRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -2866,6 +3032,10 @@ func (wh *WorkflowHandler) QueryWorkflow(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendQueryWorkflowScope, queryRequest)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if wh.config.DisallowQuery(queryRequest.GetDomain()) {
 		return nil, wh.error(errQueryDisallowedForDomain, scope)
@@ -2935,6 +3105,10 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeWorkflowExecutionScope, request)
 	defer sw.Stop()
 
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
+
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2982,6 +3156,10 @@ func (wh *WorkflowHandler) DescribeTaskList(
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendDescribeTaskListScope, request)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if err := wh.versionChecker.ClientSupported(ctx, wh.config.EnableClientVersionCheck()); err != nil {
 		return nil, wh.error(err, scope)
@@ -3035,6 +3213,10 @@ func (wh *WorkflowHandler) ListTaskListPartitions(ctx context.Context, request *
 
 	scope, sw := wh.startRequestProfileWithDomain(metrics.FrontendListTaskListPartitionsScope, request)
 	defer sw.Stop()
+
+	if wh.isShuttingDown() {
+		return nil, errShuttingDown
+	}
 
 	if request == nil {
 		return nil, wh.error(errRequestNotSet, scope)
@@ -3653,4 +3835,15 @@ type domainWrapper struct {
 
 func (d domainWrapper) GetDomain() string {
 	return d.domain
+}
+
+func (hs HealthStatus) String() string {
+	switch hs {
+	case HealthStatusOK:
+		return "OK"
+	case HealthStatusShuttingDown:
+		return "ShuttingDown"
+	default:
+		return "unknown"
+	}
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -62,7 +62,7 @@ const (
 
 const (
 	// HealthStatusOK is used when this node is healthy and rpc requests are allowed
-	HealthStatusOK HealthStatus = iota
+	HealthStatusOK HealthStatus = iota + 1
 	// HealthStatusShuttingDown is used when the rpc handler is shutting down
 	HealthStatusShuttingDown
 )
@@ -165,6 +165,7 @@ func NewWorkflowHandler(
 	return &WorkflowHandler{
 		Resource:        resource,
 		config:          config,
+		healthStatus:    HealthStatusOK,
 		tokenSerializer: common.NewJSONTaskTokenSerializer(),
 		rateLimiter: quotas.NewMultiStageRateLimiter(
 			func() float64 {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -165,7 +165,7 @@ func NewWorkflowHandler(
 	return &WorkflowHandler{
 		Resource:        resource,
 		config:          config,
-		healthStatus:    HealthStatusOK,
+		healthStatus:    int32(HealthStatusOK),
 		tokenSerializer: common.NewJSONTaskTokenSerializer(),
 		rateLimiter: quotas.NewMultiStageRateLimiter(
 			func() float64 {

--- a/service/frontend/workflowHandler_mock.go
+++ b/service/frontend/workflowHandler_mock.go
@@ -32,6 +32,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
+
 	"github.com/uber/cadence/.gen/go/health"
 	shared "github.com/uber/cadence/.gen/go/shared"
 )

--- a/service/frontend/workflowHandler_mock.go
+++ b/service/frontend/workflowHandler_mock.go
@@ -32,7 +32,7 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-
+	"github.com/uber/cadence/.gen/go/health"
 	shared "github.com/uber/cadence/.gen/go/shared"
 )
 
@@ -57,6 +57,30 @@ func NewMockWorkflowHandler(ctrl *gomock.Controller) *MockWorkflowHandler {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockWorkflowHandler) EXPECT() *MockWorkflowHandlerMockRecorder {
 	return m.recorder
+}
+
+// Start mocks base method
+func (m *MockWorkflowHandler) Start() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Start")
+}
+
+// Start indicates an expected call of Start
+func (mr *MockWorkflowHandlerMockRecorder) Start() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockWorkflowHandler)(nil).Start))
+}
+
+// Stop mocks base method
+func (m *MockWorkflowHandler) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop
+func (mr *MockWorkflowHandlerMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockWorkflowHandler)(nil).Stop))
 }
 
 // CountWorkflowExecutions mocks base method
@@ -614,4 +638,31 @@ func (m *MockWorkflowHandler) UpdateDomain(ctx context.Context, UpdateRequest *s
 func (mr *MockWorkflowHandlerMockRecorder) UpdateDomain(ctx, UpdateRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockWorkflowHandler)(nil).UpdateDomain), ctx, UpdateRequest)
+}
+
+// Health mocks base method
+func (m *MockWorkflowHandler) Health(ctx context.Context) (*health.HealthStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Health", ctx)
+	ret0, _ := ret[0].(*health.HealthStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Health indicates an expected call of Health
+func (mr *MockWorkflowHandlerMockRecorder) Health(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockWorkflowHandler)(nil).Health), ctx)
+}
+
+// UpdateHealthStatus mocks base method
+func (m *MockWorkflowHandler) UpdateHealthStatus(status HealthStatus) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UpdateHealthStatus", status)
+}
+
+// UpdateHealthStatus indicates an expected call of UpdateHealthStatus
+func (mr *MockWorkflowHandlerMockRecorder) UpdateHealthStatus(status interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHealthStatus", reflect.TypeOf((*MockWorkflowHandler)(nil).UpdateHealthStatus), status)
 }

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -457,7 +457,9 @@ func (s *Service) Stop() {
 	// 2. wait for other members to discover we are going down
 	// 3. stop acquiring new shards (periodically or based on other membership changes)
 	// 4. wait for shard ownership to transfer (and inflight requests to drain) while still accepting new requests
-	// 5. reject all requests arriving at rpc handler to avoid taking on more work
+	// 5. Reject all requests arriving at rpc handler to avoid taking on more work except for RespondXXXCompleted and
+	//    RecordXXStarted APIs - for these APIs, most of the work is already one and rejecting at last stage is
+	//    probably not that desirable. If the shard is closed, these requests will fail anyways.
 	// 6. wait for grace period
 	// 7. force stop the whole world and return
 

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -54,6 +54,7 @@ type Config struct {
 	MaxAutoResetPoints              dynamicconfig.IntPropertyFnWithDomainFilter
 	ThrottledLogRPS                 dynamicconfig.IntPropertyFn
 	EnableStickyQuery               dynamicconfig.BoolPropertyFnWithDomainFilter
+	ShutdownDrainDuration           dynamicconfig.DurationPropertyFn
 
 	// HistoryCache settings
 	// Change of these configs require shard restart
@@ -223,6 +224,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		RPS:                                                    dc.GetIntProperty(dynamicconfig.HistoryRPS, 3000),
 		MaxIDLengthLimit:                                       dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		PersistenceMaxQPS:                                      dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 9000),
+		ShutdownDrainDuration:                                  dc.GetDurationProperty(dynamicconfig.HistoryShutdownDrainDuration, 0),
 		EnableVisibilitySampling:                               dc.GetBoolProperty(dynamicconfig.EnableVisibilitySampling, true),
 		EnableReadFromClosedExecutionV2:                        dc.GetBoolProperty(dynamicconfig.EnableReadFromClosedExecutionV2, false),
 		VisibilityOpenMaxQPS:                                   dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryVisibilityOpenMaxQPS, 300),
@@ -450,10 +452,50 @@ func (s *Service) Stop() {
 		return
 	}
 
+	// initiate graceful shutdown :
+	// 1. remove self from the membership ring
+	// 2. wait for other members to discover we are going down
+	// 3. stop acquiring new shards (periodically or based on other membership changes)
+	// 4. wait for shard ownership to transfer (and inflight requests to drain) while still accepting new requests
+	// 5. reject all requests arriving at rpc handler to avoid taking on more work
+	// 6. wait for grace period
+	// 7. force stop the whole world and return
+
+	const gossipPropagationDelay = 400 * time.Millisecond
+	const shardOwnershipTransferDelay = 5 * time.Second
+	const gracePeriod = 2 * time.Second
+
+	remainingTime := s.config.ShutdownDrainDuration()
+
+	s.GetLogger().Info("ShutdownHandler: Evicting self from membership ring")
+	s.GetMembershipMonitor().EvictSelf()
+
+	s.GetLogger().Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
+	remainingTime = s.sleep(gossipPropagationDelay, remainingTime)
+
+	s.GetLogger().Info("ShutdownHandler: Initiating shardController shutdown")
+	s.handler.controller.PrepareToStop()
+	s.GetLogger().Info("ShutdownHandler: Waiting for traffic to drain")
+	remainingTime = s.sleep(shardOwnershipTransferDelay, remainingTime)
+
+	s.GetLogger().Info("ShutdownHandler: No longer taking rpc requests")
+	s.handler.PrepareToStop()
+	remainingTime = s.sleep(gracePeriod, remainingTime)
+
 	close(s.stopC)
 
 	s.handler.Stop()
 	s.Resource.Stop()
 
 	s.GetLogger().Info("history stopped")
+}
+
+// sleep sleeps for the minimum of desired and available duration
+// returns the remaining available time duration
+func (s *Service) sleep(desired time.Duration, available time.Duration) time.Duration {
+	d := common.MinDuration(desired, available)
+	if d > 0 {
+		time.Sleep(d)
+	}
+	return available - d
 }

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -31,9 +31,10 @@ import (
 type (
 	// Config represents configuration for cadence-matching service
 	Config struct {
-		PersistenceMaxQPS dynamicconfig.IntPropertyFn
-		EnableSyncMatch   dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
-		RPS               dynamicconfig.IntPropertyFn
+		PersistenceMaxQPS     dynamicconfig.IntPropertyFn
+		EnableSyncMatch       dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
+		RPS                   dynamicconfig.IntPropertyFn
+		ShutdownDrainDuration dynamicconfig.DurationPropertyFn
 
 		// taskListManager configuration
 		RangeSize                    int64
@@ -110,6 +111,7 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		ForwarderMaxOutstandingTasks:    dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingForwarderMaxOutstandingTasks, 1),
 		ForwarderMaxRatePerSecond:       dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingForwarderMaxRatePerSecond, 10),
 		ForwarderMaxChildrenPerNode:     dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingForwarderMaxChildrenPerNode, 20),
+		ShutdownDrainDuration:           dc.GetDurationProperty(dynamicconfig.MatchingShutdownDrainDuration, 0),
 	}
 }
 

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -22,6 +22,7 @@ package matching
 
 import (
 	"sync/atomic"
+	"time"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
@@ -98,6 +99,12 @@ func (s *Service) Stop() {
 	if !atomic.CompareAndSwapInt32(&s.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
+
+	// remove self from membership ring and wait for traffic to drain
+	s.GetLogger().Info("ShutdownHandler: Evicting self from membership ring")
+	s.GetMembershipMonitor().EvictSelf()
+	s.GetLogger().Info("ShutdownHandler: Waiting for others to discover I am unhealthy")
+	time.Sleep(s.config.ShutdownDrainDuration())
 
 	close(s.stopC)
 


### PR DESCRIPTION
**What changed?**
This patch implements mechanism to gracefully drain traffic during deployments to avoid availability drops. The mechanism varies somewhat based on the role.

The shutdown protocol on some host H looks like the following:

**History**
1. Remove H from the membership ring. This will make other members believe that H is unhealthy
2. Wait for other members to discover that H is unhealthy
3. Stop acquiring new shards (periodically or based on other membership changes) on H
4. Wait for shard ownership to transfer (and inflight requests to drain) while still accepting new requests on H
5. Reject all requests arriving at rpc handler on H to avoid taking on more work
6. Wait for grace period
7. Force stop the whole world and exit

**Frontend**
1. Fail rpc health check, this will cause client side load balancer to stop forwarding requests to this node
2. Wait for failure detection time, typically this will be around 5s or less
3. Stop taking new rpc requests by returning InternalServiceError
4. Wait for a second
5. Stop the world and exit

**Matching**
1. Remove H from the membership ring. This will make other members believe that H is unhealthy
2. Wait for others to discover that H is unhealthy and traffic to drain
3. Stop the world and exit

**Why?**
Grace shutdown mechanism is needed to reduce availability dips during deployments

**How did you test it?**
Tested locally. Also tested on a staging environment.

**Potential risks**
Graceful shutdown fails to work and there continues to be availability dips during deployment. 
A bug in the code causes process to crash during shutdown.

First pass at fixing #1454 