### PR TITLE
Update replication retry policy

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -221,6 +221,7 @@ var keys = map[Key]string{
 	TransferProcessorVisibilityArchivalTimeLimit:           "history.transferProcessorVisibilityArchivalTimeLimit",
 	ReplicatorTaskBatchSize:                                "history.replicatorTaskBatchSize",
 	ReplicatorTaskWorkerCount:                              "history.replicatorTaskWorkerCount",
+	ReplicatorReadTaskMaxRetryCount:                        "history.replicatorReadTaskMaxRetryCount",
 	ReplicatorTaskMaxRetryCount:                            "history.replicatorTaskMaxRetryCount",
 	ReplicatorProcessorMaxPollRPS:                          "history.replicatorProcessorMaxPollRPS",
 	ReplicatorProcessorUpdateShardTaskCount:                "history.replicatorProcessorUpdateShardTaskCount",
@@ -665,6 +666,8 @@ const (
 	ReplicatorTaskBatchSize
 	// ReplicatorTaskWorkerCount is number of worker for ReplicatorProcessor
 	ReplicatorTaskWorkerCount
+	// ReplicatorReadTaskMaxRetryCount is the number of read replication task retry time
+	ReplicatorReadTaskMaxRetryCount
 	// ReplicatorTaskMaxRetryCount is max times of retry for ReplicatorProcessor
 	ReplicatorTaskMaxRetryCount
 	// ReplicatorProcessorMaxPollRPS is max poll rate per second for ReplicatorProcessor

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -683,7 +683,7 @@ func (adh *AdminHandler) GetReplicationMessages(
 		return nil, adh.error(errClusterNameNotSet, scope)
 	}
 
-	resp, err = adh.GetHistoryClient().GetReplicationMessages(ctx, request)
+	resp, err = adh.GetHistoryRawClient().GetReplicationMessages(ctx, request)
 	if err != nil {
 		return nil, adh.error(err, scope)
 	}

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -147,6 +147,7 @@ type Config struct {
 	ReplicatorTaskBatchSize                                dynamicconfig.IntPropertyFn
 	ReplicatorTaskWorkerCount                              dynamicconfig.IntPropertyFn
 	ReplicatorTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
+	ReplicatorReadTaskMaxRetryCount                        dynamicconfig.IntPropertyFn
 	ReplicatorProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
 	ReplicatorProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
 	ReplicatorProcessorMaxPollIntervalJitterCoefficient    dynamicconfig.FloatPropertyFn
@@ -377,6 +378,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ReplicatorTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 100),
 		ReplicatorTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.ReplicatorTaskWorkerCount, 10),
 		ReplicatorTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.ReplicatorTaskMaxRetryCount, 100),
+		ReplicatorReadTaskMaxRetryCount:                        dc.GetIntProperty(dynamicconfig.ReplicatorReadTaskMaxRetryCount, 3),
 		ReplicatorProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxPollRPS, 20),
 		ReplicatorProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorMaxPollInterval, 1*time.Minute),
 		ReplicatorProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.ReplicatorProcessorMaxPollIntervalJitterCoefficient, 0.15),

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -105,7 +105,7 @@ func newReplicatorQueueProcessor(
 	}
 
 	retryPolicy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
-	retryPolicy.SetMaximumAttempts(10)
+	retryPolicy.SetMaximumAttempts(config.ReplicatorReadTaskMaxRetryCount())
 	retryPolicy.SetBackoffCoefficient(1)
 
 	processor := &replicatorQueueProcessorImpl{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use a less aggressive rpc replication retry policy

<!-- Tell your future self why have you made these changes -->
**Why?**
With the original retry policy, the DB gets flooded when it throws service busy error

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Pre prod env

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
flood the DB
