### PR TITLE
Switch common/archiver to internal types

### DIFF
--- a/common/archiver/archivalMetadata.go
+++ b/common/archiver/archivalMetadata.go
@@ -24,10 +24,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/common/types"
 )
 
 type (
@@ -43,7 +43,7 @@ type (
 		ClusterConfiguredForArchival() bool
 		GetClusterStatus() ArchivalStatus
 		ReadEnabled() bool
-		GetDomainDefaultStatus() shared.ArchivalStatus
+		GetDomainDefaultStatus() types.ArchivalStatus
 		GetDomainDefaultURI() string
 	}
 
@@ -56,7 +56,7 @@ type (
 		staticClusterStatus  ArchivalStatus
 		dynamicClusterStatus dynamicconfig.StringPropertyFn
 		enableRead           dynamicconfig.BoolPropertyFn
-		domainDefaultStatus  shared.ArchivalStatus
+		domainDefaultStatus  types.ArchivalStatus
 		domainDefaultURI     string
 	}
 
@@ -145,7 +145,7 @@ func NewDisabledArchvialConfig() ArchivalConfig {
 		staticClusterStatus:  ArchivalDisabled,
 		dynamicClusterStatus: nil,
 		enableRead:           nil,
-		domainDefaultStatus:  shared.ArchivalStatusDisabled,
+		domainDefaultStatus:  types.ArchivalStatusDisabled,
 		domainDefaultURI:     "",
 	}
 }
@@ -180,7 +180,7 @@ func (a *archivalConfig) ReadEnabled() bool {
 	return a.enableRead()
 }
 
-func (a *archivalConfig) GetDomainDefaultStatus() shared.ArchivalStatus {
+func (a *archivalConfig) GetDomainDefaultStatus() types.ArchivalStatus {
 	return a.domainDefaultStatus
 }
 
@@ -201,13 +201,13 @@ func getClusterArchivalStatus(str string) (ArchivalStatus, error) {
 	return ArchivalDisabled, fmt.Errorf("invalid archival status of %v for cluster, valid status are: {\"\", \"disabled\", \"paused\", \"enabled\"}", str)
 }
 
-func getDomainArchivalStatus(str string) (shared.ArchivalStatus, error) {
+func getDomainArchivalStatus(str string) (types.ArchivalStatus, error) {
 	str = strings.TrimSpace(strings.ToLower(str))
 	switch str {
 	case "", common.ArchivalDisabled:
-		return shared.ArchivalStatusDisabled, nil
+		return types.ArchivalStatusDisabled, nil
 	case common.ArchivalEnabled:
-		return shared.ArchivalStatusEnabled, nil
+		return types.ArchivalStatusEnabled, nil
 	}
-	return shared.ArchivalStatusDisabled, fmt.Errorf("invalid archival status of %v for domain, valid status are: {\"\", \"disabled\", \"enabled\"}", str)
+	return types.ArchivalStatusDisabled, fmt.Errorf("invalid archival status of %v for domain, valid status are: {\"\", \"disabled\", \"enabled\"}", str)
 }

--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -41,7 +41,6 @@ import (
 	"path"
 	"strconv"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/backoff"

--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -47,6 +47,7 @@ import (
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
 
@@ -141,7 +142,7 @@ func (h *historyArchiver) Archive(
 		historyIterator = archiver.NewHistoryIterator(ctx, request, h.container.HistoryV2Manager, targetHistoryBlobSize)
 	}
 
-	historyBatches := []*shared.History{}
+	historyBatches := []*types.History{}
 	for historyIterator.HasNext() {
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 		if err != nil {

--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
 
@@ -66,8 +67,8 @@ type historyArchiverSuite struct {
 	container          *archiver.HistoryBootstrapContainer
 	testArchivalURI    archiver.URI
 	testGetDirectory   string
-	historyBatchesV1   []*shared.History
-	historyBatchesV100 []*shared.History
+	historyBatchesV1   []*types.History
+	historyBatchesV100 []*types.History
 }
 
 func TestHistoryArchiverSuite(t *testing.T) {
@@ -204,11 +205,11 @@ func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	mockCtrl := gomock.NewController(s.T())
 	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion + 1),
 				},
@@ -268,25 +269,25 @@ func (s *historyArchiverSuite) TestArchive_Success() {
 	mockCtrl := gomock.NewController(s.T())
 	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 2),
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 2),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
 			},
 		},
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(testNextEventID - 1),
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(testNextEventID - 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
@@ -447,7 +448,7 @@ func (s *historyArchiverSuite) TestGet_Success_SmallPageSize() {
 		PageSize:             1,
 		CloseFailoverVersion: common.Int64Ptr(100),
 	}
-	combinedHistory := []*shared.History{}
+	combinedHistory := []*types.History{}
 
 	URI, err := archiver.NewURI("file://" + s.testGetDirectory)
 	s.NoError(err)
@@ -533,11 +534,11 @@ func (s *historyArchiverSuite) newTestHistoryArchiver(historyIterator archiver.H
 }
 
 func (s *historyArchiverSuite) setupHistoryDirectory() {
-	s.historyBatchesV1 = []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(testNextEventID - 1),
+	s.historyBatchesV1 = []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(testNextEventID - 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(1),
 				},
@@ -545,25 +546,25 @@ func (s *historyArchiverSuite) setupHistoryDirectory() {
 		},
 	}
 
-	s.historyBatchesV100 = []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+	s.historyBatchesV100 = []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
 			},
 		},
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(testNextEventID - 1),
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(testNextEventID - 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
@@ -575,7 +576,7 @@ func (s *historyArchiverSuite) setupHistoryDirectory() {
 	s.writeHistoryBatchesForGetTest(s.historyBatchesV100, testCloseFailoverVersion)
 }
 
-func (s *historyArchiverSuite) writeHistoryBatchesForGetTest(historyBatches []*shared.History, version int64) {
+func (s *historyArchiverSuite) writeHistoryBatchesForGetTest(historyBatches []*types.History, version int64) {
 	data, err := encode(historyBatches)
 	s.Require().NoError(err)
 	filename := constructHistoryFilename(testDomainID, testWorkflowID, testRunID, version)

--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -34,7 +34,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/log/loggerimpl"

--- a/common/archiver/filestore/queryParser.go
+++ b/common/archiver/filestore/queryParser.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/xwb1989/sqlparser"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
 )
 
 type (
@@ -49,7 +49,7 @@ type (
 		workflowID        *string
 		runID             *string
 		workflowTypeName  *string
-		closeStatus       *shared.WorkflowExecutionCloseStatus
+		closeStatus       *types.WorkflowExecutionCloseStatus
 		emptyResult       bool
 	}
 )
@@ -241,21 +241,21 @@ func convertToTimestamp(timeStr string) (int64, error) {
 	return parsedTime.UnixNano(), nil
 }
 
-func convertStatusStr(statusStr string) (shared.WorkflowExecutionCloseStatus, error) {
+func convertStatusStr(statusStr string) (types.WorkflowExecutionCloseStatus, error) {
 	statusStr = strings.ToLower(strings.TrimSpace(statusStr))
 	switch statusStr {
-	case "completed", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusCompleted)):
-		return shared.WorkflowExecutionCloseStatusCompleted, nil
-	case "failed", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusFailed)):
-		return shared.WorkflowExecutionCloseStatusFailed, nil
-	case "canceled", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusCanceled)):
-		return shared.WorkflowExecutionCloseStatusCanceled, nil
-	case "terminated", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusTerminated)):
-		return shared.WorkflowExecutionCloseStatusTerminated, nil
-	case "continuedasnew", "continued_as_new", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusContinuedAsNew)):
-		return shared.WorkflowExecutionCloseStatusContinuedAsNew, nil
-	case "timedout", "timed_out", strconv.Itoa(int(shared.WorkflowExecutionCloseStatusTimedOut)):
-		return shared.WorkflowExecutionCloseStatusTimedOut, nil
+	case "completed", strconv.Itoa(int(types.WorkflowExecutionCloseStatusCompleted)):
+		return types.WorkflowExecutionCloseStatusCompleted, nil
+	case "failed", strconv.Itoa(int(types.WorkflowExecutionCloseStatusFailed)):
+		return types.WorkflowExecutionCloseStatusFailed, nil
+	case "canceled", strconv.Itoa(int(types.WorkflowExecutionCloseStatusCanceled)):
+		return types.WorkflowExecutionCloseStatusCanceled, nil
+	case "terminated", strconv.Itoa(int(types.WorkflowExecutionCloseStatusTerminated)):
+		return types.WorkflowExecutionCloseStatusTerminated, nil
+	case "continuedasnew", "continued_as_new", strconv.Itoa(int(types.WorkflowExecutionCloseStatusContinuedAsNew)):
+		return types.WorkflowExecutionCloseStatusContinuedAsNew, nil
+	case "timedout", "timed_out", strconv.Itoa(int(types.WorkflowExecutionCloseStatusTimedOut)):
+		return types.WorkflowExecutionCloseStatusTimedOut, nil
 	default:
 		return 0, fmt.Errorf("unknown workflow close status: %s", statusStr)
 	}

--- a/common/archiver/filestore/queryParser_test.go
+++ b/common/archiver/filestore/queryParser_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
 )
 
 type queryParserSuite struct {
@@ -151,28 +151,28 @@ func (s *queryParserSuite) TestParseCloseStatus() {
 			query:     "CloseStatus = \"Completed\"",
 			expectErr: false,
 			parsedQuery: &parsedQuery{
-				closeStatus: shared.WorkflowExecutionCloseStatusCompleted.Ptr(),
+				closeStatus: types.WorkflowExecutionCloseStatusCompleted.Ptr(),
 			},
 		},
 		{
 			query:     "CloseStatus = 'continuedasnew'",
 			expectErr: false,
 			parsedQuery: &parsedQuery{
-				closeStatus: shared.WorkflowExecutionCloseStatusContinuedAsNew.Ptr(),
+				closeStatus: types.WorkflowExecutionCloseStatusContinuedAsNew.Ptr(),
 			},
 		},
 		{
 			query:     "CloseStatus = 'TIMED_OUT'",
 			expectErr: false,
 			parsedQuery: &parsedQuery{
-				closeStatus: shared.WorkflowExecutionCloseStatusTimedOut.Ptr(),
+				closeStatus: types.WorkflowExecutionCloseStatusTimedOut.Ptr(),
 			},
 		},
 		{
 			query:     "CloseStatus = 'Failed' and CloseStatus = \"Failed\"",
 			expectErr: false,
 			parsedQuery: &parsedQuery{
-				closeStatus: shared.WorkflowExecutionCloseStatusFailed.Ptr(),
+				closeStatus: types.WorkflowExecutionCloseStatusFailed.Ptr(),
 			},
 		},
 		{
@@ -202,7 +202,7 @@ func (s *queryParserSuite) TestParseCloseStatus() {
 			query:     "CloseStatus = 1",
 			expectErr: false,
 			parsedQuery: &parsedQuery{
-				closeStatus: shared.WorkflowExecutionCloseStatusFailed.Ptr(),
+				closeStatus: types.WorkflowExecutionCloseStatusFailed.Ptr(),
 			},
 		},
 		{
@@ -314,7 +314,7 @@ func (s *queryParserSuite) TestParse() {
 				earliestCloseTime: 2000,
 				latestCloseTime:   9999,
 				runID:             common.StringPtr("random runID"),
-				closeStatus:       shared.WorkflowExecutionCloseStatusFailed.Ptr(),
+				closeStatus:       types.WorkflowExecutionCloseStatusFailed.Ptr(),
 			},
 		},
 		{

--- a/common/archiver/filestore/util.go
+++ b/common/archiver/filestore/util.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/dgryski/go-farm"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
 
@@ -46,8 +46,8 @@ func encode(v interface{}) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-func decodeHistoryBatches(data []byte) ([]*shared.History, error) {
-	historyBatches := []*shared.History{}
+func decodeHistoryBatches(data []byte) ([]*types.History, error) {
+	historyBatches := []*types.History{}
 	err := json.Unmarshal(data, &historyBatches)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func extractCloseFailoverVersion(filename string) (int64, error) {
 	return strconv.ParseInt(filenameParts[1], 10, 64)
 }
 
-func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*shared.History, isLast bool) bool {
+func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*types.History, isLast bool) bool {
 	lastBatch := historyBatches[len(historyBatches)-1].Events
 	lastEvent := lastBatch[len(lastBatch)-1]
 	lastFailoverVersion := lastEvent.GetVersion()
@@ -144,7 +144,7 @@ func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*s
 	if !isLast {
 		return false
 	}
-	lastEventID := lastEvent.GetEventId()
+	lastEventID := lastEvent.GetEventID()
 	return lastFailoverVersion != request.CloseFailoverVersion || lastEventID+1 != request.NextEventID
 }
 

--- a/common/archiver/filestore/util_test.go
+++ b/common/archiver/filestore/util_test.go
@@ -30,9 +30,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
 
@@ -55,26 +55,26 @@ func (s *UtilSuite) SetupTest() {
 }
 
 func (s *UtilSuite) TestEncodeDecodeHistoryBatches() {
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId: common.Int64Ptr(common.FirstEventID),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID: common.Int64Ptr(common.FirstEventID),
 					Version: common.Int64Ptr(1),
 				},
 			},
 		},
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(1),
 				},
-				&shared.HistoryEvent{
-					EventId: common.Int64Ptr(common.FirstEventID + 2),
+				{
+					EventID: common.Int64Ptr(common.FirstEventID + 2),
 					Version: common.Int64Ptr(2),
-					DecisionTaskStartedEventAttributes: &shared.DecisionTaskStartedEventAttributes{
+					DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
 						Identity: common.StringPtr("some random identity"),
 					},
 				},
@@ -197,16 +197,16 @@ func (s *UtilSuite) TestExtractCloseFailoverVersion() {
 
 func (s *UtilSuite) TestHistoryMutated() {
 	testCases := []struct {
-		historyBatches []*shared.History
+		historyBatches []*types.History
 		request        *archiver.ArchiveHistoryRequest
 		isLast         bool
 		isMutated      bool
 	}{
 		{
-			historyBatches: []*shared.History{
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
 							Version: common.Int64Ptr(15),
 						},
 					},
@@ -218,23 +218,23 @@ func (s *UtilSuite) TestHistoryMutated() {
 			isMutated: true,
 		},
 		{
-			historyBatches: []*shared.History{
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
-							EventId: common.Int64Ptr(33),
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: common.Int64Ptr(33),
 							Version: common.Int64Ptr(10),
 						},
 					},
 				},
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
-							EventId: common.Int64Ptr(49),
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: common.Int64Ptr(49),
 							Version: common.Int64Ptr(10),
 						},
-						&shared.HistoryEvent{
-							EventId: common.Int64Ptr(50),
+						{
+							EventID: common.Int64Ptr(50),
 							Version: common.Int64Ptr(10),
 						},
 					},
@@ -248,10 +248,10 @@ func (s *UtilSuite) TestHistoryMutated() {
 			isMutated: true,
 		},
 		{
-			historyBatches: []*shared.History{
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
 							Version: common.Int64Ptr(9),
 						},
 					},
@@ -264,19 +264,19 @@ func (s *UtilSuite) TestHistoryMutated() {
 			isMutated: true,
 		},
 		{
-			historyBatches: []*shared.History{
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
-							EventId: common.Int64Ptr(20),
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: common.Int64Ptr(20),
 							Version: common.Int64Ptr(10),
 						},
 					},
 				},
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
-							EventId: common.Int64Ptr(33),
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: common.Int64Ptr(33),
 							Version: common.Int64Ptr(10),
 						},
 					},

