### PR TITLE
Remove wrong extra sslParam in Postgres TLS

### DIFF
--- a/common/persistence/sql/sqlplugin/postgres/plugin.go
+++ b/common/persistence/sql/sqlplugin/postgres/plugin.go
@@ -131,7 +131,6 @@ func generateCredentialString(user string, password string) string {
 func registerTLSConfig(cfg *config.SQL) (sslParams url.Values, err error) {
 	sslParams = url.Values{}
 	if cfg.TLS != nil && cfg.TLS.Enabled {
-		sslParams.Set("ssl", "true")
 		sslParams.Set("sslmode", "require")
 		sslParams.Set("sslrootcert", cfg.TLS.CaFile)
 		sslParams.Set("sslkey", cfg.TLS.KeyFile)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove wrong extra sslParam in Postgres TLS

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/3756

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test
Prerequisite: start a postgres server with SSL enabled. 

Before:
```
% ./cadence-sql-tool -p 5432 --pl postgres --tls --tls-ca-file ~/pg_sca.crt   setup-schema -v 0.0
2020/11/15 12:02:55 pq: parameter "ssl" cannot be changed now
```

After:
```
./cadence-sql-tool -p 5432 --pl postgres --tls --tls-ca-file ~/pg_sca.crt   setup-schema -v 0.0
2020/11/15 12:35:32 Starting schema setup, config=&{SchemaFilePath: InitialVersion:0.0 Overwrite:false DisableVersioning:false}
2020/11/15 12:35:32 Setting up version tables
2020/11/15 12:35:32 pq: relation "schema_version" already exists
```
and
```
% ./cadence-sql-tool -p 5432 --pl postgres --tls --tls-ca-file ~/pg_sca.crt   update-schema -d ./schema/postgres/cadence/versioned
2020/11/15 12:04:16 UpdateSchemeTask started, config=&{DBName: TargetVersion: SchemaDir:./schema/postgres/cadence/versioned IsDryRun:false}
2020/11/15 12:04:16 found zero updates from current version 0.3
2020/11/15 12:04:16 UpdateSchemeTask done
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

