### PR TITLE
Allow using Kafka TLS without cert ca and key 

### DIFF
--- a/common/messaging/kafka/clientImpl.go
+++ b/common/messaging/kafka/clientImpl.go
@@ -175,19 +175,26 @@ func convertTLSConfig(tlsConfig auth.TLS) (*tls.Config, error) {
 		return nil, nil
 	}
 
-	cert, err := tls.LoadX509KeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
-	if err != nil {
-		return nil, err
-	}
-	caCertPool := x509.NewCertPool()
-	pemData, err := ioutil.ReadFile(tlsConfig.CaFile)
-	if err != nil {
-		return nil, err
-	}
-	caCertPool.AppendCertsFromPEM(pemData)
+	if tlsConfig.CertFile != "" && tlsConfig.CaFile != "" && tlsConfig.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(tlsConfig.CertFile, tlsConfig.KeyFile)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool := x509.NewCertPool()
+		pemData, err := ioutil.ReadFile(tlsConfig.CaFile)
+		if err != nil {
+			return nil, err
+		}
+		caCertPool.AppendCertsFromPEM(pemData)
 
-	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		RootCAs:      caCertPool,
-	}, nil
+		return &tls.Config{
+			Certificates:       []tls.Certificate{cert},
+			RootCAs:            caCertPool,
+			InsecureSkipVerify: !tlsConfig.EnableHostVerification,
+		}, nil
+	} else {
+		return &tls.Config{
+			InsecureSkipVerify: !tlsConfig.EnableHostVerification,
+		}, nil
+	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow using Kafka TLS without cert ca and key 

<!-- Tell your future self why have you made these changes -->
**Why?**
This is to align with the Kafka client samples: https://github.com/Shopify/sarama/blob/0616f68815691527d3b6ab4d95a2881e09400fe3/examples/sasl_scram_client/main.go#L41
We have community users that need to connect to Kafka in this way.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested by community users.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minimal: see https://docs.google.com/document/d/1wbDyZyYkZ17LtxrevZn9uNzy6FkePgUk1ifPEQGS5ts/edit#
