### PR TITLE
Better postgresql test defaults on OSX

### DIFF
--- a/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
@@ -21,6 +21,8 @@
 package postgres
 
 import (
+	"os"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -30,12 +32,26 @@ import (
 )
 
 const (
-	testUser      = "postgres"
-	testPassword  = "cadence"
 	testSchemaDir = "schema/postgres"
 )
 
 func getTestClusterOption() *pt.TestBaseOptions {
+	testUser := "postgres"
+	testPassword := "cadence"
+
+	if runtime.GOOS == "darwin" {
+		testUser = os.Getenv("USER")
+		testPassword = ""
+	}
+
+	if os.Getenv("POSTGRES_USER") != "" {
+		testUser = os.Getenv("POSTGRES_USER")
+	}
+
+	if os.Getenv("POSTGRES_PASSWORD") != "" {
+		testUser = os.Getenv("POSTGRES_PASSWORD")
+	}
+
 	return &pt.TestBaseOptions{
 		SQLDBPluginName: PluginName,
 		DBUsername:      testUser,

--- a/environment/env.go
+++ b/environment/env.go
@@ -161,7 +161,7 @@ func GetCassandraPort() int {
 	return p
 }
 
-// GetMySQLAddress return the cassandra address
+// GetMySQLAddress return the MySQL address
 func GetMySQLAddress() string {
 	addr := os.Getenv(MySQLSeeds)
 	if addr == "" {
@@ -183,7 +183,7 @@ func GetMySQLPort() int {
 	return p
 }
 
-// GetPostgresAddress return the cassandra address
+// GetPostgresAddress return the Postgres address
 func GetPostgresAddress() string {
 	addr := os.Getenv(PostgresSeeds)
 	if addr == "" {
@@ -205,7 +205,7 @@ func GetPostgresPort() int {
 	return p
 }
 
-// GetKafkaAddress return the kafka address
+// GetKafkaAddress return the Kafka address
 func GetKafkaAddress() string {
 	addr := os.Getenv(KafkaSeeds)
 	if addr == "" {
@@ -227,7 +227,7 @@ func GetKafkaPort() int {
 	return p
 }
 
-// GetESAddress return the kafka address
+// GetESAddress return the ElasticSearch address
 func GetESAddress() string {
 	addr := os.Getenv(ESSeeds)
 	if addr == "" {
@@ -236,7 +236,7 @@ func GetESAddress() string {
 	return addr
 }
 
-// GetESPort return the Kafka port
+// GetESPort return the ElasticSearch port
 func GetESPort() int {
 	port := os.Getenv(ESPort)
 	if port == "" {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- on OSX sets postgresql username / password to "$USER" and empty string (defaults for homebrew)
- fixes some related comments

<!-- Tell your future self why have you made these changes -->
**Why?**
- better out-of-the-box testing experience on osx

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- I've run postgresql tests with `go test -v github.com/uber/cadence/common/persistence/sql/sqlplugin/postgres`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Can fail if someone has already configured postgresql in non-standard way with postgres / cadence username / password on OSX