### PR TITLE
Add back pressure logic for task loading

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1619,6 +1619,7 @@ const (
 	TaskBatchCompleteCounter
 	TaskProcessingLatency
 	TaskQueueLatency
+	TaskRedispatchQueuePendingTasksTimer
 
 	TransferTaskThrottledCounter
 	TimerTaskThrottledCounter
@@ -1973,6 +1974,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskProcessingLatency:                             {metricName: "task_latency_processing", metricType: Timer},
 		TaskQueueLatency:                                  {metricName: "task_latency_queue", metricType: Timer},
 		TaskBatchCompleteCounter:                          {metricName: "task_batch_complete_counter", metricType: Counter},
+		TaskRedispatchQueuePendingTasksTimer:              {metricName: "task_redispatch_queue_pending_tasks", metricType: Timer},
 		TransferTaskThrottledCounter:                      {metricName: "transfer_task_throttled_counter", metricType: Counter},
 		TimerTaskThrottledCounter:                         {metricName: "timer_task_throttled_counter", metricType: Counter},
 		ActivityE2ELatency:                                {metricName: "activity_end_to_end_latency", metricType: Timer},

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -165,6 +165,7 @@ var keys = map[Key]string{
 	TimerProcessorMaxPollIntervalJitterCoefficient:         "history.timerProcessorMaxPollIntervalJitterCoefficient",
 	TimerProcessorRedispatchInterval:                       "history.timerProcessorRedispatchInterval",
 	TimerProcessorRedispatchIntervalJitterCoefficient:      "history.timerProcessorRedispatchIntervalJitterCoefficient",
+	TimerProcessorMaxRedispatchQueueSize:                   "history.timerProcessorMaxRedispatchQueueSize",
 	TimerProcessorEnablePriorityTaskProcessor:              "history.timerProcessorEnablePriorityTaskProcessor",
 	TimerProcessorMaxTimeShift:                             "history.timerProcessorMaxTimeShift",
 	TimerProcessorHistoryArchivalSizeLimit:                 "history.timerProcessorHistoryArchivalSizeLimit",
@@ -183,6 +184,7 @@ var keys = map[Key]string{
 	TransferProcessorCompleteTransferInterval:              "history.transferProcessorCompleteTransferInterval",
 	TransferProcessorRedispatchInterval:                    "history.transferProcessorRedispatchInterval",
 	TransferProcessorRedispatchIntervalJitterCoefficient:   "history.transferProcessorRedispatchIntervalJitterCoefficient",
+	TransferProcessorMaxRedispatchQueueSize:                "history.transferProcessorMaxRedispatchQueueSize",
 	TransferProcessorEnablePriorityTaskProcessor:           "history.transferProcessorEnablePriorityTaskProcessor",
 	TransferProcessorVisibilityArchivalTimeLimit:           "history.transferProcessorVisibilityArchivalTimeLimit",
 	ReplicatorTaskBatchSize:                                "history.replicatorTaskBatchSize",
@@ -196,6 +198,7 @@ var keys = map[Key]string{
 	ReplicatorProcessorUpdateAckIntervalJitterCoefficient:  "history.replicatorProcessorUpdateAckIntervalJitterCoefficient",
 	ReplicatorProcessorRedispatchInterval:                  "history.replicatorProcessorRedispatchInterval",
 	ReplicatorProcessorRedispatchIntervalJitterCoefficient: "history.replicatorProcessorRedispatchIntervalJitterCoefficient",
+	ReplicatorProcessorMaxRedispatchQueueSize:              "history.replicatorProcessorMaxRedispatchQueueSize",
 	ReplicatorProcessorEnablePriorityTaskProcessor:         "history.replicatorProcessorEnablePriorityTaskProcessor",
 	ExecutionMgrNumConns:                                   "history.executionMgrNumConns",
 	HistoryMgrNumConns:                                     "history.historyMgrNumConns",
@@ -503,6 +506,8 @@ const (
 	TimerProcessorRedispatchInterval
 	// TimerProcessorRedispatchIntervalJitterCoefficient is the redispatch interval jitter coefficient
 	TimerProcessorRedispatchIntervalJitterCoefficient
+	// TimerProcessorMaxRedispatchQueueSize is the threshold of the number of tasks in the redispatch queue for timer processor
+	TimerProcessorMaxRedispatchQueueSize
 	// TimerProcessorEnablePriorityTaskProcessor indicates whether priority task processor should be used for timer processor
 	TimerProcessorEnablePriorityTaskProcessor
 	// TimerProcessorMaxTimeShift is the max shift timer processor can have
@@ -539,6 +544,8 @@ const (
 	TransferProcessorRedispatchInterval
 	// TransferProcessorRedispatchIntervalJitterCoefficient is the redispatch interval jitter coefficient
 	TransferProcessorRedispatchIntervalJitterCoefficient
+	// TransferProcessorMaxRedispatchQueueSize is the threshold of the number of tasks in the redispatch queue for transferQueueProcessor
+	TransferProcessorMaxRedispatchQueueSize
 	// TransferProcessorEnablePriorityTaskProcessor indicates whether priority task processor should be used for transferQueueProcessor
 	TransferProcessorEnablePriorityTaskProcessor
 	// TransferProcessorVisibilityArchivalTimeLimit is the upper time limit for archiving visibility records
@@ -565,6 +572,8 @@ const (
 	ReplicatorProcessorRedispatchInterval
 	// ReplicatorProcessorRedispatchIntervalJitterCoefficient is the redispatch interval jitter coefficient
 	ReplicatorProcessorRedispatchIntervalJitterCoefficient
+	// ReplicatorProcessorMaxRedispatchQueueSize is the threshold of the number of tasks in the redispatch queue for ReplicatorProcessor
+	ReplicatorProcessorMaxRedispatchQueueSize
 	// ReplicatorProcessorEnablePriorityTaskProcessor indicates whether priority task processor should be used for ReplicatorProcessor
 	ReplicatorProcessorEnablePriorityTaskProcessor
 	// ExecutionMgrNumConns is persistence connections number for ExecutionManager

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -51,6 +51,7 @@ type (
 		MaxRetryCount                       dynamicconfig.IntPropertyFn
 		RedispatchInterval                  dynamicconfig.DurationPropertyFn
 		RedispatchIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+		MaxRedispatchQueueSize              dynamicconfig.IntPropertyFn
 		EnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 		MetricScope                         int
 	}
@@ -64,7 +65,7 @@ type (
 		options              *QueueProcessorOptions
 		processor            processor
 		logger               log.Logger
-		metricsClient        metrics.Client
+		metricsScope         metrics.Scope
 		rateLimiter          quotas.Limiter // Read rate limiter
 		ackMgr               queueAckMgr
 		taskProcessor        *taskProcessor // TODO: deprecate task processor, in favor of queueTaskProcessor
@@ -98,6 +99,7 @@ func newQueueProcessorBase(
 	historyCache *historyCache,
 	queueTaskInitializer queueTaskInitializer,
 	logger log.Logger,
+	metricsScope metrics.Scope,
 ) *queueProcessorBase {
 
 	var taskProcessor *taskProcessor
@@ -123,8 +125,8 @@ func newQueueProcessorBase(
 		status:               common.DaemonStatusInitialized,
 		notifyCh:             make(chan struct{}, 1),
 		shutdownCh:           make(chan struct{}),
-		metricsClient:        shard.GetMetricsClient(),
 		logger:               logger,
+		metricsScope:         metricsScope,
 		ackMgr:               queueAckMgr,
 		lastPollTime:         time.Time{},
 		taskProcessor:        taskProcessor,
@@ -210,7 +212,15 @@ processorPumpLoop:
 			// use a separate gorouting since the caller hold the shutdownWG
 			go p.Stop()
 		case <-p.notifyCh:
-			p.processBatch()
+			if !p.isPriorityTaskProcessorEnabled() || p.redispatchQueue.Len() <= p.options.MaxRedispatchQueueSize() {
+				p.processBatch()
+				continue
+			}
+
+			// has too many pending tasks in re-dispatch queue, block loading tasks from persistence
+			p.redispatchTasks()
+			// re-enqueue the event to see if we need keep re-dispatching or load new tasks from persistence
+			p.notifyNewTask()
 		case <-pollTimer.C:
 			pollTimer.Reset(backoff.JitDuration(
 				p.options.MaxPollInterval(),
@@ -319,6 +329,7 @@ func (p *queueProcessorBase) redispatchTasks() {
 		p.redispatchQueue,
 		p.queueTaskProcessor,
 		p.logger,
+		p.metricsScope,
 		p.shutdownCh,
 	)
 }
@@ -343,9 +354,11 @@ func redispatchQueueTasks(
 	redispatchQueue collection.Queue,
 	queueTaskProcessor queueTaskProcessor,
 	logger log.Logger,
+	metricsScope metrics.Scope,
 	shutdownCh <-chan struct{},
 ) {
 	queueLength := redispatchQueue.Len()
+	metricsScope.RecordTimer(metrics.TaskRedispatchQueuePendingTasksTimer, time.Duration(queueLength))
 	for i := 0; i != queueLength; i++ {
 		queueTask := redispatchQueue.Remove().(queueTask)
 		submitted, err := queueTaskProcessor.TrySubmit(queueTask)

--- a/service/history/queueProcessor_test.go
+++ b/service/history/queueProcessor_test.go
@@ -27,10 +27,12 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
 
 	"github.com/uber/cadence/common/collection"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/metrics"
 )
 
 type (
@@ -43,6 +45,7 @@ type (
 
 		redispatchQueue collection.Queue
 		logger          log.Logger
+		metricsScope    metrics.Scope
 	}
 )
 
@@ -59,6 +62,7 @@ func (s *queueProcessorSuite) SetupTest() {
 
 	s.redispatchQueue = collection.NewConcurrentQueue()
 	s.logger = loggerimpl.NewDevelopmentForTest(s.Suite)
+	s.metricsScope = metrics.NewClient(tally.NoopScope, metrics.History).Scope(metrics.TransferQueueProcessorScope)
 }
 
 func (s *queueProcessorSuite) TearDownTest() {
@@ -85,6 +89,7 @@ func (s *queueProcessorSuite) TestRedispatchTask_ProcessorShutDown() {
 		s.redispatchQueue,
 		s.mockQueueTaskProcessor,
 		s.logger,
+		s.metricsScope,
 		shutDownCh,
 	)
 
@@ -112,6 +117,7 @@ func (s *queueProcessorSuite) TestRedispatchTask_Random() {
 		s.redispatchQueue,
 		s.mockQueueTaskProcessor,
 		s.logger,
+		s.metricsScope,
 		shutDownCh,
 	)
 

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -88,6 +88,7 @@ func newReplicatorQueueProcessor(
 		MaxRetryCount:                       config.ReplicatorTaskMaxRetryCount,
 		RedispatchInterval:                  config.ReplicatorProcessorRedispatchInterval,
 		RedispatchIntervalJitterCoefficient: config.ReplicatorProcessorRedispatchIntervalJitterCoefficient,
+		MaxRedispatchQueueSize:              config.ReplicatorProcessorMaxRedispatchQueueSize,
 		EnablePriorityTaskProcessor:         config.ReplicatorProcessorEnablePriorityTaskProcessor,
 		MetricScope:                         metrics.ReplicatorQueueProcessorScope,
 	}
@@ -129,6 +130,7 @@ func newReplicatorQueueProcessor(
 		historyCache,
 		nil, // there's no queueTask implementation for replication task
 		logger,
+		shard.GetMetricsClient().Scope(metrics.ReplicatorQueueProcessorScope),
 	)
 	processor.queueAckMgr = queueAckMgr
 	processor.queueProcessorBase = queueProcessorBase

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -102,6 +102,7 @@ type Config struct {
 	TimerProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
 	TimerProcessorRedispatchInterval                  dynamicconfig.DurationPropertyFn
 	TimerProcessorRedispatchIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	TimerProcessorMaxRedispatchQueueSize              dynamicconfig.IntPropertyFn
 	TimerProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 	TimerProcessorMaxTimeShift                        dynamicconfig.DurationPropertyFn
 	TimerProcessorHistoryArchivalSizeLimit            dynamicconfig.IntPropertyFn
@@ -121,6 +122,7 @@ type Config struct {
 	TransferProcessorCompleteTransferInterval            dynamicconfig.DurationPropertyFn
 	TransferProcessorRedispatchInterval                  dynamicconfig.DurationPropertyFn
 	TransferProcessorRedispatchIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	TransferProcessorMaxRedispatchQueueSize              dynamicconfig.IntPropertyFn
 	TransferProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 	TransferProcessorVisibilityArchivalTimeLimit         dynamicconfig.DurationPropertyFn
 
@@ -135,6 +137,7 @@ type Config struct {
 	ReplicatorProcessorUpdateAckIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
 	ReplicatorProcessorRedispatchInterval                  dynamicconfig.DurationPropertyFn
 	ReplicatorProcessorRedispatchIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	ReplicatorProcessorMaxRedispatchQueueSize              dynamicconfig.IntPropertyFn
 	ReplicatorProcessorEnablePriorityTaskProcessor         dynamicconfig.BoolPropertyFn
 	ReplicatorProcessorFetchTasksBatchSize                 dynamicconfig.IntPropertyFn
 
@@ -273,6 +276,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		TimerProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.TimerProcessorMaxPollIntervalJitterCoefficient, 0.15),
 		TimerProcessorRedispatchInterval:                  dc.GetDurationProperty(dynamicconfig.TimerProcessorRedispatchInterval, 1*time.Second),
 		TimerProcessorRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TimerProcessorRedispatchIntervalJitterCoefficient, 0.15),
+		TimerProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.TimerProcessorMaxRedispatchQueueSize, 100000),
 		TimerProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.TimerProcessorEnablePriorityTaskProcessor, false),
 		TimerProcessorMaxTimeShift:                        dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxTimeShift, 1*time.Second),
 		TimerProcessorHistoryArchivalSizeLimit:            dc.GetIntProperty(dynamicconfig.TimerProcessorHistoryArchivalSizeLimit, 500*1024),
@@ -291,6 +295,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		TransferProcessorCompleteTransferInterval:            dc.GetDurationProperty(dynamicconfig.TransferProcessorCompleteTransferInterval, 60*time.Second),
 		TransferProcessorRedispatchInterval:                  dc.GetDurationProperty(dynamicconfig.TransferProcessorRedispatchInterval, 1*time.Second),
 		TransferProcessorRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TransferProcessorRedispatchIntervalJitterCoefficient, 0.15),
+		TransferProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.TransferProcessorMaxRedispatchQueueSize, 100000),
 		TransferProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.TransferProcessorEnablePriorityTaskProcessor, false),
 		TransferProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.TransferProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
@@ -304,6 +309,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		ReplicatorProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorUpdateAckIntervalJitterCoefficient, 0.15),
 		ReplicatorProcessorRedispatchInterval:                  dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorRedispatchInterval, 5*time.Second),
 		ReplicatorProcessorRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorRedispatchIntervalJitterCoefficient, 0.15),
+		ReplicatorProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxRedispatchQueueSize, 100000),
 		ReplicatorProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.ReplicatorProcessorEnablePriorityTaskProcessor, false),
 		ReplicatorProcessorFetchTasksBatchSize:                 dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 25),
 

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -276,7 +276,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		TimerProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.TimerProcessorMaxPollIntervalJitterCoefficient, 0.15),
 		TimerProcessorRedispatchInterval:                  dc.GetDurationProperty(dynamicconfig.TimerProcessorRedispatchInterval, 1*time.Second),
 		TimerProcessorRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TimerProcessorRedispatchIntervalJitterCoefficient, 0.15),
