### PR TITLE
Not Ready For Review: Add blobstore interface

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -24,6 +24,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/uber/cadence/common/blobstore/filestore"
+
 	"github.com/uber/cadence/common/authorization"
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
@@ -203,10 +205,13 @@ func (s *server) startService() common.Daemon {
 	)
 
 	params.ArchiverProvider = provider.NewArchiverProvider(s.cfg.Archival.History.Provider, s.cfg.Archival.Visibility.Provider)
-
 	params.PersistenceConfig.TransactionSizeLimit = dc.GetIntProperty(dynamicconfig.TransactionSizeLimit, common.DefaultTransactionSizeLimit)
-
 	params.Authorizer = authorization.NewNopAuthorizer()
+	params.BlobstoreClient, err = filestore.NewFileBlobstore(s.cfg.Blobstore.FileBlobstore)
+	if err != nil {
+		log.Printf("failed to create blobstore client from file: %v", err)
+		params.BlobstoreClient = nil
+	}
 
 	params.Logger.Info("Starting service " + s.name)
 

--- a/common/blobstore/filestore/client.go
+++ b/common/blobstore/filestore/client.go
@@ -1,0 +1,91 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package filestore
+
+import (
+	"context"
+	"errors"
+	"os"
+
+	"github.com/uber/cadence/common/blobstore"
+	"github.com/uber/cadence/common/service/config"
+)
+
+var (
+	errInvalidFileMode = errors.New("invalid file mode")
+	errInvalidDirMode  = errors.New("invalid directory mode")
+)
+
+var (
+	errDirectoryExpected  = errors.New("a path to a directory was expected")
+	errFileExpected       = errors.New("a path to a file was expected")
+	errEmptyDirectoryPath = errors.New("directory path is empty")
+)
+
+type (
+	client struct {
+		outputDirectory string
+	}
+)
+
+func NewFileBlobstore(cfg *config.FileBlobstore) (blobstore.Client, error) {
+	if cfg == nil || len(cfg.OutputDirectory) {
+		// do some other verifications here or whatever
+	}
+	return &client{
+		outputDirectory: cfg.OutputDirectory,
+	}, nil
+}
+
+func (c *client) Put(_ context.Context, request *blobstore.PutRequest) (*blobstore.PutResponse, error) {
+	return nil, nil
+}
+
+func (c *client) Get(context.Context, *blobstore.GetRequest) (*blobstore.GetResponse, error) {
+	return nil, nil
+}
+
+func (c *client) Exists(context.Context, *blobstore.ExistsRequest) (*blobstore.ExistsResponse, error) {
+	return nil, nil
+}
+
+func (c *client) Delete(context.Context, *blobstore.DeleteRequest) (*blobstore.DeleteResponse, error) {
+	return nil, nil
+}
+
+func validateDirPath(dirPath string) error {
+	if len(dirPath) == 0 {
+		return errEmptyDirectoryPath
+	}
+	info, err := os.Stat(dirPath)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return errDirectoryExpected
+	}
+	return nil
+}

--- a/common/blobstore/interface.go
+++ b/common/blobstore/interface.go
@@ -1,0 +1,58 @@
+package blobstore
+
+import (
+	"context"
+)
+
+type (
+	// Client defines the interface to a blobstore client.
+	Client interface {
+		Put(context.Context, *PutRequest) (*PutResponse, error)
+		Get(context.Context, *GetRequest) (*GetResponse, error)
+		Exists(context.Context, *ExistsRequest) (*ExistsResponse, error)
+		Delete(context.Context, *DeleteRequest) (*DeleteResponse, error)
+	}
+
+	// PutRequest is the request to Put
+	PutRequest struct {
+		Key  string
+		Blob Blob
+	}
+
+	// PutResponse is the response from Put
+	PutResponse struct{}
+
+	// GetRequest is the request to Get
+	GetRequest struct {
+		Key string
+	}
+
+	// GetResponse is the response from Get
+	GetResponse struct {
+		Blob Blob
+	}
+
+	// ExistsRequest is the request to Exists
+	ExistsRequest struct {
+		Key string
+	}
+
+	// ExistsResponse is the response from Exists
+	ExistsResponse struct {
+		Exists bool
+	}
+
+	// DeleteRequest is the request to Delete
+	DeleteRequest struct {
+		Key string
+	}
+
+	// DeleteResponse is the response from Delete
+	DeleteResponse struct{}
+
+	// Blob defines a blob which can be stored and fetched from blobstore
+	Blob struct {
+		Tags map[string]string
+		Body []byte
+	}
+)

