### PR TITLE
Create internal type generator with initial types and mappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,3 +319,8 @@ start-cdc-other: bins
 
 start-canary: bins
 	./cadence-canary start
+
+gen-internal-types:
+	go run common/types/generator/main.go
+
+internal-types: gen-internal-types fmt copyright

--- a/common/types/generator/main.go
+++ b/common/types/generator/main.go
@@ -1,0 +1,434 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2020 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package main
+
+import (
+	"fmt"
+	"go/importer"
+	"go/types"
+	"html/template"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const licence = `// Copyright (c) 2017-2020 Uber Technologies Inc.
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+`
+
+var typesHeader = template.Must(template.New("struct type").Parse(licence + `package types
+
+`))
+
+var mapperHeader = template.Must(template.New("struct type").Parse(licence + `package thrift
+
+import (
+	"github.com/uber/cadence/common/types"
+
+{{range .}}	"{{.ThriftPackage}}"
+{{end}}
+)
+`))
+
+var structTemplate = template.Must(template.New("struct type").Parse(`
+type {{.Type.Name}} struct {
+{{range .Fields}}	{{.Name}} {{if .Type.IsMap}}map[string]{{end}}{{if .Type.IsArray}}[]{{end}}{{if .Type.IsPointer}}*{{end}}{{.Type.Name}}
+{{end}}}
+`))
+
+var enumTemplate = template.Must(template.New("enum type").Parse(`
+type {{.Type.Name}} int32
+
+const ({{range $i, $v := .Values}}
+	{{.}}{{if eq $i 0}} {{$.Type.Name}} = iota{{end}}{{end}}
+)
+`))
+
+var structMapperTemplate = template.Must(template.New("struct mapper").Parse(`
+// From{{.Type.Name}} converts internal {{.Type.Name}} type to thrift
+func From{{.Type.Name}}(t *types.{{.Type.Name}}) *{{.Type.ThriftPackage}}.{{.Type.Name}} {
+	if t == nil {
+		return nil
+	}
+	return &{{.Type.ThriftPackage}}.{{.Type.Name}}{
+{{range .Fields}}		{{.Name}}: {{if .Type.IsPrimitive}}t.{{.Name}}{{else}}From{{.Type.Name}}{{if .Type.IsArray}}Array{{end}}{{if .Type.IsMap}}Map{{end}}(t.{{.Name}}){{end}},
+{{end}}	}
+}
+
+// To{{.Type.Name}} converts thrift {{.Type.Name}} type to internal
+func To{{.Type.Name}}(t *{{.Type.ThriftPackage}}.{{.Type.Name}}) *types.{{.Type.Name}} {
+	if t == nil {
+		return nil
+	}
+	return &types.{{.Type.Name}}{
+{{range .Fields}}		{{.Name}}: {{if .Type.IsPrimitive}}t.{{.Name}}{{else}}To{{.Type.Name}}{{if .Type.IsArray}}Array{{end}}{{if .Type.IsMap}}Map{{end}}(t.{{.Name}}){{end}},
+{{end}}	}
+}
+`))
+
+var arrayMapperTemplate = template.Must(template.New("array mapper").Parse(`
+// From{{.Type.Name}}Array converts internal {{.Type.Name}} type array to thrift
+func From{{.Type.Name}}Array(t []*types.{{.Type.Name}}) []*{{.Type.ThriftPackage}}.{{.Type.Name}} {
+	if t == nil {
+		return nil
+	}
+	v := make([]*{{.Type.ThriftPackage}}.{{.Type.Name}}, len(t))
+	for i := range t {
+		v[i] = {{if .Type.IsPrimitive}}t[i]{{.Name}}{{else}}From{{.Type.Name}}(t[i]){{end}}
+	}
+	return v
+}
+
+// To{{.Type.Name}}Array converts thrift {{.Type.Name}} type array to internal
+func To{{.Type.Name}}Array(t []*{{.Type.ThriftPackage}}.{{.Type.Name}}) []*types.{{.Type.Name}} {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.{{.Type.Name}}, len(t))
+	for i := range t {
+		v[i] = {{if .Type.IsPrimitive}}t[i]{{.Name}}{{else}}To{{.Type.Name}}(t[i]){{end}}
+	}
+	return v
+}
+`))
+
+var mapMapperTemplate = template.Must(template.New("map mapper").Parse(`
+// From{{.Type.Name}}Map converts internal {{.Type.Name}} type map to thrift
+func From{{.Type.Name}}Map(t map[string]{{if .Type.IsPointer}}*{{end}}types.{{.Type.Name}}) map[string]{{if .Type.IsPointer}}*{{end}}{{.Type.ThriftPackage}}.{{.Type.Name}} {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]{{if .Type.IsPointer}}*{{end}}{{.Type.ThriftPackage}}.{{.Type.Name}}, len(t))
+	for key := range t {
+		v[key] = {{if .Type.IsPrimitive}}t[key]{{else}}From{{.Type.Name}}(t[key]){{end}}
+	}
+	return v
+}
+
+// To{{.Type.Name}}Map converts thrift {{.Type.Name}} type map to internal
+func To{{.Type.Name}}Map(t map[string]{{if .Type.IsPointer}}*{{end}}{{.Type.ThriftPackage}}.{{.Type.Name}}) map[string]{{if .Type.IsPointer}}*{{end}}types.{{.Type.Name}} {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]{{if .Type.IsPointer}}*{{end}}types.{{.Type.Name}}, len(t))
+	for key := range t {
+		v[key] = {{if .Type.IsPrimitive}}t[key]{{else}}To{{.Type.Name}}(t[key]){{end}}
+	}
+	return v
+}
+`))
+
+var enumMapperTemplate = template.Must(template.New("enum mapper").Parse(`
+// From{{.Type.Name}} converts internal {{.Type.Name}} type to thrift
+func From{{.Type.Name}}(t {{if .Type.IsPointer}}*{{end}}types.{{.Type.Name}}) {{if .Type.IsPointer}}*{{end}}{{.Type.ThriftPackage}}.{{.Type.Name}} {
+	{{if .Type.IsPointer}}if t == nil {
+		return nil
+	}{{end}}
+	switch {{if .Type.IsPointer}}*{{end}}t { {{range .Values}}
+		case types.{{.}}: {{if $.Type.IsPointer}}v := {{$.Type.ThriftPackage}}.{{.}}; return &v{{else}}return {{$.Type.ThriftPackage}}.{{.}}{{end}}{{end}}
+	}
+	panic("unexpected enum value")
+}
+
+// To{{.Type.Name}} converts thrift {{.Type.Name}} type to internal
+func To{{.Type.Name}}(t {{if .Type.IsPointer}}*{{end}}{{.Type.ThriftPackage}}.{{.Type.Name}}) {{if .Type.IsPointer}}*{{end}}types.{{.Type.Name}} {
+	{{if .Type.IsPointer}}if t == nil {
+		return nil
+	}{{end}}
+	switch {{if .Type.IsPointer}}*{{end}}t { {{range .Values}}
+		case {{$.Type.ThriftPackage}}.{{.}}: {{if $.Type.IsPointer}}v := types.{{.}}; return &v{{else}}return types.{{.}}{{end}}{{end}}
+	}
+	panic("unexpected enum value")
+}
+`))
+
+var requiredArrayMappers = map[string]struct{}{}
+var requiredMapMappers = map[string]struct{}{}
+
+type (
+	// Renderer can render internal type and its mappings
+	Renderer interface {
+		RenderType(w io.Writer)
+		RenderMapper(w io.Writer)
+	}
+
+	// Type describes a type
+	Type struct {
+		FullThriftPackage string
+		ThriftPackage     string
+		Name              string
+		IsPrimitive       bool
+		IsArray           bool
+		IsMap             bool
+		IsPointer         bool
+	}
+
+	// Fields describe a field within a struct
+	Field struct {
+		Name string
+		Type Type
+	}
+	// Struct describe struct type
+	Struct struct {
+		Type   Type
+		Fields []Field
+	}
+	// Array describes Array type
+	Array struct {
+		Type
+	}
+	// Map describes Map type
+	Map struct {
+		Type
+	}
+	// Map describes Enum type
+	Enum struct {
+		Type   Type
+		Values []string
+	}
+)
+
+func (s *Struct) RenderType(w io.Writer) {
+	err := structTemplate.Execute(w, s)
+	if err != nil {
+		panic(err)
+	}
+}
+func (s *Struct) RenderMapper(w io.Writer) {
+	err := structMapperTemplate.Execute(w, s)
+	if err != nil {
+		panic(err)
+	}
+}
+func (a *Array) RenderMapper(w io.Writer) {
+	err := arrayMapperTemplate.Execute(w, a)
+	if err != nil {
+		panic(err)
+	}
+}
+func (m *Map) RenderMapper(w io.Writer) {
+	err := mapMapperTemplate.Execute(w, m)
+	if err != nil {
+		panic(err)
+	}
+}
+func (e *Enum) RenderType(w io.Writer) {
+	err := enumTemplate.Execute(w, e)
+	if err != nil {
+		panic(err)
+	}
+}
+func (e *Enum) RenderMapper(w io.Writer) {
+	err := enumMapperTemplate.Execute(w, e)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// fullName example: []*github.com/uber/cadence/.gen/go/shared.VersionHistoryItem
+func newType(fullName string) Type {
+	isMap := false
+	if strings.HasPrefix(fullName, "map[string]") {
+		fullName = strings.TrimPrefix(fullName, "map[string]")
+		isMap = true
+	}
+	isArray := false
+	if strings.HasPrefix(fullName, "[]") {
+		fullName = strings.TrimPrefix(fullName, "[]")
+		isArray = true
+	}
+	isPointer := false
+	if strings.HasPrefix(fullName, "*") {
+		fullName = strings.TrimPrefix(fullName, "*")
+		isPointer = true
+	}
+	pos := strings.LastIndexByte(fullName, '.')
+	if pos > 0 {
+		pkg := fullName[:pos]
+		name := fullName[pos+1:]
+		pos = strings.LastIndexByte(pkg, '/')
+		short := pkg[pos+1:]
+		return Type{pkg, short, name, false, isArray, isMap, isPointer}
+	} else {
+		return Type{"", "", fullName, true, isArray, isMap, isPointer}
+	}
+}
+
+func newStruct(obj types.Object) *Struct {
+	u := obj.Type().Underlying().(*types.Struct)
+	fields := make([]Field, u.NumFields())
+	for i := 0; i < u.NumFields(); i++ {
+		f := u.Field(i)
+		field := Field{
+			Name: f.Name(),
+			Type: newType(f.Type().String()),
+		}
+		if field.Type.IsArray && !field.Type.IsPrimitive {
+			requiredArrayMappers[f.Type().String()] = struct{}{}
+		}
+		if field.Type.IsMap && !field.Type.IsPrimitive {
+			requiredMapMappers[f.Type().String()] = struct{}{}
+		}
+		fields[i] = field
+	}
+	return &Struct{
+		Type:   newType(obj.Type().String()),
+		Fields: fields,
+	}
+}
+
+func newArray(fullType string) *Array {
+	return &Array{
+		Type: newType(fullType),
+	}
+}
+
+func newMap(fullType string) *Map {
+	return &Map{
+		Type: newType(fullType),
+	}
+}
+
+var enumPointerExceptions = map[string]struct{}{
+	"IndexedValueType": {},
+}
+
+func newEnum(obj types.Object) *Enum {
+	enumType := newType(obj.Type().String())
+	if _, ok := enumPointerExceptions[enumType.Name]; !ok {
+		enumType.IsPointer = true
+	}
+	enumValues := make([]string, 0, 128)
+	pkg := obj.Pkg().Scope()
+	for _, name := range pkg.Names() {
+		eValue := pkg.Lookup(name)
+		if isEnumValue(eValue, obj.Type()) {
+			enumValues = append(enumValues, eValue.Name())
+		}
+	}
+	return &Enum{
+		Type:   enumType,
+		Values: enumValues,
+	}
+}
+
+func isEnumValue(v types.Object, t types.Type) bool {
+	c, isConst := v.(*types.Const)
+	return isConst && c.Type() == t
+}
+
+func rewriteFile(path string) *os.File {
+	dir := filepath.Dir(path)
+	err := os.MkdirAll(dir, os.ModePerm)
+	if err != nil {
+		panic(err)
+	}
+
+	f, err := os.OpenFile(path, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		panic(err)
+	}
+	return f
+}
+
+func createRenderer(obj types.Object) Renderer {
+	if _, ok := obj.(*types.TypeName); ok {
+		switch obj.Type().Underlying().(type) {
+		case *types.Struct:
+			return newStruct(obj)
+		case *types.Basic:
+			return newEnum(obj)
+		default:
+			fmt.Printf("encountered unexpected type: %v\n", obj)
+		}
+	}
+	return nil
+}
+
+type Package struct {
+	ThriftPackage string
+	TypesFile     string
+	MapperFile    string
+}
+
+func main() {
+	packages := []Package{
+		{
+			ThriftPackage: "github.com/uber/cadence/.gen/go/shared",
+			TypesFile:     "common/types/shared.go",
+			MapperFile:    "common/types/mapper/thrift/shared.go",
+		},
+	}
+
+	for _, p := range packages {
+		typesFile := rewriteFile(p.TypesFile)
+		mapperFile := rewriteFile(p.MapperFile)
+
+		typesHeader.Execute(typesFile, packages)
+		mapperHeader.Execute(mapperFile, packages)
+
+		pkg, err := importer.Default().Import(p.ThriftPackage)
+		if err != nil {
+			panic(err)
+		}
+
+		for _, name := range pkg.Scope().Names() {
+			obj := pkg.Scope().Lookup(name)
+			if !obj.Exported() {
+				continue
+			}
+			if r := createRenderer(obj); r != nil {
+				r.RenderType(typesFile)
+				r.RenderMapper(mapperFile)
+			}
+		}
+		for m := range requiredArrayMappers {
+			newArray(m).RenderMapper(mapperFile)
+		}
+		for m := range requiredMapMappers {
+			newMap(m).RenderMapper(mapperFile)
+		}
+
+		typesFile.Close()
+		mapperFile.Close()
+	}
+}

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -1,0 +1,6593 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+import (
+	"github.com/uber/cadence/common/types"
+
+	"github.com/uber/cadence/.gen/go/shared"
+)
+
+// FromAccessDeniedError converts internal AccessDeniedError type to thrift
+func FromAccessDeniedError(t *types.AccessDeniedError) *shared.AccessDeniedError {
+	if t == nil {
+		return nil
+	}
+	return &shared.AccessDeniedError{
+		Message: t.Message,
+	}
+}
+
+// ToAccessDeniedError converts thrift AccessDeniedError type to internal
+func ToAccessDeniedError(t *shared.AccessDeniedError) *types.AccessDeniedError {
+	if t == nil {
+		return nil
+	}
+	return &types.AccessDeniedError{
+		Message: t.Message,
+	}
+}
+
+// FromActivityTaskCancelRequestedEventAttributes converts internal ActivityTaskCancelRequestedEventAttributes type to thrift
+func FromActivityTaskCancelRequestedEventAttributes(t *types.ActivityTaskCancelRequestedEventAttributes) *shared.ActivityTaskCancelRequestedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityTaskCancelRequestedEventAttributes{
+		ActivityId:                   t.ActivityId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// ToActivityTaskCancelRequestedEventAttributes converts thrift ActivityTaskCancelRequestedEventAttributes type to internal
+func ToActivityTaskCancelRequestedEventAttributes(t *shared.ActivityTaskCancelRequestedEventAttributes) *types.ActivityTaskCancelRequestedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityTaskCancelRequestedEventAttributes{
+		ActivityId:                   t.ActivityId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// FromActivityTaskCanceledEventAttributes converts internal ActivityTaskCanceledEventAttributes type to thrift
+func FromActivityTaskCanceledEventAttributes(t *types.ActivityTaskCanceledEventAttributes) *shared.ActivityTaskCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityTaskCanceledEventAttributes{
+		Details:                      t.Details,
+		LatestCancelRequestedEventId: t.LatestCancelRequestedEventId,
+		ScheduledEventId:             t.ScheduledEventId,
+		StartedEventId:               t.StartedEventId,
+		Identity:                     t.Identity,
+	}
+}
+
+// ToActivityTaskCanceledEventAttributes converts thrift ActivityTaskCanceledEventAttributes type to internal
+func ToActivityTaskCanceledEventAttributes(t *shared.ActivityTaskCanceledEventAttributes) *types.ActivityTaskCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityTaskCanceledEventAttributes{
+		Details:                      t.Details,
+		LatestCancelRequestedEventId: t.LatestCancelRequestedEventId,
+		ScheduledEventId:             t.ScheduledEventId,
+		StartedEventId:               t.StartedEventId,
+		Identity:                     t.Identity,
+	}
+}
+
+// FromActivityTaskCompletedEventAttributes converts internal ActivityTaskCompletedEventAttributes type to thrift
+func FromActivityTaskCompletedEventAttributes(t *types.ActivityTaskCompletedEventAttributes) *shared.ActivityTaskCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityTaskCompletedEventAttributes{
+		Result:           t.Result,
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Identity:         t.Identity,
+	}
+}
+
+// ToActivityTaskCompletedEventAttributes converts thrift ActivityTaskCompletedEventAttributes type to internal
+func ToActivityTaskCompletedEventAttributes(t *shared.ActivityTaskCompletedEventAttributes) *types.ActivityTaskCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityTaskCompletedEventAttributes{
+		Result:           t.Result,
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Identity:         t.Identity,
+	}
+}
+
+// FromActivityTaskFailedEventAttributes converts internal ActivityTaskFailedEventAttributes type to thrift
+func FromActivityTaskFailedEventAttributes(t *types.ActivityTaskFailedEventAttributes) *shared.ActivityTaskFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityTaskFailedEventAttributes{
+		Reason:           t.Reason,
+		Details:          t.Details,
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Identity:         t.Identity,
+	}
+}
+
+// ToActivityTaskFailedEventAttributes converts thrift ActivityTaskFailedEventAttributes type to internal
+func ToActivityTaskFailedEventAttributes(t *shared.ActivityTaskFailedEventAttributes) *types.ActivityTaskFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityTaskFailedEventAttributes{
+		Reason:           t.Reason,
+		Details:          t.Details,
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Identity:         t.Identity,
+	}
+}
+
+// FromActivityTaskScheduledEventAttributes converts internal ActivityTaskScheduledEventAttributes type to thrift
+func FromActivityTaskScheduledEventAttributes(t *types.ActivityTaskScheduledEventAttributes) *shared.ActivityTaskScheduledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityTaskScheduledEventAttributes{
+		ActivityId:                    t.ActivityId,
+		ActivityType:                  FromActivityType(t.ActivityType),
+		Domain:                        t.Domain,
+		TaskList:                      FromTaskList(t.TaskList),
+		Input:                         t.Input,
+		ScheduleToCloseTimeoutSeconds: t.ScheduleToCloseTimeoutSeconds,
+		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
+		StartToCloseTimeoutSeconds:    t.StartToCloseTimeoutSeconds,
+		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
+		DecisionTaskCompletedEventId:  t.DecisionTaskCompletedEventId,
+		RetryPolicy:                   FromRetryPolicy(t.RetryPolicy),
+		Header:                        FromHeader(t.Header),
+	}
+}
+
+// ToActivityTaskScheduledEventAttributes converts thrift ActivityTaskScheduledEventAttributes type to internal
+func ToActivityTaskScheduledEventAttributes(t *shared.ActivityTaskScheduledEventAttributes) *types.ActivityTaskScheduledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityTaskScheduledEventAttributes{
+		ActivityId:                    t.ActivityId,
+		ActivityType:                  ToActivityType(t.ActivityType),
+		Domain:                        t.Domain,
+		TaskList:                      ToTaskList(t.TaskList),
+		Input:                         t.Input,
+		ScheduleToCloseTimeoutSeconds: t.ScheduleToCloseTimeoutSeconds,
+		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
+		StartToCloseTimeoutSeconds:    t.StartToCloseTimeoutSeconds,
+		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
+		DecisionTaskCompletedEventId:  t.DecisionTaskCompletedEventId,
+		RetryPolicy:                   ToRetryPolicy(t.RetryPolicy),
+		Header:                        ToHeader(t.Header),
+	}
+}
+
+// FromActivityTaskStartedEventAttributes converts internal ActivityTaskStartedEventAttributes type to thrift
+func FromActivityTaskStartedEventAttributes(t *types.ActivityTaskStartedEventAttributes) *shared.ActivityTaskStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityTaskStartedEventAttributes{
+		ScheduledEventId:   t.ScheduledEventId,
+		Identity:           t.Identity,
+		RequestId:          t.RequestId,
+		Attempt:            t.Attempt,
+		LastFailureReason:  t.LastFailureReason,
+		LastFailureDetails: t.LastFailureDetails,
+	}
+}
+
+// ToActivityTaskStartedEventAttributes converts thrift ActivityTaskStartedEventAttributes type to internal
+func ToActivityTaskStartedEventAttributes(t *shared.ActivityTaskStartedEventAttributes) *types.ActivityTaskStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityTaskStartedEventAttributes{
+		ScheduledEventId:   t.ScheduledEventId,
+		Identity:           t.Identity,
+		RequestId:          t.RequestId,
+		Attempt:            t.Attempt,
+		LastFailureReason:  t.LastFailureReason,
+		LastFailureDetails: t.LastFailureDetails,
+	}
+}
+
+// FromActivityTaskTimedOutEventAttributes converts internal ActivityTaskTimedOutEventAttributes type to thrift
+func FromActivityTaskTimedOutEventAttributes(t *types.ActivityTaskTimedOutEventAttributes) *shared.ActivityTaskTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityTaskTimedOutEventAttributes{
+		Details:            t.Details,
+		ScheduledEventId:   t.ScheduledEventId,
+		StartedEventId:     t.StartedEventId,
+		TimeoutType:        FromTimeoutType(t.TimeoutType),
+		LastFailureReason:  t.LastFailureReason,
+		LastFailureDetails: t.LastFailureDetails,
+	}
+}
+
+// ToActivityTaskTimedOutEventAttributes converts thrift ActivityTaskTimedOutEventAttributes type to internal
+func ToActivityTaskTimedOutEventAttributes(t *shared.ActivityTaskTimedOutEventAttributes) *types.ActivityTaskTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityTaskTimedOutEventAttributes{
+		Details:            t.Details,
+		ScheduledEventId:   t.ScheduledEventId,
+		StartedEventId:     t.StartedEventId,
+		TimeoutType:        ToTimeoutType(t.TimeoutType),
+		LastFailureReason:  t.LastFailureReason,
+		LastFailureDetails: t.LastFailureDetails,
+	}
+}
+
+// FromActivityType converts internal ActivityType type to thrift
+func FromActivityType(t *types.ActivityType) *shared.ActivityType {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityType{
+		Name: t.Name,
+	}
+}
+
+// ToActivityType converts thrift ActivityType type to internal
+func ToActivityType(t *shared.ActivityType) *types.ActivityType {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityType{
+		Name: t.Name,
+	}
+}
+
+// FromArchivalStatus converts internal ArchivalStatus type to thrift
+func FromArchivalStatus(t *types.ArchivalStatus) *shared.ArchivalStatus {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.ArchivalStatusDisabled:
+		v := shared.ArchivalStatusDisabled
+		return &v
+	case types.ArchivalStatusEnabled:
+		v := shared.ArchivalStatusEnabled
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToArchivalStatus converts thrift ArchivalStatus type to internal
+func ToArchivalStatus(t *shared.ArchivalStatus) *types.ArchivalStatus {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.ArchivalStatusDisabled:
+		v := types.ArchivalStatusDisabled
+		return &v
+	case shared.ArchivalStatusEnabled:
+		v := types.ArchivalStatusEnabled
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromBadBinaries converts internal BadBinaries type to thrift
+func FromBadBinaries(t *types.BadBinaries) *shared.BadBinaries {
+	if t == nil {
+		return nil
+	}
+	return &shared.BadBinaries{
+		Binaries: FromBadBinaryInfoMap(t.Binaries),
+	}
+}
+
+// ToBadBinaries converts thrift BadBinaries type to internal
+func ToBadBinaries(t *shared.BadBinaries) *types.BadBinaries {
+	if t == nil {
+		return nil
+	}
+	return &types.BadBinaries{
+		Binaries: ToBadBinaryInfoMap(t.Binaries),
+	}
+}
+
+// FromBadBinaryInfo converts internal BadBinaryInfo type to thrift
+func FromBadBinaryInfo(t *types.BadBinaryInfo) *shared.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.BadBinaryInfo{
+		Reason:          t.Reason,
+		Operator:        t.Operator,
+		CreatedTimeNano: t.CreatedTimeNano,
+	}
+}
+
+// ToBadBinaryInfo converts thrift BadBinaryInfo type to internal
+func ToBadBinaryInfo(t *shared.BadBinaryInfo) *types.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.BadBinaryInfo{
+		Reason:          t.Reason,
+		Operator:        t.Operator,
+		CreatedTimeNano: t.CreatedTimeNano,
+	}
+}
+
+// FromBadRequestError converts internal BadRequestError type to thrift
+func FromBadRequestError(t *types.BadRequestError) *shared.BadRequestError {
+	if t == nil {
+		return nil
+	}
+	return &shared.BadRequestError{
+		Message: t.Message,
+	}
+}
+
+// ToBadRequestError converts thrift BadRequestError type to internal
+func ToBadRequestError(t *shared.BadRequestError) *types.BadRequestError {
+	if t == nil {
+		return nil
+	}
+	return &types.BadRequestError{
+		Message: t.Message,
+	}
+}
+
+// FromCancelExternalWorkflowExecutionFailedCause converts internal CancelExternalWorkflowExecutionFailedCause type to thrift
+func FromCancelExternalWorkflowExecutionFailedCause(t *types.CancelExternalWorkflowExecutionFailedCause) *shared.CancelExternalWorkflowExecutionFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution:
+		v := shared.CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToCancelExternalWorkflowExecutionFailedCause converts thrift CancelExternalWorkflowExecutionFailedCause type to internal
+func ToCancelExternalWorkflowExecutionFailedCause(t *shared.CancelExternalWorkflowExecutionFailedCause) *types.CancelExternalWorkflowExecutionFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution:
+		v := types.CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromCancelTimerDecisionAttributes converts internal CancelTimerDecisionAttributes type to thrift
+func FromCancelTimerDecisionAttributes(t *types.CancelTimerDecisionAttributes) *shared.CancelTimerDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.CancelTimerDecisionAttributes{
+		TimerId: t.TimerId,
+	}
+}
+
+// ToCancelTimerDecisionAttributes converts thrift CancelTimerDecisionAttributes type to internal
+func ToCancelTimerDecisionAttributes(t *shared.CancelTimerDecisionAttributes) *types.CancelTimerDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.CancelTimerDecisionAttributes{
+		TimerId: t.TimerId,
+	}
+}
+
+// FromCancelTimerFailedEventAttributes converts internal CancelTimerFailedEventAttributes type to thrift
+func FromCancelTimerFailedEventAttributes(t *types.CancelTimerFailedEventAttributes) *shared.CancelTimerFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.CancelTimerFailedEventAttributes{
+		TimerId:                      t.TimerId,
+		Cause:                        t.Cause,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Identity:                     t.Identity,
+	}
+}
+
+// ToCancelTimerFailedEventAttributes converts thrift CancelTimerFailedEventAttributes type to internal
+func ToCancelTimerFailedEventAttributes(t *shared.CancelTimerFailedEventAttributes) *types.CancelTimerFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.CancelTimerFailedEventAttributes{
+		TimerId:                      t.TimerId,
+		Cause:                        t.Cause,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Identity:                     t.Identity,
+	}
+}
+
+// FromCancelWorkflowExecutionDecisionAttributes converts internal CancelWorkflowExecutionDecisionAttributes type to thrift
+func FromCancelWorkflowExecutionDecisionAttributes(t *types.CancelWorkflowExecutionDecisionAttributes) *shared.CancelWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.CancelWorkflowExecutionDecisionAttributes{
+		Details: t.Details,
+	}
+}
+
+// ToCancelWorkflowExecutionDecisionAttributes converts thrift CancelWorkflowExecutionDecisionAttributes type to internal
+func ToCancelWorkflowExecutionDecisionAttributes(t *shared.CancelWorkflowExecutionDecisionAttributes) *types.CancelWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.CancelWorkflowExecutionDecisionAttributes{
+		Details: t.Details,
+	}
+}
+
+// FromCancellationAlreadyRequestedError converts internal CancellationAlreadyRequestedError type to thrift
+func FromCancellationAlreadyRequestedError(t *types.CancellationAlreadyRequestedError) *shared.CancellationAlreadyRequestedError {
+	if t == nil {
+		return nil
+	}
+	return &shared.CancellationAlreadyRequestedError{
+		Message: t.Message,
+	}
+}
+
+// ToCancellationAlreadyRequestedError converts thrift CancellationAlreadyRequestedError type to internal
+func ToCancellationAlreadyRequestedError(t *shared.CancellationAlreadyRequestedError) *types.CancellationAlreadyRequestedError {
+	if t == nil {
+		return nil
+	}
+	return &types.CancellationAlreadyRequestedError{
+		Message: t.Message,
+	}
+}
+
+// FromChildWorkflowExecutionCanceledEventAttributes converts internal ChildWorkflowExecutionCanceledEventAttributes type to thrift
+func FromChildWorkflowExecutionCanceledEventAttributes(t *types.ChildWorkflowExecutionCanceledEventAttributes) *shared.ChildWorkflowExecutionCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ChildWorkflowExecutionCanceledEventAttributes{
+		Details:           t.Details,
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      FromWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// ToChildWorkflowExecutionCanceledEventAttributes converts thrift ChildWorkflowExecutionCanceledEventAttributes type to internal
+func ToChildWorkflowExecutionCanceledEventAttributes(t *shared.ChildWorkflowExecutionCanceledEventAttributes) *types.ChildWorkflowExecutionCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ChildWorkflowExecutionCanceledEventAttributes{
+		Details:           t.Details,
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      ToWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// FromChildWorkflowExecutionCompletedEventAttributes converts internal ChildWorkflowExecutionCompletedEventAttributes type to thrift
+func FromChildWorkflowExecutionCompletedEventAttributes(t *types.ChildWorkflowExecutionCompletedEventAttributes) *shared.ChildWorkflowExecutionCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ChildWorkflowExecutionCompletedEventAttributes{
+		Result:            t.Result,
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      FromWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// ToChildWorkflowExecutionCompletedEventAttributes converts thrift ChildWorkflowExecutionCompletedEventAttributes type to internal
+func ToChildWorkflowExecutionCompletedEventAttributes(t *shared.ChildWorkflowExecutionCompletedEventAttributes) *types.ChildWorkflowExecutionCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ChildWorkflowExecutionCompletedEventAttributes{
+		Result:            t.Result,
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      ToWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// FromChildWorkflowExecutionFailedCause converts internal ChildWorkflowExecutionFailedCause type to thrift
+func FromChildWorkflowExecutionFailedCause(t *types.ChildWorkflowExecutionFailedCause) *shared.ChildWorkflowExecutionFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning:
+		v := shared.ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToChildWorkflowExecutionFailedCause converts thrift ChildWorkflowExecutionFailedCause type to internal
+func ToChildWorkflowExecutionFailedCause(t *shared.ChildWorkflowExecutionFailedCause) *types.ChildWorkflowExecutionFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning:
+		v := types.ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromChildWorkflowExecutionFailedEventAttributes converts internal ChildWorkflowExecutionFailedEventAttributes type to thrift
+func FromChildWorkflowExecutionFailedEventAttributes(t *types.ChildWorkflowExecutionFailedEventAttributes) *shared.ChildWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ChildWorkflowExecutionFailedEventAttributes{
+		Reason:            t.Reason,
+		Details:           t.Details,
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      FromWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// ToChildWorkflowExecutionFailedEventAttributes converts thrift ChildWorkflowExecutionFailedEventAttributes type to internal
+func ToChildWorkflowExecutionFailedEventAttributes(t *shared.ChildWorkflowExecutionFailedEventAttributes) *types.ChildWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ChildWorkflowExecutionFailedEventAttributes{
+		Reason:            t.Reason,
+		Details:           t.Details,
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      ToWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// FromChildWorkflowExecutionStartedEventAttributes converts internal ChildWorkflowExecutionStartedEventAttributes type to thrift
+func FromChildWorkflowExecutionStartedEventAttributes(t *types.ChildWorkflowExecutionStartedEventAttributes) *shared.ChildWorkflowExecutionStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ChildWorkflowExecutionStartedEventAttributes{
+		Domain:            t.Domain,
+		InitiatedEventId:  t.InitiatedEventId,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      FromWorkflowType(t.WorkflowType),
+		Header:            FromHeader(t.Header),
+	}
+}
+
+// ToChildWorkflowExecutionStartedEventAttributes converts thrift ChildWorkflowExecutionStartedEventAttributes type to internal
+func ToChildWorkflowExecutionStartedEventAttributes(t *shared.ChildWorkflowExecutionStartedEventAttributes) *types.ChildWorkflowExecutionStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ChildWorkflowExecutionStartedEventAttributes{
+		Domain:            t.Domain,
+		InitiatedEventId:  t.InitiatedEventId,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      ToWorkflowType(t.WorkflowType),
+		Header:            ToHeader(t.Header),
+	}
+}
+
+// FromChildWorkflowExecutionTerminatedEventAttributes converts internal ChildWorkflowExecutionTerminatedEventAttributes type to thrift
+func FromChildWorkflowExecutionTerminatedEventAttributes(t *types.ChildWorkflowExecutionTerminatedEventAttributes) *shared.ChildWorkflowExecutionTerminatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ChildWorkflowExecutionTerminatedEventAttributes{
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      FromWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// ToChildWorkflowExecutionTerminatedEventAttributes converts thrift ChildWorkflowExecutionTerminatedEventAttributes type to internal
+func ToChildWorkflowExecutionTerminatedEventAttributes(t *shared.ChildWorkflowExecutionTerminatedEventAttributes) *types.ChildWorkflowExecutionTerminatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ChildWorkflowExecutionTerminatedEventAttributes{
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      ToWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// FromChildWorkflowExecutionTimedOutEventAttributes converts internal ChildWorkflowExecutionTimedOutEventAttributes type to thrift
+func FromChildWorkflowExecutionTimedOutEventAttributes(t *types.ChildWorkflowExecutionTimedOutEventAttributes) *shared.ChildWorkflowExecutionTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ChildWorkflowExecutionTimedOutEventAttributes{
+		TimeoutType:       FromTimeoutType(t.TimeoutType),
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      FromWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// ToChildWorkflowExecutionTimedOutEventAttributes converts thrift ChildWorkflowExecutionTimedOutEventAttributes type to internal
+func ToChildWorkflowExecutionTimedOutEventAttributes(t *shared.ChildWorkflowExecutionTimedOutEventAttributes) *types.ChildWorkflowExecutionTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ChildWorkflowExecutionTimedOutEventAttributes{
+		TimeoutType:       ToTimeoutType(t.TimeoutType),
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:      ToWorkflowType(t.WorkflowType),
+		InitiatedEventId:  t.InitiatedEventId,
+		StartedEventId:    t.StartedEventId,
+	}
+}
+
+// FromClientVersionNotSupportedError converts internal ClientVersionNotSupportedError type to thrift
+func FromClientVersionNotSupportedError(t *types.ClientVersionNotSupportedError) *shared.ClientVersionNotSupportedError {
+	if t == nil {
+		return nil
+	}
+	return &shared.ClientVersionNotSupportedError{
+		FeatureVersion:    t.FeatureVersion,
+		ClientImpl:        t.ClientImpl,
+		SupportedVersions: t.SupportedVersions,
+	}
+}
+
+// ToClientVersionNotSupportedError converts thrift ClientVersionNotSupportedError type to internal
+func ToClientVersionNotSupportedError(t *shared.ClientVersionNotSupportedError) *types.ClientVersionNotSupportedError {
+	if t == nil {
+		return nil
+	}
+	return &types.ClientVersionNotSupportedError{
+		FeatureVersion:    t.FeatureVersion,
+		ClientImpl:        t.ClientImpl,
+		SupportedVersions: t.SupportedVersions,
+	}
+}
+
+// FromCloseShardRequest converts internal CloseShardRequest type to thrift
+func FromCloseShardRequest(t *types.CloseShardRequest) *shared.CloseShardRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.CloseShardRequest{
+		ShardID: t.ShardID,
+	}
+}
+
+// ToCloseShardRequest converts thrift CloseShardRequest type to internal
+func ToCloseShardRequest(t *shared.CloseShardRequest) *types.CloseShardRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.CloseShardRequest{
+		ShardID: t.ShardID,
+	}
+}
+
+// FromClusterInfo converts internal ClusterInfo type to thrift
+func FromClusterInfo(t *types.ClusterInfo) *shared.ClusterInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.ClusterInfo{
+		SupportedClientVersions: FromSupportedClientVersions(t.SupportedClientVersions),
+	}
+}
+
+// ToClusterInfo converts thrift ClusterInfo type to internal
+func ToClusterInfo(t *shared.ClusterInfo) *types.ClusterInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.ClusterInfo{
+		SupportedClientVersions: ToSupportedClientVersions(t.SupportedClientVersions),
+	}
+}
+
+// FromClusterReplicationConfiguration converts internal ClusterReplicationConfiguration type to thrift
+func FromClusterReplicationConfiguration(t *types.ClusterReplicationConfiguration) *shared.ClusterReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &shared.ClusterReplicationConfiguration{
+		ClusterName: t.ClusterName,
+	}
+}
+
+// ToClusterReplicationConfiguration converts thrift ClusterReplicationConfiguration type to internal
+func ToClusterReplicationConfiguration(t *shared.ClusterReplicationConfiguration) *types.ClusterReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &types.ClusterReplicationConfiguration{
+		ClusterName: t.ClusterName,
+	}
+}
+
+// FromCompleteWorkflowExecutionDecisionAttributes converts internal CompleteWorkflowExecutionDecisionAttributes type to thrift
+func FromCompleteWorkflowExecutionDecisionAttributes(t *types.CompleteWorkflowExecutionDecisionAttributes) *shared.CompleteWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.CompleteWorkflowExecutionDecisionAttributes{
+		Result: t.Result,
+	}
+}
+
+// ToCompleteWorkflowExecutionDecisionAttributes converts thrift CompleteWorkflowExecutionDecisionAttributes type to internal
+func ToCompleteWorkflowExecutionDecisionAttributes(t *shared.CompleteWorkflowExecutionDecisionAttributes) *types.CompleteWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.CompleteWorkflowExecutionDecisionAttributes{
+		Result: t.Result,
+	}
+}
+
+// FromContinueAsNewInitiator converts internal ContinueAsNewInitiator type to thrift
+func FromContinueAsNewInitiator(t *types.ContinueAsNewInitiator) *shared.ContinueAsNewInitiator {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.ContinueAsNewInitiatorCronSchedule:
+		v := shared.ContinueAsNewInitiatorCronSchedule
+		return &v
+	case types.ContinueAsNewInitiatorDecider:
+		v := shared.ContinueAsNewInitiatorDecider
+		return &v
+	case types.ContinueAsNewInitiatorRetryPolicy:
+		v := shared.ContinueAsNewInitiatorRetryPolicy
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToContinueAsNewInitiator converts thrift ContinueAsNewInitiator type to internal
+func ToContinueAsNewInitiator(t *shared.ContinueAsNewInitiator) *types.ContinueAsNewInitiator {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.ContinueAsNewInitiatorCronSchedule:
+		v := types.ContinueAsNewInitiatorCronSchedule
+		return &v
+	case shared.ContinueAsNewInitiatorDecider:
+		v := types.ContinueAsNewInitiatorDecider
+		return &v
+	case shared.ContinueAsNewInitiatorRetryPolicy:
+		v := types.ContinueAsNewInitiatorRetryPolicy
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromContinueAsNewWorkflowExecutionDecisionAttributes converts internal ContinueAsNewWorkflowExecutionDecisionAttributes type to thrift
+func FromContinueAsNewWorkflowExecutionDecisionAttributes(t *types.ContinueAsNewWorkflowExecutionDecisionAttributes) *shared.ContinueAsNewWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ContinueAsNewWorkflowExecutionDecisionAttributes{
+		WorkflowType:                        FromWorkflowType(t.WorkflowType),
+		TaskList:                            FromTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		BackoffStartIntervalInSeconds:       t.BackoffStartIntervalInSeconds,
+		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
+		Initiator:                           FromContinueAsNewInitiator(t.Initiator),
+		FailureReason:                       t.FailureReason,
+		FailureDetails:                      t.FailureDetails,
+		LastCompletionResult:                t.LastCompletionResult,
+		CronSchedule:                        t.CronSchedule,
+		Header:                              FromHeader(t.Header),
+		Memo:                                FromMemo(t.Memo),
+		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// ToContinueAsNewWorkflowExecutionDecisionAttributes converts thrift ContinueAsNewWorkflowExecutionDecisionAttributes type to internal
+func ToContinueAsNewWorkflowExecutionDecisionAttributes(t *shared.ContinueAsNewWorkflowExecutionDecisionAttributes) *types.ContinueAsNewWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ContinueAsNewWorkflowExecutionDecisionAttributes{
+		WorkflowType:                        ToWorkflowType(t.WorkflowType),
+		TaskList:                            ToTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		BackoffStartIntervalInSeconds:       t.BackoffStartIntervalInSeconds,
+		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
+		Initiator:                           ToContinueAsNewInitiator(t.Initiator),
+		FailureReason:                       t.FailureReason,
+		FailureDetails:                      t.FailureDetails,
+		LastCompletionResult:                t.LastCompletionResult,
+		CronSchedule:                        t.CronSchedule,
+		Header:                              ToHeader(t.Header),
+		Memo:                                ToMemo(t.Memo),
+		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// FromCountWorkflowExecutionsRequest converts internal CountWorkflowExecutionsRequest type to thrift
+func FromCountWorkflowExecutionsRequest(t *types.CountWorkflowExecutionsRequest) *shared.CountWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.CountWorkflowExecutionsRequest{
+		Domain: t.Domain,
+		Query:  t.Query,
+	}
+}
+
+// ToCountWorkflowExecutionsRequest converts thrift CountWorkflowExecutionsRequest type to internal
+func ToCountWorkflowExecutionsRequest(t *shared.CountWorkflowExecutionsRequest) *types.CountWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.CountWorkflowExecutionsRequest{
+		Domain: t.Domain,
+		Query:  t.Query,
+	}
+}
+
+// FromCountWorkflowExecutionsResponse converts internal CountWorkflowExecutionsResponse type to thrift
+func FromCountWorkflowExecutionsResponse(t *types.CountWorkflowExecutionsResponse) *shared.CountWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.CountWorkflowExecutionsResponse{
+		Count: t.Count,
+	}
+}
+
+// ToCountWorkflowExecutionsResponse converts thrift CountWorkflowExecutionsResponse type to internal
+func ToCountWorkflowExecutionsResponse(t *shared.CountWorkflowExecutionsResponse) *types.CountWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.CountWorkflowExecutionsResponse{
+		Count: t.Count,
+	}
+}
+
+// FromCurrentBranchChangedError converts internal CurrentBranchChangedError type to thrift
+func FromCurrentBranchChangedError(t *types.CurrentBranchChangedError) *shared.CurrentBranchChangedError {
+	if t == nil {
+		return nil
+	}
+	return &shared.CurrentBranchChangedError{
+		Message:            t.Message,
+		CurrentBranchToken: t.CurrentBranchToken,
+	}
+}
+
+// ToCurrentBranchChangedError converts thrift CurrentBranchChangedError type to internal
+func ToCurrentBranchChangedError(t *shared.CurrentBranchChangedError) *types.CurrentBranchChangedError {
+	if t == nil {
+		return nil
+	}
+	return &types.CurrentBranchChangedError{
+		Message:            t.Message,
+		CurrentBranchToken: t.CurrentBranchToken,
+	}
+}
+
+// FromDataBlob converts internal DataBlob type to thrift
+func FromDataBlob(t *types.DataBlob) *shared.DataBlob {
+	if t == nil {
+		return nil
+	}
+	return &shared.DataBlob{
+		EncodingType: FromEncodingType(t.EncodingType),
+		Data:         t.Data,
+	}
+}
+
+// ToDataBlob converts thrift DataBlob type to internal
+func ToDataBlob(t *shared.DataBlob) *types.DataBlob {
+	if t == nil {
+		return nil
+	}
+	return &types.DataBlob{
+		EncodingType: ToEncodingType(t.EncodingType),
+		Data:         t.Data,
+	}
+}
+
+// FromDecision converts internal Decision type to thrift
+func FromDecision(t *types.Decision) *shared.Decision {
+	if t == nil {
+		return nil
+	}
+	return &shared.Decision{
+		DecisionType:                                             FromDecisionType(t.DecisionType),
+		ScheduleActivityTaskDecisionAttributes:                   FromScheduleActivityTaskDecisionAttributes(t.ScheduleActivityTaskDecisionAttributes),
+		StartTimerDecisionAttributes:                             FromStartTimerDecisionAttributes(t.StartTimerDecisionAttributes),
+		CompleteWorkflowExecutionDecisionAttributes:              FromCompleteWorkflowExecutionDecisionAttributes(t.CompleteWorkflowExecutionDecisionAttributes),
+		FailWorkflowExecutionDecisionAttributes:                  FromFailWorkflowExecutionDecisionAttributes(t.FailWorkflowExecutionDecisionAttributes),
+		RequestCancelActivityTaskDecisionAttributes:              FromRequestCancelActivityTaskDecisionAttributes(t.RequestCancelActivityTaskDecisionAttributes),
+		CancelTimerDecisionAttributes:                            FromCancelTimerDecisionAttributes(t.CancelTimerDecisionAttributes),
+		CancelWorkflowExecutionDecisionAttributes:                FromCancelWorkflowExecutionDecisionAttributes(t.CancelWorkflowExecutionDecisionAttributes),
+		RequestCancelExternalWorkflowExecutionDecisionAttributes: FromRequestCancelExternalWorkflowExecutionDecisionAttributes(t.RequestCancelExternalWorkflowExecutionDecisionAttributes),
+		RecordMarkerDecisionAttributes:                           FromRecordMarkerDecisionAttributes(t.RecordMarkerDecisionAttributes),
+		ContinueAsNewWorkflowExecutionDecisionAttributes:         FromContinueAsNewWorkflowExecutionDecisionAttributes(t.ContinueAsNewWorkflowExecutionDecisionAttributes),
+		StartChildWorkflowExecutionDecisionAttributes:            FromStartChildWorkflowExecutionDecisionAttributes(t.StartChildWorkflowExecutionDecisionAttributes),
+		SignalExternalWorkflowExecutionDecisionAttributes:        FromSignalExternalWorkflowExecutionDecisionAttributes(t.SignalExternalWorkflowExecutionDecisionAttributes),
+		UpsertWorkflowSearchAttributesDecisionAttributes:         FromUpsertWorkflowSearchAttributesDecisionAttributes(t.UpsertWorkflowSearchAttributesDecisionAttributes),
+	}
+}
+
+// ToDecision converts thrift Decision type to internal
+func ToDecision(t *shared.Decision) *types.Decision {
+	if t == nil {
+		return nil
+	}
+	return &types.Decision{
+		DecisionType:                                             ToDecisionType(t.DecisionType),
+		ScheduleActivityTaskDecisionAttributes:                   ToScheduleActivityTaskDecisionAttributes(t.ScheduleActivityTaskDecisionAttributes),
+		StartTimerDecisionAttributes:                             ToStartTimerDecisionAttributes(t.StartTimerDecisionAttributes),
+		CompleteWorkflowExecutionDecisionAttributes:              ToCompleteWorkflowExecutionDecisionAttributes(t.CompleteWorkflowExecutionDecisionAttributes),
+		FailWorkflowExecutionDecisionAttributes:                  ToFailWorkflowExecutionDecisionAttributes(t.FailWorkflowExecutionDecisionAttributes),
+		RequestCancelActivityTaskDecisionAttributes:              ToRequestCancelActivityTaskDecisionAttributes(t.RequestCancelActivityTaskDecisionAttributes),
+		CancelTimerDecisionAttributes:                            ToCancelTimerDecisionAttributes(t.CancelTimerDecisionAttributes),
+		CancelWorkflowExecutionDecisionAttributes:                ToCancelWorkflowExecutionDecisionAttributes(t.CancelWorkflowExecutionDecisionAttributes),
+		RequestCancelExternalWorkflowExecutionDecisionAttributes: ToRequestCancelExternalWorkflowExecutionDecisionAttributes(t.RequestCancelExternalWorkflowExecutionDecisionAttributes),
+		RecordMarkerDecisionAttributes:                           ToRecordMarkerDecisionAttributes(t.RecordMarkerDecisionAttributes),
+		ContinueAsNewWorkflowExecutionDecisionAttributes:         ToContinueAsNewWorkflowExecutionDecisionAttributes(t.ContinueAsNewWorkflowExecutionDecisionAttributes),
+		StartChildWorkflowExecutionDecisionAttributes:            ToStartChildWorkflowExecutionDecisionAttributes(t.StartChildWorkflowExecutionDecisionAttributes),
+		SignalExternalWorkflowExecutionDecisionAttributes:        ToSignalExternalWorkflowExecutionDecisionAttributes(t.SignalExternalWorkflowExecutionDecisionAttributes),
+		UpsertWorkflowSearchAttributesDecisionAttributes:         ToUpsertWorkflowSearchAttributesDecisionAttributes(t.UpsertWorkflowSearchAttributesDecisionAttributes),
+	}
+}
+
+// FromDecisionTaskCompletedEventAttributes converts internal DecisionTaskCompletedEventAttributes type to thrift
+func FromDecisionTaskCompletedEventAttributes(t *types.DecisionTaskCompletedEventAttributes) *shared.DecisionTaskCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.DecisionTaskCompletedEventAttributes{
+		ExecutionContext: t.ExecutionContext,
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Identity:         t.Identity,
+		BinaryChecksum:   t.BinaryChecksum,
+	}
+}
+
+// ToDecisionTaskCompletedEventAttributes converts thrift DecisionTaskCompletedEventAttributes type to internal
+func ToDecisionTaskCompletedEventAttributes(t *shared.DecisionTaskCompletedEventAttributes) *types.DecisionTaskCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.DecisionTaskCompletedEventAttributes{
+		ExecutionContext: t.ExecutionContext,
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Identity:         t.Identity,
+		BinaryChecksum:   t.BinaryChecksum,
+	}
+}
+
+// FromDecisionTaskFailedCause converts internal DecisionTaskFailedCause type to thrift
+func FromDecisionTaskFailedCause(t *types.DecisionTaskFailedCause) *shared.DecisionTaskFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.DecisionTaskFailedCauseBadBinary:
+		v := shared.DecisionTaskFailedCauseBadBinary
+		return &v
+	case types.DecisionTaskFailedCauseBadCancelTimerAttributes:
+		v := shared.DecisionTaskFailedCauseBadCancelTimerAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes:
+		v := shared.DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes:
+		v := shared.DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadContinueAsNewAttributes:
+		v := shared.DecisionTaskFailedCauseBadContinueAsNewAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes:
+		v := shared.DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadRecordMarkerAttributes:
+		v := shared.DecisionTaskFailedCauseBadRecordMarkerAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadRequestCancelActivityAttributes:
+		v := shared.DecisionTaskFailedCauseBadRequestCancelActivityAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes:
+		v := shared.DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadScheduleActivityAttributes:
+		v := shared.DecisionTaskFailedCauseBadScheduleActivityAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadSearchAttributes:
+		v := shared.DecisionTaskFailedCauseBadSearchAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadSignalInputSize:
+		v := shared.DecisionTaskFailedCauseBadSignalInputSize
+		return &v
+	case types.DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes:
+		v := shared.DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadStartChildExecutionAttributes:
+		v := shared.DecisionTaskFailedCauseBadStartChildExecutionAttributes
+		return &v
+	case types.DecisionTaskFailedCauseBadStartTimerAttributes:
+		v := shared.DecisionTaskFailedCauseBadStartTimerAttributes
+		return &v
+	case types.DecisionTaskFailedCauseFailoverCloseDecision:
+		v := shared.DecisionTaskFailedCauseFailoverCloseDecision
+		return &v
+	case types.DecisionTaskFailedCauseForceCloseDecision:
+		v := shared.DecisionTaskFailedCauseForceCloseDecision
+		return &v
+	case types.DecisionTaskFailedCauseResetStickyTasklist:
+		v := shared.DecisionTaskFailedCauseResetStickyTasklist
+		return &v
+	case types.DecisionTaskFailedCauseResetWorkflow:
+		v := shared.DecisionTaskFailedCauseResetWorkflow
+		return &v
+	case types.DecisionTaskFailedCauseScheduleActivityDuplicateID:
+		v := shared.DecisionTaskFailedCauseScheduleActivityDuplicateID
+		return &v
+	case types.DecisionTaskFailedCauseStartTimerDuplicateID:
+		v := shared.DecisionTaskFailedCauseStartTimerDuplicateID
+		return &v
+	case types.DecisionTaskFailedCauseUnhandledDecision:
+		v := shared.DecisionTaskFailedCauseUnhandledDecision
+		return &v
+	case types.DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure:
+		v := shared.DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToDecisionTaskFailedCause converts thrift DecisionTaskFailedCause type to internal
+func ToDecisionTaskFailedCause(t *shared.DecisionTaskFailedCause) *types.DecisionTaskFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.DecisionTaskFailedCauseBadBinary:
+		v := types.DecisionTaskFailedCauseBadBinary
+		return &v
+	case shared.DecisionTaskFailedCauseBadCancelTimerAttributes:
+		v := types.DecisionTaskFailedCauseBadCancelTimerAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes:
+		v := types.DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes:
+		v := types.DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadContinueAsNewAttributes:
+		v := types.DecisionTaskFailedCauseBadContinueAsNewAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes:
+		v := types.DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadRecordMarkerAttributes:
+		v := types.DecisionTaskFailedCauseBadRecordMarkerAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadRequestCancelActivityAttributes:
+		v := types.DecisionTaskFailedCauseBadRequestCancelActivityAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes:
+		v := types.DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadScheduleActivityAttributes:
+		v := types.DecisionTaskFailedCauseBadScheduleActivityAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadSearchAttributes:
+		v := types.DecisionTaskFailedCauseBadSearchAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadSignalInputSize:
+		v := types.DecisionTaskFailedCauseBadSignalInputSize
+		return &v
+	case shared.DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes:
+		v := types.DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadStartChildExecutionAttributes:
+		v := types.DecisionTaskFailedCauseBadStartChildExecutionAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseBadStartTimerAttributes:
+		v := types.DecisionTaskFailedCauseBadStartTimerAttributes
+		return &v
+	case shared.DecisionTaskFailedCauseFailoverCloseDecision:
+		v := types.DecisionTaskFailedCauseFailoverCloseDecision
+		return &v
+	case shared.DecisionTaskFailedCauseForceCloseDecision:
+		v := types.DecisionTaskFailedCauseForceCloseDecision
+		return &v
+	case shared.DecisionTaskFailedCauseResetStickyTasklist:
+		v := types.DecisionTaskFailedCauseResetStickyTasklist
+		return &v
+	case shared.DecisionTaskFailedCauseResetWorkflow:
+		v := types.DecisionTaskFailedCauseResetWorkflow
+		return &v
+	case shared.DecisionTaskFailedCauseScheduleActivityDuplicateID:
+		v := types.DecisionTaskFailedCauseScheduleActivityDuplicateID
+		return &v
+	case shared.DecisionTaskFailedCauseStartTimerDuplicateID:
+		v := types.DecisionTaskFailedCauseStartTimerDuplicateID
+		return &v
+	case shared.DecisionTaskFailedCauseUnhandledDecision:
+		v := types.DecisionTaskFailedCauseUnhandledDecision
+		return &v
+	case shared.DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure:
+		v := types.DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromDecisionTaskFailedEventAttributes converts internal DecisionTaskFailedEventAttributes type to thrift
+func FromDecisionTaskFailedEventAttributes(t *types.DecisionTaskFailedEventAttributes) *shared.DecisionTaskFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.DecisionTaskFailedEventAttributes{
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Cause:            FromDecisionTaskFailedCause(t.Cause),
+		Details:          t.Details,
+		Identity:         t.Identity,
+		Reason:           t.Reason,
+		BaseRunId:        t.BaseRunId,
+		NewRunId:         t.NewRunId,
+		ForkEventVersion: t.ForkEventVersion,
+		BinaryChecksum:   t.BinaryChecksum,
+	}
+}
+
+// ToDecisionTaskFailedEventAttributes converts thrift DecisionTaskFailedEventAttributes type to internal
+func ToDecisionTaskFailedEventAttributes(t *shared.DecisionTaskFailedEventAttributes) *types.DecisionTaskFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.DecisionTaskFailedEventAttributes{
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		Cause:            ToDecisionTaskFailedCause(t.Cause),
+		Details:          t.Details,
+		Identity:         t.Identity,
+		Reason:           t.Reason,
+		BaseRunId:        t.BaseRunId,
+		NewRunId:         t.NewRunId,
+		ForkEventVersion: t.ForkEventVersion,
+		BinaryChecksum:   t.BinaryChecksum,
+	}
+}
+
+// FromDecisionTaskScheduledEventAttributes converts internal DecisionTaskScheduledEventAttributes type to thrift
+func FromDecisionTaskScheduledEventAttributes(t *types.DecisionTaskScheduledEventAttributes) *shared.DecisionTaskScheduledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.DecisionTaskScheduledEventAttributes{
+		TaskList:                   FromTaskList(t.TaskList),
+		StartToCloseTimeoutSeconds: t.StartToCloseTimeoutSeconds,
+		Attempt:                    t.Attempt,
+	}
+}
+
+// ToDecisionTaskScheduledEventAttributes converts thrift DecisionTaskScheduledEventAttributes type to internal
+func ToDecisionTaskScheduledEventAttributes(t *shared.DecisionTaskScheduledEventAttributes) *types.DecisionTaskScheduledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.DecisionTaskScheduledEventAttributes{
+		TaskList:                   ToTaskList(t.TaskList),
+		StartToCloseTimeoutSeconds: t.StartToCloseTimeoutSeconds,
+		Attempt:                    t.Attempt,
+	}
+}
+
+// FromDecisionTaskStartedEventAttributes converts internal DecisionTaskStartedEventAttributes type to thrift
+func FromDecisionTaskStartedEventAttributes(t *types.DecisionTaskStartedEventAttributes) *shared.DecisionTaskStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.DecisionTaskStartedEventAttributes{
+		ScheduledEventId: t.ScheduledEventId,
+		Identity:         t.Identity,
+		RequestId:        t.RequestId,
+	}
+}
+
+// ToDecisionTaskStartedEventAttributes converts thrift DecisionTaskStartedEventAttributes type to internal
+func ToDecisionTaskStartedEventAttributes(t *shared.DecisionTaskStartedEventAttributes) *types.DecisionTaskStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.DecisionTaskStartedEventAttributes{
+		ScheduledEventId: t.ScheduledEventId,
+		Identity:         t.Identity,
+		RequestId:        t.RequestId,
+	}
+}
+
+// FromDecisionTaskTimedOutEventAttributes converts internal DecisionTaskTimedOutEventAttributes type to thrift
+func FromDecisionTaskTimedOutEventAttributes(t *types.DecisionTaskTimedOutEventAttributes) *shared.DecisionTaskTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.DecisionTaskTimedOutEventAttributes{
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		TimeoutType:      FromTimeoutType(t.TimeoutType),
+	}
+}
+
+// ToDecisionTaskTimedOutEventAttributes converts thrift DecisionTaskTimedOutEventAttributes type to internal
+func ToDecisionTaskTimedOutEventAttributes(t *shared.DecisionTaskTimedOutEventAttributes) *types.DecisionTaskTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.DecisionTaskTimedOutEventAttributes{
+		ScheduledEventId: t.ScheduledEventId,
+		StartedEventId:   t.StartedEventId,
+		TimeoutType:      ToTimeoutType(t.TimeoutType),
+	}
+}
+
+// FromDecisionType converts internal DecisionType type to thrift
+func FromDecisionType(t *types.DecisionType) *shared.DecisionType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.DecisionTypeCancelTimer:
+		v := shared.DecisionTypeCancelTimer
+		return &v
+	case types.DecisionTypeCancelWorkflowExecution:
+		v := shared.DecisionTypeCancelWorkflowExecution
+		return &v
+	case types.DecisionTypeCompleteWorkflowExecution:
+		v := shared.DecisionTypeCompleteWorkflowExecution
+		return &v
+	case types.DecisionTypeContinueAsNewWorkflowExecution:
+		v := shared.DecisionTypeContinueAsNewWorkflowExecution
+		return &v
+	case types.DecisionTypeFailWorkflowExecution:
+		v := shared.DecisionTypeFailWorkflowExecution
+		return &v
+	case types.DecisionTypeRecordMarker:
+		v := shared.DecisionTypeRecordMarker
+		return &v
+	case types.DecisionTypeRequestCancelActivityTask:
+		v := shared.DecisionTypeRequestCancelActivityTask
+		return &v
+	case types.DecisionTypeRequestCancelExternalWorkflowExecution:
+		v := shared.DecisionTypeRequestCancelExternalWorkflowExecution
+		return &v
+	case types.DecisionTypeScheduleActivityTask:
+		v := shared.DecisionTypeScheduleActivityTask
+		return &v
+	case types.DecisionTypeSignalExternalWorkflowExecution:
+		v := shared.DecisionTypeSignalExternalWorkflowExecution
+		return &v
+	case types.DecisionTypeStartChildWorkflowExecution:
+		v := shared.DecisionTypeStartChildWorkflowExecution
+		return &v
+	case types.DecisionTypeStartTimer:
+		v := shared.DecisionTypeStartTimer
+		return &v
+	case types.DecisionTypeUpsertWorkflowSearchAttributes:
+		v := shared.DecisionTypeUpsertWorkflowSearchAttributes
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToDecisionType converts thrift DecisionType type to internal
+func ToDecisionType(t *shared.DecisionType) *types.DecisionType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.DecisionTypeCancelTimer:
+		v := types.DecisionTypeCancelTimer
+		return &v
+	case shared.DecisionTypeCancelWorkflowExecution:
+		v := types.DecisionTypeCancelWorkflowExecution
+		return &v
+	case shared.DecisionTypeCompleteWorkflowExecution:
+		v := types.DecisionTypeCompleteWorkflowExecution
+		return &v
+	case shared.DecisionTypeContinueAsNewWorkflowExecution:
+		v := types.DecisionTypeContinueAsNewWorkflowExecution
+		return &v
+	case shared.DecisionTypeFailWorkflowExecution:
+		v := types.DecisionTypeFailWorkflowExecution
+		return &v
+	case shared.DecisionTypeRecordMarker:
+		v := types.DecisionTypeRecordMarker
+		return &v
+	case shared.DecisionTypeRequestCancelActivityTask:
+		v := types.DecisionTypeRequestCancelActivityTask
+		return &v
+	case shared.DecisionTypeRequestCancelExternalWorkflowExecution:
+		v := types.DecisionTypeRequestCancelExternalWorkflowExecution
+		return &v
+	case shared.DecisionTypeScheduleActivityTask:
+		v := types.DecisionTypeScheduleActivityTask
+		return &v
+	case shared.DecisionTypeSignalExternalWorkflowExecution:
+		v := types.DecisionTypeSignalExternalWorkflowExecution
+		return &v
+	case shared.DecisionTypeStartChildWorkflowExecution:
+		v := types.DecisionTypeStartChildWorkflowExecution
+		return &v
+	case shared.DecisionTypeStartTimer:
+		v := types.DecisionTypeStartTimer
+		return &v
+	case shared.DecisionTypeUpsertWorkflowSearchAttributes:
+		v := types.DecisionTypeUpsertWorkflowSearchAttributes
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromDeprecateDomainRequest converts internal DeprecateDomainRequest type to thrift
+func FromDeprecateDomainRequest(t *types.DeprecateDomainRequest) *shared.DeprecateDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.DeprecateDomainRequest{
+		Name:          t.Name,
+		SecurityToken: t.SecurityToken,
+	}
+}
+
+// ToDeprecateDomainRequest converts thrift DeprecateDomainRequest type to internal
+func ToDeprecateDomainRequest(t *shared.DeprecateDomainRequest) *types.DeprecateDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DeprecateDomainRequest{
+		Name:          t.Name,
+		SecurityToken: t.SecurityToken,
+	}
+}
+
+// FromDescribeDomainRequest converts internal DescribeDomainRequest type to thrift
+func FromDescribeDomainRequest(t *types.DescribeDomainRequest) *shared.DescribeDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeDomainRequest{
+		Name: t.Name,
+		UUID: t.UUID,
+	}
+}
+
+// ToDescribeDomainRequest converts thrift DescribeDomainRequest type to internal
+func ToDescribeDomainRequest(t *shared.DescribeDomainRequest) *types.DescribeDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeDomainRequest{
+		Name: t.Name,
+		UUID: t.UUID,
+	}
+}
+
+// FromDescribeDomainResponse converts internal DescribeDomainResponse type to thrift
+func FromDescribeDomainResponse(t *types.DescribeDomainResponse) *shared.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeDomainResponse{
+		DomainInfo:               FromDomainInfo(t.DomainInfo),
+		Configuration:            FromDomainConfiguration(t.Configuration),
+		ReplicationConfiguration: FromDomainReplicationConfiguration(t.ReplicationConfiguration),
+		FailoverVersion:          t.FailoverVersion,
+		IsGlobalDomain:           t.IsGlobalDomain,
+	}
+}
+
+// ToDescribeDomainResponse converts thrift DescribeDomainResponse type to internal
+func ToDescribeDomainResponse(t *shared.DescribeDomainResponse) *types.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeDomainResponse{
+		DomainInfo:               ToDomainInfo(t.DomainInfo),
+		Configuration:            ToDomainConfiguration(t.Configuration),
+		ReplicationConfiguration: ToDomainReplicationConfiguration(t.ReplicationConfiguration),
+		FailoverVersion:          t.FailoverVersion,
+		IsGlobalDomain:           t.IsGlobalDomain,
+	}
+}
+
+// FromDescribeHistoryHostRequest converts internal DescribeHistoryHostRequest type to thrift
+func FromDescribeHistoryHostRequest(t *types.DescribeHistoryHostRequest) *shared.DescribeHistoryHostRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeHistoryHostRequest{
+		HostAddress:      t.HostAddress,
+		ShardIdForHost:   t.ShardIdForHost,
+		ExecutionForHost: FromWorkflowExecution(t.ExecutionForHost),
+	}
+}
+
+// ToDescribeHistoryHostRequest converts thrift DescribeHistoryHostRequest type to internal
+func ToDescribeHistoryHostRequest(t *shared.DescribeHistoryHostRequest) *types.DescribeHistoryHostRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeHistoryHostRequest{
+		HostAddress:      t.HostAddress,
+		ShardIdForHost:   t.ShardIdForHost,
+		ExecutionForHost: ToWorkflowExecution(t.ExecutionForHost),
+	}
+}
+
+// FromDescribeHistoryHostResponse converts internal DescribeHistoryHostResponse type to thrift
+func FromDescribeHistoryHostResponse(t *types.DescribeHistoryHostResponse) *shared.DescribeHistoryHostResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeHistoryHostResponse{
+		NumberOfShards:        t.NumberOfShards,
+		ShardIDs:              t.ShardIDs,
+		DomainCache:           FromDomainCacheInfo(t.DomainCache),
+		ShardControllerStatus: t.ShardControllerStatus,
+		Address:               t.Address,
+	}
+}
+
+// ToDescribeHistoryHostResponse converts thrift DescribeHistoryHostResponse type to internal
+func ToDescribeHistoryHostResponse(t *shared.DescribeHistoryHostResponse) *types.DescribeHistoryHostResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeHistoryHostResponse{
+		NumberOfShards:        t.NumberOfShards,
+		ShardIDs:              t.ShardIDs,
+		DomainCache:           ToDomainCacheInfo(t.DomainCache),
+		ShardControllerStatus: t.ShardControllerStatus,
+		Address:               t.Address,
+	}
+}
+
+// FromDescribeQueueRequest converts internal DescribeQueueRequest type to thrift
+func FromDescribeQueueRequest(t *types.DescribeQueueRequest) *shared.DescribeQueueRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeQueueRequest{
+		ShardID:     t.ShardID,
+		ClusterName: t.ClusterName,
+		Type:        t.Type,
+	}
+}
+
+// ToDescribeQueueRequest converts thrift DescribeQueueRequest type to internal
+func ToDescribeQueueRequest(t *shared.DescribeQueueRequest) *types.DescribeQueueRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeQueueRequest{
+		ShardID:     t.ShardID,
+		ClusterName: t.ClusterName,
+		Type:        t.Type,
+	}
+}
+
+// FromDescribeQueueResponse converts internal DescribeQueueResponse type to thrift
+func FromDescribeQueueResponse(t *types.DescribeQueueResponse) *shared.DescribeQueueResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeQueueResponse{
+		ProcessingQueueStates: t.ProcessingQueueStates,
+	}
+}
+
+// ToDescribeQueueResponse converts thrift DescribeQueueResponse type to internal
+func ToDescribeQueueResponse(t *shared.DescribeQueueResponse) *types.DescribeQueueResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeQueueResponse{
+		ProcessingQueueStates: t.ProcessingQueueStates,
+	}
+}
+
+// FromDescribeTaskListRequest converts internal DescribeTaskListRequest type to thrift
+func FromDescribeTaskListRequest(t *types.DescribeTaskListRequest) *shared.DescribeTaskListRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeTaskListRequest{
+		Domain:                t.Domain,
+		TaskList:              FromTaskList(t.TaskList),
+		TaskListType:          FromTaskListType(t.TaskListType),
+		IncludeTaskListStatus: t.IncludeTaskListStatus,
+	}
+}
+
+// ToDescribeTaskListRequest converts thrift DescribeTaskListRequest type to internal
+func ToDescribeTaskListRequest(t *shared.DescribeTaskListRequest) *types.DescribeTaskListRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeTaskListRequest{
+		Domain:                t.Domain,
+		TaskList:              ToTaskList(t.TaskList),
+		TaskListType:          ToTaskListType(t.TaskListType),
+		IncludeTaskListStatus: t.IncludeTaskListStatus,
+	}
+}
+
+// FromDescribeTaskListResponse converts internal DescribeTaskListResponse type to thrift
+func FromDescribeTaskListResponse(t *types.DescribeTaskListResponse) *shared.DescribeTaskListResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeTaskListResponse{
+		Pollers:        FromPollerInfoArray(t.Pollers),
+		TaskListStatus: FromTaskListStatus(t.TaskListStatus),
+	}
+}
+
+// ToDescribeTaskListResponse converts thrift DescribeTaskListResponse type to internal
+func ToDescribeTaskListResponse(t *shared.DescribeTaskListResponse) *types.DescribeTaskListResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeTaskListResponse{
+		Pollers:        ToPollerInfoArray(t.Pollers),
+		TaskListStatus: ToTaskListStatus(t.TaskListStatus),
+	}
+}
+
+// FromDescribeWorkflowExecutionRequest converts internal DescribeWorkflowExecutionRequest type to thrift
+func FromDescribeWorkflowExecutionRequest(t *types.DescribeWorkflowExecutionRequest) *shared.DescribeWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeWorkflowExecutionRequest{
+		Domain:    t.Domain,
+		Execution: FromWorkflowExecution(t.Execution),
+	}
+}
+
+// ToDescribeWorkflowExecutionRequest converts thrift DescribeWorkflowExecutionRequest type to internal
+func ToDescribeWorkflowExecutionRequest(t *shared.DescribeWorkflowExecutionRequest) *types.DescribeWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeWorkflowExecutionRequest{
+		Domain:    t.Domain,
+		Execution: ToWorkflowExecution(t.Execution),
+	}
+}
+
+// FromDescribeWorkflowExecutionResponse converts internal DescribeWorkflowExecutionResponse type to thrift
+func FromDescribeWorkflowExecutionResponse(t *types.DescribeWorkflowExecutionResponse) *shared.DescribeWorkflowExecutionResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.DescribeWorkflowExecutionResponse{
+		ExecutionConfiguration: FromWorkflowExecutionConfiguration(t.ExecutionConfiguration),
+		WorkflowExecutionInfo:  FromWorkflowExecutionInfo(t.WorkflowExecutionInfo),
+		PendingActivities:      FromPendingActivityInfoArray(t.PendingActivities),
+		PendingChildren:        FromPendingChildExecutionInfoArray(t.PendingChildren),
+	}
+}
+
+// ToDescribeWorkflowExecutionResponse converts thrift DescribeWorkflowExecutionResponse type to internal
+func ToDescribeWorkflowExecutionResponse(t *shared.DescribeWorkflowExecutionResponse) *types.DescribeWorkflowExecutionResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeWorkflowExecutionResponse{
+		ExecutionConfiguration: ToWorkflowExecutionConfiguration(t.ExecutionConfiguration),
+		WorkflowExecutionInfo:  ToWorkflowExecutionInfo(t.WorkflowExecutionInfo),
+		PendingActivities:      ToPendingActivityInfoArray(t.PendingActivities),
+		PendingChildren:        ToPendingChildExecutionInfoArray(t.PendingChildren),
+	}
+}
+
+// FromDomainAlreadyExistsError converts internal DomainAlreadyExistsError type to thrift
+func FromDomainAlreadyExistsError(t *types.DomainAlreadyExistsError) *shared.DomainAlreadyExistsError {
+	if t == nil {
+		return nil
+	}
+	return &shared.DomainAlreadyExistsError{
+		Message: t.Message,
+	}
+}
+
+// ToDomainAlreadyExistsError converts thrift DomainAlreadyExistsError type to internal
+func ToDomainAlreadyExistsError(t *shared.DomainAlreadyExistsError) *types.DomainAlreadyExistsError {
+	if t == nil {
+		return nil
+	}
+	return &types.DomainAlreadyExistsError{
+		Message: t.Message,
+	}
+}
+
+// FromDomainCacheInfo converts internal DomainCacheInfo type to thrift
+func FromDomainCacheInfo(t *types.DomainCacheInfo) *shared.DomainCacheInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.DomainCacheInfo{
+		NumOfItemsInCacheByID:   t.NumOfItemsInCacheByID,
+		NumOfItemsInCacheByName: t.NumOfItemsInCacheByName,
+	}
+}
+
+// ToDomainCacheInfo converts thrift DomainCacheInfo type to internal
+func ToDomainCacheInfo(t *shared.DomainCacheInfo) *types.DomainCacheInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.DomainCacheInfo{
+		NumOfItemsInCacheByID:   t.NumOfItemsInCacheByID,
+		NumOfItemsInCacheByName: t.NumOfItemsInCacheByName,
+	}
+}
+
+// FromDomainConfiguration converts internal DomainConfiguration type to thrift
+func FromDomainConfiguration(t *types.DomainConfiguration) *shared.DomainConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &shared.DomainConfiguration{
+		WorkflowExecutionRetentionPeriodInDays: t.WorkflowExecutionRetentionPeriodInDays,
+		EmitMetric:                             t.EmitMetric,
+		BadBinaries:                            FromBadBinaries(t.BadBinaries),
+		HistoryArchivalStatus:                  FromArchivalStatus(t.HistoryArchivalStatus),
+		HistoryArchivalURI:                     t.HistoryArchivalURI,
+		VisibilityArchivalStatus:               FromArchivalStatus(t.VisibilityArchivalStatus),
+		VisibilityArchivalURI:                  t.VisibilityArchivalURI,
+	}
+}
+
+// ToDomainConfiguration converts thrift DomainConfiguration type to internal
+func ToDomainConfiguration(t *shared.DomainConfiguration) *types.DomainConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &types.DomainConfiguration{
+		WorkflowExecutionRetentionPeriodInDays: t.WorkflowExecutionRetentionPeriodInDays,
+		EmitMetric:                             t.EmitMetric,
+		BadBinaries:                            ToBadBinaries(t.BadBinaries),
+		HistoryArchivalStatus:                  ToArchivalStatus(t.HistoryArchivalStatus),
+		HistoryArchivalURI:                     t.HistoryArchivalURI,
+		VisibilityArchivalStatus:               ToArchivalStatus(t.VisibilityArchivalStatus),
+		VisibilityArchivalURI:                  t.VisibilityArchivalURI,
+	}
+}
+
+// FromDomainInfo converts internal DomainInfo type to thrift
+func FromDomainInfo(t *types.DomainInfo) *shared.DomainInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.DomainInfo{
+		Name:        t.Name,
+		Status:      FromDomainStatus(t.Status),
+		Description: t.Description,
+		OwnerEmail:  t.OwnerEmail,
+		Data:        t.Data,
+		UUID:        t.UUID,
+	}
+}
+
+// ToDomainInfo converts thrift DomainInfo type to internal
+func ToDomainInfo(t *shared.DomainInfo) *types.DomainInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.DomainInfo{
+		Name:        t.Name,
+		Status:      ToDomainStatus(t.Status),
+		Description: t.Description,
+		OwnerEmail:  t.OwnerEmail,
+		Data:        t.Data,
+		UUID:        t.UUID,
+	}
+}
+
+// FromDomainNotActiveError converts internal DomainNotActiveError type to thrift
+func FromDomainNotActiveError(t *types.DomainNotActiveError) *shared.DomainNotActiveError {
+	if t == nil {
+		return nil
+	}
+	return &shared.DomainNotActiveError{
+		Message:        t.Message,
+		DomainName:     t.DomainName,
+		CurrentCluster: t.CurrentCluster,
+		ActiveCluster:  t.ActiveCluster,
+	}
+}
+
+// ToDomainNotActiveError converts thrift DomainNotActiveError type to internal
+func ToDomainNotActiveError(t *shared.DomainNotActiveError) *types.DomainNotActiveError {
+	if t == nil {
+		return nil
+	}
+	return &types.DomainNotActiveError{
+		Message:        t.Message,
+		DomainName:     t.DomainName,
+		CurrentCluster: t.CurrentCluster,
+		ActiveCluster:  t.ActiveCluster,
+	}
+}
+
+// FromDomainReplicationConfiguration converts internal DomainReplicationConfiguration type to thrift
+func FromDomainReplicationConfiguration(t *types.DomainReplicationConfiguration) *shared.DomainReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &shared.DomainReplicationConfiguration{
+		ActiveClusterName: t.ActiveClusterName,
+		Clusters:          FromClusterReplicationConfigurationArray(t.Clusters),
+	}
+}
+
+// ToDomainReplicationConfiguration converts thrift DomainReplicationConfiguration type to internal
+func ToDomainReplicationConfiguration(t *shared.DomainReplicationConfiguration) *types.DomainReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &types.DomainReplicationConfiguration{
+		ActiveClusterName: t.ActiveClusterName,
+		Clusters:          ToClusterReplicationConfigurationArray(t.Clusters),
+	}
+}
+
+// FromDomainStatus converts internal DomainStatus type to thrift
+func FromDomainStatus(t *types.DomainStatus) *shared.DomainStatus {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.DomainStatusDeleted:
+		v := shared.DomainStatusDeleted
+		return &v
+	case types.DomainStatusDeprecated:
+		v := shared.DomainStatusDeprecated
+		return &v
+	case types.DomainStatusRegistered:
+		v := shared.DomainStatusRegistered
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToDomainStatus converts thrift DomainStatus type to internal
+func ToDomainStatus(t *shared.DomainStatus) *types.DomainStatus {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.DomainStatusDeleted:
+		v := types.DomainStatusDeleted
+		return &v
+	case shared.DomainStatusDeprecated:
+		v := types.DomainStatusDeprecated
+		return &v
+	case shared.DomainStatusRegistered:
+		v := types.DomainStatusRegistered
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromEncodingType converts internal EncodingType type to thrift
+func FromEncodingType(t *types.EncodingType) *shared.EncodingType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.EncodingTypeJSON:
+		v := shared.EncodingTypeJSON
+		return &v
+	case types.EncodingTypeThriftRW:
+		v := shared.EncodingTypeThriftRW
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToEncodingType converts thrift EncodingType type to internal
+func ToEncodingType(t *shared.EncodingType) *types.EncodingType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.EncodingTypeJSON:
+		v := types.EncodingTypeJSON
+		return &v
+	case shared.EncodingTypeThriftRW:
+		v := types.EncodingTypeThriftRW
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromEntityNotExistsError converts internal EntityNotExistsError type to thrift
+func FromEntityNotExistsError(t *types.EntityNotExistsError) *shared.EntityNotExistsError {
+	if t == nil {
+		return nil
+	}
+	return &shared.EntityNotExistsError{
+		Message:        t.Message,
+		CurrentCluster: t.CurrentCluster,
+		ActiveCluster:  t.ActiveCluster,
+	}
+}
+
+// ToEntityNotExistsError converts thrift EntityNotExistsError type to internal
+func ToEntityNotExistsError(t *shared.EntityNotExistsError) *types.EntityNotExistsError {
+	if t == nil {
+		return nil
+	}
+	return &types.EntityNotExistsError{
+		Message:        t.Message,
+		CurrentCluster: t.CurrentCluster,
+		ActiveCluster:  t.ActiveCluster,
+	}
+}
+
+// FromEventType converts internal EventType type to thrift
+func FromEventType(t *types.EventType) *shared.EventType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.EventTypeActivityTaskCancelRequested:
+		v := shared.EventTypeActivityTaskCancelRequested
+		return &v
+	case types.EventTypeActivityTaskCanceled:
+		v := shared.EventTypeActivityTaskCanceled
+		return &v
+	case types.EventTypeActivityTaskCompleted:
+		v := shared.EventTypeActivityTaskCompleted
+		return &v
+	case types.EventTypeActivityTaskFailed:
+		v := shared.EventTypeActivityTaskFailed
+		return &v
+	case types.EventTypeActivityTaskScheduled:
+		v := shared.EventTypeActivityTaskScheduled
+		return &v
+	case types.EventTypeActivityTaskStarted:
+		v := shared.EventTypeActivityTaskStarted
+		return &v
+	case types.EventTypeActivityTaskTimedOut:
+		v := shared.EventTypeActivityTaskTimedOut
+		return &v
+	case types.EventTypeCancelTimerFailed:
+		v := shared.EventTypeCancelTimerFailed
+		return &v
+	case types.EventTypeChildWorkflowExecutionCanceled:
+		v := shared.EventTypeChildWorkflowExecutionCanceled
+		return &v
+	case types.EventTypeChildWorkflowExecutionCompleted:
+		v := shared.EventTypeChildWorkflowExecutionCompleted
+		return &v
+	case types.EventTypeChildWorkflowExecutionFailed:
+		v := shared.EventTypeChildWorkflowExecutionFailed
+		return &v
+	case types.EventTypeChildWorkflowExecutionStarted:
+		v := shared.EventTypeChildWorkflowExecutionStarted
+		return &v
+	case types.EventTypeChildWorkflowExecutionTerminated:
+		v := shared.EventTypeChildWorkflowExecutionTerminated
+		return &v
+	case types.EventTypeChildWorkflowExecutionTimedOut:
+		v := shared.EventTypeChildWorkflowExecutionTimedOut
+		return &v
+	case types.EventTypeDecisionTaskCompleted:
+		v := shared.EventTypeDecisionTaskCompleted
+		return &v
+	case types.EventTypeDecisionTaskFailed:
+		v := shared.EventTypeDecisionTaskFailed
+		return &v
+	case types.EventTypeDecisionTaskScheduled:
+		v := shared.EventTypeDecisionTaskScheduled
+		return &v
+	case types.EventTypeDecisionTaskStarted:
+		v := shared.EventTypeDecisionTaskStarted
+		return &v
+	case types.EventTypeDecisionTaskTimedOut:
+		v := shared.EventTypeDecisionTaskTimedOut
+		return &v
+	case types.EventTypeExternalWorkflowExecutionCancelRequested:
+		v := shared.EventTypeExternalWorkflowExecutionCancelRequested
+		return &v
+	case types.EventTypeExternalWorkflowExecutionSignaled:
+		v := shared.EventTypeExternalWorkflowExecutionSignaled
+		return &v
+	case types.EventTypeMarkerRecorded:
+		v := shared.EventTypeMarkerRecorded
+		return &v
+	case types.EventTypeRequestCancelActivityTaskFailed:
+		v := shared.EventTypeRequestCancelActivityTaskFailed
+		return &v
+	case types.EventTypeRequestCancelExternalWorkflowExecutionFailed:
+		v := shared.EventTypeRequestCancelExternalWorkflowExecutionFailed
+		return &v
+	case types.EventTypeRequestCancelExternalWorkflowExecutionInitiated:
+		v := shared.EventTypeRequestCancelExternalWorkflowExecutionInitiated
+		return &v
+	case types.EventTypeSignalExternalWorkflowExecutionFailed:
+		v := shared.EventTypeSignalExternalWorkflowExecutionFailed
+		return &v
+	case types.EventTypeSignalExternalWorkflowExecutionInitiated:
+		v := shared.EventTypeSignalExternalWorkflowExecutionInitiated
+		return &v
+	case types.EventTypeStartChildWorkflowExecutionFailed:
+		v := shared.EventTypeStartChildWorkflowExecutionFailed
+		return &v
+	case types.EventTypeStartChildWorkflowExecutionInitiated:
+		v := shared.EventTypeStartChildWorkflowExecutionInitiated
+		return &v
+	case types.EventTypeTimerCanceled:
+		v := shared.EventTypeTimerCanceled
+		return &v
+	case types.EventTypeTimerFired:
+		v := shared.EventTypeTimerFired
+		return &v
+	case types.EventTypeTimerStarted:
+		v := shared.EventTypeTimerStarted
+		return &v
+	case types.EventTypeUpsertWorkflowSearchAttributes:
+		v := shared.EventTypeUpsertWorkflowSearchAttributes
+		return &v
+	case types.EventTypeWorkflowExecutionCancelRequested:
+		v := shared.EventTypeWorkflowExecutionCancelRequested
+		return &v
+	case types.EventTypeWorkflowExecutionCanceled:
+		v := shared.EventTypeWorkflowExecutionCanceled
+		return &v
+	case types.EventTypeWorkflowExecutionCompleted:
+		v := shared.EventTypeWorkflowExecutionCompleted
+		return &v
+	case types.EventTypeWorkflowExecutionContinuedAsNew:
+		v := shared.EventTypeWorkflowExecutionContinuedAsNew
+		return &v
+	case types.EventTypeWorkflowExecutionFailed:
+		v := shared.EventTypeWorkflowExecutionFailed
+		return &v
+	case types.EventTypeWorkflowExecutionSignaled:
+		v := shared.EventTypeWorkflowExecutionSignaled
+		return &v
+	case types.EventTypeWorkflowExecutionStarted:
+		v := shared.EventTypeWorkflowExecutionStarted
+		return &v
+	case types.EventTypeWorkflowExecutionTerminated:
+		v := shared.EventTypeWorkflowExecutionTerminated
+		return &v
+	case types.EventTypeWorkflowExecutionTimedOut:
+		v := shared.EventTypeWorkflowExecutionTimedOut
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToEventType converts thrift EventType type to internal
+func ToEventType(t *shared.EventType) *types.EventType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.EventTypeActivityTaskCancelRequested:
+		v := types.EventTypeActivityTaskCancelRequested
+		return &v
+	case shared.EventTypeActivityTaskCanceled:
+		v := types.EventTypeActivityTaskCanceled
+		return &v
+	case shared.EventTypeActivityTaskCompleted:
+		v := types.EventTypeActivityTaskCompleted
+		return &v
+	case shared.EventTypeActivityTaskFailed:
+		v := types.EventTypeActivityTaskFailed
+		return &v
+	case shared.EventTypeActivityTaskScheduled:
+		v := types.EventTypeActivityTaskScheduled
+		return &v
+	case shared.EventTypeActivityTaskStarted:
+		v := types.EventTypeActivityTaskStarted
+		return &v
+	case shared.EventTypeActivityTaskTimedOut:
+		v := types.EventTypeActivityTaskTimedOut
+		return &v
+	case shared.EventTypeCancelTimerFailed:
+		v := types.EventTypeCancelTimerFailed
+		return &v
+	case shared.EventTypeChildWorkflowExecutionCanceled:
+		v := types.EventTypeChildWorkflowExecutionCanceled
+		return &v
+	case shared.EventTypeChildWorkflowExecutionCompleted:
+		v := types.EventTypeChildWorkflowExecutionCompleted
+		return &v
+	case shared.EventTypeChildWorkflowExecutionFailed:
+		v := types.EventTypeChildWorkflowExecutionFailed
+		return &v
+	case shared.EventTypeChildWorkflowExecutionStarted:
+		v := types.EventTypeChildWorkflowExecutionStarted
+		return &v
+	case shared.EventTypeChildWorkflowExecutionTerminated:
+		v := types.EventTypeChildWorkflowExecutionTerminated
+		return &v
+	case shared.EventTypeChildWorkflowExecutionTimedOut:
+		v := types.EventTypeChildWorkflowExecutionTimedOut
+		return &v
+	case shared.EventTypeDecisionTaskCompleted:
+		v := types.EventTypeDecisionTaskCompleted
+		return &v
+	case shared.EventTypeDecisionTaskFailed:
+		v := types.EventTypeDecisionTaskFailed
+		return &v
+	case shared.EventTypeDecisionTaskScheduled:
+		v := types.EventTypeDecisionTaskScheduled
+		return &v
+	case shared.EventTypeDecisionTaskStarted:
+		v := types.EventTypeDecisionTaskStarted
+		return &v
+	case shared.EventTypeDecisionTaskTimedOut:
+		v := types.EventTypeDecisionTaskTimedOut
+		return &v
+	case shared.EventTypeExternalWorkflowExecutionCancelRequested:
+		v := types.EventTypeExternalWorkflowExecutionCancelRequested
+		return &v
+	case shared.EventTypeExternalWorkflowExecutionSignaled:
+		v := types.EventTypeExternalWorkflowExecutionSignaled
+		return &v
+	case shared.EventTypeMarkerRecorded:
+		v := types.EventTypeMarkerRecorded
+		return &v
+	case shared.EventTypeRequestCancelActivityTaskFailed:
+		v := types.EventTypeRequestCancelActivityTaskFailed
+		return &v
+	case shared.EventTypeRequestCancelExternalWorkflowExecutionFailed:
+		v := types.EventTypeRequestCancelExternalWorkflowExecutionFailed
+		return &v
+	case shared.EventTypeRequestCancelExternalWorkflowExecutionInitiated:
+		v := types.EventTypeRequestCancelExternalWorkflowExecutionInitiated
+		return &v
+	case shared.EventTypeSignalExternalWorkflowExecutionFailed:
+		v := types.EventTypeSignalExternalWorkflowExecutionFailed
+		return &v
+	case shared.EventTypeSignalExternalWorkflowExecutionInitiated:
+		v := types.EventTypeSignalExternalWorkflowExecutionInitiated
+		return &v
+	case shared.EventTypeStartChildWorkflowExecutionFailed:
+		v := types.EventTypeStartChildWorkflowExecutionFailed
+		return &v
+	case shared.EventTypeStartChildWorkflowExecutionInitiated:
+		v := types.EventTypeStartChildWorkflowExecutionInitiated
+		return &v
+	case shared.EventTypeTimerCanceled:
+		v := types.EventTypeTimerCanceled
+		return &v
+	case shared.EventTypeTimerFired:
+		v := types.EventTypeTimerFired
+		return &v
+	case shared.EventTypeTimerStarted:
+		v := types.EventTypeTimerStarted
+		return &v
+	case shared.EventTypeUpsertWorkflowSearchAttributes:
+		v := types.EventTypeUpsertWorkflowSearchAttributes
+		return &v
+	case shared.EventTypeWorkflowExecutionCancelRequested:
+		v := types.EventTypeWorkflowExecutionCancelRequested
+		return &v
+	case shared.EventTypeWorkflowExecutionCanceled:
+		v := types.EventTypeWorkflowExecutionCanceled
+		return &v
+	case shared.EventTypeWorkflowExecutionCompleted:
+		v := types.EventTypeWorkflowExecutionCompleted
+		return &v
+	case shared.EventTypeWorkflowExecutionContinuedAsNew:
+		v := types.EventTypeWorkflowExecutionContinuedAsNew
+		return &v
+	case shared.EventTypeWorkflowExecutionFailed:
+		v := types.EventTypeWorkflowExecutionFailed
+		return &v
+	case shared.EventTypeWorkflowExecutionSignaled:
+		v := types.EventTypeWorkflowExecutionSignaled
+		return &v
+	case shared.EventTypeWorkflowExecutionStarted:
+		v := types.EventTypeWorkflowExecutionStarted
+		return &v
+	case shared.EventTypeWorkflowExecutionTerminated:
+		v := types.EventTypeWorkflowExecutionTerminated
+		return &v
+	case shared.EventTypeWorkflowExecutionTimedOut:
+		v := types.EventTypeWorkflowExecutionTimedOut
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromExternalWorkflowExecutionCancelRequestedEventAttributes converts internal ExternalWorkflowExecutionCancelRequestedEventAttributes type to thrift
+func FromExternalWorkflowExecutionCancelRequestedEventAttributes(t *types.ExternalWorkflowExecutionCancelRequestedEventAttributes) *shared.ExternalWorkflowExecutionCancelRequestedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ExternalWorkflowExecutionCancelRequestedEventAttributes{
+		InitiatedEventId:  t.InitiatedEventId,
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+	}
+}
+
+// ToExternalWorkflowExecutionCancelRequestedEventAttributes converts thrift ExternalWorkflowExecutionCancelRequestedEventAttributes type to internal
+func ToExternalWorkflowExecutionCancelRequestedEventAttributes(t *shared.ExternalWorkflowExecutionCancelRequestedEventAttributes) *types.ExternalWorkflowExecutionCancelRequestedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ExternalWorkflowExecutionCancelRequestedEventAttributes{
+		InitiatedEventId:  t.InitiatedEventId,
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+	}
+}
+
+// FromExternalWorkflowExecutionSignaledEventAttributes converts internal ExternalWorkflowExecutionSignaledEventAttributes type to thrift
+func FromExternalWorkflowExecutionSignaledEventAttributes(t *types.ExternalWorkflowExecutionSignaledEventAttributes) *shared.ExternalWorkflowExecutionSignaledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ExternalWorkflowExecutionSignaledEventAttributes{
+		InitiatedEventId:  t.InitiatedEventId,
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		Control:           t.Control,
+	}
+}
+
+// ToExternalWorkflowExecutionSignaledEventAttributes converts thrift ExternalWorkflowExecutionSignaledEventAttributes type to internal
+func ToExternalWorkflowExecutionSignaledEventAttributes(t *shared.ExternalWorkflowExecutionSignaledEventAttributes) *types.ExternalWorkflowExecutionSignaledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ExternalWorkflowExecutionSignaledEventAttributes{
+		InitiatedEventId:  t.InitiatedEventId,
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		Control:           t.Control,
+	}
+}
+
+// FromFailWorkflowExecutionDecisionAttributes converts internal FailWorkflowExecutionDecisionAttributes type to thrift
+func FromFailWorkflowExecutionDecisionAttributes(t *types.FailWorkflowExecutionDecisionAttributes) *shared.FailWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.FailWorkflowExecutionDecisionAttributes{
+		Reason:  t.Reason,
+		Details: t.Details,
+	}
+}
+
+// ToFailWorkflowExecutionDecisionAttributes converts thrift FailWorkflowExecutionDecisionAttributes type to internal
+func ToFailWorkflowExecutionDecisionAttributes(t *shared.FailWorkflowExecutionDecisionAttributes) *types.FailWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.FailWorkflowExecutionDecisionAttributes{
+		Reason:  t.Reason,
+		Details: t.Details,
+	}
+}
+
+// FromGetSearchAttributesResponse converts internal GetSearchAttributesResponse type to thrift
+func FromGetSearchAttributesResponse(t *types.GetSearchAttributesResponse) *shared.GetSearchAttributesResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.GetSearchAttributesResponse{
+		Keys: FromIndexedValueTypeMap(t.Keys),
+	}
+}
+
+// ToGetSearchAttributesResponse converts thrift GetSearchAttributesResponse type to internal
+func ToGetSearchAttributesResponse(t *shared.GetSearchAttributesResponse) *types.GetSearchAttributesResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.GetSearchAttributesResponse{
+		Keys: ToIndexedValueTypeMap(t.Keys),
+	}
+}
+
+// FromGetWorkflowExecutionHistoryRequest converts internal GetWorkflowExecutionHistoryRequest type to thrift
+func FromGetWorkflowExecutionHistoryRequest(t *types.GetWorkflowExecutionHistoryRequest) *shared.GetWorkflowExecutionHistoryRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.GetWorkflowExecutionHistoryRequest{
+		Domain:                 t.Domain,
+		Execution:              FromWorkflowExecution(t.Execution),
+		MaximumPageSize:        t.MaximumPageSize,
+		NextPageToken:          t.NextPageToken,
+		WaitForNewEvent:        t.WaitForNewEvent,
+		HistoryEventFilterType: FromHistoryEventFilterType(t.HistoryEventFilterType),
+		SkipArchival:           t.SkipArchival,
+	}
+}
+
+// ToGetWorkflowExecutionHistoryRequest converts thrift GetWorkflowExecutionHistoryRequest type to internal
+func ToGetWorkflowExecutionHistoryRequest(t *shared.GetWorkflowExecutionHistoryRequest) *types.GetWorkflowExecutionHistoryRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.GetWorkflowExecutionHistoryRequest{
+		Domain:                 t.Domain,
+		Execution:              ToWorkflowExecution(t.Execution),
+		MaximumPageSize:        t.MaximumPageSize,
+		NextPageToken:          t.NextPageToken,
+		WaitForNewEvent:        t.WaitForNewEvent,
+		HistoryEventFilterType: ToHistoryEventFilterType(t.HistoryEventFilterType),
+		SkipArchival:           t.SkipArchival,
+	}
+}
+
+// FromGetWorkflowExecutionHistoryResponse converts internal GetWorkflowExecutionHistoryResponse type to thrift
+func FromGetWorkflowExecutionHistoryResponse(t *types.GetWorkflowExecutionHistoryResponse) *shared.GetWorkflowExecutionHistoryResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.GetWorkflowExecutionHistoryResponse{
+		History:       FromHistory(t.History),
+		RawHistory:    FromDataBlobArray(t.RawHistory),
+		NextPageToken: t.NextPageToken,
+		Archived:      t.Archived,
+	}
+}
+
+// ToGetWorkflowExecutionHistoryResponse converts thrift GetWorkflowExecutionHistoryResponse type to internal
+func ToGetWorkflowExecutionHistoryResponse(t *shared.GetWorkflowExecutionHistoryResponse) *types.GetWorkflowExecutionHistoryResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History:       ToHistory(t.History),
+		RawHistory:    ToDataBlobArray(t.RawHistory),
+		NextPageToken: t.NextPageToken,
+		Archived:      t.Archived,
+	}
+}
+
+// FromHeader converts internal Header type to thrift
+func FromHeader(t *types.Header) *shared.Header {
+	if t == nil {
+		return nil
+	}
+	return &shared.Header{
+		Fields: t.Fields,
+	}
+}
+
+// ToHeader converts thrift Header type to internal
+func ToHeader(t *shared.Header) *types.Header {
+	if t == nil {
+		return nil
+	}
+	return &types.Header{
+		Fields: t.Fields,
+	}
+}
+
+// FromHistory converts internal History type to thrift
+func FromHistory(t *types.History) *shared.History {
+	if t == nil {
+		return nil
+	}
+	return &shared.History{
+		Events: FromHistoryEventArray(t.Events),
+	}
+}
+
+// ToHistory converts thrift History type to internal
+func ToHistory(t *shared.History) *types.History {
+	if t == nil {
+		return nil
+	}
+	return &types.History{
+		Events: ToHistoryEventArray(t.Events),
+	}
+}
+
+// FromHistoryBranch converts internal HistoryBranch type to thrift
+func FromHistoryBranch(t *types.HistoryBranch) *shared.HistoryBranch {
+	if t == nil {
+		return nil
+	}
+	return &shared.HistoryBranch{
+		TreeID:    t.TreeID,
+		BranchID:  t.BranchID,
+		Ancestors: FromHistoryBranchRangeArray(t.Ancestors),
+	}
+}
+
+// ToHistoryBranch converts thrift HistoryBranch type to internal
+func ToHistoryBranch(t *shared.HistoryBranch) *types.HistoryBranch {
+	if t == nil {
+		return nil
+	}
+	return &types.HistoryBranch{
+		TreeID:    t.TreeID,
+		BranchID:  t.BranchID,
+		Ancestors: ToHistoryBranchRangeArray(t.Ancestors),
+	}
+}
+
+// FromHistoryBranchRange converts internal HistoryBranchRange type to thrift
+func FromHistoryBranchRange(t *types.HistoryBranchRange) *shared.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	return &shared.HistoryBranchRange{
+		BranchID:    t.BranchID,
+		BeginNodeID: t.BeginNodeID,
+		EndNodeID:   t.EndNodeID,
+	}
+}
+
+// ToHistoryBranchRange converts thrift HistoryBranchRange type to internal
+func ToHistoryBranchRange(t *shared.HistoryBranchRange) *types.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	return &types.HistoryBranchRange{
+		BranchID:    t.BranchID,
+		BeginNodeID: t.BeginNodeID,
+		EndNodeID:   t.EndNodeID,
+	}
+}
+
+// FromHistoryEvent converts internal HistoryEvent type to thrift
+func FromHistoryEvent(t *types.HistoryEvent) *shared.HistoryEvent {
+	if t == nil {
+		return nil
+	}
+	return &shared.HistoryEvent{
+		EventId:                                 t.EventId,
+		Timestamp:                               t.Timestamp,
+		EventType:                               FromEventType(t.EventType),
+		Version:                                 t.Version,
+		TaskId:                                  t.TaskId,
+		WorkflowExecutionStartedEventAttributes: FromWorkflowExecutionStartedEventAttributes(t.WorkflowExecutionStartedEventAttributes),
+		WorkflowExecutionCompletedEventAttributes:                      FromWorkflowExecutionCompletedEventAttributes(t.WorkflowExecutionCompletedEventAttributes),
+		WorkflowExecutionFailedEventAttributes:                         FromWorkflowExecutionFailedEventAttributes(t.WorkflowExecutionFailedEventAttributes),
+		WorkflowExecutionTimedOutEventAttributes:                       FromWorkflowExecutionTimedOutEventAttributes(t.WorkflowExecutionTimedOutEventAttributes),
+		DecisionTaskScheduledEventAttributes:                           FromDecisionTaskScheduledEventAttributes(t.DecisionTaskScheduledEventAttributes),
+		DecisionTaskStartedEventAttributes:                             FromDecisionTaskStartedEventAttributes(t.DecisionTaskStartedEventAttributes),
+		DecisionTaskCompletedEventAttributes:                           FromDecisionTaskCompletedEventAttributes(t.DecisionTaskCompletedEventAttributes),
+		DecisionTaskTimedOutEventAttributes:                            FromDecisionTaskTimedOutEventAttributes(t.DecisionTaskTimedOutEventAttributes),
+		DecisionTaskFailedEventAttributes:                              FromDecisionTaskFailedEventAttributes(t.DecisionTaskFailedEventAttributes),
+		ActivityTaskScheduledEventAttributes:                           FromActivityTaskScheduledEventAttributes(t.ActivityTaskScheduledEventAttributes),
+		ActivityTaskStartedEventAttributes:                             FromActivityTaskStartedEventAttributes(t.ActivityTaskStartedEventAttributes),
+		ActivityTaskCompletedEventAttributes:                           FromActivityTaskCompletedEventAttributes(t.ActivityTaskCompletedEventAttributes),
+		ActivityTaskFailedEventAttributes:                              FromActivityTaskFailedEventAttributes(t.ActivityTaskFailedEventAttributes),
+		ActivityTaskTimedOutEventAttributes:                            FromActivityTaskTimedOutEventAttributes(t.ActivityTaskTimedOutEventAttributes),
+		TimerStartedEventAttributes:                                    FromTimerStartedEventAttributes(t.TimerStartedEventAttributes),
+		TimerFiredEventAttributes:                                      FromTimerFiredEventAttributes(t.TimerFiredEventAttributes),
+		ActivityTaskCancelRequestedEventAttributes:                     FromActivityTaskCancelRequestedEventAttributes(t.ActivityTaskCancelRequestedEventAttributes),
+		RequestCancelActivityTaskFailedEventAttributes:                 FromRequestCancelActivityTaskFailedEventAttributes(t.RequestCancelActivityTaskFailedEventAttributes),
+		ActivityTaskCanceledEventAttributes:                            FromActivityTaskCanceledEventAttributes(t.ActivityTaskCanceledEventAttributes),
+		TimerCanceledEventAttributes:                                   FromTimerCanceledEventAttributes(t.TimerCanceledEventAttributes),
+		CancelTimerFailedEventAttributes:                               FromCancelTimerFailedEventAttributes(t.CancelTimerFailedEventAttributes),
+		MarkerRecordedEventAttributes:                                  FromMarkerRecordedEventAttributes(t.MarkerRecordedEventAttributes),
+		WorkflowExecutionSignaledEventAttributes:                       FromWorkflowExecutionSignaledEventAttributes(t.WorkflowExecutionSignaledEventAttributes),
+		WorkflowExecutionTerminatedEventAttributes:                     FromWorkflowExecutionTerminatedEventAttributes(t.WorkflowExecutionTerminatedEventAttributes),
+		WorkflowExecutionCancelRequestedEventAttributes:                FromWorkflowExecutionCancelRequestedEventAttributes(t.WorkflowExecutionCancelRequestedEventAttributes),
+		WorkflowExecutionCanceledEventAttributes:                       FromWorkflowExecutionCanceledEventAttributes(t.WorkflowExecutionCanceledEventAttributes),
+		RequestCancelExternalWorkflowExecutionInitiatedEventAttributes: FromRequestCancelExternalWorkflowExecutionInitiatedEventAttributes(t.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes),
+		RequestCancelExternalWorkflowExecutionFailedEventAttributes:    FromRequestCancelExternalWorkflowExecutionFailedEventAttributes(t.RequestCancelExternalWorkflowExecutionFailedEventAttributes),
+		ExternalWorkflowExecutionCancelRequestedEventAttributes:        FromExternalWorkflowExecutionCancelRequestedEventAttributes(t.ExternalWorkflowExecutionCancelRequestedEventAttributes),
+		WorkflowExecutionContinuedAsNewEventAttributes:                 FromWorkflowExecutionContinuedAsNewEventAttributes(t.WorkflowExecutionContinuedAsNewEventAttributes),
+		StartChildWorkflowExecutionInitiatedEventAttributes:            FromStartChildWorkflowExecutionInitiatedEventAttributes(t.StartChildWorkflowExecutionInitiatedEventAttributes),
+		StartChildWorkflowExecutionFailedEventAttributes:               FromStartChildWorkflowExecutionFailedEventAttributes(t.StartChildWorkflowExecutionFailedEventAttributes),
+		ChildWorkflowExecutionStartedEventAttributes:                   FromChildWorkflowExecutionStartedEventAttributes(t.ChildWorkflowExecutionStartedEventAttributes),
+		ChildWorkflowExecutionCompletedEventAttributes:                 FromChildWorkflowExecutionCompletedEventAttributes(t.ChildWorkflowExecutionCompletedEventAttributes),
+		ChildWorkflowExecutionFailedEventAttributes:                    FromChildWorkflowExecutionFailedEventAttributes(t.ChildWorkflowExecutionFailedEventAttributes),
+		ChildWorkflowExecutionCanceledEventAttributes:                  FromChildWorkflowExecutionCanceledEventAttributes(t.ChildWorkflowExecutionCanceledEventAttributes),
+		ChildWorkflowExecutionTimedOutEventAttributes:                  FromChildWorkflowExecutionTimedOutEventAttributes(t.ChildWorkflowExecutionTimedOutEventAttributes),
+		ChildWorkflowExecutionTerminatedEventAttributes:                FromChildWorkflowExecutionTerminatedEventAttributes(t.ChildWorkflowExecutionTerminatedEventAttributes),
+		SignalExternalWorkflowExecutionInitiatedEventAttributes:        FromSignalExternalWorkflowExecutionInitiatedEventAttributes(t.SignalExternalWorkflowExecutionInitiatedEventAttributes),
+		SignalExternalWorkflowExecutionFailedEventAttributes:           FromSignalExternalWorkflowExecutionFailedEventAttributes(t.SignalExternalWorkflowExecutionFailedEventAttributes),
+		ExternalWorkflowExecutionSignaledEventAttributes:               FromExternalWorkflowExecutionSignaledEventAttributes(t.ExternalWorkflowExecutionSignaledEventAttributes),
+		UpsertWorkflowSearchAttributesEventAttributes:                  FromUpsertWorkflowSearchAttributesEventAttributes(t.UpsertWorkflowSearchAttributesEventAttributes),
+	}
+}
+
+// ToHistoryEvent converts thrift HistoryEvent type to internal
+func ToHistoryEvent(t *shared.HistoryEvent) *types.HistoryEvent {
+	if t == nil {
+		return nil
+	}
+	return &types.HistoryEvent{
+		EventId:                                 t.EventId,
+		Timestamp:                               t.Timestamp,
+		EventType:                               ToEventType(t.EventType),
+		Version:                                 t.Version,
+		TaskId:                                  t.TaskId,
+		WorkflowExecutionStartedEventAttributes: ToWorkflowExecutionStartedEventAttributes(t.WorkflowExecutionStartedEventAttributes),
+		WorkflowExecutionCompletedEventAttributes:                      ToWorkflowExecutionCompletedEventAttributes(t.WorkflowExecutionCompletedEventAttributes),
+		WorkflowExecutionFailedEventAttributes:                         ToWorkflowExecutionFailedEventAttributes(t.WorkflowExecutionFailedEventAttributes),
+		WorkflowExecutionTimedOutEventAttributes:                       ToWorkflowExecutionTimedOutEventAttributes(t.WorkflowExecutionTimedOutEventAttributes),
+		DecisionTaskScheduledEventAttributes:                           ToDecisionTaskScheduledEventAttributes(t.DecisionTaskScheduledEventAttributes),
+		DecisionTaskStartedEventAttributes:                             ToDecisionTaskStartedEventAttributes(t.DecisionTaskStartedEventAttributes),
+		DecisionTaskCompletedEventAttributes:                           ToDecisionTaskCompletedEventAttributes(t.DecisionTaskCompletedEventAttributes),
+		DecisionTaskTimedOutEventAttributes:                            ToDecisionTaskTimedOutEventAttributes(t.DecisionTaskTimedOutEventAttributes),
+		DecisionTaskFailedEventAttributes:                              ToDecisionTaskFailedEventAttributes(t.DecisionTaskFailedEventAttributes),
+		ActivityTaskScheduledEventAttributes:                           ToActivityTaskScheduledEventAttributes(t.ActivityTaskScheduledEventAttributes),
+		ActivityTaskStartedEventAttributes:                             ToActivityTaskStartedEventAttributes(t.ActivityTaskStartedEventAttributes),
+		ActivityTaskCompletedEventAttributes:                           ToActivityTaskCompletedEventAttributes(t.ActivityTaskCompletedEventAttributes),
+		ActivityTaskFailedEventAttributes:                              ToActivityTaskFailedEventAttributes(t.ActivityTaskFailedEventAttributes),
+		ActivityTaskTimedOutEventAttributes:                            ToActivityTaskTimedOutEventAttributes(t.ActivityTaskTimedOutEventAttributes),
+		TimerStartedEventAttributes:                                    ToTimerStartedEventAttributes(t.TimerStartedEventAttributes),
+		TimerFiredEventAttributes:                                      ToTimerFiredEventAttributes(t.TimerFiredEventAttributes),
+		ActivityTaskCancelRequestedEventAttributes:                     ToActivityTaskCancelRequestedEventAttributes(t.ActivityTaskCancelRequestedEventAttributes),
+		RequestCancelActivityTaskFailedEventAttributes:                 ToRequestCancelActivityTaskFailedEventAttributes(t.RequestCancelActivityTaskFailedEventAttributes),
+		ActivityTaskCanceledEventAttributes:                            ToActivityTaskCanceledEventAttributes(t.ActivityTaskCanceledEventAttributes),
+		TimerCanceledEventAttributes:                                   ToTimerCanceledEventAttributes(t.TimerCanceledEventAttributes),
+		CancelTimerFailedEventAttributes:                               ToCancelTimerFailedEventAttributes(t.CancelTimerFailedEventAttributes),
+		MarkerRecordedEventAttributes:                                  ToMarkerRecordedEventAttributes(t.MarkerRecordedEventAttributes),
+		WorkflowExecutionSignaledEventAttributes:                       ToWorkflowExecutionSignaledEventAttributes(t.WorkflowExecutionSignaledEventAttributes),
+		WorkflowExecutionTerminatedEventAttributes:                     ToWorkflowExecutionTerminatedEventAttributes(t.WorkflowExecutionTerminatedEventAttributes),
+		WorkflowExecutionCancelRequestedEventAttributes:                ToWorkflowExecutionCancelRequestedEventAttributes(t.WorkflowExecutionCancelRequestedEventAttributes),
+		WorkflowExecutionCanceledEventAttributes:                       ToWorkflowExecutionCanceledEventAttributes(t.WorkflowExecutionCanceledEventAttributes),
+		RequestCancelExternalWorkflowExecutionInitiatedEventAttributes: ToRequestCancelExternalWorkflowExecutionInitiatedEventAttributes(t.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes),
+		RequestCancelExternalWorkflowExecutionFailedEventAttributes:    ToRequestCancelExternalWorkflowExecutionFailedEventAttributes(t.RequestCancelExternalWorkflowExecutionFailedEventAttributes),
+		ExternalWorkflowExecutionCancelRequestedEventAttributes:        ToExternalWorkflowExecutionCancelRequestedEventAttributes(t.ExternalWorkflowExecutionCancelRequestedEventAttributes),
+		WorkflowExecutionContinuedAsNewEventAttributes:                 ToWorkflowExecutionContinuedAsNewEventAttributes(t.WorkflowExecutionContinuedAsNewEventAttributes),
+		StartChildWorkflowExecutionInitiatedEventAttributes:            ToStartChildWorkflowExecutionInitiatedEventAttributes(t.StartChildWorkflowExecutionInitiatedEventAttributes),
+		StartChildWorkflowExecutionFailedEventAttributes:               ToStartChildWorkflowExecutionFailedEventAttributes(t.StartChildWorkflowExecutionFailedEventAttributes),
+		ChildWorkflowExecutionStartedEventAttributes:                   ToChildWorkflowExecutionStartedEventAttributes(t.ChildWorkflowExecutionStartedEventAttributes),
+		ChildWorkflowExecutionCompletedEventAttributes:                 ToChildWorkflowExecutionCompletedEventAttributes(t.ChildWorkflowExecutionCompletedEventAttributes),
+		ChildWorkflowExecutionFailedEventAttributes:                    ToChildWorkflowExecutionFailedEventAttributes(t.ChildWorkflowExecutionFailedEventAttributes),
+		ChildWorkflowExecutionCanceledEventAttributes:                  ToChildWorkflowExecutionCanceledEventAttributes(t.ChildWorkflowExecutionCanceledEventAttributes),
+		ChildWorkflowExecutionTimedOutEventAttributes:                  ToChildWorkflowExecutionTimedOutEventAttributes(t.ChildWorkflowExecutionTimedOutEventAttributes),
+		ChildWorkflowExecutionTerminatedEventAttributes:                ToChildWorkflowExecutionTerminatedEventAttributes(t.ChildWorkflowExecutionTerminatedEventAttributes),
+		SignalExternalWorkflowExecutionInitiatedEventAttributes:        ToSignalExternalWorkflowExecutionInitiatedEventAttributes(t.SignalExternalWorkflowExecutionInitiatedEventAttributes),
+		SignalExternalWorkflowExecutionFailedEventAttributes:           ToSignalExternalWorkflowExecutionFailedEventAttributes(t.SignalExternalWorkflowExecutionFailedEventAttributes),
+		ExternalWorkflowExecutionSignaledEventAttributes:               ToExternalWorkflowExecutionSignaledEventAttributes(t.ExternalWorkflowExecutionSignaledEventAttributes),
+		UpsertWorkflowSearchAttributesEventAttributes:                  ToUpsertWorkflowSearchAttributesEventAttributes(t.UpsertWorkflowSearchAttributesEventAttributes),
+	}
+}
+
+// FromHistoryEventFilterType converts internal HistoryEventFilterType type to thrift
+func FromHistoryEventFilterType(t *types.HistoryEventFilterType) *shared.HistoryEventFilterType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.HistoryEventFilterTypeAllEvent:
+		v := shared.HistoryEventFilterTypeAllEvent
+		return &v
+	case types.HistoryEventFilterTypeCloseEvent:
+		v := shared.HistoryEventFilterTypeCloseEvent
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToHistoryEventFilterType converts thrift HistoryEventFilterType type to internal
+func ToHistoryEventFilterType(t *shared.HistoryEventFilterType) *types.HistoryEventFilterType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.HistoryEventFilterTypeAllEvent:
+		v := types.HistoryEventFilterTypeAllEvent
+		return &v
+	case shared.HistoryEventFilterTypeCloseEvent:
+		v := types.HistoryEventFilterTypeCloseEvent
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromIndexedValueType converts internal IndexedValueType type to thrift
+func FromIndexedValueType(t types.IndexedValueType) shared.IndexedValueType {
+
+	switch t {
+	case types.IndexedValueTypeBool:
+		return shared.IndexedValueTypeBool
+	case types.IndexedValueTypeDatetime:
+		return shared.IndexedValueTypeDatetime
+	case types.IndexedValueTypeDouble:
+		return shared.IndexedValueTypeDouble
+	case types.IndexedValueTypeInt:
+		return shared.IndexedValueTypeInt
+	case types.IndexedValueTypeKeyword:
+		return shared.IndexedValueTypeKeyword
+	case types.IndexedValueTypeString:
+		return shared.IndexedValueTypeString
+	}
+	panic("unexpected enum value")
+}
+
+// ToIndexedValueType converts thrift IndexedValueType type to internal
+func ToIndexedValueType(t shared.IndexedValueType) types.IndexedValueType {
+
+	switch t {
+	case shared.IndexedValueTypeBool:
+		return types.IndexedValueTypeBool
+	case shared.IndexedValueTypeDatetime:
+		return types.IndexedValueTypeDatetime
+	case shared.IndexedValueTypeDouble:
+		return types.IndexedValueTypeDouble
+	case shared.IndexedValueTypeInt:
+		return types.IndexedValueTypeInt
+	case shared.IndexedValueTypeKeyword:
+		return types.IndexedValueTypeKeyword
+	case shared.IndexedValueTypeString:
+		return types.IndexedValueTypeString
+	}
+	panic("unexpected enum value")
+}
+
+// FromInternalDataInconsistencyError converts internal InternalDataInconsistencyError type to thrift
+func FromInternalDataInconsistencyError(t *types.InternalDataInconsistencyError) *shared.InternalDataInconsistencyError {
+	if t == nil {
+		return nil
+	}
+	return &shared.InternalDataInconsistencyError{
+		Message: t.Message,
+	}
+}
+
+// ToInternalDataInconsistencyError converts thrift InternalDataInconsistencyError type to internal
+func ToInternalDataInconsistencyError(t *shared.InternalDataInconsistencyError) *types.InternalDataInconsistencyError {
+	if t == nil {
+		return nil
+	}
+	return &types.InternalDataInconsistencyError{
+		Message: t.Message,
+	}
+}
+
+// FromInternalServiceError converts internal InternalServiceError type to thrift
+func FromInternalServiceError(t *types.InternalServiceError) *shared.InternalServiceError {
+	if t == nil {
+		return nil
+	}
+	return &shared.InternalServiceError{
+		Message: t.Message,
+	}
+}
+
+// ToInternalServiceError converts thrift InternalServiceError type to internal
+func ToInternalServiceError(t *shared.InternalServiceError) *types.InternalServiceError {
+	if t == nil {
+		return nil
+	}
+	return &types.InternalServiceError{
+		Message: t.Message,
+	}
+}
+
+// FromLimitExceededError converts internal LimitExceededError type to thrift
+func FromLimitExceededError(t *types.LimitExceededError) *shared.LimitExceededError {
+	if t == nil {
+		return nil
+	}
+	return &shared.LimitExceededError{
+		Message: t.Message,
+	}
+}
+
+// ToLimitExceededError converts thrift LimitExceededError type to internal
+func ToLimitExceededError(t *shared.LimitExceededError) *types.LimitExceededError {
+	if t == nil {
+		return nil
+	}
+	return &types.LimitExceededError{
+		Message: t.Message,
+	}
+}
+
+// FromListArchivedWorkflowExecutionsRequest converts internal ListArchivedWorkflowExecutionsRequest type to thrift
+func FromListArchivedWorkflowExecutionsRequest(t *types.ListArchivedWorkflowExecutionsRequest) *shared.ListArchivedWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListArchivedWorkflowExecutionsRequest{
+		Domain:        t.Domain,
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+		Query:         t.Query,
+	}
+}
+
+// ToListArchivedWorkflowExecutionsRequest converts thrift ListArchivedWorkflowExecutionsRequest type to internal
+func ToListArchivedWorkflowExecutionsRequest(t *shared.ListArchivedWorkflowExecutionsRequest) *types.ListArchivedWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ListArchivedWorkflowExecutionsRequest{
+		Domain:        t.Domain,
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+		Query:         t.Query,
+	}
+}
+
+// FromListArchivedWorkflowExecutionsResponse converts internal ListArchivedWorkflowExecutionsResponse type to thrift
+func FromListArchivedWorkflowExecutionsResponse(t *types.ListArchivedWorkflowExecutionsResponse) *shared.ListArchivedWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListArchivedWorkflowExecutionsResponse{
+		Executions:    FromWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// ToListArchivedWorkflowExecutionsResponse converts thrift ListArchivedWorkflowExecutionsResponse type to internal
+func ToListArchivedWorkflowExecutionsResponse(t *shared.ListArchivedWorkflowExecutionsResponse) *types.ListArchivedWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ListArchivedWorkflowExecutionsResponse{
+		Executions:    ToWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// FromListClosedWorkflowExecutionsRequest converts internal ListClosedWorkflowExecutionsRequest type to thrift
+func FromListClosedWorkflowExecutionsRequest(t *types.ListClosedWorkflowExecutionsRequest) *shared.ListClosedWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListClosedWorkflowExecutionsRequest{
+		Domain:          t.Domain,
+		MaximumPageSize: t.MaximumPageSize,
+		NextPageToken:   t.NextPageToken,
+		StartTimeFilter: FromStartTimeFilter(t.StartTimeFilter),
+		ExecutionFilter: FromWorkflowExecutionFilter(t.ExecutionFilter),
+		TypeFilter:      FromWorkflowTypeFilter(t.TypeFilter),
+		StatusFilter:    FromWorkflowExecutionCloseStatus(t.StatusFilter),
+	}
+}
+
+// ToListClosedWorkflowExecutionsRequest converts thrift ListClosedWorkflowExecutionsRequest type to internal
+func ToListClosedWorkflowExecutionsRequest(t *shared.ListClosedWorkflowExecutionsRequest) *types.ListClosedWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ListClosedWorkflowExecutionsRequest{
+		Domain:          t.Domain,
+		MaximumPageSize: t.MaximumPageSize,
+		NextPageToken:   t.NextPageToken,
+		StartTimeFilter: ToStartTimeFilter(t.StartTimeFilter),
+		ExecutionFilter: ToWorkflowExecutionFilter(t.ExecutionFilter),
+		TypeFilter:      ToWorkflowTypeFilter(t.TypeFilter),
+		StatusFilter:    ToWorkflowExecutionCloseStatus(t.StatusFilter),
+	}
+}
+
+// FromListClosedWorkflowExecutionsResponse converts internal ListClosedWorkflowExecutionsResponse type to thrift
+func FromListClosedWorkflowExecutionsResponse(t *types.ListClosedWorkflowExecutionsResponse) *shared.ListClosedWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListClosedWorkflowExecutionsResponse{
+		Executions:    FromWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// ToListClosedWorkflowExecutionsResponse converts thrift ListClosedWorkflowExecutionsResponse type to internal
+func ToListClosedWorkflowExecutionsResponse(t *shared.ListClosedWorkflowExecutionsResponse) *types.ListClosedWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ListClosedWorkflowExecutionsResponse{
+		Executions:    ToWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// FromListDomainsRequest converts internal ListDomainsRequest type to thrift
+func FromListDomainsRequest(t *types.ListDomainsRequest) *shared.ListDomainsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListDomainsRequest{
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// ToListDomainsRequest converts thrift ListDomainsRequest type to internal
+func ToListDomainsRequest(t *shared.ListDomainsRequest) *types.ListDomainsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ListDomainsRequest{
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// FromListDomainsResponse converts internal ListDomainsResponse type to thrift
+func FromListDomainsResponse(t *types.ListDomainsResponse) *shared.ListDomainsResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListDomainsResponse{
+		Domains:       FromDescribeDomainResponseArray(t.Domains),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// ToListDomainsResponse converts thrift ListDomainsResponse type to internal
+func ToListDomainsResponse(t *shared.ListDomainsResponse) *types.ListDomainsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ListDomainsResponse{
+		Domains:       ToDescribeDomainResponseArray(t.Domains),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// FromListOpenWorkflowExecutionsRequest converts internal ListOpenWorkflowExecutionsRequest type to thrift
+func FromListOpenWorkflowExecutionsRequest(t *types.ListOpenWorkflowExecutionsRequest) *shared.ListOpenWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListOpenWorkflowExecutionsRequest{
+		Domain:          t.Domain,
+		MaximumPageSize: t.MaximumPageSize,
+		NextPageToken:   t.NextPageToken,
+		StartTimeFilter: FromStartTimeFilter(t.StartTimeFilter),
+		ExecutionFilter: FromWorkflowExecutionFilter(t.ExecutionFilter),
+		TypeFilter:      FromWorkflowTypeFilter(t.TypeFilter),
+	}
+}
+
+// ToListOpenWorkflowExecutionsRequest converts thrift ListOpenWorkflowExecutionsRequest type to internal
+func ToListOpenWorkflowExecutionsRequest(t *shared.ListOpenWorkflowExecutionsRequest) *types.ListOpenWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ListOpenWorkflowExecutionsRequest{
+		Domain:          t.Domain,
+		MaximumPageSize: t.MaximumPageSize,
+		NextPageToken:   t.NextPageToken,
+		StartTimeFilter: ToStartTimeFilter(t.StartTimeFilter),
+		ExecutionFilter: ToWorkflowExecutionFilter(t.ExecutionFilter),
+		TypeFilter:      ToWorkflowTypeFilter(t.TypeFilter),
+	}
+}
+
+// FromListOpenWorkflowExecutionsResponse converts internal ListOpenWorkflowExecutionsResponse type to thrift
+func FromListOpenWorkflowExecutionsResponse(t *types.ListOpenWorkflowExecutionsResponse) *shared.ListOpenWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListOpenWorkflowExecutionsResponse{
+		Executions:    FromWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// ToListOpenWorkflowExecutionsResponse converts thrift ListOpenWorkflowExecutionsResponse type to internal
+func ToListOpenWorkflowExecutionsResponse(t *shared.ListOpenWorkflowExecutionsResponse) *types.ListOpenWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ListOpenWorkflowExecutionsResponse{
+		Executions:    ToWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// FromListTaskListPartitionsRequest converts internal ListTaskListPartitionsRequest type to thrift
+func FromListTaskListPartitionsRequest(t *types.ListTaskListPartitionsRequest) *shared.ListTaskListPartitionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListTaskListPartitionsRequest{
+		Domain:   t.Domain,
+		TaskList: FromTaskList(t.TaskList),
+	}
+}
+
+// ToListTaskListPartitionsRequest converts thrift ListTaskListPartitionsRequest type to internal
+func ToListTaskListPartitionsRequest(t *shared.ListTaskListPartitionsRequest) *types.ListTaskListPartitionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ListTaskListPartitionsRequest{
+		Domain:   t.Domain,
+		TaskList: ToTaskList(t.TaskList),
+	}
+}
+
+// FromListTaskListPartitionsResponse converts internal ListTaskListPartitionsResponse type to thrift
+func FromListTaskListPartitionsResponse(t *types.ListTaskListPartitionsResponse) *shared.ListTaskListPartitionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListTaskListPartitionsResponse{
+		ActivityTaskListPartitions: FromTaskListPartitionMetadataArray(t.ActivityTaskListPartitions),
+		DecisionTaskListPartitions: FromTaskListPartitionMetadataArray(t.DecisionTaskListPartitions),
+	}
+}
+
+// ToListTaskListPartitionsResponse converts thrift ListTaskListPartitionsResponse type to internal
+func ToListTaskListPartitionsResponse(t *shared.ListTaskListPartitionsResponse) *types.ListTaskListPartitionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ListTaskListPartitionsResponse{
+		ActivityTaskListPartitions: ToTaskListPartitionMetadataArray(t.ActivityTaskListPartitions),
+		DecisionTaskListPartitions: ToTaskListPartitionMetadataArray(t.DecisionTaskListPartitions),
+	}
+}
+
+// FromListWorkflowExecutionsRequest converts internal ListWorkflowExecutionsRequest type to thrift
+func FromListWorkflowExecutionsRequest(t *types.ListWorkflowExecutionsRequest) *shared.ListWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListWorkflowExecutionsRequest{
+		Domain:        t.Domain,
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+		Query:         t.Query,
+	}
+}
+
+// ToListWorkflowExecutionsRequest converts thrift ListWorkflowExecutionsRequest type to internal
+func ToListWorkflowExecutionsRequest(t *shared.ListWorkflowExecutionsRequest) *types.ListWorkflowExecutionsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ListWorkflowExecutionsRequest{
+		Domain:        t.Domain,
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+		Query:         t.Query,
+	}
+}
+
+// FromListWorkflowExecutionsResponse converts internal ListWorkflowExecutionsResponse type to thrift
+func FromListWorkflowExecutionsResponse(t *types.ListWorkflowExecutionsResponse) *shared.ListWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ListWorkflowExecutionsResponse{
+		Executions:    FromWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// ToListWorkflowExecutionsResponse converts thrift ListWorkflowExecutionsResponse type to internal
+func ToListWorkflowExecutionsResponse(t *shared.ListWorkflowExecutionsResponse) *types.ListWorkflowExecutionsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ListWorkflowExecutionsResponse{
+		Executions:    ToWorkflowExecutionInfoArray(t.Executions),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// FromMarkerRecordedEventAttributes converts internal MarkerRecordedEventAttributes type to thrift
+func FromMarkerRecordedEventAttributes(t *types.MarkerRecordedEventAttributes) *shared.MarkerRecordedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.MarkerRecordedEventAttributes{
+		MarkerName:                   t.MarkerName,
+		Details:                      t.Details,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Header:                       FromHeader(t.Header),
+	}
+}
+
+// ToMarkerRecordedEventAttributes converts thrift MarkerRecordedEventAttributes type to internal
+func ToMarkerRecordedEventAttributes(t *shared.MarkerRecordedEventAttributes) *types.MarkerRecordedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.MarkerRecordedEventAttributes{
+		MarkerName:                   t.MarkerName,
+		Details:                      t.Details,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Header:                       ToHeader(t.Header),
+	}
+}
+
+// FromMemo converts internal Memo type to thrift
+func FromMemo(t *types.Memo) *shared.Memo {
+	if t == nil {
+		return nil
+	}
+	return &shared.Memo{
+		Fields: t.Fields,
+	}
+}
+
+// ToMemo converts thrift Memo type to internal
+func ToMemo(t *shared.Memo) *types.Memo {
+	if t == nil {
+		return nil
+	}
+	return &types.Memo{
+		Fields: t.Fields,
+	}
+}
+
+// FromParentClosePolicy converts internal ParentClosePolicy type to thrift
+func FromParentClosePolicy(t *types.ParentClosePolicy) *shared.ParentClosePolicy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.ParentClosePolicyAbandon:
+		v := shared.ParentClosePolicyAbandon
+		return &v
+	case types.ParentClosePolicyRequestCancel:
+		v := shared.ParentClosePolicyRequestCancel
+		return &v
+	case types.ParentClosePolicyTerminate:
+		v := shared.ParentClosePolicyTerminate
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToParentClosePolicy converts thrift ParentClosePolicy type to internal
+func ToParentClosePolicy(t *shared.ParentClosePolicy) *types.ParentClosePolicy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.ParentClosePolicyAbandon:
+		v := types.ParentClosePolicyAbandon
+		return &v
+	case shared.ParentClosePolicyRequestCancel:
+		v := types.ParentClosePolicyRequestCancel
+		return &v
+	case shared.ParentClosePolicyTerminate:
+		v := types.ParentClosePolicyTerminate
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromPendingActivityInfo converts internal PendingActivityInfo type to thrift
+func FromPendingActivityInfo(t *types.PendingActivityInfo) *shared.PendingActivityInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.PendingActivityInfo{
+		ActivityID:             t.ActivityID,
+		ActivityType:           FromActivityType(t.ActivityType),
+		State:                  FromPendingActivityState(t.State),
+		HeartbeatDetails:       t.HeartbeatDetails,
+		LastHeartbeatTimestamp: t.LastHeartbeatTimestamp,
+		LastStartedTimestamp:   t.LastStartedTimestamp,
+		Attempt:                t.Attempt,
+		MaximumAttempts:        t.MaximumAttempts,
+		ScheduledTimestamp:     t.ScheduledTimestamp,
+		ExpirationTimestamp:    t.ExpirationTimestamp,
+		LastFailureReason:      t.LastFailureReason,
+		LastWorkerIdentity:     t.LastWorkerIdentity,
+		LastFailureDetails:     t.LastFailureDetails,
+	}
+}
+
+// ToPendingActivityInfo converts thrift PendingActivityInfo type to internal
+func ToPendingActivityInfo(t *shared.PendingActivityInfo) *types.PendingActivityInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.PendingActivityInfo{
+		ActivityID:             t.ActivityID,
+		ActivityType:           ToActivityType(t.ActivityType),
+		State:                  ToPendingActivityState(t.State),
+		HeartbeatDetails:       t.HeartbeatDetails,
+		LastHeartbeatTimestamp: t.LastHeartbeatTimestamp,
+		LastStartedTimestamp:   t.LastStartedTimestamp,
+		Attempt:                t.Attempt,
+		MaximumAttempts:        t.MaximumAttempts,
+		ScheduledTimestamp:     t.ScheduledTimestamp,
+		ExpirationTimestamp:    t.ExpirationTimestamp,
+		LastFailureReason:      t.LastFailureReason,
+		LastWorkerIdentity:     t.LastWorkerIdentity,
+		LastFailureDetails:     t.LastFailureDetails,
+	}
+}
+
+// FromPendingActivityState converts internal PendingActivityState type to thrift
+func FromPendingActivityState(t *types.PendingActivityState) *shared.PendingActivityState {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.PendingActivityStateCancelRequested:
+		v := shared.PendingActivityStateCancelRequested
+		return &v
+	case types.PendingActivityStateScheduled:
+		v := shared.PendingActivityStateScheduled
+		return &v
+	case types.PendingActivityStateStarted:
+		v := shared.PendingActivityStateStarted
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToPendingActivityState converts thrift PendingActivityState type to internal
+func ToPendingActivityState(t *shared.PendingActivityState) *types.PendingActivityState {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.PendingActivityStateCancelRequested:
+		v := types.PendingActivityStateCancelRequested
+		return &v
+	case shared.PendingActivityStateScheduled:
+		v := types.PendingActivityStateScheduled
+		return &v
+	case shared.PendingActivityStateStarted:
+		v := types.PendingActivityStateStarted
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromPendingChildExecutionInfo converts internal PendingChildExecutionInfo type to thrift
+func FromPendingChildExecutionInfo(t *types.PendingChildExecutionInfo) *shared.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.PendingChildExecutionInfo{
+		WorkflowID:        t.WorkflowID,
+		RunID:             t.RunID,
+		WorkflowTypName:   t.WorkflowTypName,
+		InitiatedID:       t.InitiatedID,
+		ParentClosePolicy: FromParentClosePolicy(t.ParentClosePolicy),
+	}
+}
+
+// ToPendingChildExecutionInfo converts thrift PendingChildExecutionInfo type to internal
+func ToPendingChildExecutionInfo(t *shared.PendingChildExecutionInfo) *types.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.PendingChildExecutionInfo{
+		WorkflowID:        t.WorkflowID,
+		RunID:             t.RunID,
+		WorkflowTypName:   t.WorkflowTypName,
+		InitiatedID:       t.InitiatedID,
+		ParentClosePolicy: ToParentClosePolicy(t.ParentClosePolicy),
+	}
+}
+
+// FromPollForActivityTaskRequest converts internal PollForActivityTaskRequest type to thrift
+func FromPollForActivityTaskRequest(t *types.PollForActivityTaskRequest) *shared.PollForActivityTaskRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.PollForActivityTaskRequest{
+		Domain:           t.Domain,
+		TaskList:         FromTaskList(t.TaskList),
+		Identity:         t.Identity,
+		TaskListMetadata: FromTaskListMetadata(t.TaskListMetadata),
+	}
+}
+
+// ToPollForActivityTaskRequest converts thrift PollForActivityTaskRequest type to internal
+func ToPollForActivityTaskRequest(t *shared.PollForActivityTaskRequest) *types.PollForActivityTaskRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.PollForActivityTaskRequest{
+		Domain:           t.Domain,
+		TaskList:         ToTaskList(t.TaskList),
+		Identity:         t.Identity,
+		TaskListMetadata: ToTaskListMetadata(t.TaskListMetadata),
+	}
+}
+
+// FromPollForActivityTaskResponse converts internal PollForActivityTaskResponse type to thrift
+func FromPollForActivityTaskResponse(t *types.PollForActivityTaskResponse) *shared.PollForActivityTaskResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.PollForActivityTaskResponse{
+		TaskToken:                       t.TaskToken,
+		WorkflowExecution:               FromWorkflowExecution(t.WorkflowExecution),
+		ActivityId:                      t.ActivityId,
+		ActivityType:                    FromActivityType(t.ActivityType),
+		Input:                           t.Input,
+		ScheduledTimestamp:              t.ScheduledTimestamp,
+		ScheduleToCloseTimeoutSeconds:   t.ScheduleToCloseTimeoutSeconds,
+		StartedTimestamp:                t.StartedTimestamp,
+		StartToCloseTimeoutSeconds:      t.StartToCloseTimeoutSeconds,
+		HeartbeatTimeoutSeconds:         t.HeartbeatTimeoutSeconds,
+		Attempt:                         t.Attempt,
+		ScheduledTimestampOfThisAttempt: t.ScheduledTimestampOfThisAttempt,
+		HeartbeatDetails:                t.HeartbeatDetails,
+		WorkflowType:                    FromWorkflowType(t.WorkflowType),
+		WorkflowDomain:                  t.WorkflowDomain,
+		Header:                          FromHeader(t.Header),
+	}
+}
+
+// ToPollForActivityTaskResponse converts thrift PollForActivityTaskResponse type to internal
+func ToPollForActivityTaskResponse(t *shared.PollForActivityTaskResponse) *types.PollForActivityTaskResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.PollForActivityTaskResponse{
+		TaskToken:                       t.TaskToken,
+		WorkflowExecution:               ToWorkflowExecution(t.WorkflowExecution),
+		ActivityId:                      t.ActivityId,
+		ActivityType:                    ToActivityType(t.ActivityType),
+		Input:                           t.Input,
+		ScheduledTimestamp:              t.ScheduledTimestamp,
+		ScheduleToCloseTimeoutSeconds:   t.ScheduleToCloseTimeoutSeconds,
+		StartedTimestamp:                t.StartedTimestamp,
+		StartToCloseTimeoutSeconds:      t.StartToCloseTimeoutSeconds,
+		HeartbeatTimeoutSeconds:         t.HeartbeatTimeoutSeconds,
+		Attempt:                         t.Attempt,
+		ScheduledTimestampOfThisAttempt: t.ScheduledTimestampOfThisAttempt,
+		HeartbeatDetails:                t.HeartbeatDetails,
+		WorkflowType:                    ToWorkflowType(t.WorkflowType),
+		WorkflowDomain:                  t.WorkflowDomain,
+		Header:                          ToHeader(t.Header),
+	}
+}
+
+// FromPollForDecisionTaskRequest converts internal PollForDecisionTaskRequest type to thrift
+func FromPollForDecisionTaskRequest(t *types.PollForDecisionTaskRequest) *shared.PollForDecisionTaskRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.PollForDecisionTaskRequest{
+		Domain:         t.Domain,
+		TaskList:       FromTaskList(t.TaskList),
+		Identity:       t.Identity,
+		BinaryChecksum: t.BinaryChecksum,
+	}
+}
+
+// ToPollForDecisionTaskRequest converts thrift PollForDecisionTaskRequest type to internal
+func ToPollForDecisionTaskRequest(t *shared.PollForDecisionTaskRequest) *types.PollForDecisionTaskRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.PollForDecisionTaskRequest{
+		Domain:         t.Domain,
+		TaskList:       ToTaskList(t.TaskList),
+		Identity:       t.Identity,
+		BinaryChecksum: t.BinaryChecksum,
+	}
+}
+
+// FromPollForDecisionTaskResponse converts internal PollForDecisionTaskResponse type to thrift
+func FromPollForDecisionTaskResponse(t *types.PollForDecisionTaskResponse) *shared.PollForDecisionTaskResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.PollForDecisionTaskResponse{
+		TaskToken:                 t.TaskToken,
+		WorkflowExecution:         FromWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:              FromWorkflowType(t.WorkflowType),
+		PreviousStartedEventId:    t.PreviousStartedEventId,
+		StartedEventId:            t.StartedEventId,
+		Attempt:                   t.Attempt,
+		BacklogCountHint:          t.BacklogCountHint,
+		History:                   FromHistory(t.History),
+		NextPageToken:             t.NextPageToken,
+		Query:                     FromWorkflowQuery(t.Query),
+		WorkflowExecutionTaskList: FromTaskList(t.WorkflowExecutionTaskList),
+		ScheduledTimestamp:        t.ScheduledTimestamp,
+		StartedTimestamp:          t.StartedTimestamp,
+		Queries:                   FromWorkflowQueryMap(t.Queries),
+	}
+}
+
+// ToPollForDecisionTaskResponse converts thrift PollForDecisionTaskResponse type to internal
+func ToPollForDecisionTaskResponse(t *shared.PollForDecisionTaskResponse) *types.PollForDecisionTaskResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.PollForDecisionTaskResponse{
+		TaskToken:                 t.TaskToken,
+		WorkflowExecution:         ToWorkflowExecution(t.WorkflowExecution),
+		WorkflowType:              ToWorkflowType(t.WorkflowType),
+		PreviousStartedEventId:    t.PreviousStartedEventId,
+		StartedEventId:            t.StartedEventId,
+		Attempt:                   t.Attempt,
+		BacklogCountHint:          t.BacklogCountHint,
+		History:                   ToHistory(t.History),
+		NextPageToken:             t.NextPageToken,
+		Query:                     ToWorkflowQuery(t.Query),
+		WorkflowExecutionTaskList: ToTaskList(t.WorkflowExecutionTaskList),
+		ScheduledTimestamp:        t.ScheduledTimestamp,
+		StartedTimestamp:          t.StartedTimestamp,
+		Queries:                   ToWorkflowQueryMap(t.Queries),
+	}
+}
+
+// FromPollerInfo converts internal PollerInfo type to thrift
+func FromPollerInfo(t *types.PollerInfo) *shared.PollerInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.PollerInfo{
+		LastAccessTime: t.LastAccessTime,
+		Identity:       t.Identity,
+		RatePerSecond:  t.RatePerSecond,
+	}
+}
+
+// ToPollerInfo converts thrift PollerInfo type to internal
+func ToPollerInfo(t *shared.PollerInfo) *types.PollerInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.PollerInfo{
+		LastAccessTime: t.LastAccessTime,
+		Identity:       t.Identity,
+		RatePerSecond:  t.RatePerSecond,
+	}
+}
+
+// FromQueryConsistencyLevel converts internal QueryConsistencyLevel type to thrift
+func FromQueryConsistencyLevel(t *types.QueryConsistencyLevel) *shared.QueryConsistencyLevel {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.QueryConsistencyLevelEventual:
+		v := shared.QueryConsistencyLevelEventual
+		return &v
+	case types.QueryConsistencyLevelStrong:
+		v := shared.QueryConsistencyLevelStrong
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToQueryConsistencyLevel converts thrift QueryConsistencyLevel type to internal
+func ToQueryConsistencyLevel(t *shared.QueryConsistencyLevel) *types.QueryConsistencyLevel {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.QueryConsistencyLevelEventual:
+		v := types.QueryConsistencyLevelEventual
+		return &v
+	case shared.QueryConsistencyLevelStrong:
+		v := types.QueryConsistencyLevelStrong
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromQueryFailedError converts internal QueryFailedError type to thrift
+func FromQueryFailedError(t *types.QueryFailedError) *shared.QueryFailedError {
+	if t == nil {
+		return nil
+	}
+	return &shared.QueryFailedError{
+		Message: t.Message,
+	}
+}
+
+// ToQueryFailedError converts thrift QueryFailedError type to internal
+func ToQueryFailedError(t *shared.QueryFailedError) *types.QueryFailedError {
+	if t == nil {
+		return nil
+	}
+	return &types.QueryFailedError{
+		Message: t.Message,
+	}
+}
+
+// FromQueryRejectCondition converts internal QueryRejectCondition type to thrift
+func FromQueryRejectCondition(t *types.QueryRejectCondition) *shared.QueryRejectCondition {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.QueryRejectConditionNotCompletedCleanly:
+		v := shared.QueryRejectConditionNotCompletedCleanly
+		return &v
+	case types.QueryRejectConditionNotOpen:
+		v := shared.QueryRejectConditionNotOpen
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToQueryRejectCondition converts thrift QueryRejectCondition type to internal
+func ToQueryRejectCondition(t *shared.QueryRejectCondition) *types.QueryRejectCondition {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.QueryRejectConditionNotCompletedCleanly:
+		v := types.QueryRejectConditionNotCompletedCleanly
+		return &v
+	case shared.QueryRejectConditionNotOpen:
+		v := types.QueryRejectConditionNotOpen
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromQueryRejected converts internal QueryRejected type to thrift
+func FromQueryRejected(t *types.QueryRejected) *shared.QueryRejected {
+	if t == nil {
+		return nil
+	}
+	return &shared.QueryRejected{
+		CloseStatus: FromWorkflowExecutionCloseStatus(t.CloseStatus),
+	}
+}
+
+// ToQueryRejected converts thrift QueryRejected type to internal
+func ToQueryRejected(t *shared.QueryRejected) *types.QueryRejected {
+	if t == nil {
+		return nil
+	}
+	return &types.QueryRejected{
+		CloseStatus: ToWorkflowExecutionCloseStatus(t.CloseStatus),
+	}
+}
+
+// FromQueryResultType converts internal QueryResultType type to thrift
+func FromQueryResultType(t *types.QueryResultType) *shared.QueryResultType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.QueryResultTypeAnswered:
+		v := shared.QueryResultTypeAnswered
+		return &v
+	case types.QueryResultTypeFailed:
+		v := shared.QueryResultTypeFailed
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToQueryResultType converts thrift QueryResultType type to internal
+func ToQueryResultType(t *shared.QueryResultType) *types.QueryResultType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.QueryResultTypeAnswered:
+		v := types.QueryResultTypeAnswered
+		return &v
+	case shared.QueryResultTypeFailed:
+		v := types.QueryResultTypeFailed
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromQueryTaskCompletedType converts internal QueryTaskCompletedType type to thrift
+func FromQueryTaskCompletedType(t *types.QueryTaskCompletedType) *shared.QueryTaskCompletedType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.QueryTaskCompletedTypeCompleted:
+		v := shared.QueryTaskCompletedTypeCompleted
+		return &v
+	case types.QueryTaskCompletedTypeFailed:
+		v := shared.QueryTaskCompletedTypeFailed
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToQueryTaskCompletedType converts thrift QueryTaskCompletedType type to internal
+func ToQueryTaskCompletedType(t *shared.QueryTaskCompletedType) *types.QueryTaskCompletedType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.QueryTaskCompletedTypeCompleted:
+		v := types.QueryTaskCompletedTypeCompleted
+		return &v
+	case shared.QueryTaskCompletedTypeFailed:
+		v := types.QueryTaskCompletedTypeFailed
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromQueryWorkflowRequest converts internal QueryWorkflowRequest type to thrift
+func FromQueryWorkflowRequest(t *types.QueryWorkflowRequest) *shared.QueryWorkflowRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.QueryWorkflowRequest{
+		Domain:                t.Domain,
+		Execution:             FromWorkflowExecution(t.Execution),
+		Query:                 FromWorkflowQuery(t.Query),
+		QueryRejectCondition:  FromQueryRejectCondition(t.QueryRejectCondition),
+		QueryConsistencyLevel: FromQueryConsistencyLevel(t.QueryConsistencyLevel),
+	}
+}
+
+// ToQueryWorkflowRequest converts thrift QueryWorkflowRequest type to internal
+func ToQueryWorkflowRequest(t *shared.QueryWorkflowRequest) *types.QueryWorkflowRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.QueryWorkflowRequest{
+		Domain:                t.Domain,
+		Execution:             ToWorkflowExecution(t.Execution),
+		Query:                 ToWorkflowQuery(t.Query),
+		QueryRejectCondition:  ToQueryRejectCondition(t.QueryRejectCondition),
+		QueryConsistencyLevel: ToQueryConsistencyLevel(t.QueryConsistencyLevel),
+	}
+}
+
+// FromQueryWorkflowResponse converts internal QueryWorkflowResponse type to thrift
+func FromQueryWorkflowResponse(t *types.QueryWorkflowResponse) *shared.QueryWorkflowResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.QueryWorkflowResponse{
+		QueryResult:   t.QueryResult,
+		QueryRejected: FromQueryRejected(t.QueryRejected),
+	}
+}
+
+// ToQueryWorkflowResponse converts thrift QueryWorkflowResponse type to internal
+func ToQueryWorkflowResponse(t *shared.QueryWorkflowResponse) *types.QueryWorkflowResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.QueryWorkflowResponse{
+		QueryResult:   t.QueryResult,
+		QueryRejected: ToQueryRejected(t.QueryRejected),
+	}
+}
+
+// FromReapplyEventsRequest converts internal ReapplyEventsRequest type to thrift
+func FromReapplyEventsRequest(t *types.ReapplyEventsRequest) *shared.ReapplyEventsRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ReapplyEventsRequest{
+		DomainName:        t.DomainName,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		Events:            FromDataBlob(t.Events),
+	}
+}
+
+// ToReapplyEventsRequest converts thrift ReapplyEventsRequest type to internal
+func ToReapplyEventsRequest(t *shared.ReapplyEventsRequest) *types.ReapplyEventsRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ReapplyEventsRequest{
+		DomainName:        t.DomainName,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		Events:            ToDataBlob(t.Events),
+	}
+}
+
+// FromRecordActivityTaskHeartbeatByIDRequest converts internal RecordActivityTaskHeartbeatByIDRequest type to thrift
+func FromRecordActivityTaskHeartbeatByIDRequest(t *types.RecordActivityTaskHeartbeatByIDRequest) *shared.RecordActivityTaskHeartbeatByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RecordActivityTaskHeartbeatByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Details:    t.Details,
+		Identity:   t.Identity,
+	}
+}
+
+// ToRecordActivityTaskHeartbeatByIDRequest converts thrift RecordActivityTaskHeartbeatByIDRequest type to internal
+func ToRecordActivityTaskHeartbeatByIDRequest(t *shared.RecordActivityTaskHeartbeatByIDRequest) *types.RecordActivityTaskHeartbeatByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RecordActivityTaskHeartbeatByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Details:    t.Details,
+		Identity:   t.Identity,
+	}
+}
+
+// FromRecordActivityTaskHeartbeatRequest converts internal RecordActivityTaskHeartbeatRequest type to thrift
+func FromRecordActivityTaskHeartbeatRequest(t *types.RecordActivityTaskHeartbeatRequest) *shared.RecordActivityTaskHeartbeatRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RecordActivityTaskHeartbeatRequest{
+		TaskToken: t.TaskToken,
+		Details:   t.Details,
+		Identity:  t.Identity,
+	}
+}
+
+// ToRecordActivityTaskHeartbeatRequest converts thrift RecordActivityTaskHeartbeatRequest type to internal
+func ToRecordActivityTaskHeartbeatRequest(t *shared.RecordActivityTaskHeartbeatRequest) *types.RecordActivityTaskHeartbeatRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RecordActivityTaskHeartbeatRequest{
+		TaskToken: t.TaskToken,
+		Details:   t.Details,
+		Identity:  t.Identity,
+	}
+}
+
+// FromRecordActivityTaskHeartbeatResponse converts internal RecordActivityTaskHeartbeatResponse type to thrift
+func FromRecordActivityTaskHeartbeatResponse(t *types.RecordActivityTaskHeartbeatResponse) *shared.RecordActivityTaskHeartbeatResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.RecordActivityTaskHeartbeatResponse{
+		CancelRequested: t.CancelRequested,
+	}
+}
+
+// ToRecordActivityTaskHeartbeatResponse converts thrift RecordActivityTaskHeartbeatResponse type to internal
+func ToRecordActivityTaskHeartbeatResponse(t *shared.RecordActivityTaskHeartbeatResponse) *types.RecordActivityTaskHeartbeatResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.RecordActivityTaskHeartbeatResponse{
+		CancelRequested: t.CancelRequested,
+	}
+}
+
+// FromRecordMarkerDecisionAttributes converts internal RecordMarkerDecisionAttributes type to thrift
+func FromRecordMarkerDecisionAttributes(t *types.RecordMarkerDecisionAttributes) *shared.RecordMarkerDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.RecordMarkerDecisionAttributes{
+		MarkerName: t.MarkerName,
+		Details:    t.Details,
+		Header:     FromHeader(t.Header),
+	}
+}
+
+// ToRecordMarkerDecisionAttributes converts thrift RecordMarkerDecisionAttributes type to internal
+func ToRecordMarkerDecisionAttributes(t *shared.RecordMarkerDecisionAttributes) *types.RecordMarkerDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.RecordMarkerDecisionAttributes{
+		MarkerName: t.MarkerName,
+		Details:    t.Details,
+		Header:     ToHeader(t.Header),
+	}
+}
+
+// FromRefreshWorkflowTasksRequest converts internal RefreshWorkflowTasksRequest type to thrift
+func FromRefreshWorkflowTasksRequest(t *types.RefreshWorkflowTasksRequest) *shared.RefreshWorkflowTasksRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RefreshWorkflowTasksRequest{
+		Domain:    t.Domain,
+		Execution: FromWorkflowExecution(t.Execution),
+	}
+}
+
+// ToRefreshWorkflowTasksRequest converts thrift RefreshWorkflowTasksRequest type to internal
+func ToRefreshWorkflowTasksRequest(t *shared.RefreshWorkflowTasksRequest) *types.RefreshWorkflowTasksRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RefreshWorkflowTasksRequest{
+		Domain:    t.Domain,
+		Execution: ToWorkflowExecution(t.Execution),
+	}
+}
+
+// FromRegisterDomainRequest converts internal RegisterDomainRequest type to thrift
+func FromRegisterDomainRequest(t *types.RegisterDomainRequest) *shared.RegisterDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RegisterDomainRequest{
+		Name:                                   t.Name,
+		Description:                            t.Description,
+		OwnerEmail:                             t.OwnerEmail,
+		WorkflowExecutionRetentionPeriodInDays: t.WorkflowExecutionRetentionPeriodInDays,
+		EmitMetric:                             t.EmitMetric,
+		Clusters:                               FromClusterReplicationConfigurationArray(t.Clusters),
+		ActiveClusterName:                      t.ActiveClusterName,
+		Data:                                   t.Data,
+		SecurityToken:                          t.SecurityToken,
+		IsGlobalDomain:                         t.IsGlobalDomain,
+		HistoryArchivalStatus:                  FromArchivalStatus(t.HistoryArchivalStatus),
+		HistoryArchivalURI:                     t.HistoryArchivalURI,
+		VisibilityArchivalStatus:               FromArchivalStatus(t.VisibilityArchivalStatus),
+		VisibilityArchivalURI:                  t.VisibilityArchivalURI,
+	}
+}
+
+// ToRegisterDomainRequest converts thrift RegisterDomainRequest type to internal
+func ToRegisterDomainRequest(t *shared.RegisterDomainRequest) *types.RegisterDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RegisterDomainRequest{
+		Name:                                   t.Name,
+		Description:                            t.Description,
+		OwnerEmail:                             t.OwnerEmail,
+		WorkflowExecutionRetentionPeriodInDays: t.WorkflowExecutionRetentionPeriodInDays,
+		EmitMetric:                             t.EmitMetric,
+		Clusters:                               ToClusterReplicationConfigurationArray(t.Clusters),
+		ActiveClusterName:                      t.ActiveClusterName,
+		Data:                                   t.Data,
+		SecurityToken:                          t.SecurityToken,
+		IsGlobalDomain:                         t.IsGlobalDomain,
+		HistoryArchivalStatus:                  ToArchivalStatus(t.HistoryArchivalStatus),
+		HistoryArchivalURI:                     t.HistoryArchivalURI,
+		VisibilityArchivalStatus:               ToArchivalStatus(t.VisibilityArchivalStatus),
+		VisibilityArchivalURI:                  t.VisibilityArchivalURI,
+	}
+}
+
+// FromRemoteSyncMatchedError converts internal RemoteSyncMatchedError type to thrift
+func FromRemoteSyncMatchedError(t *types.RemoteSyncMatchedError) *shared.RemoteSyncMatchedError {
+	if t == nil {
+		return nil
+	}
+	return &shared.RemoteSyncMatchedError{
+		Message: t.Message,
+	}
+}
+
+// ToRemoteSyncMatchedError converts thrift RemoteSyncMatchedError type to internal
+func ToRemoteSyncMatchedError(t *shared.RemoteSyncMatchedError) *types.RemoteSyncMatchedError {
+	if t == nil {
+		return nil
+	}
+	return &types.RemoteSyncMatchedError{
+		Message: t.Message,
+	}
+}
+
+// FromRemoveTaskRequest converts internal RemoveTaskRequest type to thrift
+func FromRemoveTaskRequest(t *types.RemoveTaskRequest) *shared.RemoveTaskRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RemoveTaskRequest{
+		ShardID:             t.ShardID,
+		Type:                t.Type,
+		TaskID:              t.TaskID,
+		VisibilityTimestamp: t.VisibilityTimestamp,
+	}
+}
+
+// ToRemoveTaskRequest converts thrift RemoveTaskRequest type to internal
+func ToRemoveTaskRequest(t *shared.RemoveTaskRequest) *types.RemoveTaskRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RemoveTaskRequest{
+		ShardID:             t.ShardID,
+		Type:                t.Type,
+		TaskID:              t.TaskID,
+		VisibilityTimestamp: t.VisibilityTimestamp,
+	}
+}
+
+// FromRequestCancelActivityTaskDecisionAttributes converts internal RequestCancelActivityTaskDecisionAttributes type to thrift
+func FromRequestCancelActivityTaskDecisionAttributes(t *types.RequestCancelActivityTaskDecisionAttributes) *shared.RequestCancelActivityTaskDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.RequestCancelActivityTaskDecisionAttributes{
+		ActivityId: t.ActivityId,
+	}
+}
+
+// ToRequestCancelActivityTaskDecisionAttributes converts thrift RequestCancelActivityTaskDecisionAttributes type to internal
+func ToRequestCancelActivityTaskDecisionAttributes(t *shared.RequestCancelActivityTaskDecisionAttributes) *types.RequestCancelActivityTaskDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.RequestCancelActivityTaskDecisionAttributes{
+		ActivityId: t.ActivityId,
+	}
+}
+
+// FromRequestCancelActivityTaskFailedEventAttributes converts internal RequestCancelActivityTaskFailedEventAttributes type to thrift
+func FromRequestCancelActivityTaskFailedEventAttributes(t *types.RequestCancelActivityTaskFailedEventAttributes) *shared.RequestCancelActivityTaskFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.RequestCancelActivityTaskFailedEventAttributes{
+		ActivityId:                   t.ActivityId,
+		Cause:                        t.Cause,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// ToRequestCancelActivityTaskFailedEventAttributes converts thrift RequestCancelActivityTaskFailedEventAttributes type to internal
+func ToRequestCancelActivityTaskFailedEventAttributes(t *shared.RequestCancelActivityTaskFailedEventAttributes) *types.RequestCancelActivityTaskFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.RequestCancelActivityTaskFailedEventAttributes{
+		ActivityId:                   t.ActivityId,
+		Cause:                        t.Cause,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// FromRequestCancelExternalWorkflowExecutionDecisionAttributes converts internal RequestCancelExternalWorkflowExecutionDecisionAttributes type to thrift
+func FromRequestCancelExternalWorkflowExecutionDecisionAttributes(t *types.RequestCancelExternalWorkflowExecutionDecisionAttributes) *shared.RequestCancelExternalWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.RequestCancelExternalWorkflowExecutionDecisionAttributes{
+		Domain:            t.Domain,
+		WorkflowId:        t.WorkflowId,
+		RunId:             t.RunId,
+		Control:           t.Control,
+		ChildWorkflowOnly: t.ChildWorkflowOnly,
+	}
+}
+
+// ToRequestCancelExternalWorkflowExecutionDecisionAttributes converts thrift RequestCancelExternalWorkflowExecutionDecisionAttributes type to internal
+func ToRequestCancelExternalWorkflowExecutionDecisionAttributes(t *shared.RequestCancelExternalWorkflowExecutionDecisionAttributes) *types.RequestCancelExternalWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.RequestCancelExternalWorkflowExecutionDecisionAttributes{
+		Domain:            t.Domain,
+		WorkflowId:        t.WorkflowId,
+		RunId:             t.RunId,
+		Control:           t.Control,
+		ChildWorkflowOnly: t.ChildWorkflowOnly,
+	}
+}
+
+// FromRequestCancelExternalWorkflowExecutionFailedEventAttributes converts internal RequestCancelExternalWorkflowExecutionFailedEventAttributes type to thrift
+func FromRequestCancelExternalWorkflowExecutionFailedEventAttributes(t *types.RequestCancelExternalWorkflowExecutionFailedEventAttributes) *shared.RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.RequestCancelExternalWorkflowExecutionFailedEventAttributes{
+		Cause:                        FromCancelExternalWorkflowExecutionFailedCause(t.Cause),
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
+		InitiatedEventId:             t.InitiatedEventId,
+		Control:                      t.Control,
+	}
+}
+
+// ToRequestCancelExternalWorkflowExecutionFailedEventAttributes converts thrift RequestCancelExternalWorkflowExecutionFailedEventAttributes type to internal
+func ToRequestCancelExternalWorkflowExecutionFailedEventAttributes(t *shared.RequestCancelExternalWorkflowExecutionFailedEventAttributes) *types.RequestCancelExternalWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.RequestCancelExternalWorkflowExecutionFailedEventAttributes{
+		Cause:                        ToCancelExternalWorkflowExecutionFailedCause(t.Cause),
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
+		InitiatedEventId:             t.InitiatedEventId,
+		Control:                      t.Control,
+	}
+}
+
+// FromRequestCancelExternalWorkflowExecutionInitiatedEventAttributes converts internal RequestCancelExternalWorkflowExecutionInitiatedEventAttributes type to thrift
+func FromRequestCancelExternalWorkflowExecutionInitiatedEventAttributes(t *types.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) *shared.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
+		Control:                      t.Control,
+		ChildWorkflowOnly:            t.ChildWorkflowOnly,
+	}
+}
+
+// ToRequestCancelExternalWorkflowExecutionInitiatedEventAttributes converts thrift RequestCancelExternalWorkflowExecutionInitiatedEventAttributes type to internal
+func ToRequestCancelExternalWorkflowExecutionInitiatedEventAttributes(t *shared.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) *types.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
+		Control:                      t.Control,
+		ChildWorkflowOnly:            t.ChildWorkflowOnly,
+	}
+}
+
+// FromRequestCancelWorkflowExecutionRequest converts internal RequestCancelWorkflowExecutionRequest type to thrift
+func FromRequestCancelWorkflowExecutionRequest(t *types.RequestCancelWorkflowExecutionRequest) *shared.RequestCancelWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RequestCancelWorkflowExecutionRequest{
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		Identity:          t.Identity,
+		RequestId:         t.RequestId,
+	}
+}
+
+// ToRequestCancelWorkflowExecutionRequest converts thrift RequestCancelWorkflowExecutionRequest type to internal
+func ToRequestCancelWorkflowExecutionRequest(t *shared.RequestCancelWorkflowExecutionRequest) *types.RequestCancelWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RequestCancelWorkflowExecutionRequest{
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		Identity:          t.Identity,
+		RequestId:         t.RequestId,
+	}
+}
+
+// FromResetPointInfo converts internal ResetPointInfo type to thrift
+func FromResetPointInfo(t *types.ResetPointInfo) *shared.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.ResetPointInfo{
+		BinaryChecksum:           t.BinaryChecksum,
+		RunId:                    t.RunId,
+		FirstDecisionCompletedId: t.FirstDecisionCompletedId,
+		CreatedTimeNano:          t.CreatedTimeNano,
+		ExpiringTimeNano:         t.ExpiringTimeNano,
+		Resettable:               t.Resettable,
+	}
+}
+
+// ToResetPointInfo converts thrift ResetPointInfo type to internal
+func ToResetPointInfo(t *shared.ResetPointInfo) *types.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.ResetPointInfo{
+		BinaryChecksum:           t.BinaryChecksum,
+		RunId:                    t.RunId,
+		FirstDecisionCompletedId: t.FirstDecisionCompletedId,
+		CreatedTimeNano:          t.CreatedTimeNano,
+		ExpiringTimeNano:         t.ExpiringTimeNano,
+		Resettable:               t.Resettable,
+	}
+}
+
+// FromResetPoints converts internal ResetPoints type to thrift
+func FromResetPoints(t *types.ResetPoints) *shared.ResetPoints {
+	if t == nil {
+		return nil
+	}
+	return &shared.ResetPoints{
+		Points: FromResetPointInfoArray(t.Points),
+	}
+}
+
+// ToResetPoints converts thrift ResetPoints type to internal
+func ToResetPoints(t *shared.ResetPoints) *types.ResetPoints {
+	if t == nil {
+		return nil
+	}
+	return &types.ResetPoints{
+		Points: ToResetPointInfoArray(t.Points),
+	}
+}
+
+// FromResetQueueRequest converts internal ResetQueueRequest type to thrift
+func FromResetQueueRequest(t *types.ResetQueueRequest) *shared.ResetQueueRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ResetQueueRequest{
+		ShardID:     t.ShardID,
+		ClusterName: t.ClusterName,
+		Type:        t.Type,
+	}
+}
+
+// ToResetQueueRequest converts thrift ResetQueueRequest type to internal
+func ToResetQueueRequest(t *shared.ResetQueueRequest) *types.ResetQueueRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ResetQueueRequest{
+		ShardID:     t.ShardID,
+		ClusterName: t.ClusterName,
+		Type:        t.Type,
+	}
+}
+
+// FromResetStickyTaskListRequest converts internal ResetStickyTaskListRequest type to thrift
+func FromResetStickyTaskListRequest(t *types.ResetStickyTaskListRequest) *shared.ResetStickyTaskListRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ResetStickyTaskListRequest{
+		Domain:    t.Domain,
+		Execution: FromWorkflowExecution(t.Execution),
+	}
+}
+
+// ToResetStickyTaskListRequest converts thrift ResetStickyTaskListRequest type to internal
+func ToResetStickyTaskListRequest(t *shared.ResetStickyTaskListRequest) *types.ResetStickyTaskListRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ResetStickyTaskListRequest{
+		Domain:    t.Domain,
+		Execution: ToWorkflowExecution(t.Execution),
+	}
+}
+
+// FromResetStickyTaskListResponse converts internal ResetStickyTaskListResponse type to thrift
+func FromResetStickyTaskListResponse(t *types.ResetStickyTaskListResponse) *shared.ResetStickyTaskListResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ResetStickyTaskListResponse{}
+}
+
+// ToResetStickyTaskListResponse converts thrift ResetStickyTaskListResponse type to internal
+func ToResetStickyTaskListResponse(t *shared.ResetStickyTaskListResponse) *types.ResetStickyTaskListResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ResetStickyTaskListResponse{}
+}
+
+// FromResetWorkflowExecutionRequest converts internal ResetWorkflowExecutionRequest type to thrift
+func FromResetWorkflowExecutionRequest(t *types.ResetWorkflowExecutionRequest) *shared.ResetWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.ResetWorkflowExecutionRequest{
+		Domain:                t.Domain,
+		WorkflowExecution:     FromWorkflowExecution(t.WorkflowExecution),
+		Reason:                t.Reason,
+		DecisionFinishEventId: t.DecisionFinishEventId,
+		RequestId:             t.RequestId,
+	}
+}
+
+// ToResetWorkflowExecutionRequest converts thrift ResetWorkflowExecutionRequest type to internal
+func ToResetWorkflowExecutionRequest(t *shared.ResetWorkflowExecutionRequest) *types.ResetWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ResetWorkflowExecutionRequest{
+		Domain:                t.Domain,
+		WorkflowExecution:     ToWorkflowExecution(t.WorkflowExecution),
+		Reason:                t.Reason,
+		DecisionFinishEventId: t.DecisionFinishEventId,
+		RequestId:             t.RequestId,
+	}
+}
+
+// FromResetWorkflowExecutionResponse converts internal ResetWorkflowExecutionResponse type to thrift
+func FromResetWorkflowExecutionResponse(t *types.ResetWorkflowExecutionResponse) *shared.ResetWorkflowExecutionResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.ResetWorkflowExecutionResponse{
+		RunId: t.RunId,
+	}
+}
+
+// ToResetWorkflowExecutionResponse converts thrift ResetWorkflowExecutionResponse type to internal
+func ToResetWorkflowExecutionResponse(t *shared.ResetWorkflowExecutionResponse) *types.ResetWorkflowExecutionResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ResetWorkflowExecutionResponse{
+		RunId: t.RunId,
+	}
+}
+
+// FromRespondActivityTaskCanceledByIDRequest converts internal RespondActivityTaskCanceledByIDRequest type to thrift
+func FromRespondActivityTaskCanceledByIDRequest(t *types.RespondActivityTaskCanceledByIDRequest) *shared.RespondActivityTaskCanceledByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondActivityTaskCanceledByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Details:    t.Details,
+		Identity:   t.Identity,
+	}
+}
+
+// ToRespondActivityTaskCanceledByIDRequest converts thrift RespondActivityTaskCanceledByIDRequest type to internal
+func ToRespondActivityTaskCanceledByIDRequest(t *shared.RespondActivityTaskCanceledByIDRequest) *types.RespondActivityTaskCanceledByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondActivityTaskCanceledByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Details:    t.Details,
+		Identity:   t.Identity,
+	}
+}
+
+// FromRespondActivityTaskCanceledRequest converts internal RespondActivityTaskCanceledRequest type to thrift
+func FromRespondActivityTaskCanceledRequest(t *types.RespondActivityTaskCanceledRequest) *shared.RespondActivityTaskCanceledRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondActivityTaskCanceledRequest{
+		TaskToken: t.TaskToken,
+		Details:   t.Details,
+		Identity:  t.Identity,
+	}
+}
+
+// ToRespondActivityTaskCanceledRequest converts thrift RespondActivityTaskCanceledRequest type to internal
+func ToRespondActivityTaskCanceledRequest(t *shared.RespondActivityTaskCanceledRequest) *types.RespondActivityTaskCanceledRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondActivityTaskCanceledRequest{
+		TaskToken: t.TaskToken,
+		Details:   t.Details,
+		Identity:  t.Identity,
+	}
+}
+
+// FromRespondActivityTaskCompletedByIDRequest converts internal RespondActivityTaskCompletedByIDRequest type to thrift
+func FromRespondActivityTaskCompletedByIDRequest(t *types.RespondActivityTaskCompletedByIDRequest) *shared.RespondActivityTaskCompletedByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondActivityTaskCompletedByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Result:     t.Result,
+		Identity:   t.Identity,
+	}
+}
+
+// ToRespondActivityTaskCompletedByIDRequest converts thrift RespondActivityTaskCompletedByIDRequest type to internal
+func ToRespondActivityTaskCompletedByIDRequest(t *shared.RespondActivityTaskCompletedByIDRequest) *types.RespondActivityTaskCompletedByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondActivityTaskCompletedByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Result:     t.Result,
+		Identity:   t.Identity,
+	}
+}
+
+// FromRespondActivityTaskCompletedRequest converts internal RespondActivityTaskCompletedRequest type to thrift
+func FromRespondActivityTaskCompletedRequest(t *types.RespondActivityTaskCompletedRequest) *shared.RespondActivityTaskCompletedRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondActivityTaskCompletedRequest{
+		TaskToken: t.TaskToken,
+		Result:    t.Result,
+		Identity:  t.Identity,
+	}
+}
+
+// ToRespondActivityTaskCompletedRequest converts thrift RespondActivityTaskCompletedRequest type to internal
+func ToRespondActivityTaskCompletedRequest(t *shared.RespondActivityTaskCompletedRequest) *types.RespondActivityTaskCompletedRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondActivityTaskCompletedRequest{
+		TaskToken: t.TaskToken,
+		Result:    t.Result,
+		Identity:  t.Identity,
+	}
+}
+
+// FromRespondActivityTaskFailedByIDRequest converts internal RespondActivityTaskFailedByIDRequest type to thrift
+func FromRespondActivityTaskFailedByIDRequest(t *types.RespondActivityTaskFailedByIDRequest) *shared.RespondActivityTaskFailedByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondActivityTaskFailedByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Reason:     t.Reason,
+		Details:    t.Details,
+		Identity:   t.Identity,
+	}
+}
+
+// ToRespondActivityTaskFailedByIDRequest converts thrift RespondActivityTaskFailedByIDRequest type to internal
+func ToRespondActivityTaskFailedByIDRequest(t *shared.RespondActivityTaskFailedByIDRequest) *types.RespondActivityTaskFailedByIDRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondActivityTaskFailedByIDRequest{
+		Domain:     t.Domain,
+		WorkflowID: t.WorkflowID,
+		RunID:      t.RunID,
+		ActivityID: t.ActivityID,
+		Reason:     t.Reason,
+		Details:    t.Details,
+		Identity:   t.Identity,
+	}
+}
+
+// FromRespondActivityTaskFailedRequest converts internal RespondActivityTaskFailedRequest type to thrift
+func FromRespondActivityTaskFailedRequest(t *types.RespondActivityTaskFailedRequest) *shared.RespondActivityTaskFailedRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondActivityTaskFailedRequest{
+		TaskToken: t.TaskToken,
+		Reason:    t.Reason,
+		Details:   t.Details,
+		Identity:  t.Identity,
+	}
+}
+
+// ToRespondActivityTaskFailedRequest converts thrift RespondActivityTaskFailedRequest type to internal
+func ToRespondActivityTaskFailedRequest(t *shared.RespondActivityTaskFailedRequest) *types.RespondActivityTaskFailedRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondActivityTaskFailedRequest{
+		TaskToken: t.TaskToken,
+		Reason:    t.Reason,
+		Details:   t.Details,
+		Identity:  t.Identity,
+	}
+}
+
+// FromRespondDecisionTaskCompletedRequest converts internal RespondDecisionTaskCompletedRequest type to thrift
+func FromRespondDecisionTaskCompletedRequest(t *types.RespondDecisionTaskCompletedRequest) *shared.RespondDecisionTaskCompletedRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondDecisionTaskCompletedRequest{
+		TaskToken:                  t.TaskToken,
+		Decisions:                  FromDecisionArray(t.Decisions),
+		ExecutionContext:           t.ExecutionContext,
+		Identity:                   t.Identity,
+		StickyAttributes:           FromStickyExecutionAttributes(t.StickyAttributes),
+		ReturnNewDecisionTask:      t.ReturnNewDecisionTask,
+		ForceCreateNewDecisionTask: t.ForceCreateNewDecisionTask,
+		BinaryChecksum:             t.BinaryChecksum,
+		QueryResults:               FromWorkflowQueryResultMap(t.QueryResults),
+	}
+}
+
+// ToRespondDecisionTaskCompletedRequest converts thrift RespondDecisionTaskCompletedRequest type to internal
+func ToRespondDecisionTaskCompletedRequest(t *shared.RespondDecisionTaskCompletedRequest) *types.RespondDecisionTaskCompletedRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondDecisionTaskCompletedRequest{
+		TaskToken:                  t.TaskToken,
+		Decisions:                  ToDecisionArray(t.Decisions),
+		ExecutionContext:           t.ExecutionContext,
+		Identity:                   t.Identity,
+		StickyAttributes:           ToStickyExecutionAttributes(t.StickyAttributes),
+		ReturnNewDecisionTask:      t.ReturnNewDecisionTask,
+		ForceCreateNewDecisionTask: t.ForceCreateNewDecisionTask,
+		BinaryChecksum:             t.BinaryChecksum,
+		QueryResults:               ToWorkflowQueryResultMap(t.QueryResults),
+	}
+}
+
+// FromRespondDecisionTaskCompletedResponse converts internal RespondDecisionTaskCompletedResponse type to thrift
+func FromRespondDecisionTaskCompletedResponse(t *types.RespondDecisionTaskCompletedResponse) *shared.RespondDecisionTaskCompletedResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondDecisionTaskCompletedResponse{
+		DecisionTask: FromPollForDecisionTaskResponse(t.DecisionTask),
+	}
+}
+
+// ToRespondDecisionTaskCompletedResponse converts thrift RespondDecisionTaskCompletedResponse type to internal
+func ToRespondDecisionTaskCompletedResponse(t *shared.RespondDecisionTaskCompletedResponse) *types.RespondDecisionTaskCompletedResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondDecisionTaskCompletedResponse{
+		DecisionTask: ToPollForDecisionTaskResponse(t.DecisionTask),
+	}
+}
+
+// FromRespondDecisionTaskFailedRequest converts internal RespondDecisionTaskFailedRequest type to thrift
+func FromRespondDecisionTaskFailedRequest(t *types.RespondDecisionTaskFailedRequest) *shared.RespondDecisionTaskFailedRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondDecisionTaskFailedRequest{
+		TaskToken:      t.TaskToken,
+		Cause:          FromDecisionTaskFailedCause(t.Cause),
+		Details:        t.Details,
+		Identity:       t.Identity,
+		BinaryChecksum: t.BinaryChecksum,
+	}
+}
+
+// ToRespondDecisionTaskFailedRequest converts thrift RespondDecisionTaskFailedRequest type to internal
+func ToRespondDecisionTaskFailedRequest(t *shared.RespondDecisionTaskFailedRequest) *types.RespondDecisionTaskFailedRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondDecisionTaskFailedRequest{
+		TaskToken:      t.TaskToken,
+		Cause:          ToDecisionTaskFailedCause(t.Cause),
+		Details:        t.Details,
+		Identity:       t.Identity,
+		BinaryChecksum: t.BinaryChecksum,
+	}
+}
+
+// FromRespondQueryTaskCompletedRequest converts internal RespondQueryTaskCompletedRequest type to thrift
+func FromRespondQueryTaskCompletedRequest(t *types.RespondQueryTaskCompletedRequest) *shared.RespondQueryTaskCompletedRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.RespondQueryTaskCompletedRequest{
+		TaskToken:         t.TaskToken,
+		CompletedType:     FromQueryTaskCompletedType(t.CompletedType),
+		QueryResult:       t.QueryResult,
+		ErrorMessage:      t.ErrorMessage,
+		WorkerVersionInfo: FromWorkerVersionInfo(t.WorkerVersionInfo),
+	}
+}
+
+// ToRespondQueryTaskCompletedRequest converts thrift RespondQueryTaskCompletedRequest type to internal
+func ToRespondQueryTaskCompletedRequest(t *shared.RespondQueryTaskCompletedRequest) *types.RespondQueryTaskCompletedRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.RespondQueryTaskCompletedRequest{
+		TaskToken:         t.TaskToken,
+		CompletedType:     ToQueryTaskCompletedType(t.CompletedType),
+		QueryResult:       t.QueryResult,
+		ErrorMessage:      t.ErrorMessage,
+		WorkerVersionInfo: ToWorkerVersionInfo(t.WorkerVersionInfo),
+	}
+}
+
+// FromRetryPolicy converts internal RetryPolicy type to thrift
+func FromRetryPolicy(t *types.RetryPolicy) *shared.RetryPolicy {
+	if t == nil {
+		return nil
+	}
+	return &shared.RetryPolicy{
+		InitialIntervalInSeconds:    t.InitialIntervalInSeconds,
+		BackoffCoefficient:          t.BackoffCoefficient,
+		MaximumIntervalInSeconds:    t.MaximumIntervalInSeconds,
+		MaximumAttempts:             t.MaximumAttempts,
+		NonRetriableErrorReasons:    t.NonRetriableErrorReasons,
+		ExpirationIntervalInSeconds: t.ExpirationIntervalInSeconds,
+	}
+}
+
+// ToRetryPolicy converts thrift RetryPolicy type to internal
+func ToRetryPolicy(t *shared.RetryPolicy) *types.RetryPolicy {
+	if t == nil {
+		return nil
+	}
+	return &types.RetryPolicy{
+		InitialIntervalInSeconds:    t.InitialIntervalInSeconds,
+		BackoffCoefficient:          t.BackoffCoefficient,
+		MaximumIntervalInSeconds:    t.MaximumIntervalInSeconds,
+		MaximumAttempts:             t.MaximumAttempts,
+		NonRetriableErrorReasons:    t.NonRetriableErrorReasons,
+		ExpirationIntervalInSeconds: t.ExpirationIntervalInSeconds,
+	}
+}
+
+// FromRetryTaskV2Error converts internal RetryTaskV2Error type to thrift
+func FromRetryTaskV2Error(t *types.RetryTaskV2Error) *shared.RetryTaskV2Error {
+	if t == nil {
+		return nil
+	}
+	return &shared.RetryTaskV2Error{
+		Message:           t.Message,
+		DomainId:          t.DomainId,
+		WorkflowId:        t.WorkflowId,
+		RunId:             t.RunId,
+		StartEventId:      t.StartEventId,
+		StartEventVersion: t.StartEventVersion,
+		EndEventId:        t.EndEventId,
+		EndEventVersion:   t.EndEventVersion,
+	}
+}
+
+// ToRetryTaskV2Error converts thrift RetryTaskV2Error type to internal
+func ToRetryTaskV2Error(t *shared.RetryTaskV2Error) *types.RetryTaskV2Error {
+	if t == nil {
+		return nil
+	}
+	return &types.RetryTaskV2Error{
+		Message:           t.Message,
+		DomainId:          t.DomainId,
+		WorkflowId:        t.WorkflowId,
+		RunId:             t.RunId,
+		StartEventId:      t.StartEventId,
+		StartEventVersion: t.StartEventVersion,
+		EndEventId:        t.EndEventId,
+		EndEventVersion:   t.EndEventVersion,
+	}
+}
+
+// FromScheduleActivityTaskDecisionAttributes converts internal ScheduleActivityTaskDecisionAttributes type to thrift
+func FromScheduleActivityTaskDecisionAttributes(t *types.ScheduleActivityTaskDecisionAttributes) *shared.ScheduleActivityTaskDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.ScheduleActivityTaskDecisionAttributes{
+		ActivityId:                    t.ActivityId,
+		ActivityType:                  FromActivityType(t.ActivityType),
+		Domain:                        t.Domain,
+		TaskList:                      FromTaskList(t.TaskList),
+		Input:                         t.Input,
+		ScheduleToCloseTimeoutSeconds: t.ScheduleToCloseTimeoutSeconds,
+		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
+		StartToCloseTimeoutSeconds:    t.StartToCloseTimeoutSeconds,
+		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
+		RetryPolicy:                   FromRetryPolicy(t.RetryPolicy),
+		Header:                        FromHeader(t.Header),
+	}
+}
+
+// ToScheduleActivityTaskDecisionAttributes converts thrift ScheduleActivityTaskDecisionAttributes type to internal
+func ToScheduleActivityTaskDecisionAttributes(t *shared.ScheduleActivityTaskDecisionAttributes) *types.ScheduleActivityTaskDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.ScheduleActivityTaskDecisionAttributes{
+		ActivityId:                    t.ActivityId,
+		ActivityType:                  ToActivityType(t.ActivityType),
+		Domain:                        t.Domain,
+		TaskList:                      ToTaskList(t.TaskList),
+		Input:                         t.Input,
+		ScheduleToCloseTimeoutSeconds: t.ScheduleToCloseTimeoutSeconds,
+		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
+		StartToCloseTimeoutSeconds:    t.StartToCloseTimeoutSeconds,
+		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
+		RetryPolicy:                   ToRetryPolicy(t.RetryPolicy),
+		Header:                        ToHeader(t.Header),
+	}
+}
+
+// FromSearchAttributes converts internal SearchAttributes type to thrift
+func FromSearchAttributes(t *types.SearchAttributes) *shared.SearchAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.SearchAttributes{
+		IndexedFields: t.IndexedFields,
+	}
+}
+
+// ToSearchAttributes converts thrift SearchAttributes type to internal
+func ToSearchAttributes(t *shared.SearchAttributes) *types.SearchAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.SearchAttributes{
+		IndexedFields: t.IndexedFields,
+	}
+}
+
+// FromServiceBusyError converts internal ServiceBusyError type to thrift
+func FromServiceBusyError(t *types.ServiceBusyError) *shared.ServiceBusyError {
+	if t == nil {
+		return nil
+	}
+	return &shared.ServiceBusyError{
+		Message: t.Message,
+	}
+}
+
+// ToServiceBusyError converts thrift ServiceBusyError type to internal
+func ToServiceBusyError(t *shared.ServiceBusyError) *types.ServiceBusyError {
+	if t == nil {
+		return nil
+	}
+	return &types.ServiceBusyError{
+		Message: t.Message,
+	}
+}
+
+// FromSignalExternalWorkflowExecutionDecisionAttributes converts internal SignalExternalWorkflowExecutionDecisionAttributes type to thrift
+func FromSignalExternalWorkflowExecutionDecisionAttributes(t *types.SignalExternalWorkflowExecutionDecisionAttributes) *shared.SignalExternalWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.SignalExternalWorkflowExecutionDecisionAttributes{
+		Domain:            t.Domain,
+		Execution:         FromWorkflowExecution(t.Execution),
+		SignalName:        t.SignalName,
+		Input:             t.Input,
+		Control:           t.Control,
+		ChildWorkflowOnly: t.ChildWorkflowOnly,
+	}
+}
+
+// ToSignalExternalWorkflowExecutionDecisionAttributes converts thrift SignalExternalWorkflowExecutionDecisionAttributes type to internal
+func ToSignalExternalWorkflowExecutionDecisionAttributes(t *shared.SignalExternalWorkflowExecutionDecisionAttributes) *types.SignalExternalWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.SignalExternalWorkflowExecutionDecisionAttributes{
+		Domain:            t.Domain,
+		Execution:         ToWorkflowExecution(t.Execution),
+		SignalName:        t.SignalName,
+		Input:             t.Input,
+		Control:           t.Control,
+		ChildWorkflowOnly: t.ChildWorkflowOnly,
+	}
+}
+
+// FromSignalExternalWorkflowExecutionFailedCause converts internal SignalExternalWorkflowExecutionFailedCause type to thrift
+func FromSignalExternalWorkflowExecutionFailedCause(t *types.SignalExternalWorkflowExecutionFailedCause) *shared.SignalExternalWorkflowExecutionFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution:
+		v := shared.SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToSignalExternalWorkflowExecutionFailedCause converts thrift SignalExternalWorkflowExecutionFailedCause type to internal
+func ToSignalExternalWorkflowExecutionFailedCause(t *shared.SignalExternalWorkflowExecutionFailedCause) *types.SignalExternalWorkflowExecutionFailedCause {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution:
+		v := types.SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromSignalExternalWorkflowExecutionFailedEventAttributes converts internal SignalExternalWorkflowExecutionFailedEventAttributes type to thrift
+func FromSignalExternalWorkflowExecutionFailedEventAttributes(t *types.SignalExternalWorkflowExecutionFailedEventAttributes) *shared.SignalExternalWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.SignalExternalWorkflowExecutionFailedEventAttributes{
+		Cause:                        FromSignalExternalWorkflowExecutionFailedCause(t.Cause),
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
+		InitiatedEventId:             t.InitiatedEventId,
+		Control:                      t.Control,
+	}
+}
+
+// ToSignalExternalWorkflowExecutionFailedEventAttributes converts thrift SignalExternalWorkflowExecutionFailedEventAttributes type to internal
+func ToSignalExternalWorkflowExecutionFailedEventAttributes(t *shared.SignalExternalWorkflowExecutionFailedEventAttributes) *types.SignalExternalWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.SignalExternalWorkflowExecutionFailedEventAttributes{
+		Cause:                        ToSignalExternalWorkflowExecutionFailedCause(t.Cause),
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
+		InitiatedEventId:             t.InitiatedEventId,
+		Control:                      t.Control,
+	}
+}
+
+// FromSignalExternalWorkflowExecutionInitiatedEventAttributes converts internal SignalExternalWorkflowExecutionInitiatedEventAttributes type to thrift
+func FromSignalExternalWorkflowExecutionInitiatedEventAttributes(t *types.SignalExternalWorkflowExecutionInitiatedEventAttributes) *shared.SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.SignalExternalWorkflowExecutionInitiatedEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
+		SignalName:                   t.SignalName,
+		Input:                        t.Input,
+		Control:                      t.Control,
+		ChildWorkflowOnly:            t.ChildWorkflowOnly,
+	}
+}
+
+// ToSignalExternalWorkflowExecutionInitiatedEventAttributes converts thrift SignalExternalWorkflowExecutionInitiatedEventAttributes type to internal
+func ToSignalExternalWorkflowExecutionInitiatedEventAttributes(t *shared.SignalExternalWorkflowExecutionInitiatedEventAttributes) *types.SignalExternalWorkflowExecutionInitiatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.SignalExternalWorkflowExecutionInitiatedEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Domain:                       t.Domain,
+		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
+		SignalName:                   t.SignalName,
+		Input:                        t.Input,
+		Control:                      t.Control,
+		ChildWorkflowOnly:            t.ChildWorkflowOnly,
+	}
+}
+
+// FromSignalWithStartWorkflowExecutionRequest converts internal SignalWithStartWorkflowExecutionRequest type to thrift
+func FromSignalWithStartWorkflowExecutionRequest(t *types.SignalWithStartWorkflowExecutionRequest) *shared.SignalWithStartWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.SignalWithStartWorkflowExecutionRequest{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        FromWorkflowType(t.WorkflowType),
+		TaskList:                            FromTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		Identity:                            t.Identity,
+		RequestId:                           t.RequestId,
+		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		SignalName:                          t.SignalName,
+		SignalInput:                         t.SignalInput,
+		Control:                             t.Control,
+		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Memo:                                FromMemo(t.Memo),
+		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+		Header:                              FromHeader(t.Header),
+	}
+}
+
+// ToSignalWithStartWorkflowExecutionRequest converts thrift SignalWithStartWorkflowExecutionRequest type to internal
+func ToSignalWithStartWorkflowExecutionRequest(t *shared.SignalWithStartWorkflowExecutionRequest) *types.SignalWithStartWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.SignalWithStartWorkflowExecutionRequest{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        ToWorkflowType(t.WorkflowType),
+		TaskList:                            ToTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		Identity:                            t.Identity,
+		RequestId:                           t.RequestId,
+		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		SignalName:                          t.SignalName,
+		SignalInput:                         t.SignalInput,
+		Control:                             t.Control,
+		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Memo:                                ToMemo(t.Memo),
+		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+		Header:                              ToHeader(t.Header),
+	}
+}
+
+// FromSignalWorkflowExecutionRequest converts internal SignalWorkflowExecutionRequest type to thrift
+func FromSignalWorkflowExecutionRequest(t *types.SignalWorkflowExecutionRequest) *shared.SignalWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.SignalWorkflowExecutionRequest{
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		SignalName:        t.SignalName,
+		Input:             t.Input,
+		Identity:          t.Identity,
+		RequestId:         t.RequestId,
+		Control:           t.Control,
+	}
+}
+
+// ToSignalWorkflowExecutionRequest converts thrift SignalWorkflowExecutionRequest type to internal
+func ToSignalWorkflowExecutionRequest(t *shared.SignalWorkflowExecutionRequest) *types.SignalWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.SignalWorkflowExecutionRequest{
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		SignalName:        t.SignalName,
+		Input:             t.Input,
+		Identity:          t.Identity,
+		RequestId:         t.RequestId,
+		Control:           t.Control,
+	}
+}
+
+// FromStartChildWorkflowExecutionDecisionAttributes converts internal StartChildWorkflowExecutionDecisionAttributes type to thrift
+func FromStartChildWorkflowExecutionDecisionAttributes(t *types.StartChildWorkflowExecutionDecisionAttributes) *shared.StartChildWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.StartChildWorkflowExecutionDecisionAttributes{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        FromWorkflowType(t.WorkflowType),
+		TaskList:                            FromTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		ParentClosePolicy:                   FromParentClosePolicy(t.ParentClosePolicy),
+		Control:                             t.Control,
+		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Header:                              FromHeader(t.Header),
+		Memo:                                FromMemo(t.Memo),
+		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// ToStartChildWorkflowExecutionDecisionAttributes converts thrift StartChildWorkflowExecutionDecisionAttributes type to internal
+func ToStartChildWorkflowExecutionDecisionAttributes(t *shared.StartChildWorkflowExecutionDecisionAttributes) *types.StartChildWorkflowExecutionDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.StartChildWorkflowExecutionDecisionAttributes{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        ToWorkflowType(t.WorkflowType),
+		TaskList:                            ToTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		ParentClosePolicy:                   ToParentClosePolicy(t.ParentClosePolicy),
+		Control:                             t.Control,
+		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Header:                              ToHeader(t.Header),
+		Memo:                                ToMemo(t.Memo),
+		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// FromStartChildWorkflowExecutionFailedEventAttributes converts internal StartChildWorkflowExecutionFailedEventAttributes type to thrift
+func FromStartChildWorkflowExecutionFailedEventAttributes(t *types.StartChildWorkflowExecutionFailedEventAttributes) *shared.StartChildWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.StartChildWorkflowExecutionFailedEventAttributes{
+		Domain:                       t.Domain,
+		WorkflowId:                   t.WorkflowId,
+		WorkflowType:                 FromWorkflowType(t.WorkflowType),
+		Cause:                        FromChildWorkflowExecutionFailedCause(t.Cause),
+		Control:                      t.Control,
+		InitiatedEventId:             t.InitiatedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// ToStartChildWorkflowExecutionFailedEventAttributes converts thrift StartChildWorkflowExecutionFailedEventAttributes type to internal
+func ToStartChildWorkflowExecutionFailedEventAttributes(t *shared.StartChildWorkflowExecutionFailedEventAttributes) *types.StartChildWorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.StartChildWorkflowExecutionFailedEventAttributes{
+		Domain:                       t.Domain,
+		WorkflowId:                   t.WorkflowId,
+		WorkflowType:                 ToWorkflowType(t.WorkflowType),
+		Cause:                        ToChildWorkflowExecutionFailedCause(t.Cause),
+		Control:                      t.Control,
+		InitiatedEventId:             t.InitiatedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// FromStartChildWorkflowExecutionInitiatedEventAttributes converts internal StartChildWorkflowExecutionInitiatedEventAttributes type to thrift
+func FromStartChildWorkflowExecutionInitiatedEventAttributes(t *types.StartChildWorkflowExecutionInitiatedEventAttributes) *shared.StartChildWorkflowExecutionInitiatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.StartChildWorkflowExecutionInitiatedEventAttributes{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        FromWorkflowType(t.WorkflowType),
+		TaskList:                            FromTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		ParentClosePolicy:                   FromParentClosePolicy(t.ParentClosePolicy),
+		Control:                             t.Control,
+		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
+		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Header:                              FromHeader(t.Header),
+		Memo:                                FromMemo(t.Memo),
+		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// ToStartChildWorkflowExecutionInitiatedEventAttributes converts thrift StartChildWorkflowExecutionInitiatedEventAttributes type to internal
+func ToStartChildWorkflowExecutionInitiatedEventAttributes(t *shared.StartChildWorkflowExecutionInitiatedEventAttributes) *types.StartChildWorkflowExecutionInitiatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.StartChildWorkflowExecutionInitiatedEventAttributes{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        ToWorkflowType(t.WorkflowType),
+		TaskList:                            ToTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		ParentClosePolicy:                   ToParentClosePolicy(t.ParentClosePolicy),
+		Control:                             t.Control,
+		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
+		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Header:                              ToHeader(t.Header),
+		Memo:                                ToMemo(t.Memo),
+		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// FromStartTimeFilter converts internal StartTimeFilter type to thrift
+func FromStartTimeFilter(t *types.StartTimeFilter) *shared.StartTimeFilter {
+	if t == nil {
+		return nil
+	}
+	return &shared.StartTimeFilter{
+		EarliestTime: t.EarliestTime,
+		LatestTime:   t.LatestTime,
+	}
+}
+
+// ToStartTimeFilter converts thrift StartTimeFilter type to internal
+func ToStartTimeFilter(t *shared.StartTimeFilter) *types.StartTimeFilter {
+	if t == nil {
+		return nil
+	}
+	return &types.StartTimeFilter{
+		EarliestTime: t.EarliestTime,
+		LatestTime:   t.LatestTime,
+	}
+}
+
+// FromStartTimerDecisionAttributes converts internal StartTimerDecisionAttributes type to thrift
+func FromStartTimerDecisionAttributes(t *types.StartTimerDecisionAttributes) *shared.StartTimerDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.StartTimerDecisionAttributes{
+		TimerId:                   t.TimerId,
+		StartToFireTimeoutSeconds: t.StartToFireTimeoutSeconds,
+	}
+}
+
+// ToStartTimerDecisionAttributes converts thrift StartTimerDecisionAttributes type to internal
+func ToStartTimerDecisionAttributes(t *shared.StartTimerDecisionAttributes) *types.StartTimerDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.StartTimerDecisionAttributes{
+		TimerId:                   t.TimerId,
+		StartToFireTimeoutSeconds: t.StartToFireTimeoutSeconds,
+	}
+}
+
+// FromStartWorkflowExecutionRequest converts internal StartWorkflowExecutionRequest type to thrift
+func FromStartWorkflowExecutionRequest(t *types.StartWorkflowExecutionRequest) *shared.StartWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.StartWorkflowExecutionRequest{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        FromWorkflowType(t.WorkflowType),
+		TaskList:                            FromTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		Identity:                            t.Identity,
+		RequestId:                           t.RequestId,
+		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Memo:                                FromMemo(t.Memo),
+		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+		Header:                              FromHeader(t.Header),
+	}
+}
+
+// ToStartWorkflowExecutionRequest converts thrift StartWorkflowExecutionRequest type to internal
+func ToStartWorkflowExecutionRequest(t *shared.StartWorkflowExecutionRequest) *types.StartWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.StartWorkflowExecutionRequest{
+		Domain:                              t.Domain,
+		WorkflowId:                          t.WorkflowId,
+		WorkflowType:                        ToWorkflowType(t.WorkflowType),
+		TaskList:                            ToTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		Identity:                            t.Identity,
+		RequestId:                           t.RequestId,
+		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
+		CronSchedule:                        t.CronSchedule,
+		Memo:                                ToMemo(t.Memo),
+		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+		Header:                              ToHeader(t.Header),
+	}
+}
+
+// FromStartWorkflowExecutionResponse converts internal StartWorkflowExecutionResponse type to thrift
+func FromStartWorkflowExecutionResponse(t *types.StartWorkflowExecutionResponse) *shared.StartWorkflowExecutionResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.StartWorkflowExecutionResponse{
+		RunId: t.RunId,
+	}
+}
+
+// ToStartWorkflowExecutionResponse converts thrift StartWorkflowExecutionResponse type to internal
+func ToStartWorkflowExecutionResponse(t *shared.StartWorkflowExecutionResponse) *types.StartWorkflowExecutionResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.StartWorkflowExecutionResponse{
+		RunId: t.RunId,
+	}
+}
+
+// FromStickyExecutionAttributes converts internal StickyExecutionAttributes type to thrift
+func FromStickyExecutionAttributes(t *types.StickyExecutionAttributes) *shared.StickyExecutionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.StickyExecutionAttributes{
+		WorkerTaskList:                FromTaskList(t.WorkerTaskList),
+		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
+	}
+}
+
+// ToStickyExecutionAttributes converts thrift StickyExecutionAttributes type to internal
+func ToStickyExecutionAttributes(t *shared.StickyExecutionAttributes) *types.StickyExecutionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.StickyExecutionAttributes{
+		WorkerTaskList:                ToTaskList(t.WorkerTaskList),
+		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
+	}
+}
+
+// FromSupportedClientVersions converts internal SupportedClientVersions type to thrift
+func FromSupportedClientVersions(t *types.SupportedClientVersions) *shared.SupportedClientVersions {
+	if t == nil {
+		return nil
+	}
+	return &shared.SupportedClientVersions{
+		GoSdk:   t.GoSdk,
+		JavaSdk: t.JavaSdk,
+	}
+}
+
+// ToSupportedClientVersions converts thrift SupportedClientVersions type to internal
+func ToSupportedClientVersions(t *shared.SupportedClientVersions) *types.SupportedClientVersions {
+	if t == nil {
+		return nil
+	}
+	return &types.SupportedClientVersions{
+		GoSdk:   t.GoSdk,
+		JavaSdk: t.JavaSdk,
+	}
+}
+
+// FromTaskIDBlock converts internal TaskIDBlock type to thrift
+func FromTaskIDBlock(t *types.TaskIDBlock) *shared.TaskIDBlock {
+	if t == nil {
+		return nil
+	}
+	return &shared.TaskIDBlock{
+		StartID: t.StartID,
+		EndID:   t.EndID,
+	}
+}
+
+// ToTaskIDBlock converts thrift TaskIDBlock type to internal
+func ToTaskIDBlock(t *shared.TaskIDBlock) *types.TaskIDBlock {
+	if t == nil {
+		return nil
+	}
+	return &types.TaskIDBlock{
+		StartID: t.StartID,
+		EndID:   t.EndID,
+	}
+}
+
+// FromTaskList converts internal TaskList type to thrift
+func FromTaskList(t *types.TaskList) *shared.TaskList {
+	if t == nil {
+		return nil
+	}
+	return &shared.TaskList{
+		Name: t.Name,
+		Kind: FromTaskListKind(t.Kind),
+	}
+}
+
+// ToTaskList converts thrift TaskList type to internal
+func ToTaskList(t *shared.TaskList) *types.TaskList {
+	if t == nil {
+		return nil
+	}
+	return &types.TaskList{
+		Name: t.Name,
+		Kind: ToTaskListKind(t.Kind),
+	}
+}
+
+// FromTaskListKind converts internal TaskListKind type to thrift
+func FromTaskListKind(t *types.TaskListKind) *shared.TaskListKind {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.TaskListKindNormal:
+		v := shared.TaskListKindNormal
+		return &v
+	case types.TaskListKindSticky:
+		v := shared.TaskListKindSticky
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToTaskListKind converts thrift TaskListKind type to internal
+func ToTaskListKind(t *shared.TaskListKind) *types.TaskListKind {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.TaskListKindNormal:
+		v := types.TaskListKindNormal
+		return &v
+	case shared.TaskListKindSticky:
+		v := types.TaskListKindSticky
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromTaskListMetadata converts internal TaskListMetadata type to thrift
+func FromTaskListMetadata(t *types.TaskListMetadata) *shared.TaskListMetadata {
+	if t == nil {
+		return nil
+	}
+	return &shared.TaskListMetadata{
+		MaxTasksPerSecond: t.MaxTasksPerSecond,
+	}
+}
+
+// ToTaskListMetadata converts thrift TaskListMetadata type to internal
+func ToTaskListMetadata(t *shared.TaskListMetadata) *types.TaskListMetadata {
+	if t == nil {
+		return nil
+	}
+	return &types.TaskListMetadata{
+		MaxTasksPerSecond: t.MaxTasksPerSecond,
+	}
+}
+
+// FromTaskListPartitionMetadata converts internal TaskListPartitionMetadata type to thrift
+func FromTaskListPartitionMetadata(t *types.TaskListPartitionMetadata) *shared.TaskListPartitionMetadata {
+	if t == nil {
+		return nil
+	}
+	return &shared.TaskListPartitionMetadata{
+		Key:           t.Key,
+		OwnerHostName: t.OwnerHostName,
+	}
+}
+
+// ToTaskListPartitionMetadata converts thrift TaskListPartitionMetadata type to internal
+func ToTaskListPartitionMetadata(t *shared.TaskListPartitionMetadata) *types.TaskListPartitionMetadata {
+	if t == nil {
+		return nil
+	}
+	return &types.TaskListPartitionMetadata{
+		Key:           t.Key,
+		OwnerHostName: t.OwnerHostName,
+	}
+}
+
+// FromTaskListStatus converts internal TaskListStatus type to thrift
+func FromTaskListStatus(t *types.TaskListStatus) *shared.TaskListStatus {
+	if t == nil {
+		return nil
+	}
+	return &shared.TaskListStatus{
+		BacklogCountHint: t.BacklogCountHint,
+		ReadLevel:        t.ReadLevel,
+		AckLevel:         t.AckLevel,
+		RatePerSecond:    t.RatePerSecond,
+		TaskIDBlock:      FromTaskIDBlock(t.TaskIDBlock),
+	}
+}
+
+// ToTaskListStatus converts thrift TaskListStatus type to internal
+func ToTaskListStatus(t *shared.TaskListStatus) *types.TaskListStatus {
+	if t == nil {
+		return nil
+	}
+	return &types.TaskListStatus{
+		BacklogCountHint: t.BacklogCountHint,
+		ReadLevel:        t.ReadLevel,
+		AckLevel:         t.AckLevel,
+		RatePerSecond:    t.RatePerSecond,
+		TaskIDBlock:      ToTaskIDBlock(t.TaskIDBlock),
+	}
+}
+
+// FromTaskListType converts internal TaskListType type to thrift
+func FromTaskListType(t *types.TaskListType) *shared.TaskListType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.TaskListTypeActivity:
+		v := shared.TaskListTypeActivity
+		return &v
+	case types.TaskListTypeDecision:
+		v := shared.TaskListTypeDecision
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToTaskListType converts thrift TaskListType type to internal
+func ToTaskListType(t *shared.TaskListType) *types.TaskListType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.TaskListTypeActivity:
+		v := types.TaskListTypeActivity
+		return &v
+	case shared.TaskListTypeDecision:
+		v := types.TaskListTypeDecision
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromTerminateWorkflowExecutionRequest converts internal TerminateWorkflowExecutionRequest type to thrift
+func FromTerminateWorkflowExecutionRequest(t *types.TerminateWorkflowExecutionRequest) *shared.TerminateWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.TerminateWorkflowExecutionRequest{
+		Domain:            t.Domain,
+		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
+		Reason:            t.Reason,
+		Details:           t.Details,
+		Identity:          t.Identity,
+	}
+}
+
+// ToTerminateWorkflowExecutionRequest converts thrift TerminateWorkflowExecutionRequest type to internal
+func ToTerminateWorkflowExecutionRequest(t *shared.TerminateWorkflowExecutionRequest) *types.TerminateWorkflowExecutionRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.TerminateWorkflowExecutionRequest{
+		Domain:            t.Domain,
+		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
+		Reason:            t.Reason,
+		Details:           t.Details,
+		Identity:          t.Identity,
+	}
+}
+
+// FromTimeoutType converts internal TimeoutType type to thrift
+func FromTimeoutType(t *types.TimeoutType) *shared.TimeoutType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.TimeoutTypeHeartbeat:
+		v := shared.TimeoutTypeHeartbeat
+		return &v
+	case types.TimeoutTypeScheduleToClose:
+		v := shared.TimeoutTypeScheduleToClose
+		return &v
+	case types.TimeoutTypeScheduleToStart:
+		v := shared.TimeoutTypeScheduleToStart
+		return &v
+	case types.TimeoutTypeStartToClose:
+		v := shared.TimeoutTypeStartToClose
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToTimeoutType converts thrift TimeoutType type to internal
+func ToTimeoutType(t *shared.TimeoutType) *types.TimeoutType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.TimeoutTypeHeartbeat:
+		v := types.TimeoutTypeHeartbeat
+		return &v
+	case shared.TimeoutTypeScheduleToClose:
+		v := types.TimeoutTypeScheduleToClose
+		return &v
+	case shared.TimeoutTypeScheduleToStart:
+		v := types.TimeoutTypeScheduleToStart
+		return &v
+	case shared.TimeoutTypeStartToClose:
+		v := types.TimeoutTypeStartToClose
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromTimerCanceledEventAttributes converts internal TimerCanceledEventAttributes type to thrift
+func FromTimerCanceledEventAttributes(t *types.TimerCanceledEventAttributes) *shared.TimerCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.TimerCanceledEventAttributes{
+		TimerId:                      t.TimerId,
+		StartedEventId:               t.StartedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Identity:                     t.Identity,
+	}
+}
+
+// ToTimerCanceledEventAttributes converts thrift TimerCanceledEventAttributes type to internal
+func ToTimerCanceledEventAttributes(t *shared.TimerCanceledEventAttributes) *types.TimerCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.TimerCanceledEventAttributes{
+		TimerId:                      t.TimerId,
+		StartedEventId:               t.StartedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Identity:                     t.Identity,
+	}
+}
+
+// FromTimerFiredEventAttributes converts internal TimerFiredEventAttributes type to thrift
+func FromTimerFiredEventAttributes(t *types.TimerFiredEventAttributes) *shared.TimerFiredEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.TimerFiredEventAttributes{
+		TimerId:        t.TimerId,
+		StartedEventId: t.StartedEventId,
+	}
+}
+
+// ToTimerFiredEventAttributes converts thrift TimerFiredEventAttributes type to internal
+func ToTimerFiredEventAttributes(t *shared.TimerFiredEventAttributes) *types.TimerFiredEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.TimerFiredEventAttributes{
+		TimerId:        t.TimerId,
+		StartedEventId: t.StartedEventId,
+	}
+}
+
+// FromTimerStartedEventAttributes converts internal TimerStartedEventAttributes type to thrift
+func FromTimerStartedEventAttributes(t *types.TimerStartedEventAttributes) *shared.TimerStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.TimerStartedEventAttributes{
+		TimerId:                      t.TimerId,
+		StartToFireTimeoutSeconds:    t.StartToFireTimeoutSeconds,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// ToTimerStartedEventAttributes converts thrift TimerStartedEventAttributes type to internal
+func ToTimerStartedEventAttributes(t *shared.TimerStartedEventAttributes) *types.TimerStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.TimerStartedEventAttributes{
+		TimerId:                      t.TimerId,
+		StartToFireTimeoutSeconds:    t.StartToFireTimeoutSeconds,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// FromTransientDecisionInfo converts internal TransientDecisionInfo type to thrift
+func FromTransientDecisionInfo(t *types.TransientDecisionInfo) *shared.TransientDecisionInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.TransientDecisionInfo{
+		ScheduledEvent: FromHistoryEvent(t.ScheduledEvent),
+		StartedEvent:   FromHistoryEvent(t.StartedEvent),
+	}
+}
+
+// ToTransientDecisionInfo converts thrift TransientDecisionInfo type to internal
+func ToTransientDecisionInfo(t *shared.TransientDecisionInfo) *types.TransientDecisionInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.TransientDecisionInfo{
+		ScheduledEvent: ToHistoryEvent(t.ScheduledEvent),
+		StartedEvent:   ToHistoryEvent(t.StartedEvent),
+	}
+}
+
+// FromUpdateDomainInfo converts internal UpdateDomainInfo type to thrift
+func FromUpdateDomainInfo(t *types.UpdateDomainInfo) *shared.UpdateDomainInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.UpdateDomainInfo{
+		Description: t.Description,
+		OwnerEmail:  t.OwnerEmail,
+		Data:        t.Data,
+	}
+}
+
+// ToUpdateDomainInfo converts thrift UpdateDomainInfo type to internal
+func ToUpdateDomainInfo(t *shared.UpdateDomainInfo) *types.UpdateDomainInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.UpdateDomainInfo{
+		Description: t.Description,
+		OwnerEmail:  t.OwnerEmail,
+		Data:        t.Data,
+	}
+}
+
+// FromUpdateDomainRequest converts internal UpdateDomainRequest type to thrift
+func FromUpdateDomainRequest(t *types.UpdateDomainRequest) *shared.UpdateDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &shared.UpdateDomainRequest{
+		Name:                     t.Name,
+		UpdatedInfo:              FromUpdateDomainInfo(t.UpdatedInfo),
+		Configuration:            FromDomainConfiguration(t.Configuration),
+		ReplicationConfiguration: FromDomainReplicationConfiguration(t.ReplicationConfiguration),
+		SecurityToken:            t.SecurityToken,
+		DeleteBadBinary:          t.DeleteBadBinary,
+		FailoverTimeoutInSeconds: t.FailoverTimeoutInSeconds,
+	}
+}
+
+// ToUpdateDomainRequest converts thrift UpdateDomainRequest type to internal
+func ToUpdateDomainRequest(t *shared.UpdateDomainRequest) *types.UpdateDomainRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.UpdateDomainRequest{
+		Name:                     t.Name,
+		UpdatedInfo:              ToUpdateDomainInfo(t.UpdatedInfo),
+		Configuration:            ToDomainConfiguration(t.Configuration),
+		ReplicationConfiguration: ToDomainReplicationConfiguration(t.ReplicationConfiguration),
+		SecurityToken:            t.SecurityToken,
+		DeleteBadBinary:          t.DeleteBadBinary,
+		FailoverTimeoutInSeconds: t.FailoverTimeoutInSeconds,
+	}
+}
+
+// FromUpdateDomainResponse converts internal UpdateDomainResponse type to thrift
+func FromUpdateDomainResponse(t *types.UpdateDomainResponse) *shared.UpdateDomainResponse {
+	if t == nil {
+		return nil
+	}
+	return &shared.UpdateDomainResponse{
+		DomainInfo:               FromDomainInfo(t.DomainInfo),
+		Configuration:            FromDomainConfiguration(t.Configuration),
+		ReplicationConfiguration: FromDomainReplicationConfiguration(t.ReplicationConfiguration),
+		FailoverVersion:          t.FailoverVersion,
+		IsGlobalDomain:           t.IsGlobalDomain,
+	}
+}
+
+// ToUpdateDomainResponse converts thrift UpdateDomainResponse type to internal
+func ToUpdateDomainResponse(t *shared.UpdateDomainResponse) *types.UpdateDomainResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.UpdateDomainResponse{
+		DomainInfo:               ToDomainInfo(t.DomainInfo),
+		Configuration:            ToDomainConfiguration(t.Configuration),
+		ReplicationConfiguration: ToDomainReplicationConfiguration(t.ReplicationConfiguration),
+		FailoverVersion:          t.FailoverVersion,
+		IsGlobalDomain:           t.IsGlobalDomain,
+	}
+}
+
+// FromUpsertWorkflowSearchAttributesDecisionAttributes converts internal UpsertWorkflowSearchAttributesDecisionAttributes type to thrift
+func FromUpsertWorkflowSearchAttributesDecisionAttributes(t *types.UpsertWorkflowSearchAttributesDecisionAttributes) *shared.UpsertWorkflowSearchAttributesDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.UpsertWorkflowSearchAttributesDecisionAttributes{
+		SearchAttributes: FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// ToUpsertWorkflowSearchAttributesDecisionAttributes converts thrift UpsertWorkflowSearchAttributesDecisionAttributes type to internal
+func ToUpsertWorkflowSearchAttributesDecisionAttributes(t *shared.UpsertWorkflowSearchAttributesDecisionAttributes) *types.UpsertWorkflowSearchAttributesDecisionAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.UpsertWorkflowSearchAttributesDecisionAttributes{
+		SearchAttributes: ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// FromUpsertWorkflowSearchAttributesEventAttributes converts internal UpsertWorkflowSearchAttributesEventAttributes type to thrift
+func FromUpsertWorkflowSearchAttributesEventAttributes(t *types.UpsertWorkflowSearchAttributesEventAttributes) *shared.UpsertWorkflowSearchAttributesEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.UpsertWorkflowSearchAttributesEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		SearchAttributes:             FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// ToUpsertWorkflowSearchAttributesEventAttributes converts thrift UpsertWorkflowSearchAttributesEventAttributes type to internal
+func ToUpsertWorkflowSearchAttributesEventAttributes(t *shared.UpsertWorkflowSearchAttributesEventAttributes) *types.UpsertWorkflowSearchAttributesEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.UpsertWorkflowSearchAttributesEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		SearchAttributes:             ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// FromVersionHistories converts internal VersionHistories type to thrift
+func FromVersionHistories(t *types.VersionHistories) *shared.VersionHistories {
+	if t == nil {
+		return nil
+	}
+	return &shared.VersionHistories{
+		CurrentVersionHistoryIndex: t.CurrentVersionHistoryIndex,
+		Histories:                  FromVersionHistoryArray(t.Histories),
+	}
+}
+
+// ToVersionHistories converts thrift VersionHistories type to internal
+func ToVersionHistories(t *shared.VersionHistories) *types.VersionHistories {
+	if t == nil {
+		return nil
+	}
+	return &types.VersionHistories{
+		CurrentVersionHistoryIndex: t.CurrentVersionHistoryIndex,
+		Histories:                  ToVersionHistoryArray(t.Histories),
+	}
+}
+
+// FromVersionHistory converts internal VersionHistory type to thrift
+func FromVersionHistory(t *types.VersionHistory) *shared.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	return &shared.VersionHistory{
+		BranchToken: t.BranchToken,
+		Items:       FromVersionHistoryItemArray(t.Items),
+	}
+}
+
+// ToVersionHistory converts thrift VersionHistory type to internal
+func ToVersionHistory(t *shared.VersionHistory) *types.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	return &types.VersionHistory{
+		BranchToken: t.BranchToken,
+		Items:       ToVersionHistoryItemArray(t.Items),
+	}
+}
+
+// FromVersionHistoryItem converts internal VersionHistoryItem type to thrift
+func FromVersionHistoryItem(t *types.VersionHistoryItem) *shared.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	return &shared.VersionHistoryItem{
+		EventID: t.EventID,
+		Version: t.Version,
+	}
+}
+
+// ToVersionHistoryItem converts thrift VersionHistoryItem type to internal
+func ToVersionHistoryItem(t *shared.VersionHistoryItem) *types.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	return &types.VersionHistoryItem{
+		EventID: t.EventID,
+		Version: t.Version,
+	}
+}
+
+// FromWorkerVersionInfo converts internal WorkerVersionInfo type to thrift
+func FromWorkerVersionInfo(t *types.WorkerVersionInfo) *shared.WorkerVersionInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkerVersionInfo{
+		Impl:           t.Impl,
+		FeatureVersion: t.FeatureVersion,
+	}
+}
+
+// ToWorkerVersionInfo converts thrift WorkerVersionInfo type to internal
+func ToWorkerVersionInfo(t *shared.WorkerVersionInfo) *types.WorkerVersionInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkerVersionInfo{
+		Impl:           t.Impl,
+		FeatureVersion: t.FeatureVersion,
+	}
+}
+
+// FromWorkflowExecution converts internal WorkflowExecution type to thrift
+func FromWorkflowExecution(t *types.WorkflowExecution) *shared.WorkflowExecution {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecution{
+		WorkflowId: t.WorkflowId,
+		RunId:      t.RunId,
+	}
+}
+
+// ToWorkflowExecution converts thrift WorkflowExecution type to internal
+func ToWorkflowExecution(t *shared.WorkflowExecution) *types.WorkflowExecution {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecution{
+		WorkflowId: t.WorkflowId,
+		RunId:      t.RunId,
+	}
+}
+
+// FromWorkflowExecutionAlreadyStartedError converts internal WorkflowExecutionAlreadyStartedError type to thrift
+func FromWorkflowExecutionAlreadyStartedError(t *types.WorkflowExecutionAlreadyStartedError) *shared.WorkflowExecutionAlreadyStartedError {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionAlreadyStartedError{
+		Message:        t.Message,
+		StartRequestId: t.StartRequestId,
+		RunId:          t.RunId,
+	}
+}
+
+// ToWorkflowExecutionAlreadyStartedError converts thrift WorkflowExecutionAlreadyStartedError type to internal
+func ToWorkflowExecutionAlreadyStartedError(t *shared.WorkflowExecutionAlreadyStartedError) *types.WorkflowExecutionAlreadyStartedError {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionAlreadyStartedError{
+		Message:        t.Message,
+		StartRequestId: t.StartRequestId,
+		RunId:          t.RunId,
+	}
+}
+
+// FromWorkflowExecutionCancelRequestedEventAttributes converts internal WorkflowExecutionCancelRequestedEventAttributes type to thrift
+func FromWorkflowExecutionCancelRequestedEventAttributes(t *types.WorkflowExecutionCancelRequestedEventAttributes) *shared.WorkflowExecutionCancelRequestedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionCancelRequestedEventAttributes{
+		Cause:                     t.Cause,
+		ExternalInitiatedEventId:  t.ExternalInitiatedEventId,
+		ExternalWorkflowExecution: FromWorkflowExecution(t.ExternalWorkflowExecution),
+		Identity:                  t.Identity,
+	}
+}
+
+// ToWorkflowExecutionCancelRequestedEventAttributes converts thrift WorkflowExecutionCancelRequestedEventAttributes type to internal
+func ToWorkflowExecutionCancelRequestedEventAttributes(t *shared.WorkflowExecutionCancelRequestedEventAttributes) *types.WorkflowExecutionCancelRequestedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionCancelRequestedEventAttributes{
+		Cause:                     t.Cause,
+		ExternalInitiatedEventId:  t.ExternalInitiatedEventId,
+		ExternalWorkflowExecution: ToWorkflowExecution(t.ExternalWorkflowExecution),
+		Identity:                  t.Identity,
+	}
+}
+
+// FromWorkflowExecutionCanceledEventAttributes converts internal WorkflowExecutionCanceledEventAttributes type to thrift
+func FromWorkflowExecutionCanceledEventAttributes(t *types.WorkflowExecutionCanceledEventAttributes) *shared.WorkflowExecutionCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionCanceledEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Details:                      t.Details,
+	}
+}
+
+// ToWorkflowExecutionCanceledEventAttributes converts thrift WorkflowExecutionCanceledEventAttributes type to internal
+func ToWorkflowExecutionCanceledEventAttributes(t *shared.WorkflowExecutionCanceledEventAttributes) *types.WorkflowExecutionCanceledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionCanceledEventAttributes{
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		Details:                      t.Details,
+	}
+}
+
+// FromWorkflowExecutionCloseStatus converts internal WorkflowExecutionCloseStatus type to thrift
+func FromWorkflowExecutionCloseStatus(t *types.WorkflowExecutionCloseStatus) *shared.WorkflowExecutionCloseStatus {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.WorkflowExecutionCloseStatusCanceled:
+		v := shared.WorkflowExecutionCloseStatusCanceled
+		return &v
+	case types.WorkflowExecutionCloseStatusCompleted:
+		v := shared.WorkflowExecutionCloseStatusCompleted
+		return &v
+	case types.WorkflowExecutionCloseStatusContinuedAsNew:
+		v := shared.WorkflowExecutionCloseStatusContinuedAsNew
+		return &v
+	case types.WorkflowExecutionCloseStatusFailed:
+		v := shared.WorkflowExecutionCloseStatusFailed
+		return &v
+	case types.WorkflowExecutionCloseStatusTerminated:
+		v := shared.WorkflowExecutionCloseStatusTerminated
+		return &v
+	case types.WorkflowExecutionCloseStatusTimedOut:
+		v := shared.WorkflowExecutionCloseStatusTimedOut
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToWorkflowExecutionCloseStatus converts thrift WorkflowExecutionCloseStatus type to internal
+func ToWorkflowExecutionCloseStatus(t *shared.WorkflowExecutionCloseStatus) *types.WorkflowExecutionCloseStatus {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.WorkflowExecutionCloseStatusCanceled:
+		v := types.WorkflowExecutionCloseStatusCanceled
+		return &v
+	case shared.WorkflowExecutionCloseStatusCompleted:
+		v := types.WorkflowExecutionCloseStatusCompleted
+		return &v
+	case shared.WorkflowExecutionCloseStatusContinuedAsNew:
+		v := types.WorkflowExecutionCloseStatusContinuedAsNew
+		return &v
+	case shared.WorkflowExecutionCloseStatusFailed:
+		v := types.WorkflowExecutionCloseStatusFailed
+		return &v
+	case shared.WorkflowExecutionCloseStatusTerminated:
+		v := types.WorkflowExecutionCloseStatusTerminated
+		return &v
+	case shared.WorkflowExecutionCloseStatusTimedOut:
+		v := types.WorkflowExecutionCloseStatusTimedOut
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromWorkflowExecutionCompletedEventAttributes converts internal WorkflowExecutionCompletedEventAttributes type to thrift
+func FromWorkflowExecutionCompletedEventAttributes(t *types.WorkflowExecutionCompletedEventAttributes) *shared.WorkflowExecutionCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionCompletedEventAttributes{
+		Result:                       t.Result,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// ToWorkflowExecutionCompletedEventAttributes converts thrift WorkflowExecutionCompletedEventAttributes type to internal
+func ToWorkflowExecutionCompletedEventAttributes(t *shared.WorkflowExecutionCompletedEventAttributes) *types.WorkflowExecutionCompletedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionCompletedEventAttributes{
+		Result:                       t.Result,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// FromWorkflowExecutionConfiguration converts internal WorkflowExecutionConfiguration type to thrift
+func FromWorkflowExecutionConfiguration(t *types.WorkflowExecutionConfiguration) *shared.WorkflowExecutionConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionConfiguration{
+		TaskList:                            FromTaskList(t.TaskList),
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+	}
+}
+
+// ToWorkflowExecutionConfiguration converts thrift WorkflowExecutionConfiguration type to internal
+func ToWorkflowExecutionConfiguration(t *shared.WorkflowExecutionConfiguration) *types.WorkflowExecutionConfiguration {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionConfiguration{
+		TaskList:                            ToTaskList(t.TaskList),
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+	}
+}
+
+// FromWorkflowExecutionContinuedAsNewEventAttributes converts internal WorkflowExecutionContinuedAsNewEventAttributes type to thrift
+func FromWorkflowExecutionContinuedAsNewEventAttributes(t *types.WorkflowExecutionContinuedAsNewEventAttributes) *shared.WorkflowExecutionContinuedAsNewEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionContinuedAsNewEventAttributes{
+		NewExecutionRunId:                   t.NewExecutionRunId,
+		WorkflowType:                        FromWorkflowType(t.WorkflowType),
+		TaskList:                            FromTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
+		BackoffStartIntervalInSeconds:       t.BackoffStartIntervalInSeconds,
+		Initiator:                           FromContinueAsNewInitiator(t.Initiator),
+		FailureReason:                       t.FailureReason,
+		FailureDetails:                      t.FailureDetails,
+		LastCompletionResult:                t.LastCompletionResult,
+		Header:                              FromHeader(t.Header),
+		Memo:                                FromMemo(t.Memo),
+		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// ToWorkflowExecutionContinuedAsNewEventAttributes converts thrift WorkflowExecutionContinuedAsNewEventAttributes type to internal
+func ToWorkflowExecutionContinuedAsNewEventAttributes(t *shared.WorkflowExecutionContinuedAsNewEventAttributes) *types.WorkflowExecutionContinuedAsNewEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionContinuedAsNewEventAttributes{
+		NewExecutionRunId:                   t.NewExecutionRunId,
+		WorkflowType:                        ToWorkflowType(t.WorkflowType),
+		TaskList:                            ToTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
+		BackoffStartIntervalInSeconds:       t.BackoffStartIntervalInSeconds,
+		Initiator:                           ToContinueAsNewInitiator(t.Initiator),
+		FailureReason:                       t.FailureReason,
+		FailureDetails:                      t.FailureDetails,
+		LastCompletionResult:                t.LastCompletionResult,
+		Header:                              ToHeader(t.Header),
+		Memo:                                ToMemo(t.Memo),
+		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+// FromWorkflowExecutionFailedEventAttributes converts internal WorkflowExecutionFailedEventAttributes type to thrift
+func FromWorkflowExecutionFailedEventAttributes(t *types.WorkflowExecutionFailedEventAttributes) *shared.WorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionFailedEventAttributes{
+		Reason:                       t.Reason,
+		Details:                      t.Details,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// ToWorkflowExecutionFailedEventAttributes converts thrift WorkflowExecutionFailedEventAttributes type to internal
+func ToWorkflowExecutionFailedEventAttributes(t *shared.WorkflowExecutionFailedEventAttributes) *types.WorkflowExecutionFailedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionFailedEventAttributes{
+		Reason:                       t.Reason,
+		Details:                      t.Details,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+	}
+}
+
+// FromWorkflowExecutionFilter converts internal WorkflowExecutionFilter type to thrift
+func FromWorkflowExecutionFilter(t *types.WorkflowExecutionFilter) *shared.WorkflowExecutionFilter {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionFilter{
+		WorkflowId: t.WorkflowId,
+		RunId:      t.RunId,
+	}
+}
+
+// ToWorkflowExecutionFilter converts thrift WorkflowExecutionFilter type to internal
+func ToWorkflowExecutionFilter(t *shared.WorkflowExecutionFilter) *types.WorkflowExecutionFilter {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionFilter{
+		WorkflowId: t.WorkflowId,
+		RunId:      t.RunId,
+	}
+}
+
+// FromWorkflowExecutionInfo converts internal WorkflowExecutionInfo type to thrift
+func FromWorkflowExecutionInfo(t *types.WorkflowExecutionInfo) *shared.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionInfo{
+		Execution:        FromWorkflowExecution(t.Execution),
+		Type:             FromWorkflowType(t.Type),
+		StartTime:        t.StartTime,
+		CloseTime:        t.CloseTime,
+		CloseStatus:      FromWorkflowExecutionCloseStatus(t.CloseStatus),
+		HistoryLength:    t.HistoryLength,
+		ParentDomainId:   t.ParentDomainId,
+		ParentExecution:  FromWorkflowExecution(t.ParentExecution),
+		ExecutionTime:    t.ExecutionTime,
+		Memo:             FromMemo(t.Memo),
+		SearchAttributes: FromSearchAttributes(t.SearchAttributes),
+		AutoResetPoints:  FromResetPoints(t.AutoResetPoints),
+		TaskList:         t.TaskList,
+	}
+}
+
+// ToWorkflowExecutionInfo converts thrift WorkflowExecutionInfo type to internal
+func ToWorkflowExecutionInfo(t *shared.WorkflowExecutionInfo) *types.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionInfo{
+		Execution:        ToWorkflowExecution(t.Execution),
+		Type:             ToWorkflowType(t.Type),
+		StartTime:        t.StartTime,
+		CloseTime:        t.CloseTime,
+		CloseStatus:      ToWorkflowExecutionCloseStatus(t.CloseStatus),
+		HistoryLength:    t.HistoryLength,
+		ParentDomainId:   t.ParentDomainId,
+		ParentExecution:  ToWorkflowExecution(t.ParentExecution),
+		ExecutionTime:    t.ExecutionTime,
+		Memo:             ToMemo(t.Memo),
+		SearchAttributes: ToSearchAttributes(t.SearchAttributes),
+		AutoResetPoints:  ToResetPoints(t.AutoResetPoints),
+		TaskList:         t.TaskList,
+	}
+}
+
+// FromWorkflowExecutionSignaledEventAttributes converts internal WorkflowExecutionSignaledEventAttributes type to thrift
+func FromWorkflowExecutionSignaledEventAttributes(t *types.WorkflowExecutionSignaledEventAttributes) *shared.WorkflowExecutionSignaledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionSignaledEventAttributes{
+		SignalName: t.SignalName,
+		Input:      t.Input,
+		Identity:   t.Identity,
+	}
+}
+
+// ToWorkflowExecutionSignaledEventAttributes converts thrift WorkflowExecutionSignaledEventAttributes type to internal
+func ToWorkflowExecutionSignaledEventAttributes(t *shared.WorkflowExecutionSignaledEventAttributes) *types.WorkflowExecutionSignaledEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionSignaledEventAttributes{
+		SignalName: t.SignalName,
+		Input:      t.Input,
+		Identity:   t.Identity,
+	}
+}
+
+// FromWorkflowExecutionStartedEventAttributes converts internal WorkflowExecutionStartedEventAttributes type to thrift
+func FromWorkflowExecutionStartedEventAttributes(t *types.WorkflowExecutionStartedEventAttributes) *shared.WorkflowExecutionStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionStartedEventAttributes{
+		WorkflowType:                        FromWorkflowType(t.WorkflowType),
+		ParentWorkflowDomain:                t.ParentWorkflowDomain,
+		ParentWorkflowExecution:             FromWorkflowExecution(t.ParentWorkflowExecution),
+		ParentInitiatedEventId:              t.ParentInitiatedEventId,
+		TaskList:                            FromTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		ContinuedExecutionRunId:             t.ContinuedExecutionRunId,
+		Initiator:                           FromContinueAsNewInitiator(t.Initiator),
+		ContinuedFailureReason:              t.ContinuedFailureReason,
+		ContinuedFailureDetails:             t.ContinuedFailureDetails,
+		LastCompletionResult:                t.LastCompletionResult,
+		OriginalExecutionRunId:              t.OriginalExecutionRunId,
+		Identity:                            t.Identity,
+		FirstExecutionRunId:                 t.FirstExecutionRunId,
+		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
+		Attempt:                             t.Attempt,
+		ExpirationTimestamp:                 t.ExpirationTimestamp,
+		CronSchedule:                        t.CronSchedule,
+		FirstDecisionTaskBackoffSeconds:     t.FirstDecisionTaskBackoffSeconds,
+		Memo:                                FromMemo(t.Memo),
+		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+		PrevAutoResetPoints:                 FromResetPoints(t.PrevAutoResetPoints),
+		Header:                              FromHeader(t.Header),
+	}
+}
+
+// ToWorkflowExecutionStartedEventAttributes converts thrift WorkflowExecutionStartedEventAttributes type to internal
+func ToWorkflowExecutionStartedEventAttributes(t *shared.WorkflowExecutionStartedEventAttributes) *types.WorkflowExecutionStartedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionStartedEventAttributes{
+		WorkflowType:                        ToWorkflowType(t.WorkflowType),
+		ParentWorkflowDomain:                t.ParentWorkflowDomain,
+		ParentWorkflowExecution:             ToWorkflowExecution(t.ParentWorkflowExecution),
+		ParentInitiatedEventId:              t.ParentInitiatedEventId,
+		TaskList:                            ToTaskList(t.TaskList),
+		Input:                               t.Input,
+		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
+		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
+		ContinuedExecutionRunId:             t.ContinuedExecutionRunId,
+		Initiator:                           ToContinueAsNewInitiator(t.Initiator),
+		ContinuedFailureReason:              t.ContinuedFailureReason,
+		ContinuedFailureDetails:             t.ContinuedFailureDetails,
+		LastCompletionResult:                t.LastCompletionResult,
+		OriginalExecutionRunId:              t.OriginalExecutionRunId,
+		Identity:                            t.Identity,
+		FirstExecutionRunId:                 t.FirstExecutionRunId,
+		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
+		Attempt:                             t.Attempt,
+		ExpirationTimestamp:                 t.ExpirationTimestamp,
+		CronSchedule:                        t.CronSchedule,
+		FirstDecisionTaskBackoffSeconds:     t.FirstDecisionTaskBackoffSeconds,
+		Memo:                                ToMemo(t.Memo),
+		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+		PrevAutoResetPoints:                 ToResetPoints(t.PrevAutoResetPoints),
+		Header:                              ToHeader(t.Header),
+	}
+}
+
+// FromWorkflowExecutionTerminatedEventAttributes converts internal WorkflowExecutionTerminatedEventAttributes type to thrift
+func FromWorkflowExecutionTerminatedEventAttributes(t *types.WorkflowExecutionTerminatedEventAttributes) *shared.WorkflowExecutionTerminatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionTerminatedEventAttributes{
+		Reason:   t.Reason,
+		Details:  t.Details,
+		Identity: t.Identity,
+	}
+}
+
+// ToWorkflowExecutionTerminatedEventAttributes converts thrift WorkflowExecutionTerminatedEventAttributes type to internal
+func ToWorkflowExecutionTerminatedEventAttributes(t *shared.WorkflowExecutionTerminatedEventAttributes) *types.WorkflowExecutionTerminatedEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionTerminatedEventAttributes{
+		Reason:   t.Reason,
+		Details:  t.Details,
+		Identity: t.Identity,
+	}
+}
+
+// FromWorkflowExecutionTimedOutEventAttributes converts internal WorkflowExecutionTimedOutEventAttributes type to thrift
+func FromWorkflowExecutionTimedOutEventAttributes(t *types.WorkflowExecutionTimedOutEventAttributes) *shared.WorkflowExecutionTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowExecutionTimedOutEventAttributes{
+		TimeoutType: FromTimeoutType(t.TimeoutType),
+	}
+}
+
+// ToWorkflowExecutionTimedOutEventAttributes converts thrift WorkflowExecutionTimedOutEventAttributes type to internal
+func ToWorkflowExecutionTimedOutEventAttributes(t *shared.WorkflowExecutionTimedOutEventAttributes) *types.WorkflowExecutionTimedOutEventAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowExecutionTimedOutEventAttributes{
+		TimeoutType: ToTimeoutType(t.TimeoutType),
+	}
+}
+
+// FromWorkflowIdReusePolicy converts internal WorkflowIdReusePolicy type to thrift
+func FromWorkflowIdReusePolicy(t *types.WorkflowIdReusePolicy) *shared.WorkflowIdReusePolicy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.WorkflowIdReusePolicyAllowDuplicate:
+		v := shared.WorkflowIdReusePolicyAllowDuplicate
+		return &v
+	case types.WorkflowIdReusePolicyAllowDuplicateFailedOnly:
+		v := shared.WorkflowIdReusePolicyAllowDuplicateFailedOnly
+		return &v
+	case types.WorkflowIdReusePolicyRejectDuplicate:
+		v := shared.WorkflowIdReusePolicyRejectDuplicate
+		return &v
+	case types.WorkflowIdReusePolicyTerminateIfRunning:
+		v := shared.WorkflowIdReusePolicyTerminateIfRunning
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToWorkflowIdReusePolicy converts thrift WorkflowIdReusePolicy type to internal
+func ToWorkflowIdReusePolicy(t *shared.WorkflowIdReusePolicy) *types.WorkflowIdReusePolicy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.WorkflowIdReusePolicyAllowDuplicate:
+		v := types.WorkflowIdReusePolicyAllowDuplicate
+		return &v
+	case shared.WorkflowIdReusePolicyAllowDuplicateFailedOnly:
+		v := types.WorkflowIdReusePolicyAllowDuplicateFailedOnly
+		return &v
+	case shared.WorkflowIdReusePolicyRejectDuplicate:
+		v := types.WorkflowIdReusePolicyRejectDuplicate
+		return &v
+	case shared.WorkflowIdReusePolicyTerminateIfRunning:
+		v := types.WorkflowIdReusePolicyTerminateIfRunning
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromWorkflowQuery converts internal WorkflowQuery type to thrift
+func FromWorkflowQuery(t *types.WorkflowQuery) *shared.WorkflowQuery {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowQuery{
+		QueryType: t.QueryType,
+		QueryArgs: t.QueryArgs,
+	}
+}
+
+// ToWorkflowQuery converts thrift WorkflowQuery type to internal
+func ToWorkflowQuery(t *shared.WorkflowQuery) *types.WorkflowQuery {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowQuery{
+		QueryType: t.QueryType,
+		QueryArgs: t.QueryArgs,
+	}
+}
+
+// FromWorkflowQueryResult converts internal WorkflowQueryResult type to thrift
+func FromWorkflowQueryResult(t *types.WorkflowQueryResult) *shared.WorkflowQueryResult {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowQueryResult{
+		ResultType:   FromQueryResultType(t.ResultType),
+		Answer:       t.Answer,
+		ErrorMessage: t.ErrorMessage,
+	}
+}
+
+// ToWorkflowQueryResult converts thrift WorkflowQueryResult type to internal
+func ToWorkflowQueryResult(t *shared.WorkflowQueryResult) *types.WorkflowQueryResult {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowQueryResult{
+		ResultType:   ToQueryResultType(t.ResultType),
+		Answer:       t.Answer,
+		ErrorMessage: t.ErrorMessage,
+	}
+}
+
+// FromWorkflowType converts internal WorkflowType type to thrift
+func FromWorkflowType(t *types.WorkflowType) *shared.WorkflowType {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowType{
+		Name: t.Name,
+	}
+}
+
+// ToWorkflowType converts thrift WorkflowType type to internal
+func ToWorkflowType(t *shared.WorkflowType) *types.WorkflowType {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowType{
+		Name: t.Name,
+	}
+}
+
+// FromWorkflowTypeFilter converts internal WorkflowTypeFilter type to thrift
+func FromWorkflowTypeFilter(t *types.WorkflowTypeFilter) *shared.WorkflowTypeFilter {
+	if t == nil {
+		return nil
+	}
+	return &shared.WorkflowTypeFilter{
+		Name: t.Name,
+	}
+}
+
+// ToWorkflowTypeFilter converts thrift WorkflowTypeFilter type to internal
+func ToWorkflowTypeFilter(t *shared.WorkflowTypeFilter) *types.WorkflowTypeFilter {
+	if t == nil {
+		return nil
+	}
+	return &types.WorkflowTypeFilter{
+		Name: t.Name,
+	}
+}
+
+// FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
+func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.PendingActivityInfo, len(t))
+	for i := range t {
+		v[i] = FromPendingActivityInfo(t[i])
+	}
+	return v
+}
+
+// ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
+func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PendingActivityInfo, len(t))
+	for i := range t {
+		v[i] = ToPendingActivityInfo(t[i])
+	}
+	return v
+}
+
+// FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
+func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.VersionHistoryItem, len(t))
+	for i := range t {
+		v[i] = FromVersionHistoryItem(t[i])
+	}
+	return v
+}
+
+// ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
+func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.VersionHistoryItem, len(t))
+	for i := range t {
+		v[i] = ToVersionHistoryItem(t[i])
+	}
+	return v
+}
+
+// FromHistoryEventArray converts internal HistoryEvent type array to thrift
+func FromHistoryEventArray(t []*types.HistoryEvent) []*shared.HistoryEvent {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.HistoryEvent, len(t))
+	for i := range t {
+		v[i] = FromHistoryEvent(t[i])
+	}
+	return v
+}
+
+// ToHistoryEventArray converts thrift HistoryEvent type array to internal
+func ToHistoryEventArray(t []*shared.HistoryEvent) []*types.HistoryEvent {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.HistoryEvent, len(t))
+	for i := range t {
+		v[i] = ToHistoryEvent(t[i])
+	}
+	return v
+}
+
+// FromDecisionArray converts internal Decision type array to thrift
+func FromDecisionArray(t []*types.Decision) []*shared.Decision {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.Decision, len(t))
+	for i := range t {
+		v[i] = FromDecision(t[i])
+	}
+	return v
+}
+
+// ToDecisionArray converts thrift Decision type array to internal
+func ToDecisionArray(t []*shared.Decision) []*types.Decision {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.Decision, len(t))
+	for i := range t {
+		v[i] = ToDecision(t[i])
+	}
+	return v
+}
+
+// FromPendingChildExecutionInfoArray converts internal PendingChildExecutionInfo type array to thrift
+func FromPendingChildExecutionInfoArray(t []*types.PendingChildExecutionInfo) []*shared.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.PendingChildExecutionInfo, len(t))
+	for i := range t {
+		v[i] = FromPendingChildExecutionInfo(t[i])
+	}
+	return v
+}
+
+// ToPendingChildExecutionInfoArray converts thrift PendingChildExecutionInfo type array to internal
+func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*types.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PendingChildExecutionInfo, len(t))
+	for i := range t {
+		v[i] = ToPendingChildExecutionInfo(t[i])
+	}
+	return v
+}
+
+// FromDataBlobArray converts internal DataBlob type array to thrift
+func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DataBlob, len(t))
+	for i := range t {
+		v[i] = FromDataBlob(t[i])
+	}
+	return v
+}
+
+// ToDataBlobArray converts thrift DataBlob type array to internal
+func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DataBlob, len(t))
+	for i := range t {
+		v[i] = ToDataBlob(t[i])
+	}
+	return v
+}
+
+// FromDescribeDomainResponseArray converts internal DescribeDomainResponse type array to thrift
+func FromDescribeDomainResponseArray(t []*types.DescribeDomainResponse) []*shared.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = FromDescribeDomainResponse(t[i])
+	}
+	return v
+}
+
+// ToDescribeDomainResponseArray converts thrift DescribeDomainResponse type array to internal
+func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = ToDescribeDomainResponse(t[i])
+	}
+	return v
+}
+
+// FromVersionHistoryArray converts internal VersionHistory type array to thrift
+func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.VersionHistory, len(t))
+	for i := range t {
+		v[i] = FromVersionHistory(t[i])
+	}
+	return v
+}
+
+// ToVersionHistoryArray converts thrift VersionHistory type array to internal
+func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.VersionHistory, len(t))
+	for i := range t {
+		v[i] = ToVersionHistory(t[i])
+	}
+	return v
+}
+
+// FromPollerInfoArray converts internal PollerInfo type array to thrift
+func FromPollerInfoArray(t []*types.PollerInfo) []*shared.PollerInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.PollerInfo, len(t))
+	for i := range t {
+		v[i] = FromPollerInfo(t[i])
+	}
+	return v
+}
+
+// ToPollerInfoArray converts thrift PollerInfo type array to internal
+func ToPollerInfoArray(t []*shared.PollerInfo) []*types.PollerInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PollerInfo, len(t))
+	for i := range t {
+		v[i] = ToPollerInfo(t[i])
+	}
+	return v
+}
+
+// FromClusterReplicationConfigurationArray converts internal ClusterReplicationConfiguration type array to thrift
+func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfiguration) []*shared.ClusterReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.ClusterReplicationConfiguration, len(t))
+	for i := range t {
+		v[i] = FromClusterReplicationConfiguration(t[i])
+	}
+	return v
+}
+
+// ToClusterReplicationConfigurationArray converts thrift ClusterReplicationConfiguration type array to internal
+func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfiguration) []*types.ClusterReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ClusterReplicationConfiguration, len(t))
+	for i := range t {
+		v[i] = ToClusterReplicationConfiguration(t[i])
+	}
+	return v
+}
+
+// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
+func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.HistoryBranchRange, len(t))
+	for i := range t {
+		v[i] = FromHistoryBranchRange(t[i])
+	}
+	return v
+}
+
+// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
+func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.HistoryBranchRange, len(t))
+	for i := range t {
+		v[i] = ToHistoryBranchRange(t[i])
+	}
+	return v
+}
+
+// FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
+func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.WorkflowExecutionInfo, len(t))
+	for i := range t {
+		v[i] = FromWorkflowExecutionInfo(t[i])
+	}
+	return v
+}
+
+// ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
+func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.WorkflowExecutionInfo, len(t))
+	for i := range t {
+		v[i] = ToWorkflowExecutionInfo(t[i])
+	}
+	return v
+}
+
+// FromTaskListPartitionMetadataArray converts internal TaskListPartitionMetadata type array to thrift
+func FromTaskListPartitionMetadataArray(t []*types.TaskListPartitionMetadata) []*shared.TaskListPartitionMetadata {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.TaskListPartitionMetadata, len(t))
+	for i := range t {
+		v[i] = FromTaskListPartitionMetadata(t[i])
+	}
+	return v
+}
+
+// ToTaskListPartitionMetadataArray converts thrift TaskListPartitionMetadata type array to internal
+func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*types.TaskListPartitionMetadata {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.TaskListPartitionMetadata, len(t))
+	for i := range t {
+		v[i] = ToTaskListPartitionMetadata(t[i])
+	}
+	return v
+}
+
+// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
+func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.ResetPointInfo, len(t))
+	for i := range t {
+		v[i] = FromResetPointInfo(t[i])
+	}
+	return v
+}
+
+// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
+func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ResetPointInfo, len(t))
+	for i := range t {
+		v[i] = ToResetPointInfo(t[i])
+	}
+	return v
+}
+
+// FromIndexedValueTypeMap converts internal IndexedValueType type map to thrift
+func FromIndexedValueTypeMap(t map[string]types.IndexedValueType) map[string]shared.IndexedValueType {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]shared.IndexedValueType, len(t))
+	for key := range t {
+		v[key] = FromIndexedValueType(t[key])
+	}
+	return v
+}
+
+// ToIndexedValueTypeMap converts thrift IndexedValueType type map to internal
+func ToIndexedValueTypeMap(t map[string]shared.IndexedValueType) map[string]types.IndexedValueType {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]types.IndexedValueType, len(t))
+	for key := range t {
+		v[key] = ToIndexedValueType(t[key])
+	}
+	return v
+}
+
+// FromWorkflowQueryMap converts internal WorkflowQuery type map to thrift
+func FromWorkflowQueryMap(t map[string]*types.WorkflowQuery) map[string]*shared.WorkflowQuery {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.WorkflowQuery, len(t))
+	for key := range t {
+		v[key] = FromWorkflowQuery(t[key])
+	}
+	return v
+}
+
+// ToWorkflowQueryMap converts thrift WorkflowQuery type map to internal
+func ToWorkflowQueryMap(t map[string]*shared.WorkflowQuery) map[string]*types.WorkflowQuery {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.WorkflowQuery, len(t))
+	for key := range t {
+		v[key] = ToWorkflowQuery(t[key])
+	}
+	return v
+}
+
+// FromWorkflowQueryResultMap converts internal WorkflowQueryResult type map to thrift
+func FromWorkflowQueryResultMap(t map[string]*types.WorkflowQueryResult) map[string]*shared.WorkflowQueryResult {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.WorkflowQueryResult, len(t))
+	for key := range t {
+		v[key] = FromWorkflowQueryResult(t[key])
+	}
+	return v
+}
+
+// ToWorkflowQueryResultMap converts thrift WorkflowQueryResult type map to internal
+func ToWorkflowQueryResultMap(t map[string]*shared.WorkflowQueryResult) map[string]*types.WorkflowQueryResult {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.WorkflowQueryResult, len(t))
+	for key := range t {
+		v[key] = ToWorkflowQueryResult(t[key])
+	}
+	return v
+}
+
+// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
+func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = FromBadBinaryInfo(t[key])
+	}
+	return v
+}
+
+// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
+func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = ToBadBinaryInfo(t[key])
+	}
+	return v
+}

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -1,0 +1,1622 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+type AccessDeniedError struct {
+	Message string
+}
+
+type ActivityTaskCancelRequestedEventAttributes struct {
+	ActivityId                   *string
+	DecisionTaskCompletedEventId *int64
+}
+
+type ActivityTaskCanceledEventAttributes struct {
+	Details                      []byte
+	LatestCancelRequestedEventId *int64
+	ScheduledEventId             *int64
+	StartedEventId               *int64
+	Identity                     *string
+}
+
+type ActivityTaskCompletedEventAttributes struct {
+	Result           []byte
+	ScheduledEventId *int64
+	StartedEventId   *int64
+	Identity         *string
+}
+
+type ActivityTaskFailedEventAttributes struct {
+	Reason           *string
+	Details          []byte
+	ScheduledEventId *int64
+	StartedEventId   *int64
+	Identity         *string
+}
+
+type ActivityTaskScheduledEventAttributes struct {
+	ActivityId                    *string
+	ActivityType                  *ActivityType
+	Domain                        *string
+	TaskList                      *TaskList
+	Input                         []byte
+	ScheduleToCloseTimeoutSeconds *int32
+	ScheduleToStartTimeoutSeconds *int32
+	StartToCloseTimeoutSeconds    *int32
+	HeartbeatTimeoutSeconds       *int32
+	DecisionTaskCompletedEventId  *int64
+	RetryPolicy                   *RetryPolicy
+	Header                        *Header
+}
+
+type ActivityTaskStartedEventAttributes struct {
+	ScheduledEventId   *int64
+	Identity           *string
+	RequestId          *string
+	Attempt            *int32
+	LastFailureReason  *string
+	LastFailureDetails []byte
+}
+
+type ActivityTaskTimedOutEventAttributes struct {
+	Details            []byte
+	ScheduledEventId   *int64
+	StartedEventId     *int64
+	TimeoutType        *TimeoutType
+	LastFailureReason  *string
+	LastFailureDetails []byte
+}
+
+type ActivityType struct {
+	Name *string
+}
+
+type ArchivalStatus int32
+
+const (
+	ArchivalStatusDisabled ArchivalStatus = iota
+	ArchivalStatusEnabled
+)
+
+type BadBinaries struct {
+	Binaries map[string]*BadBinaryInfo
+}
+
+type BadBinaryInfo struct {
+	Reason          *string
+	Operator        *string
+	CreatedTimeNano *int64
+}
+
+type BadRequestError struct {
+	Message string
+}
+
+type CancelExternalWorkflowExecutionFailedCause int32
+
+const (
+	CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution CancelExternalWorkflowExecutionFailedCause = iota
+)
+
+type CancelTimerDecisionAttributes struct {
+	TimerId *string
+}
+
+type CancelTimerFailedEventAttributes struct {
+	TimerId                      *string
+	Cause                        *string
+	DecisionTaskCompletedEventId *int64
+	Identity                     *string
+}
+
+type CancelWorkflowExecutionDecisionAttributes struct {
+	Details []byte
+}
+
+type CancellationAlreadyRequestedError struct {
+	Message string
+}
+
+type ChildWorkflowExecutionCanceledEventAttributes struct {
+	Details           []byte
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	WorkflowType      *WorkflowType
+	InitiatedEventId  *int64
+	StartedEventId    *int64
+}
+
+type ChildWorkflowExecutionCompletedEventAttributes struct {
+	Result            []byte
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	WorkflowType      *WorkflowType
+	InitiatedEventId  *int64
+	StartedEventId    *int64
+}
+
+type ChildWorkflowExecutionFailedCause int32
+
+const (
+	ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning ChildWorkflowExecutionFailedCause = iota
+)
+
+type ChildWorkflowExecutionFailedEventAttributes struct {
+	Reason            *string
+	Details           []byte
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	WorkflowType      *WorkflowType
+	InitiatedEventId  *int64
+	StartedEventId    *int64
+}
+
+type ChildWorkflowExecutionStartedEventAttributes struct {
+	Domain            *string
+	InitiatedEventId  *int64
+	WorkflowExecution *WorkflowExecution
+	WorkflowType      *WorkflowType
+	Header            *Header
+}
+
+type ChildWorkflowExecutionTerminatedEventAttributes struct {
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	WorkflowType      *WorkflowType
+	InitiatedEventId  *int64
+	StartedEventId    *int64
+}
+
+type ChildWorkflowExecutionTimedOutEventAttributes struct {
+	TimeoutType       *TimeoutType
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	WorkflowType      *WorkflowType
+	InitiatedEventId  *int64
+	StartedEventId    *int64
+}
+
+type ClientVersionNotSupportedError struct {
+	FeatureVersion    string
+	ClientImpl        string
+	SupportedVersions string
+}
+
+type CloseShardRequest struct {
+	ShardID *int32
+}
+
+type ClusterInfo struct {
+	SupportedClientVersions *SupportedClientVersions
+}
+
+type ClusterReplicationConfiguration struct {
+	ClusterName *string
+}
+
+type CompleteWorkflowExecutionDecisionAttributes struct {
+	Result []byte
+}
+
+type ContinueAsNewInitiator int32
+
+const (
+	ContinueAsNewInitiatorCronSchedule ContinueAsNewInitiator = iota
+	ContinueAsNewInitiatorDecider
+	ContinueAsNewInitiatorRetryPolicy
+)
+
+type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
+	WorkflowType                        *WorkflowType
+	TaskList                            *TaskList
+	Input                               []byte
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+	BackoffStartIntervalInSeconds       *int32
+	RetryPolicy                         *RetryPolicy
+	Initiator                           *ContinueAsNewInitiator
+	FailureReason                       *string
+	FailureDetails                      []byte
+	LastCompletionResult                []byte
+	CronSchedule                        *string
+	Header                              *Header
+	Memo                                *Memo
+	SearchAttributes                    *SearchAttributes
+}
+
+type CountWorkflowExecutionsRequest struct {
+	Domain *string
+	Query  *string
+}
+
+type CountWorkflowExecutionsResponse struct {
+	Count *int64
+}
+
+type CurrentBranchChangedError struct {
+	Message            string
+	CurrentBranchToken []byte
+}
+
+type DataBlob struct {
+	EncodingType *EncodingType
+	Data         []byte
+}
+
+type Decision struct {
+	DecisionType                                             *DecisionType
+	ScheduleActivityTaskDecisionAttributes                   *ScheduleActivityTaskDecisionAttributes
+	StartTimerDecisionAttributes                             *StartTimerDecisionAttributes
+	CompleteWorkflowExecutionDecisionAttributes              *CompleteWorkflowExecutionDecisionAttributes
+	FailWorkflowExecutionDecisionAttributes                  *FailWorkflowExecutionDecisionAttributes
+	RequestCancelActivityTaskDecisionAttributes              *RequestCancelActivityTaskDecisionAttributes
+	CancelTimerDecisionAttributes                            *CancelTimerDecisionAttributes
+	CancelWorkflowExecutionDecisionAttributes                *CancelWorkflowExecutionDecisionAttributes
+	RequestCancelExternalWorkflowExecutionDecisionAttributes *RequestCancelExternalWorkflowExecutionDecisionAttributes
+	RecordMarkerDecisionAttributes                           *RecordMarkerDecisionAttributes
+	ContinueAsNewWorkflowExecutionDecisionAttributes         *ContinueAsNewWorkflowExecutionDecisionAttributes
+	StartChildWorkflowExecutionDecisionAttributes            *StartChildWorkflowExecutionDecisionAttributes
+	SignalExternalWorkflowExecutionDecisionAttributes        *SignalExternalWorkflowExecutionDecisionAttributes
+	UpsertWorkflowSearchAttributesDecisionAttributes         *UpsertWorkflowSearchAttributesDecisionAttributes
+}
+
+type DecisionTaskCompletedEventAttributes struct {
+	ExecutionContext []byte
+	ScheduledEventId *int64
+	StartedEventId   *int64
+	Identity         *string
+	BinaryChecksum   *string
+}
+
+type DecisionTaskFailedCause int32
+
+const (
+	DecisionTaskFailedCauseBadBinary DecisionTaskFailedCause = iota
+	DecisionTaskFailedCauseBadCancelTimerAttributes
+	DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes
+	DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes
+	DecisionTaskFailedCauseBadContinueAsNewAttributes
+	DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes
+	DecisionTaskFailedCauseBadRecordMarkerAttributes
+	DecisionTaskFailedCauseBadRequestCancelActivityAttributes
+	DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes
+	DecisionTaskFailedCauseBadScheduleActivityAttributes
+	DecisionTaskFailedCauseBadSearchAttributes
+	DecisionTaskFailedCauseBadSignalInputSize
+	DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes
+	DecisionTaskFailedCauseBadStartChildExecutionAttributes
+	DecisionTaskFailedCauseBadStartTimerAttributes
+	DecisionTaskFailedCauseFailoverCloseDecision
+	DecisionTaskFailedCauseForceCloseDecision
+	DecisionTaskFailedCauseResetStickyTasklist
+	DecisionTaskFailedCauseResetWorkflow
+	DecisionTaskFailedCauseScheduleActivityDuplicateID
+	DecisionTaskFailedCauseStartTimerDuplicateID
+	DecisionTaskFailedCauseUnhandledDecision
+	DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure
+)
+
+type DecisionTaskFailedEventAttributes struct {
+	ScheduledEventId *int64
+	StartedEventId   *int64
+	Cause            *DecisionTaskFailedCause
+	Details          []byte
+	Identity         *string
+	Reason           *string
+	BaseRunId        *string
+	NewRunId         *string
+	ForkEventVersion *int64
+	BinaryChecksum   *string
+}
+
+type DecisionTaskScheduledEventAttributes struct {
+	TaskList                   *TaskList
+	StartToCloseTimeoutSeconds *int32
+	Attempt                    *int64
+}
+
+type DecisionTaskStartedEventAttributes struct {
+	ScheduledEventId *int64
+	Identity         *string
+	RequestId        *string
+}
+
+type DecisionTaskTimedOutEventAttributes struct {
+	ScheduledEventId *int64
+	StartedEventId   *int64
+	TimeoutType      *TimeoutType
+}
+
+type DecisionType int32
+
+const (
+	DecisionTypeCancelTimer DecisionType = iota
+	DecisionTypeCancelWorkflowExecution
+	DecisionTypeCompleteWorkflowExecution
+	DecisionTypeContinueAsNewWorkflowExecution
+	DecisionTypeFailWorkflowExecution
+	DecisionTypeRecordMarker
+	DecisionTypeRequestCancelActivityTask
+	DecisionTypeRequestCancelExternalWorkflowExecution
+	DecisionTypeScheduleActivityTask
+	DecisionTypeSignalExternalWorkflowExecution
+	DecisionTypeStartChildWorkflowExecution
+	DecisionTypeStartTimer
+	DecisionTypeUpsertWorkflowSearchAttributes
+)
+
+type DeprecateDomainRequest struct {
+	Name          *string
+	SecurityToken *string
+}
+
+type DescribeDomainRequest struct {
+	Name *string
+	UUID *string
+}
+
+type DescribeDomainResponse struct {
+	DomainInfo               *DomainInfo
+	Configuration            *DomainConfiguration
+	ReplicationConfiguration *DomainReplicationConfiguration
+	FailoverVersion          *int64
+	IsGlobalDomain           *bool
+}
+
+type DescribeHistoryHostRequest struct {
+	HostAddress      *string
+	ShardIdForHost   *int32
+	ExecutionForHost *WorkflowExecution
+}
+
+type DescribeHistoryHostResponse struct {
+	NumberOfShards        *int32
+	ShardIDs              []int32
+	DomainCache           *DomainCacheInfo
+	ShardControllerStatus *string
+	Address               *string
+}
+
+type DescribeQueueRequest struct {
+	ShardID     *int32
+	ClusterName *string
+	Type        *int32
+}
+
+type DescribeQueueResponse struct {
+	ProcessingQueueStates []string
+}
+
+type DescribeTaskListRequest struct {
+	Domain                *string
+	TaskList              *TaskList
+	TaskListType          *TaskListType
+	IncludeTaskListStatus *bool
+}
+
+type DescribeTaskListResponse struct {
+	Pollers        []*PollerInfo
+	TaskListStatus *TaskListStatus
+}
+
+type DescribeWorkflowExecutionRequest struct {
+	Domain    *string
+	Execution *WorkflowExecution
+}
+
+type DescribeWorkflowExecutionResponse struct {
+	ExecutionConfiguration *WorkflowExecutionConfiguration
+	WorkflowExecutionInfo  *WorkflowExecutionInfo
+	PendingActivities      []*PendingActivityInfo
+	PendingChildren        []*PendingChildExecutionInfo
+}
+
+type DomainAlreadyExistsError struct {
+	Message string
+}
+
+type DomainCacheInfo struct {
+	NumOfItemsInCacheByID   *int64
+	NumOfItemsInCacheByName *int64
+}
+
+type DomainConfiguration struct {
+	WorkflowExecutionRetentionPeriodInDays *int32
+	EmitMetric                             *bool
+	BadBinaries                            *BadBinaries
+	HistoryArchivalStatus                  *ArchivalStatus
+	HistoryArchivalURI                     *string
+	VisibilityArchivalStatus               *ArchivalStatus
+	VisibilityArchivalURI                  *string
+}
+
+type DomainInfo struct {
+	Name        *string
+	Status      *DomainStatus
+	Description *string
+	OwnerEmail  *string
+	Data        map[string]string
+	UUID        *string
+}
+
+type DomainNotActiveError struct {
+	Message        string
+	DomainName     string
+	CurrentCluster string
+	ActiveCluster  string
+}
+
+type DomainReplicationConfiguration struct {
+	ActiveClusterName *string
+	Clusters          []*ClusterReplicationConfiguration
+}
+
+type DomainStatus int32
+
+const (
+	DomainStatusDeleted DomainStatus = iota
+	DomainStatusDeprecated
+	DomainStatusRegistered
+)
+
+type EncodingType int32
+
+const (
+	EncodingTypeJSON EncodingType = iota
+	EncodingTypeThriftRW
+)
+
+type EntityNotExistsError struct {
+	Message        string
+	CurrentCluster *string
+	ActiveCluster  *string
+}
+
+type EventType int32
+
+const (
+	EventTypeActivityTaskCancelRequested EventType = iota
+	EventTypeActivityTaskCanceled
+	EventTypeActivityTaskCompleted
+	EventTypeActivityTaskFailed
+	EventTypeActivityTaskScheduled
+	EventTypeActivityTaskStarted
+	EventTypeActivityTaskTimedOut
+	EventTypeCancelTimerFailed
+	EventTypeChildWorkflowExecutionCanceled
+	EventTypeChildWorkflowExecutionCompleted
+	EventTypeChildWorkflowExecutionFailed
+	EventTypeChildWorkflowExecutionStarted
+	EventTypeChildWorkflowExecutionTerminated
+	EventTypeChildWorkflowExecutionTimedOut
+	EventTypeDecisionTaskCompleted
+	EventTypeDecisionTaskFailed
+	EventTypeDecisionTaskScheduled
+	EventTypeDecisionTaskStarted
+	EventTypeDecisionTaskTimedOut
+	EventTypeExternalWorkflowExecutionCancelRequested
+	EventTypeExternalWorkflowExecutionSignaled
+	EventTypeMarkerRecorded
+	EventTypeRequestCancelActivityTaskFailed
+	EventTypeRequestCancelExternalWorkflowExecutionFailed
+	EventTypeRequestCancelExternalWorkflowExecutionInitiated
+	EventTypeSignalExternalWorkflowExecutionFailed
+	EventTypeSignalExternalWorkflowExecutionInitiated
+	EventTypeStartChildWorkflowExecutionFailed
+	EventTypeStartChildWorkflowExecutionInitiated
+	EventTypeTimerCanceled
+	EventTypeTimerFired
+	EventTypeTimerStarted
+	EventTypeUpsertWorkflowSearchAttributes
+	EventTypeWorkflowExecutionCancelRequested
+	EventTypeWorkflowExecutionCanceled
+	EventTypeWorkflowExecutionCompleted
+	EventTypeWorkflowExecutionContinuedAsNew
+	EventTypeWorkflowExecutionFailed
+	EventTypeWorkflowExecutionSignaled
+	EventTypeWorkflowExecutionStarted
+	EventTypeWorkflowExecutionTerminated
+	EventTypeWorkflowExecutionTimedOut
+)
+
+type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
+	InitiatedEventId  *int64
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+}
+
+type ExternalWorkflowExecutionSignaledEventAttributes struct {
+	InitiatedEventId  *int64
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	Control           []byte
+}
+
+type FailWorkflowExecutionDecisionAttributes struct {
+	Reason  *string
+	Details []byte
+}
+
+type GetSearchAttributesResponse struct {
+	Keys map[string]IndexedValueType
+}
+
+type GetWorkflowExecutionHistoryRequest struct {
+	Domain                 *string
+	Execution              *WorkflowExecution
+	MaximumPageSize        *int32
+	NextPageToken          []byte
+	WaitForNewEvent        *bool
+	HistoryEventFilterType *HistoryEventFilterType
+	SkipArchival           *bool
+}
+
+type GetWorkflowExecutionHistoryResponse struct {
+	History       *History
+	RawHistory    []*DataBlob
+	NextPageToken []byte
+	Archived      *bool
+}
+
+type Header struct {
+	Fields map[string][]byte
+}
+
+type History struct {
+	Events []*HistoryEvent
+}
+
+type HistoryBranch struct {
+	TreeID    *string
+	BranchID  *string
+	Ancestors []*HistoryBranchRange
+}
+
+type HistoryBranchRange struct {
+	BranchID    *string
+	BeginNodeID *int64
+	EndNodeID   *int64
+}
+
+type HistoryEvent struct {
+	EventId                                                        *int64
+	Timestamp                                                      *int64
+	EventType                                                      *EventType
+	Version                                                        *int64
+	TaskId                                                         *int64
+	WorkflowExecutionStartedEventAttributes                        *WorkflowExecutionStartedEventAttributes
+	WorkflowExecutionCompletedEventAttributes                      *WorkflowExecutionCompletedEventAttributes
+	WorkflowExecutionFailedEventAttributes                         *WorkflowExecutionFailedEventAttributes
+	WorkflowExecutionTimedOutEventAttributes                       *WorkflowExecutionTimedOutEventAttributes
+	DecisionTaskScheduledEventAttributes                           *DecisionTaskScheduledEventAttributes
+	DecisionTaskStartedEventAttributes                             *DecisionTaskStartedEventAttributes
+	DecisionTaskCompletedEventAttributes                           *DecisionTaskCompletedEventAttributes
+	DecisionTaskTimedOutEventAttributes                            *DecisionTaskTimedOutEventAttributes
+	DecisionTaskFailedEventAttributes                              *DecisionTaskFailedEventAttributes
+	ActivityTaskScheduledEventAttributes                           *ActivityTaskScheduledEventAttributes
+	ActivityTaskStartedEventAttributes                             *ActivityTaskStartedEventAttributes
+	ActivityTaskCompletedEventAttributes                           *ActivityTaskCompletedEventAttributes
+	ActivityTaskFailedEventAttributes                              *ActivityTaskFailedEventAttributes
+	ActivityTaskTimedOutEventAttributes                            *ActivityTaskTimedOutEventAttributes
+	TimerStartedEventAttributes                                    *TimerStartedEventAttributes
+	TimerFiredEventAttributes                                      *TimerFiredEventAttributes
+	ActivityTaskCancelRequestedEventAttributes                     *ActivityTaskCancelRequestedEventAttributes
+	RequestCancelActivityTaskFailedEventAttributes                 *RequestCancelActivityTaskFailedEventAttributes
+	ActivityTaskCanceledEventAttributes                            *ActivityTaskCanceledEventAttributes
+	TimerCanceledEventAttributes                                   *TimerCanceledEventAttributes
+	CancelTimerFailedEventAttributes                               *CancelTimerFailedEventAttributes
+	MarkerRecordedEventAttributes                                  *MarkerRecordedEventAttributes
+	WorkflowExecutionSignaledEventAttributes                       *WorkflowExecutionSignaledEventAttributes
+	WorkflowExecutionTerminatedEventAttributes                     *WorkflowExecutionTerminatedEventAttributes
+	WorkflowExecutionCancelRequestedEventAttributes                *WorkflowExecutionCancelRequestedEventAttributes
+	WorkflowExecutionCanceledEventAttributes                       *WorkflowExecutionCanceledEventAttributes
+	RequestCancelExternalWorkflowExecutionInitiatedEventAttributes *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes
+	RequestCancelExternalWorkflowExecutionFailedEventAttributes    *RequestCancelExternalWorkflowExecutionFailedEventAttributes
+	ExternalWorkflowExecutionCancelRequestedEventAttributes        *ExternalWorkflowExecutionCancelRequestedEventAttributes
+	WorkflowExecutionContinuedAsNewEventAttributes                 *WorkflowExecutionContinuedAsNewEventAttributes
+	StartChildWorkflowExecutionInitiatedEventAttributes            *StartChildWorkflowExecutionInitiatedEventAttributes
+	StartChildWorkflowExecutionFailedEventAttributes               *StartChildWorkflowExecutionFailedEventAttributes
+	ChildWorkflowExecutionStartedEventAttributes                   *ChildWorkflowExecutionStartedEventAttributes
+	ChildWorkflowExecutionCompletedEventAttributes                 *ChildWorkflowExecutionCompletedEventAttributes
+	ChildWorkflowExecutionFailedEventAttributes                    *ChildWorkflowExecutionFailedEventAttributes
+	ChildWorkflowExecutionCanceledEventAttributes                  *ChildWorkflowExecutionCanceledEventAttributes
+	ChildWorkflowExecutionTimedOutEventAttributes                  *ChildWorkflowExecutionTimedOutEventAttributes
+	ChildWorkflowExecutionTerminatedEventAttributes                *ChildWorkflowExecutionTerminatedEventAttributes
+	SignalExternalWorkflowExecutionInitiatedEventAttributes        *SignalExternalWorkflowExecutionInitiatedEventAttributes
+	SignalExternalWorkflowExecutionFailedEventAttributes           *SignalExternalWorkflowExecutionFailedEventAttributes
+	ExternalWorkflowExecutionSignaledEventAttributes               *ExternalWorkflowExecutionSignaledEventAttributes
+	UpsertWorkflowSearchAttributesEventAttributes                  *UpsertWorkflowSearchAttributesEventAttributes
+}
+
+type HistoryEventFilterType int32
+
+const (
+	HistoryEventFilterTypeAllEvent HistoryEventFilterType = iota
+	HistoryEventFilterTypeCloseEvent
+)
+
+type IndexedValueType int32
+
+const (
+	IndexedValueTypeBool IndexedValueType = iota
+	IndexedValueTypeDatetime
+	IndexedValueTypeDouble
+	IndexedValueTypeInt
+	IndexedValueTypeKeyword
+	IndexedValueTypeString
+)
+
+type InternalDataInconsistencyError struct {
+	Message string
+}
+
+type InternalServiceError struct {
+	Message string
+}
+
+type LimitExceededError struct {
+	Message string
+}
+
+type ListArchivedWorkflowExecutionsRequest struct {
+	Domain        *string
+	PageSize      *int32
+	NextPageToken []byte
+	Query         *string
+}
+
+type ListArchivedWorkflowExecutionsResponse struct {
+	Executions    []*WorkflowExecutionInfo
+	NextPageToken []byte
+}
+
+type ListClosedWorkflowExecutionsRequest struct {
+	Domain          *string
+	MaximumPageSize *int32
+	NextPageToken   []byte
+	StartTimeFilter *StartTimeFilter
+	ExecutionFilter *WorkflowExecutionFilter
+	TypeFilter      *WorkflowTypeFilter
+	StatusFilter    *WorkflowExecutionCloseStatus
+}
+
+type ListClosedWorkflowExecutionsResponse struct {
+	Executions    []*WorkflowExecutionInfo
+	NextPageToken []byte
+}
+
+type ListDomainsRequest struct {
+	PageSize      *int32
+	NextPageToken []byte
+}
+
+type ListDomainsResponse struct {
+	Domains       []*DescribeDomainResponse
+	NextPageToken []byte
+}
+
+type ListOpenWorkflowExecutionsRequest struct {
+	Domain          *string
+	MaximumPageSize *int32
+	NextPageToken   []byte
+	StartTimeFilter *StartTimeFilter
+	ExecutionFilter *WorkflowExecutionFilter
+	TypeFilter      *WorkflowTypeFilter
+}
+
+type ListOpenWorkflowExecutionsResponse struct {
+	Executions    []*WorkflowExecutionInfo
+	NextPageToken []byte
+}
+
+type ListTaskListPartitionsRequest struct {
+	Domain   *string
+	TaskList *TaskList
+}
+
+type ListTaskListPartitionsResponse struct {
+	ActivityTaskListPartitions []*TaskListPartitionMetadata
+	DecisionTaskListPartitions []*TaskListPartitionMetadata
+}
+
+type ListWorkflowExecutionsRequest struct {
+	Domain        *string
+	PageSize      *int32
+	NextPageToken []byte
+	Query         *string
+}
+
+type ListWorkflowExecutionsResponse struct {
+	Executions    []*WorkflowExecutionInfo
+	NextPageToken []byte
+}
+
+type MarkerRecordedEventAttributes struct {
+	MarkerName                   *string
+	Details                      []byte
+	DecisionTaskCompletedEventId *int64
+	Header                       *Header
+}
+
+type Memo struct {
+	Fields map[string][]byte
+}
+
+type ParentClosePolicy int32
+
+const (
+	ParentClosePolicyAbandon ParentClosePolicy = iota
+	ParentClosePolicyRequestCancel
+	ParentClosePolicyTerminate
+)
+
+type PendingActivityInfo struct {
+	ActivityID             *string
+	ActivityType           *ActivityType
+	State                  *PendingActivityState
+	HeartbeatDetails       []byte
+	LastHeartbeatTimestamp *int64
+	LastStartedTimestamp   *int64
+	Attempt                *int32
+	MaximumAttempts        *int32
+	ScheduledTimestamp     *int64
+	ExpirationTimestamp    *int64
+	LastFailureReason      *string
+	LastWorkerIdentity     *string
+	LastFailureDetails     []byte
+}
+
+type PendingActivityState int32
+
+const (
+	PendingActivityStateCancelRequested PendingActivityState = iota
+	PendingActivityStateScheduled
+	PendingActivityStateStarted
+)
+
+type PendingChildExecutionInfo struct {
+	WorkflowID        *string
+	RunID             *string
+	WorkflowTypName   *string
+	InitiatedID       *int64
+	ParentClosePolicy *ParentClosePolicy
+}
+
+type PollForActivityTaskRequest struct {
+	Domain           *string
+	TaskList         *TaskList
+	Identity         *string
+	TaskListMetadata *TaskListMetadata
+}
+
+type PollForActivityTaskResponse struct {
+	TaskToken                       []byte
+	WorkflowExecution               *WorkflowExecution
+	ActivityId                      *string
+	ActivityType                    *ActivityType
+	Input                           []byte
+	ScheduledTimestamp              *int64
+	ScheduleToCloseTimeoutSeconds   *int32
+	StartedTimestamp                *int64
+	StartToCloseTimeoutSeconds      *int32
+	HeartbeatTimeoutSeconds         *int32
+	Attempt                         *int32
+	ScheduledTimestampOfThisAttempt *int64
+	HeartbeatDetails                []byte
+	WorkflowType                    *WorkflowType
+	WorkflowDomain                  *string
+	Header                          *Header
+}
+
+type PollForDecisionTaskRequest struct {
+	Domain         *string
+	TaskList       *TaskList
+	Identity       *string
+	BinaryChecksum *string
+}
+
+type PollForDecisionTaskResponse struct {
+	TaskToken                 []byte
+	WorkflowExecution         *WorkflowExecution
+	WorkflowType              *WorkflowType
+	PreviousStartedEventId    *int64
+	StartedEventId            *int64
+	Attempt                   *int64
+	BacklogCountHint          *int64
+	History                   *History
+	NextPageToken             []byte
+	Query                     *WorkflowQuery
+	WorkflowExecutionTaskList *TaskList
+	ScheduledTimestamp        *int64
+	StartedTimestamp          *int64
+	Queries                   map[string]*WorkflowQuery
+}
+
+type PollerInfo struct {
+	LastAccessTime *int64
+	Identity       *string
+	RatePerSecond  *float64
+}
+
+type QueryConsistencyLevel int32
+
+const (
+	QueryConsistencyLevelEventual QueryConsistencyLevel = iota
+	QueryConsistencyLevelStrong
+)
+
+type QueryFailedError struct {
+	Message string
+}
+
+type QueryRejectCondition int32
+
+const (
+	QueryRejectConditionNotCompletedCleanly QueryRejectCondition = iota
+	QueryRejectConditionNotOpen
+)
+
+type QueryRejected struct {
+	CloseStatus *WorkflowExecutionCloseStatus
+}
+
+type QueryResultType int32
+
+const (
+	QueryResultTypeAnswered QueryResultType = iota
+	QueryResultTypeFailed
+)
+
+type QueryTaskCompletedType int32
+
+const (
+	QueryTaskCompletedTypeCompleted QueryTaskCompletedType = iota
+	QueryTaskCompletedTypeFailed
+)
+
+type QueryWorkflowRequest struct {
+	Domain                *string
+	Execution             *WorkflowExecution
+	Query                 *WorkflowQuery
+	QueryRejectCondition  *QueryRejectCondition
+	QueryConsistencyLevel *QueryConsistencyLevel
+}
+
+type QueryWorkflowResponse struct {
+	QueryResult   []byte
+	QueryRejected *QueryRejected
+}
+
+type ReapplyEventsRequest struct {
+	DomainName        *string
+	WorkflowExecution *WorkflowExecution
+	Events            *DataBlob
+}
+
+type RecordActivityTaskHeartbeatByIDRequest struct {
+	Domain     *string
+	WorkflowID *string
+	RunID      *string
+	ActivityID *string
+	Details    []byte
+	Identity   *string
+}
+
+type RecordActivityTaskHeartbeatRequest struct {
+	TaskToken []byte
+	Details   []byte
+	Identity  *string
+}
+
+type RecordActivityTaskHeartbeatResponse struct {
+	CancelRequested *bool
+}
+
+type RecordMarkerDecisionAttributes struct {
+	MarkerName *string
+	Details    []byte
+	Header     *Header
+}
+
+type RefreshWorkflowTasksRequest struct {
+	Domain    *string
+	Execution *WorkflowExecution
+}
+
+type RegisterDomainRequest struct {
+	Name                                   *string
+	Description                            *string
+	OwnerEmail                             *string
+	WorkflowExecutionRetentionPeriodInDays *int32
+	EmitMetric                             *bool
+	Clusters                               []*ClusterReplicationConfiguration
+	ActiveClusterName                      *string
+	Data                                   map[string]string
+	SecurityToken                          *string
+	IsGlobalDomain                         *bool
+	HistoryArchivalStatus                  *ArchivalStatus
+	HistoryArchivalURI                     *string
+	VisibilityArchivalStatus               *ArchivalStatus
+	VisibilityArchivalURI                  *string
+}
+
+type RemoteSyncMatchedError struct {
+	Message string
+}
+
+type RemoveTaskRequest struct {
+	ShardID             *int32
+	Type                *int32
+	TaskID              *int64
+	VisibilityTimestamp *int64
+}
+
+type RequestCancelActivityTaskDecisionAttributes struct {
+	ActivityId *string
+}
+
+type RequestCancelActivityTaskFailedEventAttributes struct {
+	ActivityId                   *string
+	Cause                        *string
+	DecisionTaskCompletedEventId *int64
+}
+
+type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
+	Domain            *string
+	WorkflowId        *string
+	RunId             *string
+	Control           []byte
+	ChildWorkflowOnly *bool
+}
+
+type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
+	Cause                        *CancelExternalWorkflowExecutionFailedCause
+	DecisionTaskCompletedEventId *int64
+	Domain                       *string
+	WorkflowExecution            *WorkflowExecution
+	InitiatedEventId             *int64
+	Control                      []byte
+}
+
+type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
+	DecisionTaskCompletedEventId *int64
+	Domain                       *string
+	WorkflowExecution            *WorkflowExecution
+	Control                      []byte
+	ChildWorkflowOnly            *bool
+}
+
+type RequestCancelWorkflowExecutionRequest struct {
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	Identity          *string
+	RequestId         *string
+}
+
+type ResetPointInfo struct {
+	BinaryChecksum           *string
+	RunId                    *string
+	FirstDecisionCompletedId *int64
+	CreatedTimeNano          *int64
+	ExpiringTimeNano         *int64
+	Resettable               *bool
+}
+
+type ResetPoints struct {
+	Points []*ResetPointInfo
+}
+
+type ResetQueueRequest struct {
+	ShardID     *int32
+	ClusterName *string
+	Type        *int32
+}
+
+type ResetStickyTaskListRequest struct {
+	Domain    *string
+	Execution *WorkflowExecution
+}
+
+type ResetStickyTaskListResponse struct {
+}
+
+type ResetWorkflowExecutionRequest struct {
+	Domain                *string
+	WorkflowExecution     *WorkflowExecution
+	Reason                *string
+	DecisionFinishEventId *int64
+	RequestId             *string
+}
+
+type ResetWorkflowExecutionResponse struct {
+	RunId *string
+}
+
+type RespondActivityTaskCanceledByIDRequest struct {
+	Domain     *string
+	WorkflowID *string
+	RunID      *string
+	ActivityID *string
+	Details    []byte
+	Identity   *string
+}
+
+type RespondActivityTaskCanceledRequest struct {
+	TaskToken []byte
+	Details   []byte
+	Identity  *string
+}
+
+type RespondActivityTaskCompletedByIDRequest struct {
+	Domain     *string
+	WorkflowID *string
+	RunID      *string
+	ActivityID *string
+	Result     []byte
+	Identity   *string
+}
+
+type RespondActivityTaskCompletedRequest struct {
+	TaskToken []byte
+	Result    []byte
+	Identity  *string
+}
+
+type RespondActivityTaskFailedByIDRequest struct {
+	Domain     *string
+	WorkflowID *string
+	RunID      *string
+	ActivityID *string
+	Reason     *string
+	Details    []byte
+	Identity   *string
+}
+
+type RespondActivityTaskFailedRequest struct {
+	TaskToken []byte
+	Reason    *string
+	Details   []byte
+	Identity  *string
+}
+
+type RespondDecisionTaskCompletedRequest struct {
+	TaskToken                  []byte
+	Decisions                  []*Decision
+	ExecutionContext           []byte
+	Identity                   *string
+	StickyAttributes           *StickyExecutionAttributes
+	ReturnNewDecisionTask      *bool
+	ForceCreateNewDecisionTask *bool
+	BinaryChecksum             *string
+	QueryResults               map[string]*WorkflowQueryResult
+}
+
+type RespondDecisionTaskCompletedResponse struct {
+	DecisionTask *PollForDecisionTaskResponse
+}
+
+type RespondDecisionTaskFailedRequest struct {
+	TaskToken      []byte
+	Cause          *DecisionTaskFailedCause
+	Details        []byte
+	Identity       *string
+	BinaryChecksum *string
+}
+
+type RespondQueryTaskCompletedRequest struct {
+	TaskToken         []byte
+	CompletedType     *QueryTaskCompletedType
+	QueryResult       []byte
+	ErrorMessage      *string
+	WorkerVersionInfo *WorkerVersionInfo
+}
+
+type RetryPolicy struct {
+	InitialIntervalInSeconds    *int32
+	BackoffCoefficient          *float64
+	MaximumIntervalInSeconds    *int32
+	MaximumAttempts             *int32
+	NonRetriableErrorReasons    []string
+	ExpirationIntervalInSeconds *int32
+}
+
+type RetryTaskV2Error struct {
+	Message           string
+	DomainId          *string
+	WorkflowId        *string
+	RunId             *string
+	StartEventId      *int64
+	StartEventVersion *int64
+	EndEventId        *int64
+	EndEventVersion   *int64
+}
+
+type ScheduleActivityTaskDecisionAttributes struct {
+	ActivityId                    *string
+	ActivityType                  *ActivityType
+	Domain                        *string
+	TaskList                      *TaskList
+	Input                         []byte
+	ScheduleToCloseTimeoutSeconds *int32
+	ScheduleToStartTimeoutSeconds *int32
+	StartToCloseTimeoutSeconds    *int32
+	HeartbeatTimeoutSeconds       *int32
+	RetryPolicy                   *RetryPolicy
+	Header                        *Header
+}
+
+type SearchAttributes struct {
+	IndexedFields map[string][]byte
+}
+
+type ServiceBusyError struct {
+	Message string
+}
+
+type SignalExternalWorkflowExecutionDecisionAttributes struct {
+	Domain            *string
+	Execution         *WorkflowExecution
+	SignalName        *string
+	Input             []byte
+	Control           []byte
+	ChildWorkflowOnly *bool
+}
+
+type SignalExternalWorkflowExecutionFailedCause int32
+
+const (
+	SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution SignalExternalWorkflowExecutionFailedCause = iota
+)
+
+type SignalExternalWorkflowExecutionFailedEventAttributes struct {
+	Cause                        *SignalExternalWorkflowExecutionFailedCause
+	DecisionTaskCompletedEventId *int64
+	Domain                       *string
+	WorkflowExecution            *WorkflowExecution
+	InitiatedEventId             *int64
+	Control                      []byte
+}
+
+type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
+	DecisionTaskCompletedEventId *int64
+	Domain                       *string
+	WorkflowExecution            *WorkflowExecution
+	SignalName                   *string
+	Input                        []byte
+	Control                      []byte
+	ChildWorkflowOnly            *bool
+}
+
+type SignalWithStartWorkflowExecutionRequest struct {
+	Domain                              *string
+	WorkflowId                          *string
+	WorkflowType                        *WorkflowType
+	TaskList                            *TaskList
+	Input                               []byte
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+	Identity                            *string
+	RequestId                           *string
+	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	SignalName                          *string
+	SignalInput                         []byte
+	Control                             []byte
+	RetryPolicy                         *RetryPolicy
+	CronSchedule                        *string
+	Memo                                *Memo
+	SearchAttributes                    *SearchAttributes
+	Header                              *Header
+}
+
+type SignalWorkflowExecutionRequest struct {
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	SignalName        *string
+	Input             []byte
+	Identity          *string
+	RequestId         *string
+	Control           []byte
+}
+
+type StartChildWorkflowExecutionDecisionAttributes struct {
+	Domain                              *string
+	WorkflowId                          *string
+	WorkflowType                        *WorkflowType
+	TaskList                            *TaskList
+	Input                               []byte
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+	ParentClosePolicy                   *ParentClosePolicy
+	Control                             []byte
+	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	RetryPolicy                         *RetryPolicy
+	CronSchedule                        *string
+	Header                              *Header
+	Memo                                *Memo
+	SearchAttributes                    *SearchAttributes
+}
+
+type StartChildWorkflowExecutionFailedEventAttributes struct {
+	Domain                       *string
+	WorkflowId                   *string
+	WorkflowType                 *WorkflowType
+	Cause                        *ChildWorkflowExecutionFailedCause
+	Control                      []byte
+	InitiatedEventId             *int64
+	DecisionTaskCompletedEventId *int64
+}
+
+type StartChildWorkflowExecutionInitiatedEventAttributes struct {
+	Domain                              *string
+	WorkflowId                          *string
+	WorkflowType                        *WorkflowType
+	TaskList                            *TaskList
+	Input                               []byte
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+	ParentClosePolicy                   *ParentClosePolicy
+	Control                             []byte
+	DecisionTaskCompletedEventId        *int64
+	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	RetryPolicy                         *RetryPolicy
+	CronSchedule                        *string
+	Header                              *Header
+	Memo                                *Memo
+	SearchAttributes                    *SearchAttributes
+}
+
+type StartTimeFilter struct {
+	EarliestTime *int64
+	LatestTime   *int64
+}
+
+type StartTimerDecisionAttributes struct {
+	TimerId                   *string
+	StartToFireTimeoutSeconds *int64
+}
+
+type StartWorkflowExecutionRequest struct {
+	Domain                              *string
+	WorkflowId                          *string
+	WorkflowType                        *WorkflowType
+	TaskList                            *TaskList
+	Input                               []byte
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+	Identity                            *string
+	RequestId                           *string
+	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	RetryPolicy                         *RetryPolicy
+	CronSchedule                        *string
+	Memo                                *Memo
+	SearchAttributes                    *SearchAttributes
+	Header                              *Header
+}
+
+type StartWorkflowExecutionResponse struct {
+	RunId *string
+}
+
+type StickyExecutionAttributes struct {
+	WorkerTaskList                *TaskList
+	ScheduleToStartTimeoutSeconds *int32
+}
+
+type SupportedClientVersions struct {
+	GoSdk   *string
+	JavaSdk *string
+}
+
+type TaskIDBlock struct {
+	StartID *int64
+	EndID   *int64
+}
+
+type TaskList struct {
+	Name *string
+	Kind *TaskListKind
+}
+
+type TaskListKind int32
+
+const (
+	TaskListKindNormal TaskListKind = iota
+	TaskListKindSticky
+)
+
+type TaskListMetadata struct {
+	MaxTasksPerSecond *float64
+}
+
+type TaskListPartitionMetadata struct {
+	Key           *string
+	OwnerHostName *string
+}
+
+type TaskListStatus struct {
+	BacklogCountHint *int64
+	ReadLevel        *int64
+	AckLevel         *int64
+	RatePerSecond    *float64
+	TaskIDBlock      *TaskIDBlock
+}
+
+type TaskListType int32
+
+const (
+	TaskListTypeActivity TaskListType = iota
+	TaskListTypeDecision
+)
+
+type TerminateWorkflowExecutionRequest struct {
+	Domain            *string
+	WorkflowExecution *WorkflowExecution
+	Reason            *string
+	Details           []byte
+	Identity          *string
+}
+
+type TimeoutType int32
+
+const (
+	TimeoutTypeHeartbeat TimeoutType = iota
+	TimeoutTypeScheduleToClose
+	TimeoutTypeScheduleToStart
+	TimeoutTypeStartToClose
+)
+
+type TimerCanceledEventAttributes struct {
+	TimerId                      *string
+	StartedEventId               *int64
+	DecisionTaskCompletedEventId *int64
+	Identity                     *string
+}
+
+type TimerFiredEventAttributes struct {
+	TimerId        *string
+	StartedEventId *int64
+}
+
+type TimerStartedEventAttributes struct {
+	TimerId                      *string
+	StartToFireTimeoutSeconds    *int64
+	DecisionTaskCompletedEventId *int64
+}
+
+type TransientDecisionInfo struct {
+	ScheduledEvent *HistoryEvent
+	StartedEvent   *HistoryEvent
+}
+
+type UpdateDomainInfo struct {
+	Description *string
+	OwnerEmail  *string
+	Data        map[string]string
+}
+
+type UpdateDomainRequest struct {
+	Name                     *string
+	UpdatedInfo              *UpdateDomainInfo
+	Configuration            *DomainConfiguration
+	ReplicationConfiguration *DomainReplicationConfiguration
+	SecurityToken            *string
+	DeleteBadBinary          *string
+	FailoverTimeoutInSeconds *int32
+}
+
+type UpdateDomainResponse struct {
+	DomainInfo               *DomainInfo
+	Configuration            *DomainConfiguration
+	ReplicationConfiguration *DomainReplicationConfiguration
+	FailoverVersion          *int64
+	IsGlobalDomain           *bool
+}
+
+type UpsertWorkflowSearchAttributesDecisionAttributes struct {
+	SearchAttributes *SearchAttributes
+}
+
+type UpsertWorkflowSearchAttributesEventAttributes struct {
+	DecisionTaskCompletedEventId *int64
+	SearchAttributes             *SearchAttributes
+}
+
+type VersionHistories struct {
+	CurrentVersionHistoryIndex *int32
+	Histories                  []*VersionHistory
+}
+
+type VersionHistory struct {
+	BranchToken []byte
+	Items       []*VersionHistoryItem
+}
+
+type VersionHistoryItem struct {
+	EventID *int64
+	Version *int64
+}
+
+type WorkerVersionInfo struct {
+	Impl           *string
+	FeatureVersion *string
+}
+
+type WorkflowExecution struct {
+	WorkflowId *string
+	RunId      *string
+}
+
+type WorkflowExecutionAlreadyStartedError struct {
+	Message        *string
+	StartRequestId *string
+	RunId          *string
+}
+
+type WorkflowExecutionCancelRequestedEventAttributes struct {
+	Cause                     *string
+	ExternalInitiatedEventId  *int64
+	ExternalWorkflowExecution *WorkflowExecution
+	Identity                  *string
+}
+
+type WorkflowExecutionCanceledEventAttributes struct {
+	DecisionTaskCompletedEventId *int64
+	Details                      []byte
+}
+
+type WorkflowExecutionCloseStatus int32
+
+const (
+	WorkflowExecutionCloseStatusCanceled WorkflowExecutionCloseStatus = iota
+	WorkflowExecutionCloseStatusCompleted
+	WorkflowExecutionCloseStatusContinuedAsNew
+	WorkflowExecutionCloseStatusFailed
+	WorkflowExecutionCloseStatusTerminated
+	WorkflowExecutionCloseStatusTimedOut
+)
+
+type WorkflowExecutionCompletedEventAttributes struct {
+	Result                       []byte
+	DecisionTaskCompletedEventId *int64
+}
+
+type WorkflowExecutionConfiguration struct {
+	TaskList                            *TaskList
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+}
+
+type WorkflowExecutionContinuedAsNewEventAttributes struct {
+	NewExecutionRunId                   *string
+	WorkflowType                        *WorkflowType
+	TaskList                            *TaskList
+	Input                               []byte
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+	DecisionTaskCompletedEventId        *int64
+	BackoffStartIntervalInSeconds       *int32
+	Initiator                           *ContinueAsNewInitiator
+	FailureReason                       *string
+	FailureDetails                      []byte
+	LastCompletionResult                []byte
+	Header                              *Header
+	Memo                                *Memo
+	SearchAttributes                    *SearchAttributes
+}
+
+type WorkflowExecutionFailedEventAttributes struct {
+	Reason                       *string
+	Details                      []byte
+	DecisionTaskCompletedEventId *int64
+}
+
+type WorkflowExecutionFilter struct {
+	WorkflowId *string
+	RunId      *string
+}
+
+type WorkflowExecutionInfo struct {
+	Execution        *WorkflowExecution
+	Type             *WorkflowType
+	StartTime        *int64
+	CloseTime        *int64
+	CloseStatus      *WorkflowExecutionCloseStatus
+	HistoryLength    *int64
+	ParentDomainId   *string
+	ParentExecution  *WorkflowExecution
+	ExecutionTime    *int64
+	Memo             *Memo
+	SearchAttributes *SearchAttributes
+	AutoResetPoints  *ResetPoints
+	TaskList         *string
+}
+
+type WorkflowExecutionSignaledEventAttributes struct {
+	SignalName *string
+	Input      []byte
+	Identity   *string
+}
+
+type WorkflowExecutionStartedEventAttributes struct {
+	WorkflowType                        *WorkflowType
+	ParentWorkflowDomain                *string
+	ParentWorkflowExecution             *WorkflowExecution
+	ParentInitiatedEventId              *int64
+	TaskList                            *TaskList
+	Input                               []byte
+	ExecutionStartToCloseTimeoutSeconds *int32
+	TaskStartToCloseTimeoutSeconds      *int32
+	ContinuedExecutionRunId             *string
+	Initiator                           *ContinueAsNewInitiator
+	ContinuedFailureReason              *string
+	ContinuedFailureDetails             []byte
+	LastCompletionResult                []byte
+	OriginalExecutionRunId              *string
+	Identity                            *string
+	FirstExecutionRunId                 *string
+	RetryPolicy                         *RetryPolicy
+	Attempt                             *int32
+	ExpirationTimestamp                 *int64
+	CronSchedule                        *string
+	FirstDecisionTaskBackoffSeconds     *int32
+	Memo                                *Memo
+	SearchAttributes                    *SearchAttributes
+	PrevAutoResetPoints                 *ResetPoints
+	Header                              *Header
+}
+
+type WorkflowExecutionTerminatedEventAttributes struct {
+	Reason   *string
+	Details  []byte
+	Identity *string
+}
+
+type WorkflowExecutionTimedOutEventAttributes struct {
+	TimeoutType *TimeoutType
+}
+
+type WorkflowIdReusePolicy int32
+
+const (
+	WorkflowIdReusePolicyAllowDuplicate WorkflowIdReusePolicy = iota
+	WorkflowIdReusePolicyAllowDuplicateFailedOnly
+	WorkflowIdReusePolicyRejectDuplicate
+	WorkflowIdReusePolicyTerminateIfRunning
+)
+
+type WorkflowQuery struct {
+	QueryType *string
+	QueryArgs []byte
+}
+
+type WorkflowQueryResult struct {
+	ResultType   *QueryResultType
+	Answer       []byte
+	ErrorMessage *string
+}
+
+type WorkflowType struct {
+	Name *string
+}
+
+type WorkflowTypeFilter struct {
+	Name *string
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Created internal types code generator to generate internal types and initial 1:1 mappings to/from Thrift.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is the first step towards gRPC migration. We are introducing internal application level types to stop depending on Thrift generated types throughout Cadence codebase. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None yet. Types are not used yet. They are generated to be exact 1:1 replacement to reduce risk.
