### PR TITLE
[cli] print query result without additional message

### DIFF
--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -177,9 +177,10 @@ func newWorkflowCommands() []cli.Command {
 			},
 		},
 		{
-			Name:  "query",
-			Usage: "query workflow execution",
-			Flags: getFlagsForQuery(),
+			Name:        "query",
+			Usage:       "query workflow execution",
+			Description: "query result will be printed as JSON",
+			Flags:       getFlagsForQuery(),
 			Action: func(c *cli.Context) {
 				QueryWorkflow(c)
 			},

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -553,7 +553,7 @@ func queryWorkflowHelper(c *cli.Context, queryType string) {
 		fmt.Printf("Query was rejected, workflow is in state: %v\n", *queryResponse.QueryRejected.CloseStatus)
 	} else {
 		// assume it is json encoded
-		fmt.Printf("Query result as JSON:\n%v\n", string(queryResponse.QueryResult))
+		fmt.Print(string(queryResponse.QueryResult))
 	}
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Query result will be printed without leading message "Query result as JSON"

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously, this message prevented to pipe result to different tools like `jq`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

