### PR TITLE
Added metricScope cache implementation

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -124,7 +124,7 @@ type Entry interface {
 type GetCacheItemSizeFunc func(interface{}) uint64
 type MetricsCache interface {
 	// Get retrieves metrics scope based on me
-	Get(string) metrics.Scope
+	Get(domainID string, taskType int) metrics.Scope
 	// Put adds metrics scope for a domainID
-	Put(string, metrics.Scope)
+	Put(domainID string, taskType int, metricsScope metrics.Scope)
 }

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -21,6 +21,7 @@
 package cache
 
 import (
+	"github.com/uber/cadence/common/metrics"
 	"time"
 )
 
@@ -121,3 +122,9 @@ type Entry interface {
 
 // GetCacheItemSizeFunc returns the cache item size in bytes
 type GetCacheItemSizeFunc func(interface{}) uint64
+type MetricsCache interface {
+	// Get retrieves metrics scope based on me
+	Get(string) metrics.Scope
+	// Put adds metrics scope for a domainID
+	Put(string, metrics.Scope)
+}

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -21,8 +21,9 @@
 package cache
 
 import (
-	"github.com/uber/cadence/common/metrics"
 	"time"
+
+	"github.com/uber/cadence/common/metrics"
 )
 
 // A Cache is a generalized interface to a cache.  See cache.LRU for a specific
@@ -122,9 +123,10 @@ type Entry interface {
 
 // GetCacheItemSizeFunc returns the cache item size in bytes
 type GetCacheItemSizeFunc func(interface{}) uint64
-type MetricsCache interface {
-	// Get retrieves metrics scope based on me
-	Get(domainID string, taskType int) metrics.Scope
-	// Put adds metrics scope for a domainID
-	Put(domainID string, taskType int, metricsScope metrics.Scope)
+
+type MetricsScopeCache interface {
+	// Get retrieves metrics scope for a domainID and scopeID
+	Get(domainID string, scopeID int) (metrics.Scope, bool)
+	// Put adds metrics scope for a domainID and scopeID
+	Put(domainID string, scopeID int, metricsScope metrics.Scope)
 }

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -125,8 +125,8 @@ type Entry interface {
 type GetCacheItemSizeFunc func(interface{}) uint64
 
 type MetricsScopeCache interface {
-	// Get retrieves metrics scope for a domainID and scopeID
-	Get(domainID string, scopeID int) (metrics.Scope, bool)
-	// Put adds metrics scope for a domainID and scopeID
-	Put(domainID string, scopeID int, metricsScope metrics.Scope)
+	// Get retrieves metrics scope for a domainID and scopeIdx
+	Get(domainID string, scopeIdx int) (metrics.Scope, bool)
+	// Put adds metrics scope for a domainID and scopeIdx
+	Put(domainID string, scopeIdx int, metricsScope metrics.Scope)
 }

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -124,7 +124,8 @@ type Entry interface {
 // GetCacheItemSizeFunc returns the cache item size in bytes
 type GetCacheItemSizeFunc func(interface{}) uint64
 
-type MetricsScopeCache interface {
+// DomainMetricsScopeCache represents a interface for mapping domainID and scopeIdx to metricsScope
+type DomainMetricsScopeCache interface {
 	// Get retrieves metrics scope for a domainID and scopeIdx
 	Get(domainID string, scopeIdx int) (metrics.Scope, bool)
 	// Put adds metrics scope for a domainID and scopeIdx

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -23,6 +23,7 @@
 package cache
 
 import (
+	"strconv"
 	"sync"
 
 	"github.com/uber/cadence/common/metrics"
@@ -41,21 +42,22 @@ func NewMetricsCache() MetricsCache {
 }
 
 // Get retrieves scope using domainID from scopeMap
-func (mc *metricsCache) Get(domainID string) metrics.Scope {
+func (mc *metricsCache) Get(domainID string, taskType int) metrics.Scope {
 	mc.RLock()
 	defer mc.RUnlock()
 
-	if metricsScope, ok := mc.scopeMap[domainID]; ok {
+	key := domainID + "_" + strconv.Itoa(taskType)
+	if metricsScope, ok := mc.scopeMap[key]; ok {
 		return metricsScope
 	}
-
 	return nil
 }
 
 // Put puts map of domainID and scope in the metricsCache accessMap
-func (mc *metricsCache) Put(domainID string, scope metrics.Scope) {
+func (mc *metricsCache) Put(domainID string, taskType int, scope metrics.Scope) {
 	mc.Lock()
 	defer mc.Unlock()
 
-	mc.scopeMap[domainID] = scope
+	key := domainID + "_" + strconv.Itoa(taskType)
+	mc.scopeMap[key] = scope
 }

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -23,40 +23,50 @@
 package cache
 
 import (
+	"bytes"
 	"strconv"
 	"sync"
 
 	"github.com/uber/cadence/common/metrics"
 )
 
-type metricsScopeCache struct {
+type domainMetricsScopeCache struct {
 	sync.RWMutex
 	scopeMap map[string]metrics.Scope
 }
 
 // NewMetricsScopeCache constructs a new metricsScopeCache
-func NewMetricsScopeCache() MetricsScopeCache {
-	return &metricsScopeCache{
+func NewDomainMetricsScopeCache() DomainMetricsScopeCache {
+	return &domainMetricsScopeCache{
 		scopeMap: make(map[string]metrics.Scope),
 	}
 }
 
-// Get retrieves scope using domainID and scopeIdx from scopeMap
-func (mc *metricsScopeCache) Get(domainID string, scopeIdx int) (metrics.Scope, bool) {
-	mc.RLock()
-	defer mc.RUnlock()
+// Get retrieves scope for domainID and scopeIdx
+func (c *domainMetricsScopeCache) Get(domainID string, scopeIdx int) (metrics.Scope, bool) {
+	c.RLock()
+	defer c.RUnlock()
 
-	key := domainID + "_" + strconv.Itoa(scopeIdx)
+	var buffer bytes.Buffer
+	buffer.WriteString(domainID)
+	buffer.WriteString("_")
+	buffer.WriteString(strconv.Itoa(scopeIdx))
+	key := buffer.String()
 
-	metricsScope, found := mc.scopeMap[key]
-	return metricsScope, found
+	metricsScope, ok := c.scopeMap[key]
+	return metricsScope, ok
 }
 
-// Put puts map of domainID and scopeIdx in the metricsCache scopeMap
-func (mc *metricsScopeCache) Put(domainID string, scopeIdx int, scope metrics.Scope) {
-	mc.Lock()
-	defer mc.Unlock()
+// Put puts map of domainID and scopeIdx to metricsScope
+func (c *domainMetricsScopeCache) Put(domainID string, scopeIdx int, scope metrics.Scope) {
+	c.Lock()
+	defer c.Unlock()
 
-	key := domainID + "_" + strconv.Itoa(scopeIdx)
-	mc.scopeMap[key] = scope
+	var buffer bytes.Buffer
+	buffer.WriteString(domainID)
+	buffer.WriteString("_")
+	buffer.WriteString(strconv.Itoa(scopeIdx))
+	key := buffer.String()
+
+	c.scopeMap[key] = scope
 }

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -1,0 +1,60 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cache
+
+import (
+	"sync"
+
+	"github.com/uber/cadence/common/metrics"
+)
+
+type MetricsCache struct {
+	sync.RWMutex
+	scopeMap map[string]metrics.Scope
+}
+
+// NewMetricsCache creates a new metricsCache struct
+func NewMetricsCache() *MetricsCache {
+	return &MetricsCache{
+		scopeMap: make(map[string]metrics.Scope),
+	}
+}
+
+// Get retrieves scope using domainID from scopeMap
+func (mC *MetricsCache) Get(domainID string) metrics.Scope {
+	mC.RLock()
+	defer mC.RUnlock()
+
+	var metricsScope metrics.Scope
+	metricsScope = mC.scopeMap[domainID]
+
+	return metricsScope
+}
+
+// Put puts map of domainID and scope in the metricsCache accessMap
+func (mC *MetricsCache) Put(domainID string, scope metrics.Scope) {
+	mC.Lock()
+	defer mC.Unlock()
+
+	mC.scopeMap[domainID] = scope
+}

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -28,33 +28,34 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
-type MetricsCache struct {
+type metricsCache struct {
 	sync.RWMutex
 	scopeMap map[string]metrics.Scope
 }
 
-// NewMetricsCache creates a new metricsCache struct
-func NewMetricsCache() *MetricsCache {
-	return &MetricsCache{
+// NewMetricsCache constructs a new metricsCache struct
+func NewMetricsCache() MetricsCache {
+	return &metricsCache{
 		scopeMap: make(map[string]metrics.Scope),
 	}
 }
 
 // Get retrieves scope using domainID from scopeMap
-func (mC *MetricsCache) Get(domainID string) metrics.Scope {
-	mC.RLock()
-	defer mC.RUnlock()
+func (mc *metricsCache) Get(domainID string) metrics.Scope {
+	mc.RLock()
+	defer mc.RUnlock()
 
-	var metricsScope metrics.Scope
-	metricsScope = mC.scopeMap[domainID]
+	if metricsScope, ok := mc.scopeMap[domainID]; ok {
+		return metricsScope
+	}
 
-	return metricsScope
+	return nil
 }
 
 // Put puts map of domainID and scope in the metricsCache accessMap
-func (mC *MetricsCache) Put(domainID string, scope metrics.Scope) {
-	mC.Lock()
-	defer mC.Unlock()
+func (mc *metricsCache) Put(domainID string, scope metrics.Scope) {
+	mc.Lock()
+	defer mc.Unlock()
 
-	mC.scopeMap[domainID] = scope
+	mc.scopeMap[domainID] = scope
 }

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -29,35 +29,34 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
-type metricsCache struct {
+type metricsScopeCache struct {
 	sync.RWMutex
 	scopeMap map[string]metrics.Scope
 }
 
-// NewMetricsCache constructs a new metricsCache struct
-func NewMetricsCache() MetricsCache {
-	return &metricsCache{
+// NewMetricsCache constructs a new metricsScopeCache
+func NewMetricsScopeCache() MetricsScopeCache {
+	return &metricsScopeCache{
 		scopeMap: make(map[string]metrics.Scope),
 	}
 }
 
 // Get retrieves scope using domainID from scopeMap
-func (mc *metricsCache) Get(domainID string, taskType int) metrics.Scope {
+func (mc *metricsScopeCache) Get(domainID string, scopeIdx int) (metrics.Scope, bool) {
 	mc.RLock()
 	defer mc.RUnlock()
 
-	key := domainID + "_" + strconv.Itoa(taskType)
-	if metricsScope, ok := mc.scopeMap[key]; ok {
-		return metricsScope
-	}
-	return nil
+	key := domainID + "_" + strconv.Itoa(scopeIdx)
+
+	metricsScope, found := mc.scopeMap[key]
+	return metricsScope, found
 }
 
 // Put puts map of domainID and scope in the metricsCache accessMap
-func (mc *metricsCache) Put(domainID string, taskType int, scope metrics.Scope) {
+func (mc *metricsScopeCache) Put(domainID string, scopeIdx int, scope metrics.Scope) {
 	mc.Lock()
 	defer mc.Unlock()
 
-	key := domainID + "_" + strconv.Itoa(taskType)
+	key := domainID + "_" + strconv.Itoa(scopeIdx)
 	mc.scopeMap[key] = scope
 }

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -34,14 +34,14 @@ type metricsScopeCache struct {
 	scopeMap map[string]metrics.Scope
 }
 
-// NewMetricsCache constructs a new metricsScopeCache
+// NewMetricsScopeCache constructs a new metricsScopeCache
 func NewMetricsScopeCache() MetricsScopeCache {
 	return &metricsScopeCache{
 		scopeMap: make(map[string]metrics.Scope),
 	}
 }
 
-// Get retrieves scope using domainID from scopeMap
+// Get retrieves scope using domainID and scopeIdx from scopeMap
 func (mc *metricsScopeCache) Get(domainID string, scopeIdx int) (metrics.Scope, bool) {
 	mc.RLock()
 	defer mc.RUnlock()
@@ -52,7 +52,7 @@ func (mc *metricsScopeCache) Get(domainID string, scopeIdx int) (metrics.Scope, 
 	return metricsScope, found
 }
 
-// Put puts map of domainID and scope in the metricsCache accessMap
+// Put puts map of domainID and scopeIdx in the metricsCache scopeMap
 func (mc *metricsScopeCache) Put(domainID string, scopeIdx int, scope metrics.Scope) {
 	mc.Lock()
 	defer mc.Unlock()

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -35,7 +35,7 @@ type domainMetricsScopeCache struct {
 	scopeMap map[string]metrics.Scope
 }
 
-// NewMetricsScopeCache constructs a new metricsScopeCache
+// NewDomainMetricsScopeCache constructs a new domainMetricsScopeCache
 func NewDomainMetricsScopeCache() DomainMetricsScopeCache {
 	return &domainMetricsScopeCache{
 		scopeMap: make(map[string]metrics.Scope),

--- a/common/cache/metricsScopeCache_test.go
+++ b/common/cache/metricsScopeCache_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 func TestGetMetricsScope(t *testing.T) {
-	metricsCache := NewMetricsScopeCache()
+	metricsCache := NewDomainMetricsScopeCache()
 	var found bool
 
 	tests := []struct {
@@ -69,7 +69,7 @@ func TestGetMetricsScope(t *testing.T) {
 }
 
 func TestConcurrentMetricsScopeAccess(t *testing.T) {
-	metricsCache := NewMetricsScopeCache()
+	domainMetricsScopeCache := NewDomainMetricsScopeCache()
 
 	ch := make(chan struct{})
 	var wg sync.WaitGroup
@@ -84,8 +84,8 @@ func TestConcurrentMetricsScopeAccess(t *testing.T) {
 
 			<-ch
 
-			metricsCache.Get("test_domain", scopeIdx)
-			metricsCache.Put("test_domain", scopeIdx, metrics.NoopScope(metrics.ServiceIdx(scopeIdx)))
+			domainMetricsScopeCache.Get("test_domain", scopeIdx)
+			domainMetricsScopeCache.Put("test_domain", scopeIdx, metrics.NoopScope(metrics.ServiceIdx(scopeIdx)))
 		}(i)
 	}
 
@@ -93,7 +93,7 @@ func TestConcurrentMetricsScopeAccess(t *testing.T) {
 	wg.Wait()
 
 	for i := 0; i < 1000; i++ {
-		metricsScope, found = metricsCache.Get("test_domain", i)
+		metricsScope, found = domainMetricsScopeCache.Get("test_domain", i)
 		testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(i))
 
 		assert.Equal(t, true, found)

--- a/common/cache/metricsScopeCache_test.go
+++ b/common/cache/metricsScopeCache_test.go
@@ -1,0 +1,78 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cache
+
+import (
+	"fmt"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/bmizerany/assert"
+
+	"github.com/uber/cadence/common/metrics/mocks"
+)
+
+func TestGetMetricsScope(t *testing.T) {
+	metricsCache := NewMetricsCache()
+
+	mockMetricsScope := &mocks.Scope{}
+
+	metricsCache.Put("A", mockMetricsScope)
+	metricsCache.Put("B", mockMetricsScope)
+	metricsCache.Put("C", mockMetricsScope)
+
+	assert.Equal(t, 3, len(metricsCache.scopeMap))
+
+	assert.Equal(t, mockMetricsScope, metricsCache.Get("A"))
+	assert.Equal(t, mockMetricsScope, metricsCache.Get("B"))
+	assert.Equal(t, mockMetricsScope, metricsCache.Get("C"))
+}
+
+func TestConcurrentMetricsScopeAccess(t *testing.T) {
+	metricsCache := NewMetricsCache()
+
+	mockMetricsScope := &mocks.Scope{}
+
+	var wg sync.WaitGroup
+	for i := 0; i < 1000; i++ {
+		wg.Add(1)
+		// concurrent get and put
+		go func() {
+			defer wg.Done()
+
+			metricsCache.Get(strconv.Itoa(i))
+			metricsCache.Put(strconv.Itoa(i), mockMetricsScope)
+		}()
+	}
+
+	wg.Wait()
+
+	assert.Equal(t, 1000, len(metricsCache.scopeMap))
+
+	for i := 0; i < 1000; i++ {
+		if metricsCache.scopeMap[strconv.Itoa(i)] == nil {
+			t.Error(fmt.Sprintf("Metrics scope not set for %d", i))
+		}
+	}
+}

--- a/common/cache/metricsScopeCache_test.go
+++ b/common/cache/metricsScopeCache_test.go
@@ -28,8 +28,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/bmizerany/assert"
-
+	"github.com/stretchr/testify/assert"
 	"github.com/uber/cadence/common/metrics/mocks"
 )
 
@@ -41,8 +40,6 @@ func TestGetMetricsScope(t *testing.T) {
 	metricsCache.Put("A", mockMetricsScope)
 	metricsCache.Put("B", mockMetricsScope)
 	metricsCache.Put("C", mockMetricsScope)
-
-	assert.Equal(t, 3, len(metricsCache.scopeMap))
 
 	assert.Equal(t, mockMetricsScope, metricsCache.Get("A"))
 	assert.Equal(t, mockMetricsScope, metricsCache.Get("B"))
@@ -68,10 +65,8 @@ func TestConcurrentMetricsScopeAccess(t *testing.T) {
 
 	wg.Wait()
 
-	assert.Equal(t, 1000, len(metricsCache.scopeMap))
-
 	for i := 0; i < 1000; i++ {
-		if metricsCache.scopeMap[strconv.Itoa(i)] == nil {
+		if metricsCache.Get(strconv.Itoa(i)) != mockMetricsScope {
 			t.Error(fmt.Sprintf("Metrics scope not set for %d", i))
 		}
 	}

--- a/common/resource/resource.go
+++ b/common/resource/resource.go
@@ -61,7 +61,7 @@ type (
 		// other common resources
 
 		GetDomainCache() cache.DomainCache
-		GetMetricsScopeCache() cache.MetricsScopeCache
+		GetDomainMetricsScopeCache() cache.DomainMetricsScopeCache
 		GetTimeSource() clock.TimeSource
 		GetPayloadSerializer() persistence.PayloadSerializer
 		GetMetricsClient() metrics.Client

--- a/common/resource/resource.go
+++ b/common/resource/resource.go
@@ -61,6 +61,7 @@ type (
 		// other common resources
 
 		GetDomainCache() cache.DomainCache
+		GetMetricsScopeCache() cache.MetricsScopeCache
 		GetTimeSource() clock.TimeSource
 		GetPayloadSerializer() persistence.PayloadSerializer
 		GetMetricsClient() metrics.Client

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -428,7 +428,7 @@ func (h *Impl) GetDomainCache() cache.DomainCache {
 	return h.domainCache
 }
 
-// GetMetricsScopeCache return domain cache
+// GetDomainMetricsScopeCache return domainMetricsScope cache
 func (h *Impl) GetDomainMetricsScopeCache() cache.DomainMetricsScopeCache {
 	return h.domainMetricsScopeCache
 }

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -78,15 +78,15 @@ type (
 
 		// other common resources
 
-		domainCache       cache.DomainCache
-		metricsScopeCache cache.MetricsScopeCache
-		timeSource        clock.TimeSource
-		payloadSerializer persistence.PayloadSerializer
-		metricsClient     metrics.Client
-		messagingClient   messaging.Client
-		blobstoreClient   blobstore.Client
-		archivalMetadata  archiver.ArchivalMetadata
-		archiverProvider  provider.ArchiverProvider
+		domainCache             cache.DomainCache
+		domainMetricsScopeCache cache.DomainMetricsScopeCache
+		timeSource              clock.TimeSource
+		payloadSerializer       persistence.PayloadSerializer
+		metricsClient           metrics.Client
+		messagingClient         messaging.Client
+		blobstoreClient         blobstore.Client
+		archivalMetadata        archiver.ArchivalMetadata
+		archiverProvider        provider.ArchiverProvider
 
 		// membership infos
 
@@ -229,7 +229,7 @@ func New(
 		logger,
 	)
 
-	metricsScopeCache := cache.NewMetricsScopeCache()
+	domainMetricsScopeCache := cache.NewDomainMetricsScopeCache()
 
 	frontendRawClient := clientBean.GetFrontendClient()
 	frontendClient := frontend.NewRetryableClient(
@@ -289,15 +289,15 @@ func New(
 
 		// other common resources
 
-		domainCache:       domainCache,
-		metricsScopeCache: metricsScopeCache,
-		timeSource:        clock.NewRealTimeSource(),
-		payloadSerializer: persistence.NewPayloadSerializer(),
-		metricsClient:     params.MetricsClient,
-		messagingClient:   params.MessagingClient,
-		blobstoreClient:   params.BlobstoreClient,
-		archivalMetadata:  params.ArchivalMetadata,
-		archiverProvider:  params.ArchiverProvider,
+		domainCache:             domainCache,
+		domainMetricsScopeCache: domainMetricsScopeCache,
+		timeSource:              clock.NewRealTimeSource(),
+		payloadSerializer:       persistence.NewPayloadSerializer(),
+		metricsClient:           params.MetricsClient,
+		messagingClient:         params.MessagingClient,
+		blobstoreClient:         params.BlobstoreClient,
+		archivalMetadata:        params.ArchivalMetadata,
+		archiverProvider:        params.ArchiverProvider,
 
 		// membership infos
 
@@ -429,8 +429,8 @@ func (h *Impl) GetDomainCache() cache.DomainCache {
 }
 
 // GetMetricsScopeCache return domain cache
-func (h *Impl) GetMetricsScopeCache() cache.MetricsScopeCache {
-	return h.metricsScopeCache
+func (h *Impl) GetDomainMetricsScopeCache() cache.DomainMetricsScopeCache {
+	return h.domainMetricsScopeCache
 }
 
 // GetTimeSource return time source

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -79,6 +79,7 @@ type (
 		// other common resources
 
 		domainCache       cache.DomainCache
+		metricsScopeCache cache.MetricsScopeCache
 		timeSource        clock.TimeSource
 		payloadSerializer persistence.PayloadSerializer
 		metricsClient     metrics.Client
@@ -228,6 +229,8 @@ func New(
 		logger,
 	)
 
+	metricsScopeCache := cache.NewMetricsScopeCache()
+
 	frontendRawClient := clientBean.GetFrontendClient()
 	frontendClient := frontend.NewRetryableClient(
 		frontendRawClient,
@@ -287,6 +290,7 @@ func New(
 		// other common resources
 
 		domainCache:       domainCache,
+		metricsScopeCache: metricsScopeCache,
 		timeSource:        clock.NewRealTimeSource(),
 		payloadSerializer: persistence.NewPayloadSerializer(),
 		metricsClient:     params.MetricsClient,
@@ -422,6 +426,11 @@ func (h *Impl) GetClusterMetadata() cluster.Metadata {
 // GetDomainCache return domain cache
 func (h *Impl) GetDomainCache() cache.DomainCache {
 	return h.domainCache
+}
+
+// GetMetricsScopeCache return domain cache
+func (h *Impl) GetMetricsScopeCache() cache.MetricsScopeCache {
+	return h.metricsScopeCache
 }
 
 // GetTimeSource return time source

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -260,7 +260,7 @@ func (s *Test) GetDomainCache() cache.DomainCache {
 }
 
 // GetMetricsScopeCache for testing
-func (s *Test) GetMetricsScopeCache() cache.DomainCache {
+func (s *Test) GetMetricsScopeCache() cache.MetricsScopeCache {
 	return s.MetricsScopeCache
 }
 

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -65,6 +65,7 @@ type (
 		// other common resources
 
 		DomainCache       *cache.MockDomainCache
+		MetricsScopeCache cache.MetricsScopeCache
 		TimeSource        clock.TimeSource
 		PayloadSerializer persistence.PayloadSerializer
 		MetricsClient     metrics.Client
@@ -176,6 +177,7 @@ func NewTest(
 		// other common resources
 
 		DomainCache:       cache.NewMockDomainCache(controller),
+		MetricsScopeCache: cache.NewMetricsScopeCache(),
 		TimeSource:        clock.NewRealTimeSource(),
 		PayloadSerializer: persistence.NewPayloadSerializer(),
 		MetricsClient:     metrics.NewClient(scope, serviceMetricsIndex),
@@ -255,6 +257,11 @@ func (s *Test) GetClusterMetadata() cluster.Metadata {
 // GetDomainCache for testing
 func (s *Test) GetDomainCache() cache.DomainCache {
 	return s.DomainCache
+}
+
+// GetMetricsScopeCache for testing
+func (s *Test) GetMetricsScopeCache() cache.DomainCache {
+	return s.MetricsScopeCache
 }
 
 // GetTimeSource for testing

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -64,14 +64,14 @@ type (
 
 		// other common resources
 
-		DomainCache       *cache.MockDomainCache
-		MetricsScopeCache cache.MetricsScopeCache
-		TimeSource        clock.TimeSource
-		PayloadSerializer persistence.PayloadSerializer
-		MetricsClient     metrics.Client
-		ArchivalMetadata  *archiver.MockArchivalMetadata
-		ArchiverProvider  *provider.MockArchiverProvider
-		BlobstoreClient   *blobstore.MockClient
+		DomainCache             *cache.MockDomainCache
+		DomainMetricsScopeCache cache.DomainMetricsScopeCache
+		TimeSource              clock.TimeSource
+		PayloadSerializer       persistence.PayloadSerializer
+		MetricsClient           metrics.Client
+		ArchivalMetadata        *archiver.MockArchivalMetadata
+		ArchiverProvider        *provider.MockArchiverProvider
+		BlobstoreClient         *blobstore.MockClient
 
 		// membership infos
 
@@ -176,14 +176,14 @@ func NewTest(
 
 		// other common resources
 
-		DomainCache:       cache.NewMockDomainCache(controller),
-		MetricsScopeCache: cache.NewMetricsScopeCache(),
-		TimeSource:        clock.NewRealTimeSource(),
-		PayloadSerializer: persistence.NewPayloadSerializer(),
-		MetricsClient:     metrics.NewClient(scope, serviceMetricsIndex),
-		ArchivalMetadata:  &archiver.MockArchivalMetadata{},
-		ArchiverProvider:  &provider.MockArchiverProvider{},
-		BlobstoreClient:   &blobstore.MockClient{},
+		DomainCache:             cache.NewMockDomainCache(controller),
+		DomainMetricsScopeCache: cache.NewDomainMetricsScopeCache(),
+		TimeSource:              clock.NewRealTimeSource(),
+		PayloadSerializer:       persistence.NewPayloadSerializer(),
+		MetricsClient:           metrics.NewClient(scope, serviceMetricsIndex),
+		ArchivalMetadata:        &archiver.MockArchivalMetadata{},
+		ArchiverProvider:        &provider.MockArchiverProvider{},
+		BlobstoreClient:         &blobstore.MockClient{},
 
 		// membership infos
 
@@ -259,9 +259,9 @@ func (s *Test) GetDomainCache() cache.DomainCache {
 	return s.DomainCache
 }
 
-// GetMetricsScopeCache for testing
-func (s *Test) GetMetricsScopeCache() cache.MetricsScopeCache {
-	return s.MetricsScopeCache
+// GetDomainMetricsScopeCache for testing
+func (s *Test) GetDomainMetricsScopeCache() cache.DomainMetricsScopeCache {
+	return s.DomainMetricsScopeCache
 }
 
 // GetTimeSource for testing

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -99,7 +99,6 @@ type (
 		historyEventNotifier      events.Notifier
 		tokenSerializer           common.TaskTokenSerializer
 		executionCache            *execution.Cache
-		metricsScopeCache         cache.MetricsScopeCache
 		metricsClient             metrics.Client
 		logger                    log.Logger
 		throttledLogger           log.Logger
@@ -187,7 +186,6 @@ func NewEngineWithShardContext(
 		timeSource:           shard.GetTimeSource(),
 		historyV2Mgr:         historyV2Manager,
 		executionManager:     executionManager,
-		metricsScopeCache:    cache.NewMetricsScopeCache(),
 		visibilityMgr:        visibilityMgr,
 		tokenSerializer:      common.NewJSONTaskTokenSerializer(),
 		executionCache:       executionCache,

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -99,6 +99,7 @@ type (
 		historyEventNotifier      events.Notifier
 		tokenSerializer           common.TaskTokenSerializer
 		executionCache            *execution.Cache
+		metricsScopeCache         cache.MetricsScopeCache
 		metricsClient             metrics.Client
 		logger                    log.Logger
 		throttledLogger           log.Logger
@@ -186,6 +187,7 @@ func NewEngineWithShardContext(
 		timeSource:           shard.GetTimeSource(),
 		historyV2Mgr:         historyV2Manager,
 		executionManager:     executionManager,
+		metricsScopeCache:    cache.NewMetricsScopeCache(),
 		visibilityMgr:        visibilityMgr,
 		tokenSerializer:      common.NewJSONTaskTokenSerializer(),
 		executionCache:       executionCache,

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -252,7 +252,6 @@ func (t *taskProcessor) processTaskOnce(
 	var err error
 
 	domainID := task.task.GetDomainID()
-	taskType := task.task.GetTaskType()
 
 	scopeIdx, err = task.processor.process(task)
 	scope, found := t.metricsScopeCache.Get(domainID, scopeIdx)
@@ -261,7 +260,7 @@ func (t *taskProcessor) processTaskOnce(
 
 	if !found {
 		scope = t.metricsClient.Scope(scopeIdx).Tagged(t.getDomainTagByID(domainID))
-		t.metricsScopeCache.Put(domainID, taskType, scope)
+		t.metricsScopeCache.Put(domainID, scopeIdx, scope)
 	}
 
 	if task.shouldProcessTask {

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -252,14 +252,16 @@ func (t *taskProcessor) processTaskOnce(
 	var err error
 
 	domainID := task.task.GetDomainID()
+	taskType := task.task.GetTaskType()
+
 	scopeIdx, err = task.processor.process(task)
-	scope := t.metricsScopeCache.Get(domainID)
+	scope := t.metricsScopeCache.Get(domainID, taskType)
 
 	startTime := t.timeSource.Now()
 
 	if scope == nil {
 		scope = t.metricsClient.Scope(scopeIdx).Tagged(t.getDomainTagByID(domainID))
-		t.metricsScopeCache.Put(domainID, scope)
+		t.metricsScopeCache.Put(domainID, taskType, scope)
 	}
 
 	if task.shouldProcessTask {

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -256,12 +256,12 @@ func (t *taskProcessor) processTaskOnce(
 	scopeIdx, err = task.processor.process(task)
 	scope, found := t.domainMetricsScopeCache.Get(domainID, scopeIdx)
 
-	startTime := t.timeSource.Now()
-
 	if !found {
 		scope = t.metricsClient.Scope(scopeIdx).Tagged(t.getDomainTagByID(domainID))
 		t.domainMetricsScopeCache.Put(domainID, scopeIdx, scope)
 	}
+
+	startTime := t.timeSource.Now()
 
 	if task.shouldProcessTask {
 		scope.IncCounter(metrics.TaskRequests)

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -69,7 +69,7 @@ type (
 		timeSource    clock.TimeSource
 		retryPolicy   backoff.RetryPolicy
 		workerWG      sync.WaitGroup
-		metricsScopeCache *cache.MetricsCache
+		metricsScopeCache cache.MetricsCache
 
 		// worker coroutines notification
 		workerNotificationChans []chan struct{}
@@ -117,7 +117,6 @@ func newTaskProcessor(
 		workerNotificationChans: workerNotificationChans,
 		retryPolicy:             common.CreatePersistanceRetryPolicy(),
 		numOfWorker:             options.workerCount,
-
 	}
 
 	return base
@@ -253,13 +252,13 @@ func (t *taskProcessor) processTaskOnce(
 	var err error
 
 	domainID := task.task.GetDomainID()
+	scopeIdx, err = task.processor.process(task)
 	scope := t.metricsScopeCache.Get(domainID)
 
 	startTime := t.timeSource.Now()
 
 	if scope == nil {
-		scopeIdx, err = task.processor.process(task)
-		scope := t.metricsClient.Scope(scopeIdx).Tagged(t.getDomainTagByID(domainID))
+		scope = t.metricsClient.Scope(scopeIdx).Tagged(t.getDomainTagByID(domainID))
 		t.metricsScopeCache.Put(domainID, scope)
 	}
 

--- a/service/history/taskProcessor_test.go
+++ b/service/history/taskProcessor_test.go
@@ -183,7 +183,7 @@ func (s *taskProcessorSuite) TestProcessTaskAndAck_DomainTrue_ProcessErrNoErr() 
 	s.mockProcessor.On("process", taskInfo).Return(s.scopeIdx, err).Once()
 	s.mockProcessor.On("process", taskInfo).Return(s.scopeIdx, nil).Once()
 	s.mockProcessor.On("complete", taskInfo).Once()
-	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return(constants.TestDomainName, nil).Times(2)
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return(constants.TestDomainName, nil).Times(1)
 	s.taskProcessor.processTaskAndAck(
 		s.notificationChan,
 		taskInfo,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added generic metricsScopeCache component that keeps a record of domain to metricsScope

<!-- Tell your future self why have you made these changes -->
**Why?**
Creating scope with domainTag is an expensive operation and caused latency in taskProcessing.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Have not verified yet, this is a draft for review. Will test this in single history host in pord.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
This change might increase latency on task processing.

