### PR TITLE
k8s: fix cassandra-tool env key conflict with k8s

### DIFF
--- a/cmd/tools/cassandra/main.go
+++ b/cmd/tools/cassandra/main.go
@@ -27,5 +27,8 @@ import (
 )
 
 func main() {
-	cassandra.RunTool(os.Args) //nolint:errcheck
+	err := cassandra.RunTool(os.Args)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -30,5 +30,8 @@ import (
 // See cadence/tools/cli/README.md for usage
 func main() {
 	app := cli.NewCliApp()
-	app.Run(os.Args)
+	err := app.Run(os.Args)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/cmd/tools/sql/main.go
+++ b/cmd/tools/sql/main.go
@@ -29,5 +29,8 @@ import (
 )
 
 func main() {
-	sql.RunTool(os.Args) //nolint:errcheck
+	err := sql.RunTool(os.Args)
+	if err != nil {
+		panic(err)
+	}
 }

--- a/environment/env.go
+++ b/environment/env.go
@@ -33,7 +33,7 @@ const (
 	// CassandraSeeds env
 	CassandraSeeds = "CASSANDRA_SEEDS"
 	// CassandraPort env
-	CassandraPort = "CASSANDRA_PORT"
+	CassandraPort = "CASSANDRA_DB_PORT"
 	// CassandraDefaultPort Cassandra default port
 	CassandraDefaultPort = "9042"
 

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -73,7 +73,7 @@ func buildCLIOptions() *cli.App {
 			Name:   schema.CLIFlagPort,
 			Value:  defaultCassandraPort,
 			Usage:  "Port of cassandra host to connect to",
-			EnvVar: "CASSANDRA_PORT",
+			EnvVar: "CASSANDRA_DB_PORT",
 		},
 		cli.StringFlag{
 			Name:   schema.CLIFlagUser,


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
1.here I just raplace the CASSANDRA_PORT to CASSANDRA_DB_PORT, to avoid
use the same key with k8s. Or is there any key more fit?


<!-- Tell your future self why have you made these changes -->
**Why?**
1.the default CASSANDRA_PORT key is used by k8s when you have an
service pod named cassandra(k8s will gen a env key which is name_port).
And the CASSANDRA_PORT has valid value which is an url, cannot be i
parsed to an int value. Finally, the cadence-cassandra-tool can not be
executed. Candence cannot work well when need cadence-canssandra.