--- a/common/archiver/filestore/visibilityArchiver.go
+++ b/common/archiver/filestore/visibilityArchiver.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
 
@@ -322,13 +323,13 @@ func matchQuery(record *visibilityRecord, query *parsedQuery) bool {
 	return true
 }
 
-func convertToExecutionInfo(record *visibilityRecord) *shared.WorkflowExecutionInfo {
-	return &shared.WorkflowExecutionInfo{
-		Execution: &shared.WorkflowExecution{
-			WorkflowId: common.StringPtr(record.WorkflowID),
-			RunId:      common.StringPtr(record.RunID),
+func convertToExecutionInfo(record *visibilityRecord) *types.WorkflowExecutionInfo {
+	return &types.WorkflowExecutionInfo{
+		Execution: &types.WorkflowExecution{
+			WorkflowID: common.StringPtr(record.WorkflowID),
+			RunID:      common.StringPtr(record.RunID),
 		},
-		Type: &shared.WorkflowType{
+		Type: &types.WorkflowType{
 			Name: common.StringPtr(record.WorkflowTypeName),
 		},
 		StartTime:     common.Int64Ptr(record.StartTimestamp),
@@ -337,7 +338,7 @@ func convertToExecutionInfo(record *visibilityRecord) *shared.WorkflowExecutionI
 		CloseStatus:   record.CloseStatus.Ptr(),
 		HistoryLength: common.Int64Ptr(record.HistoryLength),
 		Memo:          record.Memo,
-		SearchAttributes: &shared.SearchAttributes{
+		SearchAttributes: &types.SearchAttributes{
 			IndexedFields: archiver.ConvertSearchAttrToBytes(record.SearchAttributes),
 		},
 	}

--- a/common/archiver/filestore/visibilityArchiver.go
+++ b/common/archiver/filestore/visibilityArchiver.go
@@ -29,7 +29,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/log/tag"

--- a/common/archiver/filestore/visibilityArchiver_test.go
+++ b/common/archiver/filestore/visibilityArchiver_test.go
@@ -35,11 +35,11 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/zap"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
 
@@ -129,7 +129,7 @@ func (s *visibilityArchiverSuite) TestArchive_Fail_InvalidURI() {
 		StartTimestamp:     time.Now().UnixNano(),
 		ExecutionTimestamp: 0, // workflow without backoff
 		CloseTimestamp:     time.Now().UnixNano(),
-		CloseStatus:        shared.WorkflowExecutionCloseStatusFailed,
+		CloseStatus:        types.WorkflowExecutionCloseStatusFailed,
 		HistoryLength:      int64(101),
 	}
 	err = visibilityArchiver.Archive(context.Background(), URI, request)
@@ -170,9 +170,9 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 		StartTimestamp:     closeTimestamp.Add(-time.Hour).UnixNano(),
 		ExecutionTimestamp: 0, // workflow without backoff
 		CloseTimestamp:     closeTimestamp.UnixNano(),
-		CloseStatus:        shared.WorkflowExecutionCloseStatusFailed,
+		CloseStatus:        types.WorkflowExecutionCloseStatusFailed,
 		HistoryLength:      int64(101),
-		Memo: &shared.Memo{
+		Memo: &types.Memo{
 			Fields: map[string][]byte{
 				"testFields": []byte{1, 2, 3},
 			},
@@ -267,11 +267,11 @@ func (s *visibilityArchiverSuite) TestMatchQuery() {
 				earliestCloseTime: int64(1000),
 				latestCloseTime:   int64(12345),
 				workflowTypeName:  common.StringPtr("some random type name"),
-				closeStatus:       shared.WorkflowExecutionCloseStatusContinuedAsNew.Ptr(),
+				closeStatus:       types.WorkflowExecutionCloseStatusContinuedAsNew.Ptr(),
 			},
 			record: &visibilityRecord{
 				CloseTimestamp:   int64(12345),
-				CloseStatus:      shared.WorkflowExecutionCloseStatusContinuedAsNew,
+				CloseStatus:      types.WorkflowExecutionCloseStatusContinuedAsNew,
 				WorkflowTypeName: "some random type name",
 			},
 			shouldMatch: true,
@@ -426,7 +426,7 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
 		earliestCloseTime: int64(1),
 		latestCloseTime:   int64(10001),
-		closeStatus:       shared.WorkflowExecutionCloseStatusFailed.Ptr(),
+		closeStatus:       types.WorkflowExecutionCloseStatusFailed.Ptr(),
 	}, nil).AnyTimes()
 	visibilityArchiver.queryParser = mockParser
 	request := &archiver.QueryVisibilityRequest{
@@ -463,7 +463,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
 		earliestCloseTime: int64(10),
 		latestCloseTime:   int64(10001),
-		closeStatus:       shared.WorkflowExecutionCloseStatusFailed.Ptr(),
+		closeStatus:       types.WorkflowExecutionCloseStatusFailed.Ptr(),
 	}, nil).AnyTimes()
 	visibilityArchiver.queryParser = mockParser
 	URI, err := archiver.NewURI("file://" + dir)
@@ -478,7 +478,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 		PageSize: 1,
 		Query:    "parsed by mockParser",
 	}
-	executions := []*shared.WorkflowExecutionInfo{}
+	executions := []*types.WorkflowExecutionInfo{}
 	for len(executions) == 0 || request.NextPageToken != nil {
 		response, err := visibilityArchiver.Query(context.Background(), URI, request)
 		s.NoError(err)
@@ -511,7 +511,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			WorkflowTypeName: testWorkflowTypeName,
 			StartTimestamp:   1,
 			CloseTimestamp:   10000,
-			CloseStatus:      shared.WorkflowExecutionCloseStatusFailed,
+			CloseStatus:      types.WorkflowExecutionCloseStatusFailed,
 			HistoryLength:    101,
 		},
 		{
@@ -523,7 +523,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			StartTimestamp:     2,
 			ExecutionTimestamp: 0,
 			CloseTimestamp:     1000,
-			CloseStatus:        shared.WorkflowExecutionCloseStatusFailed,
+			CloseStatus:        types.WorkflowExecutionCloseStatusFailed,
 			HistoryLength:      123,
 		},
 		{
@@ -535,7 +535,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			StartTimestamp:     3,
 			ExecutionTimestamp: 0,
 			CloseTimestamp:     10,
-			CloseStatus:        shared.WorkflowExecutionCloseStatusContinuedAsNew,
+			CloseStatus:        types.WorkflowExecutionCloseStatusContinuedAsNew,
 			HistoryLength:      456,
 		},
 		{
@@ -547,7 +547,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			StartTimestamp:     3,
 			ExecutionTimestamp: 0,
 			CloseTimestamp:     5,
-			CloseStatus:        shared.WorkflowExecutionCloseStatusFailed,
+			CloseStatus:        types.WorkflowExecutionCloseStatusFailed,
 			HistoryLength:      456,
 		},
 		{
@@ -559,7 +559,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			StartTimestamp:     3,
 			ExecutionTimestamp: 0,
 			CloseTimestamp:     10000,
-			CloseStatus:        shared.WorkflowExecutionCloseStatusContinuedAsNew,
+			CloseStatus:        types.WorkflowExecutionCloseStatusContinuedAsNew,
 			HistoryLength:      456,
 		},
 	}

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -26,7 +26,6 @@ import (
 	"errors"
 	"path/filepath"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/gcloud/connector"

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service/config"
+	"github.com/uber/cadence/common/types"
 )
 
 var (
@@ -217,7 +218,7 @@ func (h *historyArchiver) Get(ctx context.Context, URI archiver.URI, request *ar
 	}
 
 	response := &archiver.GetHistoryResponse{}
-	response.HistoryBatches = []*shared.History{}
+	response.HistoryBatches = []*types.History{}
 	numOfEvents := 0
 
 outer:
@@ -313,7 +314,7 @@ func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIte
 	return historyBlob, nil
 }
 
-func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*shared.History, isLast bool) bool {
+func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*types.History, isLast bool) bool {
 	lastBatch := historyBatches[len(historyBatches)-1].Events
 	lastEvent := lastBatch[len(lastBatch)-1]
 	lastFailoverVersion := lastEvent.GetVersion()
@@ -324,7 +325,7 @@ func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*s
 	if !isLast {
 		return false
 	}
-	lastEventID := lastEvent.GetEventId()
+	lastEventID := lastEvent.GetEventID()
 	return lastFailoverVersion != request.CloseFailoverVersion || lastEventID+1 != request.NextEventID
 }
 

--- a/common/archiver/gcloud/historyArchiver_test.go
+++ b/common/archiver/gcloud/historyArchiver_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/gcloud/connector"

--- a/common/archiver/gcloud/historyArchiver_test.go
+++ b/common/archiver/gcloud/historyArchiver_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/archiver/gcloud/connector/mocks"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
 )
 
 const (
@@ -246,11 +247,11 @@ func (h *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 
 	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion + 1),
 				},
@@ -323,25 +324,25 @@ func (h *historyArchiverSuite) TestArchive_Success() {
 
 	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 2),
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 2),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
 			},
 		},
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(testNextEventID - 1),
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(testNextEventID - 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},

