### PR TITLE
Leaner frontend Handler interface

### DIFF
--- a/service/frontend/accessControlledHandler_test.go
+++ b/service/frontend/accessControlledHandler_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common/authorization"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/mocks"
+	"github.com/uber/cadence/common/resource"
 )
 
 type (
@@ -40,6 +41,7 @@ type (
 		*require.Assertions
 
 		controller          *gomock.Controller
+		mockResource        *resource.Test
 		mockFrontendHandler *MockHandler
 		mockAuthorizer      *authorization.MockAuthorizer
 		mockMetricsScope    *mocks.Scope
@@ -56,10 +58,11 @@ func TestAccessControlledHandlerSuite(t *testing.T) {
 func (s *accessControlledHandlerSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.controller = gomock.NewController(s.T())
+	s.mockResource = resource.NewTest(s.controller, metrics.Frontend)
 	s.mockFrontendHandler = NewMockHandler(s.controller)
 	s.mockAuthorizer = authorization.NewMockAuthorizer(s.controller)
 	s.mockMetricsScope = &mocks.Scope{}
-	s.handler = NewAccessControlledHandlerImpl(s.mockFrontendHandler, s.mockAuthorizer)
+	s.handler = NewAccessControlledHandlerImpl(s.mockFrontendHandler, s.mockResource, s.mockAuthorizer)
 }
 
 func (s *accessControlledHandlerSuite) TearDownTest() {

--- a/service/frontend/dcRedirectionHandler_test.go
+++ b/service/frontend/dcRedirectionHandler_test.go
@@ -104,7 +104,7 @@ func (s *dcRedirectionHandlerSuite) SetupTest() {
 	frontendHandler := NewWorkflowHandler(s.mockResource, s.config, nil, client.NewVersionChecker())
 
 	s.mockFrontendHandler = NewMockHandler(s.controller)
-	s.handler = NewDCRedirectionHandler(frontendHandler, config.DCRedirectionPolicy{})
+	s.handler = NewDCRedirectionHandler(frontendHandler, s.mockResource, s.config, config.DCRedirectionPolicy{})
 	s.handler.frontendHandler = s.mockFrontendHandler
 	s.handler.redirectionPolicy = s.mockDCRedirectionPolicy
 }

--- a/service/frontend/interface.go
+++ b/service/frontend/interface.go
@@ -23,28 +23,14 @@
 package frontend
 
 import (
-	"context"
-
 	"github.com/uber/cadence/.gen/go/cadence/workflowserviceserver"
-	"github.com/uber/cadence/.gen/go/health"
-	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/.gen/go/health/metaserver"
 )
 
 type (
 	// Handler is interface wrapping frontend handler
 	Handler interface {
+		metaserver.Interface
 		workflowserviceserver.Interface
-		common.Daemon
-
-		GetResource() resource.Resource
-		GetConfig() *Config
-		// RegisterHandler register this handler, must be called before Start()
-		RegisterHandler()
-		// Health is the health check method for this rpc handler
-		Health(ctx context.Context) (*health.HealthStatus, error)
-		// UpdateHealthStatus sets the health status for this rpc handler.
-		// This health status will be used within the rpc health check handler
-		UpdateHealthStatus(status HealthStatus)
 	}
 )

--- a/service/frontend/interface_mock.go
+++ b/service/frontend/interface_mock.go
@@ -35,7 +35,6 @@ import (
 
 	health "github.com/uber/cadence/.gen/go/health"
 	shared "github.com/uber/cadence/.gen/go/shared"
-	resource "github.com/uber/cadence/common/resource"
 )
 
 // MockHandler is a mock of Handler interface
@@ -59,6 +58,21 @@ func NewMockHandler(ctrl *gomock.Controller) *MockHandler {
 // EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockHandler) EXPECT() *MockHandlerMockRecorder {
 	return m.recorder
+}
+
+// Health mocks base method
+func (m *MockHandler) Health(ctx context.Context) (*health.HealthStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Health", ctx)
+	ret0, _ := ret[0].(*health.HealthStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Health indicates an expected call of Health
+func (mr *MockHandlerMockRecorder) Health(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockHandler)(nil).Health), ctx)
 }
 
 // CountWorkflowExecutions mocks base method
@@ -616,95 +630,4 @@ func (m *MockHandler) UpdateDomain(ctx context.Context, UpdateRequest *shared.Up
 func (mr *MockHandlerMockRecorder) UpdateDomain(ctx, UpdateRequest interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomain", reflect.TypeOf((*MockHandler)(nil).UpdateDomain), ctx, UpdateRequest)
-}
-
-// Start mocks base method
-func (m *MockHandler) Start() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start")
-}
-
-// Start indicates an expected call of Start
-func (mr *MockHandlerMockRecorder) Start() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockHandler)(nil).Start))
-}
-
-// Stop mocks base method
-func (m *MockHandler) Stop() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Stop")
-}
-
-// Stop indicates an expected call of Stop
-func (mr *MockHandlerMockRecorder) Stop() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockHandler)(nil).Stop))
-}
-
-// GetResource mocks base method
-func (m *MockHandler) GetResource() resource.Resource {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetResource")
-	ret0, _ := ret[0].(resource.Resource)
-	return ret0
-}
-
-// GetResource indicates an expected call of GetResource
-func (mr *MockHandlerMockRecorder) GetResource() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResource", reflect.TypeOf((*MockHandler)(nil).GetResource))
-}
-
-// GetConfig mocks base method
-func (m *MockHandler) GetConfig() *Config {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetConfig")
-	ret0, _ := ret[0].(*Config)
-	return ret0
-}
-
-// GetConfig indicates an expected call of GetConfig
-func (mr *MockHandlerMockRecorder) GetConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetConfig", reflect.TypeOf((*MockHandler)(nil).GetConfig))
-}
-
-// RegisterHandler mocks base method
-func (m *MockHandler) RegisterHandler() {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "RegisterHandler")
-}
-
-// RegisterHandler indicates an expected call of RegisterHandler
-func (mr *MockHandlerMockRecorder) RegisterHandler() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterHandler", reflect.TypeOf((*MockHandler)(nil).RegisterHandler))
-}
-
-// Health mocks base method
-func (m *MockHandler) Health(ctx context.Context) (*health.HealthStatus, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Health", ctx)
-	ret0, _ := ret[0].(*health.HealthStatus)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Health indicates an expected call of Health
-func (mr *MockHandlerMockRecorder) Health(ctx interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Health", reflect.TypeOf((*MockHandler)(nil).Health), ctx)
-}
-
-// UpdateHealthStatus mocks base method
-func (m *MockHandler) UpdateHealthStatus(status HealthStatus) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateHealthStatus", status)
-}
-
-// UpdateHealthStatus indicates an expected call of UpdateHealthStatus
-func (mr *MockHandlerMockRecorder) UpdateHealthStatus(status interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateHealthStatus", reflect.TypeOf((*MockHandler)(nil).UpdateHealthStatus), status)
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -33,9 +33,7 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/yarpcerrors"
 
-	"github.com/uber/cadence/.gen/go/cadence/workflowserviceserver"
 	"github.com/uber/cadence/.gen/go/health"
-	"github.com/uber/cadence/.gen/go/health/metaserver"
 	h "github.com/uber/cadence/.gen/go/history"
 	m "github.com/uber/cadence/.gen/go/matching"
 	gen "github.com/uber/cadence/.gen/go/shared"
@@ -152,7 +150,7 @@ func NewWorkflowHandler(
 	config *Config,
 	replicationMessageSink messaging.Producer,
 	versionChecker client.VersionChecker,
-) Handler {
+) *WorkflowHandler {
 	return &WorkflowHandler{
 		Resource:        resource,
 		config:          config,
@@ -195,13 +193,6 @@ func NewWorkflowHandler(
 	}
 }
 
-// RegisterHandler register this handler, must be called before Start()
-// if DCRedirectionHandler is also used, use RegisterHandler in DCRedirectionHandler instead
-func (wh *WorkflowHandler) RegisterHandler() {
-	wh.GetDispatcher().Register(workflowserviceserver.New(wh))
-	wh.GetDispatcher().Register(metaserver.New(wh))
-}
-
 // Start starts the handler
 func (wh *WorkflowHandler) Start() {
 }
@@ -219,16 +210,6 @@ func (wh *WorkflowHandler) UpdateHealthStatus(status HealthStatus) {
 
 func (wh *WorkflowHandler) isShuttingDown() bool {
 	return atomic.LoadInt32(&wh.shuttingDown) != 0
-}
-
-// GetResource return resource
-func (wh *WorkflowHandler) GetResource() resource.Resource {
-	return wh.Resource
-}
-
-// GetConfig return config
-func (wh *WorkflowHandler) GetConfig() *Config {
-	return wh.config
 }
 
 // Health is for health check

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -136,7 +136,7 @@ func (s *workflowHandlerSuite) TearDownTest() {
 }
 
 func (s *workflowHandlerSuite) getWorkflowHandler(config *Config) *WorkflowHandler {
-	return NewWorkflowHandler(s.mockResource, config, s.mockProducer, s.mockVersionChecker).(*WorkflowHandler)
+	return NewWorkflowHandler(s.mockResource, config, s.mockProducer, s.mockVersionChecker)
 }
 
 func (s *workflowHandlerSuite) TestDisableListVisibilityByFilter() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Leaner frontend `Handler` interface by dropping all methods that are not actual handler methods.

<!-- Tell your future self why have you made these changes -->
**Why?**
This simplifies decorating implementations, as they do not need to forward these utility calls. Instead explicitly pass required dependencies (Config, Resources) via constructors. Also keep base handler reference within Service, to Stop it and set Health status. 

I will follow up this, with another Thrift specific handler, that will implement this leaner interface as well. While this refactoring is not strictly required for that, I believe only actual handler methods should be decorated - not the utility methods that are specific to base implementation only.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

