### PR TITLE
Fix linter errors for generated internal types

### DIFF
--- a/common/types/errors.go
+++ b/common/types/errors.go
@@ -91,12 +91,12 @@ func (err RemoteSyncMatchedError) Error() string {
 func (err RetryTaskV2Error) Error() string {
 	return fmt.Sprintf("RetryTaskV2Error{Message: %v, DomainId: %v, WorkflowId: %v, RunId: %v, StartEventId: %v, StartEventVersion: %v, EndEventId: %v, EndEventVersion: %v}",
 		err.Message,
-		err.DomainId,
-		err.WorkflowId,
-		err.RunId,
-		err.StartEventId,
+		err.DomainID,
+		err.WorkflowID,
+		err.RunID,
+		err.StartEventID,
 		err.StartEventVersion,
-		err.EndEventId,
+		err.EndEventID,
 		err.EndEventVersion,
 	)
 }
@@ -108,7 +108,7 @@ func (err ServiceBusyError) Error() string {
 func (err WorkflowExecutionAlreadyStartedError) Error() string {
 	return fmt.Sprintf("WorkflowExecutionAlreadyStartedError{Message: %v, StartRequestId: %v, RunId: %v}",
 		err.Message,
-		err.StartRequestId,
-		err.RunId,
+		err.StartRequestID,
+		err.RunID,
 	)
 }

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -52,8 +52,8 @@ func FromActivityTaskCancelRequestedEventAttributes(t *types.ActivityTaskCancelR
 		return nil
 	}
 	return &shared.ActivityTaskCancelRequestedEventAttributes{
-		ActivityId:                   t.ActivityId,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		ActivityId:                   t.ActivityID,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 	}
 }
 
@@ -63,8 +63,8 @@ func ToActivityTaskCancelRequestedEventAttributes(t *shared.ActivityTaskCancelRe
 		return nil
 	}
 	return &types.ActivityTaskCancelRequestedEventAttributes{
-		ActivityId:                   t.ActivityId,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		ActivityID:                   t.ActivityId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 	}
 }
 
@@ -75,9 +75,9 @@ func FromActivityTaskCanceledEventAttributes(t *types.ActivityTaskCanceledEventA
 	}
 	return &shared.ActivityTaskCanceledEventAttributes{
 		Details:                      t.Details,
-		LatestCancelRequestedEventId: t.LatestCancelRequestedEventId,
-		ScheduledEventId:             t.ScheduledEventId,
-		StartedEventId:               t.StartedEventId,
+		LatestCancelRequestedEventId: t.LatestCancelRequestedEventID,
+		ScheduledEventId:             t.ScheduledEventID,
+		StartedEventId:               t.StartedEventID,
 		Identity:                     t.Identity,
 	}
 }
@@ -89,9 +89,9 @@ func ToActivityTaskCanceledEventAttributes(t *shared.ActivityTaskCanceledEventAt
 	}
 	return &types.ActivityTaskCanceledEventAttributes{
 		Details:                      t.Details,
-		LatestCancelRequestedEventId: t.LatestCancelRequestedEventId,
-		ScheduledEventId:             t.ScheduledEventId,
-		StartedEventId:               t.StartedEventId,
+		LatestCancelRequestedEventID: t.LatestCancelRequestedEventId,
+		ScheduledEventID:             t.ScheduledEventId,
+		StartedEventID:               t.StartedEventId,
 		Identity:                     t.Identity,
 	}
 }
@@ -103,8 +103,8 @@ func FromActivityTaskCompletedEventAttributes(t *types.ActivityTaskCompletedEven
 	}
 	return &shared.ActivityTaskCompletedEventAttributes{
 		Result:           t.Result,
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventId: t.ScheduledEventID,
+		StartedEventId:   t.StartedEventID,
 		Identity:         t.Identity,
 	}
 }
@@ -116,8 +116,8 @@ func ToActivityTaskCompletedEventAttributes(t *shared.ActivityTaskCompletedEvent
 	}
 	return &types.ActivityTaskCompletedEventAttributes{
 		Result:           t.Result,
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventID: t.ScheduledEventId,
+		StartedEventID:   t.StartedEventId,
 		Identity:         t.Identity,
 	}
 }
@@ -130,8 +130,8 @@ func FromActivityTaskFailedEventAttributes(t *types.ActivityTaskFailedEventAttri
 	return &shared.ActivityTaskFailedEventAttributes{
 		Reason:           t.Reason,
 		Details:          t.Details,
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventId: t.ScheduledEventID,
+		StartedEventId:   t.StartedEventID,
 		Identity:         t.Identity,
 	}
 }
@@ -144,8 +144,8 @@ func ToActivityTaskFailedEventAttributes(t *shared.ActivityTaskFailedEventAttrib
 	return &types.ActivityTaskFailedEventAttributes{
 		Reason:           t.Reason,
 		Details:          t.Details,
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventID: t.ScheduledEventId,
+		StartedEventID:   t.StartedEventId,
 		Identity:         t.Identity,
 	}
 }
@@ -156,7 +156,7 @@ func FromActivityTaskScheduledEventAttributes(t *types.ActivityTaskScheduledEven
 		return nil
 	}
 	return &shared.ActivityTaskScheduledEventAttributes{
-		ActivityId:                    t.ActivityId,
+		ActivityId:                    t.ActivityID,
 		ActivityType:                  FromActivityType(t.ActivityType),
 		Domain:                        t.Domain,
 		TaskList:                      FromTaskList(t.TaskList),
@@ -165,7 +165,7 @@ func FromActivityTaskScheduledEventAttributes(t *types.ActivityTaskScheduledEven
 		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
 		StartToCloseTimeoutSeconds:    t.StartToCloseTimeoutSeconds,
 		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
-		DecisionTaskCompletedEventId:  t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId:  t.DecisionTaskCompletedEventID,
 		RetryPolicy:                   FromRetryPolicy(t.RetryPolicy),
 		Header:                        FromHeader(t.Header),
 	}
@@ -177,7 +177,7 @@ func ToActivityTaskScheduledEventAttributes(t *shared.ActivityTaskScheduledEvent
 		return nil
 	}
 	return &types.ActivityTaskScheduledEventAttributes{
-		ActivityId:                    t.ActivityId,
+		ActivityID:                    t.ActivityId,
 		ActivityType:                  ToActivityType(t.ActivityType),
 		Domain:                        t.Domain,
 		TaskList:                      ToTaskList(t.TaskList),
@@ -186,7 +186,7 @@ func ToActivityTaskScheduledEventAttributes(t *shared.ActivityTaskScheduledEvent
 		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
 		StartToCloseTimeoutSeconds:    t.StartToCloseTimeoutSeconds,
 		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
-		DecisionTaskCompletedEventId:  t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID:  t.DecisionTaskCompletedEventId,
 		RetryPolicy:                   ToRetryPolicy(t.RetryPolicy),
 		Header:                        ToHeader(t.Header),
 	}
@@ -198,9 +198,9 @@ func FromActivityTaskStartedEventAttributes(t *types.ActivityTaskStartedEventAtt
 		return nil
 	}
 	return &shared.ActivityTaskStartedEventAttributes{
-		ScheduledEventId:   t.ScheduledEventId,
+		ScheduledEventId:   t.ScheduledEventID,
 		Identity:           t.Identity,
-		RequestId:          t.RequestId,
+		RequestId:          t.RequestID,
 		Attempt:            t.Attempt,
 		LastFailureReason:  t.LastFailureReason,
 		LastFailureDetails: t.LastFailureDetails,
@@ -213,9 +213,9 @@ func ToActivityTaskStartedEventAttributes(t *shared.ActivityTaskStartedEventAttr
 		return nil
 	}
 	return &types.ActivityTaskStartedEventAttributes{
-		ScheduledEventId:   t.ScheduledEventId,
+		ScheduledEventID:   t.ScheduledEventId,
 		Identity:           t.Identity,
-		RequestId:          t.RequestId,
+		RequestID:          t.RequestId,
 		Attempt:            t.Attempt,
 		LastFailureReason:  t.LastFailureReason,
 		LastFailureDetails: t.LastFailureDetails,
@@ -229,8 +229,8 @@ func FromActivityTaskTimedOutEventAttributes(t *types.ActivityTaskTimedOutEventA
 	}
 	return &shared.ActivityTaskTimedOutEventAttributes{
 		Details:            t.Details,
-		ScheduledEventId:   t.ScheduledEventId,
-		StartedEventId:     t.StartedEventId,
+		ScheduledEventId:   t.ScheduledEventID,
+		StartedEventId:     t.StartedEventID,
 		TimeoutType:        FromTimeoutType(t.TimeoutType),
 		LastFailureReason:  t.LastFailureReason,
 		LastFailureDetails: t.LastFailureDetails,
@@ -244,8 +244,8 @@ func ToActivityTaskTimedOutEventAttributes(t *shared.ActivityTaskTimedOutEventAt
 	}
 	return &types.ActivityTaskTimedOutEventAttributes{
 		Details:            t.Details,
-		ScheduledEventId:   t.ScheduledEventId,
-		StartedEventId:     t.StartedEventId,
+		ScheduledEventID:   t.ScheduledEventId,
+		StartedEventID:     t.StartedEventId,
 		TimeoutType:        ToTimeoutType(t.TimeoutType),
 		LastFailureReason:  t.LastFailureReason,
 		LastFailureDetails: t.LastFailureDetails,
@@ -400,7 +400,7 @@ func FromCancelTimerDecisionAttributes(t *types.CancelTimerDecisionAttributes) *
 		return nil
 	}
 	return &shared.CancelTimerDecisionAttributes{
-		TimerId: t.TimerId,
+		TimerId: t.TimerID,
 	}
 }
 
@@ -410,7 +410,7 @@ func ToCancelTimerDecisionAttributes(t *shared.CancelTimerDecisionAttributes) *t
 		return nil
 	}
 	return &types.CancelTimerDecisionAttributes{
-		TimerId: t.TimerId,
+		TimerID: t.TimerId,
 	}
 }
 
@@ -420,9 +420,9 @@ func FromCancelTimerFailedEventAttributes(t *types.CancelTimerFailedEventAttribu
 		return nil
 	}
 	return &shared.CancelTimerFailedEventAttributes{
-		TimerId:                      t.TimerId,
+		TimerId:                      t.TimerID,
 		Cause:                        t.Cause,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Identity:                     t.Identity,
 	}
 }
@@ -433,9 +433,9 @@ func ToCancelTimerFailedEventAttributes(t *shared.CancelTimerFailedEventAttribut
 		return nil
 	}
 	return &types.CancelTimerFailedEventAttributes{
-		TimerId:                      t.TimerId,
+		TimerID:                      t.TimerId,
 		Cause:                        t.Cause,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Identity:                     t.Identity,
 	}
 }
@@ -490,8 +490,8 @@ func FromChildWorkflowExecutionCanceledEventAttributes(t *types.ChildWorkflowExe
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      FromWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
+		StartedEventId:    t.StartedEventID,
 	}
 }
 
@@ -505,8 +505,8 @@ func ToChildWorkflowExecutionCanceledEventAttributes(t *shared.ChildWorkflowExec
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      ToWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
+		StartedEventID:    t.StartedEventId,
 	}
 }
 
@@ -520,8 +520,8 @@ func FromChildWorkflowExecutionCompletedEventAttributes(t *types.ChildWorkflowEx
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      FromWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
+		StartedEventId:    t.StartedEventID,
 	}
 }
 
@@ -535,8 +535,8 @@ func ToChildWorkflowExecutionCompletedEventAttributes(t *shared.ChildWorkflowExe
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      ToWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
+		StartedEventID:    t.StartedEventId,
 	}
 }
 
@@ -577,8 +577,8 @@ func FromChildWorkflowExecutionFailedEventAttributes(t *types.ChildWorkflowExecu
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      FromWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
+		StartedEventId:    t.StartedEventID,
 	}
 }
 
@@ -593,8 +593,8 @@ func ToChildWorkflowExecutionFailedEventAttributes(t *shared.ChildWorkflowExecut
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      ToWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
+		StartedEventID:    t.StartedEventId,
 	}
 }
 
@@ -605,7 +605,7 @@ func FromChildWorkflowExecutionStartedEventAttributes(t *types.ChildWorkflowExec
 	}
 	return &shared.ChildWorkflowExecutionStartedEventAttributes{
 		Domain:            t.Domain,
-		InitiatedEventId:  t.InitiatedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      FromWorkflowType(t.WorkflowType),
 		Header:            FromHeader(t.Header),
@@ -619,7 +619,7 @@ func ToChildWorkflowExecutionStartedEventAttributes(t *shared.ChildWorkflowExecu
 	}
 	return &types.ChildWorkflowExecutionStartedEventAttributes{
 		Domain:            t.Domain,
-		InitiatedEventId:  t.InitiatedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      ToWorkflowType(t.WorkflowType),
 		Header:            ToHeader(t.Header),
@@ -635,8 +635,8 @@ func FromChildWorkflowExecutionTerminatedEventAttributes(t *types.ChildWorkflowE
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      FromWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
+		StartedEventId:    t.StartedEventID,
 	}
 }
 
@@ -649,8 +649,8 @@ func ToChildWorkflowExecutionTerminatedEventAttributes(t *shared.ChildWorkflowEx
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      ToWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
+		StartedEventID:    t.StartedEventId,
 	}
 }
 
@@ -664,8 +664,8 @@ func FromChildWorkflowExecutionTimedOutEventAttributes(t *types.ChildWorkflowExe
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      FromWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
+		StartedEventId:    t.StartedEventID,
 	}
 }
 
@@ -679,8 +679,8 @@ func ToChildWorkflowExecutionTimedOutEventAttributes(t *shared.ChildWorkflowExec
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:      ToWorkflowType(t.WorkflowType),
-		InitiatedEventId:  t.InitiatedEventId,
-		StartedEventId:    t.StartedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
+		StartedEventID:    t.StartedEventId,
 	}
 }
 
@@ -1013,8 +1013,8 @@ func FromDecisionTaskCompletedEventAttributes(t *types.DecisionTaskCompletedEven
 	}
 	return &shared.DecisionTaskCompletedEventAttributes{
 		ExecutionContext: t.ExecutionContext,
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventId: t.ScheduledEventID,
+		StartedEventId:   t.StartedEventID,
 		Identity:         t.Identity,
 		BinaryChecksum:   t.BinaryChecksum,
 	}
@@ -1027,8 +1027,8 @@ func ToDecisionTaskCompletedEventAttributes(t *shared.DecisionTaskCompletedEvent
 	}
 	return &types.DecisionTaskCompletedEventAttributes{
 		ExecutionContext: t.ExecutionContext,
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventID: t.ScheduledEventId,
+		StartedEventID:   t.StartedEventId,
 		Identity:         t.Identity,
 		BinaryChecksum:   t.BinaryChecksum,
 	}
@@ -1198,14 +1198,14 @@ func FromDecisionTaskFailedEventAttributes(t *types.DecisionTaskFailedEventAttri
 		return nil
 	}
 	return &shared.DecisionTaskFailedEventAttributes{
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventId: t.ScheduledEventID,
+		StartedEventId:   t.StartedEventID,
 		Cause:            FromDecisionTaskFailedCause(t.Cause),
 		Details:          t.Details,
 		Identity:         t.Identity,
 		Reason:           t.Reason,
-		BaseRunId:        t.BaseRunId,
-		NewRunId:         t.NewRunId,
+		BaseRunId:        t.BaseRunID,
+		NewRunId:         t.NewRunID,
 		ForkEventVersion: t.ForkEventVersion,
 		BinaryChecksum:   t.BinaryChecksum,
 	}
@@ -1217,14 +1217,14 @@ func ToDecisionTaskFailedEventAttributes(t *shared.DecisionTaskFailedEventAttrib
 		return nil
 	}
 	return &types.DecisionTaskFailedEventAttributes{
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventID: t.ScheduledEventId,
+		StartedEventID:   t.StartedEventId,
 		Cause:            ToDecisionTaskFailedCause(t.Cause),
 		Details:          t.Details,
 		Identity:         t.Identity,
 		Reason:           t.Reason,
-		BaseRunId:        t.BaseRunId,
-		NewRunId:         t.NewRunId,
+		BaseRunID:        t.BaseRunId,
+		NewRunID:         t.NewRunId,
 		ForkEventVersion: t.ForkEventVersion,
 		BinaryChecksum:   t.BinaryChecksum,
 	}
@@ -1260,9 +1260,9 @@ func FromDecisionTaskStartedEventAttributes(t *types.DecisionTaskStartedEventAtt
 		return nil
 	}
 	return &shared.DecisionTaskStartedEventAttributes{
-		ScheduledEventId: t.ScheduledEventId,
+		ScheduledEventId: t.ScheduledEventID,
 		Identity:         t.Identity,
-		RequestId:        t.RequestId,
+		RequestId:        t.RequestID,
 	}
 }
 
@@ -1272,9 +1272,9 @@ func ToDecisionTaskStartedEventAttributes(t *shared.DecisionTaskStartedEventAttr
 		return nil
 	}
 	return &types.DecisionTaskStartedEventAttributes{
-		ScheduledEventId: t.ScheduledEventId,
+		ScheduledEventID: t.ScheduledEventId,
 		Identity:         t.Identity,
-		RequestId:        t.RequestId,
+		RequestID:        t.RequestId,
 	}
 }
 
@@ -1284,8 +1284,8 @@ func FromDecisionTaskTimedOutEventAttributes(t *types.DecisionTaskTimedOutEventA
 		return nil
 	}
 	return &shared.DecisionTaskTimedOutEventAttributes{
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventId: t.ScheduledEventID,
+		StartedEventId:   t.StartedEventID,
 		TimeoutType:      FromTimeoutType(t.TimeoutType),
 	}
 }