--- a/common/archiver/gcloud/queryParser.go
+++ b/common/archiver/gcloud/queryParser.go
@@ -31,8 +31,8 @@ import (
 
 	"github.com/xwb1989/sqlparser"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
 )
 
 type (
@@ -264,19 +264,19 @@ func convertToTimestamp(timeStr string) (int64, error) {
 	return parsedTime.UnixNano(), nil
 }
 
-func convertStatusStr(statusStr string) (shared.WorkflowExecutionCloseStatus, error) {
+func convertStatusStr(statusStr string) (types.WorkflowExecutionCloseStatus, error) {
 	statusStr = strings.ToLower(statusStr)
 	switch statusStr {
 	case "completed":
-		return shared.WorkflowExecutionCloseStatusCompleted, nil
+		return types.WorkflowExecutionCloseStatusCompleted, nil
 	case "failed":
-		return shared.WorkflowExecutionCloseStatusFailed, nil
+		return types.WorkflowExecutionCloseStatusFailed, nil
 	case "canceled":
-		return shared.WorkflowExecutionCloseStatusCanceled, nil
+		return types.WorkflowExecutionCloseStatusCanceled, nil
 	case "continuedasnew":
-		return shared.WorkflowExecutionCloseStatusContinuedAsNew, nil
+		return types.WorkflowExecutionCloseStatusContinuedAsNew, nil
 	case "timedout":
-		return shared.WorkflowExecutionCloseStatusTimedOut, nil
+		return types.WorkflowExecutionCloseStatusTimedOut, nil
 	default:
 		return 0, fmt.Errorf("unknown workflow close status: %s", statusStr)
 	}

--- a/common/archiver/gcloud/util.go
+++ b/common/archiver/gcloud/util.go
@@ -31,18 +31,18 @@ import (
 
 	"github.com/dgryski/go-farm"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/gcloud/connector"
+	"github.com/uber/cadence/common/types"
 )
 
 func encode(v interface{}) ([]byte, error) {
 	return json.Marshal(v)
 }
 
-func decodeHistoryBatches(data []byte) ([]*shared.History, error) {
-	historyBatches := []*shared.History{}
+func decodeHistoryBatches(data []byte) ([]*types.History, error) {
+	historyBatches := []*types.History{}
 	err := json.Unmarshal(data, &historyBatches)
 	if err != nil {
 		return nil, err
@@ -155,13 +155,13 @@ func deserializeQueryVisibilityToken(bytes []byte) (*queryVisibilityToken, error
 	return token, err
 }
 
-func convertToExecutionInfo(record *visibilityRecord) *shared.WorkflowExecutionInfo {
-	return &shared.WorkflowExecutionInfo{
-		Execution: &shared.WorkflowExecution{
-			WorkflowId: common.StringPtr(record.WorkflowID),
-			RunId:      common.StringPtr(record.RunID),
+func convertToExecutionInfo(record *visibilityRecord) *types.WorkflowExecutionInfo {
+	return &types.WorkflowExecutionInfo{
+		Execution: &types.WorkflowExecution{
+			WorkflowID: common.StringPtr(record.WorkflowID),
+			RunID:      common.StringPtr(record.RunID),
 		},
-		Type: &shared.WorkflowType{
+		Type: &types.WorkflowType{
 			Name: common.StringPtr(record.WorkflowTypeName),
 		},
 		StartTime:     common.Int64Ptr(record.StartTimestamp),
@@ -170,7 +170,7 @@ func convertToExecutionInfo(record *visibilityRecord) *shared.WorkflowExecutionI
 		CloseStatus:   record.CloseStatus.Ptr(),
 		HistoryLength: common.Int64Ptr(record.HistoryLength),
 		Memo:          record.Memo,
-		SearchAttributes: &shared.SearchAttributes{
+		SearchAttributes: &types.SearchAttributes{
 			IndexedFields: archiver.ConvertSearchAttrToBytes(record.SearchAttributes),
 		},
 	}

--- a/common/archiver/gcloud/util_test.go
+++ b/common/archiver/gcloud/util_test.go
@@ -27,8 +27,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
 )
 
 func (s *utilSuite) SetupTest() {
@@ -44,26 +44,26 @@ type utilSuite struct {
 }
 
 func (s *utilSuite) TestEncodeDecodeHistoryBatches() {
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId: common.Int64Ptr(common.FirstEventID),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID: common.Int64Ptr(common.FirstEventID),
 					Version: common.Int64Ptr(1),
 				},
 			},
 		},
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(1),
 				},
-				&shared.HistoryEvent{
-					EventId: common.Int64Ptr(common.FirstEventID + 2),
+				{
+					EventID: common.Int64Ptr(common.FirstEventID + 2),
 					Version: common.Int64Ptr(2),
-					DecisionTaskStartedEventAttributes: &shared.DecisionTaskStartedEventAttributes{
+					DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
 						Identity: common.StringPtr("some random identity"),
 					},
 				},

--- a/common/archiver/gcloud/visibilityArchiver_test.go
+++ b/common/archiver/gcloud/visibilityArchiver_test.go
@@ -34,12 +34,12 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/gcloud/connector/mocks"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
 )
 
 const (
@@ -63,7 +63,7 @@ func (s *visibilityArchiverSuite) SetupTest() {
 			WorkflowTypeName: testWorkflowTypeName,
 			StartTimestamp:   1580896574804475000,
 			CloseTimestamp:   1580896575946478000,
-			CloseStatus:      shared.WorkflowExecutionCloseStatusCompleted,
+			CloseStatus:      types.WorkflowExecutionCloseStatusCompleted,
 			HistoryLength:    36,
 		},
 	}
@@ -186,7 +186,7 @@ func (s *visibilityArchiverSuite) TestVisibilityArchive() {
 		StartTimestamp:     time.Now().UnixNano(),
 		ExecutionTimestamp: 0, // workflow without backoff
 		CloseTimestamp:     time.Now().UnixNano(),
-		CloseStatus:        shared.WorkflowExecutionCloseStatusFailed,
+		CloseStatus:        types.WorkflowExecutionCloseStatusFailed,
 		HistoryLength:      int64(101),
 	}
 

--- a/common/archiver/historyIterator.go
+++ b/common/archiver/historyIterator.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"errors"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"

--- a/common/archiver/historyIterator.go
+++ b/common/archiver/historyIterator.go
@@ -30,6 +30,8 @@ import (
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 const (
@@ -61,7 +63,7 @@ type (
 	// HistoryBlob is the serializable data that forms the body of a blob
 	HistoryBlob struct {
 		Header *HistoryBlobHeader `json:"header"`
-		Body   []*shared.History  `json:"body"`
+		Body   []*types.History   `json:"body"`
 	}
 
 	historyIteratorState struct {
@@ -159,8 +161,8 @@ func (i *historyIterator) Next() (*HistoryBlob, error) {
 		IsLast:               common.BoolPtr(i.FinishedIteration),
 		FirstFailoverVersion: firstEvent.Version,
 		LastFailoverVersion:  lastEvent.Version,
-		FirstEventID:         firstEvent.EventId,
-		LastEventID:          lastEvent.EventId,
+		FirstEventID:         firstEvent.EventID,
+		LastEventID:          lastEvent.EventID,
 		EventCount:           common.Int64Ptr(eventCount),
 	}
 
@@ -180,10 +182,10 @@ func (i *historyIterator) GetState() ([]byte, error) {
 	return json.Marshal(i.historyIteratorState)
 }
 
-func (i *historyIterator) readHistoryBatches(ctx context.Context, firstEventID int64) ([]*shared.History, historyIteratorState, error) {
+func (i *historyIterator) readHistoryBatches(ctx context.Context, firstEventID int64) ([]*types.History, historyIteratorState, error) {
 	size := 0
 	targetSize := i.targetHistoryBlobSize
-	var historyBatches []*shared.History
+	var historyBatches []*types.History
 	newIterState := historyIteratorState{}
 	for size < targetSize {
 		currHistoryBatches, err := i.readHistory(ctx, firstEventID)
@@ -201,7 +203,7 @@ func (i *historyIterator) readHistoryBatches(ctx context.Context, firstEventID i
 			}
 			size += historyBatchSize
 			historyBatches = append(historyBatches, batch)
-			firstEventID = *batch.Events[len(batch.Events)-1].EventId + 1
+			firstEventID = *batch.Events[len(batch.Events)-1].EventID + 1
 
 			// In case targetSize is satisfied before reaching the end of current set of batches, return immediately.
 			// Otherwise, we need to look ahead to see if there's more history batches.
@@ -228,7 +230,7 @@ func (i *historyIterator) readHistoryBatches(ctx context.Context, firstEventID i
 	return historyBatches, newIterState, nil
 }
 
-func (i *historyIterator) readHistory(ctx context.Context, firstEventID int64) ([]*shared.History, error) {
+func (i *historyIterator) readHistory(ctx context.Context, firstEventID int64) ([]*types.History, error) {
 	req := &persistence.ReadHistoryBranchRequest{
 		BranchToken: i.request.BranchToken,
 		MinEventID:  firstEventID,
@@ -236,7 +238,14 @@ func (i *historyIterator) readHistory(ctx context.Context, firstEventID int64) (
 		PageSize:    i.historyPageSize,
 		ShardID:     common.IntPtr(i.request.ShardID),
 	}
-	historyBatches, _, _, err := persistence.ReadFullPageV2EventsByBatch(ctx, i.historyV2Manager, req)
+	thriftHistoryBatches, _, _, err := persistence.ReadFullPageV2EventsByBatch(ctx, i.historyV2Manager, req)
+	if thriftHistoryBatches == nil {
+		return nil, err
+	}
+	historyBatches := make([]*types.History, len(thriftHistoryBatches))
+	for i := range historyBatches {
+		historyBatches[i] = thrift.ToHistory(thriftHistoryBatches[i])
+	}
 	return historyBatches, err
 
 }

--- a/common/archiver/historyIterator_test.go
+++ b/common/archiver/historyIterator_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 )
 
 const (
@@ -69,7 +70,7 @@ type (
 )
 
 func (e *testSizeEstimator) EstimateSize(v interface{}) (int, error) {
-	historyBatch, ok := v.(*shared.History)
+	historyBatch, ok := v.(*types.History)
 	if !ok {
 		return -1, errors.New("test size estimator only estimate the size of history batches")
 	}
@@ -580,8 +581,8 @@ func (s *HistoryIteratorSuite) TestNext_Success_SameHistoryDifferentPage() {
 
 		s.Equal(history1.Header, history2.Header)
 		s.Equal(len(history1.Body), len(history2.Body))
-		s.Equal(expectedFirstEventID[i], history1.Body[0].Events[0].GetEventId())
-		s.Equal(expectedFirstEventID[i], history2.Body[0].Events[0].GetEventId())
+		s.Equal(expectedFirstEventID[i], history1.Body[0].Events[0].GetEventID())
+		s.Equal(expectedFirstEventID[i], history2.Body[0].Events[0].GetEventID())
 	}
 	expectedIteratorState := historyIteratorState{
 		NextEventID:       0,

--- a/common/archiver/interface.go
+++ b/common/archiver/interface.go
@@ -23,12 +23,12 @@ package archiver
 import (
 	"context"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 )
 
 type (
@@ -56,7 +56,7 @@ type (
 
 	// GetHistoryResponse is the response of Get archived history
 	GetHistoryResponse struct {
-		HistoryBatches []*shared.History
+		HistoryBatches []*types.History
 		NextPageToken  []byte
 	}
 
@@ -94,9 +94,9 @@ type (
 		StartTimestamp     int64
 		ExecutionTimestamp int64
 		CloseTimestamp     int64
-		CloseStatus        shared.WorkflowExecutionCloseStatus
+		CloseStatus        types.WorkflowExecutionCloseStatus
 		HistoryLength      int64
-		Memo               *shared.Memo
+		Memo               *types.Memo
 		SearchAttributes   map[string]string
 		HistoryArchivalURI string
 	}
@@ -111,7 +111,7 @@ type (
 
 	// QueryVisibilityResponse is the response of querying archived visibility records
 	QueryVisibilityResponse struct {
-		Executions    []*shared.WorkflowExecutionInfo
+		Executions    []*types.WorkflowExecutionInfo
 		NextPageToken []byte
 	}
 

--- a/common/archiver/s3store/historyArchiver_test.go
+++ b/common/archiver/s3store/historyArchiver_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
 )
 
 const (
@@ -331,11 +332,11 @@ func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	mockCtrl := gomock.NewController(s.T())
 	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion + 1),
 				},
@@ -395,25 +396,25 @@ func (s *historyArchiverSuite) TestArchive_Success() {
 	mockCtrl := gomock.NewController(s.T())
 	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
-	historyBatches := []*shared.History{
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 1),
+	historyBatches := []*types.History{
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(common.FirstEventID + 2),
+				{
+					EventID:   common.Int64Ptr(common.FirstEventID + 2),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
 			},
 		},
-		&shared.History{
-			Events: []*shared.HistoryEvent{
-				&shared.HistoryEvent{
-					EventId:   common.Int64Ptr(testNextEventID - 1),
+		{
+			Events: []*types.HistoryEvent{
+				{
+					EventID:   common.Int64Ptr(testNextEventID - 1),
 					Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 					Version:   common.Int64Ptr(testCloseFailoverVersion),
 				},
@@ -556,7 +557,7 @@ func (s *historyArchiverSuite) TestGet_Success_SmallPageSize() {
 		PageSize:             1,
 		CloseFailoverVersion: common.Int64Ptr(100),
 	}
-	combinedHistory := []*shared.History{}
+	combinedHistory := []*types.History{}
 
 	URI, err := archiver.NewURI(testBucketURI)
 	s.NoError(err)
@@ -637,11 +638,11 @@ func (s *historyArchiverSuite) setupHistoryDirectory() {
 			Header: &archiver.HistoryBlobHeader{
 				IsLast: common.BoolPtr(true),
 			},
-			Body: []*shared.History{
+			Body: []*types.History{
 				{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
-							EventId:   common.Int64Ptr(testNextEventID - 1),
+					Events: []*types.HistoryEvent{
+						{
+							EventID:   common.Int64Ptr(testNextEventID - 1),
 							Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 							Version:   common.Int64Ptr(1),
 						},
@@ -656,16 +657,16 @@ func (s *historyArchiverSuite) setupHistoryDirectory() {
 			Header: &archiver.HistoryBlobHeader{
 				IsLast: common.BoolPtr(false),
 			},
-			Body: []*shared.History{
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
-							EventId:   common.Int64Ptr(common.FirstEventID + 1),
+			Body: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID:   common.Int64Ptr(common.FirstEventID + 1),
 							Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 							Version:   common.Int64Ptr(testCloseFailoverVersion),
 						},
-						&shared.HistoryEvent{
-							EventId:   common.Int64Ptr(common.FirstEventID + 1),
+						{
+							EventID:   common.Int64Ptr(common.FirstEventID + 1),
 							Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 							Version:   common.Int64Ptr(testCloseFailoverVersion),
 						},
@@ -677,11 +678,11 @@ func (s *historyArchiverSuite) setupHistoryDirectory() {
 			Header: &archiver.HistoryBlobHeader{
 				IsLast: common.BoolPtr(true),
 			},
-			Body: []*shared.History{
-				&shared.History{
-					Events: []*shared.HistoryEvent{
-						&shared.HistoryEvent{
-							EventId:   common.Int64Ptr(testNextEventID - 1),
+			Body: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID:   common.Int64Ptr(testNextEventID - 1),
 							Timestamp: common.Int64Ptr(time.Now().UnixNano()),
 							Version:   common.Int64Ptr(testCloseFailoverVersion),
 						},

--- a/common/archiver/s3store/historyArchiver_test.go
+++ b/common/archiver/s3store/historyArchiver_test.go
@@ -43,7 +43,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/zap"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/s3store/mocks"

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/types"
 )
 
 // encoding & decoding util
@@ -236,7 +237,7 @@ func download(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key st
 	return body, nil
 }
 
-func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*shared.History, isLast bool) bool {
+func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*types.History, isLast bool) bool {
 	lastBatch := historyBatches[len(historyBatches)-1].Events
 	lastEvent := lastBatch[len(lastBatch)-1]
 	lastFailoverVersion := lastEvent.GetVersion()
@@ -247,7 +248,7 @@ func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*s
 	if !isLast {
 		return false
 	}
-	lastEventID := lastEvent.GetEventId()
+	lastEventID := lastEvent.GetEventID()
 	return lastFailoverVersion != request.CloseFailoverVersion || lastEventID+1 != request.NextEventID
 }
 
@@ -260,13 +261,13 @@ func contextExpired(ctx context.Context) bool {
 	}
 }
 
-func convertToExecutionInfo(record *visibilityRecord) *shared.WorkflowExecutionInfo {
-	return &shared.WorkflowExecutionInfo{
-		Execution: &shared.WorkflowExecution{
-			WorkflowId: common.StringPtr(record.WorkflowID),
-			RunId:      common.StringPtr(record.RunID),
+func convertToExecutionInfo(record *visibilityRecord) *types.WorkflowExecutionInfo {
+	return &types.WorkflowExecutionInfo{
+		Execution: &types.WorkflowExecution{
+			WorkflowID: common.StringPtr(record.WorkflowID),
+			RunID:      common.StringPtr(record.RunID),
 		},
-		Type: &shared.WorkflowType{
+		Type: &types.WorkflowType{
 			Name: common.StringPtr(record.WorkflowTypeName),
 		},
 		StartTime:     common.Int64Ptr(record.StartTimestamp),
@@ -275,7 +276,7 @@ func convertToExecutionInfo(record *visibilityRecord) *shared.WorkflowExecutionI
 		CloseStatus:   record.CloseStatus.Ptr(),
 		HistoryLength: common.Int64Ptr(record.HistoryLength),
 		Memo:          record.Memo,
-		SearchAttributes: &shared.SearchAttributes{
+		SearchAttributes: &types.SearchAttributes{
 			IndexedFields: archiver.ConvertSearchAttrToBytes(record.SearchAttributes),
 		},
 	}

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -37,7 +37,6 @@ import (
 
 	"github.com/uber/cadence/common"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/types"
 )

--- a/common/archiver/s3store/visibilityArchiver_test.go
+++ b/common/archiver/s3store/visibilityArchiver_test.go
@@ -30,25 +30,20 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/stretchr/testify/mock"
-
-	"github.com/uber-go/tally"
-
-	"github.com/uber/cadence/common/metrics"
-
-	"go.uber.org/zap"
-
-	"github.com/uber/cadence/.gen/go/shared"
-	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/archiver/s3store/mocks"
-	"github.com/uber/cadence/common/log/loggerimpl"
-
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+	"github.com/uber-go/tally"
+	"go.uber.org/zap"
 
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/archiver/s3store/mocks"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
 )
 
 type visibilityArchiverSuite struct {
@@ -163,7 +158,7 @@ func (s *visibilityArchiverSuite) TestArchive_Fail_InvalidURI() {
 		StartTimestamp:     time.Now().UnixNano(),
 		ExecutionTimestamp: 0, // workflow without backoff
 		CloseTimestamp:     time.Now().UnixNano(),
-		CloseStatus:        shared.WorkflowExecutionCloseStatusFailed,
+		CloseStatus:        types.WorkflowExecutionCloseStatusFailed,
 		HistoryLength:      int64(101),
 	}
 	err = visibilityArchiver.Archive(context.Background(), URI, request)
@@ -202,9 +197,9 @@ func (s *visibilityArchiverSuite) TestArchive_Success() {
 		StartTimestamp:     closeTimestamp.Add(-time.Hour).UnixNano(),
 		ExecutionTimestamp: 0, // workflow without backoff
 		CloseTimestamp:     closeTimestamp.UnixNano(),
-		CloseStatus:        shared.WorkflowExecutionCloseStatusFailed,
+		CloseStatus:        types.WorkflowExecutionCloseStatusFailed,
 		HistoryLength:      int64(101),
-		Memo: &shared.Memo{
+		Memo: &types.Memo{
 			Fields: map[string][]byte{
 				"testFields": {1, 2, 3},
 			},
@@ -433,7 +428,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQueryPrecisions() {
 			WorkflowTypeName: testWorkflowTypeName,
 			StartTimestamp:   testData.day*int64(time.Hour)*24 + testData.hour*int64(time.Hour) + testData.minute*int64(time.Minute) + testData.second*int64(time.Second),
 			CloseTimestamp:   (testData.day+30)*int64(time.Hour)*24 + testData.hour*int64(time.Hour) + testData.minute*int64(time.Minute) + testData.second*int64(time.Second),
-			CloseStatus:      shared.WorkflowExecutionCloseStatusFailed,
+			CloseStatus:      types.WorkflowExecutionCloseStatusFailed,
 			HistoryLength:    101,
 		}
 		err := visibilityArchiver.Archive(context.Background(), URI, &record)
@@ -519,7 +514,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 		PageSize: 1,
 		Query:    "parsed by mockParser",
 	}
-	executions := []*shared.WorkflowExecutionInfo{}
+	executions := []*types.WorkflowExecutionInfo{}
 	var first = true
 	for first || request.NextPageToken != nil {
 		response, err := visibilityArchiver.Query(context.Background(), URI, request)
@@ -544,7 +539,7 @@ func (s *visibilityArchiverSuite) TestArchiveAndQuery() {
 		PageSize: 1,
 		Query:    "parsed by mockParser",
 	}
-	executions = []*shared.WorkflowExecutionInfo{}
+	executions = []*types.WorkflowExecutionInfo{}
 	first = true
 	for first || request.NextPageToken != nil {
 		response, err := visibilityArchiver.Query(context.Background(), URI, request)
@@ -570,7 +565,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			WorkflowTypeName: testWorkflowTypeName,
 			StartTimestamp:   1,
 			CloseTimestamp:   int64(1 * time.Hour),
-			CloseStatus:      shared.WorkflowExecutionCloseStatusFailed,
+			CloseStatus:      types.WorkflowExecutionCloseStatusFailed,
 			HistoryLength:    101,
 		},
 		{
@@ -581,7 +576,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			WorkflowTypeName: testWorkflowTypeName,
 			StartTimestamp:   1,
 			CloseTimestamp:   int64(1*time.Hour + 30*time.Minute),
-			CloseStatus:      shared.WorkflowExecutionCloseStatusFailed,
+			CloseStatus:      types.WorkflowExecutionCloseStatusFailed,
 			HistoryLength:    101,
 		},
 		{
@@ -592,7 +587,7 @@ func (s *visibilityArchiverSuite) setupVisibilityDirectory() {
 			WorkflowTypeName: testWorkflowTypeName,
 			StartTimestamp:   1,
 			CloseTimestamp:   int64(3 * time.Hour),
-			CloseStatus:      shared.WorkflowExecutionCloseStatusFailed,
+			CloseStatus:      types.WorkflowExecutionCloseStatusFailed,
 			HistoryLength:    101,
 		},
 	}

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 var (
@@ -172,7 +173,7 @@ func (d *handlerImpl) RegisterDomain(
 		archivalEvent, err := d.toArchivalRegisterEvent(
 			registerRequest.HistoryArchivalStatus,
 			registerRequest.GetHistoryArchivalURI(),
-			clusterHistoryArchivalConfig.GetDomainDefaultStatus(),
+			*thrift.FromArchivalStatus(clusterHistoryArchivalConfig.GetDomainDefaultStatus().Ptr()),
 			clusterHistoryArchivalConfig.GetDomainDefaultURI(),
 		)
 		if err != nil {
@@ -192,7 +193,7 @@ func (d *handlerImpl) RegisterDomain(
 		archivalEvent, err := d.toArchivalRegisterEvent(
 			registerRequest.VisibilityArchivalStatus,
 			registerRequest.GetVisibilityArchivalURI(),
-			clusterVisibilityArchivalConfig.GetDomainDefaultStatus(),
+			*thrift.FromArchivalStatus(clusterVisibilityArchivalConfig.GetDomainDefaultStatus().Ptr()),
 			clusterVisibilityArchivalConfig.GetDomainDefaultURI(),
 		)
 		if err != nil {

--- a/common/types/mapper/thrift/replicator.go
+++ b/common/types/mapper/thrift/replicator.go
@@ -730,54 +730,6 @@ func ToSyncShardStatusTaskAttributes(t *replicator.SyncShardStatusTaskAttributes
 	}
 }
 
-// FromReplicationTaskArray converts internal ReplicationTask type array to thrift
-func FromReplicationTaskArray(t []*types.ReplicationTask) []*replicator.ReplicationTask {
-	if t == nil {
-		return nil
-	}
-	v := make([]*replicator.ReplicationTask, len(t))
-	for i := range t {
-		v[i] = FromReplicationTask(t[i])
-	}
-	return v
-}
-
-// ToReplicationTaskArray converts thrift ReplicationTask type array to internal
-func ToReplicationTaskArray(t []*replicator.ReplicationTask) []*types.ReplicationTask {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.ReplicationTask, len(t))
-	for i := range t {
-		v[i] = ToReplicationTask(t[i])
-	}
-	return v
-}
-
-// FromReplicationTokenArray converts internal ReplicationToken type array to thrift
-func FromReplicationTokenArray(t []*types.ReplicationToken) []*replicator.ReplicationToken {
-	if t == nil {
-		return nil
-	}
-	v := make([]*replicator.ReplicationToken, len(t))
-	for i := range t {
-		v[i] = FromReplicationToken(t[i])
-	}
-	return v
-}
-
-// ToReplicationTokenArray converts thrift ReplicationToken type array to internal
-func ToReplicationTokenArray(t []*replicator.ReplicationToken) []*types.ReplicationToken {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.ReplicationToken, len(t))
-	for i := range t {
-		v[i] = ToReplicationToken(t[i])
-	}
-	return v
-}
-
 // FromFailoverMarkerAttributesArray converts internal FailoverMarkerAttributes type array to thrift
 func FromFailoverMarkerAttributesArray(t []*types.FailoverMarkerAttributes) []*replicator.FailoverMarkerAttributes {
 	if t == nil {
@@ -822,6 +774,54 @@ func ToReplicationTaskInfoArray(t []*replicator.ReplicationTaskInfo) []*types.Re
 	v := make([]*types.ReplicationTaskInfo, len(t))
 	for i := range t {
 		v[i] = ToReplicationTaskInfo(t[i])
+	}
+	return v
+}
+
+// FromReplicationTaskArray converts internal ReplicationTask type array to thrift
+func FromReplicationTaskArray(t []*types.ReplicationTask) []*replicator.ReplicationTask {
+	if t == nil {
+		return nil
+	}
+	v := make([]*replicator.ReplicationTask, len(t))
+	for i := range t {
+		v[i] = FromReplicationTask(t[i])
+	}
+	return v
+}
+
+// ToReplicationTaskArray converts thrift ReplicationTask type array to internal
+func ToReplicationTaskArray(t []*replicator.ReplicationTask) []*types.ReplicationTask {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ReplicationTask, len(t))
+	for i := range t {
+		v[i] = ToReplicationTask(t[i])
+	}
+	return v
+}
+
+// FromReplicationTokenArray converts internal ReplicationToken type array to thrift
+func FromReplicationTokenArray(t []*types.ReplicationToken) []*replicator.ReplicationToken {
+	if t == nil {
+		return nil
+	}
+	v := make([]*replicator.ReplicationToken, len(t))
+	for i := range t {
+		v[i] = FromReplicationToken(t[i])
+	}
+	return v
+}
+
+// ToReplicationTokenArray converts thrift ReplicationToken type array to internal
+func ToReplicationTokenArray(t []*replicator.ReplicationToken) []*types.ReplicationToken {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ReplicationToken, len(t))
+	for i := range t {
+		v[i] = ToReplicationToken(t[i])
 	}
 	return v
 }

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -6256,54 +6256,6 @@ func ToWorkflowTypeFilter(t *shared.WorkflowTypeFilter) *types.WorkflowTypeFilte
 	}
 }
 
-// FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
-func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.PendingActivityInfo, len(t))
-	for i := range t {
-		v[i] = FromPendingActivityInfo(t[i])
-	}
-	return v
-}
-
-// ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
-func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.PendingActivityInfo, len(t))
-	for i := range t {
-		v[i] = ToPendingActivityInfo(t[i])
-	}
-	return v
-}
-
-// FromDescribeDomainResponseArray converts internal DescribeDomainResponse type array to thrift
-func FromDescribeDomainResponseArray(t []*types.DescribeDomainResponse) []*shared.DescribeDomainResponse {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.DescribeDomainResponse, len(t))
-	for i := range t {
-		v[i] = FromDescribeDomainResponse(t[i])
-	}
-	return v
-}
-
-// ToDescribeDomainResponseArray converts thrift DescribeDomainResponse type array to internal
-func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.DescribeDomainResponse {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.DescribeDomainResponse, len(t))
-	for i := range t {
-		v[i] = ToDescribeDomainResponse(t[i])
-	}
-	return v
-}
-
 // FromVersionHistoryArray converts internal VersionHistory type array to thrift
 func FromVersionHistoryArray(t []*types.VersionHistory) []*shared.VersionHistory {
 	if t == nil {
@@ -6352,6 +6304,102 @@ func ToPollerInfoArray(t []*shared.PollerInfo) []*types.PollerInfo {
 	return v
 }
 
+// FromPendingChildExecutionInfoArray converts internal PendingChildExecutionInfo type array to thrift
+func FromPendingChildExecutionInfoArray(t []*types.PendingChildExecutionInfo) []*shared.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.PendingChildExecutionInfo, len(t))
+	for i := range t {
+		v[i] = FromPendingChildExecutionInfo(t[i])
+	}
+	return v
+}
+
+// ToPendingChildExecutionInfoArray converts thrift PendingChildExecutionInfo type array to internal
+func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*types.PendingChildExecutionInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.PendingChildExecutionInfo, len(t))
+	for i := range t {
+		v[i] = ToPendingChildExecutionInfo(t[i])
+	}
+	return v
+}
+
+// FromDecisionArray converts internal Decision type array to thrift
+func FromDecisionArray(t []*types.Decision) []*shared.Decision {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.Decision, len(t))
+	for i := range t {
+		v[i] = FromDecision(t[i])
+	}
+	return v
+}
+
+// ToDecisionArray converts thrift Decision type array to internal
+func ToDecisionArray(t []*shared.Decision) []*types.Decision {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.Decision, len(t))
+	for i := range t {
+		v[i] = ToDecision(t[i])
+	}
+	return v
+}
+
+// FromDataBlobArray converts internal DataBlob type array to thrift
+func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DataBlob, len(t))
+	for i := range t {
+		v[i] = FromDataBlob(t[i])
+	}
+	return v
+}
+
+// ToDataBlobArray converts thrift DataBlob type array to internal
+func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DataBlob, len(t))
+	for i := range t {
+		v[i] = ToDataBlob(t[i])
+	}
+	return v
+}
+
+// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
+func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.HistoryBranchRange, len(t))
+	for i := range t {
+		v[i] = FromHistoryBranchRange(t[i])
+	}
+	return v
+}
+
+// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
+func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.HistoryBranchRange, len(t))
+	for i := range t {
+		v[i] = ToHistoryBranchRange(t[i])
+	}
+	return v
+}
+
 // FromHistoryEventArray converts internal HistoryEvent type array to thrift
 func FromHistoryEventArray(t []*types.HistoryEvent) []*shared.HistoryEvent {
 	if t == nil {
@@ -6376,30 +6424,6 @@ func ToHistoryEventArray(t []*shared.HistoryEvent) []*types.HistoryEvent {
 	return v
 }
 
-// FromClusterReplicationConfigurationArray converts internal ClusterReplicationConfiguration type array to thrift
-func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfiguration) []*shared.ClusterReplicationConfiguration {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.ClusterReplicationConfiguration, len(t))
-	for i := range t {
-		v[i] = FromClusterReplicationConfiguration(t[i])
-	}
-	return v
-}
-
-// ToClusterReplicationConfigurationArray converts thrift ClusterReplicationConfiguration type array to internal
-func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfiguration) []*types.ClusterReplicationConfiguration {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.ClusterReplicationConfiguration, len(t))
-	for i := range t {
-		v[i] = ToClusterReplicationConfiguration(t[i])
-	}
-	return v
-}
-
 // FromWorkflowExecutionInfoArray converts internal WorkflowExecutionInfo type array to thrift
 func FromWorkflowExecutionInfoArray(t []*types.WorkflowExecutionInfo) []*shared.WorkflowExecutionInfo {
 	if t == nil {
@@ -6420,6 +6444,30 @@ func ToWorkflowExecutionInfoArray(t []*shared.WorkflowExecutionInfo) []*types.Wo
 	v := make([]*types.WorkflowExecutionInfo, len(t))
 	for i := range t {
 		v[i] = ToWorkflowExecutionInfo(t[i])
+	}
+	return v
+}
+
+// FromDescribeDomainResponseArray converts internal DescribeDomainResponse type array to thrift
+func FromDescribeDomainResponseArray(t []*types.DescribeDomainResponse) []*shared.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*shared.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = FromDescribeDomainResponse(t[i])
+	}
+	return v
+}
+
+// ToDescribeDomainResponseArray converts thrift DescribeDomainResponse type array to internal
+func ToDescribeDomainResponseArray(t []*shared.DescribeDomainResponse) []*types.DescribeDomainResponse {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.DescribeDomainResponse, len(t))
+	for i := range t {
+		v[i] = ToDescribeDomainResponse(t[i])
 	}
 	return v
 }
@@ -6472,30 +6520,6 @@ func ToResetPointInfoArray(t []*shared.ResetPointInfo) []*types.ResetPointInfo {
 	return v
 }
 
-// FromDecisionArray converts internal Decision type array to thrift
-func FromDecisionArray(t []*types.Decision) []*shared.Decision {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.Decision, len(t))
-	for i := range t {
-		v[i] = FromDecision(t[i])
-	}
-	return v
-}
-
-// ToDecisionArray converts thrift Decision type array to internal
-func ToDecisionArray(t []*shared.Decision) []*types.Decision {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.Decision, len(t))
-	for i := range t {
-		v[i] = ToDecision(t[i])
-	}
-	return v
-}
-
 // FromVersionHistoryItemArray converts internal VersionHistoryItem type array to thrift
 func FromVersionHistoryItemArray(t []*types.VersionHistoryItem) []*shared.VersionHistoryItem {
 	if t == nil {
@@ -6520,98 +6544,50 @@ func ToVersionHistoryItemArray(t []*shared.VersionHistoryItem) []*types.VersionH
 	return v
 }
 
-// FromPendingChildExecutionInfoArray converts internal PendingChildExecutionInfo type array to thrift
-func FromPendingChildExecutionInfoArray(t []*types.PendingChildExecutionInfo) []*shared.PendingChildExecutionInfo {
+// FromPendingActivityInfoArray converts internal PendingActivityInfo type array to thrift
+func FromPendingActivityInfoArray(t []*types.PendingActivityInfo) []*shared.PendingActivityInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.PendingChildExecutionInfo, len(t))
+	v := make([]*shared.PendingActivityInfo, len(t))
 	for i := range t {
-		v[i] = FromPendingChildExecutionInfo(t[i])
+		v[i] = FromPendingActivityInfo(t[i])
 	}
 	return v
 }
 
-// ToPendingChildExecutionInfoArray converts thrift PendingChildExecutionInfo type array to internal
-func ToPendingChildExecutionInfoArray(t []*shared.PendingChildExecutionInfo) []*types.PendingChildExecutionInfo {
+// ToPendingActivityInfoArray converts thrift PendingActivityInfo type array to internal
+func ToPendingActivityInfoArray(t []*shared.PendingActivityInfo) []*types.PendingActivityInfo {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.PendingChildExecutionInfo, len(t))
+	v := make([]*types.PendingActivityInfo, len(t))
 	for i := range t {
-		v[i] = ToPendingChildExecutionInfo(t[i])
+		v[i] = ToPendingActivityInfo(t[i])
 	}
 	return v
 }
 
-// FromHistoryBranchRangeArray converts internal HistoryBranchRange type array to thrift
-func FromHistoryBranchRangeArray(t []*types.HistoryBranchRange) []*shared.HistoryBranchRange {
+// FromClusterReplicationConfigurationArray converts internal ClusterReplicationConfiguration type array to thrift
+func FromClusterReplicationConfigurationArray(t []*types.ClusterReplicationConfiguration) []*shared.ClusterReplicationConfiguration {
 	if t == nil {
 		return nil
 	}
-	v := make([]*shared.HistoryBranchRange, len(t))
+	v := make([]*shared.ClusterReplicationConfiguration, len(t))
 	for i := range t {
-		v[i] = FromHistoryBranchRange(t[i])
+		v[i] = FromClusterReplicationConfiguration(t[i])
 	}
 	return v
 }
 
-// ToHistoryBranchRangeArray converts thrift HistoryBranchRange type array to internal
-func ToHistoryBranchRangeArray(t []*shared.HistoryBranchRange) []*types.HistoryBranchRange {
+// ToClusterReplicationConfigurationArray converts thrift ClusterReplicationConfiguration type array to internal
+func ToClusterReplicationConfigurationArray(t []*shared.ClusterReplicationConfiguration) []*types.ClusterReplicationConfiguration {
 	if t == nil {
 		return nil
 	}
-	v := make([]*types.HistoryBranchRange, len(t))
+	v := make([]*types.ClusterReplicationConfiguration, len(t))
 	for i := range t {
-		v[i] = ToHistoryBranchRange(t[i])
-	}
-	return v
-}
-
-// FromDataBlobArray converts internal DataBlob type array to thrift
-func FromDataBlobArray(t []*types.DataBlob) []*shared.DataBlob {
-	if t == nil {
-		return nil
-	}
-	v := make([]*shared.DataBlob, len(t))
-	for i := range t {
-		v[i] = FromDataBlob(t[i])
-	}
-	return v
-}
-
-// ToDataBlobArray converts thrift DataBlob type array to internal
-func ToDataBlobArray(t []*shared.DataBlob) []*types.DataBlob {
-	if t == nil {
-		return nil
-	}
-	v := make([]*types.DataBlob, len(t))
-	for i := range t {
-		v[i] = ToDataBlob(t[i])
-	}
-	return v
-}
-
-// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
-func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*shared.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = FromBadBinaryInfo(t[key])
-	}
-	return v
-}
-
-// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
-func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
-	if t == nil {
-		return nil
-	}
-	v := make(map[string]*types.BadBinaryInfo, len(t))
-	for key := range t {
-		v[key] = ToBadBinaryInfo(t[key])
+		v[i] = ToClusterReplicationConfiguration(t[i])
 	}
 	return v
 }
@@ -6708,6 +6684,30 @@ func ToActivityLocalDispatchInfoMap(t map[string]*shared.ActivityLocalDispatchIn
 	v := make(map[string]*types.ActivityLocalDispatchInfo, len(t))
 	for key := range t {
 		v[key] = ToActivityLocalDispatchInfo(t[key])
+	}
+	return v
+}
+
+// FromBadBinaryInfoMap converts internal BadBinaryInfo type map to thrift
+func FromBadBinaryInfoMap(t map[string]*types.BadBinaryInfo) map[string]*shared.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*shared.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = FromBadBinaryInfo(t[key])
+	}
+	return v
+}
+
+// ToBadBinaryInfoMap converts thrift BadBinaryInfo type map to internal
+func ToBadBinaryInfoMap(t map[string]*shared.BadBinaryInfo) map[string]*types.BadBinaryInfo {
+	if t == nil {
+		return nil
+	}
+	v := make(map[string]*types.BadBinaryInfo, len(t))
+	for key := range t {
+		v[key] = ToBadBinaryInfo(t[key])
 	}
 	return v
 }

--- a/common/types/matching.go
+++ b/common/types/matching.go
@@ -20,6 +20,12 @@
 
 package types
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // AddActivityTaskRequest is an internal type (TBD...)
 type AddActivityTaskRequest struct {
 	DomainUUID                    *string            `json:"domainUUID,omitempty"`
@@ -1137,6 +1143,42 @@ type TaskSource int32
 // Ptr is a helper function for getting pointer value
 func (e TaskSource) Ptr() *TaskSource {
 	return &e
+}
+
+// String returns a readable string representation of TaskSource.
+func (e TaskSource) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "History"
+	case 1:
+		return "DbBacklog"
+	}
+	return fmt.Sprintf("TaskSource(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *TaskSource) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "history":
+		*e = TaskSourceHistory
+		return nil
+	case "dbbacklog":
+		*e = TaskSourceDbBacklog
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "TaskSource", err)
+		}
+		*e = TaskSource(val)
+		return nil
+	}
+}
+
+// MarshalText encodes TaskSource to text.
+func (e TaskSource) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -20,12 +20,54 @@
 
 package types
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // DLQType is an internal type (TBD...)
 type DLQType int32
 
 // Ptr is a helper function for getting pointer value
 func (e DLQType) Ptr() *DLQType {
 	return &e
+}
+
+// String returns a readable string representation of DLQType.
+func (e DLQType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Replication"
+	case 1:
+		return "Domain"
+	}
+	return fmt.Sprintf("DLQType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *DLQType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "replication":
+		*e = DLQTypeReplication
+		return nil
+	case "domain":
+		*e = DLQTypeDomain
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "DLQType", err)
+		}
+		*e = DLQType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes DLQType to text.
+func (e DLQType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -41,6 +83,42 @@ type DomainOperation int32
 // Ptr is a helper function for getting pointer value
 func (e DomainOperation) Ptr() *DomainOperation {
 	return &e
+}
+
+// String returns a readable string representation of DomainOperation.
+func (e DomainOperation) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Create"
+	case 1:
+		return "Update"
+	}
+	return fmt.Sprintf("DomainOperation(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *DomainOperation) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "create":
+		*e = DomainOperationCreate
+		return nil
+	case "update":
+		*e = DomainOperationUpdate
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "DomainOperation", err)
+		}
+		*e = DomainOperation(val)
+		return nil
+	}
+}
+
+// MarshalText encodes DomainOperation to text.
+func (e DomainOperation) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -749,6 +827,67 @@ type ReplicationTaskType int32
 // Ptr is a helper function for getting pointer value
 func (e ReplicationTaskType) Ptr() *ReplicationTaskType {
 	return &e
+}
+
+// String returns a readable string representation of ReplicationTaskType.
+func (e ReplicationTaskType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Domain"
+	case 1:
+		return "History"
+	case 2:
+		return "SyncShardStatus"
+	case 3:
+		return "SyncActivity"
+	case 4:
+		return "HistoryMetadata"
+	case 5:
+		return "HistoryV2"
+	case 6:
+		return "FailoverMarker"
+	}
+	return fmt.Sprintf("ReplicationTaskType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *ReplicationTaskType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "domain":
+		*e = ReplicationTaskTypeDomain
+		return nil
+	case "history":
+		*e = ReplicationTaskTypeHistory
+		return nil
+	case "syncshardstatus":
+		*e = ReplicationTaskTypeSyncShardStatus
+		return nil
+	case "syncactivity":
+		*e = ReplicationTaskTypeSyncActivity
+		return nil
+	case "historymetadata":
+		*e = ReplicationTaskTypeHistoryMetadata
+		return nil
+	case "historyv2":
+		*e = ReplicationTaskTypeHistoryV2
+		return nil
+	case "failovermarker":
+		*e = ReplicationTaskTypeFailoverMarker
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ReplicationTaskType", err)
+		}
+		*e = ReplicationTaskType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes ReplicationTaskType to text.
+func (e ReplicationTaskType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -20,6 +20,12 @@
 
 package types
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // AccessDeniedError is an internal type (TBD...)
 type AccessDeniedError struct {
 	Message string `json:"message,required"`
@@ -491,6 +497,42 @@ func (e ArchivalStatus) Ptr() *ArchivalStatus {
 	return &e
 }
 
+// String returns a readable string representation of ArchivalStatus.
+func (e ArchivalStatus) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Disabled"
+	case 1:
+		return "Enabled"
+	}
+	return fmt.Sprintf("ArchivalStatus(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *ArchivalStatus) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "disabled":
+		*e = ArchivalStatusDisabled
+		return nil
+	case "enabled":
+		*e = ArchivalStatusEnabled
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ArchivalStatus", err)
+		}
+		*e = ArchivalStatus(val)
+		return nil
+	}
+}
+
+// MarshalText encodes ArchivalStatus to text.
+func (e ArchivalStatus) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// ArchivalStatusDisabled is an option for ArchivalStatus
 	ArchivalStatusDisabled ArchivalStatus = iota
@@ -561,6 +603,37 @@ type CancelExternalWorkflowExecutionFailedCause int32
 // Ptr is a helper function for getting pointer value
 func (e CancelExternalWorkflowExecutionFailedCause) Ptr() *CancelExternalWorkflowExecutionFailedCause {
 	return &e
+}
+
+// String returns a readable string representation of CancelExternalWorkflowExecutionFailedCause.
+func (e CancelExternalWorkflowExecutionFailedCause) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "UnknownExternalWorkflowExecution"
+	}
+	return fmt.Sprintf("CancelExternalWorkflowExecutionFailedCause(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *CancelExternalWorkflowExecutionFailedCause) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "unknownexternalworkflowexecution":
+		*e = CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "CancelExternalWorkflowExecutionFailedCause", err)
+		}
+		*e = CancelExternalWorkflowExecutionFailedCause(val)
+		return nil
+	}
+}
+
+// MarshalText encodes CancelExternalWorkflowExecutionFailedCause to text.
+func (e CancelExternalWorkflowExecutionFailedCause) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -769,6 +842,37 @@ type ChildWorkflowExecutionFailedCause int32
 // Ptr is a helper function for getting pointer value
 func (e ChildWorkflowExecutionFailedCause) Ptr() *ChildWorkflowExecutionFailedCause {
 	return &e
+}
+
+// String returns a readable string representation of ChildWorkflowExecutionFailedCause.
+func (e ChildWorkflowExecutionFailedCause) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "WorkflowAlreadyRunning"
+	}
+	return fmt.Sprintf("ChildWorkflowExecutionFailedCause(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *ChildWorkflowExecutionFailedCause) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "workflowalreadyrunning":
+		*e = ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ChildWorkflowExecutionFailedCause", err)
+		}
+		*e = ChildWorkflowExecutionFailedCause(val)
+		return nil
+	}
+}
+
+// MarshalText encodes ChildWorkflowExecutionFailedCause to text.
+func (e ChildWorkflowExecutionFailedCause) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -1088,6 +1192,47 @@ type ContinueAsNewInitiator int32
 // Ptr is a helper function for getting pointer value
 func (e ContinueAsNewInitiator) Ptr() *ContinueAsNewInitiator {
 	return &e
+}
+
+// String returns a readable string representation of ContinueAsNewInitiator.
+func (e ContinueAsNewInitiator) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Decider"
+	case 1:
+		return "RetryPolicy"
+	case 2:
+		return "CronSchedule"
+	}
+	return fmt.Sprintf("ContinueAsNewInitiator(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *ContinueAsNewInitiator) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "decider":
+		*e = ContinueAsNewInitiatorDecider
+		return nil
+	case "retrypolicy":
+		*e = ContinueAsNewInitiatorRetryPolicy
+		return nil
+	case "cronschedule":
+		*e = ContinueAsNewInitiatorCronSchedule
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ContinueAsNewInitiator", err)
+		}
+		*e = ContinueAsNewInitiator(val)
+		return nil
+	}
+}
+
+// MarshalText encodes ContinueAsNewInitiator to text.
+func (e ContinueAsNewInitiator) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -1504,6 +1649,147 @@ func (e DecisionTaskFailedCause) Ptr() *DecisionTaskFailedCause {
 	return &e
 }
 
