### PR TITLE
Add cassandra username and password config values to docker image

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -51,6 +51,9 @@ docker-compose down
 docker-compose up
 ```
 
+Note that with `TARGET=auto-setup`, the images will setup all the DB/ElasticSearch schema during startup.
+By default, the image will not setup schema if you leave TARGET empty.
+
 Running cadence service with MySQL
 -----------------------------------------
 
@@ -76,20 +79,25 @@ Quickstart for production
 =========================
 In a typical production setting, dependencies (cassandra / statsd server) are
 managed / started independently of the cadence-server. To use the container in
-a production setting, use the following command:
-
+a production setting, use the following docker command:
 
 ```
 docker run -e CASSANDRA_SEEDS=10.x.x.x                  -- csv of cassandra server ipaddrs
+    -e CASSANDRA_USER=<username>                        -- Cassandra username
+    -e CASSANDRA_PASSWORD=<password>                    -- Cassandra password
     -e KEYSPACE=<keyspace>                              -- Cassandra keyspace
-    -e VISIBILITY_KEYSPACE=<visibility_keyspace>        -- Cassandra visibility keyspace
-    -e SKIP_SCHEMA_SETUP=true                           -- do not setup cassandra schema during startup
-    -e RINGPOP_SEEDS=10.x.x.x,10.x.x.x  \               -- csv of ipaddrs for gossip bootstrap
+    -e VISIBILITY_KEYSPACE=<visibility_keyspace>        -- Cassandra visibility keyspace, if using basic visibility 
+    -e KAFKA_SEEDS=10.x.x.x                             -- Kafka broker seed, if using ElasticSearch + Kafka for advanced visibility feature
+    -e ES_SEEDS=10.x.x.x                                -- ElasticSearch seed , if using ElasticSearch + Kafka for advanced visibility feature
+    -e RINGPOP_SEEDS=10.x.x.x,10.x.x.x                  -- csv of ipaddrs for gossip bootstrap
     -e STATSD_ENDPOINT=10.x.x.x:8125                    -- statsd server endpoint
