### PR TITLE
Enforce re-replication context timeout for standby tasks

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -169,6 +169,7 @@ var keys = map[Key]string{
 	ActiveTaskRedispatchInterval:                          "history.activeTaskRedispatchInterval",
 	StandbyTaskRedispatchInterval:                         "history.standbyTaskRedispatchInterval",
 	TaskRedispatchIntervalJitterCoefficient:               "history.taskRedispatchIntervalJitterCoefficient",
+	StandbyTaskReReplicationContextTimeout:                "history.standbyTaskReReplicationContextTimeout",
 	QueueProcessorEnableSplit:                             "history.queueProcessorEnableSplit",
 	QueueProcessorSplitMaxLevel:                           "history.queueProcessorSplitMaxLevel",
 	QueueProcessorEnableRandomSplitByDomainID:             "history.queueProcessorEnableRandomSplitByDomainID",
@@ -567,10 +568,12 @@ const (
 	TaskSchedulerRoundRobinWeights
 	// ActiveTaskRedispatchInterval is the active task redispatch interval
 	ActiveTaskRedispatchInterval
-	// StandbyTaskRedispatchInterval is the active task redispatch interval
+	// StandbyTaskRedispatchInterval is the standby task redispatch interval
 	StandbyTaskRedispatchInterval
 	// TaskRedispatchIntervalJitterCoefficient is the task redispatch interval jitter coefficient
 	TaskRedispatchIntervalJitterCoefficient
+	// StandbyTaskReReplicationContextTimeout is the context timeout for standby task re-replication
+	StandbyTaskReReplicationContextTimeout
 	// QueueProcessorEnableSplit indicates whether processing queue split policy should be enabled
 	QueueProcessorEnableSplit
 	// QueueProcessorSplitMaxLevel is the max processing queue level

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -89,6 +89,7 @@ type Config struct {
 	ActiveTaskRedispatchInterval            dynamicconfig.DurationPropertyFn
 	StandbyTaskRedispatchInterval           dynamicconfig.DurationPropertyFn
 	TaskRedispatchIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
+	StandbyTaskReReplicationContextTimeout  dynamicconfig.DurationPropertyFnWithDomainIDFilter
 	EnableDropStuckTaskByDomainID           dynamicconfig.BoolPropertyFnWithDomainIDFilter
 
 	// QueueProcessor settings
@@ -327,6 +328,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ActiveTaskRedispatchInterval:            dc.GetDurationProperty(dynamicconfig.ActiveTaskRedispatchInterval, 5*time.Second),
 		StandbyTaskRedispatchInterval:           dc.GetDurationProperty(dynamicconfig.StandbyTaskRedispatchInterval, 30*time.Second),
 		TaskRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TimerProcessorSplitQueueIntervalJitterCoefficient, 0.15),
+		StandbyTaskReReplicationContextTimeout:  dc.GetDurationPropertyFilteredByDomainID(dynamicconfig.StandbyTaskReReplicationContextTimeout, 3*time.Minute),
 		EnableDropStuckTaskByDomainID:           dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.EnableDropStuckTaskByDomainID, false),
 
 		QueueProcessorEnableSplit:                          dc.GetBoolProperty(dynamicconfig.QueueProcessorEnableSplit, false),

--- a/service/history/timerQueueProcessor.go
+++ b/service/history/timerQueueProcessor.go
@@ -76,6 +76,7 @@ func newTimerQueueProcessor(
 
 	currentClusterName := shard.GetService().GetClusterMetadata().GetCurrentClusterName()
 	logger = logger.WithTags(tag.ComponentTimerQueue)
+	config := shard.GetConfig()
 	taskAllocator := queue.NewTaskAllocator(shard)
 
 	standbyTimerProcessors := make(map[string]*timerQueueStandbyProcessorImpl)
@@ -93,8 +94,8 @@ func newTimerQueueProcessor(
 					return historyService.ReplicateRawEvents(ctx, request)
 				},
 				shard.GetService().GetPayloadSerializer(),
-				historyRereplicationTimeout,
-				nil,
+				historyReplicationTimeout,
+				config.StandbyTaskReReplicationContextTimeout,
 				logger,
 			)
 			nDCHistoryResender := xdc.NewNDCHistoryResender(
@@ -104,7 +105,7 @@ func newTimerQueueProcessor(
 					return historyService.ReplicateEventsV2(ctx, request)
 				},
 				shard.GetService().GetPayloadSerializer(),
-				nil,
+				config.StandbyTaskReReplicationContextTimeout,
 				openExecutionCheck,
 				logger,
 			)
@@ -126,7 +127,7 @@ func newTimerQueueProcessor(
 		currentClusterName:    currentClusterName,
 		shard:                 shard,
 		taskAllocator:         taskAllocator,
-		config:                shard.GetConfig(),
+		config:                config,
 		metricsClient:         historyService.metricsClient,
 		historyService:        historyService,
 		ackLevel:              timerKey{VisibilityTimestamp: shard.GetTimerAckLevel()},

--- a/service/history/timerQueueStandbyProcessor.go
+++ b/service/history/timerQueueStandbyProcessor.go
@@ -34,7 +34,7 @@ import (
 )
 
 const (
-	historyRereplicationTimeout = 30 * time.Second
+	historyReplicationTimeout = 30 * time.Second
 )
 
 type (

--- a/service/history/transferQueueProcessor.go
+++ b/service/history/transferQueueProcessor.go
@@ -78,7 +78,9 @@ func newTransferQueueProcessor(
 
 	logger = logger.WithTags(tag.ComponentTransferQueue)
 	currentClusterName := shard.GetService().GetClusterMetadata().GetCurrentClusterName()
+	config := shard.GetConfig()
 	taskAllocator := queue.NewTaskAllocator(shard)
+
 	standbyTaskProcessors := make(map[string]*transferQueueStandbyProcessorImpl)
 	rereplicatorLogger := shard.GetLogger().WithTags(tag.ComponentHistoryReplicator)
 	resenderLogger := shard.GetLogger().WithTags(tag.ComponentHistoryResender)
@@ -96,8 +98,8 @@ func newTransferQueueProcessor(
 					return historyService.ReplicateRawEvents(ctx, request)
 				},
 				shard.GetService().GetPayloadSerializer(),
-				historyRereplicationTimeout,
-				nil,
+				historyReplicationTimeout,
+				config.StandbyTaskReReplicationContextTimeout,
 				rereplicatorLogger,
 			)
 			nDCHistoryResender := xdc.NewNDCHistoryResender(
@@ -107,7 +109,7 @@ func newTransferQueueProcessor(
 					return historyService.ReplicateEventsV2(ctx, request)
 				},
 				shard.GetService().GetPayloadSerializer(),
-				nil,
+				config.StandbyTaskReReplicationContextTimeout,
 				openExecutionCheck,
 				resenderLogger,
 			)
@@ -131,7 +133,7 @@ func newTransferQueueProcessor(
 		currentClusterName:    currentClusterName,
 		shard:                 shard,
 		taskAllocator:         taskAllocator,
-		config:                shard.GetConfig(),
+		config:                config,
 		metricsClient:         historyService.metricsClient,
 		historyService:        historyService,
 		visibilityMgr:         visibilityMgr,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Enforce re-replication context timeout for standby tasks

<!-- Tell your future self why have you made these changes -->
**Why?**
* With host level worker pool for task processing, if re-replication takes a long time, all tasks behind it may be blocked. Instead, we should enforce a timeout for re-replication, so that the task can be retried later and not blocking other tasks. 
* In the case that re-replication does need time longer than the specified timeout, the task will eventually be discarded so it won't cause any issues.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Some standby task may be retried more times or be discarded eventually. 
