### PR TITLE
Improve filestore query parser for treating more values as valid close status

### DIFF
--- a/common/archiver/filestore/queryParser.go
+++ b/common/archiver/filestore/queryParser.go
@@ -174,7 +174,8 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 	case CloseStatus:
 		val, err := extractStringValue(valStr)
 		if err != nil {
-			return err
+			// if failed to extract string value, it means user input close status as a number
+			val = valStr
 		}
 		if op != "=" {
 			return fmt.Errorf("only operation = is support for %s", CloseStatus)
@@ -241,17 +242,19 @@ func convertToTimestamp(timeStr string) (int64, error) {
 }
 
 func convertStatusStr(statusStr string) (shared.WorkflowExecutionCloseStatus, error) {
-	statusStr = strings.ToLower(statusStr)
+	statusStr = strings.ToLower(strings.TrimSpace(statusStr))
 	switch statusStr {
-	case "completed":
+	case "completed", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusCompleted)):
 		return shared.WorkflowExecutionCloseStatusCompleted, nil
-	case "failed":
+	case "failed", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusFailed)):
 		return shared.WorkflowExecutionCloseStatusFailed, nil
-	case "canceled":
+	case "canceled", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusCanceled)):
 		return shared.WorkflowExecutionCloseStatusCanceled, nil
-	case "continuedasnew":
+	case "terminated", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusTerminated)):
+		return shared.WorkflowExecutionCloseStatusTerminated, nil
+	case "continuedasnew", "continued_as_new", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusContinuedAsNew)):
 		return shared.WorkflowExecutionCloseStatusContinuedAsNew, nil
-	case "timedout":
+	case "timedout", "timed_out", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusTimedOut)):
 		return shared.WorkflowExecutionCloseStatusTimedOut, nil
 	default:
 		return 0, fmt.Errorf("unknown workflow close status: %s", statusStr)

--- a/common/archiver/filestore/queryParser_test.go
+++ b/common/archiver/filestore/queryParser_test.go
@@ -162,6 +162,13 @@ func (s *queryParserSuite) TestParseCloseStatus() {
 			},
 		},
 		{
+			query:     "CloseStatus = 'TIMED_OUT'",
+			expectErr: false,
+			parsedQuery: &parsedQuery{
+				closeStatus: shared.WorkflowExecutionCloseStatusTimedOut.Ptr(),
+			},
+		},
+		{
 			query:     "CloseStatus = 'Failed' and CloseStatus = \"Failed\"",
 			expectErr: false,
 			parsedQuery: &parsedQuery{
@@ -189,6 +196,17 @@ func (s *queryParserSuite) TestParseCloseStatus() {
 		},
 		{
 			query:     "CloseStatus > \"Failed\"",
+			expectErr: true,
+		},
+		{
+			query:     "CloseStatus = 1",
+			expectErr: false,
+			parsedQuery: &parsedQuery{
+				closeStatus: shared.WorkflowExecutionCloseStatusFailed.Ptr(),
+			},
+		},
+		{
+			query:     "CloseStatus = 10",
 			expectErr: true,
 		},
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Improve the parse function for close status in visibility archival filestore query parse to accept more values.

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously this parse function doesn't handle terminated status. It also requires the close status to be a string (not a number), which doesn't match our internal implementation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, filestore is only used in local development, not in production.
