### PR TITLE
Fix error handling when processing parent close policy

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1708,6 +1708,9 @@ const (
 	DomainReplicationQueueSizeGauge
 	DomainReplicationQueueSizeErrorCount
 
+	ParentClosePolicyProcessorSuccess
+	ParentClosePolicyProcessorFailures
+
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
 
@@ -2004,8 +2007,6 @@ const (
 	HistoryScavengerSuccessCount
 	HistoryScavengerErrorCount
 	HistoryScavengerSkipCount
-	ParentClosePolicyProcessorSuccess
-	ParentClosePolicyProcessorFailures
 	DomainReplicationEnqueueDLQCount
 	ScannerExecutionsGauge
 	ScannerCorruptedGauge
@@ -2187,6 +2188,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		CadenceShardFailureGauge:             {metricName: "cadence_shard_failure", metricType: Gauge},
 		DomainReplicationQueueSizeGauge:      {metricName: "domain_replication_queue_size", metricType: Gauge},
 		DomainReplicationQueueSizeErrorCount: {metricName: "domain_replication_queue_failed", metricType: Counter},
+		ParentClosePolicyProcessorSuccess:    {metricName: "parent_close_policy_processor_requests", metricType: Counter},
+		ParentClosePolicyProcessorFailures:   {metricName: "parent_close_policy_processor_errors", metricType: Counter},
 	},
 	History: {
 		TaskRequests:             {metricName: "task_requests", metricType: Counter},
@@ -2470,8 +2473,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		HistoryScavengerSuccessCount:                  {metricName: "scavenger_success", metricType: Counter},
 		HistoryScavengerErrorCount:                    {metricName: "scavenger_errors", metricType: Counter},
 		HistoryScavengerSkipCount:                     {metricName: "scavenger_skips", metricType: Counter},
-		ParentClosePolicyProcessorSuccess:             {metricName: "parent_close_policy_processor_requests", metricType: Counter},
-		ParentClosePolicyProcessorFailures:            {metricName: "parent_close_policy_processor_errors", metricType: Counter},
 		DomainReplicationEnqueueDLQCount:              {metricName: "domain_replication_dlq_enqueue_requests", metricType: Counter},
 		ScannerExecutionsGauge:                        {metricName: "scanner_executions", metricType: Gauge},
 		ScannerCorruptedGauge:                         {metricName: "scanner_corrupted", metricType: Gauge},

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1441,7 +1441,11 @@ func (t *transferActiveTaskExecutor) processParentClosePolicy(
 			domainName,
 			childInfo,
 		); err != nil {
-			if _, ok := err.(*types.EntityNotExistsError); !ok {
+			switch err.(type) {
+			case *types.EntityNotExistsError, *types.CancellationAlreadyRequestedError:
+				// expected error, no-op
+				break
+			default:
 				scope.IncCounter(metrics.ParentClosePolicyProcessorFailures)
 				return err
 			}

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -22,6 +22,7 @@ package task
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -886,8 +887,14 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_NoParent_Has
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockVisibilityMgr.On("RecordWorkflowExecutionClosed", mock.Anything, mock.Anything).Return(nil).Once()
 	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
-	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil).Times(1)
-	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.mockHistoryClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(func(_, _ interface{}) error {
+		errors := []error{nil, &types.CancellationAlreadyRequestedError{}, &types.EntityNotExistsError{}}
+		return errors[rand.Intn(len(errors))]
+	}).Times(1)
+	s.mockHistoryClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), gomock.Any()).DoAndReturn(func(_, _ interface{}) error {
+		errors := []error{nil, &types.EntityNotExistsError{}}
+		return errors[rand.Intn(len(errors))]
+	}).Times(1)
 
 	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
 	s.Nil(err)

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -136,7 +136,8 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 		}
 
 		if err != nil {
-			if _, ok := err.(*types.EntityNotExistsError); ok {
+			switch err.(type) {
+			case *types.EntityNotExistsError, *types.CancellationAlreadyRequestedError:
 				err = nil
 			}
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix error handling when processing parent close policy. Treat CancellationAlreadyRequested as an expected error.

Also move ParentClosePolicyProcessor related metrics to common section as they are used by both history and worker service. 

<!-- Tell your future self why have you made these changes -->
**Why?**
If a child workflow has already been cancelled and the parent close policy is Cancel, the operation to cancel will be retried until the workflow is closed. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, bug fix
