### PR TITLE
Add global ratelimiter for frontend API

### DIFF
--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -70,9 +70,9 @@ type (
 		RemoveListener(service string, name string) error
 		// GetReachableMembers returns addresses of all members of the ring
 		GetReachableMembers() ([]string, error)
-		// GetMemberCountWithRole returns the number of reachable members
+		// GetMemberCount returns the number of reachable members
 		// currently in this node's membership list for the given role
-		GetMemberCountWithRole(role string) (int, error)
+		GetMemberCount(role string) (int, error)
 	}
 
 	// ServiceResolver provides membership information for a specific cadence service.

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -70,6 +70,9 @@ type (
 		RemoveListener(service string, name string) error
 		// GetReachableMembers returns addresses of all members of the ring
 		GetReachableMembers() ([]string, error)
+		// GetMemberCountWithRole returns the number of reachable members
+		// currently in this node's membership list for the given role
+		GetMemberCountWithRole(role string) (int, error)
 	}
 
 	// ServiceResolver provides membership information for a specific cadence service.

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -182,19 +182,19 @@ func (mr *MockMonitorMockRecorder) GetReachableMembers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReachableMembers", reflect.TypeOf((*MockMonitor)(nil).GetReachableMembers))
 }
 
-// GetMemberCountWithRole mocks base method
-func (m *MockMonitor) GetMemberCountWithRole(role string) (int, error) {
+// GetMemberCount mocks base method
+func (m *MockMonitor) GetMemberCount(service string) (int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMemberCountWithRole", role)
+	ret := m.ctrl.Call(m, "GetMemberCount", service)
 	ret0, _ := ret[0].(int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetMemberCountWithRole indicates an expected call of GetMemberCountWithRole
-func (mr *MockMonitorMockRecorder) GetMemberCountWithRole(role interface{}) *gomock.Call {
+// GetMemberCount indicates an expected call of GetMemberCount
+func (mr *MockMonitorMockRecorder) GetMemberCount(service interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCountWithRole", reflect.TypeOf((*MockMonitor)(nil).GetMemberCountWithRole), role)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCount", reflect.TypeOf((*MockMonitor)(nil).GetMemberCount), service)
 }
 
 // MockServiceResolver is a mock of ServiceResolver interface

--- a/common/membership/interfaces_mock.go
+++ b/common/membership/interfaces_mock.go
@@ -182,6 +182,21 @@ func (mr *MockMonitorMockRecorder) GetReachableMembers() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReachableMembers", reflect.TypeOf((*MockMonitor)(nil).GetReachableMembers))
 }
 
+// GetMemberCountWithRole mocks base method
+func (m *MockMonitor) GetMemberCountWithRole(role string) (int, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetMemberCountWithRole", role)
+	ret0, _ := ret[0].(int)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetMemberCountWithRole indicates an expected call of GetMemberCountWithRole
+func (mr *MockMonitorMockRecorder) GetMemberCountWithRole(role interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMemberCountWithRole", reflect.TypeOf((*MockMonitor)(nil).GetMemberCountWithRole), role)
+}
+
 // MockServiceResolver is a mock of ServiceResolver interface
 type MockServiceResolver struct {
 	ctrl     *gomock.Controller

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -155,8 +155,8 @@ func (rpo *ringpopMonitor) GetReachableMembers() ([]string, error) {
 	return rpo.rp.GetReachableMembers()
 }
 
-func (rpo *ringpopMonitor) GetMemberCountWithRole(role string) (int, error) {
-	ring, err := rpo.GetResolver(role)
+func (rpo *ringpopMonitor) GetMemberCount(service string) (int, error) {
+	ring, err := rpo.GetResolver(service)
 	if err != nil {
 		return 0, err
 	}

--- a/common/membership/rpMonitor.go
+++ b/common/membership/rpMonitor.go
@@ -154,3 +154,11 @@ func (rpo *ringpopMonitor) RemoveListener(service string, name string) error {
 func (rpo *ringpopMonitor) GetReachableMembers() ([]string, error) {
 	return rpo.rp.GetReachableMembers()
 }
+
+func (rpo *ringpopMonitor) GetMemberCountWithRole(role string) (int, error) {
+	ring, err := rpo.GetResolver(role)
+	if err != nil {
+		return 0, err
+	}
+	return ring.MemberCount(), nil
+}

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -90,6 +90,7 @@ var keys = map[Key]string{
 	FrontendHistoryMaxPageSize:            "frontend.historyMaxPageSize",
 	FrontendRPS:                           "frontend.rps",
 	FrontendDomainRPS:                     "frontend.domainrps",
+	FrontendGlobalDomainRPS:               "frontend.globalDomainrps",
 	FrontendHistoryMgrNumConns:            "frontend.historyMgrNumConns",
 	FrontendShutdownDrainDuration:         "frontend.shutdownDrainDuration",
 	DisableListVisibilityByFilter:         "frontend.disableListVisibilityByFilter",
@@ -354,6 +355,8 @@ const (
 	FrontendRPS
 	// FrontendDomainRPS is workflow domain rate limit per second
 	FrontendDomainRPS
+	// FrontendGlobalDomainRPS is workflow domain rate limit per second for the whole Cadence cluster
+	FrontendGlobalDomainRPS
 	// FrontendHistoryMgrNumConns is for persistence cluster.NumConns
 	FrontendHistoryMgrNumConns
 	// FrontendThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -89,7 +89,7 @@ var keys = map[Key]string{
 	FrontendESIndexMaxResultWindow:        "frontend.esIndexMaxResultWindow",
 	FrontendHistoryMaxPageSize:            "frontend.historyMaxPageSize",
 	FrontendRPS:                           "frontend.rps",
-	FrontendDomainRPS:                     "frontend.domainrps",
+	FrontendMaxDomainRPSPerInstance:       "frontend.domainrps",
 	FrontendGlobalDomainRPS:               "frontend.globalDomainrps",
 	FrontendHistoryMgrNumConns:            "frontend.historyMgrNumConns",
 	FrontendShutdownDrainDuration:         "frontend.shutdownDrainDuration",
@@ -353,8 +353,8 @@ const (
 	FrontendHistoryMaxPageSize
 	// FrontendRPS is workflow rate limit per second
 	FrontendRPS
-	// FrontendDomainRPS is workflow domain rate limit per second
-	FrontendDomainRPS
+	// FrontendMaxDomainRPSPerInstance is workflow domain rate limit per second
+	FrontendMaxDomainRPSPerInstance
 	// FrontendGlobalDomainRPS is workflow domain rate limit per second for the whole Cadence cluster
 	FrontendGlobalDomainRPS
 	// FrontendHistoryMgrNumConns is for persistence cluster.NumConns

--- a/host/simpleMonitor.go
+++ b/host/simpleMonitor.go
@@ -79,6 +79,6 @@ func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
 	return nil, nil
 }
 
-func (s *simpleMonitor) GetMemberCountWithRole(role string) (int, error) {
+func (s *simpleMonitor) GetMemberCount(service string) (int, error) {
 	return 0, nil
 }

--- a/host/simpleMonitor.go
+++ b/host/simpleMonitor.go
@@ -78,3 +78,7 @@ func (s *simpleMonitor) RemoveListener(service string, name string) error {
 func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
 	return nil, nil
 }
+
+func (s *simpleMonitor) GetMemberCountWithRole(role string) (int, error) {
+	return 0, nil
+}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -55,7 +55,7 @@ type Config struct {
 	ESIndexMaxResultWindow          dynamicconfig.IntPropertyFn
 	HistoryMaxPageSize              dynamicconfig.IntPropertyFnWithDomainFilter
 	RPS                             dynamicconfig.IntPropertyFn
-	DomainRPS                       dynamicconfig.IntPropertyFnWithDomainFilter
+	MaxDomainRPSPerInstance         dynamicconfig.IntPropertyFnWithDomainFilter
 	GlobalDomainRPS                 dynamicconfig.IntPropertyFnWithDomainFilter
 	MaxIDLengthLimit                dynamicconfig.IntPropertyFn
 	EnableClientVersionCheck        dynamicconfig.BoolPropertyFn
@@ -108,8 +108,8 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		ESIndexMaxResultWindow:              dc.GetIntProperty(dynamicconfig.FrontendESIndexMaxResultWindow, 10000),
 		HistoryMaxPageSize:                  dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, common.GetHistoryMaxPageSize),
 		RPS:                                 dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
-		DomainRPS:                           dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendDomainRPS, 1200),
-		GlobalDomainRPS:                     dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainRPS, 7000),
+		MaxDomainRPSPerInstance:             dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainRPSPerInstance, 1200),
+		GlobalDomainRPS:                     dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainRPS, 0),
 		MaxIDLengthLimit:                    dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		HistoryMgrNumConns:                  dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
 		MaxBadBinaries:                      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries, domain.MaxBadBinaries),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -56,6 +56,7 @@ type Config struct {
 	HistoryMaxPageSize              dynamicconfig.IntPropertyFnWithDomainFilter
 	RPS                             dynamicconfig.IntPropertyFn
 	DomainRPS                       dynamicconfig.IntPropertyFnWithDomainFilter
+	GlobalDomainRPS                 dynamicconfig.IntPropertyFnWithDomainFilter
 	MaxIDLengthLimit                dynamicconfig.IntPropertyFn
 	EnableClientVersionCheck        dynamicconfig.BoolPropertyFn
 	MinRetentionDays                dynamicconfig.IntPropertyFn
@@ -108,6 +109,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		HistoryMaxPageSize:                  dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, common.GetHistoryMaxPageSize),
 		RPS:                                 dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
 		DomainRPS:                           dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendDomainRPS, 1200),
+		GlobalDomainRPS:                     dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainRPS, 7000),
 		MaxIDLengthLimit:                    dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		HistoryMgrNumConns:                  dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
 		MaxBadBinaries:                      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries, domain.MaxBadBinaries),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -109,7 +109,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		HistoryMaxPageSize:                  dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, common.GetHistoryMaxPageSize),
 		RPS:                                 dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
 		MaxDomainRPSPerInstance:             dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainRPSPerInstance, 1200),
