### PR TITLE
Fix task processor shutdown logic

### DIFF
--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -275,7 +275,10 @@ func (t *taskProcessor) handleTaskError(
 	// this is a transient error
 	if err == task.ErrTaskRetry {
 		scope.IncCounter(metrics.TaskStandbyRetryCounter)
-		<-notificationChan
+		select {
+		case <-notificationChan:
+		case <-t.shutdownCh:
+		}
 		return err
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix race condition in task processor shutdown logic. Currently is possible that a task is retried after the notification is sent and block on the notification channel again. This cause the shutdown logic for transfer and timer processor to time out after one minute. 

This should also improve the time for ndc integration test by 1min for each run. (10min on buildkite as the test will be run 10 times.)

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
