### PR TITLE
Disable concrete execution scanner by default

### DIFF
--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -135,7 +135,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			TaskListScannerEnabled: dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
 			HistoryScannerEnabled:  dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
 			ConcreteExecutionScannerConfig: &executions.ScannerWorkflowDynamicConfig{
-				Enabled:                 dc.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerEnabled, true),
+				Enabled:                 dc.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerEnabled, false),
 				Concurrency:             dc.GetIntProperty(dynamicconfig.ConcreteExecutionsScannerConcurrency, 25),
 				ExecutionsPageSize:      dc.GetIntProperty(dynamicconfig.ConcreteExecutionsScannerPersistencePageSize, 1000),
 				BlobstoreFlushThreshold: dc.GetIntProperty(dynamicconfig.ConcreteExecutionsScannerBlobstoreFlushThreshold, 100),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed the default value for concrete execution scanner to false.


<!-- Tell your future self why have you made these changes -->
**Why?**
This was causing persistence error to increase for our open-source customers. As it looks up the dynamic config before running the scanner, leaving it disabled by default looks like a good option.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

