### PR TITLE
Introduce internal types for sql blobs

### DIFF
--- a/common/persistence/serialization/interfaces.go
+++ b/common/persistence/serialization/interfaces.go
@@ -60,7 +60,7 @@ type (
 		Description                 *string
 		Owner                       *string
 		Status                      *int32
-		RetentionDays               *time.Duration
+		Retention                   *time.Duration
 		EmitMetric                  *bool
 		ArchivalBucket              *string
 		ArchivalStatus              *int16
@@ -77,9 +77,9 @@ type (
 		HistoryArchivalURI          *string
 		VisibilityArchivalStatus    *int16
 		VisibilityArchivalURI       *string
-		FailoverEndTime             *time.Time
+		FailoverEndTimestamp        *time.Time
 		PreviousFailoverVersion     *int64
-		LastUpdatedTime             *time.Time
+		LastUpdatedTimestamp        *time.Time
 	}
 
 	// HistoryBranchRange blob in a serialization agnostic format
@@ -91,9 +91,9 @@ type (
 
 	// HistoryTreeInfo blob in a serialization agnostic format
 	HistoryTreeInfo struct {
-		CreatedTime *time.Time
-		Ancestors   []*HistoryBranchRange
-		Info        *string
+		CreatedTimestamp *time.Time
+		Ancestors        []*HistoryBranchRange
+		Info             *string
 	}
 
 	// WorkflowExecutionInfo blob in a serialization agnostic format
@@ -107,8 +107,8 @@ type (
 		CompletionEventEncoding            *string
 		TaskList                           *string
 		WorkflowTypeName                   *string
-		WorkflowTimeoutSeconds             *time.Duration
-		DecisionTaskTimeoutSeconds         *time.Duration
+		WorkflowTimeout                    *time.Duration
+		DecisionTaskTimeout                *time.Duration
 		ExecutionContext                   []byte
 		State                              *int32
 		CloseStatus                        *int32
@@ -117,8 +117,8 @@ type (
 		LastEventTaskID                    *int64
 		LastFirstEventID                   *int64
 		LastProcessedEvent                 *int64
-		StartTime                          *time.Time
-		LastUpdatedTime                    *time.Time
+		StartTimestamp                     *time.Time
+		LastUpdatedTimestamp               *time.Time
 		DecisionVersion                    *int64
 		DecisionScheduleID                 *int64
 		DecisionStartedID                  *int64
@@ -134,12 +134,12 @@ type (
 		StickyTaskList                     *string
 		StickyScheduleToStartTimeout       *time.Duration
 		RetryAttempt                       *int64
-		RetryInitialIntervalSeconds        *time.Duration
-		RetryMaximumIntervalSeconds        *time.Duration
+		RetryInitialInterval               *time.Duration
+		RetryMaximumInterval               *time.Duration
 		RetryMaximumAttempts               *int32
-		RetryExpirationSeconds             *time.Duration
+		RetryExpiration                    *time.Duration
 		RetryBackoffCoefficient            *float64
-		RetryExpirationTime                *time.Time
+		RetryExpirationTimestamp           *time.Time
 		RetryNonRetryableErrors            []string
 		HasRetryPolicy                     *bool
 		CronSchedule                       *string
@@ -160,37 +160,37 @@ type (
 
 	// ActivityInfo blob in a serialization agnostic format
 	ActivityInfo struct {
-		Version                       *int64
-		ScheduledEventBatchID         *int64
-		ScheduledEvent                []byte
-		ScheduledEventEncoding        *string
-		ScheduledTime                 *time.Time
-		StartedID                     *int64
-		StartedEvent                  []byte
-		StartedEventEncoding          *string
-		StartedTime                   *time.Time
-		ActivityID                    *string
-		RequestID                     *string
-		ScheduleToStartTimeoutSeconds *time.Duration
-		ScheduleToCloseTimeoutSeconds *time.Duration
-		StartToCloseTimeoutSeconds    *time.Duration
-		HeartbeatTimeoutSeconds       *time.Duration
-		CancelRequested               *bool
-		CancelRequestID               *int64
-		TimerTaskStatus               *int32
-		Attempt                       *int32
-		TaskList                      *string
-		StartedIdentity               *string
-		HasRetryPolicy                *bool
-		RetryInitialIntervalSeconds   *time.Duration
-		RetryMaximumIntervalSeconds   *time.Duration
-		RetryMaximumAttempts          *int32
-		RetryExpirationTime           *time.Time
-		RetryBackoffCoefficient       *float64
-		RetryNonRetryableErrors       []string
-		RetryLastFailureReason        *string
-		RetryLastWorkerIdentity       *string
-		RetryLastFailureDetails       []byte
+		Version                  *int64
+		ScheduledEventBatchID    *int64
+		ScheduledEvent           []byte
+		ScheduledEventEncoding   *string
+		ScheduledTimestamp       *time.Time
+		StartedID                *int64
+		StartedEvent             []byte
+		StartedEventEncoding     *string
+		StartedTimestamp         *time.Time
+		ActivityID               *string
+		RequestID                *string
+		ScheduleToStartTimeout   *time.Duration
+		ScheduleToCloseTimeout   *time.Duration
+		StartToCloseTimeout      *time.Duration
+		HeartbeatTimeout         *time.Duration
+		CancelRequested          *bool
+		CancelRequestID          *int64
+		TimerTaskStatus          *int32
+		Attempt                  *int32
+		TaskList                 *string
+		StartedIdentity          *string
+		HasRetryPolicy           *bool
+		RetryInitialInterval     *time.Duration
+		RetryMaximumInterval     *time.Duration
+		RetryMaximumAttempts     *int32
+		RetryExpirationTimestamp *time.Time
+		RetryBackoffCoefficient  *float64
+		RetryNonRetryableErrors  []string
+		RetryLastFailureReason   *string
+		RetryLastWorkerIdentity  *string
+		RetryLastFailureDetails  []byte
 	}
 
 	// ChildExecutionInfo blob in a serialization agnostic format
@@ -229,27 +229,27 @@ type (
 
 	// TimerInfo blob in a serialization agnostic format
 	TimerInfo struct {
-		Version    *int64
-		StartedID  *int64
-		ExpiryTime *time.Time
-		TaskID     *int64
+		Version         *int64
+		StartedID       *int64
+		ExpiryTimestamp *time.Time
+		TaskID          *int64
 	}
 
 	// TaskInfo blob in a serialization agnostic format
 	TaskInfo struct {
-		WorkflowID  *string
-		RunID       *string
-		ScheduleID  *int64
-		ExpiryTime  *time.Time
-		CreatedTime *time.Time
+		WorkflowID       *string
+		RunID            *string
+		ScheduleID       *int64
+		ExpiryTimestamp  *time.Time
+		CreatedTimestamp *time.Time
 	}
 
 	// TaskListInfo blob in a serialization agnostic format
 	TaskListInfo struct {
-		Kind        *int16
-		AckLevel    *int64
-		ExpiryTime  *time.Time
-		LastUpdated *time.Time
+		Kind            *int16
+		AckLevel        *int64
+		ExpiryTimestamp *time.Time
+		LastUpdated     *time.Time
 	}
 
 	// TransferTaskInfo blob in a serialization agnostic format
@@ -294,7 +294,7 @@ type (
 		NewRunEventStoreVersion *int32
 		BranchToken             []byte
 		NewRunBranchToken       []byte
-		CreationTime            *time.Time
+		CreationTimestamp       *time.Time
 	}
 )
 

--- a/common/persistence/serialization/interfaces.go
+++ b/common/persistence/serialization/interfaces.go
@@ -23,11 +23,279 @@
 package serialization
 
 import (
+	"time"
+
 	"go.uber.org/thriftrw/wire"
 
 	"github.com/uber/cadence/.gen/go/sqlblobs"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
+)
+
+type (
+	// ShardInfo blob in a serialization agnostic format
+	ShardInfo struct {
+		StolenSinceRenew                      *int32
+		UpdatedAt                             *time.Time
+		ReplicationAckLevel                   *int64
+		TransferAckLevel                      *int64
+		TimerAckLevel                         *time.Time
+		DomainNotificationVersion             *int64
+		ClusterTransferAckLevel               map[string]int64
+		ClusterTimerAckLevel                  map[string]time.Time
+		Owner                                 *string
+		ClusterReplicationLevel               map[string]int64
+		PendingFailoverMarkers                []byte
+		PendingFailoverMarkersEncoding        *string
+		ReplicationDlqAckLevel                map[string]int64
+		TransferProcessingQueueStates         []byte
+		TransferProcessingQueueStatesEncoding *string
+		TimerProcessingQueueStates            []byte
+		TimerProcessingQueueStatesEncoding    *string
+	}
+
+	// DomainInfo blob in a serialization agnostic format
+	DomainInfo struct {
+		Name                        *string
+		Description                 *string
+		Owner                       *string
+		Status                      *int32
+		RetentionDays               *time.Duration
+		EmitMetric                  *bool
+		ArchivalBucket              *string
+		ArchivalStatus              *int16
+		ConfigVersion               *int64
+		NotificationVersion         *int64
+		FailoverNotificationVersion *int64
+		FailoverVersion             *int64
+		ActiveClusterName           *string
+		Clusters                    []string
+		Data                        map[string]string
+		BadBinaries                 []byte
+		BadBinariesEncoding         *string
+		HistoryArchivalStatus       *int16
+		HistoryArchivalURI          *string
+		VisibilityArchivalStatus    *int16
+		VisibilityArchivalURI       *string
+		FailoverEndTime             *time.Time
+		PreviousFailoverVersion     *int64
+		LastUpdatedTime             *time.Time
+	}
+
+	// HistoryBranchRange blob in a serialization agnostic format
+	HistoryBranchRange struct {
+		BranchID    *string
+		BeginNodeID *int64
+		EndNodeID   *int64
+	}
+
+	// HistoryTreeInfo blob in a serialization agnostic format
+	HistoryTreeInfo struct {
+		CreatedTime *time.Time
+		Ancestors   []*HistoryBranchRange
+		Info        *string
+	}
+
+	// WorkflowExecutionInfo blob in a serialization agnostic format
+	WorkflowExecutionInfo struct {
+		ParentDomainID                     *string
+		ParentWorkflowID                   *string
+		ParentRunID                        *string
+		InitiatedID                        *int64
+		CompletionEventBatchID             *int64
+		CompletionEvent                    []byte
+		CompletionEventEncoding            *string
+		TaskList                           *string
+		WorkflowTypeName                   *string
+		WorkflowTimeoutSeconds             *time.Duration
+		DecisionTaskTimeoutSeconds         *time.Duration
+		ExecutionContext                   []byte
+		State                              *int32
+		CloseStatus                        *int32
+		StartVersion                       *int64
+		LastWriteEventID                   *int64
+		LastEventTaskID                    *int64
+		LastFirstEventID                   *int64
+		LastProcessedEvent                 *int64
+		StartTime                          *time.Time
+		LastUpdatedTime                    *time.Time
+		DecisionVersion                    *int64
+		DecisionScheduleID                 *int64
+		DecisionStartedID                  *int64
+		DecisionTimeout                    *time.Duration
+		DecisionAttempt                    *int64
+		DecisionStartedTimestamp           *time.Time
+		DecisionScheduledTimestamp         *time.Time
+		CancelRequested                    *bool
+		DecisionOriginalScheduledTimestamp *time.Time
+		CreateRequestID                    *string
+		DecisionRequestID                  *string
+		CancelRequestID                    *string
+		StickyTaskList                     *string
+		StickyScheduleToStartTimeout       *time.Duration
+		RetryAttempt                       *int64
+		RetryInitialIntervalSeconds        *time.Duration
+		RetryMaximumIntervalSeconds        *time.Duration
+		RetryMaximumAttempts               *int32
+		RetryExpirationSeconds             *time.Duration
+		RetryBackoffCoefficient            *float64
+		RetryExpirationTime                *time.Time
+		RetryNonRetryableErrors            []string
+		HasRetryPolicy                     *bool
+		CronSchedule                       *string
+		EventStoreVersion                  *int32
+		EventBranchToken                   []byte
+		SignalCount                        *int64
+		HistorySize                        *int64
+		ClientLibraryVersion               *string
+		ClientFeatureVersion               *string
+		ClientImpl                         *string
+		AutoResetPoints                    []byte
+		AutoResetPointsEncoding            *string
+		SearchAttributes                   map[string][]byte
+		Memo                               map[string][]byte
+		VersionHistories                   []byte
+		VersionHistoriesEncoding           *string
+	}
+
+	// ActivityInfo blob in a serialization agnostic format
+	ActivityInfo struct {
+		Version                       *int64
+		ScheduledEventBatchID         *int64
+		ScheduledEvent                []byte
+		ScheduledEventEncoding        *string
+		ScheduledTime                 *time.Time
+		StartedID                     *int64
+		StartedEvent                  []byte
+		StartedEventEncoding          *string
+		StartedTime                   *time.Time
+		ActivityID                    *string
+		RequestID                     *string
+		ScheduleToStartTimeoutSeconds *time.Duration
+		ScheduleToCloseTimeoutSeconds *time.Duration
+		StartToCloseTimeoutSeconds    *time.Duration
+		HeartbeatTimeoutSeconds       *time.Duration
+		CancelRequested               *bool
+		CancelRequestID               *int64
+		TimerTaskStatus               *int32
+		Attempt                       *int32
+		TaskList                      *string
+		StartedIdentity               *string
+		HasRetryPolicy                *bool
+		RetryInitialIntervalSeconds   *time.Duration
+		RetryMaximumIntervalSeconds   *time.Duration
+		RetryMaximumAttempts          *int32
+		RetryExpirationTime           *time.Time
+		RetryBackoffCoefficient       *float64
+		RetryNonRetryableErrors       []string
+		RetryLastFailureReason        *string
+		RetryLastWorkerIdentity       *string
+		RetryLastFailureDetails       []byte
+	}
+
+	// ChildExecutionInfo blob in a serialization agnostic format
+	ChildExecutionInfo struct {
+		Version                *int64
+		InitiatedEventBatchID  *int64
+		StartedID              *int64
+		InitiatedEvent         []byte
+		InitiatedEventEncoding *string
+		StartedWorkflowID      *string
+		StartedRunID           *string
+		StartedEvent           []byte
+		StartedEventEncoding   *string
+		CreateRequestID        *string
+		DomainName             *string
+		WorkflowTypeName       *string
+		ParentClosePolicy      *int32
+	}
+
+	// SignalInfo blob in a serialization agnostic format
+	SignalInfo struct {
+		Version               *int64
+		InitiatedEventBatchID *int64
+		RequestID             *string
+		Name                  *string
+		Input                 []byte
+		Control               []byte
+	}
+
+	// RequestCancelInfo blob in a serialization agnostic format
+	RequestCancelInfo struct {
+		Version               *int64
+		InitiatedEventBatchID *int64
+		CancelRequestID       *string
+	}
+
+	// TimerInfo blob in a serialization agnostic format
+	TimerInfo struct {
+		Version    *int64
+		StartedID  *int64
+		ExpiryTime *time.Time
+		TaskID     *int64
+	}
+
+	// TaskInfo blob in a serialization agnostic format
+	TaskInfo struct {
+		WorkflowID  *string
+		RunID       *string
+		ScheduleID  *int64
+		ExpiryTime  *time.Time
+		CreatedTime *time.Time
+	}
+
+	// TaskListInfo blob in a serialization agnostic format
+	TaskListInfo struct {
+		Kind        *int16
+		AckLevel    *int64
+		ExpiryTime  *time.Time
+		LastUpdated *time.Time
+	}
+
+	// TransferTaskInfo blob in a serialization agnostic format
+	TransferTaskInfo struct {
+		DomainID                *string
+		WorkflowID              *string
+		RunID                   *string
+		TaskType                *int16
+		TargetDomainID          *string
+		TargetWorkflowID        *string
+		TargetRunID             *string
+		TaskList                *string
+		TargetChildWorkflowOnly *bool
+		ScheduleID              *int64
+		Version                 *int64
+		VisibilityTimestamp     *time.Time
+	}
+
+	// TimerTaskInfo blob in a serialization agnostic format
+	TimerTaskInfo struct {
+		DomainID        *string
+		WorkflowID      *string
+		RunID           *string
+		TaskType        *int16
+		TimeoutType     *int16
+		Version         *int64
+		ScheduleAttempt *int64
+		EventID         *int64
+	}
+
+	// ReplicationTaskInfo blob in a serialization agnostic format
+	ReplicationTaskInfo struct {
+		DomainID                *string
+		WorkflowID              *string
+		RunID                   *string
+		TaskType                *int16
+		Version                 *int64
+		FirstEventID            *int64
+		NextEventID             *int64
+		ScheduledID             *int64
+		EventStoreVersion       *int32
+		NewRunEventStoreVersion *int32
+		BranchToken             []byte
+		NewRunBranchToken       []byte
+		CreationTime            *time.Time
+	}
 )
 
 type (


### PR DESCRIPTION
This is step 1 of the following 

**1. Introduce these types**
2. Add mappers which will convert to and from thrift types 
3. Add mappers which will convert to and from proto types 
4. Update the encoder interface methods to accept these internal types - the encoder will then use the mapper written in step 2 to convert to thrift blob before encoding. 
5. Update the decoder interface methods to return these internal types - the decoder will then use the mapper written in step 2 to convert from thrift blob to internal before returning. 
6. Implement encoder and decoder for proto just like we did for thrift 