### PR TITLE
shardController: improvements for graceful shutdown

### DIFF
--- a/service/history/MockQueueAckMgr.go
+++ b/service/history/MockQueueAckMgr.go
@@ -110,6 +110,14 @@ func (_m *MockQueueAckMgr) getQueueReadLevel() int64 {
 }
 
 // updateQueueAckLevel is mock implementation for updateQueueAckLevel of QueueAckMgr
-func (_m *MockQueueAckMgr) updateQueueAckLevel() {
-	_m.Called()
+func (_m *MockQueueAckMgr) updateQueueAckLevel() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }

--- a/service/history/MockTimerQueueAckMgr.go
+++ b/service/history/MockTimerQueueAckMgr.go
@@ -119,6 +119,14 @@ func (_m *MockTimerQueueAckMgr) getReadLevel() timerKey {
 	return r0
 }
 
-func (_m *MockTimerQueueAckMgr) updateAckLevel() {
-	_m.Called()
+func (_m *MockTimerQueueAckMgr) updateAckLevel() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
 }

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -671,12 +671,12 @@ func (h *Handler) RemoveTask(
 	return err
 }
 
-// CloseShard returns information about the internal states of a history host
+// CloseShard closes a shard hosted by this instance
 func (h *Handler) CloseShard(
 	ctx context.Context,
 	request *gen.CloseShardRequest,
 ) (retError error) {
-	h.controller.removeEngineForShard(int(request.GetShardID()))
+	h.controller.removeEngineForShard(int(request.GetShardID()), nil)
 	return nil
 }
 

--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -119,7 +119,7 @@ type (
 		completeTimerTask(timerTask *persistence.TimerTaskInfo)
 		getAckLevel() timerKey
 		getReadLevel() timerKey
-		updateAckLevel()
+		updateAckLevel() error
 	}
 
 	historyEventNotifier interface {

--- a/service/history/historyEngineInterfaces.go
+++ b/service/history/historyEngineInterfaces.go
@@ -62,7 +62,7 @@ type (
 		completeQueueTask(taskID int64)
 		getQueueAckLevel() int64
 		getQueueReadLevel() int64
-		updateQueueAckLevel()
+		updateQueueAckLevel() error
 	}
 
 	queueTaskInfo interface {

--- a/service/history/queueAckMgr.go
+++ b/service/history/queueAckMgr.go
@@ -161,7 +161,7 @@ func (a *queueAckMgrImpl) getFinishedChan() <-chan struct{} {
 	return a.finishedChan
 }
 
-func (a *queueAckMgrImpl) updateQueueAckLevel() {
+func (a *queueAckMgrImpl) updateQueueAckLevel() error {
 	a.metricsClient.IncCounter(a.options.MetricScope, metrics.AckLevelUpdateCounter)
 
 	a.Lock()
@@ -213,12 +213,14 @@ MoveAckLevelLoop:
 		if err != nil {
 			a.logger.Error("Error shutdown queue", tag.Error(err))
 		}
-		return
+		return nil
 	}
 
 	a.Unlock()
 	if err := a.processor.updateAckLevel(ackLevel); err != nil {
 		a.metricsClient.IncCounter(a.options.MetricScope, metrics.AckLevelUpdateFailedCounter)
 		a.logger.Error("Error updating ack level for shard", tag.Error(err), tag.OperationFailed)
+		return err
 	}
+	return nil
 }

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -215,7 +215,11 @@ processorPumpLoop:
 				p.options.UpdateAckInterval(),
 				p.options.UpdateAckIntervalJitterCoefficient(),
 			))
