### PR TITLE
Fix history resender source cluster

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -283,39 +283,43 @@ func NewEngineWithShardContext(
 		)
 	}
 
-	nDCHistoryResender := xdc.NewNDCHistoryResender(
-		shard.GetDomainCache(),
-		shard.GetService().GetClientBean().GetRemoteAdminClient(currentClusterName),
-		func(ctx context.Context, request *h.ReplicateEventsV2Request) error {
-			return shard.GetService().GetHistoryClient().ReplicateEventsV2(ctx, request)
-		},
-		shard.GetService().GetPayloadSerializer(),
-		nil,
-		shard.GetLogger(),
-	)
-	historyRereplicator := xdc.NewHistoryRereplicator(
-		currentClusterName,
-		shard.GetDomainCache(),
-		shard.GetService().GetClientBean().GetRemoteAdminClient(currentClusterName),
-		func(ctx context.Context, request *h.ReplicateRawEventsRequest) error {
-			return shard.GetService().GetHistoryClient().ReplicateRawEvents(ctx, request)
-		},
-		shard.GetService().GetPayloadSerializer(),
-		replicationTimeout,
-		nil,
-		shard.GetLogger(),
-	)
-	replicationTaskExecutor := replication.NewTaskExecutor(
-		shard,
-		shard.GetDomainCache(),
-		nDCHistoryResender,
-		historyRereplicator,
-		historyEngImpl,
-		shard.GetMetricsClient(),
-		shard.GetLogger(),
-	)
 	var replicationTaskProcessors []replication.TaskProcessor
+	replicationTaskExecutors := make(map[string]replication.TaskExecutor)
 	for _, replicationTaskFetcher := range replicationTaskFetchers.GetFetchers() {
+		sourceCluster := replicationTaskFetcher.GetSourceCluster()
+		nDCHistoryResender := xdc.NewNDCHistoryResender(
+			shard.GetDomainCache(),
+			shard.GetService().GetClientBean().GetRemoteAdminClient(sourceCluster),
+			func(ctx context.Context, request *h.ReplicateEventsV2Request) error {
+				return shard.GetService().GetHistoryClient().ReplicateEventsV2(ctx, request)
+			},
+			shard.GetService().GetPayloadSerializer(),
+			nil,
+			shard.GetLogger(),
+		)
+		historyRereplicator := xdc.NewHistoryRereplicator(
+			currentClusterName,
+			shard.GetDomainCache(),
+			shard.GetService().GetClientBean().GetRemoteAdminClient(sourceCluster),
+			func(ctx context.Context, request *h.ReplicateRawEventsRequest) error {
+				return shard.GetService().GetHistoryClient().ReplicateRawEvents(ctx, request)
+			},
+			shard.GetService().GetPayloadSerializer(),
+			replicationTimeout,
+			nil,
+			shard.GetLogger(),
+		)
+		replicationTaskExecutor := replication.NewTaskExecutor(
+			shard,
+			shard.GetDomainCache(),
+			nDCHistoryResender,
+			historyRereplicator,
+			historyEngImpl,
+			shard.GetMetricsClient(),
+			shard.GetLogger(),
+		)
+		replicationTaskExecutors[sourceCluster] = replicationTaskExecutor
+
 		replicationTaskProcessor := replication.NewTaskProcessor(
 			shard,
 			historyEngImpl,
@@ -327,7 +331,7 @@ func NewEngineWithShardContext(
 		replicationTaskProcessors = append(replicationTaskProcessors, replicationTaskProcessor)
 	}
 	historyEngImpl.replicationTaskProcessors = replicationTaskProcessors
-	replicationMessageHandler := replication.NewDLQHandler(shard, replicationTaskExecutor)
+	replicationMessageHandler := replication.NewDLQHandler(shard, replicationTaskExecutors)
 	historyEngImpl.replicationDLQHandler = replicationMessageHandler
 
 	shard.SetEngine(historyEngImpl)

--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -26,11 +26,16 @@ import (
 	"context"
 
 	"github.com/uber/cadence/.gen/go/replicator"
+	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/shard"
+)
+
+var (
+	errInvalidCluster = &workflow.BadRequestError{Message: "Invalid target cluster name."}
 )
 
 type (
@@ -57,9 +62,9 @@ type (
 	}
 
 	dlqHandlerImpl struct {
-		taskExecutor TaskExecutor
-		shard        shard.Context
-		logger       log.Logger
+		taskExecutors map[string]TaskExecutor
+		shard         shard.Context
+		logger        log.Logger
 	}
 )
 
@@ -68,13 +73,17 @@ var _ DLQHandler = (*dlqHandlerImpl)(nil)
 // NewDLQHandler initialize the replication message DLQ handler
 func NewDLQHandler(
 	shard shard.Context,
-	taskExecutor TaskExecutor,
+	taskExecutors map[string]TaskExecutor,
 ) DLQHandler {
 
+	if taskExecutors == nil {
+		panic("Failed to initialize replication DLQ handler due to nil task executors")
+	}
+
 	return &dlqHandlerImpl{
-		shard:        shard,
-		taskExecutor: taskExecutor,
-		logger:       shard.GetLogger(),
+		shard:         shard,
+		taskExecutors: taskExecutors,
+		logger:        shard.GetLogger(),
 	}
 }
 
@@ -180,6 +189,10 @@ func (r *dlqHandlerImpl) MergeMessages(
 	pageToken []byte,
 ) ([]byte, error) {
 
+	if _, ok := r.taskExecutors[sourceCluster]; !ok {
+		return nil, errInvalidCluster
+	}
+
 	tasks, ackLevel, token, err := r.readMessagesWithAckLevel(
 		ctx,
 		sourceCluster,
@@ -189,7 +202,7 @@ func (r *dlqHandlerImpl) MergeMessages(
 	)
 
 	for _, task := range tasks {
-		if _, err := r.taskExecutor.execute(
+		if _, err := r.taskExecutors[sourceCluster].execute(
 			sourceCluster,
 			task,
 			true,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replication task executor generates per source cluster

<!-- Tell your future self why have you made these changes -->
**Why?**
The replication resender needs the context of which remote cluster to request tasks.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Task replication will be broken for rpc replication
