### PR TITLE
Add admin list domain command

### DIFF
--- a/service/frontend/dcRedirectionHandler_test.go
+++ b/service/frontend/dcRedirectionHandler_test.go
@@ -28,11 +28,11 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/uber/cadence/common/client"
 
 	"github.com/uber/cadence/.gen/go/cadence/workflowservicetest"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -32,7 +32,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
-	"github.com/uber/cadence/common/client"
 
 	"github.com/uber/cadence/.gen/go/history/historyservicetest"
 	"github.com/uber/cadence/.gen/go/shared"
@@ -41,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/domain"
 	"github.com/uber/cadence/common/messaging"

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -342,6 +342,29 @@ func newAdminDomainCommands() []cli.Command {
 				AdminGetDomainIDOrName(c)
 			},
 		},
+		{
+			Name:    "list",
+			Aliases: []string{"l"},
+			Usage:   "List all domains in the cluster",
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  FlagPageSizeWithAlias,
+					Value: 10,
+					Usage: "Result page size",
+				},
+				cli.BoolFlag{
+					Name:  FlagAllWithAlias,
+					Usage: "List all domains, by default only domains in REGISTERED status are listed",
+				},
+				cli.BoolFlag{
+					Name:  FlagPrintFullyDetailWithAlias,
+					Usage: "Print full domain detail",
+				},
+			},
+			Action: func(c *cli.Context) {
+				newDomainCLI(c, false).ListDomains(c)
+			},
+		},
 	}
 }
 

--- a/tools/cli/util.go
+++ b/tools/cli/util.go
@@ -511,6 +511,15 @@ func mapKeysToArray(m map[string]string) []string {
 	return out
 }
 
+func mapToString(m map[string]string, sep string) string {
+	kv := make([]string, 0, len(m))
+	for key, value := range m {
+		kv = append(kv, key+": "+value)
+	}
+
+	return strings.Join(kv, sep)
+}
+
 func intSliceToSet(s []int) map[int]struct{} {
 	var ret = make(map[int]struct{}, len(s))
 	for _, v := range s {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add admin command for listing domains.
```
➜  cadence  ./cadence adm d l --ps 2 --all     
       NAME      |                 UUID                 | DOMAIN DATA |   STATUS   | IS GLOBAL DOMAIN | ACTIVE CLUSTER  
  cadence-canary | b9e0c539-2a1f-4990-b796-fd4e37e8dcd3 |             | REGISTERED | false            | active          
  cadence-system | 32049b68-7872-4094-8e63-d0dd59896a83 |             | REGISTERED | false            | active          
Press Enter to show next page, press any other key then Enter to quit: 
           NAME          |                 UUID                 |  DOMAIN DATA   |   STATUS   | IS GLOBAL DOMAIN | ACTIVE CLUSTER  
  canary-archival-domain | 2d5d4e84-850e-4193-ab53-d432ab6a3697 |                | REGISTERED | false            | active          
  samples-domain         | 6ee4e39e-41a1-4cc9-bd5d-9c575e09d807 | k1: v2, k2: v2 | REGISTERED | false            | active 
```

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/uber/cadence/issues/3392

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A. Only CLI code is changed
