### PR TITLE
Refactor persistence tests to move cassandra specifics out of common

### DIFF
--- a/common/domain/handler_GlobalDomainDisabled_test.go
+++ b/common/domain/handler_GlobalDomainDisabled_test.go
@@ -69,7 +69,7 @@ func (s *domainHandlerGlobalDomainDisabledSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(false, false),
 	})
 	s.TestBase.Setup()

--- a/common/domain/handler_GlobalDomainEnabled_MasterCluster_test.go
+++ b/common/domain/handler_GlobalDomainEnabled_MasterCluster_test.go
@@ -70,7 +70,7 @@ func (s *domainHandlerGlobalDomainEnabledMasterClusterSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true, true),
 	})
 	s.TestBase.Setup()

--- a/common/domain/handler_GlobalDomainEnabled_NotMasterCluster_test.go
+++ b/common/domain/handler_GlobalDomainEnabled_NotMasterCluster_test.go
@@ -70,7 +70,7 @@ func (s *domainHandlerGlobalDomainEnabledNotMasterClusterSuite) SetupSuite() {
 		log.SetOutput(os.Stdout)
 	}
 
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true, false),
 	})
 	s.TestBase.Setup()

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -56,7 +56,7 @@ func (s *domainReplicationTaskExecutorSuite) TearDownSuite() {
 }
 
 func (s *domainReplicationTaskExecutorSuite) SetupTest() {
-	s.TestBase = persistencetests.NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
+	s.TestBase = NewTestBaseWithCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
 	zapLogger, err := zap.NewDevelopment()
 	s.Require().NoError(err)

--- a/common/persistence/cassandra/cassandra_test.go
+++ b/common/persistence/cassandra/cassandra_test.go
@@ -18,66 +18,86 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package persistencetests
+package cassandra_test
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
+
+	"github.com/uber/cadence/common/persistence/cassandra"
+	pt "github.com/uber/cadence/common/persistence/persistence-tests"
 )
 
