### PR TITLE
Slow down decision tasks after failure

### DIFF
--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -108,6 +108,7 @@ const (
 	defaultWorkflowRetentionInDays      int32 = 1
 	defaultInitIntervalForDecisionRetry       = 1 * time.Minute
 	defaultMaxIntervalForDecisionRetry        = 5 * time.Minute
+	defaultJitterCoefficient                  = 0.2
 )
 
 var _ MutableStateTaskGenerator = (*mutableStateTaskGeneratorImpl)(nil)
@@ -576,10 +577,10 @@ func getNextDecisionTimeout(attempt int64, defaultStartToCloseTimeout time.Durat
 
 	nextInterval := float64(defaultInitIntervalForDecisionRetry) * math.Pow(2, float64(attempt-2))
 	nextInterval = math.Min(nextInterval, float64(defaultMaxIntervalForDecisionRetry))
-	jitterPortion := int(0.2 * nextInterval)
+	jitterPortion := int(defaultJitterCoefficient * nextInterval)
 	if jitterPortion < 1 {
 		jitterPortion = 1
 	}
-	nextInterval = nextInterval*0.8 + float64(rand.Intn(jitterPortion))
+	nextInterval = nextInterval*(1-defaultJitterCoefficient) + float64(rand.Intn(jitterPortion))
 	return time.Duration(nextInterval)
 }

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -24,6 +24,8 @@ package execution
 
 import (
 	"fmt"
+	"math"
+	"math/rand"
 	"time"
 
 	"github.com/uber/cadence/.gen/go/shared"
@@ -102,7 +104,11 @@ type (
 	}
 )
 
-const defaultWorkflowRetentionInDays int32 = 1
+const (
+	defaultWorkflowRetentionInDays      int32 = 1
+	defaultInitIntervalForDecisionRetry       = 1 * time.Minute
+	defaultMaxIntervalForDecisionRetry        = 5 * time.Minute
+)
 
 var _ MutableStateTaskGenerator = (*mutableStateTaskGeneratorImpl)(nil)
 
