### PR TITLE
Add timers subcommand to admin CLI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/otiai10/copy v1.1.1
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709
 	github.com/pierrec/lz4 v0.0.0-20190701081048-057d66e894a4 // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.2.1 // indirect
 	github.com/robfig/cron v1.2.0
 	github.com/sirupsen/logrus v1.4.2
@@ -55,7 +56,7 @@ require (
 	github.com/uber-go/tally v3.3.15+incompatible
 	github.com/uber/ringpop-go v0.8.5
 	github.com/uber/tchannel-go v1.16.0
-	github.com/urfave/cli v1.20.0
+	github.com/urfave/cli v1.22.4
 	github.com/valyala/fastjson v1.4.1
 	github.com/xwb1989/sqlparser v0.0.0-20180606152119-120387863bf2
 	go.opencensus.io v0.22.2 // indirect
@@ -67,6 +68,7 @@ require (
 	go.uber.org/yarpc v1.42.0
 	go.uber.org/zap v1.12.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
+	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c // indirect
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	golang.org/x/tools v0.0.0-20200127195909-ed30b9180dd3

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,8 @@ github.com/cespare/xxhash/v2 v2.1.0/go.mod h1:dgIUBU3pDso/gPgZ1osOZ0iQf77oPR28Tj
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd h1:qMd81Ts1T2OTKmB4acZcyKaMtRnY5Y44NuXGX2GFJ1w=
 github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd/go.mod h1:sE/e/2PUdi/liOCUjSTXgM1o87ZssimdTWN964YiIeI=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d h1:U+s90UTSYgptZMwQh2aRr3LuazLJIa+Pg3Kc1ylSYVY=
+github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b h1:WR1qVJzbvrVywhAk4kMQKRPx09AZVI0NdEdYs59iHcA=
 github.com/crossdock/crossdock-go v0.0.0-20160816171116-049aabb0122b/go.mod h1:v9FBN7gdVTpiD/+LZ7Po0UKvROyT87uLVxTHVky/dlQ=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -258,9 +260,13 @@ github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqn
 github.com/robfig/cron v1.2.0 h1:ZjScXvvxeQ63Dbyxy76Fj3AT3Ut0aKsyd2/tl3DTMuQ=
 github.com/robfig/cron v1.2.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0RK8m9o+Q=
+github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samuel/go-thrift v0.0.0-20190219015601-e8b6b52668fe h1:gD4vkYmuoWVgdV6UwI3tPo9MtMfVoIRY+Xn9919SJBg=
 github.com/samuel/go-thrift v0.0.0-20190219015601-e8b6b52668fe/go.mod h1:Vrkh1pnjV9Bl8c3P9zH0/D4NlOHWP5d4/hF4YTULaec=
 github.com/schollz/progressbar/v2 v2.12.1/go.mod h1:fBI3onORwtNtwCWJHsrXtjE3QnJOtqIZrvr3rDaF7L0=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
+github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v0.11.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -296,6 +302,8 @@ github.com/uber/tchannel-go v1.16.0 h1:B7dirDs15/vJJYDeoHpv3xaEUjuRZ38Rvt1qq9g7p
 github.com/uber/tchannel-go v1.16.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
 github.com/urfave/cli v1.20.0 h1:fDqGv3UG/4jbVl/QkFwEdddtEDjh/5Ov6X+0B/3bPaw=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
+github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
+github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/valyala/fastjson v1.4.1 h1:hrltpHpIpkaxll8QltMU8c3QZ5+qIiCL8yKqPFJI/yE=
 github.com/valyala/fastjson v1.4.1/go.mod h1:nV6MsjxL2IMJQUoHDIrjEI7oLyeqK6aBD7EFWPsvP8o=
 github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c/go.mod h1:lB8K/P019DLNhemzwFU4jHLhdvlE6uDZjXFejJXr49I=
@@ -380,6 +388,7 @@ golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20190423024810-112230192c58 h1:8gQV6CLnAEikrhgkHFbMAEhagSSnXWGV915qUMm9mrU=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -21,7 +21,11 @@
 
 package cli
 
-import "github.com/urfave/cli"
+import (
+	"time"
+
+	"github.com/urfave/cli"
+)
 
 func newAdminWorkflowCommands() []cli.Command {
 	return []cli.Command{
@@ -815,6 +819,59 @@ func newDBCommands() []cli.Command {
 				AdminDBScan(c)
 			},
 		},
+		{
+			Name:  "timers",
+			Usage: "get timers from multiple shards for given time range",
+			Flags: append(getDBFlags(),
+				cli.IntFlag{
+					Name:  FlagLowerShardBound,
+					Usage: "lower bound of shard to scan (inclusive)",
+					Value: 0,
+				},
+				cli.IntFlag{
+					Name:  FlagUpperShardBound,
+					Usage: "upper bound of shard to scan (exclusive)",
+					Value: 100,
+				},
+				cli.IntFlag{
+					Name:  FlagPageSize,
+					Usage: "page size used to query db executions table",
+					Value: 500,
+				},
+				cli.IntFlag{
+					Name:  FlagRPS,
+					Usage: "target rps of database queries",
+					Value: 100,
+				},
+				cli.StringFlag{
+					Name:  FlagStartDate,
+					Usage: "start date",
+					Value: time.Now().UTC().Format(time.RFC3339),
+				},
+				cli.StringFlag{
+					Name:  FlagEndDate,
+					Usage: "end date",
+					Value: time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
+				},
+				cli.StringFlag{
+					Name:  FlagDomainID,
+					Usage: "filter tasks by DomainID",
+				},
+				cli.BoolFlag{
+					Name:  FlagSkipErrorMode,
+					Usage: "skip errors",
+				},
+				cli.IntSliceFlag{
+					Name:  FlagTimerType,
+					Usage: "filter by timer types, default - 2 (User Timer). Can be provided multiple times",
+					Value: &cli.IntSlice{2},
+				},
+			),
+			Action: func(c *cli.Context) {
+				AdminTimers(c)
+			},
+		},
+
 		{
 			Name:    "clean",
 			Aliases: []string{"clean"},

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -173,6 +173,54 @@ func newAdminShardManagementCommands() []cli.Command {
 				AdminRemoveTask(c)
 			},
 		},
+		{
+			Name:  "timers",
+			Usage: "get timers from multiple shards for given time range",
+			Flags: append(getDBFlags(),
+				cli.IntFlag{
+					Name:  FlagShardID,
+					Usage: "shardID",
+				},
+				cli.IntFlag{
+					Name:  FlagPageSize,
+					Usage: "page size used to query db executions table",
+					Value: 500,
+				},
+				cli.IntFlag{
+					Name:  FlagRPS,
+					Usage: "target rps of database queries",
+					Value: 100,
+				},
+				cli.StringFlag{
+					Name:  FlagStartDate,
+					Usage: "start date",
+					Value: time.Now().UTC().Format(time.RFC3339),
+				},
+				cli.StringFlag{
+					Name:  FlagEndDate,
+					Usage: "end date",
+					Value: time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
+				},
+				cli.StringFlag{
+					Name:  FlagDomainID,
+					Usage: "filter tasks by DomainID",
+				},
+				cli.IntSliceFlag{
+					Name: FlagTimerType,
+					Usage: "timer types: 0 - DecisionTimeoutTask, 1 - TaskTypeActivityTimeout, " +
+						"2 - TaskTypeUserTimer, 3 - TaskTypeWorkflowTimeout, 4 - TaskTypeDeleteHistoryEvent, " +
+						"5 - TaskTypeActivityRetryTimer, 6 - TaskTypeWorkflowBackoffTimer",
+					Value: &cli.IntSlice{-1},
+				},
+				cli.BoolFlag{
+					Name:  FlagSkipErrorMode,
+					Usage: "skip errors",
+				},
+			),
+			Action: func(c *cli.Context) {
+				AdminTimers(c)
+			},
+		},
 	}
 }
 
@@ -819,59 +867,6 @@ func newDBCommands() []cli.Command {
 				AdminDBScan(c)
 			},
 		},