@@ -1296,8 +1296,8 @@ func ToDecisionTaskTimedOutEventAttributes(t *shared.DecisionTaskTimedOutEventAt
 		return nil
 	}
 	return &types.DecisionTaskTimedOutEventAttributes{
-		ScheduledEventId: t.ScheduledEventId,
-		StartedEventId:   t.StartedEventId,
+		ScheduledEventID: t.ScheduledEventId,
+		StartedEventID:   t.StartedEventId,
 		TimeoutType:      ToTimeoutType(t.TimeoutType),
 	}
 }
@@ -1479,7 +1479,7 @@ func FromDescribeHistoryHostRequest(t *types.DescribeHistoryHostRequest) *shared
 	}
 	return &shared.DescribeHistoryHostRequest{
 		HostAddress:      t.HostAddress,
-		ShardIdForHost:   t.ShardIdForHost,
+		ShardIdForHost:   t.ShardIDForHost,
 		ExecutionForHost: FromWorkflowExecution(t.ExecutionForHost),
 	}
 }
@@ -1491,7 +1491,7 @@ func ToDescribeHistoryHostRequest(t *shared.DescribeHistoryHostRequest) *types.D
 	}
 	return &types.DescribeHistoryHostRequest{
 		HostAddress:      t.HostAddress,
-		ShardIdForHost:   t.ShardIdForHost,
+		ShardIDForHost:   t.ShardIdForHost,
 		ExecutionForHost: ToWorkflowExecution(t.ExecutionForHost),
 	}
 }
@@ -2188,7 +2188,7 @@ func FromExternalWorkflowExecutionCancelRequestedEventAttributes(t *types.Extern
 		return nil
 	}
 	return &shared.ExternalWorkflowExecutionCancelRequestedEventAttributes{
-		InitiatedEventId:  t.InitiatedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 	}
@@ -2200,7 +2200,7 @@ func ToExternalWorkflowExecutionCancelRequestedEventAttributes(t *shared.Externa
 		return nil
 	}
 	return &types.ExternalWorkflowExecutionCancelRequestedEventAttributes{
-		InitiatedEventId:  t.InitiatedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 	}
@@ -2212,7 +2212,7 @@ func FromExternalWorkflowExecutionSignaledEventAttributes(t *types.ExternalWorkf
 		return nil
 	}
 	return &shared.ExternalWorkflowExecutionSignaledEventAttributes{
-		InitiatedEventId:  t.InitiatedEventId,
+		InitiatedEventId:  t.InitiatedEventID,
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		Control:           t.Control,
@@ -2225,7 +2225,7 @@ func ToExternalWorkflowExecutionSignaledEventAttributes(t *shared.ExternalWorkfl
 		return nil
 	}
 	return &types.ExternalWorkflowExecutionSignaledEventAttributes{
-		InitiatedEventId:  t.InitiatedEventId,
+		InitiatedEventID:  t.InitiatedEventId,
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		Control:           t.Control,
@@ -2426,11 +2426,11 @@ func FromHistoryEvent(t *types.HistoryEvent) *shared.HistoryEvent {
 		return nil
 	}
 	return &shared.HistoryEvent{
-		EventId:                                 t.EventId,
+		EventId:                                 t.EventID,
 		Timestamp:                               t.Timestamp,
 		EventType:                               FromEventType(t.EventType),
 		Version:                                 t.Version,
-		TaskId:                                  t.TaskId,
+		TaskId:                                  t.TaskID,
 		WorkflowExecutionStartedEventAttributes: FromWorkflowExecutionStartedEventAttributes(t.WorkflowExecutionStartedEventAttributes),
 		WorkflowExecutionCompletedEventAttributes:                      FromWorkflowExecutionCompletedEventAttributes(t.WorkflowExecutionCompletedEventAttributes),
 		WorkflowExecutionFailedEventAttributes:                         FromWorkflowExecutionFailedEventAttributes(t.WorkflowExecutionFailedEventAttributes),
@@ -2482,11 +2482,11 @@ func ToHistoryEvent(t *shared.HistoryEvent) *types.HistoryEvent {
 		return nil
 	}
 	return &types.HistoryEvent{
-		EventId:                                 t.EventId,
+		EventID:                                 t.EventId,
 		Timestamp:                               t.Timestamp,
 		EventType:                               ToEventType(t.EventType),
 		Version:                                 t.Version,
-		TaskId:                                  t.TaskId,
+		TaskID:                                  t.TaskId,
 		WorkflowExecutionStartedEventAttributes: ToWorkflowExecutionStartedEventAttributes(t.WorkflowExecutionStartedEventAttributes),
 		WorkflowExecutionCompletedEventAttributes:                      ToWorkflowExecutionCompletedEventAttributes(t.WorkflowExecutionCompletedEventAttributes),
 		WorkflowExecutionFailedEventAttributes:                         ToWorkflowExecutionFailedEventAttributes(t.WorkflowExecutionFailedEventAttributes),
@@ -2962,7 +2962,7 @@ func FromMarkerRecordedEventAttributes(t *types.MarkerRecordedEventAttributes) *
 	return &shared.MarkerRecordedEventAttributes{
 		MarkerName:                   t.MarkerName,
 		Details:                      t.Details,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Header:                       FromHeader(t.Header),
 	}
 }
@@ -2975,7 +2975,7 @@ func ToMarkerRecordedEventAttributes(t *shared.MarkerRecordedEventAttributes) *t
 	return &types.MarkerRecordedEventAttributes{
 		MarkerName:                   t.MarkerName,
 		Details:                      t.Details,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Header:                       ToHeader(t.Header),
 	}
 }
@@ -3182,7 +3182,7 @@ func FromPollForActivityTaskResponse(t *types.PollForActivityTaskResponse) *shar
 	return &shared.PollForActivityTaskResponse{
 		TaskToken:                       t.TaskToken,
 		WorkflowExecution:               FromWorkflowExecution(t.WorkflowExecution),
-		ActivityId:                      t.ActivityId,
+		ActivityId:                      t.ActivityID,
 		ActivityType:                    FromActivityType(t.ActivityType),
 		Input:                           t.Input,
 		ScheduledTimestamp:              t.ScheduledTimestamp,
@@ -3207,7 +3207,7 @@ func ToPollForActivityTaskResponse(t *shared.PollForActivityTaskResponse) *types
 	return &types.PollForActivityTaskResponse{
 		TaskToken:                       t.TaskToken,
 		WorkflowExecution:               ToWorkflowExecution(t.WorkflowExecution),
-		ActivityId:                      t.ActivityId,
+		ActivityID:                      t.ActivityId,
 		ActivityType:                    ToActivityType(t.ActivityType),
 		Input:                           t.Input,
 		ScheduledTimestamp:              t.ScheduledTimestamp,
@@ -3259,8 +3259,8 @@ func FromPollForDecisionTaskResponse(t *types.PollForDecisionTaskResponse) *shar
 		TaskToken:                 t.TaskToken,
 		WorkflowExecution:         FromWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:              FromWorkflowType(t.WorkflowType),
-		PreviousStartedEventId:    t.PreviousStartedEventId,
-		StartedEventId:            t.StartedEventId,
+		PreviousStartedEventId:    t.PreviousStartedEventID,
+		StartedEventId:            t.StartedEventID,
 		Attempt:                   t.Attempt,
 		BacklogCountHint:          t.BacklogCountHint,
 		History:                   FromHistory(t.History),
@@ -3282,8 +3282,8 @@ func ToPollForDecisionTaskResponse(t *shared.PollForDecisionTaskResponse) *types
 		TaskToken:                 t.TaskToken,
 		WorkflowExecution:         ToWorkflowExecution(t.WorkflowExecution),
 		WorkflowType:              ToWorkflowType(t.WorkflowType),
-		PreviousStartedEventId:    t.PreviousStartedEventId,
-		StartedEventId:            t.StartedEventId,
+		PreviousStartedEventID:    t.PreviousStartedEventId,
+		StartedEventID:            t.StartedEventId,
 		Attempt:                   t.Attempt,
 		BacklogCountHint:          t.BacklogCountHint,
 		History:                   ToHistory(t.History),
@@ -3780,7 +3780,7 @@ func FromRequestCancelActivityTaskDecisionAttributes(t *types.RequestCancelActiv
 		return nil
 	}
 	return &shared.RequestCancelActivityTaskDecisionAttributes{
-		ActivityId: t.ActivityId,
+		ActivityId: t.ActivityID,
 	}
 }
 
@@ -3790,7 +3790,7 @@ func ToRequestCancelActivityTaskDecisionAttributes(t *shared.RequestCancelActivi
 		return nil
 	}
 	return &types.RequestCancelActivityTaskDecisionAttributes{
-		ActivityId: t.ActivityId,
+		ActivityID: t.ActivityId,
 	}
 }
 
@@ -3800,9 +3800,9 @@ func FromRequestCancelActivityTaskFailedEventAttributes(t *types.RequestCancelAc
 		return nil
 	}
 	return &shared.RequestCancelActivityTaskFailedEventAttributes{
-		ActivityId:                   t.ActivityId,
+		ActivityId:                   t.ActivityID,
 		Cause:                        t.Cause,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 	}
 }
 
@@ -3812,9 +3812,9 @@ func ToRequestCancelActivityTaskFailedEventAttributes(t *shared.RequestCancelAct
 		return nil
 	}
 	return &types.RequestCancelActivityTaskFailedEventAttributes{
-		ActivityId:                   t.ActivityId,
+		ActivityID:                   t.ActivityId,
 		Cause:                        t.Cause,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 	}
 }
 
@@ -3825,8 +3825,8 @@ func FromRequestCancelExternalWorkflowExecutionDecisionAttributes(t *types.Reque
 	}
 	return &shared.RequestCancelExternalWorkflowExecutionDecisionAttributes{
 		Domain:            t.Domain,
-		WorkflowId:        t.WorkflowId,
-		RunId:             t.RunId,
+		WorkflowId:        t.WorkflowID,
+		RunId:             t.RunID,
 		Control:           t.Control,
 		ChildWorkflowOnly: t.ChildWorkflowOnly,
 	}
@@ -3839,8 +3839,8 @@ func ToRequestCancelExternalWorkflowExecutionDecisionAttributes(t *shared.Reques
 	}
 	return &types.RequestCancelExternalWorkflowExecutionDecisionAttributes{
 		Domain:            t.Domain,
-		WorkflowId:        t.WorkflowId,
-		RunId:             t.RunId,
+		WorkflowID:        t.WorkflowId,
+		RunID:             t.RunId,
 		Control:           t.Control,
 		ChildWorkflowOnly: t.ChildWorkflowOnly,
 	}
@@ -3853,10 +3853,10 @@ func FromRequestCancelExternalWorkflowExecutionFailedEventAttributes(t *types.Re
 	}
 	return &shared.RequestCancelExternalWorkflowExecutionFailedEventAttributes{
 		Cause:                        FromCancelExternalWorkflowExecutionFailedCause(t.Cause),
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Domain:                       t.Domain,
 		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
-		InitiatedEventId:             t.InitiatedEventId,
+		InitiatedEventId:             t.InitiatedEventID,
 		Control:                      t.Control,
 	}
 }
@@ -3868,10 +3868,10 @@ func ToRequestCancelExternalWorkflowExecutionFailedEventAttributes(t *shared.Req
 	}
 	return &types.RequestCancelExternalWorkflowExecutionFailedEventAttributes{
 		Cause:                        ToCancelExternalWorkflowExecutionFailedCause(t.Cause),
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Domain:                       t.Domain,
 		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
-		InitiatedEventId:             t.InitiatedEventId,
+		InitiatedEventID:             t.InitiatedEventId,
 		Control:                      t.Control,
 	}
 }
@@ -3882,7 +3882,7 @@ func FromRequestCancelExternalWorkflowExecutionInitiatedEventAttributes(t *types
 		return nil
 	}
 	return &shared.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Domain:                       t.Domain,
 		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
 		Control:                      t.Control,
@@ -3896,7 +3896,7 @@ func ToRequestCancelExternalWorkflowExecutionInitiatedEventAttributes(t *shared.
 		return nil
 	}
 	return &types.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Domain:                       t.Domain,
 		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
 		Control:                      t.Control,
@@ -3913,7 +3913,7 @@ func FromRequestCancelWorkflowExecutionRequest(t *types.RequestCancelWorkflowExe
 		Domain:            t.Domain,
 		WorkflowExecution: FromWorkflowExecution(t.WorkflowExecution),
 		Identity:          t.Identity,
-		RequestId:         t.RequestId,
+		RequestId:         t.RequestID,
 	}
 }
 
@@ -3926,7 +3926,7 @@ func ToRequestCancelWorkflowExecutionRequest(t *shared.RequestCancelWorkflowExec
 		Domain:            t.Domain,
 		WorkflowExecution: ToWorkflowExecution(t.WorkflowExecution),
 		Identity:          t.Identity,
-		RequestId:         t.RequestId,
+		RequestID:         t.RequestId,
 	}
 }
 
@@ -3937,8 +3937,8 @@ func FromResetPointInfo(t *types.ResetPointInfo) *shared.ResetPointInfo {
 	}
 	return &shared.ResetPointInfo{
 		BinaryChecksum:           t.BinaryChecksum,
-		RunId:                    t.RunId,
-		FirstDecisionCompletedId: t.FirstDecisionCompletedId,
+		RunId:                    t.RunID,
+		FirstDecisionCompletedId: t.FirstDecisionCompletedID,
 		CreatedTimeNano:          t.CreatedTimeNano,
 		ExpiringTimeNano:         t.ExpiringTimeNano,
 		Resettable:               t.Resettable,
@@ -3952,8 +3952,8 @@ func ToResetPointInfo(t *shared.ResetPointInfo) *types.ResetPointInfo {
 	}
 	return &types.ResetPointInfo{
 		BinaryChecksum:           t.BinaryChecksum,
-		RunId:                    t.RunId,
-		FirstDecisionCompletedId: t.FirstDecisionCompletedId,
+		RunID:                    t.RunId,
+		FirstDecisionCompletedID: t.FirstDecisionCompletedId,
 		CreatedTimeNano:          t.CreatedTimeNano,
 		ExpiringTimeNano:         t.ExpiringTimeNano,
 		Resettable:               t.Resettable,
@@ -4051,8 +4051,8 @@ func FromResetWorkflowExecutionRequest(t *types.ResetWorkflowExecutionRequest) *
 		Domain:                t.Domain,
 		WorkflowExecution:     FromWorkflowExecution(t.WorkflowExecution),
 		Reason:                t.Reason,
-		DecisionFinishEventId: t.DecisionFinishEventId,
-		RequestId:             t.RequestId,
+		DecisionFinishEventId: t.DecisionFinishEventID,
+		RequestId:             t.RequestID,
 	}
 }
 
@@ -4065,8 +4065,8 @@ func ToResetWorkflowExecutionRequest(t *shared.ResetWorkflowExecutionRequest) *t
 		Domain:                t.Domain,
 		WorkflowExecution:     ToWorkflowExecution(t.WorkflowExecution),
 		Reason:                t.Reason,
-		DecisionFinishEventId: t.DecisionFinishEventId,
-		RequestId:             t.RequestId,
+		DecisionFinishEventID: t.DecisionFinishEventId,
+		RequestID:             t.RequestId,
 	}
 }
 
@@ -4076,7 +4076,7 @@ func FromResetWorkflowExecutionResponse(t *types.ResetWorkflowExecutionResponse)
 		return nil
 	}
 	return &shared.ResetWorkflowExecutionResponse{
-		RunId: t.RunId,
+		RunId: t.RunID,
 	}
 }
 
@@ -4086,7 +4086,7 @@ func ToResetWorkflowExecutionResponse(t *shared.ResetWorkflowExecutionResponse) 
 		return nil
 	}
 	return &types.ResetWorkflowExecutionResponse{
-		RunId: t.RunId,
+		RunID: t.RunId,
 	}
 }
 
@@ -4405,12 +4405,12 @@ func FromRetryTaskV2Error(t *types.RetryTaskV2Error) *shared.RetryTaskV2Error {
 	}
 	return &shared.RetryTaskV2Error{
 		Message:           t.Message,
-		DomainId:          t.DomainId,
-		WorkflowId:        t.WorkflowId,
-		RunId:             t.RunId,
-		StartEventId:      t.StartEventId,
+		DomainId:          t.DomainID,
+		WorkflowId:        t.WorkflowID,
+		RunId:             t.RunID,
+		StartEventId:      t.StartEventID,
 		StartEventVersion: t.StartEventVersion,
-		EndEventId:        t.EndEventId,
+		EndEventId:        t.EndEventID,
 		EndEventVersion:   t.EndEventVersion,
 	}
 }
@@ -4422,12 +4422,12 @@ func ToRetryTaskV2Error(t *shared.RetryTaskV2Error) *types.RetryTaskV2Error {
 	}
 	return &types.RetryTaskV2Error{
 		Message:           t.Message,
-		DomainId:          t.DomainId,
-		WorkflowId:        t.WorkflowId,
-		RunId:             t.RunId,
-		StartEventId:      t.StartEventId,
+		DomainID:          t.DomainId,
+		WorkflowID:        t.WorkflowId,
+		RunID:             t.RunId,
+		StartEventID:      t.StartEventId,
 		StartEventVersion: t.StartEventVersion,
-		EndEventId:        t.EndEventId,
+		EndEventID:        t.EndEventId,
 		EndEventVersion:   t.EndEventVersion,
 	}
 }
