### PR TITLE
Improve reset CLI: add DecisionCompletedTime as resetType and also provide …

### DIFF
--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -20,7 +20,7 @@
 
 package history
 
-import ( 
+import (
 	"context"
 	"encoding/json"
 	"errors"

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -80,6 +80,7 @@ var resetTypesMap = map[string]string{
 	"LastDecisionCompleted":  "",
 	"LastContinuedAsNew":     "",
 	"BadBinary":              FlagResetBadBinaryChecksum,
+	"DecisionStartedTime":    FlagEarliestTime,
 }
 
 type jsonType int

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -80,7 +80,7 @@ var resetTypesMap = map[string]string{
 	"LastDecisionCompleted":  "",
 	"LastContinuedAsNew":     "",
 	"BadBinary":              FlagResetBadBinaryChecksum,
-	"DecisionStartedTime":    FlagEarliestTime,
+	"DecisionCompletedTime":  FlagEarliestTime,
 }
 
 type jsonType int

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -75,12 +75,18 @@ var envKeysForUserName = []string{
 	"HOME",
 }
 
+const resetTypeFirstDecisionCompleted = "FirstDecisionCompleted"
+const resetTypeLastDecisionCompleted = "LastDecisionCompleted"
+const resetTypeLastContinuedAsNew = "LastContinuedAsNew"
+const resetTypeBadBinary = "BadBinary"
+const resetTypeDecisionCompletedTime = "DecisionCompletedTime"
+
 var resetTypesMap = map[string]string{
-	"FirstDecisionCompleted": "",
-	"LastDecisionCompleted":  "",
-	"LastContinuedAsNew":     "",
-	"BadBinary":              FlagResetBadBinaryChecksum,
-	"DecisionCompletedTime":  FlagEarliestTime,
+	resetTypeFirstDecisionCompleted: "",
+	resetTypeLastDecisionCompleted:  "",
+	resetTypeLastContinuedAsNew:     "",
+	resetTypeBadBinary:              FlagResetBadBinaryChecksum,
+	resetTypeDecisionCompletedTime:  FlagEarliestTime,
 }
 
 type jsonType int

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -260,11 +260,6 @@ func newWorkflowCommands() []cli.Command {
 					Name:  FlagResetBadBinaryChecksum,
 					Usage: "Binary checksum for resetType of BadBinary",
 				},
-				cli.BoolFlag{
-					Name:  FlagSkipSignalReapply,
-					Usage: "whether or not skipping signals reapply after the reset point",
-				},
-
 				cli.StringFlag{
 					Name: FlagEarliestTimeWithAlias,
 					Usage: "EarliestTime of decision start time, required for resetType of DecisionCompletedTime." +
@@ -272,6 +267,10 @@ func newWorkflowCommands() []cli.Command {
 						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
 						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes, " +
 						"meaning that workflow will be reset to the first decision that completed in last 15 minutes.",
+				},
+				cli.BoolFlag{
+					Name:  FlagSkipSignalReapply,
+					Usage: "whether or not skipping signals reapply after the reset point",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -244,8 +244,9 @@ func newWorkflowCommands() []cli.Command {
 					Usage: "RunID, optional, default to the current/latest RunID",
 				},
 				cli.StringFlag{
-					Name:  FlagEventID,
-					Usage: "The eventID of any event after DecisionTaskStarted you want to reset to (exclusive). It can be DecisionTaskCompleted, DecisionTaskFailed or others",
+					Name: FlagEventID,
+					Usage: "The eventID of any event after DecisionTaskStarted you want to reset to (this event is exclusive in a new run. The new run " +
+						"history will fork and continue from the previous eventID of this). It can be DecisionTaskCompleted, DecisionTaskFailed or others",
 				},
 				cli.StringFlag{
 					Name:  FlagReason,
@@ -266,11 +267,11 @@ func newWorkflowCommands() []cli.Command {
 
 				cli.StringFlag{
 					Name: FlagEarliestTimeWithAlias,
-					Usage: "EarliestTime of decision start time, for resetType of DecisionStartedTime." +
+					Usage: "EarliestTime of decision start time, required for resetType of DecisionCompletedTime." +
 						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
 						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
 						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes, " +
-						"meaning that workflow will be reset to the first decision that started in last 15 minutes.",
+						"meaning that workflow will be reset to the first decision that completed in last 15 minutes.",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -342,11 +343,11 @@ func newWorkflowCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name: FlagEarliestTimeWithAlias,
-					Usage: "EarliestTime of decision start time, for resetType of DecisionStartedTime." +
+					Usage: "EarliestTime of decision start time, required for resetType of DecisionCompletedTime." +
 						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
 						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
 						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes, " +
-						"meaning that workflow will be reset to the first decision that started in last 15 minutes.",
+						"meaning that workflow will be reset to the first decision that completed in last 15 minutes.",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -237,11 +237,11 @@ func newWorkflowCommands() []cli.Command {
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagWorkflowIDWithAlias,
-					Usage: "WorkflowID",
+					Usage: "WorkflowID, required",
 				},
 				cli.StringFlag{
 					Name:  FlagRunIDWithAlias,
-					Usage: "RunID",
+					Usage: "RunID, optional, default to the current/latest RunID",
 				},
 				cli.StringFlag{
 					Name:  FlagEventID,
@@ -249,7 +249,7 @@ func newWorkflowCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  FlagReason,
-					Usage: "reason to do the reset",
+					Usage: "reason to do the reset, required for tracking purpose",
 				},
 				cli.StringFlag{
 					Name:  FlagResetType,
@@ -262,6 +262,15 @@ func newWorkflowCommands() []cli.Command {
 				cli.BoolFlag{
 					Name:  FlagSkipSignalReapply,
 					Usage: "whether or not skipping signals reapply after the reset point",
+				},
+
+				cli.StringFlag{
+					Name: FlagEarliestTimeWithAlias,
+					Usage: "EarliestTime of decision start time, for resetType of DecisionStartedTime." +
+						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
+						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes, " +
+						"meaning that workflow will be reset to the first decision that started in last 15 minutes.",
 				},
 			},
 			Action: func(c *cli.Context) {
@@ -293,7 +302,7 @@ func newWorkflowCommands() []cli.Command {
 				},
 				cli.StringFlag{
 					Name:  FlagReason,
-					Usage: "Reason for reset",
+					Usage: "Reason for reset, required for tracking purpose",
 				},
 				cli.IntFlag{
 					Name:  FlagParallism,
@@ -330,6 +339,14 @@ func newWorkflowCommands() []cli.Command {
 				cli.BoolFlag{
 					Name:  FlagSkipSignalReapply,
 					Usage: "whether or not skipping signals reapply after the reset point",
+				},
+				cli.StringFlag{
+					Name: FlagEarliestTimeWithAlias,
+					Usage: "EarliestTime of decision start time, for resetType of DecisionStartedTime." +
+						"Supported formats are '2006-01-02T15:04:05+07:00', raw UnixNano and " +
+						"time range (N<duration>), where 0 < N < 1000000 and duration (full-notation/short-notation) can be second/s, " +
+						"minute/m, hour/h, day/d, week/w, month/M or year/y. For example, '15minute' or '15m' implies last 15 minutes, " +
+						"meaning that workflow will be reset to the first decision that started in last 15 minutes.",
 				},
 			},
 			Action: func(c *cli.Context) {


### PR DESCRIPTION
…lastest runID as default

<!-- Describe what has changed in this PR -->
**What changed?**
1. The primitive reset command will use latest runID by default. 
2. Provide one more predefined reset type "DecisionStartedTime" for reset and reset-batch commands. 

<!-- Tell your future self why have you made these changes -->
**Why?**
1. It's annoying to require runID. Most of the time people just want to reset the current run or latest run. 
2. It will be useful to allow reset by time as resetType for https://github.com/uber/cadence/issues/2237


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
./cadence  --do sample wf reset -w e8988544-5852-42c7-a74c-e4b74ffb1f25 --reason test --reset_type DecisionCompletedTime --earliest_time 2020-11-01T12:00:31-08:00
resetType: DecisionCompletedTime
{
  "runId": "20a4845d-9c1d-419b-9469-e78a1f61eac7"
}

```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk