### PR TITLE
Fix ES client config NPE

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -176,7 +176,7 @@ func (s *server) startService() common.Daemon {
 
 		params.ESConfig = advancedVisStore.ElasticSearch
 		params.ESConfig.SetUsernamePassword()
-		esClient, err := elasticsearch.NewGenericClient(params.ESConfig, s.cfg.Persistence.VisibilityConfig, params.Logger)
+		esClient, err := elasticsearch.NewGenericClient(params.ESConfig, params.Logger)
 		if err != nil {
 			log.Fatalf("error creating elastic search client: %v", err)
 		}

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -40,7 +40,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/service/dynamicconfig"
-  "github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 

--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -48,7 +48,6 @@ type (
 	// elasticV6 implements Client
 	elasticV6 struct {
 		client     *elastic.Client
-		config     *config.VisibilityConfig
 		logger     log.Logger
 		serializer p.PayloadSerializer
 	}
@@ -86,7 +85,6 @@ func (c *elasticV6) IsNotFoundError(err error) bool {
 // NewV6Client returns a new implementation of GenericClient
 func NewV6Client(
 	connectConfig *config.ElasticSearchConfig,
-	visibilityConfig *config.VisibilityConfig,
 	logger log.Logger,
 	clientOptFuncs ...elastic.ClientOptionFunc,
 ) (GenericClient, error) {
@@ -105,7 +103,6 @@ func NewV6Client(
 
 	return &elasticV6{
 		client:     client,
-		config:     visibilityConfig,
 		logger:     logger,
 		serializer: p.NewPayloadSerializer(),
 	}, nil
@@ -152,7 +149,7 @@ func (c *elasticV6) Search(ctx context.Context, request *SearchRequest) (*p.Inte
 		return nil, err
 	}
 
-	return c.getListWorkflowExecutionsResponse(searchResult.Hits, token, request.ListRequest.PageSize, request.Filter)
+	return c.getListWorkflowExecutionsResponse(searchResult.Hits, token, request.ListRequest.PageSize, request.MaxResultWindow, request.Filter)
 }
 
 func (c *elasticV6) SearchByQuery(ctx context.Context, request *SearchByQueryRequest) (*p.InternalListWorkflowExecutionsResponse, error) {
@@ -166,7 +163,7 @@ func (c *elasticV6) SearchByQuery(ctx context.Context, request *SearchByQueryReq
 		return nil, err
 	}
 
-	return c.getListWorkflowExecutionsResponse(searchResult.Hits, token, request.PageSize, request.Filter)
+	return c.getListWorkflowExecutionsResponse(searchResult.Hits, token, request.PageSize, request.MaxResultWindow, request.Filter)
 }
 
 func (c *elasticV6) ScanByQuery(ctx context.Context, request *ScanByQueryRequest) (*p.InternalListWorkflowExecutionsResponse, error) {
@@ -499,8 +496,13 @@ func buildPutMappingBodyV6(root, key, valueType string) map[string]interface{} {
 	return body
 }
 
-func (c *elasticV6) getListWorkflowExecutionsResponse(searchHits *elastic.SearchHits,
-	token *ElasticVisibilityPageToken, pageSize int, isRecordValid func(rec *p.InternalVisibilityWorkflowExecutionInfo) bool) (*p.InternalListWorkflowExecutionsResponse, error) {
+func (c *elasticV6) getListWorkflowExecutionsResponse(
+	searchHits *elastic.SearchHits,
+	token *ElasticVisibilityPageToken,
+	pageSize int,
+	maxResultWindow int,
+	isRecordValid func(rec *p.InternalVisibilityWorkflowExecutionInfo) bool,
+) (*p.InternalListWorkflowExecutionsResponse, error) {
 
 	response := &p.InternalListWorkflowExecutionsResponse{}
 	actualHits := searchHits.Hits
@@ -522,7 +524,7 @@ func (c *elasticV6) getListWorkflowExecutionsResponse(searchHits *elastic.Search
 
 		// ES Search API support pagination using From and PageSize, but has limit that From+PageSize cannot exceed a threshold
 		// to retrieve deeper pages, use ES SearchAfter
-		if searchHits.TotalHits <= int64(c.config.ESIndexMaxResultWindow()-pageSize) { // use ES Search From+Size
+		if searchHits.TotalHits <= int64(maxResultWindow-pageSize) { // use ES Search From+Size
 			nextPageToken, err = SerializePageToken(&ElasticVisibilityPageToken{From: token.From + numOfActualHits})
 		} else { // use ES Search After
 			var sortVal interface{}

--- a/common/elasticsearch/interfaces.go
+++ b/common/elasticsearch/interfaces.go
@@ -35,7 +35,6 @@ import (
 // NewGenericClient create a ES client
 func NewGenericClient(
 	connectConfig *config.ElasticSearchConfig,
-	visibilityConfig *config.VisibilityConfig,
 	logger log.Logger,
 ) (GenericClient, error) {
 	if connectConfig.Version == "" {
@@ -43,9 +42,9 @@ func NewGenericClient(
 	}
 	switch connectConfig.Version {
 	case "v6":
-		return NewV6Client(connectConfig, visibilityConfig, logger)
+		return NewV6Client(connectConfig, logger)
 	case "v7":
-		return NewV7Client(connectConfig, visibilityConfig, logger)
+		return NewV7Client(connectConfig, logger)
 	default:
 		return nil, fmt.Errorf("not supported ElasticSearch version: %v", connectConfig.Version)
 	}
@@ -80,11 +79,12 @@ type (
 
 	// SearchRequest is request for Search
 	SearchRequest struct {
-		Index       string
-		ListRequest *p.InternalListWorkflowExecutionsRequest
-		IsOpen      bool
-		Filter      IsRecordValidFilter
-		MatchQuery  *GenericMatch
+		Index           string
+		ListRequest     *p.InternalListWorkflowExecutionsRequest
+		IsOpen          bool
+		Filter          IsRecordValidFilter
+		MatchQuery      *GenericMatch
+		MaxResultWindow int
 	}
 
 	// GenericMatch is a match struct
@@ -95,11 +95,12 @@ type (
 
 	// SearchByQueryRequest is request for SearchByQuery
 	SearchByQueryRequest struct {
-		Index         string
-		Query         string
-		NextPageToken []byte
-		PageSize      int
-		Filter        IsRecordValidFilter
+		Index           string
+		Query           string
+		NextPageToken   []byte
+		PageSize        int
+		Filter          IsRecordValidFilter
+		MaxResultWindow int
 	}
 
 	// ScanByQueryRequest is request for SearchByQuery

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -162,11 +162,12 @@ func (v *esVisibilityStore) ListOpenWorkflowExecutions(
 	}
 
 	resp, err := v.esClient.Search(ctx, &es.SearchRequest{
-		Index:       v.index,
-		ListRequest: request,
-		IsOpen:      true,
-		Filter:      isRecordValid,
-		MatchQuery:  nil,
+		Index:           v.index,
+		ListRequest:     request,
+		IsOpen:          true,
+		Filter:          isRecordValid,
+		MatchQuery:      nil,
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{
@@ -185,11 +186,12 @@ func (v *esVisibilityStore) ListClosedWorkflowExecutions(
 	}
 
 	resp, err := v.esClient.Search(ctx, &es.SearchRequest{
-		Index:       v.index,
-		ListRequest: request,
-		IsOpen:      false,
-		Filter:      isRecordValid,
-		MatchQuery:  nil,
+		Index:           v.index,
+		ListRequest:     request,
+		IsOpen:          false,
+		Filter:          isRecordValid,
+		MatchQuery:      nil,
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{
@@ -216,6 +218,7 @@ func (v *esVisibilityStore) ListOpenWorkflowExecutionsByType(
 			Name: es.WorkflowType,
 			Text: request.WorkflowTypeName,
 		},
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{
@@ -242,6 +245,7 @@ func (v *esVisibilityStore) ListClosedWorkflowExecutionsByType(
 			Name: es.WorkflowType,
 			Text: request.WorkflowTypeName,
 		},
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{
@@ -268,6 +272,7 @@ func (v *esVisibilityStore) ListOpenWorkflowExecutionsByWorkflowID(
 			Name: es.WorkflowID,
 			Text: request.WorkflowID,
 		},
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{
@@ -294,6 +299,7 @@ func (v *esVisibilityStore) ListClosedWorkflowExecutionsByWorkflowID(
 			Name: es.WorkflowID,
 			Text: request.WorkflowID,
 		},
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{
@@ -320,6 +326,7 @@ func (v *esVisibilityStore) ListClosedWorkflowExecutionsByStatus(
 			Name: es.CloseStatus,
 			Text: int32(*thrift.FromWorkflowExecutionCloseStatus(&request.Status)),
 		},
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{
@@ -374,11 +381,12 @@ func (v *esVisibilityStore) ListWorkflowExecutions(
 	}
 
 	resp, err := v.esClient.SearchByQuery(ctx, &es.SearchByQueryRequest{
-		Index:         v.index,
-		Query:         queryDSL,
-		NextPageToken: request.NextPageToken,
-		PageSize:      request.PageSize,
-		Filter:        nil,
+		Index:           v.index,
+		Query:           queryDSL,
+		NextPageToken:   request.NextPageToken,
+		PageSize:        request.PageSize,
+		Filter:          nil,
+		MaxResultWindow: v.config.ESIndexMaxResultWindow(),
 	})
 	if err != nil {
 		return nil, &types.InternalServiceError{

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -158,7 +158,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger) (*TestCluster, er
 			ESIndexMaxResultWindow: dynamicconfig.GetIntPropertyFn(defaultTestValueOfESIndexMaxResultWindow),
 			ValidSearchAttributes:  dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys()),
 		}
-		esClient, err = elasticsearch.NewGenericClient(options.ESConfig, visConfig, logger)
+		esClient, err = elasticsearch.NewGenericClient(options.ESConfig, logger)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix ES client config NPE by removing visibility config from es client.

<!-- Tell your future self why have you made these changes -->
**Why?**
Visibility config used by es client is not initialized in `cmd/server.go`, instead it's initialized by each service separately in `service.go` when setting up the visibility store and can potentially have different values in different services.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

