### PR TITLE
Add additional logging and metrics around size limits

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -146,6 +146,11 @@ func QueryID(queryID string) Tag {
 	return newStringTag("query-id", queryID)
 }
 
+// BlobSizeViolationOperation returns tag for BlobSizeViolationOperation
+func BlobSizeViolationOperation(operation string) Tag {
+	return newStringTag("blob-size-violation-operation", operation)
+}
+
 // domain related
 
 // WorkflowDomainID returns tag for WorkflowDomainID

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -33,6 +33,7 @@ const (
 	taskList      = "tasklist"
 	workflowType  = "workflowType"
 	activityType  = "activityType"
+	decisionType  = "decisionType"
 
 	domainAllValue = "all"
 	unknownValue   = "_unknown_"
@@ -68,6 +69,10 @@ type (
 	}
 
 	activityTypeTag struct {
+		value string
+	}
+
+	decisionTypeTag struct {
 		value string
 	}
 )
@@ -191,5 +196,23 @@ func (d activityTypeTag) Key() string {
 
 // Value returns the value of the activity type tag
 func (d activityTypeTag) Value() string {
+	return d.value
+}
+
+// DecisionTypeTag returns a new decision type tag.
+func DecisionTypeTag(value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return decisionTypeTag{value}
+}
+
+// Key returns the key of the decision type tag
+func (d decisionTypeTag) Key() string {
+	return decisionType
+}
+
+// Value returns the value of the decision type tag
+func (d decisionTypeTag) Value() string {
 	return d.value
 }

--- a/common/util.go
+++ b/common/util.go
@@ -436,13 +436,28 @@ func CreateHistoryStartWorkflowRequest(
 
 // CheckEventBlobSizeLimit checks if a blob data exceeds limits. It logs a warning if it exceeds warnLimit,
 // and return ErrBlobSizeExceedsLimit if it exceeds errorLimit.
-func CheckEventBlobSizeLimit(actualSize, warnLimit, errorLimit int, domainID, workflowID, runID string, scope metrics.Scope, logger log.Logger) error {
+func CheckEventBlobSizeLimit(
+	actualSize int,
+	warnLimit int,
+	errorLimit int,
+	domainID string,
+	workflowID string,
+	runID string,
+	scope metrics.Scope,
+	logger log.Logger,
+	blobSizeViolationOperationTag tag.Tag,
+) error {
+
 	scope.RecordTimer(metrics.EventBlobSize, time.Duration(actualSize))
 
 	if actualSize > warnLimit {
 		if logger != nil {
 			logger.Warn("Blob size exceeds limit.",
-				tag.WorkflowDomainID(domainID), tag.WorkflowID(workflowID), tag.WorkflowRunID(runID), tag.WorkflowSize(int64(actualSize)))
+				tag.WorkflowDomainID(domainID),
+				tag.WorkflowID(workflowID),
+				tag.WorkflowRunID(runID),
+				tag.WorkflowSize(int64(actualSize)),
+				blobSizeViolationOperationTag)
 		}
 
 		if actualSize > errorLimit {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -698,6 +698,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RecordActivityTaskHeartbeat"),
 	); err != nil {
 		// heartbeat details exceed size limit, we would fail the activity immediately with explicit error reason
 		failRequest := &gen.RespondActivityTaskFailedRequest{
@@ -803,6 +804,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RecordActivityTaskHeartbeatByID"),
 	); err != nil {
 		// heartbeat details exceed size limit, we would fail the activity immediately with explicit error reason
 		failRequest := &gen.RespondActivityTaskFailedRequest{
@@ -900,6 +902,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondActivityTaskCompleted"),
 	); err != nil {
 		// result exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
@@ -1007,6 +1010,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondActivityTaskCompletedByID"),
 	); err != nil {
 		// result exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
@@ -1104,6 +1108,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondActivityTaskFailed"),
 	); err != nil {
 		// details exceeds blob size limit, we would truncate the details and put a specific error reason
 		failedRequest.Reason = common.StringPtr(common.FailureReasonFailureDetailsExceedsLimit)
@@ -1198,6 +1203,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondActivityTaskFailedByID"),
 	); err != nil {
 		// details exceeds blob size limit, we would truncate the details and put a specific error reason
 		failedRequest.Reason = common.StringPtr(common.FailureReasonFailureDetailsExceedsLimit)
@@ -1284,6 +1290,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondActivityTaskCanceled"),
 	); err != nil {
 		// details exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
@@ -1390,6 +1397,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondActivityTaskCanceledByID"),
 	); err != nil {
 		// details exceeds blob size limit, we would record it as failure
 		failRequest := &gen.RespondActivityTaskFailedRequest{
@@ -1572,6 +1580,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 		taskToken.RunID,
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondDecisionTaskFailed"),
 	); err != nil {
 		// details exceed, we would just truncate the size for decision task failed as the details is not used anywhere by client code
 		failedRequest.Details = failedRequest.Details[0:sizeLimitError]
@@ -1646,6 +1655,7 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 		"",
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("RespondQueryTaskCompleted"),
 	); err != nil {
 		completeRequest = &gen.RespondQueryTaskCompletedRequest{
 			TaskToken:     completeRequest.TaskToken,
@@ -1786,6 +1796,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		"",
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("StartWorkflowExecution"),
 	); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2120,6 +2131,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(
 		signalRequest.GetWorkflowExecution().GetRunId(),
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("SignalWorkflowExecution"),
 	); err != nil {
 		return wh.error(err, scope)
 	}
@@ -2244,6 +2256,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 		"",
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("SignalWithStartWorkflowExecution"),
 	); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -2257,6 +2270,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 		"",
 		scope,
 		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("SignalWithStartWorkflowExecution"),
 	); err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -3081,7 +3095,8 @@ func (wh *WorkflowHandler) QueryWorkflow(
 		queryRequest.GetExecution().GetWorkflowId(),
 		queryRequest.GetExecution().GetRunId(),
 		scope,
-		wh.GetThrottledLogger()); err != nil {
+		wh.GetThrottledLogger(),
+		tag.BlobSizeViolationOperation("QueryWorkflow")); err != nil {
 		return nil, wh.error(err, scope)
 	}
 

--- a/service/history/decisionTaskHandler.go
+++ b/service/history/decisionTaskHandler.go
@@ -208,6 +208,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionScheduleActivity(
 	}
 
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeScheduleActivityTask.String()),
 		attr.Input,
 		"ScheduleActivityTaskDecisionAttributes.Input exceeds size limit.",
 	)
@@ -337,6 +338,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionCompleteWorkflow(
 	}
 
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeCompleteWorkflowExecution.String()),
 		attr.Result,
 		"CompleteWorkflowExecutionDecisionAttributes.Result exceeds size limit.",
 	)
@@ -412,6 +414,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionFailWorkflow(
 	}
 
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeFailWorkflowExecution.String()),
 		attr.Details,
 		"FailWorkflowExecutionDecisionAttributes.Details exceeds size limit.",
 	)
