### PR TITLE
Update metrics cache to be unblocking

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -23,6 +23,8 @@ package cache
 import (
 	"time"
 
+	"github.com/uber/cadence/common"
+
 	"github.com/uber/cadence/common/metrics"
 )
 
@@ -130,8 +132,6 @@ type DomainMetricsScopeCache interface {
 	Get(domainID string, scopeIdx int) (metrics.Scope, bool)
 	// Put adds metrics scope for a domainID and scopeIdx
 	Put(domainID string, scopeIdx int, metricsScope metrics.Scope)
-	// Start the metrics scope cache
-	Start()
-	// Stops the metrics scope cache
-	Stop()
+
+	common.Daemon
 }

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -130,4 +130,6 @@ type DomainMetricsScopeCache interface {
 	Get(domainID string, scopeIdx int) (metrics.Scope, bool)
 	// Put adds metrics scope for a domainID and scopeIdx
 	Put(domainID string, scopeIdx int, metricsScope metrics.Scope)
+	// Stops the metrics scope cache
+	Stop()
 }

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -130,6 +130,8 @@ type DomainMetricsScopeCache interface {
 	Get(domainID string, scopeIdx int) (metrics.Scope, bool)
 	// Put adds metrics scope for a domainID and scopeIdx
 	Put(domainID string, scopeIdx int, metricsScope metrics.Scope)
+	// Start the metrics scope cache
+	Start()
 	// Stops the metrics scope cache
 	Stop()
 }

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
-
 	"github.com/uber/cadence/common/metrics"
 )
 