-		{
-			Name:  "timers",
-			Usage: "get timers from multiple shards for given time range",
-			Flags: append(getDBFlags(),
-				cli.IntFlag{
-					Name:  FlagLowerShardBound,
-					Usage: "lower bound of shard to scan (inclusive)",
-					Value: 0,
-				},
-				cli.IntFlag{
-					Name:  FlagUpperShardBound,
-					Usage: "upper bound of shard to scan (exclusive)",
-					Value: 100,
-				},
-				cli.IntFlag{
-					Name:  FlagPageSize,
-					Usage: "page size used to query db executions table",
-					Value: 500,
-				},
-				cli.IntFlag{
-					Name:  FlagRPS,
-					Usage: "target rps of database queries",
-					Value: 100,
-				},
-				cli.StringFlag{
-					Name:  FlagStartDate,
-					Usage: "start date",
-					Value: time.Now().UTC().Format(time.RFC3339),
-				},
-				cli.StringFlag{
-					Name:  FlagEndDate,
-					Usage: "end date",
-					Value: time.Now().UTC().Add(24 * time.Hour).Format(time.RFC3339),
-				},
-				cli.StringFlag{
-					Name:  FlagDomainID,
-					Usage: "filter tasks by DomainID",
-				},
-				cli.BoolFlag{
-					Name:  FlagSkipErrorMode,
-					Usage: "skip errors",
-				},
-				cli.IntSliceFlag{
-					Name:  FlagTimerType,
-					Usage: "filter by timer types, default - 2 (User Timer). Can be provided multiple times",
-					Value: &cli.IntSlice{2},
-				},
-			),
-			Action: func(c *cli.Context) {
-				AdminTimers(c)
-			},
-		},
-
 		{
 			Name:    "clean",
 			Aliases: []string{"clean"},

--- a/tools/cli/adminDBTimers.go
+++ b/tools/cli/adminDBTimers.go
@@ -1,0 +1,169 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/gocql/gocql"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/persistence"
+	cassp "github.com/uber/cadence/common/persistence/cassandra"
+	"github.com/uber/cadence/common/quotas"
+)
+
+// AdminTimers is used to list scheduled timers.
+func AdminTimers(c *cli.Context) {
+	lowerShardBound := c.Int(FlagLowerShardBound)
+	upperShardBound := c.Int(FlagUpperShardBound)
+	startDate := c.String(FlagStartDate)
+	endDate := c.String(FlagEndDate)
+	rps := c.Int(FlagRPS)
+
+	ctx, cancel := newContextForLongPoll(c)
+	defer cancel()
+
+	st, err := parseSingleTs(startDate)
+	if err != nil {
+		ErrorAndExit("wrong date format for "+FlagStartDate, err)
+	}
+	et, err := parseSingleTs(endDate)
+	if err != nil {
+		ErrorAndExit("wrong date format for "+FlagEndDate, err)
+	}
+
+	session := connectToCassandra(c)
+	defer session.Close()
+
+	// shared limiter
+	limiter := quotas.NewSimpleRateLimiter(rps)
+
+	group, ctx := errgroup.WithContext(ctx)
+	for shardID := lowerShardBound; shardID < upperShardBound; shardID++ {
+		shardID := shardID
+		group.Go(func() error {
+			return printTimers(c, session, shardID, st, et, limiter)
+		})
+	}
+
+	if err := group.Wait(); err != nil {
+		ErrorAndExit("getting timers", err)
+	}
+}
+
+func printTimers(
+	c *cli.Context,
+	session *gocql.Session,
+	shardID int,
+	startDate, endDate time.Time,
+	limiter *quotas.RateLimiter,
+) error {
+	domainID := c.String(FlagDomainID)
+	skipErrMode := c.Bool(FlagSkipErrorMode)
+	batchSize := c.Int(FlagBatchSize)
+	timerTypes := intSliceToMap(c.IntSlice(FlagTimerType))
+	logger := loggerimpl.NewNopLogger()
+
+	execStore, err := cassp.NewWorkflowExecutionPersistence(shardID, session, logger)
+	if err != nil {
+		err = errors.Wrapf(err, "cannot get execution manager for shardId %d", shardID)
+		if !skipErrMode {
+			return err
+		}
+		fmt.Println(err.Error())
+		return nil
+	}
+
+	manager := persistence.NewExecutionManagerImpl(execStore, logger)
+	ratelimitedClient := persistence.NewWorkflowExecutionPersistenceRateLimitedClient(manager, limiter, logger)
+
+	var token []byte
+	isFirstIteration := true
+	for isFirstIteration || len(token) != 0 {
+		isFirstIteration = false
+		req := persistence.GetTimerIndexTasksRequest{
+			MinTimestamp:  startDate,
+			MaxTimestamp:  endDate,
+			BatchSize:     batchSize,
+			NextPageToken: token,
+		}
+
+		resp := &persistence.GetTimerIndexTasksResponse{}
+
+		op := func() error {
+			var err error
+			resp, err = ratelimitedClient.GetTimerIndexTasks(&req)
+			return err
+		}
+
+		for attempt := 0; attempt < maxDBRetries; attempt++ {
+			err = backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+			if err == nil {
+				break
+			}
+		}
+
+		if err != nil {
+			err := errors.Wrapf(err, "cannot get timer tasks for shardId %d", shardID)
+			if !skipErrMode {
+				return err
+			}
+
+			fmt.Println(err.Error())
+			return nil
+		}
+
+		token = resp.NextPageToken
+
+		for _, t := range resp.Timers {
+			if len(domainID) > 0 && t.DomainID != domainID {
+				continue
+			}
+
+			if _, ok := timerTypes[t.TaskType]; !ok {
+				continue
+			}
+
+			data, err := json.Marshal(t)
+			if err != nil {
+				err = errors.Wrap(err, "cannot marshal timer to json")
+				if !skipErrMode {
+					return err
+				}
+				fmt.Println(err.Error())
+			} else {
+				fmt.Println(string(data))
+			}
+		}
+	}
+
+	return nil
+}

