### PR TITLE
Support context in Cassandra history

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/events.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/events.go
@@ -76,7 +76,7 @@ func (db *cdb) InsertIntoHistoryTreeAndNode(ctx context.Context, treeRow *nosqlp
 	var err error
 	if treeRow != nil && nodeRow != nil {
 		// Note: for perf, prefer using batch for inserting more than one records
-		batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx).WithContext(ctx)
+		batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 		batch.Query(v2templateInsertTree,
 			treeRow.TreeID, treeRow.BranchID, ancs, treeRow.CreateTimestampMilliseconds, treeRow.Info)
 		batch.Query(v2templateUpsertData,

--- a/common/persistence/nosql/nosqlplugin/cassandra/events.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/events.go
@@ -21,6 +21,7 @@
 package cassandra
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"time"
@@ -57,7 +58,7 @@ const (
 )
 
 // InsertIntoHistoryTreeAndNode inserts one or two rows: tree row and node row(at least one of them)
-func (db *cdb) InsertIntoHistoryTreeAndNode(treeRow *nosqlplugin.HistoryTreeRow, nodeRow *nosqlplugin.HistoryNodeRow) error {
+func (db *cdb) InsertIntoHistoryTreeAndNode(ctx context.Context, treeRow *nosqlplugin.HistoryTreeRow, nodeRow *nosqlplugin.HistoryNodeRow) error {
 	if treeRow == nil && nodeRow == nil {
 		return fmt.Errorf("require at least a tree row or a node row to insert")
 	}
@@ -75,7 +76,7 @@ func (db *cdb) InsertIntoHistoryTreeAndNode(treeRow *nosqlplugin.HistoryTreeRow,
 	var err error
 	if treeRow != nil && nodeRow != nil {
 		// Note: for perf, prefer using batch for inserting more than one records
-		batch := db.session.NewBatch(gocql.LoggedBatch)
+		batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx).WithContext(ctx)
 		batch.Query(v2templateInsertTree,
 			treeRow.TreeID, treeRow.BranchID, ancs, treeRow.CreateTimestampMilliseconds, treeRow.Info)
 		batch.Query(v2templateUpsertData,
@@ -85,11 +86,11 @@ func (db *cdb) InsertIntoHistoryTreeAndNode(treeRow *nosqlplugin.HistoryTreeRow,
 		var query *gocql.Query
 		if treeRow != nil {
 			query = db.session.Query(v2templateInsertTree,
-				treeRow.TreeID, treeRow.BranchID, ancs, treeRow.CreateTimestampMilliseconds, treeRow.Info)
+				treeRow.TreeID, treeRow.BranchID, ancs, treeRow.CreateTimestampMilliseconds, treeRow.Info).WithContext(ctx)
 		}
 		if nodeRow != nil {
 			query = db.session.Query(v2templateUpsertData,
-				nodeRow.TreeID, nodeRow.BranchID, nodeRow.NodeID, nodeRow.TxnID, nodeRow.Data, nodeRow.DataEncoding)
+				nodeRow.TreeID, nodeRow.BranchID, nodeRow.NodeID, nodeRow.TxnID, nodeRow.Data, nodeRow.DataEncoding).WithContext(ctx)
 		}
 		err = query.Exec()
 	}
@@ -98,8 +99,8 @@ func (db *cdb) InsertIntoHistoryTreeAndNode(treeRow *nosqlplugin.HistoryTreeRow,
 }
 
 // SelectFromHistoryNode read nodes based on a filter
-func (db *cdb) SelectFromHistoryNode(filter *nosqlplugin.HistoryNodeFilter) ([]*nosqlplugin.HistoryNodeRow, []byte, error) {
-	query := db.session.Query(v2templateReadData, filter.TreeID, filter.BranchID, filter.MinNodeID, filter.MaxNodeID)
+func (db *cdb) SelectFromHistoryNode(ctx context.Context, filter *nosqlplugin.HistoryNodeFilter) ([]*nosqlplugin.HistoryNodeRow, []byte, error) {
+	query := db.session.Query(v2templateReadData, filter.TreeID, filter.BranchID, filter.MinNodeID, filter.MaxNodeID).WithContext(ctx)
 
 	iter := query.PageSize(filter.PageSize).PageState(filter.NextPageToken).Iter()
 	if iter == nil {
@@ -124,8 +125,8 @@ func (db *cdb) SelectFromHistoryNode(filter *nosqlplugin.HistoryNodeFilter) ([]*
 }
 
 // DeleteFromHistoryTreeAndNode delete a branch record, and a list of ranges of nodes.
-func (db *cdb) DeleteFromHistoryTreeAndNode(treeFilter *nosqlplugin.HistoryTreeFilter, nodeFilters []*nosqlplugin.HistoryNodeFilter) error {
-	batch := db.session.NewBatch(gocql.LoggedBatch)
+func (db *cdb) DeleteFromHistoryTreeAndNode(ctx context.Context, treeFilter *nosqlplugin.HistoryTreeFilter, nodeFilters []*nosqlplugin.HistoryNodeFilter) error {
+	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
 	batch.Query(v2templateDeleteBranch, treeFilter.TreeID, treeFilter.BranchID)
 	for _, nodeFilter := range nodeFilters {
 		batch.Query(v2templateRangeDeleteData,
@@ -137,8 +138,8 @@ func (db *cdb) DeleteFromHistoryTreeAndNode(treeFilter *nosqlplugin.HistoryTreeF
 }
 
 // SelectAllHistoryTrees will return all tree branches with pagination
-func (db *cdb) SelectAllHistoryTrees(nextPageToken []byte, pageSize int) ([]*nosqlplugin.HistoryTreeRow, []byte, error) {
-	query := db.session.Query(v2templateScanAllTreeBranches)
+func (db *cdb) SelectAllHistoryTrees(ctx context.Context, nextPageToken []byte, pageSize int) ([]*nosqlplugin.HistoryTreeRow, []byte, error) {
+	query := db.session.Query(v2templateScanAllTreeBranches).WithContext(ctx)
 
 	iter := query.PageSize(int(pageSize)).PageState(nextPageToken).Iter()
 	if iter == nil {
@@ -169,8 +170,8 @@ func (db *cdb) SelectAllHistoryTrees(nextPageToken []byte, pageSize int) ([]*nos
 }
 
 // SelectFromHistoryTree read branch records for a tree
-func (db *cdb) SelectFromHistoryTree(filter *nosqlplugin.HistoryTreeFilter) ([]*nosqlplugin.HistoryTreeRow, error) {
-	query := db.session.Query(v2templateReadAllBranches, filter.TreeID)
+func (db *cdb) SelectFromHistoryTree(ctx context.Context, filter *nosqlplugin.HistoryTreeFilter) ([]*nosqlplugin.HistoryTreeRow, error) {
+	query := db.session.Query(v2templateReadAllBranches, filter.TreeID).WithContext(ctx)
 	var pagingToken []byte
 	var iter *gocql.Iter
 	var rows []*nosqlplugin.HistoryTreeRow

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -21,6 +21,7 @@
 package nosqlplugin
 
 import (
+	"context"
 	"github.com/uber/cadence/.gen/go/shared"
 )
 
@@ -51,21 +52,21 @@ type (
 		**/
 
 		// InsertIntoHistoryTreeAndNode inserts one or two rows: tree row and node row(at least one of them)
-		InsertIntoHistoryTreeAndNode(treeRow *HistoryTreeRow, nodeRow *HistoryNodeRow) error
+		InsertIntoHistoryTreeAndNode(ctx context.Context, treeRow *HistoryTreeRow, nodeRow *HistoryNodeRow) error
 
 		// SelectFromHistoryNode read nodes based on a filter
-		SelectFromHistoryNode(filter *HistoryNodeFilter) ([]*HistoryNodeRow, []byte, error)
+		SelectFromHistoryNode(ctx context.Context, filter *HistoryNodeFilter) ([]*HistoryNodeRow, []byte, error)
 
 		// DeleteFromHistoryTreeAndNode delete a branch record, and a list of ranges of nodes.
 		// for each range, it will delete all nodes starting from MinNodeID(inclusive)
-		DeleteFromHistoryTreeAndNode(treeFilter *HistoryTreeFilter, nodeFilters []*HistoryNodeFilter) error
+		DeleteFromHistoryTreeAndNode(ctx context.Context, treeFilter *HistoryTreeFilter, nodeFilters []*HistoryNodeFilter) error
 
 		// SelectAllHistoryTrees will return all tree branches with pagination
-		SelectAllHistoryTrees(nextPageToken []byte, pageSize int) ([]*HistoryTreeRow, []byte, error)
+		SelectAllHistoryTrees(ctx context.Context, nextPageToken []byte, pageSize int) ([]*HistoryTreeRow, []byte, error)
 
 		// SelectFromHistoryTree read branch records for a tree.
 		// It returns without pagination, because we assume one tree won't have too many branches.
-		SelectFromHistoryTree(filter *HistoryTreeFilter) ([]*HistoryTreeRow, error)
+		SelectFromHistoryTree(ctx context.Context, filter *HistoryTreeFilter) ([]*HistoryTreeRow, error)
 	}
 
 	// HistoryNodeRow represents a row in history_node table


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use context in Casandra history persistence. History was refactored for NoSQL support in previous PR https://github.com/uber/cadence/pull/3525 so it's better to have a separate PR here to lower risk, and less conflict. 

The others will be included in NoSQL refactoring. 

<!-- Tell your future self why have you made these changes -->
**Why?**
A follow up in https://github.com/uber/cadence/pull/3524

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Use existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
low risk