-		GlobalDomainRPS:                     dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainRPS, 1200),
+		GlobalDomainRPS:                     dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainRPS, 0),
 		MaxIDLengthLimit:                    dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		HistoryMgrNumConns:                  dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
 		MaxBadBinaries:                      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries, domain.MaxBadBinaries),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -109,7 +109,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		HistoryMaxPageSize:                  dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, common.GetHistoryMaxPageSize),
 		RPS:                                 dc.GetIntProperty(dynamicconfig.FrontendRPS, 1200),
 		MaxDomainRPSPerInstance:             dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainRPSPerInstance, 1200),
-		GlobalDomainRPS:                     dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainRPS, 0),
+		GlobalDomainRPS:                     dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainRPS, 1200),
 		MaxIDLengthLimit:                    dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		HistoryMgrNumConns:                  dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns, 10),
 		MaxBadBinaries:                      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries, domain.MaxBadBinaries),

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -160,7 +160,7 @@ func NewWorkflowHandler(
 				return float64(config.RPS())
 			},
 			func(domain string) float64 {
-				if monitor := resource.GetMembershipMonitor(); monitor != nil {
+				if monitor := resource.GetMembershipMonitor(); monitor != nil && config.GlobalDomainRPS(domain) > 0 {
 					ringSize, err := monitor.GetMemberCount(common.FrontendServiceName)
 					if err == nil && ringSize > 0 {
 						avgQuota := common.MaxInt(config.GlobalDomainRPS(domain)/ringSize, 1)

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -160,6 +160,13 @@ func NewWorkflowHandler(
 				return float64(config.RPS())
 			},
 			func(domain string) float64 {
+				if monitor := resource.GetMembershipMonitor(); monitor != nil {
+					ringSize, err := monitor.GetMemberCountWithRole(common.FrontendServiceName)
+					if err == nil && ringSize > 0 {
+						avgQuota := config.GlobalDomainRPS(domain) / ringSize
+						return float64(common.MinInt(avgQuota, config.DomainRPS(domain)))
+					}
+				}
 				return float64(config.DomainRPS(domain))
 			},
 		),

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 	"sync/atomic"
 	"time"
 
@@ -161,9 +160,6 @@ func NewWorkflowHandler(
 				return float64(config.RPS())
 			},
 			func(domain string) float64 {
-				if config.GlobalDomainRPS(domain) == 0 {
-					return math.MaxFloat64
-				}
 				if monitor := resource.GetMembershipMonitor(); monitor != nil {
 					ringSize, err := monitor.GetMemberCount(common.FrontendServiceName)
 					if err == nil && ringSize > 0 {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -163,7 +163,7 @@ func NewWorkflowHandler(
 				if monitor := resource.GetMembershipMonitor(); monitor != nil {
 					ringSize, err := monitor.GetMemberCountWithRole(common.FrontendServiceName)
 					if err == nil && ringSize > 0 {
-						avgQuota := config.GlobalDomainRPS(domain) / ringSize
+						avgQuota := common.MaxInt(config.GlobalDomainRPS(domain)/ringSize, 1)
 						return float64(common.MinInt(avgQuota, config.DomainRPS(domain)))
 					}
 				}

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -115,6 +115,10 @@ func (s *workflowHandlerSuite) SetupTest() {
 	s.mockMessagingClient = mocks.NewMockMessagingClient(s.mockProducer, nil)
 	s.mockHistoryArchiver = &archiver.HistoryArchiverMock{}
 	s.mockVisibilityArchiver = &archiver.VisibilityArchiverMock{}
+
+	mockMonitor := s.mockResource.MembershipMonitor
+	mockMonitor.EXPECT().GetMemberCountWithRole(common.FrontendServiceName).Return(5, nil).AnyTimes()
+
 }
 
 func (s *workflowHandlerSuite) TearDownTest() {

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -117,7 +117,7 @@ func (s *workflowHandlerSuite) SetupTest() {
 	s.mockVisibilityArchiver = &archiver.VisibilityArchiverMock{}
 
 	mockMonitor := s.mockResource.MembershipMonitor
-	mockMonitor.EXPECT().GetMemberCountWithRole(common.FrontendServiceName).Return(5, nil).AnyTimes()
+	mockMonitor.EXPECT().GetMemberCount(common.FrontendServiceName).Return(5, nil).AnyTimes()
 
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Calculate average quota for current number of nodes in the ring. And use it for frontend rate limiter per domain.


<!-- Tell your future self why have you made these changes -->
**Why?**

Cadence is almost always Cassandra-bound, since we can scale up Cadence nodes on demand much faster than adding nodes to our CaaS cluster. It was also observed that Cassandra’s performance breaks down if Cadence is pushing more load than the CaaS can handle. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

unit tests
ran test workflows locally.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Rate limiting to the frontend API will be under(over)limited. 

