### PR TITLE
Fix update both replication queue ack level per Kafka queue and RPC replicaiton

### DIFF
--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -255,11 +255,6 @@ func (p *taskProcessorImpl) cleanupAckedReplicationTasks() error {
 		metrics.ReplicationTasksLag,
 		time.Duration(p.shard.GetTransferMaxReadLevel()-minAckLevel),
 	)
-	// update replication queue ack level.
-	// this ack level currently use by Kafka replication
-	if err := p.shard.UpdateReplicatorAckLevel(minAckLevel); err != nil {
-		return err
-	}
 	return p.shard.GetExecutionManager().RangeCompleteReplicationTask(
 		&persistence.RangeCompleteReplicationTaskRequest{
 			InclusiveEndTaskID: minAckLevel,

--- a/service/history/replicatorQueueProcessor.go
+++ b/service/history/replicatorQueueProcessor.go
@@ -494,6 +494,12 @@ func (p *replicatorQueueProcessorImpl) getTasks(
 		p.logger.Error("error updating replication level for shard", tag.Error(err), tag.OperationFailed)
 	}
 
+	if err := p.shard.UpdateReplicatorAckLevel(
+		lastReadTaskID,
+	);  err != nil {
+		p.logger.Error("error updating kafka replication level", tag.Error(err), tag.OperationFailed)
+	}
+
 	return &replicator.ReplicationMessages{
 		ReplicationTasks:       replicationTasks,
 		HasMore:                common.BoolPtr(hasMore),


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Fix update both replication queue ack level per Kafka queue and RPC replication

<!-- Tell your future self why have you made these changes -->
**Why?**
During the feature rollback, the Kafka queue can skip the messages which are processed by RPC replicaiton

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

