### PR TITLE
Make the failover end time check compatible with original value

### DIFF
--- a/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
+++ b/common/persistence/cassandra/cassandraMetadataPersistenceV2.go
@@ -434,7 +434,7 @@ func (m *cassandraMetadataPersistenceV2) GetDomain(request *p.GetDomainRequest) 
 	replicationConfig.Clusters = p.GetOrUseDefaultClusters(m.currentClusterName, replicationConfig.Clusters)
 
 	var responseFailoverEndTime *int64
-	if failoverEndTime != emptyFailoverEndTime {
+	if failoverEndTime > emptyFailoverEndTime {
 		domainFailoverEndTime := failoverEndTime
 		responseFailoverEndTime = common.Int64Ptr(domainFailoverEndTime)
 	}
@@ -515,7 +515,7 @@ func (m *cassandraMetadataPersistenceV2) ListDomains(request *p.ListDomainsReque
 			domain.ReplicationConfig.Clusters = p.DeserializeClusterConfigs(replicationClusters)
 			domain.ReplicationConfig.Clusters = p.GetOrUseDefaultClusters(m.currentClusterName, domain.ReplicationConfig.Clusters)
 
-			if failoverEndTime != emptyFailoverEndTime {
+			if failoverEndTime > emptyFailoverEndTime {
 				domainFailoverEndTime := failoverEndTime
 				domain.FailoverEndTime = common.Int64Ptr(domainFailoverEndTime)
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make the failover end time chack compatible with the original value

<!-- Tell your future self why have you made these changes -->
**Why?**
The failover endtime was set to -1 by default. The change will make -1 or 0 to be treated as empty

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