+// String returns a readable string representation of DecisionTaskFailedCause.
+func (e DecisionTaskFailedCause) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "UnhandledDecision"
+	case 1:
+		return "BadScheduleActivityAttributes"
+	case 2:
+		return "BadRequestCancelActivityAttributes"
+	case 3:
+		return "BadStartTimerAttributes"
+	case 4:
+		return "BadCancelTimerAttributes"
+	case 5:
+		return "BadRecordMarkerAttributes"
+	case 6:
+		return "BadCompleteWorkflowExecutionAttributes"
+	case 7:
+		return "BadFailWorkflowExecutionAttributes"
+	case 8:
+		return "BadCancelWorkflowExecutionAttributes"
+	case 9:
+		return "BadRequestCancelExternalWorkflowExecutionAttributes"
+	case 10:
+		return "BadContinueAsNewAttributes"
+	case 11:
+		return "StartTimerDuplicateID"
+	case 12:
+		return "ResetStickyTasklist"
+	case 13:
+		return "WorkflowWorkerUnhandledFailure"
+	case 14:
+		return "BadSignalWorkflowExecutionAttributes"
+	case 15:
+		return "BadStartChildExecutionAttributes"
+	case 16:
+		return "ForceCloseDecision"
+	case 17:
+		return "FailoverCloseDecision"
+	case 18:
+		return "BadSignalInputSize"
+	case 19:
+		return "ResetWorkflow"
+	case 20:
+		return "BadBinary"
+	case 21:
+		return "ScheduleActivityDuplicateID"
+	case 22:
+		return "BadSearchAttributes"
+	}
+	return fmt.Sprintf("DecisionTaskFailedCause(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *DecisionTaskFailedCause) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "unhandleddecision":
+		*e = DecisionTaskFailedCauseUnhandledDecision
+		return nil
+	case "badscheduleactivityattributes":
+		*e = DecisionTaskFailedCauseBadScheduleActivityAttributes
+		return nil
+	case "badrequestcancelactivityattributes":
+		*e = DecisionTaskFailedCauseBadRequestCancelActivityAttributes
+		return nil
+	case "badstarttimerattributes":
+		*e = DecisionTaskFailedCauseBadStartTimerAttributes
+		return nil
+	case "badcanceltimerattributes":
+		*e = DecisionTaskFailedCauseBadCancelTimerAttributes
+		return nil
+	case "badrecordmarkerattributes":
+		*e = DecisionTaskFailedCauseBadRecordMarkerAttributes
+		return nil
+	case "badcompleteworkflowexecutionattributes":
+		*e = DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes
+		return nil
+	case "badfailworkflowexecutionattributes":
+		*e = DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes
+		return nil
+	case "badcancelworkflowexecutionattributes":
+		*e = DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes
+		return nil
+	case "badrequestcancelexternalworkflowexecutionattributes":
+		*e = DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes
+		return nil
+	case "badcontinueasnewattributes":
+		*e = DecisionTaskFailedCauseBadContinueAsNewAttributes
+		return nil
+	case "starttimerduplicateid":
+		*e = DecisionTaskFailedCauseStartTimerDuplicateID
+		return nil
+	case "resetstickytasklist":
+		*e = DecisionTaskFailedCauseResetStickyTasklist
+		return nil
+	case "workflowworkerunhandledfailure":
+		*e = DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure
+		return nil
+	case "badsignalworkflowexecutionattributes":
+		*e = DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes
+		return nil
+	case "badstartchildexecutionattributes":
+		*e = DecisionTaskFailedCauseBadStartChildExecutionAttributes
+		return nil
+	case "forceclosedecision":
+		*e = DecisionTaskFailedCauseForceCloseDecision
+		return nil
+	case "failoverclosedecision":
+		*e = DecisionTaskFailedCauseFailoverCloseDecision
+		return nil
+	case "badsignalinputsize":
+		*e = DecisionTaskFailedCauseBadSignalInputSize
+		return nil
+	case "resetworkflow":
+		*e = DecisionTaskFailedCauseResetWorkflow
+		return nil
+	case "badbinary":
+		*e = DecisionTaskFailedCauseBadBinary
+		return nil
+	case "scheduleactivityduplicateid":
+		*e = DecisionTaskFailedCauseScheduleActivityDuplicateID
+		return nil
+	case "badsearchattributes":
+		*e = DecisionTaskFailedCauseBadSearchAttributes
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "DecisionTaskFailedCause", err)
+		}
+		*e = DecisionTaskFailedCause(val)
+		return nil
+	}
+}
+
+// MarshalText encodes DecisionTaskFailedCause to text.
+func (e DecisionTaskFailedCause) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// DecisionTaskFailedCauseUnhandledDecision is an option for DecisionTaskFailedCause
 	DecisionTaskFailedCauseUnhandledDecision DecisionTaskFailedCause = iota
