### PR TITLE
Rpc replication ack level update 

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -316,8 +316,8 @@ func (e *historyEngineImpl) Start() {
 
 	clusterMetadata := e.shard.GetClusterMetadata()
 	if e.replicatorProcessor != nil &&
-		clusterMetadata.GetReplicationConsumerConfig().Type != sconfig.ReplicationConsumerTypeRPC &&
-		e.config.EnableKafkaReplication() {
+		(clusterMetadata.GetReplicationConsumerConfig().Type != sconfig.ReplicationConsumerTypeRPC ||
+		e.config.EnableKafkaReplication()) {
 		e.replicatorProcessor.Start()
 	}
 

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -329,6 +329,8 @@ func (p *replicatorQueueProcessorImpl) readTasks(readLevel int64) ([]task.Info, 
 
 func (p *replicatorQueueProcessorImpl) updateAckLevel(ackLevel int64) error {
 	err := p.shard.UpdateReplicatorAckLevel(ackLevel)
+
+	// TODO: Remove this after enabled the rpc replication
 	clusterMetadata := p.shard.GetClusterMetadata()
 	for name, cluster := range clusterMetadata.GetAllClusterInfo() {
 		if !cluster.Enabled || clusterMetadata.GetCurrentClusterName() == name{
@@ -336,7 +338,6 @@ func (p *replicatorQueueProcessorImpl) updateAckLevel(ackLevel int64) error {
 		}
 		p.shard.UpdateClusterReplicationLevel(name, ackLevel)
 	}
-
 
 	// this is a hack, since there is not dedicated ticker on the queue processor
 	// to periodically send out sync shard message, put it here

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -329,6 +329,14 @@ func (p *replicatorQueueProcessorImpl) readTasks(readLevel int64) ([]task.Info, 
 
 func (p *replicatorQueueProcessorImpl) updateAckLevel(ackLevel int64) error {
 	err := p.shard.UpdateReplicatorAckLevel(ackLevel)
+	clusterMetadata := p.shard.GetClusterMetadata()
+	for name, cluster := range clusterMetadata.GetAllClusterInfo() {
+		if !cluster.Enabled || clusterMetadata.GetCurrentClusterName() == name{
+			continue
+		}
+		p.shard.UpdateClusterReplicationLevel(name, ackLevel)
+	}
+
 
 	// this is a hack, since there is not dedicated ticker on the queue processor
 	// to periodically send out sync shard message, put it here


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update per cluster ack level when updating the current ack level in local cluster

<!-- Tell your future self why have you made these changes -->
**Why?**
When switching to RPC replication, it can catch up the ack level without flooding the DB

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Beta environment test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is for an unlaunch feature