@@ -613,6 +616,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionRecordMarker(
 	}
 
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeRecordMarker.String()),
 		attr.Details,
 		"RecordMarkerDecisionAttributes.Details exceeds size limit.",
 	)
@@ -653,6 +657,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionContinueAsNewWorkflow(
 	}
 
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeContinueAsNewWorkflowExecution.String()),
 		attr.Input,
 		"ContinueAsNewWorkflowExecutionDecisionAttributes. Input exceeds size limit.",
 	)
@@ -737,6 +742,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionStartChildWorkflow(
 	}
 
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeStartChildWorkflowExecution.String()),
 		attr.Input,
 		"StartChildWorkflowExecutionDecisionAttributes.Input exceeds size limit.",
 	)
@@ -803,6 +809,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionSignalExternalWorkflow(
 	}
 
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeSignalExternalWorkflowExecution.String()),
 		attr.Input,
 		"SignalExternalWorkflowExecutionDecisionAttributes.Input exceeds size limit.",
 	)
@@ -853,6 +860,7 @@ func (handler *decisionTaskHandlerImpl) handleDecisionUpsertWorkflowSearchAttrib
 
 	// blob size limit check
 	failWorkflow, err := handler.sizeLimitChecker.failWorkflowIfBlobSizeExceedsLimit(
+		metrics.DecisionTypeTag(workflow.DecisionTypeUpsertWorkflowSearchAttributes.String()),
 		convertSearchAttributesToByteArray(attr.GetSearchAttributes().GetIndexedFields()),
 		"UpsertWorkflowSearchAttributesDecisionAttributes exceeds size limit.",
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Add additional logging for blob size errors. Also add tags to metrics. This will enable us to identify customers which are in violation. 