@@ -4438,7 +4438,7 @@ func FromScheduleActivityTaskDecisionAttributes(t *types.ScheduleActivityTaskDec
 		return nil
 	}
 	return &shared.ScheduleActivityTaskDecisionAttributes{
-		ActivityId:                    t.ActivityId,
+		ActivityId:                    t.ActivityID,
 		ActivityType:                  FromActivityType(t.ActivityType),
 		Domain:                        t.Domain,
 		TaskList:                      FromTaskList(t.TaskList),
@@ -4458,7 +4458,7 @@ func ToScheduleActivityTaskDecisionAttributes(t *shared.ScheduleActivityTaskDeci
 		return nil
 	}
 	return &types.ScheduleActivityTaskDecisionAttributes{
-		ActivityId:                    t.ActivityId,
+		ActivityID:                    t.ActivityId,
 		ActivityType:                  ToActivityType(t.ActivityType),
 		Domain:                        t.Domain,
 		TaskList:                      ToTaskList(t.TaskList),
@@ -4575,10 +4575,10 @@ func FromSignalExternalWorkflowExecutionFailedEventAttributes(t *types.SignalExt
 	}
 	return &shared.SignalExternalWorkflowExecutionFailedEventAttributes{
 		Cause:                        FromSignalExternalWorkflowExecutionFailedCause(t.Cause),
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Domain:                       t.Domain,
 		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
-		InitiatedEventId:             t.InitiatedEventId,
+		InitiatedEventId:             t.InitiatedEventID,
 		Control:                      t.Control,
 	}
 }
@@ -4590,10 +4590,10 @@ func ToSignalExternalWorkflowExecutionFailedEventAttributes(t *shared.SignalExte
 	}
 	return &types.SignalExternalWorkflowExecutionFailedEventAttributes{
 		Cause:                        ToSignalExternalWorkflowExecutionFailedCause(t.Cause),
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Domain:                       t.Domain,
 		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
-		InitiatedEventId:             t.InitiatedEventId,
+		InitiatedEventID:             t.InitiatedEventId,
 		Control:                      t.Control,
 	}
 }
@@ -4604,7 +4604,7 @@ func FromSignalExternalWorkflowExecutionInitiatedEventAttributes(t *types.Signal
 		return nil
 	}
 	return &shared.SignalExternalWorkflowExecutionInitiatedEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Domain:                       t.Domain,
 		WorkflowExecution:            FromWorkflowExecution(t.WorkflowExecution),
 		SignalName:                   t.SignalName,
@@ -4620,7 +4620,7 @@ func ToSignalExternalWorkflowExecutionInitiatedEventAttributes(t *shared.SignalE
 		return nil
 	}
 	return &types.SignalExternalWorkflowExecutionInitiatedEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Domain:                       t.Domain,
 		WorkflowExecution:            ToWorkflowExecution(t.WorkflowExecution),
 		SignalName:                   t.SignalName,
@@ -4637,15 +4637,15 @@ func FromSignalWithStartWorkflowExecutionRequest(t *types.SignalWithStartWorkflo
 	}
 	return &shared.SignalWithStartWorkflowExecutionRequest{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowId:                          t.WorkflowID,
 		WorkflowType:                        FromWorkflowType(t.WorkflowType),
 		TaskList:                            FromTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		Identity:                            t.Identity,
-		RequestId:                           t.RequestId,
-		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RequestId:                           t.RequestID,
+		WorkflowIdReusePolicy:               FromWorkflowIDReusePolicy(t.WorkflowIDReusePolicy),
 		SignalName:                          t.SignalName,
 		SignalInput:                         t.SignalInput,
 		Control:                             t.Control,
@@ -4664,15 +4664,15 @@ func ToSignalWithStartWorkflowExecutionRequest(t *shared.SignalWithStartWorkflow
 	}
 	return &types.SignalWithStartWorkflowExecutionRequest{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowID:                          t.WorkflowId,
 		WorkflowType:                        ToWorkflowType(t.WorkflowType),
 		TaskList:                            ToTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		Identity:                            t.Identity,
-		RequestId:                           t.RequestId,
-		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RequestID:                           t.RequestId,
+		WorkflowIDReusePolicy:               ToWorkflowIDReusePolicy(t.WorkflowIdReusePolicy),
 		SignalName:                          t.SignalName,
 		SignalInput:                         t.SignalInput,
 		Control:                             t.Control,
@@ -4695,7 +4695,7 @@ func FromSignalWorkflowExecutionRequest(t *types.SignalWorkflowExecutionRequest)
 		SignalName:        t.SignalName,
 		Input:             t.Input,
 		Identity:          t.Identity,
-		RequestId:         t.RequestId,
+		RequestId:         t.RequestID,
 		Control:           t.Control,
 	}
 }
@@ -4711,7 +4711,7 @@ func ToSignalWorkflowExecutionRequest(t *shared.SignalWorkflowExecutionRequest) 
 		SignalName:        t.SignalName,
 		Input:             t.Input,
 		Identity:          t.Identity,
-		RequestId:         t.RequestId,
+		RequestID:         t.RequestId,
 		Control:           t.Control,
 	}
 }
@@ -4723,7 +4723,7 @@ func FromStartChildWorkflowExecutionDecisionAttributes(t *types.StartChildWorkfl
 	}
 	return &shared.StartChildWorkflowExecutionDecisionAttributes{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowId:                          t.WorkflowID,
 		WorkflowType:                        FromWorkflowType(t.WorkflowType),
 		TaskList:                            FromTaskList(t.TaskList),
 		Input:                               t.Input,
@@ -4731,7 +4731,7 @@ func FromStartChildWorkflowExecutionDecisionAttributes(t *types.StartChildWorkfl
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		ParentClosePolicy:                   FromParentClosePolicy(t.ParentClosePolicy),
 		Control:                             t.Control,
-		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		WorkflowIdReusePolicy:               FromWorkflowIDReusePolicy(t.WorkflowIDReusePolicy),
 		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
 		CronSchedule:                        t.CronSchedule,
 		Header:                              FromHeader(t.Header),
@@ -4747,7 +4747,7 @@ func ToStartChildWorkflowExecutionDecisionAttributes(t *shared.StartChildWorkflo
 	}
 	return &types.StartChildWorkflowExecutionDecisionAttributes{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowID:                          t.WorkflowId,
 		WorkflowType:                        ToWorkflowType(t.WorkflowType),
 		TaskList:                            ToTaskList(t.TaskList),
 		Input:                               t.Input,
@@ -4755,7 +4755,7 @@ func ToStartChildWorkflowExecutionDecisionAttributes(t *shared.StartChildWorkflo
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		ParentClosePolicy:                   ToParentClosePolicy(t.ParentClosePolicy),
 		Control:                             t.Control,
-		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		WorkflowIDReusePolicy:               ToWorkflowIDReusePolicy(t.WorkflowIdReusePolicy),
 		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
 		CronSchedule:                        t.CronSchedule,
 		Header:                              ToHeader(t.Header),
@@ -4771,12 +4771,12 @@ func FromStartChildWorkflowExecutionFailedEventAttributes(t *types.StartChildWor
 	}
 	return &shared.StartChildWorkflowExecutionFailedEventAttributes{
 		Domain:                       t.Domain,
-		WorkflowId:                   t.WorkflowId,
+		WorkflowId:                   t.WorkflowID,
 		WorkflowType:                 FromWorkflowType(t.WorkflowType),
 		Cause:                        FromChildWorkflowExecutionFailedCause(t.Cause),
 		Control:                      t.Control,
-		InitiatedEventId:             t.InitiatedEventId,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		InitiatedEventId:             t.InitiatedEventID,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 	}
 }
 
@@ -4787,12 +4787,12 @@ func ToStartChildWorkflowExecutionFailedEventAttributes(t *shared.StartChildWork
 	}
 	return &types.StartChildWorkflowExecutionFailedEventAttributes{
 		Domain:                       t.Domain,
-		WorkflowId:                   t.WorkflowId,
+		WorkflowID:                   t.WorkflowId,
 		WorkflowType:                 ToWorkflowType(t.WorkflowType),
 		Cause:                        ToChildWorkflowExecutionFailedCause(t.Cause),
 		Control:                      t.Control,
-		InitiatedEventId:             t.InitiatedEventId,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		InitiatedEventID:             t.InitiatedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 	}
 }
 
@@ -4803,7 +4803,7 @@ func FromStartChildWorkflowExecutionInitiatedEventAttributes(t *types.StartChild
 	}
 	return &shared.StartChildWorkflowExecutionInitiatedEventAttributes{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowId:                          t.WorkflowID,
 		WorkflowType:                        FromWorkflowType(t.WorkflowType),
 		TaskList:                            FromTaskList(t.TaskList),
 		Input:                               t.Input,
@@ -4811,8 +4811,8 @@ func FromStartChildWorkflowExecutionInitiatedEventAttributes(t *types.StartChild
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		ParentClosePolicy:                   FromParentClosePolicy(t.ParentClosePolicy),
 		Control:                             t.Control,
-		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
-		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventID,
+		WorkflowIdReusePolicy:               FromWorkflowIDReusePolicy(t.WorkflowIDReusePolicy),
 		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
 		CronSchedule:                        t.CronSchedule,
 		Header:                              FromHeader(t.Header),
@@ -4828,7 +4828,7 @@ func ToStartChildWorkflowExecutionInitiatedEventAttributes(t *shared.StartChildW
 	}
 	return &types.StartChildWorkflowExecutionInitiatedEventAttributes{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowID:                          t.WorkflowId,
 		WorkflowType:                        ToWorkflowType(t.WorkflowType),
 		TaskList:                            ToTaskList(t.TaskList),
 		Input:                               t.Input,
@@ -4836,8 +4836,8 @@ func ToStartChildWorkflowExecutionInitiatedEventAttributes(t *shared.StartChildW
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		ParentClosePolicy:                   ToParentClosePolicy(t.ParentClosePolicy),
 		Control:                             t.Control,
-		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
-		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		DecisionTaskCompletedEventID:        t.DecisionTaskCompletedEventId,
+		WorkflowIDReusePolicy:               ToWorkflowIDReusePolicy(t.WorkflowIdReusePolicy),
 		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
 		CronSchedule:                        t.CronSchedule,
 		Header:                              ToHeader(t.Header),
@@ -4874,7 +4874,7 @@ func FromStartTimerDecisionAttributes(t *types.StartTimerDecisionAttributes) *sh
 		return nil
 	}
 	return &shared.StartTimerDecisionAttributes{
-		TimerId:                   t.TimerId,
+		TimerId:                   t.TimerID,
 		StartToFireTimeoutSeconds: t.StartToFireTimeoutSeconds,
 	}
 }
@@ -4885,7 +4885,7 @@ func ToStartTimerDecisionAttributes(t *shared.StartTimerDecisionAttributes) *typ
 		return nil
 	}
 	return &types.StartTimerDecisionAttributes{
-		TimerId:                   t.TimerId,
+		TimerID:                   t.TimerId,
 		StartToFireTimeoutSeconds: t.StartToFireTimeoutSeconds,
 	}
 }
@@ -4897,15 +4897,15 @@ func FromStartWorkflowExecutionRequest(t *types.StartWorkflowExecutionRequest) *
 	}
 	return &shared.StartWorkflowExecutionRequest{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowId:                          t.WorkflowID,
 		WorkflowType:                        FromWorkflowType(t.WorkflowType),
 		TaskList:                            FromTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		Identity:                            t.Identity,
-		RequestId:                           t.RequestId,
-		WorkflowIdReusePolicy:               FromWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RequestId:                           t.RequestID,
+		WorkflowIdReusePolicy:               FromWorkflowIDReusePolicy(t.WorkflowIDReusePolicy),
 		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
 		CronSchedule:                        t.CronSchedule,
 		Memo:                                FromMemo(t.Memo),
@@ -4921,15 +4921,15 @@ func ToStartWorkflowExecutionRequest(t *shared.StartWorkflowExecutionRequest) *t
 	}
 	return &types.StartWorkflowExecutionRequest{
 		Domain:                              t.Domain,
-		WorkflowId:                          t.WorkflowId,
+		WorkflowID:                          t.WorkflowId,
 		WorkflowType:                        ToWorkflowType(t.WorkflowType),
 		TaskList:                            ToTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
 		Identity:                            t.Identity,
-		RequestId:                           t.RequestId,
-		WorkflowIdReusePolicy:               ToWorkflowIdReusePolicy(t.WorkflowIdReusePolicy),
+		RequestID:                           t.RequestId,
+		WorkflowIDReusePolicy:               ToWorkflowIDReusePolicy(t.WorkflowIdReusePolicy),
 		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
 		CronSchedule:                        t.CronSchedule,
 		Memo:                                ToMemo(t.Memo),
@@ -4944,7 +4944,7 @@ func FromStartWorkflowExecutionResponse(t *types.StartWorkflowExecutionResponse)
 		return nil
 	}
 	return &shared.StartWorkflowExecutionResponse{
-		RunId: t.RunId,
+		RunId: t.RunID,
 	}
 }
 
@@ -4954,7 +4954,7 @@ func ToStartWorkflowExecutionResponse(t *shared.StartWorkflowExecutionResponse) 
 		return nil
 	}
 	return &types.StartWorkflowExecutionResponse{
-		RunId: t.RunId,
+		RunID: t.RunId,
 	}
 }
 
@@ -5258,9 +5258,9 @@ func FromTimerCanceledEventAttributes(t *types.TimerCanceledEventAttributes) *sh
 		return nil
 	}
 	return &shared.TimerCanceledEventAttributes{
-		TimerId:                      t.TimerId,
-		StartedEventId:               t.StartedEventId,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		TimerId:                      t.TimerID,
+		StartedEventId:               t.StartedEventID,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Identity:                     t.Identity,
 	}
 }
@@ -5271,9 +5271,9 @@ func ToTimerCanceledEventAttributes(t *shared.TimerCanceledEventAttributes) *typ
 		return nil
 	}
 	return &types.TimerCanceledEventAttributes{
-		TimerId:                      t.TimerId,
-		StartedEventId:               t.StartedEventId,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		TimerID:                      t.TimerId,
+		StartedEventID:               t.StartedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Identity:                     t.Identity,
 	}
 }
@@ -5284,8 +5284,8 @@ func FromTimerFiredEventAttributes(t *types.TimerFiredEventAttributes) *shared.T
 		return nil
 	}
 	return &shared.TimerFiredEventAttributes{
-		TimerId:        t.TimerId,
-		StartedEventId: t.StartedEventId,
+		TimerId:        t.TimerID,
+		StartedEventId: t.StartedEventID,
 	}
 }
 
@@ -5295,8 +5295,8 @@ func ToTimerFiredEventAttributes(t *shared.TimerFiredEventAttributes) *types.Tim
 		return nil
 	}
 	return &types.TimerFiredEventAttributes{
-		TimerId:        t.TimerId,
-		StartedEventId: t.StartedEventId,
+		TimerID:        t.TimerId,
+		StartedEventID: t.StartedEventId,
 	}
 }
 
@@ -5306,9 +5306,9 @@ func FromTimerStartedEventAttributes(t *types.TimerStartedEventAttributes) *shar
 		return nil
 	}
 	return &shared.TimerStartedEventAttributes{
-		TimerId:                      t.TimerId,
+		TimerId:                      t.TimerID,
 		StartToFireTimeoutSeconds:    t.StartToFireTimeoutSeconds,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 	}
 }
 
@@ -5318,9 +5318,9 @@ func ToTimerStartedEventAttributes(t *shared.TimerStartedEventAttributes) *types
 		return nil
 	}
 	return &types.TimerStartedEventAttributes{
-		TimerId:                      t.TimerId,
+		TimerID:                      t.TimerId,
 		StartToFireTimeoutSeconds:    t.StartToFireTimeoutSeconds,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 	}
 }
 
@@ -5456,7 +5456,7 @@ func FromUpsertWorkflowSearchAttributesEventAttributes(t *types.UpsertWorkflowSe
 		return nil
 	}
 	return &shared.UpsertWorkflowSearchAttributesEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		SearchAttributes:             FromSearchAttributes(t.SearchAttributes),
 	}
 }
@@ -5467,7 +5467,7 @@ func ToUpsertWorkflowSearchAttributesEventAttributes(t *shared.UpsertWorkflowSea
 		return nil
 	}
 	return &types.UpsertWorkflowSearchAttributesEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		SearchAttributes:             ToSearchAttributes(t.SearchAttributes),
 	}
 }
@@ -5566,8 +5566,8 @@ func FromWorkflowExecution(t *types.WorkflowExecution) *shared.WorkflowExecution
 		return nil
 	}
 	return &shared.WorkflowExecution{
-		WorkflowId: t.WorkflowId,
-		RunId:      t.RunId,
+		WorkflowId: t.WorkflowID,
+		RunId:      t.RunID,
 	}
 }
 
@@ -5577,8 +5577,8 @@ func ToWorkflowExecution(t *shared.WorkflowExecution) *types.WorkflowExecution {
 		return nil
 	}
 	return &types.WorkflowExecution{
-		WorkflowId: t.WorkflowId,
-		RunId:      t.RunId,
+		WorkflowID: t.WorkflowId,
+		RunID:      t.RunId,
 	}
 }
 
@@ -5589,8 +5589,8 @@ func FromWorkflowExecutionAlreadyStartedError(t *types.WorkflowExecutionAlreadyS
 	}
 	return &shared.WorkflowExecutionAlreadyStartedError{
 		Message:        t.Message,
-		StartRequestId: t.StartRequestId,
-		RunId:          t.RunId,
+		StartRequestId: t.StartRequestID,
+		RunId:          t.RunID,
 	}
 }
 
@@ -5601,8 +5601,8 @@ func ToWorkflowExecutionAlreadyStartedError(t *shared.WorkflowExecutionAlreadySt
 	}
 	return &types.WorkflowExecutionAlreadyStartedError{
 		Message:        t.Message,
-		StartRequestId: t.StartRequestId,
-		RunId:          t.RunId,
+		StartRequestID: t.StartRequestId,
+		RunID:          t.RunId,
 	}
 }
 
@@ -5613,7 +5613,7 @@ func FromWorkflowExecutionCancelRequestedEventAttributes(t *types.WorkflowExecut
 	}
 	return &shared.WorkflowExecutionCancelRequestedEventAttributes{
 		Cause:                     t.Cause,
-		ExternalInitiatedEventId:  t.ExternalInitiatedEventId,
+		ExternalInitiatedEventId:  t.ExternalInitiatedEventID,
 		ExternalWorkflowExecution: FromWorkflowExecution(t.ExternalWorkflowExecution),
 		Identity:                  t.Identity,
 	}
