### PR TITLE
Switch timeout type to internal

### DIFF
--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -2427,7 +2427,7 @@ func (s *ExecutionManagerSuite) TestTimerTasksComplete() {
 	}
 
 	now := time.Now()
-	initialTasks := []p.Task{&p.DecisionTimeoutTask{now.Add(1 * time.Second), 1, 2, 3, int(gen.TimeoutTypeStartToClose), 11}}
+	initialTasks := []p.Task{&p.DecisionTimeoutTask{now.Add(1 * time.Second), 1, 2, 3, int(types.TimeoutTypeStartToClose), 11}}
 
 	task0, err0 := s.CreateWorkflowExecution(ctx, domainID, workflowExecution, "taskList", "wType", 20, 13, nil, 3, 0, 2, initialTasks)
 	s.NoError(err0)
@@ -2445,7 +2445,7 @@ func (s *ExecutionManagerSuite) TestTimerTasksComplete() {
 	tasks := []p.Task{
 		&p.WorkflowTimeoutTask{now.Add(2 * time.Second), 2, 12},
 		&p.DeleteHistoryEventTask{now.Add(2 * time.Second), 3, 13},
-		&p.ActivityTimeoutTask{now.Add(3 * time.Second), 4, int(gen.TimeoutTypeStartToClose), 7, 0, 14},
+		&p.ActivityTimeoutTask{now.Add(3 * time.Second), 4, int(types.TimeoutTypeStartToClose), 7, 0, 14},
 		&p.UserTimerTask{now.Add(3 * time.Second), 5, 7, 15},
 	}
 	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
@@ -2507,10 +2507,10 @@ func (s *ExecutionManagerSuite) TestTimerTasksRangeComplete() {
 	})
 	versionHistories := p.NewVersionHistories(versionHistory)
 	tasks := []p.Task{
-		&p.DecisionTimeoutTask{time.Now(), 1, 2, 3, int(gen.TimeoutTypeStartToClose), 11},
+		&p.DecisionTimeoutTask{time.Now(), 1, 2, 3, int(types.TimeoutTypeStartToClose), 11},
 		&p.WorkflowTimeoutTask{time.Now(), 2, 12},
 		&p.DeleteHistoryEventTask{time.Now(), 3, 13},
-		&p.ActivityTimeoutTask{time.Now(), 4, int(gen.TimeoutTypeStartToClose), 7, 0, 14},
+		&p.ActivityTimeoutTask{time.Now(), 4, int(types.TimeoutTypeStartToClose), 7, 0, 14},
 		&p.UserTimerTask{time.Now(), 5, 7, 15},
 	}
 	err2 := s.UpdateWorkflowExecution(ctx, updatedInfo, updatedStats, versionHistories, []int64{int64(4)}, nil, int64(3), tasks, nil, nil, nil, nil)

--- a/common/types/generator/main.go
+++ b/common/types/generator/main.go
@@ -75,10 +75,47 @@ func capitalizeID(name string) string {
 	return name
 }
 
