### PR TITLE
Replicator internal types

### DIFF
--- a/common/types/mapper/thrift/replicator.go
+++ b/common/types/mapper/thrift/replicator.go
@@ -1,0 +1,849 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+import (
+	"github.com/uber/cadence/common/types"
+
+	"github.com/uber/cadence/.gen/go/replicator"
+)
+
+// FromDLQType converts internal DLQType type to thrift
+func FromDLQType(t *types.DLQType) *replicator.DLQType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.DLQTypeDomain:
+		v := replicator.DLQTypeDomain
+		return &v
+	case types.DLQTypeReplication:
+		v := replicator.DLQTypeReplication
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToDLQType converts thrift DLQType type to internal
+func ToDLQType(t *replicator.DLQType) *types.DLQType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case replicator.DLQTypeDomain:
+		v := types.DLQTypeDomain
+		return &v
+	case replicator.DLQTypeReplication:
+		v := types.DLQTypeReplication
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromDomainOperation converts internal DomainOperation type to thrift
+func FromDomainOperation(t *types.DomainOperation) *replicator.DomainOperation {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.DomainOperationCreate:
+		v := replicator.DomainOperationCreate
+		return &v
+	case types.DomainOperationUpdate:
+		v := replicator.DomainOperationUpdate
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToDomainOperation converts thrift DomainOperation type to internal
+func ToDomainOperation(t *replicator.DomainOperation) *types.DomainOperation {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case replicator.DomainOperationCreate:
+		v := types.DomainOperationCreate
+		return &v
+	case replicator.DomainOperationUpdate:
+		v := types.DomainOperationUpdate
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromDomainTaskAttributes converts internal DomainTaskAttributes type to thrift
+func FromDomainTaskAttributes(t *types.DomainTaskAttributes) *replicator.DomainTaskAttributes {
+	if t == nil {
+		return nil
+	}
+	return &replicator.DomainTaskAttributes{
+		DomainOperation:         FromDomainOperation(t.DomainOperation),
+		ID:                      t.ID,
+		Info:                    FromDomainInfo(t.Info),
+		Config:                  FromDomainConfiguration(t.Config),
+		ReplicationConfig:       FromDomainReplicationConfiguration(t.ReplicationConfig),
+		ConfigVersion:           t.ConfigVersion,
+		FailoverVersion:         t.FailoverVersion,
+		PreviousFailoverVersion: t.PreviousFailoverVersion,
+	}
+}
+
+// ToDomainTaskAttributes converts thrift DomainTaskAttributes type to internal
+func ToDomainTaskAttributes(t *replicator.DomainTaskAttributes) *types.DomainTaskAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.DomainTaskAttributes{
+		DomainOperation:         ToDomainOperation(t.DomainOperation),
+		ID:                      t.ID,
+		Info:                    ToDomainInfo(t.Info),
+		Config:                  ToDomainConfiguration(t.Config),
+		ReplicationConfig:       ToDomainReplicationConfiguration(t.ReplicationConfig),
+		ConfigVersion:           t.ConfigVersion,
+		FailoverVersion:         t.FailoverVersion,
+		PreviousFailoverVersion: t.PreviousFailoverVersion,
+	}
+}
+
+// FromFailoverMarkerAttributes converts internal FailoverMarkerAttributes type to thrift
+func FromFailoverMarkerAttributes(t *types.FailoverMarkerAttributes) *replicator.FailoverMarkerAttributes {
+	if t == nil {
+		return nil
+	}
+	return &replicator.FailoverMarkerAttributes{
+		DomainID:        t.DomainID,
+		FailoverVersion: t.FailoverVersion,
+		CreationTime:    t.CreationTime,
+	}
+}
+
+// ToFailoverMarkerAttributes converts thrift FailoverMarkerAttributes type to internal
+func ToFailoverMarkerAttributes(t *replicator.FailoverMarkerAttributes) *types.FailoverMarkerAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.FailoverMarkerAttributes{
+		DomainID:        t.DomainID,
+		FailoverVersion: t.FailoverVersion,
+		CreationTime:    t.CreationTime,
+	}
+}
+
+// FromFailoverMarkers converts internal FailoverMarkers type to thrift
+func FromFailoverMarkers(t *types.FailoverMarkers) *replicator.FailoverMarkers {
+	if t == nil {
+		return nil
+	}
+	return &replicator.FailoverMarkers{
+		FailoverMarkers: FromFailoverMarkerAttributesArray(t.FailoverMarkers),
+	}
+}
+
+// ToFailoverMarkers converts thrift FailoverMarkers type to internal
+func ToFailoverMarkers(t *replicator.FailoverMarkers) *types.FailoverMarkers {
+	if t == nil {
+		return nil
+	}
+	return &types.FailoverMarkers{
+		FailoverMarkers: ToFailoverMarkerAttributesArray(t.FailoverMarkers),
+	}
+}
+
+// FromGetDLQReplicationMessagesRequest converts internal GetDLQReplicationMessagesRequest type to thrift
+func FromGetDLQReplicationMessagesRequest(t *types.GetDLQReplicationMessagesRequest) *replicator.GetDLQReplicationMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &replicator.GetDLQReplicationMessagesRequest{
+		TaskInfos: FromReplicationTaskInfoArray(t.TaskInfos),
+	}
+}
+
+// ToGetDLQReplicationMessagesRequest converts thrift GetDLQReplicationMessagesRequest type to internal
+func ToGetDLQReplicationMessagesRequest(t *replicator.GetDLQReplicationMessagesRequest) *types.GetDLQReplicationMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.GetDLQReplicationMessagesRequest{
+		TaskInfos: ToReplicationTaskInfoArray(t.TaskInfos),
+	}
+}
+
+// FromGetDLQReplicationMessagesResponse converts internal GetDLQReplicationMessagesResponse type to thrift
+func FromGetDLQReplicationMessagesResponse(t *types.GetDLQReplicationMessagesResponse) *replicator.GetDLQReplicationMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &replicator.GetDLQReplicationMessagesResponse{
+		ReplicationTasks: FromReplicationTaskArray(t.ReplicationTasks),
+	}
+}
+
+// ToGetDLQReplicationMessagesResponse converts thrift GetDLQReplicationMessagesResponse type to internal
+func ToGetDLQReplicationMessagesResponse(t *replicator.GetDLQReplicationMessagesResponse) *types.GetDLQReplicationMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.GetDLQReplicationMessagesResponse{
+		ReplicationTasks: ToReplicationTaskArray(t.ReplicationTasks),
+	}
+}
+
+// FromGetDomainReplicationMessagesRequest converts internal GetDomainReplicationMessagesRequest type to thrift
+func FromGetDomainReplicationMessagesRequest(t *types.GetDomainReplicationMessagesRequest) *replicator.GetDomainReplicationMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &replicator.GetDomainReplicationMessagesRequest{
+		LastRetrievedMessageId: t.LastRetrievedMessageID,
+		LastProcessedMessageId: t.LastProcessedMessageID,
+		ClusterName:            t.ClusterName,
+	}
+}
+
+// ToGetDomainReplicationMessagesRequest converts thrift GetDomainReplicationMessagesRequest type to internal
+func ToGetDomainReplicationMessagesRequest(t *replicator.GetDomainReplicationMessagesRequest) *types.GetDomainReplicationMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.GetDomainReplicationMessagesRequest{
+		LastRetrievedMessageID: t.LastRetrievedMessageId,
+		LastProcessedMessageID: t.LastProcessedMessageId,
+		ClusterName:            t.ClusterName,
+	}
+}
+
+// FromGetDomainReplicationMessagesResponse converts internal GetDomainReplicationMessagesResponse type to thrift
+func FromGetDomainReplicationMessagesResponse(t *types.GetDomainReplicationMessagesResponse) *replicator.GetDomainReplicationMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &replicator.GetDomainReplicationMessagesResponse{
+		Messages: FromReplicationMessages(t.Messages),
+	}
+}
+
+// ToGetDomainReplicationMessagesResponse converts thrift GetDomainReplicationMessagesResponse type to internal
+func ToGetDomainReplicationMessagesResponse(t *replicator.GetDomainReplicationMessagesResponse) *types.GetDomainReplicationMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.GetDomainReplicationMessagesResponse{
+		Messages: ToReplicationMessages(t.Messages),
+	}
+}
+
+// FromGetReplicationMessagesRequest converts internal GetReplicationMessagesRequest type to thrift
+func FromGetReplicationMessagesRequest(t *types.GetReplicationMessagesRequest) *replicator.GetReplicationMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &replicator.GetReplicationMessagesRequest{
+		Tokens:      FromReplicationTokenArray(t.Tokens),
+		ClusterName: t.ClusterName,
+	}
+}
+
+// ToGetReplicationMessagesRequest converts thrift GetReplicationMessagesRequest type to internal
+func ToGetReplicationMessagesRequest(t *replicator.GetReplicationMessagesRequest) *types.GetReplicationMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.GetReplicationMessagesRequest{
+		Tokens:      ToReplicationTokenArray(t.Tokens),
+		ClusterName: t.ClusterName,
+	}
+}
+
+// FromGetReplicationMessagesResponse converts internal GetReplicationMessagesResponse type to thrift
+func FromGetReplicationMessagesResponse(t *types.GetReplicationMessagesResponse) *replicator.GetReplicationMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &replicator.GetReplicationMessagesResponse{
+		MessagesByShard: FromReplicationMessagesMap(t.MessagesByShard),
+	}
+}
+
+// ToGetReplicationMessagesResponse converts thrift GetReplicationMessagesResponse type to internal
+func ToGetReplicationMessagesResponse(t *replicator.GetReplicationMessagesResponse) *types.GetReplicationMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.GetReplicationMessagesResponse{
+		MessagesByShard: ToReplicationMessagesMap(t.MessagesByShard),
+	}
+}
+
+// FromHistoryTaskV2Attributes converts internal HistoryTaskV2Attributes type to thrift
+func FromHistoryTaskV2Attributes(t *types.HistoryTaskV2Attributes) *replicator.HistoryTaskV2Attributes {
+	if t == nil {
+		return nil
+	}
+	return &replicator.HistoryTaskV2Attributes{
+		TaskId:              t.TaskID,
+		DomainId:            t.DomainID,
+		WorkflowId:          t.WorkflowID,
+		RunId:               t.RunID,
+		VersionHistoryItems: FromVersionHistoryItemArray(t.VersionHistoryItems),
+		Events:              FromDataBlob(t.Events),
+		NewRunEvents:        FromDataBlob(t.NewRunEvents),
+	}
+}
+
+// ToHistoryTaskV2Attributes converts thrift HistoryTaskV2Attributes type to internal
+func ToHistoryTaskV2Attributes(t *replicator.HistoryTaskV2Attributes) *types.HistoryTaskV2Attributes {
+	if t == nil {
+		return nil
+	}
+	return &types.HistoryTaskV2Attributes{
+		TaskID:              t.TaskId,
+		DomainID:            t.DomainId,
+		WorkflowID:          t.WorkflowId,
+		RunID:               t.RunId,
+		VersionHistoryItems: ToVersionHistoryItemArray(t.VersionHistoryItems),
+		Events:              ToDataBlob(t.Events),
+		NewRunEvents:        ToDataBlob(t.NewRunEvents),
+	}
+}
+
+// FromMergeDLQMessagesRequest converts internal MergeDLQMessagesRequest type to thrift
+func FromMergeDLQMessagesRequest(t *types.MergeDLQMessagesRequest) *replicator.MergeDLQMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &replicator.MergeDLQMessagesRequest{
+		Type:                  FromDLQType(t.Type),
+		ShardID:               t.ShardID,
+		SourceCluster:         t.SourceCluster,
+		InclusiveEndMessageID: t.InclusiveEndMessageID,
+		MaximumPageSize:       t.MaximumPageSize,
+		NextPageToken:         t.NextPageToken,
+	}
+}
+
+// ToMergeDLQMessagesRequest converts thrift MergeDLQMessagesRequest type to internal
+func ToMergeDLQMessagesRequest(t *replicator.MergeDLQMessagesRequest) *types.MergeDLQMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.MergeDLQMessagesRequest{
+		Type:                  ToDLQType(t.Type),
+		ShardID:               t.ShardID,
+		SourceCluster:         t.SourceCluster,
+		InclusiveEndMessageID: t.InclusiveEndMessageID,
+		MaximumPageSize:       t.MaximumPageSize,
+		NextPageToken:         t.NextPageToken,
+	}
+}
+
+// FromMergeDLQMessagesResponse converts internal MergeDLQMessagesResponse type to thrift
+func FromMergeDLQMessagesResponse(t *types.MergeDLQMessagesResponse) *replicator.MergeDLQMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &replicator.MergeDLQMessagesResponse{
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// ToMergeDLQMessagesResponse converts thrift MergeDLQMessagesResponse type to internal
+func ToMergeDLQMessagesResponse(t *replicator.MergeDLQMessagesResponse) *types.MergeDLQMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.MergeDLQMessagesResponse{
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+// FromPurgeDLQMessagesRequest converts internal PurgeDLQMessagesRequest type to thrift
+func FromPurgeDLQMessagesRequest(t *types.PurgeDLQMessagesRequest) *replicator.PurgeDLQMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &replicator.PurgeDLQMessagesRequest{
+		Type:                  FromDLQType(t.Type),
+		ShardID:               t.ShardID,
+		SourceCluster:         t.SourceCluster,
+		InclusiveEndMessageID: t.InclusiveEndMessageID,
+	}
+}
+
+// ToPurgeDLQMessagesRequest converts thrift PurgeDLQMessagesRequest type to internal
+func ToPurgeDLQMessagesRequest(t *replicator.PurgeDLQMessagesRequest) *types.PurgeDLQMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.PurgeDLQMessagesRequest{
+		Type:                  ToDLQType(t.Type),
+		ShardID:               t.ShardID,
+		SourceCluster:         t.SourceCluster,
+		InclusiveEndMessageID: t.InclusiveEndMessageID,
+	}
+}
+
+// FromReadDLQMessagesRequest converts internal ReadDLQMessagesRequest type to thrift
+func FromReadDLQMessagesRequest(t *types.ReadDLQMessagesRequest) *replicator.ReadDLQMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &replicator.ReadDLQMessagesRequest{
+		Type:                  FromDLQType(t.Type),
+		ShardID:               t.ShardID,
+		SourceCluster:         t.SourceCluster,
+		InclusiveEndMessageID: t.InclusiveEndMessageID,
+		MaximumPageSize:       t.MaximumPageSize,
+		NextPageToken:         t.NextPageToken,
+	}
+}
+
+// ToReadDLQMessagesRequest converts thrift ReadDLQMessagesRequest type to internal
+func ToReadDLQMessagesRequest(t *replicator.ReadDLQMessagesRequest) *types.ReadDLQMessagesRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ReadDLQMessagesRequest{
+		Type:                  ToDLQType(t.Type),
+		ShardID:               t.ShardID,
+		SourceCluster:         t.SourceCluster,
+		InclusiveEndMessageID: t.InclusiveEndMessageID,
+		MaximumPageSize:       t.MaximumPageSize,
+		NextPageToken:         t.NextPageToken,
+	}
+}
+
+// FromReadDLQMessagesResponse converts internal ReadDLQMessagesResponse type to thrift
+func FromReadDLQMessagesResponse(t *types.ReadDLQMessagesResponse) *replicator.ReadDLQMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &replicator.ReadDLQMessagesResponse{
+		Type:             FromDLQType(t.Type),
+		ReplicationTasks: FromReplicationTaskArray(t.ReplicationTasks),
+		NextPageToken:    t.NextPageToken,
+	}
+}
+
+// ToReadDLQMessagesResponse converts thrift ReadDLQMessagesResponse type to internal
+func ToReadDLQMessagesResponse(t *replicator.ReadDLQMessagesResponse) *types.ReadDLQMessagesResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ReadDLQMessagesResponse{
+		Type:             ToDLQType(t.Type),
+		ReplicationTasks: ToReplicationTaskArray(t.ReplicationTasks),
+		NextPageToken:    t.NextPageToken,
+	}
+}
+
+// FromReplicationMessages converts internal ReplicationMessages type to thrift
+func FromReplicationMessages(t *types.ReplicationMessages) *replicator.ReplicationMessages {
+	if t == nil {
+		return nil
+	}
+	return &replicator.ReplicationMessages{
+		ReplicationTasks:       FromReplicationTaskArray(t.ReplicationTasks),
+		LastRetrievedMessageId: t.LastRetrievedMessageID,
+		HasMore:                t.HasMore,
+		SyncShardStatus:        FromSyncShardStatus(t.SyncShardStatus),
+	}
+}
+
+// ToReplicationMessages converts thrift ReplicationMessages type to internal
+func ToReplicationMessages(t *replicator.ReplicationMessages) *types.ReplicationMessages {
+	if t == nil {
+		return nil
+	}
+	return &types.ReplicationMessages{
+		ReplicationTasks:       ToReplicationTaskArray(t.ReplicationTasks),
+		LastRetrievedMessageID: t.LastRetrievedMessageId,
+		HasMore:                t.HasMore,
+		SyncShardStatus:        ToSyncShardStatus(t.SyncShardStatus),
+	}
+}
+
+// FromReplicationTask converts internal ReplicationTask type to thrift
+func FromReplicationTask(t *types.ReplicationTask) *replicator.ReplicationTask {
+	if t == nil {
+		return nil
+	}
+	return &replicator.ReplicationTask{
+		TaskType:                      FromReplicationTaskType(t.TaskType),
+		SourceTaskId:                  t.SourceTaskID,
+		DomainTaskAttributes:          FromDomainTaskAttributes(t.DomainTaskAttributes),
+		SyncShardStatusTaskAttributes: FromSyncShardStatusTaskAttributes(t.SyncShardStatusTaskAttributes),
+		SyncActivityTaskAttributes:    FromSyncActivityTaskAttributes(t.SyncActivityTaskAttributes),
+		HistoryTaskV2Attributes:       FromHistoryTaskV2Attributes(t.HistoryTaskV2Attributes),
+		FailoverMarkerAttributes:      FromFailoverMarkerAttributes(t.FailoverMarkerAttributes),
+	}
+}
+
+// ToReplicationTask converts thrift ReplicationTask type to internal
+func ToReplicationTask(t *replicator.ReplicationTask) *types.ReplicationTask {
+	if t == nil {
+		return nil
+	}
+	return &types.ReplicationTask{
+		TaskType:                      ToReplicationTaskType(t.TaskType),
+		SourceTaskID:                  t.SourceTaskId,
+		DomainTaskAttributes:          ToDomainTaskAttributes(t.DomainTaskAttributes),
+		SyncShardStatusTaskAttributes: ToSyncShardStatusTaskAttributes(t.SyncShardStatusTaskAttributes),
+		SyncActivityTaskAttributes:    ToSyncActivityTaskAttributes(t.SyncActivityTaskAttributes),
+		HistoryTaskV2Attributes:       ToHistoryTaskV2Attributes(t.HistoryTaskV2Attributes),
+		FailoverMarkerAttributes:      ToFailoverMarkerAttributes(t.FailoverMarkerAttributes),
+	}
+}
+
+// FromReplicationTaskInfo converts internal ReplicationTaskInfo type to thrift
+func FromReplicationTaskInfo(t *types.ReplicationTaskInfo) *replicator.ReplicationTaskInfo {
+	if t == nil {
+		return nil
+	}
+	return &replicator.ReplicationTaskInfo{
+		DomainID:     t.DomainID,
+		WorkflowID:   t.WorkflowID,
+		RunID:        t.RunID,
+		TaskType:     t.TaskType,
+		TaskID:       t.TaskID,
+		Version:      t.Version,
+		FirstEventID: t.FirstEventID,
+		NextEventID:  t.NextEventID,
+		ScheduledID:  t.ScheduledID,
+	}
+}
+
+// ToReplicationTaskInfo converts thrift ReplicationTaskInfo type to internal
+func ToReplicationTaskInfo(t *replicator.ReplicationTaskInfo) *types.ReplicationTaskInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.ReplicationTaskInfo{
+		DomainID:     t.DomainID,
+		WorkflowID:   t.WorkflowID,
+		RunID:        t.RunID,
+		TaskType:     t.TaskType,
+		TaskID:       t.TaskID,
+		Version:      t.Version,
+		FirstEventID: t.FirstEventID,
+		NextEventID:  t.NextEventID,
+		ScheduledID:  t.ScheduledID,
+	}
+}
+
+// FromReplicationTaskType converts internal ReplicationTaskType type to thrift
+func FromReplicationTaskType(t *types.ReplicationTaskType) *replicator.ReplicationTaskType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.ReplicationTaskTypeDomain:
+		v := replicator.ReplicationTaskTypeDomain
+		return &v
+	case types.ReplicationTaskTypeFailoverMarker:
+		v := replicator.ReplicationTaskTypeFailoverMarker
+		return &v
+	case types.ReplicationTaskTypeHistory:
+		v := replicator.ReplicationTaskTypeHistory
+		return &v
+	case types.ReplicationTaskTypeHistoryMetadata:
+		v := replicator.ReplicationTaskTypeHistoryMetadata
+		return &v
+	case types.ReplicationTaskTypeHistoryV2:
+		v := replicator.ReplicationTaskTypeHistoryV2
+		return &v
+	case types.ReplicationTaskTypeSyncActivity:
+		v := replicator.ReplicationTaskTypeSyncActivity
+		return &v
+	case types.ReplicationTaskTypeSyncShardStatus:
+		v := replicator.ReplicationTaskTypeSyncShardStatus
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// ToReplicationTaskType converts thrift ReplicationTaskType type to internal
+func ToReplicationTaskType(t *replicator.ReplicationTaskType) *types.ReplicationTaskType {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case replicator.ReplicationTaskTypeDomain:
+		v := types.ReplicationTaskTypeDomain
+		return &v
+	case replicator.ReplicationTaskTypeFailoverMarker:
+		v := types.ReplicationTaskTypeFailoverMarker
+		return &v
+	case replicator.ReplicationTaskTypeHistory:
+		v := types.ReplicationTaskTypeHistory
+		return &v
+	case replicator.ReplicationTaskTypeHistoryMetadata:
+		v := types.ReplicationTaskTypeHistoryMetadata
+		return &v
+	case replicator.ReplicationTaskTypeHistoryV2:
+		v := types.ReplicationTaskTypeHistoryV2
+		return &v
+	case replicator.ReplicationTaskTypeSyncActivity:
+		v := types.ReplicationTaskTypeSyncActivity
+		return &v
+	case replicator.ReplicationTaskTypeSyncShardStatus:
+		v := types.ReplicationTaskTypeSyncShardStatus
+		return &v
+	}
+	panic("unexpected enum value")
+}
+
+// FromReplicationToken converts internal ReplicationToken type to thrift
+func FromReplicationToken(t *types.ReplicationToken) *replicator.ReplicationToken {
+	if t == nil {
+		return nil
+	}
+	return &replicator.ReplicationToken{
+		ShardID:                t.ShardID,
+		LastRetrievedMessageId: t.LastRetrievedMessageID,
+		LastProcessedMessageId: t.LastProcessedMessageID,
+	}
+}
+
+// ToReplicationToken converts thrift ReplicationToken type to internal
+func ToReplicationToken(t *replicator.ReplicationToken) *types.ReplicationToken {
+	if t == nil {
+		return nil
+	}
+	return &types.ReplicationToken{
+		ShardID:                t.ShardID,
+		LastRetrievedMessageID: t.LastRetrievedMessageId,
+		LastProcessedMessageID: t.LastProcessedMessageId,
+	}
+}
+
+// FromSyncActivityTaskAttributes converts internal SyncActivityTaskAttributes type to thrift
+func FromSyncActivityTaskAttributes(t *types.SyncActivityTaskAttributes) *replicator.SyncActivityTaskAttributes {
+	if t == nil {
+		return nil
+	}
+	return &replicator.SyncActivityTaskAttributes{
+		DomainId:           t.DomainID,
+		WorkflowId:         t.WorkflowID,
+		RunId:              t.RunID,
+		Version:            t.Version,
+		ScheduledId:        t.ScheduledID,
+		ScheduledTime:      t.ScheduledTime,
+		StartedId:          t.StartedID,
+		StartedTime:        t.StartedTime,
+		LastHeartbeatTime:  t.LastHeartbeatTime,
+		Details:            t.Details,
+		Attempt:            t.Attempt,
+		LastFailureReason:  t.LastFailureReason,
+		LastWorkerIdentity: t.LastWorkerIdentity,
+		LastFailureDetails: t.LastFailureDetails,
+		VersionHistory:     FromVersionHistory(t.VersionHistory),
+	}
+}
+
+// ToSyncActivityTaskAttributes converts thrift SyncActivityTaskAttributes type to internal
+func ToSyncActivityTaskAttributes(t *replicator.SyncActivityTaskAttributes) *types.SyncActivityTaskAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.SyncActivityTaskAttributes{
+		DomainID:           t.DomainId,
+		WorkflowID:         t.WorkflowId,
+		RunID:              t.RunId,
+		Version:            t.Version,
+		ScheduledID:        t.ScheduledId,
+		ScheduledTime:      t.ScheduledTime,
+		StartedID:          t.StartedId,
+		StartedTime:        t.StartedTime,
+		LastHeartbeatTime:  t.LastHeartbeatTime,
+		Details:            t.Details,
+		Attempt:            t.Attempt,
+		LastFailureReason:  t.LastFailureReason,
+		LastWorkerIdentity: t.LastWorkerIdentity,
+		LastFailureDetails: t.LastFailureDetails,
+		VersionHistory:     ToVersionHistory(t.VersionHistory),
+	}
+}
+
+// FromSyncShardStatus converts internal SyncShardStatus type to thrift
+func FromSyncShardStatus(t *types.SyncShardStatus) *replicator.SyncShardStatus {
+	if t == nil {
+		return nil
+	}
+	return &replicator.SyncShardStatus{
+		Timestamp: t.Timestamp,
+	}
+}
+
+// ToSyncShardStatus converts thrift SyncShardStatus type to internal
+func ToSyncShardStatus(t *replicator.SyncShardStatus) *types.SyncShardStatus {
+	if t == nil {
+		return nil
+	}
+	return &types.SyncShardStatus{
+		Timestamp: t.Timestamp,
+	}
+}
+
+// FromSyncShardStatusTaskAttributes converts internal SyncShardStatusTaskAttributes type to thrift
+func FromSyncShardStatusTaskAttributes(t *types.SyncShardStatusTaskAttributes) *replicator.SyncShardStatusTaskAttributes {
+	if t == nil {
+		return nil
+	}
+	return &replicator.SyncShardStatusTaskAttributes{
+		SourceCluster: t.SourceCluster,
+		ShardId:       t.ShardID,
+		Timestamp:     t.Timestamp,
+	}
+}
+
+// ToSyncShardStatusTaskAttributes converts thrift SyncShardStatusTaskAttributes type to internal
+func ToSyncShardStatusTaskAttributes(t *replicator.SyncShardStatusTaskAttributes) *types.SyncShardStatusTaskAttributes {
+	if t == nil {
+		return nil
+	}
+	return &types.SyncShardStatusTaskAttributes{
+		SourceCluster: t.SourceCluster,
+		ShardID:       t.ShardId,
+		Timestamp:     t.Timestamp,
+	}
+}
+
+// FromFailoverMarkerAttributesArray converts internal FailoverMarkerAttributes type array to thrift
+func FromFailoverMarkerAttributesArray(t []*types.FailoverMarkerAttributes) []*replicator.FailoverMarkerAttributes {
+	if t == nil {
+		return nil
+	}
+	v := make([]*replicator.FailoverMarkerAttributes, len(t))
+	for i := range t {
+		v[i] = FromFailoverMarkerAttributes(t[i])
+	}
+	return v
+}
+
+// ToFailoverMarkerAttributesArray converts thrift FailoverMarkerAttributes type array to internal
+func ToFailoverMarkerAttributesArray(t []*replicator.FailoverMarkerAttributes) []*types.FailoverMarkerAttributes {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.FailoverMarkerAttributes, len(t))
+	for i := range t {
+		v[i] = ToFailoverMarkerAttributes(t[i])
+	}
+	return v
+}
+
+// FromReplicationTaskInfoArray converts internal ReplicationTaskInfo type array to thrift
+func FromReplicationTaskInfoArray(t []*types.ReplicationTaskInfo) []*replicator.ReplicationTaskInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*replicator.ReplicationTaskInfo, len(t))
+	for i := range t {
+		v[i] = FromReplicationTaskInfo(t[i])
+	}
+	return v
+}
+
+// ToReplicationTaskInfoArray converts thrift ReplicationTaskInfo type array to internal
+func ToReplicationTaskInfoArray(t []*replicator.ReplicationTaskInfo) []*types.ReplicationTaskInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ReplicationTaskInfo, len(t))
+	for i := range t {
+		v[i] = ToReplicationTaskInfo(t[i])
+	}
+	return v
+}
+
+// FromReplicationTaskArray converts internal ReplicationTask type array to thrift
+func FromReplicationTaskArray(t []*types.ReplicationTask) []*replicator.ReplicationTask {
+	if t == nil {
+		return nil
+	}
+	v := make([]*replicator.ReplicationTask, len(t))
+	for i := range t {
+		v[i] = FromReplicationTask(t[i])
+	}
+	return v
+}
+
+// ToReplicationTaskArray converts thrift ReplicationTask type array to internal
+func ToReplicationTaskArray(t []*replicator.ReplicationTask) []*types.ReplicationTask {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ReplicationTask, len(t))
+	for i := range t {
+		v[i] = ToReplicationTask(t[i])
+	}
+	return v
+}
+
+// FromReplicationTokenArray converts internal ReplicationToken type array to thrift
+func FromReplicationTokenArray(t []*types.ReplicationToken) []*replicator.ReplicationToken {
+	if t == nil {
+		return nil
+	}
+	v := make([]*replicator.ReplicationToken, len(t))
+	for i := range t {
+		v[i] = FromReplicationToken(t[i])
+	}
+	return v
+}
+
+// ToReplicationTokenArray converts thrift ReplicationToken type array to internal
+func ToReplicationTokenArray(t []*replicator.ReplicationToken) []*types.ReplicationToken {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ReplicationToken, len(t))
+	for i := range t {
+		v[i] = ToReplicationToken(t[i])
+	}
+	return v
+}
+
+// FromReplicationMessagesMap converts internal ReplicationMessages type map to thrift
+func FromReplicationMessagesMap(t map[int32]*types.ReplicationMessages) map[int32]*replicator.ReplicationMessages {
+	if t == nil {
+		return nil
+	}
+	v := make(map[int32]*replicator.ReplicationMessages, len(t))
+	for key := range t {
+		v[key] = FromReplicationMessages(t[key])
+	}
+	return v
+}
+
+// ToReplicationMessagesMap converts thrift ReplicationMessages type map to internal
+func ToReplicationMessagesMap(t map[int32]*replicator.ReplicationMessages) map[int32]*types.ReplicationMessages {
+	if t == nil {
+		return nil
+	}
+	v := make(map[int32]*types.ReplicationMessages, len(t))
+	for key := range t {
+		v[key] = ToReplicationMessages(t[key])
+	}
+	return v
+}

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -6208,6 +6208,7 @@ func ToPollerInfoArray(t []*shared.PollerInfo) []*types.PollerInfo {
 	return v
 }
 
