### PR TITLE
Redispatch task on passive processor during failover

### DIFF
--- a/service/history/queue/task_allocator.go
+++ b/service/history/queue/task_allocator.go
@@ -153,6 +153,15 @@ func (t *taskAllocatorImpl) VerifyStandbyTask(standbyCluster string, taskDomainI
 		t.logger.Debug("Domain is not standby, skip task.", tag.WorkflowDomainID(taskDomainID), tag.Value(task))
 		return false, nil
 	}
+
+	if err := t.checkDomainPendingActive(
+		domainEntry,
+		taskDomainID,
+		task,
+	); err != nil {
+		return false, err
+	}
+
 	t.logger.Debug("Domain is standby, process task.", tag.WorkflowDomainID(taskDomainID), tag.Value(task))
 	return true, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add passive task filter to check the pending active status. If the domain is in pending active, the passive task processor should re-dispatch the tasks.

<!-- Tell your future self why have you made these changes -->
**Why?**
During graceful failover, no task should be processed in both the active processor and passive processors

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A