### PR TITLE
Fixed elastic config parsing and introduced optional disableHealthCheck

### DIFF
--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -96,6 +96,9 @@ func NewV6Client(
 	if connectConfig.DisableSniff {
 		clientOptFuncs = append(clientOptFuncs, elastic.SetSniff(false))
 	}
+	if connectConfig.DisableHealthCheck {
+		clientOptFuncs = append(clientOptFuncs, elastic.SetHealthcheck(false))
+	}
 	client, err := elastic.NewClient(clientOptFuncs...)
 	if err != nil {
 		return nil, err

--- a/common/elasticsearch/client_v7.go
+++ b/common/elasticsearch/client_v7.go
@@ -89,6 +89,9 @@ func NewV7Client(
 	if connectConfig.DisableSniff {
 		clientOptFuncs = append(clientOptFuncs, elastic.SetSniff(false))
 	}
+	if connectConfig.DisableHealthCheck {
+		clientOptFuncs = append(clientOptFuncs, elastic.SetHealthcheck(false))
+	}
 	client, err := elastic.NewClient(clientOptFuncs...)
 	if err != nil {
 		return nil, err

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -29,17 +29,19 @@ import (
 // ElasticSearchConfig for connecting to ElasticSearch
 type (
 	ElasticSearchConfig struct {
-		URL     url.URL           `yaml:url`     //nolint:govet
-		Indices map[string]string `yaml:indices` //nolint:govet
+		URL     url.URL           `yaml:"url"`     //nolint:govet
+		Indices map[string]string `yaml:"indices"` //nolint:govet
 		// supporting v6 and v7. Default to v6 if empty.
-		Version string `yaml:version` //nolint:govet
+		Version string `yaml:"version"` //nolint:govet
 		// optional username to communicate with ElasticSearch
-		Username string `yaml:username` //nolint:govet
+		Username string `yaml:"username"` //nolint:govet
 		// optional password to communicate with ElasticSearch
-		Password string `yaml:password` //nolint:govet
+		Password string `yaml:"password"` //nolint:govet
 		// optional to disable sniff, according to issues on Github,
 		// Sniff could cause issue like "no Elasticsearch node available"
-		DisableSniff bool `yaml:disableSniff`
+		DisableSniff bool `yaml:"disableSniff"`
+		// optional to disable health check
+		DisableHealthCheck bool `yaml:"disableHealthCheck"`
 	}
 )
 


### PR DESCRIPTION
**What changed?**
1) Elastic config parsing fixes to correctly parse boolean values
2) Enable support to optionally disable elastic health checks

**Why?**
To allow for connecting to elastic search deployments that don't work well will sniffing enabled

**How did you test it?**
Tested locally with elastic.co managed ElasticSearch deployment

**Potential risks**
NA
