### PR TITLE
Enable processing queue split policy by domainID

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -173,9 +173,9 @@ var keys = map[Key]string{
 	QueueProcessorSplitMaxLevel:                           "history.queueProcessorSplitMaxLevel",
 	QueueProcessorEnableRandomSplitByDomainID:             "history.queueProcessorEnableRandomSplitByDomainID",
 	QueueProcessorRandomSplitProbability:                  "history.queueProcessorRandomSplitProbability",
-	QueueProcessorEnablePendingTaskSplit:                  "history.queueProcessorEnablePendingTaskSplit",
+	QueueProcessorEnablePendingTaskSplitByDomainID:        "history.queueProcessorEnablePendingTaskSplitByDomainID",
 	QueueProcessorPendingTaskSplitThreshold:               "history.queueProcessorPendingTaskSplitThreshold",
-	QueueProcessorEnableStuckTaskSplit:                    "history.queueProcessorEnableStuckTaskSplit",
+	QueueProcessorEnableStuckTaskSplitByDomainID:          "history.queueProcessorEnableStuckTaskSplitByDomainID",
 	QueueProcessorStuckTaskSplitThreshold:                 "history.queueProcessorStuckTaskSplitThreshold",
 	QueueProcessorSplitLookAheadDurationByDomainID:        "history.queueProcessorSplitLookAheadDurationByDomainID",
 	QueueProcessorPollBackoffInterval:                     "history.queueProcessorPollBackoffInterval",
@@ -579,12 +579,12 @@ const (
 	QueueProcessorEnableRandomSplitByDomainID
 	// QueueProcessorRandomSplitProbability is the probability for a domain to be split to a new processing queue
 	QueueProcessorRandomSplitProbability
-	// QueueProcessorEnablePendingTaskSplit indicates whether pending task split policy should be enabled
-	QueueProcessorEnablePendingTaskSplit
+	// QueueProcessorEnablePendingTaskSplitByDomainID indicates whether pending task split policy should be enabled
+	QueueProcessorEnablePendingTaskSplitByDomainID
 	// QueueProcessorPendingTaskSplitThreshold is the threshold for the number of pending tasks per domain
 	QueueProcessorPendingTaskSplitThreshold
-	// QueueProcessorEnableStuckTaskSplit indicates whether stuck task split policy should be enabled
-	QueueProcessorEnableStuckTaskSplit
+	// QueueProcessorEnableStuckTaskSplitByDomainID indicates whether stuck task split policy should be enabled
+	QueueProcessorEnableStuckTaskSplitByDomainID
 	// QueueProcessorStuckTaskSplitThreshold is the threshold for the number of attempts of a task
 	QueueProcessorStuckTaskSplitThreshold
 	// QueueProcessorSplitLookAheadDurationByDomainID is the look ahead duration when spliting a domain to a new processing queue

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -96,9 +96,9 @@ type Config struct {
 	QueueProcessorSplitMaxLevel                        dynamicconfig.IntPropertyFn
 	QueueProcessorEnableRandomSplitByDomainID          dynamicconfig.BoolPropertyFnWithDomainIDFilter
 	QueueProcessorRandomSplitProbability               dynamicconfig.FloatPropertyFn
-	QueueProcessorEnablePendingTaskSplit               dynamicconfig.BoolPropertyFn
+	QueueProcessorEnablePendingTaskSplitByDomainID     dynamicconfig.BoolPropertyFnWithDomainIDFilter
 	QueueProcessorPendingTaskSplitThreshold            dynamicconfig.MapPropertyFn
-	QueueProcessorEnableStuckTaskSplit                 dynamicconfig.BoolPropertyFn
+	QueueProcessorEnableStuckTaskSplitByDomainID       dynamicconfig.BoolPropertyFnWithDomainIDFilter
 	QueueProcessorStuckTaskSplitThreshold              dynamicconfig.MapPropertyFn
 	QueueProcessorSplitLookAheadDurationByDomainID     dynamicconfig.DurationPropertyFnWithDomainIDFilter
 	QueueProcessorPollBackoffInterval                  dynamicconfig.DurationPropertyFn
@@ -333,9 +333,9 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		QueueProcessorSplitMaxLevel:                        dc.GetIntProperty(dynamicconfig.QueueProcessorSplitMaxLevel, 2), // 3 levels, start from 0
 		QueueProcessorEnableRandomSplitByDomainID:          dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.QueueProcessorEnableRandomSplitByDomainID, false),
 		QueueProcessorRandomSplitProbability:               dc.GetFloat64Property(dynamicconfig.QueueProcessorRandomSplitProbability, 0.01),
-		QueueProcessorEnablePendingTaskSplit:               dc.GetBoolProperty(dynamicconfig.QueueProcessorEnablePendingTaskSplit, false),
+		QueueProcessorEnablePendingTaskSplitByDomainID:     dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.QueueProcessorEnablePendingTaskSplitByDomainID, false),
 		QueueProcessorPendingTaskSplitThreshold:            dc.GetMapProperty(dynamicconfig.QueueProcessorPendingTaskSplitThreshold, common.ConvertIntMapToDynamicConfigMapProperty(DefaultPendingTaskSplitThreshold)),
-		QueueProcessorEnableStuckTaskSplit:                 dc.GetBoolProperty(dynamicconfig.QueueProcessorEnableStuckTaskSplit, false),
+		QueueProcessorEnableStuckTaskSplitByDomainID:       dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.QueueProcessorEnableStuckTaskSplitByDomainID, false),
 		QueueProcessorStuckTaskSplitThreshold:              dc.GetMapProperty(dynamicconfig.QueueProcessorStuckTaskSplitThreshold, common.ConvertIntMapToDynamicConfigMapProperty(DefaultStuckTaskSplitThreshold)),
 		QueueProcessorSplitLookAheadDurationByDomainID:     dc.GetDurationPropertyFilteredByDomainID(dynamicconfig.QueueProcessorSplitLookAheadDurationByDomainID, 20*time.Minute),
 		QueueProcessorPollBackoffInterval:                  dc.GetDurationProperty(dynamicconfig.QueueProcessorPollBackoffInterval, 5*time.Second),

