### PR TITLE
Fix NDC resetter persistence bugs

### DIFF
--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -285,7 +285,7 @@ func (r *workflowResetterImpl) persistToDB(
 	if err != nil {
 		return err
 	}
-	resetHistorySize, err := resetWorkflow.GetContext().PersistFirstWorkflowEvents(resetWorkflowEventsSeq[0])
+	resetHistorySize, err := resetWorkflow.GetContext().PersistNonFirstWorkflowEvents(resetWorkflowEventsSeq[0])
 	if err != nil {
 		return err
 	}
@@ -312,7 +312,7 @@ func (r *workflowResetterImpl) replayResetWorkflow(
 	resetRequestID string,
 ) (execution.Workflow, error) {
 
-	resetBranchToken, err := r.generateBranchToken(
+	resetBranchToken, err := r.forkAndGenerateBranchToken(
 		domainID,
 		workflowID,
 		baseBranchToken,
@@ -399,7 +399,7 @@ func (r *workflowResetterImpl) failInflightActivity(
 	return nil
 }
 
-func (r *workflowResetterImpl) generateBranchToken(
+func (r *workflowResetterImpl) forkAndGenerateBranchToken(
 	domainID string,
 	workflowID string,
 	forkBranchToken []byte,

--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -285,6 +285,11 @@ func (r *workflowResetterImpl) persistToDB(
 	if err != nil {
 		return err
 	}
+	if len(resetWorkflowEventsSeq) != 1{
+		return &shared.InternalServiceError{
+			Message: "there should be EXACTLY one batch of events for reset",
+		}
+	}
 	resetHistorySize, err := resetWorkflow.GetContext().PersistNonFirstWorkflowEvents(resetWorkflowEventsSeq[0])
 	if err != nil {
 		return err

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -191,7 +191,7 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 		gomock.Any(),
 		execution.TransactionPolicyActive,
 	).Return(resetSnapshot, resetEventsSeq, nil).Times(1)
-	resetContext.EXPECT().PersistFirstWorkflowEvents(resetEventsSeq[0]).Return(resetEventsSize, nil).Times(1)
+	resetContext.EXPECT().PersistNonFirstWorkflowEvents(resetEventsSeq[0]).Return(resetEventsSize, nil).Times(1)
 	resetContext.EXPECT().CreateWorkflowExecution(
 		resetSnapshot,
 		resetEventsSize,

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -312,7 +312,7 @@ func (s *workflowResetterSuite) TestGenerateBranchToken() {
 		ShardID:         common.IntPtr(s.mockShard.GetShardID()),
 	}).Return(&persistence.ForkHistoryBranchResponse{NewBranchToken: resetBranchToken}, nil).Times(1)
 
-	newBranchToken, err := s.workflowResetter.generateBranchToken(
+	newBranchToken, err := s.workflowResetter.forkAndGenerateBranchToken(
 		s.domainID, s.workflowID, baseBranchToken, baseNodeID, s.resetRunID,
 	)
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Resetter call `PersistNonFirstWorkflowEvents` instead of `PersistFirstWorkflowEvents`
2. SqlExecutionManager allows CreateWorkflowModeContinueAsNew in `createWorkflowExecutionTx`

<!-- Tell your future self why have you made these changes -->
**Why?**
Without the change reset won't work in SQLin NDC path

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
TODO

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk as they are bug fix. 
