### PR TITLE
Add more options to config_template for docker image and disable archival by default

### DIFF
--- a/common/service/config/archival.go
+++ b/common/service/config/archival.go
@@ -22,7 +22,6 @@ package config
 
 import (
 	"errors"
-
 	"github.com/uber/cadence/common"
 )
 
@@ -50,6 +49,6 @@ func isArchivalConfigValid(
 	URISet := len(domianDefaultURI) != 0
 
 	validEnable := archivalEnabled && URISet && specifiedProvider
-	validDisabled := !archivalEnabled && !enableRead && domainDefaultStatus != common.ArchivalEnabled && !URISet && !specifiedProvider
+	validDisabled := !archivalEnabled && !enableRead && domainDefaultStatus != common.ArchivalEnabled && !URISet
 	return validEnable || validDisabled
 }

--- a/common/service/config/archival.go
+++ b/common/service/config/archival.go
@@ -22,7 +22,6 @@ package config
 
 import (
 	"errors"
-
 	"github.com/uber/cadence/common"
 )
 

--- a/common/service/config/archival.go
+++ b/common/service/config/archival.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"errors"
+	
 	"github.com/uber/cadence/common"
 )
 

--- a/common/service/config/archival.go
+++ b/common/service/config/archival.go
@@ -22,7 +22,7 @@ package config
 
 import (
 	"errors"
-	
+
 	"github.com/uber/cadence/common"
 )
 

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -211,28 +211,28 @@ dcRedirectionPolicy:
 
 archival:
   history:
-    status: {{ default .Env.HISTORY_ARCHIVAL "disabled" }}
-    enableRead: true
+    status: {{ default .Env.HISTORY_ARCHIVAL_STATUS "disabled" }}
+    enableRead: {{ default .Env.HISTORY_ARCHIVAL_ENABLE_READ "false" }}
     provider:
       filestore:
-        fileMode: "0666"
-        dirMode: "0766"
+        fileMode: {{ default .Env.HISTORY_ARCHIVAL_FILE_MODE }}
+        dirMode: {{ default .Env.HISTORY_ARCHIVAL_DIR_MODE }}
   visibility:
-    status: {{ default .Env.VISIBILITY_ARCHIVAL "disabled" }}
-    enableRead: true
+    status: {{ default .Env.VISIBILITY_ARCHIVAL_STATUS "disabled" }}
+    enableRead: {{ default .Env.VISIBILITY_ARCHIVAL_ENABLE_READ "false" }}
     provider:
       filestore:
-        fileMode: "0666"
-        dirMode: "0766"
+        fileMode: {{ default .Env.VISIBILITY_ARCHIVAL_FILE_MODE "" }}
+        dirMode: {{ default .Env.VISIBILITY_ARCHIVAL_DIR_MODE "" }}
 
 domainDefaults:
   archival:
     history:
-      status: {{ default .Env.HISTORY_ARCHIVAL "disabled" }}
-      URI: "file:///tmp/cadence_archival/development"
+      status: {{ default .Env.DOMAIN_DEFAULTS_HISTORY_ARCHIVAL_STATUS "disabled" }}
+      URI: {{ default .Env.DOMAIN_DEFAULTS_HISTORY_ARCHIVAL_URI "" }}
     visibility:
-      status: {{ default .Env.VISIBILITY_ARCHIVAL "disabled" }}
-      URI: "file:///tmp/cadence_vis_archival/development"
+      status: {{ default .Env.DOMAIN_DEFAULTS_VISIBILITY_ARCHIVAL_STATUS "disabled" }}
+      URI: {{ default .Env.DOMAIN_DEFAULTS_VISIBILITY_ARCHIVAL_URI "" }}
 
 kafka:
     tls:
@@ -260,4 +260,4 @@ dynamicConfigClient:
 
 blobstore:
   filestore:
-    outputDirectory: {{ default .Env.FILE_BLOB_STORE_OUTPUT_DIRECTYORY "/tmp/blobstore" }}
+    outputDirectory: {{ default .Env.FILE_BLOB_STORE_OUTPUT_DIRECTYORY "" }}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -194,31 +194,31 @@ services:
         {{- end }}
 
 clusterMetadata:
