### PR TITLE
Make persistence-tests universal

### DIFF
--- a/common/domain/failover_watcher_test.go
+++ b/common/domain/failover_watcher_test.go
@@ -68,7 +68,7 @@ func (s *failoverWatcherSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true, true),
 	})
 	s.TestBase.Setup()

--- a/common/domain/handler_GlobalDomainDisabled_test.go
+++ b/common/domain/handler_GlobalDomainDisabled_test.go
@@ -69,7 +69,7 @@ func (s *domainHandlerGlobalDomainDisabledSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(false, false),
 	})
 	s.TestBase.Setup()

--- a/common/domain/handler_GlobalDomainEnabled_MasterCluster_test.go
+++ b/common/domain/handler_GlobalDomainEnabled_MasterCluster_test.go
@@ -70,7 +70,7 @@ func (s *domainHandlerGlobalDomainEnabledMasterClusterSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true, true),
 	})
 	s.TestBase.Setup()

--- a/common/domain/handler_GlobalDomainEnabled_NotMasterCluster_test.go
+++ b/common/domain/handler_GlobalDomainEnabled_NotMasterCluster_test.go
@@ -70,7 +70,7 @@ func (s *domainHandlerGlobalDomainEnabledNotMasterClusterSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true, false),
 	})
 	s.TestBase.Setup()

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -41,7 +41,8 @@ import (
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
-	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/common/persistence/cassandra"
+	pt "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/service/config"
 	dc "github.com/uber/cadence/common/service/dynamicconfig"
 )
