### PR TITLE
Fix task redispatch logic

### DIFF
--- a/service/history/queue/queue_processor_util.go
+++ b/service/history/queue/queue_processor_util.go
@@ -102,7 +102,12 @@ func RedispatchTasks(
 	queueLength := redispatchQueue.Len()
 	metricsScope.RecordTimer(metrics.TaskRedispatchQueuePendingTasksTimer, time.Duration(queueLength))
 	for i := 0; i != queueLength; i++ {
-		queueTask := redispatchQueue.Remove().(task.Task)
+		element := redispatchQueue.Remove()
+		if element == nil {
+			// queue is empty, may due to concurrent redispatch on the same queue
+			return
+		}
+		queueTask := element.(task.Task)
 		submitted, err := taskProcessor.TrySubmit(queueTask)
 		if err != nil {
 			select {

--- a/service/history/queueProcessor.go
+++ b/service/history/queueProcessor.go
@@ -310,10 +310,6 @@ redispatchTaskLoop:
 			}
 
 			p.redispatchTasks()
-
-			if !p.redispatchQueue.IsEmpty() {
-				p.notifyRedispatch()
-			}
 		}
 	}
 
@@ -407,6 +403,10 @@ func (p *queueProcessorBase) redispatchTasks() {
 		p.metricsScope,
 		p.shutdownCh,
 	)
+
+	if !p.redispatchQueue.IsEmpty() {
+		p.notifyRedispatch()
+	}
 }
 
 func (p *queueProcessorBase) retryTasks() {

--- a/service/history/task/task_util.go
+++ b/service/history/task/task_util.go
@@ -23,6 +23,8 @@ package task
 import (
 	"fmt"
 
+	gomock "github.com/golang/mock/gomock"
+
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
@@ -31,6 +33,12 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/service/history/execution"
 	"github.com/uber/cadence/service/history/shard"
+)
+
+type (
+	mockTaskMatcher struct {
+		task *MockTask
+	}
 )
 
 // InitializeLoggerForTask creates a new logger with additional tags for task info
@@ -344,4 +352,23 @@ func retryWorkflow(
 		return nil, err
 	}
 	return newMutableState, nil
+}
+
+// NewMockTaskMatcher creates a gomock matcher for mock Task
+func NewMockTaskMatcher(mockTask *MockTask) gomock.Matcher {
+	return &mockTaskMatcher{
+		task: mockTask,
+	}
+}
+
+func (m *mockTaskMatcher) Matches(x interface{}) bool {
+	taskPtr, ok := x.(*MockTask)
+	if !ok {
+		return false
+	}
+	return taskPtr == m.task
+}
+
+func (m *mockTaskMatcher) String() string {
+	return fmt.Sprintf("is equal to %v", m.task)
 }

--- a/service/history/timerQueueProcessorBase.go
+++ b/service/history/timerQueueProcessorBase.go
@@ -249,10 +249,6 @@ redispatchTaskLoop:
 			}
 
 			t.redispatchTasks()
-
-			if !t.redispatchQueue.IsEmpty() {
-				t.notifyRedispatch()
-			}
 		}
 	}
 
@@ -475,6 +471,10 @@ func (t *timerQueueProcessorBase) redispatchTasks() {
 		t.metricsScope,
 		t.shutdownCh,
 	)
+
+	if !t.redispatchQueue.IsEmpty() {
+		t.notifyRedispatch()
+	}
 }
 
 func (t *timerQueueProcessorBase) retryTasks() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Fix NPE when one re-dispatch queue is being re-dispatched concurrently
* Fix the case where re-dispatch queue is not notified when redispatch is started by processor loop

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

