### PR TITLE
Various fixes and improvements for reset and retry error, add integration test for reset

### DIFF
--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -105,6 +105,8 @@ func (s *RetrySuite) TestRetryFailed_ReturnPreviousError() {
 
 	policy := NewExponentialRetryPolicy(1 * time.Millisecond)
 	policy.SetMaximumInterval(5 * time.Millisecond)
+	// Note that this is retry attempts(maybe it should be renamed to SetMaximumRetryAttempts),
+	// so the total attempts is 5+1=6
 	policy.SetMaximumAttempts(5)
 
 	err := Retry(op, policy, nil)

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -87,6 +87,32 @@ func (s *RetrySuite) TestRetryFailed() {
 	s.Error(err)
 }
 
+func (s *RetrySuite) TestRetryFailed_ReturnPreviousError() {
+	i := 0
+
+	the5thError := fmt.Errorf("this is the error of the 5th attempt(4th retry attempt)")
+	op := func() error {
+		i++
+		if i == 5 {
+			return the5thError
+		}
+		if i == 7 {
+			return nil
+		}
+
+		return &someError{}
+	}
+
+	policy := NewExponentialRetryPolicy(1 * time.Millisecond)
+	policy.SetMaximumInterval(5 * time.Millisecond)
+	policy.SetMaximumAttempts(5)
+
+	err := Retry(op, policy, nil)
+	s.Error(err)
+	s.Equal(6, i)
+	s.Equal(the5thError, err)
+}
+
 func (s *RetrySuite) TestIsRetryableSuccess() {
 	i := 0
 	op := func() error {

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -26,6 +26,7 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
+
 	"github.com/uber/cadence/common/persistence/serialization"
 
 	workflow "github.com/uber/cadence/.gen/go/shared"

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -26,7 +26,6 @@ import (
 	"encoding/binary"
 	"encoding/gob"
 	"fmt"
-
 	"github.com/uber/cadence/common/persistence/serialization"
 
 	workflow "github.com/uber/cadence/.gen/go/shared"

--- a/host/activity_test.go
+++ b/host/activity_test.go
@@ -146,7 +146,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Success() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(*we.RunId))
 
 	s.False(workflowComplete)
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 	s.True(workflowComplete)
 	s.True(activityExecutedCount == 1)
@@ -330,7 +330,7 @@ func (s *integrationSuite) TestActivityHeartbeatDetailsDuringRetry() {
 		}
 	}
 
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.True(err == nil, err)
 
 	s.True(workflowComplete)
@@ -650,7 +650,7 @@ func (s *integrationSuite) TestActivityHeartBeatWorkflow_Timeout() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(*we.RunId))
 
 	s.False(workflowComplete)
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 	s.True(workflowComplete)
 }
@@ -1329,7 +1329,7 @@ func (s *integrationSuite) TestActivityCancellationNotStarted() {
 	// Process signal in decider and send request cancellation
 	scheduleActivity = false
 	requestCancellation = true
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 
 	scheduleActivity = false

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -335,7 +335,7 @@ func (s *integrationSuite) startAndFinishWorkflow(id, wt, tl, domain, domainID s
 			s.Nil(err)
 		}
 
-		_, err = poller.PollAndProcessDecisionTask(true, false)
+		_, err = poller.PollAndProcessDecisionTask(false, false)
 		s.Nil(err)
 	}
 