--- a/tools/cli/adminTimers.go
+++ b/tools/cli/adminTimers.go
@@ -25,31 +25,42 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"time"
 
-	"github.com/gocql/gocql"
-	"github.com/pkg/errors"
 	"github.com/urfave/cli"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/persistence"
-	cassp "github.com/uber/cadence/common/persistence/cassandra"
+	"github.com/uber/cadence/common/persistence/cassandra"
 	"github.com/uber/cadence/common/quotas"
 )
 
 // AdminTimers is used to list scheduled timers.
 func AdminTimers(c *cli.Context) {
-	lowerShardBound := c.Int(FlagLowerShardBound)
-	upperShardBound := c.Int(FlagUpperShardBound)
+	shardID := getRequiredIntOption(c, FlagShardID)
+
 	startDate := c.String(FlagStartDate)
 	endDate := c.String(FlagEndDate)
 	rps := c.Int(FlagRPS)
+	domainID := c.String(FlagDomainID)
+	batchSize := c.Int(FlagBatchSize)
+	timerTypes := c.IntSlice(FlagTimerType)
+	skipErrMode := c.Bool(FlagSkipErrorMode)
 
-	ctx, cancel := newContextForLongPoll(c)
-	defer cancel()
+	if !c.IsSet(FlagTimerType) || (len(timerTypes) == 1 && timerTypes[0] == -1) {
+		timerTypes = []int{
+			persistence.TaskTypeDecisionTimeout,
+			persistence.TaskTypeActivityTimeout,
+			persistence.TaskTypeUserTimer,
+			persistence.TaskTypeWorkflowTimeout,
+			persistence.TaskTypeDeleteHistoryEvent,
+			persistence.TaskTypeActivityRetryTimer,
+			persistence.TaskTypeWorkflowBackoffTimer,
+		}
+	}
+
+	taskTypes := intSliceToMap(timerTypes)
 
 	st, err := parseSingleTs(startDate)
 	if err != nil {
@@ -63,55 +74,27 @@ func AdminTimers(c *cli.Context) {
 	session := connectToCassandra(c)
 	defer session.Close()
 
-	// shared limiter
 	limiter := quotas.NewSimpleRateLimiter(rps)
-
-	group, ctx := errgroup.WithContext(ctx)
-	for shardID := lowerShardBound; shardID < upperShardBound; shardID++ {
-		shardID := shardID
-		group.Go(func() error {
-			return printTimers(c, session, shardID, st, et, limiter)
-		})
-	}
-
-	if err := group.Wait(); err != nil {
-		ErrorAndExit("getting timers", err)
-	}
-}
-
-func printTimers(
-	c *cli.Context,
-	session *gocql.Session,
-	shardID int,
-	startDate, endDate time.Time,
-	limiter *quotas.RateLimiter,
-) error {
-	domainID := c.String(FlagDomainID)
-	skipErrMode := c.Bool(FlagSkipErrorMode)
-	batchSize := c.Int(FlagBatchSize)
-	timerTypes := intSliceToMap(c.IntSlice(FlagTimerType))
 	logger := loggerimpl.NewNopLogger()
 
-	execStore, err := cassp.NewWorkflowExecutionPersistence(shardID, session, logger)
+	execStore, err := cassandra.NewWorkflowExecutionPersistence(shardID, session, logger)
 	if err != nil {
-		err = errors.Wrapf(err, "cannot get execution manager for shardId %d", shardID)
-		if !skipErrMode {
-			return err
-		}
-		fmt.Println(err.Error())
-		return nil
+		ErrorAndExit("cannot get execution store", err)
 	}
 
-	manager := persistence.NewExecutionManagerImpl(execStore, logger)
-	ratelimitedClient := persistence.NewWorkflowExecutionPersistenceRateLimitedClient(manager, limiter, logger)
+	ratelimitedClient := persistence.NewWorkflowExecutionPersistenceRateLimitedClient(
+		persistence.NewExecutionManagerImpl(execStore, logger),
+		limiter,
+		logger,
+	)
 
 	var token []byte
 	isFirstIteration := true
 	for isFirstIteration || len(token) != 0 {
 		isFirstIteration = false
 		req := persistence.GetTimerIndexTasksRequest{
-			MinTimestamp:  startDate,
-			MaxTimestamp:  endDate,
+			MinTimestamp:  st,
+			MaxTimestamp:  et,
 			BatchSize:     batchSize,
 			NextPageToken: token,
 		}
@@ -124,21 +107,10 @@ func printTimers(
 			return err
 		}
 
-		for attempt := 0; attempt < maxDBRetries; attempt++ {
-			err = backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
-			if err == nil {
-				break
-			}
-		}
+		err = backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
 
 		if err != nil {
-			err := errors.Wrapf(err, "cannot get timer tasks for shardId %d", shardID)
-			if !skipErrMode {
-				return err
-			}
-
-			fmt.Println(err.Error())
-			return nil
+			ErrorAndExit("cannot get timer tasks for shard", err)
 		}
 
 		token = resp.NextPageToken
@@ -148,15 +120,14 @@ func printTimers(
 				continue
 			}
 
-			if _, ok := timerTypes[t.TaskType]; !ok {
+			if _, ok := taskTypes[t.TaskType]; !ok {
 				continue
 			}
 
 			data, err := json.Marshal(t)
 			if err != nil {
-				err = errors.Wrap(err, "cannot marshal timer to json")
 				if !skipErrMode {
-					return err
+					ErrorAndExit("cannot marshal timer to json", err)
 				}
 				fmt.Println(err.Error())
 			} else {
@@ -164,6 +135,4 @@ func printTimers(
 			}
 		}
 	}
-
-	return nil
 }

--- a/tools/cli/adminTimers.go
+++ b/tools/cli/adminTimers.go
@@ -60,7 +60,7 @@ func AdminTimers(c *cli.Context) {
 		}
 	}
 
-	taskTypes := intSliceToMap(timerTypes)
+	taskTypes := intSliceToSet(timerTypes)
 
 	st, err := parseSingleTs(startDate)
 	if err != nil {

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -162,6 +162,7 @@ const (
 	FlagSecurityToken                     = "security_token"
 	FlagSecurityTokenWithAlias            = FlagSecurityToken + ", st"
 	FlagSkipErrorMode                     = "skip_errors"
+	FlagTimerType                         = "timer_type"
 	FlagSkipErrorModeWithAlias            = FlagSkipErrorMode + ", serr"
 	FlagHeadersMode                       = "headers"
 	FlagHeadersModeWithAlias              = FlagHeadersMode + ", he"
@@ -234,6 +235,8 @@ const (
 	FlagHeaderKey                         = "header_key"
 	FlagHeaderValue                       = "header_value"
 	FlagHeaderFile                        = "header_file"
+	FlagStartDate                         = "start_date"
+	FlagEndDate                           = "end_date"
 )
 
 var flagsForExecution = []cli.Flag{

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -511,7 +511,7 @@ func mapKeysToArray(m map[string]string) []string {
 	return out
 }
 
-func intSliceToMap(s []int) map[int]struct{} {
+func intSliceToSet(s []int) map[int]struct{} {
 	var ret = make(map[int]struct{}, len(s))
 	for _, v := range s {
 		ret[v] = struct{}{}

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -511,6 +511,14 @@ func mapKeysToArray(m map[string]string) []string {
 	return out
 }
 
+func intSliceToMap(s []int) map[int]struct{} {
+	var ret = make(map[int]struct{}, len(s))
+	for _, v := range s {
+		ret[v] = struct{}{}
+	}
+	return ret
+}
+
 func printError(msg string, err error) {
 	if err != nil {
 		fmt.Printf("%s %s\n%s %+v\n", colorRed("Error:"), msg, colorMagenta("Error Details:"), err)
@@ -670,6 +678,18 @@ func parseTimeRange(timeRange string) (time.Time, error) {
 		res = epochTime
 	}
 	return res, nil
+}
+
+func parseSingleTs(ts string) (time.Time, error) {
+	var tsOut time.Time
+	var err error
+	formats := []string{"2006-01-02T15:04:05", "2006-01-02T15:04", "2006-01-02", "2006-01-02T15:04:05+0700", time.RFC3339}
+	for _, format := range formats {
+		if tsOut, err = time.Parse(format, ts); err == nil {
+			return tsOut, err
+		}
+	}
+	return tsOut, err
 }
 
 // parseTimeDuration parses the given time duration in either short or long convention


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding helper command under admin/db section in CLI.

This command returns timers scheduled.
You can use number of filters:
* time range
* domain UUID
* shard range
* timer types to retrieve


<!-- Tell your future self why have you made these changes -->
**Why?**
This tool can be used for operational needs. It helps inspect what timers are scheduled for specific time range. For now, additional, external, tooling is needed to visualize results. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

