### PR TITLE
Added initial internal types and their mappers to/from thrift

### DIFF
--- a/common/types/common.go
+++ b/common/types/common.go
@@ -1,0 +1,68 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+import (
+	"time"
+)
+
+// WorkflowExecution identifies workflow execution
+type WorkflowExecution struct {
+	WorkflowId string
+	RunId      string
+}
+
+// WorkflowType identifies workflow type
+type WorkflowType struct {
+	Name string
+}
+
+// ActivityType identifies activity type
+type ActivityType struct {
+	Name string
+}
+
+// Header is used for context propagation
+type Header struct {
+	Fields map[string][]byte
+}
+
+// Memo allows adding arbitrary key-value pairs to a workflow
+type Memo struct {
+	Fields map[string][]byte
+}
+
+// SearchAttributes allows adding indexed key-values pairs that can be searched by
+type SearchAttributes struct {
+	IndexedFields map[string][]byte
+}
+
+// RetryPolicy is a retry policy
+type RetryPolicy struct {
+	InitialInterval          time.Duration
+	BackoffCoefficient       float64
+	MaximumInterval          time.Duration
+	MaximumAttempts          int32
+	NonRetriableErrorReasons []string
+	ExpirationInterval       time.Duration
+}

--- a/common/types/mappers/thrift/common.go
+++ b/common/types/mappers/thrift/common.go
@@ -83,52 +83,61 @@ func ToActivityType(at *thrift.ActivityType) types.ActivityType {
 }
 
 // FromHeader converts internal Header type to thrift