+var capitalizedEnums = map[string]struct{}{
+	"DomainStatus":            {},
+	"TimeoutType":             {},
+	"ParentClosePolicy":       {},
+	"DecisionTaskFailedCause": {},
+	"CancelExternalWorkflowExecutionFailedCause": {},
+	"SignalExternalWorkflowExecutionFailedCause": {},
+	"ChildWorkflowExecutionFailedCause":          {},
+	"WorkflowExecutionCloseStatus":               {},
+	"QueryTaskCompletedType":                     {},
+	"QueryResultType":                            {},
+	"PendingActivityState":                       {},
+	"PendingDecisionState":                       {},
+	"HistoryEventFilterType":                     {},
+	"TaskListKind":                               {},
+	"ArchivalStatus":                             {},
+	"IndexedValueType":                           {},
+	"QueryRejectCondition":                       {},
+	"QueryConsistencyLevel":                      {},
+	"TaskSource":                                 {},
+}
+
+func enumString(value, enum string) string {
+	trimmed := strings.TrimPrefix(value, enum)
+	if _, ok := capitalizedEnums[enum]; ok {
+		capitalized := ""
+		for i, c := range trimmed {
+			if i > 0 && unicode.IsUpper(c) {
+				capitalized = capitalized + "_"
+			}
+			capitalized = capitalized + string(unicode.ToUpper(c))
+		}
+		return capitalized
+	}
+	return trimmed
+}
+
 var funcMap = template.FuncMap{
 	"internal":   internalName,
-	"enumString": strings.TrimPrefix,
-	"lower":      strings.ToLower,
+	"enumString": enumString,
+	"upper":      strings.ToUpper,
 }
 
 var typesHeader = template.Must(template.New("struct type").Funcs(funcMap).Parse(licence + `package types
@@ -132,8 +169,8 @@ func (e {{internal .Name}}) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *{{internal .Name}}) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s { {{range $i, $v := .EnumValues}}
-	case "{{lower (enumString . $.Name)}}":
+	switch s := strings.ToUpper(string(value)); s { {{range $i, $v := .EnumValues}}
+	case "{{upper (enumString . $.Name)}}":
 		*e = {{internal .}}
 		return nil{{end}}
 	default:

--- a/common/types/matching.go
+++ b/common/types/matching.go
@@ -1150,20 +1150,20 @@ func (e TaskSource) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "History"
+		return "HISTORY"
 	case 1:
-		return "DbBacklog"
+		return "DB_BACKLOG"
 	}
 	return fmt.Sprintf("TaskSource(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *TaskSource) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "history":
+	switch s := strings.ToUpper(string(value)); s {
+	case "HISTORY":
 		*e = TaskSourceHistory
 		return nil
-	case "dbbacklog":
+	case "DB_BACKLOG":
 		*e = TaskSourceDbBacklog
 		return nil
 	default:

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -48,11 +48,11 @@ func (e DLQType) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *DLQType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "replication":
+	switch s := strings.ToUpper(string(value)); s {
+	case "REPLICATION":
 		*e = DLQTypeReplication
 		return nil
-	case "domain":
+	case "DOMAIN":
 		*e = DLQTypeDomain
 		return nil
 	default:
@@ -99,11 +99,11 @@ func (e DomainOperation) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *DomainOperation) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "create":
+	switch s := strings.ToUpper(string(value)); s {
+	case "CREATE":
 		*e = DomainOperationCreate
 		return nil
-	case "update":
+	case "UPDATE":
 		*e = DomainOperationUpdate
 		return nil
 	default:
@@ -853,26 +853,26 @@ func (e ReplicationTaskType) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *ReplicationTaskType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "domain":
+	switch s := strings.ToUpper(string(value)); s {
+	case "DOMAIN":
 		*e = ReplicationTaskTypeDomain
 		return nil
-	case "history":
+	case "HISTORY":
 		*e = ReplicationTaskTypeHistory
 		return nil
-	case "syncshardstatus":
+	case "SYNCSHARDSTATUS":
 		*e = ReplicationTaskTypeSyncShardStatus
 		return nil
-	case "syncactivity":
+	case "SYNCACTIVITY":
 		*e = ReplicationTaskTypeSyncActivity
 		return nil
-	case "historymetadata":
+	case "HISTORYMETADATA":
 		*e = ReplicationTaskTypeHistoryMetadata
 		return nil
-	case "historyv2":
+	case "HISTORYV2":
 		*e = ReplicationTaskTypeHistoryV2
 		return nil
-	case "failovermarker":
+	case "FAILOVERMARKER":
 		*e = ReplicationTaskTypeFailoverMarker
 		return nil
 	default:

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -502,20 +502,20 @@ func (e ArchivalStatus) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Disabled"
+		return "DISABLED"
 	case 1:
-		return "Enabled"
+		return "ENABLED"
 	}
 	return fmt.Sprintf("ArchivalStatus(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *ArchivalStatus) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "disabled":
+	switch s := strings.ToUpper(string(value)); s {
+	case "DISABLED":
 		*e = ArchivalStatusDisabled
 		return nil
-	case "enabled":
+	case "ENABLED":
 		*e = ArchivalStatusEnabled
 		return nil
 	default:
@@ -610,15 +610,15 @@ func (e CancelExternalWorkflowExecutionFailedCause) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "UnknownExternalWorkflowExecution"
+		return "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
 	}
 	return fmt.Sprintf("CancelExternalWorkflowExecutionFailedCause(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *CancelExternalWorkflowExecutionFailedCause) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "unknownexternalworkflowexecution":
+	switch s := strings.ToUpper(string(value)); s {
+	case "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION":
 		*e = CancelExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
 		return nil
 	default:
@@ -849,15 +849,15 @@ func (e ChildWorkflowExecutionFailedCause) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "WorkflowAlreadyRunning"
+		return "WORKFLOW_ALREADY_RUNNING"
 	}
 	return fmt.Sprintf("ChildWorkflowExecutionFailedCause(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *ChildWorkflowExecutionFailedCause) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "workflowalreadyrunning":
+	switch s := strings.ToUpper(string(value)); s {
+	case "WORKFLOW_ALREADY_RUNNING":
 		*e = ChildWorkflowExecutionFailedCauseWorkflowAlreadyRunning
 		return nil
 	default:
@@ -1210,14 +1210,14 @@ func (e ContinueAsNewInitiator) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *ContinueAsNewInitiator) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "decider":
+	switch s := strings.ToUpper(string(value)); s {
+	case "DECIDER":
 		*e = ContinueAsNewInitiatorDecider
 		return nil
-	case "retrypolicy":
+	case "RETRYPOLICY":
 		*e = ContinueAsNewInitiatorRetryPolicy
 		return nil
-	case "cronschedule":
+	case "CRONSCHEDULE":
 		*e = ContinueAsNewInitiatorCronSchedule
 		return nil
 	default:
@@ -1654,125 +1654,125 @@ func (e DecisionTaskFailedCause) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "UnhandledDecision"
+		return "UNHANDLED_DECISION"
 	case 1:
-		return "BadScheduleActivityAttributes"
+		return "BAD_SCHEDULE_ACTIVITY_ATTRIBUTES"
 	case 2:
-		return "BadRequestCancelActivityAttributes"
+		return "BAD_REQUEST_CANCEL_ACTIVITY_ATTRIBUTES"
 	case 3:
-		return "BadStartTimerAttributes"
+		return "BAD_START_TIMER_ATTRIBUTES"
 	case 4:
-		return "BadCancelTimerAttributes"
+		return "BAD_CANCEL_TIMER_ATTRIBUTES"
 	case 5:
-		return "BadRecordMarkerAttributes"
+		return "BAD_RECORD_MARKER_ATTRIBUTES"
 	case 6:
-		return "BadCompleteWorkflowExecutionAttributes"
+		return "BAD_COMPLETE_WORKFLOW_EXECUTION_ATTRIBUTES"
 	case 7:
-		return "BadFailWorkflowExecutionAttributes"
+		return "BAD_FAIL_WORKFLOW_EXECUTION_ATTRIBUTES"
 	case 8:
-		return "BadCancelWorkflowExecutionAttributes"
+		return "BAD_CANCEL_WORKFLOW_EXECUTION_ATTRIBUTES"
 	case 9:
-		return "BadRequestCancelExternalWorkflowExecutionAttributes"
+		return "BAD_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_ATTRIBUTES"
 	case 10:
-		return "BadContinueAsNewAttributes"
+		return "BAD_CONTINUE_AS_NEW_ATTRIBUTES"
 	case 11:
-		return "StartTimerDuplicateID"
+		return "START_TIMER_DUPLICATE_I_D"
 	case 12:
-		return "ResetStickyTasklist"
+		return "RESET_STICKY_TASKLIST"
 	case 13:
-		return "WorkflowWorkerUnhandledFailure"
+		return "WORKFLOW_WORKER_UNHANDLED_FAILURE"
 	case 14:
-		return "BadSignalWorkflowExecutionAttributes"
+		return "BAD_SIGNAL_WORKFLOW_EXECUTION_ATTRIBUTES"
 	case 15:
-		return "BadStartChildExecutionAttributes"
+		return "BAD_START_CHILD_EXECUTION_ATTRIBUTES"
 	case 16:
-		return "ForceCloseDecision"
+		return "FORCE_CLOSE_DECISION"
 	case 17:
-		return "FailoverCloseDecision"
+		return "FAILOVER_CLOSE_DECISION"
 	case 18:
-		return "BadSignalInputSize"
+		return "BAD_SIGNAL_INPUT_SIZE"
 	case 19:
-		return "ResetWorkflow"
+		return "RESET_WORKFLOW"
 	case 20:
-		return "BadBinary"
+		return "BAD_BINARY"
 	case 21:
-		return "ScheduleActivityDuplicateID"
+		return "SCHEDULE_ACTIVITY_DUPLICATE_I_D"
 	case 22:
-		return "BadSearchAttributes"
+		return "BAD_SEARCH_ATTRIBUTES"
 	}
 	return fmt.Sprintf("DecisionTaskFailedCause(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *DecisionTaskFailedCause) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "unhandleddecision":
+	switch s := strings.ToUpper(string(value)); s {
+	case "UNHANDLED_DECISION":
 		*e = DecisionTaskFailedCauseUnhandledDecision
 		return nil
-	case "badscheduleactivityattributes":
+	case "BAD_SCHEDULE_ACTIVITY_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadScheduleActivityAttributes
 		return nil
-	case "badrequestcancelactivityattributes":
+	case "BAD_REQUEST_CANCEL_ACTIVITY_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadRequestCancelActivityAttributes
 		return nil
-	case "badstarttimerattributes":
+	case "BAD_START_TIMER_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadStartTimerAttributes
 		return nil
-	case "badcanceltimerattributes":
+	case "BAD_CANCEL_TIMER_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadCancelTimerAttributes
 		return nil
-	case "badrecordmarkerattributes":
+	case "BAD_RECORD_MARKER_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadRecordMarkerAttributes
 		return nil
-	case "badcompleteworkflowexecutionattributes":
+	case "BAD_COMPLETE_WORKFLOW_EXECUTION_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadCompleteWorkflowExecutionAttributes
 		return nil
-	case "badfailworkflowexecutionattributes":
+	case "BAD_FAIL_WORKFLOW_EXECUTION_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadFailWorkflowExecutionAttributes
 		return nil
-	case "badcancelworkflowexecutionattributes":
+	case "BAD_CANCEL_WORKFLOW_EXECUTION_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadCancelWorkflowExecutionAttributes
 		return nil
-	case "badrequestcancelexternalworkflowexecutionattributes":
+	case "BAD_REQUEST_CANCEL_EXTERNAL_WORKFLOW_EXECUTION_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadRequestCancelExternalWorkflowExecutionAttributes
 		return nil
-	case "badcontinueasnewattributes":
+	case "BAD_CONTINUE_AS_NEW_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadContinueAsNewAttributes
 		return nil
-	case "starttimerduplicateid":
+	case "START_TIMER_DUPLICATE_I_D":
 		*e = DecisionTaskFailedCauseStartTimerDuplicateID
 		return nil
-	case "resetstickytasklist":
+	case "RESET_STICKY_TASKLIST":
 		*e = DecisionTaskFailedCauseResetStickyTasklist
 		return nil
-	case "workflowworkerunhandledfailure":
+	case "WORKFLOW_WORKER_UNHANDLED_FAILURE":
 		*e = DecisionTaskFailedCauseWorkflowWorkerUnhandledFailure
 		return nil
-	case "badsignalworkflowexecutionattributes":
+	case "BAD_SIGNAL_WORKFLOW_EXECUTION_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadSignalWorkflowExecutionAttributes
 		return nil
-	case "badstartchildexecutionattributes":
+	case "BAD_START_CHILD_EXECUTION_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadStartChildExecutionAttributes
 		return nil
-	case "forceclosedecision":
+	case "FORCE_CLOSE_DECISION":
 		*e = DecisionTaskFailedCauseForceCloseDecision
 		return nil
-	case "failoverclosedecision":
+	case "FAILOVER_CLOSE_DECISION":
 		*e = DecisionTaskFailedCauseFailoverCloseDecision
 		return nil
-	case "badsignalinputsize":
+	case "BAD_SIGNAL_INPUT_SIZE":
 		*e = DecisionTaskFailedCauseBadSignalInputSize
 		return nil
-	case "resetworkflow":
+	case "RESET_WORKFLOW":
 		*e = DecisionTaskFailedCauseResetWorkflow
 		return nil
-	case "badbinary":
+	case "BAD_BINARY":
 		*e = DecisionTaskFailedCauseBadBinary
 		return nil
-	case "scheduleactivityduplicateid":
+	case "SCHEDULE_ACTIVITY_DUPLICATE_I_D":
 		*e = DecisionTaskFailedCauseScheduleActivityDuplicateID
 		return nil
-	case "badsearchattributes":
+	case "BAD_SEARCH_ATTRIBUTES":
 		*e = DecisionTaskFailedCauseBadSearchAttributes
 		return nil
 	default:
@@ -2070,44 +2070,44 @@ func (e DecisionType) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *DecisionType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "scheduleactivitytask":
+	switch s := strings.ToUpper(string(value)); s {
+	case "SCHEDULEACTIVITYTASK":
 		*e = DecisionTypeScheduleActivityTask
 		return nil
-	case "requestcancelactivitytask":
+	case "REQUESTCANCELACTIVITYTASK":
 		*e = DecisionTypeRequestCancelActivityTask
 		return nil
-	case "starttimer":
+	case "STARTTIMER":
 		*e = DecisionTypeStartTimer
 		return nil
-	case "completeworkflowexecution":
+	case "COMPLETEWORKFLOWEXECUTION":
 		*e = DecisionTypeCompleteWorkflowExecution
 		return nil
-	case "failworkflowexecution":
+	case "FAILWORKFLOWEXECUTION":
 		*e = DecisionTypeFailWorkflowExecution
 		return nil
-	case "canceltimer":
+	case "CANCELTIMER":
 		*e = DecisionTypeCancelTimer
 		return nil
-	case "cancelworkflowexecution":
+	case "CANCELWORKFLOWEXECUTION":
 		*e = DecisionTypeCancelWorkflowExecution
 		return nil
-	case "requestcancelexternalworkflowexecution":
+	case "REQUESTCANCELEXTERNALWORKFLOWEXECUTION":
 		*e = DecisionTypeRequestCancelExternalWorkflowExecution
 		return nil
-	case "recordmarker":
+	case "RECORDMARKER":
 		*e = DecisionTypeRecordMarker
 		return nil
-	case "continueasnewworkflowexecution":
+	case "CONTINUEASNEWWORKFLOWEXECUTION":
 		*e = DecisionTypeContinueAsNewWorkflowExecution
 		return nil
-	case "startchildworkflowexecution":
+	case "STARTCHILDWORKFLOWEXECUTION":
 		*e = DecisionTypeStartChildWorkflowExecution
 		return nil
-	case "signalexternalworkflowexecution":
+	case "SIGNALEXTERNALWORKFLOWEXECUTION":
 		*e = DecisionTypeSignalExternalWorkflowExecution
 		return nil
-	case "upsertworkflowsearchattributes":
+	case "UPSERTWORKFLOWSEARCHATTRIBUTES":
 		*e = DecisionTypeUpsertWorkflowSearchAttributes
 		return nil
 	default:
@@ -2739,25 +2739,25 @@ func (e DomainStatus) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Registered"
+		return "REGISTERED"
 	case 1:
-		return "Deprecated"
+		return "DEPRECATED"
 	case 2:
-		return "Deleted"
+		return "DELETED"
 	}
 	return fmt.Sprintf("DomainStatus(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *DomainStatus) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "registered":
+	switch s := strings.ToUpper(string(value)); s {
+	case "REGISTERED":
 		*e = DomainStatusRegistered
 		return nil
-	case "deprecated":
+	case "DEPRECATED":
 		*e = DomainStatusDeprecated
 		return nil
-	case "deleted":
+	case "DELETED":
 		*e = DomainStatusDeleted
 		return nil
 	default:
@@ -2806,11 +2806,11 @@ func (e EncodingType) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *EncodingType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "thriftrw":
+	switch s := strings.ToUpper(string(value)); s {
+	case "THRIFTRW":
 		*e = EncodingTypeThriftRW
 		return nil
-	case "json":
+	case "JSON":
 		*e = EncodingTypeJSON
 		return nil
 	default:
@@ -2968,131 +2968,131 @@ func (e EventType) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *EventType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "workflowexecutionstarted":
+	switch s := strings.ToUpper(string(value)); s {
+	case "WORKFLOWEXECUTIONSTARTED":
 		*e = EventTypeWorkflowExecutionStarted
 		return nil
-	case "workflowexecutioncompleted":
+	case "WORKFLOWEXECUTIONCOMPLETED":
 		*e = EventTypeWorkflowExecutionCompleted
 		return nil
-	case "workflowexecutionfailed":
+	case "WORKFLOWEXECUTIONFAILED":
 		*e = EventTypeWorkflowExecutionFailed
 		return nil
-	case "workflowexecutiontimedout":
+	case "WORKFLOWEXECUTIONTIMEDOUT":
 		*e = EventTypeWorkflowExecutionTimedOut
 		return nil
-	case "decisiontaskscheduled":
+	case "DECISIONTASKSCHEDULED":
 		*e = EventTypeDecisionTaskScheduled
 		return nil
-	case "decisiontaskstarted":
+	case "DECISIONTASKSTARTED":
 		*e = EventTypeDecisionTaskStarted
 		return nil
-	case "decisiontaskcompleted":
+	case "DECISIONTASKCOMPLETED":
 		*e = EventTypeDecisionTaskCompleted
 		return nil
-	case "decisiontasktimedout":
+	case "DECISIONTASKTIMEDOUT":
 		*e = EventTypeDecisionTaskTimedOut
 		return nil
-	case "decisiontaskfailed":
+	case "DECISIONTASKFAILED":
 		*e = EventTypeDecisionTaskFailed
 		return nil
-	case "activitytaskscheduled":
+	case "ACTIVITYTASKSCHEDULED":
 		*e = EventTypeActivityTaskScheduled
 		return nil
-	case "activitytaskstarted":
+	case "ACTIVITYTASKSTARTED":
 		*e = EventTypeActivityTaskStarted
 		return nil
-	case "activitytaskcompleted":
+	case "ACTIVITYTASKCOMPLETED":
 		*e = EventTypeActivityTaskCompleted
 		return nil
-	case "activitytaskfailed":
+	case "ACTIVITYTASKFAILED":
 		*e = EventTypeActivityTaskFailed
 		return nil
-	case "activitytasktimedout":
+	case "ACTIVITYTASKTIMEDOUT":
 		*e = EventTypeActivityTaskTimedOut
 		return nil
-	case "activitytaskcancelrequested":
+	case "ACTIVITYTASKCANCELREQUESTED":
 		*e = EventTypeActivityTaskCancelRequested
 		return nil
-	case "requestcancelactivitytaskfailed":
+	case "REQUESTCANCELACTIVITYTASKFAILED":
 		*e = EventTypeRequestCancelActivityTaskFailed
 		return nil
-	case "activitytaskcanceled":
+	case "ACTIVITYTASKCANCELED":
 		*e = EventTypeActivityTaskCanceled
 		return nil
-	case "timerstarted":
+	case "TIMERSTARTED":
 		*e = EventTypeTimerStarted
 		return nil
-	case "timerfired":
+	case "TIMERFIRED":
 		*e = EventTypeTimerFired
 		return nil
-	case "canceltimerfailed":
+	case "CANCELTIMERFAILED":
 		*e = EventTypeCancelTimerFailed
 		return nil
-	case "timercanceled":
+	case "TIMERCANCELED":
 		*e = EventTypeTimerCanceled
 		return nil
-	case "workflowexecutioncancelrequested":
+	case "WORKFLOWEXECUTIONCANCELREQUESTED":
 		*e = EventTypeWorkflowExecutionCancelRequested
 		return nil
-	case "workflowexecutioncanceled":
+	case "WORKFLOWEXECUTIONCANCELED":
 		*e = EventTypeWorkflowExecutionCanceled
 		return nil
-	case "requestcancelexternalworkflowexecutioninitiated":
+	case "REQUESTCANCELEXTERNALWORKFLOWEXECUTIONINITIATED":
 		*e = EventTypeRequestCancelExternalWorkflowExecutionInitiated
 		return nil
-	case "requestcancelexternalworkflowexecutionfailed":
+	case "REQUESTCANCELEXTERNALWORKFLOWEXECUTIONFAILED":
 		*e = EventTypeRequestCancelExternalWorkflowExecutionFailed
 		return nil
-	case "externalworkflowexecutioncancelrequested":
+	case "EXTERNALWORKFLOWEXECUTIONCANCELREQUESTED":
 		*e = EventTypeExternalWorkflowExecutionCancelRequested
 		return nil
-	case "markerrecorded":
+	case "MARKERRECORDED":
 		*e = EventTypeMarkerRecorded
 		return nil
-	case "workflowexecutionsignaled":
+	case "WORKFLOWEXECUTIONSIGNALED":
 		*e = EventTypeWorkflowExecutionSignaled
 		return nil
-	case "workflowexecutionterminated":
+	case "WORKFLOWEXECUTIONTERMINATED":
 		*e = EventTypeWorkflowExecutionTerminated
 		return nil
-	case "workflowexecutioncontinuedasnew":
+	case "WORKFLOWEXECUTIONCONTINUEDASNEW":
 		*e = EventTypeWorkflowExecutionContinuedAsNew
 		return nil
-	case "startchildworkflowexecutioninitiated":
+	case "STARTCHILDWORKFLOWEXECUTIONINITIATED":
 		*e = EventTypeStartChildWorkflowExecutionInitiated
 		return nil
-	case "startchildworkflowexecutionfailed":
+	case "STARTCHILDWORKFLOWEXECUTIONFAILED":
 		*e = EventTypeStartChildWorkflowExecutionFailed
 		return nil
-	case "childworkflowexecutionstarted":
+	case "CHILDWORKFLOWEXECUTIONSTARTED":
 		*e = EventTypeChildWorkflowExecutionStarted
 		return nil
-	case "childworkflowexecutioncompleted":
+	case "CHILDWORKFLOWEXECUTIONCOMPLETED":
 		*e = EventTypeChildWorkflowExecutionCompleted
 		return nil
-	case "childworkflowexecutionfailed":
+	case "CHILDWORKFLOWEXECUTIONFAILED":
 		*e = EventTypeChildWorkflowExecutionFailed
 		return nil
-	case "childworkflowexecutioncanceled":
+	case "CHILDWORKFLOWEXECUTIONCANCELED":
 		*e = EventTypeChildWorkflowExecutionCanceled
 		return nil
-	case "childworkflowexecutiontimedout":
+	case "CHILDWORKFLOWEXECUTIONTIMEDOUT":
 		*e = EventTypeChildWorkflowExecutionTimedOut
 		return nil
-	case "childworkflowexecutionterminated":
+	case "CHILDWORKFLOWEXECUTIONTERMINATED":
 		*e = EventTypeChildWorkflowExecutionTerminated
 		return nil
-	case "signalexternalworkflowexecutioninitiated":
+	case "SIGNALEXTERNALWORKFLOWEXECUTIONINITIATED":
 		*e = EventTypeSignalExternalWorkflowExecutionInitiated
 		return nil
-	case "signalexternalworkflowexecutionfailed":
+	case "SIGNALEXTERNALWORKFLOWEXECUTIONFAILED":
 		*e = EventTypeSignalExternalWorkflowExecutionFailed
 		return nil
-	case "externalworkflowexecutionsignaled":
+	case "EXTERNALWORKFLOWEXECUTIONSIGNALED":
 		*e = EventTypeExternalWorkflowExecutionSignaled
 		return nil
-	case "upsertworkflowsearchattributes":
+	case "UPSERTWORKFLOWSEARCHATTRIBUTES":
 		*e = EventTypeUpsertWorkflowSearchAttributes
 		return nil
 	default:
@@ -3938,20 +3938,20 @@ func (e HistoryEventFilterType) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "AllEvent"
+		return "ALL_EVENT"
 	case 1:
-		return "CloseEvent"
+		return "CLOSE_EVENT"
 	}
 	return fmt.Sprintf("HistoryEventFilterType(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *HistoryEventFilterType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "allevent":
+	switch s := strings.ToUpper(string(value)); s {
+	case "ALL_EVENT":
 		*e = HistoryEventFilterTypeAllEvent
 		return nil
-	case "closeevent":
+	case "CLOSE_EVENT":
 		*e = HistoryEventFilterTypeCloseEvent
 		return nil
 	default:
@@ -3989,40 +3989,40 @@ func (e IndexedValueType) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "String"
+		return "STRING"
 	case 1:
-		return "Keyword"
+		return "KEYWORD"
 	case 2:
-		return "Int"
+		return "INT"
 	case 3:
-		return "Double"
+		return "DOUBLE"
 	case 4:
-		return "Bool"
+		return "BOOL"
 	case 5:
-		return "Datetime"
+		return "DATETIME"
 	}
 	return fmt.Sprintf("IndexedValueType(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *IndexedValueType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "string":
+	switch s := strings.ToUpper(string(value)); s {
+	case "STRING":
 		*e = IndexedValueTypeString
 		return nil
-	case "keyword":
+	case "KEYWORD":
 		*e = IndexedValueTypeKeyword
 		return nil
-	case "int":
+	case "INT":
 		*e = IndexedValueTypeInt
 		return nil
-	case "double":
+	case "DOUBLE":
 		*e = IndexedValueTypeDouble
 		return nil
-	case "bool":
+	case "BOOL":
 		*e = IndexedValueTypeBool
 		return nil
-	case "datetime":
+	case "DATETIME":
 		*e = IndexedValueTypeDatetime
 		return nil
 	default:
@@ -4541,25 +4541,25 @@ func (e ParentClosePolicy) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Abandon"
+		return "ABANDON"
 	case 1:
-		return "RequestCancel"
+		return "REQUEST_CANCEL"
 	case 2:
-		return "Terminate"
+		return "TERMINATE"
 	}
 	return fmt.Sprintf("ParentClosePolicy(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *ParentClosePolicy) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "abandon":
+	switch s := strings.ToUpper(string(value)); s {
+	case "ABANDON":
 		*e = ParentClosePolicyAbandon
 		return nil
-	case "requestcancel":
+	case "REQUEST_CANCEL":
 		*e = ParentClosePolicyRequestCancel
 		return nil
-	case "terminate":
+	case "TERMINATE":
 		*e = ParentClosePolicyTerminate
 		return nil
 	default:
@@ -4720,25 +4720,25 @@ func (e PendingActivityState) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Scheduled"
+		return "SCHEDULED"
 	case 1:
-		return "Started"
+		return "STARTED"
 	case 2:
-		return "CancelRequested"
+		return "CANCEL_REQUESTED"
 	}
 	return fmt.Sprintf("PendingActivityState(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *PendingActivityState) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "scheduled":
+	switch s := strings.ToUpper(string(value)); s {
+	case "SCHEDULED":
 		*e = PendingActivityStateScheduled
 		return nil
-	case "started":
+	case "STARTED":
 		*e = PendingActivityStateStarted
 		return nil
-	case "cancelrequested":
+	case "CANCEL_REQUESTED":
 		*e = PendingActivityStateCancelRequested
 		return nil
 	default:
@@ -4876,20 +4876,20 @@ func (e PendingDecisionState) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Scheduled"
+		return "SCHEDULED"
 	case 1:
-		return "Started"
+		return "STARTED"
 	}
 	return fmt.Sprintf("PendingDecisionState(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *PendingDecisionState) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "scheduled":
+	switch s := strings.ToUpper(string(value)); s {
+	case "SCHEDULED":
 		*e = PendingDecisionStateScheduled
 		return nil
-	case "started":
+	case "STARTED":
 		*e = PendingDecisionStateStarted
 		return nil
 	default:
@@ -5316,20 +5316,20 @@ func (e QueryConsistencyLevel) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Eventual"
+		return "EVENTUAL"
 	case 1:
-		return "Strong"
+		return "STRONG"
 	}
 	return fmt.Sprintf("QueryConsistencyLevel(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *QueryConsistencyLevel) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "eventual":
+	switch s := strings.ToUpper(string(value)); s {
+	case "EVENTUAL":
 		*e = QueryConsistencyLevelEventual
 		return nil
-	case "strong":
+	case "STRONG":
 		*e = QueryConsistencyLevelStrong
 		return nil
 	default:
@@ -5380,20 +5380,20 @@ func (e QueryRejectCondition) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "NotOpen"
+		return "NOT_OPEN"
 	case 1:
-		return "NotCompletedCleanly"
+		return "NOT_COMPLETED_CLEANLY"
 	}
 	return fmt.Sprintf("QueryRejectCondition(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *QueryRejectCondition) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "notopen":
+	switch s := strings.ToUpper(string(value)); s {
+	case "NOT_OPEN":
 		*e = QueryRejectConditionNotOpen
 		return nil
-	case "notcompletedcleanly":
+	case "NOT_COMPLETED_CLEANLY":
 		*e = QueryRejectConditionNotCompletedCleanly
 		return nil
 	default:
@@ -5444,20 +5444,20 @@ func (e QueryResultType) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Answered"
+		return "ANSWERED"
 	case 1:
-		return "Failed"
+		return "FAILED"
 	}
 	return fmt.Sprintf("QueryResultType(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *QueryResultType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "answered":
+	switch s := strings.ToUpper(string(value)); s {
+	case "ANSWERED":
 		*e = QueryResultTypeAnswered
 		return nil
-	case "failed":
+	case "FAILED":
 		*e = QueryResultTypeFailed
 		return nil
 	default:
@@ -5495,20 +5495,20 @@ func (e QueryTaskCompletedType) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Completed"
+		return "COMPLETED"
 	case 1:
-		return "Failed"
+		return "FAILED"
 	}
 	return fmt.Sprintf("QueryTaskCompletedType(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *QueryTaskCompletedType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "completed":
+	switch s := strings.ToUpper(string(value)); s {
+	case "COMPLETED":
 		*e = QueryTaskCompletedTypeCompleted
 		return nil
-	case "failed":
+	case "FAILED":
 		*e = QueryTaskCompletedTypeFailed
 		return nil
 	default:
@@ -7246,15 +7246,15 @@ func (e SignalExternalWorkflowExecutionFailedCause) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "UnknownExternalWorkflowExecution"
+		return "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION"
 	}
 	return fmt.Sprintf("SignalExternalWorkflowExecutionFailedCause(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *SignalExternalWorkflowExecutionFailedCause) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "unknownexternalworkflowexecution":
+	switch s := strings.ToUpper(string(value)); s {
+	case "UNKNOWN_EXTERNAL_WORKFLOW_EXECUTION":
 		*e = SignalExternalWorkflowExecutionFailedCauseUnknownExternalWorkflowExecution
 		return nil
 	default:
@@ -8286,20 +8286,20 @@ func (e TaskListKind) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Normal"
+		return "NORMAL"
 	case 1:
-		return "Sticky"
+		return "STICKY"
 	}
 	return fmt.Sprintf("TaskListKind(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *TaskListKind) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "normal":
+	switch s := strings.ToUpper(string(value)); s {
+	case "NORMAL":
 		*e = TaskListKindNormal
 		return nil
-	case "sticky":
+	case "STICKY":
 		*e = TaskListKindSticky
 		return nil
 	default:
@@ -8430,11 +8430,11 @@ func (e TaskListType) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *TaskListType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "decision":
+	switch s := strings.ToUpper(string(value)); s {
+	case "DECISION":
 		*e = TaskListTypeDecision
 		return nil
-	case "activity":
+	case "ACTIVITY":
 		*e = TaskListTypeActivity
 		return nil
 	default:
@@ -8521,30 +8521,30 @@ func (e TimeoutType) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "StartToClose"
+		return "START_TO_CLOSE"
 	case 1:
-		return "ScheduleToStart"
+		return "SCHEDULE_TO_START"
 	case 2:
-		return "ScheduleToClose"
+		return "SCHEDULE_TO_CLOSE"
 	case 3:
-		return "Heartbeat"
+		return "HEARTBEAT"
 	}
 	return fmt.Sprintf("TimeoutType(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *TimeoutType) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "starttoclose":
+	switch s := strings.ToUpper(string(value)); s {
+	case "START_TO_CLOSE":
 		*e = TimeoutTypeStartToClose
 		return nil
-	case "scheduletostart":
+	case "SCHEDULE_TO_START":
 		*e = TimeoutTypeScheduleToStart
 		return nil
-	case "scheduletoclose":
+	case "SCHEDULE_TO_CLOSE":
 		*e = TimeoutTypeScheduleToClose
 		return nil
-	case "heartbeat":
+	case "HEARTBEAT":
 		*e = TimeoutTypeHeartbeat
 		return nil
 	default:
@@ -9086,40 +9086,40 @@ func (e WorkflowExecutionCloseStatus) String() string {
 	w := int32(e)
 	switch w {
 	case 0:
-		return "Completed"
+		return "COMPLETED"
 	case 1:
-		return "Failed"
+		return "FAILED"
 	case 2:
-		return "Canceled"
+		return "CANCELED"
 	case 3:
-		return "Terminated"
+		return "TERMINATED"
 	case 4:
-		return "ContinuedAsNew"
+		return "CONTINUED_AS_NEW"
 	case 5:
-		return "TimedOut"
+		return "TIMED_OUT"
 	}
 	return fmt.Sprintf("WorkflowExecutionCloseStatus(%d)", w)
 }
 
 // UnmarshalText parses enum value from string representation
 func (e *WorkflowExecutionCloseStatus) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "completed":
+	switch s := strings.ToUpper(string(value)); s {
+	case "COMPLETED":
 		*e = WorkflowExecutionCloseStatusCompleted
 		return nil
-	case "failed":
+	case "FAILED":
 		*e = WorkflowExecutionCloseStatusFailed
 		return nil
-	case "canceled":
+	case "CANCELED":
 		*e = WorkflowExecutionCloseStatusCanceled
 		return nil
-	case "terminated":
+	case "TERMINATED":
 		*e = WorkflowExecutionCloseStatusTerminated
 		return nil
-	case "continuedasnew":
+	case "CONTINUED_AS_NEW":
 		*e = WorkflowExecutionCloseStatusContinuedAsNew
 		return nil
-	case "timedout":
+	case "TIMED_OUT":
 		*e = WorkflowExecutionCloseStatusTimedOut
 		return nil
 	default:
@@ -9848,17 +9848,17 @@ func (e WorkflowIDReusePolicy) String() string {
 
 // UnmarshalText parses enum value from string representation
 func (e *WorkflowIDReusePolicy) UnmarshalText(value []byte) error {
-	switch s := strings.ToLower(string(value)); s {
-	case "allowduplicatefailedonly":
+	switch s := strings.ToUpper(string(value)); s {
+	case "ALLOWDUPLICATEFAILEDONLY":
 		*e = WorkflowIDReusePolicyAllowDuplicateFailedOnly
 		return nil
-	case "allowduplicate":
+	case "ALLOWDUPLICATE":
 		*e = WorkflowIDReusePolicyAllowDuplicate
 		return nil
-	case "rejectduplicate":
+	case "REJECTDUPLICATE":
 		*e = WorkflowIDReusePolicyRejectDuplicate
 		return nil
-	case "terminateifrunning":
+	case "TERMINATEIFRUNNING":
 		*e = WorkflowIDReusePolicyTerminateIfRunning
 		return nil
 	default:

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -263,7 +263,7 @@ func (adh *adminHandlerImpl) DescribeWorkflowExecution(
 	historyAddr := historyHost.GetAddress()
 	resp2, err := adh.GetHistoryClient().DescribeMutableState(ctx, &types.DescribeMutableStateRequest{
 		DomainUUID: &domainID,
-		Execution: request.Execution,
+		Execution:  request.Execution,
 	})
 	if err != nil {
 		return &types.AdminDescribeWorkflowExecutionResponse{}, err

--- a/service/frontend/dcRedirectionHandler_test.go
+++ b/service/frontend/dcRedirectionHandler_test.go
@@ -202,7 +202,7 @@ func (s *dcRedirectionHandlerSuite) TestListArchivedWorkflowExecutions() {
 	s.mockFrontendHandler.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(), req).Return(&types.ListArchivedWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(),req).Return(&types.ListArchivedWorkflowExecutionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(), req).Return(&types.ListArchivedWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }

--- a/service/history/execution/history_builder.go
+++ b/service/history/execution/history_builder.go
@@ -127,7 +127,7 @@ func (b *HistoryBuilder) AddDecisionTaskCompletedEvent(scheduleEventID, startedE
 
 // AddDecisionTaskTimedOutEvent adds DecisionTaskTimedOut event to history
 func (b *HistoryBuilder) AddDecisionTaskTimedOutEvent(scheduleEventID int64,
-	startedEventID int64, timeoutType workflow.TimeoutType) *workflow.HistoryEvent {
+	startedEventID int64, timeoutType types.TimeoutType) *workflow.HistoryEvent {
 	event := b.newDecisionTaskTimedOutEvent(scheduleEventID, startedEventID, timeoutType)
 
 	return b.addEventToHistory(event)
@@ -182,7 +182,7 @@ func (b *HistoryBuilder) AddActivityTaskFailedEvent(scheduleEventID, startedEven
 func (b *HistoryBuilder) AddActivityTaskTimedOutEvent(
 	scheduleEventID,
 	startedEventID int64,
-	timeoutType workflow.TimeoutType,
+	timeoutType types.TimeoutType,
 	lastHeartBeatDetails []byte,
 	lastFailureReason string,
 	lastFailureDetail []byte,
@@ -613,12 +613,12 @@ func (b *HistoryBuilder) newDecisionTaskCompletedEvent(scheduleEventID, startedE
 	return historyEvent
 }
 
-func (b *HistoryBuilder) newDecisionTaskTimedOutEvent(scheduleEventID int64, startedEventID int64, timeoutType workflow.TimeoutType) *workflow.HistoryEvent {
+func (b *HistoryBuilder) newDecisionTaskTimedOutEvent(scheduleEventID int64, startedEventID int64, timeoutType types.TimeoutType) *workflow.HistoryEvent {
 	historyEvent := b.msBuilder.CreateNewHistoryEvent(workflow.EventTypeDecisionTaskTimedOut)
 	attributes := &workflow.DecisionTaskTimedOutEventAttributes{}
 	attributes.ScheduledEventId = common.Int64Ptr(scheduleEventID)
 	attributes.StartedEventId = common.Int64Ptr(startedEventID)
-	attributes.TimeoutType = common.TimeoutTypePtr(timeoutType)
+	attributes.TimeoutType = thrift.FromTimeoutType(&timeoutType)
 	historyEvent.DecisionTaskTimedOutEventAttributes = attributes
 
 	return historyEvent
@@ -686,7 +686,7 @@ func (b *HistoryBuilder) newActivityTaskCompletedEvent(scheduleEventID, startedE
 
 func (b *HistoryBuilder) newActivityTaskTimedOutEvent(
 	scheduleEventID, startedEventID int64,
-	timeoutType workflow.TimeoutType,
+	timeoutType types.TimeoutType,
 	lastHeartBeatDetails []byte,
 	lastFailureReason string,
 	lastFailureDetail []byte,
@@ -695,7 +695,7 @@ func (b *HistoryBuilder) newActivityTaskTimedOutEvent(
 	attributes := &workflow.ActivityTaskTimedOutEventAttributes{}
 	attributes.ScheduledEventId = common.Int64Ptr(scheduleEventID)
 	attributes.StartedEventId = common.Int64Ptr(startedEventID)
-	attributes.TimeoutType = common.TimeoutTypePtr(timeoutType)
+	attributes.TimeoutType = thrift.FromTimeoutType(&timeoutType)
 	attributes.Details = lastHeartBeatDetails
 	attributes.LastFailureReason = common.StringPtr(lastFailureReason)
 	attributes.LastFailureDetails = lastFailureDetail

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -65,7 +65,7 @@ type (
 		AddActivityTaskFailedEvent(int64, int64, *workflow.RespondActivityTaskFailedRequest) (*workflow.HistoryEvent, error)
 		AddActivityTaskScheduledEvent(int64, *types.ScheduleActivityTaskDecisionAttributes) (*workflow.HistoryEvent, *persistence.ActivityInfo, *workflow.ActivityLocalDispatchInfo, error)
 		AddActivityTaskStartedEvent(*persistence.ActivityInfo, int64, string, string) (*workflow.HistoryEvent, error)
-		AddActivityTaskTimedOutEvent(int64, int64, workflow.TimeoutType, []uint8) (*workflow.HistoryEvent, error)
+		AddActivityTaskTimedOutEvent(int64, int64, types.TimeoutType, []uint8) (*workflow.HistoryEvent, error)
 		AddCancelTimerFailedEvent(int64, *types.CancelTimerDecisionAttributes, string) (*workflow.HistoryEvent, error)
 		AddChildWorkflowExecutionCanceledEvent(int64, *types.WorkflowExecution, *workflow.WorkflowExecutionCanceledEventAttributes) (*workflow.HistoryEvent, error)
 		AddChildWorkflowExecutionCompletedEvent(int64, *types.WorkflowExecution, *workflow.WorkflowExecutionCompletedEventAttributes) (*workflow.HistoryEvent, error)
@@ -183,7 +183,7 @@ type (
 		ReplicateDecisionTaskFailedEvent() error
 		ReplicateDecisionTaskScheduledEvent(int64, int64, string, int32, int64, int64, int64) (*DecisionInfo, error)
 		ReplicateDecisionTaskStartedEvent(*DecisionInfo, int64, int64, int64, string, int64) (*DecisionInfo, error)
-		ReplicateDecisionTaskTimedOutEvent(workflow.TimeoutType) error
+		ReplicateDecisionTaskTimedOutEvent(types.TimeoutType) error
 		ReplicateExternalWorkflowExecutionCancelRequested(*workflow.HistoryEvent) error
 		ReplicateExternalWorkflowExecutionSignaled(*workflow.HistoryEvent) error
 		ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(*workflow.HistoryEvent) error

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -2032,7 +2032,7 @@ func (e *mutableStateBuilder) AddDecisionTaskTimedOutEvent(
 }
 
 func (e *mutableStateBuilder) ReplicateDecisionTaskTimedOutEvent(
-	timeoutType workflow.TimeoutType,
+	timeoutType types.TimeoutType,
 ) error {
 	return e.decisionTaskManager.ReplicateDecisionTaskTimedOutEvent(timeoutType)
 }
@@ -2351,7 +2351,7 @@ func (e *mutableStateBuilder) ReplicateActivityTaskFailedEvent(
 func (e *mutableStateBuilder) AddActivityTaskTimedOutEvent(
 	scheduleEventID int64,
 	startedEventID int64,
-	timeoutType workflow.TimeoutType,
+	timeoutType types.TimeoutType,
 	lastHeartBeatDetails []byte,
 ) (*workflow.HistoryEvent, error) {
 
@@ -2361,8 +2361,8 @@ func (e *mutableStateBuilder) AddActivityTaskTimedOutEvent(
 	}
 
 	ai, ok := e.GetActivityInfo(scheduleEventID)
-	if !ok || ai.StartedID != startedEventID || ((timeoutType == workflow.TimeoutTypeStartToClose ||
-		timeoutType == workflow.TimeoutTypeHeartbeat) && ai.StartedID == common.EmptyEventID) {
+	if !ok || ai.StartedID != startedEventID || ((timeoutType == types.TimeoutTypeStartToClose ||
+		timeoutType == types.TimeoutTypeHeartbeat) && ai.StartedID == common.EmptyEventID) {
 		e.logger.Warn(mutableStateInvalidHistoryActionMsg, opTag,
 			tag.WorkflowEventID(e.GetNextEventID()),
 			tag.ErrorTypeInvalidHistoryAction,

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -159,7 +159,7 @@ func (mr *MockMutableStateMockRecorder) AddActivityTaskStartedEvent(arg0, arg1, 
 }
 
 // AddActivityTaskTimedOutEvent mocks base method
-func (m *MockMutableState) AddActivityTaskTimedOutEvent(arg0, arg1 int64, arg2 shared.TimeoutType, arg3 []uint8) (*shared.HistoryEvent, error) {
+func (m *MockMutableState) AddActivityTaskTimedOutEvent(arg0, arg1 int64, arg2 types.TimeoutType, arg3 []uint8) (*shared.HistoryEvent, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddActivityTaskTimedOutEvent", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*shared.HistoryEvent)
@@ -1864,7 +1864,7 @@ func (mr *MockMutableStateMockRecorder) ReplicateDecisionTaskStartedEvent(arg0, 
 }
 
 // ReplicateDecisionTaskTimedOutEvent mocks base method
-func (m *MockMutableState) ReplicateDecisionTaskTimedOutEvent(arg0 shared.TimeoutType) error {
+func (m *MockMutableState) ReplicateDecisionTaskTimedOutEvent(arg0 types.TimeoutType) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplicateDecisionTaskTimedOutEvent", arg0)
 	ret0, _ := ret[0].(error)

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -25,8 +25,6 @@ package execution
 import (
 	"time"
 
-	"github.com/uber/cadence/common/types/mapper/thrift"
-
 	"github.com/pborman/uuid"
 
 	"github.com/uber/cadence/.gen/go/shared"
@@ -37,6 +35,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/thrift"
 	"github.com/uber/cadence/service/history/shard"
 )
 

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -25,6 +25,8 @@ package execution
 import (
 	"time"
 
+	"github.com/uber/cadence/common/types/mapper/thrift"
+
 	"github.com/pborman/uuid"
 
 	"github.com/uber/cadence/.gen/go/shared"
@@ -238,7 +240,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 		case shared.EventTypeDecisionTaskTimedOut:
 			if err := b.mutableState.ReplicateDecisionTaskTimedOutEvent(
-				event.DecisionTaskTimedOutEventAttributes.GetTimeoutType(),
+				*thrift.ToTimeoutType(event.DecisionTaskTimedOutEventAttributes.GetTimeoutType().Ptr()),
 			); err != nil {
 				return nil, err
 			}

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -789,7 +789,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeDecisionTaskTimedOut() {
 			TimeoutType:      shared.TimeoutTypeStartToClose.Ptr(),
 		},
 	}
-	s.mockMutableState.EXPECT().ReplicateDecisionTaskTimedOutEvent(shared.TimeoutTypeStartToClose).Return(nil).Times(1)
+	s.mockMutableState.EXPECT().ReplicateDecisionTaskTimedOutEvent(types.TimeoutTypeStartToClose).Return(nil).Times(1)
 	tasklist := "some random tasklist"
 	newScheduleID := int64(233)
 	executionInfo := &persistence.WorkflowExecutionInfo{

--- a/service/history/execution/timer_sequence.go
+++ b/service/history/execution/timer_sequence.go
@@ -27,7 +27,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/persistence"
@@ -41,13 +40,13 @@ type (
 
 const (
 	// TimerTypeStartToClose is the timer type for activity startToClose timer
-	TimerTypeStartToClose = TimerType(shared.TimeoutTypeStartToClose)
+	TimerTypeStartToClose = TimerType(types.TimeoutTypeStartToClose)
 	// TimerTypeScheduleToStart is the timer type for activity scheduleToStart timer
-	TimerTypeScheduleToStart = TimerType(shared.TimeoutTypeScheduleToStart)
+	TimerTypeScheduleToStart = TimerType(types.TimeoutTypeScheduleToStart)
 	// TimerTypeScheduleToClose is the timer type for activity scheduleToClose timer
-	TimerTypeScheduleToClose = TimerType(shared.TimeoutTypeScheduleToClose)
+	TimerTypeScheduleToClose = TimerType(types.TimeoutTypeScheduleToClose)
 	// TimerTypeHeartbeat is the timer type for activity heartbeat timer
-	TimerTypeHeartbeat = TimerType(shared.TimeoutTypeHeartbeat)
+	TimerTypeHeartbeat = TimerType(types.TimeoutTypeHeartbeat)
 )
 
 const (
@@ -396,38 +395,38 @@ func TimerTypeToTimerMask(
 	}
 }
 
-// TimerTypeToThrift converts TimeType to its thrift representation
-func TimerTypeToThrift(
+// TimerTypeToInternal converts TimeType to its internal representation
+func TimerTypeToInternal(
 	TimerType TimerType,
-) shared.TimeoutType {
+) types.TimeoutType {
 
 	switch TimerType {
 	case TimerTypeStartToClose:
-		return shared.TimeoutTypeStartToClose
+		return types.TimeoutTypeStartToClose
 	case TimerTypeScheduleToStart:
-		return shared.TimeoutTypeScheduleToStart
+		return types.TimeoutTypeScheduleToStart
 	case TimerTypeScheduleToClose:
-		return shared.TimeoutTypeScheduleToClose
+		return types.TimeoutTypeScheduleToClose
 	case TimerTypeHeartbeat:
-		return shared.TimeoutTypeHeartbeat
+		return types.TimeoutTypeHeartbeat
 	default:
 		panic(fmt.Sprintf("invalid timer type: %v", TimerType))
 	}
 }
 
-// TimerTypeFromThrift gets TimerType from its thrift representation
-func TimerTypeFromThrift(
-	TimerType shared.TimeoutType,
+// TimerTypeFromInternal gets TimerType from internal type
+func TimerTypeFromInternal(
+	TimerType types.TimeoutType,
 ) TimerType {
 
 	switch TimerType {
-	case shared.TimeoutTypeStartToClose:
+	case types.TimeoutTypeStartToClose:
 		return TimerTypeStartToClose
-	case shared.TimeoutTypeScheduleToStart:
+	case types.TimeoutTypeScheduleToStart:
 		return TimerTypeScheduleToStart
-	case shared.TimeoutTypeScheduleToClose:
+	case types.TimeoutTypeScheduleToClose:
 		return TimerTypeScheduleToClose
-	case shared.TimeoutTypeHeartbeat:
+	case types.TimeoutTypeHeartbeat:
 		return TimerTypeHeartbeat
 	default:
 		panic(fmt.Sprintf("invalid timeout type: %v", TimerType))
@@ -438,7 +437,7 @@ func TimerTypeFromThrift(
 func TimerTypeToReason(
 	timerType TimerType,
 ) string {
-	return fmt.Sprintf("cadenceInternal:Timeout %v", TimerTypeToThrift(timerType))
+	return fmt.Sprintf("cadenceInternal:Timeout %v", TimerTypeToInternal(timerType))
 }
 
 // Len implements sort.Interface

--- a/service/history/execution/timer_sequence_test.go
+++ b/service/history/execution/timer_sequence_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/cadence/common/types"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -177,7 +179,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated() {
 		VisibilityTimestamp: activityInfo.ScheduledTime.Add(
 			time.Duration(activityInfo.ScheduleToStartTimeout) * time.Second,
 		),
-		TimeoutType: int(shared.TimeoutTypeScheduleToStart),
+		TimeoutType: int(types.TimeoutTypeScheduleToStart),
 		EventID:     activityInfo.ScheduleID,
 		Attempt:     int64(activityInfo.Attempt),
 		Version:     currentVersion,
@@ -1047,15 +1049,15 @@ func (s *timerSequenceSuite) TestGetActivityHeartbeatTimeout_WithoutHeartbeat_St
 }
 
 func (s *timerSequenceSuite) TestConversion() {
-	s.Equal(shared.TimeoutTypeStartToClose, TimerTypeToThrift(TimerTypeStartToClose))
-	s.Equal(shared.TimeoutTypeScheduleToStart, TimerTypeToThrift(TimerTypeScheduleToStart))
-	s.Equal(shared.TimeoutTypeScheduleToClose, TimerTypeToThrift(TimerTypeScheduleToClose))
-	s.Equal(shared.TimeoutTypeHeartbeat, TimerTypeToThrift(TimerTypeHeartbeat))
+	s.Equal(types.TimeoutTypeStartToClose, TimerTypeToInternal(TimerTypeStartToClose))
+	s.Equal(types.TimeoutTypeScheduleToStart, TimerTypeToInternal(TimerTypeScheduleToStart))
+	s.Equal(types.TimeoutTypeScheduleToClose, TimerTypeToInternal(TimerTypeScheduleToClose))
+	s.Equal(types.TimeoutTypeHeartbeat, TimerTypeToInternal(TimerTypeHeartbeat))
 
-	s.Equal(TimerTypeFromThrift(shared.TimeoutTypeStartToClose), TimerTypeStartToClose)
-	s.Equal(TimerTypeFromThrift(shared.TimeoutTypeScheduleToStart), TimerTypeScheduleToStart)
-	s.Equal(TimerTypeFromThrift(shared.TimeoutTypeScheduleToClose), TimerTypeScheduleToClose)
-	s.Equal(TimerTypeFromThrift(shared.TimeoutTypeHeartbeat), TimerTypeHeartbeat)
+	s.Equal(TimerTypeFromInternal(types.TimeoutTypeStartToClose), TimerTypeStartToClose)
+	s.Equal(TimerTypeFromInternal(types.TimeoutTypeScheduleToStart), TimerTypeScheduleToStart)
+	s.Equal(TimerTypeFromInternal(types.TimeoutTypeScheduleToClose), TimerTypeScheduleToClose)
+	s.Equal(TimerTypeFromInternal(types.TimeoutTypeHeartbeat), TimerTypeHeartbeat)
 
 	s.Equal(int32(TimerTaskStatusCreatedStartToClose), TimerTypeToTimerMask(TimerTypeStartToClose))
 	s.Equal(int32(TimerTaskStatusCreatedScheduleToStart), TimerTypeToTimerMask(TimerTypeScheduleToStart))

--- a/service/history/execution/timer_sequence_test.go
+++ b/service/history/execution/timer_sequence_test.go
@@ -24,8 +24,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber/cadence/common/types"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -34,6 +32,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 )
 
 type (

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -55,9 +55,9 @@ type (
 		*require.Assertions
 		controller *gomock.Controller
 
-		mockShard  *shard.TestContext
-		mockEngine *engine.MockEngine
-		config     *config.Config
+		mockShard        *shard.TestContext
+		mockEngine       *engine.MockEngine
+		config           *config.Config
 		historyClient    *historyservicetest.MockClient
 		taskFetcher      *MockTaskFetcher
 		mockDomainCache  *cache.MockDomainCache

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -238,7 +238,7 @@ Loop:
 		if _, err := mutableState.AddActivityTaskTimedOutEvent(
 			activityInfo.ScheduleID,
 			activityInfo.StartedID,
-			execution.TimerTypeToThrift(timerSequenceID.TimerType),
+			execution.TimerTypeToInternal(timerSequenceID.TimerType),
 			activityInfo.Details,
 		); err != nil {
 			return err
@@ -292,7 +292,7 @@ func (t *timerActiveTaskExecutor) executeDecisionTimeoutTask(
 	}
 
 	scheduleDecision := false
-	switch execution.TimerTypeFromThrift(workflow.TimeoutType(task.TimeoutType)) {
+	switch execution.TimerTypeFromInternal(types.TimeoutType(task.TimeoutType)) {
 	case execution.TimerTypeStartToClose:
 		t.emitTimeoutMetricScopeWithDomainTag(
 			mutableState.GetExecutionInfo().DomainID,

--- a/service/history/task/timer_active_task_executor_test.go
+++ b/service/history/task/timer_active_task_executor_test.go
@@ -202,7 +202,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Fire() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeUserTimer,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: task.(*persistence.UserTimerTask).GetVisibilityTimestamp(),
 		EventID:             event.GetEventId(),
 	}
@@ -272,7 +272,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Noop() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeUserTimer,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: task.(*persistence.UserTimerTask).GetVisibilityTimestamp(),
 		EventID:             event.GetEventId(),
 	}
@@ -353,7 +353,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToClose),
+		TimeoutType:         int(types.TimeoutTypeScheduleToClose),
 		VisibilityTimestamp: task.(*persistence.ActivityTimeoutTask).GetVisibilityTimestamp(),
 		EventID:             scheduledEvent.GetEventId(),
 	}
@@ -438,7 +438,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToClose),
+		TimeoutType:         int(types.TimeoutTypeScheduleToClose),
 		VisibilityTimestamp: task.(*persistence.ActivityTimeoutTask).GetVisibilityTimestamp(),
 		EventID:             scheduledEvent.GetEventId(),
 	}
@@ -530,7 +530,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToClose),
+		TimeoutType:         int(types.TimeoutTypeScheduleToClose),
 		VisibilityTimestamp: task.(*persistence.ActivityTimeoutTask).GetVisibilityTimestamp(),
 		EventID:             scheduledEvent.GetEventId(),
 	}
@@ -624,7 +624,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToClose),
+		TimeoutType:         int(types.TimeoutTypeScheduleToClose),
 		VisibilityTimestamp: task.(*persistence.ActivityTimeoutTask).GetVisibilityTimestamp(),
 		EventID:             scheduledEvent.GetEventId(),
 	}
@@ -720,7 +720,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_No
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToClose),
+		TimeoutType:         int(types.TimeoutTypeScheduleToClose),
 		VisibilityTimestamp: task.(*persistence.ActivityTimeoutTask).GetVisibilityTimestamp(),
 		EventID:             scheduledEvent.GetEventId(),
 	}
@@ -865,7 +865,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionTimeout_Fire() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeDecisionTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 		EventID:             di.ScheduleID,
 	}
@@ -925,7 +925,7 @@ func (s *timerActiveTaskExecutorSuite) TestDecisionTimeout_Noop() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeDecisionTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 		EventID:             di.ScheduleID - 1,
 	}
@@ -1267,7 +1267,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_Fire() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 	}
 
@@ -1333,7 +1333,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_ContinueAsNew_Retry()
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 	}
 
@@ -1396,7 +1396,7 @@ func (s *timerActiveTaskExecutorSuite) TestWorkflowTimeout_ContinueAsNew_Cron() 
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 	}
 

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -280,7 +280,7 @@ func (t *timerStandbyTaskExecutor) executeDecisionTimeoutTask(
 	// decision schedule to start timer task is a special snowflake.
 	// the schedule to start timer is for sticky decision, which is
 	// not applicable on the passive cluster
-	if timerTask.TimeoutType == int(workflow.TimeoutTypeScheduleToStart) {
+	if timerTask.TimeoutType == int(types.TimeoutTypeScheduleToStart) {
 		return nil
 	}
 

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -209,7 +209,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeUserTimer,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: task.(*persistence.UserTimerTask).GetVisibilityTimestamp(),
 		EventID:             event.GetEventId(),
 	}
@@ -292,7 +292,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Success() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeUserTimer,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: task.(*persistence.UserTimerTask).GetVisibilityTimestamp(),
 		EventID:             event.GetEventId(),
 	}
@@ -364,7 +364,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Multiple() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeUserTimer,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: task.(*persistence.UserTimerTask).GetVisibilityTimestamp(),
 		EventID:             event.GetEventId(),
 	}
@@ -436,7 +436,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToClose),
+		TimeoutType:         int(types.TimeoutTypeScheduleToClose),
 		VisibilityTimestamp: task.(*persistence.ActivityTimeoutTask).GetVisibilityTimestamp(),
 		EventID:             scheduledEvent.GetEventId(),
 	}
@@ -523,7 +523,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Success() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToClose),
+		TimeoutType:         int(types.TimeoutTypeScheduleToClose),
 		VisibilityTimestamp: task.(*persistence.ActivityTimeoutTask).GetVisibilityTimestamp(),
 		EventID:             scheduledEvent.GetEventId(),
 	}
@@ -771,7 +771,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeDecisionTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 		EventID:             di.ScheduleID,
 	}
@@ -817,7 +817,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_ScheduleToSta
 		RunID:               execution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeDecisionTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeScheduleToStart),
+		TimeoutType:         int(types.TimeoutTypeScheduleToStart),
 		VisibilityTimestamp: s.now,
 		EventID:             decisionScheduleID,
 	}
@@ -869,7 +869,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Success() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeDecisionTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 		EventID:             di.ScheduleID,
 	}
@@ -1043,7 +1043,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 	}
 
@@ -1115,7 +1115,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Success() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeWorkflowTimeout,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 	}
 
@@ -1164,7 +1164,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessRetryTimeout() {
 		RunID:               workflowExecution.GetRunID(),
 		TaskID:              int64(100),
 		TaskType:            persistence.TaskTypeActivityRetryTimer,
-		TimeoutType:         int(workflow.TimeoutTypeStartToClose),
+		TimeoutType:         int(types.TimeoutTypeStartToClose),
 		VisibilityTimestamp: s.now,
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Switched TimeoutType to internal type.
- Modified internal types generator to use CAPITALIZED_STRINGS for some enums to match thrift IDLs.

<!-- Tell your future self why have you made these changes -->
**Why?**
To propagate internal types throughout Cadence codebase.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

