### PR TITLE
Add automerge workflow as Github Action

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,37 @@
+name: automerge
+on:
+  pull_request:
+    types:
+      - labeled
+      - unlabeled
+      - synchronize
+      - opened
+      - edited
+      - ready_for_review
+      - reopened
+      - unlocked
+  pull_request_review:
+    types:
+      - submitted
+  check_suite:
+    types:
+      - completed
+  status: {}
+jobs:
+  automerge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: automerge
+        uses: "pascalgn/automerge-action@v0.11.0"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          MERGE_LABELS: "automerge,!work in progress"
+          MERGE_REMOVE_LABELS: "automerge"
+          MERGE_METHOD: "squash"
+          MERGE_COMMIT_MESSAGE: "pull-request-title"
+          MERGE_RETRIES: "30"
+          MERGE_RETRY_SLEEP: "60000"
+          UPDATE_LABELS: ""
+          UPDATE_METHOD: "rebase"
+          UPDATE_RETRIES: "30"
+          UPDATE_RETRY_SLEEP: "60000"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Using Github Action https://github.com/marketplace/actions/merge-pull-requests#configuration 
to automatically merge pull requests when they are ready

<!-- Tell your future self why have you made these changes -->
**Why?**
Our merging experience is not idea. Merging into master has to be serialized. But today to merge a PR after getting a review approval, we have to manually click a "update branch" button to rebase, and then rerun the whole buildkite tests, and then click another button to merge it. 

This Github action will automize it:
After getting a review approval, and also put a label "automerge" in a PR, the PR will kick off a workflow.
The workflow will wait for all test runs are succeeded, and then try to do a non-conflict rebase, and then merge it.

If rebase has conflict then  the workflow will be aborted. 
The merge request message will be the title of the PR, which is the same as we are doing today.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested here in my personal repo: https://github.com/longquanzheng/cadence-lab/pull/4

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk.