@@ -1746,6 +2032,97 @@ type DecisionType int32
 // Ptr is a helper function for getting pointer value
 func (e DecisionType) Ptr() *DecisionType {
 	return &e
+}
+
+// String returns a readable string representation of DecisionType.
+func (e DecisionType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "ScheduleActivityTask"
+	case 1:
+		return "RequestCancelActivityTask"
+	case 2:
+		return "StartTimer"
+	case 3:
+		return "CompleteWorkflowExecution"
+	case 4:
+		return "FailWorkflowExecution"
+	case 5:
+		return "CancelTimer"
+	case 6:
+		return "CancelWorkflowExecution"
+	case 7:
+		return "RequestCancelExternalWorkflowExecution"
+	case 8:
+		return "RecordMarker"
+	case 9:
+		return "ContinueAsNewWorkflowExecution"
+	case 10:
+		return "StartChildWorkflowExecution"
+	case 11:
+		return "SignalExternalWorkflowExecution"
+	case 12:
+		return "UpsertWorkflowSearchAttributes"
+	}
+	return fmt.Sprintf("DecisionType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *DecisionType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "scheduleactivitytask":
+		*e = DecisionTypeScheduleActivityTask
+		return nil
+	case "requestcancelactivitytask":
+		*e = DecisionTypeRequestCancelActivityTask
+		return nil
+	case "starttimer":
+		*e = DecisionTypeStartTimer
+		return nil
+	case "completeworkflowexecution":
+		*e = DecisionTypeCompleteWorkflowExecution
+		return nil
+	case "failworkflowexecution":
+		*e = DecisionTypeFailWorkflowExecution
+		return nil
+	case "canceltimer":
+		*e = DecisionTypeCancelTimer
+		return nil
+	case "cancelworkflowexecution":
+		*e = DecisionTypeCancelWorkflowExecution
+		return nil
+	case "requestcancelexternalworkflowexecution":
+		*e = DecisionTypeRequestCancelExternalWorkflowExecution
+		return nil
+	case "recordmarker":
+		*e = DecisionTypeRecordMarker
+		return nil
+	case "continueasnewworkflowexecution":
+		*e = DecisionTypeContinueAsNewWorkflowExecution
+		return nil
+	case "startchildworkflowexecution":
+		*e = DecisionTypeStartChildWorkflowExecution
+		return nil
+	case "signalexternalworkflowexecution":
+		*e = DecisionTypeSignalExternalWorkflowExecution
+		return nil
+	case "upsertworkflowsearchattributes":
+		*e = DecisionTypeUpsertWorkflowSearchAttributes
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "DecisionType", err)
+		}
+		*e = DecisionType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes DecisionType to text.
+func (e DecisionType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -2357,6 +2734,47 @@ func (e DomainStatus) Ptr() *DomainStatus {
 	return &e
 }
 
+// String returns a readable string representation of DomainStatus.
+func (e DomainStatus) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Registered"
+	case 1:
+		return "Deprecated"
+	case 2:
+		return "Deleted"
+	}
+	return fmt.Sprintf("DomainStatus(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *DomainStatus) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "registered":
+		*e = DomainStatusRegistered
+		return nil
+	case "deprecated":
+		*e = DomainStatusDeprecated
+		return nil
+	case "deleted":
+		*e = DomainStatusDeleted
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "DomainStatus", err)
+		}
+		*e = DomainStatus(val)
+		return nil
+	}
+}
+
+// MarshalText encodes DomainStatus to text.
+func (e DomainStatus) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// DomainStatusRegistered is an option for DomainStatus
 	DomainStatusRegistered DomainStatus = iota