+<<<<<<< HEAD
 // FromDataBlobArray converts internal DataBlob type array to thrift
 func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
 	if t == nil {
@@ -6216,46 +6217,7 @@ func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
 	v := make([]*shared.DataBlob, len(t))
 	for i := range t {
 		v[i] = FromDataBlob(t[i])
-	}
-	return v
-}
-
-// ToDataBlobArray converts thrift DataBlob type array to internal
-func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.DataBlob, len(t))
-	for i := range t {
-		v[i] = ToDataBlob(t[i])
-	}
-	return v
-}
-
-// FromDecisionArray converts internal Decision type array to thrift
-func FromDecisionArray(t []*types.Decision) []*shared.Decision {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.Decision, len(t))
-	for i := range t {
-		v[i] = FromDecision(t[i])
-	}
-	return v
-}
-
-// ToDecisionArray converts thrift Decision type array to internal
-func ToDecisionArray(t []*shared.Decision) []*types.Decision {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.Decision, len(t))
-	for i := range t {
-		v[i] = ToDecision(t[i])
-	}
-	return v
-}
-
+=======
 // FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
 func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
 	if t == nil {
@@ -6264,10 +6226,21 @@ func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.Pend
 	v := make([]*shared.PendingActivityInfo, len(t))
 	for i := range t {
 		v[i] = FromPendingActivityInfo(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
+<<<<<<< HEAD
+// ToDataBlobArray converts thrift DataBlob type array to internal
+func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DataBlob, len(t))
+	for i := range t {
+		v[i] = ToDataBlob(t[i])
+=======
 // ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
 func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
 	if t == nil {
@@ -6276,6 +6249,99 @@ func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.Pendin
 	v := make([]*types.PendingActivityInfo, len(t))
 	for i := range t {
 		v[i] = ToPendingActivityInfo(t[i])
+>>>>>>> a75cac73... Add replicator types
+	}
+	return v
+}
+
+<<<<<<< HEAD
+// FromDecisionArray converts internal Decision type array to thrift
+func FromDecisionArray(t []*types.Decision) []*shared.Decision {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.Decision, len(t))
+	for i := range t {
+		v[i] = FromDecision(t[i])
+=======
+// FromDescribeDomainResponseArray converts internal DescribeDomainResponse type array to thrift
+func FromDescribeDomainResponseArray(t []*types.DescribeDomainResponse) []*shared.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = FromDescribeDomainResponse(t[i])
+>>>>>>> a75cac73... Add replicator types
+	}
+	return v
+}
+
+<<<<<<< HEAD
+// ToDecisionArray converts thrift Decision type array to internal
+func ToDecisionArray(t []*shared.Decision) []*types.Decision {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.Decision, len(t))
+	for i := range t {
+		v[i] = ToDecision(t[i])
+=======
+// ToDescribeDomainResponseArray converts thrift DescribeDomainResponse type array to internal
+func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = ToDescribeDomainResponse(t[i])
+>>>>>>> a75cac73... Add replicator types
+	}
+	return v
+}
+
+<<<<<<< HEAD
+// FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
+func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.PendingActivityInfo, len(t))
+	for i := range t {
+		v[i] = FromPendingActivityInfo(t[i])
+=======
+// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
+func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.ResetPointInfo, len(t))
+	for i := range t {
+		v[i] = FromResetPointInfo(t[i])
+>>>>>>> a75cac73... Add replicator types
+	}
+	return v
+}
+
+<<<<<<< HEAD
+// ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
+func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PendingActivityInfo, len(t))
+	for i := range t {
+		v[i] = ToPendingActivityInfo(t[i])
+=======
+// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
+func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ResetPointInfo, len(t))
+	for i := range t {
+		v[i] = ToResetPointInfo(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
@@ -6304,6 +6370,7 @@ func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*
 	return v
 }
 
+<<<<<<< HEAD
 // FromClusterReplicationConfigurationArray converts internal ClusterReplicationConfiguration type array to thrift
 func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfiguration) []*shared.ClusterReplicationConfiguration {
 	if t == nil {
@@ -6312,10 +6379,21 @@ func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfi
 	v := make([]*shared.ClusterReplicationConfiguration, len(t))
 	for i := range t {
 		v[i] = FromClusterReplicationConfiguration(t[i])
+=======
+// FromDataBlobArray converts internal DataBlob type array to thrift
+func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DataBlob, len(t))
+	for i := range t {
+		v[i] = FromDataBlob(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
+<<<<<<< HEAD
 // ToClusterReplicationConfigurationArray converts thrift ClusterReplicationConfiguration type array to internal
 func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfiguration) []*types.ClusterReplicationConfiguration {
 	if t == nil {
@@ -6324,6 +6402,16 @@ func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfig
 	v := make([]*types.ClusterReplicationConfiguration, len(t))
 	for i := range t {
 		v[i] = ToClusterReplicationConfiguration(t[i])
+=======
+// ToDataBlobArray converts thrift DataBlob type array to internal
+func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DataBlob, len(t))
+	for i := range t {
+		v[i] = ToDataBlob(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
@@ -6352,6 +6440,7 @@ func ToHistoryEventArray(t []*shared.HistoryEvent) []*types.HistoryEvent {
 	return v
 }
 
+<<<<<<< HEAD
 // FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
 func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
 	if t == nil {
@@ -6360,10 +6449,21 @@ func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.Histor
 	v := make([]*shared.HistoryBranchRange, len(t))
 	for i := range t {
 		v[i] = FromHistoryBranchRange(t[i])
+=======
+// FromVersionHistoryArray converts internal VersionHistory type array to thrift
+func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.VersionHistory, len(t))
+	for i := range t {
+		v[i] = FromVersionHistory(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
+<<<<<<< HEAD
 // ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
 func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
 	if t == nil {
@@ -6372,10 +6472,21 @@ func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryB
 	v := make([]*types.HistoryBranchRange, len(t))
 	for i := range t {
 		v[i] = ToHistoryBranchRange(t[i])
+=======
+// ToVersionHistoryArray converts thrift VersionHistory type array to internal
+func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.VersionHistory, len(t))
+	for i := range t {
+		v[i] = ToVersionHistory(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
+<<<<<<< HEAD
 // FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
 func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
 	if t == nil {
@@ -6384,10 +6495,21 @@ func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.
 	v := make([]*shared.WorkflowExecutionInfo, len(t))
 	for i := range t {
 		v[i] = FromWorkflowExecutionInfo(t[i])
+=======
+// FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
+func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.VersionHistoryItem, len(t))
+	for i := range t {
+		v[i] = FromVersionHistoryItem(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
+<<<<<<< HEAD
 // ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
 func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
 	if t == nil {
@@ -6396,6 +6518,16 @@ func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.Wo
 	v := make([]*types.WorkflowExecutionInfo, len(t))
 	for i := range t {
 		v[i] = ToWorkflowExecutionInfo(t[i])
+=======
+// ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
+func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.VersionHistoryItem, len(t))
+	for i := range t {
+		v[i] = ToVersionHistoryItem(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
@@ -6424,6 +6556,7 @@ func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.
 	return v
 }
 
+<<<<<<< HEAD
 // FromVersionHistoryArray converts internal VersionHistory type array to thrift
 func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
 	if t == nil {
@@ -6432,10 +6565,21 @@ func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory
 	v := make([]*shared.VersionHistory, len(t))
 	for i := range t {
 		v[i] = FromVersionHistory(t[i])
+=======
+// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
+func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.HistoryBranchRange, len(t))
+	for i := range t {
+		v[i] = FromHistoryBranchRange(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
+<<<<<<< HEAD
 // ToVersionHistoryArray converts thrift VersionHistory type array to internal
 func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
 	if t == nil {
@@ -6444,6 +6588,16 @@ func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
 	v := make([]*types.VersionHistory, len(t))
 	for i := range t {
 		v[i] = ToVersionHistory(t[i])
+=======
+// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
+func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.HistoryBranchRange, len(t))
+	for i := range t {
+		v[i] = ToHistoryBranchRange(t[i])
+>>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
@@ -6472,26 +6626,26 @@ func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*
 	return v
 }
 
-// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
-func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
+// FromTaskListPartitionMetadataArray converts internal TaskListPartitionMetadata type array to thrift
+func FromTaskListPartitionMetadataArray(t []*types.TaskListPartitionMetadata) []*shared.TaskListPartitionMetadata {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.ResetPointInfo, len(t))
+	v := make([]*shared.TaskListPartitionMetadata, len(t))
 	for i := range t {
-		v[i] = FromResetPointInfo(t[i])
+		v[i] = FromTaskListPartitionMetadata(t[i])
 	}
 	return v
 }
 
-// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
-func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
+// ToTaskListPartitionMetadataArray converts thrift TaskListPartitionMetadata type array to internal
+func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*types.TaskListPartitionMetadata {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.ResetPointInfo, len(t))
+	v := make([]*types.TaskListPartitionMetadata, len(t))
 	for i := range t {
-		v[i] = ToResetPointInfo(t[i])
+		v[i] = ToTaskListPartitionMetadata(t[i])
 	}
 	return v
 }
@@ -6515,7 +6669,83 @@ func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionH
 	}
 	v := make([]*types.VersionHistoryItem, len(t))
 	for i := range t {
+<<<<<<< HEAD
 		v[i] = ToVersionHistoryItem(t[i])
+=======
+		v[i] = ToDecision(t[i])
+	}
+	return v
+}
+
+// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
+func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = FromBadBinaryInfo(t[key])
+	}
+	return v
+}
+
+// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
+func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = ToBadBinaryInfo(t[key])
+>>>>>>> a75cac73... Add replicator types
+	}
+	return v
+}
+
+// FromIndexedValueTypeMap converts internal IndexedValueType type map to thrift
+func FromIndexedValueTypeMap(t map[string]types.IndexedValueType) map[string]shared.IndexedValueType {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]shared.IndexedValueType, len(t))
+	for key := range t {
+		v[key] = FromIndexedValueType(t[key])
+	}
+	return v
+}
+
+// ToIndexedValueTypeMap converts thrift IndexedValueType type map to internal
+func ToIndexedValueTypeMap(t map[string]shared.IndexedValueType) map[string]types.IndexedValueType {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]types.IndexedValueType, len(t))
+	for key := range t {
+		v[key] = ToIndexedValueType(t[key])
+	}
+	return v
+}
+
+// FromWorkflowQueryMap converts internal WorkflowQuery type map to thrift
+func FromWorkflowQueryMap(t map[string]*types.WorkflowQuery) map[string]*shared.WorkflowQuery {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.WorkflowQuery, len(t))
+	for key := range t {
+		v[key] = FromWorkflowQuery(t[key])
+	}
+	return v
+}
+
+// ToWorkflowQueryMap converts thrift WorkflowQuery type map to internal
+func ToWorkflowQueryMap(t map[string]*shared.WorkflowQuery) map[string]*types.WorkflowQuery {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.WorkflowQuery, len(t))
+	for key := range t {
+		v[key] = ToWorkflowQuery(t[key])
 	}
 	return v
 }
@@ -6564,54 +6794,6 @@ func ToActivityLocalDispatchInfoMap(t map[string]*shared.ActivityLocalDispatchIn
 	v := make(map[string]*types.ActivityLocalDispatchInfo, len(t))
 	for key := range t {
 		v[key] = ToActivityLocalDispatchInfo(t[key])
-	}
-	return v
-}
-
-// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
-func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*shared.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = FromBadBinaryInfo(t[key])
-	}
-	return v
-}
-
-// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
-func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*types.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = ToBadBinaryInfo(t[key])
-	}
-	return v
-}
-
-// FromIndexedValueTypeMap converts internal IndexedValueType type map to thrift
-func FromIndexedValueTypeMap(t map[string]types.IndexedValueType) map[string]shared.IndexedValueType {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]shared.IndexedValueType, len(t))
-	for key := range t {
-		v[key] = FromIndexedValueType(t[key])
-	}
-	return v
-}
-
-// ToIndexedValueTypeMap converts thrift IndexedValueType type map to internal
-func ToIndexedValueTypeMap(t map[string]shared.IndexedValueType) map[string]types.IndexedValueType {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]types.IndexedValueType, len(t))
-	for key := range t {
-		v[key] = ToIndexedValueType(t[key])
 	}
 	return v
 }

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -6184,77 +6184,30 @@ func ToWorkflowTypeFilter(t *shared.WorkflowTypeFilter) *types.WorkflowTypeFilte
 	}
 }
 
