### PR TITLE
Add flag for replication cleanup process

### DIFF
--- a/common/persistence/domainReplicationQueue.go
+++ b/common/persistence/domainReplicationQueue.go
@@ -101,7 +101,7 @@ func (q *domainReplicationQueueImpl) Start() {
 }
 
 func (q *domainReplicationQueueImpl) Stop() {
-	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+	if !atomic.CompareAndSwapInt32(&q.status, common.DaemonStatusInitialized, common.DaemonStatusStopped) {
 		return
 	}
 	close(q.done)

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -101,6 +101,7 @@ var keys = map[Key]string{
 	ValidSearchAttributes:                 "frontend.validSearchAttributes",
 	SendRawWorkflowHistory:                "frontend.sendRawWorkflowHistory",
 	FrontendEnableRPCReplication:          "frontend.enableRPCReplication",
+	FrontendEnableCleanupReplicationTask:  "frontend.enableCleanupReplicationTask",
 	SearchAttributesNumberOfKeysLimit:     "frontend.searchAttributesNumberOfKeysLimit",
 	SearchAttributesSizeOfValueLimit:      "frontend.searchAttributesSizeOfValueLimit",
 	SearchAttributesTotalSizeLimit:        "frontend.searchAttributesTotalSizeLimit",
@@ -236,6 +237,7 @@ var keys = map[Key]string{
 	ReplicationTaskProcessorCleanupJitterCoefficient:       "history.ReplicationTaskProcessorCleanupJitterCoefficient",
 	HistoryEnableRPCReplication:                            "history.EnableRPCReplication",
 	HistoryEnableKafkaReplication:                          "history.EnableKafkaReplication",
+	HistoryEnableCleanupReplicationTask:                    "history.EnableCleanupReplicationTask",
 	EnableConsistentQuery:                                  "history.EnableConsistentQuery",
 	EnableConsistentQueryByDomain:                          "history.EnableConsistentQueryByDomain",
 	MaxBufferedQueryCount:                                  "history.MaxBufferedQueryCount",
@@ -391,6 +393,8 @@ const (
 	SendRawWorkflowHistory
 	// FrontendEnableRPCReplication is a feature flag for rpc replication
 	FrontendEnableRPCReplication
+	// FrontendEnableCleanupReplicationTask is a feature flag for rpc replication cleanup
+	FrontendEnableCleanupReplicationTask
 	// SearchAttributesNumberOfKeysLimit is the limit of number of keys
 	SearchAttributesNumberOfKeysLimit
 	// SearchAttributesSizeOfValueLimit is the size limit of each value
@@ -733,6 +737,8 @@ const (
 	HistoryEnableRPCReplication
 	// HistoryEnableKafkaReplication is the migration flag for Kafka replication
 	HistoryEnableKafkaReplication
+	// HistoryEnableCleanupReplicationTask is the migration flag for Kafka replication
+	HistoryEnableCleanupReplicationTask
 	// EnableConsistentQuery indicates if consistent query is enabled for the cluster
 	EnableConsistentQuery
 	// EnableConsistentQueryByDomain indicates if consistent query is enabled for a domain

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -124,9 +124,7 @@ func (adh *AdminHandler) Start() {
 
 // Stop stops the handler
 func (adh *AdminHandler) Stop() {
-	if adh.config.EnableCleanupReplicationTask() {
-		adh.Resource.GetDomainReplicationQueue().Stop()
-	}
+	adh.Resource.GetDomainReplicationQueue().Stop()
 }
 
 // AddSearchAttribute add search attribute to whitelist

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -117,12 +117,16 @@ func (adh *AdminHandler) RegisterHandler() {
 // Start starts the handler
 func (adh *AdminHandler) Start() {
 	// Start domain replication queue cleanup
-	adh.Resource.GetDomainReplicationQueue().Start()
+	if adh.config.EnableCleanupReplicationTask() {
+		adh.Resource.GetDomainReplicationQueue().Start()
+	}
 }
 
 // Stop stops the handler
 func (adh *AdminHandler) Stop() {
-	adh.Resource.GetDomainReplicationQueue().Stop()
+	if adh.config.EnableCleanupReplicationTask() {
+		adh.Resource.GetDomainReplicationQueue().Stop()
+	}
 }
 
 // AddSearchAttribute add search attribute to whitelist

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -93,6 +93,7 @@ func (s *adminHandlerSuite) SetupTest() {
 	}
 	config := &Config{
 		EnableAdminProtection: dynamicconfig.GetBoolPropertyFn(false),
+		EnableCleanupReplicationTask: dynamicconfig.GetBoolPropertyFn(false),
 	}
 	s.handler = NewAdminHandler(s.mockResource, params, config)
 	s.handler.Start()
@@ -554,6 +555,7 @@ func (s *adminHandlerSuite) Test_AddSearchAttribute_Permission() {
 	handler.config = &Config{
 		EnableAdminProtection: dynamicconfig.GetBoolPropertyFn(true),
 		AdminOperationToken:   dynamicconfig.GetStringPropertyFn(common.DefaultAdminOperationToken),
+		EnableCleanupReplicationTask: dynamicconfig.GetBoolPropertyFn(false),
 	}
 
 	type test struct {

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -94,7 +94,8 @@ type Config struct {
 
 	SendRawWorkflowHistory dynamicconfig.BoolPropertyFnWithDomainFilter
 
-	EnableRPCReplication dynamicconfig.BoolPropertyFn
+	EnableRPCReplication         dynamicconfig.BoolPropertyFn
+	EnableCleanupReplicationTask dynamicconfig.BoolPropertyFn
 }
 
 // NewConfig returns new service config with default values
@@ -135,6 +136,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		DisallowQuery:                       dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.DisallowQuery, false),
 		SendRawWorkflowHistory:              dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.SendRawWorkflowHistory, false),
 		EnableRPCReplication:                dc.GetBoolProperty(dynamicconfig.FrontendEnableRPCReplication, false),
+		EnableCleanupReplicationTask:        dc.GetBoolProperty(dynamicconfig.FrontendEnableCleanupReplicationTask, false),
 	}
 }
 

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -136,7 +136,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		DisallowQuery:                       dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.DisallowQuery, false),
 		SendRawWorkflowHistory:              dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.SendRawWorkflowHistory, false),
 		EnableRPCReplication:                dc.GetBoolProperty(dynamicconfig.FrontendEnableRPCReplication, false),
-		EnableCleanupReplicationTask:        dc.GetBoolProperty(dynamicconfig.FrontendEnableCleanupReplicationTask, false),
+		EnableCleanupReplicationTask:        dc.GetBoolProperty(dynamicconfig.FrontendEnableCleanupReplicationTask, true),
 	}
 }
 

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -206,6 +206,7 @@ type Config struct {
 	// TODO: those two flags are for migration. Consider remove them after the migration complete
 	EnableRPCReplication   dynamicconfig.BoolPropertyFn
 	EnableKafkaReplication dynamicconfig.BoolPropertyFn
+	EnableCleanupReplicationTask dynamicconfig.BoolPropertyFn
 
 	// The following are used by consistent query
 	EnableConsistentQuery         dynamicconfig.BoolPropertyFn
@@ -371,6 +372,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ReplicationTaskProcessorCleanupJitterCoefficient: dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorCleanupJitterCoefficient, 0.15),
 		EnableRPCReplication:                             dc.GetBoolProperty(dynamicconfig.HistoryEnableRPCReplication, false),
 		EnableKafkaReplication:                           dc.GetBoolProperty(dynamicconfig.HistoryEnableKafkaReplication, true),
+		EnableCleanupReplicationTask:                     dc.GetBoolProperty(dynamicconfig.HistoryEnableCleanupReplicationTask, false),
 
 		EnableConsistentQuery:                 dc.GetBoolProperty(dynamicconfig.EnableConsistentQuery, true),
 		EnableConsistentQueryByDomain:         dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.EnableConsistentQueryByDomain, false),

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -372,7 +372,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ReplicationTaskProcessorCleanupJitterCoefficient: dc.GetFloat64PropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorCleanupJitterCoefficient, 0.15),
 		EnableRPCReplication:                             dc.GetBoolProperty(dynamicconfig.HistoryEnableRPCReplication, false),
 		EnableKafkaReplication:                           dc.GetBoolProperty(dynamicconfig.HistoryEnableKafkaReplication, true),
