### PR TITLE
matching: per task list metrics

### DIFF
--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -104,7 +104,8 @@ func (m *ClientImpl) UpdateGauge(scopeIdx int, gaugeIdx int, value float64) {
 // Scope return a new internal metrics scope that can be used to add additional
 // information to the metrics emitted
 func (m *ClientImpl) Scope(scopeIdx int, tags ...Tag) Scope {
-	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs, false, false).Tagged(tags...)
+	scope := m.childScopes[scopeIdx]
+	return newMetricsScope(scope, scope, m.metricDefs, false).Tagged(tags...)
 }
 
 func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {

--- a/common/metrics/client.go
+++ b/common/metrics/client.go
@@ -104,7 +104,7 @@ func (m *ClientImpl) UpdateGauge(scopeIdx int, gaugeIdx int, value float64) {
 // Scope return a new internal metrics scope that can be used to add additional
 // information to the metrics emitted
 func (m *ClientImpl) Scope(scopeIdx int, tags ...Tag) Scope {
-	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs, false).Tagged(tags...)
+	return newMetricsScope(m.childScopes[scopeIdx], m.metricDefs, false, false).Tagged(tags...)
 }
 
 func getMetricDefs(serviceIdx ServiceIdx) map[int]metricDefinition {

--- a/common/metrics/defs_test.go
+++ b/common/metrics/defs_test.go
@@ -85,7 +85,7 @@ func TestMetricDefsMapped(t *testing.T) {
 		require.True(t, ok)
 		require.NotEmpty(t, key)
 	}
-	for i := PollSuccessCounter; i < NumMatchingMetrics; i++ {
+	for i := PollSuccessPerTaskListCounter; i < NumMatchingMetrics; i++ {
 		key, ok := MetricDefs[Matching][i]
 		require.True(t, ok)
 		require.NotEmpty(t, key)

--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -69,3 +69,10 @@ type (
 		Tagged(tags ...Tag) Scope
 	}
 )
+
+var sanitizer = tally.NewSanitizer(tally.SanitizeOptions{
+	NameCharacters:       tally.ValidCharacters{tally.AlphanumericRange, tally.UnderscoreCharacters},
+	KeyCharacters:        tally.ValidCharacters{tally.AlphanumericRange, tally.UnderscoreCharacters},
+	ValueCharacters:      tally.ValidCharacters{tally.AlphanumericRange, tally.UnderscoreCharacters},
+	ReplacementCharacter: '_',
+})

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -35,9 +35,8 @@ const (
 	activityType  = "activityType"
 	decisionType  = "decisionType"
 
-	domainAllValue   = "all"
-	taskListAllValue = "all"
-	unknownValue     = "_unknown_"
+	domainAllValue = "all"
+	unknownValue   = "_unknown_"
 )
 
 // Tag is an interface to define metrics tags

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -35,8 +35,9 @@ const (
 	activityType  = "activityType"
 	decisionType  = "decisionType"
 
-	domainAllValue = "all"
-	unknownValue   = "_unknown_"
+	domainAllValue   = "all"
+	taskListAllValue = "all"
+	unknownValue     = "_unknown_"
 )
 
 // Tag is an interface to define metrics tags

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -53,6 +53,8 @@ type (
 
 	domainUnknownTag struct{}
 
+	taskListUnknownTag struct{}
+
 	instanceTag struct {
 		value string
 	}
@@ -104,6 +106,21 @@ func DomainUnknownTag() Tag {
 }
 
 // Key returns the key of the domain unknown tag
+func (d taskListUnknownTag) Key() string {
+	return domain
+}
+
+// Value returns the value of the domain unknown tag
+func (d taskListUnknownTag) Value() string {
+	return unknownValue
+}
+
+// TaskListUnknownTag returns a new tasklist:unknown tag-value
+func TaskListUnknownTag() Tag {
+	return taskListUnknownTag{}
+}
+
+// Key returns the key of the domain unknown tag
 func (d domainUnknownTag) Key() string {
 	return domain
 }
@@ -151,7 +168,7 @@ func TaskListTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return taskListTag{value}
+	return taskListTag{sanitizer.Value(value)}
 }
 
 // Key returns the key of the task list tag

--- a/service/matching/context.go
+++ b/service/matching/context.go
@@ -1,0 +1,120 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	"context"
+	"sync"
+
+	"github.com/uber/cadence/common/metrics"
+
+	gen "github.com/uber/cadence/.gen/go/shared"
+)
+
+type handlerContext struct {
+	context.Context
+	scope metrics.Scope
+}
+
+var stickyTaskListMetricTag = metrics.TaskListTag("__sticky__")
+
+func newHandlerContext(
+	ctx context.Context,
+	domain string,
+	taskList *gen.TaskList,
+	metricsClient metrics.Client,
+	metricsScope int,
+) *handlerContext {
+	return &handlerContext{
+		Context: ctx,
+		scope:   newPerTaskListScope(domain, taskList.GetName(), taskList.GetKind(), metricsClient, metricsScope),
+	}
+}
+
+func newPerTaskListScope(
+	domain string,
+	taskListName string,
+	taskListKind gen.TaskListKind,
+	client metrics.Client,
+	scopeIdx int,
+) metrics.Scope {
+	domainTag := metrics.DomainUnknownTag()
+	taskListTag := metrics.TaskListUnknownTag()
+	if domain != "" {
+		domainTag = metrics.DomainTag(domain)
+	}
+	if taskListName != "" && taskListKind != gen.TaskListKindSticky {
+		taskListTag = metrics.TaskListTag(taskListName)
+	}
+	if taskListKind == gen.TaskListKindSticky {
+		taskListTag = stickyTaskListMetricTag
+	}
+	return client.Scope(scopeIdx, domainTag, taskListTag)
+}
+
+// startProfiling initiates recording of request metrics
+func (reqCtx *handlerContext) startProfiling(wg *sync.WaitGroup) metrics.Stopwatch {
+	wg.Wait()
+	sw := reqCtx.scope.StartTimer(metrics.CadenceLatencyPerTaskList)
+	reqCtx.scope.IncCounter(metrics.CadenceRequestsPerTaskList)
+	return sw
+}
+
+func (reqCtx *handlerContext) handleErr(err error) error {
+	if err == nil {
+		return nil
+	}
+
+	scope := reqCtx.scope
+
+	switch err.(type) {
+	case *gen.InternalServiceError:
+		scope.IncCounter(metrics.CadenceFailuresPerTaskList)
+		return err
+	case *gen.BadRequestError:
+		scope.IncCounter(metrics.CadenceErrBadRequestPerTaskListCounter)
+		return err
+	case *gen.EntityNotExistsError:
+		scope.IncCounter(metrics.CadenceErrEntityNotExistsPerTaskListCounter)
+		return err
+	case *gen.WorkflowExecutionAlreadyStartedError:
+		scope.IncCounter(metrics.CadenceErrExecutionAlreadyStartedPerTaskListCounter)
+		return err
+	case *gen.DomainAlreadyExistsError:
+		scope.IncCounter(metrics.CadenceErrDomainAlreadyExistsPerTaskListCounter)
+		return err
+	case *gen.QueryFailedError:
+		scope.IncCounter(metrics.CadenceErrQueryFailedPerTaskListCounter)
+		return err
+	case *gen.LimitExceededError:
+		scope.IncCounter(metrics.CadenceErrLimitExceededPerTaskListCounter)
+		return err
+	case *gen.ServiceBusyError:
+		scope.IncCounter(metrics.CadenceErrServiceBusyPerTaskListCounter)
+		return err
+	case *gen.DomainNotActiveError:
+		scope.IncCounter(metrics.CadenceErrDomainNotActivePerTaskListCounter)
+		return err
+	default:
+		scope.IncCounter(metrics.CadenceFailuresPerTaskList)
+		return &gen.InternalServiceError{Message: err.Error()}
+	}
+}

--- a/service/matching/forwarder.go
+++ b/service/matching/forwarder.go
@@ -28,7 +28,6 @@ import (
 	gen "github.com/uber/cadence/.gen/go/matching"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client/matching"
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
@@ -59,15 +58,6 @@ type (
 		// todo: implement a rate limiter that automatically
 		// adjusts rate based on ServiceBusy errors from API calls
 		limiter *quotas.DynamicRateLimiter
-
-		// cached metric scopes for API calls
-		//nolint
-		scope struct {
-			forwardTask  metrics.Scope
-			forwardQuery metrics.Scope
-			forwardPoll  metrics.Scope
-		}
-		scopeFunc func() metrics.Scope
 	}
 	// ForwarderReqToken is the token that must be acquired before
 	// making forwarder API calls. This type contains the state
@@ -102,7 +92,6 @@ func newForwarder(
 	taskListID *taskListID,
 	kind shared.TaskListKind,
 	client matching.Client,
-	scopeFunc func() metrics.Scope,
 ) *Forwarder {
 	rpsFunc := func() float64 { return float64(cfg.ForwarderMaxRatePerSecond()) }
 	fwdr := &Forwarder{
@@ -113,7 +102,6 @@ func newForwarder(
 		outstandingTasksLimit: int32(cfg.ForwarderMaxOutstandingTasks()),
 		outstandingPollsLimit: int32(cfg.ForwarderMaxOutstandingPolls()),
 		limiter:               quotas.NewDynamicRateLimiter(rpsFunc),
-		scopeFunc:             scopeFunc,
 	}
 	fwdr.addReqToken.Store(newForwarderReqToken(cfg.ForwarderMaxOutstandingTasks()))
 	fwdr.pollReqToken.Store(newForwarderReqToken(cfg.ForwarderMaxOutstandingPolls()))

--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/uber/cadence/.gen/go/matching/matchingservicetest"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 )
 
@@ -63,8 +62,7 @@ func (t *ForwarderTestSuite) SetupTest() {
 		ForwarderMaxOutstandingTasks: func() int { return 1 },
 	}
 	t.taskList = newTestTaskListID("fwdr", "tl0", persistence.TaskListTypeDecision)
-	scope := func() metrics.Scope { return metrics.NoopScope(metrics.Matching) }
-	t.fwdr = newForwarder(t.cfg, t.taskList, shared.TaskListKindNormal, t.client, scope)
+	t.fwdr = newForwarder(t.cfg, t.taskList, shared.TaskListKindNormal, t.client)
 }
 
 func (t *ForwarderTestSuite) TearDownTest() {

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -122,7 +122,10 @@ func (h *Handler) newHandlerContext(
 }
 
 // AddActivityTask - adds an activity task.
-func (h *Handler) AddActivityTask(ctx context.Context, request *m.AddActivityTaskRequest) (retError error) {
+func (h *Handler) AddActivityTask(
+	ctx context.Context,
+	request *m.AddActivityTaskRequest,
+) (retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	startT := time.Now()
 	hCtx := h.newHandlerContext(

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -25,8 +25,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/uber-go/tally"
-
 	"github.com/uber/cadence/.gen/go/health"
 	"github.com/uber/cadence/.gen/go/health/metaserver"
 	m "github.com/uber/cadence/.gen/go/matching"
@@ -108,76 +106,105 @@ func (h *Handler) Health(ctx context.Context) (*health.HealthStatus, error) {
 	return hs, nil
 }
 
-// startRequestProfile initiates recording of request metrics
-func (h *Handler) startRequestProfile(api string, scope int) tally.Stopwatch {
-	h.startWG.Wait()
-	sw := h.metricsClient.StartTimer(scope, metrics.CadenceLatency)
-	h.metricsClient.IncCounter(scope, metrics.CadenceRequests)
-	return sw
+func (h *Handler) newHandlerContext(
+	ctx context.Context,
+	domainID string,
+	taskList *gen.TaskList,
+	scope int,
+) *handlerContext {
+	return newHandlerContext(
+		ctx,
+		h.domainName(domainID),
+		taskList,
+		h.metricsClient,
+		scope,
+	)
 }
 
 // AddActivityTask - adds an activity task.
-func (h *Handler) AddActivityTask(ctx context.Context, addRequest *m.AddActivityTaskRequest) (retError error) {
+func (h *Handler) AddActivityTask(ctx context.Context, request *m.AddActivityTaskRequest) (retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	startT := time.Now()
-	scope := metrics.MatchingAddActivityTaskScope
-	sw := h.startRequestProfile("AddActivityTask", scope)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetTaskList(),
+		metrics.MatchingAddActivityTaskScope,
+	)
+
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
-	if addRequest.GetForwardedFrom() != "" {
-		h.metricsClient.IncCounter(scope, metrics.ForwardedCounter)
+	if request.GetForwardedFrom() != "" {
+		hCtx.scope.IncCounter(metrics.ForwardedPerTaskListCounter)
 	}
 
 	if ok := h.rateLimiter.Allow(); !ok {
-		return h.handleErr(errMatchingHostThrottle, scope)
+		return hCtx.handleErr(errMatchingHostThrottle)
 	}
 
-	syncMatch, err := h.engine.AddActivityTask(ctx, addRequest)
+	syncMatch, err := h.engine.AddActivityTask(hCtx, request)
 	if syncMatch {
-		h.metricsClient.RecordTimer(scope, metrics.SyncMatchLatency, time.Since(startT))
+		hCtx.scope.RecordTimer(metrics.SyncMatchLatencyPerTaskList, time.Since(startT))
 	}
 
-	return h.handleErr(err, scope)
+	return hCtx.handleErr(err)
 }
 
 // AddDecisionTask - adds a decision task.
-func (h *Handler) AddDecisionTask(ctx context.Context, addRequest *m.AddDecisionTaskRequest) (retError error) {
+func (h *Handler) AddDecisionTask(
+	ctx context.Context,
+	request *m.AddDecisionTaskRequest,
+) (retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	startT := time.Now()
-	scope := metrics.MatchingAddDecisionTaskScope
-	sw := h.startRequestProfile("AddDecisionTask", scope)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetTaskList(),
+		metrics.MatchingAddDecisionTaskScope,
+	)
+
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
-	if addRequest.GetForwardedFrom() != "" {
-		h.metricsClient.IncCounter(scope, metrics.ForwardedCounter)
+	if request.GetForwardedFrom() != "" {
+		hCtx.scope.IncCounter(metrics.ForwardedPerTaskListCounter)
 	}
 
 	if ok := h.rateLimiter.Allow(); !ok {
-		return h.handleErr(errMatchingHostThrottle, scope)
+		return hCtx.handleErr(errMatchingHostThrottle)
 	}
 
-	syncMatch, err := h.engine.AddDecisionTask(ctx, addRequest)
+	syncMatch, err := h.engine.AddDecisionTask(hCtx, request)
 	if syncMatch {
-		h.metricsClient.RecordTimer(scope, metrics.SyncMatchLatency, time.Since(startT))
+		hCtx.scope.RecordTimer(metrics.SyncMatchLatencyPerTaskList, time.Since(startT))
 	}
-	return h.handleErr(err, scope)
+	return hCtx.handleErr(err)
 }
 
 // PollForActivityTask - long poll for an activity task.
-func (h *Handler) PollForActivityTask(ctx context.Context,
-	pollRequest *m.PollForActivityTaskRequest) (resp *gen.PollForActivityTaskResponse, retError error) {
+func (h *Handler) PollForActivityTask(
+	ctx context.Context,
+	request *m.PollForActivityTaskRequest,
+) (resp *gen.PollForActivityTaskResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetPollRequest().GetTaskList(),
+		metrics.MatchingPollForActivityTaskScope,
+	)
 
-	scope := metrics.MatchingPollForActivityTaskScope
-	sw := h.startRequestProfile("PollForActivityTask", scope)
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
-	if pollRequest.GetForwardedFrom() != "" {
-		h.metricsClient.IncCounter(scope, metrics.ForwardedCounter)
+	if request.GetForwardedFrom() != "" {
+		hCtx.scope.IncCounter(metrics.ForwardedPerTaskListCounter)
 	}
 
 	if ok := h.rateLimiter.Allow(); !ok {
-		return nil, h.handleErr(errMatchingHostThrottle, scope)
+		return nil, hCtx.handleErr(errMatchingHostThrottle)
 	}
 
 	if _, err := common.ValidateLongPollContextTimeoutIsSet(
@@ -185,28 +212,35 @@ func (h *Handler) PollForActivityTask(ctx context.Context,
 		"PollForActivityTask",
 		h.Resource.GetThrottledLogger(),
 	); err != nil {
-		return nil, h.handleErr(err, scope)
+		return nil, hCtx.handleErr(err)
 	}
 
-	response, err := h.engine.PollForActivityTask(ctx, pollRequest)
-	return response, h.handleErr(err, scope)
+	response, err := h.engine.PollForActivityTask(hCtx, request)
+	return response, hCtx.handleErr(err)
 }
 
 // PollForDecisionTask - long poll for a decision task.
-func (h *Handler) PollForDecisionTask(ctx context.Context,
-	pollRequest *m.PollForDecisionTaskRequest) (resp *m.PollForDecisionTaskResponse, retError error) {
+func (h *Handler) PollForDecisionTask(
+	ctx context.Context,
+	request *m.PollForDecisionTaskRequest,
+) (resp *m.PollForDecisionTaskResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetPollRequest().GetTaskList(),
+		metrics.MatchingPollForDecisionTaskScope,
+	)
 
-	scope := metrics.MatchingPollForDecisionTaskScope
-	sw := h.startRequestProfile("PollForDecisionTask", scope)
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
-	if pollRequest.GetForwardedFrom() != "" {
-		h.metricsClient.IncCounter(scope, metrics.ForwardedCounter)
+	if request.GetForwardedFrom() != "" {
+		hCtx.scope.IncCounter(metrics.ForwardedPerTaskListCounter)
 	}
 
 	if ok := h.rateLimiter.Allow(); !ok {
-		return nil, h.handleErr(errMatchingHostThrottle, scope)
+		return nil, hCtx.handleErr(errMatchingHostThrottle)
 	}
 
 	if _, err := common.ValidateLongPollContextTimeoutIsSet(
@@ -214,130 +248,140 @@ func (h *Handler) PollForDecisionTask(ctx context.Context,
 		"PollForDecisionTask",
 		h.Resource.GetThrottledLogger(),
 	); err != nil {
-		return nil, h.handleErr(err, scope)
+		return nil, hCtx.handleErr(err)
 	}
 
-	response, err := h.engine.PollForDecisionTask(ctx, pollRequest)
-	return response, h.handleErr(err, scope)
+	response, err := h.engine.PollForDecisionTask(hCtx, request)
+	return response, hCtx.handleErr(err)
 }
 
 // QueryWorkflow queries a given workflow synchronously and return the query result.
-func (h *Handler) QueryWorkflow(ctx context.Context,
-	queryRequest *m.QueryWorkflowRequest) (resp *gen.QueryWorkflowResponse, retError error) {
+func (h *Handler) QueryWorkflow(
+	ctx context.Context,
+	request *m.QueryWorkflowRequest,
+) (resp *gen.QueryWorkflowResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
-	scope := metrics.MatchingQueryWorkflowScope
-	sw := h.startRequestProfile("QueryWorkflow", scope)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetTaskList(),
+		metrics.MatchingQueryWorkflowScope,
+	)
+
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
-	if queryRequest.GetForwardedFrom() != "" {
-		h.metricsClient.IncCounter(scope, metrics.ForwardedCounter)
+	if request.GetForwardedFrom() != "" {
+		hCtx.scope.IncCounter(metrics.ForwardedPerTaskListCounter)
 	}
 
 	if ok := h.rateLimiter.Allow(); !ok {
-		return nil, h.handleErr(errMatchingHostThrottle, scope)
+		return nil, hCtx.handleErr(errMatchingHostThrottle)
 	}
 
-	response, err := h.engine.QueryWorkflow(ctx, queryRequest)
-	return response, h.handleErr(err, scope)
+	response, err := h.engine.QueryWorkflow(hCtx, request)
+	return response, hCtx.handleErr(err)
 }
 
 // RespondQueryTaskCompleted responds a query task completed
-func (h *Handler) RespondQueryTaskCompleted(ctx context.Context, request *m.RespondQueryTaskCompletedRequest) (retError error) {
+func (h *Handler) RespondQueryTaskCompleted(
+	ctx context.Context,
+	request *m.RespondQueryTaskCompletedRequest,
+) (retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
-	scope := metrics.MatchingRespondQueryTaskCompletedScope
-	sw := h.startRequestProfile("RespondQueryTaskCompleted", scope)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetTaskList(),
+		metrics.MatchingRespondQueryTaskCompletedScope,
+	)
+
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
 	// Count the request in the RPS, but we still accept it even if RPS is exceeded
 	h.rateLimiter.Allow()
 
-	err := h.engine.RespondQueryTaskCompleted(ctx, request)
-	return h.handleErr(err, scope)
+	err := h.engine.RespondQueryTaskCompleted(hCtx, request)
+	return hCtx.handleErr(err)
 }
 
 // CancelOutstandingPoll is used to cancel outstanding pollers
 func (h *Handler) CancelOutstandingPoll(ctx context.Context,
 	request *m.CancelOutstandingPollRequest) (retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
-	scope := metrics.MatchingCancelOutstandingPollScope
-	sw := h.startRequestProfile("CancelOutstandingPoll", scope)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetTaskList(),
+		metrics.MatchingCancelOutstandingPollScope,
+	)
+
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
 	// Count the request in the RPS, but we still accept it even if RPS is exceeded
 	h.rateLimiter.Allow()
 
-	err := h.engine.CancelOutstandingPoll(ctx, request)
-	return h.handleErr(err, scope)
+	err := h.engine.CancelOutstandingPoll(hCtx, request)
+	return hCtx.handleErr(err)
 }
 
 // DescribeTaskList returns information about the target tasklist, right now this API returns the
 // pollers which polled this tasklist in last few minutes. If includeTaskListStatus field is true,
 // it will also return status of tasklist's ackManager (readLevel, ackLevel, backlogCountHint and taskIDBlock).
-func (h *Handler) DescribeTaskList(ctx context.Context, request *m.DescribeTaskListRequest) (resp *gen.DescribeTaskListResponse, retError error) {
+func (h *Handler) DescribeTaskList(
+	ctx context.Context,
+	request *m.DescribeTaskListRequest,
+) (resp *gen.DescribeTaskListResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
-	scope := metrics.MatchingDescribeTaskListScope
-	sw := h.startRequestProfile("DescribeTaskList", scope)
+	hCtx := h.newHandlerContext(
+		ctx,
+		request.GetDomainUUID(),
+		request.GetDescRequest().GetTaskList(),
+		metrics.MatchingDescribeTaskListScope,
+	)
+
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
 	if ok := h.rateLimiter.Allow(); !ok {
-		return nil, h.handleErr(errMatchingHostThrottle, scope)
+		return nil, hCtx.handleErr(errMatchingHostThrottle)
 	}
 
-	response, err := h.engine.DescribeTaskList(ctx, request)
-	return response, h.handleErr(err, scope)
+	response, err := h.engine.DescribeTaskList(hCtx, request)
+	return response, hCtx.handleErr(err)
 }
 
 // ListTaskListPartitions returns information about partitions for a taskList
-func (h *Handler) ListTaskListPartitions(ctx context.Context, request *m.ListTaskListPartitionsRequest) (resp *gen.ListTaskListPartitionsResponse, retError error) {
+func (h *Handler) ListTaskListPartitions(
+	ctx context.Context,
+	request *m.ListTaskListPartitionsRequest,
+) (resp *gen.ListTaskListPartitionsResponse, retError error) {
 	defer log.CapturePanic(h.GetLogger(), &retError)
-	scope := metrics.MatchingListTaskListPartitionsScope
-	sw := h.startRequestProfile("ListTaskListPartitions", scope)
+	hCtx := newHandlerContext(
+		ctx,
+		request.GetDomain(),
+		request.GetTaskList(),
+		h.metricsClient,
+		metrics.MatchingListTaskListPartitionsScope,
+	)
+
+	sw := hCtx.startProfiling(&h.startWG)
 	defer sw.Stop()
 
 	if ok := h.rateLimiter.Allow(); !ok {
-		return nil, h.handleErr(errMatchingHostThrottle, scope)
+		return nil, hCtx.handleErr(errMatchingHostThrottle)
 	}
 
-	response, err := h.engine.ListTaskListPartitions(ctx, request)
-	return response, h.handleErr(err, scope)
+	response, err := h.engine.ListTaskListPartitions(hCtx, request)
+	return response, hCtx.handleErr(err)
 }
 
-func (h *Handler) handleErr(err error, scope int) error {
-
-	if err == nil {
-		return nil
+func (h *Handler) domainName(id string) string {
+	entry, err := h.GetDomainCache().GetDomainByID(id)
+	if err != nil {
+		return ""
 	}
-
-	switch err.(type) {
-	case *gen.InternalServiceError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceFailures)
-		return err
-	case *gen.BadRequestError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrBadRequestCounter)
-		return err
-	case *gen.EntityNotExistsError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrEntityNotExistsCounter)
-		return err
-	case *gen.WorkflowExecutionAlreadyStartedError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrExecutionAlreadyStartedCounter)
-		return err
-	case *gen.DomainAlreadyExistsError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrDomainAlreadyExistsCounter)
-		return err
-	case *gen.QueryFailedError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrQueryFailedCounter)
-		return err
-	case *gen.LimitExceededError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrLimitExceededCounter)
-		return err
-	case *gen.ServiceBusyError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrServiceBusyCounter)
-		return err
-	case *gen.DomainNotActiveError:
-		h.metricsClient.IncCounter(scope, metrics.CadenceErrDomainNotActiveCounter)
-		return err
-	default:
-		h.metricsClient.IncCounter(scope, metrics.CadenceFailures)
-		return &gen.InternalServiceError{Message: err.Error()}
-	}
+	return entry.GetInfo().Name
 }

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -110,7 +110,7 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *internalTask) (bool, err
 	if !task.isForwarded() {
 		rsv, err = tm.ratelimit(ctx)
 		if err != nil {
-			tm.scope().IncCounter(metrics.SyncThrottleCounter)
+			tm.scope().IncCounter(metrics.SyncThrottlePerTaskListCounter)
 			return false, err
 		}
 	}
@@ -316,16 +316,16 @@ func (tm *TaskMatcher) pollOrForward(
 	select {
 	case task := <-taskC:
 		if task.responseC != nil {
-			tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
+			tm.scope().IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
 		}
-		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		tm.scope().IncCounter(metrics.PollSuccessPerTaskListCounter)
 		return task, nil
 	case task := <-queryTaskC:
-		tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
-		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		tm.scope().IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
+		tm.scope().IncCounter(metrics.PollSuccessPerTaskListCounter)
 		return task, nil
 	case <-ctx.Done():
-		tm.scope().IncCounter(metrics.PollTimeoutCounter)
+		tm.scope().IncCounter(metrics.PollTimeoutPerTaskListCounter)
 		return nil, ErrNoTasks
 	case token := <-tm.fwdrPollReqTokenC():
 		if task, err := tm.fwdr.ForwardPoll(ctx); err == nil {
@@ -345,16 +345,16 @@ func (tm *TaskMatcher) poll(
 	select {
 	case task := <-taskC:
 		if task.responseC != nil {
-			tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
+			tm.scope().IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
 		}
-		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		tm.scope().IncCounter(metrics.PollSuccessPerTaskListCounter)
 		return task, nil
 	case task := <-queryTaskC:
-		tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
-		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		tm.scope().IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
+		tm.scope().IncCounter(metrics.PollSuccessPerTaskListCounter)
 		return task, nil
 	case <-ctx.Done():
-		tm.scope().IncCounter(metrics.PollTimeoutCounter)
+		tm.scope().IncCounter(metrics.PollTimeoutPerTaskListCounter)
 		return nil, ErrNoTasks
 	}
 }
@@ -367,13 +367,13 @@ func (tm *TaskMatcher) pollNonBlocking(
 	select {
 	case task := <-taskC:
 		if task.responseC != nil {
-			tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
+			tm.scope().IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
 		}
-		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		tm.scope().IncCounter(metrics.PollSuccessPerTaskListCounter)
 		return task, nil
 	case task := <-queryTaskC:
-		tm.scope().IncCounter(metrics.PollSuccessWithSyncCounter)
-		tm.scope().IncCounter(metrics.PollSuccessCounter)
+		tm.scope().IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
+		tm.scope().IncCounter(metrics.PollSuccessPerTaskListCounter)
 		return task, nil
 	default:
 		return nil, ErrNoTasks

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -68,8 +68,7 @@ func (t *MatcherTestSuite) SetupTest() {
 		ForwarderMaxChildrenPerNode:  func() int { return 20 },
 	}
 	t.cfg = tlCfg
-	scope := func() metrics.Scope { return metrics.NoopScope(metrics.Matching) }
-	t.fwdr = newForwarder(&t.cfg.forwarderConfig, t.taskList, shared.TaskListKindNormal, t.client, scope)
+	t.fwdr = newForwarder(&t.cfg.forwarderConfig, t.taskList, shared.TaskListKindNormal, t.client)
 	t.matcher = newTaskMatcher(tlCfg, t.fwdr, func() metrics.Scope { return metrics.NoopScope(metrics.Matching) })
 
 	rootTaskList := newTestTaskListID(t.taskList.domainID, t.taskList.Parent(20), persistence.TaskListTypeDecision)

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -211,17 +211,17 @@ func (e *matchingEngineImpl) removeTaskListManager(id *taskListID) {
 }
 
 // AddDecisionTask either delivers task directly to waiting poller or save it into task list persistence.
-func (e *matchingEngineImpl) AddDecisionTask(ctx context.Context, addRequest *m.AddDecisionTaskRequest) (bool, error) {
-	domainID := addRequest.GetDomainUUID()
-	taskListName := addRequest.TaskList.GetName()
-	taskListKind := common.TaskListKindPtr(addRequest.TaskList.GetKind())
+func (e *matchingEngineImpl) AddDecisionTask(hCtx *handlerContext, request *m.AddDecisionTaskRequest) (bool, error) {
+	domainID := request.GetDomainUUID()
+	taskListName := request.TaskList.GetName()
+	taskListKind := common.TaskListKindPtr(request.TaskList.GetKind())
 
 	e.logger.Debug(
 		fmt.Sprintf("Received AddDecisionTask for taskList=%v, WorkflowID=%v, RunID=%v, ScheduleToStartTimeout=%v",
-			addRequest.TaskList.GetName(),
-			addRequest.Execution.GetWorkflowId(),
-			addRequest.Execution.GetRunId(),
-			addRequest.GetScheduleToStartTimeoutSeconds()))
+			request.TaskList.GetName(),
+			request.Execution.GetWorkflowId(),
+			request.Execution.GetRunId(),
+			request.GetScheduleToStartTimeoutSeconds()))
 
 	taskList, err := newTaskListID(domainID, taskListName, persistence.TaskListTypeDecision)
 	if err != nil {
@@ -235,32 +235,35 @@ func (e *matchingEngineImpl) AddDecisionTask(ctx context.Context, addRequest *m.
 
 	taskInfo := &persistence.TaskInfo{
 		DomainID:               domainID,
-		RunID:                  addRequest.Execution.GetRunId(),
-		WorkflowID:             addRequest.Execution.GetWorkflowId(),
-		ScheduleID:             addRequest.GetScheduleId(),
-		ScheduleToStartTimeout: addRequest.GetScheduleToStartTimeoutSeconds(),
+		RunID:                  request.Execution.GetRunId(),
+		WorkflowID:             request.Execution.GetWorkflowId(),
+		ScheduleID:             request.GetScheduleId(),
+		ScheduleToStartTimeout: request.GetScheduleToStartTimeoutSeconds(),
 		CreatedTime:            time.Now(),
 	}
-	return tlMgr.AddTask(ctx, addTaskParams{
-		execution:     addRequest.Execution,
+	return tlMgr.AddTask(hCtx.Context, addTaskParams{
+		execution:     request.Execution,
 		taskInfo:      taskInfo,
-		source:        addRequest.GetSource(),
-		forwardedFrom: addRequest.GetForwardedFrom(),
+		source:        request.GetSource(),
+		forwardedFrom: request.GetForwardedFrom(),
 	})
 }
 
 // AddActivityTask either delivers task directly to waiting poller or save it into task list persistence.
-func (e *matchingEngineImpl) AddActivityTask(ctx context.Context, addRequest *m.AddActivityTaskRequest) (bool, error) {
-	domainID := addRequest.GetDomainUUID()
-	sourceDomainID := addRequest.GetSourceDomainUUID()
-	taskListName := addRequest.TaskList.GetName()
-	taskListKind := common.TaskListKindPtr(addRequest.TaskList.GetKind())
+func (e *matchingEngineImpl) AddActivityTask(
+	hCtx *handlerContext,
+	request *m.AddActivityTaskRequest,
+) (bool, error) {
+	domainID := request.GetDomainUUID()
+	sourceDomainID := request.GetSourceDomainUUID()
+	taskListName := request.TaskList.GetName()
+	taskListKind := common.TaskListKindPtr(request.TaskList.GetKind())
 
 	e.logger.Debug(
 		fmt.Sprintf("Received AddActivityTask for taskList=%v WorkflowID=%v, RunID=%v",
 			taskListName,
-			addRequest.Execution.WorkflowId,
-			addRequest.Execution.RunId))
+			request.Execution.WorkflowId,
+			request.Execution.RunId))
 
 	taskList, err := newTaskListID(domainID, taskListName, persistence.TaskListTypeActivity)
 	if err != nil {
@@ -274,23 +277,25 @@ func (e *matchingEngineImpl) AddActivityTask(ctx context.Context, addRequest *m.
 
 	taskInfo := &persistence.TaskInfo{
 		DomainID:               sourceDomainID,
-		RunID:                  addRequest.Execution.GetRunId(),
-		WorkflowID:             addRequest.Execution.GetWorkflowId(),
-		ScheduleID:             addRequest.GetScheduleId(),
-		ScheduleToStartTimeout: addRequest.GetScheduleToStartTimeoutSeconds(),
+		RunID:                  request.Execution.GetRunId(),
+		WorkflowID:             request.Execution.GetWorkflowId(),
+		ScheduleID:             request.GetScheduleId(),
+		ScheduleToStartTimeout: request.GetScheduleToStartTimeoutSeconds(),
 		CreatedTime:            time.Now(),
 	}
-	return tlMgr.AddTask(ctx, addTaskParams{
-		execution:     addRequest.Execution,
+	return tlMgr.AddTask(hCtx.Context, addTaskParams{
+		execution:     request.Execution,
 		taskInfo:      taskInfo,
-		source:        addRequest.GetSource(),
-		forwardedFrom: addRequest.GetForwardedFrom(),
+		source:        request.GetSource(),
+		forwardedFrom: request.GetForwardedFrom(),
 	})
 }
 
 // PollForDecisionTask tries to get the decision task using exponential backoff.
-func (e *matchingEngineImpl) PollForDecisionTask(ctx context.Context, req *m.PollForDecisionTaskRequest) (
-	*m.PollForDecisionTaskResponse, error) {
+func (e *matchingEngineImpl) PollForDecisionTask(
+	hCtx *handlerContext,
+	req *m.PollForDecisionTaskRequest,
+) (*m.PollForDecisionTaskResponse, error) {
 	domainID := req.GetDomainUUID()
 	pollerID := req.GetPollerID()
 	request := req.PollRequest
@@ -298,13 +303,13 @@ func (e *matchingEngineImpl) PollForDecisionTask(ctx context.Context, req *m.Pol
 	e.logger.Debug("Received PollForDecisionTask for taskList", tag.WorkflowTaskListName(taskListName))
 pollLoop:
 	for {
-		err := common.IsValidContext(ctx)
+		err := common.IsValidContext(hCtx.Context)
 		if err != nil {
 			return nil, err
 		}
 		// Add frontend generated pollerID to context so tasklistMgr can support cancellation of
 		// long-poll when frontend calls CancelOutstandingPoll API
-		pollerCtx := context.WithValue(ctx, pollerIDKey, pollerID)
+		pollerCtx := context.WithValue(hCtx.Context, pollerIDKey, pollerID)
 		pollerCtx = context.WithValue(pollerCtx, identityKey, request.GetIdentity())
 		taskList, err := newTaskListID(domainID, taskListName, persistence.TaskListTypeDecision)
 		if err != nil {
@@ -320,7 +325,7 @@ pollLoop:
 			return nil, err
 		}
 
-		e.emitForwardedFromStats(metrics.MatchingPollForDecisionTaskScope, task.isForwarded(), req.GetForwardedFrom())
+		e.emitForwardedFromStats(hCtx.scope, task.isForwarded(), req.GetForwardedFrom())
 
 		if task.isStarted() {
 			// tasks received from remote are already started. So, simply forward the response
@@ -332,7 +337,7 @@ pollLoop:
 
 			// for query task, we don't need to update history to record decision task started. but we need to know
 			// the NextEventID so front end knows what are the history events to load for this decision task.
-			mutableStateResp, err := e.historyService.GetMutableState(ctx, &h.GetMutableStateRequest{
+			mutableStateResp, err := e.historyService.GetMutableState(hCtx.Context, &h.GetMutableStateRequest{
 				DomainUUID: req.DomainUUID,
 				Execution:  task.workflowExecution(),
 			})
@@ -355,10 +360,10 @@ pollLoop:
 				WorkflowExecutionTaskList: mutableStateResp.TaskList,
 				BranchToken:               mutableStateResp.CurrentBranchToken,
 			}
-			return e.createPollForDecisionTaskResponse(task, resp), nil
+			return e.createPollForDecisionTaskResponse(task, resp, hCtx.scope), nil
 		}
 
-		resp, err := e.recordDecisionTaskStarted(ctx, request, task)
+		resp, err := e.recordDecisionTaskStarted(hCtx.Context, request, task)
 		if err != nil {
 			switch err.(type) {
 			case *workflow.EntityNotExistsError, *h.EventAlreadyStartedError:
@@ -372,15 +377,17 @@ pollLoop:
 			continue pollLoop
 		}
 		task.finish(nil)
-		return e.createPollForDecisionTaskResponse(task, resp), nil
+		return e.createPollForDecisionTaskResponse(task, resp, hCtx.scope), nil
 	}
 }
 
 // pollForActivityTaskOperation takes one task from the task manager, update workflow execution history, mark task as
 // completed and return it to user. If a task from task manager is already started, return an empty response, without
 // error. Timeouts handled by the timer queue.
-func (e *matchingEngineImpl) PollForActivityTask(ctx context.Context, req *m.PollForActivityTaskRequest) (
-	*workflow.PollForActivityTaskResponse, error) {
+func (e *matchingEngineImpl) PollForActivityTask(
+	hCtx *handlerContext,
+	req *m.PollForActivityTaskRequest,
+) (*workflow.PollForActivityTaskResponse, error) {
 	domainID := req.GetDomainUUID()
 	pollerID := req.GetPollerID()
 	request := req.PollRequest
@@ -388,7 +395,7 @@ func (e *matchingEngineImpl) PollForActivityTask(ctx context.Context, req *m.Pol
 	e.logger.Debug(fmt.Sprintf("Received PollForActivityTask for taskList=%v", taskListName))
 pollLoop:
 	for {
-		err := common.IsValidContext(ctx)
+		err := common.IsValidContext(hCtx.Context)
 		if err != nil {
 			return nil, err
 		}
@@ -404,7 +411,7 @@ pollLoop:
 		}
 		// Add frontend generated pollerID to context so tasklistMgr can support cancellation of
 		// long-poll when frontend calls CancelOutstandingPoll API
-		pollerCtx := context.WithValue(ctx, pollerIDKey, pollerID)
+		pollerCtx := context.WithValue(hCtx.Context, pollerIDKey, pollerID)
 		pollerCtx = context.WithValue(pollerCtx, identityKey, request.GetIdentity())
 		taskListKind := common.TaskListKindPtr(request.TaskList.GetKind())
 		task, err := e.getTask(pollerCtx, taskList, maxDispatch, taskListKind)
@@ -416,14 +423,14 @@ pollLoop:
 			return nil, err
 		}
 
-		e.emitForwardedFromStats(metrics.MatchingPollForActivityTaskScope, task.isForwarded(), req.GetForwardedFrom())
+		e.emitForwardedFromStats(hCtx.scope, task.isForwarded(), req.GetForwardedFrom())
 
 		if task.isStarted() {
 			// tasks received from remote are already started. So, simply forward the response
 			return task.pollForActivityResponse(), nil
 		}
 
-		resp, err := e.recordActivityTaskStarted(ctx, request, task)
+		resp, err := e.recordActivityTaskStarted(hCtx.Context, request, task)
 		if err != nil {
 			switch err.(type) {
 			case *workflow.EntityNotExistsError, *h.EventAlreadyStartedError:
@@ -437,7 +444,7 @@ pollLoop:
 			continue pollLoop
 		}
 		task.finish(nil)
-		return e.createPollForActivityTaskResponse(task, resp), nil
+		return e.createPollForActivityTaskResponse(task, resp, hCtx.scope), nil
 	}
 }
 
@@ -448,7 +455,10 @@ type queryResult struct {
 
 // QueryWorkflow creates a DecisionTask with query data, send it through sync match channel, wait for that DecisionTask
 // to be processed by worker, and then return the query result.
-func (e *matchingEngineImpl) QueryWorkflow(ctx context.Context, queryRequest *m.QueryWorkflowRequest) (*workflow.QueryWorkflowResponse, error) {
+func (e *matchingEngineImpl) QueryWorkflow(
+	hCtx *handlerContext,
+	queryRequest *m.QueryWorkflowRequest,
+) (*workflow.QueryWorkflowResponse, error) {
 	domainID := queryRequest.GetDomainUUID()
 	taskListName := queryRequest.TaskList.GetName()
 	taskListKind := common.TaskListKindPtr(queryRequest.TaskList.GetKind())
@@ -462,7 +472,7 @@ func (e *matchingEngineImpl) QueryWorkflow(ctx context.Context, queryRequest *m.
 		return nil, err
 	}
 	taskID := uuid.New()
-	resp, err := tlMgr.DispatchQueryTask(ctx, taskID, queryRequest)
+	resp, err := tlMgr.DispatchQueryTask(hCtx.Context, taskID, queryRequest)
 
 	// if get response or error it means that query task was handled by forwarding to another matching host
 	// this remote host's result can be returned directly
@@ -500,14 +510,14 @@ func (e *matchingEngineImpl) QueryWorkflow(ctx context.Context, queryRequest *m.
 		default:
 			return nil, &workflow.InternalServiceError{Message: "unknown query completed type"}
 		}
-	case <-ctx.Done():
-		return nil, ctx.Err()
+	case <-hCtx.Done():
+		return nil, hCtx.Err()
 	}
 }
 
-func (e *matchingEngineImpl) RespondQueryTaskCompleted(ctx context.Context, request *m.RespondQueryTaskCompletedRequest) error {
+func (e *matchingEngineImpl) RespondQueryTaskCompleted(hCtx *handlerContext, request *m.RespondQueryTaskCompletedRequest) error {
 	if err := e.deliverQueryResult(request.GetTaskID(), &queryResult{workerResponse: request}); err != nil {
-		e.metricsClient.IncCounter(metrics.MatchingRespondQueryTaskCompletedScope, metrics.RespondQueryTaskFailedCounter)
+		hCtx.scope.IncCounter(metrics.RespondQueryTaskFailedPerTaskListCounter)
 		return err
 	}
 	return nil
@@ -522,7 +532,10 @@ func (e *matchingEngineImpl) deliverQueryResult(taskID string, queryResult *quer
 	return nil
 }
 
-func (e *matchingEngineImpl) CancelOutstandingPoll(ctx context.Context, request *m.CancelOutstandingPollRequest) error {
+func (e *matchingEngineImpl) CancelOutstandingPoll(
+	hCtx *handlerContext,
+	request *m.CancelOutstandingPollRequest,
+) error {
 	domainID := request.GetDomainUUID()
 	taskListType := int(request.GetTaskListType())
 	taskListName := request.TaskList.GetName()
@@ -542,7 +555,10 @@ func (e *matchingEngineImpl) CancelOutstandingPoll(ctx context.Context, request 
 	return nil
 }
 
-func (e *matchingEngineImpl) DescribeTaskList(ctx context.Context, request *m.DescribeTaskListRequest) (*workflow.DescribeTaskListResponse, error) {
+func (e *matchingEngineImpl) DescribeTaskList(
+	hCtx *handlerContext,
+	request *m.DescribeTaskListRequest,
+) (*workflow.DescribeTaskListResponse, error) {
 	domainID := request.GetDomainUUID()
 	taskListType := persistence.TaskListTypeDecision
 	if request.DescRequest.GetTaskListType() == workflow.TaskListTypeActivity {
@@ -562,7 +578,10 @@ func (e *matchingEngineImpl) DescribeTaskList(ctx context.Context, request *m.De
 	return tlMgr.DescribeTaskList(request.DescRequest.GetIncludeTaskListStatus()), nil
 }
 
-func (e *matchingEngineImpl) ListTaskListPartitions(ctx context.Context, request *m.ListTaskListPartitionsRequest) (*workflow.ListTaskListPartitionsResponse, error) {
+func (e *matchingEngineImpl) ListTaskListPartitions(
+	hCtx *handlerContext,
+	request *m.ListTaskListPartitionsRequest,
+) (*workflow.ListTaskListPartitionsResponse, error) {
 	activityTaskListInfo, err := e.listTaskListPartitions(request, persistence.TaskListTypeActivity)
 	if err != nil {
 		return nil, err
@@ -667,6 +686,7 @@ func (e *matchingEngineImpl) unloadTaskList(id *taskListID) {
 func (e *matchingEngineImpl) createPollForDecisionTaskResponse(
 	task *internalTask,
 	historyResponse *h.RecordDecisionTaskStartedResponse,
+	scope metrics.Scope,
 ) *m.PollForDecisionTaskResponse {
 
 	var token []byte
@@ -689,8 +709,7 @@ func (e *matchingEngineImpl) createPollForDecisionTaskResponse(
 		}
 		token, _ = e.tokenSerializer.Serialize(taskoken)
 		if task.responseC == nil {
-			scope := e.metricsClient.Scope(metrics.MatchingPollForDecisionTaskScope)
-			scope.Tagged(metrics.DomainTag(task.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.event.CreatedTime))
+			scope.RecordTimer(metrics.AsyncMatchLatencyPerTaskList, time.Since(task.event.CreatedTime))
 		}
 	}
 
@@ -706,6 +725,7 @@ func (e *matchingEngineImpl) createPollForDecisionTaskResponse(
 func (e *matchingEngineImpl) createPollForActivityTaskResponse(
 	task *internalTask,
 	historyResponse *h.RecordActivityTaskStartedResponse,
+	scope metrics.Scope,
 ) *workflow.PollForActivityTaskResponse {
 
 	scheduledEvent := historyResponse.ScheduledEvent
@@ -717,8 +737,7 @@ func (e *matchingEngineImpl) createPollForActivityTaskResponse(
 		panic("ActivityTaskScheduledEventAttributes.ActivityID is not set")
 	}
 	if task.responseC == nil {
-		scope := e.metricsClient.Scope(metrics.MatchingPollForActivityTaskScope)
-		scope.Tagged(metrics.DomainTag(task.domainName)).RecordTimer(metrics.AsyncMatchLatency, time.Since(task.event.CreatedTime))
+		scope.RecordTimer(metrics.AsyncMatchLatencyPerTaskList, time.Since(task.event.CreatedTime))
 	}
 
 	response := &workflow.PollForActivityTaskResponse{}
@@ -811,17 +830,21 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 	return resp, err
 }
 
-func (e *matchingEngineImpl) emitForwardedFromStats(scope int, isTaskForwarded bool, pollForwardedFrom string) {
+func (e *matchingEngineImpl) emitForwardedFromStats(
+	scope metrics.Scope,
+	isTaskForwarded bool,
+	pollForwardedFrom string,
+) {
 	isPollForwarded := len(pollForwardedFrom) > 0
 	switch {
 	case isTaskForwarded && isPollForwarded:
-		e.metricsClient.IncCounter(scope, metrics.RemoteToRemoteMatchCounter)
+		scope.IncCounter(metrics.RemoteToRemoteMatchPerTaskListCounter)
 	case isTaskForwarded:
-		e.metricsClient.IncCounter(scope, metrics.RemoteToLocalMatchCounter)
+		scope.IncCounter(metrics.RemoteToLocalMatchPerTaskListCounter)
 	case isPollForwarded:
-		e.metricsClient.IncCounter(scope, metrics.LocalToRemoteMatchCounter)
+		scope.IncCounter(metrics.LocalToRemoteMatchPerTaskListCounter)
 	default:
-		e.metricsClient.IncCounter(scope, metrics.LocalToLocalMatchCounter)
+		scope.IncCounter(metrics.LocalToLocalMatchPerTaskListCounter)
 	}
 }
 

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -211,7 +211,10 @@ func (e *matchingEngineImpl) removeTaskListManager(id *taskListID) {
 }
 
 // AddDecisionTask either delivers task directly to waiting poller or save it into task list persistence.
-func (e *matchingEngineImpl) AddDecisionTask(hCtx *handlerContext, request *m.AddDecisionTaskRequest) (bool, error) {
+func (e *matchingEngineImpl) AddDecisionTask(
+	hCtx *handlerContext,
+	request *m.AddDecisionTaskRequest,
+) (bool, error) {
 	domainID := request.GetDomainUUID()
 	taskListName := request.TaskList.GetName()
 	taskListKind := common.TaskListKindPtr(request.TaskList.GetKind())

--- a/service/matching/matchingEngineInterfaces.go
+++ b/service/matching/matchingEngineInterfaces.go
@@ -21,8 +21,6 @@
 package matching
 
 import (
-	"context"
-
 	m "github.com/uber/cadence/.gen/go/matching"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 )
@@ -31,14 +29,14 @@ type (
 	// Engine exposes interfaces for clients to poll for activity and decision tasks.
 	Engine interface {
 		Stop()
-		AddDecisionTask(ctx context.Context, addRequest *m.AddDecisionTaskRequest) (syncMatch bool, err error)
-		AddActivityTask(ctx context.Context, addRequest *m.AddActivityTaskRequest) (syncMatch bool, err error)
-		PollForDecisionTask(ctx context.Context, request *m.PollForDecisionTaskRequest) (*m.PollForDecisionTaskResponse, error)
-		PollForActivityTask(ctx context.Context, request *m.PollForActivityTaskRequest) (*workflow.PollForActivityTaskResponse, error)
-		QueryWorkflow(ctx context.Context, request *m.QueryWorkflowRequest) (*workflow.QueryWorkflowResponse, error)
-		RespondQueryTaskCompleted(ctx context.Context, request *m.RespondQueryTaskCompletedRequest) error
-		CancelOutstandingPoll(ctx context.Context, request *m.CancelOutstandingPollRequest) error
-		DescribeTaskList(ctx context.Context, request *m.DescribeTaskListRequest) (*workflow.DescribeTaskListResponse, error)
-		ListTaskListPartitions(ctx context.Context, request *m.ListTaskListPartitionsRequest) (*workflow.ListTaskListPartitionsResponse, error)
+		AddDecisionTask(hCtx *handlerContext, request *m.AddDecisionTaskRequest) (syncMatch bool, err error)
+		AddActivityTask(hCtx *handlerContext, request *m.AddActivityTaskRequest) (syncMatch bool, err error)
+		PollForDecisionTask(hCtx *handlerContext, request *m.PollForDecisionTaskRequest) (*m.PollForDecisionTaskResponse, error)
+		PollForActivityTask(hCtx *handlerContext, request *m.PollForActivityTaskRequest) (*workflow.PollForActivityTaskResponse, error)
+		QueryWorkflow(hCtx *handlerContext, request *m.QueryWorkflowRequest) (*workflow.QueryWorkflowResponse, error)
+		RespondQueryTaskCompleted(hCtx *handlerContext, request *m.RespondQueryTaskCompletedRequest) error
+		CancelOutstandingPoll(hCtx *handlerContext, request *m.CancelOutstandingPollRequest) error
+		DescribeTaskList(hCtx *handlerContext, request *m.DescribeTaskListRequest) (*workflow.DescribeTaskListResponse, error)
+		ListTaskListPartitions(hCtx *handlerContext, request *m.ListTaskListPartitionsRequest) (*workflow.ListTaskListPartitionsResponse, error)
 	}
 )

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -104,7 +104,7 @@ dispatchLoop:
 					break dispatchLoop
 				}
 				// this should never happen unless there is a bug - don't drop the task
-				tr.scope().IncCounter(metrics.BufferThrottleCounter)
+				tr.scope().IncCounter(metrics.BufferThrottlePerTaskListCounter)
 				tr.logger().Error("taskReader: unexpected error dispatching task", tag.Error(err))
 				runtime.Gosched()
 			}
@@ -239,7 +239,7 @@ func (tr *taskReader) addTasksToBuffer(
 	now := time.Now()
 	for _, t := range tasks {
 		if tr.isTaskExpired(t, now) {
-			tr.scope().IncCounter(metrics.ExpiredTasksCounter)
+			tr.scope().IncCounter(metrics.ExpiredTasksPerTaskListCounter)
 			// Also increment readLevel for expired tasks otherwise it could result in
 			// looping over the same tasks if all tasks read in the batch are expired
 			tr.tlMgr.taskAckManager.setReadLevel(t.TaskID)
@@ -283,5 +283,5 @@ func (tr *taskReader) logger() log.Logger {
 }
 
 func (tr *taskReader) scope() metrics.Scope {
-	return tr.tlMgr.domainScope()
+	return tr.tlMgr.metricScope()
 }


### PR DESCRIPTION
**What changed?**
As of today, cadence-matching doesn't emit metrics with taskList name as one of the tags. But this is becoming a necessity operationally to get visibility into things like tasks_in, tasks_out, tasks_buffered at task list level. There is some visibility today from the client side SDK, but that doesn't always provide a complete picture. 

In order to enable taskList specific metrics, the tags {  'domain': 'domainName', 'taskList: taskListName' } has to be associated along with the metric name. Once we do this, we get visibility at task list level. However, we don't want to lose visibility into global aggregated view across all domain / all task-lists. Not all metrics servers can support aggregation across thousands of time-series data at the time of querying. To avoid having to do aggregation at the query time, this patch adds support for dual emitting metrics once for per_tasklist and another for aggregate. This is done in a backwards compatible manner so that existing dashboards / metrics will not be broken.

To achieve this, support for a new "metricRollupName" is added to the metricScope class. The idea behind this is the following - let's say, matching has a per-tasklist metric called "sync_matches_per_tl".
This metric also is needed at an aggregate level. So, when defining metric constants, we specify metricRollupName to be "sync_matches". Now, the scope will emit the metric twice - once with "sync_matches_per_tl" with tags "domain: and tasklist:" and another with metric name "sync_matches" without these tags.

**Why?**
To enable per task list metrics inside of cadence-matching.

**How did you test it?**
Tested on localhost (using a localhost m3 docker as metrics server)

**Potential risks**
If there is a bug or typo in this patch, existing metrics and dashboards can be broken for cadence-matching.