-// FromPollerInfoArray converts internal PollerInfo type array to thrift
-func FromPollerInfoArray(t []*types.PollerInfo) []*shared.PollerInfo {
+// FromTaskListPartitionMetadataArray converts internal TaskListPartitionMetadata type array to thrift
+func FromTaskListPartitionMetadataArray(t []*types.TaskListPartitionMetadata) []*shared.TaskListPartitionMetadata {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.PollerInfo, len(t))
+	v := make([]*shared.TaskListPartitionMetadata, len(t))
 	for i := range t {
-		v[i] = FromPollerInfo(t[i])
+		v[i] = FromTaskListPartitionMetadata(t[i])
 	}
 	return v
 }
 
-// ToPollerInfoArray converts thrift PollerInfo type array to internal
-func ToPollerInfoArray(t []*shared.PollerInfo) []*types.PollerInfo {
+// ToTaskListPartitionMetadataArray converts thrift TaskListPartitionMetadata type array to internal
+func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*types.TaskListPartitionMetadata {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.PollerInfo, len(t))
+	v := make([]*types.TaskListPartitionMetadata, len(t))
 	for i := range t {
-		v[i] = ToPollerInfo(t[i])
+		v[i] = ToTaskListPartitionMetadata(t[i])
 	}
 	return v
 }
 
