### PR TITLE
Remove unused default IDReusePolicy for SignalWithStart

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -581,17 +581,10 @@ func (e *historyEngineImpl) startWorkflowHelper(
 				prevLastWriteVersion,
 			)
 		}
-		// for signalWithStart, WorkflowIDReusePolicy is default to WorkflowIDReusePolicyAllowDuplicate
-		// while for startWorkflow it is default to WorkflowIdReusePolicyAllowDuplicateFailedOnly.
-		policy := workflow.WorkflowIdReusePolicyAllowDuplicate
-		if request.WorkflowIdReusePolicy != nil {
-			policy = request.GetWorkflowIdReusePolicy()
-		}
-
 		err = e.applyWorkflowIDReusePolicyForSigWithStart(
 			prevMutableState.GetExecutionInfo(),
 			workflowExecution,
-			policy,
+			request.GetWorkflowIdReusePolicy(),
 		)
 		if err != nil {
 			return nil, err
@@ -2850,7 +2843,6 @@ func getStartRequest(
 	return startRequest
 }
 
-// for startWorkflowExecution & signalWithStart to handle workflow reuse policy
 func (e *historyEngineImpl) applyWorkflowIDReusePolicyForSigWithStart(
 	prevExecutionInfo *persistence.WorkflowExecutionInfo,
 	execution workflow.WorkflowExecution,

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -1283,6 +1283,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 	signalName := "my signal name"
 	input := []byte("test input")
 	requestID := uuid.New()
+	policy := workflow.WorkflowIdReusePolicyAllowDuplicate
 	sRequest = &h.SignalWithStartWorkflowExecutionRequest{
 		DomainUUID: common.StringPtr(domainID),
 		SignalWithStartRequest: &workflow.SignalWithStartWorkflowExecutionRequest{
@@ -1296,6 +1297,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotRunning()
 			SignalName:                          common.StringPtr(signalName),
 			Input:                               input,
 			RequestId:                           common.StringPtr(requestID),
+			WorkflowIdReusePolicy:               &policy,
 		},
 	}
 
@@ -1327,6 +1329,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateReque
 	signalName := "my signal name"
 	input := []byte("test input")
 	requestID := "testRequestID"
+	policy := workflow.WorkflowIdReusePolicyAllowDuplicate
 	sRequest := &h.SignalWithStartWorkflowExecutionRequest{
 		DomainUUID: common.StringPtr(domainID),
 		SignalWithStartRequest: &workflow.SignalWithStartWorkflowExecutionRequest{
@@ -1340,6 +1343,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_DuplicateReque
 			SignalName:                          common.StringPtr(signalName),
 			Input:                               input,
 			RequestId:                           common.StringPtr(requestID),
+			WorkflowIdReusePolicy:               &policy,
 		},
 	}
 
@@ -1379,6 +1383,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_WorkflowAlread
 	signalName := "my signal name"
 	input := []byte("test input")
 	requestID := "testRequestID"
+	policy := workflow.WorkflowIdReusePolicyAllowDuplicate
 	sRequest := &h.SignalWithStartWorkflowExecutionRequest{
 		DomainUUID: common.StringPtr(domainID),
 		SignalWithStartRequest: &workflow.SignalWithStartWorkflowExecutionRequest{
@@ -1392,6 +1397,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_Start_WorkflowAlread
 			SignalName:                          common.StringPtr(signalName),
 			Input:                               input,
 			RequestId:                           common.StringPtr(requestID),
+			WorkflowIdReusePolicy:               &policy,
 		},
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove default IDReusePolicy overwrite in server

<!-- Tell your future self why have you made these changes -->
**Why?**
Originally for SignalWithStart, we want to make the default start IDReusePolicy to AllowDuplicate (instead of AllowDuplicateFailedOnly) for customer convenience. This was done by checking if `IDReusePolicy == nil` we set it to AllowDuplicate. 

However, I just found this never worked as expected, because client side will always set IDReusePolicy even when customer set nothing in their StartWorkflowOpitons. 

So this overwrite on server become useless. Just remove it, and will make it clear that start and signalwithstart use exactly same default IDReusePolicy (which is AllowDuplicateFailedOnly)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risk.
