### PR TITLE
0.16.x compatible with future releases

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -928,10 +928,7 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 				lastWriteVersion = common.EmptyVersion
 				if replicationState != nil {
 					lastWriteVersion = replicationState.LastWriteVersion
-				} else if previous["workflow_last_write_version"] != nil {
-					lastWriteVersion = previous["workflow_last_write_version"].(int64)
 				}
-
 				return nil, &p.WorkflowExecutionAlreadyStartedError{
 					Msg:              msg,
 					StartRequestID:   executionInfo.CreateRequestID,

--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -891,6 +891,8 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 					lastWriteVersion = common.EmptyVersion
 					if replicationState != nil {
 						lastWriteVersion = replicationState.LastWriteVersion
+					} else if previous["workflow_last_write_version"] != nil {
+						lastWriteVersion = previous["workflow_last_write_version"].(int64)
 					}
 
 					msg := fmt.Sprintf("Workflow execution already running. WorkflowId: %v, RunId: %v, rangeID: %v, columns: (%v)",
@@ -926,7 +928,10 @@ func (d *cassandraPersistence) CreateWorkflowExecution(
 				lastWriteVersion = common.EmptyVersion
 				if replicationState != nil {
 					lastWriteVersion = replicationState.LastWriteVersion
+				} else if previous["workflow_last_write_version"] != nil {
+					lastWriteVersion = previous["workflow_last_write_version"].(int64)
 				}
+
 				return nil, &p.WorkflowExecutionAlreadyStartedError{
 					Msg:              msg,
 					StartRequestID:   executionInfo.CreateRequestID,
@@ -1694,7 +1699,10 @@ func (d *cassandraPersistence) GetCurrentExecution(
 	lastWriteVersion := common.EmptyVersion
 	if replicationState != nil {
 		lastWriteVersion = replicationState.LastWriteVersion
+	} else if result["workflow_last_write_version"] != nil {
+		lastWriteVersion = result["workflow_last_write_version"].(int64)
 	}
+
 	return &p.GetCurrentExecutionResponse{
 		RunID:            currentRunID,
 		StartRequestID:   executionInfo.CreateRequestID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
0.16.x compatible with future releases

<!-- Tell your future self why have you made these changes -->
**Why?**
The replication state is deprecated in 0.17. To make 0.16 compatible with future releases, we need to add a check for the last write version.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