@@ -5626,7 +5626,7 @@ func ToWorkflowExecutionCancelRequestedEventAttributes(t *shared.WorkflowExecuti
 	}
 	return &types.WorkflowExecutionCancelRequestedEventAttributes{
 		Cause:                     t.Cause,
-		ExternalInitiatedEventId:  t.ExternalInitiatedEventId,
+		ExternalInitiatedEventID:  t.ExternalInitiatedEventId,
 		ExternalWorkflowExecution: ToWorkflowExecution(t.ExternalWorkflowExecution),
 		Identity:                  t.Identity,
 	}
@@ -5638,7 +5638,7 @@ func FromWorkflowExecutionCanceledEventAttributes(t *types.WorkflowExecutionCanc
 		return nil
 	}
 	return &shared.WorkflowExecutionCanceledEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 		Details:                      t.Details,
 	}
 }
@@ -5649,7 +5649,7 @@ func ToWorkflowExecutionCanceledEventAttributes(t *shared.WorkflowExecutionCance
 		return nil
 	}
 	return &types.WorkflowExecutionCanceledEventAttributes{
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 		Details:                      t.Details,
 	}
 }
@@ -5717,7 +5717,7 @@ func FromWorkflowExecutionCompletedEventAttributes(t *types.WorkflowExecutionCom
 	}
 	return &shared.WorkflowExecutionCompletedEventAttributes{
 		Result:                       t.Result,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 	}
 }
 
@@ -5728,7 +5728,7 @@ func ToWorkflowExecutionCompletedEventAttributes(t *shared.WorkflowExecutionComp
 	}
 	return &types.WorkflowExecutionCompletedEventAttributes{
 		Result:                       t.Result,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 	}
 }
 
@@ -5762,13 +5762,13 @@ func FromWorkflowExecutionContinuedAsNewEventAttributes(t *types.WorkflowExecuti
 		return nil
 	}
 	return &shared.WorkflowExecutionContinuedAsNewEventAttributes{
-		NewExecutionRunId:                   t.NewExecutionRunId,
+		NewExecutionRunId:                   t.NewExecutionRunID,
 		WorkflowType:                        FromWorkflowType(t.WorkflowType),
 		TaskList:                            FromTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
-		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventID,
 		BackoffStartIntervalInSeconds:       t.BackoffStartIntervalInSeconds,
 		Initiator:                           FromContinueAsNewInitiator(t.Initiator),
 		FailureReason:                       t.FailureReason,
@@ -5786,13 +5786,13 @@ func ToWorkflowExecutionContinuedAsNewEventAttributes(t *shared.WorkflowExecutio
 		return nil
 	}
 	return &types.WorkflowExecutionContinuedAsNewEventAttributes{
-		NewExecutionRunId:                   t.NewExecutionRunId,
+		NewExecutionRunID:                   t.NewExecutionRunId,
 		WorkflowType:                        ToWorkflowType(t.WorkflowType),
 		TaskList:                            ToTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
-		DecisionTaskCompletedEventId:        t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID:        t.DecisionTaskCompletedEventId,
 		BackoffStartIntervalInSeconds:       t.BackoffStartIntervalInSeconds,
 		Initiator:                           ToContinueAsNewInitiator(t.Initiator),
 		FailureReason:                       t.FailureReason,
@@ -5812,7 +5812,7 @@ func FromWorkflowExecutionFailedEventAttributes(t *types.WorkflowExecutionFailed
 	return &shared.WorkflowExecutionFailedEventAttributes{
 		Reason:                       t.Reason,
 		Details:                      t.Details,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventID,
 	}
 }
 
@@ -5824,7 +5824,7 @@ func ToWorkflowExecutionFailedEventAttributes(t *shared.WorkflowExecutionFailedE
 	return &types.WorkflowExecutionFailedEventAttributes{
 		Reason:                       t.Reason,
 		Details:                      t.Details,
-		DecisionTaskCompletedEventId: t.DecisionTaskCompletedEventId,
+		DecisionTaskCompletedEventID: t.DecisionTaskCompletedEventId,
 	}
 }
 
@@ -5834,8 +5834,8 @@ func FromWorkflowExecutionFilter(t *types.WorkflowExecutionFilter) *shared.Workf
 		return nil
 	}
 	return &shared.WorkflowExecutionFilter{
-		WorkflowId: t.WorkflowId,
-		RunId:      t.RunId,
+		WorkflowId: t.WorkflowID,
+		RunId:      t.RunID,
 	}
 }
 
@@ -5845,8 +5845,8 @@ func ToWorkflowExecutionFilter(t *shared.WorkflowExecutionFilter) *types.Workflo
 		return nil
 	}
 	return &types.WorkflowExecutionFilter{
-		WorkflowId: t.WorkflowId,
-		RunId:      t.RunId,
+		WorkflowID: t.WorkflowId,
+		RunID:      t.RunId,
 	}
 }
 
@@ -5862,7 +5862,7 @@ func FromWorkflowExecutionInfo(t *types.WorkflowExecutionInfo) *shared.WorkflowE
 		CloseTime:        t.CloseTime,
 		CloseStatus:      FromWorkflowExecutionCloseStatus(t.CloseStatus),
 		HistoryLength:    t.HistoryLength,
-		ParentDomainId:   t.ParentDomainId,
+		ParentDomainId:   t.ParentDomainID,
 		ParentExecution:  FromWorkflowExecution(t.ParentExecution),
 		ExecutionTime:    t.ExecutionTime,
 		Memo:             FromMemo(t.Memo),
@@ -5884,7 +5884,7 @@ func ToWorkflowExecutionInfo(t *shared.WorkflowExecutionInfo) *types.WorkflowExe
 		CloseTime:        t.CloseTime,
 		CloseStatus:      ToWorkflowExecutionCloseStatus(t.CloseStatus),
 		HistoryLength:    t.HistoryLength,
-		ParentDomainId:   t.ParentDomainId,
+		ParentDomainID:   t.ParentDomainId,
 		ParentExecution:  ToWorkflowExecution(t.ParentExecution),
 		ExecutionTime:    t.ExecutionTime,
 		Memo:             ToMemo(t.Memo),
@@ -5927,19 +5927,19 @@ func FromWorkflowExecutionStartedEventAttributes(t *types.WorkflowExecutionStart
 		WorkflowType:                        FromWorkflowType(t.WorkflowType),
 		ParentWorkflowDomain:                t.ParentWorkflowDomain,
 		ParentWorkflowExecution:             FromWorkflowExecution(t.ParentWorkflowExecution),
-		ParentInitiatedEventId:              t.ParentInitiatedEventId,
+		ParentInitiatedEventId:              t.ParentInitiatedEventID,
 		TaskList:                            FromTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
-		ContinuedExecutionRunId:             t.ContinuedExecutionRunId,
+		ContinuedExecutionRunId:             t.ContinuedExecutionRunID,
 		Initiator:                           FromContinueAsNewInitiator(t.Initiator),
 		ContinuedFailureReason:              t.ContinuedFailureReason,
 		ContinuedFailureDetails:             t.ContinuedFailureDetails,
 		LastCompletionResult:                t.LastCompletionResult,
-		OriginalExecutionRunId:              t.OriginalExecutionRunId,
+		OriginalExecutionRunId:              t.OriginalExecutionRunID,
 		Identity:                            t.Identity,
-		FirstExecutionRunId:                 t.FirstExecutionRunId,
+		FirstExecutionRunId:                 t.FirstExecutionRunID,
 		RetryPolicy:                         FromRetryPolicy(t.RetryPolicy),
 		Attempt:                             t.Attempt,
 		ExpirationTimestamp:                 t.ExpirationTimestamp,
@@ -5961,19 +5961,19 @@ func ToWorkflowExecutionStartedEventAttributes(t *shared.WorkflowExecutionStarte
 		WorkflowType:                        ToWorkflowType(t.WorkflowType),
 		ParentWorkflowDomain:                t.ParentWorkflowDomain,
 		ParentWorkflowExecution:             ToWorkflowExecution(t.ParentWorkflowExecution),
-		ParentInitiatedEventId:              t.ParentInitiatedEventId,
+		ParentInitiatedEventID:              t.ParentInitiatedEventId,
 		TaskList:                            ToTaskList(t.TaskList),
 		Input:                               t.Input,
 		ExecutionStartToCloseTimeoutSeconds: t.ExecutionStartToCloseTimeoutSeconds,
 		TaskStartToCloseTimeoutSeconds:      t.TaskStartToCloseTimeoutSeconds,
-		ContinuedExecutionRunId:             t.ContinuedExecutionRunId,
+		ContinuedExecutionRunID:             t.ContinuedExecutionRunId,
 		Initiator:                           ToContinueAsNewInitiator(t.Initiator),
 		ContinuedFailureReason:              t.ContinuedFailureReason,
 		ContinuedFailureDetails:             t.ContinuedFailureDetails,
 		LastCompletionResult:                t.LastCompletionResult,
-		OriginalExecutionRunId:              t.OriginalExecutionRunId,
+		OriginalExecutionRunID:              t.OriginalExecutionRunId,
 		Identity:                            t.Identity,
-		FirstExecutionRunId:                 t.FirstExecutionRunId,
+		FirstExecutionRunID:                 t.FirstExecutionRunId,
 		RetryPolicy:                         ToRetryPolicy(t.RetryPolicy),
 		Attempt:                             t.Attempt,
 		ExpirationTimestamp:                 t.ExpirationTimestamp,
@@ -6030,45 +6030,45 @@ func ToWorkflowExecutionTimedOutEventAttributes(t *shared.WorkflowExecutionTimed
 	}
 }
 
-// FromWorkflowIdReusePolicy converts internal WorkflowIdReusePolicy type to thrift
-func FromWorkflowIdReusePolicy(t *types.WorkflowIdReusePolicy) *shared.WorkflowIdReusePolicy {
+// FromWorkflowIDReusePolicy converts internal WorkflowIDReusePolicy type to thrift
+func FromWorkflowIDReusePolicy(t *types.WorkflowIDReusePolicy) *shared.WorkflowIdReusePolicy {
 	if t == nil {
 		return nil
 	}
 	switch *t {
-	case types.WorkflowIdReusePolicyAllowDuplicate:
+	case types.WorkflowIDReusePolicyAllowDuplicate:
 		v := shared.WorkflowIdReusePolicyAllowDuplicate
 		return &v
-	case types.WorkflowIdReusePolicyAllowDuplicateFailedOnly:
+	case types.WorkflowIDReusePolicyAllowDuplicateFailedOnly:
 		v := shared.WorkflowIdReusePolicyAllowDuplicateFailedOnly
 		return &v
-	case types.WorkflowIdReusePolicyRejectDuplicate:
+	case types.WorkflowIDReusePolicyRejectDuplicate:
 		v := shared.WorkflowIdReusePolicyRejectDuplicate
 		return &v
-	case types.WorkflowIdReusePolicyTerminateIfRunning:
+	case types.WorkflowIDReusePolicyTerminateIfRunning:
 		v := shared.WorkflowIdReusePolicyTerminateIfRunning
 		return &v
 	}
 	panic("unexpected enum value")
 }
 
-// ToWorkflowIdReusePolicy converts thrift WorkflowIdReusePolicy type to internal
-func ToWorkflowIdReusePolicy(t *shared.WorkflowIdReusePolicy) *types.WorkflowIdReusePolicy {
+// ToWorkflowIDReusePolicy converts thrift WorkflowIdReusePolicy type to internal
+func ToWorkflowIDReusePolicy(t *shared.WorkflowIdReusePolicy) *types.WorkflowIDReusePolicy {
 	if t == nil {
 		return nil
 	}
 	switch *t {
 	case shared.WorkflowIdReusePolicyAllowDuplicate:
-		v := types.WorkflowIdReusePolicyAllowDuplicate
+		v := types.WorkflowIDReusePolicyAllowDuplicate
 		return &v
 	case shared.WorkflowIdReusePolicyAllowDuplicateFailedOnly:
-		v := types.WorkflowIdReusePolicyAllowDuplicateFailedOnly
+		v := types.WorkflowIDReusePolicyAllowDuplicateFailedOnly
 		return &v
 	case shared.WorkflowIdReusePolicyRejectDuplicate:
-		v := types.WorkflowIdReusePolicyRejectDuplicate
+		v := types.WorkflowIDReusePolicyRejectDuplicate
 		return &v
 	case shared.WorkflowIdReusePolicyTerminateIfRunning:
-		v := types.WorkflowIdReusePolicyTerminateIfRunning
+		v := types.WorkflowIDReusePolicyTerminateIfRunning
 		return &v
 	}
 	panic("unexpected enum value")
@@ -6160,6 +6160,54 @@ func ToWorkflowTypeFilter(t *shared.WorkflowTypeFilter) *types.WorkflowTypeFilte
 	}
 }
 
+// FromPollerInfoArray converts internal PollerInfo type array to thrift
+func FromPollerInfoArray(t []*types.PollerInfo) []*shared.PollerInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.PollerInfo, len(t))
+	for i := range t {
+		v[i] = FromPollerInfo(t[i])
+	}
+	return v
+}
+
+// ToPollerInfoArray converts thrift PollerInfo type array to internal
+func ToPollerInfoArray(t []*shared.PollerInfo) []*types.PollerInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PollerInfo, len(t))
+	for i := range t {
+		v[i] = ToPollerInfo(t[i])
+	}
+	return v
+}
+
+// FromPendingChildExecutionInfoArray converts internal PendingChildExecutionInfo type array to thrift
+func FromPendingChildExecutionInfoArray(t []*types.PendingChildExecutionInfo) []*shared.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.PendingChildExecutionInfo, len(t))
+	for i := range t {
+		v[i] = FromPendingChildExecutionInfo(t[i])
+	}
+	return v
+}
+
+// ToPendingChildExecutionInfoArray converts thrift PendingChildExecutionInfo type array to internal
+func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*types.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PendingChildExecutionInfo, len(t))
+	for i := range t {
+		v[i] = ToPendingChildExecutionInfo(t[i])
+	}
+	return v
+}
+
 // FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
 func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
 	if t == nil {
@@ -6180,30 +6228,6 @@ func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.Pendin
 	v := make([]*types.PendingActivityInfo, len(t))
 	for i := range t {
 		v[i] = ToPendingActivityInfo(t[i])
-	}
-	return v
-}
-
-// FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
-func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.VersionHistoryItem, len(t))
-	for i := range t {
-		v[i] = FromVersionHistoryItem(t[i])
-	}
-	return v
-}
-
-// ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
-func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.VersionHistoryItem, len(t))
-	for i := range t {
-		v[i] = ToVersionHistoryItem(t[i])
 	}
 	return v
 }
@@ -6232,6 +6256,30 @@ func ToHistoryEventArray(t []*shared.HistoryEvent) []*types.HistoryEvent {
 	return v
 }
 
+// FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
+func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.WorkflowExecutionInfo, len(t))
+	for i := range t {
+		v[i] = FromWorkflowExecutionInfo(t[i])
+	}
+	return v
+}
+
+// ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
+func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.WorkflowExecutionInfo, len(t))
+	for i := range t {
+		v[i] = ToWorkflowExecutionInfo(t[i])
+	}
+	return v
+}
+
 // FromDecisionArray converts internal Decision type array to thrift
 func FromDecisionArray(t []*types.Decision) []*shared.Decision {
 	if t == nil {
@@ -6256,26 +6304,98 @@ func ToDecisionArray(t []*shared.Decision) []*types.Decision {
 	return v
 }
 
-// FromPendingChildExecutionInfoArray converts internal PendingChildExecutionInfo type array to thrift
-func FromPendingChildExecutionInfoArray(t []*types.PendingChildExecutionInfo) []*shared.PendingChildExecutionInfo {
+// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
+func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.PendingChildExecutionInfo, len(t))
+	v := make([]*shared.HistoryBranchRange, len(t))
 	for i := range t {
-		v[i] = FromPendingChildExecutionInfo(t[i])
+		v[i] = FromHistoryBranchRange(t[i])
 	}
 	return v
 }
 
-// ToPendingChildExecutionInfoArray converts thrift PendingChildExecutionInfo type array to internal
-func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*types.PendingChildExecutionInfo {
+// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
+func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.PendingChildExecutionInfo, len(t))
+	v := make([]*types.HistoryBranchRange, len(t))
 	for i := range t {
-		v[i] = ToPendingChildExecutionInfo(t[i])
+		v[i] = ToHistoryBranchRange(t[i])
+	}
+	return v
+}
+
+// FromTaskListPartitionMetadataArray converts internal TaskListPartitionMetadata type array to thrift
+func FromTaskListPartitionMetadataArray(t []*types.TaskListPartitionMetadata) []*shared.TaskListPartitionMetadata {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.TaskListPartitionMetadata, len(t))
+	for i := range t {
+		v[i] = FromTaskListPartitionMetadata(t[i])
+	}
+	return v
+}
+
+// ToTaskListPartitionMetadataArray converts thrift TaskListPartitionMetadata type array to internal
+func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*types.TaskListPartitionMetadata {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.TaskListPartitionMetadata, len(t))
+	for i := range t {
+		v[i] = ToTaskListPartitionMetadata(t[i])
+	}
+	return v
+}
+
+// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
+func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.ResetPointInfo, len(t))
+	for i := range t {
+		v[i] = FromResetPointInfo(t[i])
+	}
+	return v
+}
+
+// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
+func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ResetPointInfo, len(t))
+	for i := range t {
+		v[i] = ToResetPointInfo(t[i])
+	}
+	return v
+}
+
+// FromClusterReplicationConfigurationArray converts internal ClusterReplicationConfiguration type array to thrift
+func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfiguration) []*shared.ClusterReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.ClusterReplicationConfiguration, len(t))
+	for i := range t {
+		v[i] = FromClusterReplicationConfiguration(t[i])
+	}
+	return v
+}
+
+// ToClusterReplicationConfigurationArray converts thrift ClusterReplicationConfiguration type array to internal
+func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfiguration) []*types.ClusterReplicationConfiguration {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ClusterReplicationConfiguration, len(t))
+	for i := range t {
+		v[i] = ToClusterReplicationConfiguration(t[i])
 	}
 	return v
 }
@@ -6352,146 +6472,50 @@ func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
 	return v
 }
 
