### PR TITLE
Update slack link to un-expired one

### DIFF
--- a/_includes/top_bar.html
+++ b/_includes/top_bar.html
@@ -9,7 +9,7 @@
         <ul class="search-results"></ul>
       </div>
       <a href="{{ "/docs" | absolute_url }}">Docs</a>
-      <a class="join-slack" title="Join the Cadence Slack channel" href="https://join.slack.com/t/uber-cadence/shared_invite/enQtNDczNTgxMjYxNDEzLTQyYjcxZDM2YTIxMTZkMzQ0NjgxYmI3OWY5ODhiOTliM2I5MzA4NTM4MjU4YzgzZDkwNGEzOTUzNTBlNDk3Yjc">
+      <a class="join-slack" title="Join the Cadence Slack channel" href="https://join.slack.com/t/uber-cadence/shared_invite/zt-dvjoiacm-1U2UM4R4mMxKhaRogEx_OQ">
         <svg class="slack"><use xlink:href="#icon-slack"></use></svg>
       </a>
       <a class="github-link" title="Cadence server on GitHub" href="https://github.com/uber/cadence">


### PR DESCRIPTION
slack link is expired, update to a non-expired link
https://github.com/uber/cadence/pull/2697 