### PR TITLE
Fix visibility archival config for docker

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -187,8 +187,12 @@ archival:
         fileMode: "0666"
         dirMode: "0766"
   visibility:
-    status: "disabled"
-    enableRead: false
+    status: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
 
 domainDefaults:
   archival:
@@ -196,7 +200,8 @@ domainDefaults:
       status: "enabled"
       URI: "file:///tmp/cadence_archival/development"
     visibility:
-      status: "disabled"
+      status: "enabled"
+      URI: "file:///tmp/cadence_vis_archival/development"
 
 kafka:
     tls:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update docker config file to enable visibility archival at cluster level.

<!-- Tell your future self why have you made these changes -->
**Why?**
Visibility archival is disabled in the config file for docker image

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Built and ran docker locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
