### PR TITLE
Delete unused dynamic configs that have no referrence anymore

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -50,6 +50,16 @@ var keys = map[Key]string{
 	testGetBoolPropertyFilteredByDomainIDKey:         "testGetBoolPropertyFilteredByDomainIDKey",
 	testGetBoolPropertyFilteredByTaskListInfoKey:     "testGetBoolPropertyFilteredByTaskListInfoKey",
 
+	// used by internal repos, need to moved out of this repo
+	// TODO https://github.com/uber/cadence/issues/3861
+	EnableAuthorization:                             "system.enableAuthorization",
+	VisibilityArchivalQueryMaxRangeInDays:           "frontend.visibilityArchivalQueryMaxRangeInDays",
+	VisibilityArchivalQueryMaxQPS:                   "frontend.visibilityArchivalQueryMaxQPS",
+	EnableArchivalCompression:                       "worker.EnableArchivalCompression",
+	WorkerTargetArchivalBlobSize:                    "worker.WorkerTargetArchivalBlobSize",
+	WorkerDeterministicConstructionCheckProbability: "worker.DeterministicConstructionCheckProbability",
+	WorkerBlobIntegrityCheckProbability:             "worker.BlobIntegrityCheckProbability",
+
 	// system settings
 	EnableGlobalDomain:                  "system.enableGlobalDomain",
 	EnableVisibilitySampling:            "system.enableVisibilitySampling",
@@ -339,6 +349,16 @@ const (
 	testGetDurationPropertyFilteredByTaskListInfoKey
 	testGetBoolPropertyFilteredByDomainIDKey
 	testGetBoolPropertyFilteredByTaskListInfoKey
+
+	// used by internal repos, need to moved out of this repo
+	// TODO https://github.com/uber/cadence/issues/3861
+	EnableAuthorization
+	VisibilityArchivalQueryMaxRangeInDays
+	VisibilityArchivalQueryMaxQPS
+	EnableArchivalCompression
+	WorkerTargetArchivalBlobSize
+	WorkerDeterministicConstructionCheckProbability
+	WorkerBlobIntegrityCheckProbability
 
 	// EnableGlobalDomain is key for enable global domain
 	EnableGlobalDomain

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -56,7 +56,6 @@ var keys = map[Key]string{
 	VisibilityArchivalQueryMaxRangeInDays:           "frontend.visibilityArchivalQueryMaxRangeInDays",
 	VisibilityArchivalQueryMaxQPS:                   "frontend.visibilityArchivalQueryMaxQPS",
 	EnableArchivalCompression:                       "worker.EnableArchivalCompression",
-	WorkerTargetArchivalBlobSize:                    "worker.WorkerTargetArchivalBlobSize",
 	WorkerDeterministicConstructionCheckProbability: "worker.DeterministicConstructionCheckProbability",
 	WorkerBlobIntegrityCheckProbability:             "worker.BlobIntegrityCheckProbability",
 
@@ -356,7 +355,6 @@ const (
 	VisibilityArchivalQueryMaxRangeInDays
 	VisibilityArchivalQueryMaxQPS
 	EnableArchivalCompression
-	WorkerTargetArchivalBlobSize
 	WorkerDeterministicConstructionCheckProbability
 	WorkerBlobIntegrityCheckProbability
 

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -289,6 +289,7 @@ var keys = map[Key]string{
 
 	WorkerPersistenceMaxQPS:                                  "worker.persistenceMaxQPS",
 	WorkerPersistenceGlobalMaxQPS:                            "worker.persistenceGlobalMaxQPS",
+	WorkerReplicationTaskMaxRetryDuration:                    "worker.replicationTaskMaxRetryDuration",
 	WorkerIndexerConcurrency:                                 "worker.indexerConcurrency",
 	WorkerESProcessorNumOfWorkers:                            "worker.ESProcessorNumOfWorkers",
 	WorkerESProcessorBulkActions:                             "worker.ESProcessorBulkActions",
@@ -758,6 +759,8 @@ const (
 	WorkerPersistenceMaxQPS
 	// WorkerPersistenceGlobalMaxQPS is the max qps worker cluster can query DB
 	WorkerPersistenceGlobalMaxQPS
+	// WorkerReplicationTaskMaxRetryDuration is the max retry duration for any task
+	WorkerReplicationTaskMaxRetryDuration
 	// WorkerIndexerConcurrency is the max concurrent messages to be processed at any given time
 	WorkerIndexerConcurrency
 	// WorkerESProcessorNumOfWorkers is num of workers for esProcessor

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -297,16 +297,6 @@ var keys = map[Key]string{
 
 	WorkerPersistenceMaxQPS:                                  "worker.persistenceMaxQPS",
 	WorkerPersistenceGlobalMaxQPS:                            "worker.persistenceGlobalMaxQPS",
-	WorkerReplicatorMetaTaskConcurrency:                      "worker.replicatorMetaTaskConcurrency",
-	WorkerReplicatorTaskConcurrency:                          "worker.replicatorTaskConcurrency",
-	WorkerReplicatorMessageConcurrency:                       "worker.replicatorMessageConcurrency",
-	WorkerReplicatorActivityBufferRetryCount:                 "worker.replicatorActivityBufferRetryCount",
-	WorkerReplicatorHistoryBufferRetryCount:                  "worker.replicatorHistoryBufferRetryCount",
-	WorkerReplicationTaskMaxRetryCount:                       "worker.replicationTaskMaxRetryCount",
-	WorkerReplicationTaskMaxRetryDuration:                    "worker.replicationTaskMaxRetryDuration",
-	WorkerReplicationTaskContextDuration:                     "worker.replicationTaskContextDuration",
-	WorkerReReplicationContextTimeout:                        "worker.workerReReplicationContextTimeout",
-	WorkerEnableReplication:                                  "worker.enableReplication",
 	WorkerIndexerConcurrency:                                 "worker.indexerConcurrency",
 	WorkerESProcessorNumOfWorkers:                            "worker.ESProcessorNumOfWorkers",
 	WorkerESProcessorBulkActions:                             "worker.ESProcessorBulkActions",
@@ -797,26 +787,8 @@ const (
 	WorkerPersistenceMaxQPS
 	// WorkerPersistenceGlobalMaxQPS is the max qps worker cluster can query DB
 	WorkerPersistenceGlobalMaxQPS
-	// WorkerReplicatorMetaTaskConcurrency is the number of coroutine handling metadata related tasks
-	WorkerReplicatorMetaTaskConcurrency
-	// WorkerReplicatorTaskConcurrency is the number of coroutine handling non metadata related tasks
-	WorkerReplicatorTaskConcurrency
-	// WorkerReplicatorMessageConcurrency is the max concurrent tasks provided by messaging client
-	WorkerReplicatorMessageConcurrency
-	// WorkerReplicatorActivityBufferRetryCount is the retry attempt when encounter retry error on activity
-	WorkerReplicatorActivityBufferRetryCount
-	// WorkerReplicatorHistoryBufferRetryCount is the retry attempt when encounter retry error on history
-	WorkerReplicatorHistoryBufferRetryCount
-	// WorkerReplicationTaskMaxRetryCount is the max retry count for any task
-	WorkerReplicationTaskMaxRetryCount
 	// WorkerReplicationTaskMaxRetryDuration is the max retry duration for any task
 	WorkerReplicationTaskMaxRetryDuration
-	// WorkerReplicationTaskContextDuration is the context timeout for apply replication tasks
-	WorkerReplicationTaskContextDuration
-	// WorkerReReplicationContextTimeout is the context timeout for end to end  re-replication process
-	WorkerReReplicationContextTimeout
-	// WorkerEnableReplication is the feature flag for kafka replication
-	WorkerEnableReplication
 	// WorkerIndexerConcurrency is the max concurrent messages to be processed at any given time
 	WorkerIndexerConcurrency
 	// WorkerESProcessorNumOfWorkers is num of workers for esProcessor

--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -52,7 +52,6 @@ var keys = map[Key]string{
 
 	// system settings
 	EnableGlobalDomain:                  "system.enableGlobalDomain",
-	EnableNewKafkaClient:                "system.enableNewKafkaClient",
 	EnableVisibilitySampling:            "system.enableVisibilitySampling",
 	EnableReadFromClosedExecutionV2:     "system.enableReadFromClosedExecutionV2",
 	AdvancedVisibilityWritingMode:       "system.advancedVisibilityWritingMode",
@@ -73,7 +72,6 @@ var keys = map[Key]string{
 	EnableFailoverManager:               "system.enableFailoverManager",
 	EnableStickyQuery:                   "system.enableStickyQuery",
 	EnablePriorityTaskProcessor:         "system.enablePriorityTaskProcessor",
-	EnableAuthorization:                 "system.enableAuthorization",
 
 	// size limit
 	BlobSizeLimitError:      "limit.blobSize.error",
@@ -113,8 +111,6 @@ var keys = map[Key]string{
 	SearchAttributesSizeOfValueLimit:            "frontend.searchAttributesSizeOfValueLimit",
 	SearchAttributesTotalSizeLimit:              "frontend.searchAttributesTotalSizeLimit",
 	VisibilityArchivalQueryMaxPageSize:          "frontend.visibilityArchivalQueryMaxPageSize",
-	VisibilityArchivalQueryMaxRangeInDays:       "frontend.visibilityArchivalQueryMaxRangeInDays",
-	VisibilityArchivalQueryMaxQPS:               "frontend.visibilityArchivalQueryMaxQPS",
 	DomainFailoverRefreshInterval:               "frontend.domainFailoverRefreshInterval",
 	DomainFailoverRefreshTimerJitterCoefficient: "frontend.domainFailoverRefreshTimerJitterCoefficient",
 	FrontendErrorInjectionRate:                  "frontend.errorInjectionRate",
@@ -197,7 +193,6 @@ var keys = map[Key]string{
 	TimerTaskMaxRetryCount:                                "history.timerTaskMaxRetryCount",
 	TimerProcessorGetFailureRetryCount:                    "history.timerProcessorGetFailureRetryCount",
 	TimerProcessorCompleteTimerFailureRetryCount:          "history.timerProcessorCompleteTimerFailureRetryCount",
-	TimerProcessorUpdateShardTaskCount:                    "history.timerProcessorUpdateShardTaskCount",
 	TimerProcessorUpdateAckInterval:                       "history.timerProcessorUpdateAckInterval",
 	TimerProcessorUpdateAckIntervalJitterCoefficient:      "history.timerProcessorUpdateAckIntervalJitterCoefficient",
 	TimerProcessorCompleteTimerInterval:                   "history.timerProcessorCompleteTimerInterval",
@@ -219,7 +214,6 @@ var keys = map[Key]string{
 	TransferTaskWorkerCount:                               "history.transferTaskWorkerCount",
 	TransferTaskMaxRetryCount:                             "history.transferTaskMaxRetryCount",
 	TransferProcessorCompleteTransferFailureRetryCount:    "history.transferProcessorCompleteTransferFailureRetryCount",
-	TransferProcessorUpdateShardTaskCount:                 "history.transferProcessorUpdateShardTaskCount",
 	TransferProcessorMaxPollInterval:                      "history.transferProcessorMaxPollInterval",
 	TransferProcessorMaxPollIntervalJitterCoefficient:     "history.transferProcessorMaxPollIntervalJitterCoefficient",
 	TransferProcessorSplitQueueInterval:                   "history.transferProcessorSplitQueueInterval",
@@ -236,7 +230,6 @@ var keys = map[Key]string{
 	ReplicatorReadTaskMaxRetryCount:                       "history.replicatorReadTaskMaxRetryCount",
 	ReplicatorTaskMaxRetryCount:                           "history.replicatorTaskMaxRetryCount",
 	ReplicatorProcessorMaxPollRPS:                         "history.replicatorProcessorMaxPollRPS",
-	ReplicatorProcessorUpdateShardTaskCount:               "history.replicatorProcessorUpdateShardTaskCount",
 	ReplicatorProcessorMaxPollInterval:                    "history.replicatorProcessorMaxPollInterval",
 	ReplicatorProcessorMaxPollIntervalJitterCoefficient:   "history.replicatorProcessorMaxPollIntervalJitterCoefficient",
 	ReplicatorProcessorUpdateAckInterval:                  "history.replicatorProcessorUpdateAckInterval",
@@ -249,7 +242,6 @@ var keys = map[Key]string{
 	MaximumSignalsPerExecution:                            "history.maximumSignalsPerExecution",
 	ShardUpdateMinInterval:                                "history.shardUpdateMinInterval",
 	ShardSyncMinInterval:                                  "history.shardSyncMinInterval",
-	ShardSyncTimerJitterCoefficient:                       "history.shardSyncMinInterval",
 	DefaultEventEncoding:                                  "history.defaultEventEncoding",
 	EnableAdminProtection:                                 "history.enableAdminProtection",
 	AdminOperationToken:                                   "history.adminOperationToken",
@@ -302,13 +294,8 @@ var keys = map[Key]string{
 	WorkerESProcessorBulkActions:                             "worker.ESProcessorBulkActions",
 	WorkerESProcessorBulkSize:                                "worker.ESProcessorBulkSize",
 	WorkerESProcessorFlushInterval:                           "worker.ESProcessorFlushInterval",
-	EnableArchivalCompression:                                "worker.EnableArchivalCompression",
-	WorkerHistoryPageSize:                                    "worker.WorkerHistoryPageSize",
-	WorkerTargetArchivalBlobSize:                             "worker.WorkerTargetArchivalBlobSize",
 	WorkerArchiverConcurrency:                                "worker.ArchiverConcurrency",
 	WorkerArchivalsPerIteration:                              "worker.ArchivalsPerIteration",
-	WorkerDeterministicConstructionCheckProbability:          "worker.DeterministicConstructionCheckProbability",
-	WorkerBlobIntegrityCheckProbability:                      "worker.BlobIntegrityCheckProbability",
 	WorkerTimeLimitPerArchivalIteration:                      "worker.TimeLimitPerArchivalIteration",
 	WorkerThrottledLogRPS:                                    "worker.throttledLogRPS",
 	ScannerPersistenceMaxQPS:                                 "worker.scannerPersistenceMaxQPS",
@@ -354,8 +341,6 @@ const (
 
 	// EnableGlobalDomain is key for enable global domain
 	EnableGlobalDomain
-	// EnableNewKafkaClient is key for using New Kafka client
-	EnableNewKafkaClient
 	// EnableVisibilitySampling is key for enable visibility sampling
 	EnableVisibilitySampling
 	// EnableReadFromClosedExecutionV2 is key for enable read from cadence_visibility.closed_executions_v2
@@ -393,8 +378,6 @@ const (
 	DisallowQuery
 	// EnablePriorityTaskProcessor is the key for enabling priority task processor
 	EnablePriorityTaskProcessor
-	// EnableAuthorization is the key to enable authorization for a domain
-	EnableAuthorization
 
 	// BlobSizeLimitError is the per event blob size limit
 	BlobSizeLimitError
@@ -470,10 +453,6 @@ const (
 	SearchAttributesTotalSizeLimit
 	// VisibilityArchivalQueryMaxPageSize is the maximum page size for a visibility archival query
 	VisibilityArchivalQueryMaxPageSize
-	// VisibilityArchivalQueryMaxRangeInDays is the maximum number of days for a visibility archival query
-	VisibilityArchivalQueryMaxRangeInDays
-	// VisibilityArchivalQueryMaxQPS is the timeout for a visibility archival query
-	VisibilityArchivalQueryMaxQPS
 
 	// DomainFailoverRefreshInterval is the domain failover refresh timer
 	DomainFailoverRefreshInterval
@@ -638,8 +617,6 @@ const (
 	TimerProcessorGetFailureRetryCount
 	// TimerProcessorCompleteTimerFailureRetryCount is retry count for timer processor complete timer operation
 	TimerProcessorCompleteTimerFailureRetryCount
-	// TimerProcessorUpdateShardTaskCount is update shard count for timer processor
-	TimerProcessorUpdateShardTaskCount
 	// TimerProcessorUpdateAckInterval is update interval for timer processor
 	TimerProcessorUpdateAckInterval
 	// TimerProcessorUpdateAckIntervalJitterCoefficient is the update interval jitter coefficient
@@ -682,8 +659,6 @@ const (
 	TransferTaskMaxRetryCount
 	// TransferProcessorCompleteTransferFailureRetryCount is times of retry for failure
 	TransferProcessorCompleteTransferFailureRetryCount
-	// TransferProcessorUpdateShardTaskCount is update shard count for transferQueueProcessor
-	TransferProcessorUpdateShardTaskCount
 	// TransferProcessorMaxPollInterval max poll interval for transferQueueProcessor
 	TransferProcessorMaxPollInterval
 	// TransferProcessorMaxPollIntervalJitterCoefficient is the max poll interval jitter coefficient
@@ -716,8 +691,6 @@ const (
 	ReplicatorTaskMaxRetryCount
 	// ReplicatorProcessorMaxPollRPS is max poll rate per second for ReplicatorProcessor
 	ReplicatorProcessorMaxPollRPS
-	// ReplicatorProcessorUpdateShardTaskCount is update shard count for ReplicatorProcessor
-	ReplicatorProcessorUpdateShardTaskCount
 	// ReplicatorProcessorMaxPollInterval is max poll interval for ReplicatorProcessor
 	ReplicatorProcessorMaxPollInterval
 	// ReplicatorProcessorMaxPollIntervalJitterCoefficient is the max poll interval jitter coefficient
@@ -742,8 +715,6 @@ const (
 	ShardUpdateMinInterval
 	// ShardSyncMinInterval is the minimal time interval which the shard info should be sync to remote
 	ShardSyncMinInterval
-	// ShardSyncTimerJitterCoefficient is the sync shard jitter coefficient
-	ShardSyncTimerJitterCoefficient
 	// DefaultEventEncoding is the encoding type for history events
 	DefaultEventEncoding
 	// NumArchiveSystemWorkflows is key for number of archive system workflows running in total
@@ -787,8 +758,6 @@ const (
 	WorkerPersistenceMaxQPS
 	// WorkerPersistenceGlobalMaxQPS is the max qps worker cluster can query DB
 	WorkerPersistenceGlobalMaxQPS
-	// WorkerReplicationTaskMaxRetryDuration is the max retry duration for any task
-	WorkerReplicationTaskMaxRetryDuration
 	// WorkerIndexerConcurrency is the max concurrent messages to be processed at any given time
 	WorkerIndexerConcurrency
 	// WorkerESProcessorNumOfWorkers is num of workers for esProcessor
@@ -799,20 +768,10 @@ const (
 	WorkerESProcessorBulkSize
 	// WorkerESProcessorFlushInterval is flush interval for esProcessor
 	WorkerESProcessorFlushInterval
-	// EnableArchivalCompression indicates whether blobs are compressed before they are archived
-	EnableArchivalCompression
-	// WorkerHistoryPageSize indicates the page size of history fetched from persistence for archival
-	WorkerHistoryPageSize
-	// WorkerTargetArchivalBlobSize indicates the target blob size in bytes for archival, actual blob size may vary
-	WorkerTargetArchivalBlobSize
 	// WorkerArchiverConcurrency controls the number of coroutines handling archival work per archival workflow
 	WorkerArchiverConcurrency
 	// WorkerArchivalsPerIteration controls the number of archivals handled in each iteration of archival workflow
 	WorkerArchivalsPerIteration
-	// WorkerDeterministicConstructionCheckProbability controls the probability of running a deterministic construction check for any given archival
-	WorkerDeterministicConstructionCheckProbability
-	// WorkerBlobIntegrityCheckProbability controls the probability of running an integrity check for any given archival
-	WorkerBlobIntegrityCheckProbability
 	// WorkerTimeLimitPerArchivalIteration controls the time limit of each iteration of archival workflow
 	WorkerTimeLimitPerArchivalIteration
 	// WorkerThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Delete unused dynamic config for XDC.
Those configs have no referrence anymore across the code base.
If they are referred in the internal repo for internal implementation, we should define them in the internal repos. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Not being used anymore
Based on comment in https://github.com/uber/cadence-docs/pull/14

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