-// FromPollerInfoArray converts internal PollerInfo type array to thrift
-func FromPollerInfoArray(t []*types.PollerInfo) []*shared.PollerInfo {
+// FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
+func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.PollerInfo, len(t))
+	v := make([]*shared.VersionHistoryItem, len(t))
 	for i := range t {
-		v[i] = FromPollerInfo(t[i])
+		v[i] = FromVersionHistoryItem(t[i])
 	}
 	return v
 }
 
-// ToPollerInfoArray converts thrift PollerInfo type array to internal
-func ToPollerInfoArray(t []*shared.PollerInfo) []*types.PollerInfo {
+// ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
+func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.PollerInfo, len(t))
+	v := make([]*types.VersionHistoryItem, len(t))
 	for i := range t {
-		v[i] = ToPollerInfo(t[i])
+		v[i] = ToVersionHistoryItem(t[i])
 	}
 	return v
 }
 
-// FromClusterReplicationConfigurationArray converts internal ClusterReplicationConfiguration type array to thrift
-func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfiguration) []*shared.ClusterReplicationConfiguration {
+// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
+func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.ClusterReplicationConfiguration, len(t))
-	for i := range t {
-		v[i] = FromClusterReplicationConfiguration(t[i])
+	v := make(map[string]*shared.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = FromBadBinaryInfo(t[key])
 	}
 	return v
 }
 
-// ToClusterReplicationConfigurationArray converts thrift ClusterReplicationConfiguration type array to internal
-func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfiguration) []*types.ClusterReplicationConfiguration {
+// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
+func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.ClusterReplicationConfiguration, len(t))
-	for i := range t {
-		v[i] = ToClusterReplicationConfiguration(t[i])
-	}
-	return v
-}
-
-// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
-func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.HistoryBranchRange, len(t))
-	for i := range t {
-		v[i] = FromHistoryBranchRange(t[i])
-	}
-	return v
-}
-
-// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
-func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.HistoryBranchRange, len(t))
-	for i := range t {
-		v[i] = ToHistoryBranchRange(t[i])
-	}
-	return v
-}
-
-// FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
-func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.WorkflowExecutionInfo, len(t))
-	for i := range t {
-		v[i] = FromWorkflowExecutionInfo(t[i])
-	}
-	return v
-}
-
-// ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
-func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.WorkflowExecutionInfo, len(t))
-	for i := range t {
-		v[i] = ToWorkflowExecutionInfo(t[i])
-	}
-	return v
-}
-
-// FromTaskListPartitionMetadataArray converts internal TaskListPartitionMetadata type array to thrift
-func FromTaskListPartitionMetadataArray(t []*types.TaskListPartitionMetadata) []*shared.TaskListPartitionMetadata {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.TaskListPartitionMetadata, len(t))
-	for i := range t {
-		v[i] = FromTaskListPartitionMetadata(t[i])
-	}
-	return v
-}
-
-// ToTaskListPartitionMetadataArray converts thrift TaskListPartitionMetadata type array to internal
-func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*types.TaskListPartitionMetadata {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.TaskListPartitionMetadata, len(t))
-	for i := range t {
-		v[i] = ToTaskListPartitionMetadata(t[i])
-	}
-	return v
-}
-
-// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
-func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.ResetPointInfo, len(t))
-	for i := range t {
-		v[i] = FromResetPointInfo(t[i])
-	}
-	return v
-}
-
-// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
-func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.ResetPointInfo, len(t))
-	for i := range t {
-		v[i] = ToResetPointInfo(t[i])
+	v := make(map[string]*types.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = ToBadBinaryInfo(t[key])
 	}
 	return v
 }
@@ -6564,30 +6588,6 @@ func ToWorkflowQueryResultMap(t map[string]*shared.WorkflowQueryResult) map[stri
 	v := make(map[string]*types.WorkflowQueryResult, len(t))
 	for key := range t {
 		v[key] = ToWorkflowQueryResult(t[key])
-	}
-	return v
-}
-
-// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
-func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*shared.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = FromBadBinaryInfo(t[key])
-	}
-	return v
-}
-
-// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
-func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*types.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = ToBadBinaryInfo(t[key])
 	}
 	return v
 }

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -20,40 +20,46 @@
 
 package types
 
+// AccessDeniedError is an internal type (TBD...)
 type AccessDeniedError struct {
 	Message string
 }
 
+// ActivityTaskCancelRequestedEventAttributes is an internal type (TBD...)
 type ActivityTaskCancelRequestedEventAttributes struct {
-	ActivityId                   *string
-	DecisionTaskCompletedEventId *int64
+	ActivityID                   *string
+	DecisionTaskCompletedEventID *int64
 }
 
+// ActivityTaskCanceledEventAttributes is an internal type (TBD...)
 type ActivityTaskCanceledEventAttributes struct {
 	Details                      []byte
-	LatestCancelRequestedEventId *int64
-	ScheduledEventId             *int64
-	StartedEventId               *int64
+	LatestCancelRequestedEventID *int64
+	ScheduledEventID             *int64
+	StartedEventID               *int64
 	Identity                     *string
 }
 
+// ActivityTaskCompletedEventAttributes is an internal type (TBD...)
 type ActivityTaskCompletedEventAttributes struct {
 	Result           []byte
-	ScheduledEventId *int64
-	StartedEventId   *int64
+	ScheduledEventID *int64
+	StartedEventID   *int64
 	Identity         *string
 }
 
+// ActivityTaskFailedEventAttributes is an internal type (TBD...)
 type ActivityTaskFailedEventAttributes struct {
 	Reason           *string
 	Details          []byte
-	ScheduledEventId *int64
-	StartedEventId   *int64
+	ScheduledEventID *int64
+	StartedEventID   *int64
 	Identity         *string
 }
 
+// ActivityTaskScheduledEventAttributes is an internal type (TBD...)
 type ActivityTaskScheduledEventAttributes struct {
-	ActivityId                    *string
+	ActivityID                    *string
 	ActivityType                  *ActivityType
 	Domain                        *string
 	TaskList                      *TaskList
@@ -62,168 +68,201 @@ type ActivityTaskScheduledEventAttributes struct {
 	ScheduleToStartTimeoutSeconds *int32
 	StartToCloseTimeoutSeconds    *int32
 	HeartbeatTimeoutSeconds       *int32
-	DecisionTaskCompletedEventId  *int64
+	DecisionTaskCompletedEventID  *int64
 	RetryPolicy                   *RetryPolicy
 	Header                        *Header
 }
 
+// ActivityTaskStartedEventAttributes is an internal type (TBD...)
 type ActivityTaskStartedEventAttributes struct {
-	ScheduledEventId   *int64
+	ScheduledEventID   *int64
 	Identity           *string
-	RequestId          *string
+	RequestID          *string
 	Attempt            *int32
 	LastFailureReason  *string
 	LastFailureDetails []byte
 }
 
+// ActivityTaskTimedOutEventAttributes is an internal type (TBD...)
 type ActivityTaskTimedOutEventAttributes struct {
 	Details            []byte
-	ScheduledEventId   *int64
-	StartedEventId     *int64
+	ScheduledEventID   *int64
+	StartedEventID     *int64
 	TimeoutType        *TimeoutType
 	LastFailureReason  *string
 	LastFailureDetails []byte
 }
 
+// ActivityType is an internal type (TBD...)
 type ActivityType struct {
 	Name *string
 }
 
+// ArchivalStatus is an internal type (TBD...)
 type ArchivalStatus int32
 
 const (
+	// ArchivalStatusDisabled is an option for ArchivalStatus
 	ArchivalStatusDisabled ArchivalStatus = iota
+	// ArchivalStatusEnabled is an option for ArchivalStatus
 	ArchivalStatusEnabled
 )
 
+// BadBinaries is an internal type (TBD...)
 type BadBinaries struct {
 	Binaries map[string]*BadBinaryInfo
 }
 
+// BadBinaryInfo is an internal type (TBD...)
 type BadBinaryInfo struct {
 	Reason          *string
 	Operator        *string
 	CreatedTimeNano *int64
 }
 
+// BadRequestError is an internal type (TBD...)
 type BadRequestError struct {
 	Message string
 }
 
+// CancelExternalWorkflowExecutionFailedCause is an internal type (TBD...)
 type CancelExternalWorkflowExecutionFailedCause int32
 
 const (
+	// CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution is an option for CancelExternalWorkflowExecutionFailedCause
 	CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution CancelExternalWorkflowExecutionFailedCause = iota
 )
 
+// CancelTimerDecisionAttributes is an internal type (TBD...)
 type CancelTimerDecisionAttributes struct {
-	TimerId *string
+	TimerID *string
 }
 
+// CancelTimerFailedEventAttributes is an internal type (TBD...)
 type CancelTimerFailedEventAttributes struct {
-	TimerId                      *string
+	TimerID                      *string
 	Cause                        *string
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	Identity                     *string
 }
 
+// CancelWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type CancelWorkflowExecutionDecisionAttributes struct {
 	Details []byte
 }
 
+// CancellationAlreadyRequestedError is an internal type (TBD...)
 type CancellationAlreadyRequestedError struct {
 	Message string
 }
 
+// ChildWorkflowExecutionCanceledEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionCanceledEventAttributes struct {
 	Details           []byte
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	WorkflowType      *WorkflowType
-	InitiatedEventId  *int64
-	StartedEventId    *int64
+	InitiatedEventID  *int64
+	StartedEventID    *int64
 }
 
+// ChildWorkflowExecutionCompletedEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionCompletedEventAttributes struct {
 	Result            []byte
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	WorkflowType      *WorkflowType
-	InitiatedEventId  *int64
-	StartedEventId    *int64
+	InitiatedEventID  *int64
+	StartedEventID    *int64
 }
 
+// ChildWorkflowExecutionFailedCause is an internal type (TBD...)
 type ChildWorkflowExecutionFailedCause int32
 
 const (
+	// ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning is an option for ChildWorkflowExecutionFailedCause
 	ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning ChildWorkflowExecutionFailedCause = iota
 )
 
+// ChildWorkflowExecutionFailedEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionFailedEventAttributes struct {
 	Reason            *string
 	Details           []byte
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	WorkflowType      *WorkflowType
-	InitiatedEventId  *int64
-	StartedEventId    *int64
+	InitiatedEventID  *int64
+	StartedEventID    *int64
 }
 
+// ChildWorkflowExecutionStartedEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionStartedEventAttributes struct {
 	Domain            *string
-	InitiatedEventId  *int64
+	InitiatedEventID  *int64
 	WorkflowExecution *WorkflowExecution
 	WorkflowType      *WorkflowType
 	Header            *Header
 }
 
+// ChildWorkflowExecutionTerminatedEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionTerminatedEventAttributes struct {
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	WorkflowType      *WorkflowType
-	InitiatedEventId  *int64
-	StartedEventId    *int64
+	InitiatedEventID  *int64
+	StartedEventID    *int64
 }
 
+// ChildWorkflowExecutionTimedOutEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionTimedOutEventAttributes struct {
 	TimeoutType       *TimeoutType
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	WorkflowType      *WorkflowType
-	InitiatedEventId  *int64
-	StartedEventId    *int64
+	InitiatedEventID  *int64
+	StartedEventID    *int64
 }
 
+// ClientVersionNotSupportedError is an internal type (TBD...)
 type ClientVersionNotSupportedError struct {
 	FeatureVersion    string
 	ClientImpl        string
 	SupportedVersions string
 }
 
+// CloseShardRequest is an internal type (TBD...)
 type CloseShardRequest struct {
 	ShardID *int32
 }
 
+// ClusterInfo is an internal type (TBD...)
 type ClusterInfo struct {
 	SupportedClientVersions *SupportedClientVersions
 }
 
+// ClusterReplicationConfiguration is an internal type (TBD...)
 type ClusterReplicationConfiguration struct {
 	ClusterName *string
 }
 
+// CompleteWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type CompleteWorkflowExecutionDecisionAttributes struct {
 	Result []byte
 }
 
+// ContinueAsNewInitiator is an internal type (TBD...)
 type ContinueAsNewInitiator int32
 
 const (
+	// ContinueAsNewInitiatorCronSchedule is an option for ContinueAsNewInitiator
 	ContinueAsNewInitiatorCronSchedule ContinueAsNewInitiator = iota
+	// ContinueAsNewInitiatorDecider is an option for ContinueAsNewInitiator
 	ContinueAsNewInitiatorDecider
+	// ContinueAsNewInitiatorRetryPolicy is an option for ContinueAsNewInitiator
 	ContinueAsNewInitiatorRetryPolicy
 )
 
+// ContinueAsNewWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
 	WorkflowType                        *WorkflowType
 	TaskList                            *TaskList
@@ -242,25 +281,30 @@ type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+// CountWorkflowExecutionsRequest is an internal type (TBD...)
 type CountWorkflowExecutionsRequest struct {
 	Domain *string
 	Query  *string
 }
 
+// CountWorkflowExecutionsResponse is an internal type (TBD...)
 type CountWorkflowExecutionsResponse struct {
 	Count *int64
 }
 
+// CurrentBranchChangedError is an internal type (TBD...)
 type CurrentBranchChangedError struct {
 	Message            string
 	CurrentBranchToken []byte
 }
 
+// DataBlob is an internal type (TBD...)
 type DataBlob struct {
 	EncodingType *EncodingType
 	Data         []byte
 }
 