@@ -82,7 +81,12 @@ func (c *domainMetricsScopeCache) flushBufferedMetricsScope(flushDuration time.D
 
 				// Copy from buffered array
 				for key, val := range c.buffer.bufferMap {
-					scopeMap[key] = val
+					if _, ok := scopeMap[key]; !ok {
+						scopeMap[key] = map[int]metrics.Scope{}
+					}
+					for k, v := range val {
+						scopeMap[key][k] = v
+					}
 				}
 
 				c.cache.Store(scopeMap)

--- a/common/cache/metricsScopeCache.go
+++ b/common/cache/metricsScopeCache.go
@@ -76,7 +76,10 @@ func (c *domainMetricsScopeCache) flushBufferedMetricsScope(flushDuration time.D
 				data := c.cache.Load().(metricsScopeMap)
 				// Copy everything over after atomic load
 				for key, val := range data {
-					scopeMap[key] = val
+					scopeMap[key] = map[int]metrics.Scope{}
+					for k, v := range val {
+						scopeMap[key][k] = v
+					}
 				}
 
 				// Copy from buffered array

--- a/common/cache/metricsScopeCache_test.go
+++ b/common/cache/metricsScopeCache_test.go
@@ -23,17 +23,34 @@
 package cache
 
 import (
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/uber/cadence/common/metrics"
 	"sync"
 	"testing"
 	"time"
-
-	"github.com/stretchr/testify/assert"
-
-	"github.com/uber/cadence/common/metrics"
 )
 
-func TestGetMetricsScope(t *testing.T) {
-	metricsCache := NewDomainMetricsScopeCache()
+type domainMetricsCacheSuite struct {
+	suite.Suite
+	*require.Assertions
+
+	metricsCache DomainMetricsScopeCache
+}
+
+func TestDomainMetricsCacheSuite(t *testing.T) {
+	s := new(domainMetricsCacheSuite)
+	suite.Run(t, s)
+}
+
+func (s *domainMetricsCacheSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.metricsCache = NewDomainMetricsScopeCache(100 * time.Millisecond)
+}
+
+
+func (s *domainMetricsCacheSuite) TestGetMetricsScope() {
 	var found bool
 
 	tests := []struct {
@@ -47,32 +64,96 @@ func TestGetMetricsScope(t *testing.T) {
 
 	for _, t := range tests {
 		mockMetricsScope := metrics.NoopScope(metrics.ServiceIdx(t.scopeID))
-		metricsCache.Put(t.domainID, t.scopeID, mockMetricsScope)
+		s.metricsCache.Put(t.domainID, t.scopeID, mockMetricsScope)
 	}
 
-	time.Sleep(11 * time.Second)
+	time.Sleep(110 * time.Millisecond)
 
-	metricsScope, found := metricsCache.Get("A", 1)
+	metricsScope, found := s.metricsCache.Get("A", 1)
 	testMetricsScope := metrics.NoopScope(metrics.ServiceIdx(1))
-	assert.Equal(t, testMetricsScope, metricsScope)
-	assert.Equal(t, found, true)
+	s.Equal(testMetricsScope, metricsScope)
+	s.Equal(found, true)
 
-	_, found = metricsCache.Get("B", 2)
-	assert.Equal(t, found, true)
+	_, found = s.metricsCache.Get("B", 2)
+	s.Equal(found, true)
 
-	metricsScope, found = metricsCache.Get("C", 1)
+	metricsScope, found = s.metricsCache.Get("C", 1)
 	testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(3))
-	assert.NotEqual(t, testMetricsScope, metricsScope)
-	assert.Equal(t, found, true)
+	s.NotEqual(testMetricsScope, metricsScope)
+	s.Equal(found, true)
 
-	metricsScope, found = metricsCache.Get("D", 3)
+	metricsScope, found = s.metricsCache.Get("D", 3)
 	testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(3))
-	assert.NotEqual(t, testMetricsScope, metricsScope)
-	assert.Equal(t, found, false)
+	s.NotEqual(testMetricsScope, metricsScope)
+	s.Equal(found, false)
 }
 
-func TestConcurrentMetricsScopeAccess(t *testing.T) {
-	domainMetricsScopeCache := NewDomainMetricsScopeCache()
+func (s *domainMetricsCacheSuite) TestGetMetricsScopeMultipleFlushLoop() {
+	var found bool
+
+	tests := []struct {
+		scopeID  int
+		domainID string
+	}{
+		{1, "A"},
+		{2, "B"},
+		{1, "C"},
+		{5, "D"},
+		{3, "E"},
+	}
+
+	for i:=0; i<3; i++ {
+		t := tests[i]
+		mockMetricsScope := metrics.NoopScope(metrics.ServiceIdx(t.scopeID))
+		s.metricsCache.Put(t.domainID, t.scopeID, mockMetricsScope)
+	}
+
+	time.Sleep(110 * time.Millisecond)
+
+	for i:=3; i<len(tests); i++ {
+		t := tests[i]
+		mockMetricsScope := metrics.NoopScope(metrics.ServiceIdx(t.scopeID))
+		s.metricsCache.Put(t.domainID, t.scopeID, mockMetricsScope)
+	}
+
+
+	metricsScope, found := s.metricsCache.Get("A", 1)
+	testMetricsScope := metrics.NoopScope(metrics.ServiceIdx(1))
+	s.Equal(testMetricsScope, metricsScope)
+	s.Equal(found, true)
+
+	_, found = s.metricsCache.Get("B", 2)
+	s.Equal(found, true)
+
+	metricsScope, found = s.metricsCache.Get("C", 1)
+	testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(3))
+	s.NotEqual(testMetricsScope, metricsScope)
+	s.Equal(found, true)
+
+	metricsScope, found = s.metricsCache.Get("D", 5)
+	testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(5))
+	s.NotEqual(testMetricsScope, metricsScope)
+	s.Equal(found, false)
+
+	metricsScope, found = s.metricsCache.Get("E", 3)
+	testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(3))
+	s.NotEqual(testMetricsScope, metricsScope)
+	s.Equal(found, false)
+
+	time.Sleep(200*time.Millisecond)
+
+	metricsScope, found = s.metricsCache.Get("D", 5)
+	testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(5))
+	s.Equal(testMetricsScope, metricsScope)
+	s.Equal(found, true)
+
+	metricsScope, found = s.metricsCache.Get("E", 3)
+	testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(3))
+	s.Equal(testMetricsScope, metricsScope)
+	s.Equal(found, true)
+}
+
+func (s *domainMetricsCacheSuite) TestConcurrentMetricsScopeAccess() {
 
 	ch := make(chan struct{})
 	var wg sync.WaitGroup
@@ -87,21 +168,21 @@ func TestConcurrentMetricsScopeAccess(t *testing.T) {
 
 			<-ch
 
-			domainMetricsScopeCache.Get("test_domain", scopeIdx)
-			domainMetricsScopeCache.Put("test_domain", scopeIdx, metrics.NoopScope(metrics.ServiceIdx(scopeIdx)))
+			s.metricsCache.Get("test_domain", scopeIdx)
+			s.metricsCache.Put("test_domain", scopeIdx, metrics.NoopScope(metrics.ServiceIdx(scopeIdx)))
 		}(i)
 	}
 
 	close(ch)
 	wg.Wait()
 
-	time.Sleep(11 * time.Second)
+	time.Sleep(110 * time.Millisecond)
 
 	for i := 0; i < 1000; i++ {
-		metricsScope, found = domainMetricsScopeCache.Get("test_domain", i)
+		metricsScope, found = s.metricsCache.Get("test_domain", i)
 		testMetricsScope = metrics.NoopScope(metrics.ServiceIdx(i))
 
-		assert.Equal(t, true, found)
-		assert.Equal(t, testMetricsScope, metricsScope)
+		s.Equal(true, found)
+		s.Equal(testMetricsScope, metricsScope)
 	}
 }