@@ -49,7 +50,7 @@ import (
 type (
 	domainHandlerCommonSuite struct {
 		suite.Suite
-		persistencetests.TestBase
+		pt.TestBase
 
 		minRetentionDays     int
 		maxBadBinaryCount    int
@@ -63,6 +64,24 @@ type (
 	}
 )
 
+// NewTestBaseWithCassandra returns a persistence test base backed by cassandra datastore
+func NewTestBaseWithCassandra(options *pt.TestBaseOptions) pt.TestBase {
+	if options.DBName == "" {
+		options.DBName = "test_" + pt.GenerateRandomDBName(10)
+	}
+	testCluster := cassandra.NewTestCluster(
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+	)
+
+	return pt.NewTestBase(options, testCluster)
+}
+
+
 var nowInt64 = time.Now().UnixNano()
 
 func TestDomainHandlerCommonSuite(t *testing.T) {
@@ -75,7 +94,7 @@ func (s *domainHandlerCommonSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true, true),
 	})
 	s.TestBase.Setup()

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -56,7 +56,7 @@ func (s *domainReplicationTaskExecutorSuite) TearDownSuite() {
 }
 
 func (s *domainReplicationTaskExecutorSuite) SetupTest() {
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
 	zapLogger, err := zap.NewDevelopment()
 	s.Require().NoError(err)

--- a/common/persistence/cassandra/cassandra_test.go
+++ b/common/persistence/cassandra/cassandra_test.go
@@ -18,66 +18,86 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package persistencetests
+package cassandra_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/uber/cadence/common/persistence/cassandra"
+	pt "github.com/uber/cadence/common/persistence/persistence-tests"
 )
 
+// NewTestBaseWithCassandra returns a persistence test base backed by cassandra datastore
+func NewTestBaseWithCassandra(options *pt.TestBaseOptions) pt.TestBase {
+	if options.DBName == "" {
+		options.DBName = "test_" + pt.GenerateRandomDBName(10)
+	}
+	testCluster := cassandra.NewTestCluster(
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+	)
+
+	return pt.NewTestBase(options, testCluster)
+}
+
 func TestCassandraHistoryV2Persistence(t *testing.T) {
-	s := new(HistoryV2PersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.HistoryV2PersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraMatchingPersistence(t *testing.T) {
-	s := new(MatchingPersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.MatchingPersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraMetadataPersistenceV2(t *testing.T) {
-	s := new(MetadataPersistenceSuiteV2)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.MetadataPersistenceSuiteV2)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraShardPersistence(t *testing.T) {
-	s := new(ShardPersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.ShardPersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraVisibilityPersistence(t *testing.T) {
-	s := new(VisibilityPersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.VisibilityPersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraExecutionManager(t *testing.T) {
-	s := new(ExecutionManagerSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.ExecutionManagerSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraExecutionManagerWithEventsV2(t *testing.T) {
-	s := new(ExecutionManagerSuiteForEventsV2)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.ExecutionManagerSuiteForEventsV2)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestQueuePersistence(t *testing.T) {
-	s := new(QueuePersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.QueuePersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -40,9 +40,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	p "github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/cassandra"
 	"github.com/uber/cadence/common/persistence/client"
-	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/service/config"
 )
@@ -105,37 +103,7 @@ const (
 	defaultScheduleToStartTimeout = 111
 )
 
-// NewTestBaseWithCassandra returns a persistence test base backed by cassandra datastore
-func NewTestBaseWithCassandra(options *TestBaseOptions) TestBase {
-	if options.DBName == "" {
-		options.DBName = "test_" + GenerateRandomDBName(10)
-	}
-	testCluster := cassandra.NewTestCluster(options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir)
-	return newTestBase(options, testCluster)
-}
-
-// NewTestBaseWithSQL returns a new persistence test base backed by SQL
-func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
-	if options.DBName == "" {
-		options.DBName = "test_" + GenerateRandomDBName(10)
-	}
-	testCluster := sql.NewTestCluster(options.SQLDBPluginName, options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir)
-	return newTestBase(options, testCluster)
-}
-
-// NewTestBase returns a persistence test base backed by either cassandra or sql
-func NewTestBase(options *TestBaseOptions) TestBase {
-	switch options.StoreType {
-	case config.StoreTypeSQL:
-		return NewTestBaseWithSQL(options)
-	case config.StoreTypeCassandra:
-		return NewTestBaseWithCassandra(options)
-	default:
-		panic("invalid storeType " + options.StoreType)
-	}
-}
-
-func newTestBase(options *TestBaseOptions, testCluster PersistenceTestCluster) TestBase {
+func NewTestBase(options *TestBaseOptions, testCluster PersistenceTestCluster) TestBase {
 	metadata := options.ClusterMetadata
 	if metadata == nil {
 		metadata = cluster.GetTestClusterMetadata(false, false)

--- a/common/persistence/sql/sqlplugin/mysql/mysql_server_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/mysql_server_test.go
@@ -26,60 +26,77 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/common/persistence/sql"
 )
+
+func NewTestBaseWithSQL(options *pt.TestBaseOptions) pt.TestBase {
+	if options.DBName == "" {
+		options.DBName = "test_" + pt.GenerateRandomDBName(10)
+	}
+	testCluster := sql.NewTestCluster(
+		options.SQLDBPluginName,
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+	)
+	return pt.NewTestBase(options, testCluster)
+}
 
 func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
 	s := new(pt.HistoryV2PersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLMatchingPersistenceSuite(t *testing.T) {
 	s := new(pt.MatchingPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(pt.MetadataPersistenceSuiteV2)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLShardPersistenceSuite(t *testing.T) {
 	s := new(pt.ShardPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLExecutionManagerSuite(t *testing.T) {
 	s := new(pt.ExecutionManagerSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
 	s := new(pt.ExecutionManagerSuiteForEventsV2)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLVisibilityPersistenceSuite(t *testing.T) {
 	s := new(pt.VisibilityPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLQueuePersistence(t *testing.T) {
 	s := new(pt.QueuePersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }

--- a/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/postgres_server_test.go
@@ -28,12 +28,29 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/environment"
 )
 
 const (
 	testSchemaDir = "schema/postgres"
 )
+
+func NewTestBaseWithSQL(options *pt.TestBaseOptions) pt.TestBase {
+	if options.DBName == "" {
+		options.DBName = "test_" + pt.GenerateRandomDBName(10)
+	}
+	testCluster := sql.NewTestCluster(
+		options.SQLDBPluginName,
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+	)
+	return pt.NewTestBase(options, testCluster)
+}
 
 func getTestClusterOption() *pt.TestBaseOptions {
 	testUser := "postgres"
@@ -64,49 +81,49 @@ func getTestClusterOption() *pt.TestBaseOptions {
 
 func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
 	s := new(pt.HistoryV2PersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLMatchingPersistenceSuite(t *testing.T) {
 	s := new(pt.MatchingPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(pt.MetadataPersistenceSuiteV2)
-	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLShardPersistenceSuite(t *testing.T) {
 	s := new(pt.ShardPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLExecutionManagerSuite(t *testing.T) {
 	s := new(pt.ExecutionManagerSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
 	s := new(pt.ExecutionManagerSuiteForEventsV2)
-	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLVisibilityPersistenceSuite(t *testing.T) {
 	s := new(pt.VisibilityPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
@@ -124,7 +141,7 @@ FAIL: TestSQLQueuePersistence/TestDomainReplicationQueue (0.26s)
 */
 //func TestSQLQueuePersistence(t *testing.T) {
 //	s := new(pt.QueuePersistenceSuite)
-//	s.TestBase = pt.NewTestBaseWithSQL(getTestClusterOption())
+//	s.TestBase = NewTestBaseWithSQL(getTestClusterOption())
 //	s.TestBase.Setup()
 //	suite.Run(t, s)
 //}


### PR DESCRIPTION
**What changed?**

All implementation-related code is moved from persistence-tests to appropriate directories. In particular:

- cassandra_test.go is moved to `common/persistence/cassandra`
- constructors for test bases are moved to relevant test files

**Why?**

clear separation of shared persistence tests from implementation-dependent tests

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I've run tests for each provider


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
none

