### PR TITLE
Add various default config to startup

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -55,7 +55,7 @@ func startHandler(c *cli.Context) {
 		log.Printf("config=\n%v\n", cfg.String())
 	}
 
-	if err := cfg.Validate(); err != nil {
+	if err := cfg.ValidateAndFillDefaults(); err != nil {
 		log.Fatalf("config validation failed: %v", err)
 	}
 	// cassandra schema version validation

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -311,6 +311,14 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 	case defaultCfg.Cassandra != nil:
 		defaultDataStore.factory = cassandra.NewFactory(*defaultCfg.Cassandra, clusterName, f.logger)
 	case defaultCfg.SQL != nil:
+		if defaultCfg.SQL.EncodingType == "" {
+			defaultCfg.SQL.EncodingType = string(common.EncodingTypeThriftRW)
+		}
+		if len(defaultCfg.SQL.DecodingTypes) == 0 {
+			defaultCfg.SQL.DecodingTypes = []string{
+				string(common.EncodingTypeThriftRW),
+			}
+		}
 		var decodingTypes []common.EncodingType
 		for _, dt := range defaultCfg.SQL.DecodingTypes {
 			decodingTypes = append(decodingTypes, common.EncodingType(dt))

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -22,15 +22,14 @@ package config
 
 import (
 	"encoding/json"
-	"github.com/uber/cadence/common"
 	"time"
-
-	"github.com/uber/cadence/common/auth"
 
 	"github.com/uber-go/tally/m3"
 	"github.com/uber-go/tally/prometheus"
 	"github.com/uber/ringpop-go/discovery"
 
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/auth"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/service/dynamicconfig"
 )

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -456,7 +456,7 @@ func (c *Config) fillDefaults() error {
 			c.Persistence.DataStores[k] = store
 		}
 	}
-	// filling RPCName with default value if empty
+	// filling RPCName with a default value if empty
 	if c.ClusterMetadata != nil {
 		for k, cluster := range c.ClusterMetadata.ClusterInformation {
 			if cluster.RPCName == "" {

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -456,7 +456,7 @@ func (c *Config) fillDefaults() error {
 			c.Persistence.DataStores[k] = store
 		}
 	}
-	// filling RPCName if empty
+	// filling RPCName with default value if empty
 	if c.ClusterMetadata != nil {
 		for k, cluster := range c.ClusterMetadata.ClusterInformation {
 			if cluster.RPCName == "" {

--- a/common/service/config/config.go
+++ b/common/service/config/config.go
@@ -456,6 +456,7 @@ func (c *Config) fillDefaults() error {
 			c.Persistence.DataStores[k] = store
 		}
 	}
+	// filling RPCName if empty
 	if c.ClusterMetadata != nil {
 		for k, cluster := range c.ClusterMetadata.ClusterInformation {
 			if cluster.RPCName == "" {

--- a/common/service/config/config_test.go
+++ b/common/service/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/cadence/common"
 )
 
 func TestToString(t *testing.T) {
@@ -31,4 +32,34 @@ func TestToString(t *testing.T) {
 	err := Load("", "../../../config", "", &cfg)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, cfg.String())
+}
+
+func TestFillingDefaultSQLEncodingDecodingTypes(t *testing.T) {
+	cfg := &Config{
+		Persistence: Persistence{
+			DataStores: map[string]DataStore{
+				"sql": {
+					SQL: &SQL{},
+				},
+			},
+		},
+	}
+	cfg.fillDefaults()
+	assert.Equal(t, string(common.EncodingTypeThriftRW), cfg.Persistence.DataStores["sql"].SQL.EncodingType)
+	assert.Equal(t, []string{string(common.EncodingTypeThriftRW)}, cfg.Persistence.DataStores["sql"].SQL.DecodingTypes)
+}
+
+func TestFillingDefaultRpcName(t *testing.T) {
+	cfg := &Config{
+		ClusterMetadata: &ClusterMetadata{
+			ClusterInformation: map[string]ClusterInformation{
+				"clusterA": {
+
+				},
+			},
+		},
+	}
+
+	cfg.fillDefaults()
+	assert.Equal(t, "cadence-frontend", cfg.ClusterMetadata.ClusterInformation["clusterA"].RPCName)
 }

--- a/common/service/config/config_test.go
+++ b/common/service/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uber/cadence/common"
 )
 
@@ -53,9 +54,7 @@ func TestFillingDefaultRpcName(t *testing.T) {
 	cfg := &Config{
 		ClusterMetadata: &ClusterMetadata{
 			ClusterInformation: map[string]ClusterInformation{
-				"clusterA": {
-
-				},
+				"clusterA": {},
 			},
 		},
 	}

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -14,8 +14,6 @@ persistence:
         maxConns: 20
         maxIdleConns: 20
         maxConnLifetime: "1h"
-        encodingType: "thriftrw"
-        decodingTypes: [ "thriftrw" ]
     mysql-visibility:
       sql:
         pluginName: "mysql"
@@ -27,8 +25,6 @@ persistence:
         maxConns: 2
         maxIdleConns: 2
         maxConnLifetime: "1h"
-        encodingType: "thriftrw"
-        decodingTypes: [ "thriftrw" ]
 
 ringpop:
   name: cadence

--- a/config/development_postgres.yaml
+++ b/config/development_postgres.yaml
@@ -14,8 +14,6 @@ persistence:
         maxConns: 20
         maxIdleConns: 20
         maxConnLifetime: "1h"
-        encodingType: "thriftrw"
-        decodingTypes: [ "thriftrw" ]
     postgres-visibility:
       sql:
         pluginName: "postgres"
@@ -27,8 +25,6 @@ persistence:
         maxConns: 2
         maxIdleConns: 2
         maxConnLifetime: "1h"
-        encodingType: "thriftrw"
-        decodingTypes: [ "thriftrw" ]
 
 ringpop:
   name: cadence

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -29,8 +29,6 @@ persistence:
         default:
             sql:
                 pluginName: "mysql"
-                encodingType: "thriftrw"
-                decodingTypes: ["thriftrw"]
                 databaseName: {{ default .Env.DBNAME "cadence" }}
                 connectAddr: "{{ default .Env.MYSQL_SEEDS "" }}:{{ default .Env.DB_PORT "3306" }}"
                 connectProtocol: "tcp"
@@ -43,8 +41,6 @@ persistence:
         visibility:
             sql:
                 pluginName: "mysql"
-                encodingType: "thriftrw"
-                decodingTypes: ["thriftrw"]
                 databaseName: {{ default .Env.VISIBILITY_DBNAME "cadence_visibility" }}
                 connectAddr: "{{ default .Env.MYSQL_SEEDS "" }}:{{ default .Env.DB_PORT "3306" }}"
                 connectProtocol: "tcp"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. add default values for SQL encodingType and decodingTypes
2. add default value for RPCName in clusterInformation

<!-- Tell your future self why have you made these changes -->
**Why?**
Because https://github.com/uber/cadence/pull/3534 our new release is going to break all the existing customers unless you upgrade their config. And also reuiqre us to update the helm chart https://github.com/banzaicloud/banzai-charts/blob/master/cadence/templates/server-configmap.yaml#L40

For https://github.com/uber/cadence/pull/3577

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test and local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