--- a/common/cache/metricsScopeCache_test.go
+++ b/common/cache/metricsScopeCache_test.go
@@ -48,7 +48,7 @@ func TestDomainMetricsCacheSuite(t *testing.T) {
 func (s *domainMetricsCacheSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
-	metricsCache := NewDomainMetricsScopeCache()
+	metricsCache := NewDomainMetricsScopeCache().(*domainMetricsScopeCache)
 	metricsCache.flushDuration = 100 * time.Millisecond
 	s.metricsCache = metricsCache
 
@@ -184,7 +184,7 @@ func (s *domainMetricsCacheSuite) TestConcurrentMetricsScopeAccess() {
 	close(ch)
 	wg.Wait()
 
-	time.Sleep(110 * time.Millisecond)
+	time.Sleep(120 * time.Millisecond)
 
 	for i := 0; i < 1000; i++ {
 		metricsScope, found = s.metricsCache.Get("test_domain", i)

--- a/common/cache/metricsScopeCache_test.go
+++ b/common/cache/metricsScopeCache_test.go
@@ -25,6 +25,7 @@ package cache
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -48,6 +49,8 @@ func TestGetMetricsScope(t *testing.T) {
 		mockMetricsScope := metrics.NoopScope(metrics.ServiceIdx(t.scopeID))
 		metricsCache.Put(t.domainID, t.scopeID, mockMetricsScope)
 	}
+
+	time.Sleep(11 * time.Second)
 
 	metricsScope, found := metricsCache.Get("A", 1)
 	testMetricsScope := metrics.NoopScope(metrics.ServiceIdx(1))
@@ -91,6 +94,8 @@ func TestConcurrentMetricsScopeAccess(t *testing.T) {
 
 	close(ch)
 	wg.Wait()
+
+	time.Sleep(11 * time.Second)
 
 	for i := 0; i < 1000; i++ {
 		metricsScope, found = domainMetricsScopeCache.Get("test_domain", i)

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -392,6 +392,7 @@ func (h *Impl) Stop() {
 	}
 
 	h.domainCache.Stop()
+	h.domainMetricsScopeCache.Stop()
 	h.membershipMonitor.Stop()
 	if err := h.dispatcher.Stop(); err != nil {
 		h.logger.WithTags(tag.Error(err)).Error("failed to stop dispatcher")

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -367,6 +367,7 @@ func (h *Impl) Start() {
 	}
 	h.membershipMonitor.Start()
 	h.domainCache.Start()
+	h.domainMetricsScopeCache.Start()
 
 	hostInfo, err := h.membershipMonitor.WhoAmI()
 	if err != nil {

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -58,7 +58,7 @@ type (
 		logger                log.Logger
 		retryPolicy           backoff.RetryPolicy
 		// This is the batch size used by pull based RPC replicator.
-		fetchTasksBatchSize dynamicconfig.IntPropertyFnWithShardIDFilter
+		fetchTasksBatchSize   dynamicconfig.IntPropertyFnWithShardIDFilter
 		*queueProcessorBase
 		queueAckMgr
 

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -58,7 +58,7 @@ type (
 		logger                log.Logger
 		retryPolicy           backoff.RetryPolicy
 		// This is the batch size used by pull based RPC replicator.
-		fetchTasksBatchSize   dynamicconfig.IntPropertyFnWithShardIDFilter
+		fetchTasksBatchSize dynamicconfig.IntPropertyFnWithShardIDFilter
 		*queueProcessorBase
 		queueAckMgr
 

--- a/service/history/taskProcessor_test.go
+++ b/service/history/taskProcessor_test.go
@@ -183,7 +183,7 @@ func (s *taskProcessorSuite) TestProcessTaskAndAck_DomainTrue_ProcessErrNoErr() 
 	s.mockProcessor.On("process", taskInfo).Return(s.scopeIdx, err).Once()
 	s.mockProcessor.On("process", taskInfo).Return(s.scopeIdx, nil).Once()
 	s.mockProcessor.On("complete", taskInfo).Once()
-	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return(constants.TestDomainName, nil).Times(1)
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return(constants.TestDomainName, nil).Times(2)
 	s.taskProcessor.processTaskAndAck(
 		s.notificationChan,
 		taskInfo,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update metrics cache to be non-blocking on Get().


<!-- Tell your future self why have you made these changes -->
**Why?**
There might be task processing latency increase if metrics cache is blocked on Get(). This change will help to amortize the task processing latency by using a non-blocking cache and doing flush of all put requests every 10s.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Might increase task processing latency.

