### PR TITLE
Add operator to admin failover

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -174,3 +174,6 @@ const (
 
 // StickyTaskConditionFailedErrorMsg error msg for sticky task ConditionFailedError
 const StickyTaskConditionFailedErrorMsg = "StickyTaskConditionFailedError"
+
+// MemoKeyForOperator is the memo key for operator
+const MemoKeyForOperator = "operator"

--- a/tools/cli/adminFailoverCommands.go
+++ b/tools/cli/adminFailoverCommands.go
@@ -23,6 +23,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os/user"
 	"time"
 
 	"go.uber.org/cadence/.gen/go/shared"
@@ -69,6 +70,9 @@ func failoverStart(c *cli.Context, params *startParams) {
 		WorkflowIDReusePolicy:        cclient.WorkflowIDReusePolicyAllowDuplicate,
 		TaskList:                     failovermanager.TaskListName,
 		ExecutionStartToCloseTimeout: workflowTimeout,
+		Memo: map[string]interface{}{
+			common.MemoKeyForOperator: getOperator(),
+		},
 	}
 	foParams := failovermanager.FailoverParams{
 		TargetCluster:                  targetCluster,
@@ -262,4 +266,13 @@ func getRunID(c *cli.Context) string {
 		return c.String(FlagRunID)
 	}
 	return ""
+}
+
+func getOperator() string {
+	user, err := user.Current()
+	if err != nil {
+		ErrorAndExit("Unable to get operator info", err)
+	}
+
+	return fmt.Sprintf("%s (username: %s)", user.Name, user.Username)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When team perform managed failover, operator info will be auto recorded and quarable.
![image](https://user-images.githubusercontent.com/1283368/95796973-2121d500-0ca3-11eb-85cc-9a17f2c51cc4.png)


<!-- Tell your future self why have you made these changes -->
**Why?**
People are interested in who did the failover for multiple reasons such learning or auditing 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risk

