### PR TITLE
Add global ratelimiter for persistence

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -82,6 +82,7 @@ var keys = map[Key]string{
 
 	// frontend settings
 	FrontendPersistenceMaxQPS:             "frontend.persistenceMaxQPS",
+	FrontendPersistenceGlobalMaxQPS:       "frontend.persistenceGlobalMaxQPS",
 	FrontendVisibilityMaxPageSize:         "frontend.visibilityMaxPageSize",
 	FrontendVisibilityListMaxQPS:          "frontend.visibilityListMaxQPS",
 	FrontendESVisibilityListMaxQPS:        "frontend.esVisibilityListMaxQPS",
@@ -108,6 +109,7 @@ var keys = map[Key]string{
 	// matching settings
 	MatchingRPS:                             "matching.rps",
 	MatchingPersistenceMaxQPS:               "matching.persistenceMaxQPS",
+	MatchingPersistenceGlobalMaxQPS:         "matching.persistenceGlobalMaxQPS",
 	MatchingMinTaskThrottlingBurstSize:      "matching.minTaskThrottlingBurstSize",
 	MatchingGetTasksBatchSize:               "matching.getTasksBatchSize",
 	MatchingLongPollExpirationInterval:      "matching.longPollExpirationInterval",
@@ -130,6 +132,7 @@ var keys = map[Key]string{
 	// history settings
 	HistoryRPS:                                             "history.rps",
 	HistoryPersistenceMaxQPS:                               "history.persistenceMaxQPS",
+	HistoryPersistenceGlobalMaxQPS:                         "history.persistenceGlobalMaxQPS",
 	HistoryVisibilityOpenMaxQPS:                            "history.historyVisibilityOpenMaxQPS",
 	HistoryVisibilityClosedMaxQPS:                          "history.historyVisibilityClosedMaxQPS",
 	HistoryLongPollExpirationInterval:                      "history.longPollExpirationInterval",
@@ -234,6 +237,7 @@ var keys = map[Key]string{
 	MutableStateChecksumInvalidateBefore:                   "history.mutableStateChecksumInvalidateBefore",
 
 	WorkerPersistenceMaxQPS:                         "worker.persistenceMaxQPS",
+	WorkerPersistenceGlobalMaxQPS:                   "worker.persistenceGlobalMaxQPS",
 	WorkerReplicatorMetaTaskConcurrency:             "worker.replicatorMetaTaskConcurrency",
 	WorkerReplicatorTaskConcurrency:                 "worker.replicatorTaskConcurrency",
 	WorkerReplicatorMessageConcurrency:              "worker.replicatorMessageConcurrency",
@@ -341,6 +345,8 @@ const (
 
 	// FrontendPersistenceMaxQPS is the max qps frontend host can query DB
 	FrontendPersistenceMaxQPS
+	// FrontendPersistenceMaxGlobalQPS is the max qps frontend cluster can query DB
+	FrontendPersistenceGlobalMaxQPS
 	// FrontendVisibilityMaxPageSize is default max size for ListWorkflowExecutions in one page
 	FrontendVisibilityMaxPageSize
 	// FrontendVisibilityListMaxQPS is max qps frontend can list open/close workflows
@@ -391,6 +397,8 @@ const (
 	MatchingRPS
 	// MatchingPersistenceMaxQPS is the max qps matching host can query DB
 	MatchingPersistenceMaxQPS
+	// MatchingPersistenceMaxQPS is the max qps matching cluster can query DB
+	MatchingPersistenceGlobalMaxQPS
 	// MatchingMinTaskThrottlingBurstSize is the minimum burst size for task list throttling
 	MatchingMinTaskThrottlingBurstSize
 	// MatchingGetTasksBatchSize is the maximum batch size to fetch from the task buffer
@@ -434,6 +442,8 @@ const (
 	HistoryRPS
 	// HistoryPersistenceMaxQPS is the max qps history host can query DB
 	HistoryPersistenceMaxQPS
+	// HistoryPersistenceGlobalMaxQPS is the max qps history cluster can query DB
+	HistoryPersistenceGlobalMaxQPS
 	// HistoryVisibilityOpenMaxQPS is max qps one history host can write visibility open_executions
 	HistoryVisibilityOpenMaxQPS
 	// HistoryVisibilityClosedMaxQPS is max qps one history host can write visibility closed_executions
@@ -617,6 +627,8 @@ const (
 
 	// WorkerPersistenceMaxQPS is the max qps worker host can query DB
 	WorkerPersistenceMaxQPS
+	// WorkerPersistenceGlobalMaxQPS is the max qps worker cluster can query DB
+	WorkerPersistenceGlobalMaxQPS
 	// WorkerReplicatorMetaTaskConcurrency is the number of coroutine handling metadata related tasks
 	WorkerReplicatorMetaTaskConcurrency
 	// WorkerReplicatorTaskConcurrency is the number of coroutine handling non metadata related tasks

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -46,6 +46,7 @@ import (
 type Config struct {
 	NumHistoryShards                int
 	PersistenceMaxQPS               dynamicconfig.IntPropertyFn
+	PersistenceGlobalMaxQPS         dynamicconfig.IntPropertyFn
 	VisibilityMaxPageSize           dynamicconfig.IntPropertyFnWithDomainFilter
 	EnableVisibilitySampling        dynamicconfig.BoolPropertyFn
 	EnableReadFromClosedExecutionV2 dynamicconfig.BoolPropertyFn
@@ -99,6 +100,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 	return &Config{
 		NumHistoryShards:                    numHistoryShards,
 		PersistenceMaxQPS:                   dc.GetIntProperty(dynamicconfig.FrontendPersistenceMaxQPS, 2000),
+		PersistenceGlobalMaxQPS:             dc.GetIntProperty(dynamicconfig.FrontendPersistenceGlobalMaxQPS, 0),
 		VisibilityMaxPageSize:               dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendVisibilityMaxPageSize, 1000),
 		EnableVisibilitySampling:            dc.GetBoolProperty(dynamicconfig.EnableVisibilitySampling, true),
 		EnableReadFromClosedExecutionV2:     dc.GetBoolProperty(dynamicconfig.EnableReadFromClosedExecutionV2, false),
@@ -190,6 +192,7 @@ func NewService(
 		params,
 		common.FrontendServiceName,
 		serviceConfig.PersistenceMaxQPS,
+		serviceConfig.PersistenceGlobalMaxQPS,
 		serviceConfig.ThrottledLogRPS,
 		visibilityManagerInitializer,
 	)

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -46,6 +46,7 @@ type Config struct {
 	RPS                             dynamicconfig.IntPropertyFn
 	MaxIDLengthLimit                dynamicconfig.IntPropertyFn
 	PersistenceMaxQPS               dynamicconfig.IntPropertyFn
+	PersistenceGlobalMaxQPS         dynamicconfig.IntPropertyFn
 	EnableVisibilitySampling        dynamicconfig.BoolPropertyFn
 	EnableReadFromClosedExecutionV2 dynamicconfig.BoolPropertyFn
 	VisibilityOpenMaxQPS            dynamicconfig.IntPropertyFnWithDomainFilter
@@ -230,6 +231,7 @@ func NewConfig(dc *dynamicconfig.Collection, numberOfShards int, storeType strin
 		RPS:                                  dc.GetIntProperty(dynamicconfig.HistoryRPS, 3000),
 		MaxIDLengthLimit:                     dc.GetIntProperty(dynamicconfig.MaxIDLengthLimit, 1000),
 		PersistenceMaxQPS:                    dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 9000),
+		PersistenceGlobalMaxQPS:              dc.GetIntProperty(dynamicconfig.HistoryPersistenceGlobalMaxQPS, 0),
 		ShutdownDrainDuration:                dc.GetDurationProperty(dynamicconfig.HistoryShutdownDrainDuration, 0),
 		EnableVisibilitySampling:             dc.GetBoolProperty(dynamicconfig.EnableVisibilitySampling, true),
 		EnableReadFromClosedExecutionV2:      dc.GetBoolProperty(dynamicconfig.EnableReadFromClosedExecutionV2, false),
@@ -424,6 +426,7 @@ func NewService(
 		params,
 		common.HistoryServiceName,
 		serviceConfig.PersistenceMaxQPS,
+		serviceConfig.PersistenceGlobalMaxQPS,
 		serviceConfig.ThrottledLogRPS,
 		visibilityManagerInitializer,
 	)

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -31,10 +31,11 @@ import (
 type (
 	// Config represents configuration for cadence-matching service
 	Config struct {
-		PersistenceMaxQPS     dynamicconfig.IntPropertyFn
-		EnableSyncMatch       dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
-		RPS                   dynamicconfig.IntPropertyFn
-		ShutdownDrainDuration dynamicconfig.DurationPropertyFn
+		PersistenceMaxQPS       dynamicconfig.IntPropertyFn
+		PersistenceGlobalMaxQPS dynamicconfig.IntPropertyFn
+		EnableSyncMatch         dynamicconfig.BoolPropertyFnWithTaskListInfoFilters
+		RPS                     dynamicconfig.IntPropertyFn
+		ShutdownDrainDuration   dynamicconfig.DurationPropertyFn
 
 		// taskListManager configuration
 		RangeSize                    int64
@@ -92,6 +93,7 @@ type (
 func NewConfig(dc *dynamicconfig.Collection) *Config {
 	return &Config{
 		PersistenceMaxQPS:               dc.GetIntProperty(dynamicconfig.MatchingPersistenceMaxQPS, 3000),
+		PersistenceGlobalMaxQPS:         dc.GetIntProperty(dynamicconfig.MatchingPersistenceGlobalMaxQPS, 0),
 		EnableSyncMatch:                 dc.GetBoolPropertyFilteredByTaskListInfo(dynamicconfig.MatchingEnableSyncMatch, true),
 		RPS:                             dc.GetIntProperty(dynamicconfig.MatchingRPS, 1200),
 		RangeSize:                       100000,

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -53,6 +53,7 @@ func NewService(
 		params,
 		common.MatchingServiceName,
 		serviceConfig.PersistenceMaxQPS,
+		serviceConfig.PersistenceGlobalMaxQPS,
 		serviceConfig.ThrottledLogRPS,
 		func(
 			persistenceBean persistenceClient.Bean,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -65,6 +65,7 @@ type (
 		ScannerCfg                    *scanner.Config
 		BatcherCfg                    *batcher.Config
 		ThrottledLogRPS               dynamicconfig.IntPropertyFn
+		PersistenceGlobalMaxQPS       dynamicconfig.IntPropertyFn
 		EnableBatcher                 dynamicconfig.BoolPropertyFn
 		EnableParentClosePolicyWorker dynamicconfig.BoolPropertyFn
 	}
@@ -81,6 +82,7 @@ func NewService(
 		params,
 		common.WorkerServiceName,
 		serviceConfig.ReplicationCfg.PersistenceMaxQPS,
+		serviceConfig.PersistenceGlobalMaxQPS,
 		serviceConfig.ThrottledLogRPS,
 		func(
 			persistenceBean persistenceClient.Bean,
@@ -138,6 +140,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 		EnableBatcher:                 dc.GetBoolProperty(dynamicconfig.EnableBatcher, false),
 		EnableParentClosePolicyWorker: dc.GetBoolProperty(dynamicconfig.EnableParentClosePolicyWorker, true),
 		ThrottledLogRPS:               dc.GetIntProperty(dynamicconfig.WorkerThrottledLogRPS, 20),
+		PersistenceGlobalMaxQPS:       dc.GetIntProperty(dynamicconfig.WorkerPersistenceGlobalMaxQPS, 0),
 	}
 	advancedVisWritingMode := dc.GetStringProperty(
 		dynamicconfig.AdvancedVisibilityWritingMode,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Calculate average quota for current number of nodes in the ring. And use it for persistence API rate limiters of frontend, history, matching and worker.


<!-- Tell your future self why have you made these changes -->
**Why?**

Follow up for https://github.com/uber/cadence/pull/3161: cadence is almost always Cassandra-bound, since we can scale up Cadence nodes on demand much faster than adding nodes to our CaaS cluster. It was also observed that Cassandra’s performance breaks down if Cadence is pushing more load than the CaaS can handle. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

unit tests
ran test workflows locally.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Rate limiting to the persistence API will be under(over)limited. 

