### PR TITLE
Improve logging when loading a dynamic config

### DIFF
--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -76,7 +76,7 @@ func (c *Collection) logValue(
 ) {
 	loadedValue, loaded := c.keys.LoadOrStore(key, value)
 	if !loaded || !cmpValueEquals(loadedValue, value) {
-		c.logger.Debug("Get dynamic config",
+		c.logger.Info("Get dynamic config",
 			tag.Name(key.String()), tag.Value(value), tag.DefaultValue(defaultValue))
 	}
 }

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -75,9 +75,10 @@ func (c *Collection) logValue(
 	cmpValueEquals func(interface{}, interface{}) bool,
 ) {
 	loadedValue, loaded := c.keys.LoadOrStore(key, value)
-	if !loaded || !cmpValueEquals(loadedValue, value) {
+	// If not loaded before, then print the log for the first loaded 
+	if !loaded {
 		c.logger.Info("Get dynamic config",
-			tag.Name(key.String()), tag.Value(value), tag.DefaultValue(defaultValue))
+			tag.Name(key.String()), tag.Value(loadedValue), tag.DefaultValue(defaultValue))
 	}
 }
 

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -76,12 +76,12 @@ func (c *Collection) logValue(
 ) {
 	loadedValue, loaded := c.logKeys.LoadOrStore(key, value)
 	if !loaded {
-		c.logger.Info("first loading dynamic config",
+		c.logger.Info("First loading dynamic config",
 			tag.Key(key.String()), tag.Value(value), tag.DefaultValue(defaultValue))
 	} else {
 		// it's loaded before, check if the value has changed
 		if !cmpValueEquals(loadedValue, value) {
-			c.logger.Info("dynamic config has changed",
+			c.logger.Info("Dynamic config has changed",
 				tag.Key(key.String()), tag.Value(value), tag.DefaultValue(loadedValue))
 			// update the logKeys so that we can capture the changes again
 			// (ignore the racing condition here because it's just for logging, we need a lock if really need to solve it)

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -84,7 +84,7 @@ func (c *Collection) logValue(
 			c.logger.Info("Dynamic config has changed",
 				tag.Key(key.String()), tag.Value(value), tag.DefaultValue(loadedValue))
 			// update the logKeys so that we can capture the changes again
-			// (ignore the racing condition here because it's just for logging, we need a lock if really need to solve it)
+			// (ignore the racing condition here because it's just for logging, we need a lock if really need to solve it) 
 			c.logKeys.Store(key, value)
 		}
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use info log level for first time loading a dynamic config

<!-- Tell your future self why have you made these changes -->
**Why?**
It will be useful for debugging dynamic config. Because default logging level is Info in Cadence.
This would cause too many logging becuase it only emit the logs for the firs time loading.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
