### PR TITLE
Fix history scanner panic

### DIFF
--- a/service/worker/scanner/executions/workflows.go
+++ b/service/worker/scanner/executions/workflows.go
@@ -35,13 +35,13 @@ import (
 
 const (
 	// ConcreteScannerContextKey is the key used to access ScannerContext in activities for concrete executions
-	ConcreteScannerContextKey = ContextKey(0)
+	ConcreteScannerContextKey = "ConcreteScannerContextKey"
 	// ConcreteFixerContextKey is the key used to access FixerContext in activities for concrete executions
-	ConcreteFixerContextKey = ContextKey(1)
+	ConcreteFixerContextKey = "ConcreteFixerContextKey"
 	// CurrentScannerContextKey is the key used to access ScannerContext in activities for current executions
-	CurrentScannerContextKey = ContextKey(2)
+	CurrentScannerContextKey = "CurrentScannerContextKey"
 	// CurrentFixerContextKey is the key used to access FixerContext in activities for current executions
-	CurrentFixerContextKey = ContextKey(3)
+	CurrentFixerContextKey = "CurrentFixerContextKey"
 
 	// ShardReportQuery is the query name for the query used to get a single shard's report
 	ShardReportQuery = "shard_report"
@@ -82,9 +82,6 @@ var ScanTypeFixerContextKeyMap = map[ScanType]interface{}{
 }
 
 type (
-	// ContextKey is the type which identifies context keys
-	ContextKey int
-
 	// ScannerContext is the resource that is available in activities under ConcreteScannerContextKey context key
 	ScannerContext struct {
 		Resource                     resource.Resource

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -118,8 +118,10 @@ func New(
 
 // Start starts the scanner
 func (s *Scanner) Start() error {
+	ctx := context.WithValue(context.Background(), scannerContextKey, s.context)
+
 	backgroundActivityContext, taskListNames :=
-		s.startExecutionWorkflowWithRetry(context.Background(), executions.ConcreteScannerContextKey, executions.ConcreteFixerContextKey,
+		s.startExecutionWorkflowWithRetry(ctx, executions.ConcreteScannerContextKey, executions.ConcreteFixerContextKey,
 			s.context.cfg.ConcreteExecutionScannerConfig, concreteExecutionsScannerTaskListName, concreteExecutionsFixerTaskListName,
 			concreteExecutionsScannerWFTypeName, concreteExecutionsScannerWFStartOptions, executions.ConcreteExecutionType)
 	backgroundActivityContext, workerTaskListNames :=

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -36,12 +36,8 @@ import (
 	"github.com/uber/cadence/service/worker/scanner/tasklist"
 )
 
-type (
-	contextKey int
-)
-
 const (
-	scannerContextKey = contextKey(0)
+	scannerContextKey = "scannerContextKey"
 
 	maxConcurrentActivityExecutionSize     = 10
 	maxConcurrentDecisionTaskExecutionSize = 10


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add the missing scanner context to worker option

<!-- Tell your future self why have you made these changes -->
**Why?**
It was removed somehow when adding the execution scanner to workers. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally to make sure the issue https://github.com/uber/cadence/issues/3582 is gone

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.
