### PR TITLE
Allow dockerize to use config template from a different directory

### DIFF
--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -2,6 +2,6 @@
 
 set -ex
 
-dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml
+dockerize -template /etc/cadence/config_map/config_template.yaml:/etc/cadence/config/docker.yaml
 
 exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -2,7 +2,7 @@
 
 set -ex
 
-CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:/etc/cadence/config/config_template.yaml}"
+CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence/config/config_template.yaml}"
 
 dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
 

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -4,6 +4,6 @@ set -ex
 
 CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:/etc/cadence/config/config_template.yaml}"
 
-dockerize -template CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
+dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
 
 exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -2,6 +2,8 @@
 
 set -ex
 
-dockerize -template /etc/cadence/config_map/config_template.yaml:/etc/cadence/config/docker.yaml
+CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:/etc/cadence/config/config_template.yaml}"
+
+dockerize -template CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
 
 exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -7,3 +7,4 @@ CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence/config/config_templat
 dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
 
 exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
+

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -7,4 +7,4 @@ CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence/config/config_templat
 dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
 
 exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
- 
+

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -7,3 +7,4 @@ CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence/config/config_templat
 dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
 
 exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
+ 

--- a/docker/start-cadence.sh
+++ b/docker/start-cadence.sh
@@ -7,4 +7,3 @@ CONFIG_TEMPLATE_PATH="${CONFIG_TEMPLATE_PATH:-/etc/cadence/config/config_templat
 dockerize -template $CONFIG_TEMPLATE_PATH:/etc/cadence/config/docker.yaml
 
 exec cadence-server --root $CADENCE_HOME --env docker start --services=$SERVICES
-


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow dockerize to use config template from a different directory from Env parameter

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/3471
Some K8s clusters have very strict rules that they won't allow a service running as root, hence no write permission onto any directory, unless it's a temporary empty directory.
Cadence's dockerize command relays on write permission to generate the final config file. The only way is to write into a temporary empty directory. However, we can't initialize the empty  directory with a template. So the config template mush be loaded from somewhere else.

For example, we can change the helm chart to put config template into another folder, and initialize an empty directory for writing: https://github.com/longquanzheng/banzai-charts/commit/45408470dd91f36e3191a4fa7a12aa89fe8abb0d

However, current docker file has hardcoded the config template path. We have to give it another option to load template.

In the long term, we may want to get rid of the empty directory as well. One idea is to let Cadence run without the docerize. This may be a bigger change in the code base, to load config in a different way.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested on local and on my production K8s cluster running with NonRoot.
```
cadence_1      | + exec /start-cadence.sh
cadence_1      | + CONFIG_TEMPLATE_PATH=/etc/cadence/config/config_template.yaml
cadence_1      | + dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml
cadence_1      | + exec cadence-server --root /etc/cadence --env docker start --services=history,matching,frontend,worker
cadence_1      | 2020/11/01 22:10:20 Loading config; env=docker,zone=,configDir=/etc/cadence/config
cadence_1      | 2020/11/01 22:10:20 Loading configFiles=[/etc/cadence/config/docker.yaml]
cadence_1      | {"level":"info","ts":"2020-11-01T22:10:20.626Z","msg":"Updated dynamic config","service":"cadence-history","logging-call-at":"file_based_client.go:258"}
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No. It doesn't change anything by default, just allowing helm chart to specify a different path for config template. 
