### PR TITLE
Backfill workflow version histories when resetting

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -349,6 +349,17 @@ type (
 		HistorySize int64
 	}
 
+	// ReplicationState represents mutable state information for global domains.
+	// This information is used by replication protocol when applying events from remote clusters
+	// TODO: remove this struct after all 2DC workflows complete
+	ReplicationState struct {
+		CurrentVersion      int64
+		StartVersion        int64
+		LastWriteVersion    int64
+		LastWriteEventID    int64
+		LastReplicationInfo map[string]*ReplicationInfo
+	}
+
 	// CurrentWorkflowExecution describes a current execution record
 	CurrentWorkflowExecution struct {
 		DomainID     string
@@ -649,6 +660,7 @@ type (
 		ExecutionStats      *ExecutionStats
 		BufferedEvents      []*workflow.HistoryEvent
 		VersionHistories    *VersionHistories
+		ReplicationState    *ReplicationState // TODO: remove this after all 2DC workflows complete
 		Checksum            checksum.Checksum
 	}
 

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -82,6 +82,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 			RequestCancelInfos: response.State.RequestCancelInfos,
 			SignalInfos:        response.State.SignalInfos,
 			SignalRequestedIDs: response.State.SignalRequestedIDs,
+			ReplicationState:   response.State.ReplicationState, // TODO: remove this after all 2DC workflows complete
 			Checksum:           response.State.Checksum,
 		},
 	}

--- a/common/persistence/persistenceInterface.go
+++ b/common/persistence/persistenceInterface.go
@@ -311,6 +311,7 @@ type (
 	InternalWorkflowMutableState struct {
 		ExecutionInfo    *InternalWorkflowExecutionInfo
 		VersionHistories *DataBlob
+		ReplicationState *ReplicationState // TODO: remove this after all 2DC workflows complete
 		ActivityInfos    map[int64]*InternalActivityInfo
 
 		TimerInfos          map[string]*TimerInfo

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -298,6 +298,14 @@ func (m *sqlExecutionManager) GetWorkflowExecution(
 		Memo:                               info.GetMemo(),
 	}
 
+	// TODO: remove this after all 2DC workflows complete
+	if info.LastWriteEventID != nil {
+		state.ReplicationState = &p.ReplicationState{}
+		state.ReplicationState.StartVersion = info.GetStartVersion()
+		state.ReplicationState.LastWriteVersion = execution.LastWriteVersion
+		state.ReplicationState.LastWriteEventID = info.GetLastWriteEventID()
+	}
+
 	if info.GetVersionHistories() != nil {
 		state.VersionHistories = p.NewDataBlob(
 			info.GetVersionHistories(),

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -116,6 +116,8 @@ type (
 
 		executionInfo    *persistence.WorkflowExecutionInfo // Workflow mutable state info.
 		versionHistories *persistence.VersionHistories
+		// TODO: remove this struct after all 2DC workflows complete
+		replicationState *persistence.ReplicationState
 		hBuilder         *HistoryBuilder
 
 		// in memory only attributes
@@ -325,6 +327,8 @@ func (e *mutableStateBuilder) Load(
 	e.stateInDB = state.ExecutionInfo.State
 	e.nextEventIDInDB = state.ExecutionInfo.NextEventID
 	e.versionHistories = state.VersionHistories
+	// TODO: remove this after all 2DC workflows complete
+	e.replicationState = state.ReplicationState
 	e.checksum = state.Checksum
 
 	if len(state.Checksum.Value) > 0 {
@@ -550,6 +554,11 @@ func (e *mutableStateBuilder) GetStartVersion() (int64, error) {
 }
 
 func (e *mutableStateBuilder) GetLastWriteVersion() (int64, error) {
+
+	// TODO: remove this after all 2DC workflows complete
+	if e.replicationState != nil {
+		return e.replicationState.LastWriteVersion, nil
+	}
 
 	if e.versionHistories != nil {
 		versionHistory, err := e.versionHistories.GetCurrentVersionHistory()

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -151,30 +151,29 @@ func (r *stateRebuilderImpl) Rebuild(
 		return nil, 0, err
 	}
 	rebuildVersionHistories := rebuiltMutableState.GetVersionHistories()
-	if rebuildVersionHistories == nil {
-		return nil, 0, ErrMissingVersionHistories
-	}
-	currentVersionHistory, err := rebuildVersionHistories.GetCurrentVersionHistory()
-	if err != nil {
-		return nil, 0, err
-	}
-	lastItem, err := currentVersionHistory.GetLastItem()
-	if err != nil {
-		return nil, 0, err
-	}
-	if !lastItem.Equals(persistence.NewVersionHistoryItem(
-		baseLastEventID,
-		baseLastEventVersion,
-	)) {
-		return nil, 0, &shared.BadRequestError{Message: fmt.Sprintf(
-			"nDCStateRebuilder unable to rebuild mutable state to event ID: %v, version: %v, "+
-				"baseLastEventID + baseLastEventVersion is not the same as the last event of the last "+
-				"batch, event ID: %v, version :%v ,typicaly because of attemptting to rebuild to a middle of a batch",
+	if rebuildVersionHistories != nil {
+		currentVersionHistory, err := rebuildVersionHistories.GetCurrentVersionHistory()
+		if err != nil {
+			return nil, 0, err
+		}
+		lastItem, err := currentVersionHistory.GetLastItem()
+		if err != nil {
+			return nil, 0, err
+		}
+		if !lastItem.Equals(persistence.NewVersionHistoryItem(
 			baseLastEventID,
 			baseLastEventVersion,
-			lastItem.EventID,
-			lastItem.Version,
-		)}
+		)) {
+			return nil, 0, &shared.BadRequestError{Message: fmt.Sprintf(
+				"nDCStateRebuilder unable to rebuild mutable state to event ID: %v, version: %v, "+
+					"baseLastEventID + baseLastEventVersion is not the same as the last event of the last "+
+					"batch, event ID: %v, version :%v ,typicaly because of attemptting to rebuild to a middle of a batch",
+				baseLastEventID,
+				baseLastEventVersion,
+				lastItem.EventID,
+				lastItem.Version,
+			)}
+		}
 	}
 
 	// close rebuilt mutable state transaction clearing all generated tasks, etc.

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -145,6 +145,7 @@ func (s *workflowResetterSuite) TestResetWorkflow_NoError() {
 	newBranchToken := []byte("other random branch token")
 
 	s.mockBaseMutableState.EXPECT().GetVersionHistories().Return(versionHistories).AnyTimes()
+	s.mockBaseMutableState.EXPECT().GetCurrentBranchToken().Return(branchToken, nil).AnyTimes()
 
 	mockBaseWorkflowReleaseFnCalled := false
 	mockBaseWorkflowReleaseFn := func(err error) {
@@ -220,6 +221,7 @@ func (s *workflowResetterSuite) TestResetWorkflow_Error() {
 	incomingFirstEventVersion := baseVersion + 3
 
 	s.mockBaseMutableState.EXPECT().GetVersionHistories().Return(versionHistories).AnyTimes()
+	s.mockBaseMutableState.EXPECT().GetCurrentBranchToken().Return(branchToken, nil).AnyTimes()
 
 	mockBaseWorkflowReleaseFn := func(err error) {
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Backfill workflow version histories when resetting
2. Handle version histories missing error during replication

<!-- Tell your future self why have you made these changes -->
**Why?**
Provide a way to backfill the version histories when resetting a 2dc workflow

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

