### PR TITLE
Use version history to get branch token as fall back

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -436,7 +436,7 @@ workflow_state = ? ` +
 		`and visibility_ts = ? ` +
 		`and task_id = ?`
 
-	templateListWorkflowExecutionQuery = `SELECT run_id, execution ` +
+	templateListWorkflowExecutionQuery = `SELECT run_id, execution, version_histories, version_histories_encoding ` +
 		`FROM executions ` +
 		`WHERE shard_id = ? ` +
 		`and type = ?`
@@ -1311,10 +1311,7 @@ func (d *cassandraPersistence) GetWorkflowExecution(request *p.GetWorkflowExecut
 	replicationState := createReplicationState(result["replication_state"].(map[string]interface{}))
 	state.ReplicationState = replicationState
 
-	state.VersionHistories = p.NewDataBlob(
-		result["version_histories"].([]byte),
-		common.EncodingType(result["version_histories_encoding"].(string)),
-	)
+	state.VersionHistories = p.NewDataBlob(result["version_histories"].([]byte), common.EncodingType(result["version_histories_encoding"].(string)))
 
 	if state.VersionHistories != nil && state.ReplicationState != nil {
 		return nil, &workflow.InternalServiceError{
@@ -2062,10 +2059,10 @@ func (d *cassandraPersistence) ListConcreteExecutions(
 			result = make(map[string]interface{})
 			continue
 		}
-		if _, ok := result["execution"]; ok {
-			wfInfo := createWorkflowExecutionInfo(result["execution"].(map[string]interface{}))
-			response.ExecutionInfos = append(response.ExecutionInfos, wfInfo)
-		}
+		response.Executions = append(response.Executions, &p.InternalListConcreteExecutionsEntity{
+			ExecutionInfo:    createWorkflowExecutionInfo(result["execution"].(map[string]interface{})),
+			VersionHistories: p.NewDataBlob(result["version_histories"].([]byte), common.EncodingType(result["version_histories_encoding"].(string))),
+		})
 		result = make(map[string]interface{})
 	}
 	nextPageToken := iter.PageState()

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -792,8 +792,14 @@ type (
 
 	// ListConcreteExecutionsResponse is response to ListConcreteExecutions
 	ListConcreteExecutionsResponse struct {
-		ExecutionInfos []*WorkflowExecutionInfo
-		PageToken      []byte
+		Executions []*ListConcreteExecutionsEntity
+		PageToken  []byte
+	}
+
+	// ListConcreteExecutionsEntity is a single entity in ListConcreteExecutionsResponse
+	ListConcreteExecutionsEntity struct {
+		ExecutionInfo    *WorkflowExecutionInfo
+		VersionHistories *VersionHistories
 	}
 
 	// GetCurrentExecutionResponse is the response to GetCurrentExecution

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -786,13 +786,21 @@ func (m *executionManagerImpl) ListConcreteExecutions(
 		return nil, err
 	}
 	newResponse := &ListConcreteExecutionsResponse{
-		ExecutionInfos: make([]*WorkflowExecutionInfo, len(response.ExecutionInfos), len(response.ExecutionInfos)),
-		PageToken:      response.NextPageToken,
+		Executions: make([]*ListConcreteExecutionsEntity, len(response.Executions), len(response.Executions)),
+		PageToken:  response.NextPageToken,
 	}
-	for i, info := range response.ExecutionInfos {
-		newResponse.ExecutionInfos[i], _, err = m.DeserializeExecutionInfo(info)
+	for i, e := range response.Executions {
+		info, _, err := m.DeserializeExecutionInfo(e.ExecutionInfo)
 		if err != nil {
 			return nil, err
+		}
+		vh, err := m.DeserializeVersionHistories(e.VersionHistories)
+		if err != nil {
+			return nil, err
+		}
+		newResponse.Executions[i] = &ListConcreteExecutionsEntity{
+			ExecutionInfo:    info,
+			VersionHistories: vh,
 		}
 	}
 	return newResponse, nil

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -457,8 +457,14 @@ type (
 
 	// InternalListConcreteExecutionsResponse is the response to ListConcreteExecutions for Persistence Interface
 	InternalListConcreteExecutionsResponse struct {
-		ExecutionInfos []*InternalWorkflowExecutionInfo
-		NextPageToken  []byte
+		Executions    []*InternalListConcreteExecutionsEntity
+		NextPageToken []byte
+	}
+
+	// InternalListConcreteExecutionsEntity is a single entity in InternalListConcreteExecutionsResponse
+	InternalListConcreteExecutionsEntity struct {
+		ExecutionInfo    *InternalWorkflowExecutionInfo
+		VersionHistories *DataBlob
 	}
 
 	// InternalForkHistoryBranchRequest is used to fork a history branch


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
DB admin scan was not using versionHistory to get branch token in case of NDC. This diff will first try to get branch token from execution but if that fails it will try to access it from version history. 


<!-- Tell your future self why have you made these changes -->
This is needed to get branch token in NDC.  