-<<<<<<< HEAD
-// FromDataBlobArray converts internal DataBlob type array to thrift
-func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.DataBlob, len(t))
-	for i := range t {
-		v[i] = FromDataBlob(t[i])
-=======
-// FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
-func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.PendingActivityInfo, len(t))
-	for i := range t {
-		v[i] = FromPendingActivityInfo(t[i])
->>>>>>> a75cac73... Add replicator types
-	}
-	return v
-}
-
-<<<<<<< HEAD
-// ToDataBlobArray converts thrift DataBlob type array to internal
-func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.DataBlob, len(t))
-	for i := range t {
-		v[i] = ToDataBlob(t[i])
-=======
-// ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
-func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.PendingActivityInfo, len(t))
-	for i := range t {
-		v[i] = ToPendingActivityInfo(t[i])
->>>>>>> a75cac73... Add replicator types
-	}
-	return v
-}
-
-<<<<<<< HEAD
 // FromDecisionArray converts internal Decision type array to thrift
 func FromDecisionArray(t []*types.Decision) []*shared.Decision {
 	if t == nil {
@@ -6263,21 +6216,10 @@ func FromDecisionArray(t []*types.Decision) []*shared.Decision {
 	v := make([]*shared.Decision, len(t))
 	for i := range t {
 		v[i] = FromDecision(t[i])
-=======
-// FromDescribeDomainResponseArray converts internal DescribeDomainResponse type array to thrift
-func FromDescribeDomainResponseArray(t []*types.DescribeDomainResponse) []*shared.DescribeDomainResponse {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.DescribeDomainResponse, len(t))
-	for i := range t {
-		v[i] = FromDescribeDomainResponse(t[i])
->>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
-<<<<<<< HEAD
 // ToDecisionArray converts thrift Decision type array to internal
 func ToDecisionArray(t []*shared.Decision) []*types.Decision {
 	if t == nil {
@@ -6286,21 +6228,34 @@ func ToDecisionArray(t []*shared.Decision) []*types.Decision {
 	v := make([]*types.Decision, len(t))
 	for i := range t {
 		v[i] = ToDecision(t[i])
-=======
-// ToDescribeDomainResponseArray converts thrift DescribeDomainResponse type array to internal
-func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.DescribeDomainResponse {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.DescribeDomainResponse, len(t))
-	for i := range t {
-		v[i] = ToDescribeDomainResponse(t[i])
->>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
-<<<<<<< HEAD
+// FromVersionHistoryArray converts internal VersionHistory type array to thrift
+func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.VersionHistory, len(t))
+	for i := range t {
+		v[i] = FromVersionHistory(t[i])
+	}
+	return v
+}
+
+// ToVersionHistoryArray converts thrift VersionHistory type array to internal
+func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.VersionHistory, len(t))
+	for i := range t {
+		v[i] = ToVersionHistory(t[i])
+	}
+	return v
+}
+
 // FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
 func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
 	if t == nil {
@@ -6309,21 +6264,10 @@ func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.Pend
 	v := make([]*shared.PendingActivityInfo, len(t))
 	for i := range t {
 		v[i] = FromPendingActivityInfo(t[i])
-=======
-// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
-func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.ResetPointInfo, len(t))
-	for i := range t {
-		v[i] = FromResetPointInfo(t[i])
->>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
-<<<<<<< HEAD
 // ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
 func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
 	if t == nil {
@@ -6332,16 +6276,54 @@ func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.Pendin
 	v := make([]*types.PendingActivityInfo, len(t))
 	for i := range t {
 		v[i] = ToPendingActivityInfo(t[i])
-=======
-// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
-func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
+	}
+	return v
+}
+
+// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
+func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.ResetPointInfo, len(t))
+	v := make([]*shared.HistoryBranchRange, len(t))
 	for i := range t {
-		v[i] = ToResetPointInfo(t[i])
->>>>>>> a75cac73... Add replicator types
+		v[i] = FromHistoryBranchRange(t[i])
+	}
+	return v
+}
+
+// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
+func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.HistoryBranchRange, len(t))
+	for i := range t {
+		v[i] = ToHistoryBranchRange(t[i])
+	}
+	return v
+}
+
+// FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
+func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.WorkflowExecutionInfo, len(t))
+	for i := range t {
+		v[i] = FromWorkflowExecutionInfo(t[i])
+	}
+	return v
+}
+
+// ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
+func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.WorkflowExecutionInfo, len(t))
+	for i := range t {
+		v[i] = ToWorkflowExecutionInfo(t[i])
 	}
 	return v
 }
@@ -6370,7 +6352,6 @@ func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*
 	return v
 }
 
-<<<<<<< HEAD
 // FromClusterReplicationConfigurationArray converts internal ClusterReplicationConfiguration type array to thrift
 func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfiguration) []*shared.ClusterReplicationConfiguration {
 	if t == nil {
@@ -6379,21 +6360,10 @@ func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfi
 	v := make([]*shared.ClusterReplicationConfiguration, len(t))
 	for i := range t {
 		v[i] = FromClusterReplicationConfiguration(t[i])
-=======
-// FromDataBlobArray converts internal DataBlob type array to thrift
-func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.DataBlob, len(t))
-	for i := range t {
-		v[i] = FromDataBlob(t[i])
->>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
-<<<<<<< HEAD
 // ToClusterReplicationConfigurationArray converts thrift ClusterReplicationConfiguration type array to internal
 func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfiguration) []*types.ClusterReplicationConfiguration {
 	if t == nil {
@@ -6402,16 +6372,30 @@ func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfig
 	v := make([]*types.ClusterReplicationConfiguration, len(t))
 	for i := range t {
 		v[i] = ToClusterReplicationConfiguration(t[i])
-=======
-// ToDataBlobArray converts thrift DataBlob type array to internal
-func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
+	}
+	return v
+}
+
+// FromPollerInfoArray converts internal PollerInfo type array to thrift
+func FromPollerInfoArray(t []*types.PollerInfo) []*shared.PollerInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.DataBlob, len(t))
+	v := make([]*shared.PollerInfo, len(t))
 	for i := range t {
-		v[i] = ToDataBlob(t[i])
->>>>>>> a75cac73... Add replicator types
+		v[i] = FromPollerInfo(t[i])
+	}
+	return v
+}
+
+// ToPollerInfoArray converts thrift PollerInfo type array to internal
+func ToPollerInfoArray(t []*shared.PollerInfo) []*types.PollerInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PollerInfo, len(t))
+	for i := range t {
+		v[i] = ToPollerInfo(t[i])
 	}
 	return v
 }
@@ -6440,62 +6424,6 @@ func ToHistoryEventArray(t []*shared.HistoryEvent) []*types.HistoryEvent {
 	return v
 }
 
