### PR TITLE
Add username/password support for ElasticSearch

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -175,6 +175,7 @@ func (s *server) startService() common.Daemon {
 		}
 
 		params.ESConfig = advancedVisStore.ElasticSearch
+		params.ESConfig.SetUsernamePassword()
 		esClient, err := elasticsearch.NewGenericClient(params.ESConfig, s.cfg.Persistence.VisibilityConfig, params.Logger)
 		if err != nil {
 			log.Fatalf("error creating elastic search client: %v", err)

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -35,7 +35,7 @@ type (
 		Version string `yaml:version` //nolint:govet
 		// optional username to communicate with ElasticSearch
 		Username string `yaml:username` //nolint:govet
-		// optional password to communicate with ElasticSearch
+		// optional password to communicate with ElasticSearch 
 		Password string `yaml:password` //nolint:govet
 	}
 )

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -33,10 +33,23 @@ type (
 		Indices map[string]string `yaml:indices` //nolint:govet
 		// supporting v6 and v7. Default to v6 if empty.
 		Version string `yaml:version` //nolint:govet
+		// optional username to communicate with ElasticSearch
+		Username string
+		// optional password to communicate with ElasticSearch
+		Password string
 	}
 )
 
 // GetVisibilityIndex return visibility index name
 func (cfg *ElasticSearchConfig) GetVisibilityIndex() string {
 	return cfg.Indices[common.VisibilityAppName]
+}
+
+// SetUsernamePassword set the username/password into URL
+// It is a bit tricky here because url.URL doesn't expose the username/password in the struct
+// because of the security concern.
+func (cfg *ElasticSearchConfig) SetUsernamePassword() {
+	if cfg.Username != "" {
+		cfg.URL.User = url.UserPassword(cfg.Username, cfg.Password)
+	}
 }

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -35,7 +35,7 @@ type (
 		Version string `yaml:version` //nolint:govet
 		// optional username to communicate with ElasticSearch
 		Username string `yaml:username` //nolint:govet
-		// optional password to communicate with ElasticSearch 
+		// optional password to communicate with ElasticSearch
 		Password string `yaml:password` //nolint:govet
 	}
 )

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -34,9 +34,9 @@ type (
 		// supporting v6 and v7. Default to v6 if empty.
 		Version string `yaml:version` //nolint:govet
 		// optional username to communicate with ElasticSearch
-		Username string
+		Username string `yaml:username` //nolint:govet
 		// optional password to communicate with ElasticSearch
-		Password string
+		Password string `yaml:password` //nolint:govet
 	}
 )
 

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -81,7 +81,9 @@ persistence:
         {{- if eq $es "true" }}
         es-visibility:
             elasticsearch:
-                version: { { default .Env.ES_VERSION "" } }
+                version: {{ default .Env.ES_VERSION "" }}
+                username: {{ default .Env.ES_USER "" }}
+                password: {{ default .Env.ES_PWD "" }}
                 url:
                     scheme: "http"
                     host: "{{ default .Env.ES_SEEDS "" }}:9200"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Add username/password support for ElasticSearch
2. Fix a typo in the config_template. It should be "{{ }}" not "{ { } }". The typo was from my IDE auto saving action :( that I didn't notice. Our integ test can't discover that because they don't start the docker image from there. 

<!-- Tell your future self why have you made these changes -->
**Why?**
My ElasticSearch cluster requires username/password. This is usually implemented by web proxy for the ES operation team .
I think this is normal setup in production for lots of people. Adding this here will let me get rid of my custom build/image for me and other people. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested already in my production env. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Very superficial change, no risk. 
