### PR TITLE
Don't retry when reset to a middle of a batch to save perf

### DIFF
--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -162,8 +162,10 @@ func (r *stateRebuilderImpl) Rebuild(
 		baseLastEventID,
 		baseLastEventVersion,
 	)) {
-		return nil, 0, &shared.InternalServiceError{Message: fmt.Sprintf(
-			"nDCStateRebuilder unable to rebuild mutable state to event ID: %v, version: %v",
+		return nil, 0, &shared.BadRequestError{Message: fmt.Sprintf(
+			"nDCStateRebuilder unable to rebuild mutable state to event ID: %v, version: %v, "+
+				"baseLastEventID + baseLastEventVersion is not the same as the last event of the last batch, "+
+				"typicaly because of attemptting to rebuild to a middle of a batch",
 			baseLastEventID,
 			baseLastEventVersion,
 		)}

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -164,10 +164,12 @@ func (r *stateRebuilderImpl) Rebuild(
 	)) {
 		return nil, 0, &shared.BadRequestError{Message: fmt.Sprintf(
 			"nDCStateRebuilder unable to rebuild mutable state to event ID: %v, version: %v, "+
-				"baseLastEventID + baseLastEventVersion is not the same as the last event of the last batch, "+
-				"typicaly because of attemptting to rebuild to a middle of a batch",
+				"baseLastEventID + baseLastEventVersion is not the same as the last event of the last "+
+				"batch, event ID: %v, version :%v ,typicaly because of attemptting to rebuild to a middle of a batch",
 			baseLastEventID,
 			baseLastEventVersion,
+			lastItem.EventID,
+			lastItem.Version,
 		)}
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change the error return from StateBuilder from InternalServiceError to BadRequestError

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/3720
InternalServiceError in harmful because FrontendService will keep retrying until context timeouts. 
Reset relys on replaying, which is very expensive and potentially making down the history service.  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local tested.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
StateBuilder is also being used by NDC replication. I believe returning BadRequestError should also work(better) fro NDC. 
@yux0 

