### PR TITLE
Add getters to internal generated types

### DIFF
--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -46,6 +46,26 @@ func ToAccessDeniedError(t *shared.AccessDeniedError) *types.AccessDeniedError {
 	}
 }
 
+// FromActivityLocalDispatchInfo converts internal ActivityLocalDispatchInfo type to thrift
+func FromActivityLocalDispatchInfo(t *types.ActivityLocalDispatchInfo) *shared.ActivityLocalDispatchInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActivityLocalDispatchInfo{
+		ActivityId: t.ActivityID,
+	}
+}
+
+// ToActivityLocalDispatchInfo converts thrift ActivityLocalDispatchInfo type to internal
+func ToActivityLocalDispatchInfo(t *shared.ActivityLocalDispatchInfo) *types.ActivityLocalDispatchInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.ActivityLocalDispatchInfo{
+		ActivityID: t.ActivityId,
+	}
+}
+
 // FromActivityTaskCancelRequestedEventAttributes converts internal ActivityTaskCancelRequestedEventAttributes type to thrift
 func FromActivityTaskCancelRequestedEventAttributes(t *types.ActivityTaskCancelRequestedEventAttributes) *shared.ActivityTaskCancelRequestedEventAttributes {
 	if t == nil {
@@ -4298,7 +4318,8 @@ func FromRespondDecisionTaskCompletedResponse(t *types.RespondDecisionTaskComple
 		return nil
 	}
 	return &shared.RespondDecisionTaskCompletedResponse{
-		DecisionTask: FromPollForDecisionTaskResponse(t.DecisionTask),
+		DecisionTask:                FromPollForDecisionTaskResponse(t.DecisionTask),
+		ActivitiesToDispatchLocally: FromActivityLocalDispatchInfoMap(t.ActivitiesToDispatchLocally),
 	}
 }
 
@@ -4308,7 +4329,8 @@ func ToRespondDecisionTaskCompletedResponse(t *shared.RespondDecisionTaskComplet
 		return nil
 	}
 	return &types.RespondDecisionTaskCompletedResponse{
-		DecisionTask: ToPollForDecisionTaskResponse(t.DecisionTask),
+		DecisionTask:                ToPollForDecisionTaskResponse(t.DecisionTask),
+		ActivitiesToDispatchLocally: ToActivityLocalDispatchInfoMap(t.ActivitiesToDispatchLocally),
 	}
 }
 
@@ -4449,6 +4471,7 @@ func FromScheduleActivityTaskDecisionAttributes(t *types.ScheduleActivityTaskDec
 		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
 		RetryPolicy:                   FromRetryPolicy(t.RetryPolicy),
 		Header:                        FromHeader(t.Header),
+		RequestLocalDispatch:          t.RequestLocalDispatch,
 	}
 }
 
@@ -4469,6 +4492,7 @@ func ToScheduleActivityTaskDecisionAttributes(t *shared.ScheduleActivityTaskDeci
 		HeartbeatTimeoutSeconds:       t.HeartbeatTimeoutSeconds,
 		RetryPolicy:                   ToRetryPolicy(t.RetryPolicy),
 		Header:                        ToHeader(t.Header),
+		RequestLocalDispatch:          t.RequestLocalDispatch,
 	}
 }
 
@@ -6208,26 +6232,74 @@ func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*
 	return v
 }
 
-// FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
-func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
+// FromVersionHistoryArray converts internal VersionHistory type array to thrift
+func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.PendingActivityInfo, len(t))
+	v := make([]*shared.VersionHistory, len(t))
 	for i := range t {
-		v[i] = FromPendingActivityInfo(t[i])
+		v[i] = FromVersionHistory(t[i])
 	}
 	return v
 }
 
-// ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
-func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
+// ToVersionHistoryArray converts thrift VersionHistory type array to internal
+func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.PendingActivityInfo, len(t))
+	v := make([]*types.VersionHistory, len(t))
 	for i := range t {
-		v[i] = ToPendingActivityInfo(t[i])
+		v[i] = ToVersionHistory(t[i])
+	}
+	return v
+}
+
+// FromDescribeDomainResponseArray converts internal DescribeDomainResponse type array to thrift
+func FromDescribeDomainResponseArray(t []*types.DescribeDomainResponse) []*shared.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = FromDescribeDomainResponse(t[i])
+	}
+	return v
+}
+
+// ToDescribeDomainResponseArray converts thrift DescribeDomainResponse type array to internal
+func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = ToDescribeDomainResponse(t[i])
+	}
+	return v
+}
+
+// FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
+func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.VersionHistoryItem, len(t))
+	for i := range t {
+		v[i] = FromVersionHistoryItem(t[i])
+	}
+	return v
+}
+
+// ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
+func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.VersionHistoryItem, len(t))
+	for i := range t {
+		v[i] = ToVersionHistoryItem(t[i])
 	}
 	return v
 }
@@ -6252,54 +6324,6 @@ func ToHistoryEventArray(t []*shared.HistoryEvent) []*types.HistoryEvent {
 	v := make([]*types.HistoryEvent, len(t))
 	for i := range t {
 		v[i] = ToHistoryEvent(t[i])
-	}
-	return v
-}
-
-// FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
-func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.WorkflowExecutionInfo, len(t))
-	for i := range t {
-		v[i] = FromWorkflowExecutionInfo(t[i])
-	}
-	return v
-}
-
-// ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
-func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.WorkflowExecutionInfo, len(t))
-	for i := range t {
-		v[i] = ToWorkflowExecutionInfo(t[i])
-	}
-	return v
-}
-
-// FromDecisionArray converts internal Decision type array to thrift
-func FromDecisionArray(t []*types.Decision) []*shared.Decision {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.Decision, len(t))
-	for i := range t {
-		v[i] = FromDecision(t[i])
-	}
-	return v
-}
-
-// ToDecisionArray converts thrift Decision type array to internal
-func ToDecisionArray(t []*shared.Decision) []*types.Decision {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.Decision, len(t))
-	for i := range t {
-		v[i] = ToDecision(t[i])
 	}
 	return v
 }
@@ -6352,26 +6376,26 @@ func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*
 	return v
 }
 
-// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
-func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
+// FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
+func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.ResetPointInfo, len(t))
+	v := make([]*shared.PendingActivityInfo, len(t))
 	for i := range t {
-		v[i] = FromResetPointInfo(t[i])
+		v[i] = FromPendingActivityInfo(t[i])
 	}
 	return v
 }
 
-// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
-func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
+// ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
+func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.ResetPointInfo, len(t))
+	v := make([]*types.PendingActivityInfo, len(t))
 	for i := range t {
-		v[i] = ToResetPointInfo(t[i])
+		v[i] = ToPendingActivityInfo(t[i])
 	}
 	return v
 }
@@ -6424,122 +6448,74 @@ func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
 	return v
 }
 
-// FromDescribeDomainResponseArray converts internal DescribeDomainResponse type array to thrift
-func FromDescribeDomainResponseArray(t []*types.DescribeDomainResponse) []*shared.DescribeDomainResponse {
+// FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
+func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.DescribeDomainResponse, len(t))
+	v := make([]*shared.WorkflowExecutionInfo, len(t))
 	for i := range t {
-		v[i] = FromDescribeDomainResponse(t[i])
+		v[i] = FromWorkflowExecutionInfo(t[i])
 	}
 	return v
 }
 
-// ToDescribeDomainResponseArray converts thrift DescribeDomainResponse type array to internal
-func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.DescribeDomainResponse {
+// ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
+func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.DescribeDomainResponse, len(t))
+	v := make([]*types.WorkflowExecutionInfo, len(t))
 	for i := range t {
-		v[i] = ToDescribeDomainResponse(t[i])
+		v[i] = ToWorkflowExecutionInfo(t[i])
 	}
 	return v
 }
 
-// FromVersionHistoryArray converts internal VersionHistory type array to thrift
-func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
+// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
+func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.VersionHistory, len(t))
+	v := make([]*shared.ResetPointInfo, len(t))
 	for i := range t {
-		v[i] = FromVersionHistory(t[i])
+		v[i] = FromResetPointInfo(t[i])
 	}
 	return v
 }
 
-// ToVersionHistoryArray converts thrift VersionHistory type array to internal
-func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
+// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
+func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.VersionHistory, len(t))
+	v := make([]*types.ResetPointInfo, len(t))
 	for i := range t {
-		v[i] = ToVersionHistory(t[i])
+		v[i] = ToResetPointInfo(t[i])
 	}
 	return v
 }
 
-// FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
-func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
+// FromDecisionArray converts internal Decision type array to thrift
+func FromDecisionArray(t []*types.Decision) []*shared.Decision {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.VersionHistoryItem, len(t))
+	v := make([]*shared.Decision, len(t))
 	for i := range t {
-		v[i] = FromVersionHistoryItem(t[i])
+		v[i] = FromDecision(t[i])
 	}
 	return v
 }
 
-// ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
-func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
+// ToDecisionArray converts thrift Decision type array to internal
+func ToDecisionArray(t []*shared.Decision) []*types.Decision {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.VersionHistoryItem, len(t))
+	v := make([]*types.Decision, len(t))
 	for i := range t {
-		v[i] = ToVersionHistoryItem(t[i])
-	}
-	return v
-}
-
-// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
-func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*shared.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = FromBadBinaryInfo(t[key])
-	}
-	return v
-}
-
-// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
-func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*types.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = ToBadBinaryInfo(t[key])
-	}
-	return v
-}
-
-// FromIndexedValueTypeMap converts internal IndexedValueType type map to thrift
-func FromIndexedValueTypeMap(t map[string]types.IndexedValueType) map[string]shared.IndexedValueType {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]shared.IndexedValueType, len(t))
-	for key := range t {
-		v[key] = FromIndexedValueType(t[key])
-	}
-	return v
-}
-
-// ToIndexedValueTypeMap converts thrift IndexedValueType type map to internal
-func ToIndexedValueTypeMap(t map[string]shared.IndexedValueType) map[string]types.IndexedValueType {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]types.IndexedValueType, len(t))
-	for key := range t {
-		v[key] = ToIndexedValueType(t[key])
+		v[i] = ToDecision(t[i])
 	}
 	return v
 }
@@ -6588,6 +6564,78 @@ func ToWorkflowQueryResultMap(t map[string]*shared.WorkflowQueryResult) map[stri
 	v := make(map[string]*types.WorkflowQueryResult, len(t))
 	for key := range t {
 		v[key] = ToWorkflowQueryResult(t[key])
+	}
+	return v
+}
+
+// FromActivityLocalDispatchInfoMap converts internal ActivityLocalDispatchInfo type map to thrift
+func FromActivityLocalDispatchInfoMap(t map[string]*types.ActivityLocalDispatchInfo) map[string]*shared.ActivityLocalDispatchInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.ActivityLocalDispatchInfo, len(t))
+	for key := range t {
+		v[key] = FromActivityLocalDispatchInfo(t[key])
+	}
+	return v
+}
+
+// ToActivityLocalDispatchInfoMap converts thrift ActivityLocalDispatchInfo type map to internal
+func ToActivityLocalDispatchInfoMap(t map[string]*shared.ActivityLocalDispatchInfo) map[string]*types.ActivityLocalDispatchInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.ActivityLocalDispatchInfo, len(t))
+	for key := range t {
+		v[key] = ToActivityLocalDispatchInfo(t[key])
+	}
+	return v
+}
+
+// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
+func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = FromBadBinaryInfo(t[key])
+	}
+	return v
+}
+
+// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
+func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = ToBadBinaryInfo(t[key])
+	}
+	return v
+}
+
+// FromIndexedValueTypeMap converts internal IndexedValueType type map to thrift
+func FromIndexedValueTypeMap(t map[string]types.IndexedValueType) map[string]shared.IndexedValueType {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]shared.IndexedValueType, len(t))
+	for key := range t {
+		v[key] = FromIndexedValueType(t[key])
+	}
+	return v
+}
+
+// ToIndexedValueTypeMap converts thrift IndexedValueType type map to internal
+func ToIndexedValueTypeMap(t map[string]shared.IndexedValueType) map[string]types.IndexedValueType {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]types.IndexedValueType, len(t))
+	for key := range t {
+		v[key] = ToIndexedValueType(t[key])
 	}
 	return v
 }

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -25,10 +25,42 @@ type AccessDeniedError struct {
 	Message string
 }
 
+func (v *AccessDeniedError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+
+// ActivityLocalDispatchInfo is an internal type (TBD...)
+type ActivityLocalDispatchInfo struct {
+	ActivityID *string
+}
+
+func (v *ActivityLocalDispatchInfo) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+
 // ActivityTaskCancelRequestedEventAttributes is an internal type (TBD...)
 type ActivityTaskCancelRequestedEventAttributes struct {
 	ActivityID                   *string
 	DecisionTaskCompletedEventID *int64
+}
+
+func (v *ActivityTaskCancelRequestedEventAttributes) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *ActivityTaskCancelRequestedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
 }
 
 // ActivityTaskCanceledEventAttributes is an internal type (TBD...)
@@ -40,12 +72,68 @@ type ActivityTaskCanceledEventAttributes struct {
 	Identity                     *string
 }
 
+func (v *ActivityTaskCanceledEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *ActivityTaskCanceledEventAttributes) GetLatestCancelRequestedEventID() (o int64) {
+	if v != nil && v.LatestCancelRequestedEventID != nil {
+		return *v.LatestCancelRequestedEventID
+	}
+	return
+}
+func (v *ActivityTaskCanceledEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *ActivityTaskCanceledEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *ActivityTaskCanceledEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // ActivityTaskCompletedEventAttributes is an internal type (TBD...)
 type ActivityTaskCompletedEventAttributes struct {
 	Result           []byte
 	ScheduledEventID *int64
 	StartedEventID   *int64
 	Identity         *string
+}
+
+func (v *ActivityTaskCompletedEventAttributes) GetResult() (o []byte) {
+	if v != nil && v.Result != nil {
+		return v.Result
+	}
+	return
+}
+func (v *ActivityTaskCompletedEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *ActivityTaskCompletedEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *ActivityTaskCompletedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
 }
 
 // ActivityTaskFailedEventAttributes is an internal type (TBD...)
@@ -55,6 +143,37 @@ type ActivityTaskFailedEventAttributes struct {
 	ScheduledEventID *int64
 	StartedEventID   *int64
 	Identity         *string
+}
+
+func (v *ActivityTaskFailedEventAttributes) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *ActivityTaskFailedEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *ActivityTaskFailedEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *ActivityTaskFailedEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *ActivityTaskFailedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
 }
 
 // ActivityTaskScheduledEventAttributes is an internal type (TBD...)
@@ -73,6 +192,79 @@ type ActivityTaskScheduledEventAttributes struct {
 	Header                        *Header
 }
 
