### PR TITLE
Add shard distribution metrics and query

### DIFF
--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -242,5 +242,3 @@ func (r *retrierImpl) NextBackOff() time.Duration {
 func (r *retrierImpl) getElapsedTime() time.Duration {
 	return r.clock.Now().Sub(r.startTime)
 }
-
-

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1924,6 +1924,7 @@ const (
 	ScannerCheckFailedGauge
 	ScannerCorruptionByTypeGauge
 	ScannerCorruptedOpenExecutionGauge
+	ScannerShardSize
 
 	NumWorkerMetrics
 )
@@ -2344,6 +2345,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ScannerCheckFailedGauge:                       {metricName: "scanner_check_failed", metricType: Gauge},
 		ScannerCorruptionByTypeGauge:                  {metricName: "scanner_corruption_by_type", metricType: Gauge},
 		ScannerCorruptedOpenExecutionGauge:            {metricName: "scanner_corrupted_open_execution", metricType: Gauge},
+		ScannerShardSize:                              {metricName: "scanner_shard_size", metricType: Timer},
 	},
 }
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1924,13 +1924,13 @@ const (
 	ScannerCheckFailedGauge
 	ScannerCorruptionByTypeGauge
 	ScannerCorruptedOpenExecutionGauge
-	ScannerShardSizeMax
-	ScannerShardSizeMedian
-	ScannerShardSizeMin
-	ScannerShardSizeP90
-	ScannerShardSizeP75
-	ScannerShardSizeP25
-	ScannerShardSizeP10
+	ScannerShardSizeMaxGauge
+	ScannerShardSizeMedianGauge
+	ScannerShardSizeMinGauge
+	ScannerShardSizeNinetyGauge
+	ScannerShardSizeSeventyFiveGauge
+	ScannerShardSizeTwentyFiveGauge
+	ScannerShardSizeTenGauge
 
 	NumWorkerMetrics
 )
@@ -2351,13 +2351,13 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ScannerCheckFailedGauge:                       {metricName: "scanner_check_failed", metricType: Gauge},
 		ScannerCorruptionByTypeGauge:                  {metricName: "scanner_corruption_by_type", metricType: Gauge},
 		ScannerCorruptedOpenExecutionGauge:            {metricName: "scanner_corrupted_open_execution", metricType: Gauge},
-		ScannerShardSizeMax:                           {metricName: "scanner_shard_size_max", metricType: Gauge},
-		ScannerShardSizeMedian:                        {metricName: "scanner_shard_size_median", metricType: Gauge},
-		ScannerShardSizeMin:                           {metricName: "scanner_shard_size_min", metricType: Gauge},
-		ScannerShardSizeP90:                           {metricName: "scanner_shard_size_p90", metricType: Gauge},
-		ScannerShardSizeP75:                           {metricName: "scanner_shard_size_p75", metricType: Gauge},
-		ScannerShardSizeP25:                           {metricName: "scanner_shard_size_p25", metricType: Gauge},
-		ScannerShardSizeP10:                           {metricName: "scanner_shard_size_max", metricType: Gauge},
+		ScannerShardSizeMaxGauge:                      {metricName: "scanner_shard_size_max", metricType: Gauge},
+		ScannerShardSizeMedianGauge:                   {metricName: "scanner_shard_size_median", metricType: Gauge},
+		ScannerShardSizeMinGauge:                      {metricName: "scanner_shard_size_min", metricType: Gauge},
+		ScannerShardSizeNinetyGauge:                   {metricName: "scanner_shard_size_ninety", metricType: Gauge},
+		ScannerShardSizeSeventyFiveGauge:              {metricName: "scanner_shard_size_seventy_five", metricType: Gauge},
+		ScannerShardSizeTwentyFiveGauge:               {metricName: "scanner_shard_size_twenty_five", metricType: Gauge},
+		ScannerShardSizeTenGauge:                      {metricName: "scanner_shard_size_ten", metricType: Gauge},
 	},
 }
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1924,7 +1924,13 @@ const (
 	ScannerCheckFailedGauge
 	ScannerCorruptionByTypeGauge
 	ScannerCorruptedOpenExecutionGauge
-	ScannerShardSize
+	ScannerShardSizeMax
+	ScannerShardSizeMedian
+	ScannerShardSizeMin
+	ScannerShardSizeP90
+	ScannerShardSizeP75
+	ScannerShardSizeP25
+	ScannerShardSizeP10
 
 	NumWorkerMetrics
 )
