### PR TITLE
Disable cadenceworkflow.io domain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-cadenceworkflow.io


### PR DESCRIPTION
Cannot have two CNAMEs pointing to same domain in the same org. Removing this one as it will be superseded by:
https://github.com/uber/cadence-docs/blob/gh-pages/CNAME

From the documentation:
```The CNAME entry can only be used once on GitHub. For example, if another repository's CNAME file contains example.com, you cannot use example.com in the CNAME file for your repository.```

Check out https://docs.github.com/articles/troubleshooting-custom-domains#cname-errors for more information.