### PR TITLE
Add primrary key to mysql domain_metadata table for replication group

### DIFF
--- a/schema/mysql/v57/cadence/schema.sql
+++ b/schema/mysql/v57/cadence/schema.sql
@@ -10,7 +10,9 @@ CREATE TABLE domains(
 );
 
 CREATE TABLE domain_metadata (
-  notification_version BIGINT NOT NULL
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  notification_version BIGINT NOT NULL,
+  PRIMARY KEY (`id`)
 );
 
 INSERT INTO domain_metadata (notification_version) VALUES (1);

--- a/schema/mysql/v57/cadence/schema.sql
+++ b/schema/mysql/v57/cadence/schema.sql
@@ -10,7 +10,7 @@ CREATE TABLE domains(
 );
 
 CREATE TABLE domain_metadata (
-  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  `id` bigint(20) NOT NULL AUTO_INCREMENT, 
   notification_version BIGINT NOT NULL,
   PRIMARY KEY (`id`)
 );

--- a/schema/mysql/v57/cadence/versioned/v0.1/base.sql
+++ b/schema/mysql/v57/cadence/versioned/v0.1/base.sql
@@ -10,7 +10,9 @@ CREATE TABLE domains(
 );
 
 CREATE TABLE domain_metadata (
-  notification_version BIGINT NOT NULL
+  `id` bigint(20) NOT NULL AUTO_INCREMENT,
+  notification_version BIGINT NOT NULL,
+  PRIMARY KEY (`id`)
 );
 
 INSERT INTO domain_metadata (notification_version) VALUES (1);


### PR DESCRIPTION
…d for MySQL with replicaiton group

<!-- Describe what has changed in this PR -->
**What changed?**
Add primrary key to mysql table domain_metadata so that it can be used for MySQL with replication group

<!-- Tell your future self why have you made these changes -->
**Why?**
See https://dev.mysql.com/doc/refman/5.7/en/group-replication-requirements.html
And 
https://stackoverflow.com/questions/54829568/error-my-011542-repl-plugin-group-replication-reported-table-repl-test-does-no
I found this when tried to run Cadence with a MySQL cluster with Replication Group.
Adding this primary key fix the issue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested with a prod environment with RG, and also locally without RG. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No, this is completely backward compatible. 
