### PR TITLE
Enforce timeout for getting workflow execution in task processing

### DIFF
--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -23,6 +23,7 @@ package execution
 import (
 	"context"
 	"sync/atomic"
+	"time"
 
 	"github.com/pborman/uuid"
 
@@ -155,12 +156,26 @@ func (c *Cache) GetAndCreateWorkflowExecution(
 }
 
 // GetOrCreateWorkflowExecutionForBackground gets or creates workflow execution context with background context
+// currently only used in tests
 func (c *Cache) GetOrCreateWorkflowExecutionForBackground(
 	domainID string,
 	execution workflow.WorkflowExecution,
 ) (Context, ReleaseFunc, error) {
 
 	return c.GetOrCreateWorkflowExecution(context.Background(), domainID, execution)
+}
+
+// GetOrCreateWorkflowExecutionWithTimeout gets or creates workflow execution context with timeout
+func (c *Cache) GetOrCreateWorkflowExecutionWithTimeout(
+	domainID string,
+	execution workflow.WorkflowExecution,
+	timeout time.Duration,
+) (Context, ReleaseFunc, error) {
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	return c.GetOrCreateWorkflowExecution(ctx, domainID, execution)
 }
 
 // GetOrCreateWorkflowExecution gets or creates workflow execution context

--- a/service/history/task/task_util.go
+++ b/service/history/task/task_util.go
@@ -23,7 +23,7 @@ package task
 import (
 	"fmt"
 
-	gomock "github.com/golang/mock/gomock"
+	"github.com/golang/mock/gomock"
 
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
@@ -352,6 +352,16 @@ func retryWorkflow(
 		return nil, err
 	}
 	return newMutableState, nil
+}
+
+func getWorkflowExecution(
+	taskInfo Info,
+) workflow.WorkflowExecution {
+
+	return workflow.WorkflowExecution{
+		WorkflowId: common.StringPtr(taskInfo.GetWorkflowID()),
+		RunId:      common.StringPtr(taskInfo.GetRunID()),
+	}
 }
 
 // NewMockTaskMatcher creates a gomock matcher for mock Task

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -101,8 +101,10 @@ func (t *timerActiveTaskExecutor) executeUserTimerTimeoutTask(
 	task *persistence.TimerTaskInfo,
 ) (retError error) {
 
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(task),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		task.DomainID,
+		getWorkflowExecution(task),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err
@@ -153,8 +155,10 @@ func (t *timerActiveTaskExecutor) executeActivityTimeoutTask(
 	task *persistence.TimerTaskInfo,
 ) (retError error) {
 
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(task),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		task.DomainID,
+		getWorkflowExecution(task),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err
@@ -250,8 +254,10 @@ func (t *timerActiveTaskExecutor) executeDecisionTimeoutTask(
 	task *persistence.TimerTaskInfo,
 ) (retError error) {
 
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(task),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		task.DomainID,
+		getWorkflowExecution(task),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err
@@ -322,8 +328,10 @@ func (t *timerActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 	task *persistence.TimerTaskInfo,
 ) (retError error) {
 
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(task),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		task.DomainID,
+		getWorkflowExecution(task),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err
@@ -357,8 +365,10 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 	task *persistence.TimerTaskInfo,
 ) (retError error) {
 
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(task),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		task.DomainID,
+		getWorkflowExecution(task),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err
@@ -441,8 +451,10 @@ func (t *timerActiveTaskExecutor) executeWorkflowTimeoutTask(
 	task *persistence.TimerTaskInfo,
 ) (retError error) {
 
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(task),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		task.DomainID,
+		getWorkflowExecution(task),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -403,8 +403,10 @@ func (t *timerStandbyTaskExecutor) processTimer(
 	postActionFn standbyPostActionFn,
 ) (retError error) {
 
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(timerTask),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		timerTask.DomainID,
+		getWorkflowExecution(timerTask),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -479,8 +479,10 @@ func (t *transferStandbyTaskExecutor) processTransfer(
 ) (retError error) {
 
 	transferTask := taskInfo.(*persistence.TransferTaskInfo)
-	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionForBackground(
-		t.getDomainIDAndWorkflowExecution(transferTask),
+	context, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
+		transferTask.DomainID,
+		getWorkflowExecution(transferTask),
+		taskDefaultTimeout,
 	)
 	if err != nil {
 		return err

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -39,9 +39,9 @@ import (
 )
 
 const (
-	transferActiveTaskDefaultTimeout = 3 * time.Second
-	secondsInDay                     = int32(24 * time.Hour / time.Second)
-	defaultDomainName                = "defaultDomainName"
+	taskDefaultTimeout = 3 * time.Second
+	secondsInDay       = int32(24 * time.Hour / time.Second)
+	defaultDomainName  = "defaultDomainName"
 )
 
 type (
@@ -77,22 +77,12 @@ func newTransferTaskExecutorBase(
 	}
 }
 
-func (t *transferTaskExecutorBase) getDomainIDAndWorkflowExecution(
-	task *persistence.TransferTaskInfo,
-) (string, workflow.WorkflowExecution) {
-
-	return task.DomainID, workflow.WorkflowExecution{
-		WorkflowId: common.StringPtr(task.WorkflowID),
-		RunId:      common.StringPtr(task.RunID),
-	}
-}
-
 func (t *transferTaskExecutorBase) pushActivity(
 	task *persistence.TransferTaskInfo,
 	activityScheduleToStartTimeout int32,
 ) error {
 
-	ctx, cancel := context.WithTimeout(context.Background(), transferActiveTaskDefaultTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
 	defer cancel()
 
 	if task.TaskType != persistence.TransferTaskTypeActivityTask {
@@ -120,7 +110,7 @@ func (t *transferTaskExecutorBase) pushDecision(
 	decisionScheduleToStartTimeout int32,
 ) error {
 
-	ctx, cancel := context.WithTimeout(context.Background(), transferActiveTaskDefaultTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
 	defer cancel()
 
 	if task.TaskType != persistence.TransferTaskTypeDecisionTask {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Enforce timeout for getting workflow execution in task processing

<!-- Tell your future self why have you made these changes -->
**Why?**
* Currently task will wait indefinitely on the lock for workflow execution as context.Background() is used. This becomes a problem if a certain workflow is running hot and it takes a long time to get the lock, as it not only block this task from being processed, but also blocked other tasks in the task ch from being processed. Instead of keep waiting for the lock, we should fail this task for now, ask it to backoff and retry it later.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Increased # task failures due to timeout is expected.
