### PR TITLE
Fix canary domain creation

### DIFF
--- a/canary/client.go
+++ b/canary/client.go
@@ -48,6 +48,7 @@ type cadenceClient struct {
 // if the domain already exist, this method silently returns success
 func (client *cadenceClient) createDomain(name string, desc string, owner string, archivalStatus *shared.ArchivalStatus) error {
 	emitMetric := true
+	isGlobalDomain := false
 	retention := int32(workflowRetentionDays)
 	if archivalStatus != nil && *archivalStatus == shared.ArchivalStatusEnabled {
 		retention = int32(0)
@@ -59,6 +60,8 @@ func (client *cadenceClient) createDomain(name string, desc string, owner string
 		WorkflowExecutionRetentionPeriodInDays: &retention,
 		EmitMetric:                             &emitMetric,
 		HistoryArchivalStatus:                  archivalStatus,
+		VisibilityArchivalStatus:               archivalStatus,
+		IsGlobalDomain:                         &isGlobalDomain,
 	}
 	err := client.Register(context.Background(), req)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Specify visibilityArchivalStatus and isGlobalDomain when creating canary domain (`cadence-canary` and `canary-archival-domain`)

<!-- Tell your future self why have you made these changes -->
**Why?**
Visibility archival is a new field and isGlobalDomain is required when registering a domain in a cluster where global domain is enabled.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run canary locally against both single cluster and multi-cluster setup.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A. Canary is test service and canary domains has already been created in staging/production. This pr only has effect if the domain doesn't exist before.
