### PR TITLE
Run concrete executions scanner always

### DIFF
--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -100,7 +100,7 @@ var (
 		TaskList:                     executionsScannerTaskListName,
 		ExecutionStartToCloseTimeout: infiniteDuration,
 		WorkflowIDReusePolicy:        cclient.WorkflowIDReusePolicyAllowDuplicate,
-		CronSchedule:                 "0 */12 * * *",
+		CronSchedule:                 "* * * * *",
 	}
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
This makes concrete executions scanner run always. Cron workflows will not start next iteration until current one is finished so this change has the effect of simply always having concrete executions scanner run. This is preferable to bursty behavior of only running sometimes. 

