### PR TITLE
Add timers shardscanner

### DIFF
--- a/common/reconciliation/entity/types.go
+++ b/common/reconciliation/entity/types.go
@@ -25,6 +25,7 @@ package entity
 import (
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/uber/cadence/common/persistence"
 )
@@ -52,7 +53,51 @@ type (
 		CurrentRunID string
 		Execution
 	}
+
+	// Timer is a timer scheduled to be fired
+	Timer struct {
+		ShardID             int
+		WorkflowID          string
+		DomainID            string
+		RunID               string
+		VisibilityTimestamp time.Time
+		TaskID              int64
+		TaskType            int
+		TimeoutType         int
+		EventID             int64
+		ScheduleAttempt     int64
+		Version             int64
+	}
 )
+
+func (t *Timer) Validate() error {
+	if t.ShardID < 0 {
+		return fmt.Errorf("invalid ShardID: %v", t.ShardID)
+	}
+	if len(t.DomainID) == 0 {
+		return errors.New("empty DomainID")
+	}
+	if len(t.WorkflowID) == 0 {
+		return errors.New("empty WorkflowID")
+	}
+	if len(t.RunID) == 0 {
+		return errors.New("empty RunID")
+	}
+
+	return nil
+}
+
+func (t *Timer) Clone() Entity {
+	return &Timer{}
+}
+
+func (t *Timer) GetShardID() int {
+	return t.ShardID
+}
+
+func (t *Timer) GetDomainID() string {
+	return t.DomainID
+}
 
 // ValidateExecution returns an error if Execution is not valid, nil otherwise.
 func validateExecution(execution *Execution) error {

--- a/common/reconciliation/fetcher/timer.go
+++ b/common/reconciliation/fetcher/timer.go
@@ -1,0 +1,93 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package fetcher
+
+import (
+	"context"
+	"time"
+
+	"github.com/uber/cadence/common/pagination"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/reconciliation/entity"
+)
+
+// ConcreteExecutionIterator is used to retrieve Concrete executions.
+func TimerIterator(
+	ctx context.Context,
+	retryer persistence.Retryer,
+	minTimestamp time.Time,
+	maxTimestamp time.Time,
+	pageSize int,
+) pagination.Iterator {
+	return pagination.NewIterator(ctx, nil, getTimers(retryer, minTimestamp, maxTimestamp, pageSize))
+}
+
+func getTimers(
+	pr persistence.Retryer,
+	minTimestamp time.Time,
+	maxTimestamp time.Time,
+	pageSize int,
+) pagination.FetchFn {
+	return func(ctx context.Context, token pagination.PageToken) (pagination.Page, error) {
+		req := &persistence.GetTimerIndexTasksRequest{
+			MinTimestamp: minTimestamp,
+			MaxTimestamp: maxTimestamp,
+			BatchSize:    pageSize,
+		}
+		if token != nil {
+			req.NextPageToken = token.([]byte)
+		}
+		resp, err := pr.GetTimerIndexTasks(ctx, req)
+
+		if err != nil {
+			return pagination.Page{}, err
+		}
+		timers := make([]pagination.Entity, len(resp.Timers), len(resp.Timers))
+		for i, t := range resp.Timers {
+			timer := &entity.Timer{
+				ShardID:             pr.GetShardID(),
+				DomainID:            t.DomainID,
+				WorkflowID:          t.WorkflowID,
+				RunID:               t.RunID,
+				TaskType:            t.TaskType,
+				VisibilityTimestamp: t.VisibilityTimestamp,
+			}
+
+			if err := timer.Validate(); err != nil {
+				return pagination.Page{}, err
+			}
+			timers[i] = timer
+		}
+		var nextToken interface{} = resp.NextPageToken
+		if len(resp.NextPageToken) == 0 {
+			nextToken = nil
+		}
+
+		page := pagination.Page{
+			CurrentToken: token,
+			NextToken:    nextToken,
+			Entities:     timers,
+		}
+		return page, nil
+	}
+}

--- a/common/reconciliation/invariant/timerInvalid.go
+++ b/common/reconciliation/invariant/timerInvalid.go
@@ -118,13 +118,13 @@ func (h *TimerInvalid) Fix(
 		return *fixResult
 	}
 
-	timer, ok := e.(*entity.Timer)
+	timer, _ := e.(*entity.Timer)
 
-	if !ok {
+	if timer.TaskType != persistence.TaskTypeUserTimer {
 		return FixResult{
 			FixResultType: FixResultTypeSkipped,
 			InvariantName: h.Name(),
-			Info:          "entity is not a timer",
+			Info:          "timer is not a TaskTypeUserTimer",
 		}
 	}
 

--- a/common/reconciliation/invariant/timerInvalid.go
+++ b/common/reconciliation/invariant/timerInvalid.go
@@ -1,0 +1,153 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package invariant
+
+import (
+	"context"
+
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/reconciliation/entity"
+	"github.com/uber/cadence/common/types"
+)
+
+type TimerInvalid struct {
+	pr persistence.Retryer
+}
+
+// NewTimerInvalid returns a new history exists invariant
+func NewTimerInvalid(
+	pr persistence.Retryer,
+) Invariant {
+	return &TimerInvalid{
+		pr: pr,
+	}
+}
+
+// Check checks if timer is scheduled for open execution
+func (h *TimerInvalid) Check(
+	ctx context.Context,
+	e interface{},
+) CheckResult {
+	if checkResult := validateCheckContext(ctx, h.Name()); checkResult != nil {
+		return *checkResult
+	}
+
+	timer, ok := e.(*entity.Timer)
+
+	if !ok {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   h.Name(),
+			Info:            "failed to check: expected timer entity",
+		}
+	}
+
+	req := &persistence.GetWorkflowExecutionRequest{
+		DomainID: timer.DomainID,
+		Execution: types.WorkflowExecution{
+			WorkflowID: &timer.WorkflowID,
+			RunID:      &timer.RunID,
+		},
+	}
+
+	resp, err := h.pr.GetWorkflowExecution(ctx, req)
+
+	if err != nil {
+		switch err.(type) {
+		case *types.EntityNotExistsError:
+			return CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   h.Name(),
+				Info:            "timer scheduled for non existing workflow",
+			}
+		default:
+			return CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   h.Name(),
+				Info:            "failed to get workflow for timer",
+			}
+		}
+	}
+
+	if !Open(resp.State.ExecutionInfo.State) {
+		return CheckResult{
+			CheckResultType: CheckResultTypeCorrupted,
+			InvariantName:   h.Name(),
+			Info:            "timer scheduled for closed workflow",
+		}
+	}
+
+	return CheckResult{
+		CheckResultType: CheckResultTypeHealthy,
+		InvariantName:   h.Name(),
+	}
+}
+
+// Fix will delete invalid timer
+func (h *TimerInvalid) Fix(
+	ctx context.Context,
+	e interface{},
+) FixResult {
+
+	if fixResult := validateFixContext(ctx, h.Name()); fixResult != nil {
+		return *fixResult
+	}
+
+	fixResult, checkResult := checkBeforeFix(ctx, h, e)
+	if fixResult != nil {
+		return *fixResult
+	}
+
+	timer, ok := e.(*entity.Timer)
+
+	if !ok {
+		return FixResult{
+			FixResultType: FixResultTypeSkipped,
+			InvariantName: h.Name(),
+			Info:          "entity is not a timer",
+		}
+	}
+
+	req := persistence.CompleteTimerTaskRequest{
+		VisibilityTimestamp: timer.VisibilityTimestamp,
+		TaskID:              timer.TaskID,
+	}
+
+	if err := h.pr.CompleteTimerTask(ctx, &req); err != nil {
+		return FixResult{
+			FixResultType: FixResultTypeFailed,
+			InvariantName: h.Name(),
+			Info:          err.Error(),
+		}
+	}
+
+	return FixResult{
+		FixResultType: FixResultTypeFixed,
+		InvariantName: h.Name(),
+		CheckResult:   *checkResult,
+	}
+}
+
+func (h *TimerInvalid) Name() Name {
+	return "TimerInvalid"
+}

