### PR TITLE
Extend activity ScheduleToClose timeout to expiration time

### DIFF
--- a/service/history/decisionChecker_test.go
+++ b/service/history/decisionChecker_test.go
@@ -600,7 +600,7 @@ func (s *decisionAttrValidatorSuite) TestValidateActivityScheduleAttributes_NoRe
 }
 
 func (s *decisionAttrValidatorSuite) TestValidateActivityScheduleAttributes_WithRetryPolicy_ScheduleToStartRetryable() {
-	wfTimeout := int32(2000)
+	wfTimeout := int32(3000)
 	attributes := &workflow.ScheduleActivityTaskDecisionAttributes{
 		ActivityId: common.StringPtr("some random activityID"),
 		ActivityType: &workflow.ActivityType{
@@ -618,7 +618,7 @@ func (s *decisionAttrValidatorSuite) TestValidateActivityScheduleAttributes_With
 		RetryPolicy: &workflow.RetryPolicy{
 			InitialIntervalInSeconds:    common.Int32Ptr(1),
 			BackoffCoefficient:          common.Float64Ptr(1.1),
-			ExpirationIntervalInSeconds: common.Int32Ptr(maximumScheduleToStartTimeoutForRetryInSeconds + 1000), // larger than wfTimeout and maximumScheduleToStartTimeoutForRetryInSeconds
+			ExpirationIntervalInSeconds: common.Int32Ptr(maximumScheduleToStartTimeoutForRetryInSeconds + 1000), // larger than maximumScheduleToStartTimeoutForRetryInSeconds
 			NonRetriableErrorReasons:    []string{"non-retryable error"},
 		},
 	}
@@ -629,7 +629,7 @@ func (s *decisionAttrValidatorSuite) TestValidateActivityScheduleAttributes_With
 		Domain:                        attributes.Domain,
 		TaskList:                      attributes.TaskList,
 		Input:                         attributes.Input,
-		ScheduleToCloseTimeoutSeconds: common.Int32Ptr(wfTimeout),
+		ScheduleToCloseTimeoutSeconds: attributes.RetryPolicy.ExpirationIntervalInSeconds,
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(maximumScheduleToStartTimeoutForRetryInSeconds),
 		StartToCloseTimeoutSeconds:    attributes.StartToCloseTimeoutSeconds,
 		HeartbeatTimeoutSeconds:       attributes.HeartbeatTimeoutSeconds,
@@ -691,7 +691,7 @@ func (s *decisionAttrValidatorSuite) TestValidateActivityScheduleAttributes_With
 		Domain:                        attributes.Domain,
 		TaskList:                      attributes.TaskList,
 		Input:                         attributes.Input,
-		ScheduleToCloseTimeoutSeconds: common.Int32Ptr(503),
+		ScheduleToCloseTimeoutSeconds: common.Int32Ptr(wfTimeout),
 		ScheduleToStartTimeoutSeconds: attributes.ScheduleToStartTimeoutSeconds,
 		StartToCloseTimeoutSeconds:    attributes.StartToCloseTimeoutSeconds,
 		HeartbeatTimeoutSeconds:       attributes.HeartbeatTimeoutSeconds,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Extend activity ScheduleToClose timeout to expiration time

<!-- Tell your future self why have you made these changes -->
**Why?**
Revert this change after https://github.com/uber-go/cadence-client/pull/1022 is landed and rolled out to all customers

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, this is the original behavior
