### PR TITLE
Move batcher to new domain

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -105,12 +105,13 @@ const (
 	SystemGlobalDomainName = "cadence-system-global"
 	// SystemLocalDomainName is domain name for cadence system workflows running in local cluster
 	SystemLocalDomainName = "cadence-system"
-	// SystemDomainID is domain id for all cadence system workflows
-	SystemDomainID = "32049b68-7872-4094-8e63-d0dd59896a83"
 	// SystemDomainRetentionDays is retention config for all cadence system workflows
 	SystemDomainRetentionDays = 7
 	// DefaultAdminOperationToken is the default dynamic config value for AdminOperationToken
 	DefaultAdminOperationToken = "CadenceTeamONLY"
+	// BatcherLocalDomainName is domain name for batcher workflows running in local cluster
+	// Batcher cannot use SystemLocalDomain because auth
+	BatcherLocalDomainName = "cadence-batcher"
 )
 
 const (

--- a/common/constants.go
+++ b/common/constants.go
@@ -103,12 +103,16 @@ const (
 const (
 	// SystemGlobalDomainName is global domain name for cadence system workflows running globally
 	SystemGlobalDomainName = "cadence-system-global"
+	// SystemDomainID is domain id for all cadence system workflows
+	SystemDomainID = "32049b68-7872-4094-8e63-d0dd59896a83"
 	// SystemLocalDomainName is domain name for cadence system workflows running in local cluster
 	SystemLocalDomainName = "cadence-system"
 	// SystemDomainRetentionDays is retention config for all cadence system workflows
 	SystemDomainRetentionDays = 7
 	// DefaultAdminOperationToken is the default dynamic config value for AdminOperationToken
 	DefaultAdminOperationToken = "CadenceTeamONLY"
+	// BatcherDomainID is domain id for batcher local domain
+	BatcherDomainID = "3116607e-419b-4783-85fc-47726a4c3fe9"
 	// BatcherLocalDomainName is domain name for batcher workflows running in local cluster
 	// Batcher cannot use SystemLocalDomain because auth
 	BatcherLocalDomainName = "cadence-batcher"

--- a/common/persistence/elasticsearch/esVisibilityStore_test.go
+++ b/common/persistence/elasticsearch/esVisibilityStore_test.go
@@ -285,7 +285,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 
 	request := &p.InternalListWorkflowExecutionsByTypeRequest{
 		InternalListWorkflowExecutionsRequest: *testRequest,
-		WorkflowTypeName:              testWorkflowType,
+		WorkflowTypeName:                      testWorkflowType,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
@@ -312,7 +312,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 
 	request := &p.InternalListWorkflowExecutionsByTypeRequest{
 		InternalListWorkflowExecutionsRequest: *testRequest,
-		WorkflowTypeName:              testWorkflowType,
+		WorkflowTypeName:                      testWorkflowType,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
@@ -339,7 +339,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 
 	request := &p.InternalListWorkflowExecutionsByWorkflowIDRequest{
 		InternalListWorkflowExecutionsRequest: *testRequest,
-		WorkflowID:                    testWorkflowID,
+		WorkflowID:                            testWorkflowID,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
@@ -366,7 +366,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
 
 	request := &p.InternalListWorkflowExecutionsByWorkflowIDRequest{
 		InternalListWorkflowExecutionsRequest: *testRequest,
-		WorkflowID:                    testWorkflowID,
+		WorkflowID:                            testWorkflowID,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
@@ -393,7 +393,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
 
 	request := &p.InternalListClosedWorkflowExecutionsByStatusRequest{
 		InternalListWorkflowExecutionsRequest: *testRequest,
-		Status:                        workflow.WorkflowExecutionCloseStatus(testCloseStatus),
+		Status:                                workflow.WorkflowExecutionCloseStatus(testCloseStatus),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)

--- a/service/worker/batcher/batcher.go
+++ b/service/worker/batcher/batcher.go
@@ -95,6 +95,6 @@ func (s *Batcher) Start() error {
 		BackgroundActivityContext: ctx,
 		Tracer:                    opentracing.GlobalTracer(),
 	}
-	batchWorker := worker.New(s.svcClient, common.SystemLocalDomainName, BatcherTaskListName, workerOpts)
+	batchWorker := worker.New(s.svcClient, common.BatcherLocalDomainName, BatcherTaskListName, workerOpts)
 	return batchWorker.Start()
 }

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -28,7 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/definition"
@@ -361,7 +360,7 @@ func (s *Service) registerSystemDomain(domain string) {
 	currentClusterName := s.GetClusterMetadata().GetCurrentClusterName()
 	_, err := s.GetMetadataManager().CreateDomain(context.Background(), &persistence.CreateDomainRequest{
 		Info: &persistence.DomainInfo{
-			ID:          uuid.New().String(),
+			ID:          getDomainID(domain),
 			Name:        domain,
 			Description: "Cadence internal system domain",
 		},
@@ -382,4 +381,15 @@ func (s *Service) registerSystemDomain(domain string) {
 		}
 		s.GetLogger().Fatal("failed to register system domain", tag.Error(err))
 	}
+}
+
+func getDomainID(domain string) string {
+	var domainID string
+	switch domain {
+	case common.SystemLocalDomainName:
+		domainID = common.SystemDomainID
+	case common.BatcherLocalDomainName:
+		domainID = common.BatcherDomainID
+	}
+	return domainID
 }

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -29,7 +29,6 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/definition"
@@ -198,7 +197,7 @@ func (s *Service) Start() {
 
 	s.Resource.Start()
 
-	s.ensureSystemDomainExists(common.SystemLocalDomainName)
+	s.ensureDomainExists(common.SystemLocalDomainName)
 	s.startScanner()
 	if s.config.IndexerCfg != nil {
 		s.startIndexer()
@@ -211,7 +210,7 @@ func (s *Service) Start() {
 		s.startArchiver()
 	}
 	if s.config.EnableBatcher() {
-		s.ensureSystemDomainExists(common.BatcherLocalDomainName)
+		s.ensureDomainExists(common.BatcherLocalDomainName)
 		s.startBatcher()
 	}
 	if s.config.EnableParentClosePolicyWorker() {
@@ -344,16 +343,16 @@ func (s *Service) startFailoverManager() {
 	}
 }
 
-func (s *Service) ensureSystemDomainExists(domain string) {
+func (s *Service) ensureDomainExists(domain string) {
 	_, err := s.GetMetadataManager().GetDomain(context.Background(), &persistence.GetDomainRequest{Name: domain})
 	switch err.(type) {
 	case nil:
 		// noop
 	case *shared.EntityNotExistsError:
-		s.GetLogger().Info(fmt.Sprintf("cadence system %s does not exist, attempting to register domain", domain))
+		s.GetLogger().Info(fmt.Sprintf("domain %s does not exist, attempting to register domain", domain))
 		s.registerSystemDomain(domain)
 	default:
-		s.GetLogger().Fatal("failed to verify if cadence system domain exists", tag.Error(err))
+		s.GetLogger().Fatal("failed to verify if system domain exists", tag.Error(err))
 	}
 }
 

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -40,7 +40,7 @@ func TerminateBatchJob(c *cli.Context) {
 	jobID := getRequiredOption(c, FlagJobID)
 	reason := getRequiredOption(c, FlagReason)
 	svcClient := cFactory.ClientFrontendClient(c)
-	client := cclient.NewClient(svcClient, common.SystemLocalDomainName, &cclient.Options{})
+	client := cclient.NewClient(svcClient, common.BatcherLocalDomainName, &cclient.Options{})
 	tcCtx, cancel := newContext(c)
 	defer cancel()
 	err := client.TerminateWorkflow(tcCtx, jobID, "", reason, nil)
@@ -58,7 +58,7 @@ func DescribeBatchJob(c *cli.Context) {
 	jobID := getRequiredOption(c, FlagJobID)
 
 	svcClient := cFactory.ClientFrontendClient(c)
-	client := cclient.NewClient(svcClient, common.SystemLocalDomainName, &cclient.Options{})
+	client := cclient.NewClient(svcClient, common.BatcherLocalDomainName, &cclient.Options{})
 	tcCtx, cancel := newContext(c)
 	defer cancel()
 	wf, err := client.DescribeWorkflowExecution(tcCtx, jobID, "")
@@ -93,11 +93,11 @@ func ListBatchJobs(c *cli.Context) {
 	domain := getRequiredGlobalOption(c, FlagDomain)
 	pageSize := c.Int(FlagPageSize)
 	svcClient := cFactory.ClientFrontendClient(c)
-	client := cclient.NewClient(svcClient, common.SystemLocalDomainName, &cclient.Options{})
+	client := cclient.NewClient(svcClient, common.BatcherLocalDomainName, &cclient.Options{})
 	tcCtx, cancel := newContext(c)
 	defer cancel()
 	resp, err := client.ListWorkflow(tcCtx, &shared.ListWorkflowExecutionsRequest{
-		Domain:   common.StringPtr(common.SystemLocalDomainName),
+		Domain:   common.StringPtr(common.BatcherLocalDomainName),
 		PageSize: common.Int32Ptr(int32(pageSize)),
 		Query:    common.StringPtr(fmt.Sprintf("CustomDomain = '%v'", domain)),
 	})
@@ -143,7 +143,7 @@ func StartBatchJob(c *cli.Context) {
 	rps := c.Int(FlagRPS)
 
 	svcClient := cFactory.ClientFrontendClient(c)
-	client := cclient.NewClient(svcClient, common.SystemLocalDomainName, &cclient.Options{})
+	client := cclient.NewClient(svcClient, common.BatcherLocalDomainName, &cclient.Options{})
 	tcCtx, cancel := newContext(c)
 	defer cancel()
 	resp, err := client.CountWorkflow(tcCtx, &shared.CountWorkflowExecutionsRequest{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move batcher to use new domain

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to enable auth on cadence-system so that only cadence maintainer/team can use CLI or Web to perform admin related tasks, e.g managed failover, scanner, archiver 
To enable it, we will add auth policy on cadence-system domain.
If not moving batcher out from system domain, only cadence team will be able to do batch in CLI, which is wrong.  

I considered several other approaches, this is probably the best long-term solution. but I am open to other suggestions if concerns. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk. also batcher is off by default. 
