### PR TITLE
Fix indexer to filter out invalid msg

### DIFF
--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -156,7 +156,10 @@ func (p *esProcessorImpl) bulkAfterAction(id int64, requests []elastic.BulkableR
 				}
 				wid, rid, domainID := p.getMsgWithInfo(key)
 				p.logger.Error("ES request failed.",
-					tag.ESResponseStatus(getErrorStatusCode(err)), tag.ESRequest(request.String()), tag.WorkflowID(wid), tag.WorkflowRunID(rid),
+					tag.ESResponseStatus(getErrorStatusCode(err)),
+					tag.ESRequest(request.String()),
+					tag.WorkflowID(wid),
+					tag.WorkflowRunID(rid),
 					tag.WorkflowDomainID(domainID))
 				p.nackKafkaMsg(key)
 			} else {

--- a/service/worker/indexer/processor.go
+++ b/service/worker/indexer/processor.go
@@ -63,6 +63,7 @@ type indexProcessor struct {
 const (
 	esDocIDDelimiter = "~"
 	esDocType        = "_doc"
+	esDocIDSizeLimit = 512
 
 	versionTypeExternal = "external"
 )
@@ -192,7 +193,15 @@ func (p *indexProcessor) deserialize(payload []byte) (*indexer.Message, error) {
 }
 
 func (p *indexProcessor) addMessageToES(indexMsg *indexer.Message, kafkaMsg messaging.Message, logger log.Logger) error {
-	docID := indexMsg.GetWorkflowID() + esDocIDDelimiter + indexMsg.GetRunID()
+	docID := generateDocID(indexMsg.GetWorkflowID(), indexMsg.GetRunID())
+	// check and skip invalid docID
+	if len(docID) >= esDocIDSizeLimit {
+		logger.Error("Index message is too long",
+			tag.WorkflowDomainID(indexMsg.GetDomainID()),
+			tag.WorkflowID(indexMsg.GetWorkflowID()),
+			tag.WorkflowRunID(indexMsg.GetRunID()))
+		return nil
+	}
 
 	var keyToKafkaMsg string
 	var req elastic.BulkableRequest
@@ -288,4 +297,8 @@ func fulfillDoc(doc map[string]interface{}, msg *indexer.Message, keyToKafkaMsg 
 	doc[definition.WorkflowID] = msg.GetWorkflowID()
 	doc[definition.RunID] = msg.GetRunID()
 	doc[definition.KafkaKey] = keyToKafkaMsg
+}
+
+func generateDocID(wid, rid string) string {
+	return wid + esDocIDDelimiter + rid
 }

--- a/service/worker/indexer/processor.go
+++ b/service/worker/indexer/processor.go
@@ -200,6 +200,7 @@ func (p *indexProcessor) addMessageToES(indexMsg *indexer.Message, kafkaMsg mess
 			tag.WorkflowDomainID(indexMsg.GetDomainID()),
 			tag.WorkflowID(indexMsg.GetWorkflowID()),
 			tag.WorkflowRunID(indexMsg.GetRunID()))
+		kafkaMsg.Nack()
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix indexer to filter out invalid msg

<!-- Tell your future self why have you made these changes -->
**Why?**
ES has a limit of 512 for docID size. Cadence use wid~rid as docID for visibility in ES, but currently do not have limit on wid size. 
For users who use advanced visibility on ES, this PR will filter out those workflow with wid too long.

Team is also considering a breaking change to limit wid in near future.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local and staging tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
For user who use advanced visibility on ES, if the wid+rid is longer than 512, it will not be searchable because of this change. 