-    enableGlobalDomain: false
+    enableGlobalDomain: {{ default .Env.ENABLE_GLOBAL_DOMAIN false }}
     failoverVersionIncrement: 10
-    masterClusterName: "active"
-    currentClusterName: "active"
+    masterClusterName: "master"
+    currentClusterName: "master"
     clusterInformation:
-        active:
+        master:
             enabled: true
             initialFailoverVersion: 0
             rpcName: "cadence-frontend"
             rpcAddress: "127.0.0.1:7933"
 
 dcRedirectionPolicy:
-    policy: "noop"
+    policy: {{ default .Env.DC_REDIRECT_POLICY "selected-apis-forwarding" }}
     toDC: ""
 
 archival:
   history:
-    status: "enabled"
+    status: {{ default .Env.HISTORY_ARCHIVAL "disabled" }}
     enableRead: true
     provider:
       filestore:
         fileMode: "0666"
         dirMode: "0766"
   visibility:
-    status: "enabled"
+    status: {{ default .Env.VISIBILITY_ARCHIVAL "disabled" }}
     enableRead: true
     provider:
       filestore:
@@ -228,10 +228,10 @@ archival:
 domainDefaults:
   archival:
     history:
-      status: "enabled"
+      status: {{ default .Env.HISTORY_ARCHIVAL "disabled" }}
       URI: "file:///tmp/cadence_archival/development"
     visibility:
-      status: "enabled"
+      status: {{ default .Env.VISIBILITY_ARCHIVAL "disabled" }}
       URI: "file:///tmp/cadence_vis_archival/development"
 
 kafka:
@@ -260,4 +260,4 @@ dynamicConfigClient:
 
 blobstore:
   filestore:
-    outputDirectory: "/tmp/blobstore"
+    outputDirectory: {{ default .Env.FILE_BLOB_STORE_OUTPUT_DIRECTYORY "/tmp/blobstore" }}

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -194,7 +194,7 @@ services:
         {{- end }}
 
 clusterMetadata:
-    enableGlobalDomain: {{ default .Env.ENABLE_GLOBAL_DOMAIN false }}
+    enableGlobalDomain: {{ default .Env.ENABLE_GLOBAL_DOMAIN "false" }}
     failoverVersionIncrement: 10
     masterClusterName: "master"
     currentClusterName: "master"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -215,8 +215,8 @@ archival:
     enableRead: {{ default .Env.HISTORY_ARCHIVAL_ENABLE_READ "false" }}
     provider:
       filestore:
-        fileMode: {{ default .Env.HISTORY_ARCHIVAL_FILE_MODE }}
-        dirMode: {{ default .Env.HISTORY_ARCHIVAL_DIR_MODE }}
+        fileMode: {{ default .Env.HISTORY_ARCHIVAL_FILE_MODE "" }}
+        dirMode: {{ default .Env.HISTORY_ARCHIVAL_DIR_MODE "" }}
   visibility:
     status: {{ default .Env.VISIBILITY_ARCHIVAL_STATUS "disabled" }}
     enableRead: {{ default .Env.VISIBILITY_ARCHIVAL_ENABLE_READ "false" }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
for https://github.com/uber/cadence/issues/3870
1. Disable archival by default in `docker run`
2. Add more options to config_template for docker image

<!-- Tell your future self why have you made these changes -->
**Why?**
It's impossible now to change or disable config like archival when using `docker run`. That's not a problem in helm chart because Helm chart already override it. https://github.com/banzaicloud/banzai-charts/blob/master/cadence/templates/server-configmap.yaml#L159  However, there are some users not in K8s yet, they are still using `docker run` to start cadence. For those users, most of them need to disable archival to save the disk space.
 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
External user that rely on disk based archival from raw docker image will be broken, and they have to explicitly passing in parameter in `docker run` to enable it back.
It's very unlikely that people will rely on that, but we need to clarify it in our release note that from this change, the local file based archival is disabled by default. If anyone wants to enable it, they should pass in the parameters in `docker run` command. Helm charts has disabled it by default. 