@@ -2345,7 +2351,13 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ScannerCheckFailedGauge:                       {metricName: "scanner_check_failed", metricType: Gauge},
 		ScannerCorruptionByTypeGauge:                  {metricName: "scanner_corruption_by_type", metricType: Gauge},
 		ScannerCorruptedOpenExecutionGauge:            {metricName: "scanner_corrupted_open_execution", metricType: Gauge},
-		ScannerShardSize:                              {metricName: "scanner_shard_size", metricType: Timer},
+		ScannerShardSizeMax:                           {metricName: "scanner_shard_size_max", metricType: Gauge},
+		ScannerShardSizeMedian:                        {metricName: "scanner_shard_size_median", metricType: Gauge},
+		ScannerShardSizeMin:                           {metricName: "scanner_shard_size_min", metricType: Gauge},
+		ScannerShardSizeP90:                           {metricName: "scanner_shard_size_p90", metricType: Gauge},
+		ScannerShardSizeP75:                           {metricName: "scanner_shard_size_p75", metricType: Gauge},
+		ScannerShardSizeP25:                           {metricName: "scanner_shard_size_p25", metricType: Gauge},
+		ScannerShardSizeP10:                           {metricName: "scanner_shard_size_max", metricType: Gauge},
 	},
 }
 

--- a/service/worker/scanner/executions/activities.go
+++ b/service/worker/scanner/executions/activities.go
@@ -147,13 +147,13 @@ func ScannerEmitMetricsActivity(
 		scope.Tagged(metrics.InvariantTypeTag(string(k))).UpdateGauge(metrics.ScannerCorruptionByTypeGauge, float64(v))
 	}
 	shardStats := params.ShardDistributionStats
-	scope.UpdateGauge(metrics.ScannerShardSizeMax, float64(shardStats.Max))
-	scope.UpdateGauge(metrics.ScannerShardSizeMedian, float64(shardStats.Median))
-	scope.UpdateGauge(metrics.ScannerShardSizeMin, float64(shardStats.Min))
-	scope.UpdateGauge(metrics.ScannerShardSizeP90, float64(shardStats.P90))
-	scope.UpdateGauge(metrics.ScannerShardSizeP75, float64(shardStats.P75))
-	scope.UpdateGauge(metrics.ScannerShardSizeP25, float64(shardStats.P25))
-	scope.UpdateGauge(metrics.ScannerShardSizeP10, float64(shardStats.P10))
+	scope.UpdateGauge(metrics.ScannerShardSizeMaxGauge, float64(shardStats.Max))
+	scope.UpdateGauge(metrics.ScannerShardSizeMedianGauge, float64(shardStats.Median))
+	scope.UpdateGauge(metrics.ScannerShardSizeMinGauge, float64(shardStats.Min))
+	scope.UpdateGauge(metrics.ScannerShardSizeNinetyGauge, float64(shardStats.P90))
+	scope.UpdateGauge(metrics.ScannerShardSizeSeventyFiveGauge, float64(shardStats.P75))
+	scope.UpdateGauge(metrics.ScannerShardSizeTwentyFiveGauge, float64(shardStats.P25))
+	scope.UpdateGauge(metrics.ScannerShardSizeTenGauge, float64(shardStats.P10))
 	return nil
 }
 

--- a/service/worker/scanner/executions/activities.go
+++ b/service/worker/scanner/executions/activities.go
@@ -25,7 +25,6 @@ package executions
 import (
 	"context"
 	"encoding/json"
-	"time"
 
 	"go.uber.org/cadence"
 
@@ -148,13 +147,13 @@ func ScannerEmitMetricsActivity(
 		scope.Tagged(metrics.InvariantTypeTag(string(k))).UpdateGauge(metrics.ScannerCorruptionByTypeGauge, float64(v))
 	}
 	shardStats := params.ShardDistributionStats
-	scope.RecordTimer(metrics.ScannerShardSize, time.Duration(shardStats.Max))
-	scope.RecordTimer(metrics.ScannerShardSize, time.Duration(shardStats.Min))
-	scope.RecordTimer(metrics.ScannerShardSize, time.Duration(shardStats.Median))
-	scope.RecordTimer(metrics.ScannerShardSize, time.Duration(shardStats.P90))
-	scope.RecordTimer(metrics.ScannerShardSize, time.Duration(shardStats.P75))
-	scope.RecordTimer(metrics.ScannerShardSize, time.Duration(shardStats.P25))
-	scope.RecordTimer(metrics.ScannerShardSize, time.Duration(shardStats.P10))
+	scope.UpdateGauge(metrics.ScannerShardSizeMax, float64(shardStats.Max))
+	scope.UpdateGauge(metrics.ScannerShardSizeMedian, float64(shardStats.Median))
+	scope.UpdateGauge(metrics.ScannerShardSizeMin, float64(shardStats.Min))
+	scope.UpdateGauge(metrics.ScannerShardSizeP90, float64(shardStats.P90))
+	scope.UpdateGauge(metrics.ScannerShardSizeP75, float64(shardStats.P75))
+	scope.UpdateGauge(metrics.ScannerShardSizeP25, float64(shardStats.P25))
+	scope.UpdateGauge(metrics.ScannerShardSizeP10, float64(shardStats.P10))
 	return nil
 }
 

