### PR TITLE
Make Postgres plugin update all fields on upsert collision.

### DIFF
--- a/common/persistence/sql/sqlplugin/postgres/execution_maps.go
+++ b/common/persistence/sql/sqlplugin/postgres/execution_maps.go
@@ -47,11 +47,8 @@ run_id = $4`
 VALUES
 (:shard_id, :domain_id, :workflow_id, :run_id, :%[4]v, %[3]v)
 ON CONFLICT (shard_id, domain_id, workflow_id, run_id, %[4]v) DO UPDATE 
-  SET shard_id = excluded.shard_id,
-      domain_id = excluded.domain_id,
-      workflow_id = excluded.workflow_id,
-	  run_id = excluded.run_id,
-      %[4]v = excluded.%[4]v `
+SET (shard_id, domain_id, workflow_id, run_id, %[4]v, %[2]v)
+= (:shard_id, :domain_id, :workflow_id, :run_id, :%[4]v, %[3]v)`
 
 	// %[2]v is the name of the key
 	deleteKeyInMapQueryTemplate = `DELETE FROM %[1]v


### PR DESCRIPTION
 Fixes issue #3482.

<!-- Describe what has changed in this PR -->
After an upsert collision, all fields should be updated (as if the row was newly inserted).
Example rendered SQL before:
```
INSERT INTO activity_info_maps (shard_id, domain_id, workflow_id, run_id, schedule_id, data,data_encoding,last_heartbeat_details,last_heartbeat_updated_time)
VALUES (:shard_id, :domain_id, :workflow_id, :run_id, :schedule_id, :data,:data_encoding,:last_heartbeat_details,:last_heartbeat_updated_time)
ON CONFLICT (shard_id, domain_id, workflow_id, run_id, schedule_id) DO UPDATE
SET shard_id = excluded.shard_id, domain_id = excluded.domain_id, workflow_id = excluded.workflow_id, run_id = excluded.run_id, schedule_id = excluded.schedule_id
```
After:
```
INSERT INTO activity_info_maps (shard_id, domain_id, workflow_id, run_id, schedule_id, data,data_encoding,last_heartbeat_details,last_heartbeat_updated_time)
VALUES (:shard_id, :domain_id, :workflow_id, :run_id, :schedule_id, :data,:data_encoding,:last_heartbeat_details,:last_heartbeat_updated_time)
ON CONFLICT (shard_id, domain_id, workflow_id, run_id, schedule_id) DO UPDATE
SET (shard_id, domain_id, workflow_id, run_id, schedule_id, data,data_encoding,last_heartbeat_details,last_heartbeat_updated_time)
= (:shard_id, :domain_id, :workflow_id, :run_id, :schedule_id, :data,:data_encoding,:last_heartbeat_details,:last_heartbeat_updated_time)
```
For comparison, here is the MySQL template:
```
REPLACE INTO %[1]v
(shard_id, domain_id, workflow_id, run_id, %[4]v, %[2]v)
VALUES
(:shard_id, :domain_id, :workflow_id, :run_id, :%[4]v, %[3]v)
```

<!-- Tell your future self why have you made these changes -->
Previously, the Postgres plugin was not updating all data when it should have.
See linked issue for repro case.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
I have tested locally and in our staging environment.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Worst case:  Could introduce new bugs in the Postgres plugin.