-		TimerProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.TimerProcessorMaxRedispatchQueueSize, 100000),
+		TimerProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.TimerProcessorMaxRedispatchQueueSize, 10000),
 		TimerProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.TimerProcessorEnablePriorityTaskProcessor, false),
 		TimerProcessorMaxTimeShift:                        dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxTimeShift, 1*time.Second),
 		TimerProcessorHistoryArchivalSizeLimit:            dc.GetIntProperty(dynamicconfig.TimerProcessorHistoryArchivalSizeLimit, 500*1024),
@@ -295,7 +295,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		TransferProcessorCompleteTransferInterval:            dc.GetDurationProperty(dynamicconfig.TransferProcessorCompleteTransferInterval, 60*time.Second),
 		TransferProcessorRedispatchInterval:                  dc.GetDurationProperty(dynamicconfig.TransferProcessorRedispatchInterval, 1*time.Second),
 		TransferProcessorRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TransferProcessorRedispatchIntervalJitterCoefficient, 0.15),
-		TransferProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.TransferProcessorMaxRedispatchQueueSize, 100000),
+		TransferProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.TransferProcessorMaxRedispatchQueueSize, 10000),
 		TransferProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.TransferProcessorEnablePriorityTaskProcessor, false),
 		TransferProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicconfig.TransferProcessorVisibilityArchivalTimeLimit, 200*time.Millisecond),
 
