### PR TITLE
Remove -i go build flag (#3128)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,23 +123,23 @@ copyright: cmd/tools/copyright/licensegen.go
 
 cadence-cassandra-tool: $(TOOLS_SRC)
 	@echo "compiling cadence-cassandra-tool with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o cadence-cassandra-tool cmd/tools/cassandra/main.go
+	go build -o cadence-cassandra-tool cmd/tools/cassandra/main.go
 
 cadence-sql-tool: $(TOOLS_SRC)
 	@echo "compiling cadence-sql-tool with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o cadence-sql-tool cmd/tools/sql/main.go
+	go build -o cadence-sql-tool cmd/tools/sql/main.go
 
 cadence: $(TOOLS_SRC)
 	@echo "compiling cadence with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o cadence cmd/tools/cli/main.go
+	go build -o cadence cmd/tools/cli/main.go
 
 cadence-server: $(ALL_SRC)
 	@echo "compiling cadence-server with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -ldflags '$(GO_BUILD_LDFLAGS)' -i -o cadence-server cmd/server/main.go
+	go build -ldflags '$(GO_BUILD_LDFLAGS)' -o cadence-server cmd/server/main.go
 
 cadence-canary: $(ALL_SRC)
 	@echo "compiling cadence-canary with OS: $(GOOS), ARCH: $(GOARCH)"
-	go build -i -o cadence-canary cmd/canary/main.go
+	go build -o cadence-canary cmd/canary/main.go
 
 go-generate:
 	GO111MODULE=off go get -u github.com/myitcv/gobin


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed -i go build flag in Makefile

<!-- Tell your future self why have you made these changes -->
**Why?**
Having -i go build flag tries to install target dependencies,
which on some systems can result in permission denied errors.

After some research it appears that this flag could had been used for
improving build performance but this is no longer necessary after Go 1.10.
https://golang.org/doc/go1.10#build

There is an outstanding go issue https://github.com/golang/go/issues/27285
that is possibly related permission errors seen by some users.
The advise there is to not use -i flag.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Successful build.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This only affect build process. Worst case - not being able to build it.