+func (v *ActivityTaskScheduledEventAttributes) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetActivityType() (o *ActivityType) {
+	if v != nil && v.ActivityType != nil {
+		return v.ActivityType
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetScheduleToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ScheduleToCloseTimeoutSeconds != nil {
+		return *v.ScheduleToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetScheduleToStartTimeoutSeconds() (o int32) {
+	if v != nil && v.ScheduleToStartTimeoutSeconds != nil {
+		return *v.ScheduleToStartTimeoutSeconds
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.StartToCloseTimeoutSeconds != nil {
+		return *v.StartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetHeartbeatTimeoutSeconds() (o int32) {
+	if v != nil && v.HeartbeatTimeoutSeconds != nil {
+		return *v.HeartbeatTimeoutSeconds
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *ActivityTaskScheduledEventAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // ActivityTaskStartedEventAttributes is an internal type (TBD...)
 type ActivityTaskStartedEventAttributes struct {
 	ScheduledEventID   *int64
@@ -81,6 +273,43 @@ type ActivityTaskStartedEventAttributes struct {
 	Attempt            *int32
 	LastFailureReason  *string
 	LastFailureDetails []byte
+}
+
+func (v *ActivityTaskStartedEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *ActivityTaskStartedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *ActivityTaskStartedEventAttributes) GetRequestID() (o string) {
+	if v != nil && v.RequestID != nil {
+		return *v.RequestID
+	}
+	return
+}
+func (v *ActivityTaskStartedEventAttributes) GetAttempt() (o int32) {
+	if v != nil && v.Attempt != nil {
+		return *v.Attempt
+	}
+	return
+}
+func (v *ActivityTaskStartedEventAttributes) GetLastFailureReason() (o string) {
+	if v != nil && v.LastFailureReason != nil {
+		return *v.LastFailureReason
+	}
+	return
+}
+func (v *ActivityTaskStartedEventAttributes) GetLastFailureDetails() (o []byte) {
+	if v != nil && v.LastFailureDetails != nil {
+		return v.LastFailureDetails
+	}
+	return
 }
 
 // ActivityTaskTimedOutEventAttributes is an internal type (TBD...)
@@ -93,9 +322,53 @@ type ActivityTaskTimedOutEventAttributes struct {
 	LastFailureDetails []byte
 }
 
+func (v *ActivityTaskTimedOutEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *ActivityTaskTimedOutEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *ActivityTaskTimedOutEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *ActivityTaskTimedOutEventAttributes) GetTimeoutType() (o TimeoutType) {
+	if v != nil && v.TimeoutType != nil {
+		return *v.TimeoutType
+	}
+	return
+}
+func (v *ActivityTaskTimedOutEventAttributes) GetLastFailureReason() (o string) {
+	if v != nil && v.LastFailureReason != nil {
+		return *v.LastFailureReason
+	}
+	return
+}
+func (v *ActivityTaskTimedOutEventAttributes) GetLastFailureDetails() (o []byte) {
+	if v != nil && v.LastFailureDetails != nil {
+		return v.LastFailureDetails
+	}
+	return
+}
+
 // ActivityType is an internal type (TBD...)
 type ActivityType struct {
 	Name *string
+}
+
+func (v *ActivityType) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
 }
 
 // ArchivalStatus is an internal type (TBD...)
@@ -113,6 +386,13 @@ type BadBinaries struct {
 	Binaries map[string]*BadBinaryInfo
 }
 
+func (v *BadBinaries) GetBinaries() (o map[string]*BadBinaryInfo) {
+	if v != nil && v.Binaries != nil {
+		return v.Binaries
+	}
+	return
+}
+
 // BadBinaryInfo is an internal type (TBD...)
 type BadBinaryInfo struct {
 	Reason          *string
@@ -120,9 +400,35 @@ type BadBinaryInfo struct {
 	CreatedTimeNano *int64
 }
 
+func (v *BadBinaryInfo) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *BadBinaryInfo) GetOperator() (o string) {
+	if v != nil && v.Operator != nil {
+		return *v.Operator
+	}
+	return
+}
+func (v *BadBinaryInfo) GetCreatedTimeNano() (o int64) {
+	if v != nil && v.CreatedTimeNano != nil {
+		return *v.CreatedTimeNano
+	}
+	return
+}
+
 // BadRequestError is an internal type (TBD...)
 type BadRequestError struct {
 	Message string
+}
+
+func (v *BadRequestError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
 }
 
 // CancelExternalWorkflowExecutionFailedCause is an internal type (TBD...)
@@ -138,6 +444,13 @@ type CancelTimerDecisionAttributes struct {
 	TimerID *string
 }
 
+func (v *CancelTimerDecisionAttributes) GetTimerID() (o string) {
+	if v != nil && v.TimerID != nil {
+		return *v.TimerID
+	}
+	return
+}
+
 // CancelTimerFailedEventAttributes is an internal type (TBD...)
 type CancelTimerFailedEventAttributes struct {
 	TimerID                      *string
@@ -146,14 +459,53 @@ type CancelTimerFailedEventAttributes struct {
 	Identity                     *string
 }
 
+func (v *CancelTimerFailedEventAttributes) GetTimerID() (o string) {
+	if v != nil && v.TimerID != nil {
+		return *v.TimerID
+	}
+	return
+}
+func (v *CancelTimerFailedEventAttributes) GetCause() (o string) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *CancelTimerFailedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *CancelTimerFailedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // CancelWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type CancelWorkflowExecutionDecisionAttributes struct {
 	Details []byte
 }
 
+func (v *CancelWorkflowExecutionDecisionAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+
 // CancellationAlreadyRequestedError is an internal type (TBD...)
 type CancellationAlreadyRequestedError struct {
 	Message string
+}
+
+func (v *CancellationAlreadyRequestedError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
 }
 
 // ChildWorkflowExecutionCanceledEventAttributes is an internal type (TBD...)
@@ -166,6 +518,43 @@ type ChildWorkflowExecutionCanceledEventAttributes struct {
 	StartedEventID    *int64
 }
 
+func (v *ChildWorkflowExecutionCanceledEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCanceledEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCanceledEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCanceledEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCanceledEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCanceledEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+
 // ChildWorkflowExecutionCompletedEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionCompletedEventAttributes struct {
 	Result            []byte
@@ -174,6 +563,43 @@ type ChildWorkflowExecutionCompletedEventAttributes struct {
 	WorkflowType      *WorkflowType
 	InitiatedEventID  *int64
 	StartedEventID    *int64
+}
+
+func (v *ChildWorkflowExecutionCompletedEventAttributes) GetResult() (o []byte) {
+	if v != nil && v.Result != nil {
+		return v.Result
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCompletedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCompletedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCompletedEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCompletedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ChildWorkflowExecutionCompletedEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
 }
 
 // ChildWorkflowExecutionFailedCause is an internal type (TBD...)
@@ -195,6 +621,49 @@ type ChildWorkflowExecutionFailedEventAttributes struct {
 	StartedEventID    *int64
 }
 
+func (v *ChildWorkflowExecutionFailedEventAttributes) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *ChildWorkflowExecutionFailedEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *ChildWorkflowExecutionFailedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ChildWorkflowExecutionFailedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ChildWorkflowExecutionFailedEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *ChildWorkflowExecutionFailedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ChildWorkflowExecutionFailedEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+
 // ChildWorkflowExecutionStartedEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionStartedEventAttributes struct {
 	Domain            *string
@@ -204,6 +673,37 @@ type ChildWorkflowExecutionStartedEventAttributes struct {
 	Header            *Header
 }
 
+func (v *ChildWorkflowExecutionStartedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ChildWorkflowExecutionStartedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ChildWorkflowExecutionStartedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ChildWorkflowExecutionStartedEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *ChildWorkflowExecutionStartedEventAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // ChildWorkflowExecutionTerminatedEventAttributes is an internal type (TBD...)
 type ChildWorkflowExecutionTerminatedEventAttributes struct {
 	Domain            *string
@@ -211,6 +711,37 @@ type ChildWorkflowExecutionTerminatedEventAttributes struct {
 	WorkflowType      *WorkflowType
 	InitiatedEventID  *int64
 	StartedEventID    *int64
+}
+
+func (v *ChildWorkflowExecutionTerminatedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTerminatedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTerminatedEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTerminatedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTerminatedEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
 }
 
 // ChildWorkflowExecutionTimedOutEventAttributes is an internal type (TBD...)
@@ -223,6 +754,43 @@ type ChildWorkflowExecutionTimedOutEventAttributes struct {
 	StartedEventID    *int64
 }
 
+func (v *ChildWorkflowExecutionTimedOutEventAttributes) GetTimeoutType() (o TimeoutType) {
+	if v != nil && v.TimeoutType != nil {
+		return *v.TimeoutType
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTimedOutEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTimedOutEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTimedOutEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTimedOutEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ChildWorkflowExecutionTimedOutEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+
 // ClientVersionNotSupportedError is an internal type (TBD...)
 type ClientVersionNotSupportedError struct {
 	FeatureVersion    string
@@ -230,9 +798,35 @@ type ClientVersionNotSupportedError struct {
 	SupportedVersions string
 }
 
+func (v *ClientVersionNotSupportedError) GetFeatureVersion() (o string) {
+	if v != nil {
+		return v.FeatureVersion
+	}
+	return
+}
+func (v *ClientVersionNotSupportedError) GetClientImpl() (o string) {
+	if v != nil {
+		return v.ClientImpl
+	}
+	return
+}
+func (v *ClientVersionNotSupportedError) GetSupportedVersions() (o string) {
+	if v != nil {
+		return v.SupportedVersions
+	}
+	return
+}
+
 // CloseShardRequest is an internal type (TBD...)
 type CloseShardRequest struct {
 	ShardID *int32
+}
+
+func (v *CloseShardRequest) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
 }
 
 // ClusterInfo is an internal type (TBD...)
@@ -240,14 +834,35 @@ type ClusterInfo struct {
 	SupportedClientVersions *SupportedClientVersions
 }
 
+func (v *ClusterInfo) GetSupportedClientVersions() (o *SupportedClientVersions) {
+	if v != nil && v.SupportedClientVersions != nil {
+		return v.SupportedClientVersions
+	}
+	return
+}
+
 // ClusterReplicationConfiguration is an internal type (TBD...)
 type ClusterReplicationConfiguration struct {
 	ClusterName *string
 }
 
+func (v *ClusterReplicationConfiguration) GetClusterName() (o string) {
+	if v != nil && v.ClusterName != nil {
+		return *v.ClusterName
+	}
+	return
+}
+
 // CompleteWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type CompleteWorkflowExecutionDecisionAttributes struct {
 	Result []byte
+}
+
+func (v *CompleteWorkflowExecutionDecisionAttributes) GetResult() (o []byte) {
+	if v != nil && v.Result != nil {
+		return v.Result
+	}
+	return
 }
 
 // ContinueAsNewInitiator is an internal type (TBD...)
@@ -281,15 +896,126 @@ type ContinueAsNewWorkflowExecutionDecisionAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetBackoffStartIntervalInSeconds() (o int32) {
+	if v != nil && v.BackoffStartIntervalInSeconds != nil {
+		return *v.BackoffStartIntervalInSeconds
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetInitiator() (o ContinueAsNewInitiator) {
+	if v != nil && v.Initiator != nil {
+		return *v.Initiator
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetFailureReason() (o string) {
+	if v != nil && v.FailureReason != nil {
+		return *v.FailureReason
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetFailureDetails() (o []byte) {
+	if v != nil && v.FailureDetails != nil {
+		return v.FailureDetails
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetLastCompletionResult() (o []byte) {
+	if v != nil && v.LastCompletionResult != nil {
+		return v.LastCompletionResult
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetCronSchedule() (o string) {
+	if v != nil && v.CronSchedule != nil {
+		return *v.CronSchedule
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *ContinueAsNewWorkflowExecutionDecisionAttributes) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+
 // CountWorkflowExecutionsRequest is an internal type (TBD...)
 type CountWorkflowExecutionsRequest struct {
 	Domain *string
 	Query  *string
 }
 
+func (v *CountWorkflowExecutionsRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *CountWorkflowExecutionsRequest) GetQuery() (o string) {
+	if v != nil && v.Query != nil {
+		return *v.Query
+	}
+	return
+}
+
 // CountWorkflowExecutionsResponse is an internal type (TBD...)
 type CountWorkflowExecutionsResponse struct {
 	Count *int64
+}
+
+func (v *CountWorkflowExecutionsResponse) GetCount() (o int64) {
+	if v != nil && v.Count != nil {
+		return *v.Count
+	}
+	return
 }
 
 // CurrentBranchChangedError is an internal type (TBD...)
@@ -298,10 +1024,36 @@ type CurrentBranchChangedError struct {
 	CurrentBranchToken []byte
 }
 
+func (v *CurrentBranchChangedError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+func (v *CurrentBranchChangedError) GetCurrentBranchToken() (o []byte) {
+	if v != nil && v.CurrentBranchToken != nil {
+		return v.CurrentBranchToken
+	}
+	return
+}
+
 // DataBlob is an internal type (TBD...)
 type DataBlob struct {
 	EncodingType *EncodingType
 	Data         []byte
+}
+
+func (v *DataBlob) GetEncodingType() (o EncodingType) {
+	if v != nil && v.EncodingType != nil {
+		return *v.EncodingType
+	}
+	return
+}
+func (v *DataBlob) GetData() (o []byte) {
+	if v != nil && v.Data != nil {
+		return v.Data
+	}
+	return
 }
 
 // Decision is an internal type (TBD...)
@@ -322,6 +1074,91 @@ type Decision struct {
 	UpsertWorkflowSearchAttributesDecisionAttributes         *UpsertWorkflowSearchAttributesDecisionAttributes
 }
 
+func (v *Decision) GetDecisionType() (o DecisionType) {
+	if v != nil && v.DecisionType != nil {
+		return *v.DecisionType
+	}
+	return
+}
+func (v *Decision) GetScheduleActivityTaskDecisionAttributes() (o *ScheduleActivityTaskDecisionAttributes) {
+	if v != nil && v.ScheduleActivityTaskDecisionAttributes != nil {
+		return v.ScheduleActivityTaskDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetStartTimerDecisionAttributes() (o *StartTimerDecisionAttributes) {
+	if v != nil && v.StartTimerDecisionAttributes != nil {
+		return v.StartTimerDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetCompleteWorkflowExecutionDecisionAttributes() (o *CompleteWorkflowExecutionDecisionAttributes) {
+	if v != nil && v.CompleteWorkflowExecutionDecisionAttributes != nil {
+		return v.CompleteWorkflowExecutionDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetFailWorkflowExecutionDecisionAttributes() (o *FailWorkflowExecutionDecisionAttributes) {
+	if v != nil && v.FailWorkflowExecutionDecisionAttributes != nil {
+		return v.FailWorkflowExecutionDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetRequestCancelActivityTaskDecisionAttributes() (o *RequestCancelActivityTaskDecisionAttributes) {
+	if v != nil && v.RequestCancelActivityTaskDecisionAttributes != nil {
+		return v.RequestCancelActivityTaskDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetCancelTimerDecisionAttributes() (o *CancelTimerDecisionAttributes) {
+	if v != nil && v.CancelTimerDecisionAttributes != nil {
+		return v.CancelTimerDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetCancelWorkflowExecutionDecisionAttributes() (o *CancelWorkflowExecutionDecisionAttributes) {
+	if v != nil && v.CancelWorkflowExecutionDecisionAttributes != nil {
+		return v.CancelWorkflowExecutionDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetRequestCancelExternalWorkflowExecutionDecisionAttributes() (o *RequestCancelExternalWorkflowExecutionDecisionAttributes) {
+	if v != nil && v.RequestCancelExternalWorkflowExecutionDecisionAttributes != nil {
+		return v.RequestCancelExternalWorkflowExecutionDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetRecordMarkerDecisionAttributes() (o *RecordMarkerDecisionAttributes) {
+	if v != nil && v.RecordMarkerDecisionAttributes != nil {
+		return v.RecordMarkerDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetContinueAsNewWorkflowExecutionDecisionAttributes() (o *ContinueAsNewWorkflowExecutionDecisionAttributes) {
+	if v != nil && v.ContinueAsNewWorkflowExecutionDecisionAttributes != nil {
+		return v.ContinueAsNewWorkflowExecutionDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetStartChildWorkflowExecutionDecisionAttributes() (o *StartChildWorkflowExecutionDecisionAttributes) {
+	if v != nil && v.StartChildWorkflowExecutionDecisionAttributes != nil {
+		return v.StartChildWorkflowExecutionDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetSignalExternalWorkflowExecutionDecisionAttributes() (o *SignalExternalWorkflowExecutionDecisionAttributes) {
+	if v != nil && v.SignalExternalWorkflowExecutionDecisionAttributes != nil {
+		return v.SignalExternalWorkflowExecutionDecisionAttributes
+	}
+	return
+}
+func (v *Decision) GetUpsertWorkflowSearchAttributesDecisionAttributes() (o *UpsertWorkflowSearchAttributesDecisionAttributes) {
+	if v != nil && v.UpsertWorkflowSearchAttributesDecisionAttributes != nil {
+		return v.UpsertWorkflowSearchAttributesDecisionAttributes
+	}
+	return
+}
+
 // DecisionTaskCompletedEventAttributes is an internal type (TBD...)
 type DecisionTaskCompletedEventAttributes struct {
 	ExecutionContext []byte
@@ -329,6 +1166,37 @@ type DecisionTaskCompletedEventAttributes struct {
 	StartedEventID   *int64
 	Identity         *string
 	BinaryChecksum   *string
+}
+
+func (v *DecisionTaskCompletedEventAttributes) GetExecutionContext() (o []byte) {
+	if v != nil && v.ExecutionContext != nil {
+		return v.ExecutionContext
+	}
+	return
+}
+func (v *DecisionTaskCompletedEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *DecisionTaskCompletedEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *DecisionTaskCompletedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *DecisionTaskCompletedEventAttributes) GetBinaryChecksum() (o string) {
+	if v != nil && v.BinaryChecksum != nil {
+		return *v.BinaryChecksum
+	}
+	return
 }
 
 // DecisionTaskFailedCause is an internal type (TBD...)
@@ -397,11 +1265,91 @@ type DecisionTaskFailedEventAttributes struct {
 	BinaryChecksum   *string
 }
 
+func (v *DecisionTaskFailedEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetCause() (o DecisionTaskFailedCause) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetBaseRunID() (o string) {
+	if v != nil && v.BaseRunID != nil {
+		return *v.BaseRunID
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetNewRunID() (o string) {
+	if v != nil && v.NewRunID != nil {
+		return *v.NewRunID
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetForkEventVersion() (o int64) {
+	if v != nil && v.ForkEventVersion != nil {
+		return *v.ForkEventVersion
+	}
+	return
+}
+func (v *DecisionTaskFailedEventAttributes) GetBinaryChecksum() (o string) {
+	if v != nil && v.BinaryChecksum != nil {
+		return *v.BinaryChecksum
+	}
+	return
+}
+
 // DecisionTaskScheduledEventAttributes is an internal type (TBD...)
 type DecisionTaskScheduledEventAttributes struct {
 	TaskList                   *TaskList
 	StartToCloseTimeoutSeconds *int32
 	Attempt                    *int64
+}
+
+func (v *DecisionTaskScheduledEventAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *DecisionTaskScheduledEventAttributes) GetStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.StartToCloseTimeoutSeconds != nil {
+		return *v.StartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *DecisionTaskScheduledEventAttributes) GetAttempt() (o int64) {
+	if v != nil && v.Attempt != nil {
+		return *v.Attempt
+	}
+	return
 }
 
 // DecisionTaskStartedEventAttributes is an internal type (TBD...)
@@ -411,11 +1359,49 @@ type DecisionTaskStartedEventAttributes struct {
 	RequestID        *string
 }
 
+func (v *DecisionTaskStartedEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *DecisionTaskStartedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *DecisionTaskStartedEventAttributes) GetRequestID() (o string) {
+	if v != nil && v.RequestID != nil {
+		return *v.RequestID
+	}
+	return
+}
+
 // DecisionTaskTimedOutEventAttributes is an internal type (TBD...)
 type DecisionTaskTimedOutEventAttributes struct {
 	ScheduledEventID *int64
 	StartedEventID   *int64
 	TimeoutType      *TimeoutType
+}
+
+func (v *DecisionTaskTimedOutEventAttributes) GetScheduledEventID() (o int64) {
+	if v != nil && v.ScheduledEventID != nil {
+		return *v.ScheduledEventID
+	}
+	return
+}
+func (v *DecisionTaskTimedOutEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *DecisionTaskTimedOutEventAttributes) GetTimeoutType() (o TimeoutType) {
+	if v != nil && v.TimeoutType != nil {
+		return *v.TimeoutType
+	}
+	return
 }
 
 // DecisionType is an internal type (TBD...)
@@ -456,10 +1442,36 @@ type DeprecateDomainRequest struct {
 	SecurityToken *string
 }
 
+func (v *DeprecateDomainRequest) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
+}
+func (v *DeprecateDomainRequest) GetSecurityToken() (o string) {
+	if v != nil && v.SecurityToken != nil {
+		return *v.SecurityToken
+	}
+	return
+}
+
 // DescribeDomainRequest is an internal type (TBD...)
 type DescribeDomainRequest struct {
 	Name *string
 	UUID *string
+}
+
+func (v *DescribeDomainRequest) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
+}
+func (v *DescribeDomainRequest) GetUUID() (o string) {
+	if v != nil && v.UUID != nil {
+		return *v.UUID
+	}
+	return
 }
 
 // DescribeDomainResponse is an internal type (TBD...)
@@ -471,11 +1483,61 @@ type DescribeDomainResponse struct {
 	IsGlobalDomain           *bool
 }
 
+func (v *DescribeDomainResponse) GetDomainInfo() (o *DomainInfo) {
+	if v != nil && v.DomainInfo != nil {
+		return v.DomainInfo
+	}
+	return
+}
+func (v *DescribeDomainResponse) GetConfiguration() (o *DomainConfiguration) {
+	if v != nil && v.Configuration != nil {
+		return v.Configuration
+	}
+	return
+}
+func (v *DescribeDomainResponse) GetReplicationConfiguration() (o *DomainReplicationConfiguration) {
+	if v != nil && v.ReplicationConfiguration != nil {
+		return v.ReplicationConfiguration
+	}
+	return
+}
+func (v *DescribeDomainResponse) GetFailoverVersion() (o int64) {
+	if v != nil && v.FailoverVersion != nil {
+		return *v.FailoverVersion
+	}
+	return
+}
+func (v *DescribeDomainResponse) GetIsGlobalDomain() (o bool) {
+	if v != nil && v.IsGlobalDomain != nil {
+		return *v.IsGlobalDomain
+	}
+	return
+}
+
 // DescribeHistoryHostRequest is an internal type (TBD...)
 type DescribeHistoryHostRequest struct {
 	HostAddress      *string
 	ShardIDForHost   *int32
 	ExecutionForHost *WorkflowExecution
+}
+
+func (v *DescribeHistoryHostRequest) GetHostAddress() (o string) {
+	if v != nil && v.HostAddress != nil {
+		return *v.HostAddress
+	}
+	return
+}
+func (v *DescribeHistoryHostRequest) GetShardIDForHost() (o int32) {
+	if v != nil && v.ShardIDForHost != nil {
+		return *v.ShardIDForHost
+	}
+	return
+}
+func (v *DescribeHistoryHostRequest) GetExecutionForHost() (o *WorkflowExecution) {
+	if v != nil && v.ExecutionForHost != nil {
+		return v.ExecutionForHost
+	}
+	return
 }
 
 // DescribeHistoryHostResponse is an internal type (TBD...)
@@ -487,6 +1549,37 @@ type DescribeHistoryHostResponse struct {
 	Address               *string
 }
 
+func (v *DescribeHistoryHostResponse) GetNumberOfShards() (o int32) {
+	if v != nil && v.NumberOfShards != nil {
+		return *v.NumberOfShards
+	}
+	return
+}
+func (v *DescribeHistoryHostResponse) GetShardIDs() (o []int32) {
+	if v != nil && v.ShardIDs != nil {
+		return v.ShardIDs
+	}
+	return
+}
+func (v *DescribeHistoryHostResponse) GetDomainCache() (o *DomainCacheInfo) {
+	if v != nil && v.DomainCache != nil {
+		return v.DomainCache
+	}
+	return
+}
+func (v *DescribeHistoryHostResponse) GetShardControllerStatus() (o string) {
+	if v != nil && v.ShardControllerStatus != nil {
+		return *v.ShardControllerStatus
+	}
+	return
+}
+func (v *DescribeHistoryHostResponse) GetAddress() (o string) {
+	if v != nil && v.Address != nil {
+		return *v.Address
+	}
+	return
+}
+
 // DescribeQueueRequest is an internal type (TBD...)
 type DescribeQueueRequest struct {
 	ShardID     *int32
@@ -494,9 +1587,35 @@ type DescribeQueueRequest struct {
 	Type        *int32
 }
 
+func (v *DescribeQueueRequest) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *DescribeQueueRequest) GetClusterName() (o string) {
+	if v != nil && v.ClusterName != nil {
+		return *v.ClusterName
+	}
+	return
+}
+func (v *DescribeQueueRequest) GetType() (o int32) {
+	if v != nil && v.Type != nil {
+		return *v.Type
+	}
+	return
+}
+
 // DescribeQueueResponse is an internal type (TBD...)
 type DescribeQueueResponse struct {
 	ProcessingQueueStates []string
+}
+
+func (v *DescribeQueueResponse) GetProcessingQueueStates() (o []string) {
+	if v != nil && v.ProcessingQueueStates != nil {
+		return v.ProcessingQueueStates
+	}
+	return
 }
 
 // DescribeTaskListRequest is an internal type (TBD...)
@@ -507,16 +1626,67 @@ type DescribeTaskListRequest struct {
 	IncludeTaskListStatus *bool
 }
 
+func (v *DescribeTaskListRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *DescribeTaskListRequest) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *DescribeTaskListRequest) GetTaskListType() (o TaskListType) {
+	if v != nil && v.TaskListType != nil {
+		return *v.TaskListType
+	}
+	return
+}
+func (v *DescribeTaskListRequest) GetIncludeTaskListStatus() (o bool) {
+	if v != nil && v.IncludeTaskListStatus != nil {
+		return *v.IncludeTaskListStatus
+	}
+	return
+}
+
 // DescribeTaskListResponse is an internal type (TBD...)
 type DescribeTaskListResponse struct {
 	Pollers        []*PollerInfo
 	TaskListStatus *TaskListStatus
 }
 
+func (v *DescribeTaskListResponse) GetPollers() (o []*PollerInfo) {
+	if v != nil && v.Pollers != nil {
+		return v.Pollers
+	}
+	return
+}
+func (v *DescribeTaskListResponse) GetTaskListStatus() (o *TaskListStatus) {
+	if v != nil && v.TaskListStatus != nil {
+		return v.TaskListStatus
+	}
+	return
+}
+
 // DescribeWorkflowExecutionRequest is an internal type (TBD...)
 type DescribeWorkflowExecutionRequest struct {
 	Domain    *string
 	Execution *WorkflowExecution
+}
+
+func (v *DescribeWorkflowExecutionRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *DescribeWorkflowExecutionRequest) GetExecution() (o *WorkflowExecution) {
+	if v != nil && v.Execution != nil {
+		return v.Execution
+	}
+	return
 }
 
 // DescribeWorkflowExecutionResponse is an internal type (TBD...)
@@ -527,15 +1697,60 @@ type DescribeWorkflowExecutionResponse struct {
 	PendingChildren        []*PendingChildExecutionInfo
 }
 
+func (v *DescribeWorkflowExecutionResponse) GetExecutionConfiguration() (o *WorkflowExecutionConfiguration) {
+	if v != nil && v.ExecutionConfiguration != nil {
+		return v.ExecutionConfiguration
+	}
+	return
+}
+func (v *DescribeWorkflowExecutionResponse) GetWorkflowExecutionInfo() (o *WorkflowExecutionInfo) {
+	if v != nil && v.WorkflowExecutionInfo != nil {
+		return v.WorkflowExecutionInfo
+	}
+	return
+}
+func (v *DescribeWorkflowExecutionResponse) GetPendingActivities() (o []*PendingActivityInfo) {
+	if v != nil && v.PendingActivities != nil {
+		return v.PendingActivities
+	}
+	return
+}
+func (v *DescribeWorkflowExecutionResponse) GetPendingChildren() (o []*PendingChildExecutionInfo) {
+	if v != nil && v.PendingChildren != nil {
+		return v.PendingChildren
+	}
+	return
+}
+
 // DomainAlreadyExistsError is an internal type (TBD...)
 type DomainAlreadyExistsError struct {
 	Message string
+}
+
+func (v *DomainAlreadyExistsError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
 }
 
 // DomainCacheInfo is an internal type (TBD...)
 type DomainCacheInfo struct {
 	NumOfItemsInCacheByID   *int64
 	NumOfItemsInCacheByName *int64
+}
+
+func (v *DomainCacheInfo) GetNumOfItemsInCacheByID() (o int64) {
+	if v != nil && v.NumOfItemsInCacheByID != nil {
+		return *v.NumOfItemsInCacheByID
+	}
+	return
+}
+func (v *DomainCacheInfo) GetNumOfItemsInCacheByName() (o int64) {
+	if v != nil && v.NumOfItemsInCacheByName != nil {
+		return *v.NumOfItemsInCacheByName
+	}
+	return
 }
 
 // DomainConfiguration is an internal type (TBD...)
@@ -549,6 +1764,49 @@ type DomainConfiguration struct {
 	VisibilityArchivalURI                  *string
 }
 
+func (v *DomainConfiguration) GetWorkflowExecutionRetentionPeriodInDays() (o int32) {
+	if v != nil && v.WorkflowExecutionRetentionPeriodInDays != nil {
+		return *v.WorkflowExecutionRetentionPeriodInDays
+	}
+	return
+}
+func (v *DomainConfiguration) GetEmitMetric() (o bool) {
+	if v != nil && v.EmitMetric != nil {
+		return *v.EmitMetric
+	}
+	return
+}
+func (v *DomainConfiguration) GetBadBinaries() (o *BadBinaries) {
+	if v != nil && v.BadBinaries != nil {
+		return v.BadBinaries
+	}
+	return
+}
+func (v *DomainConfiguration) GetHistoryArchivalStatus() (o ArchivalStatus) {
+	if v != nil && v.HistoryArchivalStatus != nil {
+		return *v.HistoryArchivalStatus
+	}
+	return
+}
+func (v *DomainConfiguration) GetHistoryArchivalURI() (o string) {
+	if v != nil && v.HistoryArchivalURI != nil {
+		return *v.HistoryArchivalURI
+	}
+	return
+}
+func (v *DomainConfiguration) GetVisibilityArchivalStatus() (o ArchivalStatus) {
+	if v != nil && v.VisibilityArchivalStatus != nil {
+		return *v.VisibilityArchivalStatus
+	}
+	return
+}
+func (v *DomainConfiguration) GetVisibilityArchivalURI() (o string) {
+	if v != nil && v.VisibilityArchivalURI != nil {
+		return *v.VisibilityArchivalURI
+	}
+	return
+}
+
 // DomainInfo is an internal type (TBD...)
 type DomainInfo struct {
 	Name        *string
@@ -559,6 +1817,43 @@ type DomainInfo struct {
 	UUID        *string
 }
 
+func (v *DomainInfo) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
+}
+func (v *DomainInfo) GetStatus() (o DomainStatus) {
+	if v != nil && v.Status != nil {
+		return *v.Status
+	}
+	return
+}
+func (v *DomainInfo) GetDescription() (o string) {
+	if v != nil && v.Description != nil {
+		return *v.Description
+	}
+	return
+}
+func (v *DomainInfo) GetOwnerEmail() (o string) {
+	if v != nil && v.OwnerEmail != nil {
+		return *v.OwnerEmail
+	}
+	return
+}
+func (v *DomainInfo) GetData() (o map[string]string) {
+	if v != nil && v.Data != nil {
+		return v.Data
+	}
+	return
+}
+func (v *DomainInfo) GetUUID() (o string) {
+	if v != nil && v.UUID != nil {
+		return *v.UUID
+	}
+	return
+}
+
 // DomainNotActiveError is an internal type (TBD...)
 type DomainNotActiveError struct {
 	Message        string
@@ -567,10 +1862,48 @@ type DomainNotActiveError struct {
 	ActiveCluster  string
 }
 
+func (v *DomainNotActiveError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+func (v *DomainNotActiveError) GetDomainName() (o string) {
+	if v != nil {
+		return v.DomainName
+	}
+	return
+}
+func (v *DomainNotActiveError) GetCurrentCluster() (o string) {
+	if v != nil {
+		return v.CurrentCluster
+	}
+	return
+}
+func (v *DomainNotActiveError) GetActiveCluster() (o string) {
+	if v != nil {
+		return v.ActiveCluster
+	}
+	return
+}
+
 // DomainReplicationConfiguration is an internal type (TBD...)
 type DomainReplicationConfiguration struct {
 	ActiveClusterName *string
 	Clusters          []*ClusterReplicationConfiguration
+}
+
+func (v *DomainReplicationConfiguration) GetActiveClusterName() (o string) {
+	if v != nil && v.ActiveClusterName != nil {
+		return *v.ActiveClusterName
+	}
+	return
+}
+func (v *DomainReplicationConfiguration) GetClusters() (o []*ClusterReplicationConfiguration) {
+	if v != nil && v.Clusters != nil {
+		return v.Clusters
+	}
+	return
 }
 
 // DomainStatus is an internal type (TBD...)
@@ -600,6 +1933,25 @@ type EntityNotExistsError struct {
 	Message        string
 	CurrentCluster *string
 	ActiveCluster  *string
+}
+
+func (v *EntityNotExistsError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+func (v *EntityNotExistsError) GetCurrentCluster() (o string) {
+	if v != nil && v.CurrentCluster != nil {
+		return *v.CurrentCluster
+	}
+	return
+}
+func (v *EntityNotExistsError) GetActiveCluster() (o string) {
+	if v != nil && v.ActiveCluster != nil {
+		return *v.ActiveCluster
+	}
+	return
 }
 
 // EventType is an internal type (TBD...)
@@ -699,6 +2051,25 @@ type ExternalWorkflowExecutionCancelRequestedEventAttributes struct {
 	WorkflowExecution *WorkflowExecution
 }
 
+func (v *ExternalWorkflowExecutionCancelRequestedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ExternalWorkflowExecutionCancelRequestedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ExternalWorkflowExecutionCancelRequestedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+
 // ExternalWorkflowExecutionSignaledEventAttributes is an internal type (TBD...)
 type ExternalWorkflowExecutionSignaledEventAttributes struct {
 	InitiatedEventID  *int64
@@ -707,15 +2078,60 @@ type ExternalWorkflowExecutionSignaledEventAttributes struct {
 	Control           []byte
 }
 
+func (v *ExternalWorkflowExecutionSignaledEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *ExternalWorkflowExecutionSignaledEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ExternalWorkflowExecutionSignaledEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ExternalWorkflowExecutionSignaledEventAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+
 // FailWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type FailWorkflowExecutionDecisionAttributes struct {
 	Reason  *string
 	Details []byte
 }
 
+func (v *FailWorkflowExecutionDecisionAttributes) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *FailWorkflowExecutionDecisionAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+
 // GetSearchAttributesResponse is an internal type (TBD...)
 type GetSearchAttributesResponse struct {
 	Keys map[string]IndexedValueType
+}
+
+func (v *GetSearchAttributesResponse) GetKeys() (o map[string]IndexedValueType) {
+	if v != nil && v.Keys != nil {
+		return v.Keys
+	}
+	return
 }
 
 // GetWorkflowExecutionHistoryRequest is an internal type (TBD...)
@@ -729,6 +2145,49 @@ type GetWorkflowExecutionHistoryRequest struct {
 	SkipArchival           *bool
 }
 
+func (v *GetWorkflowExecutionHistoryRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryRequest) GetExecution() (o *WorkflowExecution) {
+	if v != nil && v.Execution != nil {
+		return v.Execution
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryRequest) GetMaximumPageSize() (o int32) {
+	if v != nil && v.MaximumPageSize != nil {
+		return *v.MaximumPageSize
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryRequest) GetWaitForNewEvent() (o bool) {
+	if v != nil && v.WaitForNewEvent != nil {
+		return *v.WaitForNewEvent
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryRequest) GetHistoryEventFilterType() (o HistoryEventFilterType) {
+	if v != nil && v.HistoryEventFilterType != nil {
+		return *v.HistoryEventFilterType
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryRequest) GetSkipArchival() (o bool) {
+	if v != nil && v.SkipArchival != nil {
+		return *v.SkipArchival
+	}
+	return
+}
+
 // GetWorkflowExecutionHistoryResponse is an internal type (TBD...)
 type GetWorkflowExecutionHistoryResponse struct {
 	History       *History
@@ -737,14 +2196,53 @@ type GetWorkflowExecutionHistoryResponse struct {
 	Archived      *bool
 }
 
+func (v *GetWorkflowExecutionHistoryResponse) GetHistory() (o *History) {
+	if v != nil && v.History != nil {
+		return v.History
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryResponse) GetRawHistory() (o []*DataBlob) {
+	if v != nil && v.RawHistory != nil {
+		return v.RawHistory
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+func (v *GetWorkflowExecutionHistoryResponse) GetArchived() (o bool) {
+	if v != nil && v.Archived != nil {
+		return *v.Archived
+	}
+	return
+}
+
 // Header is an internal type (TBD...)
 type Header struct {
 	Fields map[string][]byte
 }
 
+func (v *Header) GetFields() (o map[string][]byte) {
+	if v != nil && v.Fields != nil {
+		return v.Fields
+	}
+	return
+}
+
 // History is an internal type (TBD...)
 type History struct {
 	Events []*HistoryEvent
+}
+
+func (v *History) GetEvents() (o []*HistoryEvent) {
+	if v != nil && v.Events != nil {
+		return v.Events
+	}
+	return
 }
 
 // HistoryBranch is an internal type (TBD...)
@@ -754,11 +2252,49 @@ type HistoryBranch struct {
 	Ancestors []*HistoryBranchRange
 }
 
+func (v *HistoryBranch) GetTreeID() (o string) {
+	if v != nil && v.TreeID != nil {
+		return *v.TreeID
+	}
+	return
+}
+func (v *HistoryBranch) GetBranchID() (o string) {
+	if v != nil && v.BranchID != nil {
+		return *v.BranchID
+	}
+	return
+}
+func (v *HistoryBranch) GetAncestors() (o []*HistoryBranchRange) {
+	if v != nil && v.Ancestors != nil {
+		return v.Ancestors
+	}
+	return
+}
+
 // HistoryBranchRange is an internal type (TBD...)
 type HistoryBranchRange struct {
 	BranchID    *string
 	BeginNodeID *int64
 	EndNodeID   *int64
+}
+
+func (v *HistoryBranchRange) GetBranchID() (o string) {
+	if v != nil && v.BranchID != nil {
+		return *v.BranchID
+	}
+	return
+}
+func (v *HistoryBranchRange) GetBeginNodeID() (o int64) {
+	if v != nil && v.BeginNodeID != nil {
+		return *v.BeginNodeID
+	}
+	return
+}
+func (v *HistoryBranchRange) GetEndNodeID() (o int64) {
+	if v != nil && v.EndNodeID != nil {
+		return *v.EndNodeID
+	}
+	return
 }
 
 // HistoryEvent is an internal type (TBD...)
@@ -812,6 +2348,289 @@ type HistoryEvent struct {
 	UpsertWorkflowSearchAttributesEventAttributes                  *UpsertWorkflowSearchAttributesEventAttributes
 }
 
+func (v *HistoryEvent) GetEventID() (o int64) {
+	if v != nil && v.EventID != nil {
+		return *v.EventID
+	}
+	return
+}
+func (v *HistoryEvent) GetTimestamp() (o int64) {
+	if v != nil && v.Timestamp != nil {
+		return *v.Timestamp
+	}
+	return
+}
+func (v *HistoryEvent) GetEventType() (o EventType) {
+	if v != nil && v.EventType != nil {
+		return *v.EventType
+	}
+	return
+}
+func (v *HistoryEvent) GetVersion() (o int64) {
+	if v != nil && v.Version != nil {
+		return *v.Version
+	}
+	return
+}
+func (v *HistoryEvent) GetTaskID() (o int64) {
+	if v != nil && v.TaskID != nil {
+		return *v.TaskID
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionStartedEventAttributes() (o *WorkflowExecutionStartedEventAttributes) {
+	if v != nil && v.WorkflowExecutionStartedEventAttributes != nil {
+		return v.WorkflowExecutionStartedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionCompletedEventAttributes() (o *WorkflowExecutionCompletedEventAttributes) {
+	if v != nil && v.WorkflowExecutionCompletedEventAttributes != nil {
+		return v.WorkflowExecutionCompletedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionFailedEventAttributes() (o *WorkflowExecutionFailedEventAttributes) {
+	if v != nil && v.WorkflowExecutionFailedEventAttributes != nil {
+		return v.WorkflowExecutionFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionTimedOutEventAttributes() (o *WorkflowExecutionTimedOutEventAttributes) {
+	if v != nil && v.WorkflowExecutionTimedOutEventAttributes != nil {
+		return v.WorkflowExecutionTimedOutEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetDecisionTaskScheduledEventAttributes() (o *DecisionTaskScheduledEventAttributes) {
+	if v != nil && v.DecisionTaskScheduledEventAttributes != nil {
+		return v.DecisionTaskScheduledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetDecisionTaskStartedEventAttributes() (o *DecisionTaskStartedEventAttributes) {
+	if v != nil && v.DecisionTaskStartedEventAttributes != nil {
+		return v.DecisionTaskStartedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetDecisionTaskCompletedEventAttributes() (o *DecisionTaskCompletedEventAttributes) {
+	if v != nil && v.DecisionTaskCompletedEventAttributes != nil {
+		return v.DecisionTaskCompletedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetDecisionTaskTimedOutEventAttributes() (o *DecisionTaskTimedOutEventAttributes) {
+	if v != nil && v.DecisionTaskTimedOutEventAttributes != nil {
+		return v.DecisionTaskTimedOutEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetDecisionTaskFailedEventAttributes() (o *DecisionTaskFailedEventAttributes) {
+	if v != nil && v.DecisionTaskFailedEventAttributes != nil {
+		return v.DecisionTaskFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetActivityTaskScheduledEventAttributes() (o *ActivityTaskScheduledEventAttributes) {
+	if v != nil && v.ActivityTaskScheduledEventAttributes != nil {
+		return v.ActivityTaskScheduledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetActivityTaskStartedEventAttributes() (o *ActivityTaskStartedEventAttributes) {
+	if v != nil && v.ActivityTaskStartedEventAttributes != nil {
+		return v.ActivityTaskStartedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetActivityTaskCompletedEventAttributes() (o *ActivityTaskCompletedEventAttributes) {
+	if v != nil && v.ActivityTaskCompletedEventAttributes != nil {
+		return v.ActivityTaskCompletedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetActivityTaskFailedEventAttributes() (o *ActivityTaskFailedEventAttributes) {
+	if v != nil && v.ActivityTaskFailedEventAttributes != nil {
+		return v.ActivityTaskFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetActivityTaskTimedOutEventAttributes() (o *ActivityTaskTimedOutEventAttributes) {
+	if v != nil && v.ActivityTaskTimedOutEventAttributes != nil {
+		return v.ActivityTaskTimedOutEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetTimerStartedEventAttributes() (o *TimerStartedEventAttributes) {
+	if v != nil && v.TimerStartedEventAttributes != nil {
+		return v.TimerStartedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetTimerFiredEventAttributes() (o *TimerFiredEventAttributes) {
+	if v != nil && v.TimerFiredEventAttributes != nil {
+		return v.TimerFiredEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetActivityTaskCancelRequestedEventAttributes() (o *ActivityTaskCancelRequestedEventAttributes) {
+	if v != nil && v.ActivityTaskCancelRequestedEventAttributes != nil {
+		return v.ActivityTaskCancelRequestedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetRequestCancelActivityTaskFailedEventAttributes() (o *RequestCancelActivityTaskFailedEventAttributes) {
+	if v != nil && v.RequestCancelActivityTaskFailedEventAttributes != nil {
+		return v.RequestCancelActivityTaskFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetActivityTaskCanceledEventAttributes() (o *ActivityTaskCanceledEventAttributes) {
+	if v != nil && v.ActivityTaskCanceledEventAttributes != nil {
+		return v.ActivityTaskCanceledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetTimerCanceledEventAttributes() (o *TimerCanceledEventAttributes) {
+	if v != nil && v.TimerCanceledEventAttributes != nil {
+		return v.TimerCanceledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetCancelTimerFailedEventAttributes() (o *CancelTimerFailedEventAttributes) {
+	if v != nil && v.CancelTimerFailedEventAttributes != nil {
+		return v.CancelTimerFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetMarkerRecordedEventAttributes() (o *MarkerRecordedEventAttributes) {
+	if v != nil && v.MarkerRecordedEventAttributes != nil {
+		return v.MarkerRecordedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionSignaledEventAttributes() (o *WorkflowExecutionSignaledEventAttributes) {
+	if v != nil && v.WorkflowExecutionSignaledEventAttributes != nil {
+		return v.WorkflowExecutionSignaledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionTerminatedEventAttributes() (o *WorkflowExecutionTerminatedEventAttributes) {
+	if v != nil && v.WorkflowExecutionTerminatedEventAttributes != nil {
+		return v.WorkflowExecutionTerminatedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionCancelRequestedEventAttributes() (o *WorkflowExecutionCancelRequestedEventAttributes) {
+	if v != nil && v.WorkflowExecutionCancelRequestedEventAttributes != nil {
+		return v.WorkflowExecutionCancelRequestedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionCanceledEventAttributes() (o *WorkflowExecutionCanceledEventAttributes) {
+	if v != nil && v.WorkflowExecutionCanceledEventAttributes != nil {
+		return v.WorkflowExecutionCanceledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetRequestCancelExternalWorkflowExecutionInitiatedEventAttributes() (o *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) {
+	if v != nil && v.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes != nil {
+		return v.RequestCancelExternalWorkflowExecutionInitiatedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetRequestCancelExternalWorkflowExecutionFailedEventAttributes() (o *RequestCancelExternalWorkflowExecutionFailedEventAttributes) {
+	if v != nil && v.RequestCancelExternalWorkflowExecutionFailedEventAttributes != nil {
+		return v.RequestCancelExternalWorkflowExecutionFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetExternalWorkflowExecutionCancelRequestedEventAttributes() (o *ExternalWorkflowExecutionCancelRequestedEventAttributes) {
+	if v != nil && v.ExternalWorkflowExecutionCancelRequestedEventAttributes != nil {
+		return v.ExternalWorkflowExecutionCancelRequestedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetWorkflowExecutionContinuedAsNewEventAttributes() (o *WorkflowExecutionContinuedAsNewEventAttributes) {
+	if v != nil && v.WorkflowExecutionContinuedAsNewEventAttributes != nil {
+		return v.WorkflowExecutionContinuedAsNewEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetStartChildWorkflowExecutionInitiatedEventAttributes() (o *StartChildWorkflowExecutionInitiatedEventAttributes) {
+	if v != nil && v.StartChildWorkflowExecutionInitiatedEventAttributes != nil {
+		return v.StartChildWorkflowExecutionInitiatedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetStartChildWorkflowExecutionFailedEventAttributes() (o *StartChildWorkflowExecutionFailedEventAttributes) {
+	if v != nil && v.StartChildWorkflowExecutionFailedEventAttributes != nil {
+		return v.StartChildWorkflowExecutionFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetChildWorkflowExecutionStartedEventAttributes() (o *ChildWorkflowExecutionStartedEventAttributes) {
+	if v != nil && v.ChildWorkflowExecutionStartedEventAttributes != nil {
+		return v.ChildWorkflowExecutionStartedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetChildWorkflowExecutionCompletedEventAttributes() (o *ChildWorkflowExecutionCompletedEventAttributes) {
+	if v != nil && v.ChildWorkflowExecutionCompletedEventAttributes != nil {
+		return v.ChildWorkflowExecutionCompletedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetChildWorkflowExecutionFailedEventAttributes() (o *ChildWorkflowExecutionFailedEventAttributes) {
+	if v != nil && v.ChildWorkflowExecutionFailedEventAttributes != nil {
+		return v.ChildWorkflowExecutionFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetChildWorkflowExecutionCanceledEventAttributes() (o *ChildWorkflowExecutionCanceledEventAttributes) {
+	if v != nil && v.ChildWorkflowExecutionCanceledEventAttributes != nil {
+		return v.ChildWorkflowExecutionCanceledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetChildWorkflowExecutionTimedOutEventAttributes() (o *ChildWorkflowExecutionTimedOutEventAttributes) {
+	if v != nil && v.ChildWorkflowExecutionTimedOutEventAttributes != nil {
+		return v.ChildWorkflowExecutionTimedOutEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetChildWorkflowExecutionTerminatedEventAttributes() (o *ChildWorkflowExecutionTerminatedEventAttributes) {
+	if v != nil && v.ChildWorkflowExecutionTerminatedEventAttributes != nil {
+		return v.ChildWorkflowExecutionTerminatedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetSignalExternalWorkflowExecutionInitiatedEventAttributes() (o *SignalExternalWorkflowExecutionInitiatedEventAttributes) {
+	if v != nil && v.SignalExternalWorkflowExecutionInitiatedEventAttributes != nil {
+		return v.SignalExternalWorkflowExecutionInitiatedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetSignalExternalWorkflowExecutionFailedEventAttributes() (o *SignalExternalWorkflowExecutionFailedEventAttributes) {
+	if v != nil && v.SignalExternalWorkflowExecutionFailedEventAttributes != nil {
+		return v.SignalExternalWorkflowExecutionFailedEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetExternalWorkflowExecutionSignaledEventAttributes() (o *ExternalWorkflowExecutionSignaledEventAttributes) {
+	if v != nil && v.ExternalWorkflowExecutionSignaledEventAttributes != nil {
+		return v.ExternalWorkflowExecutionSignaledEventAttributes
+	}
+	return
+}
+func (v *HistoryEvent) GetUpsertWorkflowSearchAttributesEventAttributes() (o *UpsertWorkflowSearchAttributesEventAttributes) {
+	if v != nil && v.UpsertWorkflowSearchAttributesEventAttributes != nil {
+		return v.UpsertWorkflowSearchAttributesEventAttributes
+	}
+	return
+}
+
 // HistoryEventFilterType is an internal type (TBD...)
 type HistoryEventFilterType int32
 
@@ -845,14 +2664,35 @@ type InternalDataInconsistencyError struct {
 	Message string
 }
 
+func (v *InternalDataInconsistencyError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+
 // InternalServiceError is an internal type (TBD...)
 type InternalServiceError struct {
 	Message string
 }
 
+func (v *InternalServiceError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+
 // LimitExceededError is an internal type (TBD...)
 type LimitExceededError struct {
 	Message string
+}
+
+func (v *LimitExceededError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
 }
 
 // ListArchivedWorkflowExecutionsRequest is an internal type (TBD...)
@@ -863,10 +2703,48 @@ type ListArchivedWorkflowExecutionsRequest struct {
 	Query         *string
 }
 
+func (v *ListArchivedWorkflowExecutionsRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ListArchivedWorkflowExecutionsRequest) GetPageSize() (o int32) {
+	if v != nil && v.PageSize != nil {
+		return *v.PageSize
+	}
+	return
+}
+func (v *ListArchivedWorkflowExecutionsRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+func (v *ListArchivedWorkflowExecutionsRequest) GetQuery() (o string) {
+	if v != nil && v.Query != nil {
+		return *v.Query
+	}
+	return
+}
+
 // ListArchivedWorkflowExecutionsResponse is an internal type (TBD...)
 type ListArchivedWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
+}
+
+func (v *ListArchivedWorkflowExecutionsResponse) GetExecutions() (o []*WorkflowExecutionInfo) {
+	if v != nil && v.Executions != nil {
+		return v.Executions
+	}
+	return
+}
+func (v *ListArchivedWorkflowExecutionsResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
 }
 
 // ListClosedWorkflowExecutionsRequest is an internal type (TBD...)
@@ -880,10 +2758,66 @@ type ListClosedWorkflowExecutionsRequest struct {
 	StatusFilter    *WorkflowExecutionCloseStatus
 }
 
+func (v *ListClosedWorkflowExecutionsRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ListClosedWorkflowExecutionsRequest) GetMaximumPageSize() (o int32) {
+	if v != nil && v.MaximumPageSize != nil {
+		return *v.MaximumPageSize
+	}
+	return
+}
+func (v *ListClosedWorkflowExecutionsRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+func (v *ListClosedWorkflowExecutionsRequest) GetStartTimeFilter() (o *StartTimeFilter) {
+	if v != nil && v.StartTimeFilter != nil {
+		return v.StartTimeFilter
+	}
+	return
+}
+func (v *ListClosedWorkflowExecutionsRequest) GetExecutionFilter() (o *WorkflowExecutionFilter) {
+	if v != nil && v.ExecutionFilter != nil {
+		return v.ExecutionFilter
+	}
+	return
+}
+func (v *ListClosedWorkflowExecutionsRequest) GetTypeFilter() (o *WorkflowTypeFilter) {
+	if v != nil && v.TypeFilter != nil {
+		return v.TypeFilter
+	}
+	return
+}
+func (v *ListClosedWorkflowExecutionsRequest) GetStatusFilter() (o WorkflowExecutionCloseStatus) {
+	if v != nil && v.StatusFilter != nil {
+		return *v.StatusFilter
+	}
+	return
+}
+
 // ListClosedWorkflowExecutionsResponse is an internal type (TBD...)
 type ListClosedWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
+}
+
+func (v *ListClosedWorkflowExecutionsResponse) GetExecutions() (o []*WorkflowExecutionInfo) {
+	if v != nil && v.Executions != nil {
+		return v.Executions
+	}
+	return
+}
+func (v *ListClosedWorkflowExecutionsResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
 }
 
 // ListDomainsRequest is an internal type (TBD...)
@@ -892,10 +2826,36 @@ type ListDomainsRequest struct {
 	NextPageToken []byte
 }
 
+func (v *ListDomainsRequest) GetPageSize() (o int32) {
+	if v != nil && v.PageSize != nil {
+		return *v.PageSize
+	}
+	return
+}
+func (v *ListDomainsRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+
 // ListDomainsResponse is an internal type (TBD...)
 type ListDomainsResponse struct {
 	Domains       []*DescribeDomainResponse
 	NextPageToken []byte
+}
+
+func (v *ListDomainsResponse) GetDomains() (o []*DescribeDomainResponse) {
+	if v != nil && v.Domains != nil {
+		return v.Domains
+	}
+	return
+}
+func (v *ListDomainsResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
 }
 
 // ListOpenWorkflowExecutionsRequest is an internal type (TBD...)
@@ -908,10 +2868,60 @@ type ListOpenWorkflowExecutionsRequest struct {
 	TypeFilter      *WorkflowTypeFilter
 }
 
+func (v *ListOpenWorkflowExecutionsRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ListOpenWorkflowExecutionsRequest) GetMaximumPageSize() (o int32) {
+	if v != nil && v.MaximumPageSize != nil {
+		return *v.MaximumPageSize
+	}
+	return
+}
+func (v *ListOpenWorkflowExecutionsRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+func (v *ListOpenWorkflowExecutionsRequest) GetStartTimeFilter() (o *StartTimeFilter) {
+	if v != nil && v.StartTimeFilter != nil {
+		return v.StartTimeFilter
+	}
+	return
+}
+func (v *ListOpenWorkflowExecutionsRequest) GetExecutionFilter() (o *WorkflowExecutionFilter) {
+	if v != nil && v.ExecutionFilter != nil {
+		return v.ExecutionFilter
+	}
+	return
+}
+func (v *ListOpenWorkflowExecutionsRequest) GetTypeFilter() (o *WorkflowTypeFilter) {
+	if v != nil && v.TypeFilter != nil {
+		return v.TypeFilter
+	}
+	return
+}
+
 // ListOpenWorkflowExecutionsResponse is an internal type (TBD...)
 type ListOpenWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
+}
+
+func (v *ListOpenWorkflowExecutionsResponse) GetExecutions() (o []*WorkflowExecutionInfo) {
+	if v != nil && v.Executions != nil {
+		return v.Executions
+	}
+	return
+}
+func (v *ListOpenWorkflowExecutionsResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
 }
 
 // ListTaskListPartitionsRequest is an internal type (TBD...)
@@ -920,10 +2930,36 @@ type ListTaskListPartitionsRequest struct {
 	TaskList *TaskList
 }
 
+func (v *ListTaskListPartitionsRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ListTaskListPartitionsRequest) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+
 // ListTaskListPartitionsResponse is an internal type (TBD...)
 type ListTaskListPartitionsResponse struct {
 	ActivityTaskListPartitions []*TaskListPartitionMetadata
 	DecisionTaskListPartitions []*TaskListPartitionMetadata
+}
+
+func (v *ListTaskListPartitionsResponse) GetActivityTaskListPartitions() (o []*TaskListPartitionMetadata) {
+	if v != nil && v.ActivityTaskListPartitions != nil {
+		return v.ActivityTaskListPartitions
+	}
+	return
+}
+func (v *ListTaskListPartitionsResponse) GetDecisionTaskListPartitions() (o []*TaskListPartitionMetadata) {
+	if v != nil && v.DecisionTaskListPartitions != nil {
+		return v.DecisionTaskListPartitions
+	}
+	return
 }
 
 // ListWorkflowExecutionsRequest is an internal type (TBD...)
@@ -934,10 +2970,48 @@ type ListWorkflowExecutionsRequest struct {
 	Query         *string
 }
 
+func (v *ListWorkflowExecutionsRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ListWorkflowExecutionsRequest) GetPageSize() (o int32) {
+	if v != nil && v.PageSize != nil {
+		return *v.PageSize
+	}
+	return
+}
+func (v *ListWorkflowExecutionsRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+func (v *ListWorkflowExecutionsRequest) GetQuery() (o string) {
+	if v != nil && v.Query != nil {
+		return *v.Query
+	}
+	return
+}
+
 // ListWorkflowExecutionsResponse is an internal type (TBD...)
 type ListWorkflowExecutionsResponse struct {
 	Executions    []*WorkflowExecutionInfo
 	NextPageToken []byte
+}
+
+func (v *ListWorkflowExecutionsResponse) GetExecutions() (o []*WorkflowExecutionInfo) {
+	if v != nil && v.Executions != nil {
+		return v.Executions
+	}
+	return
+}
+func (v *ListWorkflowExecutionsResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
 }
 
 // MarkerRecordedEventAttributes is an internal type (TBD...)
@@ -948,9 +3022,41 @@ type MarkerRecordedEventAttributes struct {
 	Header                       *Header
 }
 
+func (v *MarkerRecordedEventAttributes) GetMarkerName() (o string) {
+	if v != nil && v.MarkerName != nil {
+		return *v.MarkerName
+	}
+	return
+}
+func (v *MarkerRecordedEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *MarkerRecordedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *MarkerRecordedEventAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // Memo is an internal type (TBD...)
 type Memo struct {
 	Fields map[string][]byte
+}
+
+func (v *Memo) GetFields() (o map[string][]byte) {
+	if v != nil && v.Fields != nil {
+		return v.Fields
+	}
+	return
 }
 
 // ParentClosePolicy is an internal type (TBD...)
@@ -982,6 +3088,85 @@ type PendingActivityInfo struct {
 	LastFailureDetails     []byte
 }
 
+func (v *PendingActivityInfo) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *PendingActivityInfo) GetActivityType() (o *ActivityType) {
+	if v != nil && v.ActivityType != nil {
+		return v.ActivityType
+	}
+	return
+}
+func (v *PendingActivityInfo) GetState() (o PendingActivityState) {
+	if v != nil && v.State != nil {
+		return *v.State
+	}
+	return
+}
+func (v *PendingActivityInfo) GetHeartbeatDetails() (o []byte) {
+	if v != nil && v.HeartbeatDetails != nil {
+		return v.HeartbeatDetails
+	}
+	return
+}
+func (v *PendingActivityInfo) GetLastHeartbeatTimestamp() (o int64) {
+	if v != nil && v.LastHeartbeatTimestamp != nil {
+		return *v.LastHeartbeatTimestamp
+	}
+	return
+}
+func (v *PendingActivityInfo) GetLastStartedTimestamp() (o int64) {
+	if v != nil && v.LastStartedTimestamp != nil {
+		return *v.LastStartedTimestamp
+	}
+	return
+}
+func (v *PendingActivityInfo) GetAttempt() (o int32) {
+	if v != nil && v.Attempt != nil {
+		return *v.Attempt
+	}
+	return
+}
+func (v *PendingActivityInfo) GetMaximumAttempts() (o int32) {
+	if v != nil && v.MaximumAttempts != nil {
+		return *v.MaximumAttempts
+	}
+	return
+}
+func (v *PendingActivityInfo) GetScheduledTimestamp() (o int64) {
+	if v != nil && v.ScheduledTimestamp != nil {
+		return *v.ScheduledTimestamp
+	}
+	return
+}
+func (v *PendingActivityInfo) GetExpirationTimestamp() (o int64) {
+	if v != nil && v.ExpirationTimestamp != nil {
+		return *v.ExpirationTimestamp
+	}
+	return
+}
+func (v *PendingActivityInfo) GetLastFailureReason() (o string) {
+	if v != nil && v.LastFailureReason != nil {
+		return *v.LastFailureReason
+	}
+	return
+}
+func (v *PendingActivityInfo) GetLastWorkerIdentity() (o string) {
+	if v != nil && v.LastWorkerIdentity != nil {
+		return *v.LastWorkerIdentity
+	}
+	return
+}
+func (v *PendingActivityInfo) GetLastFailureDetails() (o []byte) {
+	if v != nil && v.LastFailureDetails != nil {
+		return v.LastFailureDetails
+	}
+	return
+}
+
 // PendingActivityState is an internal type (TBD...)
 type PendingActivityState int32
 
@@ -1003,12 +3188,68 @@ type PendingChildExecutionInfo struct {
 	ParentClosePolicy *ParentClosePolicy
 }
 
+func (v *PendingChildExecutionInfo) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *PendingChildExecutionInfo) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *PendingChildExecutionInfo) GetWorkflowTypName() (o string) {
+	if v != nil && v.WorkflowTypName != nil {
+		return *v.WorkflowTypName
+	}
+	return
+}
+func (v *PendingChildExecutionInfo) GetInitiatedID() (o int64) {
+	if v != nil && v.InitiatedID != nil {
+		return *v.InitiatedID
+	}
+	return
+}
+func (v *PendingChildExecutionInfo) GetParentClosePolicy() (o ParentClosePolicy) {
+	if v != nil && v.ParentClosePolicy != nil {
+		return *v.ParentClosePolicy
+	}
+	return
+}
+
 // PollForActivityTaskRequest is an internal type (TBD...)
 type PollForActivityTaskRequest struct {
 	Domain           *string
 	TaskList         *TaskList
 	Identity         *string
 	TaskListMetadata *TaskListMetadata
+}
+
+func (v *PollForActivityTaskRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *PollForActivityTaskRequest) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *PollForActivityTaskRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *PollForActivityTaskRequest) GetTaskListMetadata() (o *TaskListMetadata) {
+	if v != nil && v.TaskListMetadata != nil {
+		return v.TaskListMetadata
+	}
+	return
 }
 
 // PollForActivityTaskResponse is an internal type (TBD...)
@@ -1031,12 +3272,134 @@ type PollForActivityTaskResponse struct {
 	Header                          *Header
 }
 
+func (v *PollForActivityTaskResponse) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetActivityType() (o *ActivityType) {
+	if v != nil && v.ActivityType != nil {
+		return v.ActivityType
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetScheduledTimestamp() (o int64) {
+	if v != nil && v.ScheduledTimestamp != nil {
+		return *v.ScheduledTimestamp
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetScheduleToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ScheduleToCloseTimeoutSeconds != nil {
+		return *v.ScheduleToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetStartedTimestamp() (o int64) {
+	if v != nil && v.StartedTimestamp != nil {
+		return *v.StartedTimestamp
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.StartToCloseTimeoutSeconds != nil {
+		return *v.StartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetHeartbeatTimeoutSeconds() (o int32) {
+	if v != nil && v.HeartbeatTimeoutSeconds != nil {
+		return *v.HeartbeatTimeoutSeconds
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetAttempt() (o int32) {
+	if v != nil && v.Attempt != nil {
+		return *v.Attempt
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetScheduledTimestampOfThisAttempt() (o int64) {
+	if v != nil && v.ScheduledTimestampOfThisAttempt != nil {
+		return *v.ScheduledTimestampOfThisAttempt
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetHeartbeatDetails() (o []byte) {
+	if v != nil && v.HeartbeatDetails != nil {
+		return v.HeartbeatDetails
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetWorkflowDomain() (o string) {
+	if v != nil && v.WorkflowDomain != nil {
+		return *v.WorkflowDomain
+	}
+	return
+}
+func (v *PollForActivityTaskResponse) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // PollForDecisionTaskRequest is an internal type (TBD...)
 type PollForDecisionTaskRequest struct {
 	Domain         *string
 	TaskList       *TaskList
 	Identity       *string
 	BinaryChecksum *string
+}
+
+func (v *PollForDecisionTaskRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *PollForDecisionTaskRequest) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *PollForDecisionTaskRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *PollForDecisionTaskRequest) GetBinaryChecksum() (o string) {
+	if v != nil && v.BinaryChecksum != nil {
+		return *v.BinaryChecksum
+	}
+	return
 }
 
 // PollForDecisionTaskResponse is an internal type (TBD...)
@@ -1057,11 +3420,115 @@ type PollForDecisionTaskResponse struct {
 	Queries                   map[string]*WorkflowQuery
 }
 
+func (v *PollForDecisionTaskResponse) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetPreviousStartedEventID() (o int64) {
+	if v != nil && v.PreviousStartedEventID != nil {
+		return *v.PreviousStartedEventID
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetAttempt() (o int64) {
+	if v != nil && v.Attempt != nil {
+		return *v.Attempt
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetBacklogCountHint() (o int64) {
+	if v != nil && v.BacklogCountHint != nil {
+		return *v.BacklogCountHint
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetHistory() (o *History) {
+	if v != nil && v.History != nil {
+		return v.History
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetQuery() (o *WorkflowQuery) {
+	if v != nil && v.Query != nil {
+		return v.Query
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetWorkflowExecutionTaskList() (o *TaskList) {
+	if v != nil && v.WorkflowExecutionTaskList != nil {
+		return v.WorkflowExecutionTaskList
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetScheduledTimestamp() (o int64) {
+	if v != nil && v.ScheduledTimestamp != nil {
+		return *v.ScheduledTimestamp
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetStartedTimestamp() (o int64) {
+	if v != nil && v.StartedTimestamp != nil {
+		return *v.StartedTimestamp
+	}
+	return
+}
+func (v *PollForDecisionTaskResponse) GetQueries() (o map[string]*WorkflowQuery) {
+	if v != nil && v.Queries != nil {
+		return v.Queries
+	}
+	return
+}
+
 // PollerInfo is an internal type (TBD...)
 type PollerInfo struct {
 	LastAccessTime *int64
 	Identity       *string
 	RatePerSecond  *float64
+}
+
+func (v *PollerInfo) GetLastAccessTime() (o int64) {
+	if v != nil && v.LastAccessTime != nil {
+		return *v.LastAccessTime
+	}
+	return
+}
+func (v *PollerInfo) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *PollerInfo) GetRatePerSecond() (o float64) {
+	if v != nil && v.RatePerSecond != nil {
+		return *v.RatePerSecond
+	}
+	return
 }
 
 // QueryConsistencyLevel is an internal type (TBD...)
@@ -1079,6 +3546,13 @@ type QueryFailedError struct {
 	Message string
 }
 
+func (v *QueryFailedError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+
 // QueryRejectCondition is an internal type (TBD...)
 type QueryRejectCondition int32
 
@@ -1092,6 +3566,13 @@ const (
 // QueryRejected is an internal type (TBD...)
 type QueryRejected struct {
 	CloseStatus *WorkflowExecutionCloseStatus
+}
+
+func (v *QueryRejected) GetCloseStatus() (o WorkflowExecutionCloseStatus) {
+	if v != nil && v.CloseStatus != nil {
+		return *v.CloseStatus
+	}
+	return
 }
 
 // QueryResultType is an internal type (TBD...)
@@ -1123,10 +3604,54 @@ type QueryWorkflowRequest struct {
 	QueryConsistencyLevel *QueryConsistencyLevel
 }
 
+func (v *QueryWorkflowRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *QueryWorkflowRequest) GetExecution() (o *WorkflowExecution) {
+	if v != nil && v.Execution != nil {
+		return v.Execution
+	}
+	return
+}
+func (v *QueryWorkflowRequest) GetQuery() (o *WorkflowQuery) {
+	if v != nil && v.Query != nil {
+		return v.Query
+	}
+	return
+}
+func (v *QueryWorkflowRequest) GetQueryRejectCondition() (o QueryRejectCondition) {
+	if v != nil && v.QueryRejectCondition != nil {
+		return *v.QueryRejectCondition
+	}
+	return
+}
+func (v *QueryWorkflowRequest) GetQueryConsistencyLevel() (o QueryConsistencyLevel) {
+	if v != nil && v.QueryConsistencyLevel != nil {
+		return *v.QueryConsistencyLevel
+	}
+	return
+}
+
 // QueryWorkflowResponse is an internal type (TBD...)
 type QueryWorkflowResponse struct {
 	QueryResult   []byte
 	QueryRejected *QueryRejected
+}
+
+func (v *QueryWorkflowResponse) GetQueryResult() (o []byte) {
+	if v != nil && v.QueryResult != nil {
+		return v.QueryResult
+	}
+	return
+}
+func (v *QueryWorkflowResponse) GetQueryRejected() (o *QueryRejected) {
+	if v != nil && v.QueryRejected != nil {
+		return v.QueryRejected
+	}
+	return
 }
 
 // ReapplyEventsRequest is an internal type (TBD...)
@@ -1134,6 +3659,25 @@ type ReapplyEventsRequest struct {
 	DomainName        *string
 	WorkflowExecution *WorkflowExecution
 	Events            *DataBlob
+}
+
+func (v *ReapplyEventsRequest) GetDomainName() (o string) {
+	if v != nil && v.DomainName != nil {
+		return *v.DomainName
+	}
+	return
+}
+func (v *ReapplyEventsRequest) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ReapplyEventsRequest) GetEvents() (o *DataBlob) {
+	if v != nil && v.Events != nil {
+		return v.Events
+	}
+	return
 }
 
 // RecordActivityTaskHeartbeatByIDRequest is an internal type (TBD...)
@@ -1146,6 +3690,43 @@ type RecordActivityTaskHeartbeatByIDRequest struct {
 	Identity   *string
 }
 
+func (v *RecordActivityTaskHeartbeatByIDRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RecordActivityTaskHeartbeatByIDRequest) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *RecordActivityTaskHeartbeatByIDRequest) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *RecordActivityTaskHeartbeatByIDRequest) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *RecordActivityTaskHeartbeatByIDRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RecordActivityTaskHeartbeatByIDRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // RecordActivityTaskHeartbeatRequest is an internal type (TBD...)
 type RecordActivityTaskHeartbeatRequest struct {
 	TaskToken []byte
@@ -1153,9 +3734,35 @@ type RecordActivityTaskHeartbeatRequest struct {
 	Identity  *string
 }
 
+func (v *RecordActivityTaskHeartbeatRequest) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *RecordActivityTaskHeartbeatRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RecordActivityTaskHeartbeatRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // RecordActivityTaskHeartbeatResponse is an internal type (TBD...)
 type RecordActivityTaskHeartbeatResponse struct {
 	CancelRequested *bool
+}
+
+func (v *RecordActivityTaskHeartbeatResponse) GetCancelRequested() (o bool) {
+	if v != nil && v.CancelRequested != nil {
+		return *v.CancelRequested
+	}
+	return
 }
 
 // RecordMarkerDecisionAttributes is an internal type (TBD...)
@@ -1165,10 +3772,42 @@ type RecordMarkerDecisionAttributes struct {
 	Header     *Header
 }
 
+func (v *RecordMarkerDecisionAttributes) GetMarkerName() (o string) {
+	if v != nil && v.MarkerName != nil {
+		return *v.MarkerName
+	}
+	return
+}
+func (v *RecordMarkerDecisionAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RecordMarkerDecisionAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // RefreshWorkflowTasksRequest is an internal type (TBD...)
 type RefreshWorkflowTasksRequest struct {
 	Domain    *string
 	Execution *WorkflowExecution
+}
+
+func (v *RefreshWorkflowTasksRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RefreshWorkflowTasksRequest) GetExecution() (o *WorkflowExecution) {
+	if v != nil && v.Execution != nil {
+		return v.Execution
+	}
+	return
 }
 
 // RegisterDomainRequest is an internal type (TBD...)
@@ -1189,9 +3828,101 @@ type RegisterDomainRequest struct {
 	VisibilityArchivalURI                  *string
 }
 
+func (v *RegisterDomainRequest) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetDescription() (o string) {
+	if v != nil && v.Description != nil {
+		return *v.Description
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetOwnerEmail() (o string) {
+	if v != nil && v.OwnerEmail != nil {
+		return *v.OwnerEmail
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetWorkflowExecutionRetentionPeriodInDays() (o int32) {
+	if v != nil && v.WorkflowExecutionRetentionPeriodInDays != nil {
+		return *v.WorkflowExecutionRetentionPeriodInDays
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetEmitMetric() (o bool) {
+	if v != nil && v.EmitMetric != nil {
+		return *v.EmitMetric
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetClusters() (o []*ClusterReplicationConfiguration) {
+	if v != nil && v.Clusters != nil {
+		return v.Clusters
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetActiveClusterName() (o string) {
+	if v != nil && v.ActiveClusterName != nil {
+		return *v.ActiveClusterName
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetData() (o map[string]string) {
+	if v != nil && v.Data != nil {
+		return v.Data
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetSecurityToken() (o string) {
+	if v != nil && v.SecurityToken != nil {
+		return *v.SecurityToken
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetIsGlobalDomain() (o bool) {
+	if v != nil && v.IsGlobalDomain != nil {
+		return *v.IsGlobalDomain
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetHistoryArchivalStatus() (o ArchivalStatus) {
+	if v != nil && v.HistoryArchivalStatus != nil {
+		return *v.HistoryArchivalStatus
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetHistoryArchivalURI() (o string) {
+	if v != nil && v.HistoryArchivalURI != nil {
+		return *v.HistoryArchivalURI
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetVisibilityArchivalStatus() (o ArchivalStatus) {
+	if v != nil && v.VisibilityArchivalStatus != nil {
+		return *v.VisibilityArchivalStatus
+	}
+	return
+}
+func (v *RegisterDomainRequest) GetVisibilityArchivalURI() (o string) {
+	if v != nil && v.VisibilityArchivalURI != nil {
+		return *v.VisibilityArchivalURI
+	}
+	return
+}
+
 // RemoteSyncMatchedError is an internal type (TBD...)
 type RemoteSyncMatchedError struct {
 	Message string
+}
+
+func (v *RemoteSyncMatchedError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
 }
 
 // RemoveTaskRequest is an internal type (TBD...)
@@ -1202,9 +3933,41 @@ type RemoveTaskRequest struct {
 	VisibilityTimestamp *int64
 }
 
+func (v *RemoveTaskRequest) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *RemoveTaskRequest) GetType() (o int32) {
+	if v != nil && v.Type != nil {
+		return *v.Type
+	}
+	return
+}
+func (v *RemoveTaskRequest) GetTaskID() (o int64) {
+	if v != nil && v.TaskID != nil {
+		return *v.TaskID
+	}
+	return
+}
+func (v *RemoveTaskRequest) GetVisibilityTimestamp() (o int64) {
+	if v != nil && v.VisibilityTimestamp != nil {
+		return *v.VisibilityTimestamp
+	}
+	return
+}
+
 // RequestCancelActivityTaskDecisionAttributes is an internal type (TBD...)
 type RequestCancelActivityTaskDecisionAttributes struct {
 	ActivityID *string
+}
+
+func (v *RequestCancelActivityTaskDecisionAttributes) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
 }
 
 // RequestCancelActivityTaskFailedEventAttributes is an internal type (TBD...)
@@ -1214,6 +3977,25 @@ type RequestCancelActivityTaskFailedEventAttributes struct {
 	DecisionTaskCompletedEventID *int64
 }
 
+func (v *RequestCancelActivityTaskFailedEventAttributes) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *RequestCancelActivityTaskFailedEventAttributes) GetCause() (o string) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *RequestCancelActivityTaskFailedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+
 // RequestCancelExternalWorkflowExecutionDecisionAttributes is an internal type (TBD...)
 type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 	Domain            *string
@@ -1221,6 +4003,37 @@ type RequestCancelExternalWorkflowExecutionDecisionAttributes struct {
 	RunID             *string
 	Control           []byte
 	ChildWorkflowOnly *bool
+}
+
+func (v *RequestCancelExternalWorkflowExecutionDecisionAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionDecisionAttributes) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionDecisionAttributes) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionDecisionAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionDecisionAttributes) GetChildWorkflowOnly() (o bool) {
+	if v != nil && v.ChildWorkflowOnly != nil {
+		return *v.ChildWorkflowOnly
+	}
+	return
 }
 
 // RequestCancelExternalWorkflowExecutionFailedEventAttributes is an internal type (TBD...)
@@ -1233,6 +4046,43 @@ type RequestCancelExternalWorkflowExecutionFailedEventAttributes struct {
 	Control                      []byte
 }
 
+func (v *RequestCancelExternalWorkflowExecutionFailedEventAttributes) GetCause() (o CancelExternalWorkflowExecutionFailedCause) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionFailedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionFailedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionFailedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionFailedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionFailedEventAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+
 // RequestCancelExternalWorkflowExecutionInitiatedEventAttributes is an internal type (TBD...)
 type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
 	DecisionTaskCompletedEventID *int64
@@ -1242,12 +4092,68 @@ type RequestCancelExternalWorkflowExecutionInitiatedEventAttributes struct {
 	ChildWorkflowOnly            *bool
 }
 
+func (v *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *RequestCancelExternalWorkflowExecutionInitiatedEventAttributes) GetChildWorkflowOnly() (o bool) {
+	if v != nil && v.ChildWorkflowOnly != nil {
+		return *v.ChildWorkflowOnly
+	}
+	return
+}
+
 // RequestCancelWorkflowExecutionRequest is an internal type (TBD...)
 type RequestCancelWorkflowExecutionRequest struct {
 	Domain            *string
 	WorkflowExecution *WorkflowExecution
 	Identity          *string
 	RequestID         *string
+}
+
+func (v *RequestCancelWorkflowExecutionRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RequestCancelWorkflowExecutionRequest) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *RequestCancelWorkflowExecutionRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *RequestCancelWorkflowExecutionRequest) GetRequestID() (o string) {
+	if v != nil && v.RequestID != nil {
+		return *v.RequestID
+	}
+	return
 }
 
 // ResetPointInfo is an internal type (TBD...)
@@ -1260,9 +4166,53 @@ type ResetPointInfo struct {
 	Resettable               *bool
 }
 
+func (v *ResetPointInfo) GetBinaryChecksum() (o string) {
+	if v != nil && v.BinaryChecksum != nil {
+		return *v.BinaryChecksum
+	}
+	return
+}
+func (v *ResetPointInfo) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *ResetPointInfo) GetFirstDecisionCompletedID() (o int64) {
+	if v != nil && v.FirstDecisionCompletedID != nil {
+		return *v.FirstDecisionCompletedID
+	}
+	return
+}
+func (v *ResetPointInfo) GetCreatedTimeNano() (o int64) {
+	if v != nil && v.CreatedTimeNano != nil {
+		return *v.CreatedTimeNano
+	}
+	return
+}
+func (v *ResetPointInfo) GetExpiringTimeNano() (o int64) {
+	if v != nil && v.ExpiringTimeNano != nil {
+		return *v.ExpiringTimeNano
+	}
+	return
+}
+func (v *ResetPointInfo) GetResettable() (o bool) {
+	if v != nil && v.Resettable != nil {
+		return *v.Resettable
+	}
+	return
+}
+
 // ResetPoints is an internal type (TBD...)
 type ResetPoints struct {
 	Points []*ResetPointInfo
+}
+
+func (v *ResetPoints) GetPoints() (o []*ResetPointInfo) {
+	if v != nil && v.Points != nil {
+		return v.Points
+	}
+	return
 }
 
 // ResetQueueRequest is an internal type (TBD...)
@@ -1272,10 +4222,42 @@ type ResetQueueRequest struct {
 	Type        *int32
 }
 
+func (v *ResetQueueRequest) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *ResetQueueRequest) GetClusterName() (o string) {
+	if v != nil && v.ClusterName != nil {
+		return *v.ClusterName
+	}
+	return
+}
+func (v *ResetQueueRequest) GetType() (o int32) {
+	if v != nil && v.Type != nil {
+		return *v.Type
+	}
+	return
+}
+
 // ResetStickyTaskListRequest is an internal type (TBD...)
 type ResetStickyTaskListRequest struct {
 	Domain    *string
 	Execution *WorkflowExecution
+}
+
+func (v *ResetStickyTaskListRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ResetStickyTaskListRequest) GetExecution() (o *WorkflowExecution) {
+	if v != nil && v.Execution != nil {
+		return v.Execution
+	}
+	return
 }
 
 // ResetStickyTaskListResponse is an internal type (TBD...)
@@ -1291,9 +4273,47 @@ type ResetWorkflowExecutionRequest struct {
 	RequestID             *string
 }
 
+func (v *ResetWorkflowExecutionRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ResetWorkflowExecutionRequest) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *ResetWorkflowExecutionRequest) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *ResetWorkflowExecutionRequest) GetDecisionFinishEventID() (o int64) {
+	if v != nil && v.DecisionFinishEventID != nil {
+		return *v.DecisionFinishEventID
+	}
+	return
+}
+func (v *ResetWorkflowExecutionRequest) GetRequestID() (o string) {
+	if v != nil && v.RequestID != nil {
+		return *v.RequestID
+	}
+	return
+}
+
 // ResetWorkflowExecutionResponse is an internal type (TBD...)
 type ResetWorkflowExecutionResponse struct {
 	RunID *string
+}
+
+func (v *ResetWorkflowExecutionResponse) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
 }
 
 // RespondActivityTaskCanceledByIDRequest is an internal type (TBD...)
@@ -1306,11 +4326,67 @@ type RespondActivityTaskCanceledByIDRequest struct {
 	Identity   *string
 }
 
+func (v *RespondActivityTaskCanceledByIDRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RespondActivityTaskCanceledByIDRequest) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *RespondActivityTaskCanceledByIDRequest) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *RespondActivityTaskCanceledByIDRequest) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *RespondActivityTaskCanceledByIDRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RespondActivityTaskCanceledByIDRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // RespondActivityTaskCanceledRequest is an internal type (TBD...)
 type RespondActivityTaskCanceledRequest struct {
 	TaskToken []byte
 	Details   []byte
 	Identity  *string
+}
+
+func (v *RespondActivityTaskCanceledRequest) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *RespondActivityTaskCanceledRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RespondActivityTaskCanceledRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
 }
 
 // RespondActivityTaskCompletedByIDRequest is an internal type (TBD...)
@@ -1323,11 +4399,67 @@ type RespondActivityTaskCompletedByIDRequest struct {
 	Identity   *string
 }
 
+func (v *RespondActivityTaskCompletedByIDRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RespondActivityTaskCompletedByIDRequest) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *RespondActivityTaskCompletedByIDRequest) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *RespondActivityTaskCompletedByIDRequest) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *RespondActivityTaskCompletedByIDRequest) GetResult() (o []byte) {
+	if v != nil && v.Result != nil {
+		return v.Result
+	}
+	return
+}
+func (v *RespondActivityTaskCompletedByIDRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // RespondActivityTaskCompletedRequest is an internal type (TBD...)
 type RespondActivityTaskCompletedRequest struct {
 	TaskToken []byte
 	Result    []byte
 	Identity  *string
+}
+
+func (v *RespondActivityTaskCompletedRequest) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *RespondActivityTaskCompletedRequest) GetResult() (o []byte) {
+	if v != nil && v.Result != nil {
+		return v.Result
+	}
+	return
+}
+func (v *RespondActivityTaskCompletedRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
 }
 
 // RespondActivityTaskFailedByIDRequest is an internal type (TBD...)
@@ -1341,12 +4473,80 @@ type RespondActivityTaskFailedByIDRequest struct {
 	Identity   *string
 }
 
+func (v *RespondActivityTaskFailedByIDRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *RespondActivityTaskFailedByIDRequest) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *RespondActivityTaskFailedByIDRequest) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *RespondActivityTaskFailedByIDRequest) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *RespondActivityTaskFailedByIDRequest) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *RespondActivityTaskFailedByIDRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RespondActivityTaskFailedByIDRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // RespondActivityTaskFailedRequest is an internal type (TBD...)
 type RespondActivityTaskFailedRequest struct {
 	TaskToken []byte
 	Reason    *string
 	Details   []byte
 	Identity  *string
+}
+
+func (v *RespondActivityTaskFailedRequest) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *RespondActivityTaskFailedRequest) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *RespondActivityTaskFailedRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RespondActivityTaskFailedRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
 }
 
 // RespondDecisionTaskCompletedRequest is an internal type (TBD...)
@@ -1362,9 +4562,78 @@ type RespondDecisionTaskCompletedRequest struct {
 	QueryResults               map[string]*WorkflowQueryResult
 }
 
+func (v *RespondDecisionTaskCompletedRequest) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetDecisions() (o []*Decision) {
+	if v != nil && v.Decisions != nil {
+		return v.Decisions
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetExecutionContext() (o []byte) {
+	if v != nil && v.ExecutionContext != nil {
+		return v.ExecutionContext
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetStickyAttributes() (o *StickyExecutionAttributes) {
+	if v != nil && v.StickyAttributes != nil {
+		return v.StickyAttributes
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetReturnNewDecisionTask() (o bool) {
+	if v != nil && v.ReturnNewDecisionTask != nil {
+		return *v.ReturnNewDecisionTask
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetForceCreateNewDecisionTask() (o bool) {
+	if v != nil && v.ForceCreateNewDecisionTask != nil {
+		return *v.ForceCreateNewDecisionTask
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetBinaryChecksum() (o string) {
+	if v != nil && v.BinaryChecksum != nil {
+		return *v.BinaryChecksum
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedRequest) GetQueryResults() (o map[string]*WorkflowQueryResult) {
+	if v != nil && v.QueryResults != nil {
+		return v.QueryResults
+	}
+	return
+}
+
 // RespondDecisionTaskCompletedResponse is an internal type (TBD...)
 type RespondDecisionTaskCompletedResponse struct {
-	DecisionTask *PollForDecisionTaskResponse
+	DecisionTask                *PollForDecisionTaskResponse
+	ActivitiesToDispatchLocally map[string]*ActivityLocalDispatchInfo
+}
+
+func (v *RespondDecisionTaskCompletedResponse) GetDecisionTask() (o *PollForDecisionTaskResponse) {
+	if v != nil && v.DecisionTask != nil {
+		return v.DecisionTask
+	}
+	return
+}
+func (v *RespondDecisionTaskCompletedResponse) GetActivitiesToDispatchLocally() (o map[string]*ActivityLocalDispatchInfo) {
+	if v != nil && v.ActivitiesToDispatchLocally != nil {
+		return v.ActivitiesToDispatchLocally
+	}
+	return
 }
 
 // RespondDecisionTaskFailedRequest is an internal type (TBD...)
@@ -1376,6 +4645,37 @@ type RespondDecisionTaskFailedRequest struct {
 	BinaryChecksum *string
 }
 
+func (v *RespondDecisionTaskFailedRequest) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *RespondDecisionTaskFailedRequest) GetCause() (o DecisionTaskFailedCause) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *RespondDecisionTaskFailedRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *RespondDecisionTaskFailedRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *RespondDecisionTaskFailedRequest) GetBinaryChecksum() (o string) {
+	if v != nil && v.BinaryChecksum != nil {
+		return *v.BinaryChecksum
+	}
+	return
+}
+
 // RespondQueryTaskCompletedRequest is an internal type (TBD...)
 type RespondQueryTaskCompletedRequest struct {
 	TaskToken         []byte
@@ -1383,6 +4683,37 @@ type RespondQueryTaskCompletedRequest struct {
 	QueryResult       []byte
 	ErrorMessage      *string
 	WorkerVersionInfo *WorkerVersionInfo
+}
+
+func (v *RespondQueryTaskCompletedRequest) GetTaskToken() (o []byte) {
+	if v != nil && v.TaskToken != nil {
+		return v.TaskToken
+	}
+	return
+}
+func (v *RespondQueryTaskCompletedRequest) GetCompletedType() (o QueryTaskCompletedType) {
+	if v != nil && v.CompletedType != nil {
+		return *v.CompletedType
+	}
+	return
+}
+func (v *RespondQueryTaskCompletedRequest) GetQueryResult() (o []byte) {
+	if v != nil && v.QueryResult != nil {
+		return v.QueryResult
+	}
+	return
+}
+func (v *RespondQueryTaskCompletedRequest) GetErrorMessage() (o string) {
+	if v != nil && v.ErrorMessage != nil {
+		return *v.ErrorMessage
+	}
+	return
+}
+func (v *RespondQueryTaskCompletedRequest) GetWorkerVersionInfo() (o *WorkerVersionInfo) {
+	if v != nil && v.WorkerVersionInfo != nil {
+		return v.WorkerVersionInfo
+	}
+	return
 }
 
 // RetryPolicy is an internal type (TBD...)
@@ -1395,6 +4726,43 @@ type RetryPolicy struct {
 	ExpirationIntervalInSeconds *int32
 }
 
+func (v *RetryPolicy) GetInitialIntervalInSeconds() (o int32) {
+	if v != nil && v.InitialIntervalInSeconds != nil {
+		return *v.InitialIntervalInSeconds
+	}
+	return
+}
+func (v *RetryPolicy) GetBackoffCoefficient() (o float64) {
+	if v != nil && v.BackoffCoefficient != nil {
+		return *v.BackoffCoefficient
+	}
+	return
+}
+func (v *RetryPolicy) GetMaximumIntervalInSeconds() (o int32) {
+	if v != nil && v.MaximumIntervalInSeconds != nil {
+		return *v.MaximumIntervalInSeconds
+	}
+	return
+}
+func (v *RetryPolicy) GetMaximumAttempts() (o int32) {
+	if v != nil && v.MaximumAttempts != nil {
+		return *v.MaximumAttempts
+	}
+	return
+}
+func (v *RetryPolicy) GetNonRetriableErrorReasons() (o []string) {
+	if v != nil && v.NonRetriableErrorReasons != nil {
+		return v.NonRetriableErrorReasons
+	}
+	return
+}
+func (v *RetryPolicy) GetExpirationIntervalInSeconds() (o int32) {
+	if v != nil && v.ExpirationIntervalInSeconds != nil {
+		return *v.ExpirationIntervalInSeconds
+	}
+	return
+}
+
 // RetryTaskV2Error is an internal type (TBD...)
 type RetryTaskV2Error struct {
 	Message           string
@@ -1405,6 +4773,55 @@ type RetryTaskV2Error struct {
 	StartEventVersion *int64
 	EndEventID        *int64
 	EndEventVersion   *int64
+}
+
+func (v *RetryTaskV2Error) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
+}
+func (v *RetryTaskV2Error) GetDomainID() (o string) {
+	if v != nil && v.DomainID != nil {
+		return *v.DomainID
+	}
+	return
+}
+func (v *RetryTaskV2Error) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *RetryTaskV2Error) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *RetryTaskV2Error) GetStartEventID() (o int64) {
+	if v != nil && v.StartEventID != nil {
+		return *v.StartEventID
+	}
+	return
+}
+func (v *RetryTaskV2Error) GetStartEventVersion() (o int64) {
+	if v != nil && v.StartEventVersion != nil {
+		return *v.StartEventVersion
+	}
+	return
+}
+func (v *RetryTaskV2Error) GetEndEventID() (o int64) {
+	if v != nil && v.EndEventID != nil {
+		return *v.EndEventID
+	}
+	return
+}
+func (v *RetryTaskV2Error) GetEndEventVersion() (o int64) {
+	if v != nil && v.EndEventVersion != nil {
+		return *v.EndEventVersion
+	}
+	return
 }
 
 // ScheduleActivityTaskDecisionAttributes is an internal type (TBD...)
@@ -1420,6 +4837,80 @@ type ScheduleActivityTaskDecisionAttributes struct {
 	HeartbeatTimeoutSeconds       *int32
 	RetryPolicy                   *RetryPolicy
 	Header                        *Header
+	RequestLocalDispatch          *bool
+}
+
+func (v *ScheduleActivityTaskDecisionAttributes) GetActivityID() (o string) {
+	if v != nil && v.ActivityID != nil {
+		return *v.ActivityID
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetActivityType() (o *ActivityType) {
+	if v != nil && v.ActivityType != nil {
+		return v.ActivityType
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetScheduleToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ScheduleToCloseTimeoutSeconds != nil {
+		return *v.ScheduleToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetScheduleToStartTimeoutSeconds() (o int32) {
+	if v != nil && v.ScheduleToStartTimeoutSeconds != nil {
+		return *v.ScheduleToStartTimeoutSeconds
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.StartToCloseTimeoutSeconds != nil {
+		return *v.StartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetHeartbeatTimeoutSeconds() (o int32) {
+	if v != nil && v.HeartbeatTimeoutSeconds != nil {
+		return *v.HeartbeatTimeoutSeconds
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+func (v *ScheduleActivityTaskDecisionAttributes) GetRequestLocalDispatch() (o bool) {
+	if v != nil && v.RequestLocalDispatch != nil {
+		return *v.RequestLocalDispatch
+	}
+	return
 }
 
 // SearchAttributes is an internal type (TBD...)
@@ -1427,9 +4918,23 @@ type SearchAttributes struct {
 	IndexedFields map[string][]byte
 }
 
+func (v *SearchAttributes) GetIndexedFields() (o map[string][]byte) {
+	if v != nil && v.IndexedFields != nil {
+		return v.IndexedFields
+	}
+	return
+}
+
 // ServiceBusyError is an internal type (TBD...)
 type ServiceBusyError struct {
 	Message string
+}
+
+func (v *ServiceBusyError) GetMessage() (o string) {
+	if v != nil {
+		return v.Message
+	}
+	return
 }
 
 // SignalExternalWorkflowExecutionDecisionAttributes is an internal type (TBD...)
@@ -1440,6 +4945,43 @@ type SignalExternalWorkflowExecutionDecisionAttributes struct {
 	Input             []byte
 	Control           []byte
 	ChildWorkflowOnly *bool
+}
+
+func (v *SignalExternalWorkflowExecutionDecisionAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionDecisionAttributes) GetExecution() (o *WorkflowExecution) {
+	if v != nil && v.Execution != nil {
+		return v.Execution
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionDecisionAttributes) GetSignalName() (o string) {
+	if v != nil && v.SignalName != nil {
+		return *v.SignalName
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionDecisionAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionDecisionAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionDecisionAttributes) GetChildWorkflowOnly() (o bool) {
+	if v != nil && v.ChildWorkflowOnly != nil {
+		return *v.ChildWorkflowOnly
+	}
+	return
 }
 
 // SignalExternalWorkflowExecutionFailedCause is an internal type (TBD...)
@@ -1460,6 +5002,43 @@ type SignalExternalWorkflowExecutionFailedEventAttributes struct {
 	Control                      []byte
 }
 
+func (v *SignalExternalWorkflowExecutionFailedEventAttributes) GetCause() (o SignalExternalWorkflowExecutionFailedCause) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionFailedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionFailedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionFailedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionFailedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionFailedEventAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+
 // SignalExternalWorkflowExecutionInitiatedEventAttributes is an internal type (TBD...)
 type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	DecisionTaskCompletedEventID *int64
@@ -1469,6 +5048,49 @@ type SignalExternalWorkflowExecutionInitiatedEventAttributes struct {
 	Input                        []byte
 	Control                      []byte
 	ChildWorkflowOnly            *bool
+}
+
+func (v *SignalExternalWorkflowExecutionInitiatedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionInitiatedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionInitiatedEventAttributes) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionInitiatedEventAttributes) GetSignalName() (o string) {
+	if v != nil && v.SignalName != nil {
+		return *v.SignalName
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionInitiatedEventAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionInitiatedEventAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *SignalExternalWorkflowExecutionInitiatedEventAttributes) GetChildWorkflowOnly() (o bool) {
+	if v != nil && v.ChildWorkflowOnly != nil {
+		return *v.ChildWorkflowOnly
+	}
+	return
 }
 
 // SignalWithStartWorkflowExecutionRequest is an internal type (TBD...)
@@ -1493,6 +5115,115 @@ type SignalWithStartWorkflowExecutionRequest struct {
 	Header                              *Header
 }
 
+func (v *SignalWithStartWorkflowExecutionRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetRequestID() (o string) {
+	if v != nil && v.RequestID != nil {
+		return *v.RequestID
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetWorkflowIDReusePolicy() (o WorkflowIDReusePolicy) {
+	if v != nil && v.WorkflowIDReusePolicy != nil {
+		return *v.WorkflowIDReusePolicy
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetSignalName() (o string) {
+	if v != nil && v.SignalName != nil {
+		return *v.SignalName
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetSignalInput() (o []byte) {
+	if v != nil && v.SignalInput != nil {
+		return v.SignalInput
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetCronSchedule() (o string) {
+	if v != nil && v.CronSchedule != nil {
+		return *v.CronSchedule
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+func (v *SignalWithStartWorkflowExecutionRequest) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // SignalWorkflowExecutionRequest is an internal type (TBD...)
 type SignalWorkflowExecutionRequest struct {
 	Domain            *string
@@ -1502,6 +5233,49 @@ type SignalWorkflowExecutionRequest struct {
 	Identity          *string
 	RequestID         *string
 	Control           []byte
+}
+
+func (v *SignalWorkflowExecutionRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *SignalWorkflowExecutionRequest) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *SignalWorkflowExecutionRequest) GetSignalName() (o string) {
+	if v != nil && v.SignalName != nil {
+		return *v.SignalName
+	}
+	return
+}
+func (v *SignalWorkflowExecutionRequest) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *SignalWorkflowExecutionRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *SignalWorkflowExecutionRequest) GetRequestID() (o string) {
+	if v != nil && v.RequestID != nil {
+		return *v.RequestID
+	}
+	return
+}
+func (v *SignalWorkflowExecutionRequest) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
 }
 
 // StartChildWorkflowExecutionDecisionAttributes is an internal type (TBD...)
@@ -1523,6 +5297,97 @@ type StartChildWorkflowExecutionDecisionAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetParentClosePolicy() (o ParentClosePolicy) {
+	if v != nil && v.ParentClosePolicy != nil {
+		return *v.ParentClosePolicy
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetWorkflowIDReusePolicy() (o WorkflowIDReusePolicy) {
+	if v != nil && v.WorkflowIDReusePolicy != nil {
+		return *v.WorkflowIDReusePolicy
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetCronSchedule() (o string) {
+	if v != nil && v.CronSchedule != nil {
+		return *v.CronSchedule
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionDecisionAttributes) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+
 // StartChildWorkflowExecutionFailedEventAttributes is an internal type (TBD...)
 type StartChildWorkflowExecutionFailedEventAttributes struct {
 	Domain                       *string
@@ -1532,6 +5397,49 @@ type StartChildWorkflowExecutionFailedEventAttributes struct {
 	Control                      []byte
 	InitiatedEventID             *int64
 	DecisionTaskCompletedEventID *int64
+}
+
+func (v *StartChildWorkflowExecutionFailedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionFailedEventAttributes) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionFailedEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionFailedEventAttributes) GetCause() (o ChildWorkflowExecutionFailedCause) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionFailedEventAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionFailedEventAttributes) GetInitiatedEventID() (o int64) {
+	if v != nil && v.InitiatedEventID != nil {
+		return *v.InitiatedEventID
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionFailedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
 }
 
 // StartChildWorkflowExecutionInitiatedEventAttributes is an internal type (TBD...)
@@ -1554,16 +5462,139 @@ type StartChildWorkflowExecutionInitiatedEventAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetParentClosePolicy() (o ParentClosePolicy) {
+	if v != nil && v.ParentClosePolicy != nil {
+		return *v.ParentClosePolicy
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetControl() (o []byte) {
+	if v != nil && v.Control != nil {
+		return v.Control
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetWorkflowIDReusePolicy() (o WorkflowIDReusePolicy) {
+	if v != nil && v.WorkflowIDReusePolicy != nil {
+		return *v.WorkflowIDReusePolicy
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetCronSchedule() (o string) {
+	if v != nil && v.CronSchedule != nil {
+		return *v.CronSchedule
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+
 // StartTimeFilter is an internal type (TBD...)
 type StartTimeFilter struct {
 	EarliestTime *int64
 	LatestTime   *int64
 }
 
+func (v *StartTimeFilter) GetEarliestTime() (o int64) {
+	if v != nil && v.EarliestTime != nil {
+		return *v.EarliestTime
+	}
+	return
+}
+func (v *StartTimeFilter) GetLatestTime() (o int64) {
+	if v != nil && v.LatestTime != nil {
+		return *v.LatestTime
+	}
+	return
+}
+
 // StartTimerDecisionAttributes is an internal type (TBD...)
 type StartTimerDecisionAttributes struct {
 	TimerID                   *string
 	StartToFireTimeoutSeconds *int64
+}
+
+func (v *StartTimerDecisionAttributes) GetTimerID() (o string) {
+	if v != nil && v.TimerID != nil {
+		return *v.TimerID
+	}
+	return
+}
+func (v *StartTimerDecisionAttributes) GetStartToFireTimeoutSeconds() (o int64) {
+	if v != nil && v.StartToFireTimeoutSeconds != nil {
+		return *v.StartToFireTimeoutSeconds
+	}
+	return
 }
 
 // StartWorkflowExecutionRequest is an internal type (TBD...)
@@ -1585,9 +5616,107 @@ type StartWorkflowExecutionRequest struct {
 	Header                              *Header
 }
 
+func (v *StartWorkflowExecutionRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetRequestID() (o string) {
+	if v != nil && v.RequestID != nil {
+		return *v.RequestID
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetWorkflowIDReusePolicy() (o WorkflowIDReusePolicy) {
+	if v != nil && v.WorkflowIDReusePolicy != nil {
+		return *v.WorkflowIDReusePolicy
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetCronSchedule() (o string) {
+	if v != nil && v.CronSchedule != nil {
+		return *v.CronSchedule
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+func (v *StartWorkflowExecutionRequest) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // StartWorkflowExecutionResponse is an internal type (TBD...)
 type StartWorkflowExecutionResponse struct {
 	RunID *string
+}
+
+func (v *StartWorkflowExecutionResponse) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
 }
 
 // StickyExecutionAttributes is an internal type (TBD...)
@@ -1596,10 +5725,36 @@ type StickyExecutionAttributes struct {
 	ScheduleToStartTimeoutSeconds *int32
 }
 
+func (v *StickyExecutionAttributes) GetWorkerTaskList() (o *TaskList) {
+	if v != nil && v.WorkerTaskList != nil {
+		return v.WorkerTaskList
+	}
+	return
+}
+func (v *StickyExecutionAttributes) GetScheduleToStartTimeoutSeconds() (o int32) {
+	if v != nil && v.ScheduleToStartTimeoutSeconds != nil {
+		return *v.ScheduleToStartTimeoutSeconds
+	}
+	return
+}
+
 // SupportedClientVersions is an internal type (TBD...)
 type SupportedClientVersions struct {
 	GoSdk   *string
 	JavaSdk *string
+}
+
+func (v *SupportedClientVersions) GetGoSdk() (o string) {
+	if v != nil && v.GoSdk != nil {
+		return *v.GoSdk
+	}
+	return
+}
+func (v *SupportedClientVersions) GetJavaSdk() (o string) {
+	if v != nil && v.JavaSdk != nil {
+		return *v.JavaSdk
+	}
+	return
 }
 
 // TaskIDBlock is an internal type (TBD...)
@@ -1608,10 +5763,36 @@ type TaskIDBlock struct {
 	EndID   *int64
 }
 
+func (v *TaskIDBlock) GetStartID() (o int64) {
+	if v != nil && v.StartID != nil {
+		return *v.StartID
+	}
+	return
+}
+func (v *TaskIDBlock) GetEndID() (o int64) {
+	if v != nil && v.EndID != nil {
+		return *v.EndID
+	}
+	return
+}
+
 // TaskList is an internal type (TBD...)
 type TaskList struct {
 	Name *string
 	Kind *TaskListKind
+}
+
+func (v *TaskList) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
+}
+func (v *TaskList) GetKind() (o TaskListKind) {
+	if v != nil && v.Kind != nil {
+		return *v.Kind
+	}
+	return
 }
 
 // TaskListKind is an internal type (TBD...)
@@ -1629,10 +5810,30 @@ type TaskListMetadata struct {
 	MaxTasksPerSecond *float64
 }
 
+func (v *TaskListMetadata) GetMaxTasksPerSecond() (o float64) {
+	if v != nil && v.MaxTasksPerSecond != nil {
+		return *v.MaxTasksPerSecond
+	}
+	return
+}
+
 // TaskListPartitionMetadata is an internal type (TBD...)
 type TaskListPartitionMetadata struct {
 	Key           *string
 	OwnerHostName *string
+}
+
+func (v *TaskListPartitionMetadata) GetKey() (o string) {
+	if v != nil && v.Key != nil {
+		return *v.Key
+	}
+	return
+}
+func (v *TaskListPartitionMetadata) GetOwnerHostName() (o string) {
+	if v != nil && v.OwnerHostName != nil {
+		return *v.OwnerHostName
+	}
+	return
 }
 
 // TaskListStatus is an internal type (TBD...)
@@ -1642,6 +5843,37 @@ type TaskListStatus struct {
 	AckLevel         *int64
 	RatePerSecond    *float64
 	TaskIDBlock      *TaskIDBlock
+}
+
+func (v *TaskListStatus) GetBacklogCountHint() (o int64) {
+	if v != nil && v.BacklogCountHint != nil {
+		return *v.BacklogCountHint
+	}
+	return
+}
+func (v *TaskListStatus) GetReadLevel() (o int64) {
+	if v != nil && v.ReadLevel != nil {
+		return *v.ReadLevel
+	}
+	return
+}
+func (v *TaskListStatus) GetAckLevel() (o int64) {
+	if v != nil && v.AckLevel != nil {
+		return *v.AckLevel
+	}
+	return
+}
+func (v *TaskListStatus) GetRatePerSecond() (o float64) {
+	if v != nil && v.RatePerSecond != nil {
+		return *v.RatePerSecond
+	}
+	return
+}
+func (v *TaskListStatus) GetTaskIDBlock() (o *TaskIDBlock) {
+	if v != nil && v.TaskIDBlock != nil {
+		return v.TaskIDBlock
+	}
+	return
 }
 
 // TaskListType is an internal type (TBD...)
@@ -1661,6 +5893,37 @@ type TerminateWorkflowExecutionRequest struct {
 	Reason            *string
 	Details           []byte
 	Identity          *string
+}
+
+func (v *TerminateWorkflowExecutionRequest) GetDomain() (o string) {
+	if v != nil && v.Domain != nil {
+		return *v.Domain
+	}
+	return
+}
+func (v *TerminateWorkflowExecutionRequest) GetWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.WorkflowExecution != nil {
+		return v.WorkflowExecution
+	}
+	return
+}
+func (v *TerminateWorkflowExecutionRequest) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *TerminateWorkflowExecutionRequest) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *TerminateWorkflowExecutionRequest) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
 }
 
 // TimeoutType is an internal type (TBD...)
@@ -1685,10 +5948,48 @@ type TimerCanceledEventAttributes struct {
 	Identity                     *string
 }
 
+func (v *TimerCanceledEventAttributes) GetTimerID() (o string) {
+	if v != nil && v.TimerID != nil {
+		return *v.TimerID
+	}
+	return
+}
+func (v *TimerCanceledEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
+}
+func (v *TimerCanceledEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *TimerCanceledEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // TimerFiredEventAttributes is an internal type (TBD...)
 type TimerFiredEventAttributes struct {
 	TimerID        *string
 	StartedEventID *int64
+}
+
+func (v *TimerFiredEventAttributes) GetTimerID() (o string) {
+	if v != nil && v.TimerID != nil {
+		return *v.TimerID
+	}
+	return
+}
+func (v *TimerFiredEventAttributes) GetStartedEventID() (o int64) {
+	if v != nil && v.StartedEventID != nil {
+		return *v.StartedEventID
+	}
+	return
 }
 
 // TimerStartedEventAttributes is an internal type (TBD...)
@@ -1698,10 +5999,42 @@ type TimerStartedEventAttributes struct {
 	DecisionTaskCompletedEventID *int64
 }
 
+func (v *TimerStartedEventAttributes) GetTimerID() (o string) {
+	if v != nil && v.TimerID != nil {
+		return *v.TimerID
+	}
+	return
+}
+func (v *TimerStartedEventAttributes) GetStartToFireTimeoutSeconds() (o int64) {
+	if v != nil && v.StartToFireTimeoutSeconds != nil {
+		return *v.StartToFireTimeoutSeconds
+	}
+	return
+}
+func (v *TimerStartedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+
 // TransientDecisionInfo is an internal type (TBD...)
 type TransientDecisionInfo struct {
 	ScheduledEvent *HistoryEvent
 	StartedEvent   *HistoryEvent
+}
+
+func (v *TransientDecisionInfo) GetScheduledEvent() (o *HistoryEvent) {
+	if v != nil && v.ScheduledEvent != nil {
+		return v.ScheduledEvent
+	}
+	return
+}
+func (v *TransientDecisionInfo) GetStartedEvent() (o *HistoryEvent) {
+	if v != nil && v.StartedEvent != nil {
+		return v.StartedEvent
+	}
+	return
 }
 
 // UpdateDomainInfo is an internal type (TBD...)
@@ -1709,6 +6042,25 @@ type UpdateDomainInfo struct {
 	Description *string
 	OwnerEmail  *string
 	Data        map[string]string
+}
+
+func (v *UpdateDomainInfo) GetDescription() (o string) {
+	if v != nil && v.Description != nil {
+		return *v.Description
+	}
+	return
+}
+func (v *UpdateDomainInfo) GetOwnerEmail() (o string) {
+	if v != nil && v.OwnerEmail != nil {
+		return *v.OwnerEmail
+	}
+	return
+}
+func (v *UpdateDomainInfo) GetData() (o map[string]string) {
+	if v != nil && v.Data != nil {
+		return v.Data
+	}
+	return
 }
 
 // UpdateDomainRequest is an internal type (TBD...)
@@ -1722,6 +6074,49 @@ type UpdateDomainRequest struct {
 	FailoverTimeoutInSeconds *int32
 }
 
+func (v *UpdateDomainRequest) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
+}
+func (v *UpdateDomainRequest) GetUpdatedInfo() (o *UpdateDomainInfo) {
+	if v != nil && v.UpdatedInfo != nil {
+		return v.UpdatedInfo
+	}
+	return
+}
+func (v *UpdateDomainRequest) GetConfiguration() (o *DomainConfiguration) {
+	if v != nil && v.Configuration != nil {
+		return v.Configuration
+	}
+	return
+}
+func (v *UpdateDomainRequest) GetReplicationConfiguration() (o *DomainReplicationConfiguration) {
+	if v != nil && v.ReplicationConfiguration != nil {
+		return v.ReplicationConfiguration
+	}
+	return
+}
+func (v *UpdateDomainRequest) GetSecurityToken() (o string) {
+	if v != nil && v.SecurityToken != nil {
+		return *v.SecurityToken
+	}
+	return
+}
+func (v *UpdateDomainRequest) GetDeleteBadBinary() (o string) {
+	if v != nil && v.DeleteBadBinary != nil {
+		return *v.DeleteBadBinary
+	}
+	return
+}
+func (v *UpdateDomainRequest) GetFailoverTimeoutInSeconds() (o int32) {
+	if v != nil && v.FailoverTimeoutInSeconds != nil {
+		return *v.FailoverTimeoutInSeconds
+	}
+	return
+}
+
 // UpdateDomainResponse is an internal type (TBD...)
 type UpdateDomainResponse struct {
 	DomainInfo               *DomainInfo
@@ -1731,9 +6126,47 @@ type UpdateDomainResponse struct {
 	IsGlobalDomain           *bool
 }
 
+func (v *UpdateDomainResponse) GetDomainInfo() (o *DomainInfo) {
+	if v != nil && v.DomainInfo != nil {
+		return v.DomainInfo
+	}
+	return
+}
+func (v *UpdateDomainResponse) GetConfiguration() (o *DomainConfiguration) {
+	if v != nil && v.Configuration != nil {
+		return v.Configuration
+	}
+	return
+}
+func (v *UpdateDomainResponse) GetReplicationConfiguration() (o *DomainReplicationConfiguration) {
+	if v != nil && v.ReplicationConfiguration != nil {
+		return v.ReplicationConfiguration
+	}
+	return
+}
+func (v *UpdateDomainResponse) GetFailoverVersion() (o int64) {
+	if v != nil && v.FailoverVersion != nil {
+		return *v.FailoverVersion
+	}
+	return
+}
+func (v *UpdateDomainResponse) GetIsGlobalDomain() (o bool) {
+	if v != nil && v.IsGlobalDomain != nil {
+		return *v.IsGlobalDomain
+	}
+	return
+}
+
 // UpsertWorkflowSearchAttributesDecisionAttributes is an internal type (TBD...)
 type UpsertWorkflowSearchAttributesDecisionAttributes struct {
 	SearchAttributes *SearchAttributes
+}
+
+func (v *UpsertWorkflowSearchAttributesDecisionAttributes) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
 }
 
 // UpsertWorkflowSearchAttributesEventAttributes is an internal type (TBD...)
@@ -1742,10 +6175,36 @@ type UpsertWorkflowSearchAttributesEventAttributes struct {
 	SearchAttributes             *SearchAttributes
 }
 
+func (v *UpsertWorkflowSearchAttributesEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *UpsertWorkflowSearchAttributesEventAttributes) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+
 // VersionHistories is an internal type (TBD...)
 type VersionHistories struct {
 	CurrentVersionHistoryIndex *int32
 	Histories                  []*VersionHistory
+}
+
+func (v *VersionHistories) GetCurrentVersionHistoryIndex() (o int32) {
+	if v != nil && v.CurrentVersionHistoryIndex != nil {
+		return *v.CurrentVersionHistoryIndex
+	}
+	return
+}
+func (v *VersionHistories) GetHistories() (o []*VersionHistory) {
+	if v != nil && v.Histories != nil {
+		return v.Histories
+	}
+	return
 }
 
 // VersionHistory is an internal type (TBD...)
@@ -1754,10 +6213,36 @@ type VersionHistory struct {
 	Items       []*VersionHistoryItem
 }
 
+func (v *VersionHistory) GetBranchToken() (o []byte) {
+	if v != nil && v.BranchToken != nil {
+		return v.BranchToken
+	}
+	return
+}
+func (v *VersionHistory) GetItems() (o []*VersionHistoryItem) {
+	if v != nil && v.Items != nil {
+		return v.Items
+	}
+	return
+}
+
 // VersionHistoryItem is an internal type (TBD...)
 type VersionHistoryItem struct {
 	EventID *int64
 	Version *int64
+}
+
+func (v *VersionHistoryItem) GetEventID() (o int64) {
+	if v != nil && v.EventID != nil {
+		return *v.EventID
+	}
+	return
+}
+func (v *VersionHistoryItem) GetVersion() (o int64) {
+	if v != nil && v.Version != nil {
+		return *v.Version
+	}
+	return
 }
 
 // WorkerVersionInfo is an internal type (TBD...)
@@ -1766,10 +6251,36 @@ type WorkerVersionInfo struct {
 	FeatureVersion *string
 }
 
+func (v *WorkerVersionInfo) GetImpl() (o string) {
+	if v != nil && v.Impl != nil {
+		return *v.Impl
+	}
+	return
+}
+func (v *WorkerVersionInfo) GetFeatureVersion() (o string) {
+	if v != nil && v.FeatureVersion != nil {
+		return *v.FeatureVersion
+	}
+	return
+}
+
 // WorkflowExecution is an internal type (TBD...)
 type WorkflowExecution struct {
 	WorkflowID *string
 	RunID      *string
+}
+
+func (v *WorkflowExecution) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *WorkflowExecution) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
 }
 
 // WorkflowExecutionAlreadyStartedError is an internal type (TBD...)
@@ -1777,6 +6288,25 @@ type WorkflowExecutionAlreadyStartedError struct {
 	Message        *string
 	StartRequestID *string
 	RunID          *string
+}
+
+func (v *WorkflowExecutionAlreadyStartedError) GetMessage() (o string) {
+	if v != nil && v.Message != nil {
+		return *v.Message
+	}
+	return
+}
+func (v *WorkflowExecutionAlreadyStartedError) GetStartRequestID() (o string) {
+	if v != nil && v.StartRequestID != nil {
+		return *v.StartRequestID
+	}
+	return
+}
+func (v *WorkflowExecutionAlreadyStartedError) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
 }
 
 // WorkflowExecutionCancelRequestedEventAttributes is an internal type (TBD...)
@@ -1787,10 +6317,48 @@ type WorkflowExecutionCancelRequestedEventAttributes struct {
 	Identity                  *string
 }
 
+func (v *WorkflowExecutionCancelRequestedEventAttributes) GetCause() (o string) {
+	if v != nil && v.Cause != nil {
+		return *v.Cause
+	}
+	return
+}
+func (v *WorkflowExecutionCancelRequestedEventAttributes) GetExternalInitiatedEventID() (o int64) {
+	if v != nil && v.ExternalInitiatedEventID != nil {
+		return *v.ExternalInitiatedEventID
+	}
+	return
+}
+func (v *WorkflowExecutionCancelRequestedEventAttributes) GetExternalWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.ExternalWorkflowExecution != nil {
+		return v.ExternalWorkflowExecution
+	}
+	return
+}
+func (v *WorkflowExecutionCancelRequestedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // WorkflowExecutionCanceledEventAttributes is an internal type (TBD...)
 type WorkflowExecutionCanceledEventAttributes struct {
 	DecisionTaskCompletedEventID *int64
 	Details                      []byte
+}
+
+func (v *WorkflowExecutionCanceledEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *WorkflowExecutionCanceledEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
 }
 
 // WorkflowExecutionCloseStatus is an internal type (TBD...)
@@ -1817,11 +6385,43 @@ type WorkflowExecutionCompletedEventAttributes struct {
 	DecisionTaskCompletedEventID *int64
 }
 
+func (v *WorkflowExecutionCompletedEventAttributes) GetResult() (o []byte) {
+	if v != nil && v.Result != nil {
+		return v.Result
+	}
+	return
+}
+func (v *WorkflowExecutionCompletedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+
 // WorkflowExecutionConfiguration is an internal type (TBD...)
 type WorkflowExecutionConfiguration struct {
 	TaskList                            *TaskList
 	ExecutionStartToCloseTimeoutSeconds *int32
 	TaskStartToCloseTimeoutSeconds      *int32
+}
+
+func (v *WorkflowExecutionConfiguration) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *WorkflowExecutionConfiguration) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *WorkflowExecutionConfiguration) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
 }
 
 // WorkflowExecutionContinuedAsNewEventAttributes is an internal type (TBD...)
@@ -1843,6 +6443,97 @@ type WorkflowExecutionContinuedAsNewEventAttributes struct {
 	SearchAttributes                    *SearchAttributes
 }
 
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetNewExecutionRunID() (o string) {
+	if v != nil && v.NewExecutionRunID != nil {
+		return *v.NewExecutionRunID
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetBackoffStartIntervalInSeconds() (o int32) {
+	if v != nil && v.BackoffStartIntervalInSeconds != nil {
+		return *v.BackoffStartIntervalInSeconds
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetInitiator() (o ContinueAsNewInitiator) {
+	if v != nil && v.Initiator != nil {
+		return *v.Initiator
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetFailureReason() (o string) {
+	if v != nil && v.FailureReason != nil {
+		return *v.FailureReason
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetFailureDetails() (o []byte) {
+	if v != nil && v.FailureDetails != nil {
+		return v.FailureDetails
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetLastCompletionResult() (o []byte) {
+	if v != nil && v.LastCompletionResult != nil {
+		return v.LastCompletionResult
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *WorkflowExecutionContinuedAsNewEventAttributes) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+
 // WorkflowExecutionFailedEventAttributes is an internal type (TBD...)
 type WorkflowExecutionFailedEventAttributes struct {
 	Reason                       *string
@@ -1850,10 +6541,42 @@ type WorkflowExecutionFailedEventAttributes struct {
 	DecisionTaskCompletedEventID *int64
 }
 
+func (v *WorkflowExecutionFailedEventAttributes) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *WorkflowExecutionFailedEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *WorkflowExecutionFailedEventAttributes) GetDecisionTaskCompletedEventID() (o int64) {
+	if v != nil && v.DecisionTaskCompletedEventID != nil {
+		return *v.DecisionTaskCompletedEventID
+	}
+	return
+}
+
 // WorkflowExecutionFilter is an internal type (TBD...)
 type WorkflowExecutionFilter struct {
 	WorkflowID *string
 	RunID      *string
+}
+
+func (v *WorkflowExecutionFilter) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *WorkflowExecutionFilter) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
 }
 
 // WorkflowExecutionInfo is an internal type (TBD...)
@@ -1873,11 +6596,109 @@ type WorkflowExecutionInfo struct {
 	TaskList         *string
 }
 
+func (v *WorkflowExecutionInfo) GetExecution() (o *WorkflowExecution) {
+	if v != nil && v.Execution != nil {
+		return v.Execution
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetType() (o *WorkflowType) {
+	if v != nil && v.Type != nil {
+		return v.Type
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetStartTime() (o int64) {
+	if v != nil && v.StartTime != nil {
+		return *v.StartTime
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetCloseTime() (o int64) {
+	if v != nil && v.CloseTime != nil {
+		return *v.CloseTime
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetCloseStatus() (o WorkflowExecutionCloseStatus) {
+	if v != nil && v.CloseStatus != nil {
+		return *v.CloseStatus
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetHistoryLength() (o int64) {
+	if v != nil && v.HistoryLength != nil {
+		return *v.HistoryLength
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetParentDomainID() (o string) {
+	if v != nil && v.ParentDomainID != nil {
+		return *v.ParentDomainID
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetParentExecution() (o *WorkflowExecution) {
+	if v != nil && v.ParentExecution != nil {
+		return v.ParentExecution
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetExecutionTime() (o int64) {
+	if v != nil && v.ExecutionTime != nil {
+		return *v.ExecutionTime
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetAutoResetPoints() (o *ResetPoints) {
+	if v != nil && v.AutoResetPoints != nil {
+		return v.AutoResetPoints
+	}
+	return
+}
+func (v *WorkflowExecutionInfo) GetTaskList() (o string) {
+	if v != nil && v.TaskList != nil {
+		return *v.TaskList
+	}
+	return
+}
+
 // WorkflowExecutionSignaledEventAttributes is an internal type (TBD...)
 type WorkflowExecutionSignaledEventAttributes struct {
 	SignalName *string
 	Input      []byte
 	Identity   *string
+}
+
+func (v *WorkflowExecutionSignaledEventAttributes) GetSignalName() (o string) {
+	if v != nil && v.SignalName != nil {
+		return *v.SignalName
+	}
+	return
+}
+func (v *WorkflowExecutionSignaledEventAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *WorkflowExecutionSignaledEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
 }
 
 // WorkflowExecutionStartedEventAttributes is an internal type (TBD...)
@@ -1909,6 +6730,157 @@ type WorkflowExecutionStartedEventAttributes struct {
 	Header                              *Header
 }
 
+func (v *WorkflowExecutionStartedEventAttributes) GetWorkflowType() (o *WorkflowType) {
+	if v != nil && v.WorkflowType != nil {
+		return v.WorkflowType
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetParentWorkflowDomain() (o string) {
+	if v != nil && v.ParentWorkflowDomain != nil {
+		return *v.ParentWorkflowDomain
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetParentWorkflowExecution() (o *WorkflowExecution) {
+	if v != nil && v.ParentWorkflowExecution != nil {
+		return v.ParentWorkflowExecution
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetParentInitiatedEventID() (o int64) {
+	if v != nil && v.ParentInitiatedEventID != nil {
+		return *v.ParentInitiatedEventID
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetTaskList() (o *TaskList) {
+	if v != nil && v.TaskList != nil {
+		return v.TaskList
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetInput() (o []byte) {
+	if v != nil && v.Input != nil {
+		return v.Input
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetContinuedExecutionRunID() (o string) {
+	if v != nil && v.ContinuedExecutionRunID != nil {
+		return *v.ContinuedExecutionRunID
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetInitiator() (o ContinueAsNewInitiator) {
+	if v != nil && v.Initiator != nil {
+		return *v.Initiator
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetContinuedFailureReason() (o string) {
+	if v != nil && v.ContinuedFailureReason != nil {
+		return *v.ContinuedFailureReason
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetContinuedFailureDetails() (o []byte) {
+	if v != nil && v.ContinuedFailureDetails != nil {
+		return v.ContinuedFailureDetails
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetLastCompletionResult() (o []byte) {
+	if v != nil && v.LastCompletionResult != nil {
+		return v.LastCompletionResult
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetOriginalExecutionRunID() (o string) {
+	if v != nil && v.OriginalExecutionRunID != nil {
+		return *v.OriginalExecutionRunID
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetFirstExecutionRunID() (o string) {
+	if v != nil && v.FirstExecutionRunID != nil {
+		return *v.FirstExecutionRunID
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetRetryPolicy() (o *RetryPolicy) {
+	if v != nil && v.RetryPolicy != nil {
+		return v.RetryPolicy
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetAttempt() (o int32) {
+	if v != nil && v.Attempt != nil {
+		return *v.Attempt
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetExpirationTimestamp() (o int64) {
+	if v != nil && v.ExpirationTimestamp != nil {
+		return *v.ExpirationTimestamp
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetCronSchedule() (o string) {
+	if v != nil && v.CronSchedule != nil {
+		return *v.CronSchedule
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetFirstDecisionTaskBackoffSeconds() (o int32) {
+	if v != nil && v.FirstDecisionTaskBackoffSeconds != nil {
+		return *v.FirstDecisionTaskBackoffSeconds
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetMemo() (o *Memo) {
+	if v != nil && v.Memo != nil {
+		return v.Memo
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetSearchAttributes() (o *SearchAttributes) {
+	if v != nil && v.SearchAttributes != nil {
+		return v.SearchAttributes
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetPrevAutoResetPoints() (o *ResetPoints) {
+	if v != nil && v.PrevAutoResetPoints != nil {
+		return v.PrevAutoResetPoints
+	}
+	return
+}
+func (v *WorkflowExecutionStartedEventAttributes) GetHeader() (o *Header) {
+	if v != nil && v.Header != nil {
+		return v.Header
+	}
+	return
+}
+
 // WorkflowExecutionTerminatedEventAttributes is an internal type (TBD...)
 type WorkflowExecutionTerminatedEventAttributes struct {
 	Reason   *string
@@ -1916,9 +6888,35 @@ type WorkflowExecutionTerminatedEventAttributes struct {
 	Identity *string
 }
 
+func (v *WorkflowExecutionTerminatedEventAttributes) GetReason() (o string) {
+	if v != nil && v.Reason != nil {
+		return *v.Reason
+	}
+	return
+}
+func (v *WorkflowExecutionTerminatedEventAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *WorkflowExecutionTerminatedEventAttributes) GetIdentity() (o string) {
+	if v != nil && v.Identity != nil {
+		return *v.Identity
+	}
+	return
+}
+
 // WorkflowExecutionTimedOutEventAttributes is an internal type (TBD...)
 type WorkflowExecutionTimedOutEventAttributes struct {
 	TimeoutType *TimeoutType
+}
+
+func (v *WorkflowExecutionTimedOutEventAttributes) GetTimeoutType() (o TimeoutType) {
+	if v != nil && v.TimeoutType != nil {
+		return *v.TimeoutType
+	}
+	return
 }
 
 // WorkflowIDReusePolicy is an internal type (TBD...)
@@ -1941,6 +6939,19 @@ type WorkflowQuery struct {
 	QueryArgs []byte
 }
 
+func (v *WorkflowQuery) GetQueryType() (o string) {
+	if v != nil && v.QueryType != nil {
+		return *v.QueryType
+	}
+	return
+}
+func (v *WorkflowQuery) GetQueryArgs() (o []byte) {
+	if v != nil && v.QueryArgs != nil {
+		return v.QueryArgs
+	}
+	return
+}
+
 // WorkflowQueryResult is an internal type (TBD...)
 type WorkflowQueryResult struct {
 	ResultType   *QueryResultType
@@ -1948,12 +6959,45 @@ type WorkflowQueryResult struct {
 	ErrorMessage *string
 }
 
+func (v *WorkflowQueryResult) GetResultType() (o QueryResultType) {
+	if v != nil && v.ResultType != nil {
+		return *v.ResultType
+	}
+	return
+}
+func (v *WorkflowQueryResult) GetAnswer() (o []byte) {
+	if v != nil && v.Answer != nil {
+		return v.Answer
+	}
+	return
+}
+func (v *WorkflowQueryResult) GetErrorMessage() (o string) {
+	if v != nil && v.ErrorMessage != nil {
+		return *v.ErrorMessage
+	}
+	return
+}
+
 // WorkflowType is an internal type (TBD...)
 type WorkflowType struct {
 	Name *string
 }
 
+func (v *WorkflowType) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
+}
+
 // WorkflowTypeFilter is an internal type (TBD...)
 type WorkflowTypeFilter struct {
 	Name *string
+}
+
+func (v *WorkflowTypeFilter) GetName() (o string) {
+	if v != nil && v.Name != nil {
+		return *v.Name
+	}
+	return
 }


### PR DESCRIPTION
This adds getters to internal types. This is needed because we are attempting to move from generated thrift types to internal types and in some places in the code we use thrift accessors. The purpose of these generated getters is to do the same thing that the thrift access methods