+// NewTestBaseWithCassandra returns a persistence test base backed by cassandra datastore
+func NewTestBaseWithCassandra(options *pt.TestBaseOptions) pt.TestBase {
+	if options.DBName == "" {
+		options.DBName = "test_" + pt.GenerateRandomDBName(10)
+	}
+	testCluster := cassandra.NewTestCluster(
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+	)
+
+	return pt.NewTestBase(options, testCluster)
+}
+
 func TestCassandraHistoryV2Persistence(t *testing.T) {
-	s := new(HistoryV2PersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.HistoryV2PersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraMatchingPersistence(t *testing.T) {
-	s := new(MatchingPersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.MatchingPersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraMetadataPersistenceV2(t *testing.T) {
-	s := new(MetadataPersistenceSuiteV2)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.MetadataPersistenceSuiteV2)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraShardPersistence(t *testing.T) {
-	s := new(ShardPersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.ShardPersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraVisibilityPersistence(t *testing.T) {
-	s := new(VisibilityPersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.VisibilityPersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraExecutionManager(t *testing.T) {
-	s := new(ExecutionManagerSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.ExecutionManagerSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestCassandraExecutionManagerWithEventsV2(t *testing.T) {
-	s := new(ExecutionManagerSuiteForEventsV2)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.ExecutionManagerSuiteForEventsV2)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestQueuePersistence(t *testing.T) {
-	s := new(QueuePersistenceSuite)
-	s.TestBase = NewTestBaseWithCassandra(&TestBaseOptions{})
+	s := new(pt.QueuePersistenceSuite)
+	s.TestBase = NewTestBaseWithCassandra(&pt.TestBaseOptions{})
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -41,9 +41,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	p "github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/cassandra"
 	"github.com/uber/cadence/common/persistence/client"
-	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/service/config"
 )
@@ -107,37 +105,8 @@ const (
 	defaultScheduleToStartTimeout = 111
 )
 
-// NewTestBaseWithCassandra returns a persistence test base backed by cassandra datastore
-func NewTestBaseWithCassandra(options *TestBaseOptions) TestBase {
-	if options.DBName == "" {
-		options.DBName = "test_" + GenerateRandomDBName(10)
-	}
-	testCluster := cassandra.NewTestCluster(options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir)
-	return newTestBase(options, testCluster)
-}
-
-// NewTestBaseWithSQL returns a new persistence test base backed by SQL
-func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
-	if options.DBName == "" {
-		options.DBName = "test_" + GenerateRandomDBName(10)
-	}
-	testCluster := sql.NewTestCluster(options.SQLDBPluginName, options.DBName, options.DBUsername, options.DBPassword, options.DBHost, options.DBPort, options.SchemaDir)
-	return newTestBase(options, testCluster)
-}
-
-// NewTestBase returns a persistence test base backed by either cassandra or sql
-func NewTestBase(options *TestBaseOptions) TestBase {
-	switch options.StoreType {
-	case config.StoreTypeSQL:
-		return NewTestBaseWithSQL(options)
-	case config.StoreTypeCassandra:
-		return NewTestBaseWithCassandra(options)
-	default:
-		panic("invalid storeType " + options.StoreType)
-	}
-}
-
-func newTestBase(options *TestBaseOptions, testCluster PersistenceTestCluster) TestBase {
+// NewTestBase creates a new test base for persitence tests
+func NewTestBase(options *TestBaseOptions, testCluster PersistenceTestCluster) TestBase {
 	metadata := options.ClusterMetadata
 	if metadata == nil {
 		metadata = cluster.GetTestClusterMetadata(false, false)

--- a/common/persistence/sql/sqlplugin/mysql/mysql_server_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/mysql_server_test.go
@@ -23,63 +23,81 @@ package mysql
 import (
 	"testing"
 
+	"github.com/uber/cadence/common/persistence/sql"
+
 	"github.com/stretchr/testify/suite"
 
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
 )
 
+func NewTestBaseWithSQL(options *pt.TestBaseOptions) pt.TestBase {
+	if options.DBName == "" {
+		options.DBName = "test_" + pt.GenerateRandomDBName(10)
+	}
+	testCluster := sql.NewTestCluster(
+		options.SQLDBPluginName,
+		options.DBName,
+		options.DBUsername,
+		options.DBPassword,
+		options.DBHost,
+		options.DBPort,
+		options.SchemaDir,
+	)
+	return pt.NewTestBase(options, testCluster)
+}
+
 func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
 	s := new(pt.HistoryV2PersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLMatchingPersistenceSuite(t *testing.T) {
 	s := new(pt.MatchingPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
 	s := new(pt.MetadataPersistenceSuiteV2)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLShardPersistenceSuite(t *testing.T) {
 	s := new(pt.ShardPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLExecutionManagerSuite(t *testing.T) {
 	s := new(pt.ExecutionManagerSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
 	s := new(pt.ExecutionManagerSuiteForEventsV2)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLVisibilityPersistenceSuite(t *testing.T) {
 	s := new(pt.VisibilityPersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
 
 func TestSQLQueuePersistence(t *testing.T) {
 	s := new(pt.QueuePersistenceSuite)
-	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase = NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -21,6 +21,7 @@
 package host
 
 import (
+	"github.com/uber/cadence/common/persistence/cassandra"
 	"io/ioutil"
 	"os"
 
@@ -133,7 +134,15 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 		options.Persistence.SchemaDir = ops.SchemaDir
 	}
 	options.Persistence.ClusterMetadata = clusterMetadata
-	testBase := persistencetests.NewTestBase(&options.Persistence)
+	testCluster := cassandra.NewTestCluster(
+		options.Persistence.DBName,
+		options.Persistence.DBUsername,
+		options.Persistence.DBPassword,
+		options.Persistence.DBHost,
+		options.Persistence.DBPort,
+		options.Persistence.SchemaDir,
+	)
+	testBase := persistencetests.NewTestBase(&options.Persistence, testCluster)
 	testBase.Setup()
 	setupShards(testBase, options.HistoryConfig.NumHistoryShards, logger)
 	archiverBase := newArchiverBase(options.EnableArchival, logger)


### PR DESCRIPTION
Please refer to: https://github.com/uber/cadence/pull/3261 for details. 