@@ -309,7 +309,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		ReplicatorProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorUpdateAckIntervalJitterCoefficient, 0.15),
 		ReplicatorProcessorRedispatchInterval:                  dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorRedispatchInterval, 5*time.Second),
 		ReplicatorProcessorRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorRedispatchIntervalJitterCoefficient, 0.15),
-		ReplicatorProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxRedispatchQueueSize, 100000),
+		ReplicatorProcessorMaxRedispatchQueueSize:              dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxRedispatchQueueSize, 10000),
 		ReplicatorProcessorEnablePriorityTaskProcessor:         dc.GetBoolProperty(dynamicconfig.ReplicatorProcessorEnablePriorityTaskProcessor, false),
 		ReplicatorProcessorFetchTasksBatchSize:                 dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 25),
 

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -130,6 +130,7 @@ func newTimerQueueActiveProcessor(
 		timerGate,
 		shard.GetConfig().TimerProcessorMaxPollRPS,
 		logger,
+		shard.GetMetricsClient().Scope(metrics.TimerActiveQueueProcessorScope),
 	)
 
 	return processor
@@ -244,6 +245,7 @@ func newTimerQueueFailoverProcessor(
 		timerGate,
 		shard.GetConfig().TimerProcessorFailoverMaxPollRPS,
 		logger,
+		shard.GetMetricsClient().Scope(metrics.TimerActiveQueueProcessorScope),
 	)
 
 	return updateShardAckLevel, processor

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -135,6 +135,7 @@ func newTimerQueueStandbyProcessor(
 		timerGate,
 		shard.GetConfig().TimerProcessorMaxPollRPS,
 		logger,
+		shard.GetMetricsClient().Scope(metrics.TimerStandbyQueueProcessorScope),
 	)
 
 	return processor

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -74,6 +74,7 @@ func newTransferQueueActiveProcessor(
 		MaxRetryCount:                       config.TransferTaskMaxRetryCount,
 		RedispatchInterval:                  config.TransferProcessorRedispatchInterval,
 		RedispatchIntervalJitterCoefficient: config.TransferProcessorRedispatchIntervalJitterCoefficient,
+		MaxRedispatchQueueSize:              config.TransferProcessorMaxRedispatchQueueSize,
 		EnablePriorityTaskProcessor:         config.TransferProcessorEnablePriorityTaskProcessor,
 		MetricScope:                         metrics.TransferActiveQueueProcessorScope,
 	}
