### PR TITLE
Add pending activities to show workflow result

### DIFF
--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -151,6 +151,27 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 			ErrorAndExit("Failed to export history data file.", err)
 		}
 	}
+
+	// finally append activities with retry
+	frontendClient := cFactory.ServerFrontendClient(c)
+	domain := getRequiredGlobalOption(c, FlagDomain)
+	resp, err := frontendClient.DescribeWorkflowExecution(ctx, &shared.DescribeWorkflowExecutionRequest{
+		Domain: common.StringPtr(domain),
+		Execution: &shared.WorkflowExecution{
+			WorkflowId: common.StringPtr(wid),
+			RunId:      common.StringPtr(rid),
+		},
+	})
+	if err != nil {
+		ErrorAndExit("Describe workflow execution failed, cannot get information of activities with retry", err)
+	}
+
+	descOutput := convertDescribeWorkflowExecutionResponse(resp, frontendClient, c)
+	if len(descOutput.PendingActivities) > 0 {
+		fmt.Println("============Pending activities============")
+		prettyPrintJSONObject(descOutput.PendingActivities)
+	}
+
 }
 
 // StartWorkflow starts a new workflow execution

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -163,13 +163,14 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 		},
 	})
 	if err != nil {
-		ErrorAndExit("Describe workflow execution failed, cannot get information of activities with retry", err)
+		ErrorAndExit("Describe workflow execution failed, cannot get information of pending activities", err)
 	}
 
 	descOutput := convertDescribeWorkflowExecutionResponse(resp, frontendClient, c)
 	if len(descOutput.PendingActivities) > 0 {
 		fmt.Println("============Pending activities============")
 		prettyPrintJSONObject(descOutput.PendingActivities)
+		fmt.Println("NOTE: ActivityStartedEvent with retry policy will be written into history when the activity is finished.")
 	}
 
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add pending activities to show workflow result

<!-- Tell your future self why have you made these changes -->
**Why?**
https://github.com/uber/cadence/issues/3607

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
~/cadence [qlong-cli-wf-show-actvities-retry] M % ./cadence --do qlong wf show -w retry_db345b68-0e50-4c24-8d2d-8c6dd18d88dc
   1  WorkflowExecutionStarted  {WorkflowType:{Name:main.retryWorkflow},
                                TaskList:{Name:retryactivityGroup}, Input:[],
                                ExecutionStartToCloseTimeoutSeconds:120,
                                TaskStartToCloseTimeoutSeconds:60,
                                ContinuedFailureDetails:[], LastCompletionResult:[],
                                OriginalExecutionRunId:63acf35f-9ede-48ef-aee7-66579382fed5,
                                Identity:35027@IT-USA-25920@,
...
...
...
...
                                ExpirationIntervalInSeconds:20},
                                Header:{Fields:map{}}}
============Pending activities============
[
  {
    "ActivityID": "0",
    "ActivityType": {
      "name": "main.batchProcessingActivity"
    },
    "State": "STARTED",
    "LastStartedTimestamp": "2020-10-11T22:47:16-07:00",
    "LastHeartbeatTimestamp": "2020-10-11T22:47:16-07:00",
    "Attempt": 0,
    "MaximumAttempts": 15,
    "ExpirationTimestamp": "2020-10-11T22:47:36-07:00"
  }
]
NOTE: ActivityStartedEvent with retry policy will be written into history when the activity is finished.
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