-			p.ackMgr.updateQueueAckLevel()
+			if err := p.ackMgr.updateQueueAckLevel(); err == ErrShardClosed {
+				// shard is no longer owned by this instance, bail out
+				go p.Stop()
+				break processorPumpLoop
+			}
 		case <-redispatchTimer.C:
 			redispatchTimer.Reset(backoff.JitDuration(
 				p.options.RedispatchInterval(),

--- a/service/history/replicationDLQHandler_test.go
+++ b/service/history/replicationDLQHandler_test.go
@@ -96,7 +96,6 @@ func (s *replicationDLQHandlerSuite) SetupTest() {
 			ReplicationDLQAckLevel: map[string]int64{"test": -1}},
 		transferSequenceNumber:    1,
 		maxTransferSequenceNumber: 100000,
-		closeCh:                   make(chan int, 100),
 		config:                    NewDynamicConfigForTest(),
 		logger:                    logger,
 		remoteClusterCurrentTime:  make(map[string]time.Time),

--- a/service/history/replicationTaskExecutor_test.go
+++ b/service/history/replicationTaskExecutor_test.go
@@ -109,7 +109,6 @@ func (s *replicationTaskExecutorSuite) SetupTest() {
 			ReplicationDLQAckLevel: map[string]int64{"test": -1}},
 		transferSequenceNumber:    1,
 		maxTransferSequenceNumber: 100000,
-		closeCh:                   make(chan int, 100),
 		config:                    NewDynamicConfigForTest(),
 		logger:                    logger,
 		remoteClusterCurrentTime:  make(map[string]time.Time),

--- a/service/history/replicationTaskProcessor_test.go
+++ b/service/history/replicationTaskProcessor_test.go
@@ -101,7 +101,6 @@ func (s *replicationTaskProcessorSuite) SetupTest() {
 		shardInfo:                 &persistence.ShardInfo{ShardID: 0, RangeID: 1, TransferAckLevel: 0},
 		transferSequenceNumber:    1,
 		maxTransferSequenceNumber: 100000,
-		closeCh:                   make(chan int, 100),
 		config:                    NewDynamicConfigForTest(),
 		logger:                    logger,
 		remoteClusterCurrentTime:  make(map[string]time.Time),

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -879,7 +879,6 @@ func (s *shardContextImpl) closeShard() {
 
 	go func() {
 		s.closeCallback(s.shardID, s.shardItem)
-		s.shardItem.stopEngine()
 	}()
 
 	// fails any writes that may start after this point.

--- a/service/history/shardContext.go
+++ b/service/history/shardContext.go
@@ -21,6 +21,7 @@
 package history
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"sync"
@@ -115,8 +116,8 @@ type (
 		rangeID          int64
 		executionManager persistence.ExecutionManager
 		eventsCache      eventsCache
-		closeCh          chan<- int
-		isClosed         bool
+		closeCallback    func(int, *historyShardsItem)
+		closed           int32
 		config           *Config
 		logger           log.Logger
 		throttledLogger  log.Logger
@@ -139,6 +140,9 @@ type (
 )
 
 var _ ShardContext = (*shardContextImpl)(nil)
+
+// ErrShardClosed is returned when shard is closed and a req cannot be processed
+var ErrShardClosed = errors.New("shard closed")
 
 const (
 	logWarnTransferLevelDiff = 3000000 // 3 million
@@ -489,6 +493,7 @@ Create_Loop:
 					} else {
 						// Shard is stolen, trigger shutdown of history engine
 						s.closeShard()
+						break Create_Loop
 					}
 				}
 			default:
@@ -503,6 +508,7 @@ Create_Loop:
 						// At this point we have no choice but to unload the shard, so that it
 						// gets a new RangeID when it's reloaded.
 						s.closeShard()
+						break Create_Loop
 					}
 				}
 			}
@@ -580,6 +586,7 @@ Update_Loop:
 					} else {
 						// Shard is stolen, trigger shutdown of history engine
 						s.closeShard()
+						break Update_Loop
 					}
 				}
 			default:
@@ -594,6 +601,7 @@ Update_Loop:
 						// At this point we have no choice but to unload the shard, so that it
 						// gets a new RangeID when it's reloaded.
 						s.closeShard()
+						break Update_Loop
 					}
 				}
 			}
@@ -666,6 +674,7 @@ Reset_Loop:
 					} else {
 						// Shard is stolen, trigger shutdown of history engine
 						s.closeShard()
+						break Reset_Loop
 					}
 				}
 			default:
@@ -680,6 +689,7 @@ Reset_Loop:
 						// At this point we have no choice but to unload the shard, so that it
 						// gets a new RangeID when it's reloaded.
 						s.closeShard()
+						break Reset_Loop
 					}
 				}
 			}
@@ -765,6 +775,7 @@ Reset_Loop:
 					} else {
 						// Shard is stolen, trigger shutdown of history engine
 						s.closeShard()
+						break Reset_Loop
 					}
 				}
 			default:
@@ -779,6 +790,7 @@ Reset_Loop:
 						// At this point we have no choice but to unload the shard, so that it
 						// gets a new RangeID when it's reloaded.
 						s.closeShard()
+						break Reset_Loop
 					}
 				}
 			}
@@ -856,24 +868,23 @@ func (s *shardContextImpl) getRangeID() int64 {
 	return s.shardInfo.RangeID
 }
 
