### PR TITLE
Disable history scanner by default and tune the default RPS

### DIFF
--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -49,8 +49,9 @@ const (
 type (
 	// Config defines the configuration for scanner
 	Config struct {
-		// PersistenceMaxQPS the max rate of calls to persistence
-		PersistenceMaxQPS dynamicconfig.IntPropertyFn
+		// ScannerPersistenceMaxQPS the max rate of calls to persistence
+		// Right now is being used by historyScanner to determine the rate of persistence API calls
+		ScannerPersistenceMaxQPS dynamicconfig.IntPropertyFn
 		// Persistence contains the persistence configuration
 		Persistence *config.Persistence
 		// ClusterMetadata contains the metadata for this cluster

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -49,7 +49,7 @@ const (
 type (
 	// Config defines the configuration for scanner
 	Config struct {
-		// ScannerPersistenceMaxQPS the max rate of calls to persistence
+		// ScannerPersistenceMaxQPS the max rate of calls to persistence 
 		// Right now is being used by historyScanner to determine the rate of persistence API calls
 		ScannerPersistenceMaxQPS dynamicconfig.IntPropertyFn
 		// Persistence contains the persistence configuration

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -49,7 +49,7 @@ const (
 type (
 	// Config defines the configuration for scanner
 	Config struct {
-		// ScannerPersistenceMaxQPS the max rate of calls to persistence 
+		// ScannerPersistenceMaxQPS the max rate of calls to persistence
 		// Right now is being used by historyScanner to determine the rate of persistence API calls
 		ScannerPersistenceMaxQPS dynamicconfig.IntPropertyFn
 		// Persistence contains the persistence configuration

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -160,7 +160,7 @@ func HistoryScavengerActivity(
 ) (history.ScavengerHeartbeatDetails, error) {
 
 	ctx := activityCtx.Value(scannerContextKey).(scannerContext)
-	rps := ctx.cfg.PersistenceMaxQPS()
+	rps := ctx.cfg.ScannerPersistenceMaxQPS()
 
 	hbd := history.ScavengerHeartbeatDetails{}
 	if activity.HasHeartbeatDetails(activityCtx) {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -131,7 +131,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			Persistence:              &params.PersistenceConfig,
 			ClusterMetadata:          params.ClusterMetadata,
 			TaskListScannerEnabled:   dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
-			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
+			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, false),
 			ConcreteExecutionScannerConfig: &executions.ScannerWorkflowDynamicConfig{
 				Enabled:                 dc.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerEnabled, false),
 				Concurrency:             dc.GetIntProperty(dynamicconfig.ConcreteExecutionsScannerConcurrency, 25),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -127,11 +127,11 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			TimeLimitPerArchivalIteration: dc.GetDurationProperty(dynamicconfig.WorkerTimeLimitPerArchivalIteration, archiver.MaxArchivalIterationTimeout()),
 		},
 		ScannerCfg: &scanner.Config{
-			PersistenceMaxQPS:      dc.GetIntProperty(dynamicconfig.ScannerPersistenceMaxQPS, 100),
-			Persistence:            &params.PersistenceConfig,
-			ClusterMetadata:        params.ClusterMetadata,
-			TaskListScannerEnabled: dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
-			HistoryScannerEnabled:  dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
+			ScannerPersistenceMaxQPS: dc.GetIntProperty(dynamicconfig.ScannerPersistenceMaxQPS, 5),
+			Persistence:              &params.PersistenceConfig,
+			ClusterMetadata:          params.ClusterMetadata,
+			TaskListScannerEnabled:   dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
+			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
 			ConcreteExecutionScannerConfig: &executions.ScannerWorkflowDynamicConfig{
 				Enabled:                 dc.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerEnabled, false),
 				Concurrency:             dc.GetIntProperty(dynamicconfig.ConcreteExecutionsScannerConcurrency, 25),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Disable history scanner by default
2. Tune the default RPC
3. Rename the var to be more accurate. 

<!-- Tell your future self why have you made these changes -->
**Why?**
People has been running into issues with this(see slack discussion in https://uber-cadence.slack.com/archives/CL22WDF70/p1602637050263800?thread_ts=1602636086.263700&cid=CL22WDF70). It's not quite important for 99% of the user because they don't have a big cluster like Uber internally. So we should disable that by default. 
Also 100 rps is quite high for a lot of small clusters that people usually start with. Change it to a lower number so that it won't make issues when people start to using it. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Just config default values

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It should be very safe. 
