### PR TITLE
Enforce time resolution for timerMaxReadLevel

### DIFF
--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -22,6 +22,7 @@ package queue
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -610,6 +611,10 @@ func (k timerTaskKey) Less(
 		return k.taskID < timerKey.taskID
 	}
 	return k.visibilityTimestamp.Before(timerKey.visibilityTimestamp)
+}
+
+func (k timerTaskKey) String() string {
+	return fmt.Sprintf("{visibilityTimestamp: %v, taskID: %v}", k.visibilityTimestamp, k.taskID)
 }
 
 func newTimerQueueProcessorOptions(

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -453,7 +453,7 @@ func (s *contextImpl) UpdateTimerMaxReadLevel(cluster string) time.Time {
 		currentTime = s.remoteClusterCurrentTime[cluster]
 	}
 
-	s.timerMaxReadLevelMap[cluster] = currentTime.Add(s.config.TimerProcessorMaxTimeShift())
+	s.timerMaxReadLevelMap[cluster] = currentTime.Add(s.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
 	return s.timerMaxReadLevelMap[cluster]
 }
 
@@ -1441,6 +1441,8 @@ func acquireShard(
 		} else { // active cluster
 			timerMaxReadLevelMap[clusterName] = shardInfo.TimerAckLevel
 		}
+
+		timerMaxReadLevelMap[clusterName] = timerMaxReadLevelMap[clusterName].Truncate(time.Millisecond)
 	}
 
 	executionMgr, err := shardItem.GetExecutionManager(shardItem.shardID)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Truncate timerMaxReadLevel to millisecond
* Add Stringer method for timerTaskKey

<!-- Tell your future self why have you made these changes -->
**Why?**
Time resolution is one millisecond in Cassandra, but previously the resolution timerMaxReadLevel is not one millisecond. This means when using timerMaxReadLevel as the minQueryLevel for reading timer tasks (when previous read finished, we move minQueryLevel to the old maxReadLevel), tasks with timestamp less then the minQueryLevel may be loaded. The logic works for the existing task processing logic as there's only one queue ever and no task will be missed. However, in new multi-cursor logic, it will cause a sanity check failure and tasks being assigned to the wrong processing queue. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Staging2 bench test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low risk as timerMaxReadLevel is an adjustable value, so this change can be regard as changing the constant `TimerProcessorMaxTimeShift` to a dynamic value which always makes timerMaxReadLevel as a time resolution of one millisecond.
