### PR TITLE
Move sql connection interface to plugin level

### DIFF
--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -749,11 +749,4 @@ type (
 		PluginName() string
 		Close() error
 	}
-	// Conn defines the API for a single database connection
-	Conn interface {
-		Exec(query string, args ...interface{}) (sql.Result, error)
-		NamedExec(query string, arg interface{}) (sql.Result, error)
-		Get(dest interface{}, query string, args ...interface{}) error
-		Select(dest interface{}, query string, args ...interface{}) error
-	}
 )

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -21,19 +21,29 @@
 package mysql
 
 import (
+	"database/sql"
+
 	"github.com/go-sql-driver/mysql"
 	"github.com/jmoiron/sqlx"
 
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
 
-// db represents a logical connection to mysql database
-type db struct {
-	db        *sqlx.DB
-	tx        *sqlx.Tx
-	conn      sqlplugin.Conn
-	converter DataConverter
-}
+type (
+	db struct {
+		db        *sqlx.DB
+		tx        *sqlx.Tx
+		converter DataConverter
+		conn      conn
+	}
+
+	conn interface {
+		Exec(query string, args ...interface{}) (sql.Result, error)
+		NamedExec(query string, arg interface{}) (sql.Result, error)
+		Get(dest interface{}, query string, args ...interface{}) error
+		Select(dest interface{}, query string, args ...interface{}) error
+	}
+)
 
 var _ sqlplugin.AdminDB = (*db)(nil)
 var _ sqlplugin.DB = (*db)(nil)
@@ -51,13 +61,16 @@ func (mdb *db) IsDupEntryError(err error) bool {
 // newDB returns an instance of DB, which is a logical
 // connection to the underlying mysql database
 func newDB(xdb *sqlx.DB, tx *sqlx.Tx) *db {
-	mdb := &db{db: xdb, tx: tx}
-	mdb.conn = xdb
-	if tx != nil {
-		mdb.conn = tx
+	db := &db{
+		db:        xdb,
+		tx:        tx,
+		converter: &converter{},
+		conn:      xdb,
 	}
-	mdb.converter = &converter{}
-	return mdb
+	if tx != nil {
+		db.conn = tx
+	}
+	return db
 }
 
 // BeginTx starts a new transaction and returns a reference to the Tx object


### PR DESCRIPTION
The connection interface being defined at the level of sql rather than plugin is confusing because it makes it seems like a plugin would have to be able to implement this interface. When in actuality as long as a plugin can implement the adminCrud interface it will work. The connection interface is simply an implementation detail of how MySQL and Postgres happen to implement the crud interface. 
