### PR TITLE
Reduce context timeout for transfer tasks

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -231,8 +231,7 @@ func IsServiceTransientError(err error) bool {
 		return true
 	case *yarpcerrors.Status:
 		// We only selectively retry the following yarpc errors client can safe retry with a backoff
-		if yarpcerrors.IsDeadlineExceeded(err) ||
-			yarpcerrors.IsUnavailable(err) ||
+		if yarpcerrors.IsUnavailable(err) ||
 			yarpcerrors.IsUnknown(err) ||
 			yarpcerrors.IsInternal(err) {
 			return true
@@ -250,6 +249,11 @@ func IsServiceBusyError(err error) bool {
 		return true
 	}
 	return false
+}
+
+// IsContextTimeoutError checks if the error is context timeout error
+func IsContextTimeoutError(err error) bool {
+	return err == context.DeadlineExceeded || yarpcerrors.IsDeadlineExceeded(err)
 }
 
 // WorkflowIDToHistoryShard is used to map a workflowID to a shardID

--- a/common/util.go
+++ b/common/util.go
@@ -253,6 +253,10 @@ func IsServiceBusyError(err error) bool {
 
 // IsContextTimeoutError checks if the error is context timeout error
 func IsContextTimeoutError(err error) bool {
+	switch err := err.(type) {
+	case *workflow.InternalServiceError:
+		return err.Message == context.DeadlineExceeded.Error()
+	}
 	return err == context.DeadlineExceeded || yarpcerrors.IsDeadlineExceeded(err)
 }
 

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -60,6 +60,7 @@ func TestIsContextTimeoutError(t *testing.T) {
 	defer cancel()
 	time.Sleep(50 * time.Millisecond)
 	require.True(t, IsContextTimeoutError(ctx.Err()))
+	require.True(t, IsContextTimeoutError(&workflow.InternalServiceError{Message: ctx.Err().Error()}))
 
 	yarpcErr := yarpcerrors.DeadlineExceededErrorf("yarpc deadline exceeded")
 	require.True(t, IsContextTimeoutError(yarpcErr))

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/yarpcerrors"
 
 	workflow "github.com/uber/cadence/.gen/go/shared"
 )
@@ -40,6 +41,11 @@ func TestIsServiceTransientError_ContextTimeout(t *testing.T) {
 	time.Sleep(100 * time.Millisecond)
 
 	require.False(t, IsServiceTransientError(ctx.Err()))
+}
+
+func TestIsServiceTransientError_YARPCDeadlineExceeded(t *testing.T) {
+	yarpcErr := yarpcerrors.DeadlineExceededErrorf("yarpc deadline exceeded")
+	require.False(t, IsServiceTransientError(yarpcErr))
 }
 
 func TestIsServiceTransientError_ContextCancel(t *testing.T) {

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -346,7 +346,7 @@ func (t *taskBase) HandleErr(
 func (t *taskBase) RetryErr(
 	err error,
 ) bool {
-	if err == ErrTaskRedispatch || err == ErrTaskPendingActive {
+	if err == ErrTaskRedispatch || err == ErrTaskPendingActive || common.IsContextTimeoutError(err) {
 		return false
 	}
 

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -401,7 +401,7 @@ func (t *transferActiveTaskExecutor) processCancelExecution(
 
 		// Check to see if the error is non-transient, in which case add RequestCancelFailed
 		// event and complete transfer task by setting the err = nil
-		if common.IsServiceTransientError(err) {
+		if common.IsServiceTransientError(err) || common.IsContextTimeoutError(err) {
 			// for retryable error just return
 			return err
 		}
@@ -491,7 +491,7 @@ func (t *transferActiveTaskExecutor) processSignalExecution(
 
 		// Check to see if the error is non-transient, in which case add SignalFailed
 		// event and complete transfer task by setting the err = nil
-		if common.IsServiceTransientError(err) {
+		if common.IsServiceTransientError(err) || common.IsContextTimeoutError(err) {
 			// for retryable error just return
 			return err
 		}

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -39,7 +39,7 @@ import (
 )
 
 const (
-	transferActiveTaskDefaultTimeout = 30 * time.Second
+	transferActiveTaskDefaultTimeout = 3 * time.Second
 	secondsInDay                     = int32(24 * time.Hour / time.Second)
 	defaultDomainName                = "defaultDomainName"
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Reduce default timeout for API calls in transfer task processing to 3s. 
* Make yarpc deadline exceeded error non-retryable
* In task processing also do not retry context timeout error as it will block other tasks from be processed. Redispatch that task so that it will backoff for some time.

<!-- Tell your future self why have you made these changes -->
**Why?**
* Currently transfer task is using 30s as the default context timeout when calling APIs. When system is busy, or latency is high for certain history shards, waiting 30s is meaningless (it will still timeout) and will block other tasks in the task queue. Instead, we should fail this task, backoff it for some time and retry later. 
* Context timeout error (from yarpc package) should be non-retryable when the same context is used throughout the retry. The idea is the same as https://github.com/uber/cadence/pull/3327. Without this change, even if context timeout is 3s, the retry policy will still retry the operation for 30s.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Missed retry on server for unknown error