@@ -300,6 +306,14 @@ func (r *mutableStateTaskGeneratorImpl) GenerateDecisionStartTasks(
 	startToCloseTimeout := time.Duration(
 		decision.DecisionTimeout,
 	) * time.Second
+
+	// schedule timer exponentially if decision keeps failing
+	if decision.Attempt > 1 {
+		defaultStartToCloseTimeout := r.mutableState.GetExecutionInfo().DecisionStartToCloseTimeout
+		startToCloseTimeout = getNextDecisionTimeout(decision.Attempt, time.Duration(defaultStartToCloseTimeout)*time.Second)
+		decision.DecisionTimeout = int32(startToCloseTimeout.Seconds()) // override decision timeout
+		r.mutableState.UpdateDecision(decision)
+	}
 
 	r.mutableState.AddTimerTasks(&persistence.DecisionTimeoutTask{
 		// TaskID is set by shard
@@ -553,4 +567,19 @@ func (r *mutableStateTaskGeneratorImpl) getTargetDomainID(
 	}
 
 	return targetDomainID, nil
+}
+
+func getNextDecisionTimeout(attempt int64, defaultStartToCloseTimeout time.Duration) time.Duration {
+	if attempt <= 1 {
+		return defaultStartToCloseTimeout
+	}
+
+	nextInterval := float64(defaultInitIntervalForDecisionRetry) * math.Pow(2, float64(attempt-2))
+	nextInterval = math.Min(nextInterval, float64(defaultMaxIntervalForDecisionRetry))
+	jitterPortion := int(0.2 * nextInterval)
+	if jitterPortion < 1 {
+		jitterPortion = 1
+	}
+	nextInterval = nextInterval*0.8 + float64(rand.Intn(jitterPortion))
+	return time.Duration(nextInterval)
 }

--- a/service/history/execution/mutable_state_task_generator_test.go
+++ b/service/history/execution/mutable_state_task_generator_test.go
@@ -1,0 +1,56 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package execution
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetNextDecisionTimeout(t *testing.T) {
+	a := assert.New(t)
+	defaultStartToCloseTimeout := 10 * time.Second
+	expectedResult := []time.Duration{
+		defaultStartToCloseTimeout,
+		defaultStartToCloseTimeout,
+		defaultInitIntervalForDecisionRetry,
+		defaultInitIntervalForDecisionRetry * 2,
+		defaultInitIntervalForDecisionRetry * 4,
+		defaultMaxIntervalForDecisionRetry,
+		defaultMaxIntervalForDecisionRetry,
+		defaultMaxIntervalForDecisionRetry,
+	}
+	for i := 0; i < 8; i++ {
+		next := getNextDecisionTimeout(int64(i), defaultStartToCloseTimeout)
+		expected := expectedResult[i]
+		//print("Iter: ", i, ", Next Backoff: ", next.String(), "\n")
+		min, max := getNextBackoffRange(expected)
+		a.True(next >= min, "NextBackoff too low: actual: %v, expected: %v", next, expected)
+		a.True(next <= max, "NextBackoff too high: actual: %v, expected: %v", next, expected)
+	}
+}
+
+func getNextBackoffRange(duration time.Duration) (time.Duration, time.Duration) {
+	rangeMin := time.Duration(0.8 * float64(duration))
+	return rangeMin, duration
+}

--- a/service/history/execution/mutable_state_task_generator_test.go
+++ b/service/history/execution/mutable_state_task_generator_test.go
@@ -40,7 +40,7 @@ func TestGetNextDecisionTimeout(t *testing.T) {
 		defaultMaxIntervalForDecisionRetry,
 		defaultMaxIntervalForDecisionRetry,
 	}
-	for i := 0; i < 8; i++ {
+	for i := 0; i < len(expectedResult); i++ {
 		next := getNextDecisionTimeout(int64(i), defaultStartToCloseTimeout)
 		expected := expectedResult[i]
 		//print("Iter: ", i, ", Next Backoff: ", next.String(), "\n")
@@ -51,6 +51,6 @@ func TestGetNextDecisionTimeout(t *testing.T) {
 }
 
 func getNextBackoffRange(duration time.Duration) (time.Duration, time.Duration) {
-	rangeMin := time.Duration(0.8 * float64(duration))
+	rangeMin := time.Duration((1 - defaultJitterCoefficient) * float64(duration))
 	return rangeMin, duration
 }

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -133,7 +133,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			Persistence:            &params.PersistenceConfig,
 			ClusterMetadata:        params.ClusterMetadata,
 			TaskListScannerEnabled: dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
-			HistoryScannerEnabled:  dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
+			HistoryScannerEnabled:  dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, false),
 			ConcreteExecutionScannerConfig: &executions.ScannerWorkflowDynamicConfig{
 				Enabled:                 dc.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerEnabled, false),
 				Concurrency:             dc.GetIntProperty(dynamicconfig.ConcreteExecutionsScannerConcurrency, 25),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -133,7 +133,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			Persistence:            &params.PersistenceConfig,
 			ClusterMetadata:        params.ClusterMetadata,
 			TaskListScannerEnabled: dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
-			HistoryScannerEnabled:  dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, false),
+			HistoryScannerEnabled:  dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
 			ConcreteExecutionScannerConfig: &executions.ScannerWorkflowDynamicConfig{
 				Enabled:                 dc.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerEnabled, false),
 				Concurrency:             dc.GetIntProperty(dynamicconfig.ConcreteExecutionsScannerConcurrency, 25),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Better handling of decision task failure.

<!-- Tell your future self why have you made these changes -->
**Why?**
Right now decision task will be retried immediately if it failed. This will created a lot of load on cadence if large number of decision tasks are failing (e.g. customer rolls out a bad deployment causing workflow to panic).

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test
manual tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Worker will wait longer than expected (up to 5min) for new decision in some failure cases. 
