### PR TITLE
Fix message for admin DLQ merge command

### DIFF
--- a/tools/cli/adminDLQCommands.go
+++ b/tools/cli/adminDLQCommands.go
@@ -144,10 +144,14 @@ func AdminMergeDLQMessages(c *cli.Context) {
 
 	var response *replicator.MergeDLQMessagesResponse
 	var err error
-	for response == nil || len(response.GetNextPageToken()) > 0 {
+	for {
 		response, err = adminClient.MergeDLQMessages(ctx, request)
 		if err != nil {
 			ErrorAndExit("Failed to merge DLQ message", err)
+		}
+
+		if len(response.NextPageToken) == 0 {
+			break
 		}
 
 		request.NextPageToken = response.NextPageToken


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix message for admin DLQ merge command

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently `More messages to merge` will be printed even if there's actually there's no more DLQ messages. This pr fix it.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