--- a/service/worker/scanner/executions/aggregators.go
+++ b/service/worker/scanner/executions/aggregators.go
@@ -33,21 +33,22 @@ type (
 		minShard int
 		maxShard int
 
-		reports     map[int]common.ShardFixReport
-		status      ShardStatusResult
-		aggregation AggregateFixReportResult
+		reports       map[int]common.ShardFixReport
+		status        ShardStatusResult
+		statusSummary ShardStatusSummaryResult
+		aggregation   AggregateFixReportResult
 	}
 
 	shardScanResultAggregator struct {
 		minShard int
 		maxShard int
 
-		reports                 map[int]common.ShardScanReport
-		status                  ShardStatusResult
-		aggregation             AggregateScanReportResult
-		corruptionKeys          map[int]common.Keys
-		controlFlowFailureCount int
-		successCount            int
+		reports        map[int]common.ShardScanReport
+		status         ShardStatusResult
+		statusSummary  ShardStatusSummaryResult
+		aggregation    AggregateScanReportResult
+		shardSizes     ShardSizeQueryResult
+		corruptionKeys map[int]common.Keys
 	}
 )
 
@@ -60,13 +61,19 @@ func newShardFixResultAggregator(
 	for _, s := range corruptKeys {
 		status[s.ShardID] = ShardStatusRunning
 	}
+	statusSummary := map[ShardStatus]int{
+		ShardStatusRunning:            len(corruptKeys),
+		ShardStatusSuccess:            0,
+		ShardStatusControlFlowFailure: 0,
+	}
 	return &shardFixResultAggregator{
 		minShard: minShard,
 		maxShard: maxShard,
 
-		reports:     make(map[int]common.ShardFixReport),
-		status:      status,
-		aggregation: AggregateFixReportResult{},
+		reports:       make(map[int]common.ShardFixReport),
+		status:        status,
+		statusSummary: statusSummary,
+		aggregation:   AggregateFixReportResult{},
 	}
 }
 
@@ -75,27 +82,17 @@ func (a *shardFixResultAggregator) getStatusResult(req PaginatedShardQueryReques
 }
 
 func (a *shardFixResultAggregator) addReport(report common.ShardFixReport) {
-	a.removeReport(report.ShardID)
 	a.reports[report.ShardID] = report
+	a.statusSummary[ShardStatusRunning]--
 	if report.Result.ControlFlowFailure != nil {
 		a.status[report.ShardID] = ShardStatusControlFlowFailure
+		a.statusSummary[ShardStatusControlFlowFailure]++
 	} else {
 		a.status[report.ShardID] = ShardStatusSuccess
+		a.statusSummary[ShardStatusSuccess]++
 	}
 	if report.Result.ShardFixKeys != nil {
 		a.adjustAggregation(report.Stats, func(a, b int64) int64 { return a + b })
-	}
-}
-
-func (a *shardFixResultAggregator) removeReport(shardID int) {
-	report, ok := a.reports[shardID]
-	if !ok {
-		return
-	}
-	delete(a.reports, shardID)
-	delete(a.status, shardID)
-	if report.Result.ShardFixKeys != nil {
-		a.adjustAggregation(report.Stats, func(a, b int64) int64 { return a - b })
 	}
 }
 
