### PR TITLE
Set default MaximumSignalsPerExecution to 10K

### DIFF
--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -406,7 +406,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ExecutionMgrNumConns:            dc.GetIntProperty(dynamicconfig.ExecutionMgrNumConns, 50),
 		HistoryMgrNumConns:              dc.GetIntProperty(dynamicconfig.HistoryMgrNumConns, 50),
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
-		// 10K signals should big enough given workflow has 200K history lengh limit. It needs to be non-zero to protect continueAsNew from infinit loop
+		// 10K signals should big enough given a workflow execution has 200K history lengh limit. It needs to be non-zero to protect continueAsNew from infinit loop
 		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:          dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardSyncMinInterval:            dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -406,7 +406,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ExecutionMgrNumConns:            dc.GetIntProperty(dynamicconfig.ExecutionMgrNumConns, 50),
 		HistoryMgrNumConns:              dc.GetIntProperty(dynamicconfig.HistoryMgrNumConns, 50),
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
-		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaximumSignalsPerExecution, 0),
+		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:          dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardSyncMinInterval:            dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),
 		ShardSyncTimerJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -406,6 +406,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ExecutionMgrNumConns:            dc.GetIntProperty(dynamicconfig.ExecutionMgrNumConns, 50),
 		HistoryMgrNumConns:              dc.GetIntProperty(dynamicconfig.HistoryMgrNumConns, 50),
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
+		// 10K signals should big enough given 200K history lengh limit. It needs to be non-zero to protect continueAsNew from infinit loop
 		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:          dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardSyncMinInterval:            dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -406,7 +406,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ExecutionMgrNumConns:            dc.GetIntProperty(dynamicconfig.ExecutionMgrNumConns, 50),
 		HistoryMgrNumConns:              dc.GetIntProperty(dynamicconfig.HistoryMgrNumConns, 50),
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
-		// 10K signals should big enough given 200K history lengh limit. It needs to be non-zero to protect continueAsNew from infinit loop
+		// 10K signals should big enough given workflow has 200K history lengh limit. It needs to be non-zero to protect continueAsNew from infinit loop
 		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:          dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardSyncMinInterval:            dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -406,7 +406,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ExecutionMgrNumConns:            dc.GetIntProperty(dynamicconfig.ExecutionMgrNumConns, 50),
 		HistoryMgrNumConns:              dc.GetIntProperty(dynamicconfig.HistoryMgrNumConns, 50),
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch, 100),
-		// 10K signals should big enough given a workflow execution has 200K history lengh limit. It needs to be non-zero to protect continueAsNew from infinit loop
+		// 10K signals should big enough given workflow execution has 200K history lengh limit. It needs to be non-zero to protect continueAsNew from infinit loop
 		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaximumSignalsPerExecution, 10000),
 		ShardUpdateMinInterval:          dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval, 5*time.Minute),
 		ShardSyncMinInterval:            dc.GetDurationProperty(dynamicconfig.ShardSyncMinInterval, 5*time.Minute),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set default MaximumSignalsPerExecution to 10K

<!-- Tell your future self why have you made these changes -->
**Why?**
If keep receiving signals in very high rate, existing behavior will keep failing decision and workflow can't do continueAsNew, because continueAsNew is not allowed when there is any bufferedEvents. So this can make an infinite loop:
1. workflow worker has started a decision because there is some signals
2. incoming signals go to buffered events
3. workflow made a decision to do continueAsNew because the total signals. has reached a big number(like 1K)
4. RespondDecisionTaskComplete failed and it becomes decisionTaskFailed, because there is buffered events. 
6. A new decision task is scheduled...go to 1 again. 


Eventually the workflow will get terminated when exceeding 200K event limit. This was design to protect this scenario. 
10K should be high even given our history length limit of 200K.

Related to discussion in https://uber-cadence.slack.com/archives/CL22WDF70/p1605881855052000?thread_ts=1605767738.022500&cid=CL22WDF70

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing tests. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Internally there should be set to some value.
This is to protect the external customers because mostly people rely on the default values. 