-		EnableCleanupReplicationTask:                     dc.GetBoolProperty(dynamicconfig.HistoryEnableCleanupReplicationTask, false),
+		EnableCleanupReplicationTask:                     dc.GetBoolProperty(dynamicconfig.HistoryEnableCleanupReplicationTask, true),
 
 		EnableConsistentQuery:                 dc.GetBoolProperty(dynamicconfig.EnableConsistentQuery, true),
 		EnableConsistentQueryByDomain:         dc.GetBoolPropertyFnWithDomainFilter(dynamicconfig.EnableConsistentQueryByDomain, false),

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -211,10 +211,12 @@ func (p *taskProcessorImpl) cleanupReplicationTaskLoop() {
 			timer.Stop()
 			return
 		case <-timer.C:
-			err := p.cleanupAckedReplicationTasks()
-			if err != nil {
-				p.logger.Error("Failed to clean up replication messages.", tag.Error(err))
-				p.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupFailure)
+			if p.config.EnableCleanupReplicationTask() {
+				err := p.cleanupAckedReplicationTasks()
+				if err != nil {
+					p.logger.Error("Failed to clean up replication messages.", tag.Error(err))
+					p.metricsClient.Scope(metrics.ReplicationTaskCleanupScope).IncCounter(metrics.ReplicationTaskCleanupFailure)
+				}
 			}
 			timer.Reset(backoff.JitDuration(
 				p.config.ShardSyncMinInterval(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a feature flag to config rpc replication queue clean up process

<!-- Tell your future self why have you made these changes -->
**Why?**
Disable this cleanup so that we don't have backward compatibility if we want to rollback

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The task deletes by the process and after rolled back, the original logic cannot find the task and throws internal service error