@@ -2372,6 +2790,42 @@ type EncodingType int32
 // Ptr is a helper function for getting pointer value
 func (e EncodingType) Ptr() *EncodingType {
 	return &e
+}
+
+// String returns a readable string representation of EncodingType.
+func (e EncodingType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "ThriftRW"
+	case 1:
+		return "JSON"
+	}
+	return fmt.Sprintf("EncodingType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *EncodingType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "thriftrw":
+		*e = EncodingTypeThriftRW
+		return nil
+	case "json":
+		*e = EncodingTypeJSON
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EncodingType", err)
+		}
+		*e = EncodingType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes EncodingType to text.
+func (e EncodingType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -2418,6 +2872,242 @@ type EventType int32
 // Ptr is a helper function for getting pointer value
 func (e EventType) Ptr() *EventType {
 	return &e
+}
+
+// String returns a readable string representation of EventType.
+func (e EventType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "WorkflowExecutionStarted"
+	case 1:
+		return "WorkflowExecutionCompleted"
+	case 2:
+		return "WorkflowExecutionFailed"
+	case 3:
+		return "WorkflowExecutionTimedOut"
+	case 4:
+		return "DecisionTaskScheduled"
+	case 5:
+		return "DecisionTaskStarted"
+	case 6:
+		return "DecisionTaskCompleted"
+	case 7:
+		return "DecisionTaskTimedOut"
+	case 8:
+		return "DecisionTaskFailed"
+	case 9:
+		return "ActivityTaskScheduled"
+	case 10:
+		return "ActivityTaskStarted"
+	case 11:
+		return "ActivityTaskCompleted"
+	case 12:
+		return "ActivityTaskFailed"
+	case 13:
+		return "ActivityTaskTimedOut"
+	case 14:
+		return "ActivityTaskCancelRequested"
+	case 15:
+		return "RequestCancelActivityTaskFailed"
+	case 16:
+		return "ActivityTaskCanceled"
+	case 17:
+		return "TimerStarted"
+	case 18:
+		return "TimerFired"
+	case 19:
+		return "CancelTimerFailed"
+	case 20:
+		return "TimerCanceled"
+	case 21:
+		return "WorkflowExecutionCancelRequested"
+	case 22:
+		return "WorkflowExecutionCanceled"
+	case 23:
+		return "RequestCancelExternalWorkflowExecutionInitiated"
+	case 24:
+		return "RequestCancelExternalWorkflowExecutionFailed"
+	case 25:
+		return "ExternalWorkflowExecutionCancelRequested"
+	case 26:
+		return "MarkerRecorded"
+	case 27:
+		return "WorkflowExecutionSignaled"
+	case 28:
+		return "WorkflowExecutionTerminated"
+	case 29:
+		return "WorkflowExecutionContinuedAsNew"
+	case 30:
+		return "StartChildWorkflowExecutionInitiated"
+	case 31:
+		return "StartChildWorkflowExecutionFailed"
+	case 32:
+		return "ChildWorkflowExecutionStarted"
+	case 33:
+		return "ChildWorkflowExecutionCompleted"
+	case 34:
+		return "ChildWorkflowExecutionFailed"
+	case 35:
+		return "ChildWorkflowExecutionCanceled"
+	case 36:
+		return "ChildWorkflowExecutionTimedOut"
+	case 37:
+		return "ChildWorkflowExecutionTerminated"
+	case 38:
+		return "SignalExternalWorkflowExecutionInitiated"
+	case 39:
+		return "SignalExternalWorkflowExecutionFailed"
+	case 40:
+		return "ExternalWorkflowExecutionSignaled"
+	case 41:
+		return "UpsertWorkflowSearchAttributes"
+	}
+	return fmt.Sprintf("EventType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *EventType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "workflowexecutionstarted":
+		*e = EventTypeWorkflowExecutionStarted
+		return nil
+	case "workflowexecutioncompleted":
+		*e = EventTypeWorkflowExecutionCompleted
+		return nil
+	case "workflowexecutionfailed":
+		*e = EventTypeWorkflowExecutionFailed
+		return nil
+	case "workflowexecutiontimedout":
+		*e = EventTypeWorkflowExecutionTimedOut
+		return nil
+	case "decisiontaskscheduled":
+		*e = EventTypeDecisionTaskScheduled
+		return nil
+	case "decisiontaskstarted":
+		*e = EventTypeDecisionTaskStarted
+		return nil
+	case "decisiontaskcompleted":
+		*e = EventTypeDecisionTaskCompleted
+		return nil
+	case "decisiontasktimedout":
+		*e = EventTypeDecisionTaskTimedOut
+		return nil
+	case "decisiontaskfailed":
+		*e = EventTypeDecisionTaskFailed
+		return nil
+	case "activitytaskscheduled":
+		*e = EventTypeActivityTaskScheduled
+		return nil
+	case "activitytaskstarted":
+		*e = EventTypeActivityTaskStarted
+		return nil
+	case "activitytaskcompleted":
+		*e = EventTypeActivityTaskCompleted
+		return nil
+	case "activitytaskfailed":
+		*e = EventTypeActivityTaskFailed
+		return nil
+	case "activitytasktimedout":
+		*e = EventTypeActivityTaskTimedOut
+		return nil
+	case "activitytaskcancelrequested":
+		*e = EventTypeActivityTaskCancelRequested
+		return nil
+	case "requestcancelactivitytaskfailed":
+		*e = EventTypeRequestCancelActivityTaskFailed
+		return nil
+	case "activitytaskcanceled":
+		*e = EventTypeActivityTaskCanceled
+		return nil
+	case "timerstarted":
+		*e = EventTypeTimerStarted
+		return nil
+	case "timerfired":
+		*e = EventTypeTimerFired
+		return nil
+	case "canceltimerfailed":
+		*e = EventTypeCancelTimerFailed
+		return nil
+	case "timercanceled":
+		*e = EventTypeTimerCanceled
+		return nil
+	case "workflowexecutioncancelrequested":
+		*e = EventTypeWorkflowExecutionCancelRequested
+		return nil
+	case "workflowexecutioncanceled":
+		*e = EventTypeWorkflowExecutionCanceled
+		return nil
+	case "requestcancelexternalworkflowexecutioninitiated":
+		*e = EventTypeRequestCancelExternalWorkflowExecutionInitiated
+		return nil
+	case "requestcancelexternalworkflowexecutionfailed":
+		*e = EventTypeRequestCancelExternalWorkflowExecutionFailed
+		return nil
+	case "externalworkflowexecutioncancelrequested":
+		*e = EventTypeExternalWorkflowExecutionCancelRequested
+		return nil
+	case "markerrecorded":
+		*e = EventTypeMarkerRecorded
+		return nil
+	case "workflowexecutionsignaled":
+		*e = EventTypeWorkflowExecutionSignaled
+		return nil
+	case "workflowexecutionterminated":
+		*e = EventTypeWorkflowExecutionTerminated
+		return nil
+	case "workflowexecutioncontinuedasnew":
+		*e = EventTypeWorkflowExecutionContinuedAsNew
+		return nil
+	case "startchildworkflowexecutioninitiated":
+		*e = EventTypeStartChildWorkflowExecutionInitiated
+		return nil
+	case "startchildworkflowexecutionfailed":
+		*e = EventTypeStartChildWorkflowExecutionFailed
+		return nil
+	case "childworkflowexecutionstarted":
+		*e = EventTypeChildWorkflowExecutionStarted
+		return nil
+	case "childworkflowexecutioncompleted":
+		*e = EventTypeChildWorkflowExecutionCompleted
+		return nil
+	case "childworkflowexecutionfailed":
+		*e = EventTypeChildWorkflowExecutionFailed
+		return nil
+	case "childworkflowexecutioncanceled":
+		*e = EventTypeChildWorkflowExecutionCanceled
+		return nil
+	case "childworkflowexecutiontimedout":
+		*e = EventTypeChildWorkflowExecutionTimedOut
+		return nil
+	case "childworkflowexecutionterminated":
+		*e = EventTypeChildWorkflowExecutionTerminated
+		return nil
+	case "signalexternalworkflowexecutioninitiated":
+		*e = EventTypeSignalExternalWorkflowExecutionInitiated
+		return nil
+	case "signalexternalworkflowexecutionfailed":
+		*e = EventTypeSignalExternalWorkflowExecutionFailed
+		return nil
+	case "externalworkflowexecutionsignaled":
+		*e = EventTypeExternalWorkflowExecutionSignaled
+		return nil
+	case "upsertworkflowsearchattributes":
+		*e = EventTypeUpsertWorkflowSearchAttributes
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "EventType", err)
+		}
+		*e = EventType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes EventType to text.
+func (e EventType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -3243,6 +3933,42 @@ func (e HistoryEventFilterType) Ptr() *HistoryEventFilterType {
 	return &e
 }
 
+// String returns a readable string representation of HistoryEventFilterType.
+func (e HistoryEventFilterType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "AllEvent"
+	case 1:
+		return "CloseEvent"
+	}
+	return fmt.Sprintf("HistoryEventFilterType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *HistoryEventFilterType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "allevent":
+		*e = HistoryEventFilterTypeAllEvent
+		return nil
+	case "closeevent":
+		*e = HistoryEventFilterTypeCloseEvent
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "HistoryEventFilterType", err)
+		}
+		*e = HistoryEventFilterType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes HistoryEventFilterType to text.
+func (e HistoryEventFilterType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// HistoryEventFilterTypeAllEvent is an option for HistoryEventFilterType
 	HistoryEventFilterTypeAllEvent HistoryEventFilterType = iota
@@ -3256,6 +3982,62 @@ type IndexedValueType int32
 // Ptr is a helper function for getting pointer value
 func (e IndexedValueType) Ptr() *IndexedValueType {
 	return &e
+}
+
+// String returns a readable string representation of IndexedValueType.
+func (e IndexedValueType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "String"
+	case 1:
+		return "Keyword"
+	case 2:
+		return "Int"
+	case 3:
+		return "Double"
+	case 4:
+		return "Bool"
+	case 5:
+		return "Datetime"
+	}
+	return fmt.Sprintf("IndexedValueType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *IndexedValueType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "string":
+		*e = IndexedValueTypeString
+		return nil
+	case "keyword":
+		*e = IndexedValueTypeKeyword
+		return nil
+	case "int":
+		*e = IndexedValueTypeInt
+		return nil
+	case "double":
+		*e = IndexedValueTypeDouble
+		return nil
+	case "bool":
+		*e = IndexedValueTypeBool
+		return nil
+	case "datetime":
+		*e = IndexedValueTypeDatetime
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "IndexedValueType", err)
+		}
+		*e = IndexedValueType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes IndexedValueType to text.
+func (e IndexedValueType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -3754,6 +4536,47 @@ func (e ParentClosePolicy) Ptr() *ParentClosePolicy {
 	return &e
 }
 
+// String returns a readable string representation of ParentClosePolicy.
+func (e ParentClosePolicy) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Abandon"
+	case 1:
+		return "RequestCancel"
+	case 2:
+		return "Terminate"
+	}
+	return fmt.Sprintf("ParentClosePolicy(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *ParentClosePolicy) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "abandon":
+		*e = ParentClosePolicyAbandon
+		return nil
+	case "requestcancel":
+		*e = ParentClosePolicyRequestCancel
+		return nil
+	case "terminate":
+		*e = ParentClosePolicyTerminate
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ParentClosePolicy", err)
+		}
+		*e = ParentClosePolicy(val)
+		return nil
+	}
+}
+
+// MarshalText encodes ParentClosePolicy to text.
+func (e ParentClosePolicy) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// ParentClosePolicyAbandon is an option for ParentClosePolicy
 	ParentClosePolicyAbandon ParentClosePolicy = iota
