### PR TITLE
Rate limit domain cache refresh

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -483,9 +483,6 @@ UpdateLoop:
 		}
 	}
 
-	// only update last refresh time when refresh succeeded
-	c.lastRefreshTime = now
-
 	// NOTE: READ REF BEFORE MODIFICATION
 	// ref: historyEngine.go registerDomainFailoverCallback function
 	c.callbackLock.Lock()
@@ -494,6 +491,10 @@ UpdateLoop:
 	c.cacheByID.Store(newCacheByID)
 	c.cacheNameToID.Store(newCacheNameToID)
 	c.triggerDomainChangeCallbackLocked(prevEntries, nextEntries)
+
+	// only update last refresh time when refresh succeeded
+	c.lastRefreshTime = now
+
 	return nil
 }
 

--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -54,9 +54,10 @@ const (
 )
 
 const (
-	domainCacheInitialSize = 10 * 1024
-	domainCacheMaxSize     = 64 * 1024
-	domainCacheTTL         = 0 // 0 means infinity
+	domainCacheInitialSize        = 10 * 1024
+	domainCacheMaxSize            = 64 * 1024
+	domainCacheTTL                = 0 // 0 means infinity
+	domainCacheMinRefreshInterval = 1 * time.Second
 	// DomainCacheRefreshInterval domain cache refresh interval
 	DomainCacheRefreshInterval = 10 * time.Second
 	// DomainCacheRefreshFailureRetryInterval is the wait time
@@ -108,7 +109,8 @@ type (
 
 		// refresh lock is used to guarantee at most one
 		// coroutine is doing domain refreshment
-		refreshLock sync.Mutex
+		refreshLock     sync.Mutex
+		lastRefreshTime time.Time
 
 		callbackLock     sync.Mutex
 		prepareCallbacks map[int]PrepareCallbackFn
@@ -412,6 +414,11 @@ func (c *domainCache) refreshDomains() error {
 // this function only refresh the domains in the v2 table
 // the domains in the v1 table will be refreshed if cache is stale
 func (c *domainCache) refreshDomainsLocked() error {
+	now := c.timeSource.Now()
+	if now.Sub(c.lastRefreshTime) < domainCacheMinRefreshInterval {
+		return nil
+	}
+
 	// first load the metadata record, then load domains
 	// this can guarantee that domains in the cache are not updated more than metadata record
 	metadata, err := c.metadataMgr.GetMetadata()
@@ -475,6 +482,9 @@ UpdateLoop:
 			nextEntries = append(nextEntries, nextEntry)
 		}
 	}
+
+	// only update last refresh time when refresh succeeded
+	c.lastRefreshTime = now
 
 	// NOTE: READ REF BEFORE MODIFICATION
 	// ref: historyEngine.go registerDomainFailoverCallback function


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Skip domain cache refresh if the time duration is too short since last refresh

<!-- Tell your future self why have you made these changes -->
**Why?**
If a domain doesn't exist and client keeping calling API for that domain, domain cache will be refreshed for every call, causing a large load on persistence layer and other APIs to fail due to service busy error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
