### PR TITLE
Switch remaining task/matching types to internal

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/checksum"
 	"github.com/uber/cadence/common/codec"
+	"github.com/uber/cadence/common/types"
 )
 
 // Domain status
@@ -1130,7 +1131,7 @@ type (
 
 	// CreateTaskInfo describes a task to be created in CreateTasksRequest
 	CreateTaskInfo struct {
-		Execution workflow.WorkflowExecution
+		Execution types.WorkflowExecution
 		Data      *TaskInfo
 		TaskID    int64
 	}

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -31,9 +31,9 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 
-	gen "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	p "github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 )
 
 type (
@@ -74,8 +74,8 @@ func (s *MatchingPersistenceSuite) TestCreateTask() {
 	defer cancel()
 
 	domainID := "11adbd1b-f164-4ea7-b2f3-2e857a5048f1"
-	workflowExecution := gen.WorkflowExecution{WorkflowId: common.StringPtr("create-task-test"),
-		RunId: common.StringPtr("c949447a-691a-4132-8b2a-a5b38106793c")}
+	workflowExecution := types.WorkflowExecution{WorkflowID: common.StringPtr("create-task-test"),
+		RunID: common.StringPtr("c949447a-691a-4132-8b2a-a5b38106793c")}
 	task0, err0 := s.CreateDecisionTask(ctx, domainID, workflowExecution, "a5b38106793c", 5)
 	s.NoError(err0)
 	s.NotNil(task0, "Expected non empty task identifier.")
@@ -105,8 +105,8 @@ func (s *MatchingPersistenceSuite) TestCreateTask() {
 		s.NoError(err)
 		s.Equal(1, len(resp.Tasks))
 		s.Equal(domainID, resp.Tasks[0].DomainID)
-		s.Equal(*workflowExecution.WorkflowId, resp.Tasks[0].WorkflowID)
-		s.Equal(*workflowExecution.RunId, resp.Tasks[0].RunID)
+		s.Equal(*workflowExecution.WorkflowID, resp.Tasks[0].WorkflowID)
+		s.Equal(*workflowExecution.RunID, resp.Tasks[0].RunID)
 		s.Equal(sid, resp.Tasks[0].ScheduleID)
 		s.True(resp.Tasks[0].CreatedTime.UnixNano() > 0)
 		if s.TaskMgr.GetName() != "cassandra" {
@@ -123,8 +123,8 @@ func (s *MatchingPersistenceSuite) TestGetDecisionTasks() {
 	defer cancel()
 
 	domainID := "aeac8287-527b-4b35-80a9-667cb47e7c6d"
-	workflowExecution := gen.WorkflowExecution{WorkflowId: common.StringPtr("get-decision-task-test"),
-		RunId: common.StringPtr("db20f7e2-1a1e-40d9-9278-d8b886738e05")}
+	workflowExecution := types.WorkflowExecution{WorkflowID: common.StringPtr("get-decision-task-test"),
+		RunID: common.StringPtr("db20f7e2-1a1e-40d9-9278-d8b886738e05")}
 	taskList := "d8b886738e05"
 	task0, err0 := s.CreateDecisionTask(ctx, domainID, workflowExecution, taskList, 5)
 	s.NoError(err0)
@@ -147,8 +147,8 @@ func (s *MatchingPersistenceSuite) TestGetTasksWithNoMaxReadLevel() {
 		return
 	}
 	domainID := "f1116985-d1f1-40e0-aba9-83344db915bc"
-	workflowExecution := gen.WorkflowExecution{WorkflowId: common.StringPtr("complete-decision-task-test"),
-		RunId: common.StringPtr("2aa0a74e-16ee-4f27-983d-48b07ec1915d")}
+	workflowExecution := types.WorkflowExecution{WorkflowID: common.StringPtr("complete-decision-task-test"),
+		RunID: common.StringPtr("2aa0a74e-16ee-4f27-983d-48b07ec1915d")}
 	taskList := "48b07ec1915d"
 	_, err0 := s.CreateActivityTasks(ctx, domainID, workflowExecution, map[int64]string{
 		10: taskList,
@@ -196,8 +196,8 @@ func (s *MatchingPersistenceSuite) TestCompleteDecisionTask() {
 	defer cancel()
 
 	domainID := "f1116985-d1f1-40e0-aba9-83344db915bc"
-	workflowExecution := gen.WorkflowExecution{WorkflowId: common.StringPtr("complete-decision-task-test"),
-		RunId: common.StringPtr("2aa0a74e-16ee-4f27-983d-48b07ec1915d")}
+	workflowExecution := types.WorkflowExecution{WorkflowID: common.StringPtr("complete-decision-task-test"),
+		RunID: common.StringPtr("2aa0a74e-16ee-4f27-983d-48b07ec1915d")}
 	taskList := "48b07ec1915d"
 	tasks0, err0 := s.CreateActivityTasks(ctx, domainID, workflowExecution, map[int64]string{
 		10: taskList,
@@ -222,8 +222,8 @@ func (s *MatchingPersistenceSuite) TestCompleteDecisionTask() {
 	s.Equal(5, len(tasksWithID1), "Expected 5 activity tasks.")
 	for _, t := range tasksWithID1 {
 		s.Equal(domainID, t.DomainID)
-		s.Equal(*workflowExecution.WorkflowId, t.WorkflowID)
-		s.Equal(*workflowExecution.RunId, t.RunID)
+		s.Equal(*workflowExecution.WorkflowID, t.WorkflowID)
+		s.Equal(*workflowExecution.RunID, t.RunID)
 		s.True(t.TaskID > 0)
 
 		err2 := s.CompleteTask(ctx, domainID, taskList, p.TaskListTypeActivity, t.TaskID, 100)
@@ -238,9 +238,9 @@ func (s *MatchingPersistenceSuite) TestCompleteTasksLessThan() {
 
 	domainID := uuid.New()
 	taskList := "range-complete-task-tl0"
-	wfExec := gen.WorkflowExecution{
-		WorkflowId: common.StringPtr("range-complete-task-test"),
-		RunId:      common.StringPtr(uuid.New()),
+	wfExec := types.WorkflowExecution{
+		WorkflowID: common.StringPtr("range-complete-task-test"),
+		RunID:      common.StringPtr(uuid.New()),
 	}
 	_, err := s.CreateActivityTasks(ctx, domainID, wfExec, map[int64]string{
 		10: taskList,

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -47,6 +47,7 @@ import (
 	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/types"
 )
 
 type (
@@ -1695,7 +1696,7 @@ func (s *TestBase) RangeCompleteTimerTask(ctx context.Context, inclusiveBeginTim
 }
 
 // CreateDecisionTask is a utility method to create a task
-func (s *TestBase) CreateDecisionTask(ctx context.Context, domainID string, workflowExecution workflow.WorkflowExecution, taskList string,
+func (s *TestBase) CreateDecisionTask(ctx context.Context, domainID string, workflowExecution types.WorkflowExecution, taskList string,
 	decisionScheduleID int64) (int64, error) {
 	leaseResponse, err := s.TaskMgr.LeaseTaskList(ctx, &p.LeaseTaskListRequest{
 		DomainID: domainID,
@@ -1713,8 +1714,8 @@ func (s *TestBase) CreateDecisionTask(ctx context.Context, domainID string, work
 			Execution: workflowExecution,
 			Data: &p.TaskInfo{
 				DomainID:   domainID,
-				WorkflowID: *workflowExecution.WorkflowId,
-				RunID:      *workflowExecution.RunId,
+				WorkflowID: *workflowExecution.WorkflowID,
+				RunID:      *workflowExecution.RunID,
 				TaskID:     taskID,
 				ScheduleID: decisionScheduleID,
 			},
@@ -1734,7 +1735,7 @@ func (s *TestBase) CreateDecisionTask(ctx context.Context, domainID string, work
 }
 
 // CreateActivityTasks is a utility method to create tasks
-func (s *TestBase) CreateActivityTasks(ctx context.Context, domainID string, workflowExecution workflow.WorkflowExecution,
+func (s *TestBase) CreateActivityTasks(ctx context.Context, domainID string, workflowExecution types.WorkflowExecution,
 	activities map[int64]string) ([]int64, error) {
 
 	taskLists := make(map[string]*p.TaskListInfo)
@@ -1760,8 +1761,8 @@ func (s *TestBase) CreateActivityTasks(ctx context.Context, domainID string, wor
 				Execution: workflowExecution,
 				Data: &p.TaskInfo{
 					DomainID:               domainID,
-					WorkflowID:             *workflowExecution.WorkflowId,
-					RunID:                  *workflowExecution.RunId,
+					WorkflowID:             *workflowExecution.WorkflowID,
+					RunID:                  *workflowExecution.RunID,
 					TaskID:                 taskID,
 					ScheduleID:             activityScheduleID,
 					ScheduleToStartTimeout: defaultScheduleToStartTimeout,

--- a/common/persistence/taskManager.go
+++ b/common/persistence/taskManager.go
@@ -24,8 +24,6 @@ package persistence
 
 import (
 	"context"
-
-	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 type (
@@ -110,7 +108,7 @@ func (t *taskManager) toInternalCreateTaskInfo(createTaskInfo *CreateTaskInfo) *
 		return nil
 	}
 	return &InternalCreateTasksInfo{
-		Execution: *thrift.ToWorkflowExecution(&createTaskInfo.Execution),
+		Execution: createTaskInfo.Execution,
 		Data:      t.toInternalTaskInfo(createTaskInfo.Data),
 		TaskID:    createTaskInfo.TaskID,
 	}

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1920,10 +1920,10 @@ func (m *testTaskManager) CreateTasks(
 		scheduleID := task.Data.ScheduleID
 		info := &persistence.TaskInfo{
 			DomainID:   domainID,
-			RunID:      *task.Execution.RunId,
+			RunID:      *task.Execution.RunID,
 			ScheduleID: scheduleID,
 			TaskID:     task.TaskID,
-			WorkflowID: *task.Execution.WorkflowId,
+			WorkflowID: *task.Execution.WorkflowID,
 		}
 		if task.Data.ScheduleToStartTimeout != 0 {
 			info.Expiry = time.Now().Add(time.Duration(task.Data.ScheduleToStartTimeout) * time.Second)

--- a/service/matching/taskWriter.go
+++ b/service/matching/taskWriter.go
@@ -28,7 +28,6 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
-	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 type (
@@ -166,7 +165,7 @@ writerLoop:
 				for i, req := range reqs {
 					tasks = append(tasks, &persistence.CreateTaskInfo{
 						TaskID:    taskIDs[i],
-						Execution: *thrift.FromWorkflowExecution(req.execution),
+						Execution: *req.execution,
 						Data:      req.taskInfo,
 					})
 					maxReadLevel = taskIDs[i]


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Switch remaining thrift types to internal types from task manager upwards to matching service. This concludes task/matching stack conversion, all types in this vertical are now internal.

<!-- Tell your future self why have you made these changes -->
**Why?**
To propagate internal types through Cadence codebase.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

