### PR TITLE
Fix dynamic config map property conversion func

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -735,17 +735,27 @@ func ConvertIntMapToDynamicConfigMapProperty(
 func ConvertDynamicConfigMapPropertyToIntMap(
 	dcValue map[string]interface{},
 ) (map[int]int, error) {
-	thresholds := make(map[int]int)
+	intMap := make(map[int]int)
 	for key, value := range dcValue {
-		level, err := strconv.Atoi(strings.TrimSpace(key))
+		intKey, err := strconv.Atoi(strings.TrimSpace(key))
 		if err != nil {
-			return nil, fmt.Errorf("failed to convert level: %v", err)
+			return nil, fmt.Errorf("failed to convert key %v, error: %v", key, err)
 		}
-		threshold, ok := value.(int)
-		if !ok {
-			return nil, fmt.Errorf("failed to convert threshold %v", value)
+
+		var intValue int
+		switch value.(type) {
+		case float64:
+			intValue = int(value.(float64))
+		case int:
+			intValue = value.(int)
+		case int32:
+			intValue = int(value.(int32))
+		case int64:
+			intValue = int(value.(int64))
+		default:
+			return nil, fmt.Errorf("unknown value %v with type %T", value, value)
 		}
-		thresholds[level] = threshold
+		intMap[intKey] = intValue
 	}
-	return thresholds, nil
+	return intMap, nil
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -24,6 +24,7 @@ package common
 
 import (
 	"context"
+	"strconv"
 	"testing"
 	"time"
 
@@ -42,4 +43,18 @@ func TestIsServiceTransientError_ContextCancel(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 	require.False(t, IsServiceTransientError(ctx.Err()))
+}
+
+func TestConvertDynamicConfigMapPropertyToIntMap(t *testing.T) {
+	dcValue := make(map[string]interface{})
+	for idx, value := range []interface{}{int(0), int32(1), int64(2), float64(3.0)} {
+		dcValue[strconv.Itoa(idx)] = value
+	}
+
+	intMap, err := ConvertDynamicConfigMapPropertyToIntMap(dcValue)
+	require.NoError(t, err)
+	require.Len(t, intMap, 4)
+	for i := 0; i != 4; i++ {
+		require.Equal(t, i, intMap[i])
+	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix dynamic config map property conversion func. Basically add support for more value types

<!-- Tell your future self why have you made these changes -->
**Why?**
previous for value only int type is supported which may not be the actual type returned by dynamic config client. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
In staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the worst case, won't be able to read map property from dynamic config
