### PR TITLE
Improve Error Handling For Cassandra Persistence Implementation

### DIFF
--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -355,7 +355,7 @@ func fromV6ToGenericBulkResponseItem(v *elastic.BulkResponseItem) *GenericBulkRe
 	return &GenericBulkResponseItem{
 		Index:         v.Index,
 		Type:          v.Type,
-		Id:            v.Id,
+		ID:            v.Id,
 		Version:       v.Version,
 		Result:        v.Result,
 		SeqNo:         v.SeqNo,
@@ -432,14 +432,14 @@ func (v *v6BulkProcessor) Add(request *GenericBulkableAddRequest) {
 		req = elastic.NewBulkDeleteRequest().
 			Index(request.Index).
 			Type(request.Type).
-			Id(request.Id).
+			Id(request.ID).
 			VersionType(request.VersionType).
 			Version(request.Version)
 	} else {
 		req = elastic.NewBulkIndexRequest().
 			Index(request.Index).
 			Type(request.Type).
-			Id(request.Id).
+			Id(request.ID).
 			VersionType(request.VersionType).
 			Version(request.Version).
 			Doc(request.Doc)

--- a/common/elasticsearch/interfaces.go
+++ b/common/elasticsearch/interfaces.go
@@ -157,7 +157,7 @@ type (
 	GenericBulkableAddRequest struct {
 		Index       string
 		Type        string
-		Id          string
+		ID          string
 		VersionType string
 		Version     int64
 		// true means it's delete, otherwise it's a index request
@@ -183,7 +183,7 @@ type (
 	GenericBulkResponseItem struct {
 		Index         string `json:"_index,omitempty"`
 		Type          string `json:"_type,omitempty"`
-		Id            string `json:"_id,omitempty"`
+		ID            string `json:"_id,omitempty"`
 		Version       int64  `json:"_version,omitempty"`
 		Result        string `json:"result,omitempty"`
 		SeqNo         int64  `json:"_seq_no,omitempty"`

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -1655,7 +1655,7 @@ func (d *cassandraPersistence) IsWorkflowExecutionExists(
 			return &p.IsWorkflowExecutionExistsResponse{Exists: false}, nil
 		}
 
-		return nil, convertCommonErrors(nil, "IsWorkflowExecutionExists", nil)
+		return nil, convertCommonErrors(nil, "IsWorkflowExecutionExists", err)
 	}
 	return &p.IsWorkflowExecutionExistsResponse{Exists: true}, nil
 }
@@ -1740,7 +1740,7 @@ func (d *cassandraPersistence) GetTransferTasks(
 	copy(response.NextPageToken, nextPageToken)
 
 	if err := iter.Close(); err != nil {
-		return nil, convertCommonErrors(nil, "GetTransferTasks", nil)
+		return nil, convertCommonErrors(nil, "GetTransferTasks", err)
 	}
 
 	return response, nil

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	p "github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra"
 )
 
 type (
@@ -770,7 +771,8 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 		// noop
 
 	default:
-		if err := createOrUpdateCurrentExecution(batch,
+		if err := createOrUpdateCurrentExecution(
+			batch,
 			request.Mode,
 			d.shardID,
 			domainID,
@@ -788,7 +790,8 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 		}
 	}
 
-	if err := applyWorkflowSnapshotBatchAsNew(batch,
+	if err := applyWorkflowSnapshotBatchAsNew(
+		batch,
 		d.shardID,
 		&newWorkflow,
 	); err != nil {
@@ -816,19 +819,7 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 	}()
 
 	if err != nil {
-		if isTimeoutError(err) {
-			// Write may have succeeded, but we don't know
-			// return this info to the caller so they have the option of trying to find out by executing a read
-			return nil, &p.TimeoutError{Msg: fmt.Sprintf("CreateWorkflowExecution timed out. Error: %v", err)}
-		} else if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("CreateWorkflowExecution operation failed. Error: %v", err),
-			}
-		}
-
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CreateWorkflowExecution operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "CreateWorkflowExecution", err)
 	}
 
 	if !applied {
@@ -941,20 +932,14 @@ func (d *cassandraPersistence) GetWorkflowExecution(
 
 	result := make(map[string]interface{})
 	if err := query.MapScan(result); err != nil {
-		if err == gocql.ErrNotFound {
+		if cassandra.IsNotFoundError(err) {
 			return nil, &workflow.EntityNotExistsError{
 				Message: fmt.Sprintf("Workflow execution not found.  WorkflowId: %v, RunId: %v",
 					*execution.WorkflowId, *execution.RunId),
 			}
-		} else if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("GetWorkflowExecution operation failed. Error: %v", err),
-			}
 		}
 
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetWorkflowExecution operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetWorkflowExecution", err)
 	}
 
 	state := &p.InternalWorkflowMutableState{}
@@ -1148,18 +1133,7 @@ func (d *cassandraPersistence) UpdateWorkflowExecution(
 	}()
 
 	if err != nil {
-		if isTimeoutError(err) {
-			// Write may have succeeded, but we don't know
-			// return this info to the caller so they have the option of trying to find out by executing a read
-			return &p.TimeoutError{Msg: fmt.Sprintf("UpdateWorkflowExecution timed out. Error: %v", err)}
-		} else if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("UpdateWorkflowExecution operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateWorkflowExecution operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "UpdateWorkflowExecution", err)
 	}
 
 	if !applied {
@@ -1272,18 +1246,7 @@ func (d *cassandraPersistence) ResetWorkflowExecution(
 	}()
 
 	if err != nil {
-		if isTimeoutError(err) {
-			// Write may have succeeded, but we don't know
-			// return this info to the caller so they have the option of trying to find out by executing a read
-			return &p.TimeoutError{Msg: fmt.Sprintf("ResetWorkflowExecution timed out. Error: %v", err)}
-		} else if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ResetWorkflowExecution operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ResetWorkflowExecution operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "ResetWorkflowExecution", err)
 	}
 
 	if !applied {
@@ -1428,18 +1391,7 @@ func (d *cassandraPersistence) ConflictResolveWorkflowExecution(
 	}()
 
 	if err != nil {
-		if isTimeoutError(err) {
-			// Write may have succeeded, but we don't know
-			// return this info to the caller so they have the option of trying to find out by executing a read
-			return &p.TimeoutError{Msg: fmt.Sprintf("ConflictResolveWorkflowExecution timed out. Error: %v", err)}
-		} else if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ConflictResolveWorkflowExecution operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "ConflictResolveWorkflowExecution", err)
 	}
 
 	if !applied {
@@ -1572,14 +1524,7 @@ func (d *cassandraPersistence) DeleteWorkflowExecution(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("DeleteWorkflowExecution operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteWorkflowExecution operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "DeleteWorkflowExecution", err)
 	}
 
 	return nil
@@ -1601,14 +1546,7 @@ func (d *cassandraPersistence) DeleteCurrentWorkflowExecution(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("DeleteWorkflowCurrentRow operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteWorkflowCurrentRow operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "DeleteWorkflowCurrentRow", err)
 	}
 
 	return nil
@@ -1630,20 +1568,14 @@ func (d *cassandraPersistence) GetCurrentExecution(
 
 	result := make(map[string]interface{})
 	if err := query.MapScan(result); err != nil {
-		if err == gocql.ErrNotFound {
+		if cassandra.IsNotFoundError(err) {
 			return nil, &workflow.EntityNotExistsError{
 				Message: fmt.Sprintf("Workflow execution not found.  WorkflowId: %v",
 					request.WorkflowID),
 			}
-		} else if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("GetCurrentExecution operation failed. Error: %v", err),
-			}
 		}
 
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetCurrentExecution operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetCurrentExecution", err)
 	}
 
 	currentRunID := result["current_run_id"].(gocql.UUID).String()
@@ -1699,9 +1631,7 @@ func (d *cassandraPersistence) ListCurrentExecutions(
 	copy(response.PageToken, nextPageToken)
 
 	if err := iter.Close(); err != nil {
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListCurrentExecutions operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListCurrentExecutions", err)
 	}
 	return response, nil
 }
@@ -1721,17 +1651,11 @@ func (d *cassandraPersistence) IsWorkflowExecutionExists(
 
 	result := make(map[string]interface{})
 	if err := query.MapScan(result); err != nil {
-		if err == gocql.ErrNotFound {
+		if cassandra.IsNotFoundError(err) {
 			return &p.IsWorkflowExecutionExistsResponse{Exists: false}, nil
-		} else if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("IsWorkflowExecutionExists operation failed. Error: %v", err),
-			}
 		}
 
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("IsWorkflowExecutionExists operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "IsWorkflowExecutionExists", nil)
 	}
 	return &p.IsWorkflowExecutionExistsResponse{Exists: true}, nil
 }
@@ -1772,9 +1696,7 @@ func (d *cassandraPersistence) ListConcreteExecutions(
 	copy(response.NextPageToken, nextPageToken)
 
 	if err := iter.Close(); err != nil {
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListConcreteExecutions operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListConcreteExecutions", err)
 	}
 
 	return response, nil
@@ -1818,9 +1740,7 @@ func (d *cassandraPersistence) GetTransferTasks(
 	copy(response.NextPageToken, nextPageToken)
 
 	if err := iter.Close(); err != nil {
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetTransferTasks operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetTransferTasks", nil)
 	}
 
 	return response, nil
@@ -1870,9 +1790,7 @@ func (d *cassandraPersistence) populateGetReplicationTasksResponse(
 	copy(response.NextPageToken, nextPageToken)
 
 	if err := iter.Close(); err != nil {
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetReplicationTasks operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetReplicationTasks", err)
 	}
 
 	return response, nil
@@ -1893,14 +1811,7 @@ func (d *cassandraPersistence) CompleteTransferTask(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("CompleteTransferTask operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CompleteTransferTask operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "CompleteTransferTask", err)
 	}
 
 	return nil
@@ -1923,14 +1834,7 @@ func (d *cassandraPersistence) RangeCompleteTransferTask(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("RangeCompleteTransferTask operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("RangeCompleteTransferTask operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "RangeCompleteTransferTask", err)
 	}
 
 	return nil
@@ -1951,14 +1855,7 @@ func (d *cassandraPersistence) CompleteReplicationTask(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("CompleteReplicationTask operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CompleteReplicationTask operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "CompleteReplicationTask", err)
 	}
 
 	return nil
@@ -1981,14 +1878,7 @@ func (d *cassandraPersistence) RangeCompleteReplicationTask(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("RangeCompleteReplicationTask operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("RangeCompleteReplicationTask operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "RangeCompleteReplicationTask", err)
 	}
 
 	return nil
@@ -2010,14 +1900,7 @@ func (d *cassandraPersistence) CompleteTimerTask(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CompleteTimerTask operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "CompleteTimerTask", err)
 	}
 
 	return nil
@@ -2041,14 +1924,7 @@ func (d *cassandraPersistence) RangeCompleteTimerTask(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("RangeCompleteTimerTask operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("RangeCompleteTimerTask operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "RangeCompleteTimerTask", err)
 	}
 
 	return nil
@@ -2092,14 +1968,7 @@ func (d *cassandraPersistence) GetTimerIndexTasks(
 	copy(response.NextPageToken, nextPageToken)
 
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("GetTimerTasks operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetTimerTasks operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetTimerTasks", err)
 	}
 
 	return response, nil
@@ -2137,14 +2006,7 @@ func (d *cassandraPersistence) PutReplicationTaskToDLQ(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("PutReplicationTaskToDLQ operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("PutReplicationTaskToDLQ operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "PutReplicationTaskToDLQ", err)
 	}
 
 	return nil
@@ -2185,16 +2047,9 @@ func (d *cassandraPersistence) GetReplicationDLQSize(
 
 	result := make(map[string]interface{})
 	if err := query.MapScan(result); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("GetReplicationDLQSize operation failed. Error: %v", err),
-			}
-		}
-
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetReplicationDLQSize operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetReplicationDLQSize", err)
 	}
+
 	queueSize := result["count"].(int64)
 	return &p.GetReplicationDLQSizeResponse{
 		Size: queueSize,
@@ -2218,15 +2073,9 @@ func (d *cassandraPersistence) DeleteReplicationTaskFromDLQ(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("DeleteReplicationTaskFromDLQ operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("DeleteReplicationTaskFromDLQ operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "DeleteReplicationTaskFromDLQ", err)
 	}
+
 	return nil
 }
 
@@ -2248,15 +2097,9 @@ func (d *cassandraPersistence) RangeDeleteReplicationTaskFromDLQ(
 
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("RangeDeleteReplicationTaskFromDLQ operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("RangeDeleteReplicationTaskFromDLQ operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "RangeDeleteReplicationTaskFromDLQ", err)
 	}
+
 	return nil
 }
 
@@ -2301,15 +2144,9 @@ func (d *cassandraPersistence) CreateFailoverMarkerTasks(
 		}
 	}()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("CreateFailoverMarkerTasks operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CreateFailoverMarkerTasks operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "CreateFailoverMarkerTasks", err)
 	}
+
 	if !applied {
 		rowType, ok := previous["type"].(int)
 		if !ok {

--- a/common/persistence/cassandra/cassandraShardPersistence.go
+++ b/common/persistence/cassandra/cassandraShardPersistence.go
@@ -178,14 +178,7 @@ func (d *cassandraShardPersistence) CreateShard(
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("CreateShard operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("CreateShard operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "CreateShard", err)
 	}
 
 	if !applied {
@@ -215,19 +208,13 @@ func (d *cassandraShardPersistence) GetShard(
 
 	result := make(map[string]interface{})
 	if err := query.MapScan(result); err != nil {
-		if err == gocql.ErrNotFound {
+		if cassandra.IsNotFoundError(err) {
 			return nil, &workflow.EntityNotExistsError{
 				Message: fmt.Sprintf("Shard not found.  ShardId: %v", shardID),
 			}
-		} else if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("GetShard operation failed. Error: %v", err),
-			}
 		}
 
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetShard operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetShard", err)
 	}
 
 	rangeID := result["range_id"].(int64)
@@ -285,14 +272,7 @@ func (d *cassandraShardPersistence) updateRangeID(
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("UpdateRangeID operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateRangeID operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "UpdateRangeID", err)
 	}
 
 	if !applied {
@@ -354,14 +334,7 @@ func (d *cassandraShardPersistence) UpdateShard(
 	previous := make(map[string]interface{})
 	applied, err := query.MapScanCAS(previous)
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("UpdateShard operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "UpdateShard", err)
 	}
 
 	if !applied {

--- a/common/persistence/cassandra/cassandraVisibilityPersistence.go
+++ b/common/persistence/cassandra/cassandraVisibilityPersistence.go
@@ -261,14 +261,7 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionStarted(
 	query = query.WithTimestamp(p.UnixNanoToDBTimestamp(request.StartTimestamp))
 	err := query.Exec()
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("RecordWorkflowExecutionStarted operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("RecordWorkflowExecutionStarted operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "RecordWorkflowExecutionStarted", err)
 	}
 
 	return nil
@@ -378,14 +371,7 @@ func (v *cassandraVisibilityPersistence) RecordWorkflowExecutionClosed(
 	batch = batch.WithTimestamp(p.UnixNanoToDBTimestamp(queryTimeStamp))
 	err := v.session.ExecuteBatch(batch)
 	if err != nil {
-		if isThrottlingError(err) {
-			return &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("RecordWorkflowExecutionClosed operation failed. Error: %v", err),
-			}
-		}
-		return &workflow.InternalServiceError{
-			Message: fmt.Sprintf("RecordWorkflowExecutionClosed operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(nil, "RecordWorkflowExecutionClosed", err)
 	}
 	return nil
 }
@@ -429,14 +415,7 @@ func (v *cassandraVisibilityPersistence) ListOpenWorkflowExecutions(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListOpenWorkflowExecutions operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListOpenWorkflowExecutions operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListOpenWorkflowExecutions", err)
 	}
 
 	return response, nil
@@ -474,14 +453,7 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutions(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutions", err)
 	}
 
 	return response, nil
@@ -517,14 +489,7 @@ func (v *cassandraVisibilityPersistence) ListOpenWorkflowExecutionsByType(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListOpenWorkflowExecutionsByType operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListOpenWorkflowExecutionsByType operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListOpenWorkflowExecutionsByType", err)
 	}
 
 	return response, nil
@@ -563,14 +528,7 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutionsByType(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutionsByType", err)
 	}
 
 	return response, nil
@@ -606,14 +564,7 @@ func (v *cassandraVisibilityPersistence) ListOpenWorkflowExecutionsByWorkflowID(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListOpenWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListOpenWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListOpenWorkflowExecutionsByWorkflowID", err)
 	}
 
 	return response, nil
@@ -652,14 +603,7 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutionsByWorkflowI
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutionsByWorkflowID", err)
 	}
 
 	return response, nil
@@ -698,14 +642,7 @@ func (v *cassandraVisibilityPersistence) ListClosedWorkflowExecutionsByStatus(
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutionsByStatus", err)
 	}
 
 	return response, nil
@@ -738,14 +675,7 @@ func (v *cassandraVisibilityPersistence) GetClosedWorkflowExecution(
 	}
 
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("GetClosedWorkflowExecution operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("GetClosedWorkflowExecution operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "GetClosedWorkflowExecution", err)
 	}
 
 	return &p.InternalGetClosedWorkflowExecutionResponse{
@@ -810,14 +740,7 @@ func (v *cassandraVisibilityPersistence) listClosedWorkflowExecutionsOrderByClos
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutions operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutions", err)
 	}
 
 	return response, nil
@@ -853,14 +776,7 @@ func (v *cassandraVisibilityPersistence) listClosedWorkflowExecutionsByTypeOrder
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByType operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutionsByType", err)
 	}
 
 	return response, nil
@@ -896,14 +812,7 @@ func (v *cassandraVisibilityPersistence) listClosedWorkflowExecutionsByWorkflowI
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByWorkflowID operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutionsByWorkflowID", err)
 	}
 
 	return response, nil
@@ -939,14 +848,7 @@ func (v *cassandraVisibilityPersistence) listClosedWorkflowExecutionsByStatusOrd
 	response.NextPageToken = make([]byte, len(nextPageToken))
 	copy(response.NextPageToken, nextPageToken)
 	if err := iter.Close(); err != nil {
-		if isThrottlingError(err) {
-			return nil, &workflow.ServiceBusyError{
-				Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
-			}
-		}
-		return nil, &workflow.InternalServiceError{
-			Message: fmt.Sprintf("ListClosedWorkflowExecutionsByStatus operation failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(nil, "ListClosedWorkflowExecutionsByStatus", err)
 	}
 
 	return response, nil

--- a/common/persistence/nosql/nosqlplugin/cassandra/db.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/db.go
@@ -81,16 +81,9 @@ func (db *cdb) IsTimeoutError(err error) bool {
 }
 
 func (db *cdb) IsThrottlingError(err error) bool {
-	if req, ok := err.(gocql.RequestError); ok {
-		// gocql does not expose the constant errOverloaded = 0x1001
-		return req.Code() == 0x1001
-	}
-	return false
+	return IsThrottlingError(err)
 }
 
 func (db *cdb) IsConditionFailedError(err error) bool {
-	if err == errConditionFailed {
-		return true
-	}
-	return false
+	return IsConditionFailedError(err)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain.go
@@ -452,7 +452,7 @@ func (db *cdb) SelectAllDomains(ctx context.Context, pageSize int, pageToken []b
 
 	nextPageToken := iter.PageState()
 	if err := iter.Close(); err != nil {
-		return nil, nil, fmt.Errorf("ListDomains operation failed. Error: %v", err)
+		return nil, nil, err
 	}
 	return rows, nextPageToken, nil
 }
@@ -509,12 +509,12 @@ func (db *cdb) SelectDomainMetadata(ctx context.Context) (int64, error) {
 func (db *cdb) deleteDomain(ctx context.Context, name, ID string) error {
 	query := db.session.Query(templateDeleteDomainByNameQueryV2, constDomainPartition, name).WithContext(ctx)
 	if err := query.Exec(); err != nil {
-		return fmt.Errorf("DeleteDomainByName operation failed. Error %v", err)
+		return err
 	}
 
 	query = db.session.Query(templateDeleteDomainQuery, ID).WithContext(ctx)
 	if err := query.Exec(); err != nil {
-		return fmt.Errorf("DeleteDomain operation failed. Error %v", err)
+		return err
 	}
 
 	return nil

--- a/common/persistence/nosql/nosqlplugin/cassandra/events.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/events.go
@@ -117,9 +117,7 @@ func (db *cdb) SelectFromHistoryNode(ctx context.Context, filter *nosqlplugin.Hi
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, nil, &shared.InternalServiceError{
-			Message: fmt.Sprintf("SelectFromHistoryNode. Close operation failed. Error: %v", err),
-		}
+		return nil, nil, err
 	}
 	return rows, pagingToken, nil
 }
@@ -162,9 +160,7 @@ func (db *cdb) SelectAllHistoryTrees(ctx context.Context, nextPageToken []byte, 
 	}
 
 	if err := iter.Close(); err != nil {
-		return nil, nil, &shared.InternalServiceError{
-			Message: fmt.Sprintf("SelectAllHistoryTrees. Close operation failed. Error: %v", err),
-		}
+		return nil, nil, err
 	}
 	return rows, pagingToken, nil
 }
@@ -208,9 +204,7 @@ func (db *cdb) SelectFromHistoryTree(ctx context.Context, filter *nosqlplugin.Hi
 		}
 
 		if err := iter.Close(); err != nil {
-			return nil, &shared.InternalServiceError{
-				Message: fmt.Sprintf("SelectFromHistoryTree. Close operation failed. Error: %v", err),
-			}
+			return nil, err
 		}
 
 		if len(pagingToken) == 0 {

--- a/common/persistence/nosql/nosqlplugin/cassandra/queue.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue.go
@@ -183,7 +183,7 @@ func (db *cdb) InsertQueueMetadata(
 	query := db.session.Query(templateInsertQueueMetadataQuery, queueType, clusterAckLevels, version).WithContext(ctx)
 	_, err := query.ScanCAS()
 	if err != nil {
-		return fmt.Errorf("failed to insert initial queue metadata record: %v, Type: %v", err, queueType)
+		return err
 	}
 	// it's ok if the query is not applied, which means that the record exists already.
 	return nil

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -23,10 +23,9 @@ package nosqlplugin
 import (
 	"context"
 
-	"github.com/uber/cadence/common/types"
-
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 )
 
 type (

--- a/service/worker/indexer/esProcessor_test.go
+++ b/service/worker/indexer/esProcessor_test.go
@@ -186,7 +186,7 @@ func (s *esProcessorSuite) TestBulkAfterActionX() {
 		"index": {
 			Index:   testIndex,
 			Type:    testType,
-			Id:      testID,
+			ID:      testID,
 			Version: version,
 			Status:  200,
 		},
@@ -217,7 +217,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Nack() {
 		"index": {
 			Index:   testIndex,
 			Type:    testType,
-			Id:      testID,
+			ID:      testID,
 			Version: version,
 			Status:  400,
 		},
@@ -254,7 +254,7 @@ func (s *esProcessorSuite) TestBulkAfterAction_Error() {
 		"index": {
 			Index:   testIndex,
 			Type:    testType,
-			Id:      testID,
+			ID:      testID,
 			Version: version,
 			Status:  400,
 		},

--- a/service/worker/indexer/processor.go
+++ b/service/worker/indexer/processor.go
@@ -206,7 +206,7 @@ func (p *indexProcessor) addMessageToES(indexMsg *indexer.Message, kafkaMsg mess
 	req := &es.GenericBulkableAddRequest{
 		Index:       p.esIndexName,
 		Type:        esDocType,
-		Id:          docID,
+		ID:          docID,
 		VersionType: versionTypeExternal,
 		Version:     indexMsg.GetVersion(),
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Check if `err == context.DeadlineExceeded` when checking for timeout error
- Replace duplicated error handling logic with a common error conversion function, which can return more detailed error types instead of just InternalServiceError.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve error handling

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally


