### PR TITLE
Multicursor Queue Processor Improvements

### DIFF
--- a/service/history/queue/split_policy.go
+++ b/service/history/queue/split_policy.go
@@ -27,6 +27,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/service/dynamicconfig"
+	t "github.com/uber/cadence/common/task"
 	"github.com/uber/cadence/service/history/task"
 )
 
@@ -186,7 +187,9 @@ func (p *pendingTaskSplitPolicy) Evaluate(
 
 	pendingTasksPerDomain := make(map[string]int) // domainID -> # of pending tasks
 	for _, task := range queueImpl.outstandingTasks {
-		pendingTasksPerDomain[task.GetDomainID()]++
+		if task.State() != t.TaskStateAcked {
+			pendingTasksPerDomain[task.GetDomainID()]++
+		}
 	}
 
 	domainToSplit := make(map[string]struct{})

--- a/service/history/queue/split_policy_test.go
+++ b/service/history/queue/split_policy_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/service/dynamicconfig"
+	t "github.com/uber/cadence/common/task"
 	"github.com/uber/cadence/service/history/task"
 )
 
@@ -263,6 +264,7 @@ func (s *splitPolicySuite) TestPendingTaskSplitPolicy() {
 			for i := 0; i != numPendingTasks; i++ {
 				mockTask := task.NewMockTask(s.controller)
 				mockTask.EXPECT().GetDomainID().Return(domainID).MaxTimes(1)
+				mockTask.EXPECT().State().Return(t.TaskStatePending).MaxTimes(1)
 				outstandingTasks[task.NewMockKey(s.controller)] = mockTask
 			}
 		}

--- a/service/history/queue/timer_queue_processor_base_test.go
+++ b/service/history/queue/timer_queue_processor_base_test.go
@@ -234,7 +234,6 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_NoNext
 
 	readLevel := newTimerTaskKey(time.Now().Add(-10*time.Second), 0)
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
-	lookAheadMaxLevel := newTimerTaskKey(time.Now().Add(10*time.Second), 0)
 
 	request := &persistence.GetTimerIndexTasksRequest{
 		MinTimestamp:  readLevel.(timerTaskKey).visibilityTimestamp,
@@ -245,7 +244,7 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_NoNext
 
 	lookAheadRequest := &persistence.GetTimerIndexTasksRequest{
 		MinTimestamp:  maxReadLevel.(timerTaskKey).visibilityTimestamp,
-		MaxTimestamp:  lookAheadMaxLevel.(timerTaskKey).visibilityTimestamp,
+		MaxTimestamp:  maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp,
 		BatchSize:     1,
 		NextPageToken: nil,
 	}
@@ -272,7 +271,7 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_NoNext
 	mockExecutionMgr.On("GetTimerIndexTasks", lookAheadRequest).Return(&persistence.GetTimerIndexTasksResponse{}, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken, lookAheadMaxLevel)
+	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
 	s.Equal(response.Timers, filteredTasks)
 	s.Nil(lookAheadTask)
@@ -285,7 +284,6 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_HasNex
 
 	readLevel := newTimerTaskKey(time.Now().Add(-10*time.Second), 0)
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
-	lookAheadMaxLevel := newTimerTaskKey(time.Now().Add(10*time.Second), 0)
 
 	request := &persistence.GetTimerIndexTasksRequest{
 		MinTimestamp:  readLevel.(timerTaskKey).visibilityTimestamp,
@@ -315,7 +313,7 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_HasNex
 	mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken, lookAheadMaxLevel)
+	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
 	s.Equal(response.Timers, filteredTasks)
 	s.Nil(lookAheadTask)
@@ -328,7 +326,6 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_NoNex
 
 	readLevel := newTimerTaskKey(time.Now().Add(-10*time.Second), 0)
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
-	lookAheadMaxLevel := newTimerTaskKey(time.Now().Add(10*time.Second), 0)
 
 	request := &persistence.GetTimerIndexTasksRequest{
 		MinTimestamp:  readLevel.(timerTaskKey).visibilityTimestamp,
@@ -369,7 +366,7 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_NoNex
 	mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken, lookAheadMaxLevel)
+	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
 	s.Equal([]*persistence.TimerTaskInfo{response.Timers[0]}, filteredTasks)
 	s.Equal(response.Timers[1], lookAheadTask)
@@ -382,7 +379,6 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_HasNe
 
 	readLevel := newTimerTaskKey(time.Now().Add(-10*time.Second), 0)
 	maxReadLevel := newTimerTaskKey(time.Now().Add(1*time.Second), 0)
-	lookAheadMaxLevel := newTimerTaskKey(time.Now().Add(10*time.Second), 0)
 
 	request := &persistence.GetTimerIndexTasksRequest{
 		MinTimestamp:  readLevel.(timerTaskKey).visibilityTimestamp,
@@ -423,7 +419,7 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_HasNe
 	mockExecutionMgr.On("GetTimerIndexTasks", request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken, lookAheadMaxLevel)
+	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
 	s.Equal([]*persistence.TimerTaskInfo{response.Timers[0]}, filteredTasks)
 	s.Equal(response.Timers[1], lookAheadTask)
@@ -731,7 +727,7 @@ func (s *timerQueueProcessorBaseSuite) TestProcessBatch_NoNextPage_NoLookAhead()
 
 	lookAheadRequest := &persistence.GetTimerIndexTasksRequest{
 		MinTimestamp:  shardMaxReadLevel.(timerTaskKey).visibilityTimestamp,
-		MaxTimestamp:  maxLevel.(timerTaskKey).visibilityTimestamp,
+		MaxTimestamp:  maximumTimerTaskKey.(timerTaskKey).visibilityTimestamp,
 		BatchSize:     1,
 		NextPageToken: nil,
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Simplify timer task look ahead logic 
* Only count pending tasks in pendingTaskSplitPolicy
* Cap max transfer task look ahead during split

<!-- Tell your future self why have you made these changes -->
**Why?**
* Make code simpler
* Make pendingTaskSplitPolicy threshold more accurate
* When rangeID is renewed, taskID will increase by a large number, we don't want to take that into account when calculating look ahead for transfer queue

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Feature flag disabled
