### PR TITLE
Make output of file based blobstore human readable

### DIFF
--- a/common/blobstore/filestore/client_test.go
+++ b/common/blobstore/filestore/client_test.go
@@ -125,7 +125,7 @@ func (s *ClientSuite) TestCrudOperations() {
 	get2, err := c.Get(nil, &blobstore.GetRequest{Key: key2})
 	s.NoError(err)
 	s.Equal(map[string]string{"key1": "value1"}, get2.Blob.Tags)
-	s.Nil(get2.Blob.Body)
+	s.Empty(get2.Blob.Body)
 	get3, err := c.Get(nil, &blobstore.GetRequest{Key: key3})
 	s.NoError(err)
 	s.Equal(map[string]string{"key1": "value1", "key2": "value2"}, get3.Blob.Tags)

--- a/common/blobstore/interface.go
+++ b/common/blobstore/interface.go
@@ -22,7 +22,9 @@
 
 package blobstore
 
-import "context"
+import (
+	"context"
+)
 
 type (
 	// Client defines the interface to a blobstore client.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
When a byte array is serialized using json.Marshal it is not human readable. This is an issue for the filestore based implementation of blobstore. In order to fix this two files are written instead of one - one for the body and one for the tags. There are no important performance implications of this because filestore is just used for local testing. 

