### PR TITLE
Fix returned error in update wf when shard lost

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -515,7 +515,7 @@ Create_Loop:
 							tag.Error(err),
 						)
 						s.closeShard()
-						break Create_Loop
+						return nil, err
 					}
 				}
 			default:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix returned error in update wf when shard lost

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, when handle ShardOwnershipLostError during update workflow, it closeShard then return errMaxAttemptsExceeded, which is wrong and confusing. 
With this fix, history handler will catch and wrap it.  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risk