-func FromHeader(h types.Header) *thrift.Header {
+func FromHeader(h *types.Header) *thrift.Header {
+	if h == nil {
+		return nil
+	}
 	return &thrift.Header{
 		Fields: h.Fields,
 	}
 }
 
 // ToHeader converts thrift Header type to internal
-func ToHeader(h *thrift.Header) types.Header {
+func ToHeader(h *thrift.Header) *types.Header {
 	if h == nil {
-		return types.Header{}
+		return nil
 	}
-	return types.Header{
+	return &types.Header{
 		Fields: h.Fields,
 	}
 }
 
 // FromMemo converts internal Memo type to thrift
-func FromMemo(h types.Memo) *thrift.Memo {
+func FromMemo(m *types.Memo) *thrift.Memo {
+	if m == nil {
+		return nil
+	}
 	return &thrift.Memo{
-		Fields: h.Fields,
+		Fields: m.Fields,
 	}
 }
 
 // ToMemo converts thrift Memo type to internal
-func ToMemo(h *thrift.Memo) types.Memo {
-	if h == nil {
-		return types.Memo{}
+func ToMemo(m *thrift.Memo) *types.Memo {
+	if m == nil {
+		return nil
 	}
-	return types.Memo{
-		Fields: h.Fields,
+	return &types.Memo{
+		Fields: m.Fields,
 	}
 }
 
 // FromSearchAttributes converts internal SearchAttributes type to thrift
-func FromSearchAttributes(sa types.SearchAttributes) *thrift.SearchAttributes {
+func FromSearchAttributes(sa *types.SearchAttributes) *thrift.SearchAttributes {
+	if sa == nil {
+		return nil
+	}
 	return &thrift.SearchAttributes{
 		IndexedFields: sa.IndexedFields,
 	}
 }
 
 // ToSearchAttributes converts thrift SearchAttributes type to internal
-func ToSearchAttributes(sa *thrift.SearchAttributes) types.SearchAttributes {
+func ToSearchAttributes(sa *thrift.SearchAttributes) *types.SearchAttributes {
 	if sa == nil {
-		return types.SearchAttributes{}
+		return nil
 	}
-	return types.SearchAttributes{
+	return &types.SearchAttributes{
 		IndexedFields: sa.IndexedFields,
 	}
 }

--- a/common/types/mappers/thrift/common.go
+++ b/common/types/mappers/thrift/common.go
@@ -32,8 +32,8 @@ import (
 // FromWorkflowExecution converts internal WorkflowExectution type to thrift
 func FromWorkflowExecution(we types.WorkflowExecution) *thrift.WorkflowExecution {
 	return &thrift.WorkflowExecution{
-		WorkflowId: stringPtr(we.WorkflowId),
-		RunId:      stringPtr(we.RunId),
+		WorkflowId: &we.WorkflowId,
+		RunId:      &we.RunId,
 	}
 }
 
@@ -43,15 +43,15 @@ func ToWorkflowExecution(we *thrift.WorkflowExecution) types.WorkflowExecution {
 		return types.WorkflowExecution{}
 	}
 	return types.WorkflowExecution{
-		WorkflowId: stringVal(we.WorkflowId),
-		RunId:      stringVal(we.RunId),
+		WorkflowId: we.GetWorkflowId(),
+		RunId:      we.GetRunId(),
 	}
 }
 
 // FromWorkflowType converts internal WorkflowType type to thrift
 func FromWorkflowType(wt types.WorkflowType) *thrift.WorkflowType {
 	return &thrift.WorkflowType{
-		Name: stringPtr(wt.Name),
+		Name: &wt.Name,
 	}
 }
 
@@ -61,14 +61,14 @@ func ToWorkflowType(wt *thrift.WorkflowType) types.WorkflowType {
 		return types.WorkflowType{}
 	}
 	return types.WorkflowType{
-		Name: stringVal(wt.Name),
+		Name: wt.GetName(),
 	}
 }
 
 // FromActivityType converts internal ActivityType type to thrift
 func FromActivityType(at types.ActivityType) *thrift.ActivityType {
 	return &thrift.ActivityType{
-		Name: stringPtr(at.Name),
+		Name: &at.Name,
 	}
 }
 
@@ -78,7 +78,7 @@ func ToActivityType(at *thrift.ActivityType) types.ActivityType {
 		return types.ActivityType{}
 	}
 	return types.ActivityType{
-		Name: stringVal(at.Name),
+		Name: at.GetName(),
 	}
 }
 
@@ -139,12 +139,12 @@ func FromRetryPolicy(rp *types.RetryPolicy) *thrift.RetryPolicy {
 		return nil
 	}
 	return &thrift.RetryPolicy{
-		InitialIntervalInSeconds:    int32Ptr(int32(rp.InitialInterval.Seconds())),
-		BackoffCoefficient:          float64Ptr(rp.BackoffCoefficient),
-		MaximumIntervalInSeconds:    int32Ptr(int32(rp.MaximumInterval.Seconds())),
-		MaximumAttempts:             int32Ptr(rp.MaximumAttempts),
+		InitialIntervalInSeconds:    durationToSeconds(rp.InitialInterval),
+		BackoffCoefficient:          &rp.BackoffCoefficient,
+		MaximumIntervalInSeconds:    durationToSeconds(rp.MaximumInterval),
+		MaximumAttempts:             &rp.MaximumAttempts,
 		NonRetriableErrorReasons:    rp.NonRetriableErrorReasons,
-		ExpirationIntervalInSeconds: int32Ptr(int32(rp.ExpirationInterval.Seconds())),
+		ExpirationIntervalInSeconds: durationToSeconds(rp.ExpirationInterval),
 	}
 }
 
@@ -154,11 +154,20 @@ func ToRetryPolicy(rp *thrift.RetryPolicy) *types.RetryPolicy {
 		return nil
 	}
 	return &types.RetryPolicy{
-		InitialInterval:          time.Second * time.Duration(int32Val(rp.InitialIntervalInSeconds)),
-		BackoffCoefficient:       float64Val(rp.BackoffCoefficient),
-		MaximumInterval:          time.Second * time.Duration(int32Val(rp.MaximumIntervalInSeconds)),
-		MaximumAttempts:          int32Val(rp.MaximumAttempts),
+		InitialInterval:          secondsToDuration(rp.GetInitialIntervalInSeconds()),
+		BackoffCoefficient:       rp.GetBackoffCoefficient(),
+		MaximumInterval:          secondsToDuration(rp.GetMaximumIntervalInSeconds()),
+		MaximumAttempts:          rp.GetMaximumAttempts(),
 		NonRetriableErrorReasons: rp.NonRetriableErrorReasons,
-		ExpirationInterval:       time.Second * time.Duration(int32Val(rp.ExpirationIntervalInSeconds)),
+		ExpirationInterval:       secondsToDuration(rp.GetExpirationIntervalInSeconds()),
 	}
+}
+
+func durationToSeconds(d time.Duration) *int32 {
+	seconds := int32(d.Seconds())
+	return &seconds
+}
+
+func secondsToDuration(s int32) time.Duration {
+	return time.Duration(s) * time.Second
 }

--- a/common/types/mappers/thrift/common.go
+++ b/common/types/mappers/thrift/common.go
@@ -1,0 +1,164 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+import (
+	"time"
+
+	thrift "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common/types"
+)
+
+// FromWorkflowExecution converts internal WorkflowExectution type to thrift
+func FromWorkflowExecution(we types.WorkflowExecution) *thrift.WorkflowExecution {
+	return &thrift.WorkflowExecution{
+		WorkflowId: stringPtr(we.WorkflowId),
+		RunId:      stringPtr(we.RunId),
+	}
+}
+
+// ToWorkflowExecution converts thrift WorkflowExectution type to internal
+func ToWorkflowExecution(we *thrift.WorkflowExecution) types.WorkflowExecution {
+	if we == nil {
+		return types.WorkflowExecution{}
+	}
+	return types.WorkflowExecution{
+		WorkflowId: stringVal(we.WorkflowId),
+		RunId:      stringVal(we.RunId),
+	}
+}
+
+// FromWorkflowType converts internal WorkflowType type to thrift
+func FromWorkflowType(wt types.WorkflowType) *thrift.WorkflowType {
+	return &thrift.WorkflowType{
+		Name: stringPtr(wt.Name),
+	}
+}
+
+// ToWorkflowType converts thrift WorkflowType type to internal
+func ToWorkflowType(wt *thrift.WorkflowType) types.WorkflowType {
+	if wt == nil {
+		return types.WorkflowType{}
+	}
+	return types.WorkflowType{
+		Name: stringVal(wt.Name),
+	}
+}
+
+// FromActivityType converts internal ActivityType type to thrift
+func FromActivityType(at types.ActivityType) *thrift.ActivityType {
+	return &thrift.ActivityType{
+		Name: stringPtr(at.Name),
+	}
+}
+
+// ToActivityType converts thrift ActivityType type to internal
+func ToActivityType(at *thrift.ActivityType) types.ActivityType {
+	if at == nil {
+		return types.ActivityType{}
+	}
+	return types.ActivityType{
+		Name: stringVal(at.Name),
+	}
+}
+
+// FromHeader converts internal Header type to thrift
+func FromHeader(h types.Header) *thrift.Header {
+	return &thrift.Header{
+		Fields: h.Fields,
+	}
+}
+
+// ToHeader converts thrift Header type to internal
+func ToHeader(h *thrift.Header) types.Header {
+	if h == nil {
+		return types.Header{}
+	}
+	return types.Header{
+		Fields: h.Fields,
+	}
+}
+
+// FromMemo converts internal Memo type to thrift
+func FromMemo(h types.Memo) *thrift.Memo {
+	return &thrift.Memo{
+		Fields: h.Fields,
+	}
+}
+
+// ToMemo converts thrift Memo type to internal
+func ToMemo(h *thrift.Memo) types.Memo {
+	if h == nil {
+		return types.Memo{}
+	}
+	return types.Memo{
+		Fields: h.Fields,
+	}
+}
+
+// FromSearchAttributes converts internal SearchAttributes type to thrift
+func FromSearchAttributes(sa types.SearchAttributes) *thrift.SearchAttributes {
+	return &thrift.SearchAttributes{
+		IndexedFields: sa.IndexedFields,
+	}
+}
+
+// ToSearchAttributes converts thrift SearchAttributes type to internal
+func ToSearchAttributes(sa *thrift.SearchAttributes) types.SearchAttributes {
+	if sa == nil {
+		return types.SearchAttributes{}
+	}
+	return types.SearchAttributes{
+		IndexedFields: sa.IndexedFields,
+	}
+}
+
+// FromRetryPolicy converts internal RetryPolicy type to thrift
+func FromRetryPolicy(rp *types.RetryPolicy) *thrift.RetryPolicy {
+	if rp == nil {
+		return nil
+	}
+	return &thrift.RetryPolicy{
+		InitialIntervalInSeconds:    int32Ptr(int32(rp.InitialInterval.Seconds())),
+		BackoffCoefficient:          float64Ptr(rp.BackoffCoefficient),
+		MaximumIntervalInSeconds:    int32Ptr(int32(rp.MaximumInterval.Seconds())),
+		MaximumAttempts:             int32Ptr(rp.MaximumAttempts),
+		NonRetriableErrorReasons:    rp.NonRetriableErrorReasons,
+		ExpirationIntervalInSeconds: int32Ptr(int32(rp.ExpirationInterval.Seconds())),
+	}
+}
+
+// ToRetryPolicy converts thrift RetryPolicy type to internal
+func ToRetryPolicy(rp *thrift.RetryPolicy) *types.RetryPolicy {
+	if rp == nil {
+		return nil
+	}
+	return &types.RetryPolicy{
+		InitialInterval:          time.Second * time.Duration(int32Val(rp.InitialIntervalInSeconds)),
+		BackoffCoefficient:       float64Val(rp.BackoffCoefficient),
+		MaximumInterval:          time.Second * time.Duration(int32Val(rp.MaximumIntervalInSeconds)),
+		MaximumAttempts:          int32Val(rp.MaximumAttempts),
+		NonRetriableErrorReasons: rp.NonRetriableErrorReasons,
+		ExpirationInterval:       time.Second * time.Duration(int32Val(rp.ExpirationIntervalInSeconds)),
+	}
+}

--- a/common/types/mappers/thrift/common_test.go
+++ b/common/types/mappers/thrift/common_test.go
@@ -99,41 +99,44 @@ func Test_ToActivityType(t *testing.T) {
 
 func Test_FromHeader(t *testing.T) {
 	fields := map[string][]byte{"A": {1, 2, 3}}
-	assert.Equal(t, &thrift.Header{}, FromHeader(types.Header{}))
-	assert.Equal(t, &thrift.Header{Fields: fields}, FromHeader(types.Header{Fields: fields}))
+	assert.Equal(t, (*thrift.Header)(nil), FromHeader(nil))
+	assert.Equal(t, &thrift.Header{}, FromHeader(&types.Header{}))
+	assert.Equal(t, &thrift.Header{Fields: fields}, FromHeader(&types.Header{Fields: fields}))
 }
 
 func Test_ToHeader(t *testing.T) {
 	fields := map[string][]byte{"A": {1, 2, 3}}
-	assert.Equal(t, types.Header{}, ToHeader(nil))
-	assert.Equal(t, types.Header{}, ToHeader(&thrift.Header{}))
-	assert.Equal(t, types.Header{Fields: fields}, ToHeader(&thrift.Header{Fields: fields}))
+	assert.Equal(t, (*types.Header)(nil), ToHeader(nil))
+	assert.Equal(t, &types.Header{}, ToHeader(&thrift.Header{}))
+	assert.Equal(t, &types.Header{Fields: fields}, ToHeader(&thrift.Header{Fields: fields}))
 }
 
 func Test_FromMemo(t *testing.T) {
 	fields := map[string][]byte{"A": {1, 2, 3}}
-	assert.Equal(t, &thrift.Memo{}, FromMemo(types.Memo{}))
-	assert.Equal(t, &thrift.Memo{Fields: fields}, FromMemo(types.Memo{Fields: fields}))
+	assert.Equal(t, (*thrift.Memo)(nil), FromMemo(nil))
+	assert.Equal(t, &thrift.Memo{}, FromMemo(&types.Memo{}))
+	assert.Equal(t, &thrift.Memo{Fields: fields}, FromMemo(&types.Memo{Fields: fields}))
 }
 
 func Test_ToMemo(t *testing.T) {
 	fields := map[string][]byte{"A": {1, 2, 3}}
-	assert.Equal(t, types.Memo{}, ToMemo(nil))
-	assert.Equal(t, types.Memo{}, ToMemo(&thrift.Memo{}))
-	assert.Equal(t, types.Memo{Fields: fields}, ToMemo(&thrift.Memo{Fields: fields}))
+	assert.Equal(t, (*types.Memo)(nil), ToMemo(nil))
+	assert.Equal(t, &types.Memo{}, ToMemo(&thrift.Memo{}))
+	assert.Equal(t, &types.Memo{Fields: fields}, ToMemo(&thrift.Memo{Fields: fields}))
 }
 
 func Test_FromSearchAttributes(t *testing.T) {
 	fields := map[string][]byte{"A": {1, 2, 3}}
-	assert.Equal(t, &thrift.SearchAttributes{}, FromSearchAttributes(types.SearchAttributes{}))
-	assert.Equal(t, &thrift.SearchAttributes{IndexedFields: fields}, FromSearchAttributes(types.SearchAttributes{IndexedFields: fields}))
+	assert.Equal(t, (*thrift.SearchAttributes)(nil), FromSearchAttributes(nil))
+	assert.Equal(t, &thrift.SearchAttributes{}, FromSearchAttributes(&types.SearchAttributes{}))
+	assert.Equal(t, &thrift.SearchAttributes{IndexedFields: fields}, FromSearchAttributes(&types.SearchAttributes{IndexedFields: fields}))
 }
 
 func Test_ToSearchAttributes(t *testing.T) {
 	fields := map[string][]byte{"A": {1, 2, 3}}
-	assert.Equal(t, types.SearchAttributes{}, ToSearchAttributes(nil))
-	assert.Equal(t, types.SearchAttributes{}, ToSearchAttributes(&thrift.SearchAttributes{}))
-	assert.Equal(t, types.SearchAttributes{IndexedFields: fields}, ToSearchAttributes(&thrift.SearchAttributes{IndexedFields: fields}))
+	assert.Equal(t, (*types.SearchAttributes)(nil), ToSearchAttributes(nil))
+	assert.Equal(t, &types.SearchAttributes{}, ToSearchAttributes(&thrift.SearchAttributes{}))
+	assert.Equal(t, &types.SearchAttributes{IndexedFields: fields}, ToSearchAttributes(&thrift.SearchAttributes{IndexedFields: fields}))
 }
 
 func Test_FromRetryPolicy(t *testing.T) {

--- a/common/types/mappers/thrift/common_test.go
+++ b/common/types/mappers/thrift/common_test.go
@@ -1,0 +1,203 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	thrift "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common/types"
+)
+
+func Test_FromWorkflowExecution(t *testing.T) {
+	assert.Equal(t,
+		&thrift.WorkflowExecution{
+			WorkflowId: stringPtr(""),
+			RunId:      stringPtr(""),
+		},
+		FromWorkflowExecution(types.WorkflowExecution{}),
+	)
+
+	assert.Equal(t,
+		&thrift.WorkflowExecution{
+			WorkflowId: stringPtr("WorkflowId"),
+			RunId:      stringPtr("RunId"),
+		},
+		FromWorkflowExecution(types.WorkflowExecution{
+			WorkflowId: "WorkflowId",
+			RunId:      "RunId",
+		}),
+	)
+}
+
+func Test_ToWorkflowExecution(t *testing.T) {
+	assert.Equal(t,
+		types.WorkflowExecution{},
+		ToWorkflowExecution(nil),
+	)
+
+	assert.Equal(t,
+		types.WorkflowExecution{},
+		ToWorkflowExecution(&thrift.WorkflowExecution{}),
+	)
+
+	assert.Equal(t,
+		types.WorkflowExecution{
+			WorkflowId: "WorkflowId",
+			RunId:      "RunId",
+		},
+		ToWorkflowExecution(&thrift.WorkflowExecution{
+			WorkflowId: stringPtr("WorkflowId"),
+			RunId:      stringPtr("RunId"),
+		}),
+	)
+}
+
+func Test_FromWorkflowType(t *testing.T) {
+	assert.Equal(t, &thrift.WorkflowType{Name: stringPtr("")}, FromWorkflowType(types.WorkflowType{}))
+	assert.Equal(t, &thrift.WorkflowType{Name: stringPtr("Name")}, FromWorkflowType(types.WorkflowType{Name: "Name"}))
+}
+
+func Test_ToWorkflowType(t *testing.T) {
+	assert.Equal(t, types.WorkflowType{}, ToWorkflowType(nil))
+	assert.Equal(t, types.WorkflowType{}, ToWorkflowType(&thrift.WorkflowType{}))
+	assert.Equal(t, types.WorkflowType{Name: "Name"}, ToWorkflowType(&thrift.WorkflowType{Name: stringPtr("Name")}))
+}
+
+func Test_FromActivityType(t *testing.T) {
+	assert.Equal(t, &thrift.ActivityType{Name: stringPtr("")}, FromActivityType(types.ActivityType{}))
+	assert.Equal(t, &thrift.ActivityType{Name: stringPtr("Name")}, FromActivityType(types.ActivityType{Name: "Name"}))
+}
+
+func Test_ToActivityType(t *testing.T) {
+	assert.Equal(t, types.ActivityType{}, ToActivityType(nil))
+	assert.Equal(t, types.ActivityType{}, ToActivityType(&thrift.ActivityType{}))
+	assert.Equal(t, types.ActivityType{Name: "Name"}, ToActivityType(&thrift.ActivityType{Name: stringPtr("Name")}))
+}
+
+func Test_FromHeader(t *testing.T) {
+	fields := map[string][]byte{"A": {1, 2, 3}}
+	assert.Equal(t, &thrift.Header{}, FromHeader(types.Header{}))
+	assert.Equal(t, &thrift.Header{Fields: fields}, FromHeader(types.Header{Fields: fields}))
+}
+
+func Test_ToHeader(t *testing.T) {
+	fields := map[string][]byte{"A": {1, 2, 3}}
+	assert.Equal(t, types.Header{}, ToHeader(nil))
+	assert.Equal(t, types.Header{}, ToHeader(&thrift.Header{}))
+	assert.Equal(t, types.Header{Fields: fields}, ToHeader(&thrift.Header{Fields: fields}))
+}
+
+func Test_FromMemo(t *testing.T) {
+	fields := map[string][]byte{"A": {1, 2, 3}}
+	assert.Equal(t, &thrift.Memo{}, FromMemo(types.Memo{}))
+	assert.Equal(t, &thrift.Memo{Fields: fields}, FromMemo(types.Memo{Fields: fields}))
+}
+
+func Test_ToMemo(t *testing.T) {
+	fields := map[string][]byte{"A": {1, 2, 3}}
+	assert.Equal(t, types.Memo{}, ToMemo(nil))
+	assert.Equal(t, types.Memo{}, ToMemo(&thrift.Memo{}))
+	assert.Equal(t, types.Memo{Fields: fields}, ToMemo(&thrift.Memo{Fields: fields}))
+}
+
+func Test_FromSearchAttributes(t *testing.T) {
+	fields := map[string][]byte{"A": {1, 2, 3}}
+	assert.Equal(t, &thrift.SearchAttributes{}, FromSearchAttributes(types.SearchAttributes{}))
+	assert.Equal(t, &thrift.SearchAttributes{IndexedFields: fields}, FromSearchAttributes(types.SearchAttributes{IndexedFields: fields}))
+}
+
+func Test_ToSearchAttributes(t *testing.T) {
+	fields := map[string][]byte{"A": {1, 2, 3}}
+	assert.Equal(t, types.SearchAttributes{}, ToSearchAttributes(nil))
+	assert.Equal(t, types.SearchAttributes{}, ToSearchAttributes(&thrift.SearchAttributes{}))
+	assert.Equal(t, types.SearchAttributes{IndexedFields: fields}, ToSearchAttributes(&thrift.SearchAttributes{IndexedFields: fields}))
+}
+
+func Test_FromRetryPolicy(t *testing.T) {
+	assert.Equal(t, (*thrift.RetryPolicy)(nil), FromRetryPolicy(nil))
+
+	assert.Equal(t,
+		&thrift.RetryPolicy{
+			InitialIntervalInSeconds:    int32Ptr(0),
+			BackoffCoefficient:          float64Ptr(0.0),
+			MaximumIntervalInSeconds:    int32Ptr(0),
+			MaximumAttempts:             int32Ptr(0),
+			NonRetriableErrorReasons:    nil,
+			ExpirationIntervalInSeconds: int32Ptr(0),
+		},
+		FromRetryPolicy(&types.RetryPolicy{}))
+
+	assert.Equal(t,
+		&thrift.RetryPolicy{
+			InitialIntervalInSeconds:    int32Ptr(1),
+			BackoffCoefficient:          float64Ptr(2.0),
+			MaximumIntervalInSeconds:    int32Ptr(3),
+			MaximumAttempts:             int32Ptr(4),
+			NonRetriableErrorReasons:    []string{"5"},
+			ExpirationIntervalInSeconds: int32Ptr(6),
+		},
+		FromRetryPolicy(&types.RetryPolicy{
+			InitialInterval:          1 * time.Second,
+			BackoffCoefficient:       2.0,
+			MaximumInterval:          3 * time.Second,
+			MaximumAttempts:          4,
+			NonRetriableErrorReasons: []string{"5"},
+			ExpirationInterval:       6 * time.Second,
+		}))
+}
+
+func Test_ToRetryPolicy(t *testing.T) {
+	assert.Equal(t, (*types.RetryPolicy)(nil), ToRetryPolicy(nil))
+
+	assert.Equal(t,
+		&types.RetryPolicy{
+			InitialInterval:          0 * time.Second,
+			BackoffCoefficient:       0.0,
+			MaximumInterval:          0 * time.Second,
+			MaximumAttempts:          0,
+			NonRetriableErrorReasons: nil,
+			ExpirationInterval:       0 * time.Second,
+		},
+		ToRetryPolicy(&thrift.RetryPolicy{}))
+
+	assert.Equal(t,
+		&types.RetryPolicy{
+			InitialInterval:          1 * time.Second,
+			BackoffCoefficient:       2.0,
+			MaximumInterval:          3 * time.Second,
+			MaximumAttempts:          4,
+			NonRetriableErrorReasons: []string{"5"},
+			ExpirationInterval:       6 * time.Second,
+		},
+		ToRetryPolicy(&thrift.RetryPolicy{
+			InitialIntervalInSeconds:    int32Ptr(1),
+			BackoffCoefficient:          float64Ptr(2.0),
+			MaximumIntervalInSeconds:    int32Ptr(3),
+			MaximumAttempts:             int32Ptr(4),
+			NonRetriableErrorReasons:    []string{"5"},
+			ExpirationIntervalInSeconds: int32Ptr(6),
+		}))
+}

--- a/common/types/mappers/thrift/tasklist.go
+++ b/common/types/mappers/thrift/tasklist.go
@@ -1,0 +1,79 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+import (
+	thrift "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common/types"
+)
+
+// FromTaskListKind converts internal TaskListKind type to thrift
+func FromTaskListKind(kind types.TaskListKind) *thrift.TaskListKind {
+	switch kind {
+	case types.TaskListKindNormal:
+		return taskListKindPtr(thrift.TaskListKindNormal)
+	case types.TaskListKindSticky:
+		return taskListKindPtr(thrift.TaskListKindSticky)
+	}
+
+	panic("unexpected TaskListKind value")
+}
+
+// ToTaskListKind converts thrift TaskListKind type to internal
+func ToTaskListKind(kind *thrift.TaskListKind) types.TaskListKind {
+	if kind == nil {
+		return types.TaskListKindNormal
+	}
+
+	switch *kind {
+	case thrift.TaskListKindNormal:
+		return types.TaskListKindNormal
+	case thrift.TaskListKindSticky:
+		return types.TaskListKindSticky
+	}
+
+	panic("unexpected TaskListKind value")
+}
+
+// FromTaskList converts internal TaskList type to thrift
+func FromTaskList(tl types.TaskList) *thrift.TaskList {
+	return &thrift.TaskList{
+		Name: stringPtr(tl.Name),
+		Kind: FromTaskListKind(tl.Kind),
+	}
+}
+
+// ToTaskList converts thrift TaskList type to internal
+func ToTaskList(tl *thrift.TaskList) types.TaskList {
+	if tl == nil {
+		return types.TaskList{}
+	}
+	return types.TaskList{
+		Name: stringVal(tl.Name),
+		Kind: ToTaskListKind(tl.Kind),
+	}
+}
+
+func taskListKindPtr(kind thrift.TaskListKind) *thrift.TaskListKind {
+	return &kind
+}

--- a/common/types/mappers/thrift/tasklist.go
+++ b/common/types/mappers/thrift/tasklist.go
@@ -29,14 +29,8 @@ import (
 
 // FromTaskListKind converts internal TaskListKind type to thrift
 func FromTaskListKind(kind types.TaskListKind) *thrift.TaskListKind {
-	switch kind {
-	case types.TaskListKindNormal:
-		return taskListKindPtr(thrift.TaskListKindNormal)
-	case types.TaskListKindSticky:
-		return taskListKindPtr(thrift.TaskListKindSticky)
-	}
-
-	panic("unexpected TaskListKind value")
+	k := thrift.TaskListKind(kind)
+	return &k
 }
 
 // ToTaskListKind converts thrift TaskListKind type to internal
@@ -44,21 +38,13 @@ func ToTaskListKind(kind *thrift.TaskListKind) types.TaskListKind {
 	if kind == nil {
 		return types.TaskListKindNormal
 	}
-
-	switch *kind {
-	case thrift.TaskListKindNormal:
-		return types.TaskListKindNormal
-	case thrift.TaskListKindSticky:
-		return types.TaskListKindSticky
-	}
-
-	panic("unexpected TaskListKind value")
+	return types.TaskListKind(*kind)
 }
 
 // FromTaskList converts internal TaskList type to thrift
 func FromTaskList(tl types.TaskList) *thrift.TaskList {
 	return &thrift.TaskList{
-		Name: stringPtr(tl.Name),
+		Name: &tl.Name,
 		Kind: FromTaskListKind(tl.Kind),
 	}
 }
@@ -69,11 +55,7 @@ func ToTaskList(tl *thrift.TaskList) types.TaskList {
 		return types.TaskList{}
 	}
 	return types.TaskList{
-		Name: stringVal(tl.Name),
+		Name: tl.GetName(),
 		Kind: ToTaskListKind(tl.Kind),
 	}
-}
-
-func taskListKindPtr(kind thrift.TaskListKind) *thrift.TaskListKind {
-	return &kind
 }

--- a/common/types/mappers/thrift/tasklist_test.go
+++ b/common/types/mappers/thrift/tasklist_test.go
@@ -33,14 +33,14 @@ import (
 func Test_FromTaskListKind(t *testing.T) {
 	assert.Equal(t, taskListKindPtr(thrift.TaskListKindNormal), FromTaskListKind(types.TaskListKindNormal))
 	assert.Equal(t, taskListKindPtr(thrift.TaskListKindSticky), FromTaskListKind(types.TaskListKindSticky))
-	assert.Panics(t, func() { FromTaskListKind(types.TaskListKind(99)) })
+	assert.Equal(t, taskListKindPtr(99), FromTaskListKind(types.TaskListKind(99)))
 }
 
 func Test_ToTaskListKind(t *testing.T) {
 	assert.Equal(t, types.TaskListKindNormal, ToTaskListKind(nil))
 	assert.Equal(t, types.TaskListKindNormal, ToTaskListKind(taskListKindPtr(thrift.TaskListKindNormal)))
 	assert.Equal(t, types.TaskListKindSticky, ToTaskListKind(taskListKindPtr(thrift.TaskListKindSticky)))
-	assert.Panics(t, func() { ToTaskListKind(taskListKindPtr(thrift.TaskListKind(99))) })
+	assert.Equal(t, types.TaskListKind(99), ToTaskListKind(taskListKindPtr(thrift.TaskListKind(99))))
 }
 
 func Test_FromTaskList(t *testing.T) {
@@ -82,4 +82,8 @@ func Test_ToTaskList(t *testing.T) {
 			Kind: taskListKindPtr(thrift.TaskListKindSticky),
 		}),
 	)
+}
+
+func taskListKindPtr(kind thrift.TaskListKind) *thrift.TaskListKind {
+	return &kind
 }

--- a/common/types/mappers/thrift/tasklist_test.go
+++ b/common/types/mappers/thrift/tasklist_test.go
@@ -31,30 +31,30 @@ import (
 )
 
 func Test_FromTaskListKind(t *testing.T) {
-	assert.Equal(t, taskListKindPtr(thrift.TaskListKindNormal), FromTaskListKind(types.TaskListKindNormal))
-	assert.Equal(t, taskListKindPtr(thrift.TaskListKindSticky), FromTaskListKind(types.TaskListKindSticky))
-	assert.Equal(t, taskListKindPtr(99), FromTaskListKind(types.TaskListKind(99)))
+	assert.Equal(t, thrift.TaskListKindNormal.Ptr(), FromTaskListKind(types.TaskListKindNormal))
+	assert.Equal(t, thrift.TaskListKindSticky.Ptr(), FromTaskListKind(types.TaskListKindSticky))
+	assert.Equal(t, thrift.TaskListKind(99).Ptr(), FromTaskListKind(types.TaskListKind(99)))
 }
 
 func Test_ToTaskListKind(t *testing.T) {
 	assert.Equal(t, types.TaskListKindNormal, ToTaskListKind(nil))
-	assert.Equal(t, types.TaskListKindNormal, ToTaskListKind(taskListKindPtr(thrift.TaskListKindNormal)))
-	assert.Equal(t, types.TaskListKindSticky, ToTaskListKind(taskListKindPtr(thrift.TaskListKindSticky)))
-	assert.Equal(t, types.TaskListKind(99), ToTaskListKind(taskListKindPtr(thrift.TaskListKind(99))))
+	assert.Equal(t, types.TaskListKindNormal, ToTaskListKind(thrift.TaskListKindNormal.Ptr()))
+	assert.Equal(t, types.TaskListKindSticky, ToTaskListKind(thrift.TaskListKindSticky.Ptr()))
+	assert.Equal(t, types.TaskListKind(99), ToTaskListKind(thrift.TaskListKind(99).Ptr()))
 }
 
 func Test_FromTaskList(t *testing.T) {
 	assert.Equal(t,
 		&thrift.TaskList{
 			Name: stringPtr(""),
-			Kind: taskListKindPtr(thrift.TaskListKindNormal),
+			Kind: thrift.TaskListKindNormal.Ptr(),
 		},
 		FromTaskList(types.TaskList{}),
 	)
 	assert.Equal(t,
 		&thrift.TaskList{
 			Name: stringPtr("Name"),
-			Kind: taskListKindPtr(thrift.TaskListKindSticky),
+			Kind: thrift.TaskListKindSticky.Ptr(),
 		},
 		FromTaskList(types.TaskList{
 			Name: "Name",
@@ -79,11 +79,7 @@ func Test_ToTaskList(t *testing.T) {
 		},
 		ToTaskList(&thrift.TaskList{
 			Name: stringPtr("Name"),
-			Kind: taskListKindPtr(thrift.TaskListKindSticky),
+			Kind: thrift.TaskListKindSticky.Ptr(),
 		}),
 	)
-}
-
-func taskListKindPtr(kind thrift.TaskListKind) *thrift.TaskListKind {
-	return &kind
 }

--- a/common/types/mappers/thrift/tasklist_test.go
+++ b/common/types/mappers/thrift/tasklist_test.go
@@ -1,0 +1,85 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	thrift "github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common/types"
+)
+
+func Test_FromTaskListKind(t *testing.T) {
+	assert.Equal(t, taskListKindPtr(thrift.TaskListKindNormal), FromTaskListKind(types.TaskListKindNormal))
+	assert.Equal(t, taskListKindPtr(thrift.TaskListKindSticky), FromTaskListKind(types.TaskListKindSticky))
+	assert.Panics(t, func() { FromTaskListKind(types.TaskListKind(99)) })
+}
+
+func Test_ToTaskListKind(t *testing.T) {
+	assert.Equal(t, types.TaskListKindNormal, ToTaskListKind(nil))
+	assert.Equal(t, types.TaskListKindNormal, ToTaskListKind(taskListKindPtr(thrift.TaskListKindNormal)))
+	assert.Equal(t, types.TaskListKindSticky, ToTaskListKind(taskListKindPtr(thrift.TaskListKindSticky)))
+	assert.Panics(t, func() { ToTaskListKind(taskListKindPtr(thrift.TaskListKind(99))) })
+}
+
+func Test_FromTaskList(t *testing.T) {
+	assert.Equal(t,
+		&thrift.TaskList{
+			Name: stringPtr(""),
+			Kind: taskListKindPtr(thrift.TaskListKindNormal),
+		},
+		FromTaskList(types.TaskList{}),
+	)
+	assert.Equal(t,
+		&thrift.TaskList{
+			Name: stringPtr("Name"),
+			Kind: taskListKindPtr(thrift.TaskListKindSticky),
+		},
+		FromTaskList(types.TaskList{
+			Name: "Name",
+			Kind: types.TaskListKindSticky,
+		}),
+	)
+}
+
+func Test_ToTaskList(t *testing.T) {
+	assert.Equal(t,
+		types.TaskList{},
+		ToTaskList(nil),
+	)
+	assert.Equal(t,
+		types.TaskList{},
+		ToTaskList(&thrift.TaskList{}),
+	)
+	assert.Equal(t,
+		types.TaskList{
+			Name: "Name",
+			Kind: types.TaskListKindSticky,
+		},
+		ToTaskList(&thrift.TaskList{
+			Name: stringPtr("Name"),
+			Kind: taskListKindPtr(thrift.TaskListKindSticky),
+		}),
+	)
+}

--- a/common/types/mappers/thrift/utils.go
+++ b/common/types/mappers/thrift/utils.go
@@ -1,0 +1,56 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+func stringPtr(s string) *string {
+	return &s
+}
+
+func stringVal(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+func int32Ptr(i int32) *int32 {
+	return &i
+}
+
+func int32Val(i *int32) int32 {
+	if i == nil {
+		return 0
+	}
+	return *i
+}
+
+func float64Ptr(f float64) *float64 {
+	return &f
+}
+
+func float64Val(f *float64) float64 {
+	if f == nil {
+		return 0.0
+	}
+	return *f
+}

--- a/common/types/mappers/thrift/utils.go
+++ b/common/types/mappers/thrift/utils.go
@@ -26,31 +26,10 @@ func stringPtr(s string) *string {
 	return &s
 }
 
-func stringVal(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
-}
-
 func int32Ptr(i int32) *int32 {
 	return &i
 }
 
-func int32Val(i *int32) int32 {
-	if i == nil {
-		return 0
-	}
-	return *i
-}
-
 func float64Ptr(f float64) *float64 {
 	return &f
-}
-
-func float64Val(f *float64) float64 {
-	if f == nil {
-		return 0.0
-	}
-	return *f
 }

--- a/common/types/tasklist.go
+++ b/common/types/tasklist.go
@@ -1,0 +1,39 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+// TaskListKind is a kind of a task list
+type TaskListKind int32
+
+const (
+	// TaskListKindNormal identifies normal task list
+	TaskListKindNormal TaskListKind = 0
+	// TaskListKindSticky identifies sticky task list
+	TaskListKindSticky TaskListKind = 1
+)
+
+// TaskList defines Cadence task list
+type TaskList struct {
+	Name string
+	Kind TaskListKind
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This change introduces a sample of common internal types to be used throughout the Cadence codebase in place of generated Thrift counterparts.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a prerequisite for migration to gRPC as we want to stop using Thrift generated types throughout Cadence codebase. Instead start using internal types that are independent of serialization protocol used at network and persistence boundaries.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
100% coverage with unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None yet. Types are not used yet.