+func (s *shardContextImpl) isClosed() bool {
+	return atomic.LoadInt32(&s.closed) != 0
+}
+
 func (s *shardContextImpl) closeShard() {
-	if s.isClosed {
+	if !atomic.CompareAndSwapInt32(&s.closed, 0, 1) {
 		return
 	}
 
-	s.isClosed = true
-
-	go s.shardItem.stopEngine()
+	go func() {
+		s.closeCallback(s.shardID, s.shardItem)
+		s.shardItem.stopEngine()
+	}()
 
 	// fails any writes that may start after this point.
 	s.shardInfo.RangeID = -1
 	atomic.StoreInt64(&s.rangeID, s.shardInfo.RangeID)
-
-	if s.closeCh != nil {
-		// This is the channel passed in by shard controller to monitor if a shard needs to be unloaded
-		// It will trigger the HistoryEngine unload and removal of engine from shard controller
-		s.closeCh <- s.shardID
-	}
 }
 
 func (s *shardContextImpl) generateTransferTaskIDLocked() (int64, error) {
@@ -943,6 +954,10 @@ func (s *shardContextImpl) updateMaxReadLevelLocked(rl int64) {
 }
 
 func (s *shardContextImpl) updateShardInfoLocked() error {
+	if s.isClosed() {
+		return ErrShardClosed
+	}
+
 	var err error
 	now := clock.NewRealTimeSource().Now()
 	if s.lastUpdated.Add(s.config.ShardUpdateMinInterval()).After(now) {
@@ -1142,8 +1157,10 @@ func (s *shardContextImpl) GetLastUpdatedTime() time.Time {
 	return s.lastUpdated
 }
 
-func acquireShard(shardItem *historyShardsItem, closeCh chan<- int) (ShardContext,
-	error) {
+func acquireShard(
+	shardItem *historyShardsItem,
+	closeCallback func(int, *historyShardsItem),
+) (ShardContext, error) {
 
 	var shardInfo *persistence.ShardInfo
 
@@ -1223,7 +1240,7 @@ func acquireShard(shardItem *historyShardsItem, closeCh chan<- int) (ShardContex
 		shardID:                        shardItem.shardID,
 		executionManager:               executionMgr,
 		shardInfo:                      updatedShardInfo,
-		closeCh:                        closeCh,
+		closeCallback:                  closeCallback,
 		config:                         shardItem.config,
 		remoteClusterCurrentTime:       remoteClusterCurrentTime,
 		timerMaxReadLevelMap:           timerMaxReadLevelMap, // use ack to init read level

--- a/service/history/shardContextTest.go
+++ b/service/history/shardContextTest.go
@@ -53,8 +53,6 @@ func newTestShardContext(
 		rangeID:                   shardInfo.RangeID,
 		shardInfo:                 shardInfo,
 		executionManager:          resource.ExecutionMgr,
-		isClosed:                  false,
-		closeCh:                   make(chan int, 100),
 		config:                    config,
 		logger:                    resource.GetLogger(),
 		throttledLogger:           resource.GetThrottledLogger(),

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -172,6 +172,10 @@ func (c *shardController) removeEngineForShard(shardID int, shardItem *historySh
 	sw := c.metricsScope.StartTimer(metrics.RemoveEngineForShardLatency)
 	defer sw.Stop()
 	item, _ := c.removeHistoryShardItem(shardID)
+	// the shardItem comparison is just a defensive check to make sure we are deleting
+	// what we intend to delete. In the event that multiple callers call removeEngine / getEngine
+	// concurrently, it is possible to reorder a delete/delete/add sequence into a delete/add/delete
+	// sequence. This check is to protect against those scenarios.
 	if item != nil && (item == shardItem || shardItem == nil) {
 		item.stopEngine()
 	}

--- a/service/history/shardController.go
+++ b/service/history/shardController.go
@@ -45,7 +45,6 @@ type (
 
 		membershipUpdateCh chan *membership.ChangedEvent
 		engineFactory      EngineFactory
-		shardClosedCh      chan int
 		status             int32
 		shutdownWG         sync.WaitGroup
 		shutdownCh         chan struct{}
@@ -93,7 +92,6 @@ func newShardController(
 		membershipUpdateCh: make(chan *membership.ChangedEvent, 10),
 		engineFactory:      factory,
 		historyShards:      make(map[int]*historyShardsItem),
-		shardClosedCh:      make(chan int, config.NumberOfShards),
 		shutdownCh:         make(chan struct{}),
 		logger:             resource.GetLogger().WithTags(tag.ComponentShardController, tag.Address(hostIdentity)),
 		throttledLogger:    resource.GetThrottledLogger().WithTags(tag.ComponentShardController, tag.Address(hostIdentity)),
@@ -167,16 +165,22 @@ func (c *shardController) getEngineForShard(shardID int) (Engine, error) {
 	if err != nil {
 		return nil, err
 	}
-	return item.getOrCreateEngine(c.shardClosedCh)
+	return item.getOrCreateEngine(c.shardClosedCallback)
 }
 
-func (c *shardController) removeEngineForShard(shardID int) {
+func (c *shardController) removeEngineForShard(shardID int, shardItem *historyShardsItem) {
 	sw := c.metricsScope.StartTimer(metrics.RemoveEngineForShardLatency)
 	defer sw.Stop()
 	item, _ := c.removeHistoryShardItem(shardID)
-	if item != nil {
+	if item != nil && (item == shardItem || shardItem == nil) {
 		item.stopEngine()
 	}
+}
+
+func (c *shardController) shardClosedCallback(shardID int, shardItem *historyShardsItem) {
+	c.metricsScope.IncCounter(metrics.ShardClosedCounter)
+	c.logger.Info("", tag.LifeCycleStopping, tag.ComponentShard, tag.ShardID(shardID))
+	c.removeEngineForShard(shardID, shardItem)
 }
 
 func (c *shardController) getOrCreateHistoryShardItem(shardID int) (*historyShardsItem, error) {
@@ -276,18 +280,6 @@ func (c *shardController) shardManagementPump() {
 				tag.NumberDeleted(len(changedEvent.HostsRemoved)),
 				tag.Number(int64(len(changedEvent.HostsUpdated))))
 			c.acquireShards()
-		case shardID := <-c.shardClosedCh:
-			c.metricsScope.IncCounter(metrics.ShardClosedCounter)
-			c.logger.Info("", tag.LifeCycleStopping, tag.ComponentShard, tag.ShardID(shardID))
-			c.removeEngineForShard(shardID)
-			// The async close notifications can cause a race
-			// between acquire/release when nodes are flapping
-			// The impact of this race is un-necessary shard load/unloads
-			// even though things will settle eventually
-			// To reduce the chance of the race happening, lets
-			// process all closed events at once before we attempt
-			// to acquire new shards again
-			c.processShardClosedEvents()
 		}
 	}
 }
@@ -317,8 +309,6 @@ func (c *shardController) acquireShards() {
 							c.metricsScope.IncCounter(metrics.GetEngineForShardErrorCounter)
 							c.logger.Error("Unable to create history shard engine", tag.Error(err1), tag.OperationFailed, tag.ShardID(shardID))
 						}
-					} else {
-						c.removeEngineForShard(shardID)
 					}
 				}
 			}
@@ -345,19 +335,6 @@ func (c *shardController) doShutdown() {
 	c.historyShards = nil
 }
 
-func (c *shardController) processShardClosedEvents() {
-	for {
-		select {
-		case shardID := <-c.shardClosedCh:
-			c.metricsScope.IncCounter(metrics.ShardClosedCounter)
-			c.logger.Info("", tag.LifeCycleStopping, tag.ComponentShard, tag.ShardID(shardID))
-			c.removeEngineForShard(shardID)
-		default:
-			return
-		}
-	}
-}
-
 func (c *shardController) numShards() int {
 	nShards := 0
 	c.RLock()
@@ -377,7 +354,9 @@ func (c *shardController) shardIDs() []int32 {
 	return ids
 }
 
-func (i *historyShardsItem) getOrCreateEngine(shardClosedCh chan<- int) (Engine, error) {
+func (i *historyShardsItem) getOrCreateEngine(
+	closeCallback func(int, *historyShardsItem),
+) (Engine, error) {
 	i.RLock()
 	if i.status == historyShardsItemStatusStarted {
 		defer i.RUnlock()
@@ -390,7 +369,7 @@ func (i *historyShardsItem) getOrCreateEngine(shardClosedCh chan<- int) (Engine,
 	switch i.status {
 	case historyShardsItemStatusInitialized:
 		i.logger.Info("", tag.LifeCycleStarting, tag.ComponentShardEngine)
-		context, err := acquireShard(i, shardClosedCh)
+		context, err := acquireShard(i, closeCallback)
 		if err != nil {
 			return nil, err
 		}

--- a/service/history/timerQueueAckMgr.go
+++ b/service/history/timerQueueAckMgr.go
@@ -317,7 +317,7 @@ func (t *timerQueueAckMgrImpl) getAckLevel() timerKey {
 	return t.ackLevel
 }
 
-func (t *timerQueueAckMgrImpl) updateAckLevel() {
+func (t *timerQueueAckMgrImpl) updateAckLevel() error {
 	t.metricsClient.IncCounter(t.scope, metrics.AckLevelUpdateCounter)
 
 	t.Lock()
@@ -368,14 +368,16 @@ MoveAckLevelLoop:
 		if err != nil {
 			t.logger.Error("Error shutting down timer queue", tag.Error(err))
 		}
-		return
+		return err
 	}
 
 	t.Unlock()
 	if err := t.updateTimerAckLevel(ackLevel); err != nil {
 		t.metricsClient.IncCounter(t.scope, metrics.AckLevelUpdateFailedCounter)
 		t.logger.Error("Error updating timer ack level for shard", tag.Error(err))
+		return err
 	}
+	return nil
 }
 
 // this function does not take cluster name as parameter, due to we only have one timer queue on Cassandra

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -261,6 +261,11 @@ func (t *timerQueueProcessorImpl) completeTimersLoop() {
 				err := t.completeTimers()
 				if err != nil {
 					t.logger.Info("Failed to complete timers.", tag.Error(err))
+					if err == ErrShardClosed {
+						// shard is unloaded, timer processor should quit as well
+						go t.Stop()
+						return
+					}
 					backoff := time.Duration(attempt * 100)
 					time.Sleep(backoff * time.Millisecond)
 				} else {

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -288,7 +288,11 @@ func (t *timerQueueProcessorBase) internalProcessor() error {
 				t.config.TimerProcessorUpdateAckInterval(),
 				t.config.TimerProcessorUpdateAckIntervalJitterCoefficient(),
 			))
-			t.timerQueueAckMgr.updateAckLevel()
+			if err := t.timerQueueAckMgr.updateAckLevel(); err == ErrShardClosed {
+				// shard is closed, shutdown timerQProcessor and bail out
+				go t.Stop()
+				return err
+			}
 		case <-t.newTimerCh:
 			t.newTimeLock.Lock()
 			newTime := t.newTime

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -286,6 +286,11 @@ func (t *transferQueueProcessorImpl) completeTransferLoop() {
 				err := t.completeTransfer()
 				if err != nil {
 					t.logger.Info("Failed to complete transfer task", tag.Error(err))
+					if err == ErrShardClosed {
+						// shard closed, trigger shutdown and bail out
+						t.Stop()
+						return
+					}
 					backoff := time.Duration(attempt * 100)
 					time.Sleep(backoff * time.Millisecond)
 				} else {


### PR DESCRIPTION
**What changed?**
This patch contains a set of changes to reduce availability dips during shard load / unloads. The changes specifically are:

- On ring membership changes, the current code used to remove shards no longer owned by the instance. However pro-actively removing the shard doesn't buy much but causes availability blip. 
Shards no longer owned will be automatically closed when the new owner steals the shard from this instance. So, this patch gets rid of removeShard on membership change and also implements mechanism to unload queue processors on shardOwnershipLost errors.

- shardContext is the class that implements operations that can be executed only by a shard owner. Pretty much any workflow related operation needs to go through this class. During deployments, when shard ownership moves to another instance (and the host which is going down is draining traffic),  the shardContext operations will receive a ShardOwnershipLost error on the instance that is going down. However, the retry loop in shardContext is dumb and continues to loop through retries even after this error. This can hold requests for much longer, increasing latency, decreasing availability and creating additional DB load. This patch fails the requests as soon as shard is closed due to shardownershipLost errors.

- When a shard is closed due to ownershipLost errors, previously, a channel is used to send an async notification to the shardController, which in turn will delete the shard entry from its map and stop the processors. However, this async mechanism has a race condition during shutdown when shards are constantly moving around. This patch eliminates the race by using a callback function instead of async mechanism.

**Why?**
The goal here is to reduce availability dips during deployment (shard unload  / load)

**How did you test it?**
Tested locally and in staging.

**Potential risks**
This patch modifies the shutdown path of shard / shardController etc which are key components involved in all workflow operations. A bug could cause shards to constantly move between hosts reducing availability or increasing latency.  

Related to #1454