@@ -158,6 +159,7 @@ func newTransferQueueActiveProcessor(
 		historyService.historyCache,
 		transferQueueTaskInitializer,
 		logger,
+		shard.GetMetricsClient().Scope(metrics.TransferActiveQueueProcessorScope),
 	)
 	processor.queueAckMgr = queueAckMgr
 	processor.queueProcessorBase = queueProcessorBase
@@ -192,6 +194,7 @@ func newTransferQueueFailoverProcessor(
 		MaxRetryCount:                       config.TransferTaskMaxRetryCount,
 		RedispatchInterval:                  config.TransferProcessorRedispatchInterval,
 		RedispatchIntervalJitterCoefficient: config.TransferProcessorRedispatchIntervalJitterCoefficient,
+		MaxRedispatchQueueSize:              config.TransferProcessorMaxRedispatchQueueSize,
 		EnablePriorityTaskProcessor:         config.TransferProcessorEnablePriorityTaskProcessor,
 		MetricScope:                         metrics.TransferActiveQueueProcessorScope,
 	}
@@ -291,6 +294,7 @@ func newTransferQueueFailoverProcessor(
 		historyService.historyCache,
 		transferQueueTaskInitializer,
 		logger,
+		shard.GetMetricsClient().Scope(metrics.TransferActiveQueueProcessorScope),
 	)
 	processor.queueAckMgr = queueAckMgr
 	processor.queueProcessorBase = queueProcessorBase

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -71,6 +71,7 @@ func newTransferQueueStandbyProcessor(
 		MaxRetryCount:                       config.TransferTaskMaxRetryCount,
 		RedispatchInterval:                  config.TransferProcessorRedispatchInterval,
 		RedispatchIntervalJitterCoefficient: config.TransferProcessorRedispatchIntervalJitterCoefficient,
+		MaxRedispatchQueueSize:              config.TransferProcessorMaxRedispatchQueueSize,
 		EnablePriorityTaskProcessor:         config.TransferProcessorEnablePriorityTaskProcessor,
 		MetricScope:                         metrics.TransferStandbyQueueProcessorScope,
 	}