--- a/common/reconciliation/invariant/timerInvalid_test.go
+++ b/common/reconciliation/invariant/timerInvalid_test.go
@@ -8,10 +8,10 @@
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -28,16 +28,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber/cadence/common/types"
-
-	"github.com/uber/cadence/common/reconciliation/entity"
-
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
-
-	"github.com/stretchr/testify/suite"
+	"github.com/uber/cadence/common/reconciliation/entity"
+	"github.com/uber/cadence/common/types"
 )
 
 type TimerInvalidTest struct {

--- a/common/reconciliation/invariant/timerInvalid_test.go
+++ b/common/reconciliation/invariant/timerInvalid_test.go
@@ -1,0 +1,287 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package invariant
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/uber/cadence/common/types"
+
+	"github.com/uber/cadence/common/reconciliation/entity"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/mocks"
+	"github.com/uber/cadence/common/persistence"
+
+	"github.com/stretchr/testify/suite"
+)
+
+type TimerInvalidTest struct {
+	suite.Suite
+}
+
+func TestTimerInvalidSuite(t *testing.T) {
+	suite.Run(t, new(TimerInvalidTest))
+}
+
+func (ts *TimerInvalidTest) TestCheck() {
+	testCases := []struct {
+		name           string
+		ctxExpired     bool
+		getExecResp    *persistence.GetWorkflowExecutionResponse
+		getExecErr     error
+		expectedResult CheckResult
+		entity         interface{}
+	}{
+		{
+			name:       "Context expired",
+			ctxExpired: true,
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   "TimerInvalid",
+				Info:            "failed to check: context expired or cancelled",
+				InfoDetails:     "context deadline exceeded",
+			},
+			getExecResp: &persistence.GetWorkflowExecutionResponse{},
+			getExecErr:  errors.New("random error"),
+			entity:      &entity.Timer{},
+		},
+		{
+			name: "Check if entity is a timer",
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   "TimerInvalid",
+				Info:            "failed to check: expected timer entity",
+				InfoDetails:     "",
+			},
+		},
+		{
+			name: "Check for persistence error",
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeFailed,
+				InvariantName:   "TimerInvalid",
+				Info:            "failed to get workflow for timer",
+				InfoDetails:     "",
+			},
+			getExecResp: nil,
+			getExecErr:  errors.New("random error"),
+			entity:      &entity.Timer{},
+		},
+		{
+			name: "Workflow not found in persistence",
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   "TimerInvalid",
+				Info:            "timer scheduled for non existing workflow",
+				InfoDetails:     "",
+			},
+			getExecResp: nil,
+			getExecErr:  &types.EntityNotExistsError{},
+			entity:      &entity.Timer{},
+		},
+		{
+			name: "Workflow is closed",
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeCorrupted,
+				InvariantName:   "TimerInvalid",
+				Info:            "timer scheduled for closed workflow",
+				InfoDetails:     "",
+			},
+			getExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State: closedState,
+					},
+				},
+			},
+			getExecErr: nil,
+			entity:     &entity.Timer{},
+		},
+		{
+			name: "Check passed",
+			expectedResult: CheckResult{
+				CheckResultType: CheckResultTypeHealthy,
+				InvariantName:   "TimerInvalid",
+			},
+			getExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State: openState,
+					},
+				},
+			},
+			getExecErr: nil,
+			entity:     &entity.Timer{},
+		},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.name, func() {
+			execManager := &mocks.ExecutionManager{}
+			execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getExecResp, tc.getExecErr)
+			i := NewTimerInvalid(
+				persistence.NewPersistenceRetryer(
+					execManager,
+					nil,
+					common.CreatePersistenceRetryPolicy(),
+				),
+			)
+			ctx := context.Background()
+			if tc.ctxExpired {
+				ctx, _ = context.WithDeadline(ctx, time.Now())
+			}
+			result := i.Check(ctx, tc.entity)
+			ts.Equal(tc.expectedResult, result)
+		})
+	}
+}
+
+func (ts *TimerInvalidTest) TestFix() {
+	testCases := []struct {
+		name           string
+		ctxExpired     bool
+		getExecResp    *persistence.GetWorkflowExecutionResponse
+		getExecErr     error
+		expectedResult FixResult
+		entity         interface{}
+		ttComplete     error
+	}{
+		{
+			name:       "context expired",
+			ctxExpired: true,
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFailed,
+				InvariantName: "TimerInvalid",
+				Info:          "failed to check: context expired or cancelled",
+				InfoDetails:   "context deadline exceeded",
+			},
+			getExecResp: &persistence.GetWorkflowExecutionResponse{},
+			getExecErr:  errors.New("random error"),
+			entity:      &entity.Timer{},
+		},
+		{
+			name: "check before fix fails bc it's not a timer",
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFailed,
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeFailed,
+					InvariantName:   "TimerInvalid",
+					Info:            "failed to check: expected timer entity",
+				},
+				InvariantName: "TimerInvalid",
+				Info:          "failed fix because check failed",
+				InfoDetails:   "",
+			},
+		},
+		{
+			name: "timer type is not a user timer",
+			getExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State: closedState,
+					},
+				},
+			},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeSkipped,
+				InvariantName: "TimerInvalid",
+				Info:          "timer is not a TaskTypeUserTimer",
+				InfoDetails:   "",
+			},
+			entity: &entity.Timer{
+				TaskType: persistence.TaskTypeActivityRetryTimer,
+			},
+		},
+		{
+			name: "timer deletion fails on persistence",
+			getExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State: closedState,
+					},
+				},
+			},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFailed,
+				InvariantName: "TimerInvalid",
+				Info:          "error from persistence",
+				InfoDetails:   "",
+			},
+			entity: &entity.Timer{
+				TaskType: persistence.TaskTypeUserTimer,
+			},
+			ttComplete: errors.New("error from persistence"),
+		},
+		{
+			name: "timer deleted",
+			getExecResp: &persistence.GetWorkflowExecutionResponse{
+				State: &persistence.WorkflowMutableState{
+					ExecutionInfo: &persistence.WorkflowExecutionInfo{
+						State: closedState,
+					},
+				},
+			},
+			expectedResult: FixResult{
+				FixResultType: FixResultTypeFixed,
+				InvariantName: "TimerInvalid",
+				Info:          "",
+				InfoDetails:   "",
+				CheckResult: CheckResult{
+					CheckResultType: CheckResultTypeCorrupted,
+					InvariantName:   "TimerInvalid",
+					Info:            "timer scheduled for closed workflow",
+				},
+			},
+			entity: &entity.Timer{
+				TaskType: persistence.TaskTypeUserTimer,
+			},
+			ttComplete: nil,
+		},
+	}
+
+	for _, tc := range testCases {
+		ts.Run(tc.name, func() {
+			execManager := &mocks.ExecutionManager{}
+			execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getExecResp, tc.getExecErr)
+			execManager.On("CompleteTimerTask", mock.Anything, mock.Anything).Return(tc.ttComplete)
+			i := NewTimerInvalid(
+				persistence.NewPersistenceRetryer(
+					execManager,
+					nil,
+					common.CreatePersistenceRetryPolicy(),
+				),
+			)
+			ctx := context.Background()
+			if tc.ctxExpired {
+				ctx, _ = context.WithDeadline(ctx, time.Now())
+			}
+			result := i.Fix(ctx, tc.entity)
+			ts.Equal(tc.expectedResult, result)
+		})
+	}
+
+}

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -329,6 +329,15 @@ var keys = map[Key]string{
 	CurrentExecutionFixerDomainAllow:                         "worker.currentExecutionFixerDomainAllow",
 	ConcreteExecutionFixerEnabled:                            "worker.concreteExecutionFixerEnabled",
 	CurrentExecutionFixerEnabled:                             "worker.currentExecutionFixerEnabled",
+	TimersScannerEnabled:                                     "worker.timersScannerEnabled",
+	TimersFixerEnabled:                                       "worker.timersFixerEnabled",
+	TimersScannerConcurrency:                                 "worker.timersScannerConcurrency",
+	TimersScannerPersistencePageSize:                         "worker.timersScannerPersistencePageSize",
+	TimersScannerBlobstoreFlushThreshold:                     "worker.timersScannerConcurrency",
+	TimersScannerActivityBatchSize:                           "worker.timersScannerBlobstoreFlushThreshold",
+	TimersScannerPeriodStart:                                 "worker.timersScannerPeriodStart",
+	TimersScannerPeriodEnd:                                   "worker.timersScannerPeriodEnd",
+	TimersFixerDomainAllow:                                   "worker.timersFixerDomainAllow",
 }
 
 const (
@@ -842,6 +851,24 @@ const (
 	ConcreteExecutionFixerDomainAllow
 	// CurrentExecutionFixerDomainAllow indicates which domains are allowed to be fixed by current fixer workflow
 	CurrentExecutionFixerDomainAllow
+	// TimersScannerEnabled indicates if timers scanner should be started as part of worker.Scanner
+	TimersScannerEnabled
+	// TimersFixerEnabled indicates if timers fixer should be started as part of worker.Scanner
+	TimersFixerEnabled
+	// TimersScannerConcurrency indicates the concurrency of timers scanner
+	TimersScannerConcurrency
+	// TimersScannerPersistencePageSize indicates the page size of timers persistence fetches in timers scanner.
+	TimersScannerPersistencePageSize
+	// TimersScannerBlobstoreFlushThreshold
+	TimersScannerBlobstoreFlushThreshold
+	// TimersScannerActivityBatchSize
+	TimersScannerActivityBatchSize
+	// TimersScannerPeriodStart indicates interval start for fetching scheduled timers
+	TimersScannerPeriodStart
+	// TimersScannerPeriodEnd indicates interval end for fetching scheduled timers
+	TimersScannerPeriodEnd
+	// TimersFixerDomainAllow indicates if domain is allowed to fix timers
+	TimersFixerDomainAllow
 	// ConcreteExecutionFixerEnabled indicates if concrete execution fixer workflow is enabled
 	ConcreteExecutionFixerEnabled
 	// CurrentExecutionFixerEnabled indicates if current execution fixer workflow is enabled

--- a/service/worker/scanner/shardscanner/fixer_workflow.go
+++ b/service/worker/scanner/shardscanner/fixer_workflow.go
@@ -66,7 +66,10 @@ type FixerHooks struct {
 }
 
 // NewFixerHooks returns initialized callbacks for shard scanner workflow implementation.
-func NewFixerHooks(manager FixerManagerCB, iterator FixerIteratorCB) (*FixerHooks, error) {
+func NewFixerHooks(
+	manager FixerManagerCB,
+	iterator FixerIteratorCB,
+) (*FixerHooks, error) {
 	if manager == nil || iterator == nil {
 		return nil, errors.New("manager or iterator not provided")
 	}
@@ -104,6 +107,10 @@ func NewFixerWorkflow(
 	if err != nil {
 		return nil, err
 	}
+	if corruptKeys.CorruptedKeys == nil {
+		return nil, errors.New("corrupted keys not found")
+	}
+
 	wf.Keys = corruptKeys
 	wf.Aggregator = NewShardFixResultAggregator(corruptKeys.CorruptedKeys, *corruptKeys.MinShard, *corruptKeys.MaxShard)
 

--- a/service/worker/scanner/timers/timers.go
+++ b/service/worker/scanner/timers/timers.go
@@ -1,5 +1,3 @@
-package timers
-
 // The MIT License (MIT)
 //
 // Copyright (c) 2017-2020 Uber Technologies Inc.
@@ -21,6 +19,8 @@ package timers
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
+
+package timers
 
 import (
 	"context"

--- a/service/worker/scanner/timers/timers.go
+++ b/service/worker/scanner/timers/timers.go
@@ -1,0 +1,201 @@
+package timers
+
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/uber/cadence/common/blobstore"
+	"github.com/uber/cadence/common/pagination"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/reconciliation/entity"
+	"github.com/uber/cadence/common/reconciliation/fetcher"
+	"github.com/uber/cadence/common/reconciliation/invariant"
+	"github.com/uber/cadence/common/reconciliation/store"
+	"github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/service/worker/scanner/shardscanner"
+
+	"go.uber.org/cadence/client"
+	"go.uber.org/cadence/workflow"
+)
+
+const (
+	// ScannerWFTypeName defines workflow type name for concrete executions scanner
+	ScannerWFTypeName   = "cadence-sys-timers-scanner-workflow"
+	wfid                = "cadence-sys-timers-scanner"
+	scannerTaskListName = "cadence-sys-timers-scanner-tasklist-0"
+
+	// FixerWFTypeName defines workflow type name for timers fixer
+	FixerWFTypeName   = "cadence-sys-timers-fixer-workflow"
+	fixerTaskListName = "cadence-sys-timers-fixer-tasklist-0"
+	periodStartKey    = "period_start"
+	periodEndKey      = "period_end"
+
+	// period is defined in hours
+	_defaultPeriodStart = 24
+	_defaultPeriodEnd   = 3
+)
+
+// ScannerWorkflow starts timers scanner.
+func ScannerWorkflow(
+	ctx workflow.Context,
+	params shardscanner.ScannerWorkflowParams,
+) error {
+	wf, err := shardscanner.NewScannerWorkflow(ctx, ScannerWFTypeName, params)
+	if err != nil {
+		return err
+	}
+
+	return wf.Start(ctx)
+}
+
+// FixerWorkflow starts timers executions fixer.
+func FixerWorkflow(
+	ctx workflow.Context,
+	params shardscanner.FixerWorkflowParams,
+) error {
+	wf, err := shardscanner.NewFixerWorkflow(ctx, FixerWFTypeName, params)
+	if err != nil {
+		return err
+	}
+
+	return wf.Start(ctx)
+}
+
+// ScannerHooks provides hooks for timers scanner.
+func ScannerHooks() *shardscanner.ScannerHooks {
+	h, err := shardscanner.NewScannerHooks(Manager, Iterator)
+	if err != nil {
+		return nil
+	}
+	h.SetConfig(Config)
+
+	return h
+}
+
+// FixerHooks provides hooks needed for timers fixer.
+func FixerHooks() *shardscanner.FixerHooks {
+	h, err := shardscanner.NewFixerHooks(FixerManager, FixerIterator)
+	if err != nil {
+		return nil
+	}
+	return h
+}
+
+// Manager provides invariant manager for timers scanner.
+func Manager(
+	_ context.Context,
+	pr persistence.Retryer,
+	_ shardscanner.ScanShardActivityParams,
+	_ shardscanner.ScannerConfig,
+) invariant.Manager {
+	return invariant.NewInvariantManager(getInvariants(pr))
+}
+
+// Iterator provides iterator for timers scanner.
+func Iterator(
+	ctx context.Context,
+	pr persistence.Retryer,
+	params shardscanner.ScanShardActivityParams,
+	_ shardscanner.ScannerConfig,
+) pagination.Iterator {
+	start, err := strconv.Atoi(params.ScannerConfig[periodStartKey])
+	if err != nil {
+		return nil
+	}
+	end, err := strconv.Atoi(params.ScannerConfig[periodEndKey])
+	if err != nil {
+		return nil
+	}
+
+	startAt := time.Now().Add(time.Hour * time.Duration(start))
+	endAt := startAt.Add(time.Hour * time.Duration(end))
+
+	return fetcher.TimerIterator(ctx, pr, startAt, endAt, params.PageSize)
+
+}
+
+// FixerIterator provides iterator for concrete execution fixer.
+func FixerIterator(
+	ctx context.Context,
+	client blobstore.Client,
+	keys store.Keys,
+	_ shardscanner.FixShardActivityParams,
+	_ shardscanner.ScannerConfig,
+) store.ScanOutputIterator {
+	return store.NewBlobstoreIterator(ctx, client, keys, &entity.Timer{})
+}
+
+// FixerManager provides invariant manager for concrete execution fixer.
+func FixerManager(
+	_ context.Context,
+	pr persistence.Retryer,
+	_ shardscanner.FixShardActivityParams,
+	_ shardscanner.ScannerConfig,
+) invariant.Manager {
+	return invariant.NewInvariantManager(getInvariants(pr))
+}
+
+// Config resolves dynamic config for timers scanner.
+func Config(ctx shardscanner.Context) shardscanner.CustomScannerConfig {
+	res := shardscanner.CustomScannerConfig{}
+	res[periodStartKey] = strconv.Itoa(ctx.Config.DynamicCollection.GetIntProperty(dynamicconfig.TimersScannerPeriodStart, _defaultPeriodStart)())
+	res[periodEndKey] = strconv.Itoa(ctx.Config.DynamicCollection.GetIntProperty(dynamicconfig.TimersScannerPeriodEnd, _defaultPeriodEnd)())
+	return res
+}
+
+// ScannerConfig configures timers scanner
+func ScannerConfig(dc *dynamicconfig.Collection) *shardscanner.ScannerConfig {
+	return &shardscanner.ScannerConfig{
+		ScannerWFTypeName: ScannerWFTypeName,
+		FixerWFTypeName:   FixerWFTypeName,
+		DynamicParams: shardscanner.DynamicParams{
+			ScannerEnabled:          dc.GetBoolProperty(dynamicconfig.TimersScannerEnabled, false),
+			FixerEnabled:            dc.GetBoolProperty(dynamicconfig.TimersFixerEnabled, false),
+			Concurrency:             dc.GetIntProperty(dynamicconfig.TimersScannerConcurrency, 5),
+			PageSize:                dc.GetIntProperty(dynamicconfig.TimersScannerPersistencePageSize, 1000),
+			BlobstoreFlushThreshold: dc.GetIntProperty(dynamicconfig.TimersScannerBlobstoreFlushThreshold, 100),
+			ActivityBatchSize:       dc.GetIntProperty(dynamicconfig.TimersScannerActivityBatchSize, 25),
+			AllowDomain:             dc.GetBoolPropertyFilteredByDomain(dynamicconfig.TimersFixerDomainAllow, false),
+		},
+		DynamicCollection: dc,
+		ScannerHooks:      ScannerHooks,
+		FixerHooks:        FixerHooks,
+		FixerTLName:       fixerTaskListName,
+		StartWorkflowOptions: client.StartWorkflowOptions{
+			ID:                           wfid,
+			TaskList:                     scannerTaskListName,
+			ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour,
+			WorkflowIDReusePolicy:        client.WorkflowIDReusePolicyAllowDuplicate,
+			CronSchedule:                 "* * * * *",
+		},
+	}
+}
+
+func getInvariants(pr persistence.Retryer) []invariant.Invariant {
+	return []invariant.Invariant{
+		invariant.NewTimerInvalid(pr),
+	}
+}

--- a/service/worker/scanner/timers/timers_test.go
+++ b/service/worker/scanner/timers/timers_test.go
@@ -1,0 +1,250 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package timers
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/workflow"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/reconciliation/invariant"
+	"github.com/uber/cadence/common/reconciliation/store"
+	"github.com/uber/cadence/common/service/dynamicconfig"
+	"github.com/uber/cadence/service/worker/scanner/shardscanner"
+)
+
+type timersWorkflowsSuite struct {
+	suite.Suite
+	testsuite.WorkflowTestSuite
+	controller *gomock.Controller
+}
+
+func TestScannerWorkflowSuite(t *testing.T) {
+	suite.Run(t, new(timersWorkflowsSuite))
+}
+
+func (s *timersWorkflowsSuite) SetupSuite() {
+	workflow.Register(ScannerWorkflow)
+	s.controller = gomock.NewController(s.T())
+
+}
+func (s *timersWorkflowsSuite) TestScannerWorkflow_SetsHooks() {
+	dcClient := dynamicconfig.NewMockClient(s.controller)
+	logger := log.NewNoop()
+
+	dc := dynamicconfig.NewCollection(dcClient, logger)
+	cfg := ScannerConfig(dc)
+	s.Equal(ScannerWFTypeName, cfg.ScannerWFTypeName, "scanner wf type name is set")
+	s.NotNil(cfg.FixerHooks)
+	s.NotNil(cfg.ScannerHooks)
+}
+func (s *timersWorkflowsSuite) TestScannerWorkflow_Success() {
+	env := s.NewTestWorkflowEnvironment()
+	cconfig := shardscanner.CustomScannerConfig{
+		periodStartKey: "1",
+		periodEndKey:   "2",
+	}
+	env.OnActivity(shardscanner.ActivityScannerConfig, mock.Anything, mock.Anything).Return(shardscanner.ResolvedScannerWorkflowConfig{
+		GenericScannerConfig: shardscanner.GenericScannerConfig{
+			Enabled:           true,
+			Concurrency:       3,
+			ActivityBatchSize: 5,
+		},
+		CustomScannerConfig: cconfig,
+	}, nil)
+	env.OnActivity(shardscanner.ActivityScannerEmitMetrics, mock.Anything, mock.Anything).Return(nil)
+	shards := shardscanner.Shards{
+		Range: &shardscanner.ShardRange{
+			Min: 0,
+			Max: 30,
+		},
+	}
+
+	batches := [][]int{
+		{0, 3, 6, 9, 12},
+		{15, 18, 21, 24, 27},
+		{1, 4, 7, 10, 13},
+		{16, 19, 22, 25, 28},
+		{2, 5, 8, 11, 14},
+		{17, 20, 23, 26, 29},
+	}
+
+	for _, batch := range batches {
+		var reports []shardscanner.ScanReport
+		for i := range batch {
+			if i == 0 {
+				reports = append(reports, shardscanner.ScanReport{
+					ShardID: batch[i],
+					Stats: shardscanner.ScanStats{
+						EntitiesCount: 10,
+					},
+					Result: shardscanner.ScanResult{
+						ControlFlowFailure: &shardscanner.ControlFlowFailure{
+							Info: "got control flow failure",
+						},
+					},
+				})
+			} else {
+				reports = append(reports, shardscanner.ScanReport{
+					ShardID: batch[i],
+					Stats: shardscanner.ScanStats{
+						EntitiesCount:    10,
+						CorruptedCount:   2,
+						CheckFailedCount: 1,
+						CorruptionByType: map[invariant.Name]int64{},
+					},
+					Result: shardscanner.ScanResult{
+						ShardScanKeys: &shardscanner.ScanKeys{
+							Corrupt: &store.Keys{
+								UUID:    "test_uuid",
+								MinPage: 0,
+								MaxPage: 10,
+							},
+						},
+					},
+				})
+			}
+		}
+		//var customc shardscanner.CustomScannerConfig
+		env.OnActivity(shardscanner.ActivityScanShard, mock.Anything, shardscanner.ScanShardActivityParams{
+			Shards:        batch,
+			ContextKey:    ScannerWFTypeName,
+			ScannerConfig: cconfig,
+		}).Return(reports, nil)
+	}
+
+	env.ExecuteWorkflow(ScannerWorkflow, shardscanner.ScannerWorkflowParams{
+		Shards: shards,
+	})
+	s.True(env.IsWorkflowCompleted())
+	s.NoError(env.GetWorkflowError())
+
+	aggValue, err := env.QueryWorkflow(shardscanner.AggregateReportQuery)
+	s.NoError(err)
+	var agg shardscanner.AggregateScanReportResult
+	s.NoError(aggValue.Get(&agg))
+	s.Equal(shardscanner.AggregateScanReportResult{
+		EntitiesCount:    240,
+		CorruptedCount:   48,
+		CheckFailedCount: 24,
+		CorruptionByType: map[invariant.Name]int64{},
+	}, agg)
+
+	for i := 0; i < 30; i++ {
+		shardReportValue, err := env.QueryWorkflow(shardscanner.ShardReportQuery, i)
+		s.NoError(err)
+		var shardReport *shardscanner.ScanReport
+		s.NoError(shardReportValue.Get(&shardReport))
+		if i == 0 || i == 1 || i == 2 || i == 15 || i == 16 || i == 17 {
+			s.Equal(&shardscanner.ScanReport{
+				ShardID: i,
+				Stats: shardscanner.ScanStats{
+					EntitiesCount: 10,
+				},
+				Result: shardscanner.ScanResult{
+					ControlFlowFailure: &shardscanner.ControlFlowFailure{
+						Info: "got control flow failure",
+					},
+				},
+			}, shardReport)
+		} else {
+			s.Equal(&shardscanner.ScanReport{
+				ShardID: i,
+				Stats: shardscanner.ScanStats{
+					EntitiesCount:    10,
+					CorruptedCount:   2,
+					CheckFailedCount: 1,
+					CorruptionByType: map[invariant.Name]int64{},
+				},
+				Result: shardscanner.ScanResult{
+					ShardScanKeys: &shardscanner.ScanKeys{
+						Corrupt: &store.Keys{
+							UUID:    "test_uuid",
+							MinPage: 0,
+							MaxPage: 10,
+						},
+					},
+				},
+			}, shardReport)
+		}
+	}
+
+	statusValue, err := env.QueryWorkflow(shardscanner.ShardStatusQuery, shardscanner.PaginatedShardQueryRequest{})
+	s.NoError(err)
+	var status *shardscanner.ShardStatusQueryResult
+	s.NoError(statusValue.Get(&status))
+	expected := make(map[int]shardscanner.ShardStatus)
+	for i := 0; i < 30; i++ {
+		if i == 0 || i == 1 || i == 2 || i == 15 || i == 16 || i == 17 {
+			expected[i] = shardscanner.ShardStatusControlFlowFailure
+		} else {
+			expected[i] = shardscanner.ShardStatusSuccess
+		}
+	}
+	s.Equal(shardscanner.ShardStatusResult(expected), status.Result)
+	s.True(status.ShardQueryPaginationToken.IsDone)
+	s.Nil(status.ShardQueryPaginationToken.NextShardID)
+
+	// check for paginated query result
+	statusValue, err = env.QueryWorkflow(shardscanner.ShardStatusQuery, shardscanner.PaginatedShardQueryRequest{
+		StartingShardID: common.IntPtr(5),
+		LimitShards:     common.IntPtr(10),
+	})
+	s.NoError(err)
+	status = &shardscanner.ShardStatusQueryResult{}
+	s.NoError(statusValue.Get(&status))
+	expected = make(map[int]shardscanner.ShardStatus)
+	for i := 5; i < 15; i++ {
+		if i == 0 || i == 1 || i == 2 || i == 15 || i == 16 || i == 17 {
+			expected[i] = shardscanner.ShardStatusControlFlowFailure
+		} else {
+			expected[i] = shardscanner.ShardStatusSuccess
+		}
+	}
+	s.Equal(shardscanner.ShardStatusResult(expected), status.Result)
+	s.False(status.ShardQueryPaginationToken.IsDone)
+	s.Equal(15, *status.ShardQueryPaginationToken.NextShardID)
+
+	corruptionKeysValue, err := env.QueryWorkflow(shardscanner.ShardCorruptKeysQuery, shardscanner.PaginatedShardQueryRequest{})
+	s.NoError(err)
+	var shardCorruptKeysResult *shardscanner.ShardCorruptKeysQueryResult
+	s.NoError(corruptionKeysValue.Get(&shardCorruptKeysResult))
+	expectedCorrupted := make(map[int]store.Keys)
+	for i := 0; i < 30; i++ {
+		if i != 0 && i != 1 && i != 2 && i != 15 && i != 16 && i != 17 {
+			expectedCorrupted[i] = store.Keys{
+				UUID:    "test_uuid",
+				MinPage: 0,
+				MaxPage: 10,
+			}
+		}
+	}
+	s.Equal(shardscanner.ShardCorruptKeysResult(expectedCorrupted), shardCorruptKeysResult.Result)
+}

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -24,16 +24,16 @@ import (
 	"context"
 	"time"
 
-	"github.com/uber/cadence/service/worker/scanner/executions"
-
 	"go.uber.org/cadence"
 	"go.uber.org/cadence/activity"
 	cclient "go.uber.org/cadence/client"
 	"go.uber.org/cadence/workflow"
 
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/service/worker/scanner/executions"
 	"github.com/uber/cadence/service/worker/scanner/history"
 	"github.com/uber/cadence/service/worker/scanner/tasklist"
+	"github.com/uber/cadence/service/worker/scanner/timers"
 )
 
 const (
@@ -96,7 +96,8 @@ func init() {
 	workflow.RegisterWithOptions(executions.CurrentScannerWorkflow, workflow.RegisterOptions{Name: executions.CurrentExecutionsScannerWFTypeName})
 	workflow.RegisterWithOptions(executions.ConcreteFixerWorkflow, workflow.RegisterOptions{Name: executions.ConcreteExecutionsFixerWFTypeName})
 	workflow.RegisterWithOptions(executions.CurrentFixerWorkflow, workflow.RegisterOptions{Name: executions.CurrentExecutionsFixerWFTypeName})
-
+	workflow.RegisterWithOptions(timers.ScannerWorkflow, workflow.RegisterOptions{Name: timers.ScannerWFTypeName})
+	workflow.RegisterWithOptions(timers.FixerWorkflow, workflow.RegisterOptions{Name: timers.FixerWFTypeName})
 }
 
 // TaskListScannerWorkflow is the workflow that runs the task-list scanner background daemon

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -28,8 +28,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/uber/cadence/service/worker/scanner/shardscanner"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/domain"
@@ -49,6 +47,8 @@ import (
 	"github.com/uber/cadence/service/worker/replicator"
 	"github.com/uber/cadence/service/worker/scanner"
 	"github.com/uber/cadence/service/worker/scanner/executions"
+	"github.com/uber/cadence/service/worker/scanner/shardscanner"
+	"github.com/uber/cadence/service/worker/scanner/timers"
 )
 
 type (
@@ -137,6 +137,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			ShardScanners: []*shardscanner.ScannerConfig{
 				executions.ConcreteExecutionScannerConfig(dc),
 				executions.CurrentExecutionScannerConfig(dc),
+				timers.ScannerConfig(dc),
 			},
 		},
 		BatcherCfg: &batcher.Config{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
New shard scanner which will scan periodically and will check if scheduled timers are still valid.

<!-- Tell your future self why have you made these changes -->
**Why?**
Timers can become invalid if workflow is closed before timers are fired. Cadence will fire them regardless of workflow state.
Sometimes this wastes lots of computing resources and can cause outages.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Scanner workflow:
```
 1  WorkflowExecutionStarted         {WorkflowType:{Name:cadence-sys-timers-scanner-workflow}, TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"Shards":{"List":null,"Range":{"Min":0,"Max":4}},"ScannerWorkflowConfigOverwrites":{"GenericScannerConfig":{"Enabled":
                                       null,"Concurrency":null,"PageSize":null,"BlobstoreFlushThreshold":null,"ActivityBatchSize":null},"CustomScannerConfig":n
                                       ull}}], ExecutionStartToCloseTimeoutSeconds:630720000, TaskStartToCloseTimeoutSeconds:10,
                                       ContinuedExecutionRunId:d420b40f-dcaa-4563-8964-6fc1f20f09a3, Initiator:CronSchedule,
                                       ContinuedFailureDetails:[], LastCompletionResult:[], OriginalExecutionRunId:0887af74-8bed-488f-9657-70995780e653,
                                       FirstExecutionRunId:0095bb03-bd65-4cc8-9eb4-e738448b7ed6, Attempt:0, CronSchedule:* * * * *,
                                       FirstDecisionTaskBackoffSeconds:60, PrevAutoResetPoints:{Points:[len=16]}, Header:{Fields:map{}}}
   2  DecisionTaskScheduled            {TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
   3  DecisionTaskStarted              {ScheduledEventId:2,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:698a105b-cb59-4b86-8650-369d9beaae7c}
   4  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:2, StartedEventId:3,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       BinaryChecksum:22eacb7c20e56f65c3aa6ebfade8b537}
   5  ActivityTaskScheduled            {ActivityId:0, ActivityType:{Name:cadence-sys-shardscanner-config-activity},
                                       TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"ContextKey":"cadence-sys-timers-scanner-workflow","Overwrites":{"GenericScannerConfig":{"Enabled":null,"Concurrency":
                                       null,"PageSize":null,"BlobstoreFlushThreshold":null,"ActivityBatchSize":null},"CustomScannerConfig":null}}],
                                       ScheduleToCloseTimeoutSeconds:600, ScheduleToStartTimeoutSeconds:600, StartToCloseTimeoutSeconds:300,
                                       HeartbeatTimeoutSeconds:0, DecisionTaskCompletedEventId:4, RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7,
                                       MaximumIntervalInSeconds:100, MaximumAttempts:0, NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:600},
                                       Header:{Fields:map{}}}
   6  ActivityTaskStarted              {ScheduledEventId:5,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:1f1486c0-0697-40aa-ab6b-dca98e4a7343, Attempt:0,
                                       LastFailureDetails:[]}
   7  ActivityTaskCompleted            {Result:[{"GenericScannerConfig":{"Enabled":true,"Concurrency":5,"PageSize":1000,"BlobstoreFlushThreshold":100,"ActivityBatchSiz
                                       e":25},"CustomScannerConfig":{"period_end":"3","period_start":"24"}}], ScheduledEventId:5, StartedEventId:6,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0}
   8  DecisionTaskScheduled            {TaskList:{Name:mantas-laptop:80537792-fe75-421a-a5ed-5735ae1fa663},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
   9  DecisionTaskStarted              {ScheduledEventId:8,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:3febc956-6e14-41e0-a49d-6c314b834a32}
  10  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:8, StartedEventId:9,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       BinaryChecksum:22eacb7c20e56f65c3aa6ebfade8b537}
  11  ActivityTaskScheduled            {ActivityId:1, ActivityType:{Name:cadence-sys-shardscanner-scanshard-activity},
                                       TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"Shards":[0],"PageSize":1000,"BlobstoreFlushThreshold":100,"ContextKey":"cadence-sys-timers-scanner-workflow","Scanner
                                       Config":{"period_end":"3","period_start":"24"}}], ScheduleToCloseTimeoutSeconds:172860, ScheduleToStartTimeoutSeconds:1800,
                                       StartToCloseTimeoutSeconds:172800, HeartbeatTimeoutSeconds:60, DecisionTaskCompletedEventId:10,
                                       RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7, MaximumIntervalInSeconds:100, MaximumAttempts:0,
                                       NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:172800}, Header:{Fields:map{}}}
  12  ActivityTaskScheduled            {ActivityId:2, ActivityType:{Name:cadence-sys-shardscanner-scanshard-activity},
                                       TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"Shards":[1],"PageSize":1000,"BlobstoreFlushThreshold":100,"ContextKey":"cadence-sys-timers-scanner-workflow","Scanner
                                       Config":{"period_end":"3","period_start":"24"}}], ScheduleToCloseTimeoutSeconds:172860, ScheduleToStartTimeoutSeconds:1800,
                                       StartToCloseTimeoutSeconds:172800, HeartbeatTimeoutSeconds:60, DecisionTaskCompletedEventId:10,
                                       RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7, MaximumIntervalInSeconds:100, MaximumAttempts:0,
                                       NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:172800}, Header:{Fields:map{}}}
  13  ActivityTaskScheduled            {ActivityId:3, ActivityType:{Name:cadence-sys-shardscanner-scanshard-activity},
                                       TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"Shards":[2],"PageSize":1000,"BlobstoreFlushThreshold":100,"ContextKey":"cadence-sys-timers-scanner-workflow","Scanner
                                       Config":{"period_end":"3","period_start":"24"}}], ScheduleToCloseTimeoutSeconds:172860, ScheduleToStartTimeoutSeconds:1800,
                                       StartToCloseTimeoutSeconds:172800, HeartbeatTimeoutSeconds:60, DecisionTaskCompletedEventId:10,
                                       RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7, MaximumIntervalInSeconds:100, MaximumAttempts:0,
                                       NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:172800}, Header:{Fields:map{}}}
  14  ActivityTaskScheduled            {ActivityId:4, ActivityType:{Name:cadence-sys-shardscanner-scanshard-activity},
                                       TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"Shards":[3],"PageSize":1000,"BlobstoreFlushThreshold":100,"ContextKey":"cadence-sys-timers-scanner-workflow","Scanner
                                       Config":{"period_end":"3","period_start":"24"}}], ScheduleToCloseTimeoutSeconds:172860, ScheduleToStartTimeoutSeconds:1800,
                                       StartToCloseTimeoutSeconds:172800, HeartbeatTimeoutSeconds:60, DecisionTaskCompletedEventId:10,
                                       RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7, MaximumIntervalInSeconds:100, MaximumAttempts:0,
                                       NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:172800}, Header:{Fields:map{}}}
  15  ActivityTaskStarted              {ScheduledEventId:14,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:1812c79f-2549-4c9d-9e28-eb35a4ed8917, Attempt:0,
                                       LastFailureDetails:[]}
  16  ActivityTaskCompleted            {Result:[[{"ShardID":3,"Stats":{"EntitiesCount":0,"CorruptedCount":0,"CheckFailedCount":0,"CorruptionByType":{}},"Result":{"Shar
                                       dScanKeys":{"Corrupt":null,"Failed":null},"ControlFlowFailure":null}}]], ScheduledEventId:14, StartedEventId:15,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0}
  17  DecisionTaskScheduled            {TaskList:{Name:mantas-laptop:80537792-fe75-421a-a5ed-5735ae1fa663},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
  18  ActivityTaskStarted              {ScheduledEventId:12,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:8ce9a522-5193-47ad-b87e-43adc70acfc9, Attempt:0,
                                       LastFailureDetails:[]}
  19  ActivityTaskCompleted            {Result:[[{"ShardID":1,"Stats":{"EntitiesCount":0,"CorruptedCount":0,"CheckFailedCount":0,"CorruptionByType":{}},"Result":{"Shar
                                       dScanKeys":{"Corrupt":null,"Failed":null},"ControlFlowFailure":null}}]], ScheduledEventId:12, StartedEventId:18,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0}
  20  ActivityTaskStarted              {ScheduledEventId:11,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:6034abcf-10d6-4cbc-a335-ddfbf85d4f1c, Attempt:0,
                                       LastFailureDetails:[]}
  21  ActivityTaskCompleted            {Result:[[{"ShardID":0,"Stats":{"EntitiesCount":0,"CorruptedCount":0,"CheckFailedCount":0,"CorruptionByType":{}},"Result":{"Shar
                                       dScanKeys":{"Corrupt":null,"Failed":null},"ControlFlowFailure":null}}]], ScheduledEventId:11, StartedEventId:20,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0}
  22  DecisionTaskStarted              {ScheduledEventId:17,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:bdf62dc0-290a-4e51-ab84-f4d1c5a1e523}
  23  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:17, StartedEventId:22,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       BinaryChecksum:22eacb7c20e56f65c3aa6ebfade8b537}
  24  ActivityTaskStarted              {ScheduledEventId:13,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:d855b82e-d694-4a38-befd-634981994496, Attempt:0,
                                       LastFailureDetails:[]}
  25  ActivityTaskCompleted            {Result:[[{"ShardID":2,"Stats":{"EntitiesCount":180,"CorruptedCount":180,"CheckFailedCount":0,"CorruptionByType":{"TimerInvalid"
                                       :180}},"Result":{"ShardScanKeys":{"Corrupt":{"UUID":"56fe75d6-e847-4595-a11e-6289627adab7","MinPage":0,"MaxPage":1,"Exte
                                       nsion":"corrupted"},"Failed":null},"ControlFlowFailure":null}}]], ScheduledEventId:13, StartedEventId:24,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0}
  26  DecisionTaskScheduled            {TaskList:{Name:mantas-laptop:80537792-fe75-421a-a5ed-5735ae1fa663},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
  27  DecisionTaskStarted              {ScheduledEventId:26,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:0cb91510-744d-40d6-83ec-84a6ca4f2b89}
  28  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:26, StartedEventId:27,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       BinaryChecksum:22eacb7c20e56f65c3aa6ebfade8b537}
  29  ActivityTaskScheduled            {ActivityId:5, ActivityType:{Name:cadence-sys-shardscanner-emit-metrics-activity},
                                       TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"ShardSuccessCount":4,"ShardControlFlowFailureCount":0,"AggregateReportResult":{"EntitiesCount":180,"CorruptedCount":1
                                       80,"CheckFailedCount":0,"CorruptionByType":{"TimerInvalid":180}},"ShardDistributionStats":{"Max":180,"Median":0,"Min":0,
                                       "P90":180,"P75":0,"P25":0,"P10":0},"ContextKey":"cadence-sys-timers-scanner-workflow"}], ScheduleToCloseTimeoutSeconds:600,
                                       ScheduleToStartTimeoutSeconds:600, StartToCloseTimeoutSeconds:300, HeartbeatTimeoutSeconds:0, DecisionTaskCompletedEventId:28,
                                       RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7, MaximumIntervalInSeconds:100, MaximumAttempts:0,
                                       NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:600}, Header:{Fields:map{}}}
  30  ActivityTaskStarted              {ScheduledEventId:29,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:da925b0b-0906-436b-ac69-e705e2b98a53, Attempt:0,
                                       LastFailureDetails:[]}
  31  ActivityTaskCompleted            {Result:[], ScheduledEventId:29, StartedEventId:30,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0}
  32  DecisionTaskScheduled            {TaskList:{Name:mantas-laptop:80537792-fe75-421a-a5ed-5735ae1fa663},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
  33  DecisionTaskStarted              {ScheduledEventId:32,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       RequestId:f0e3b223-2bb5-4316-809b-b9e60c0c70b5}
  34  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:32, StartedEventId:33,
                                       Identity:45248@mantas-laptop@cadence-sys-timers-scanner-tasklist-0,
                                       BinaryChecksum:22eacb7c20e56f65c3aa6ebfade8b537}
  35  WorkflowExecutionContinuedAsNew  {NewExecutionRunId:bf930715-8646-47fa-b013-674d77f648b3,
                                       WorkflowType:{Name:cadence-sys-timers-scanner-workflow}, TaskList:{Name:cadence-sys-timers-scanner-tasklist-0},
                                       Input:[{"Shards":{"List":null,"Range":{"Min":0,"Max":4}},"ScannerWorkflowConfigOverwrites":{"GenericScannerConfig":{"Enabled":
                                       null,"Concurrency":null,"PageSize":null,"BlobstoreFlushThreshold":null,"ActivityBatchSize":null},"CustomScannerConfig":n
                                       ull}}], ExecutionStartToCloseTimeoutSeconds:630720000, TaskStartToCloseTimeoutSeconds:10, DecisionTaskCompletedEventId:34,
                                       BackoffStartIntervalInSeconds:60, Initiator:CronSchedule, FailureDetails:[], LastCompletionResult:[], Header:{Fields:map{}}}
```


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Timers scanner is disabled by default, it should not cause any problems

