### PR TITLE
Start queue processor before failover callback registration

### DIFF
--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -367,7 +367,7 @@ func (c *Collection) GetBoolPropertyFilteredByDomain(key Key, defaultValue bool)
 // GetBoolPropertyFilteredByDomainID gets property with domainID filter and asserts that it's a bool
 func (c *Collection) GetBoolPropertyFilteredByDomainID(key Key, defaultValue bool) BoolPropertyFnWithDomainIDFilter {
 	return func(domainID string) bool {
-		val, err := c.client.GetBoolValue(key, getFilterMap(DomainFilter(domainID)), defaultValue)
+		val, err := c.client.GetBoolValue(key, getFilterMap(DomainIDFilter(domainID)), defaultValue)
 		if err != nil {
 			c.logError(key, err)
 		}

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -387,10 +387,10 @@ func (e *historyEngineImpl) Start() {
 	e.logger.Info("History engine state changed", tag.LifeCycleStarting)
 	defer e.logger.Info("History engine state changed", tag.LifeCycleStarted)
 
-	e.registerDomainFailoverCallback()
-
 	e.txProcessor.Start()
 	e.timerProcessor.Start()
+
+	e.registerDomainFailoverCallback()
 
 	clusterMetadata := e.shard.GetClusterMetadata()
 	if e.replicatorProcessor != nil && clusterMetadata.GetReplicationConsumerConfig().Type != sconfig.ReplicationConsumerTypeRPC {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -390,6 +390,11 @@ func (e *historyEngineImpl) Start() {
 	e.txProcessor.Start()
 	e.timerProcessor.Start()
 
+	// failover callback will try to create a failover queue processor to scan all inflight tasks
+	// if domain needs to be failovered. However, in the multicursor queue logic, the scan range
+	// can't be retrieved before the processor is started. If failover callback is registered
+	// before queue processor is started, it may result in a deadline as to create the failover queue,
+	// queue processor need to be started.
 	e.registerDomainFailoverCallback()
 
 	clusterMetadata := e.shard.GetClusterMetadata()

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -241,6 +241,9 @@ func (t *timerQueueProcessor) NotifyNewTask(
 func (t *timerQueueProcessor) FailoverDomain(
 	domainIDs map[string]struct{},
 ) {
+	// Failover queue is used to scan all inflight tasks, if queue processor is not
+	// started, there's no inflight task and we don't need to create a failover processor.
+	// Also the HandleAction will be blocked if queue processor processing loop is not running.
 	if atomic.LoadInt32(&t.status) != common.DaemonStatusStarted {
 		return
 	}

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -241,6 +241,10 @@ func (t *timerQueueProcessor) NotifyNewTask(
 func (t *timerQueueProcessor) FailoverDomain(
 	domainIDs map[string]struct{},
 ) {
+	if atomic.LoadInt32(&t.status) != common.DaemonStatusStarted {
+		return
+	}
+
 	minLevel := t.shard.GetTimerClusterAckLevel(t.currentClusterName)
 	standbyClusterName := t.currentClusterName
 	for clusterName, info := range t.shard.GetClusterMetadata().GetAllClusterInfo() {

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -254,6 +254,10 @@ func (t *transferQueueProcessor) NotifyNewTask(
 func (t *transferQueueProcessor) FailoverDomain(
 	domainIDs map[string]struct{},
 ) {
+	if atomic.LoadInt32(&t.status) != common.DaemonStatusStarted {
+		return
+	}
+
 	minLevel := t.shard.GetTransferClusterAckLevel(t.currentClusterName)
 	standbyClusterName := t.currentClusterName
 	for clusterName, info := range t.shard.GetService().GetClusterMetadata().GetAllClusterInfo() {

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -254,6 +254,9 @@ func (t *transferQueueProcessor) NotifyNewTask(
 func (t *transferQueueProcessor) FailoverDomain(
 	domainIDs map[string]struct{},
 ) {
+	// Failover queue is used to scan all inflight tasks, if queue processor is not
+	// started, there's no inflight task and we don't need to create a failover processor.
+	// Also the HandleAction will be blocked if queue processor processing loop is not running.
 	if atomic.LoadInt32(&t.status) != common.DaemonStatusStarted {
 		return
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Start queue processor before failover callback registration

<!-- Tell your future self why have you made these changes -->
**Why?**
Failover callback will try to create a failover queue processor for domains that need to be failover. On host start, the process can happen before tx or timer queue is started. 

In new queue processor logic, queue readlevel(which will be used as max level for failover queue) can't be retrieved before queue processor is started, and failover callback registration will be blocked. 

When tx or timer queue is not started, we don't need failover processor at all because we don't need to scan any tasks. Also we can start the queue processor before failover callback is registered to avoid the deadlock.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested in staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Tasks get dropped when domain tries to failover while there are shard movements.
