### PR TITLE
Only emit domain tag metrics for active task processor

### DIFF
--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -104,6 +104,7 @@ func newQueueProcessorBase(
 	taskExecutor task.Executor,
 	logger log.Logger,
 	metricsScope metrics.Scope,
+	emitMetricsWithDomainTag bool,
 ) *queueProcessorBase {
 
 	var taskProcessor *taskProcessor
@@ -112,7 +113,7 @@ func newQueueProcessorBase(
 			queueSize:   options.BatchSize(),
 			workerCount: options.WorkerCount(),
 		}
-		taskProcessor = newTaskProcessor(taskProcessorOptions, shard, executionCache, logger)
+		taskProcessor = newTaskProcessor(taskProcessorOptions, shard, executionCache, logger, emitMetricsWithDomainTag)
 	}
 
 	p := &queueProcessorBase{

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -138,6 +138,7 @@ func newReplicatorQueueProcessor(
 		nil, // there's no queueTask implementation for replication task
 		logger,
 		shard.GetMetricsClient().Scope(metrics.ReplicatorQueueProcessorScope),
+		false,
 	)
 	processor.queueAckMgr = queueAckMgr
 	processor.queueProcessorBase = queueProcessorBase

--- a/service/history/taskProcessor_test.go
+++ b/service/history/taskProcessor_test.go
@@ -103,7 +103,7 @@ func (s *taskProcessorSuite) SetupTest() {
 		queueSize:   s.mockShard.GetConfig().TimerTaskBatchSize() * s.mockShard.GetConfig().TimerTaskWorkerCount(),
 		workerCount: s.mockShard.GetConfig().TimerTaskWorkerCount(),
 	}
-	s.taskProcessor = newTaskProcessor(options, s.mockShard, h.executionCache, s.logger)
+	s.taskProcessor = newTaskProcessor(options, s.mockShard, h.executionCache, s.logger, false)
 }
 
 func (s *taskProcessorSuite) TearDownTest() {

--- a/service/history/timerQueueActiveProcessor.go
+++ b/service/history/timerQueueActiveProcessor.go
@@ -112,6 +112,7 @@ func newTimerQueueActiveProcessor(
 		shard.GetConfig().TimerProcessorMaxPollRPS,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TimerActiveQueueProcessorScope),
+		true,
 	)
 
 	return processor
@@ -207,6 +208,7 @@ func newTimerQueueFailoverProcessor(
 		shard.GetConfig().TimerProcessorFailoverMaxPollRPS,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TimerActiveQueueProcessorScope),
+		true,
 	)
 
 	return updateShardAckLevel, processor

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -93,6 +93,7 @@ func newTimerQueueProcessorBase(
 	maxPollRPS dynamicconfig.IntPropertyFn,
 	logger log.Logger,
 	metricsScope metrics.Scope,
+	emitMetricsWithDomainTag bool,
 ) *timerQueueProcessorBase {
 
 	logger = logger.WithTags(tag.ComponentTimerQueue)
@@ -104,7 +105,7 @@ func newTimerQueueProcessorBase(
 			workerCount: config.TimerTaskWorkerCount(),
 			queueSize:   config.TimerTaskWorkerCount() * config.TimerTaskBatchSize(),
 		}
-		taskProcessor = newTaskProcessor(options, shard, historyService.executionCache, logger)
+		taskProcessor = newTaskProcessor(options, shard, historyService.executionCache, logger, emitMetricsWithDomainTag)
 	}
 
 	base := &timerQueueProcessorBase{

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -120,7 +120,7 @@ func newTimerQueueStandbyProcessor(
 		shard.GetConfig().TimerProcessorMaxPollRPS,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TimerStandbyQueueProcessorScope),
-		true,
+		false,
 	)
 
 	return processor

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -120,6 +120,7 @@ func newTimerQueueStandbyProcessor(
 		shard.GetConfig().TimerProcessorMaxPollRPS,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TimerStandbyQueueProcessorScope),
+		true,
 	)
 
 	return processor

--- a/service/history/transferQueueActiveProcessor.go
+++ b/service/history/transferQueueActiveProcessor.go
@@ -148,6 +148,7 @@ func newTransferQueueActiveProcessor(
 		processor.taskExecutor,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TransferActiveQueueProcessorScope),
+		true,
 	)
 
 	processor.queueAckMgr = queueAckMgr
@@ -269,6 +270,7 @@ func newTransferQueueFailoverProcessor(
 		processor.taskExecutor,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TransferActiveQueueProcessorScope),
+		true,
 	)
 
 	processor.queueAckMgr = queueAckMgr

--- a/service/history/transferQueueStandbyProcessor.go
+++ b/service/history/transferQueueStandbyProcessor.go
@@ -146,6 +146,7 @@ func newTransferQueueStandbyProcessor(
 		processor.taskExecutor,
 		logger,
 		shard.GetMetricsClient().Scope(metrics.TransferStandbyQueueProcessorScope),
+		false,
 	)
 
 	processor.queueAckMgr = queueAckMgr


### PR DESCRIPTION
Emit domain metrics only for active task processor in old task processor

<!-- Describe what has changed in this PR -->
**What changed?**
Added a boolean config to be passed in task processor in order to emit domainTag metrics for only active task processor.


<!-- Tell your future self why have you made these changes -->
**Why?**
Made this change because we were seeing latency increase only for standby transfer and timer queue and not active transfer and timer queue.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Haven't verified. Need to test this staging2.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No major risk or impact.

