### PR TITLE
Change queue message id to big integer in Cas

### DIFF
--- a/common/domain/dlqMessageHandler.go
+++ b/common/domain/dlqMessageHandler.go
@@ -33,9 +33,9 @@ import (
 type (
 	// DLQMessageHandler is the interface handles domain DLQ messages
 	DLQMessageHandler interface {
-		Read(lastMessageID int, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error)
-		Purge(lastMessageID int) error
-		Merge(lastMessageID int, pageSize int, pageToken []byte) ([]byte, error)
+		Read(lastMessageID int64, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error)
+		Purge(lastMessageID int64) error
+		Merge(lastMessageID int64, pageSize int, pageToken []byte) ([]byte, error)
 	}
 
 	dlqMessageHandlerImpl struct {
@@ -60,7 +60,7 @@ func NewDLQMessageHandler(
 
 // ReadMessages reads domain replication DLQ messages
 func (d *dlqMessageHandlerImpl) Read(
-	lastMessageID int,
+	lastMessageID int64,
 	pageSize int,
 	pageToken []byte,
 ) ([]*replicator.ReplicationTask, []byte, error) {
@@ -80,7 +80,7 @@ func (d *dlqMessageHandlerImpl) Read(
 
 // PurgeMessages purges domain replication DLQ messages
 func (d *dlqMessageHandlerImpl) Purge(
-	lastMessageID int,
+	lastMessageID int64,
 ) error {
 
 	ackLevel, err := d.domainReplicationQueue.GetDLQAckLevel()
@@ -106,7 +106,7 @@ func (d *dlqMessageHandlerImpl) Purge(
 
 // MergeMessages merges domain replication DLQ messages
 func (d *dlqMessageHandlerImpl) Merge(
-	lastMessageID int,
+	lastMessageID int64,
 	pageSize int,
 	pageToken []byte,
 ) ([]byte, error) {
@@ -126,7 +126,7 @@ func (d *dlqMessageHandlerImpl) Merge(
 		return nil, err
 	}
 
-	var ackedMessageID int
+	var ackedMessageID int64
 	for _, message := range messages {
 		domainTask := message.GetDomainTaskAttributes()
 		if domainTask == nil {
@@ -138,7 +138,7 @@ func (d *dlqMessageHandlerImpl) Merge(
 		); err != nil {
 			return nil, err
 		}
-		ackedMessageID = int(*message.SourceTaskId)
+		ackedMessageID = *message.SourceTaskId
 	}
 
 	if err := d.domainReplicationQueue.RangeDeleteMessagesFromDLQ(

--- a/common/domain/dlqMessageHandler_mock.go
+++ b/common/domain/dlqMessageHandler_mock.go
@@ -59,7 +59,7 @@ func (m *MockDLQMessageHandler) EXPECT() *MockDLQMessageHandlerMockRecorder {
 }
 
 // Read mocks base method
-func (m *MockDLQMessageHandler) Read(lastMessageID, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error) {
+func (m *MockDLQMessageHandler) Read(lastMessageID int64, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Read", lastMessageID, pageSize, pageToken)
 	ret0, _ := ret[0].([]*replicator.ReplicationTask)
@@ -75,7 +75,7 @@ func (mr *MockDLQMessageHandlerMockRecorder) Read(lastMessageID, pageSize, pageT
 }
 
 // Purge mocks base method
-func (m *MockDLQMessageHandler) Purge(lastMessageID int) error {
+func (m *MockDLQMessageHandler) Purge(lastMessageID int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Purge", lastMessageID)
 	ret0, _ := ret[0].(error)
@@ -89,7 +89,7 @@ func (mr *MockDLQMessageHandlerMockRecorder) Purge(lastMessageID interface{}) *g
 }
 
 // Merge mocks base method
-func (m *MockDLQMessageHandler) Merge(lastMessageID, pageSize int, pageToken []byte) ([]byte, error) {
+func (m *MockDLQMessageHandler) Merge(lastMessageID int64, pageSize int, pageToken []byte) ([]byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Merge", lastMessageID, pageSize, pageToken)
 	ret0, _ := ret[0].([]byte)

--- a/common/domain/dlqMessageHandler_test.go
+++ b/common/domain/dlqMessageHandler_test.go
@@ -18,8 +18,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-//+build test
-
 package domain
 
 import (

--- a/common/domain/dlqMessageHandler_test.go
+++ b/common/domain/dlqMessageHandler_test.go
@@ -18,6 +18,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+//+build test
+
 package domain
 
 import (
@@ -82,8 +84,8 @@ func (s *dlqMessageHandlerSuite) TearDownTest() {
 }
 
 func (s *dlqMessageHandlerSuite) TestReadMessages() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
 
@@ -105,7 +107,7 @@ func (s *dlqMessageHandlerSuite) TestReadMessages() {
 }
 
 func (s *dlqMessageHandlerSuite) TestReadMessages_ThrowErrorOnGetDLQAckLevel() {
-	lastMessageID := 20
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
 
@@ -116,7 +118,7 @@ func (s *dlqMessageHandlerSuite) TestReadMessages_ThrowErrorOnGetDLQAckLevel() {
 		},
 	}
 	testError := fmt.Errorf("test")
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(-1, testError).Times(1)
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(int64(-1), testError).Times(1)
 	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(tasks, nil, nil).Times(0)
 
@@ -126,8 +128,8 @@ func (s *dlqMessageHandlerSuite) TestReadMessages_ThrowErrorOnGetDLQAckLevel() {
 }
 
 func (s *dlqMessageHandlerSuite) TestReadMessages_ThrowErrorOnReadMessages() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
 
@@ -142,8 +144,8 @@ func (s *dlqMessageHandlerSuite) TestReadMessages_ThrowErrorOnReadMessages() {
 }
 
 func (s *dlqMessageHandlerSuite) TestPurgeMessages() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 
 	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil).Times(1)
 	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(ackLevel, lastMessageID).Return(nil).Times(1)
@@ -154,10 +156,10 @@ func (s *dlqMessageHandlerSuite) TestPurgeMessages() {
 }
 
 func (s *dlqMessageHandlerSuite) TestPurgeMessages_ThrowErrorOnGetDLQAckLevel() {
-	lastMessageID := 20
+	lastMessageID := int64(20)
 	testError := fmt.Errorf("test")
 
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(-1, testError).Times(1)
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(int64(-1), testError).Times(1)
 	s.mockReplicationQueue.EXPECT().RangeDeleteMessagesFromDLQ(gomock.Any(), gomock.Any()).Return(nil).Times(0)
 	s.mockReplicationQueue.EXPECT().UpdateDLQAckLevel(gomock.Any()).Times(0)
 	err := s.dlqMessageHandler.Purge(lastMessageID)
@@ -166,8 +168,8 @@ func (s *dlqMessageHandlerSuite) TestPurgeMessages_ThrowErrorOnGetDLQAckLevel() 
 }
 
 func (s *dlqMessageHandlerSuite) TestPurgeMessages_ThrowErrorOnPurgeMessages() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	testError := fmt.Errorf("test")
 
 	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(ackLevel, nil).Times(1)
@@ -179,11 +181,11 @@ func (s *dlqMessageHandlerSuite) TestPurgeMessages_ThrowErrorOnPurgeMessages() {
 }
 
 func (s *dlqMessageHandlerSuite) TestMergeMessages() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
-	messageID := 11
+	messageID := int64(11)
 
 	domainAttribute := &replicator.DomainTaskAttributes{
 		ID: common.StringPtr(uuid.New()),
@@ -192,7 +194,7 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages() {
 	tasks := []*replicator.ReplicationTask{
 		{
 			TaskType:             replicator.ReplicationTaskTypeDomain.Ptr(),
-			SourceTaskId:         common.Int64Ptr(int64(messageID)),
+			SourceTaskId:         common.Int64Ptr(messageID),
 			DomainTaskAttributes: domainAttribute,
 		},
 	}
@@ -209,10 +211,10 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages() {
 }
 
 func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnGetDLQAckLevel() {
-	lastMessageID := 20
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
-	messageID := 11
+	messageID := int64(11)
 	testError := fmt.Errorf("test")
 	domainAttribute := &replicator.DomainTaskAttributes{
 		ID: common.StringPtr(uuid.New()),
@@ -225,7 +227,7 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnGetDLQAckLevel() 
 			DomainTaskAttributes: domainAttribute,
 		},
 	}
-	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(-1, testError).Times(1)
+	s.mockReplicationQueue.EXPECT().GetDLQAckLevel().Return(int64(-1), testError).Times(1)
 	s.mockReplicationQueue.EXPECT().GetMessagesFromDLQ(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(tasks, nil, nil).Times(0)
 	s.mockReplicationTaskExecutor.EXPECT().Execute(gomock.Any()).Times(0)
@@ -238,8 +240,8 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnGetDLQAckLevel() 
 }
 
 func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnGetDLQMessages() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
 	testError := fmt.Errorf("test")
@@ -257,12 +259,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnGetDLQMessages() 
 }
 
 func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnHandleReceivingTask() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
-	messageID1 := 11
-	messageID2 := 12
+	messageID1 := int64(11)
+	messageID2 := int64(12)
 	testError := fmt.Errorf("test")
 	domainAttribute1 := &replicator.DomainTaskAttributes{
 		ID: common.StringPtr(uuid.New()),
@@ -273,12 +275,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnHandleReceivingTa
 	tasks := []*replicator.ReplicationTask{
 		{
 			TaskType:             replicator.ReplicationTaskTypeDomain.Ptr(),
-			SourceTaskId:         common.Int64Ptr(int64(messageID1)),
+			SourceTaskId:         common.Int64Ptr(messageID1),
 			DomainTaskAttributes: domainAttribute1,
 		},
 		{
 			TaskType:             replicator.ReplicationTaskTypeDomain.Ptr(),
-			SourceTaskId:         common.Int64Ptr(int64(messageID2)),
+			SourceTaskId:         common.Int64Ptr(messageID2),
 			DomainTaskAttributes: domainAttribute2,
 		},
 	}
@@ -297,12 +299,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnHandleReceivingTa
 }
 
 func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnDeleteMessages() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
-	messageID1 := 11
-	messageID2 := 12
+	messageID1 := int64(11)
+	messageID2 := int64(12)
 	testError := fmt.Errorf("test")
 	domainAttribute1 := &replicator.DomainTaskAttributes{
 		ID: common.StringPtr(uuid.New()),
@@ -313,12 +315,12 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnDeleteMessages() 
 	tasks := []*replicator.ReplicationTask{
 		{
 			TaskType:             replicator.ReplicationTaskTypeDomain.Ptr(),
-			SourceTaskId:         common.Int64Ptr(int64(messageID1)),
+			SourceTaskId:         common.Int64Ptr(messageID1),
 			DomainTaskAttributes: domainAttribute1,
 		},
 		{
 			TaskType:             replicator.ReplicationTaskTypeDomain.Ptr(),
-			SourceTaskId:         common.Int64Ptr(int64(messageID2)),
+			SourceTaskId:         common.Int64Ptr(messageID2),
 			DomainTaskAttributes: domainAttribute2,
 		},
 	}
@@ -336,11 +338,11 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_ThrowErrorOnDeleteMessages() 
 }
 
 func (s *dlqMessageHandlerSuite) TestMergeMessages_IgnoreErrorOnUpdateDLQAckLevel() {
-	ackLevel := 10
-	lastMessageID := 20
+	ackLevel := int64(10)
+	lastMessageID := int64(20)
 	pageSize := 100
 	pageToken := []byte{}
-	messageID := 11
+	messageID := int64(11)
 	testError := fmt.Errorf("test")
 	domainAttribute := &replicator.DomainTaskAttributes{
 		ID: common.StringPtr(uuid.New()),
@@ -349,7 +351,7 @@ func (s *dlqMessageHandlerSuite) TestMergeMessages_IgnoreErrorOnUpdateDLQAckLeve
 	tasks := []*replicator.ReplicationTask{
 		{
 			TaskType:             replicator.ReplicationTaskTypeDomain.Ptr(),
-			SourceTaskId:         common.Int64Ptr(int64(messageID)),
+			SourceTaskId:         common.Int64Ptr(messageID),
 			DomainTaskAttributes: domainAttribute,
 		},
 	}

--- a/common/persistence/domainReplicationQueue.go
+++ b/common/persistence/domainReplicationQueue.go
@@ -82,14 +82,14 @@ type (
 		common.Daemon
 		Publish(message interface{}) error
 		PublishToDLQ(message interface{}) error
-		GetReplicationMessages(lastMessageID int, maxCount int) ([]*replicator.ReplicationTask, int, error)
-		UpdateAckLevel(lastProcessedMessageID int, clusterName string) error
-		GetAckLevels() (map[string]int, error)
-		GetMessagesFromDLQ(firstMessageID int, lastMessageID int, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error)
-		UpdateDLQAckLevel(lastProcessedMessageID int) error
-		GetDLQAckLevel() (int, error)
-		RangeDeleteMessagesFromDLQ(firstMessageID int, lastMessageID int) error
-		DeleteMessageFromDLQ(messageID int) error
+		GetReplicationMessages(lastMessageID int64, maxCount int) ([]*replicator.ReplicationTask, int64, error)
+		UpdateAckLevel(lastProcessedMessageID int64, clusterName string) error
+		GetAckLevels() (map[string]int64, error)
+		GetMessagesFromDLQ(firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error)
+		UpdateDLQAckLevel(lastProcessedMessageID int64) error
+		GetDLQAckLevel() (int64, error)
+		RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error
+		DeleteMessageFromDLQ(messageID int64) error
 	}
 )
 
@@ -145,9 +145,9 @@ func (q *domainReplicationQueueImpl) PublishToDLQ(message interface{}) error {
 }
 
 func (q *domainReplicationQueueImpl) GetReplicationMessages(
-	lastMessageID int,
+	lastMessageID int64,
 	maxCount int,
-) ([]*replicator.ReplicationTask, int, error) {
+) ([]*replicator.ReplicationTask, int64, error) {
 
 	messages, err := q.queue.ReadMessages(lastMessageID, maxCount)
 	if err != nil {
@@ -170,7 +170,7 @@ func (q *domainReplicationQueueImpl) GetReplicationMessages(
 }
 
 func (q *domainReplicationQueueImpl) UpdateAckLevel(
-	lastProcessedMessageID int,
+	lastProcessedMessageID int64,
 	clusterName string,
 ) error {
 
@@ -187,13 +187,13 @@ func (q *domainReplicationQueueImpl) UpdateAckLevel(
 	return nil
 }
 
-func (q *domainReplicationQueueImpl) GetAckLevels() (map[string]int, error) {
+func (q *domainReplicationQueueImpl) GetAckLevels() (map[string]int64, error) {
 	return q.queue.GetAckLevels()
 }
 
 func (q *domainReplicationQueueImpl) GetMessagesFromDLQ(
-	firstMessageID int,
-	lastMessageID int,
+	firstMessageID int64,
+	lastMessageID int64,
 	pageSize int,
 	pageToken []byte,
 ) ([]*replicator.ReplicationTask, []byte, error) {
@@ -220,7 +220,7 @@ func (q *domainReplicationQueueImpl) GetMessagesFromDLQ(
 }
 
 func (q *domainReplicationQueueImpl) UpdateDLQAckLevel(
-	lastProcessedMessageID int,
+	lastProcessedMessageID int64,
 ) error {
 
 	if err := q.queue.UpdateDLQAckLevel(
@@ -239,7 +239,7 @@ func (q *domainReplicationQueueImpl) UpdateDLQAckLevel(
 	return nil
 }
 
-func (q *domainReplicationQueueImpl) GetDLQAckLevel() (int, error) {
+func (q *domainReplicationQueueImpl) GetDLQAckLevel() (int64, error) {
 	dlqMetadata, err := q.queue.GetDLQAckLevels()
 	if err != nil {
 		return emptyMessageID, err
@@ -253,8 +253,8 @@ func (q *domainReplicationQueueImpl) GetDLQAckLevel() (int, error) {
 }
 
 func (q *domainReplicationQueueImpl) RangeDeleteMessagesFromDLQ(
-	firstMessageID int,
-	lastMessageID int,
+	firstMessageID int64,
+	lastMessageID int64,
 ) error {
 
 	if err := q.queue.RangeDeleteMessagesFromDLQ(
@@ -268,7 +268,7 @@ func (q *domainReplicationQueueImpl) RangeDeleteMessagesFromDLQ(
 }
 
 func (q *domainReplicationQueueImpl) DeleteMessageFromDLQ(
-	messageID int,
+	messageID int64,
 ) error {
 
 	return q.queue.DeleteMessageFromDLQ(messageID)
@@ -284,7 +284,7 @@ func (q *domainReplicationQueueImpl) purgeAckedMessages() error {
 		return nil
 	}
 
-	minAckLevel := math.MaxInt64
+	minAckLevel := int64(math.MaxInt64)
 	for _, ackLevel := range ackLevelByCluster {
 		if ackLevel < minAckLevel {
 			minAckLevel = ackLevel

--- a/common/persistence/domainReplicationQueue_mock.go
+++ b/common/persistence/domainReplicationQueue_mock.go
@@ -111,11 +111,11 @@ func (mr *MockDomainReplicationQueueMockRecorder) PublishToDLQ(message interface
 }
 
 // GetReplicationMessages mocks base method
-func (m *MockDomainReplicationQueue) GetReplicationMessages(lastMessageID, maxCount int) ([]*replicator.ReplicationTask, int, error) {
+func (m *MockDomainReplicationQueue) GetReplicationMessages(lastMessageID int64, maxCount int) ([]*replicator.ReplicationTask, int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReplicationMessages", lastMessageID, maxCount)
 	ret0, _ := ret[0].([]*replicator.ReplicationTask)
-	ret1, _ := ret[1].(int)
+	ret1, _ := ret[1].(int64)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -127,7 +127,7 @@ func (mr *MockDomainReplicationQueueMockRecorder) GetReplicationMessages(lastMes
 }
 
 // UpdateAckLevel mocks base method
-func (m *MockDomainReplicationQueue) UpdateAckLevel(lastProcessedMessageID int, clusterName string) error {
+func (m *MockDomainReplicationQueue) UpdateAckLevel(lastProcessedMessageID int64, clusterName string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAckLevel", lastProcessedMessageID, clusterName)
 	ret0, _ := ret[0].(error)
@@ -141,10 +141,10 @@ func (mr *MockDomainReplicationQueueMockRecorder) UpdateAckLevel(lastProcessedMe
 }
 
 // GetAckLevels mocks base method
-func (m *MockDomainReplicationQueue) GetAckLevels() (map[string]int, error) {
+func (m *MockDomainReplicationQueue) GetAckLevels() (map[string]int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAckLevels")
-	ret0, _ := ret[0].(map[string]int)
+	ret0, _ := ret[0].(map[string]int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -156,7 +156,7 @@ func (mr *MockDomainReplicationQueueMockRecorder) GetAckLevels() *gomock.Call {
 }
 
 // GetMessagesFromDLQ mocks base method
-func (m *MockDomainReplicationQueue) GetMessagesFromDLQ(firstMessageID, lastMessageID, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error) {
+func (m *MockDomainReplicationQueue) GetMessagesFromDLQ(firstMessageID, lastMessageID int64, pageSize int, pageToken []byte) ([]*replicator.ReplicationTask, []byte, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetMessagesFromDLQ", firstMessageID, lastMessageID, pageSize, pageToken)
 	ret0, _ := ret[0].([]*replicator.ReplicationTask)
@@ -172,7 +172,7 @@ func (mr *MockDomainReplicationQueueMockRecorder) GetMessagesFromDLQ(firstMessag
 }
 
 // UpdateDLQAckLevel mocks base method
-func (m *MockDomainReplicationQueue) UpdateDLQAckLevel(lastProcessedMessageID int) error {
+func (m *MockDomainReplicationQueue) UpdateDLQAckLevel(lastProcessedMessageID int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateDLQAckLevel", lastProcessedMessageID)
 	ret0, _ := ret[0].(error)
@@ -186,10 +186,10 @@ func (mr *MockDomainReplicationQueueMockRecorder) UpdateDLQAckLevel(lastProcesse
 }
 
 // GetDLQAckLevel mocks base method
-func (m *MockDomainReplicationQueue) GetDLQAckLevel() (int, error) {
+func (m *MockDomainReplicationQueue) GetDLQAckLevel() (int64, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDLQAckLevel")
-	ret0, _ := ret[0].(int)
+	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -201,7 +201,7 @@ func (mr *MockDomainReplicationQueueMockRecorder) GetDLQAckLevel() *gomock.Call 
 }
 
 // RangeDeleteMessagesFromDLQ mocks base method
-func (m *MockDomainReplicationQueue) RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID int) error {
+func (m *MockDomainReplicationQueue) RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RangeDeleteMessagesFromDLQ", firstMessageID, lastMessageID)
 	ret0, _ := ret[0].(error)
@@ -215,7 +215,7 @@ func (mr *MockDomainReplicationQueueMockRecorder) RangeDeleteMessagesFromDLQ(fir
 }
 
 // DeleteMessageFromDLQ mocks base method
-func (m *MockDomainReplicationQueue) DeleteMessageFromDLQ(messageID int) error {
+func (m *MockDomainReplicationQueue) DeleteMessageFromDLQ(messageID int64) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteMessageFromDLQ", messageID)
 	ret0, _ := ret[0].(error)

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1461,16 +1461,16 @@ func isMessageIDConflictError(err error) bool {
 
 // GetReplicationMessages is a utility method to get messages from the queue
 func (s *TestBase) GetReplicationMessages(
-	lastMessageID int,
+	lastMessageID int64,
 	maxCount int,
-) ([]*replicator.ReplicationTask, int, error) {
+) ([]*replicator.ReplicationTask, int64, error) {
 
 	return s.DomainReplicationQueue.GetReplicationMessages(lastMessageID, maxCount)
 }
 
 // UpdateAckLevel updates replication queue ack level
 func (s *TestBase) UpdateAckLevel(
-	lastProcessedMessageID int,
+	lastProcessedMessageID int64,
 	clusterName string,
 ) error {
 
@@ -1478,7 +1478,7 @@ func (s *TestBase) UpdateAckLevel(
 }
 
 // GetAckLevels returns replication queue ack levels
-func (s *TestBase) GetAckLevels() (map[string]int, error) {
+func (s *TestBase) GetAckLevels() (map[string]int64, error) {
 	return s.DomainReplicationQueue.GetAckLevels()
 }
 
@@ -1503,8 +1503,8 @@ func (s *TestBase) PublishToDomainDLQ(
 
 // GetMessagesFromDomainDLQ is a utility method to get messages from the domain DLQ
 func (s *TestBase) GetMessagesFromDomainDLQ(
-	firstMessageID int,
-	lastMessageID int,
+	firstMessageID int64,
+	lastMessageID int64,
 	pageSize int,
 	pageToken []byte,
 ) ([]*replicator.ReplicationTask, []byte, error) {
@@ -1519,20 +1519,20 @@ func (s *TestBase) GetMessagesFromDomainDLQ(
 
 // UpdateDomainDLQAckLevel updates domain dlq ack level
 func (s *TestBase) UpdateDomainDLQAckLevel(
-	lastProcessedMessageID int,
+	lastProcessedMessageID int64,
 ) error {
 
 	return s.DomainReplicationQueue.UpdateDLQAckLevel(lastProcessedMessageID)
 }
 
 // GetDomainDLQAckLevel returns domain dlq ack level
-func (s *TestBase) GetDomainDLQAckLevel() (int, error) {
+func (s *TestBase) GetDomainDLQAckLevel() (int64, error) {
 	return s.DomainReplicationQueue.GetDLQAckLevel()
 }
 
 // DeleteMessageFromDomainDLQ deletes one message from domain DLQ
 func (s *TestBase) DeleteMessageFromDomainDLQ(
-	messageID int,
+	messageID int64,
 ) error {
 
 	return s.DomainReplicationQueue.DeleteMessageFromDLQ(messageID)
@@ -1540,8 +1540,8 @@ func (s *TestBase) DeleteMessageFromDomainDLQ(
 
 // RangeDeleteMessagesFromDomainDLQ deletes messages from domain DLQ
 func (s *TestBase) RangeDeleteMessagesFromDomainDLQ(
-	firstMessageID int,
-	lastMessageID int,
+	firstMessageID int64,
+	lastMessageID int64,
 ) error {
 
 	return s.DomainReplicationQueue.RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID)

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -140,21 +140,21 @@ type (
 	Queue interface {
 		Closeable
 		EnqueueMessage(messagePayload []byte) error
-		ReadMessages(lastMessageID int, maxCount int) ([]*QueueMessage, error)
-		DeleteMessagesBefore(messageID int) error
-		UpdateAckLevel(messageID int, clusterName string) error
-		GetAckLevels() (map[string]int, error)
-		EnqueueMessageToDLQ(messagePayload []byte) (int, error)
-		ReadMessagesFromDLQ(firstMessageID int, lastMessageID int, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error)
-		DeleteMessageFromDLQ(messageID int) error
-		RangeDeleteMessagesFromDLQ(firstMessageID int, lastMessageID int) error
-		UpdateDLQAckLevel(messageID int, clusterName string) error
-		GetDLQAckLevels() (map[string]int, error)
+		ReadMessages(lastMessageID int64, maxCount int) ([]*QueueMessage, error)
+		DeleteMessagesBefore(messageID int64) error
+		UpdateAckLevel(messageID int64, clusterName string) error
+		GetAckLevels() (map[string]int64, error)
+		EnqueueMessageToDLQ(messagePayload []byte) (int64, error)
+		ReadMessagesFromDLQ(firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error)
+		DeleteMessageFromDLQ(messageID int64) error
+		RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error
+		UpdateDLQAckLevel(messageID int64, clusterName string) error
+		GetDLQAckLevels() (map[string]int64, error)
 	}
 
 	// QueueMessage is the message that stores in the queue
 	QueueMessage struct {
-		ID        int       `json:"message_id"`
+		ID        int64     `json:"message_id"`
 		QueueType QueueType `json:"queue_type"`
 		Payload   []byte    `json:"message_payload"`
 	}

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -1187,7 +1187,7 @@ func (p *queuePersistenceClient) EnqueueMessage(message []byte) error {
 	return err
 }
 
-func (p *queuePersistenceClient) ReadMessages(lastMessageID int, maxCount int) ([]*QueueMessage, error) {
+func (p *queuePersistenceClient) ReadMessages(lastMessageID int64, maxCount int) ([]*QueueMessage, error) {
 	p.metricClient.IncCounter(metrics.PersistenceReadQueueMessagesScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceReadQueueMessagesScope, metrics.PersistenceLatency)
@@ -1201,7 +1201,7 @@ func (p *queuePersistenceClient) ReadMessages(lastMessageID int, maxCount int) (
 	return result, err
 }
 
-func (p *queuePersistenceClient) UpdateAckLevel(messageID int, clusterName string) error {
+func (p *queuePersistenceClient) UpdateAckLevel(messageID int64, clusterName string) error {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateAckLevelScope, metrics.PersistenceLatency)
@@ -1215,7 +1215,7 @@ func (p *queuePersistenceClient) UpdateAckLevel(messageID int, clusterName strin
 	return err
 }
 
-func (p *queuePersistenceClient) GetAckLevels() (map[string]int, error) {
+func (p *queuePersistenceClient) GetAckLevels() (map[string]int64, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetAckLevelScope, metrics.PersistenceLatency)
@@ -1229,7 +1229,7 @@ func (p *queuePersistenceClient) GetAckLevels() (map[string]int, error) {
 	return result, err
 }
 
-func (p *queuePersistenceClient) DeleteMessagesBefore(messageID int) error {
+func (p *queuePersistenceClient) DeleteMessagesBefore(messageID int64) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteQueueMessagesScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteQueueMessagesScope, metrics.PersistenceLatency)
@@ -1243,7 +1243,7 @@ func (p *queuePersistenceClient) DeleteMessagesBefore(messageID int) error {
 	return err
 }
 
-func (p *queuePersistenceClient) EnqueueMessageToDLQ(message []byte) (int, error) {
+func (p *queuePersistenceClient) EnqueueMessageToDLQ(message []byte) (int64, error) {
 	p.metricClient.IncCounter(metrics.PersistenceEnqueueMessageToDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceEnqueueMessageToDLQScope, metrics.PersistenceLatency)
@@ -1257,7 +1257,7 @@ func (p *queuePersistenceClient) EnqueueMessageToDLQ(message []byte) (int, error
 	return messageID, err
 }
 
-func (p *queuePersistenceClient) ReadMessagesFromDLQ(firstMessageID int, lastMessageID int, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error) {
+func (p *queuePersistenceClient) ReadMessagesFromDLQ(firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error) {
 	p.metricClient.IncCounter(metrics.PersistenceReadQueueMessagesFromDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceReadQueueMessagesFromDLQScope, metrics.PersistenceLatency)
@@ -1271,7 +1271,7 @@ func (p *queuePersistenceClient) ReadMessagesFromDLQ(firstMessageID int, lastMes
 	return result, token, err
 }
 
-func (p *queuePersistenceClient) DeleteMessageFromDLQ(messageID int) error {
+func (p *queuePersistenceClient) DeleteMessageFromDLQ(messageID int64) error {
 	p.metricClient.IncCounter(metrics.PersistenceDeleteQueueMessageFromDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceDeleteQueueMessageFromDLQScope, metrics.PersistenceLatency)
@@ -1285,7 +1285,7 @@ func (p *queuePersistenceClient) DeleteMessageFromDLQ(messageID int) error {
 	return err
 }
 
-func (p *queuePersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int, lastMessageID int) error {
+func (p *queuePersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error {
 	p.metricClient.IncCounter(metrics.PersistenceRangeDeleteMessagesFromDLQScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceRangeDeleteMessagesFromDLQScope, metrics.PersistenceLatency)
@@ -1299,7 +1299,7 @@ func (p *queuePersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int, 
 	return err
 }
 
-func (p *queuePersistenceClient) UpdateDLQAckLevel(messageID int, clusterName string) error {
+func (p *queuePersistenceClient) UpdateDLQAckLevel(messageID int64, clusterName string) error {
 	p.metricClient.IncCounter(metrics.PersistenceUpdateDLQAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceUpdateDLQAckLevelScope, metrics.PersistenceLatency)
@@ -1313,7 +1313,7 @@ func (p *queuePersistenceClient) UpdateDLQAckLevel(messageID int, clusterName st
 	return err
 }
 
-func (p *queuePersistenceClient) GetDLQAckLevels() (map[string]int, error) {
+func (p *queuePersistenceClient) GetDLQAckLevels() (map[string]int64, error) {
 	p.metricClient.IncCounter(metrics.PersistenceGetDLQAckLevelScope, metrics.PersistenceRequests)
 
 	sw := p.metricClient.StartTimer(metrics.PersistenceGetDLQAckLevelScope, metrics.PersistenceLatency)

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -763,7 +763,7 @@ func (p *queueRateLimitedPersistenceClient) EnqueueMessage(message []byte) error
 	return p.persistence.EnqueueMessage(message)
 }
 
-func (p *queueRateLimitedPersistenceClient) ReadMessages(lastMessageID int, maxCount int) ([]*QueueMessage, error) {
+func (p *queueRateLimitedPersistenceClient) ReadMessages(lastMessageID int64, maxCount int) ([]*QueueMessage, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
@@ -771,7 +771,7 @@ func (p *queueRateLimitedPersistenceClient) ReadMessages(lastMessageID int, maxC
 	return p.persistence.ReadMessages(lastMessageID, maxCount)
 }
 
-func (p *queueRateLimitedPersistenceClient) UpdateAckLevel(messageID int, clusterName string) error {
+func (p *queueRateLimitedPersistenceClient) UpdateAckLevel(messageID int64, clusterName string) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
@@ -779,7 +779,7 @@ func (p *queueRateLimitedPersistenceClient) UpdateAckLevel(messageID int, cluste
 	return p.persistence.UpdateAckLevel(messageID, clusterName)
 }
 
-func (p *queueRateLimitedPersistenceClient) GetAckLevels() (map[string]int, error) {
+func (p *queueRateLimitedPersistenceClient) GetAckLevels() (map[string]int64, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
@@ -787,7 +787,7 @@ func (p *queueRateLimitedPersistenceClient) GetAckLevels() (map[string]int, erro
 	return p.persistence.GetAckLevels()
 }
 
-func (p *queueRateLimitedPersistenceClient) DeleteMessagesBefore(messageID int) error {
+func (p *queueRateLimitedPersistenceClient) DeleteMessagesBefore(messageID int64) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
@@ -795,7 +795,7 @@ func (p *queueRateLimitedPersistenceClient) DeleteMessagesBefore(messageID int) 
 	return p.persistence.DeleteMessagesBefore(messageID)
 }
 
-func (p *queueRateLimitedPersistenceClient) EnqueueMessageToDLQ(message []byte) (int, error) {
+func (p *queueRateLimitedPersistenceClient) EnqueueMessageToDLQ(message []byte) (int64, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return emptyMessageID, ErrPersistenceLimitExceeded
 	}
@@ -803,7 +803,7 @@ func (p *queueRateLimitedPersistenceClient) EnqueueMessageToDLQ(message []byte) 
 	return p.persistence.EnqueueMessageToDLQ(message)
 }
 
-func (p *queueRateLimitedPersistenceClient) ReadMessagesFromDLQ(firstMessageID int, lastMessageID int, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error) {
+func (p *queueRateLimitedPersistenceClient) ReadMessagesFromDLQ(firstMessageID int64, lastMessageID int64, pageSize int, pageToken []byte) ([]*QueueMessage, []byte, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, nil, ErrPersistenceLimitExceeded
 	}
@@ -811,14 +811,14 @@ func (p *queueRateLimitedPersistenceClient) ReadMessagesFromDLQ(firstMessageID i
 	return p.persistence.ReadMessagesFromDLQ(firstMessageID, lastMessageID, pageSize, pageToken)
 }
 
-func (p *queueRateLimitedPersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int, lastMessageID int) error {
+func (p *queueRateLimitedPersistenceClient) RangeDeleteMessagesFromDLQ(firstMessageID int64, lastMessageID int64) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
 
 	return p.persistence.RangeDeleteMessagesFromDLQ(firstMessageID, lastMessageID)
 }
-func (p *queueRateLimitedPersistenceClient) UpdateDLQAckLevel(messageID int, clusterName string) error {
+func (p *queueRateLimitedPersistenceClient) UpdateDLQAckLevel(messageID int64, clusterName string) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
@@ -826,7 +826,7 @@ func (p *queueRateLimitedPersistenceClient) UpdateDLQAckLevel(messageID int, clu
 	return p.persistence.UpdateDLQAckLevel(messageID, clusterName)
 }
 
-func (p *queueRateLimitedPersistenceClient) GetDLQAckLevels() (map[string]int, error) {
+func (p *queueRateLimitedPersistenceClient) GetDLQAckLevels() (map[string]int64, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
@@ -834,7 +834,7 @@ func (p *queueRateLimitedPersistenceClient) GetDLQAckLevels() (map[string]int, e
 	return p.persistence.GetDLQAckLevels()
 }
 
-func (p *queueRateLimitedPersistenceClient) DeleteMessageFromDLQ(messageID int) error {
+func (p *queueRateLimitedPersistenceClient) DeleteMessageFromDLQ(messageID int64) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}

--- a/common/persistence/sql/sqlQueue.go
+++ b/common/persistence/sql/sqlQueue.go
@@ -84,7 +84,7 @@ func (q *sqlQueue) EnqueueMessage(
 }
 
 func (q *sqlQueue) ReadMessages(
-	lastMessageID int,
+	lastMessageID int64,
 	maxCount int,
 ) ([]*persistence.QueueMessage, error) {
 
@@ -102,7 +102,7 @@ func (q *sqlQueue) ReadMessages(
 
 func newQueueRow(
 	queueType persistence.QueueType,
-	messageID int,
+	messageID int64,
 	payload []byte,
 ) *sqlplugin.QueueRow {
 
@@ -110,7 +110,7 @@ func newQueueRow(
 }
 
 func (q *sqlQueue) DeleteMessagesBefore(
-	messageID int,
+	messageID int64,
 ) error {
 
 	_, err := q.db.DeleteMessagesBefore(q.queueType, messageID)
@@ -123,7 +123,7 @@ func (q *sqlQueue) DeleteMessagesBefore(
 }
 
 func (q *sqlQueue) UpdateAckLevel(
-	messageID int,
+	messageID int64,
 	clusterName string,
 ) error {
 
@@ -166,15 +166,15 @@ func (q *sqlQueue) UpdateAckLevel(
 	return nil
 }
 
-func (q *sqlQueue) GetAckLevels() (map[string]int, error) {
+func (q *sqlQueue) GetAckLevels() (map[string]int64, error) {
 	return q.db.GetAckLevels(q.queueType, false)
 }
 
 func (q *sqlQueue) EnqueueMessageToDLQ(
 	messagePayload []byte,
-) (int, error) {
+) (int64, error) {
 
-	var lastMessageID int
+	var lastMessageID int64
 	err := q.txExecute("EnqueueMessageToDLQ", func(tx sqlplugin.Tx) error {
 		var err error
 		lastMessageID, err = tx.GetLastEnqueuedMessageIDForUpdate(q.getDLQTypeFromQueueType())
@@ -195,8 +195,8 @@ func (q *sqlQueue) EnqueueMessageToDLQ(
 }
 
 func (q *sqlQueue) ReadMessagesFromDLQ(
-	firstMessageID int,
-	lastMessageID int,
+	firstMessageID int64,
+	lastMessageID int64,
 	pageSize int,
 	pageToken []byte,
 ) ([]*persistence.QueueMessage, []byte, error) {
@@ -207,7 +207,7 @@ func (q *sqlQueue) ReadMessagesFromDLQ(
 			return nil, nil, &shared.InternalServiceError{
 				Message: fmt.Sprintf("invalid next page token %v", pageToken)}
 		}
-		firstMessageID = int(lastReadMessageID)
+		firstMessageID = lastReadMessageID
 	}
 
 	rows, err := q.db.GetMessagesBetween(q.getDLQTypeFromQueueType(), firstMessageID, lastMessageID, pageSize)
@@ -231,7 +231,7 @@ func (q *sqlQueue) ReadMessagesFromDLQ(
 }
 
 func (q *sqlQueue) DeleteMessageFromDLQ(
-	messageID int,
+	messageID int64,
 ) error {
 
 	_, err := q.db.DeleteMessage(q.getDLQTypeFromQueueType(), messageID)
@@ -244,8 +244,8 @@ func (q *sqlQueue) DeleteMessageFromDLQ(
 }
 
 func (q *sqlQueue) RangeDeleteMessagesFromDLQ(
-	firstMessageID int,
-	lastMessageID int,
+	firstMessageID int64,
+	lastMessageID int64,
 ) error {
 
 	_, err := q.db.RangeDeleteMessages(q.getDLQTypeFromQueueType(), firstMessageID, lastMessageID)
@@ -258,7 +258,7 @@ func (q *sqlQueue) RangeDeleteMessagesFromDLQ(
 }
 
 func (q *sqlQueue) UpdateDLQAckLevel(
-	messageID int,
+	messageID int64,
 	clusterName string,
 ) error {
 
@@ -301,7 +301,7 @@ func (q *sqlQueue) UpdateDLQAckLevel(
 	return nil
 }
 
-func (q *sqlQueue) GetDLQAckLevels() (map[string]int, error) {
+func (q *sqlQueue) GetDLQAckLevels() (map[string]int64, error) {
 
 	return q.db.GetAckLevels(q.getDLQTypeFromQueueType(), false)
 }

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -484,7 +484,7 @@ type (
 	// QueueRow represents a row in queue table
 	QueueRow struct {
 		QueueType      persistence.QueueType
-		MessageID      int
+		MessageID      int64
 		MessagePayload []byte
 	}
 
@@ -691,15 +691,15 @@ type (
 		DeleteFromVisibility(filter *VisibilityFilter) (sql.Result, error)
 
 		InsertIntoQueue(row *QueueRow) (sql.Result, error)
-		GetLastEnqueuedMessageIDForUpdate(queueType persistence.QueueType) (int, error)
-		GetMessagesFromQueue(queueType persistence.QueueType, lastMessageID, maxRows int) ([]QueueRow, error)
-		GetMessagesBetween(queueType persistence.QueueType, firstMessageID int, lastMessageID int, maxRows int) ([]QueueRow, error)
-		DeleteMessagesBefore(queueType persistence.QueueType, messageID int) (sql.Result, error)
-		RangeDeleteMessages(queueType persistence.QueueType, exclusiveBeginMessageID int, inclusiveEndMessageID int) (sql.Result, error)
-		DeleteMessage(queueType persistence.QueueType, messageID int) (sql.Result, error)
-		InsertAckLevel(queueType persistence.QueueType, messageID int, clusterName string) error
-		UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels map[string]int) error
-		GetAckLevels(queueType persistence.QueueType, forUpdate bool) (map[string]int, error)
+		GetLastEnqueuedMessageIDForUpdate(queueType persistence.QueueType) (int64, error)
+		GetMessagesFromQueue(queueType persistence.QueueType, lastMessageID int64, maxRows int) ([]QueueRow, error)
+		GetMessagesBetween(queueType persistence.QueueType, firstMessageID int64, lastMessageID int64, maxRows int) ([]QueueRow, error)
+		DeleteMessagesBefore(queueType persistence.QueueType, messageID int64) (sql.Result, error)
+		RangeDeleteMessages(queueType persistence.QueueType, exclusiveBeginMessageID int64, inclusiveEndMessageID int64) (sql.Result, error)
+		DeleteMessage(queueType persistence.QueueType, messageID int64) (sql.Result, error)
+		InsertAckLevel(queueType persistence.QueueType, messageID int64, clusterName string) error
+		UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels map[string]int64) error
+		GetAckLevels(queueType persistence.QueueType, forUpdate bool) (map[string]int64, error)
 	}
 
 	// adminCRUD defines admin operations for CLI and test suites

--- a/common/persistence/sql/sqlplugin/mysql/queue.go
+++ b/common/persistence/sql/sqlplugin/mysql/queue.go
@@ -48,44 +48,44 @@ func (mdb *db) InsertIntoQueue(row *sqlplugin.QueueRow) (sql.Result, error) {
 }
 
 // GetLastEnqueuedMessageIDForUpdate returns the last enqueued message ID
-func (mdb *db) GetLastEnqueuedMessageIDForUpdate(queueType persistence.QueueType) (int, error) {
-	var lastMessageID int
+func (mdb *db) GetLastEnqueuedMessageIDForUpdate(queueType persistence.QueueType) (int64, error) {
+	var lastMessageID int64
 	err := mdb.conn.Get(&lastMessageID, templateGetLastMessageIDQuery, queueType)
 	return lastMessageID, err
 }
 
 // GetMessagesFromQueue retrieves messages from the queue
-func (mdb *db) GetMessagesFromQueue(queueType persistence.QueueType, lastMessageID, maxRows int) ([]sqlplugin.QueueRow, error) {
+func (mdb *db) GetMessagesFromQueue(queueType persistence.QueueType, lastMessageID int64, maxRows int) ([]sqlplugin.QueueRow, error) {
 	var rows []sqlplugin.QueueRow
 	err := mdb.conn.Select(&rows, templateGetMessagesQuery, queueType, lastMessageID, maxRows)
 	return rows, err
 }
 
 // GetMessagesBetween retrieves messages from the queue
-func (mdb *db) GetMessagesBetween(queueType persistence.QueueType, firstMessageID int, lastMessageID int, maxRows int) ([]sqlplugin.QueueRow, error) {
+func (mdb *db) GetMessagesBetween(queueType persistence.QueueType, firstMessageID int64, lastMessageID int64, maxRows int) ([]sqlplugin.QueueRow, error) {
 	var rows []sqlplugin.QueueRow
 	err := mdb.conn.Select(&rows, templateGetMessagesBetweenQuery, queueType, firstMessageID, lastMessageID, maxRows)
 	return rows, err
 }
 
 // DeleteMessagesBefore deletes messages before messageID from the queue
-func (mdb *db) DeleteMessagesBefore(queueType persistence.QueueType, messageID int) (sql.Result, error) {
+func (mdb *db) DeleteMessagesBefore(queueType persistence.QueueType, messageID int64) (sql.Result, error) {
 	return mdb.conn.Exec(templateDeleteMessagesBeforeQuery, queueType, messageID)
 }
 
 // RangeDeleteMessages deletes messages before messageID from the queue
-func (mdb *db) RangeDeleteMessages(queueType persistence.QueueType, exclusiveBeginMessageID int, inclusiveEndMessageID int) (sql.Result, error) {
+func (mdb *db) RangeDeleteMessages(queueType persistence.QueueType, exclusiveBeginMessageID int64, inclusiveEndMessageID int64) (sql.Result, error) {
 	return mdb.conn.Exec(templateRangeDeleteMessagesQuery, queueType, exclusiveBeginMessageID, inclusiveEndMessageID)
 }
 
 // DeleteMessage deletes message with a messageID from the queue
-func (mdb *db) DeleteMessage(queueType persistence.QueueType, messageID int) (sql.Result, error) {
+func (mdb *db) DeleteMessage(queueType persistence.QueueType, messageID int64) (sql.Result, error) {
 	return mdb.conn.Exec(templateDeleteMessageQuery, queueType, messageID)
 }
 
 // InsertAckLevel inserts ack level
-func (mdb *db) InsertAckLevel(queueType persistence.QueueType, messageID int, clusterName string) error {
-	clusterAckLevels := map[string]int{clusterName: messageID}
+func (mdb *db) InsertAckLevel(queueType persistence.QueueType, messageID int64, clusterName string) error {
+	clusterAckLevels := map[string]int64{clusterName: messageID}
 	data, err := json.Marshal(clusterAckLevels)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func (mdb *db) InsertAckLevel(queueType persistence.QueueType, messageID int, cl
 }
 
 // UpdateAckLevels updates cluster ack levels
-func (mdb *db) UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels map[string]int) error {
+func (mdb *db) UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels map[string]int64) error {
 	data, err := json.Marshal(clusterAckLevels)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (mdb *db) UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels
 }
 
 // GetAckLevels returns ack levels for pulling clusters
-func (mdb *db) GetAckLevels(queueType persistence.QueueType, forUpdate bool) (map[string]int, error) {
+func (mdb *db) GetAckLevels(queueType persistence.QueueType, forUpdate bool) (map[string]int64, error) {
 	queryStr := templateGetQueueMetadataQuery
 	if forUpdate {
 		queryStr = templateGetQueueMetadataForUpdateQuery
@@ -124,7 +124,7 @@ func (mdb *db) GetAckLevels(queueType persistence.QueueType, forUpdate bool) (ma
 		return nil, err
 	}
 
-	var clusterAckLevels map[string]int
+	var clusterAckLevels map[string]int64
 	if err := json.Unmarshal(data, &clusterAckLevels); err != nil {
 		return nil, err
 	}

--- a/common/persistence/sql/sqlplugin/postgres/queue.go
+++ b/common/persistence/sql/sqlplugin/postgres/queue.go
@@ -48,44 +48,44 @@ func (pdb *db) InsertIntoQueue(row *sqlplugin.QueueRow) (sql.Result, error) {
 }
 
 // GetLastEnqueuedMessageIDForUpdate returns the last enqueued message ID
-func (pdb *db) GetLastEnqueuedMessageIDForUpdate(queueType persistence.QueueType) (int, error) {
-	var lastMessageID int
+func (pdb *db) GetLastEnqueuedMessageIDForUpdate(queueType persistence.QueueType) (int64, error) {
+	var lastMessageID int64
 	err := pdb.conn.Get(&lastMessageID, templateGetLastMessageIDQuery, queueType)
 	return lastMessageID, err
 }
 
 // GetMessagesFromQueue retrieves messages from the queue
-func (pdb *db) GetMessagesFromQueue(queueType persistence.QueueType, lastMessageID, maxRows int) ([]sqlplugin.QueueRow, error) {
+func (pdb *db) GetMessagesFromQueue(queueType persistence.QueueType, lastMessageID int64, maxRows int) ([]sqlplugin.QueueRow, error) {
 	var rows []sqlplugin.QueueRow
 	err := pdb.conn.Select(&rows, templateGetMessagesQuery, queueType, lastMessageID, maxRows)
 	return rows, err
 }
 
 // GetMessagesBetween retrieves messages from the queue
-func (pdb *db) GetMessagesBetween(queueType persistence.QueueType, firstMessageID int, lastMessageID int, maxRows int) ([]sqlplugin.QueueRow, error) {
+func (pdb *db) GetMessagesBetween(queueType persistence.QueueType, firstMessageID int64, lastMessageID int64, maxRows int) ([]sqlplugin.QueueRow, error) {
 	var rows []sqlplugin.QueueRow
 	err := pdb.conn.Select(&rows, templateGetMessagesBetweenQuery, queueType, firstMessageID, lastMessageID, maxRows)
 	return rows, err
 }
 
 // DeleteMessagesBefore deletes messages before messageID from the queue
-func (pdb *db) DeleteMessagesBefore(queueType persistence.QueueType, messageID int) (sql.Result, error) {
+func (pdb *db) DeleteMessagesBefore(queueType persistence.QueueType, messageID int64) (sql.Result, error) {
 	return pdb.conn.Exec(templateDeleteMessagesBeforeQuery, queueType, messageID)
 }
 
 // RangeDeleteMessages deletes messages before messageID from the queue
-func (pdb *db) RangeDeleteMessages(queueType persistence.QueueType, exclusiveBeginMessageID int, inclusiveEndMessageID int) (sql.Result, error) {
+func (pdb *db) RangeDeleteMessages(queueType persistence.QueueType, exclusiveBeginMessageID int64, inclusiveEndMessageID int64) (sql.Result, error) {
 	return pdb.conn.Exec(templateRangeDeleteMessagesQuery, queueType, exclusiveBeginMessageID, inclusiveEndMessageID)
 }
 
 // DeleteMessage deletes message with a messageID from the queue
-func (pdb *db) DeleteMessage(queueType persistence.QueueType, messageID int) (sql.Result, error) {
+func (pdb *db) DeleteMessage(queueType persistence.QueueType, messageID int64) (sql.Result, error) {
 	return pdb.conn.Exec(templateDeleteMessageQuery, queueType, messageID)
 }
 
 // InsertAckLevel inserts ack level
-func (pdb *db) InsertAckLevel(queueType persistence.QueueType, messageID int, clusterName string) error {
-	clusterAckLevels := map[string]int{clusterName: messageID}
+func (pdb *db) InsertAckLevel(queueType persistence.QueueType, messageID int64, clusterName string) error {
+	clusterAckLevels := map[string]int64{clusterName: messageID}
 	data, err := json.Marshal(clusterAckLevels)
 	if err != nil {
 		return err
@@ -97,7 +97,7 @@ func (pdb *db) InsertAckLevel(queueType persistence.QueueType, messageID int, cl
 }
 
 // UpdateAckLevels updates cluster ack levels
-func (pdb *db) UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels map[string]int) error {
+func (pdb *db) UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels map[string]int64) error {
 	data, err := json.Marshal(clusterAckLevels)
 	if err != nil {
 		return err
@@ -108,7 +108,7 @@ func (pdb *db) UpdateAckLevels(queueType persistence.QueueType, clusterAckLevels
 }
 
 // GetAckLevels returns ack levels for pulling clusters
-func (pdb *db) GetAckLevels(queueType persistence.QueueType, forUpdate bool) (map[string]int, error) {
+func (pdb *db) GetAckLevels(queueType persistence.QueueType, forUpdate bool) (map[string]int64, error) {
 	queryStr := templateGetQueueMetadataQuery
 	if forUpdate {
 		queryStr = templateGetQueueMetadataForUpdateQuery
@@ -124,7 +124,7 @@ func (pdb *db) GetAckLevels(queueType persistence.QueueType, forUpdate bool) (ma
 		return nil, err
 	}
 
-	var clusterAckLevels map[string]int
+	var clusterAckLevels map[string]int64
 	if err := json.Unmarshal(data, &clusterAckLevels); err != nil {
 		return nil, err
 	}

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -452,7 +452,7 @@ INSERT INTO domains (
 
 CREATE TABLE queue (
   queue_type      int,
-  message_id      int,
+  message_id      bigint,
   message_payload blob,
   PRIMARY KEY  (queue_type, message_id)
 ) WITH COMPACTION = {

--- a/schema/cassandra/cadence/versioned/v0.26/domain_dlq_id.cql
+++ b/schema/cassandra/cadence/versioned/v0.26/domain_dlq_id.cql
@@ -1,0 +1,2 @@
+ALTER TYPE shard ADD replication_dlq_ack_level map<text, bigint>;
+ALTER TABLE queue ALTER message_id TYPE bigint;

--- a/schema/cassandra/cadence/versioned/v0.26/domain_dlq_id.cql
+++ b/schema/cassandra/cadence/versioned/v0.26/domain_dlq_id.cql
@@ -1,2 +1,9 @@
-ALTER TYPE shard ADD replication_dlq_ack_level map<text, bigint>;
-ALTER TABLE queue ALTER message_id TYPE bigint;
+DROP TABLE queue;
+CREATE TABLE queue (
+  queue_type      int,
+  message_id      bigint,
+  message_payload blob,
+  PRIMARY KEY  (queue_type, message_id)
+) WITH COMPACTION = {
+    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+  };

--- a/schema/cassandra/cadence/versioned/v0.26/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.26/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.26",
+  "MinCompatibleVersion": "0.26",
+  "Description": "Alter domain DLQ message ID type to big integer",
+  "SchemaUpdateCqlFiles": [
+    "domain_dlq_id.cql"
+  ]
+}

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -23,7 +23,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.25"
+const Version = "0.26"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.4"

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -688,7 +688,7 @@ func (adh *AdminHandler) GetDomainReplicationMessages(
 
 	lastMessageID := defaultLastMessageID
 	if request.IsSetLastRetrievedMessageId() {
-		lastMessageID = int(request.GetLastRetrievedMessageId())
+		lastMessageID = request.GetLastRetrievedMessageId()
 	}
 
 	if lastMessageID == defaultLastMessageID {
@@ -708,7 +708,7 @@ func (adh *AdminHandler) GetDomainReplicationMessages(
 
 	lastProcessedMessageID := defaultLastMessageID
 	if request.IsSetLastProcessedMessageId() {
-		lastProcessedMessageID = int(request.GetLastProcessedMessageId())
+		lastProcessedMessageID = request.GetLastProcessedMessageId()
 	}
 
 	if lastProcessedMessageID != defaultLastMessageID {
@@ -832,7 +832,7 @@ func (adh *AdminHandler) ReadDLQMessages(
 			default:
 				var err error
 				tasks, token, err = adh.domainDLQHandler.Read(
-					int(request.GetInclusiveEndMessageID()),
+					request.GetInclusiveEndMessageID(),
 					int(request.GetMaximumPageSize()),
 					request.GetNextPageToken())
 				return err
@@ -885,7 +885,7 @@ func (adh *AdminHandler) PurgeDLQMessages(
 				return ctx.Err()
 			default:
 				return adh.domainDLQHandler.Purge(
-					int(request.GetInclusiveEndMessageID()),
+					request.GetInclusiveEndMessageID(),
 				)
 			}
 		}
@@ -936,7 +936,7 @@ func (adh *AdminHandler) MergeDLQMessages(
 			default:
 				var err error
 				token, err = adh.domainDLQHandler.Merge(
-					int(request.GetInclusiveEndMessageID()),
+					request.GetInclusiveEndMessageID(),
 					int(request.GetMaximumPageSize()),
 					request.GetNextPageToken(),
 				)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -55,7 +55,7 @@ import (
 
 const (
 	getDomainReplicationMessageBatchSize = 100
-	defaultLastMessageID                 = -1
+	defaultLastMessageID                 = int64(-1)
 )
 
 const (

--- a/tools/common/schema/updatetask.go
+++ b/tools/common/schema/updatetask.go
@@ -72,7 +72,7 @@ const (
 )
 
 var (
-	whitelistedCQLPrefixes = [3]string{"CREATE", "ALTER", "INSERT"}
+	whitelistedCQLPrefixes = [4]string{"CREATE", "ALTER", "INSERT", "DROP"}
 )
 
 // NewUpdateSchemaTask returns a new instance of UpdateTask


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use int64 for domain max message id in Cassandra

<!-- Tell your future self why have you made these changes -->
**Why?**
The message id type is different in mysql and cassandra. We should use the same type in all persistence.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
integration tests and local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The feature is not enabled