@@ -3892,6 +4715,47 @@ func (e PendingActivityState) Ptr() *PendingActivityState {
 	return &e
 }
 
+// String returns a readable string representation of PendingActivityState.
+func (e PendingActivityState) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Scheduled"
+	case 1:
+		return "Started"
+	case 2:
+		return "CancelRequested"
+	}
+	return fmt.Sprintf("PendingActivityState(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *PendingActivityState) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "scheduled":
+		*e = PendingActivityStateScheduled
+		return nil
+	case "started":
+		*e = PendingActivityStateStarted
+		return nil
+	case "cancelrequested":
+		*e = PendingActivityStateCancelRequested
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "PendingActivityState", err)
+		}
+		*e = PendingActivityState(val)
+		return nil
+	}
+}
+
+// MarshalText encodes PendingActivityState to text.
+func (e PendingActivityState) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// PendingActivityStateScheduled is an option for PendingActivityState
 	PendingActivityStateScheduled PendingActivityState = iota
@@ -4005,6 +4869,42 @@ type PendingDecisionState int32
 // Ptr is a helper function for getting pointer value
 func (e PendingDecisionState) Ptr() *PendingDecisionState {
 	return &e
+}
+
+// String returns a readable string representation of PendingDecisionState.
+func (e PendingDecisionState) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Scheduled"
+	case 1:
+		return "Started"
+	}
+	return fmt.Sprintf("PendingDecisionState(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *PendingDecisionState) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "scheduled":
+		*e = PendingDecisionStateScheduled
+		return nil
+	case "started":
+		*e = PendingDecisionStateStarted
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "PendingDecisionState", err)
+		}
+		*e = PendingDecisionState(val)
+		return nil
+	}
+}
+
+// MarshalText encodes PendingDecisionState to text.
+func (e PendingDecisionState) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -4411,6 +5311,42 @@ func (e QueryConsistencyLevel) Ptr() *QueryConsistencyLevel {
 	return &e
 }
 
+// String returns a readable string representation of QueryConsistencyLevel.
+func (e QueryConsistencyLevel) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Eventual"
+	case 1:
+		return "Strong"
+	}
+	return fmt.Sprintf("QueryConsistencyLevel(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *QueryConsistencyLevel) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "eventual":
+		*e = QueryConsistencyLevelEventual
+		return nil
+	case "strong":
+		*e = QueryConsistencyLevelStrong
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "QueryConsistencyLevel", err)
+		}
+		*e = QueryConsistencyLevel(val)
+		return nil
+	}
+}
+
+// MarshalText encodes QueryConsistencyLevel to text.
+func (e QueryConsistencyLevel) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// QueryConsistencyLevelEventual is an option for QueryConsistencyLevel
 	QueryConsistencyLevelEventual QueryConsistencyLevel = iota
@@ -4437,6 +5373,42 @@ type QueryRejectCondition int32
 // Ptr is a helper function for getting pointer value
 func (e QueryRejectCondition) Ptr() *QueryRejectCondition {
 	return &e
+}
+
+// String returns a readable string representation of QueryRejectCondition.
+func (e QueryRejectCondition) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "NotOpen"
+	case 1:
+		return "NotCompletedCleanly"
+	}
+	return fmt.Sprintf("QueryRejectCondition(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *QueryRejectCondition) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "notopen":
+		*e = QueryRejectConditionNotOpen
+		return nil
+	case "notcompletedcleanly":
+		*e = QueryRejectConditionNotCompletedCleanly
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "QueryRejectCondition", err)
+		}
+		*e = QueryRejectCondition(val)
+		return nil
+	}
+}
+
+// MarshalText encodes QueryRejectCondition to text.
+func (e QueryRejectCondition) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -4467,6 +5439,42 @@ func (e QueryResultType) Ptr() *QueryResultType {
 	return &e
 }
 