@@ -125,19 +122,34 @@ func newShardScanResultAggregator(
 	for _, s := range shards {
 		status[s] = ShardStatusRunning
 	}
+	statusSummary := map[ShardStatus]int{
+		ShardStatusSuccess:            0,
+		ShardStatusControlFlowFailure: 0,
+		ShardStatusRunning:            len(shards),
+	}
 	return &shardScanResultAggregator{
 		minShard: minShard,
 		maxShard: maxShard,
 
-		reports: make(map[int]common.ShardScanReport),
-		status:  status,
+		reports:       make(map[int]common.ShardScanReport),
+		status:        status,
+		statusSummary: statusSummary,
+		shardSizes:    nil,
 		aggregation: AggregateScanReportResult{
 			CorruptionByType: make(map[common.InvariantType]int64),
 		},
-		corruptionKeys:          make(map[int]common.Keys),
-		controlFlowFailureCount: 0,
-		successCount:            0,
+		corruptionKeys: make(map[int]common.Keys),
 	}
+}
+
+func (a *shardScanResultAggregator) getShardSizeQueryResult(req ShardSizeQueryRequest) (ShardSizeQueryResult, error) {
+	if req.StartIndex < 0 || req.StartIndex >= req.EndIndex || req.EndIndex > len(a.shardSizes) {
+		return nil, fmt.Errorf("index out of bounds exception (required startIndex >= 0 && startIndex < endIndex && endIndex <= %v)", len(a.shardSizes))
+	}
+	if req.EndIndex-req.StartIndex > maxShardQueryResult {
+		return nil, fmt.Errorf("too many shards requested, the limit is %v", maxShardQueryResult)
+	}
+	return a.shardSizes[req.StartIndex:req.EndIndex], nil
 }
 
 func (a *shardScanResultAggregator) getCorruptionKeys(req PaginatedShardQueryRequest) (*ShardCorruptKeysQueryResult, error) {
@@ -186,14 +198,15 @@ func (a *shardScanResultAggregator) getStatusResult(req PaginatedShardQueryReque
 }
 
 func (a *shardScanResultAggregator) addReport(report common.ShardScanReport) {
-	a.removeReport(report.ShardID)
+	a.insertReportIntoSizes(report)
 	a.reports[report.ShardID] = report
+	a.statusSummary[ShardStatusRunning]--
 	if report.Result.ControlFlowFailure != nil {
 		a.status[report.ShardID] = ShardStatusControlFlowFailure
-		a.controlFlowFailureCount++
+		a.statusSummary[ShardStatusControlFlowFailure]++
 	} else {
 		a.status[report.ShardID] = ShardStatusSuccess
-		a.successCount++
+		a.statusSummary[ShardStatusSuccess]++
 	}
 	if report.Result.ShardScanKeys != nil {
 		a.adjustAggregation(report.Stats, func(a, b int64) int64 { return a + b })
@@ -203,19 +216,33 @@ func (a *shardScanResultAggregator) addReport(report common.ShardScanReport) {
 	}
 }
 
-func (a *shardScanResultAggregator) removeReport(shardID int) {
-	report, ok := a.reports[shardID]
-	if !ok {
-		return
+func (a *shardScanResultAggregator) insertReportIntoSizes(report common.ShardScanReport) {
+	tuple := ShardSizeTuple{
+		ShardID:         report.ShardID,
+		ExecutionsCount: report.Stats.ExecutionsCount,
 	}
-	delete(a.reports, shardID)
-	delete(a.status, shardID)
-	delete(a.corruptionKeys, shardID)
-	if report.Result.ShardScanKeys != nil {
-		a.adjustAggregation(report.Stats, func(a, b int64) int64 { return a - b })
-		a.successCount--
-	} else {
-		a.controlFlowFailureCount--
+	insertIndex := 0
+	for insertIndex < len(a.shardSizes) {
+		if a.shardSizes[insertIndex].ExecutionsCount < tuple.ExecutionsCount {
+			break
+		}
+		insertIndex++
+	}
+	newShardSizes := append([]ShardSizeTuple{}, a.shardSizes[0:insertIndex]...)
+	newShardSizes = append(newShardSizes, tuple)
+	newShardSizes = append(newShardSizes, a.shardSizes[insertIndex:]...)
+	a.shardSizes = newShardSizes
+}
+
+func (a *shardScanResultAggregator) getShardDistributionStats() ShardDistributionStats {
+	return ShardDistributionStats{
+		Max:    a.shardSizes[0].ExecutionsCount,
+		Median: a.shardSizes[int(float64(len(a.shardSizes))*.5)].ExecutionsCount,
+		Min:    a.shardSizes[len(a.shardSizes)-1].ExecutionsCount,
+		P90:    a.shardSizes[int(float64(len(a.shardSizes))*.1)].ExecutionsCount,
+		P75:    a.shardSizes[int(float64(len(a.shardSizes))*.25)].ExecutionsCount,
+		P25:    a.shardSizes[int(float64(len(a.shardSizes))*.75)].ExecutionsCount,
+		P10:    a.shardSizes[int(float64(len(a.shardSizes))*.9)].ExecutionsCount,
 	}
 }
 

--- a/service/worker/scanner/executions/aggregators.go
+++ b/service/worker/scanner/executions/aggregators.go
@@ -198,7 +198,9 @@ func (a *shardScanResultAggregator) getStatusResult(req PaginatedShardQueryReque
 }
 
 func (a *shardScanResultAggregator) addReport(report common.ShardScanReport) {
-	a.insertReportIntoSizes(report)
+	if report.Result.ShardScanKeys != nil {
+		a.insertReportIntoSizes(report)
+	}
 	a.reports[report.ShardID] = report
 	a.statusSummary[ShardStatusRunning]--
 	if report.Result.ControlFlowFailure != nil {

--- a/service/worker/scanner/executions/aggregators_test.go
+++ b/service/worker/scanner/executions/aggregators_test.go
@@ -23,6 +23,8 @@
 package executions
 
 import (
+	"math/rand"
+
 	c "github.com/uber/cadence/common"
 	"github.com/uber/cadence/service/worker/scanner/executions/common"
 )
@@ -41,9 +43,13 @@ func (s *workflowsSuite) TestShardScanResultAggregator() {
 		aggregation: AggregateScanReportResult{
 			CorruptionByType: make(map[common.InvariantType]int64),
 		},
-		corruptionKeys:          make(map[int]common.Keys),
-		controlFlowFailureCount: 0,
-		successCount:            0,
+		corruptionKeys: make(map[int]common.Keys),
+		statusSummary: map[ShardStatus]int{
+			ShardStatusRunning:            3,
+			ShardStatusControlFlowFailure: 0,
+			ShardStatusSuccess:            0,
+		},
+		shardSizes: nil,
 	}
 	s.Equal(expected, agg)
 	report, err := agg.getReport(1)
@@ -74,7 +80,15 @@ func (s *workflowsSuite) TestShardScanResultAggregator() {
 	}
 	agg.addReport(firstReport)
 	expected.status[1] = ShardStatusSuccess
+	expected.statusSummary[ShardStatusRunning] = 2
+	expected.statusSummary[ShardStatusSuccess] = 1
 	expected.reports[1] = firstReport
+	expected.shardSizes = []ShardSizeTuple{
+		{
+			ShardID:         1,
+			ExecutionsCount: 10,
+		},
+	}
 	expected.aggregation.ExecutionsCount = 10
 	expected.aggregation.CorruptedCount = 3
 	expected.aggregation.CheckFailedCount = 1
@@ -88,9 +102,6 @@ func (s *workflowsSuite) TestShardScanResultAggregator() {
 			UUID: "test_uuid",
 		},
 	}
-	expected.successCount = 1
-	s.Equal(expected, agg)
-	agg.addReport(firstReport)
 	s.Equal(expected, agg)
 	report, err = agg.getReport(1)
 	s.NoError(err)
@@ -113,8 +124,19 @@ func (s *workflowsSuite) TestShardScanResultAggregator() {
 	}
 	agg.addReport(secondReport)
 	expected.status[2] = ShardStatusControlFlowFailure
+	expected.statusSummary[ShardStatusRunning] = 1
+	expected.statusSummary[ShardStatusControlFlowFailure] = 1
 	expected.reports[2] = secondReport
-	expected.controlFlowFailureCount = 1
+	expected.shardSizes = []ShardSizeTuple{
+		{
+			ShardID:         1,
+			ExecutionsCount: 10,
+		},
+		{
+			ShardID:         2,
+			ExecutionsCount: 10,
+		},
+	}
 	s.Equal(expected, agg)
 	shardStatus, err := agg.getStatusResult(PaginatedShardQueryRequest{
 		StartingShardID: c.IntPtr(1),
@@ -160,6 +182,11 @@ func (s *workflowsSuite) TestShardFixResultAggregator() {
 			2: ShardStatusRunning,
 			3: ShardStatusRunning,
 		},
+		statusSummary: map[ShardStatus]int{
+			ShardStatusRunning:            3,
+			ShardStatusControlFlowFailure: 0,
+			ShardStatusSuccess:            0,
+		},
 		aggregation: AggregateFixReportResult{},
 	}
 	s.Equal(expected, agg)
@@ -186,12 +213,12 @@ func (s *workflowsSuite) TestShardFixResultAggregator() {
 	}
 	agg.addReport(firstReport)
 	expected.status[1] = ShardStatusSuccess
+	expected.statusSummary[ShardStatusSuccess] = 1
+	expected.statusSummary[ShardStatusRunning] = 2
 	expected.reports[1] = firstReport
 	expected.aggregation.ExecutionCount = 10
 	expected.aggregation.FixedCount = 3
 	expected.aggregation.FailedCount = 1
-	s.Equal(expected, agg)
-	agg.addReport(firstReport)
 	s.Equal(expected, agg)
 	report, err = agg.getReport(1)
 	s.NoError(err)
@@ -209,6 +236,8 @@ func (s *workflowsSuite) TestShardFixResultAggregator() {
 	}
 	agg.addReport(secondReport)
 	expected.status[2] = ShardStatusControlFlowFailure
+	expected.statusSummary[ShardStatusControlFlowFailure] = 1
+	expected.statusSummary[ShardStatusRunning] = 1
 	expected.reports[2] = secondReport
 	s.Equal(expected, agg)
 	shardStatus, err := agg.getStatusResult(PaginatedShardQueryRequest{
@@ -363,5 +392,159 @@ func (s *workflowsSuite) TestGetStatusResult() {
 		} else {
 			s.NoError(err)
 		}
+	}
+}
+
+func (s *workflowsSuite) TestGetShardSizeQueryResult() {
+	testCases := []struct {
+		shardSizes       []ShardSizeTuple
+		req              ShardSizeQueryRequest
+		expectedErrorStr *string
+		expectedResult   ShardSizeQueryResult
+	}{
+		{
+			shardSizes: nil,
+			req: ShardSizeQueryRequest{
+				StartIndex: -1,
+			},
+			expectedErrorStr: c.StringPtr("index out of bounds exception (required startIndex >= 0 && startIndex < endIndex && endIndex <= 0)"),
+			expectedResult:   nil,
+		},
+		{
+			shardSizes: nil,
+			req: ShardSizeQueryRequest{
+				StartIndex: 1,
+				EndIndex:   1,
+			},
+			expectedErrorStr: c.StringPtr("index out of bounds exception (required startIndex >= 0 && startIndex < endIndex && endIndex <= 0)"),
+			expectedResult:   nil,
+		},
+		{
+			shardSizes: nil,
+			req: ShardSizeQueryRequest{
+				StartIndex: 0,
+				EndIndex:   1,
+			},
+			expectedErrorStr: c.StringPtr("index out of bounds exception (required startIndex >= 0 && startIndex < endIndex && endIndex <= 0)"),
+			expectedResult:   nil,
+		},
+		{
+			shardSizes: make([]ShardSizeTuple, 10, 10),
+			req: ShardSizeQueryRequest{
+				StartIndex: 0,
+				EndIndex:   11,
+			},
+			expectedErrorStr: c.StringPtr("index out of bounds exception (required startIndex >= 0 && startIndex < endIndex && endIndex <= 10)"),
+			expectedResult:   nil,
+		},
+		{
+			shardSizes: make([]ShardSizeTuple, 10000, 10000),
+			req: ShardSizeQueryRequest{
+				StartIndex: 0,
+				EndIndex:   maxShardQueryResult + 1,
+			},
+			expectedErrorStr: c.StringPtr("too many shards requested, the limit is 1000"),
+			expectedResult:   nil,
+		},
+		{
+			shardSizes: []ShardSizeTuple{
+				{
+					ShardID: 1,
+				},
+				{
+					ShardID: 2,
+				},
+				{
+					ShardID: 3,
+				},
+				{
+					ShardID: 4,
+				},
+				{
+					ShardID: 5,
+				},
+			},
+			req: ShardSizeQueryRequest{
+				StartIndex: 0,
+				EndIndex:   1,
+			},
+			expectedErrorStr: nil,
+			expectedResult: []ShardSizeTuple{
+				{
+					ShardID: 1,
+				},
+			},
+		},
+		{
+			shardSizes: []ShardSizeTuple{
+				{
+					ShardID: 1,
+				},
+				{
+					ShardID: 2,
+				},
+				{
+					ShardID: 3,
+				},
+				{
+					ShardID: 4,
+				},
+				{
+					ShardID: 5,
+				},
+			},
+			req: ShardSizeQueryRequest{
+				StartIndex: 0,
+				EndIndex:   5,
+			},
+			expectedErrorStr: nil,
+			expectedResult: []ShardSizeTuple{
+				{
+					ShardID: 1,
+				},
+				{
+					ShardID: 2,
+				},
+				{
+					ShardID: 3,
+				},
+				{
+					ShardID: 4,
+				},
+				{
+					ShardID: 5,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		agg := &shardScanResultAggregator{
+			shardSizes: tc.shardSizes,
+		}
+		result, err := agg.getShardSizeQueryResult(tc.req)
+		if tc.expectedErrorStr != nil {
+			s.Equal(*tc.expectedErrorStr, err.Error())
+		} else {
+			s.Equal(tc.expectedResult, result)
+		}
+	}
+}
+
+func (s *workflowsSuite) TestInsertReportIntoSizes() {
+	randomReport := func() common.ShardScanReport {
+		return common.ShardScanReport{
+			ShardID: 0,
+			Stats: common.ShardScanStats{
+				ExecutionsCount: int64(rand.Intn(10)),
+			},
+		}
+	}
+	agg := &shardScanResultAggregator{}
+	for i := 0; i < 1000; i++ {
+		agg.insertReportIntoSizes(randomReport())
+	}
+	for i := 0; i < 999; i++ {
+		s.GreaterOrEqual(agg.shardSizes[i].ExecutionsCount, agg.shardSizes[i+1].ExecutionsCount)
 	}
 }

--- a/service/worker/scanner/executions/aggregators_test.go
+++ b/service/worker/scanner/executions/aggregators_test.go
@@ -132,10 +132,6 @@ func (s *workflowsSuite) TestShardScanResultAggregator() {
 			ShardID:         1,
 			ExecutionsCount: 10,
 		},
-		{
-			ShardID:         2,
-			ExecutionsCount: 10,
-		},
 	}
 	s.Equal(expected, agg)
 	shardStatus, err := agg.getStatusResult(PaginatedShardQueryRequest{

--- a/service/worker/scanner/executions/workflows.go
+++ b/service/worker/scanner/executions/workflows.go
@@ -219,7 +219,7 @@ func ScannerWorkflow(
 	if err := workflow.SetQueryHandler(ctx, ShardStatusSummaryQuery, func() (ShardStatusSummaryResult, error) {
 		return aggregator.statusSummary, nil
 	}); err != nil {
-		return nil
+		return err
 	}
 	if err := workflow.SetQueryHandler(ctx, AggregateReportQuery, func() (AggregateScanReportResult, error) {
 		return aggregator.aggregation, nil
@@ -331,7 +331,7 @@ func FixerWorkflow(
 		}
 		return aggregator.statusSummary, nil
 	}); err != nil {
-		return nil
+		return err
 	}
 	if err := workflow.SetQueryHandler(ctx, AggregateReportQuery, func() (AggregateFixReportResult, error) {
 		if aggregator == nil {

--- a/service/worker/scanner/executions/workflows.go
+++ b/service/worker/scanner/executions/workflows.go
@@ -41,11 +41,15 @@ const (
 	// ShardReportQuery is the query name for the query used to get a single shard's report
 	ShardReportQuery = "shard_report"
 	// ShardStatusQuery is the query name for the query used to get the status of all shards
-	ShardStatusQuery = "shard_status_query"
+	ShardStatusQuery = "shard_status"
+	// ShardStatusSummaryQuery is the query name for the query used to get the shard status -> counts map
+	ShardStatusSummaryQuery = "shard_status_summary"
 	// AggregateReportQuery is the query name for the query used to get the aggregate result of all finished shards
 	AggregateReportQuery = "aggregate_report"
 	// ShardCorruptKeysQuery is the query name for the query used to get all completed shards with at least one corruption
 	ShardCorruptKeysQuery = "shard_corrupt_keys"
+	// ShardSizeQuery is the query name for the query used to get the number of executions per shard in sorted order
+	ShardSizeQuery = "shard_size"
 
 	// ShardStatusRunning indicates the shard has not completed yet
 	ShardStatusRunning ShardStatus = "running"
@@ -106,6 +110,9 @@ type (
 	// ShardStatusResult indicates the status for all shards
 	ShardStatusResult map[int]ShardStatus
 
+	// ShardStatusSummaryResult indicates the counts of shards in each status
+	ShardStatusSummaryResult map[ShardStatus]int
+
 	// AggregateScanReportResult indicates the result of summing together all
 	// shard reports which have finished scan.
 	AggregateScanReportResult common.ShardScanStats
@@ -132,6 +139,15 @@ type (
 	FixReportError struct {
 		Reports  []common.ShardFixReport
 		ErrorStr *string
+	}
+
+	// ShardSizeQueryRequest is the request used for ShardSizeQuery.
+	// The following must be true: 0 <= StartIndex < EndIndex <= len(shards successfully finished)
+	// The following must be true: EndIndex - StartIndex <= maxShardQueryResult.
+	// StartIndex is inclusive, EndIndex is exclusive.
+	ShardSizeQueryRequest struct {
+		StartIndex int
+		EndIndex   int
 	}
 
 	// PaginatedShardQueryRequest is the request used for queries which return results over all shards
@@ -164,6 +180,16 @@ type (
 		Result                    ShardCorruptKeysResult
 		ShardQueryPaginationToken ShardQueryPaginationToken
 	}
+
+	// ShardSizeQueryResult is the result from ShardSizeQuery.
+	// Contains sorted list of shards, sorted by the number of executions per shard.
+	ShardSizeQueryResult []ShardSizeTuple
+
+	// ShardSizeTuple indicates the size and sorted index of a single shard
+	ShardSizeTuple struct {
+		ShardID         int
+		ExecutionsCount int64
+	}
 )
 
 var (
@@ -190,6 +216,11 @@ func ScannerWorkflow(
 	}); err != nil {
 		return err
 	}
+	if err := workflow.SetQueryHandler(ctx, ShardStatusSummaryQuery, func() (ShardStatusSummaryResult, error) {
+		return aggregator.statusSummary, nil
+	}); err != nil {
+		return nil
+	}
 	if err := workflow.SetQueryHandler(ctx, AggregateReportQuery, func() (AggregateScanReportResult, error) {
 		return aggregator.aggregation, nil
 	}); err != nil {
@@ -197,6 +228,11 @@ func ScannerWorkflow(
 	}
 	if err := workflow.SetQueryHandler(ctx, ShardCorruptKeysQuery, func(req PaginatedShardQueryRequest) (*ShardCorruptKeysQueryResult, error) {
 		return aggregator.getCorruptionKeys(req)
+	}); err != nil {
+		return err
+	}
+	if err := workflow.SetQueryHandler(ctx, ShardSizeQuery, func(req ShardSizeQueryRequest) (ShardSizeQueryResult, error) {
+		return aggregator.getShardSizeQueryResult(req)
 	}); err != nil {
 		return err
 	}
@@ -256,9 +292,10 @@ func ScannerWorkflow(
 
 	activityCtx = getShortActivityContext(ctx)
 	if err := workflow.ExecuteActivity(activityCtx, ScannerEmitMetricsActivityName, ScannerEmitMetricsActivityParams{
-		ShardSuccessCount:            aggregator.successCount,
-		ShardControlFlowFailureCount: aggregator.controlFlowFailureCount,
+		ShardSuccessCount:            aggregator.statusSummary[ShardStatusSuccess],
+		ShardControlFlowFailureCount: aggregator.statusSummary[ShardStatusControlFlowFailure],
 		AggregateReportResult:        aggregator.aggregation,
+		ShardDistributionStats:       aggregator.getShardDistributionStats(),
 	}).Get(ctx, nil); err != nil {
 		return err
 	}
@@ -287,6 +324,14 @@ func FixerWorkflow(
 		return aggregator.getStatusResult(req)
 	}); err != nil {
 		return err
+	}
+	if err := workflow.SetQueryHandler(ctx, ShardStatusSummaryQuery, func() (ShardStatusSummaryResult, error) {
+		if aggregator == nil {
+			return nil, errQueryNotReady
+		}
+		return aggregator.statusSummary, nil
+	}); err != nil {
+		return nil
 	}
 	if err := workflow.SetQueryHandler(ctx, AggregateReportQuery, func() (AggregateFixReportResult, error) {
 		if aggregator == nil {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -135,14 +135,14 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			TaskListScannerEnabled: dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
 			HistoryScannerEnabled:  dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
 			ExecutionScannerConfig: &executions.ScannerWorkflowDynamicConfig{
-				Enabled:                 dc.GetBoolProperty(dynamicconfig.ExecutionsScannerEnabled, false),
+				Enabled:                 dc.GetBoolProperty(dynamicconfig.ExecutionsScannerEnabled, true),
 				Concurrency:             dc.GetIntProperty(dynamicconfig.ExecutionsScannerConcurrency, 25),
 				ExecutionsPageSize:      dc.GetIntProperty(dynamicconfig.ExecutionsScannerPersistencePageSize, 1000),
 				BlobstoreFlushThreshold: dc.GetIntProperty(dynamicconfig.ExecutionsScannerBlobstoreFlushThreshold, 100),
-				ActivityBatchSize:       dc.GetIntProperty(dynamicconfig.ExecutionsScannerActivityBatchSize, 200),
+				ActivityBatchSize:       dc.GetIntProperty(dynamicconfig.ExecutionsScannerActivityBatchSize, 25),
 				DynamicConfigInvariantCollections: executions.DynamicConfigInvariantCollections{
-					InvariantCollectionMutableState: dc.GetBoolProperty(dynamicconfig.ExecutionsScannerInvariantCollectionMutableState, false),
-					InvariantCollectionHistory:      dc.GetBoolProperty(dynamicconfig.ExecutionsScannerInvariantCollectionHistory, false),
+					InvariantCollectionMutableState: dc.GetBoolProperty(dynamicconfig.ExecutionsScannerInvariantCollectionMutableState, true),
+					InvariantCollectionHistory:      dc.GetBoolProperty(dynamicconfig.ExecutionsScannerInvariantCollectionHistory, true),
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
In this PR I add query endpoints to executions scanner to get the shard progress of the scanner. I also add metrics on the distribution of executions in shards and expose a query endpoint to get this information. 
