### PR TITLE
Patch a change to support reset 2dc workflow

### DIFF
--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -530,6 +530,11 @@ func (e *mutableStateBuilder) UpdateCurrentVersion(
 
 func (e *mutableStateBuilder) GetCurrentVersion() int64 {
 
+	// TODO: remove this after all 2DC workflows complete
+	if e.replicationState != nil {
+		return e.replicationState.CurrentVersion
+	}
+
 	if e.versionHistories != nil {
 		return e.currentVersion
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Take the replication state back in mutable state for 2dc reset

<!-- Tell your future self why have you made these changes -->
**Why?**
Should be part of https://github.com/uber/cadence/pull/3742/files

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