--- a/common/blobstore/interface.go
+++ b/common/blobstore/interface.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package blobstore
 
 import (

--- a/common/resource/resource.go
+++ b/common/resource/resource.go
@@ -23,8 +23,6 @@ package resource
 import (
 	"go.uber.org/yarpc"
 
-	"github.com/uber/cadence/common/blobstore"
-
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 
 	"github.com/uber/cadence/client"
@@ -35,6 +33,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
+	"github.com/uber/cadence/common/blobstore"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"

--- a/common/resource/resource.go
+++ b/common/resource/resource.go
@@ -23,6 +23,8 @@ package resource
 import (
 	"go.uber.org/yarpc"
 
+	"github.com/uber/cadence/common/blobstore"
+
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 
 	"github.com/uber/cadence/client"
@@ -65,6 +67,7 @@ type (
 		GetMetricsClient() metrics.Client
 		GetArchiverProvider() provider.ArchiverProvider
 		GetMessagingClient() messaging.Client
+		GetBlobstoreClient() blobstore.Client
 
 		// membership infos
 

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -26,6 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/uber/cadence/common/blobstore"
+
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/yarpc"
@@ -84,6 +86,7 @@ type (
 		messagingClient   messaging.Client
 		archivalMetadata  archiver.ArchivalMetadata
 		archiverProvider  provider.ArchiverProvider
+		blobstoreClient   blobstore.Client
 
 		// membership infos
 
@@ -291,6 +294,7 @@ func New(
 		messagingClient:   params.MessagingClient,
 		archivalMetadata:  params.ArchivalMetadata,
 		archiverProvider:  params.ArchiverProvider,
+		blobstoreClient:   params.BlobstoreClient,
 
 		// membership infos
 
@@ -449,6 +453,10 @@ func (h *Impl) GetArchivalMetadata() archiver.ArchivalMetadata {
 // GetArchiverProvider return archival provider
 func (h *Impl) GetArchiverProvider() provider.ArchiverProvider {
 	return h.archiverProvider
+}
+
+func (h *Impl) GetBlobstoreClient() blobstore.Client {
+	return h.blobstoreClient
 }
 
 // membership infos

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -68,6 +68,8 @@ type (
 		DynamicConfigClient dynamicconfig.FileBasedClientConfig `yaml:"dynamicConfigClient"`
 		// DomainDefaults is the default config for every domain
 		DomainDefaults DomainDefaults `yaml:"domainDefaults"`
+		// Blobstore is the config for blobstore
+		Blobstore Blobstore `yaml:"blobstore"`
 	}
 
 	// Service contains the service specific config items
@@ -315,6 +317,16 @@ type (
 		// If FlushBytes is unspecified, it defaults  to 1432 bytes, which is
 		// considered safe for local traffic.
 		FlushBytes int `yaml:"flushBytes"`
+	}
+
+	// Blobstore contains the config for blobstore
+	Blobstore struct {
+		FileBlobstore *FileBlobstore
+	}
+
+	// FileBlobstore contains the config for file blobstore
+	FileBlobstore struct {
+		OutputDirectory string `yaml:"outputDirectory"`
 	}
 
 	// Archival contains the config for archival

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -26,6 +26,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/uber/cadence/common/blobstore"
+
 	persistenceClient "github.com/uber/cadence/common/persistence/client"
 
 	"github.com/uber/cadence/common/authorization"
@@ -70,6 +72,7 @@ type (
 		ReplicatorConfig         config.Replicator
 		MetricsClient            metrics.Client
 		MessagingClient          messaging.Client
+		BlobstoreClient          blobstore.Client
 		ESClient                 es.Client
 		ESConfig                 *es.Config
 		DynamicConfig            dynamicconfig.Client
@@ -115,6 +118,7 @@ type (
 		archivalMetadata       archiver.ArchivalMetadata
 		archiverProvider       provider.ArchiverProvider
 		serializer             persistence.PayloadSerializer
+		blobstoreClient        blobstore.Client
 	}
 )
 
@@ -142,6 +146,7 @@ func New(params *BootstrapParams) Service {
 		archivalMetadata:      params.ArchivalMetadata,
 		archiverProvider:      params.ArchiverProvider,
 		serializer:            persistence.NewPayloadSerializer(),
+		blobstoreClient:       params.BlobstoreClient,
 	}
 
 	sVice.runtimeMetricsReporter = metrics.NewRuntimeMetricsReporter(params.MetricScope, time.Minute, sVice.GetLogger(), params.InstanceID)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Add an interface to blobstore. This has several potentially interesting usecases, but the one that this is being added for is the scan/clean workflow.  This interface is meant to start very simple and as we find reason to add to it - we can make it more complex. End users do not depend on this interface so we can safely make changes in the future. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
If the interface is defined poorly its possible that we will need to change it and potentially also make some changes to implementations of it. 