-    -e NUM_HISTORY_SHARDS=1024  \                       -- Number of history shards
-    -e SERVICES=history,matching \                      -- Spinup only the provided services
-    -e LOG_LEVEL=debug,info \                           -- Logging level
-    -e DYNAMIC_CONFIG_FILE_PATH=config/foo.yaml         -- Dynamic config file to be watched
+    -e NUM_HISTORY_SHARDS=1024                          -- Number of history shards
+    -e SERVICES=history,matching                        -- Spinup only the provided services, separated by commas, options are frontend,history,matching and workers
+    -e LOG_LEVEL=debug,info                             -- Logging level
+    -e DYNAMIC_CONFIG_FILE_PATH=<dynamic_config_file>   -- Dynamic config file to be watched, default to /etc/cadence/config/dynamicconfig/development.yaml, but you can choose /etc/cadence/config/dynamicconfig/development_es.yaml if using ElasticSearch
     ubercadence/server:<tag>
 ```
+Note that each env variable has a default value, so you don't have to specify it if the default works for you. 
+For more options to configure the docker, please refer to `config_template.yaml`.
 
+For <tag>, you may not use `auto-setup` images for production deployment. See the above explanation.

--- a/docker/README.md
+++ b/docker/README.md
@@ -100,4 +100,4 @@ docker run -e CASSANDRA_SEEDS=10.x.x.x                  -- csv of cassandra serv
 Note that each env variable has a default value, so you don't have to specify it if the default works for you. 
 For more options to configure the docker, please refer to `config_template.yaml`.
 
-For <tag>, you may not use `auto-setup` images for production deployment. See the above explanation.
+For <tag>, you may not use `auto-setup` images for production deployment. See the above explanation. 

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -15,12 +15,16 @@ persistence:
         {{- if eq $db "cassandra" }}
         default:
             cassandra:
-                hosts: {{ default .Env.CASSANDRA_SEEDS "" }}
-                keyspace: {{ default .Env.KEYSPACE "cadence" }}
+                hosts: { { default .Env.CASSANDRA_SEEDS "" } }
+                keyspace: { { default .Env.KEYSPACE "cadence" } }
+                user: { { default .Env.CASSANDRA_USER "" } }
+                password: { { default .Env.CASSANDRA_PASSWORD "" } }
         visibility:
             cassandra:
-                hosts: {{ default .Env.CASSANDRA_SEEDS "" }}
-                keyspace: {{ default .Env.VISIBILITY_KEYSPACE "cadence_visibility" }}
+                hosts: { { default .Env.CASSANDRA_SEEDS "" } }
+                keyspace: { { default .Env.VISIBILITY_KEYSPACE "cadence_visibility" } }
+                user: { { default .Env.CASSANDRA_USER "" } }
+                password: { { default .Env.CASSANDRA_PASSWORD "" } }
         {{- else if eq $db "mysql" }}
         default:
             sql:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -15,16 +15,16 @@ persistence:
         {{- if eq $db "cassandra" }}
         default:
             cassandra:
-                hosts: { { default .Env.CASSANDRA_SEEDS "" } }
-                keyspace: { { default .Env.KEYSPACE "cadence" } }
-                user: { { default .Env.CASSANDRA_USER "" } }
-                password: { { default .Env.CASSANDRA_PASSWORD "" } }
+                hosts: {{ default .Env.CASSANDRA_SEEDS "" }}
+                keyspace: {{ default .Env.KEYSPACE "cadence" }}
+                user: {{ default .Env.CASSANDRA_USER "" }}
+                password: {{ default .Env.CASSANDRA_PASSWORD "" }}
         visibility:
             cassandra:
-                hosts: { { default .Env.CASSANDRA_SEEDS "" } }
-                keyspace: { { default .Env.VISIBILITY_KEYSPACE "cadence_visibility" } }
-                user: { { default .Env.CASSANDRA_USER "" } }
-                password: { { default .Env.CASSANDRA_PASSWORD "" } }
+                hosts: {{ default .Env.CASSANDRA_SEEDS "" }}
+                keyspace: {{ default .Env.VISIBILITY_KEYSPACE "cadence_visibility" }}
+                user: {{ default .Env.CASSANDRA_USER "" }}
+                password: {{ default .Env.CASSANDRA_PASSWORD "" }}
         {{- else if eq $db "mysql" }}
         default:
             sql:

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -239,7 +239,7 @@ publicClient:
     hostPort: {{ default .Env.BIND_ON_IP "127.0.0.1" }}:7933
 
 dynamicConfigClient:
-    filepath: {{ default .Env.DYNAMIC_CONFIG_FILE_PATH "/etc/cadence/config/dynamicconfig" }}
+    filepath: {{ default .Env.DYNAMIC_CONFIG_FILE_PATH "/etc/cadence/config/dynamicconfig/development.yaml" }}
     pollInterval: "60s"
 
 blobstore:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -9,6 +9,8 @@ ES_VERSION="${ES_VERSION:-v6}"
 RF=${RF:-1}
 
 # cassandra env
+export CASSANDRA_USER="${CASSANDRA_USER:-cassandra}"
+export CASSANDRA_PASSWORD="${CASSANDRA_PASSWORD:-cassandra}"
 export KEYSPACE="${KEYSPACE:-cadence}"
 export VISIBILITY_KEYSPACE="${VISIBILITY_KEYSPACE:-cadence_visibility}"
 
@@ -82,7 +84,7 @@ setup_schema() {
 
 wait_for_cassandra() {
     server=`echo $CASSANDRA_SEEDS | awk -F ',' '{print $1}'`
-    until cqlsh --cqlversion=3.4.4 $server < /dev/null; do
+    until cqlsh -u $CASSANDRA_USER -p $CASSANDRA_PASSWORD --cqlversion=3.4.4 $server < /dev/null; do
         echo 'waiting for cassandra to start up'
         sleep 1
     done


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. In config template, take user/password from env for dockerize command
2. In start.sh, take user/password from env and set default value(default to "cassandra/cassandra" as this is default values), and ping Cassandra server with user/password. 
3. Fix default dynamic config file path. The current default value is not valid. 

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/3063

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally:
with correct password:
```
[qlong] ~/cadence [qlong-docker-config-template-cass] ?? % docker run -e CASSANDRA_USER=cassandra -e CASSANDRA_PASSWORD=cassandra -e CASSANDRA_SEEDS=host.docker.internal -p 7933:7933  ubercadence/qlong-server:local
+ dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml
+ exec cadence-server --root /etc/cadence --env docker start --services=history,matching,frontend,worker
2020/11/03 19:33:48 Loading config; env=docker,zone=,configDir=/etc/cadence/config
2020/11/03 19:33:48 Loading configFiles=[/etc/cadence/config/docker.yaml]
...
{"level":"info","ts":"2020-11-03T19:33:49.247Z","msg":"Creating RPC dispatcher outbound","service":"cadence-frontend","address":"172.30.254.5:7933","logging-call-at":"clientBean.go:277"}
{"level":"info","ts":"2020-11-03T19:33:49.248Z","msg":"Add new peers by DNS lookup","address":"172.30.254.5","addresses":"[172.30.254.5:7933]","logging-call-at":"clientBean.go:321"}
{"level":"info","ts":"2020-11-03T19:33:49.249Z","msg":"Starting service history","logging-call-at":"server.go:215"}
```
With wrong password:
```
~/cadence [qlong-docker-config-template-cass] ?? % docker run -e CASSANDRA_SEEDS=host.docker.internal -p 7933:7933  ubercadence/qlong-server:local
+ dockerize -template /etc/cadence/config/config_template.yaml:/etc/cadence/config/docker.yaml
+ exec cadence-server --root /etc/cadence --env docker start --services=history,matching,frontend,worker
2020/11/03 19:28:26 Loading config; env=docker,zone=,configDir=/etc/cadence/config
2020/11/03 19:28:26 Loading configFiles=[/etc/cadence/config/docker.yaml]
2020/11/03 19:28:26 gocql: unable to dial control conn 192.168.65.2: authentication required (using "org.apache.cassandra.auth.PasswordAuthenticator")
2020/11/03 19:28:26 cassandra schema version compatibility check failed: unable to create CQL Client: gocql: unable to create session: control: unable to connect to initial hosts: authentication required (using "org.apache.cassandra.auth.PasswordAuthenticator")
```
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