--- a/host/cancelworkflow_test.go
+++ b/host/cancelworkflow_test.go
@@ -138,7 +138,7 @@ func (s *integrationSuite) TestExternalRequestCancelWorkflowExecution() {
 	s.NotNil(err)
 	s.IsType(&workflow.CancellationAlreadyRequestedError{}, err)
 
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -320,7 +320,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution() {
 	s.Nil(err)
 
 	// Cancel the foreign workflow with this decision request.
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -488,7 +488,7 @@ func (s *integrationSuite) TestRequestCancelWorkflowDecisionExecution_UnKnownTar
 	s.Nil(err)
 
 	// Cancel the foreign workflow with this decision request.
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 

--- a/host/continueasnew_test.go
+++ b/host/continueasnew_test.go
@@ -130,7 +130,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow() {
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessDecisionTask(true, false)
+	_, err := poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 	s.True(workflowComplete)
 	s.Equal(previousRunID, lastRunStartedEvent.WorkflowExecutionStartedEventAttributes.GetContinuedExecutionRunId())
@@ -210,7 +210,7 @@ func (s *integrationSuite) TestContinueAsNewWorkflow_Timeout() {
 	}
 
 	// process the decision and continue as new
-	_, err := poller.PollAndProcessDecisionTask(true, false)
+	_, err := poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -471,7 +471,7 @@ func (s *integrationSuite) TestChildWorkflowWithContinueAsNew() {
 	s.NotNil(startedEvent)
 
 	// Process Child Execution final decision to complete it
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 	s.True(childComplete)

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -240,7 +240,7 @@ GetHistoryLoop:
 		Logger:          s.Logger,
 		T:               s.T(),
 	}
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 	// duplicate requests
@@ -270,7 +270,7 @@ GetHistoryLoop:
 	s.NotEqual(we3.GetRunId(), we4.GetRunId())
 
 	// complete workflow
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -545,7 +545,7 @@ func (s *integrationSuite) TestSequentialWorkflow() {
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessDecisionTask(true, false)
+	_, err := poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 	s.True(workflowComplete)
 }
@@ -725,7 +725,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 		s.Logger.Info("Calling Decision Task", tag.Counter(i))
 		var err error
 		if dropDecisionTask {
-			_, err = poller.PollAndProcessDecisionTask(true, true)
+			_, err = poller.PollAndProcessDecisionTask(false, true)
 		} else {
 			_, err = poller.PollAndProcessDecisionTaskWithAttempt(true, false, false, false, int64(1))
 		}
@@ -752,7 +752,7 @@ func (s *integrationSuite) TestDecisionAndActivityTimeoutsWorkflow() {
 	s.Logger.Info("Waiting for workflow to complete", tag.WorkflowRunID(*we.RunId))
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessDecisionTask(true, false)
+	_, err := poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 	s.True(workflowComplete)
 }
@@ -1397,7 +1397,7 @@ func (s *integrationSuite) TestSequential_UserTimers() {
 	}
 
 	s.False(workflowComplete)
-	_, err := poller.PollAndProcessDecisionTask(true, false)
+	_, err := poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 	s.True(workflowComplete)
 }
@@ -1494,7 +1494,7 @@ func (s *integrationSuite) TestRateLimitBufferedEvents() {
 	s.EqualError(err, "EntityNotExistsError{Message: Decision task not found.}")
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -1613,7 +1613,7 @@ func (s *integrationSuite) TestBufferedEvents() {
 	s.Equal(histResp.History.Events[5].GetEventType(), workflow.EventTypeWorkflowExecutionSignaled)
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 	s.NotNil(signalEvent)
@@ -1736,7 +1736,7 @@ func (s *integrationSuite) TestDescribeWorkflowExecution() {
 	s.Equal(0, len(dweResponse.PendingActivities))
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Nil(err)
 	s.True(workflowComplete)
 
@@ -2500,7 +2500,7 @@ func (s *integrationSuite) TestDecisionTaskFailed() {
 	s.Nil(err, "failed to send signal to execution")
 
 	// process signal
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 	s.Equal(1, signalCount)
@@ -2770,7 +2770,7 @@ func (s *integrationSuite) TestTransientDecisionTimeout() {
 	s.Nil(err, "failed to send signal to execution")
 
 	// Drop decision task to cause a Decision Timeout
-	_, err = poller.PollAndProcessDecisionTask(true, true)
+	_, err = poller.PollAndProcessDecisionTask(false, true)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -2864,7 +2864,7 @@ func (s *integrationSuite) TestNoTransientDecisionAfterFlushBufferedEvents() {
 
 	// fist decision, this try to do a continue as new but there is a buffered event,
 	// so it will fail and create a new decision
-	_, err := poller.PollAndProcessDecisionTask(true, false)
+	_, err := poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("pollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 

--- a/host/resetworkflow_test.go
+++ b/host/resetworkflow_test.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package host
+
+import (
+	"bytes"
+	"encoding/binary"
+	"strconv"
+
+	"github.com/pborman/uuid"
+
+	"github.com/uber/cadence/.gen/go/shared"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/log/tag"
+)
+
+func (s *integrationSuite) TestResetWorkflow() {
+	id := "integration-reset-workflow-test"
+	wt := "integration-reset-workflow-test-type"
+	tl := "integration-reset-workflow-test-taskqueue"
+	identity := "worker1"
+
+	workflowType := &shared.WorkflowType{Name: common.StringPtr(wt)}
+
+	tasklist := &shared.TaskList{Name: common.StringPtr(tl)}
+
+	// Start workflow execution
+	request := &shared.StartWorkflowExecutionRequest{
+		RequestId:                           common.StringPtr(uuid.New()),
+		Domain:                              common.StringPtr(s.domainName),
+		WorkflowId:                          common.StringPtr(id),
+		WorkflowType:                        workflowType,
+		TaskList:                            tasklist,
+		Input:                               nil,
+		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(100),
+		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(2),
+		Identity:                            common.StringPtr(identity),
+	}
+
+	we, err0 := s.engine.StartWorkflowExecution(createContext(), request)
+	s.NoError(err0)
+
+	s.Logger.Info("StartWorkflowExecution", tag.WorkflowRunID(we.GetRunId()))
+
+	// workflow logic
+	workflowComplete := false
+	activityData := int32(1)
+	activityCount := 3
+	isFirstTaskProcessed := false
+	isSecondTaskProcessed := false
+	var firstActivityCompletionEvent *shared.HistoryEvent
+	wtHandler := func(execution *shared.WorkflowExecution, wt *shared.WorkflowType,
+		previousStartedEventID, startedEventID int64, history *shared.History) ([]byte, []*shared.Decision, error) {
+
+		if !isFirstTaskProcessed {
+			// Schedule 3 activities on first workflow task
+			isFirstTaskProcessed = true
+			buf := new(bytes.Buffer)
+			s.Nil(binary.Write(buf, binary.LittleEndian, activityData))
+
+			var scheduleActivityCommands []*shared.Decision
+			for i := 1; i <= activityCount; i++ {
+				scheduleActivityCommands = append(scheduleActivityCommands, &shared.Decision{
+					DecisionType: common.DecisionTypePtr(shared.DecisionTypeScheduleActivityTask),
+					ScheduleActivityTaskDecisionAttributes: &shared.ScheduleActivityTaskDecisionAttributes{
+						ActivityId:                    common.StringPtr(strconv.Itoa(i)),
+						ActivityType:                  &shared.ActivityType{Name: common.StringPtr("ResetActivity")},
+						TaskList:                      tasklist,
+						Input:                         buf.Bytes(),
+						ScheduleToCloseTimeoutSeconds: common.Int32Ptr(100),
+						ScheduleToStartTimeoutSeconds: common.Int32Ptr(100),
+						StartToCloseTimeoutSeconds:    common.Int32Ptr(50),
+						HeartbeatTimeoutSeconds:       common.Int32Ptr(5),
+					},
+				})
+			}
+
+			return nil, scheduleActivityCommands, nil
+		} else if !isSecondTaskProcessed {
+			// Confirm one activity completion on second workflow task
+			isSecondTaskProcessed = true
+			for _, event := range history.Events[previousStartedEventID:] {
+				if event.GetEventType() == shared.EventTypeActivityTaskCompleted {
+					firstActivityCompletionEvent = event
+					return nil, []*shared.Decision{}, nil
+				}
+			}
+		}
+
+		// Complete workflow after reset
+		workflowComplete = true
+		return nil, []*shared.Decision{{
+			DecisionType: common.DecisionTypePtr(shared.DecisionTypeCompleteWorkflowExecution),
+			CompleteWorkflowExecutionDecisionAttributes: &shared.CompleteWorkflowExecutionDecisionAttributes{
+				Result: []byte("Done."),
+			},
+		}}, nil
+
+	}
+
+	// activity handler
+	atHandler := func(execution *shared.WorkflowExecution, activityType *shared.ActivityType,
+		activityID string, input []byte, taskToken []byte) ([]byte, bool, error) {
+
+		return []byte("Activity Result."), false, nil
+	}
+
+	poller := &TaskPoller{
+		Engine:          s.engine,
+		Domain:          s.domainName,
+		TaskList:        tasklist,
+		Identity:        identity,
+		DecisionHandler: wtHandler,
+		ActivityHandler: atHandler,
+		Logger:          s.Logger,
+		T:               s.T(),
+	}
+
+	// Process first workflow decision task to schedule activities
+	_, err := poller.PollAndProcessDecisionTask(false, false)
+	s.Logger.Info("PollAndProcessWorkflowTask", tag.Error(err))
+	s.NoError(err)
+
+	// Process one activity task which also creates second workflow task
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("Poll and process first activity", tag.Error(err))
+	s.NoError(err)
+
+	// Process second workflow task which checks activity completion
+	_, err = poller.PollAndProcessDecisionTask(false, false)
+	s.Logger.Info("Poll and process second workflow task", tag.Error(err))
+	s.NoError(err)
+
+	// Find reset point (last completed decision task)
+	events := s.getHistory(s.domainName, &shared.WorkflowExecution{
+		WorkflowId: common.StringPtr(id),
+		RunId:      common.StringPtr(we.GetRunId()),
+	})
+	var lastWorkflowTask *shared.HistoryEvent
+	for _, event := range events {
+		if event.GetEventType() == shared.EventTypeDecisionTaskCompleted {
+			lastWorkflowTask = event
+		}
+	}
+
+	// Reset workflow execution
+	_, err = s.engine.ResetWorkflowExecution(createContext(), &shared.ResetWorkflowExecutionRequest{
+		Domain: common.StringPtr(s.domainName),
+		WorkflowExecution: &shared.WorkflowExecution{
+			WorkflowId: common.StringPtr(id),
+			RunId:      we.RunId,
+		},
+		Reason:                common.StringPtr("reset execution from test"),
+		DecisionFinishEventId: common.Int64Ptr(lastWorkflowTask.GetEventId()),
+		RequestId:             common.StringPtr(uuid.New()),
+	})
+	s.NoError(err)
+
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("Poll and process second activity", tag.Error(err))
+	s.NoError(err)
+
+	err = poller.PollAndProcessActivityTask(false)
+	s.Logger.Info("Poll and process third activity", tag.Error(err))
+	s.NoError(err)
+
+	_, err = poller.PollAndProcessDecisionTask(false, false)
+	s.Logger.Info("Poll and process final workflow task", tag.Error(err))
+	s.NoError(err)
+
+	s.NotNil(firstActivityCompletionEvent)
+	s.True(workflowComplete)
+}

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -166,7 +166,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	s.Nil(err)
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -191,7 +191,7 @@ func (s *integrationSuite) TestSignalWorkflow() {
 	s.Nil(err)
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -363,7 +363,7 @@ func (s *integrationSuite) TestSignalWorkflow_DuplicateRequest() {
 	s.Nil(err)
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -539,7 +539,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision() {
 	s.Nil(err)
 
 	// Signal the foreign workflow with this decision request.
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -579,7 +579,7 @@ CheckHistoryLoopForSignalSent:
 	s.True(signalSent)
 
 	// process signal in decider for foreign workflow
-	_, err = foreignPoller.PollAndProcessDecisionTask(true, false)
+	_, err = foreignPoller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -836,7 +836,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_WithoutRunID() {
 	s.Nil(err)
 
 	// Signal the foreign workflow with this decision request.
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -875,7 +875,7 @@ CheckHistoryLoopForSignalSent:
 	s.True(signalSent)
 
 	// process signal in decider for foreign workflow
-	_, err = foreignPoller.PollAndProcessDecisionTask(true, false)
+	_, err = foreignPoller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -976,7 +976,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_UnKnownTarget() {
 	s.Nil(err)
 
 	// Signal the foreign workflow with this decision request.
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -1103,7 +1103,7 @@ func (s *integrationSuite) TestSignalExternalWorkflowDecision_SignalSelf() {
 	s.Nil(err)
 
 	// Signal the foreign workflow with this decision request.
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -1283,7 +1283,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	s.Equal(we.GetRunId(), resp.GetRunId())
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -1319,7 +1319,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	newWorkflowStarted = true
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 
@@ -1344,7 +1344,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	newWorkflowStarted = true
 
 	// Process signal in decider
-	_, err = poller.PollAndProcessDecisionTask(true, false)
+	_, err = poller.PollAndProcessDecisionTask(false, false)
 	s.Logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -682,7 +682,7 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 	s.Equal(clusterName[0], updateResp.ReplicationConfiguration.GetActiveClusterName())
 	s.Equal(int64(10), updateResp.GetFailoverVersion())
 
-	_, err = poller1.PollAndProcessDecisionTask(true, false)
+	_, err = poller1.PollAndProcessDecisionTask(false, false)
 	s.logger.Info("PollAndProcessDecisionTask", tag.Error(err))
 	s.Nil(err)
 	s.True(workflowCompleted)
@@ -1494,7 +1494,7 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 
 	for i := 1; i < 20; i++ {
 		if !workflowCompleted {
-			_, err = poller2.PollAndProcessDecisionTask(true, false)
+			_, err = poller2.PollAndProcessDecisionTask(false, false)
 			s.Nil(err)
 			time.Sleep(time.Second)
 		}

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1,4 +1,5 @@
 // Copyright (c) 2020 Uber Technologies, Inc.
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Fix reset failure when current run is open. It's the same issue that I should have fixed in https://github.com/uber/cadence/pull/3500 (sorry for missing this case). 
2. Add reset integration test for 3 cases: reset open, reset closed and reset of reset. For https://github.com/uber/cadence/issues/1688 
3. Dumping history is making the buildkite output really large. Disable dumpHistory flag in all integ test. I don't think anyone is looking at that. It's only useful when reproducing locally for debugging. But LMK if I am wrong. 
4. Improve error handling for retry policy. After introducing context, we need to return the previous error if exists instead of the last error. This will significantly improve our life when troubleshooting. 


<!-- Tell your future self why have you made these changes -->
**Why?**
1. reset is broken
2. we have been missing reset integ for a while(even though we have canary)
3. see above explanation. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test, unit test , integ test.

before any fixes:
```
[qlong] ~/cadence [qlong-reset-integ-test] M?? % ./cadence --ct 30 --do qlong wf reset -w cancel_9db64e27-3882-4854-bb27-45ed898971e2 --event_id 4 --reason test
Error: reset failed
Error Details: code:deadline-exceeded message:timeout
```

after the retry fix:
```
[qlong] ~/cadence [qlong-reset-integ-test] M?? % ./cadence --ct 30 --do qlong wf reset -w cancel_494d32a1-122d-4619-9254-2925143cab48  --event_id 4 --reason test

Error: reset failed
Error Details: code:internal message:cadence internal error, msg: AppendHistoryNodes: pq: duplicate key value violates unique constraint "history_tree_pkey"
('export CADENCE_CLI_SHOW_STACKS=1' to see stack traces)
```

after the reset fix:
```
[qlong] ~/cadence [qlong-reset-integ-test] M?? % ./cadence --do qlong wf list --open
        WORKFLOW TYPE       |                 WORKFLOW ID                 |                RUN ID                | TASK LIST | START TIME | EXECUTION TIME
  main.sampleCancelWorkflow | cancel_d32a3a20-11c0-4459-822a-b43a7b3b8739 | 40f1238f-184b-4e4f-9520-7ae5f68177c8 |           | 18:11:59   | 18:11:59
[qlong] ~/cadence [qlong-reset-integ-test] M?? % ./cadence --ct 30 --do qlong wf reset -w cancel_d32a3a20-11c0-4459-822a-b43a7b3b8739 --event_id 4 --reason test
{
  "runId": "e5fcdca2-4be5-4cdd-8156-a47c3d557139"
}
```
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no.
