### PR TITLE
Log short context timeout for long poll GetWorkflowExecutionHistory

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1968,9 +1968,10 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 				tag.WorkflowID(getRequest.Execution.GetWorkflowId()),
 				tag.WorkflowRunID(getRequest.Execution.GetRunId()),
 			)
-			if err := common.ValidateLongPollContextTimeout(ctx, "GetWorkflowExecutionHistory", logger); err != nil {
-				return nil, wh.error(err, scope, getWfIDRunIDTags(wfExecution)...)
-			}
+			// TODO: for now we only logger the invalid timeout (this is done inside the helper function) in case
+			// this change break existing customers. Once we are sure no one is calling this API with very short timeout
+			// we can return the error.
+			_ = common.ValidateLongPollContextTimeout(ctx, "GetWorkflowExecutionHistory", logger)
 
 			if !isCloseEventOnly {
 				queryNextEventID = token.NextEventID

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1963,6 +1963,15 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 
 		// we need to update the current next event ID and whether workflow is running
 		if len(token.PersistenceToken) == 0 && isLongPoll && token.IsWorkflowRunning {
+			logger := wh.GetLogger().WithTags(
+				tag.WorkflowDomainName(getRequest.GetDomain()),
+				tag.WorkflowID(getRequest.Execution.GetWorkflowId()),
+				tag.WorkflowRunID(getRequest.Execution.GetRunId()),
+			)
+			if err := common.ValidateLongPollContextTimeout(ctx, "GetWorkflowExecutionHistory", logger); err != nil {
+				return nil, wh.error(err, scope, getWfIDRunIDTags(wfExecution)...)
+			}
+
 			if !isCloseEventOnly {
 				queryNextEventID = token.NextEventID
 			}

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1968,8 +1968,8 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 				tag.WorkflowID(getRequest.Execution.GetWorkflowId()),
 				tag.WorkflowRunID(getRequest.Execution.GetRunId()),
 			)
-			// TODO: for now we only logger the invalid timeout (this is done inside the helper function) in case
-			// this change break existing customers. Once we are sure no one is calling this API with very short timeout
+			// TODO: for now we only log the invalid timeout (this is done inside the helper function) in case
+			// this change breaks existing customers. Once we are sure no one is calling this API with very short timeout
 			// we can return the error.
 			_ = common.ValidateLongPollContextTimeout(ctx, "GetWorkflowExecutionHistory", logger)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Log short context timeout for long poll GetWorkflowExecutionHistory.

<!-- Tell your future self why have you made these changes -->
**Why?**
By default long poll GetWorkflowExecutionHistory will return after 20s if workflow's no progress or doesn't reach the specified eventID. If customer specified a shorter timeout for the call and their workflow takes much longer to run due to some downstream dependencies issues, they will see timeouts and the timeout will impact our worker SLA. 

Add this logging so that we have evidence that customer has specified an invalid timeout for this API. We can also use this information to adjust the default wait time for polling mutable state. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, this diff only adds logging for invalid timeout.