-<<<<<<< HEAD
-// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
-func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.HistoryBranchRange, len(t))
-	for i := range t {
-		v[i] = FromHistoryBranchRange(t[i])
-=======
-// FromVersionHistoryArray converts internal VersionHistory type array to thrift
-func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.VersionHistory, len(t))
-	for i := range t {
-		v[i] = FromVersionHistory(t[i])
->>>>>>> a75cac73... Add replicator types
-	}
-	return v
-}
-
-<<<<<<< HEAD
-// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
-func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.HistoryBranchRange, len(t))
-	for i := range t {
-		v[i] = ToHistoryBranchRange(t[i])
-=======
-// ToVersionHistoryArray converts thrift VersionHistory type array to internal
-func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.VersionHistory, len(t))
-	for i := range t {
-		v[i] = ToVersionHistory(t[i])
->>>>>>> a75cac73... Add replicator types
-	}
-	return v
-}
-
-<<<<<<< HEAD
-// FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
-func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.WorkflowExecutionInfo, len(t))
-	for i := range t {
-		v[i] = FromWorkflowExecutionInfo(t[i])
-=======
 // FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
 func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
 	if t == nil {
@@ -6504,21 +6432,10 @@ func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.Versio
 	v := make([]*shared.VersionHistoryItem, len(t))
 	for i := range t {
 		v[i] = FromVersionHistoryItem(t[i])
->>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
 
-<<<<<<< HEAD
-// ToWorkflowExecutionInfoArray converts thrift WorkflowExecutionInfo type array to internal
-func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.WorkflowExecutionInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.WorkflowExecutionInfo, len(t))
-	for i := range t {
-		v[i] = ToWorkflowExecutionInfo(t[i])
-=======
 // ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
 func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
 	if t == nil {
@@ -6527,7 +6444,30 @@ func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionH
 	v := make([]*types.VersionHistoryItem, len(t))
 	for i := range t {
 		v[i] = ToVersionHistoryItem(t[i])
->>>>>>> a75cac73... Add replicator types
+	}
+	return v
+}
+
+// FromDataBlobArray converts internal DataBlob type array to thrift
+func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DataBlob, len(t))
+	for i := range t {
+		v[i] = FromDataBlob(t[i])
+	}
+	return v
+}
+
+// ToDataBlobArray converts thrift DataBlob type array to internal
+func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DataBlob, len(t))
+	for i := range t {
+		v[i] = ToDataBlob(t[i])
 	}
 	return v
 }
@@ -6556,123 +6496,26 @@ func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.
 	return v
 }
 
-<<<<<<< HEAD
-// FromVersionHistoryArray converts internal VersionHistory type array to thrift
-func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
+// FromResetPointInfoArray converts internal ResetPointInfo type array to thrift
+func FromResetPointInfoArray(t []*types.ResetPointInfo) []*shared.ResetPointInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.VersionHistory, len(t))
+	v := make([]*shared.ResetPointInfo, len(t))
 	for i := range t {
-		v[i] = FromVersionHistory(t[i])
-=======
-// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
-func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.HistoryBranchRange, len(t))
-	for i := range t {
-		v[i] = FromHistoryBranchRange(t[i])
->>>>>>> a75cac73... Add replicator types
+		v[i] = FromResetPointInfo(t[i])
 	}
 	return v
 }
 
-<<<<<<< HEAD
-// ToVersionHistoryArray converts thrift VersionHistory type array to internal
-func ToVersionHistoryArray(t []*shared.VersionHistory) []*types.VersionHistory {
+// ToResetPointInfoArray converts thrift ResetPointInfo type array to internal
+func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.VersionHistory, len(t))
+	v := make([]*types.ResetPointInfo, len(t))
 	for i := range t {
-		v[i] = ToVersionHistory(t[i])
-=======
-// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
-func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.HistoryBranchRange, len(t))
-	for i := range t {
-		v[i] = ToHistoryBranchRange(t[i])
->>>>>>> a75cac73... Add replicator types
-	}
-	return v
-}
-
-// FromTaskListPartitionMetadataArray converts internal TaskListPartitionMetadata type array to thrift
-func FromTaskListPartitionMetadataArray(t []*types.TaskListPartitionMetadata) []*shared.TaskListPartitionMetadata {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.TaskListPartitionMetadata, len(t))
-	for i := range t {
-		v[i] = FromTaskListPartitionMetadata(t[i])
-	}
-	return v
-}
-
-// ToTaskListPartitionMetadataArray converts thrift TaskListPartitionMetadata type array to internal
-func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*types.TaskListPartitionMetadata {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.TaskListPartitionMetadata, len(t))
-	for i := range t {
-		v[i] = ToTaskListPartitionMetadata(t[i])
-	}
-	return v
-}
-
-// FromTaskListPartitionMetadataArray converts internal TaskListPartitionMetadata type array to thrift
-func FromTaskListPartitionMetadataArray(t []*types.TaskListPartitionMetadata) []*shared.TaskListPartitionMetadata {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.TaskListPartitionMetadata, len(t))
-	for i := range t {
-		v[i] = FromTaskListPartitionMetadata(t[i])
-	}
-	return v
-}
-
-// ToTaskListPartitionMetadataArray converts thrift TaskListPartitionMetadata type array to internal
-func ToTaskListPartitionMetadataArray(t []*shared.TaskListPartitionMetadata) []*types.TaskListPartitionMetadata {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.TaskListPartitionMetadata, len(t))
-	for i := range t {
-		v[i] = ToTaskListPartitionMetadata(t[i])
-	}
-	return v
-}
-
-// FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
-func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.VersionHistoryItem, len(t))
-	for i := range t {
-		v[i] = FromVersionHistoryItem(t[i])
-	}
-	return v
-}
-
-// ToVersionHistoryItemArray converts thrift VersionHistoryItem type array to internal
-func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionHistoryItem {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.VersionHistoryItem, len(t))
-	for i := range t {
-<<<<<<< HEAD
-		v[i] = ToVersionHistoryItem(t[i])
-=======
-		v[i] = ToDecision(t[i])
+		v[i] = ToResetPointInfo(t[i])
 	}
 	return v
 }
@@ -6697,7 +6540,6 @@ func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.Ba
 	v := make(map[string]*types.BadBinaryInfo, len(t))
 	for key := range t {
 		v[key] = ToBadBinaryInfo(t[key])
->>>>>>> a75cac73... Add replicator types
 	}
 	return v
 }