@@ -158,6 +159,7 @@ func newTransferQueueStandbyProcessor(
 		historyService.historyCache,
 		transferQueueTaskInitializer,
 		logger,
+		shard.GetMetricsClient().Scope(metrics.TransferStandbyQueueProcessorScope),
 	)
 
 	processor.queueAckMgr = queueAckMgr


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Skip task loading when there are too many pending tasks in re-dispatch queue. 
Note that task loading is not completely blocked. There's a timer for `maxPollInterval`, when that timer fires, task queue will still load some tasks from persistence. This is timer has a quite large value (1 min) so it shouldn't be a problem.
* Emit metrics for re-dispatch queue size

<!-- Tell your future self why have you made these changes -->
**Why?**
For multi-tenant task processing, the queue processor will first load tasks from persistence and try to submit the task to the task processor. For bursty domain, the submit will fail as the task queue for that domain (priority, actually) is full and the task will be buffered in the re-dispatch queue. It's possible that one domain keeps generating large number of tasks which results in the re-dispatch queue holding large number of tasks. This may cause the host to go out of memory. 

This PR adds some back pressure logic to block task loading when the re-dispatch queue contains too many tasks. Basically when the number of tasks in the re-dispatch queue reaches a threshold, only do re-dispatch and stop loading new tasks. (Of course the loading is not completed blocked, new tasks will be eventually loaded after some time period).

Note that the value for the threshold represents a tradeoff between multi-tenancy and system protection.
- Large threshold means more tasks can be buffered so it's better at handling busty domains while not affecting other domains.
- Small threshold means the queue processor will use less resource on the host and provides better system protection.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test, integration test, local canary.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the worst case, new tasks can't be loaded from persistence and processing is blocked, if the feature flag is enabled. 