+// Decision is an internal type (TBD...)
 type Decision struct {
 	DecisionType                                             *DecisionType
 	ScheduleActivityTaskDecisionAttributes                   *ScheduleActivityTaskDecisionAttributes
@@ -278,101 +322,147 @@ type Decision struct {
 	UpsertWorkflowSearchAttributesDecisionAttributes         *UpsertWorkflowSearchAttributesDecisionAttributes
 }
 
+// DecisionTaskCompletedEventAttributes is an internal type (TBD...)
 type DecisionTaskCompletedEventAttributes struct {
 	ExecutionContext []byte
-	ScheduledEventId *int64
-	StartedEventId   *int64
+	ScheduledEventID *int64
+	StartedEventID   *int64
 	Identity         *string
 	BinaryChecksum   *string
 }
 
+// DecisionTaskFailedCause is an internal type (TBD...)
 type DecisionTaskFailedCause int32
 
 const (
+	// DecisionTaskFailedCauseBadBinary is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadBinary DecisionTaskFailedCause = iota
+	// DecisionTaskFailedCauseBadCancelTimerAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadCancelTimerAttributes
+	// DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes
+	// DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes
+	// DecisionTaskFailedCauseBadContinueAsNewAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadContinueAsNewAttributes
+	// DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes
+	// DecisionTaskFailedCauseBadRecordMarkerAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadRecordMarkerAttributes
+	// DecisionTaskFailedCauseBadRequestCancelActivityAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadRequestCancelActivityAttributes
+	// DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes
+	// DecisionTaskFailedCauseBadScheduleActivityAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadScheduleActivityAttributes
+	// DecisionTaskFailedCauseBadSearchAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadSearchAttributes
+	// DecisionTaskFailedCauseBadSignalInputSize is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadSignalInputSize
+	// DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes
+	// DecisionTaskFailedCauseBadStartChildExecutionAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadStartChildExecutionAttributes
+	// DecisionTaskFailedCauseBadStartTimerAttributes is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseBadStartTimerAttributes
+	// DecisionTaskFailedCauseFailoverCloseDecision is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseFailoverCloseDecision
+	// DecisionTaskFailedCauseForceCloseDecision is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseForceCloseDecision
+	// DecisionTaskFailedCauseResetStickyTasklist is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseResetStickyTasklist
+	// DecisionTaskFailedCauseResetWorkflow is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseResetWorkflow
+	// DecisionTaskFailedCauseScheduleActivityDuplicateID is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseScheduleActivityDuplicateID
+	// DecisionTaskFailedCauseStartTimerDuplicateID is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseStartTimerDuplicateID
+	// DecisionTaskFailedCauseUnhandledDecision is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseUnhandledDecision
+	// DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure
 )
 
+// DecisionTaskFailedEventAttributes is an internal type (TBD...)
 type DecisionTaskFailedEventAttributes struct {
-	ScheduledEventId *int64
-	StartedEventId   *int64
+	ScheduledEventID *int64
+	StartedEventID   *int64
 	Cause            *DecisionTaskFailedCause
 	Details          []byte
 	Identity         *string
 	Reason           *string
-	BaseRunId        *string
-	NewRunId         *string
+	BaseRunID        *string
+	NewRunID         *string
 	ForkEventVersion *int64
 	BinaryChecksum   *string
 }
 
+// DecisionTaskScheduledEventAttributes is an internal type (TBD...)
 type DecisionTaskScheduledEventAttributes struct {
 	TaskList                   *TaskList
 	StartToCloseTimeoutSeconds *int32
 	Attempt                    *int64
 }
 
+// DecisionTaskStartedEventAttributes is an internal type (TBD...)
 type DecisionTaskStartedEventAttributes struct {
-	ScheduledEventId *int64
+	ScheduledEventID *int64
 	Identity         *string
-	RequestId        *string
+	RequestID        *string
 }
 
+// DecisionTaskTimedOutEventAttributes is an internal type (TBD...)
 type DecisionTaskTimedOutEventAttributes struct {
-	ScheduledEventId *int64
-	StartedEventId   *int64
+	ScheduledEventID *int64
+	StartedEventID   *int64
 	TimeoutType      *TimeoutType
 }
 
+// DecisionType is an internal type (TBD...)
 type DecisionType int32
 
 const (
+	// DecisionTypeCancelTimer is an option for DecisionType
 	DecisionTypeCancelTimer DecisionType = iota
+	// DecisionTypeCancelWorkflowExecution is an option for DecisionType
 	DecisionTypeCancelWorkflowExecution
+	// DecisionTypeCompleteWorkflowExecution is an option for DecisionType
 	DecisionTypeCompleteWorkflowExecution
+	// DecisionTypeContinueAsNewWorkflowExecution is an option for DecisionType
 	DecisionTypeContinueAsNewWorkflowExecution
+	// DecisionTypeFailWorkflowExecution is an option for DecisionType
 	DecisionTypeFailWorkflowExecution
+	// DecisionTypeRecordMarker is an option for DecisionType
 	DecisionTypeRecordMarker
+	// DecisionTypeRequestCancelActivityTask is an option for DecisionType
 	DecisionTypeRequestCancelActivityTask
+	// DecisionTypeRequestCancelExternalWorkflowExecution is an option for DecisionType
 	DecisionTypeRequestCancelExternalWorkflowExecution
+	// DecisionTypeScheduleActivityTask is an option for DecisionType
 	DecisionTypeScheduleActivityTask
+	// DecisionTypeSignalExternalWorkflowExecution is an option for DecisionType
 	DecisionTypeSignalExternalWorkflowExecution
+	// DecisionTypeStartChildWorkflowExecution is an option for DecisionType
 	DecisionTypeStartChildWorkflowExecution
+	// DecisionTypeStartTimer is an option for DecisionType
 	DecisionTypeStartTimer
+	// DecisionTypeUpsertWorkflowSearchAttributes is an option for DecisionType
 	DecisionTypeUpsertWorkflowSearchAttributes
 )
 
+// DeprecateDomainRequest is an internal type (TBD...)
 type DeprecateDomainRequest struct {
 	Name          *string
 	SecurityToken *string
 }
 
+// DescribeDomainRequest is an internal type (TBD...)
 type DescribeDomainRequest struct {
 	Name *string
 	UUID *string
 }
 
+// DescribeDomainResponse is an internal type (TBD...)
 type DescribeDomainResponse struct {
 	DomainInfo               *DomainInfo
 	Configuration            *DomainConfiguration
@@ -381,12 +471,14 @@ type DescribeDomainResponse struct {
 	IsGlobalDomain           *bool
 }
 
+// DescribeHistoryHostRequest is an internal type (TBD...)
 type DescribeHistoryHostRequest struct {
 	HostAddress      *string
-	ShardIdForHost   *int32
+	ShardIDForHost   *int32
 	ExecutionForHost *WorkflowExecution
 }
 
+// DescribeHistoryHostResponse is an internal type (TBD...)
 type DescribeHistoryHostResponse struct {
 	NumberOfShards        *int32
 	ShardIDs              []int32
@@ -395,16 +487,19 @@ type DescribeHistoryHostResponse struct {
 	Address               *string
 }
 
+// DescribeQueueRequest is an internal type (TBD...)
 type DescribeQueueRequest struct {
 	ShardID     *int32
 	ClusterName *string
 	Type        *int32
 }
 
+// DescribeQueueResponse is an internal type (TBD...)
 type DescribeQueueResponse struct {
 	ProcessingQueueStates []string
 }
 
+// DescribeTaskListRequest is an internal type (TBD...)
 type DescribeTaskListRequest struct {
 	Domain                *string
 	TaskList              *TaskList
@@ -412,16 +507,19 @@ type DescribeTaskListRequest struct {
 	IncludeTaskListStatus *bool
 }
 
+// DescribeTaskListResponse is an internal type (TBD...)
 type DescribeTaskListResponse struct {
 	Pollers        []*PollerInfo
 	TaskListStatus *TaskListStatus
 }
 
+// DescribeWorkflowExecutionRequest is an internal type (TBD...)
 type DescribeWorkflowExecutionRequest struct {
 	Domain    *string
 	Execution *WorkflowExecution
 }
 
+// DescribeWorkflowExecutionResponse is an internal type (TBD...)
 type DescribeWorkflowExecutionResponse struct {
 	ExecutionConfiguration *WorkflowExecutionConfiguration
 	WorkflowExecutionInfo  *WorkflowExecutionInfo
@@ -429,15 +527,18 @@ type DescribeWorkflowExecutionResponse struct {
 	PendingChildren        []*PendingChildExecutionInfo
 }
 
+// DomainAlreadyExistsError is an internal type (TBD...)
 type DomainAlreadyExistsError struct {
 	Message string
 }
 
+// DomainCacheInfo is an internal type (TBD...)
 type DomainCacheInfo struct {
 	NumOfItemsInCacheByID   *int64
 	NumOfItemsInCacheByName *int64
 }
 
+// DomainConfiguration is an internal type (TBD...)
 type DomainConfiguration struct {
 	WorkflowExecutionRetentionPeriodInDays *int32
 	EmitMetric                             *bool
@@ -448,6 +549,7 @@ type DomainConfiguration struct {
 	VisibilityArchivalURI                  *string
 }
 
+// DomainInfo is an internal type (TBD...)
 type DomainInfo struct {
 	Name        *string
 	Status      *DomainStatus
@@ -457,6 +559,7 @@ type DomainInfo struct {
 	UUID        *string
 }
 
+// DomainNotActiveError is an internal type (TBD...)
 type DomainNotActiveError struct {
 	Message        string
 	DomainName     string
@@ -464,101 +567,158 @@ type DomainNotActiveError struct {
 	ActiveCluster  string
 }
 
+// DomainReplicationConfiguration is an internal type (TBD...)
 type DomainReplicationConfiguration struct {
 	ActiveClusterName *string
 	Clusters          []*ClusterReplicationConfiguration
 }
 
+// DomainStatus is an internal type (TBD...)
 type DomainStatus int32
 
 const (
+	// DomainStatusDeleted is an option for DomainStatus
 	DomainStatusDeleted DomainStatus = iota
+	// DomainStatusDeprecated is an option for DomainStatus
 	DomainStatusDeprecated
+	// DomainStatusRegistered is an option for DomainStatus
 	DomainStatusRegistered
 )
 
+// EncodingType is an internal type (TBD...)
 type EncodingType int32
 
 const (
+	// EncodingTypeJSON is an option for EncodingType
 	EncodingTypeJSON EncodingType = iota
+	// EncodingTypeThriftRW is an option for EncodingType
 	EncodingTypeThriftRW
 )
 
+// EntityNotExistsError is an internal type (TBD...)
 type EntityNotExistsError struct {
 	Message        string
 	CurrentCluster *string
 	ActiveCluster  *string
 }
 
+// EventType is an internal type (TBD...)
 type EventType int32
 
 const (
+	// EventTypeActivityTaskCancelRequested is an option for EventType
 	EventTypeActivityTaskCancelRequested EventType = iota
+	// EventTypeActivityTaskCanceled is an option for EventType
 	EventTypeActivityTaskCanceled
+	// EventTypeActivityTaskCompleted is an option for EventType
 	EventTypeActivityTaskCompleted
+	// EventTypeActivityTaskFailed is an option for EventType
 	EventTypeActivityTaskFailed
+	// EventTypeActivityTaskScheduled is an option for EventType
 	EventTypeActivityTaskScheduled
+	// EventTypeActivityTaskStarted is an option for EventType
 	EventTypeActivityTaskStarted
+	// EventTypeActivityTaskTimedOut is an option for EventType
 	EventTypeActivityTaskTimedOut
+	// EventTypeCancelTimerFailed is an option for EventType
 	EventTypeCancelTimerFailed
+	// EventTypeChildWorkflowExecutionCanceled is an option for EventType
 	EventTypeChildWorkflowExecutionCanceled
+	// EventTypeChildWorkflowExecutionCompleted is an option for EventType
 	EventTypeChildWorkflowExecutionCompleted
+	// EventTypeChildWorkflowExecutionFailed is an option for EventType
 	EventTypeChildWorkflowExecutionFailed
+	// EventTypeChildWorkflowExecutionStarted is an option for EventType
 	EventTypeChildWorkflowExecutionStarted
+	// EventTypeChildWorkflowExecutionTerminated is an option for EventType
 	EventTypeChildWorkflowExecutionTerminated
+	// EventTypeChildWorkflowExecutionTimedOut is an option for EventType
 	EventTypeChildWorkflowExecutionTimedOut
+	// EventTypeDecisionTaskCompleted is an option for EventType
 	EventTypeDecisionTaskCompleted
+	// EventTypeDecisionTaskFailed is an option for EventType
 	EventTypeDecisionTaskFailed
+	// EventTypeDecisionTaskScheduled is an option for EventType
 	EventTypeDecisionTaskScheduled
+	// EventTypeDecisionTaskStarted is an option for EventType
 	EventTypeDecisionTaskStarted
+	// EventTypeDecisionTaskTimedOut is an option for EventType
 	EventTypeDecisionTaskTimedOut
+	// EventTypeExternalWorkflowExecutionCancelRequested is an option for EventType
 	EventTypeExternalWorkflowExecutionCancelRequested
+	// EventTypeExternalWorkflowExecutionSignaled is an option for EventType
 	EventTypeExternalWorkflowExecutionSignaled
+	// EventTypeMarkerRecorded is an option for EventType
 	EventTypeMarkerRecorded
+	// EventTypeRequestCancelActivityTaskFailed is an option for EventType
 	EventTypeRequestCancelActivityTaskFailed
+	// EventTypeRequestCancelExternalWorkflowExecutionFailed is an option for EventType
 	EventTypeRequestCancelExternalWorkflowExecutionFailed
+	// EventTypeRequestCancelExternalWorkflowExecutionInitiated is an option for EventType
 	EventTypeRequestCancelExternalWorkflowExecutionInitiated
+	// EventTypeSignalExternalWorkflowExecutionFailed is an option for EventType
 	EventTypeSignalExternalWorkflowExecutionFailed
+	// EventTypeSignalExternalWorkflowExecutionInitiated is an option for EventType
 	EventTypeSignalExternalWorkflowExecutionInitiated
+	// EventTypeStartChildWorkflowExecutionFailed is an option for EventType
 	EventTypeStartChildWorkflowExecutionFailed
+	// EventTypeStartChildWorkflowExecutionInitiated is an option for EventType
 	EventTypeStartChildWorkflowExecutionInitiated
+	// EventTypeTimerCanceled is an option for EventType
 	EventTypeTimerCanceled
+	// EventTypeTimerFired is an option for EventType
 	EventTypeTimerFired
+	// EventTypeTimerStarted is an option for EventType
 	EventTypeTimerStarted
+	// EventTypeUpsertWorkflowSearchAttributes is an option for EventType
 	EventTypeUpsertWorkflowSearchAttributes
+	// EventTypeWorkflowExecutionCancelRequested is an option for EventType
 	EventTypeWorkflowExecutionCancelRequested
+	// EventTypeWorkflowExecutionCanceled is an option for EventType
 	EventTypeWorkflowExecutionCanceled
+	// EventTypeWorkflowExecutionCompleted is an option for EventType
 	EventTypeWorkflowExecutionCompleted
+	// EventTypeWorkflowExecutionContinuedAsNew is an option for EventType
 	EventTypeWorkflowExecutionContinuedAsNew
+	// EventTypeWorkflowExecutionFailed is an option for EventType
 	EventTypeWorkflowExecutionFailed
+	// EventTypeWorkflowExecutionSignaled is an option for EventType
 	EventTypeWorkflowExecutionSignaled
+	// EventTypeWorkflowExecutionStarted is an option for EventType
 	EventTypeWorkflowExecutionStarted
+	// EventTypeWorkflowExecutionTerminated is an option for EventType
 	EventTypeWorkflowExecutionTerminated
+	// EventTypeWorkflowExecutionTimedOut is an option for EventType
 	EventTypeWorkflowExecutionTimedOut
 )
 
+// ExternalWorkflowExecutionCancelRequestedEventAttributes is an internal type (TBD...)
 type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
-	InitiatedEventId  *int64
+	InitiatedEventID  *int64
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 }
 
+// ExternalWorkflowExecutionSignaledEventAttributes is an internal type (TBD...)
 type ExternalWorkflowExecutionSignaledEventAttributes struct {
-	InitiatedEventId  *int64
+	InitiatedEventID  *int64
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	Control           []byte
 }
 
+// FailWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type FailWorkflowExecutionDecisionAttributes struct {
 	Reason  *string
 	Details []byte
 }
 
+// GetSearchAttributesResponse is an internal type (TBD...)
 type GetSearchAttributesResponse struct {
 	Keys map[string]IndexedValueType
 }
 
+// GetWorkflowExecutionHistoryRequest is an internal type (TBD...)
 type GetWorkflowExecutionHistoryRequest struct {
 	Domain                 *string
 	Execution              *WorkflowExecution
@@ -569,6 +729,7 @@ type GetWorkflowExecutionHistoryRequest struct {
 	SkipArchival           *bool
 }
 
+// GetWorkflowExecutionHistoryResponse is an internal type (TBD...)
 type GetWorkflowExecutionHistoryResponse struct {
 	History       *History
 	RawHistory    []*DataBlob
@@ -576,32 +737,37 @@ type GetWorkflowExecutionHistoryResponse struct {
 	Archived      *bool
 }
 
+// Header is an internal type (TBD...)
 type Header struct {
 	Fields map[string][]byte
 }
 
+// History is an internal type (TBD...)
 type History struct {
 	Events []*HistoryEvent
 }
 
+// HistoryBranch is an internal type (TBD...)
 type HistoryBranch struct {
 	TreeID    *string
 	BranchID  *string
 	Ancestors []*HistoryBranchRange
 }
 
+// HistoryBranchRange is an internal type (TBD...)
 type HistoryBranchRange struct {
 	BranchID    *string
 	BeginNodeID *int64
 	EndNodeID   *int64
 }
 
+// HistoryEvent is an internal type (TBD...)
 type HistoryEvent struct {
-	EventId                                                        *int64
+	EventID                                                        *int64
 	Timestamp                                                      *int64
 	EventType                                                      *EventType
 	Version                                                        *int64
-	TaskId                                                         *int64
+	TaskID                                                         *int64
 	WorkflowExecutionStartedEventAttributes                        *WorkflowExecutionStartedEventAttributes
 	WorkflowExecutionCompletedEventAttributes                      *WorkflowExecutionCompletedEventAttributes
 	WorkflowExecutionFailedEventAttributes                         *WorkflowExecutionFailedEventAttributes
@@ -646,36 +812,50 @@ type HistoryEvent struct {
 	UpsertWorkflowSearchAttributesEventAttributes                  *UpsertWorkflowSearchAttributesEventAttributes
 }
 
+// HistoryEventFilterType is an internal type (TBD...)
 type HistoryEventFilterType int32
 
 const (
+	// HistoryEventFilterTypeAllEvent is an option for HistoryEventFilterType
 	HistoryEventFilterTypeAllEvent HistoryEventFilterType = iota
+	// HistoryEventFilterTypeCloseEvent is an option for HistoryEventFilterType
 	HistoryEventFilterTypeCloseEvent
 )
 
+// IndexedValueType is an internal type (TBD...)
 type IndexedValueType int32
 
 const (
+	// IndexedValueTypeBool is an option for IndexedValueType
 	IndexedValueTypeBool IndexedValueType = iota
+	// IndexedValueTypeDatetime is an option for IndexedValueType
 	IndexedValueTypeDatetime
+	// IndexedValueTypeDouble is an option for IndexedValueType
 	IndexedValueTypeDouble
+	// IndexedValueTypeInt is an option for IndexedValueType
 	IndexedValueTypeInt
+	// IndexedValueTypeKeyword is an option for IndexedValueType
 	IndexedValueTypeKeyword
+	// IndexedValueTypeString is an option for IndexedValueType
 	IndexedValueTypeString
 )
 
+// InternalDataInconsistencyError is an internal type (TBD...)
 type InternalDataInconsistencyError struct {
 	Message string
 }
 
+// InternalServiceError is an internal type (TBD...)
 type InternalServiceError struct {
 	Message string
 }
 
+// LimitExceededError is an internal type (TBD...)
 type LimitExceededError struct {
 	Message string
 }
 
+// ListArchivedWorkflowExecutionsRequest is an internal type (TBD...)
 type ListArchivedWorkflowExecutionsRequest struct {
 	Domain        *string
 	PageSize      *int32
@@ -683,11 +863,13 @@ type ListArchivedWorkflowExecutionsRequest struct {
 	Query         *string
 }
 
+// ListArchivedWorkflowExecutionsResponse is an internal type (TBD...)
 type ListArchivedWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
 }
 
+// ListClosedWorkflowExecutionsRequest is an internal type (TBD...)
 type ListClosedWorkflowExecutionsRequest struct {
 	Domain          *string
 	MaximumPageSize *int32
@@ -698,21 +880,25 @@ type ListClosedWorkflowExecutionsRequest struct {
 	StatusFilter    *WorkflowExecutionCloseStatus
 }
 
+// ListClosedWorkflowExecutionsResponse is an internal type (TBD...)
 type ListClosedWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
 }
 
+// ListDomainsRequest is an internal type (TBD...)
 type ListDomainsRequest struct {
 	PageSize      *int32
 	NextPageToken []byte
 }
 
+// ListDomainsResponse is an internal type (TBD...)
 type ListDomainsResponse struct {
 	Domains       []*DescribeDomainResponse
 	NextPageToken []byte
 }
 
+// ListOpenWorkflowExecutionsRequest is an internal type (TBD...)
 type ListOpenWorkflowExecutionsRequest struct {
 	Domain          *string
 	MaximumPageSize *int32
@@ -722,21 +908,25 @@ type ListOpenWorkflowExecutionsRequest struct {
 	TypeFilter      *WorkflowTypeFilter
 }
 
+// ListOpenWorkflowExecutionsResponse is an internal type (TBD...)
 type ListOpenWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
 }
 
+// ListTaskListPartitionsRequest is an internal type (TBD...)
 type ListTaskListPartitionsRequest struct {
 	Domain   *string
 	TaskList *TaskList
 }
 
+// ListTaskListPartitionsResponse is an internal type (TBD...)
 type ListTaskListPartitionsResponse struct {
 	ActivityTaskListPartitions []*TaskListPartitionMetadata
 	DecisionTaskListPartitions []*TaskListPartitionMetadata
 }
 
+// ListWorkflowExecutionsRequest is an internal type (TBD...)
 type ListWorkflowExecutionsRequest struct {
 	Domain        *string
 	PageSize      *int32
@@ -744,30 +934,38 @@ type ListWorkflowExecutionsRequest struct {
 	Query         *string
 }
 
+// ListWorkflowExecutionsResponse is an internal type (TBD...)
 type ListWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
 }
 
+// MarkerRecordedEventAttributes is an internal type (TBD...)
 type MarkerRecordedEventAttributes struct {
 	MarkerName                   *string
 	Details                      []byte
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	Header                       *Header
 }
 
+// Memo is an internal type (TBD...)
 type Memo struct {
 	Fields map[string][]byte
 }
 
+// ParentClosePolicy is an internal type (TBD...)
 type ParentClosePolicy int32
 
 const (
+	// ParentClosePolicyAbandon is an option for ParentClosePolicy
 	ParentClosePolicyAbandon ParentClosePolicy = iota
+	// ParentClosePolicyRequestCancel is an option for ParentClosePolicy
 	ParentClosePolicyRequestCancel
+	// ParentClosePolicyTerminate is an option for ParentClosePolicy
 	ParentClosePolicyTerminate
 )
 
+// PendingActivityInfo is an internal type (TBD...)
 type PendingActivityInfo struct {
 	ActivityID             *string
 	ActivityType           *ActivityType
@@ -784,14 +982,19 @@ type PendingActivityInfo struct {
 	LastFailureDetails     []byte
 }
 
+// PendingActivityState is an internal type (TBD...)
 type PendingActivityState int32
 
 const (
+	// PendingActivityStateCancelRequested is an option for PendingActivityState
 	PendingActivityStateCancelRequested PendingActivityState = iota
+	// PendingActivityStateScheduled is an option for PendingActivityState
 	PendingActivityStateScheduled
+	// PendingActivityStateStarted is an option for PendingActivityState
 	PendingActivityStateStarted
 )
 
+// PendingChildExecutionInfo is an internal type (TBD...)
 type PendingChildExecutionInfo struct {
 	WorkflowID        *string
 	RunID             *string
@@ -800,6 +1003,7 @@ type PendingChildExecutionInfo struct {
 	ParentClosePolicy *ParentClosePolicy
 }
 
+// PollForActivityTaskRequest is an internal type (TBD...)
 type PollForActivityTaskRequest struct {
 	Domain           *string
 	TaskList         *TaskList
@@ -807,10 +1011,11 @@ type PollForActivityTaskRequest struct {
 	TaskListMetadata *TaskListMetadata
 }
 
+// PollForActivityTaskResponse is an internal type (TBD...)
 type PollForActivityTaskResponse struct {
 	TaskToken                       []byte
 	WorkflowExecution               *WorkflowExecution
-	ActivityId                      *string
+	ActivityID                      *string
 	ActivityType                    *ActivityType
 	Input                           []byte
 	ScheduledTimestamp              *int64
@@ -826,6 +1031,7 @@ type PollForActivityTaskResponse struct {
 	Header                          *Header
 }
 
+// PollForDecisionTaskRequest is an internal type (TBD...)
 type PollForDecisionTaskRequest struct {
 	Domain         *string
 	TaskList       *TaskList
@@ -833,12 +1039,13 @@ type PollForDecisionTaskRequest struct {
 	BinaryChecksum *string
 }
 
+// PollForDecisionTaskResponse is an internal type (TBD...)
 type PollForDecisionTaskResponse struct {
 	TaskToken                 []byte
 	WorkflowExecution         *WorkflowExecution
 	WorkflowType              *WorkflowType
-	PreviousStartedEventId    *int64
-	StartedEventId            *int64
+	PreviousStartedEventID    *int64
+	StartedEventID            *int64
 	Attempt                   *int64
 	BacklogCountHint          *int64
 	History                   *History
@@ -850,48 +1057,64 @@ type PollForDecisionTaskResponse struct {
 	Queries                   map[string]*WorkflowQuery
 }
 
+// PollerInfo is an internal type (TBD...)
 type PollerInfo struct {
 	LastAccessTime *int64
 	Identity       *string
 	RatePerSecond  *float64
 }
 
+// QueryConsistencyLevel is an internal type (TBD...)
 type QueryConsistencyLevel int32
 
 const (
+	// QueryConsistencyLevelEventual is an option for QueryConsistencyLevel
 	QueryConsistencyLevelEventual QueryConsistencyLevel = iota
+	// QueryConsistencyLevelStrong is an option for QueryConsistencyLevel
 	QueryConsistencyLevelStrong
 )
 
+// QueryFailedError is an internal type (TBD...)
 type QueryFailedError struct {
 	Message string
 }
 
+// QueryRejectCondition is an internal type (TBD...)
 type QueryRejectCondition int32
 
 const (
+	// QueryRejectConditionNotCompletedCleanly is an option for QueryRejectCondition
 	QueryRejectConditionNotCompletedCleanly QueryRejectCondition = iota
+	// QueryRejectConditionNotOpen is an option for QueryRejectCondition
 	QueryRejectConditionNotOpen
 )
 
+// QueryRejected is an internal type (TBD...)
 type QueryRejected struct {
 	CloseStatus *WorkflowExecutionCloseStatus
 }
 
+// QueryResultType is an internal type (TBD...)
 type QueryResultType int32
 
 const (
+	// QueryResultTypeAnswered is an option for QueryResultType
 	QueryResultTypeAnswered QueryResultType = iota
+	// QueryResultTypeFailed is an option for QueryResultType
 	QueryResultTypeFailed
 )
 
+// QueryTaskCompletedType is an internal type (TBD...)
 type QueryTaskCompletedType int32
 
 const (
+	// QueryTaskCompletedTypeCompleted is an option for QueryTaskCompletedType
 	QueryTaskCompletedTypeCompleted QueryTaskCompletedType = iota
+	// QueryTaskCompletedTypeFailed is an option for QueryTaskCompletedType
 	QueryTaskCompletedTypeFailed
 )
 
+// QueryWorkflowRequest is an internal type (TBD...)
 type QueryWorkflowRequest struct {
 	Domain                *string
 	Execution             *WorkflowExecution
@@ -900,17 +1123,20 @@ type QueryWorkflowRequest struct {
 	QueryConsistencyLevel *QueryConsistencyLevel
 }
 
+// QueryWorkflowResponse is an internal type (TBD...)
 type QueryWorkflowResponse struct {
 	QueryResult   []byte
 	QueryRejected *QueryRejected
 }
 
+// ReapplyEventsRequest is an internal type (TBD...)
 type ReapplyEventsRequest struct {
 	DomainName        *string
 	WorkflowExecution *WorkflowExecution
 	Events            *DataBlob
 }
 
+// RecordActivityTaskHeartbeatByIDRequest is an internal type (TBD...)
 type RecordActivityTaskHeartbeatByIDRequest struct {
 	Domain     *string
 	WorkflowID *string
@@ -920,27 +1146,32 @@ type RecordActivityTaskHeartbeatByIDRequest struct {
 	Identity   *string
 }
 
+// RecordActivityTaskHeartbeatRequest is an internal type (TBD...)
 type RecordActivityTaskHeartbeatRequest struct {
 	TaskToken []byte
 	Details   []byte
 	Identity  *string
 }
 
+// RecordActivityTaskHeartbeatResponse is an internal type (TBD...)
 type RecordActivityTaskHeartbeatResponse struct {
 	CancelRequested *bool
 }
 
+// RecordMarkerDecisionAttributes is an internal type (TBD...)
 type RecordMarkerDecisionAttributes struct {
 	MarkerName *string
 	Details    []byte
 	Header     *Header
 }
 
+// RefreshWorkflowTasksRequest is an internal type (TBD...)
 type RefreshWorkflowTasksRequest struct {
 	Domain    *string
 	Execution *WorkflowExecution
 }
 
+// RegisterDomainRequest is an internal type (TBD...)
 type RegisterDomainRequest struct {
 	Name                                   *string
 	Description                            *string
@@ -958,10 +1189,12 @@ type RegisterDomainRequest struct {
 	VisibilityArchivalURI                  *string
 }
 
+// RemoteSyncMatchedError is an internal type (TBD...)
 type RemoteSyncMatchedError struct {
 	Message string
 }
 
+// RemoveTaskRequest is an internal type (TBD...)
 type RemoveTaskRequest struct {
 	ShardID             *int32
 	Type                *int32
@@ -969,87 +1202,101 @@ type RemoveTaskRequest struct {
 	VisibilityTimestamp *int64
 }
 
+// RequestCancelActivityTaskDecisionAttributes is an internal type (TBD...)
 type RequestCancelActivityTaskDecisionAttributes struct {
-	ActivityId *string
+	ActivityID *string
 }
 
+// RequestCancelActivityTaskFailedEventAttributes is an internal type (TBD...)
 type RequestCancelActivityTaskFailedEventAttributes struct {
-	ActivityId                   *string
+	ActivityID                   *string
 	Cause                        *string
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 }
 
+// RequestCancelExternalWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 	Domain            *string
-	WorkflowId        *string
-	RunId             *string
+	WorkflowID        *string
+	RunID             *string
 	Control           []byte
 	ChildWorkflowOnly *bool
 }
 
+// RequestCancelExternalWorkflowExecutionFailedEventAttributes is an internal type (TBD...)
 type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
 	Cause                        *CancelExternalWorkflowExecutionFailedCause
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	Domain                       *string
 	WorkflowExecution            *WorkflowExecution
-	InitiatedEventId             *int64
+	InitiatedEventID             *int64
 	Control                      []byte
 }
 
+// RequestCancelExternalWorkflowExecutionInitiatedEventAttributes is an internal type (TBD...)
 type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	Domain                       *string
 	WorkflowExecution            *WorkflowExecution
 	Control                      []byte
 	ChildWorkflowOnly            *bool
 }
 
+// RequestCancelWorkflowExecutionRequest is an internal type (TBD...)
 type RequestCancelWorkflowExecutionRequest struct {
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	Identity          *string
-	RequestId         *string
+	RequestID         *string
 }
 
+// ResetPointInfo is an internal type (TBD...)
 type ResetPointInfo struct {
 	BinaryChecksum           *string
-	RunId                    *string
-	FirstDecisionCompletedId *int64
+	RunID                    *string
+	FirstDecisionCompletedID *int64
 	CreatedTimeNano          *int64
 	ExpiringTimeNano         *int64
 	Resettable               *bool
 }
 
+// ResetPoints is an internal type (TBD...)
 type ResetPoints struct {
 	Points []*ResetPointInfo
 }
 
+// ResetQueueRequest is an internal type (TBD...)
 type ResetQueueRequest struct {
 	ShardID     *int32
 	ClusterName *string
 	Type        *int32
 }
 
+// ResetStickyTaskListRequest is an internal type (TBD...)
 type ResetStickyTaskListRequest struct {
 	Domain    *string
 	Execution *WorkflowExecution
 }
 
+// ResetStickyTaskListResponse is an internal type (TBD...)
 type ResetStickyTaskListResponse struct {
 }
 
+// ResetWorkflowExecutionRequest is an internal type (TBD...)
 type ResetWorkflowExecutionRequest struct {
 	Domain                *string
 	WorkflowExecution     *WorkflowExecution
 	Reason                *string
-	DecisionFinishEventId *int64
-	RequestId             *string
+	DecisionFinishEventID *int64
+	RequestID             *string
 }
 
+// ResetWorkflowExecutionResponse is an internal type (TBD...)
 type ResetWorkflowExecutionResponse struct {
-	RunId *string
+	RunID *string
 }
 
+// RespondActivityTaskCanceledByIDRequest is an internal type (TBD...)
 type RespondActivityTaskCanceledByIDRequest struct {
 	Domain     *string
 	WorkflowID *string
@@ -1059,12 +1306,14 @@ type RespondActivityTaskCanceledByIDRequest struct {
 	Identity   *string
 }
 
+// RespondActivityTaskCanceledRequest is an internal type (TBD...)
 type RespondActivityTaskCanceledRequest struct {
 	TaskToken []byte
 	Details   []byte
 	Identity  *string
 }
 
+// RespondActivityTaskCompletedByIDRequest is an internal type (TBD...)
 type RespondActivityTaskCompletedByIDRequest struct {
 	Domain     *string
 	WorkflowID *string
@@ -1074,12 +1323,14 @@ type RespondActivityTaskCompletedByIDRequest struct {
 	Identity   *string
 }
 
+// RespondActivityTaskCompletedRequest is an internal type (TBD...)
 type RespondActivityTaskCompletedRequest struct {
 	TaskToken []byte
 	Result    []byte
 	Identity  *string
 }
 
+// RespondActivityTaskFailedByIDRequest is an internal type (TBD...)
 type RespondActivityTaskFailedByIDRequest struct {
 	Domain     *string
 	WorkflowID *string
@@ -1090,6 +1341,7 @@ type RespondActivityTaskFailedByIDRequest struct {
 	Identity   *string
 }
 
+// RespondActivityTaskFailedRequest is an internal type (TBD...)
 type RespondActivityTaskFailedRequest struct {
 	TaskToken []byte
 	Reason    *string
@@ -1097,6 +1349,7 @@ type RespondActivityTaskFailedRequest struct {
 	Identity  *string
 }
 
+// RespondDecisionTaskCompletedRequest is an internal type (TBD...)
 type RespondDecisionTaskCompletedRequest struct {
 	TaskToken                  []byte
 	Decisions                  []*Decision
@@ -1109,10 +1362,12 @@ type RespondDecisionTaskCompletedRequest struct {
 	QueryResults               map[string]*WorkflowQueryResult
 }
 
+// RespondDecisionTaskCompletedResponse is an internal type (TBD...)
 type RespondDecisionTaskCompletedResponse struct {
 	DecisionTask *PollForDecisionTaskResponse
 }
 
+// RespondDecisionTaskFailedRequest is an internal type (TBD...)
 type RespondDecisionTaskFailedRequest struct {
 	TaskToken      []byte
 	Cause          *DecisionTaskFailedCause
@@ -1121,6 +1376,7 @@ type RespondDecisionTaskFailedRequest struct {
 	BinaryChecksum *string
 }
 
+// RespondQueryTaskCompletedRequest is an internal type (TBD...)
 type RespondQueryTaskCompletedRequest struct {
 	TaskToken         []byte
 	CompletedType     *QueryTaskCompletedType
@@ -1129,6 +1385,7 @@ type RespondQueryTaskCompletedRequest struct {
 	WorkerVersionInfo *WorkerVersionInfo
 }
 
+// RetryPolicy is an internal type (TBD...)
 type RetryPolicy struct {
 	InitialIntervalInSeconds    *int32
 	BackoffCoefficient          *float64
@@ -1138,19 +1395,21 @@ type RetryPolicy struct {
 	ExpirationIntervalInSeconds *int32
 }
 
+// RetryTaskV2Error is an internal type (TBD...)
 type RetryTaskV2Error struct {
 	Message           string
-	DomainId          *string
-	WorkflowId        *string
-	RunId             *string
-	StartEventId      *int64
+	DomainID          *string
+	WorkflowID        *string
+	RunID             *string
+	StartEventID      *int64
 	StartEventVersion *int64
-	EndEventId        *int64
+	EndEventID        *int64
 	EndEventVersion   *int64
 }
 
+// ScheduleActivityTaskDecisionAttributes is an internal type (TBD...)
 type ScheduleActivityTaskDecisionAttributes struct {
-	ActivityId                    *string
+	ActivityID                    *string
 	ActivityType                  *ActivityType
 	Domain                        *string
 	TaskList                      *TaskList
@@ -1163,14 +1422,17 @@ type ScheduleActivityTaskDecisionAttributes struct {
 	Header                        *Header
 }
 
+// SearchAttributes is an internal type (TBD...)
 type SearchAttributes struct {
 	IndexedFields map[string][]byte
 }
 
+// ServiceBusyError is an internal type (TBD...)
 type ServiceBusyError struct {
 	Message string
 }
 
+// SignalExternalWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type SignalExternalWorkflowExecutionDecisionAttributes struct {
 	Domain            *string
 	Execution         *WorkflowExecution
@@ -1180,23 +1442,27 @@ type SignalExternalWorkflowExecutionDecisionAttributes struct {
 	ChildWorkflowOnly *bool
 }
 
+// SignalExternalWorkflowExecutionFailedCause is an internal type (TBD...)
 type SignalExternalWorkflowExecutionFailedCause int32
 
 const (
+	// SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution is an option for SignalExternalWorkflowExecutionFailedCause
 	SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution SignalExternalWorkflowExecutionFailedCause = iota
 )
 
+// SignalExternalWorkflowExecutionFailedEventAttributes is an internal type (TBD...)
 type SignalExternalWorkflowExecutionFailedEventAttributes struct {
 	Cause                        *SignalExternalWorkflowExecutionFailedCause
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	Domain                       *string
 	WorkflowExecution            *WorkflowExecution
-	InitiatedEventId             *int64
+	InitiatedEventID             *int64
 	Control                      []byte
 }
 
+// SignalExternalWorkflowExecutionInitiatedEventAttributes is an internal type (TBD...)
 type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	Domain                       *string
 	WorkflowExecution            *WorkflowExecution
 	SignalName                   *string
@@ -1205,17 +1471,18 @@ type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	ChildWorkflowOnly            *bool
 }
 
+// SignalWithStartWorkflowExecutionRequest is an internal type (TBD...)
 type SignalWithStartWorkflowExecutionRequest struct {
 	Domain                              *string
-	WorkflowId                          *string
+	WorkflowID                          *string
 	WorkflowType                        *WorkflowType
 	TaskList                            *TaskList
 	Input                               []byte
 	ExecutionStartToCloseTimeoutSeconds *int32
 	TaskStartToCloseTimeoutSeconds      *int32
 	Identity                            *string
-	RequestId                           *string
-	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	RequestID                           *string
+	WorkflowIDReusePolicy               *WorkflowIDReusePolicy
 	SignalName                          *string
 	SignalInput                         []byte
 	Control                             []byte
@@ -1226,19 +1493,21 @@ type SignalWithStartWorkflowExecutionRequest struct {
 	Header                              *Header
 }
 
+// SignalWorkflowExecutionRequest is an internal type (TBD...)
 type SignalWorkflowExecutionRequest struct {
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	SignalName        *string
 	Input             []byte
 	Identity          *string
-	RequestId         *string
+	RequestID         *string
 	Control           []byte
 }
 
+// StartChildWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type StartChildWorkflowExecutionDecisionAttributes struct {
 	Domain                              *string
-	WorkflowId                          *string
+	WorkflowID                          *string
 	WorkflowType                        *WorkflowType
 	TaskList                            *TaskList
 	Input                               []byte
@@ -1246,7 +1515,7 @@ type StartChildWorkflowExecutionDecisionAttributes struct {
 	TaskStartToCloseTimeoutSeconds      *int32
 	ParentClosePolicy                   *ParentClosePolicy
 	Control                             []byte
-	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	WorkflowIDReusePolicy               *WorkflowIDReusePolicy
 	RetryPolicy                         *RetryPolicy
 	CronSchedule                        *string
 	Header                              *Header
@@ -1254,19 +1523,21 @@ type StartChildWorkflowExecutionDecisionAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+// StartChildWorkflowExecutionFailedEventAttributes is an internal type (TBD...)
 type StartChildWorkflowExecutionFailedEventAttributes struct {
 	Domain                       *string
-	WorkflowId                   *string
+	WorkflowID                   *string
 	WorkflowType                 *WorkflowType
 	Cause                        *ChildWorkflowExecutionFailedCause
 	Control                      []byte
-	InitiatedEventId             *int64
-	DecisionTaskCompletedEventId *int64
+	InitiatedEventID             *int64
+	DecisionTaskCompletedEventID *int64
 }
 
+// StartChildWorkflowExecutionInitiatedEventAttributes is an internal type (TBD...)
 type StartChildWorkflowExecutionInitiatedEventAttributes struct {
 	Domain                              *string
-	WorkflowId                          *string
+	WorkflowID                          *string
 	WorkflowType                        *WorkflowType
 	TaskList                            *TaskList
 	Input                               []byte
@@ -1274,8 +1545,8 @@ type StartChildWorkflowExecutionInitiatedEventAttributes struct {
 	TaskStartToCloseTimeoutSeconds      *int32
 	ParentClosePolicy                   *ParentClosePolicy
 	Control                             []byte
-	DecisionTaskCompletedEventId        *int64
-	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	DecisionTaskCompletedEventID        *int64
+	WorkflowIDReusePolicy               *WorkflowIDReusePolicy
 	RetryPolicy                         *RetryPolicy
 	CronSchedule                        *string
 	Header                              *Header
@@ -1283,27 +1554,30 @@ type StartChildWorkflowExecutionInitiatedEventAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+// StartTimeFilter is an internal type (TBD...)
 type StartTimeFilter struct {
 	EarliestTime *int64
 	LatestTime   *int64
 }
 
+// StartTimerDecisionAttributes is an internal type (TBD...)
 type StartTimerDecisionAttributes struct {
-	TimerId                   *string
+	TimerID                   *string
 	StartToFireTimeoutSeconds *int64
 }
 
+// StartWorkflowExecutionRequest is an internal type (TBD...)
 type StartWorkflowExecutionRequest struct {
 	Domain                              *string
-	WorkflowId                          *string
+	WorkflowID                          *string
 	WorkflowType                        *WorkflowType
 	TaskList                            *TaskList
 	Input                               []byte
 	ExecutionStartToCloseTimeoutSeconds *int32
 	TaskStartToCloseTimeoutSeconds      *int32
 	Identity                            *string
-	RequestId                           *string
-	WorkflowIdReusePolicy               *WorkflowIdReusePolicy
+	RequestID                           *string
+	WorkflowIDReusePolicy               *WorkflowIDReusePolicy
 	RetryPolicy                         *RetryPolicy
 	CronSchedule                        *string
 	Memo                                *Memo
@@ -1311,46 +1585,57 @@ type StartWorkflowExecutionRequest struct {
 	Header                              *Header
 }
 
+// StartWorkflowExecutionResponse is an internal type (TBD...)
 type StartWorkflowExecutionResponse struct {
-	RunId *string
+	RunID *string
 }
 
+// StickyExecutionAttributes is an internal type (TBD...)
 type StickyExecutionAttributes struct {
 	WorkerTaskList                *TaskList
 	ScheduleToStartTimeoutSeconds *int32
 }
 
+// SupportedClientVersions is an internal type (TBD...)
 type SupportedClientVersions struct {
 	GoSdk   *string
 	JavaSdk *string
 }
 
+// TaskIDBlock is an internal type (TBD...)
 type TaskIDBlock struct {
 	StartID *int64
 	EndID   *int64
 }
 
+// TaskList is an internal type (TBD...)
 type TaskList struct {
 	Name *string
 	Kind *TaskListKind
 }
 
+// TaskListKind is an internal type (TBD...)
 type TaskListKind int32
 
 const (
+	// TaskListKindNormal is an option for TaskListKind
 	TaskListKindNormal TaskListKind = iota
+	// TaskListKindSticky is an option for TaskListKind
 	TaskListKindSticky
 )
 
+// TaskListMetadata is an internal type (TBD...)
 type TaskListMetadata struct {
 	MaxTasksPerSecond *float64
 }
 
+// TaskListPartitionMetadata is an internal type (TBD...)
 type TaskListPartitionMetadata struct {
 	Key           *string
 	OwnerHostName *string
 }
 
+// TaskListStatus is an internal type (TBD...)
 type TaskListStatus struct {
 	BacklogCountHint *int64
 	ReadLevel        *int64
@@ -1359,13 +1644,17 @@ type TaskListStatus struct {
 	TaskIDBlock      *TaskIDBlock
 }
 
+// TaskListType is an internal type (TBD...)
 type TaskListType int32
 
 const (
+	// TaskListTypeActivity is an option for TaskListType
 	TaskListTypeActivity TaskListType = iota
+	// TaskListTypeDecision is an option for TaskListType
 	TaskListTypeDecision
 )
 
+// TerminateWorkflowExecutionRequest is an internal type (TBD...)
 type TerminateWorkflowExecutionRequest struct {
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
@@ -1374,44 +1663,55 @@ type TerminateWorkflowExecutionRequest struct {
 	Identity          *string
 }
 
+// TimeoutType is an internal type (TBD...)
 type TimeoutType int32
 
 const (
+	// TimeoutTypeHeartbeat is an option for TimeoutType
 	TimeoutTypeHeartbeat TimeoutType = iota
+	// TimeoutTypeScheduleToClose is an option for TimeoutType
 	TimeoutTypeScheduleToClose
+	// TimeoutTypeScheduleToStart is an option for TimeoutType
 	TimeoutTypeScheduleToStart
+	// TimeoutTypeStartToClose is an option for TimeoutType
 	TimeoutTypeStartToClose
 )
 
+// TimerCanceledEventAttributes is an internal type (TBD...)
 type TimerCanceledEventAttributes struct {
-	TimerId                      *string
-	StartedEventId               *int64
-	DecisionTaskCompletedEventId *int64
+	TimerID                      *string
+	StartedEventID               *int64
+	DecisionTaskCompletedEventID *int64
 	Identity                     *string
 }
 
+// TimerFiredEventAttributes is an internal type (TBD...)
 type TimerFiredEventAttributes struct {
-	TimerId        *string
-	StartedEventId *int64
+	TimerID        *string
+	StartedEventID *int64
 }
 
+// TimerStartedEventAttributes is an internal type (TBD...)
 type TimerStartedEventAttributes struct {
-	TimerId                      *string
+	TimerID                      *string
 	StartToFireTimeoutSeconds    *int64
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 }
 
+// TransientDecisionInfo is an internal type (TBD...)
 type TransientDecisionInfo struct {
 	ScheduledEvent *HistoryEvent
 	StartedEvent   *HistoryEvent
 }
 
+// UpdateDomainInfo is an internal type (TBD...)
 type UpdateDomainInfo struct {
 	Description *string
 	OwnerEmail  *string
 	Data        map[string]string
 }
 
+// UpdateDomainRequest is an internal type (TBD...)
 type UpdateDomainRequest struct {
 	Name                     *string
 	UpdatedInfo              *UpdateDomainInfo
@@ -1422,6 +1722,7 @@ type UpdateDomainRequest struct {
 	FailoverTimeoutInSeconds *int32
 }
 
+// UpdateDomainResponse is an internal type (TBD...)
 type UpdateDomainResponse struct {
 	DomainInfo               *DomainInfo
 	Configuration            *DomainConfiguration
@@ -1430,88 +1731,108 @@ type UpdateDomainResponse struct {
 	IsGlobalDomain           *bool
 }
 
+// UpsertWorkflowSearchAttributesDecisionAttributes is an internal type (TBD...)
 type UpsertWorkflowSearchAttributesDecisionAttributes struct {
 	SearchAttributes *SearchAttributes
 }
 
+// UpsertWorkflowSearchAttributesEventAttributes is an internal type (TBD...)
 type UpsertWorkflowSearchAttributesEventAttributes struct {
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	SearchAttributes             *SearchAttributes
 }
 
+// VersionHistories is an internal type (TBD...)
 type VersionHistories struct {
 	CurrentVersionHistoryIndex *int32
 	Histories                  []*VersionHistory
 }
 
+// VersionHistory is an internal type (TBD...)
 type VersionHistory struct {
 	BranchToken []byte
 	Items       []*VersionHistoryItem
 }
 
+// VersionHistoryItem is an internal type (TBD...)
 type VersionHistoryItem struct {
 	EventID *int64
 	Version *int64
 }
 
+// WorkerVersionInfo is an internal type (TBD...)
 type WorkerVersionInfo struct {
 	Impl           *string
 	FeatureVersion *string
 }
 
+// WorkflowExecution is an internal type (TBD...)
 type WorkflowExecution struct {
-	WorkflowId *string
-	RunId      *string
+	WorkflowID *string
+	RunID      *string
 }
 
+// WorkflowExecutionAlreadyStartedError is an internal type (TBD...)
 type WorkflowExecutionAlreadyStartedError struct {
 	Message        *string
-	StartRequestId *string
-	RunId          *string
+	StartRequestID *string
+	RunID          *string
 }
 
+// WorkflowExecutionCancelRequestedEventAttributes is an internal type (TBD...)
 type WorkflowExecutionCancelRequestedEventAttributes struct {
 	Cause                     *string
-	ExternalInitiatedEventId  *int64
+	ExternalInitiatedEventID  *int64
 	ExternalWorkflowExecution *WorkflowExecution
 	Identity                  *string
 }
 
+// WorkflowExecutionCanceledEventAttributes is an internal type (TBD...)
 type WorkflowExecutionCanceledEventAttributes struct {
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 	Details                      []byte
 }
 
+// WorkflowExecutionCloseStatus is an internal type (TBD...)
 type WorkflowExecutionCloseStatus int32
 
 const (
+	// WorkflowExecutionCloseStatusCanceled is an option for WorkflowExecutionCloseStatus
 	WorkflowExecutionCloseStatusCanceled WorkflowExecutionCloseStatus = iota
+	// WorkflowExecutionCloseStatusCompleted is an option for WorkflowExecutionCloseStatus
 	WorkflowExecutionCloseStatusCompleted
+	// WorkflowExecutionCloseStatusContinuedAsNew is an option for WorkflowExecutionCloseStatus
 	WorkflowExecutionCloseStatusContinuedAsNew
+	// WorkflowExecutionCloseStatusFailed is an option for WorkflowExecutionCloseStatus
 	WorkflowExecutionCloseStatusFailed
+	// WorkflowExecutionCloseStatusTerminated is an option for WorkflowExecutionCloseStatus
 	WorkflowExecutionCloseStatusTerminated
+	// WorkflowExecutionCloseStatusTimedOut is an option for WorkflowExecutionCloseStatus
 	WorkflowExecutionCloseStatusTimedOut
 )
 
+// WorkflowExecutionCompletedEventAttributes is an internal type (TBD...)
 type WorkflowExecutionCompletedEventAttributes struct {
 	Result                       []byte
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 }
 
+// WorkflowExecutionConfiguration is an internal type (TBD...)
 type WorkflowExecutionConfiguration struct {
 	TaskList                            *TaskList
 	ExecutionStartToCloseTimeoutSeconds *int32
 	TaskStartToCloseTimeoutSeconds      *int32
 }
 
+// WorkflowExecutionContinuedAsNewEventAttributes is an internal type (TBD...)
 type WorkflowExecutionContinuedAsNewEventAttributes struct {
-	NewExecutionRunId                   *string
+	NewExecutionRunID                   *string
 	WorkflowType                        *WorkflowType
 	TaskList                            *TaskList
 	Input                               []byte
 	ExecutionStartToCloseTimeoutSeconds *int32
 	TaskStartToCloseTimeoutSeconds      *int32
-	DecisionTaskCompletedEventId        *int64
+	DecisionTaskCompletedEventID        *int64
 	BackoffStartIntervalInSeconds       *int32
 	Initiator                           *ContinueAsNewInitiator
 	FailureReason                       *string
@@ -1522,17 +1843,20 @@ type WorkflowExecutionContinuedAsNewEventAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+// WorkflowExecutionFailedEventAttributes is an internal type (TBD...)
 type WorkflowExecutionFailedEventAttributes struct {
 	Reason                       *string
 	Details                      []byte
-	DecisionTaskCompletedEventId *int64
+	DecisionTaskCompletedEventID *int64
 }
 
+// WorkflowExecutionFilter is an internal type (TBD...)
 type WorkflowExecutionFilter struct {
-	WorkflowId *string
-	RunId      *string
+	WorkflowID *string
+	RunID      *string
 }
 
+// WorkflowExecutionInfo is an internal type (TBD...)
 type WorkflowExecutionInfo struct {
 	Execution        *WorkflowExecution
 	Type             *WorkflowType
@@ -1540,7 +1864,7 @@ type WorkflowExecutionInfo struct {
 	CloseTime        *int64
 	CloseStatus      *WorkflowExecutionCloseStatus
 	HistoryLength    *int64
-	ParentDomainId   *string
+	ParentDomainID   *string
 	ParentExecution  *WorkflowExecution
 	ExecutionTime    *int64
 	Memo             *Memo
@@ -1549,29 +1873,31 @@ type WorkflowExecutionInfo struct {
 	TaskList         *string
 }
 
+// WorkflowExecutionSignaledEventAttributes is an internal type (TBD...)
 type WorkflowExecutionSignaledEventAttributes struct {
 	SignalName *string
 	Input      []byte
 	Identity   *string
 }
 
+// WorkflowExecutionStartedEventAttributes is an internal type (TBD...)
 type WorkflowExecutionStartedEventAttributes struct {
 	WorkflowType                        *WorkflowType
 	ParentWorkflowDomain                *string
 	ParentWorkflowExecution             *WorkflowExecution
-	ParentInitiatedEventId              *int64
+	ParentInitiatedEventID              *int64
 	TaskList                            *TaskList
 	Input                               []byte
 	ExecutionStartToCloseTimeoutSeconds *int32
 	TaskStartToCloseTimeoutSeconds      *int32
-	ContinuedExecutionRunId             *string
+	ContinuedExecutionRunID             *string
 	Initiator                           *ContinueAsNewInitiator
 	ContinuedFailureReason              *string
 	ContinuedFailureDetails             []byte
 	LastCompletionResult                []byte
-	OriginalExecutionRunId              *string
+	OriginalExecutionRunID              *string
 	Identity                            *string
-	FirstExecutionRunId                 *string
+	FirstExecutionRunID                 *string
 	RetryPolicy                         *RetryPolicy
 	Attempt                             *int32
 	ExpirationTimestamp                 *int64
@@ -1583,40 +1909,51 @@ type WorkflowExecutionStartedEventAttributes struct {
 	Header                              *Header
 }
 
+// WorkflowExecutionTerminatedEventAttributes is an internal type (TBD...)
 type WorkflowExecutionTerminatedEventAttributes struct {
 	Reason   *string
 	Details  []byte
 	Identity *string
 }
 
+// WorkflowExecutionTimedOutEventAttributes is an internal type (TBD...)
 type WorkflowExecutionTimedOutEventAttributes struct {
 	TimeoutType *TimeoutType
 }
 
-type WorkflowIdReusePolicy int32
+// WorkflowIDReusePolicy is an internal type (TBD...)
+type WorkflowIDReusePolicy int32
 
 const (
-	WorkflowIdReusePolicyAllowDuplicate WorkflowIdReusePolicy = iota
-	WorkflowIdReusePolicyAllowDuplicateFailedOnly
-	WorkflowIdReusePolicyRejectDuplicate
-	WorkflowIdReusePolicyTerminateIfRunning
+	// WorkflowIDReusePolicyAllowDuplicate is an option for WorkflowIDReusePolicy
+	WorkflowIDReusePolicyAllowDuplicate WorkflowIDReusePolicy = iota
+	// WorkflowIDReusePolicyAllowDuplicateFailedOnly is an option for WorkflowIDReusePolicy
+	WorkflowIDReusePolicyAllowDuplicateFailedOnly
+	// WorkflowIDReusePolicyRejectDuplicate is an option for WorkflowIDReusePolicy
+	WorkflowIDReusePolicyRejectDuplicate
+	// WorkflowIDReusePolicyTerminateIfRunning is an option for WorkflowIDReusePolicy
+	WorkflowIDReusePolicyTerminateIfRunning
 )
 
+// WorkflowQuery is an internal type (TBD...)
 type WorkflowQuery struct {
 	QueryType *string
 	QueryArgs []byte
 }
 
+// WorkflowQueryResult is an internal type (TBD...)
 type WorkflowQueryResult struct {
 	ResultType   *QueryResultType
 	Answer       []byte
 	ErrorMessage *string
 }
 
+// WorkflowType is an internal type (TBD...)
 type WorkflowType struct {
 	Name *string
 }
 
+// WorkflowTypeFilter is an internal type (TBD...)
 type WorkflowTypeFilter struct {
 	Name *string
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix linter errors by:
- Adding placeholder comment for generated types
- Replacing "Id" with "ID" for names, types, enum values used in internal types

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

