### PR TITLE
Refactor db scan checks and include in delete

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -774,6 +774,10 @@ func newDBCommands() []cli.Command {
 					Name:  FlagReportRate,
 					Usage: "the number of shards which get handled between each emitting of progress",
 					Value: 10,
+				},
+				cli.BoolFlag{
+					Name:  FlagSkipHistoryChecks,
+					Usage: "skip over history check invariants",
 				}),
 			Action: func(c *cli.Context) {
 				AdminDBScan(c)
@@ -823,9 +827,9 @@ func newDBCommands() []cli.Command {
 					Usage: "the number of shards which get handled between each emitting of progress",
 					Value: 10,
 				},
-				cli.StringSliceFlag{
-					Name: FlagDBInvariantChecks,
-					Usage: ""
+				cli.BoolFlag{
+					Name:  FlagSkipHistoryChecks,
+					Usage: "skip over history check invariants",
 				}),
 			Action: func(c *cli.Context) {
 				AdminDBClean(c)

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -822,6 +822,10 @@ func newDBCommands() []cli.Command {
 					Name:  FlagReportRate,
 					Usage: "the number of shards which get handled between each emitting of progress",
 					Value: 10,
+				},
+				cli.StringSliceFlag{
+					Name: FlagDBInvariantChecks,
+					Usage: ""
 				}),
 			Action: func(c *cli.Context) {
 				AdminDBClean(c)

--- a/tools/cli/adminDBChecks.go
+++ b/tools/cli/adminDBChecks.go
@@ -256,17 +256,17 @@ func (c *firstHistoryEventCheck) Check(cr *CheckRequest) *CheckResult {
 
 // ValidRequest returns true if the request is valid, false otherwise
 func (c *firstHistoryEventCheck) ValidRequest(cr *CheckRequest) bool {
-	payloadValid := cr.PrerequisiteCheckPayload != nil
-	if payloadValid {
-		history, ok := cr.PrerequisiteCheckPayload.(*persistence.InternalReadHistoryBranchResponse)
-		if !ok {
-			payloadValid = false
-		}
-		if history.History == nil || len(history.History) == 0 {
-			payloadValid = false
-		}
+	if cr.PrerequisiteCheckPayload == nil {
+		return false
 	}
-	return payloadValid && validRequestHelper(cr)
+	history, ok := cr.PrerequisiteCheckPayload.(*persistence.InternalReadHistoryBranchResponse)
+	if !ok {
+		return false
+	}
+	if history.History == nil || len(history.History) == 0 {
+		return false
+	}
+	return validRequestHelper(cr)
 }
 
 func (c *orphanExecutionCheck) Check(cr *CheckRequest) *CheckResult {

--- a/tools/cli/adminDBChecks.go
+++ b/tools/cli/adminDBChecks.go
@@ -1,34 +1,57 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package cli
 
 import (
 	"fmt"
+
 	"github.com/gocql/gocql"
+
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/codec"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
 
 type (
-	// CheckResultType is the result type of a check
-	CheckResultType string
+	// CheckResultStatus is the result status of a check
+	CheckResultStatus string
 	// CheckType is the type of check
 	CheckType string
 )
 
 const (
-	// CheckResultTypeHealthy indicates check successfully ran and detected no corruption
-	CheckResultTypeHealthy CheckResultType = "healthy"
-	// CheckResultTypeCorruption indicates check successfully ran and detected corruption
-	CheckResultTypeCorruption = "corruption"
-	// CheckResultTypeFailure indicates check failed to run
-	CheckResultTypeFailure = "failure"
+	// CheckResultHealthy indicates check successfully ran and detected no corruption
+	CheckResultHealthy CheckResultStatus = "healthy"
+	// CheckResultCorrupted indicates check successfully ran and detected corruption
+	CheckResultCorrupted = "corrupted"
+	// CheckResultFailed indicates check failed to run
+	CheckResultFailed = "failed"
 
 	// CheckTypeHistoryExists is the check type for history exists
 	CheckTypeHistoryExists CheckType = "history_exists"
 	// CheckTypeValidFirstEvent is the check type for valid first event
-	CheckTypeValidFirstEvent CheckType = "valid_first_event"
+	CheckTypeValidFirstEvent = "valid_first_event"
 	// CheckTypeOrphanExecution is the check type for orphan execution
 	CheckTypeOrphanExecution = "orphan_execution"
 
@@ -36,116 +59,95 @@ const (
 )
 
 type (
+	// AdminDBCheck is used to check database invariants
 	AdminDBCheck interface {
 		Check(*CheckRequest) *CheckResult
+		ValidRequest(*CheckRequest) bool
 	}
 
 	historyExistsCheck struct {
-		branchDecoder *codec.ThriftRWEncoder
-		shardID int
-		dbRateLimiter *quotas.DynamicRateLimiter
-		historyStore persistence.HistoryStore
+		dbRateLimiter  *quotas.DynamicRateLimiter
+		historyStore   persistence.HistoryStore
 		executionStore persistence.ExecutionStore
-		payloadSerializer persistence.PayloadSerializer
 	}
 
 	firstHistoryEventCheck struct {
-		branchDecoder *codec.ThriftRWEncoder
-		shardID int
-		dbRateLimiter *quotas.DynamicRateLimiter
-		historyStore persistence.HistoryStore
-		executionStore persistence.ExecutionStore
 		payloadSerializer persistence.PayloadSerializer
 	}
 
 	orphanExecutionCheck struct {
-		branchDecoder *codec.ThriftRWEncoder
-		shardID int
-		dbRateLimiter *quotas.DynamicRateLimiter
-		historyStore persistence.HistoryStore
-		executionStore persistence.ExecutionStore
+		dbRateLimiter     *quotas.DynamicRateLimiter
+		executionStore    persistence.ExecutionStore
 		payloadSerializer persistence.PayloadSerializer
 	}
 
+	// CheckRequest is a request to check an execution
 	CheckRequest struct {
-		ShardID int
-		DomainID string
+		ShardID    int
+		DomainID   string
 		WorkflowID string
-		RunID string
-		TreeID string
-		BranchID string
-		State int
+		RunID      string
+		TreeID     string
+		BranchID   string
+		State      int
+		// PrerequisiteCheckPayload is used to take in any payloads which this check needs
+		// which were created by a check ran earlier
 		PrerequisiteCheckPayload interface{}
 	}
 
+	// CheckResult is the result of checking an execution
 	CheckResult struct {
-		CheckType CheckType
-		CheckResultType CheckResultType
+		CheckType             CheckType
+		CheckResultStatus     CheckResultStatus
 		TotalDatabaseRequests int64
-		Payload interface{}
+		// Payload can be used to return additional data which can be used by later checks
+		Payload   interface{}
 		ErrorInfo *ErrorInfo
 	}
 
+	// ErrorInfo contains information about any errors that occurred
 	ErrorInfo struct {
-		Note string
+		Note    string
 		Details string
 	}
 )
 
+// NewHistoryExistsCheck constructs a historyExistsCheck
 func NewHistoryExistsCheck(
-	branchDecoder *codec.ThriftRWEncoder,
-	shardID int,
 	dbRateLimiter *quotas.DynamicRateLimiter,
 	historyStore persistence.HistoryStore,
 	executionStore persistence.ExecutionStore,
-	payloadSerializer persistence.PayloadSerializer,
 ) AdminDBCheck {
 	return &historyExistsCheck{
-		branchDecoder: branchDecoder,
-		shardID: shardID,
-		dbRateLimiter: dbRateLimiter,
-		historyStore: historyStore,
+		dbRateLimiter:  dbRateLimiter,
+		historyStore:   historyStore,
 		executionStore: executionStore,
-		payloadSerializer: payloadSerializer,
 	}
 }
 
+// NewFirstHistoryEventCheck constructs a firstHistoryEventCheck
 func NewFirstHistoryEventCheck(
-	branchDecoder *codec.ThriftRWEncoder,
-	shardID int,
-	dbRateLimiter *quotas.DynamicRateLimiter,
-	historyStore persistence.HistoryStore,
-	executionStore persistence.ExecutionStore,
 	payloadSerializer persistence.PayloadSerializer,
 ) AdminDBCheck {
 	return &firstHistoryEventCheck{
-		branchDecoder: branchDecoder,
-		shardID: shardID,
-		dbRateLimiter: dbRateLimiter,
-		historyStore: historyStore,
-		executionStore: executionStore,
 		payloadSerializer: payloadSerializer,
 	}
 }
 
+// NewOrphanExecutionCheck constructs an orphanExecutionCheck
 func NewOrphanExecutionCheck(
-	branchDecoder *codec.ThriftRWEncoder,
-	shardID int,
 	dbRateLimiter *quotas.DynamicRateLimiter,
-	historyStore persistence.HistoryStore,
 	executionStore persistence.ExecutionStore,
 	payloadSerializer persistence.PayloadSerializer,
 ) AdminDBCheck {
 	return &orphanExecutionCheck{
-		branchDecoder: branchDecoder,
-		shardID: shardID,
-		dbRateLimiter: dbRateLimiter,
-		historyStore: historyStore,
-		executionStore: executionStore,
+		dbRateLimiter:     dbRateLimiter,
+		executionStore:    executionStore,
 		payloadSerializer: payloadSerializer,
 	}
 }
 
+// Check checks that history exists
 func (c *historyExistsCheck) Check(cr *CheckRequest) *CheckResult {
 	result := &CheckResult{
 		CheckType: CheckTypeHistoryExists,
@@ -171,46 +173,53 @@ func (c *historyExistsCheck) Check(cr *CheckRequest) *CheckResult {
 		&result.TotalDatabaseRequests)
 
 	if executionErr != nil {
-		result.CheckResultType = CheckResultTypeFailure
+		result.CheckResultStatus = CheckResultFailed
 		result.ErrorInfo = &ErrorInfo{
-			Note: "failed to verify if concrete execution still exists",
+			Note:    "failed to verify if concrete execution still exists",
 			Details: executionErr.Error(),
 		}
 		return result
 	}
 	if !stillExists {
-		result.CheckResultType = CheckResultTypeHealthy
+		result.CheckResultStatus = CheckResultHealthy
 		return result
 	}
 
 	if historyErr != nil {
 		if historyErr == gocql.ErrNotFound {
-			result.CheckResultType = CheckResultTypeCorruption
+			result.CheckResultStatus = CheckResultCorrupted
 			result.ErrorInfo = &ErrorInfo{
-				Note: "concrete execution exists but history does not",
+				Note:    "concrete execution exists but history does not",
 				Details: historyErr.Error(),
 			}
 			return result
 		}
-		result.CheckResultType = CheckResultTypeFailure
+		result.CheckResultStatus = CheckResultFailed
 		result.ErrorInfo = &ErrorInfo{
-			Note: "failed to verify if history exists",
+			Note:    "failed to verify if history exists",
 			Details: historyErr.Error(),
 		}
 		return result
 	}
 	if history == nil || len(history.History) == 0 {
-		result.CheckResultType = CheckResultTypeCorruption
+		result.CheckResultStatus = CheckResultCorrupted
 		result.ErrorInfo = &ErrorInfo{
 			Note: "got empty history",
 		}
 		return result
 	}
-	result.CheckResultType = CheckResultTypeHealthy
+	result.CheckResultStatus = CheckResultHealthy
 	result.Payload = history
 	return result
 }
 
+// ValidRequest returns true if the request is valid, false otherwise
+func (c *historyExistsCheck) ValidRequest(cr *CheckRequest) bool {
+	return validRequestHelper(cr)
+}
+
+// Check checks that first event in history is valid
+// CheckRequest must contain a payload of type *persistence.InternalReadHistoryBranchResponse
 func (c *firstHistoryEventCheck) Check(cr *CheckRequest) *CheckResult {
 	result := &CheckResult{
 		CheckType: CheckTypeValidFirstEvent,
@@ -218,31 +227,46 @@ func (c *firstHistoryEventCheck) Check(cr *CheckRequest) *CheckResult {
 	history := cr.PrerequisiteCheckPayload.(*persistence.InternalReadHistoryBranchResponse)
 	firstBatch, err := c.payloadSerializer.DeserializeBatchEvents(history.History[0])
 	if err != nil || len(firstBatch) == 0 {
-		result.CheckResultType = CheckResultTypeFailure
+		result.CheckResultStatus = CheckResultFailed
 		result.ErrorInfo = &ErrorInfo{
-			Note: "failed to deserialize batch events",
+			Note:    "failed to deserialize batch events",
 			Details: err.Error(),
 		}
 		return result
 	}
 	if firstBatch[0].GetEventId() != common.FirstEventID {
-		result.CheckResultType = CheckResultTypeCorruption
+		result.CheckResultStatus = CheckResultCorrupted
 		result.ErrorInfo = &ErrorInfo{
-			Note: "got unexpected first eventID",
-			Details:        fmt.Sprintf("expected: %v but got %v", common.FirstEventID, firstBatch[0].GetEventId()),
+			Note:    "got unexpected first eventID",
+			Details: fmt.Sprintf("expected: %v but got %v", common.FirstEventID, firstBatch[0].GetEventId()),
 		}
 		return result
 	}
 	if firstBatch[0].GetEventType() != shared.EventTypeWorkflowExecutionStarted {
-		result.CheckResultType = CheckResultTypeCorruption
+		result.CheckResultStatus = CheckResultCorrupted
 		result.ErrorInfo = &ErrorInfo{
-			Note: "got unexpected first eventType",
-			Details:        fmt.Sprintf("expected: %v but got %v", shared.EventTypeWorkflowExecutionStarted.String(), firstBatch[0].GetEventType().String()),
+			Note:    "got unexpected first eventType",
+			Details: fmt.Sprintf("expected: %v but got %v", shared.EventTypeWorkflowExecutionStarted.String(), firstBatch[0].GetEventType().String()),
 		}
 		return result
 	}
-	result.CheckResultType = CheckResultTypeHealthy
+	result.CheckResultStatus = CheckResultHealthy
 	return result
+}
+
+// ValidRequest returns true if the request is valid, false otherwise
+func (c *firstHistoryEventCheck) ValidRequest(cr *CheckRequest) bool {
+	payloadValid := cr.PrerequisiteCheckPayload != nil
+	if payloadValid {
+		history, ok := cr.PrerequisiteCheckPayload.(*persistence.InternalReadHistoryBranchResponse)
+		if !ok {
+			payloadValid = false
+		}
+		if history.History == nil || len(history.History) == 0 {
+			payloadValid = false
+		}
+	}
+	return payloadValid && validRequestHelper(cr)
 }
 
 func (c *orphanExecutionCheck) Check(cr *CheckRequest) *CheckResult {
@@ -250,7 +274,7 @@ func (c *orphanExecutionCheck) Check(cr *CheckRequest) *CheckResult {
 		CheckType: CheckTypeOrphanExecution,
 	}
 	if !executionOpen(cr) {
-		result.CheckResultType = CheckResultTypeHealthy
+		result.CheckResultStatus = CheckResultHealthy
 		return result
 	}
 	getCurrentExecutionRequest := &persistence.GetCurrentExecutionRequest{
@@ -265,44 +289,49 @@ func (c *orphanExecutionCheck) Check(cr *CheckRequest) *CheckResult {
 
 	stillOpen, concreteErr := concreteExecutionStillOpen(cr, c.executionStore, c.dbRateLimiter, &result.TotalDatabaseRequests)
 	if concreteErr != nil {
-		result.CheckResultType = CheckResultTypeFailure
+		result.CheckResultStatus = CheckResultFailed
 		result.ErrorInfo = &ErrorInfo{
-			Note: "failed to check if concrete execution is still open",
+			Note:    "failed to check if concrete execution is still open",
 			Details: concreteErr.Error(),
 		}
 		return result
 	}
 	if !stillOpen {
-		result.CheckResultType = CheckResultTypeHealthy
+		result.CheckResultStatus = CheckResultHealthy
 		return result
 	}
 
 	if currentErr != nil {
 		switch currentErr.(type) {
 		case *shared.EntityNotExistsError:
-			result.CheckResultType = CheckResultTypeCorruption
+			result.CheckResultStatus = CheckResultCorrupted
 			result.ErrorInfo = &ErrorInfo{
-				Note: "execution is open without having current execution",
+				Note:    "execution is open without having current execution",
 				Details: currentErr.Error(),
 			}
 			return result
 		}
-		result.CheckResultType = CheckResultTypeFailure
+		result.CheckResultStatus = CheckResultFailed
 		result.ErrorInfo = &ErrorInfo{
-			Note: "failed to check if current execution exists",
+			Note:    "failed to check if current execution exists",
 			Details: currentErr.Error(),
 		}
 		return result
 	}
 	if currentExecution.RunID != cr.RunID {
-		result.CheckResultType = CheckResultTypeCorruption
+		result.CheckResultStatus = CheckResultCorrupted
 		result.ErrorInfo = &ErrorInfo{
 			Note: "execution is open but current points at a different execution",
 		}
 		return result
 	}
-	result.CheckResultType = CheckResultTypeHealthy
+	result.CheckResultStatus = CheckResultHealthy
 	return result
+}
+
+// ValidRequest returns true if the request is valid, false otherwise
+func (c *orphanExecutionCheck) ValidRequest(cr *CheckRequest) bool {
+	return validRequestHelper(cr)
 }
 
 func concreteExecutionStillOpen(
@@ -360,4 +389,12 @@ func concreteExecutionStillExists(
 func executionOpen(cr *CheckRequest) bool {
 	return cr.State == persistence.WorkflowStateCreated ||
 		cr.State == persistence.WorkflowStateRunning
+}
+
+func validRequestHelper(cr *CheckRequest) bool {
+	return len(cr.DomainID) > 0 &&
+		len(cr.WorkflowID) > 0 &&
+		len(cr.RunID) > 0 &&
+		len(cr.TreeID) > 0 &&
+		len(cr.BranchID) > 0
 }

--- a/tools/cli/adminDBChecks.go
+++ b/tools/cli/adminDBChecks.go
@@ -1,0 +1,363 @@
+package cli
+
+import (
+	"fmt"
+	"github.com/gocql/gocql"
+	"github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/codec"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/quotas"
+)
+
+type (
+	// CheckResultType is the result type of a check
+	CheckResultType string
+	// CheckType is the type of check
+	CheckType string
+)
+
+const (
+	// CheckResultTypeHealthy indicates check successfully ran and detected no corruption
+	CheckResultTypeHealthy CheckResultType = "healthy"
+	// CheckResultTypeCorruption indicates check successfully ran and detected corruption
+	CheckResultTypeCorruption = "corruption"
+	// CheckResultTypeFailure indicates check failed to run
+	CheckResultTypeFailure = "failure"
+
+	// CheckTypeHistoryExists is the check type for history exists
+	CheckTypeHistoryExists CheckType = "history_exists"
+	// CheckTypeValidFirstEvent is the check type for valid first event
+	CheckTypeValidFirstEvent CheckType = "valid_first_event"
+	// CheckTypeOrphanExecution is the check type for orphan execution
+	CheckTypeOrphanExecution = "orphan_execution"
+
+	historyPageSize = 1
+)
+
+type (
+	AdminDBCheck interface {
+		Check(*CheckRequest) *CheckResult
+	}
+
+	historyExistsCheck struct {
+		branchDecoder *codec.ThriftRWEncoder
+		shardID int
+		dbRateLimiter *quotas.DynamicRateLimiter
+		historyStore persistence.HistoryStore
+		executionStore persistence.ExecutionStore
+		payloadSerializer persistence.PayloadSerializer
+	}
+
+	firstHistoryEventCheck struct {
+		branchDecoder *codec.ThriftRWEncoder
+		shardID int
+		dbRateLimiter *quotas.DynamicRateLimiter
+		historyStore persistence.HistoryStore
+		executionStore persistence.ExecutionStore
+		payloadSerializer persistence.PayloadSerializer
+	}
+
+	orphanExecutionCheck struct {
+		branchDecoder *codec.ThriftRWEncoder
+		shardID int
+		dbRateLimiter *quotas.DynamicRateLimiter
+		historyStore persistence.HistoryStore
+		executionStore persistence.ExecutionStore
+		payloadSerializer persistence.PayloadSerializer
+	}
+
+	CheckRequest struct {
+		ShardID int
+		DomainID string
+		WorkflowID string
+		RunID string
+		TreeID string
+		BranchID string
+		State int
+		PrerequisiteCheckPayload interface{}
+	}
+
+	CheckResult struct {
+		CheckType CheckType
+		CheckResultType CheckResultType
+		TotalDatabaseRequests int64
+		Payload interface{}
+		ErrorInfo *ErrorInfo
+	}
+
+	ErrorInfo struct {
+		Note string
+		Details string
+	}
+)
+
+func NewHistoryExistsCheck(
+	branchDecoder *codec.ThriftRWEncoder,
+	shardID int,
+	dbRateLimiter *quotas.DynamicRateLimiter,
+	historyStore persistence.HistoryStore,
+	executionStore persistence.ExecutionStore,
+	payloadSerializer persistence.PayloadSerializer,
+) AdminDBCheck {
+	return &historyExistsCheck{
+		branchDecoder: branchDecoder,
+		shardID: shardID,
+		dbRateLimiter: dbRateLimiter,
+		historyStore: historyStore,
+		executionStore: executionStore,
+		payloadSerializer: payloadSerializer,
+	}
+}
+
+func NewFirstHistoryEventCheck(
+	branchDecoder *codec.ThriftRWEncoder,
+	shardID int,
+	dbRateLimiter *quotas.DynamicRateLimiter,
+	historyStore persistence.HistoryStore,
+	executionStore persistence.ExecutionStore,
+	payloadSerializer persistence.PayloadSerializer,
+) AdminDBCheck {
+	return &firstHistoryEventCheck{
+		branchDecoder: branchDecoder,
+		shardID: shardID,
+		dbRateLimiter: dbRateLimiter,
+		historyStore: historyStore,
+		executionStore: executionStore,
+		payloadSerializer: payloadSerializer,
+	}
+}
+
+func NewOrphanExecutionCheck(
+	branchDecoder *codec.ThriftRWEncoder,
+	shardID int,
+	dbRateLimiter *quotas.DynamicRateLimiter,
+	historyStore persistence.HistoryStore,
+	executionStore persistence.ExecutionStore,
+	payloadSerializer persistence.PayloadSerializer,
+) AdminDBCheck {
+	return &orphanExecutionCheck{
+		branchDecoder: branchDecoder,
+		shardID: shardID,
+		dbRateLimiter: dbRateLimiter,
+		historyStore: historyStore,
+		executionStore: executionStore,
+		payloadSerializer: payloadSerializer,
+	}
+}
+
+func (c *historyExistsCheck) Check(cr *CheckRequest) *CheckResult {
+	result := &CheckResult{
+		CheckType: CheckTypeHistoryExists,
+	}
+	readHistoryBranchReq := &persistence.InternalReadHistoryBranchRequest{
+		TreeID:    cr.TreeID,
+		BranchID:  cr.BranchID,
+		MinNodeID: common.FirstEventID,
+		MaxNodeID: common.EndEventID,
+		ShardID:   cr.ShardID,
+		PageSize:  historyPageSize,
+	}
+	history, historyErr := retryReadHistoryBranch(
+		c.dbRateLimiter,
+		&result.TotalDatabaseRequests,
+		c.historyStore,
+		readHistoryBranchReq)
+
+	stillExists, executionErr := concreteExecutionStillExists(
+		cr,
+		c.executionStore,
+		c.dbRateLimiter,
+		&result.TotalDatabaseRequests)
+
+	if executionErr != nil {
+		result.CheckResultType = CheckResultTypeFailure
+		result.ErrorInfo = &ErrorInfo{
+			Note: "failed to verify if concrete execution still exists",
+			Details: executionErr.Error(),
+		}
+		return result
+	}
+	if !stillExists {
+		result.CheckResultType = CheckResultTypeHealthy
+		return result
+	}
+
+	if historyErr != nil {
+		if historyErr == gocql.ErrNotFound {
+			result.CheckResultType = CheckResultTypeCorruption
+			result.ErrorInfo = &ErrorInfo{
+				Note: "concrete execution exists but history does not",
+				Details: historyErr.Error(),
+			}
+			return result
+		}
+		result.CheckResultType = CheckResultTypeFailure
+		result.ErrorInfo = &ErrorInfo{
+			Note: "failed to verify if history exists",
+			Details: historyErr.Error(),
+		}
+		return result
+	}
+	if history == nil || len(history.History) == 0 {
+		result.CheckResultType = CheckResultTypeCorruption
+		result.ErrorInfo = &ErrorInfo{
+			Note: "got empty history",
+		}
+		return result
+	}
+	result.CheckResultType = CheckResultTypeHealthy
+	result.Payload = history
+	return result
+}
+
+func (c *firstHistoryEventCheck) Check(cr *CheckRequest) *CheckResult {
+	result := &CheckResult{
+		CheckType: CheckTypeValidFirstEvent,
+	}
+	history := cr.PrerequisiteCheckPayload.(*persistence.InternalReadHistoryBranchResponse)
+	firstBatch, err := c.payloadSerializer.DeserializeBatchEvents(history.History[0])
+	if err != nil || len(firstBatch) == 0 {
+		result.CheckResultType = CheckResultTypeFailure
+		result.ErrorInfo = &ErrorInfo{
+			Note: "failed to deserialize batch events",
+			Details: err.Error(),
+		}
+		return result
+	}
+	if firstBatch[0].GetEventId() != common.FirstEventID {
+		result.CheckResultType = CheckResultTypeCorruption
+		result.ErrorInfo = &ErrorInfo{
+			Note: "got unexpected first eventID",
+			Details:        fmt.Sprintf("expected: %v but got %v", common.FirstEventID, firstBatch[0].GetEventId()),
+		}
+		return result
+	}
+	if firstBatch[0].GetEventType() != shared.EventTypeWorkflowExecutionStarted {
+		result.CheckResultType = CheckResultTypeCorruption
+		result.ErrorInfo = &ErrorInfo{
+			Note: "got unexpected first eventType",
+			Details:        fmt.Sprintf("expected: %v but got %v", shared.EventTypeWorkflowExecutionStarted.String(), firstBatch[0].GetEventType().String()),
+		}
+		return result
+	}
+	result.CheckResultType = CheckResultTypeHealthy
+	return result
+}
+
+func (c *orphanExecutionCheck) Check(cr *CheckRequest) *CheckResult {
+	result := &CheckResult{
+		CheckType: CheckTypeOrphanExecution,
+	}
+	if !executionOpen(cr) {
+		result.CheckResultType = CheckResultTypeHealthy
+		return result
+	}
+	getCurrentExecutionRequest := &persistence.GetCurrentExecutionRequest{
+		DomainID:   cr.DomainID,
+		WorkflowID: cr.WorkflowID,
+	}
+	currentExecution, currentErr := retryGetCurrentExecution(
+		c.dbRateLimiter,
+		&result.TotalDatabaseRequests,
+		c.executionStore,
+		getCurrentExecutionRequest)
+
+	stillOpen, concreteErr := concreteExecutionStillOpen(cr, c.executionStore, c.dbRateLimiter, &result.TotalDatabaseRequests)
+	if concreteErr != nil {
+		result.CheckResultType = CheckResultTypeFailure
+		result.ErrorInfo = &ErrorInfo{
+			Note: "failed to check if concrete execution is still open",
+			Details: concreteErr.Error(),
+		}
+		return result
+	}
+	if !stillOpen {
+		result.CheckResultType = CheckResultTypeHealthy
+		return result
+	}
+
+	if currentErr != nil {
+		switch currentErr.(type) {
+		case *shared.EntityNotExistsError:
+			result.CheckResultType = CheckResultTypeCorruption
+			result.ErrorInfo = &ErrorInfo{
+				Note: "execution is open without having current execution",
+				Details: currentErr.Error(),
+			}
+			return result
+		}
+		result.CheckResultType = CheckResultTypeFailure
+		result.ErrorInfo = &ErrorInfo{
+			Note: "failed to check if current execution exists",
+			Details: currentErr.Error(),
+		}
+		return result
+	}
+	if currentExecution.RunID != cr.RunID {
+		result.CheckResultType = CheckResultTypeCorruption
+		result.ErrorInfo = &ErrorInfo{
+			Note: "execution is open but current points at a different execution",
+		}
+		return result
+	}
+	result.CheckResultType = CheckResultTypeHealthy
+	return result
+}
+
+func concreteExecutionStillOpen(
+	cr *CheckRequest,
+	execStore persistence.ExecutionStore,
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+) (bool, error) {
+	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
+		DomainID: cr.DomainID,
+		Execution: shared.WorkflowExecution{
+			WorkflowId: &cr.WorkflowID,
+			RunId:      &cr.RunID,
+		},
+	}
+	_, err := retryGetWorkflowExecution(limiter, totalDBRequests, execStore, getConcreteExecution)
+
+	if err != nil {
+		switch err.(type) {
+		case *shared.EntityNotExistsError:
+			return false, nil
+		default:
+			return false, err
+		}
+	}
+	return executionOpen(cr), nil
+}
+
+func concreteExecutionStillExists(
+	cr *CheckRequest,
+	execStore persistence.ExecutionStore,
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+) (bool, error) {
+	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
+		DomainID: cr.DomainID,
+		Execution: shared.WorkflowExecution{
+			WorkflowId: &cr.WorkflowID,
+			RunId:      &cr.RunID,
+		},
+	}
+	_, err := retryGetWorkflowExecution(limiter, totalDBRequests, execStore, getConcreteExecution)
+	if err == nil {
+		return true, nil
+	}
+
+	switch err.(type) {
+	case *shared.EntityNotExistsError:
+		return false, nil
+	default:
+		return false, err
+	}
+}
+
+func executionOpen(cr *CheckRequest) bool {
+	return cr.State == persistence.WorkflowStateCreated ||
+		cr.State == persistence.WorkflowStateRunning
+}

--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -30,9 +30,6 @@ import (
 	"os"
 	"time"
 
-	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/backoff"
-
 	"github.com/gocql/gocql"
 	"github.com/urfave/cli"
 
@@ -54,9 +51,10 @@ type (
 	// ShardCleanReportHandled is the part of ShardCleanReport of executions which were read from corruption file
 	// and were attempted to be deleted
 	ShardCleanReportHandled struct {
-		TotalExecutionsCount     int64
-		SuccessfullyCleanedCount int64
-		FailedCleanedCount       int64
+		TotalExecutionsCount          int64
+		SuccessfullyCleanedCount      int64
+		FailedCleanedCount            int64
+		FailedToConfirmCorruptedCount int64
 	}
 
 	// ShardCleanReportFailure is the part of ShardCleanReport that indicates a failure to clean some or all
@@ -68,16 +66,18 @@ type (
 
 	// CleanProgressReport represents the aggregate progress of the clean job.
 	// It is periodically printed to stdout
+	// TODO: move these reports into there own file like we did for scan
 	CleanProgressReport struct {
-		NumberOfShardsFinished     int
-		TotalExecutionsCount       int64
-		SuccessfullyCleanedCount   int64
-		FailedCleanedCount         int64
-		TotalDBRequests            int64
-		DatabaseRPS                float64
-		NumberOfShardCleanFailures int64
-		ShardsPerHour              float64
-		ExecutionsPerHour          float64
+		NumberOfShardsFinished        int
+		TotalExecutionsCount          int64
+		SuccessfullyCleanedCount      int64
+		FailedCleanedCount            int64
+		FailedToConfirmCorruptedCount int64
+		TotalDBRequests               int64
+		DatabaseRPS                   float64
+		NumberOfShardCleanFailures    int64
+		ShardsPerHour                 float64
+		ExecutionsPerHour             float64
 	}
 
 	// CleanOutputDirectories are the directory paths for output of clean
@@ -109,10 +109,13 @@ func AdminDBClean(c *cli.Context) {
 		scanWorkerCount = numShards
 	}
 	inputDirectory := getRequiredOption(c, FlagInputDirectory)
+	skipHistoryChecks := c.Bool(FlagSkipHistoryChecks)
 
+	payloadSerializer := persistence.NewPayloadSerializer()
 	rateLimiter := getRateLimiter(startingRPS, targetRPS, scaleUpSeconds)
 	session := connectToCassandra(c)
 	defer session.Close()
+	historyStore := cassp.NewHistoryV2PersistenceFromSession(session, loggerimpl.NewNopLogger())
 	cleanOutputDirectories := createCleanOutputDirectories()
 
 	reports := make(chan *ShardCleanReport)
@@ -125,7 +128,10 @@ func AdminDBClean(c *cli.Context) {
 						session,
 						cleanOutputDirectories,
 						inputDirectory,
-						shardID)
+						shardID,
+						skipHistoryChecks,
+						payloadSerializer,
+						historyStore)
 				}
 			}
 		}(i)
@@ -152,6 +158,9 @@ func cleanShard(
 	outputDirectories *CleanOutputDirectories,
 	inputDirectory string,
 	shardID int,
+	skipHistoryChecks bool,
+	payloadSerializer persistence.PayloadSerializer,
+	historyStore persistence.HistoryStore,
 ) *ShardCleanReport {
 	outputFiles, closeFn := createShardCleanOutputFiles(shardID, outputDirectories)
 	report := &ShardCleanReport{
@@ -186,6 +195,8 @@ func cleanShard(
 		return report
 	}
 
+	checks := getChecks(skipHistoryChecks, limiter, execStore, payloadSerializer, historyStore)
+
 	scanner := bufio.NewScanner(shardCorruptedFile)
 	for scanner.Scan() {
 		if report.Handled == nil {
@@ -196,36 +207,63 @@ func cleanShard(
 			continue
 		}
 		report.Handled.TotalExecutionsCount++
-		var ce CorruptedExecution
-		err := json.Unmarshal([]byte(line), &ce)
+		var etr ExecutionToRecord
+		err := json.Unmarshal([]byte(line), &etr)
 		if err != nil {
 			report.Handled.FailedCleanedCount++
 			continue
 		}
 
+		// run checks again to confirm that the execution is still corrupted
+		cr := &CheckRequest{
+			ShardID:    etr.ShardID,
+			DomainID:   etr.DomainID,
+			WorkflowID: etr.WorkflowID,
+			RunID:      etr.RunID,
+			TreeID:     etr.TreeID,
+			BranchID:   etr.BranchID,
+			State:      etr.State,
+		}
+		confirmedCorrupted := false
+		for _, c := range checks {
+			if !c.ValidRequest(cr) {
+				continue
+			}
+			result := c.Check(cr)
+			cr.PrerequisiteCheckPayload = result.Payload
+			if result.CheckResultStatus == CheckResultCorrupted {
+				confirmedCorrupted = true
+				break
+			}
+		}
+		if !confirmedCorrupted {
+			report.Handled.FailedToConfirmCorruptedCount++
+			continue
+		}
+
 		deleteConcreteReq := &persistence.DeleteWorkflowExecutionRequest{
-			DomainID:   ce.DomainID,
-			WorkflowID: ce.WorkflowID,
-			RunID:      ce.RunID,
+			DomainID:   etr.DomainID,
+			WorkflowID: etr.WorkflowID,
+			RunID:      etr.RunID,
 		}
 		err = retryDeleteWorkflowExecution(limiter, &report.TotalDBRequests, execStore, deleteConcreteReq)
 		if err != nil {
 			report.Handled.FailedCleanedCount++
-			failedCleanWriter.Add(&ce)
+			failedCleanWriter.Add(&etr)
 			continue
 		}
 		report.Handled.SuccessfullyCleanedCount++
-		successfullyCleanWriter.Add(&ce)
+		successfullyCleanWriter.Add(&etr)
 		deleteCurrentReq := &persistence.DeleteCurrentWorkflowExecutionRequest{
-			DomainID:   ce.DomainID,
-			WorkflowID: ce.WorkflowID,
-			RunID:      ce.RunID,
+			DomainID:   etr.DomainID,
+			WorkflowID: etr.WorkflowID,
+			RunID:      etr.RunID,
 		}
 		// deleting current execution is best effort, the success or failure of the cleanup
 		// is determined above based on if the concrete execution could be deleted
 		retryDeleteCurrentWorkflowExecution(limiter, &report.TotalDBRequests, execStore, deleteCurrentReq)
 
-		// TODO: we will want to also cleanup history for corrupted workflows, this will be punted on until this is converted to a workflow
+		// TODO: also need to clean up histories of corrupted workflows
 	}
 	return report
 }
@@ -245,6 +283,7 @@ func includeShardCleanInProgressReport(report *ShardCleanReport, progressReport 
 	if report.Handled != nil {
 		progressReport.TotalExecutionsCount += report.Handled.TotalExecutionsCount
 		progressReport.FailedCleanedCount += report.Handled.FailedCleanedCount
+		progressReport.FailedToConfirmCorruptedCount += report.Handled.FailedToConfirmCorruptedCount
 		progressReport.SuccessfullyCleanedCount += report.Handled.SuccessfullyCleanedCount
 	}
 

--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -309,39 +309,3 @@ func recordShardCleanReport(file *os.File, sdr *ShardCleanReport) {
 	}
 	writeToFile(file, string(data))
 }
-
-func retryDeleteWorkflowExecution(
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-	execStore persistence.ExecutionStore,
-	req *persistence.DeleteWorkflowExecutionRequest,
-) error {
-	op := func() error {
-		preconditionForDBCall(totalDBRequests, limiter)
-		return execStore.DeleteWorkflowExecution(req)
-	}
-
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func retryDeleteCurrentWorkflowExecution(
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-	execStore persistence.ExecutionStore,
-	req *persistence.DeleteCurrentWorkflowExecutionRequest,
-) error {
-	op := func() error {
-		preconditionForDBCall(totalDBRequests, limiter)
-		return execStore.DeleteCurrentWorkflowExecution(req)
-	}
-
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
-	if err != nil {
-		return err
-	}
-	return nil
-}

--- a/tools/cli/adminDBPersistenceRetrier.go
+++ b/tools/cli/adminDBPersistenceRetrier.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"context"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/quotas"
+)
+
+const maxDBRetries    = 10
+
+var (
+	persistenceOperationRetryPolicy = common.CreatePersistanceRetryPolicy()
+)
+
+func retryGetWorkflowExecution(
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+	execStore persistence.ExecutionStore,
+	req *persistence.GetWorkflowExecutionRequest,
+) (*persistence.InternalGetWorkflowExecutionResponse, error) {
+	var resp *persistence.InternalGetWorkflowExecutionResponse
+	op := func() error {
+		var err error
+		preconditionForDBCall(totalDBRequests, limiter)
+		resp, err = execStore.GetWorkflowExecution(req)
+		return err
+	}
+
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func retryGetCurrentExecution(
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+	execStore persistence.ExecutionStore,
+	req *persistence.GetCurrentExecutionRequest,
+) (*persistence.GetCurrentExecutionResponse, error) {
+	var resp *persistence.GetCurrentExecutionResponse
+	op := func() error {
+		var err error
+		preconditionForDBCall(totalDBRequests, limiter)
+		resp, err = execStore.GetCurrentExecution(req)
+		return err
+	}
+
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func retryReadHistoryBranch(
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+	historyStore persistence.HistoryStore,
+	req *persistence.InternalReadHistoryBranchRequest,
+) (*persistence.InternalReadHistoryBranchResponse, error) {
+	var resp *persistence.InternalReadHistoryBranchResponse
+	op := func() error {
+		var err error
+		preconditionForDBCall(totalDBRequests, limiter)
+		resp, err = historyStore.ReadHistoryBranch(req)
+		return err
+	}
+
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+func retryDeleteWorkflowExecution(
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+	execStore persistence.ExecutionStore,
+	req *persistence.DeleteWorkflowExecutionRequest,
+) error {
+	op := func() error {
+		preconditionForDBCall(totalDBRequests, limiter)
+		return execStore.DeleteWorkflowExecution(req)
+	}
+
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func retryDeleteCurrentWorkflowExecution(
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+	execStore persistence.ExecutionStore,
+	req *persistence.DeleteCurrentWorkflowExecutionRequest,
+) error {
+	op := func() error {
+		preconditionForDBCall(totalDBRequests, limiter)
+		return execStore.DeleteCurrentWorkflowExecution(req)
+	}
+
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func preconditionForDBCall(totalDBRequests *int64, limiter *quotas.DynamicRateLimiter) {
+	*totalDBRequests = *totalDBRequests + 1
+	limiter.Wait(context.Background())
+}

--- a/tools/cli/adminDBPersistenceRetrier.go
+++ b/tools/cli/adminDBPersistenceRetrier.go
@@ -1,18 +1,69 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package cli
 
 import (
 	"context"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
 
-const maxDBRetries    = 10
+const maxDBRetries = 10
 
 var (
 	persistenceOperationRetryPolicy = common.CreatePersistanceRetryPolicy()
 )
+
+func retryListConcreteExecutions(
+	limiter *quotas.DynamicRateLimiter,
+	totalDBRequests *int64,
+	execStore persistence.ExecutionStore,
+	req *persistence.ListConcreteExecutionsRequest,
+) (*persistence.InternalListConcreteExecutionsResponse, error) {
+	var resp *persistence.InternalListConcreteExecutionsResponse
+	op := func() error {
+		var err error
+		preconditionForDBCall(totalDBRequests, limiter)
+		resp, err = execStore.ListConcreteExecutions(req)
+		return err
+	}
+
+	var err error
+	// only  add this extra layer of retries for ListConcreteExecutions because a failure
+	// here will cause a scan over a full shard to stop while a failure on any other db will just
+	// result in one failed execution check
+	for i := 0; i < maxDBRetries; i++ {
+		err = backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+		// TODO: we have seen cases in which gocql iterator return empty result even when there are results, consider retrying more.
+		if err == nil {
+			return resp, nil
+		}
+	}
+	return nil, err
+}
 
 func retryGetWorkflowExecution(
 	limiter *quotas.DynamicRateLimiter,

--- a/tools/cli/adminDBScanCommand.go
+++ b/tools/cli/adminDBScanCommand.go
@@ -406,15 +406,12 @@ func getChecks(
 ) []AdminDBCheck {
 	// the order in which checks are added to the list is important
 	// some checks depend on the output of other checks
-	var checks []AdminDBCheck
 	if skipHistoryChecks {
-		checks = []AdminDBCheck{NewOrphanExecutionCheck(limiter, execStore, payloadSerializer)}
-	} else {
-		checks = []AdminDBCheck{
-			NewHistoryExistsCheck(limiter, historyStore, execStore),
-			NewFirstHistoryEventCheck(payloadSerializer),
-			NewOrphanExecutionCheck(limiter, execStore, payloadSerializer),
-		}
+		return []AdminDBCheck{NewOrphanExecutionCheck(limiter, execStore, payloadSerializer)}
 	}
-	return checks
+	return []AdminDBCheck{
+		NewHistoryExistsCheck(limiter, historyStore, execStore),
+		NewFirstHistoryEventCheck(payloadSerializer),
+		NewOrphanExecutionCheck(limiter, execStore, payloadSerializer),
+	}
 }

--- a/tools/cli/adminDBScanCommand.go
+++ b/tools/cli/adminDBScanCommand.go
@@ -23,11 +23,9 @@
 package cli
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"math"
 	"os"
 	"time"
 
@@ -35,47 +33,11 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/uber/cadence/.gen/go/shared"
-	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/codec"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/persistence"
 	cassp "github.com/uber/cadence/common/persistence/cassandra"
 	"github.com/uber/cadence/common/quotas"
-)
-
-type (
-	// CorruptionType indicates the type of corruption that was found
-	CorruptionType string
-	// VerificationResult is the result of running a verification
-	VerificationResult int
-)
-
-const (
-	// HistoryMissing is the CorruptionType indicating that history is missing
-	HistoryMissing CorruptionType = "history_missing"
-	// InvalidFirstEvent is the CorruptionType indicating that the first event is invalid
-	InvalidFirstEvent = "invalid_first_event"
-	// OpenExecutionInvalidCurrentExecution is the CorruptionType that indicates there is an orphan concrete execution
-	OpenExecutionInvalidCurrentExecution = "open_execution_invalid_current_execution"
-)
-
-const (
-	// VerificationResultNoCorruption indicates that no corruption was found
-	VerificationResultNoCorruption VerificationResult = iota
-	// VerificationResultDetectedCorruption indicates a corruption was found
-	VerificationResultDetectedCorruption
-	// VerificationResultCheckFailure indicates there was a failure to check corruption
-	VerificationResultCheckFailure
-)
-
-const (
-	historyPageSize = 1
-	maxDBRetries    = 10
-)
-
-var (
-	persistenceOperationRetryPolicy = common.CreatePersistanceRetryPolicy()
 )
 
 type (
@@ -93,122 +55,7 @@ type (
 		CorruptedExecutionFile    *os.File
 	}
 
-	// CorruptedExecution is the type that gets written to CorruptedExecutionFile
-	CorruptedExecution struct {
-		ShardID                    int
-		DomainID                   string
-		WorkflowID                 string
-		RunID                      string
-		NextEventID                int64
-		TreeID                     string
-		BranchID                   string
-		CloseStatus                int
-		CorruptedExceptionMetadata CorruptedExceptionMetadata
-	}
 
-	// CorruptedExceptionMetadata is the metadata for a CorruptedExecution
-	CorruptedExceptionMetadata struct {
-		CorruptionType CorruptionType
-		Note           string
-		Details        string
-	}
-
-	// ExecutionCheckFailure is the type that gets written to ExecutionCheckFailureFile
-	ExecutionCheckFailure struct {
-		ShardID    int
-		DomainID   string
-		WorkflowID string
-		RunID      string
-		Note       string
-		Details    string
-	}
-
-	// ShardScanReport is the type that gets written to ShardScanReportFile
-	ShardScanReport struct {
-		ShardID         int
-		TotalDBRequests int64
-		Scanned         *ShardScanReportExecutionsScanned
-		Failure         *ShardScanReportFailure
-	}
-
-	// ShardScanReportExecutionsScanned is the part of the ShardScanReport of executions which were scanned
-	ShardScanReportExecutionsScanned struct {
-		TotalExecutionsCount       int64
-		CorruptedExecutionsCount   int64
-		ExecutionCheckFailureCount int64
-		CorruptionTypeBreakdown    CorruptionTypeBreakdown
-		OpenCorruptions            OpenCorruptions
-	}
-
-	// ShardScanReportFailure is the part of the ShardScanReport that indicates failure to scan all or part of the shard
-	ShardScanReportFailure struct {
-		Note    string
-		Details string
-	}
-
-	// ProgressReport contains metadata about the scan for all shards which have been finished
-	// This is periodically printed to stdout
-	ProgressReport struct {
-		ShardStats     ShardStats
-		ExecutionStats ExecutionStats
-		Rates          Rates
-	}
-
-	// ShardStats breaks out shard level stats
-	ShardStats struct {
-		NumberOfShardsFinished    int
-		NumberOfShardScanFailures int
-		ShardsFailed              []int
-		MinExecutions             *int64
-		MaxExecutions             *int64
-		AverageExecutions         int64
-	}
-
-	// ExecutionStats breaks down execution level stats
-	ExecutionStats struct {
-		TotalExecutionsCount int64
-		CorruptionStats      CorruptionStats
-		CheckFailureStats    CheckFailureStats
-	}
-
-	// CorruptionStats breaks out stats regarding corrupted executions
-	CorruptionStats struct {
-		CorruptedExecutionsCount int64
-		PercentageCorrupted      float64
-		CorruptionTypeBreakdown  CorruptionTypeBreakdown
-		OpenCorruptions          OpenCorruptions
-	}
-
-	// CheckFailureStats breaks out stats regarding execution check failures
-	CheckFailureStats struct {
-		ExecutionCheckFailureCount int64
-		PercentageCheckFailure     float64
-	}
-
-	// CorruptionTypeBreakdown breaks down counts and percentages of corruption types
-	CorruptionTypeBreakdown struct {
-		TotalHistoryMissing                            int64
-		TotalInvalidFirstEvent                         int64
-		TotalOpenExecutionInvalidCurrentExecution      int64
-		PercentageHistoryMissing                       float64
-		PercentageInvalidStartEvent                    float64
-		PercentageOpenExecutionInvalidCurrentExecution float64
-	}
-
-	// OpenCorruptions breaks down the count and percentage of open workflows which are corrupted
-	OpenCorruptions struct {
-		TotalOpen      int64
-		PercentageOpen float64
-	}
-
-	// Rates indicates the rates at which the scan is progressing
-	Rates struct {
-		TimeRunning       string
-		DatabaseRPS       float64
-		TotalDBRequests   int64
-		ShardsPerHour     float64
-		ExecutionsPerHour float64
-	}
 )
 
 // AdminDBScan is used to scan over all executions in database and detect corruptions
@@ -225,6 +72,9 @@ func AdminDBScan(c *cli.Context) {
 	if numShards < scanWorkerCount {
 		scanWorkerCount = numShards
 	}
+
+	// get a list of checkers here or an error if combination is not valid
+	var checkers []AdminDBCheck
 
 	payloadSerializer := persistence.NewPayloadSerializer()
 	rateLimiter := getRateLimiter(startingRPS, targetRPS, scaleUpSeconds)
@@ -308,7 +158,7 @@ func scanShard(
 			PageSize:  executionsPageSize,
 			PageToken: token,
 		}
-		resp, err := retryListConcreteExecutions(limiter, &report.TotalDBRequests, execStore, req)
+		resp, err := (limiter, &report.TotalDBRequests, execStore, req)
 		if err != nil {
 			report.Failure = &ShardScanReportFailure{
 				Note:    "failed to call ListConcreteExecutions",
@@ -406,302 +256,6 @@ func scanShard(
 	return report
 }
 
-func verifyHistoryExists(
-	execution *persistence.InternalListConcreteExecutionsEntity,
-	branchDecoder *codec.ThriftRWEncoder,
-	corruptedExecutionWriter BufferedWriter,
-	checkFailureWriter BufferedWriter,
-	shardID int,
-	limiter *quotas.DynamicRateLimiter,
-	historyStore persistence.HistoryStore,
-	totalDBRequests *int64,
-	execStore persistence.ExecutionStore,
-	payloadSerializer persistence.PayloadSerializer,
-) (VerificationResult, *persistence.InternalReadHistoryBranchResponse, *shared.HistoryBranch) {
-	branch, err := getHistoryBranch(execution, payloadSerializer, branchDecoder)
-	if err != nil {
-		checkFailureWriter.Add(&ExecutionCheckFailure{
-			ShardID:    shardID,
-			DomainID:   execution.ExecutionInfo.DomainID,
-			WorkflowID: execution.ExecutionInfo.WorkflowID,
-			RunID:      execution.ExecutionInfo.RunID,
-			Note:       "failed to get history branch",
-			Details:    err.Error(),
-		})
-		return VerificationResultCheckFailure, nil, nil
-	}
-	readHistoryBranchReq := &persistence.InternalReadHistoryBranchRequest{
-		TreeID:    branch.GetTreeID(),
-		BranchID:  branch.GetBranchID(),
-		MinNodeID: common.FirstEventID,
-		MaxNodeID: common.EndEventID,
-		ShardID:   shardID,
-		PageSize:  historyPageSize,
-	}
-	history, err := retryReadHistoryBranch(limiter, totalDBRequests, historyStore, readHistoryBranchReq)
-
-	ecf, stillExists := concreteExecutionStillExists(execution.ExecutionInfo, shardID, execStore, limiter, totalDBRequests)
-	if ecf != nil {
-		checkFailureWriter.Add(ecf)
-		return VerificationResultCheckFailure, nil, nil
-	}
-	if !stillExists {
-		return VerificationResultNoCorruption, nil, nil
-	}
-
-	if err != nil {
-		if err == gocql.ErrNotFound {
-			corruptedExecutionWriter.Add(&CorruptedExecution{
-				ShardID:     shardID,
-				DomainID:    execution.ExecutionInfo.DomainID,
-				WorkflowID:  execution.ExecutionInfo.WorkflowID,
-				RunID:       execution.ExecutionInfo.RunID,
-				NextEventID: execution.ExecutionInfo.NextEventID,
-				TreeID:      branch.GetTreeID(),
-				BranchID:    branch.GetBranchID(),
-				CloseStatus: execution.ExecutionInfo.CloseStatus,
-				CorruptedExceptionMetadata: CorruptedExceptionMetadata{
-					CorruptionType: HistoryMissing,
-					Note:           "detected history missing based on gocql.ErrNotFound",
-					Details:        err.Error(),
-				},
-			})
-			return VerificationResultDetectedCorruption, nil, nil
-		}
-		checkFailureWriter.Add(&ExecutionCheckFailure{
-			ShardID:    shardID,
-			DomainID:   execution.ExecutionInfo.DomainID,
-			WorkflowID: execution.ExecutionInfo.WorkflowID,
-			RunID:      execution.ExecutionInfo.RunID,
-			Note:       "failed to read history branch with error other than gocql.ErrNotFond",
-			Details:    err.Error(),
-		})
-		return VerificationResultCheckFailure, nil, nil
-	} else if history == nil || len(history.History) == 0 {
-		corruptedExecutionWriter.Add(&CorruptedExecution{
-			ShardID:     shardID,
-			DomainID:    execution.ExecutionInfo.DomainID,
-			WorkflowID:  execution.ExecutionInfo.WorkflowID,
-			RunID:       execution.ExecutionInfo.RunID,
-			NextEventID: execution.ExecutionInfo.NextEventID,
-			TreeID:      branch.GetTreeID(),
-			BranchID:    branch.GetBranchID(),
-			CloseStatus: execution.ExecutionInfo.CloseStatus,
-			CorruptedExceptionMetadata: CorruptedExceptionMetadata{
-				CorruptionType: HistoryMissing,
-				Note:           "got empty history",
-			},
-		})
-		return VerificationResultDetectedCorruption, nil, nil
-	}
-	return VerificationResultNoCorruption, history, branch
-}
-
-func verifyFirstHistoryEvent(
-	execution *persistence.InternalListConcreteExecutionsEntity,
-	branch *shared.HistoryBranch,
-	corruptedExecutionWriter BufferedWriter,
-	checkFailureWriter BufferedWriter,
-	shardID int,
-	payloadSerializer persistence.PayloadSerializer,
-	history *persistence.InternalReadHistoryBranchResponse,
-) VerificationResult {
-	firstBatch, err := payloadSerializer.DeserializeBatchEvents(history.History[0])
-	if err != nil || len(firstBatch) == 0 {
-		checkFailureWriter.Add(&ExecutionCheckFailure{
-			ShardID:    shardID,
-			DomainID:   execution.ExecutionInfo.DomainID,
-			WorkflowID: execution.ExecutionInfo.WorkflowID,
-			RunID:      execution.ExecutionInfo.RunID,
-			Note:       "failed to deserialize batch events",
-			Details:    err.Error(),
-		})
-		return VerificationResultCheckFailure
-	} else if firstBatch[0].GetEventId() != common.FirstEventID {
-		corruptedExecutionWriter.Add(&CorruptedExecution{
-			ShardID:     shardID,
-			DomainID:    execution.ExecutionInfo.DomainID,
-			WorkflowID:  execution.ExecutionInfo.WorkflowID,
-			RunID:       execution.ExecutionInfo.RunID,
-			NextEventID: execution.ExecutionInfo.NextEventID,
-			TreeID:      branch.GetTreeID(),
-			BranchID:    branch.GetBranchID(),
-			CloseStatus: execution.ExecutionInfo.CloseStatus,
-			CorruptedExceptionMetadata: CorruptedExceptionMetadata{
-				CorruptionType: InvalidFirstEvent,
-				Note:           "got unexpected first eventID",
-				Details:        fmt.Sprintf("expected: %v but got %v", common.FirstEventID, firstBatch[0].GetEventId()),
-			},
-		})
-		return VerificationResultDetectedCorruption
-	} else if firstBatch[0].GetEventType() != shared.EventTypeWorkflowExecutionStarted {
-		corruptedExecutionWriter.Add(&CorruptedExecution{
-			ShardID:     shardID,
-			DomainID:    execution.ExecutionInfo.DomainID,
-			WorkflowID:  execution.ExecutionInfo.WorkflowID,
-			RunID:       execution.ExecutionInfo.RunID,
-			NextEventID: execution.ExecutionInfo.NextEventID,
-			TreeID:      branch.GetTreeID(),
-			BranchID:    branch.GetBranchID(),
-			CloseStatus: execution.ExecutionInfo.CloseStatus,
-			CorruptedExceptionMetadata: CorruptedExceptionMetadata{
-				CorruptionType: InvalidFirstEvent,
-				Note:           "got unexpected first eventType",
-				Details:        fmt.Sprintf("expected: %v but got %v", shared.EventTypeWorkflowExecutionStarted.String(), firstBatch[0].GetEventType().String()),
-			},
-		})
-		return VerificationResultDetectedCorruption
-	}
-	return VerificationResultNoCorruption
-}
-
-func verifyCurrentExecution(
-	execution *persistence.InternalListConcreteExecutionsEntity,
-	corruptedExecutionWriter BufferedWriter,
-	checkFailureWriter BufferedWriter,
-	shardID int,
-	branch *shared.HistoryBranch,
-	execStore persistence.ExecutionStore,
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-) VerificationResult {
-	if !executionOpen(execution.ExecutionInfo) {
-		return VerificationResultNoCorruption
-	}
-	getCurrentExecutionRequest := &persistence.GetCurrentExecutionRequest{
-		DomainID:   execution.ExecutionInfo.DomainID,
-		WorkflowID: execution.ExecutionInfo.WorkflowID,
-	}
-	currentExecution, err := retryGetCurrentExecution(limiter, totalDBRequests, execStore, getCurrentExecutionRequest)
-
-	ecf, stillOpen := concreteExecutionStillOpen(execution.ExecutionInfo, shardID, execStore, limiter, totalDBRequests)
-	if ecf != nil {
-		checkFailureWriter.Add(ecf)
-		return VerificationResultCheckFailure
-	}
-	if !stillOpen {
-		return VerificationResultNoCorruption
-	}
-
-	if err != nil {
-		switch err.(type) {
-		case *shared.EntityNotExistsError:
-			corruptedExecutionWriter.Add(&CorruptedExecution{
-				ShardID:     shardID,
-				DomainID:    execution.ExecutionInfo.DomainID,
-				WorkflowID:  execution.ExecutionInfo.WorkflowID,
-				RunID:       execution.ExecutionInfo.RunID,
-				NextEventID: execution.ExecutionInfo.NextEventID,
-				TreeID:      branch.GetTreeID(),
-				BranchID:    branch.GetBranchID(),
-				CloseStatus: execution.ExecutionInfo.CloseStatus,
-				CorruptedExceptionMetadata: CorruptedExceptionMetadata{
-					CorruptionType: OpenExecutionInvalidCurrentExecution,
-					Note:           "execution is open without having a current execution",
-					Details:        err.Error(),
-				},
-			})
-			return VerificationResultDetectedCorruption
-		default:
-			checkFailureWriter.Add(&ExecutionCheckFailure{
-				ShardID:    shardID,
-				DomainID:   execution.ExecutionInfo.DomainID,
-				WorkflowID: execution.ExecutionInfo.WorkflowID,
-				RunID:      execution.ExecutionInfo.RunID,
-				Note:       "failed to access current execution but could not confirm that it does not exist",
-				Details:    err.Error(),
-			})
-			return VerificationResultCheckFailure
-		}
-	} else if currentExecution.RunID != execution.ExecutionInfo.RunID {
-		corruptedExecutionWriter.Add(&CorruptedExecution{
-			ShardID:     shardID,
-			DomainID:    execution.ExecutionInfo.DomainID,
-			WorkflowID:  execution.ExecutionInfo.WorkflowID,
-			RunID:       execution.ExecutionInfo.RunID,
-			NextEventID: execution.ExecutionInfo.NextEventID,
-			TreeID:      branch.GetTreeID(),
-			BranchID:    branch.GetBranchID(),
-			CloseStatus: execution.ExecutionInfo.CloseStatus,
-			CorruptedExceptionMetadata: CorruptedExceptionMetadata{
-				CorruptionType: OpenExecutionInvalidCurrentExecution,
-				Note:           "found open execution for which there exists current execution pointing at a different concrete execution",
-			},
-		})
-		return VerificationResultDetectedCorruption
-	}
-	return VerificationResultNoCorruption
-}
-
-func concreteExecutionStillExists(
-	execution *persistence.InternalWorkflowExecutionInfo,
-	shardID int,
-	execStore persistence.ExecutionStore,
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-) (*ExecutionCheckFailure, bool) {
-	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
-		DomainID: execution.DomainID,
-		Execution: shared.WorkflowExecution{
-			WorkflowId: &execution.WorkflowID,
-			RunId:      &execution.RunID,
-		},
-	}
-	_, err := retryGetWorkflowExecution(limiter, totalDBRequests, execStore, getConcreteExecution)
-	if err == nil {
-		return nil, true
-	}
-
-	switch err.(type) {
-	case *shared.EntityNotExistsError:
-		return nil, false
-	default:
-		return &ExecutionCheckFailure{
-			ShardID:    shardID,
-			DomainID:   execution.DomainID,
-			WorkflowID: execution.WorkflowID,
-			RunID:      execution.RunID,
-			Note:       "failed to verify that concrete execution still exists",
-			Details:    err.Error(),
-		}, false
-	}
-}
-
-func concreteExecutionStillOpen(
-	execution *persistence.InternalWorkflowExecutionInfo,
-	shardID int,
-	execStore persistence.ExecutionStore,
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-) (*ExecutionCheckFailure, bool) {
-	getConcreteExecution := &persistence.GetWorkflowExecutionRequest{
-		DomainID: execution.DomainID,
-		Execution: shared.WorkflowExecution{
-			WorkflowId: &execution.WorkflowID,
-			RunId:      &execution.RunID,
-		},
-	}
-	ce, err := retryGetWorkflowExecution(limiter, totalDBRequests, execStore, getConcreteExecution)
-
-	if err != nil {
-		switch err.(type) {
-		case *shared.EntityNotExistsError:
-			return nil, false
-		default:
-			return &ExecutionCheckFailure{
-				ShardID:    shardID,
-				DomainID:   execution.DomainID,
-				WorkflowID: execution.WorkflowID,
-				RunID:      execution.RunID,
-				Note:       "failed to access concrete execution to verify it is still open",
-				Details:    err.Error(),
-			}, false
-		}
-	}
-
-	return nil, executionOpen(ce.State.ExecutionInfo)
-}
-
 func deleteEmptyFiles(files ...*os.File) {
 	shouldDelete := func(filepath string) bool {
 		fi, err := os.Stat(filepath)
@@ -778,76 +332,6 @@ func writeToFile(file *os.File, message string) {
 	}
 }
 
-func includeShardInProgressReport(report *ShardScanReport, progressReport *ProgressReport, startTime time.Time) {
-	includeExecutionStats(report, &progressReport.ExecutionStats)
-	includeShardStats(report, &progressReport.ShardStats, progressReport.ExecutionStats.TotalExecutionsCount)
-	includeRates(report, &progressReport.Rates, startTime, progressReport.ExecutionStats.TotalExecutionsCount, progressReport.ShardStats.NumberOfShardsFinished)
-}
-
-func includeExecutionStats(report *ShardScanReport, executionStats *ExecutionStats) {
-	if report.Scanned != nil {
-		executionStats.TotalExecutionsCount += report.Scanned.TotalExecutionsCount
-		executionStats.CorruptionStats.CorruptedExecutionsCount += report.Scanned.CorruptedExecutionsCount
-		executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalHistoryMissing += report.Scanned.CorruptionTypeBreakdown.TotalHistoryMissing
-		executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalOpenExecutionInvalidCurrentExecution += report.Scanned.CorruptionTypeBreakdown.TotalOpenExecutionInvalidCurrentExecution
-		executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalInvalidFirstEvent += report.Scanned.CorruptionTypeBreakdown.TotalInvalidFirstEvent
-		executionStats.CorruptionStats.OpenCorruptions.TotalOpen += report.Scanned.OpenCorruptions.TotalOpen
-		executionStats.CheckFailureStats.ExecutionCheckFailureCount += report.Scanned.ExecutionCheckFailureCount
-	}
-	if executionStats.TotalExecutionsCount > 0 {
-		executionStats.CorruptionStats.PercentageCorrupted = math.Round((float64(executionStats.CorruptionStats.CorruptedExecutionsCount) * 100.0) /
-			float64(executionStats.TotalExecutionsCount))
-
-		executionStats.CheckFailureStats.PercentageCheckFailure = math.Round((float64(executionStats.CheckFailureStats.ExecutionCheckFailureCount) * 100.0) /
-			float64(executionStats.TotalExecutionsCount))
-	}
-
-	if executionStats.CorruptionStats.CorruptedExecutionsCount > 0 {
-		executionStats.CorruptionStats.CorruptionTypeBreakdown.PercentageHistoryMissing = math.Round((float64(executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalHistoryMissing) * 100.0) /
-			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
-
-		executionStats.CorruptionStats.CorruptionTypeBreakdown.PercentageInvalidStartEvent = math.Round((float64(executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalInvalidFirstEvent) * 100.0) /
-			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
-
-		executionStats.CorruptionStats.CorruptionTypeBreakdown.PercentageOpenExecutionInvalidCurrentExecution = math.Round((float64(executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalOpenExecutionInvalidCurrentExecution) * 100.0) /
-			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
-
-		executionStats.CorruptionStats.OpenCorruptions.PercentageOpen = math.Round((float64(executionStats.CorruptionStats.OpenCorruptions.TotalOpen) * 100.0) /
-			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
-	}
-}
-
-func includeShardStats(report *ShardScanReport, shardStats *ShardStats, totalExecutions int64) {
-	shardStats.NumberOfShardsFinished++
-	if report.Failure != nil {
-		shardStats.NumberOfShardScanFailures++
-		shardStats.ShardsFailed = append(shardStats.ShardsFailed, report.ShardID)
-	}
-	if report.Scanned != nil &&
-		(shardStats.MinExecutions == nil || *shardStats.MinExecutions > report.Scanned.TotalExecutionsCount) {
-		shardStats.MinExecutions = &report.Scanned.TotalExecutionsCount
-	}
-	if report.Scanned != nil &&
-		(shardStats.MaxExecutions == nil || *shardStats.MaxExecutions < report.Scanned.TotalExecutionsCount) {
-		shardStats.MaxExecutions = &report.Scanned.TotalExecutionsCount
-	}
-	successfullyFinishedShards := shardStats.NumberOfShardsFinished - shardStats.NumberOfShardScanFailures
-	if successfullyFinishedShards > 0 {
-		shardStats.AverageExecutions = totalExecutions / int64(successfullyFinishedShards)
-	}
-}
-
-func includeRates(report *ShardScanReport, rates *Rates, startTime time.Time, totalExecutions int64, numberOfShardsFinished int) {
-	rates.TotalDBRequests += report.TotalDBRequests
-	rates.TimeRunning = time.Now().Sub(startTime).String()
-	pastTime := time.Now().Sub(startTime)
-	hoursPast := float64(pastTime) / float64(time.Hour)
-	secondsPast := float64(pastTime) / float64(time.Second)
-	rates.ShardsPerHour = math.Round(float64(numberOfShardsFinished) / hoursPast)
-	rates.ExecutionsPerHour = math.Round(float64(totalExecutions) / hoursPast)
-	rates.DatabaseRPS = math.Round(float64(rates.TotalDBRequests) / secondsPast)
-}
-
 func getRateLimiter(startRPS int, targetRPS int, scaleUpSeconds int) *quotas.DynamicRateLimiter {
 	if startRPS >= targetRPS {
 		ErrorAndExit("startRPS is greater than target RPS", nil)
@@ -865,105 +349,6 @@ func getRateLimiter(startRPS int, targetRPS int, scaleUpSeconds int) *quotas.Dyn
 		return float64((rpsIncreasePerSecond * secondsPast) + startRPS)
 	}
 	return quotas.NewDynamicRateLimiter(rpsFn)
-}
-
-func preconditionForDBCall(totalDBRequests *int64, limiter *quotas.DynamicRateLimiter) {
-	*totalDBRequests = *totalDBRequests + 1
-	limiter.Wait(context.Background())
-}
-
-func executionOpen(execution *persistence.InternalWorkflowExecutionInfo) bool {
-	return execution.State == persistence.WorkflowStateCreated || execution.State == persistence.WorkflowStateRunning
-}
-
-func retryListConcreteExecutions(
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-	execStore persistence.ExecutionStore,
-	req *persistence.ListConcreteExecutionsRequest,
-) (*persistence.InternalListConcreteExecutionsResponse, error) {
-	var resp *persistence.InternalListConcreteExecutionsResponse
-	op := func() error {
-		var err error
-		preconditionForDBCall(totalDBRequests, limiter)
-		resp, err = execStore.ListConcreteExecutions(req)
-		return err
-	}
-
-	var err error
-	// only  add this extra layer of retries for ListConcreteExecutions because a failure
-	// here will cause a scan over a full shard to stop while a failure on any other db will just
-	// result in one failed execution check
-	for i := 0; i < maxDBRetries; i++ {
-		err = backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
-		if err == nil {
-			return resp, nil
-		}
-	}
-	return nil, err
-}
-
-func retryGetWorkflowExecution(
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-	execStore persistence.ExecutionStore,
-	req *persistence.GetWorkflowExecutionRequest,
-) (*persistence.InternalGetWorkflowExecutionResponse, error) {
-	var resp *persistence.InternalGetWorkflowExecutionResponse
-	op := func() error {
-		var err error
-		preconditionForDBCall(totalDBRequests, limiter)
-		resp, err = execStore.GetWorkflowExecution(req)
-		return err
-	}
-
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func retryGetCurrentExecution(
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-	execStore persistence.ExecutionStore,
-	req *persistence.GetCurrentExecutionRequest,
-) (*persistence.GetCurrentExecutionResponse, error) {
-	var resp *persistence.GetCurrentExecutionResponse
-	op := func() error {
-		var err error
-		preconditionForDBCall(totalDBRequests, limiter)
-		resp, err = execStore.GetCurrentExecution(req)
-		return err
-	}
-
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
-}
-
-func retryReadHistoryBranch(
-	limiter *quotas.DynamicRateLimiter,
-	totalDBRequests *int64,
-	historyStore persistence.HistoryStore,
-	req *persistence.InternalReadHistoryBranchRequest,
-) (*persistence.InternalReadHistoryBranchResponse, error) {
-	var resp *persistence.InternalReadHistoryBranchResponse
-	op := func() error {
-		var err error
-		preconditionForDBCall(totalDBRequests, limiter)
-		resp, err = historyStore.ReadHistoryBranch(req)
-		return err
-	}
-
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
-	if err != nil {
-		return nil, err
-	}
-	return resp, nil
 }
 
 func getHistoryBranch(

--- a/tools/cli/adminDBScanProgressReport.go
+++ b/tools/cli/adminDBScanProgressReport.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package cli
 
 import (

--- a/tools/cli/adminDBScanProgressReport.go
+++ b/tools/cli/adminDBScanProgressReport.go
@@ -1,0 +1,165 @@
+package cli
+
+import (
+	"math"
+	"time"
+)
+
+type (
+	// ShardScanReport is the type that gets written to ShardScanReportFile
+	ShardScanReport struct {
+		ShardID         int
+		TotalDBRequests int64
+		Scanned         *ShardScanReportExecutionsScanned
+		Failure         *ShardScanReportFailure
+	}
+
+	// ShardScanReportExecutionsScanned is the part of the ShardScanReport of executions which were scanned
+	ShardScanReportExecutionsScanned struct {
+		TotalExecutionsCount       int64
+		CorruptedExecutionsCount   int64
+		ExecutionCheckFailureCount int64
+		CorruptionTypeBreakdown    CorruptionTypeBreakdown
+		OpenCorruptions            OpenCorruptions
+	}
+
+	// ShardScanReportFailure is the part of the ShardScanReport that indicates failure to scan all or part of the shard
+	ShardScanReportFailure struct {
+		Note    string
+		Details string
+	}
+
+	// ProgressReport contains metadata about the scan for all shards which have been finished
+	// This is periodically printed to stdout
+	ProgressReport struct {
+		ShardStats     ShardStats
+		ExecutionStats ExecutionStats
+		Rates          Rates
+	}
+
+	// ShardStats breaks out shard level stats
+	ShardStats struct {
+		NumberOfShardsFinished    int
+		NumberOfShardScanFailures int
+		ShardsFailed              []int
+		MinExecutions             *int64
+		MaxExecutions             *int64
+		AverageExecutions         int64
+	}
+
+	// ExecutionStats breaks down execution level stats
+	ExecutionStats struct {
+		TotalExecutionsCount int64
+		CorruptionStats      CorruptionStats
+		CheckFailureStats    CheckFailureStats
+	}
+
+	// CorruptionStats breaks out stats regarding corrupted executions
+	CorruptionStats struct {
+		CorruptedExecutionsCount int64
+		PercentageCorrupted      float64
+		CorruptionTypeBreakdown  CorruptionTypeBreakdown
+		OpenCorruptions          OpenCorruptions
+	}
+
+	// CheckFailureStats breaks out stats regarding execution check failures
+	CheckFailureStats struct {
+		ExecutionCheckFailureCount int64
+		PercentageCheckFailure     float64
+	}
+
+	// CorruptionTypeBreakdown breaks down counts and percentages of corruption types
+	CorruptionTypeBreakdown struct {
+		TotalHistoryMissing                            int64
+		TotalInvalidFirstEvent                         int64
+		TotalOpenExecutionInvalidCurrentExecution      int64
+		PercentageHistoryMissing                       float64
+		PercentageInvalidStartEvent                    float64
+		PercentageOpenExecutionInvalidCurrentExecution float64
+	}
+
+	// OpenCorruptions breaks down the count and percentage of open workflows which are corrupted
+	OpenCorruptions struct {
+		TotalOpen      int64
+		PercentageOpen float64
+	}
+
+	// Rates indicates the rates at which the scan is progressing
+	Rates struct {
+		TimeRunning       string
+		DatabaseRPS       float64
+		TotalDBRequests   int64
+		ShardsPerHour     float64
+		ExecutionsPerHour float64
+	}
+)
+
+func includeShardInProgressReport(report *ShardScanReport, progressReport *ProgressReport, startTime time.Time) {
+	includeExecutionStats(report, &progressReport.ExecutionStats)
+	includeShardStats(report, &progressReport.ShardStats, progressReport.ExecutionStats.TotalExecutionsCount)
+	includeRates(report, &progressReport.Rates, startTime, progressReport.ExecutionStats.TotalExecutionsCount, progressReport.ShardStats.NumberOfShardsFinished)
+}
+
+func includeExecutionStats(report *ShardScanReport, executionStats *ExecutionStats) {
+	if report.Scanned != nil {
+		executionStats.TotalExecutionsCount += report.Scanned.TotalExecutionsCount
+		executionStats.CorruptionStats.CorruptedExecutionsCount += report.Scanned.CorruptedExecutionsCount
+		executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalHistoryMissing += report.Scanned.CorruptionTypeBreakdown.TotalHistoryMissing
+		executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalOpenExecutionInvalidCurrentExecution += report.Scanned.CorruptionTypeBreakdown.TotalOpenExecutionInvalidCurrentExecution
+		executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalInvalidFirstEvent += report.Scanned.CorruptionTypeBreakdown.TotalInvalidFirstEvent
+		executionStats.CorruptionStats.OpenCorruptions.TotalOpen += report.Scanned.OpenCorruptions.TotalOpen
+		executionStats.CheckFailureStats.ExecutionCheckFailureCount += report.Scanned.ExecutionCheckFailureCount
+	}
+	if executionStats.TotalExecutionsCount > 0 {
+		executionStats.CorruptionStats.PercentageCorrupted = math.Round((float64(executionStats.CorruptionStats.CorruptedExecutionsCount) * 100.0) /
+			float64(executionStats.TotalExecutionsCount))
+
+		executionStats.CheckFailureStats.PercentageCheckFailure = math.Round((float64(executionStats.CheckFailureStats.ExecutionCheckFailureCount) * 100.0) /
+			float64(executionStats.TotalExecutionsCount))
+	}
+
+	if executionStats.CorruptionStats.CorruptedExecutionsCount > 0 {
+		executionStats.CorruptionStats.CorruptionTypeBreakdown.PercentageHistoryMissing = math.Round((float64(executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalHistoryMissing) * 100.0) /
+			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
+
+		executionStats.CorruptionStats.CorruptionTypeBreakdown.PercentageInvalidStartEvent = math.Round((float64(executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalInvalidFirstEvent) * 100.0) /
+			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
+
+		executionStats.CorruptionStats.CorruptionTypeBreakdown.PercentageOpenExecutionInvalidCurrentExecution = math.Round((float64(executionStats.CorruptionStats.CorruptionTypeBreakdown.TotalOpenExecutionInvalidCurrentExecution) * 100.0) /
+			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
+
+		executionStats.CorruptionStats.OpenCorruptions.PercentageOpen = math.Round((float64(executionStats.CorruptionStats.OpenCorruptions.TotalOpen) * 100.0) /
+			float64(executionStats.CorruptionStats.CorruptedExecutionsCount))
+	}
+}
+
+func includeShardStats(report *ShardScanReport, shardStats *ShardStats, totalExecutions int64) {
+	shardStats.NumberOfShardsFinished++
+	if report.Failure != nil {
+		shardStats.NumberOfShardScanFailures++
+		shardStats.ShardsFailed = append(shardStats.ShardsFailed, report.ShardID)
+	}
+	if report.Scanned != nil &&
+		(shardStats.MinExecutions == nil || *shardStats.MinExecutions > report.Scanned.TotalExecutionsCount) {
+		shardStats.MinExecutions = &report.Scanned.TotalExecutionsCount
+	}
+	if report.Scanned != nil &&
+		(shardStats.MaxExecutions == nil || *shardStats.MaxExecutions < report.Scanned.TotalExecutionsCount) {
+		shardStats.MaxExecutions = &report.Scanned.TotalExecutionsCount
+	}
+	successfullyFinishedShards := shardStats.NumberOfShardsFinished - shardStats.NumberOfShardScanFailures
+	if successfullyFinishedShards > 0 {
+		shardStats.AverageExecutions = totalExecutions / int64(successfullyFinishedShards)
+	}
+}
+
+func includeRates(report *ShardScanReport, rates *Rates, startTime time.Time, totalExecutions int64, numberOfShardsFinished int) {
+	rates.TotalDBRequests += report.TotalDBRequests
+	rates.TimeRunning = time.Now().Sub(startTime).String()
+	pastTime := time.Now().Sub(startTime)
+	hoursPast := float64(pastTime) / float64(time.Hour)
+	secondsPast := float64(pastTime) / float64(time.Second)
+	rates.ShardsPerHour = math.Round(float64(numberOfShardsFinished) / hoursPast)
+	rates.ExecutionsPerHour = math.Round(float64(totalExecutions) / hoursPast)
+	rates.DatabaseRPS = math.Round(float64(rates.TotalDBRequests) / secondsPast)
+}

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -220,7 +220,7 @@ const (
 	FlagLowerShardBound                   = "lower_shard_bound"
 	FlagUpperShardBound                   = "upper_shard_bound"
 	FlagInputDirectory                    = "input_directory"
-	FlagDBInvariantChecks                 = "db_invariant_checks"
+	FlagSkipHistoryChecks                 = "skip_history_checks"
 )
 
 var flagsForExecution = []cli.Flag{

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -220,6 +220,7 @@ const (
 	FlagLowerShardBound                   = "lower_shard_bound"
 	FlagUpperShardBound                   = "upper_shard_bound"
 	FlagInputDirectory                    = "input_directory"
+	FlagDBInvariantChecks                 = "db_invariant_checks"
 )
 
 var flagsForExecution = []cli.Flag{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
This factors out db scan checks into there own interface. This makes it easier to add more checks in the future. It also enables re-verifying that an execution is still corrupted in the delete code path.


<!-- Tell your future self why have you made these changes -->
This makes the code more extensible. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I have tested locally. This code is missing unit tests, unit tests will be added once logic is converted to workflow. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
If there is any bug in scan or delete it could lead an operator to delete non-corrupted production data. 

