### PR TITLE
Only query on sticky task list when domain is active

### DIFF
--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1218,11 +1218,16 @@ func (e *historyEngineImpl) queryDirectlyThroughMatching(
 	sw := scope.StartTimer(metrics.DirectQueryDispatchLatency)
 	defer sw.Stop()
 
+	de, err := e.shard.GetDomainCache().GetDomainByID(domainID)
+	if err != nil {
+		return nil, err
+	}
 	supportsStickyQuery := e.clientChecker.SupportsStickyQuery(msResp.GetClientImpl(), msResp.GetClientFeatureVersion()) == nil
 	if msResp.GetIsStickyTaskListEnabled() &&
 		len(msResp.GetStickyTaskList().GetName()) != 0 &&
 		supportsStickyQuery &&
-		e.config.EnableStickyQuery(queryRequest.GetDomain()) {
+		e.config.EnableStickyQuery(queryRequest.GetDomain()) &&
+		de.IsDomainActive() {
 
 		stickyMatchingRequest := &m.QueryWorkflowRequest{
 			DomainUUID:   common.StringPtr(domainID),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1218,6 +1218,12 @@ func (e *historyEngineImpl) queryDirectlyThroughMatching(
 	sw := scope.StartTimer(metrics.DirectQueryDispatchLatency)
 	defer sw.Stop()
 
+	// Sticky task list is not very useful in the standby cluster because the decider cache is
+	// not updated by dispatching tasks to it (it is only updated in the case of query).
+	// Additionally on the standby side we are not even able to clear sticky.
+	// Stickiness might be outdated if the customer did a restart of their nodes causing a query
+	// dispatched on the standby side on sticky to hang. We decided it made sense to simply not attempt
+	// query on sticky task list at all on the passive side.
 	de, err := e.shard.GetDomainCache().GetDomainByID(domainID)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
In the non-active cluster we no longer attempt to query on sticky task list. 


<!-- Tell your future self why have you made these changes -->
Sticky task list is not very useful in the standby cluster because the decider cache is not updated by dispatching tasks to it (it is only updated in the case of query). Additionally on the standby side we are not even able to clear sticky. Stickiness might be outdated if the customer did a restart of their nodes causing a query dispatched on the standby side on sticky to hang. We decided it made sense to simply not attempt query on sticky task list at all on the passive side. 
