### PR TITLE
Update replication task retry with two phase retry

### DIFF
--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -102,6 +102,12 @@ func NewExponentialRetryPolicy(initialInterval time.Duration) *ExponentialRetryP
 
 // NewMultiPhasesRetryPolicy creates MultiPhasesRetryPolicy
 func NewMultiPhasesRetryPolicy(policies ...*ExponentialRetryPolicy) *MultiPhasesRetryPolicy {
+
+	for i := 0; i < len(policies)-1; i++ {
+		if policies[i].maximumAttempts == noMaximumAttempts {
+			panic("Non final retry policy in MultiPhasesRetryPolicy need to set maximum attempts")
+		}
+	}
 	return &MultiPhasesRetryPolicy{
 		policies: policies,
 	}

--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -36,8 +36,6 @@ const (
 	defaultMaximumInterval    = 10 * time.Second
 	defaultExpirationInterval = time.Minute
 	defaultMaximumAttempts    = noMaximumAttempts
-
-	defaultFirstPhaseMaximumAttempts = 3
 )
 
 type (
@@ -67,12 +65,13 @@ type (
 		maximumAttempts    int
 	}
 
-	// TwoPhaseRetryPolicy implements a policy that first use one policy to get next delay,
-	// and once expired use the second policy for the following retry.
+	// MultiPhasesRetryPolicy implements a policy that first use one policy to get next delay,
+	// and once expired use the next policy for the following retry.
 	// It can achieve fast retries in first phase then slowly retires in second phase.
-	TwoPhaseRetryPolicy struct {
-		firstPolicy  RetryPolicy
-		secondPolicy RetryPolicy
+	// The supported retry policy is ExponentialRetryPolicy.
+	// To have the correct next delay, set the maximumAttempts in the non-final policy.
+	MultiPhasesRetryPolicy struct {
+		policies []*ExponentialRetryPolicy
 	}
 
 	systemClock struct{}
@@ -101,23 +100,10 @@ func NewExponentialRetryPolicy(initialInterval time.Duration) *ExponentialRetryP
 	return p
 }
 
-// NewTwoPhaseRetryPolicy creates TwoPhaseRetryPolicy
-func NewTwoPhaseRetryPolicy() *TwoPhaseRetryPolicy {
-	firstPolicy := &ExponentialRetryPolicy{
-		initialInterval:    50 * time.Millisecond,
-		backoffCoefficient: defaultBackoffCoefficient,
-		maximumAttempts:    defaultFirstPhaseMaximumAttempts,
-	}
-	secondPolicy := &ExponentialRetryPolicy{
-		initialInterval:    2 * time.Second,
-		backoffCoefficient: defaultBackoffCoefficient,
-		maximumInterval:    128 * time.Second,
-		expirationInterval: 5 * time.Minute,
-		maximumAttempts:    defaultMaximumAttempts,
-	}
-	return &TwoPhaseRetryPolicy{
-		firstPolicy:  firstPolicy,
-		secondPolicy: secondPolicy,
+// NewMultiPhasesRetryPolicy creates MultiPhasesRetryPolicy
+func NewMultiPhasesRetryPolicy(policies ...*ExponentialRetryPolicy) *MultiPhasesRetryPolicy {
+	return &MultiPhasesRetryPolicy{
+		policies: policies,
 	}
 }
 
@@ -211,12 +197,16 @@ func (p *ExponentialRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, num
 }
 
 // ComputeNextDelay returns the next delay interval.
-func (tp *TwoPhaseRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, numAttempts int) time.Duration {
-	nextInterval := tp.firstPolicy.ComputeNextDelay(elapsedTime, numAttempts)
-	if nextInterval == done {
-		nextInterval = tp.secondPolicy.ComputeNextDelay(elapsedTime, numAttempts-defaultFirstPhaseMaximumAttempts)
+func (tp MultiPhasesRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, numAttempts int) time.Duration {
+	previousStageRetryCount := 0
+	for _, policy := range tp.policies {
+		nextInterval := policy.ComputeNextDelay(elapsedTime, numAttempts-previousStageRetryCount)
+		if nextInterval != done {
+			return nextInterval
+		}
+		previousStageRetryCount += policy.maximumAttempts
 	}
-	return nextInterval
+	return done
 }
 
 // Now returns the current time using the system clock

--- a/common/backoff/retrypolicy_test.go
+++ b/common/backoff/retrypolicy_test.go
@@ -202,8 +202,13 @@ func (s *RetryPolicySuite) TestUnbounded() {
 	}
 }
 
-func (s *RetryPolicySuite) TestTwoPhaseRetryPolicy() {
-	policy := NewTwoPhaseRetryPolicy()
+func (s *RetryPolicySuite) TestMultiPhasesRetryPolicy() {
+	firstPolicy := NewExponentialRetryPolicy(50 * time.Millisecond)
+	firstPolicy.SetMaximumAttempts(3)
+	secondPolicy := NewExponentialRetryPolicy(2 * time.Second)
+	secondPolicy.SetMaximumInterval(128 * time.Second)
+	secondPolicy.SetExpirationInterval(5 * time.Minute)
+	policy := NewMultiPhasesRetryPolicy(firstPolicy, secondPolicy)
 
 	r, clock := createRetrier(policy)
 	expectedResult := []time.Duration{

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -261,6 +261,9 @@ var keys = map[Key]string{
 	ReplicationTaskFetcherServiceBusyWait:                 "history.ReplicationTaskFetcherServiceBusyWait",
 	ReplicationTaskProcessorErrorRetryWait:                "history.ReplicationTaskProcessorErrorRetryWait",
 	ReplicationTaskProcessorErrorRetryMaxAttempts:         "history.ReplicationTaskProcessorErrorRetryMaxAttempts",
+	ReplicationTaskProcessorErrorSecondRetryWait:          "history.ReplicationTaskProcessorErrorSecondRetryWait",
+	ReplicationTaskProcessorErrorSecondRetryMaxWait:       "history.ReplicationTaskProcessorErrorSecondRetryMaxWait",
+	ReplicationTaskProcessorErrorSecondRetryExpiration:    "history.ReplicationTaskProcessorErrorSecondRetryExpiration",
 	ReplicationTaskProcessorNoTaskInitialWait:             "history.ReplicationTaskProcessorNoTaskInitialWait",
 	ReplicationTaskProcessorCleanupInterval:               "history.ReplicationTaskProcessorCleanupInterval",
 	ReplicationTaskProcessorCleanupJitterCoefficient:      "history.ReplicationTaskProcessorCleanupJitterCoefficient",
@@ -863,6 +866,12 @@ const (
 	ReplicationTaskProcessorErrorRetryWait
 	// ReplicationTaskProcessorErrorRetryMaxAttempts is the max retry attempts for applying replication tasks
 	ReplicationTaskProcessorErrorRetryMaxAttempts
+	// ReplicationTaskProcessorErrorSecondRetryWait is the initial retry wait for the second phase retry
+	ReplicationTaskProcessorErrorSecondRetryWait
+	// ReplicationTaskProcessorErrorSecondRetryMaxWait is the max wait time for the second phase retry
+	ReplicationTaskProcessorErrorSecondRetryMaxWait
+	// ReplicationTaskProcessorErrorSecondRetryExpiration is the expiration duration for the second phase retry
+	ReplicationTaskProcessorErrorSecondRetryExpiration
 	// ReplicationTaskProcessorNoTaskInitialWait is the wait time when not ask is returned
 	ReplicationTaskProcessorNoTaskInitialWait
 	// ReplicationTaskProcessorCleanupInterval determines how frequently the cleanup replication queue

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -227,6 +227,9 @@ type Config struct {
 	ReplicationTaskFetcherServiceBusyWait              dynamicconfig.DurationPropertyFn
 	ReplicationTaskProcessorErrorRetryWait             dynamicconfig.DurationPropertyFnWithShardIDFilter
 	ReplicationTaskProcessorErrorRetryMaxAttempts      dynamicconfig.IntPropertyFnWithShardIDFilter
+	ReplicationTaskProcessorErrorSecondRetryWait       dynamicconfig.DurationPropertyFnWithShardIDFilter
+	ReplicationTaskProcessorErrorSecondRetryMaxWait    dynamicconfig.DurationPropertyFnWithShardIDFilter
+	ReplicationTaskProcessorErrorSecondRetryExpiration dynamicconfig.DurationPropertyFnWithShardIDFilter
 	ReplicationTaskProcessorNoTaskRetryWait            dynamicconfig.DurationPropertyFnWithShardIDFilter
 	ReplicationTaskProcessorCleanupInterval            dynamicconfig.DurationPropertyFnWithShardIDFilter
 	ReplicationTaskProcessorCleanupJitterCoefficient   dynamicconfig.FloatPropertyFnWithShardIDFilter
@@ -439,7 +442,10 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ReplicationTaskFetcherErrorRetryWait:               dc.GetDurationProperty(dynamicconfig.ReplicationTaskFetcherErrorRetryWait, time.Second),
 		ReplicationTaskFetcherServiceBusyWait:              dc.GetDurationProperty(dynamicconfig.ReplicationTaskFetcherServiceBusyWait, 60*time.Second),
 		ReplicationTaskProcessorErrorRetryWait:             dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryWait, 50*time.Millisecond),
-		ReplicationTaskProcessorErrorRetryMaxAttempts:      dc.GetIntPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts, 5),
+		ReplicationTaskProcessorErrorRetryMaxAttempts:      dc.GetIntPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorRetryMaxAttempts, 10),
+		ReplicationTaskProcessorErrorSecondRetryWait:       dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorSecondRetryWait, 5*time.Second),
+		ReplicationTaskProcessorErrorSecondRetryMaxWait:    dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorSecondRetryMaxWait, 30*time.Second),
+		ReplicationTaskProcessorErrorSecondRetryExpiration: dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorErrorSecondRetryExpiration, 5*time.Minute),
 		ReplicationTaskProcessorNoTaskRetryWait:            dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorNoTaskInitialWait, 2*time.Second),
 		ReplicationTaskProcessorCleanupInterval:            dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorCleanupInterval, 1*time.Minute),
 		ReplicationTaskProcessorCleanupJitterCoefficient:   dc.GetFloat64PropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorCleanupJitterCoefficient, 0.15),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Update TwoPhaseRetryPolicy to MultiPhasesRetryPolicy.
2. Update the replication task retry to use two phases retry.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Current TwoPhaseRetryPolicy uses default retry policies. This PR introduces customized retry policies for multi phases retry
2. Replication task execution uses two phases retry. The first retry policy has a fast rate retry to handle transient errors. The seconds retry policy to handle any errors that could last for a few minutes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The replication task may take a longer time in execution and slow down the replication stack.
