### PR TITLE
Fix panic on get history API

### DIFF
--- a/common/cache/domainCache_test.go
+++ b/common/cache/domainCache_test.go
@@ -24,14 +24,10 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/uber/cadence/common/service/config"
-	"github.com/uber/cadence/common/service/dynamicconfig"
-
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
-
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cluster"
@@ -40,6 +36,8 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/service/dynamicconfig"
 )
 
 type (

--- a/common/cache/domainCache_test.go
+++ b/common/cache/domainCache_test.go
@@ -24,6 +24,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/service/dynamicconfig"
+
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -643,4 +646,40 @@ func Test_IsSampledForLongerRetention(t *testing.T) {
 
 	d.info.Data[SampleRateKey] = "invalid-value"
 	require.False(t, d.IsSampledForLongerRetention(wid))
+}
+
+func Test_DomainCacheEntry_GetDomainNotActiveErr(t *testing.T) {
+	clusterMetadata := cluster.NewMetadata(
+		loggerimpl.NewNopLogger(),
+		dynamicconfig.GetBoolPropertyFn(true),
+		int64(10),
+		cluster.TestCurrentClusterName,
+		cluster.TestCurrentClusterName,
+		cluster.TestAllClusterInfo,
+		&config.ReplicationConsumerConfig{
+			Type: config.ReplicationConsumerTypeRPC,
+		},
+	)
+	domainEntry := NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{Name: "test-domain"},
+		nil,
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		1234,
+		clusterMetadata,
+	)
+
+	require.Nil(t, domainEntry.GetDomainNotActiveErr())
+
+	// update to become not active
+	domainEntry.replicationConfig.ActiveClusterName = cluster.TestAlternativeClusterName
+	err := domainEntry.GetDomainNotActiveErr()
+	require.NotNil(t, err)
+	_, ok := err.(*shared.DomainNotActiveError)
+	require.True(t, ok)
 }

--- a/common/persistence/sql/sqlplugin/postgres/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgres/plugin.go
@@ -35,8 +35,8 @@ import (
 
 const (
 	// PluginName is the name of the plugin
-	PluginName             = "postgres"
-	dataSourceNamePostgres = "user=%v host=%v port=%v dbname=%v sslmode=disable %v "
+	PluginName                     = "postgres"
+	dataSourceNamePostgres         = "user=%v host=%v port=%v dbname=%v sslmode=disable %v "
 	dataSourceNamePostgresPassword = "password=%v"
 )
 

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -667,12 +667,13 @@ func (e *historyEngineImpl) updateEntityNotExistsErrorOnPassiveCluster(err error
 		if domainCacheErr != nil {
 			return err // if could not access domain cache simply return original error
 		}
-		domainNotActiveErr := domainCache.GetDomainNotActiveErr().(*workflow.DomainNotActiveError)
-		if domainNotActiveErr != nil {
+
+		if domainNotActiveErr := domainCache.GetDomainNotActiveErr(); domainNotActiveErr != nil {
+			domainNotActiveErrCasted := domainNotActiveErr.(*workflow.DomainNotActiveError)
 			return &workflow.EntityNotExistsError{
 				Message:        "Workflow execution not found in non-active cluster",
-				ActiveCluster:  common.StringPtr(domainNotActiveErr.GetActiveCluster()),
-				CurrentCluster: common.StringPtr(domainNotActiveErr.GetCurrentCluster()),
+				ActiveCluster:  common.StringPtr(domainNotActiveErrCasted.GetActiveCluster()),
+				CurrentCluster: common.StringPtr(domainNotActiveErrCasted.GetCurrentCluster()),
 			}
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix panic on get history API

<!-- Tell your future self why have you made these changes -->
**Why?**
when get history for non-exist workflow, currently it will cause server panic, and leading client side get unexpected context deadline exceed error.  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test, 
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risk. fix bug that are not in release yet. 
