### PR TITLE
Improve retry policy for operations in task processing

### DIFF
--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -37,7 +37,7 @@ import (
 )
 
 var (
-	persistenceOperationRetryPolicy = common.CreatePersistenceRetryPolicy()
+	taskRetryPolicy = common.CreateTaskProcessingRetryPolicy()
 )
 
 type (
@@ -227,7 +227,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowExecution(
 			RunID:      task.RunID,
 		})
 	}
-	return backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
 }
 
 func (t *timerTaskExecutorBase) deleteCurrentWorkflowExecution(
@@ -242,7 +242,7 @@ func (t *timerTaskExecutorBase) deleteCurrentWorkflowExecution(
 			RunID:      task.RunID,
 		})
 	}
-	return backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
 }
 
 func (t *timerTaskExecutorBase) deleteWorkflowHistory(
@@ -262,7 +262,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowHistory(
 		})
 
 	}
-	return backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
 }
 
 func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
@@ -280,5 +280,5 @@ func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
 		// TODO: expose GetVisibilityManager method on shardContext interface
 		return t.shard.GetService().GetVisibilityManager().DeleteWorkflowExecution(ctx, request) // delete from db
 	}
-	return backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
 }

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1213,7 +1213,7 @@ func (t *transferActiveTaskExecutor) requestCancelExternalExecutionWithRetry(
 		return thrift.FromError(err)
 	}
 
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
 
 	if _, ok := err.(*workflow.CancellationAlreadyRequestedError); ok {
 		// err is CancellationAlreadyRequestedError
@@ -1260,7 +1260,7 @@ func (t *transferActiveTaskExecutor) signalExternalExecutionWithRetry(
 		return thrift.FromError(err)
 	}
 
-	return backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
 }
 
 func (t *transferActiveTaskExecutor) startWorkflowWithRetry(
@@ -1321,7 +1321,7 @@ func (t *transferActiveTaskExecutor) startWorkflowWithRetry(
 		return err
 	}
 
-	err = backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	err = backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change retry policy in task processing from 30s expiration interval to a max attempt of 3.

<!-- Tell your future self why have you made these changes -->
**Why?**
Retry 30s will block other tasks from being processed

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
