### PR TITLE
Fix and improve archival query parser error messages

### DIFF
--- a/common/archiver/filestore/queryParser.go
+++ b/common/archiver/filestore/queryParser.go
@@ -103,7 +103,7 @@ func (p *queryParser) convertWhereExpr(expr sqlparser.Expr, parsedQuery *parsedQ
 	case *sqlparser.ParenExpr:
 		return p.convertParenExpr(expr.(*sqlparser.ParenExpr), parsedQuery)
 	default:
-		return errors.New("only comparsion and \"and\" expression is supported")
+		return errors.New("only comparison and \"and\" expression is supported")
 	}
 }
 
@@ -138,7 +138,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", WorkflowID)
+			return fmt.Errorf("only operator = is supported for %s with file system", WorkflowID)
 		}
 		if parsedQuery.workflowID != nil && *parsedQuery.workflowID != val {
 			parsedQuery.emptyResult = true
@@ -151,7 +151,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", RunID)
+			return fmt.Errorf("only operator = is supported for %s with file system", RunID)
 		}
 		if parsedQuery.runID != nil && *parsedQuery.runID != val {
 			parsedQuery.emptyResult = true
@@ -164,7 +164,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", WorkflowType)
+			return fmt.Errorf("only operator = is supported for %s with file system", WorkflowType)
 		}
 		if parsedQuery.workflowTypeName != nil && *parsedQuery.workflowTypeName != val {
 			parsedQuery.emptyResult = true
@@ -178,7 +178,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			val = valStr
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", CloseStatus)
+			return fmt.Errorf("only operator = is supported for %s with file system", CloseStatus)
 		}
 		status, err := convertStatusStr(val)
 		if err != nil {

--- a/common/archiver/gcloud/queryParser.go
+++ b/common/archiver/gcloud/queryParser.go
@@ -119,7 +119,7 @@ func (p *queryParser) convertWhereExpr(expr sqlparser.Expr, parsedQuery *parsedQ
 	case *sqlparser.ParenExpr:
 		return p.convertParenExpr(expr.(*sqlparser.ParenExpr), parsedQuery)
 	default:
-		return errors.New("only comparsion and \"and\" expression is supported")
+		return errors.New("only comparison and \"and\" expression is supported")
 	}
 }
 
@@ -154,7 +154,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", WorkflowID)
+			return fmt.Errorf("only operator = is supported for %s with Google Cloud Storage", WorkflowID)
 		}
 		if parsedQuery.workflowID != nil && *parsedQuery.workflowID != val {
 			parsedQuery.emptyResult = true
@@ -167,7 +167,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", RunID)
+			return fmt.Errorf("only operator = is supported for %s with Google Cloud Storage", RunID)
 		}
 		if parsedQuery.runID != nil && *parsedQuery.runID != val {
 			parsedQuery.emptyResult = true
@@ -180,7 +180,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", CloseTime)
+			return fmt.Errorf("only operator = is supported for %s with Google Cloud Storage", CloseTime)
 		}
 		parsedQuery.closeTime = timestamp
 
@@ -190,7 +190,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", CloseTime)
+			return fmt.Errorf("only operator = is supported for %s with Google Cloud Storage", StartTime)
 		}
 		parsedQuery.startTime = timestamp
 	case WorkflowType:
@@ -199,7 +199,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", WorkflowType)
+			return fmt.Errorf("only operator = is supported for %s with Google Cloud Storage", WorkflowType)
 		}
 		if parsedQuery.workflowType != nil && *parsedQuery.workflowType != val {
 			parsedQuery.emptyResult = true
@@ -212,7 +212,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", SearchPrecision)
+			return fmt.Errorf("only operator = is supported for %s with Google Cloud Storage", SearchPrecision)
 		}
 		if parsedQuery.searchPrecision != nil && *parsedQuery.searchPrecision != val {
 			return fmt.Errorf("only one expression is allowed for %s", SearchPrecision)

--- a/common/archiver/s3store/queryParser.go
+++ b/common/archiver/s3store/queryParser.go
@@ -118,7 +118,7 @@ func (p *queryParser) convertWhereExpr(expr sqlparser.Expr, parsedQuery *parsedQ
 	case *sqlparser.ParenExpr:
 		return p.convertParenExpr(expr.(*sqlparser.ParenExpr), parsedQuery)
 	default:
-		return errors.New("only comparsion and \"and\" expression is supported")
+		return errors.New("only comparison and \"and\" expression is supported")
 	}
 }
 
@@ -153,7 +153,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", WorkflowTypeName)
+			return fmt.Errorf("only operator = is supported for %s with Amazon S3", WorkflowTypeName)
 		}
 		if parsedQuery.workflowTypeName != nil {
 			return fmt.Errorf("can not query %s multiple times", WorkflowTypeName)
@@ -165,7 +165,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", WorkflowID)
+			return fmt.Errorf("only operator = is supported for %s with Amazon S3", WorkflowID)
 		}
 		if parsedQuery.workflowID != nil {
 			return fmt.Errorf("can not query %s multiple times", WorkflowID)
@@ -177,7 +177,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", CloseTime)
+			return fmt.Errorf("only operator = is supported for %s with Amazon S3", CloseTime)
 		}
 		parsedQuery.closeTime = &timestamp
 	case StartTime:
@@ -186,7 +186,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", CloseTime)
+			return fmt.Errorf("only operator = is supported for %s with Amazon S3", StartTime)
 		}
 		parsedQuery.startTime = &timestamp
 	case SearchPrecision:
@@ -195,7 +195,7 @@ func (p *queryParser) convertComparisonExpr(compExpr *sqlparser.ComparisonExpr, 
 			return err
 		}
 		if op != "=" {
-			return fmt.Errorf("only operation = is support for %s", SearchPrecision)
+			return fmt.Errorf("only operator = is supported for %s with Amazon S3", SearchPrecision)
 		}
 		if parsedQuery.searchPrecision != nil && *parsedQuery.searchPrecision != val {
 			return fmt.Errorf("only one expression is allowed for %s", SearchPrecision)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fixed typos and grammar
- Fixed the issue where the error message talks about CloseTime even though it's intended for StartTime
- Added store information to the error messages (I think this provides better context when displayed on Cadence UI but any feedback is welcome.)

resolves https://github.com/uber/cadence/issues/3544

<!-- Tell your future self why have you made these changes -->
**Why?**
Error messages weren't clear enough when end-users were having query issues on Cadence UI. Required code reading to understand what is happening.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No functional changes. Passed `make test`.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