+// String returns a readable string representation of QueryResultType.
+func (e QueryResultType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Answered"
+	case 1:
+		return "Failed"
+	}
+	return fmt.Sprintf("QueryResultType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *QueryResultType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "answered":
+		*e = QueryResultTypeAnswered
+		return nil
+	case "failed":
+		*e = QueryResultTypeFailed
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "QueryResultType", err)
+		}
+		*e = QueryResultType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes QueryResultType to text.
+func (e QueryResultType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// QueryResultTypeAnswered is an option for QueryResultType
 	QueryResultTypeAnswered QueryResultType = iota
@@ -4480,6 +5488,42 @@ type QueryTaskCompletedType int32
 // Ptr is a helper function for getting pointer value
 func (e QueryTaskCompletedType) Ptr() *QueryTaskCompletedType {
 	return &e
+}
+
+// String returns a readable string representation of QueryTaskCompletedType.
+func (e QueryTaskCompletedType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Completed"
+	case 1:
+		return "Failed"
+	}
+	return fmt.Sprintf("QueryTaskCompletedType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *QueryTaskCompletedType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "completed":
+		*e = QueryTaskCompletedTypeCompleted
+		return nil
+	case "failed":
+		*e = QueryTaskCompletedTypeFailed
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "QueryTaskCompletedType", err)
+		}
+		*e = QueryTaskCompletedType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes QueryTaskCompletedType to text.
+func (e QueryTaskCompletedType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -6196,6 +7240,37 @@ func (e SignalExternalWorkflowExecutionFailedCause) Ptr() *SignalExternalWorkflo
 	return &e
 }
 
+// String returns a readable string representation of SignalExternalWorkflowExecutionFailedCause.
+func (e SignalExternalWorkflowExecutionFailedCause) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "UnknownExternalWorkflowExecution"
+	}
+	return fmt.Sprintf("SignalExternalWorkflowExecutionFailedCause(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *SignalExternalWorkflowExecutionFailedCause) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "unknownexternalworkflowexecution":
+		*e = SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "SignalExternalWorkflowExecutionFailedCause", err)
+		}
+		*e = SignalExternalWorkflowExecutionFailedCause(val)
+		return nil
+	}
+}
+
+// MarshalText encodes SignalExternalWorkflowExecutionFailedCause to text.
+func (e SignalExternalWorkflowExecutionFailedCause) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution is an option for SignalExternalWorkflowExecutionFailedCause
 	SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution SignalExternalWorkflowExecutionFailedCause = iota
@@ -7205,6 +8280,42 @@ func (e TaskListKind) Ptr() *TaskListKind {
 	return &e
 }
 
+// String returns a readable string representation of TaskListKind.
+func (e TaskListKind) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Normal"
+	case 1:
+		return "Sticky"
+	}
+	return fmt.Sprintf("TaskListKind(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *TaskListKind) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "normal":
+		*e = TaskListKindNormal
+		return nil
+	case "sticky":
+		*e = TaskListKindSticky
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "TaskListKind", err)
+		}
+		*e = TaskListKind(val)
+		return nil
+	}
+}
+
+// MarshalText encodes TaskListKind to text.
+func (e TaskListKind) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// TaskListKindNormal is an option for TaskListKind
 	TaskListKindNormal TaskListKind = iota
@@ -7304,6 +8415,42 @@ func (e TaskListType) Ptr() *TaskListType {
 	return &e
 }
 
+// String returns a readable string representation of TaskListType.
+func (e TaskListType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Decision"
+	case 1:
+		return "Activity"
+	}
+	return fmt.Sprintf("TaskListType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *TaskListType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "decision":
+		*e = TaskListTypeDecision
+		return nil
+	case "activity":
+		*e = TaskListTypeActivity
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "TaskListType", err)
+		}
+		*e = TaskListType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes TaskListType to text.
+func (e TaskListType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
 const (
 	// TaskListTypeDecision is an option for TaskListType
 	TaskListTypeDecision TaskListType = iota
@@ -7366,6 +8513,52 @@ type TimeoutType int32
 // Ptr is a helper function for getting pointer value
 func (e TimeoutType) Ptr() *TimeoutType {
 	return &e
+}
+
+// String returns a readable string representation of TimeoutType.
+func (e TimeoutType) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "StartToClose"
+	case 1:
+		return "ScheduleToStart"
+	case 2:
+		return "ScheduleToClose"
+	case 3:
+		return "Heartbeat"
+	}
+	return fmt.Sprintf("TimeoutType(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *TimeoutType) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "starttoclose":
+		*e = TimeoutTypeStartToClose
+		return nil
+	case "scheduletostart":
+		*e = TimeoutTypeScheduleToStart
+		return nil
+	case "scheduletoclose":
+		*e = TimeoutTypeScheduleToClose
+		return nil
+	case "heartbeat":
+		*e = TimeoutTypeHeartbeat
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "TimeoutType", err)
+		}
+		*e = TimeoutType(val)
+		return nil
+	}
+}
+
+// MarshalText encodes TimeoutType to text.
+func (e TimeoutType) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -7885,6 +9078,62 @@ type WorkflowExecutionCloseStatus int32
 // Ptr is a helper function for getting pointer value
 func (e WorkflowExecutionCloseStatus) Ptr() *WorkflowExecutionCloseStatus {
 	return &e
+}
+
+// String returns a readable string representation of WorkflowExecutionCloseStatus.
+func (e WorkflowExecutionCloseStatus) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "Completed"
+	case 1:
+		return "Failed"
+	case 2:
+		return "Canceled"
+	case 3:
+		return "Terminated"
+	case 4:
+		return "ContinuedAsNew"
+	case 5:
+		return "TimedOut"
+	}
+	return fmt.Sprintf("WorkflowExecutionCloseStatus(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *WorkflowExecutionCloseStatus) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "completed":
+		*e = WorkflowExecutionCloseStatusCompleted
+		return nil
+	case "failed":
+		*e = WorkflowExecutionCloseStatusFailed
+		return nil
+	case "canceled":
+		*e = WorkflowExecutionCloseStatusCanceled
+		return nil
+	case "terminated":
+		*e = WorkflowExecutionCloseStatusTerminated
+		return nil
+	case "continuedasnew":
+		*e = WorkflowExecutionCloseStatusContinuedAsNew
+		return nil
+	case "timedout":
+		*e = WorkflowExecutionCloseStatusTimedOut
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "WorkflowExecutionCloseStatus", err)
+		}
+		*e = WorkflowExecutionCloseStatus(val)
+		return nil
+	}
+}
+
+// MarshalText encodes WorkflowExecutionCloseStatus to text.
+func (e WorkflowExecutionCloseStatus) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (
@@ -8578,6 +9827,52 @@ type WorkflowIDReusePolicy int32
 // Ptr is a helper function for getting pointer value
 func (e WorkflowIDReusePolicy) Ptr() *WorkflowIDReusePolicy {
 	return &e
+}
+
+// String returns a readable string representation of WorkflowIDReusePolicy.
+func (e WorkflowIDReusePolicy) String() string {
+	w := int32(e)
+	switch w {
+	case 0:
+		return "AllowDuplicateFailedOnly"
+	case 1:
+		return "AllowDuplicate"
+	case 2:
+		return "RejectDuplicate"
+	case 3:
+		return "TerminateIfRunning"
+	}
+	return fmt.Sprintf("WorkflowIDReusePolicy(%d)", w)
+}
+
+// UnmarshalText parses enum value from string representation
+func (e *WorkflowIDReusePolicy) UnmarshalText(value []byte) error {
+	switch s := strings.ToLower(string(value)); s {
+	case "allowduplicatefailedonly":
+		*e = WorkflowIDReusePolicyAllowDuplicateFailedOnly
+		return nil
+	case "allowduplicate":
+		*e = WorkflowIDReusePolicyAllowDuplicate
+		return nil
+	case "rejectduplicate":
+		*e = WorkflowIDReusePolicyRejectDuplicate
+		return nil
+	case "terminateifrunning":
+		*e = WorkflowIDReusePolicyTerminateIfRunning
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "WorkflowIDReusePolicy", err)
+		}
+		*e = WorkflowIDReusePolicy(val)
+		return nil
+	}
+}
+
+// MarshalText encodes WorkflowIDReusePolicy to text.
+func (e WorkflowIDReusePolicy) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
 }
 
 const (

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2708,7 +2708,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(
 	}
 
 	return &gen.ListArchivedWorkflowExecutionsResponse{
-		Executions:    archiverResponse.Executions,
+		Executions:    thrift.FromWorkflowExecutionInfoArray(archiverResponse.Executions),
 		NextPageToken: archiverResponse.NextPageToken,
 	}, nil
 }
@@ -3932,12 +3932,12 @@ func (wh *WorkflowHandler) getArchivedHistory(
 		return nil, wh.error(err, scope, getWfIDRunIDTags(wfExecution)...)
 	}
 
-	history := &gen.History{}
+	history := &types.History{}
 	for _, batch := range resp.HistoryBatches {
 		history.Events = append(history.Events, batch.Events...)
 	}
 	return &gen.GetWorkflowExecutionHistoryResponse{
-		History:       history,
+		History:       thrift.FromHistory(history),
 		NextPageToken: resp.NextPageToken,
 		Archived:      common.BoolPtr(true),
 	}, nil

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -936,25 +936,25 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
 	s.mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(domainEntry, nil).AnyTimes()
 
 	nextPageToken := []byte{'1', '2', '3'}
-	historyBatch1 := &shared.History{
-		Events: []*shared.HistoryEvent{
-			&shared.HistoryEvent{EventId: common.Int64Ptr(1)},
-			&shared.HistoryEvent{EventId: common.Int64Ptr(2)},
+	historyBatch1 := &types.History{
+		Events: []*types.HistoryEvent{
+			{EventID: common.Int64Ptr(1)},
+			{EventID: common.Int64Ptr(2)},
 		},
 	}
-	historyBatch2 := &shared.History{
-		Events: []*shared.HistoryEvent{
-			&shared.HistoryEvent{EventId: common.Int64Ptr(3)},
-			&shared.HistoryEvent{EventId: common.Int64Ptr(4)},
-			&shared.HistoryEvent{EventId: common.Int64Ptr(5)},
+	historyBatch2 := &types.History{
+		Events: []*types.HistoryEvent{
+			{EventID: common.Int64Ptr(3)},
+			{EventID: common.Int64Ptr(4)},
+			{EventID: common.Int64Ptr(5)},
 		},
 	}
-	history := &shared.History{}
+	history := &types.History{}
 	history.Events = append(history.Events, historyBatch1.Events...)
 	history.Events = append(history.Events, historyBatch2.Events...)
 	s.mockHistoryArchiver.On("Get", mock.Anything, mock.Anything, mock.Anything).Return(&archiver.GetHistoryResponse{
 		NextPageToken:  nextPageToken,
-		HistoryBatches: []*shared.History{historyBatch1, historyBatch2},
+		HistoryBatches: []*types.History{historyBatch1, historyBatch2},
 	}, nil)
 	s.mockArchiverProvider.On("GetHistoryArchiver", mock.Anything, mock.Anything).Return(s.mockHistoryArchiver, nil)
 

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -50,6 +50,7 @@ import (
 	"github.com/uber/cadence/common/resource"
 	dc "github.com/uber/cadence/common/service/dynamicconfig"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 const (
@@ -964,7 +965,7 @@ func (s *workflowHandlerSuite) TestGetArchivedHistory_Success_GetFirstPage() {
 	s.NoError(err)
 	s.NotNil(resp)
 	s.NotNil(resp.History)
-	s.Equal(history, resp.History)
+	s.Equal(history, thrift.ToHistory(resp.History))
 	s.Equal(nextPageToken, resp.NextPageToken)
 	s.True(resp.GetArchived())
 }

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"errors"
 
+	"github.com/uber/cadence/common/types/mapper/thrift"
+
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 
@@ -155,9 +157,9 @@ func archiveVisibilityActivity(ctx context.Context, request ArchiveRequest) (err
 		StartTimestamp:     request.StartTimestamp,
 		ExecutionTimestamp: request.ExecutionTimestamp,
 		CloseTimestamp:     request.CloseTimestamp,
-		CloseStatus:        request.CloseStatus,
+		CloseStatus:        *thrift.ToWorkflowExecutionCloseStatus(&request.CloseStatus),
 		HistoryLength:      request.HistoryLength,
-		Memo:               request.Memo,
+		Memo:               thrift.ToMemo(request.Memo),
 		SearchAttributes:   convertSearchAttributesToString(request.SearchAttributes),
 		HistoryArchivalURI: request.URI,
 	}, carchiver.GetNonRetriableErrorOption(errArchiveVisibilityNonRetriable))

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/uber/cadence/common/types/mapper/thrift"
-
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 
@@ -34,6 +32,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 const (

--- a/service/worker/archiver/client.go
+++ b/service/worker/archiver/client.go
@@ -27,6 +27,8 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/uber/cadence/common/types/mapper/thrift"
+
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	cclient "go.uber.org/cadence/client"
 
@@ -251,9 +253,9 @@ func (c *client) archiveVisibilityInline(ctx context.Context, request *ClientReq
 		StartTimestamp:     request.ArchiveRequest.StartTimestamp,
 		ExecutionTimestamp: request.ArchiveRequest.ExecutionTimestamp,
 		CloseTimestamp:     request.ArchiveRequest.CloseTimestamp,
-		CloseStatus:        request.ArchiveRequest.CloseStatus,
+		CloseStatus:        *thrift.ToWorkflowExecutionCloseStatus(&request.ArchiveRequest.CloseStatus),
 		HistoryLength:      request.ArchiveRequest.HistoryLength,
-		Memo:               request.ArchiveRequest.Memo,
+		Memo:               thrift.ToMemo(request.ArchiveRequest.Memo),
 		SearchAttributes:   convertSearchAttributesToString(request.ArchiveRequest.SearchAttributes),
 		HistoryArchivalURI: request.ArchiveRequest.URI,
 	})

--- a/service/worker/archiver/client.go
+++ b/service/worker/archiver/client.go
@@ -27,8 +27,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/uber/cadence/common/types/mapper/thrift"
-
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	cclient "go.uber.org/cadence/client"
 
@@ -41,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/quotas"
 	"github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 type (


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Switched `common/archive` package to use internal types.
- Since json marshaler is used on internal types, also added `MarshalText`/`UnmarshalText` on internal type enums. Otherwise they get serialized as numbers.

<!-- Tell your future self why have you made these changes -->
**Why?**
To propagate internal types throughout Cadence codebase.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

