### PR TITLE
Add retries to range renewal

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -992,7 +992,7 @@ Retry_Loop:
 				tag.Attempt(attempt),
 			)
 			s.closeShard()
-			break
+			break Retry_Loop
 		default:
 			s.logger.Warn("UpdateShard failed with an unknown error.",
 				tag.Error(err),
@@ -1284,7 +1284,7 @@ Retry_Loop:
 				tag.Error(err),
 			)
 			s.closeShard()
-			break
+			break Retry_Loop
 		default:
 			s.logger.Error(
 				"Failed to insert the failover marker into replication queue.",

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -513,7 +513,7 @@ Create_Loop:
 							"Closing shard: CreateWorkflowExecution failed due to stolen shard.",
 							tag.ShardID(s.GetShardID()),
 							tag.Error(err),
-							)
+						)
 						s.closeShard()
 						break Create_Loop
 					}
@@ -973,26 +973,42 @@ func (s *contextImpl) renewRangeLocked(isStealing bool) error {
 		updatedShardInfo.StolenSinceRenew++
 	}
 
-	err := s.GetShardManager().UpdateShard(&persistence.UpdateShardRequest{
-		ShardInfo:       updatedShardInfo,
-		PreviousRangeID: s.shardInfo.RangeID})
-	if err != nil {
-		// Shard is stolen, trigger history engine shutdown
-		if _, ok := err.(*persistence.ShardOwnershipLostError); ok {
+	var err error
+	var attempt int32
+Retry_Loop:
+	for attempt = 0; attempt < conditionalRetryCount; attempt++ {
+		err = s.GetShardManager().UpdateShard(&persistence.UpdateShardRequest{
+			ShardInfo:       updatedShardInfo,
+			PreviousRangeID: s.shardInfo.RangeID})
+		switch err.(type) {
+		case nil:
+			break Retry_Loop
+		case *persistence.ShardOwnershipLostError:
+			// Shard is stolen, trigger history engine shutdown
 			s.logger.Warn(
 				"Closing shard: renewRangeLocked failed due to stolen shard.",
 				tag.ShardID(s.GetShardID()),
 				tag.Error(err),
+				tag.Attempt(attempt),
 			)
 			s.closeShard()
-		} else {
-			// Failure in updating shard to grab new RangeID
-			s.logger.Error("renewRangeLocked failed due to unknown error.",
-				tag.StoreOperationUpdateShard,
+			break
+		default:
+			s.logger.Warn("UpdateShard failed with an unknown error.",
 				tag.Error(err),
 				tag.ShardRangeID(updatedShardInfo.RangeID),
-				tag.PreviousShardRangeID(s.shardInfo.RangeID))
+				tag.PreviousShardRangeID(s.shardInfo.RangeID),
+				tag.Attempt(attempt))
 		}
+	}
+	if err != nil {
+		// Failure in updating shard to grab new RangeID
+		s.logger.Error("renewRangeLocked failed.",
+			tag.StoreOperationUpdateShard,
+			tag.Error(err),
+			tag.ShardRangeID(updatedShardInfo.RangeID),
+			tag.PreviousShardRangeID(s.shardInfo.RangeID),
+			tag.Attempt(attempt))
 		return err
 	}
 
@@ -1249,6 +1265,7 @@ func (s *contextImpl) ReplicateFailoverMarkers(
 	defer s.updateMaxReadLevelLocked(transferMaxReadLevel)
 
 	var err error
+Retry_Loop:
 	for attempt := int32(0); attempt < conditionalRetryCount; attempt++ {
 		err = s.executionManager.CreateFailoverMarkerTasks(
 			&persistence.CreateFailoverMarkersRequest{
@@ -1258,7 +1275,7 @@ func (s *contextImpl) ReplicateFailoverMarkers(
 		)
 		switch err.(type) {
 		case nil:
-			break
+			break Retry_Loop
 		case *persistence.ShardOwnershipLostError:
 			// do not retry on ShardOwnershipLostError
 			s.logger.Warn(

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+// 
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package shard
 
 import (

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -1,0 +1,122 @@
+package shard
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/loggerimpl"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/uber/cadence/common/mocks"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/service/history/config"
+	"github.com/uber/cadence/service/history/events"
+	"github.com/uber/cadence/service/history/resource"
+)
+
+type (
+	contextTestSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller       *gomock.Controller
+		mockResource     *resource.Test
+		mockShardManager *mocks.ShardManager
+
+		metricsClient metrics.Client
+		logger        log.Logger
+
+		context *contextImpl
+	}
+)
+
+func TestContextSuite(t *testing.T) {
+	s := new(contextTestSuite)
+	suite.Run(t, s)
+}
+
+func (s *contextTestSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.controller = gomock.NewController(s.T())
+	s.mockResource = resource.NewTest(s.controller, metrics.History)
+	s.mockShardManager = s.mockResource.ShardMgr
+
+	s.metricsClient = metrics.NewClient(tally.NoopScope, metrics.History)
+	s.logger = loggerimpl.NewNopLogger()
+
+	s.context = s.newContext()
+}
+
+func (s *contextTestSuite) newContext() *contextImpl {
+	eventsCache := events.NewMockCache(s.controller)
+	config := config.NewForTest()
+	shardInfo := &persistence.ShardInfo{
+		ShardID:          0,
+		RangeID:          1,
+		TransferAckLevel: 0,
+	}
+	context := &contextImpl{
+		Resource:                  s.mockResource,
+		shardID:                   shardInfo.ShardID,
+		rangeID:                   shardInfo.RangeID,
+		shardInfo:                 shardInfo,
+		executionManager:          s.mockResource.ExecutionMgr,
+		config:                    config,
+		logger:                    s.logger,
+		throttledLogger:           s.logger,
+		transferSequenceNumber:    1,
+		transferMaxReadLevel:      0,
+		maxTransferSequenceNumber: 100000,
+		timerMaxReadLevelMap:      make(map[string]time.Time),
+		remoteClusterCurrentTime:  make(map[string]time.Time),
+		eventsCache:               eventsCache,
+	}
+	return context
+}
+
+func (s *contextTestSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *contextTestSuite) TestRenewRangeLockedSuccess() {
+	s.mockShardManager.On("UpdateShard", mock.Anything).Once().Return(nil)
+
+	err := s.context.renewRangeLocked(false)
+	s.NoError(err)
+}
+
+func (s *contextTestSuite) TestRenewRangeLockedSuccessAfterRetries() {
+	retryCount := conditionalRetryCount
+	someError := errors.New("some error")
+	s.mockShardManager.On("UpdateShard", mock.Anything).Times(retryCount - 1).Return(someError)
+	s.mockShardManager.On("UpdateShard", mock.Anything).Return(nil)
+
+	err := s.context.renewRangeLocked(false)
+	s.NoError(err)
+}
+
+func (s *contextTestSuite) TestRenewRangeLockedRetriesExceeded() {
+	retryCount := conditionalRetryCount
+	someError := errors.New("some error")
+	s.mockShardManager.On("UpdateShard", mock.Anything).Times(retryCount).Return(someError)
+
+	err := s.context.renewRangeLocked(false)
+	s.Error(err)
+}
+
+func (s *contextTestSuite) TestReplicateFailoverMarkersSuccess() {
+	s.mockResource.ExecutionMgr.On("CreateFailoverMarkerTasks", mock.Anything).Once().Return(nil)
+
+	markers := make([]*persistence.FailoverMarkerTask, 0)
+	err := s.context.ReplicateFailoverMarkers(markers)
+	s.NoError(err)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added retries to rangeID renewal code to make it more robust.

<!-- Tell your future self why have you made these changes -->
**Why?**
When rangeID renewal fails, we close the shard and that affects availability if the shard closure was unnecessary. With the retries, we aim to reduce the number of unnecessary shard closures.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Retries may increase the load on the DB but that shouldn't be too much given the small size of retries and how often that code path would be utilized.
