### PR TITLE
Implement simple RWMutex cache to be used in domainCache

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -54,14 +54,24 @@ type Cache interface {
 // Options control the behavior of the cache
 type Options struct {
 	// TTL controls the time-to-live for a given cache entry.  Cache entries that
-	// are older than the TTL will not be returned
+	// are older than the TTL will not be returned.
 	TTL time.Duration
 
 	// InitialCapacity controls the initial capacity of the cache
 	InitialCapacity int
 
-	// Pin prevents in-use objects from getting evicted
+	// Pin prevents in-use objects from getting evicted.
 	Pin bool
+
+	// RemovedFunc is an optional function called when an element
+	// is scheduled for deletion
+	RemovedFunc RemovedFunc
+}
+
+// SimpleOptions provides options that can be used to configure SimpleCache
+type SimpleOptions struct {
+	// InitialCapacity controls the initial capacity of the cache
+	InitialCapacity int
 
 	// RemovedFunc is an optional function called when an element
 	// is scheduled for deletion

--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -165,10 +165,9 @@ func NewDomainCache(
 }
 
 func newDomainCache() Cache {
-	opts := &Options{}
-	opts.InitialCapacity = domainCacheInitialSize
-	opts.TTL = domainCacheTTL
-	return New(domainCacheMaxSize, opts)
+	return NewSimple(domainCacheMaxSize, &SimpleOptions{
+		InitialCapacity: domainCacheInitialSize,
+	})
 }
 
 func newDomainCacheEntry(

--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -165,7 +165,7 @@ func NewDomainCache(
 }
 
 func newDomainCache() Cache {
-	return NewSimple(domainCacheMaxSize, &SimpleOptions{
+	return NewSimple(&SimpleOptions{
 		InitialCapacity: domainCacheInitialSize,
 	})
 }

--- a/common/cache/simple.go
+++ b/common/cache/simple.go
@@ -143,7 +143,15 @@ func (c *simple) Put(key interface{}, value interface{}) interface{} {
 func (c *simple) PutIfNotExist(key interface{}, value interface{}) (interface{}, error) {
 	c.Lock()
 	defer c.Unlock()
-	return c.putInternal(key, value, false)
+	existing, err := c.putInternal(key, value, false)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		// This is a new value
+		return value, nil
+	}
+	return existing, nil
 }
 
 // Delete deletes a key, value pair associated with a key

--- a/common/cache/simple.go
+++ b/common/cache/simple.go
@@ -96,8 +96,6 @@ func (e *simpleEntry) CreateTime() time.Time {
 // Simple cache also does not have the concept of pinning that LRU cache has.
 // Internally simple cache uses a RWMutex instead of the exclusive Mutex that LRU cache uses.
 // The RWMutex makes simple cache readable by many threads without introducing lock contention.
-// The maxSize provided to simple cache should be larger than the possible largest size because
-// simple cache will simply panic if max size is exceeded.
 func NewSimple(opts *SimpleOptions) Cache {
 	if opts == nil {
 		opts = &SimpleOptions{}
@@ -122,7 +120,6 @@ func (c *simple) Get(key interface{}) interface{} {
 }
 
 // Put puts a new value associated with a given key, returning the existing value (if present).
-// If Put is called on a cache which is already full it will panic.
 func (c *simple) Put(key interface{}, value interface{}) interface{} {
 	c.Lock()
 	defer c.Unlock()

--- a/common/cache/simple.go
+++ b/common/cache/simple.go
@@ -1,0 +1,204 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cache
+
+import (
+	"container/list"
+	"errors"
+	"sync"
+	"time"
+)
+
+var (
+	// SimpleCacheFull is the error that is returned from PutIfNotExists if cache is full
+	SimpleCacheFull = errors.New("simple cache is full")
+
+	// DummyCreateTime is the create time used by all entries in the cache.
+	DummyCreateTime = time.Now()
+)
+
+type (
+	simple struct {
+		sync.RWMutex
+		accessMap   map[interface{}]*list.Element
+		iterateList *list.List
+		maxSize     int
+		rmFunc      RemovedFunc
+	}
+
+	simpleItr struct {
+		simple   *simple
+		nextItem *list.Element
+	}
+
+	simpleEntry struct {
+		key   interface{}
+		value interface{}
+	}
+)
+
+// Close closes the iterator
+func (it *simpleItr) Close() {
+	it.simple.RUnlock()
+}
+
+// HasNext return true if there is more items to be returned
+func (it *simpleItr) HasNext() bool {
+	return it.nextItem != nil
+}
+
+// Next returns the next item
+func (it *simpleItr) Next() Entry {
+	if it.nextItem == nil {
+		panic("Simple cache iterator Next called when there is no next item")
+	}
+
+	entry := it.nextItem.Value.(*simpleEntry)
+	it.nextItem = it.nextItem.Next()
+	// make a copy of the entry so there will be no concurrent access to this entry
+	entry = &simpleEntry{
+		key:   entry.key,
+		value: entry.value,
+	}
+	return entry
+}
+
+func (e *simpleEntry) Key() interface{} {
+	return e.key
+}
+
+func (e *simpleEntry) Value() interface{} {
+	return e.value
+}
+
+// CreateTime is not implemented for simple cache entries
+func (e *simpleEntry) CreateTime() time.Time {
+	return DummyCreateTime
+}
+
+// NewSimple creates a new simple cache with given options.
+// Simple cache will never evict entries and it will never reorder the elements.
+// Simple cache also does not have the concept of pinning that LRU cache has.
+// Internally simple cache uses a RWMutex instead of the exclusive Mutex that LRU cache uses.
+// The RWMutex makes simple cache readable by many threads without introducing lock contention.
+// The maxSize provided to simple cache should be larger than the possible largest size because
+// simple cache will simply panic if max size is exceeded.
+func NewSimple(maxSize int, opts *SimpleOptions) Cache {
+	if opts == nil {
+		opts = &SimpleOptions{}
+	}
+	return &simple{
+		iterateList: list.New(),
+		accessMap:   make(map[interface{}]*list.Element, opts.InitialCapacity),
+		maxSize:     maxSize,
+		rmFunc:      opts.RemovedFunc,
+	}
+}
+
+// Get retrieves the value stored under the given key
+func (c *simple) Get(key interface{}) interface{} {
+	c.RLock()
+	defer c.RUnlock()
+
+	element := c.accessMap[key]
+	if element == nil {
+		return nil
+	}
+	return element.Value.(*simpleEntry).Value()
+}
+
+// Put puts a new value associated with a given key, returning the existing value (if present).
+// If Put is called on a cache which is already full it will panic.
+func (c *simple) Put(key interface{}, value interface{}) interface{} {
+	c.Lock()
+	defer c.Unlock()
+	existing, err := c.putInternal(key, value, true)
+	if err != nil {
+		panic(err)
+	}
+	return existing
+}
+
+// PutIfNotExist puts a value associated with a given key if it does not exist
+func (c *simple) PutIfNotExist(key interface{}, value interface{}) (interface{}, error) {
+	c.Lock()
+	defer c.Unlock()
+	return c.putInternal(key, value, false)
+}
+
+// Delete deletes a key, value pair associated with a key
+func (c *simple) Delete(key interface{}) {
+	c.Lock()
+	defer c.Unlock()
+
+	element := c.accessMap[key]
+	if element == nil {
+		return
+	}
+	entry := c.iterateList.Remove(element).(*simpleEntry)
+	if c.rmFunc != nil {
+		go c.rmFunc(entry.value)
+	}
+	delete(c.accessMap, entry.key)
+}
+
+// Release does nothing for simple cache
+func (c *simple) Release(_ interface{}) {}
+
+// Size returns the number of entries currently in the cache
+func (c *simple) Size() int {
+	c.RLock()
+	defer c.RUnlock()
+
+	return len(c.accessMap)
+}
+
+func (c *simple) Iterator() Iterator {
+	c.RLock()
+	iterator := &simpleItr{
+		simple:   c,
+		nextItem: c.iterateList.Front(),
+	}
+	return iterator
+}
+
+func (c *simple) putInternal(key interface{}, value interface{}, allowUpdate bool) (interface{}, error) {
+	elt := c.accessMap[key]
+	if elt != nil {
+		entry := elt.Value.(*simpleEntry)
+		existing := entry.value
+		if allowUpdate {
+			entry.value = value
+		}
+		return existing, nil
+	}
+	if len(c.accessMap) >= c.maxSize {
+		return nil, SimpleCacheFull
+	}
+	entry := &simpleEntry{
+		key:   key,
+		value: value,
+	}
+	c.accessMap[key] = c.iterateList.PushFront(entry)
+	return nil, nil
+}

--- a/common/cache/simple_test.go
+++ b/common/cache/simple_test.go
@@ -1,0 +1,189 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cache
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSimple(t *testing.T) {
+	cache := NewSimple(5, nil)
+
+	cache.Put("A", "Foo")
+	assert.Equal(t, "Foo", cache.Get("A"))
+	assert.Nil(t, cache.Get("B"))
+	assert.Equal(t, 1, cache.Size())
+
+	cache.Put("B", "Bar")
+	cache.Put("C", "Cid")
+	cache.Put("D", "Delt")
+	assert.Equal(t, 4, cache.Size())
+
+	assert.Equal(t, "Bar", cache.Get("B"))
+	assert.Equal(t, "Cid", cache.Get("C"))
+	assert.Equal(t, "Delt", cache.Get("D"))
+
+	cache.Put("A", "Foo2")
+	assert.Equal(t, "Foo2", cache.Get("A"))
+
+	cache.Put("E", "Epsi")
+	assert.Equal(t, "Epsi", cache.Get("E"))
+	assert.Equal(t, "Foo2", cache.Get("A"))
+
+	cache.Delete("A")
+	assert.Nil(t, cache.Get("A"))
+}
+
+func TestSimpleGenerics(t *testing.T) {
+	key := keyType{
+		dummyString: "some random key",
+		dummyInt:    59,
+	}
+	value := "some random value"
+
+	cache := NewSimple(5, nil)
+	cache.Put(key, value)
+
+	assert.Equal(t, value, cache.Get(key))
+	assert.Equal(t, value, cache.Get(keyType{
+		dummyString: "some random key",
+		dummyInt:    59,
+	}))
+	assert.Nil(t, cache.Get(keyType{
+		dummyString: "some other random key",
+		dummyInt:    56,
+	}))
+}
+
+func TestSimpleCacheConcurrentAccess(t *testing.T) {
+	cache := NewSimple(5, nil)
+	values := map[string]string{
+		"A": "foo",
+		"B": "bar",
+		"C": "zed",
+		"D": "dank",
+		"E": "ezpz",
+	}
+
+	for k, v := range values {
+		cache.Put(k, v)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(2)
+
+		// concurrent get and put
+		go func() {
+			defer wg.Done()
+
+			<-start
+
+			for j := 0; j < 1000; j++ {
+				cache.Get("A")
+				cache.Put("A", "fooo")
+			}
+		}()
+
+		// concurrent iteration
+		go func() {
+			defer wg.Done()
+
+			<-start
+
+			for j := 0; j < 50; j++ {
+				var result []Entry
+				it := cache.Iterator()
+				for it.HasNext() {
+					entry := it.Next()
+					result = append(result, entry) //nolint:staticcheck
+				}
+				it.Close()
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+}
+
+func TestSimpleRemoveFunc(t *testing.T) {
+	ch := make(chan bool)
+	cache := NewSimple(5, &SimpleOptions{
+		RemovedFunc: func(i interface{}) {
+			_, ok := i.(*testing.T)
+			assert.True(t, ok)
+			ch <- true
+		},
+	})
+
+	cache.Put("testing", t)
+	cache.Delete("testing")
+	assert.Nil(t, cache.Get("testing"))
+
+	timeout := time.NewTimer(time.Millisecond * 300)
+	select {
+	case b := <-ch:
+		assert.True(t, b)
+	case <-timeout.C:
+		t.Error("RemovedFunc did not send true on channel ch")
+	}
+}
+
+func TestSimpleIterator(t *testing.T) {
+	expected := map[string]string{
+		"A": "Alpha",
+		"B": "Beta",
+		"G": "Gamma",
+		"D": "Delta",
+	}
+
+	cache := NewSimple(5, nil)
+
+	for k, v := range expected {
+		cache.Put(k, v)
+	}
+
+	actual := map[string]string{}
+
+	it := cache.Iterator()
+	for it.HasNext() {
+		entry := it.Next()
+		actual[entry.Key().(string)] = entry.Value().(string)
+	}
+	it.Close()
+	assert.Equal(t, expected, actual)
+
+	it = cache.Iterator()
+	for i := 0; i < len(expected); i++ {
+		entry := it.Next()
+		actual[entry.Key().(string)] = entry.Value().(string)
+	}
+	it.Close()
+	assert.Equal(t, expected, actual)
+}

--- a/common/cache/simple_test.go
+++ b/common/cache/simple_test.go
@@ -31,7 +31,7 @@ import (
 )
 
 func TestSimple(t *testing.T) {
-	cache := NewSimple(5, nil)
+	cache := NewSimple(nil)
 
 	cache.Put("A", "Foo")
 	assert.Equal(t, "Foo", cache.Get("A"))
@@ -65,7 +65,7 @@ func TestSimpleGenerics(t *testing.T) {
 	}
 	value := "some random value"
 
-	cache := NewSimple(5, nil)
+	cache := NewSimple(nil)
 	cache.Put(key, value)
 
 	assert.Equal(t, value, cache.Get(key))
@@ -80,7 +80,7 @@ func TestSimpleGenerics(t *testing.T) {
 }
 
 func TestSimpleCacheConcurrentAccess(t *testing.T) {
-	cache := NewSimple(5, nil)
+	cache := NewSimple(nil)
 	values := map[string]string{
 		"A": "foo",
 		"B": "bar",
@@ -134,7 +134,7 @@ func TestSimpleCacheConcurrentAccess(t *testing.T) {
 
 func TestSimpleRemoveFunc(t *testing.T) {
 	ch := make(chan bool)
-	cache := NewSimple(5, &SimpleOptions{
+	cache := NewSimple(&SimpleOptions{
 		RemovedFunc: func(i interface{}) {
 			_, ok := i.(*testing.T)
 			assert.True(t, ok)
@@ -163,7 +163,7 @@ func TestSimpleIterator(t *testing.T) {
 		"D": "Delta",
 	}
 
-	cache := NewSimple(5, nil)
+	cache := NewSimple(nil)
 
 	for k, v := range expected {
 		cache.Put(k, v)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
We are facing an issue in which domain specific metrics cannot be emitted in task processing. We suspect that this is due the lock contention associated with using a LRU cache. LRU cache grabs a write lock every time Get is called so that it can move elements to the front of the cache. This is not actually needed in the case of domain cache because we never expect to evict entries from domain cache. 