@@ -6794,30 +6636,6 @@ func ToActivityLocalDispatchInfoMap(t map[string]*shared.ActivityLocalDispatchIn
 	v := make(map[string]*types.ActivityLocalDispatchInfo, len(t))
 	for key := range t {
 		v[key] = ToActivityLocalDispatchInfo(t[key])
-	}
-	return v
-}
-
-// FromWorkflowQueryMap converts internal WorkflowQuery type map to thrift
-func FromWorkflowQueryMap(t map[string]*types.WorkflowQuery) map[string]*shared.WorkflowQuery {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*shared.WorkflowQuery, len(t))
-	for key := range t {
-		v[key] = FromWorkflowQuery(t[key])
-	}
-	return v
-}
-
-// ToWorkflowQueryMap converts thrift WorkflowQuery type map to internal
-func ToWorkflowQueryMap(t map[string]*shared.WorkflowQuery) map[string]*types.WorkflowQuery {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*types.WorkflowQuery, len(t))
-	for key := range t {
-		v[key] = ToWorkflowQuery(t[key])
 	}
 	return v
 }

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -1,0 +1,801 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package types
+
+// DLQType is an internal type (TBD...)
+type DLQType int32
+
+const (
+	// DLQTypeDomain is an option for DLQType
+	DLQTypeDomain DLQType = iota
+	// DLQTypeReplication is an option for DLQType
+	DLQTypeReplication
+)
+
+// DomainOperation is an internal type (TBD...)
+type DomainOperation int32
+
+const (
+	// DomainOperationCreate is an option for DomainOperation
+	DomainOperationCreate DomainOperation = iota
+	// DomainOperationUpdate is an option for DomainOperation
+	DomainOperationUpdate
+)
+
+// DomainTaskAttributes is an internal type (TBD...)
+type DomainTaskAttributes struct {
+	DomainOperation         *DomainOperation
+	ID                      *string
+	Info                    *DomainInfo
+	Config                  *DomainConfiguration
+	ReplicationConfig       *DomainReplicationConfiguration
+	ConfigVersion           *int64
+	FailoverVersion         *int64
+	PreviousFailoverVersion *int64
+}
+
+func (v *DomainTaskAttributes) GetDomainOperation() (o DomainOperation) {
+	if v != nil && v.DomainOperation != nil {
+		return *v.DomainOperation
+	}
+	return
+}
+func (v *DomainTaskAttributes) GetID() (o string) {
+	if v != nil && v.ID != nil {
+		return *v.ID
+	}
+	return
+}
+func (v *DomainTaskAttributes) GetInfo() (o *DomainInfo) {
+	if v != nil && v.Info != nil {
+		return v.Info
+	}
+	return
+}
+func (v *DomainTaskAttributes) GetConfig() (o *DomainConfiguration) {
+	if v != nil && v.Config != nil {
+		return v.Config
+	}
+	return
+}
+func (v *DomainTaskAttributes) GetReplicationConfig() (o *DomainReplicationConfiguration) {
+	if v != nil && v.ReplicationConfig != nil {
+		return v.ReplicationConfig
+	}
+	return
+}
+func (v *DomainTaskAttributes) GetConfigVersion() (o int64) {
+	if v != nil && v.ConfigVersion != nil {
+		return *v.ConfigVersion
+	}
+	return
+}
+func (v *DomainTaskAttributes) GetFailoverVersion() (o int64) {
+	if v != nil && v.FailoverVersion != nil {
+		return *v.FailoverVersion
+	}
+	return
+}
+func (v *DomainTaskAttributes) GetPreviousFailoverVersion() (o int64) {
+	if v != nil && v.PreviousFailoverVersion != nil {
+		return *v.PreviousFailoverVersion
+	}
+	return
+}
+
+// FailoverMarkerAttributes is an internal type (TBD...)
+type FailoverMarkerAttributes struct {
+	DomainID        *string
+	FailoverVersion *int64
+	CreationTime    *int64
+}
+
+func (v *FailoverMarkerAttributes) GetDomainID() (o string) {
+	if v != nil && v.DomainID != nil {
+		return *v.DomainID
+	}
+	return
+}
+func (v *FailoverMarkerAttributes) GetFailoverVersion() (o int64) {
+	if v != nil && v.FailoverVersion != nil {
+		return *v.FailoverVersion
+	}
+	return
+}
+func (v *FailoverMarkerAttributes) GetCreationTime() (o int64) {
+	if v != nil && v.CreationTime != nil {
+		return *v.CreationTime
+	}
+	return
+}
+
+// FailoverMarkers is an internal type (TBD...)
+type FailoverMarkers struct {
+	FailoverMarkers []*FailoverMarkerAttributes
+}
+
+func (v *FailoverMarkers) GetFailoverMarkers() (o []*FailoverMarkerAttributes) {
+	if v != nil && v.FailoverMarkers != nil {
+		return v.FailoverMarkers
+	}
+	return
+}
+
+// GetDLQReplicationMessagesRequest is an internal type (TBD...)
+type GetDLQReplicationMessagesRequest struct {
+	TaskInfos []*ReplicationTaskInfo
+}
+
+func (v *GetDLQReplicationMessagesRequest) GetTaskInfos() (o []*ReplicationTaskInfo) {
+	if v != nil && v.TaskInfos != nil {
+		return v.TaskInfos
+	}
+	return
+}
+
+// GetDLQReplicationMessagesResponse is an internal type (TBD...)
+type GetDLQReplicationMessagesResponse struct {
+	ReplicationTasks []*ReplicationTask
+}
+
+func (v *GetDLQReplicationMessagesResponse) GetReplicationTasks() (o []*ReplicationTask) {
+	if v != nil && v.ReplicationTasks != nil {
+		return v.ReplicationTasks
+	}
+	return
+}
+
+// GetDomainReplicationMessagesRequest is an internal type (TBD...)
+type GetDomainReplicationMessagesRequest struct {
+	LastRetrievedMessageID *int64
+	LastProcessedMessageID *int64
+	ClusterName            *string
+}
+
+func (v *GetDomainReplicationMessagesRequest) GetLastRetrievedMessageID() (o int64) {
+	if v != nil && v.LastRetrievedMessageID != nil {
+		return *v.LastRetrievedMessageID
+	}
+	return
+}
+func (v *GetDomainReplicationMessagesRequest) GetLastProcessedMessageID() (o int64) {
+	if v != nil && v.LastProcessedMessageID != nil {
+		return *v.LastProcessedMessageID
+	}
+	return
+}
+func (v *GetDomainReplicationMessagesRequest) GetClusterName() (o string) {
+	if v != nil && v.ClusterName != nil {
+		return *v.ClusterName
+	}
+	return
+}
+
+// GetDomainReplicationMessagesResponse is an internal type (TBD...)
+type GetDomainReplicationMessagesResponse struct {
+	Messages *ReplicationMessages
+}
+
+func (v *GetDomainReplicationMessagesResponse) GetMessages() (o *ReplicationMessages) {
+	if v != nil && v.Messages != nil {
+		return v.Messages
+	}
+	return
+}
+
+// GetReplicationMessagesRequest is an internal type (TBD...)
+type GetReplicationMessagesRequest struct {
+	Tokens      []*ReplicationToken
+	ClusterName *string
+}
+
+func (v *GetReplicationMessagesRequest) GetTokens() (o []*ReplicationToken) {
+	if v != nil && v.Tokens != nil {
+		return v.Tokens
+	}
+	return
+}
+func (v *GetReplicationMessagesRequest) GetClusterName() (o string) {
+	if v != nil && v.ClusterName != nil {
+		return *v.ClusterName
+	}
+	return
+}
+
+// GetReplicationMessagesResponse is an internal type (TBD...)
+type GetReplicationMessagesResponse struct {
+	MessagesByShard map[int32]*ReplicationMessages
+}
+
+func (v *GetReplicationMessagesResponse) GetMessagesByShard() (o map[int32]*ReplicationMessages) {
+	if v != nil && v.MessagesByShard != nil {
+		return v.MessagesByShard
+	}
+	return
+}
+
+// HistoryTaskV2Attributes is an internal type (TBD...)
+type HistoryTaskV2Attributes struct {
+	TaskID              *int64
+	DomainID            *string
+	WorkflowID          *string
+	RunID               *string
+	VersionHistoryItems []*VersionHistoryItem
+	Events              *DataBlob
+	NewRunEvents        *DataBlob
+}
+
+func (v *HistoryTaskV2Attributes) GetTaskID() (o int64) {
+	if v != nil && v.TaskID != nil {
+		return *v.TaskID
+	}
+	return
+}
+func (v *HistoryTaskV2Attributes) GetDomainID() (o string) {
+	if v != nil && v.DomainID != nil {
+		return *v.DomainID
+	}
+	return
+}
+func (v *HistoryTaskV2Attributes) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *HistoryTaskV2Attributes) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *HistoryTaskV2Attributes) GetVersionHistoryItems() (o []*VersionHistoryItem) {
+	if v != nil && v.VersionHistoryItems != nil {
+		return v.VersionHistoryItems
+	}
+	return
+}
+func (v *HistoryTaskV2Attributes) GetEvents() (o *DataBlob) {
+	if v != nil && v.Events != nil {
+		return v.Events
+	}
+	return
+}
+func (v *HistoryTaskV2Attributes) GetNewRunEvents() (o *DataBlob) {
+	if v != nil && v.NewRunEvents != nil {
+		return v.NewRunEvents
+	}
+	return
+}
+
+// MergeDLQMessagesRequest is an internal type (TBD...)
+type MergeDLQMessagesRequest struct {
+	Type                  *DLQType
+	ShardID               *int32
+	SourceCluster         *string
+	InclusiveEndMessageID *int64
+	MaximumPageSize       *int32
+	NextPageToken         []byte
+}
+
+func (v *MergeDLQMessagesRequest) GetType() (o DLQType) {
+	if v != nil && v.Type != nil {
+		return *v.Type
+	}
+	return
+}
+func (v *MergeDLQMessagesRequest) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *MergeDLQMessagesRequest) GetSourceCluster() (o string) {
+	if v != nil && v.SourceCluster != nil {
+		return *v.SourceCluster
+	}
+	return
+}
+func (v *MergeDLQMessagesRequest) GetInclusiveEndMessageID() (o int64) {
+	if v != nil && v.InclusiveEndMessageID != nil {
+		return *v.InclusiveEndMessageID
+	}
+	return
+}
+func (v *MergeDLQMessagesRequest) GetMaximumPageSize() (o int32) {
+	if v != nil && v.MaximumPageSize != nil {
+		return *v.MaximumPageSize
+	}
+	return
+}
+func (v *MergeDLQMessagesRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+
+// MergeDLQMessagesResponse is an internal type (TBD...)
+type MergeDLQMessagesResponse struct {
+	NextPageToken []byte
+}
+
+func (v *MergeDLQMessagesResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+
+// PurgeDLQMessagesRequest is an internal type (TBD...)
+type PurgeDLQMessagesRequest struct {
+	Type                  *DLQType
+	ShardID               *int32
+	SourceCluster         *string
+	InclusiveEndMessageID *int64
+}
+
+func (v *PurgeDLQMessagesRequest) GetType() (o DLQType) {
+	if v != nil && v.Type != nil {
+		return *v.Type
+	}
+	return
+}
+func (v *PurgeDLQMessagesRequest) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *PurgeDLQMessagesRequest) GetSourceCluster() (o string) {
+	if v != nil && v.SourceCluster != nil {
+		return *v.SourceCluster
+	}
+	return
+}
+func (v *PurgeDLQMessagesRequest) GetInclusiveEndMessageID() (o int64) {
+	if v != nil && v.InclusiveEndMessageID != nil {
+		return *v.InclusiveEndMessageID
+	}
+	return
+}
+
+// ReadDLQMessagesRequest is an internal type (TBD...)
+type ReadDLQMessagesRequest struct {
+	Type                  *DLQType
+	ShardID               *int32
+	SourceCluster         *string
+	InclusiveEndMessageID *int64
+	MaximumPageSize       *int32
+	NextPageToken         []byte
+}
+
+func (v *ReadDLQMessagesRequest) GetType() (o DLQType) {
+	if v != nil && v.Type != nil {
+		return *v.Type
+	}
+	return
+}
+func (v *ReadDLQMessagesRequest) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *ReadDLQMessagesRequest) GetSourceCluster() (o string) {
+	if v != nil && v.SourceCluster != nil {
+		return *v.SourceCluster
+	}
+	return
+}
+func (v *ReadDLQMessagesRequest) GetInclusiveEndMessageID() (o int64) {
+	if v != nil && v.InclusiveEndMessageID != nil {
+		return *v.InclusiveEndMessageID
+	}
+	return
+}
+func (v *ReadDLQMessagesRequest) GetMaximumPageSize() (o int32) {
+	if v != nil && v.MaximumPageSize != nil {
+		return *v.MaximumPageSize
+	}
+	return
+}
+func (v *ReadDLQMessagesRequest) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+
+// ReadDLQMessagesResponse is an internal type (TBD...)
+type ReadDLQMessagesResponse struct {
+	Type             *DLQType
+	ReplicationTasks []*ReplicationTask
+	NextPageToken    []byte
+}
+
+func (v *ReadDLQMessagesResponse) GetType() (o DLQType) {
+	if v != nil && v.Type != nil {
+		return *v.Type
+	}
+	return
+}
+func (v *ReadDLQMessagesResponse) GetReplicationTasks() (o []*ReplicationTask) {
+	if v != nil && v.ReplicationTasks != nil {
+		return v.ReplicationTasks
+	}
+	return
+}
+func (v *ReadDLQMessagesResponse) GetNextPageToken() (o []byte) {
+	if v != nil && v.NextPageToken != nil {
+		return v.NextPageToken
+	}
+	return
+}
+
+// ReplicationMessages is an internal type (TBD...)
+type ReplicationMessages struct {
+	ReplicationTasks       []*ReplicationTask
+	LastRetrievedMessageID *int64
+	HasMore                *bool
+	SyncShardStatus        *SyncShardStatus
+}
+
+func (v *ReplicationMessages) GetReplicationTasks() (o []*ReplicationTask) {
+	if v != nil && v.ReplicationTasks != nil {
+		return v.ReplicationTasks
+	}
+	return
+}
+func (v *ReplicationMessages) GetLastRetrievedMessageID() (o int64) {
+	if v != nil && v.LastRetrievedMessageID != nil {
+		return *v.LastRetrievedMessageID
+	}
+	return
+}
+func (v *ReplicationMessages) GetHasMore() (o bool) {
+	if v != nil && v.HasMore != nil {
+		return *v.HasMore
+	}
+	return
+}
+func (v *ReplicationMessages) GetSyncShardStatus() (o *SyncShardStatus) {
+	if v != nil && v.SyncShardStatus != nil {
+		return v.SyncShardStatus
+	}
+	return
+}
+
+// ReplicationTask is an internal type (TBD...)
+type ReplicationTask struct {
+	TaskType                      *ReplicationTaskType
+	SourceTaskID                  *int64
+	DomainTaskAttributes          *DomainTaskAttributes
+	SyncShardStatusTaskAttributes *SyncShardStatusTaskAttributes
+	SyncActivityTaskAttributes    *SyncActivityTaskAttributes
+	HistoryTaskV2Attributes       *HistoryTaskV2Attributes
+	FailoverMarkerAttributes      *FailoverMarkerAttributes
+}
+
+func (v *ReplicationTask) GetTaskType() (o ReplicationTaskType) {
+	if v != nil && v.TaskType != nil {
+		return *v.TaskType
+	}
+	return
+}
+func (v *ReplicationTask) GetSourceTaskID() (o int64) {
+	if v != nil && v.SourceTaskID != nil {
+		return *v.SourceTaskID
+	}
+	return
+}
+func (v *ReplicationTask) GetDomainTaskAttributes() (o *DomainTaskAttributes) {
+	if v != nil && v.DomainTaskAttributes != nil {
+		return v.DomainTaskAttributes
+	}
+	return
+}
+func (v *ReplicationTask) GetSyncShardStatusTaskAttributes() (o *SyncShardStatusTaskAttributes) {
+	if v != nil && v.SyncShardStatusTaskAttributes != nil {
+		return v.SyncShardStatusTaskAttributes
+	}
+	return
+}
+func (v *ReplicationTask) GetSyncActivityTaskAttributes() (o *SyncActivityTaskAttributes) {
+	if v != nil && v.SyncActivityTaskAttributes != nil {
+		return v.SyncActivityTaskAttributes
+	}
+	return
+}
+func (v *ReplicationTask) GetHistoryTaskV2Attributes() (o *HistoryTaskV2Attributes) {
+	if v != nil && v.HistoryTaskV2Attributes != nil {
+		return v.HistoryTaskV2Attributes
+	}
+	return
+}
+func (v *ReplicationTask) GetFailoverMarkerAttributes() (o *FailoverMarkerAttributes) {
+	if v != nil && v.FailoverMarkerAttributes != nil {
+		return v.FailoverMarkerAttributes
+	}
+	return
+}
+
+// ReplicationTaskInfo is an internal type (TBD...)
+type ReplicationTaskInfo struct {
+	DomainID     *string
+	WorkflowID   *string
+	RunID        *string
+	TaskType     *int16
+	TaskID       *int64
+	Version      *int64
+	FirstEventID *int64
+	NextEventID  *int64
+	ScheduledID  *int64
+}
+
+func (v *ReplicationTaskInfo) GetDomainID() (o string) {
+	if v != nil && v.DomainID != nil {
+		return *v.DomainID
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetTaskType() (o int16) {
+	if v != nil && v.TaskType != nil {
+		return *v.TaskType
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetTaskID() (o int64) {
+	if v != nil && v.TaskID != nil {
+		return *v.TaskID
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetVersion() (o int64) {
+	if v != nil && v.Version != nil {
+		return *v.Version
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetFirstEventID() (o int64) {
+	if v != nil && v.FirstEventID != nil {
+		return *v.FirstEventID
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetNextEventID() (o int64) {
+	if v != nil && v.NextEventID != nil {
+		return *v.NextEventID
+	}
+	return
+}
+func (v *ReplicationTaskInfo) GetScheduledID() (o int64) {
+	if v != nil && v.ScheduledID != nil {
+		return *v.ScheduledID
+	}
+	return
+}
+
+// ReplicationTaskType is an internal type (TBD...)
+type ReplicationTaskType int32
+
+const (
+	// ReplicationTaskTypeDomain is an option for ReplicationTaskType
+	ReplicationTaskTypeDomain ReplicationTaskType = iota
+	// ReplicationTaskTypeFailoverMarker is an option for ReplicationTaskType
+	ReplicationTaskTypeFailoverMarker
+	// ReplicationTaskTypeHistory is an option for ReplicationTaskType
+	ReplicationTaskTypeHistory
+	// ReplicationTaskTypeHistoryMetadata is an option for ReplicationTaskType
+	ReplicationTaskTypeHistoryMetadata
+	// ReplicationTaskTypeHistoryV2 is an option for ReplicationTaskType
+	ReplicationTaskTypeHistoryV2
+	// ReplicationTaskTypeSyncActivity is an option for ReplicationTaskType
+	ReplicationTaskTypeSyncActivity
+	// ReplicationTaskTypeSyncShardStatus is an option for ReplicationTaskType
+	ReplicationTaskTypeSyncShardStatus
+)
+
+// ReplicationToken is an internal type (TBD...)
+type ReplicationToken struct {
+	ShardID                *int32
+	LastRetrievedMessageID *int64
+	LastProcessedMessageID *int64
+}
+
+func (v *ReplicationToken) GetShardID() (o int32) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *ReplicationToken) GetLastRetrievedMessageID() (o int64) {
+	if v != nil && v.LastRetrievedMessageID != nil {
+		return *v.LastRetrievedMessageID
+	}
+	return
+}
+func (v *ReplicationToken) GetLastProcessedMessageID() (o int64) {
+	if v != nil && v.LastProcessedMessageID != nil {
+		return *v.LastProcessedMessageID
+	}
+	return
+}
+
+// SyncActivityTaskAttributes is an internal type (TBD...)
+type SyncActivityTaskAttributes struct {
+	DomainID           *string
+	WorkflowID         *string
+	RunID              *string
+	Version            *int64
+	ScheduledID        *int64
+	ScheduledTime      *int64
+	StartedID          *int64
+	StartedTime        *int64
+	LastHeartbeatTime  *int64
+	Details            []byte
+	Attempt            *int32
+	LastFailureReason  *string
+	LastWorkerIdentity *string
+	LastFailureDetails []byte
+	VersionHistory     *VersionHistory
+}
+
+func (v *SyncActivityTaskAttributes) GetDomainID() (o string) {
+	if v != nil && v.DomainID != nil {
+		return *v.DomainID
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetWorkflowID() (o string) {
+	if v != nil && v.WorkflowID != nil {
+		return *v.WorkflowID
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetRunID() (o string) {
+	if v != nil && v.RunID != nil {
+		return *v.RunID
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetVersion() (o int64) {
+	if v != nil && v.Version != nil {
+		return *v.Version
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetScheduledID() (o int64) {
+	if v != nil && v.ScheduledID != nil {
+		return *v.ScheduledID
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetScheduledTime() (o int64) {
+	if v != nil && v.ScheduledTime != nil {
+		return *v.ScheduledTime
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetStartedID() (o int64) {
+	if v != nil && v.StartedID != nil {
+		return *v.StartedID
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetStartedTime() (o int64) {
+	if v != nil && v.StartedTime != nil {
+		return *v.StartedTime
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetLastHeartbeatTime() (o int64) {
+	if v != nil && v.LastHeartbeatTime != nil {
+		return *v.LastHeartbeatTime
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetDetails() (o []byte) {
+	if v != nil && v.Details != nil {
+		return v.Details
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetAttempt() (o int32) {
+	if v != nil && v.Attempt != nil {
+		return *v.Attempt
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetLastFailureReason() (o string) {
+	if v != nil && v.LastFailureReason != nil {
+		return *v.LastFailureReason
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetLastWorkerIdentity() (o string) {
+	if v != nil && v.LastWorkerIdentity != nil {
+		return *v.LastWorkerIdentity
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetLastFailureDetails() (o []byte) {
+	if v != nil && v.LastFailureDetails != nil {
+		return v.LastFailureDetails
+	}
+	return
+}
+func (v *SyncActivityTaskAttributes) GetVersionHistory() (o *VersionHistory) {
+	if v != nil && v.VersionHistory != nil {
+		return v.VersionHistory
+	}
+	return
+}
+
+// SyncShardStatus is an internal type (TBD...)
+type SyncShardStatus struct {
+	Timestamp *int64
+}
+
+func (v *SyncShardStatus) GetTimestamp() (o int64) {
+	if v != nil && v.Timestamp != nil {
+		return *v.Timestamp
+	}
+	return
+}
+
+// SyncShardStatusTaskAttributes is an internal type (TBD...)
+type SyncShardStatusTaskAttributes struct {
+	SourceCluster *string
+	ShardID       *int64
+	Timestamp     *int64
+}
+
+func (v *SyncShardStatusTaskAttributes) GetSourceCluster() (o string) {
+	if v != nil && v.SourceCluster != nil {
+		return *v.SourceCluster
+	}
+	return
+}
+func (v *SyncShardStatusTaskAttributes) GetShardID() (o int64) {
+	if v != nil && v.ShardID != nil {
+		return *v.ShardID
+	}
+	return
+}
+func (v *SyncShardStatusTaskAttributes) GetTimestamp() (o int64) {
+	if v != nil && v.Timestamp != nil {
+		return *v.Timestamp
+	}
+	return
+}

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -52,48 +52,63 @@ type DomainTaskAttributes struct {
 	PreviousFailoverVersion *int64
 }
 
+// GetDomainOperation is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetDomainOperation() (o DomainOperation) {
 	if v != nil && v.DomainOperation != nil {
 		return *v.DomainOperation
 	}
 	return
 }
+
+// GetID is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetID() (o string) {
 	if v != nil && v.ID != nil {
 		return *v.ID
 	}
 	return
 }
+
+// GetInfo is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetInfo() (o *DomainInfo) {
 	if v != nil && v.Info != nil {
 		return v.Info
 	}
 	return
 }
+
+// GetConfig is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetConfig() (o *DomainConfiguration) {
 	if v != nil && v.Config != nil {
 		return v.Config
 	}
 	return
 }
+
+// GetReplicationConfig is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetReplicationConfig() (o *DomainReplicationConfiguration) {
 	if v != nil && v.ReplicationConfig != nil {
 		return v.ReplicationConfig
 	}
 	return
 }
+
+// GetConfigVersion is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetConfigVersion() (o int64) {
 	if v != nil && v.ConfigVersion != nil {
 		return *v.ConfigVersion
 	}
 	return
 }
+
+// GetFailoverVersion is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetFailoverVersion() (o int64) {
 	if v != nil && v.FailoverVersion != nil {
 		return *v.FailoverVersion
 	}
 	return
 }
+
+// GetPreviousFailoverVersion is an internal getter (TBD...)
 func (v *DomainTaskAttributes) GetPreviousFailoverVersion() (o int64) {
 	if v != nil && v.PreviousFailoverVersion != nil {
 		return *v.PreviousFailoverVersion
@@ -108,18 +123,23 @@ type FailoverMarkerAttributes struct {
 	CreationTime    *int64
 }
 
+// GetDomainID is an internal getter (TBD...)
 func (v *FailoverMarkerAttributes) GetDomainID() (o string) {
 	if v != nil && v.DomainID != nil {
 		return *v.DomainID
 	}
 	return
 }
+
+// GetFailoverVersion is an internal getter (TBD...)
 func (v *FailoverMarkerAttributes) GetFailoverVersion() (o int64) {
 	if v != nil && v.FailoverVersion != nil {
 		return *v.FailoverVersion
 	}
 	return
 }
+
+// GetCreationTime is an internal getter (TBD...)
 func (v *FailoverMarkerAttributes) GetCreationTime() (o int64) {
 	if v != nil && v.CreationTime != nil {
 		return *v.CreationTime
@@ -132,6 +152,7 @@ type FailoverMarkers struct {
 	FailoverMarkers []*FailoverMarkerAttributes
 }
 
+// GetFailoverMarkers is an internal getter (TBD...)
 func (v *FailoverMarkers) GetFailoverMarkers() (o []*FailoverMarkerAttributes) {
 	if v != nil && v.FailoverMarkers != nil {
 		return v.FailoverMarkers
@@ -144,6 +165,7 @@ type GetDLQReplicationMessagesRequest struct {
 	TaskInfos []*ReplicationTaskInfo
 }
 
+// GetTaskInfos is an internal getter (TBD...)
 func (v *GetDLQReplicationMessagesRequest) GetTaskInfos() (o []*ReplicationTaskInfo) {
 	if v != nil && v.TaskInfos != nil {
 		return v.TaskInfos
@@ -156,6 +178,7 @@ type GetDLQReplicationMessagesResponse struct {
 	ReplicationTasks []*ReplicationTask
 }
 
+// GetReplicationTasks is an internal getter (TBD...)
 func (v *GetDLQReplicationMessagesResponse) GetReplicationTasks() (o []*ReplicationTask) {
 	if v != nil && v.ReplicationTasks != nil {
 		return v.ReplicationTasks
@@ -170,18 +193,23 @@ type GetDomainReplicationMessagesRequest struct {
 	ClusterName            *string
 }
 
+// GetLastRetrievedMessageID is an internal getter (TBD...)
 func (v *GetDomainReplicationMessagesRequest) GetLastRetrievedMessageID() (o int64) {
 	if v != nil && v.LastRetrievedMessageID != nil {
 		return *v.LastRetrievedMessageID
 	}
 	return
 }
+
+// GetLastProcessedMessageID is an internal getter (TBD...)
 func (v *GetDomainReplicationMessagesRequest) GetLastProcessedMessageID() (o int64) {
 	if v != nil && v.LastProcessedMessageID != nil {
 		return *v.LastProcessedMessageID
 	}
 	return
 }
+
+// GetClusterName is an internal getter (TBD...)
 func (v *GetDomainReplicationMessagesRequest) GetClusterName() (o string) {
 	if v != nil && v.ClusterName != nil {
 		return *v.ClusterName
@@ -194,6 +222,7 @@ type GetDomainReplicationMessagesResponse struct {
 	Messages *ReplicationMessages
 }
 
+// GetMessages is an internal getter (TBD...)
 func (v *GetDomainReplicationMessagesResponse) GetMessages() (o *ReplicationMessages) {
 	if v != nil && v.Messages != nil {
 		return v.Messages
@@ -207,12 +236,15 @@ type GetReplicationMessagesRequest struct {
 	ClusterName *string
 }
 
+// GetTokens is an internal getter (TBD...)
 func (v *GetReplicationMessagesRequest) GetTokens() (o []*ReplicationToken) {
 	if v != nil && v.Tokens != nil {
 		return v.Tokens
 	}
 	return
 }
+
+// GetClusterName is an internal getter (TBD...)
 func (v *GetReplicationMessagesRequest) GetClusterName() (o string) {
 	if v != nil && v.ClusterName != nil {
 		return *v.ClusterName
@@ -225,6 +257,7 @@ type GetReplicationMessagesResponse struct {
 	MessagesByShard map[int32]*ReplicationMessages
 }
 
+// GetMessagesByShard is an internal getter (TBD...)
 func (v *GetReplicationMessagesResponse) GetMessagesByShard() (o map[int32]*ReplicationMessages) {
 	if v != nil && v.MessagesByShard != nil {
 		return v.MessagesByShard
@@ -243,42 +276,55 @@ type HistoryTaskV2Attributes struct {
 	NewRunEvents        *DataBlob
 }
 
+// GetTaskID is an internal getter (TBD...)
 func (v *HistoryTaskV2Attributes) GetTaskID() (o int64) {
 	if v != nil && v.TaskID != nil {
 		return *v.TaskID
 	}
 	return
 }
+
+// GetDomainID is an internal getter (TBD...)
 func (v *HistoryTaskV2Attributes) GetDomainID() (o string) {
 	if v != nil && v.DomainID != nil {
 		return *v.DomainID
 	}
 	return
 }
+
+// GetWorkflowID is an internal getter (TBD...)
 func (v *HistoryTaskV2Attributes) GetWorkflowID() (o string) {
 	if v != nil && v.WorkflowID != nil {
 		return *v.WorkflowID
 	}
 	return
 }
+
+// GetRunID is an internal getter (TBD...)
 func (v *HistoryTaskV2Attributes) GetRunID() (o string) {
 	if v != nil && v.RunID != nil {
 		return *v.RunID
 	}
 	return
 }
+
+// GetVersionHistoryItems is an internal getter (TBD...)
 func (v *HistoryTaskV2Attributes) GetVersionHistoryItems() (o []*VersionHistoryItem) {
 	if v != nil && v.VersionHistoryItems != nil {
 		return v.VersionHistoryItems
 	}
 	return
 }
+
+// GetEvents is an internal getter (TBD...)
 func (v *HistoryTaskV2Attributes) GetEvents() (o *DataBlob) {
 	if v != nil && v.Events != nil {
 		return v.Events
 	}
 	return
 }
+
+// GetNewRunEvents is an internal getter (TBD...)
 func (v *HistoryTaskV2Attributes) GetNewRunEvents() (o *DataBlob) {
 	if v != nil && v.NewRunEvents != nil {
 		return v.NewRunEvents
@@ -296,36 +342,47 @@ type MergeDLQMessagesRequest struct {
 	NextPageToken         []byte
 }
 
+// GetType is an internal getter (TBD...)
 func (v *MergeDLQMessagesRequest) GetType() (o DLQType) {
 	if v != nil && v.Type != nil {
 		return *v.Type
 	}
 	return
 }
+
+// GetShardID is an internal getter (TBD...)
 func (v *MergeDLQMessagesRequest) GetShardID() (o int32) {
 	if v != nil && v.ShardID != nil {
 		return *v.ShardID
 	}
 	return
 }
+
+// GetSourceCluster is an internal getter (TBD...)
 func (v *MergeDLQMessagesRequest) GetSourceCluster() (o string) {
 	if v != nil && v.SourceCluster != nil {
 		return *v.SourceCluster
 	}
 	return
 }
+
+// GetInclusiveEndMessageID is an internal getter (TBD...)
 func (v *MergeDLQMessagesRequest) GetInclusiveEndMessageID() (o int64) {
 	if v != nil && v.InclusiveEndMessageID != nil {
 		return *v.InclusiveEndMessageID
 	}
 	return
 }
+
+// GetMaximumPageSize is an internal getter (TBD...)
 func (v *MergeDLQMessagesRequest) GetMaximumPageSize() (o int32) {
 	if v != nil && v.MaximumPageSize != nil {
 		return *v.MaximumPageSize
 	}
 	return
 }
+
+// GetNextPageToken is an internal getter (TBD...)
 func (v *MergeDLQMessagesRequest) GetNextPageToken() (o []byte) {
 	if v != nil && v.NextPageToken != nil {
 		return v.NextPageToken
@@ -338,6 +395,7 @@ type MergeDLQMessagesResponse struct {
 	NextPageToken []byte
 }
 
+// GetNextPageToken is an internal getter (TBD...)
 func (v *MergeDLQMessagesResponse) GetNextPageToken() (o []byte) {
 	if v != nil && v.NextPageToken != nil {
 		return v.NextPageToken
@@ -353,24 +411,31 @@ type PurgeDLQMessagesRequest struct {
 	InclusiveEndMessageID *int64
 }
 
+// GetType is an internal getter (TBD...)
 func (v *PurgeDLQMessagesRequest) GetType() (o DLQType) {
 	if v != nil && v.Type != nil {
 		return *v.Type
 	}
 	return
 }
+
+// GetShardID is an internal getter (TBD...)
 func (v *PurgeDLQMessagesRequest) GetShardID() (o int32) {
 	if v != nil && v.ShardID != nil {
 		return *v.ShardID
 	}
 	return
 }
+
+// GetSourceCluster is an internal getter (TBD...)
 func (v *PurgeDLQMessagesRequest) GetSourceCluster() (o string) {
 	if v != nil && v.SourceCluster != nil {
 		return *v.SourceCluster
 	}
 	return
 }
+
+// GetInclusiveEndMessageID is an internal getter (TBD...)
 func (v *PurgeDLQMessagesRequest) GetInclusiveEndMessageID() (o int64) {
 	if v != nil && v.InclusiveEndMessageID != nil {
 		return *v.InclusiveEndMessageID
@@ -388,36 +453,47 @@ type ReadDLQMessagesRequest struct {
 	NextPageToken         []byte
 }
 
+// GetType is an internal getter (TBD...)
 func (v *ReadDLQMessagesRequest) GetType() (o DLQType) {
 	if v != nil && v.Type != nil {
 		return *v.Type
 	}
 	return
 }
+
+// GetShardID is an internal getter (TBD...)
 func (v *ReadDLQMessagesRequest) GetShardID() (o int32) {
 	if v != nil && v.ShardID != nil {
 		return *v.ShardID
 	}
 	return
 }
+
+// GetSourceCluster is an internal getter (TBD...)
 func (v *ReadDLQMessagesRequest) GetSourceCluster() (o string) {
 	if v != nil && v.SourceCluster != nil {
 		return *v.SourceCluster
 	}
 	return
 }
+
+// GetInclusiveEndMessageID is an internal getter (TBD...)
 func (v *ReadDLQMessagesRequest) GetInclusiveEndMessageID() (o int64) {
 	if v != nil && v.InclusiveEndMessageID != nil {
 		return *v.InclusiveEndMessageID
 	}
 	return
 }
+
+// GetMaximumPageSize is an internal getter (TBD...)
 func (v *ReadDLQMessagesRequest) GetMaximumPageSize() (o int32) {
 	if v != nil && v.MaximumPageSize != nil {
 		return *v.MaximumPageSize
 	}
 	return
 }
+
+// GetNextPageToken is an internal getter (TBD...)
 func (v *ReadDLQMessagesRequest) GetNextPageToken() (o []byte) {
 	if v != nil && v.NextPageToken != nil {
 		return v.NextPageToken
@@ -432,18 +508,23 @@ type ReadDLQMessagesResponse struct {
 	NextPageToken    []byte
 }
 
+// GetType is an internal getter (TBD...)
 func (v *ReadDLQMessagesResponse) GetType() (o DLQType) {
 	if v != nil && v.Type != nil {
 		return *v.Type
 	}
 	return
 }
+
+// GetReplicationTasks is an internal getter (TBD...)
 func (v *ReadDLQMessagesResponse) GetReplicationTasks() (o []*ReplicationTask) {
 	if v != nil && v.ReplicationTasks != nil {
 		return v.ReplicationTasks
 	}
 	return
 }
+
+// GetNextPageToken is an internal getter (TBD...)
 func (v *ReadDLQMessagesResponse) GetNextPageToken() (o []byte) {
 	if v != nil && v.NextPageToken != nil {
 		return v.NextPageToken
@@ -459,24 +540,31 @@ type ReplicationMessages struct {
 	SyncShardStatus        *SyncShardStatus
 }
 
+// GetReplicationTasks is an internal getter (TBD...)
 func (v *ReplicationMessages) GetReplicationTasks() (o []*ReplicationTask) {
 	if v != nil && v.ReplicationTasks != nil {
 		return v.ReplicationTasks
 	}
 	return
 }
+
+// GetLastRetrievedMessageID is an internal getter (TBD...)
 func (v *ReplicationMessages) GetLastRetrievedMessageID() (o int64) {
 	if v != nil && v.LastRetrievedMessageID != nil {
 		return *v.LastRetrievedMessageID
 	}
 	return
 }
+
+// GetHasMore is an internal getter (TBD...)
 func (v *ReplicationMessages) GetHasMore() (o bool) {
 	if v != nil && v.HasMore != nil {
 		return *v.HasMore
 	}
 	return
 }
+
+// GetSyncShardStatus is an internal getter (TBD...)
 func (v *ReplicationMessages) GetSyncShardStatus() (o *SyncShardStatus) {
 	if v != nil && v.SyncShardStatus != nil {
 		return v.SyncShardStatus
@@ -495,42 +583,55 @@ type ReplicationTask struct {
 	FailoverMarkerAttributes      *FailoverMarkerAttributes
 }
 
+// GetTaskType is an internal getter (TBD...)
 func (v *ReplicationTask) GetTaskType() (o ReplicationTaskType) {
 	if v != nil && v.TaskType != nil {
 		return *v.TaskType
 	}
 	return
 }
+
+// GetSourceTaskID is an internal getter (TBD...)
 func (v *ReplicationTask) GetSourceTaskID() (o int64) {
 	if v != nil && v.SourceTaskID != nil {
 		return *v.SourceTaskID
 	}
 	return
 }
+
+// GetDomainTaskAttributes is an internal getter (TBD...)
 func (v *ReplicationTask) GetDomainTaskAttributes() (o *DomainTaskAttributes) {
 	if v != nil && v.DomainTaskAttributes != nil {
 		return v.DomainTaskAttributes
 	}
 	return
 }
+
+// GetSyncShardStatusTaskAttributes is an internal getter (TBD...)
 func (v *ReplicationTask) GetSyncShardStatusTaskAttributes() (o *SyncShardStatusTaskAttributes) {
 	if v != nil && v.SyncShardStatusTaskAttributes != nil {
 		return v.SyncShardStatusTaskAttributes
 	}
 	return
 }
+
+// GetSyncActivityTaskAttributes is an internal getter (TBD...)
 func (v *ReplicationTask) GetSyncActivityTaskAttributes() (o *SyncActivityTaskAttributes) {
 	if v != nil && v.SyncActivityTaskAttributes != nil {
 		return v.SyncActivityTaskAttributes
 	}
 	return
 }
+
+// GetHistoryTaskV2Attributes is an internal getter (TBD...)
 func (v *ReplicationTask) GetHistoryTaskV2Attributes() (o *HistoryTaskV2Attributes) {
 	if v != nil && v.HistoryTaskV2Attributes != nil {
 		return v.HistoryTaskV2Attributes
 	}
 	return
 }
+
+// GetFailoverMarkerAttributes is an internal getter (TBD...)
 func (v *ReplicationTask) GetFailoverMarkerAttributes() (o *FailoverMarkerAttributes) {
 	if v != nil && v.FailoverMarkerAttributes != nil {
 		return v.FailoverMarkerAttributes
@@ -551,54 +652,71 @@ type ReplicationTaskInfo struct {
 	ScheduledID  *int64
 }
 
+// GetDomainID is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetDomainID() (o string) {
 	if v != nil && v.DomainID != nil {
 		return *v.DomainID
 	}
 	return
 }
+
+// GetWorkflowID is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetWorkflowID() (o string) {
 	if v != nil && v.WorkflowID != nil {
 		return *v.WorkflowID
 	}
 	return
 }
+
+// GetRunID is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetRunID() (o string) {
 	if v != nil && v.RunID != nil {
 		return *v.RunID
 	}
 	return
 }
+
+// GetTaskType is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetTaskType() (o int16) {
 	if v != nil && v.TaskType != nil {
 		return *v.TaskType
 	}
 	return
 }
+
+// GetTaskID is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetTaskID() (o int64) {
 	if v != nil && v.TaskID != nil {
 		return *v.TaskID
 	}
 	return
 }
+
+// GetVersion is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetVersion() (o int64) {
 	if v != nil && v.Version != nil {
 		return *v.Version
 	}
 	return
 }
+
+// GetFirstEventID is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetFirstEventID() (o int64) {
 	if v != nil && v.FirstEventID != nil {
 		return *v.FirstEventID
 	}
 	return
 }
+
+// GetNextEventID is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetNextEventID() (o int64) {
 	if v != nil && v.NextEventID != nil {
 		return *v.NextEventID
 	}
 	return
 }
+
+// GetScheduledID is an internal getter (TBD...)
 func (v *ReplicationTaskInfo) GetScheduledID() (o int64) {
 	if v != nil && v.ScheduledID != nil {
 		return *v.ScheduledID
@@ -633,18 +751,23 @@ type ReplicationToken struct {
 	LastProcessedMessageID *int64
 }
 
+// GetShardID is an internal getter (TBD...)
 func (v *ReplicationToken) GetShardID() (o int32) {
 	if v != nil && v.ShardID != nil {
 		return *v.ShardID
 	}
 	return
 }
+
+// GetLastRetrievedMessageID is an internal getter (TBD...)
 func (v *ReplicationToken) GetLastRetrievedMessageID() (o int64) {
 	if v != nil && v.LastRetrievedMessageID != nil {
 		return *v.LastRetrievedMessageID
 	}
 	return
 }
+
+// GetLastProcessedMessageID is an internal getter (TBD...)
 func (v *ReplicationToken) GetLastProcessedMessageID() (o int64) {
 	if v != nil && v.LastProcessedMessageID != nil {
 		return *v.LastProcessedMessageID
@@ -671,90 +794,119 @@ type SyncActivityTaskAttributes struct {
 	VersionHistory     *VersionHistory
 }
 
+// GetDomainID is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetDomainID() (o string) {
 	if v != nil && v.DomainID != nil {
 		return *v.DomainID
 	}
 	return
 }
+
+// GetWorkflowID is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetWorkflowID() (o string) {
 	if v != nil && v.WorkflowID != nil {
 		return *v.WorkflowID
 	}
 	return
 }
+
+// GetRunID is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetRunID() (o string) {
 	if v != nil && v.RunID != nil {
 		return *v.RunID
 	}
 	return
 }
+
+// GetVersion is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetVersion() (o int64) {
 	if v != nil && v.Version != nil {
 		return *v.Version
 	}
 	return
 }
+
+// GetScheduledID is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetScheduledID() (o int64) {
 	if v != nil && v.ScheduledID != nil {
 		return *v.ScheduledID
 	}
 	return
 }
+
+// GetScheduledTime is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetScheduledTime() (o int64) {
 	if v != nil && v.ScheduledTime != nil {
 		return *v.ScheduledTime
 	}
 	return
 }
+
+// GetStartedID is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetStartedID() (o int64) {
 	if v != nil && v.StartedID != nil {
 		return *v.StartedID
 	}
 	return
 }
+
+// GetStartedTime is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetStartedTime() (o int64) {
 	if v != nil && v.StartedTime != nil {
 		return *v.StartedTime
 	}
 	return
 }
+
+// GetLastHeartbeatTime is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetLastHeartbeatTime() (o int64) {
 	if v != nil && v.LastHeartbeatTime != nil {
 		return *v.LastHeartbeatTime
 	}
 	return
 }
+
+// GetDetails is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetDetails() (o []byte) {
 	if v != nil && v.Details != nil {
 		return v.Details
 	}
 	return
 }
+
+// GetAttempt is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetAttempt() (o int32) {
 	if v != nil && v.Attempt != nil {
 		return *v.Attempt
 	}
 	return
 }
+
+// GetLastFailureReason is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetLastFailureReason() (o string) {
 	if v != nil && v.LastFailureReason != nil {
 		return *v.LastFailureReason
 	}
 	return
 }
+
+// GetLastWorkerIdentity is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetLastWorkerIdentity() (o string) {
 	if v != nil && v.LastWorkerIdentity != nil {
 		return *v.LastWorkerIdentity
 	}
 	return
 }
+
+// GetLastFailureDetails is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetLastFailureDetails() (o []byte) {
 	if v != nil && v.LastFailureDetails != nil {
 		return v.LastFailureDetails
 	}
 	return
 }
+
+// GetVersionHistory is an internal getter (TBD...)
 func (v *SyncActivityTaskAttributes) GetVersionHistory() (o *VersionHistory) {
 	if v != nil && v.VersionHistory != nil {
 		return v.VersionHistory
@@ -767,6 +919,7 @@ type SyncShardStatus struct {
 	Timestamp *int64
 }
 
+// GetTimestamp is an internal getter (TBD...)
 func (v *SyncShardStatus) GetTimestamp() (o int64) {
 	if v != nil && v.Timestamp != nil {
 		return *v.Timestamp
@@ -781,18 +934,23 @@ type SyncShardStatusTaskAttributes struct {
 	Timestamp     *int64
 }
 
+// GetSourceCluster is an internal getter (TBD...)
 func (v *SyncShardStatusTaskAttributes) GetSourceCluster() (o string) {
 	if v != nil && v.SourceCluster != nil {
 		return *v.SourceCluster
 	}
 	return
 }
+
+// GetShardID is an internal getter (TBD...)
 func (v *SyncShardStatusTaskAttributes) GetShardID() (o int64) {
 	if v != nil && v.ShardID != nil {
 		return *v.ShardID
 	}
 	return
 }
+
+// GetTimestamp is an internal getter (TBD...)
 func (v *SyncShardStatusTaskAttributes) GetTimestamp() (o int64) {
 	if v != nil && v.Timestamp != nil {
 		return *v.Timestamp


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
This diff adds replicator internal types to the set of generated types. In order to this a few changes had to be made 
- Handling all map types now instead of just string maps 
- Handling fields which are declared in other packages correctly keeping track of current symbols in addition to global symbols. 