--- a/service/history/queue/split_policy_test.go
+++ b/service/history/queue/split_policy_test.go
@@ -81,6 +81,7 @@ func (s *splitPolicySuite) TestPendingTaskSplitPolicy() {
 	}
 	pendingTaskSplitPolicy := NewPendingTaskSplitPolicy(
 		pendingTaskThreshold,
+		dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
 		lookAheadFunc,
 		maxNewQueueLevel,
 		s.logger,
@@ -288,6 +289,7 @@ func (s *splitPolicySuite) TestStuckTaskSplitPolicy() {
 
 	stuckTaskSplitPolicy := NewStuckTaskSplitPolicy(
 		attemptThreshold,
+		dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
 		maxNewQueueLevel,
 		s.logger,
 		s.metricsScope,

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -656,9 +656,9 @@ func newTimerQueueProcessorOptions(
 		options.SplitMaxLevel = config.QueueProcessorSplitMaxLevel
 		options.EnableRandomSplitByDomainID = config.QueueProcessorEnableRandomSplitByDomainID
 		options.RandomSplitProbability = config.QueueProcessorRandomSplitProbability
-		options.EnablePendingTaskSplit = config.QueueProcessorEnablePendingTaskSplit
+		options.EnablePendingTaskSplitByDomainID = config.QueueProcessorEnablePendingTaskSplitByDomainID
 		options.PendingTaskSplitThreshold = config.QueueProcessorPendingTaskSplitThreshold
-		options.EnableStuckTaskSplit = config.QueueProcessorEnableStuckTaskSplit
+		options.EnableStuckTaskSplitByDomainID = config.QueueProcessorEnableStuckTaskSplitByDomainID
 		options.StuckTaskSplitThreshold = config.QueueProcessorStuckTaskSplitThreshold
 		options.SplitLookAheadDurationByDomainID = config.QueueProcessorSplitLookAheadDurationByDomainID
 	}

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -463,9 +463,9 @@ func newTransferQueueProcessorOptions(
 		options.SplitMaxLevel = config.QueueProcessorSplitMaxLevel
 		options.EnableRandomSplitByDomainID = config.QueueProcessorEnableRandomSplitByDomainID
 		options.RandomSplitProbability = config.QueueProcessorRandomSplitProbability
-		options.EnablePendingTaskSplit = config.QueueProcessorEnablePendingTaskSplit
+		options.EnablePendingTaskSplitByDomainID = config.QueueProcessorEnablePendingTaskSplitByDomainID
 		options.PendingTaskSplitThreshold = config.QueueProcessorPendingTaskSplitThreshold
-		options.EnableStuckTaskSplit = config.QueueProcessorEnableStuckTaskSplit
+		options.EnableStuckTaskSplitByDomainID = config.QueueProcessorEnableStuckTaskSplitByDomainID
 		options.StuckTaskSplitThreshold = config.QueueProcessorStuckTaskSplitThreshold
 		options.SplitLookAheadDurationByDomainID = config.QueueProcessorSplitLookAheadDurationByDomainID
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change feature flag for enabling different kinds of split policy to be ones filtered by domainID. 

<!-- Tell your future self why have you made these changes -->
**Why?**
so that we can only enable split policy for certain domains, in case most of them get split

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Will test on staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, disabled by default
