### PR TITLE
Improve task latency metrics

### DIFF
--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -430,7 +430,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ReplicationTaskFetcherAggregationInterval:        dc.GetDurationProperty(dynamicconfig.ReplicationTaskFetcherAggregationInterval, 2*time.Second),
 		ReplicationTaskFetcherTimerJitterCoefficient:     dc.GetFloat64Property(dynamicconfig.ReplicationTaskFetcherTimerJitterCoefficient, 0.15),
 		ReplicationTaskFetcherErrorRetryWait:             dc.GetDurationProperty(dynamicconfig.ReplicationTaskFetcherErrorRetryWait, time.Second),
-		ReplicationTaskProcessorErrorRetryWait:           dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryWait, 50 * time.Millisecond),
+		ReplicationTaskProcessorErrorRetryWait:           dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryWait, 50*time.Millisecond),
 		ReplicationTaskProcessorErrorRetryMaxAttempts:    dc.GetIntPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts, 5),
 		ReplicationTaskProcessorNoTaskRetryWait:          dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorNoTaskInitialWait, 2*time.Second),
 		ReplicationTaskProcessorCleanupInterval:          dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorCleanupInterval, 1*time.Minute),

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -340,8 +340,9 @@ func (p *queueProcessorBase) processBatch() {
 		return
 	}
 
+	taskStartTime := p.timeSource.Now()
 	for _, task := range tasks {
-		if submitted := p.submitTask(task); !submitted {
+		if submitted := p.submitTask(task, taskStartTime); !submitted {
 			// not submitted since processor has been shutdown
 			return
 		}
@@ -358,6 +359,7 @@ func (p *queueProcessorBase) processBatch() {
 
 func (p *queueProcessorBase) submitTask(
 	taskInfo task.Info,
+	taskStartTime time.Time,
 ) bool {
 	if !p.isPriorityTaskProcessorEnabled() {
 		return p.taskProcessor.addTask(
@@ -365,6 +367,7 @@ func (p *queueProcessorBase) submitTask(
 				p.processor,
 				taskInfo,
 				task.InitializeLoggerForTask(p.shard.GetShardID(), taskInfo, p.logger),
+				taskStartTime,
 			),
 		)
 	}

--- a/service/history/replicatorQueueProcessor_test.go
+++ b/service/history/replicatorQueueProcessor_test.go
@@ -153,7 +153,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowMissing() {
 		nil,
 	), nil).AnyTimes()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger, s.mockShard.GetTimeSource().Now()))
 	s.Nil(err)
 }
 
@@ -201,7 +201,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_WorkflowCompleted() {
 		nil,
 	), nil).AnyTimes()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger, s.mockShard.GetTimeSource().Now()))
 	s.Nil(err)
 }
 
@@ -250,7 +250,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityCompleted() {
 		nil,
 	), nil).AnyTimes()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger, s.mockShard.GetTimeSource().Now()))
 	s.Nil(err)
 }
 
@@ -360,7 +360,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRetry() {
 		},
 	}).Return(nil).Once()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger, s.mockShard.GetTimeSource().Now()))
 	s.Nil(err)
 }
 
@@ -469,7 +469,7 @@ func (s *replicatorQueueProcessorSuite) TestSyncActivity_ActivityRunning() {
 		},
 	}).Return(nil).Once()
 
-	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger))
+	_, err := s.replicatorQueueProcessor.process(newTaskInfo(nil, task, s.logger, s.mockShard.GetTimeSource().Now()))
 	s.Nil(err)
 }
 

--- a/service/history/taskProcessor.go
+++ b/service/history/taskProcessor.go
@@ -82,12 +82,13 @@ func newTaskInfo(
 	processor taskExecutor,
 	task task.Info,
 	logger log.Logger,
+	startTime time.Time,
 ) *taskInfo {
 	return &taskInfo{
 		processor:         processor,
 		task:              task,
 		attempt:           0,
-		startTime:         time.Now(), // used for metrics
+		startTime:         startTime, // used for metrics
 		logger:            logger,
 		shouldProcessTask: true,
 	}

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -409,8 +409,9 @@ func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*persistence.TimerT
 		return nil, err
 	}
 
+	taskStartTime := t.timeSource.Now()
 	for _, task := range timerTasks {
-		if submitted := t.submitTask(task); !submitted {
+		if submitted := t.submitTask(task, taskStartTime); !submitted {
 			// not submitted due to shard shutdown
 			return nil, nil
 		}
@@ -426,6 +427,7 @@ func (t *timerQueueProcessorBase) readAndFanoutTimerTasks() (*persistence.TimerT
 
 func (t *timerQueueProcessorBase) submitTask(
 	taskInfo task.Info,
+	taskStartTime time.Time,
 ) bool {
 	if !t.isPriorityTaskProcessorEnabled() {
 		return t.taskProcessor.addTask(
@@ -433,6 +435,7 @@ func (t *timerQueueProcessorBase) submitTask(
 				t.timerProcessor,
 				taskInfo,
 				task.InitializeLoggerForTask(t.shard.GetShardID(), taskInfo, t.logger),
+				taskStartTime,
 			),
 		)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change how task_latency metric is calculated

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously the time during which task is waiting to be submitted to task ch is not part of the task_latency metrics. This means task_latency metric doesn't measure the total in-memory latency for a task

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested in staging

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
