### PR TITLE
Task processing debug logs

### DIFF
--- a/common/service/dynamicconfig/constants.go
+++ b/common/service/dynamicconfig/constants.go
@@ -81,6 +81,7 @@ var keys = map[Key]string{
 	EnableFailoverManager:               "system.enableFailoverManager",
 	EnableStickyQuery:                   "system.enableStickyQuery",
 	EnablePriorityTaskProcessor:         "system.enablePriorityTaskProcessor",
+	EnableDebugMode:                     "system.enableDebugMode",
 
 	// size limit
 	BlobSizeLimitError:      "limit.blobSize.error",
@@ -147,6 +148,7 @@ var keys = map[Key]string{
 	MatchingForwarderMaxChildrenPerNode:     "matching.forwarderMaxChildrenPerNode",
 	MatchingShutdownDrainDuration:           "matching.shutdownDrainDuration",
 	MatchingErrorInjectionRate:              "matching.errorInjectionRate",
+	MatchingEnableTaskInfoLogByDomainID:     "matching.enableTaskInfoLogByDomainID",
 
 	// history settings
 	HistoryRPS:                                            "history.rps",
@@ -295,6 +297,7 @@ var keys = map[Key]string{
 	EnableDropStuckTaskByDomainID:                         "history.DropStuckTaskByDomain",
 	EnableActivityLocalDispatchByDomain:                   "history.enableActivityLocalDispatchByDomain",
 	HistoryErrorInjectionRate:                             "history.errorInjectionRate",
+	HistoryEnableTaskInfoLogByDomainID:                    "history.enableTaskInfoLogByDomainID",
 
 	WorkerPersistenceMaxQPS:                                  "worker.persistenceMaxQPS",
 	WorkerPersistenceGlobalMaxQPS:                            "worker.persistenceGlobalMaxQPS",
@@ -413,6 +416,8 @@ const (
 	DisallowQuery
 	// EnablePriorityTaskProcessor is the key for enabling priority task processor
 	EnablePriorityTaskProcessor
+	// EnableDebugMode is the key for enabling debugging components, logs and metrics
+	EnableDebugMode
 
 	// BlobSizeLimitError is the per event blob size limit
 	BlobSizeLimitError
@@ -543,6 +548,8 @@ const (
 	MatchingShutdownDrainDuration
 	// MatchingErrorInjectionRate is the rate for injecting random error in matching client
 	MatchingErrorInjectionRate
+	// MatchingEnableTaskInfoLogByDomainID enables info level logs for decision/activity task based on the request domainID
+	MatchingEnableTaskInfoLogByDomainID
 
 	// key for history
 
@@ -786,6 +793,9 @@ const (
 
 	// HistoryErrorInjectionRate is the rate for injecting random error in history client
 	HistoryErrorInjectionRate
+
+	// HistoryEnableTaskInfoLogByDomainID enables info level logs for decision/activity task based on the request domainID
+	HistoryEnableTaskInfoLogByDomainID
 
 	// key for worker
 

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -251,16 +251,20 @@ type Config struct {
 	MutableStateChecksumVerifyProbability dynamicconfig.IntPropertyFnWithDomainFilter
 	MutableStateChecksumInvalidateBefore  dynamicconfig.FloatPropertyFn
 
-	//Cross DC Replication configuration
+	// Cross DC Replication configuration
 	ReplicationEventsFromCurrentCluster dynamicconfig.BoolPropertyFnWithDomainFilter
 
-	//Failover marker heartbeat
+	// Failover marker heartbeat
 	NotifyFailoverMarkerInterval               dynamicconfig.DurationPropertyFn
 	NotifyFailoverMarkerTimerJitterCoefficient dynamicconfig.FloatPropertyFn
 	EnableGracefulFailover                     dynamicconfig.BoolPropertyFn
 
 	// Allows worker to dispatch activity tasks through local tunnel after decisions are made. This is an performance optimization to skip activity scheduling efforts.
 	EnableActivityLocalDispatchByDomain dynamicconfig.BoolPropertyFnWithDomainFilter
+
+	// Debugging configurations
+	EnableDebugMode             bool // note that this value is initialized once on service start
+	EnableTaskInfoLogByDomainID dynamicconfig.BoolPropertyFnWithDomainIDFilter
 }
 
 const (
@@ -476,6 +480,9 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		EnableGracefulFailover:                     dc.GetBoolProperty(dynamicconfig.EnableGracefulFailover, false),
 
 		EnableActivityLocalDispatchByDomain: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableActivityLocalDispatchByDomain, false),
+
+		EnableDebugMode:             dc.GetBoolProperty(dynamicconfig.EnableDebugMode, false)(),
+		EnableTaskInfoLogByDomainID: dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.HistoryEnableTaskInfoLogByDomainID, false),
 	}
 
 	return cfg

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -325,6 +325,16 @@ func (h *handlerImpl) RecordActivityTaskStarted(
 	domainID := recordRequest.GetDomainUUID()
 	workflowExecution := recordRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowID()
+
+	h.emitInfoOrDebugLog(
+		domainID,
+		"RecordActivityTaskStarted",
+		tag.WorkflowDomainID(domainID),
+		tag.WorkflowID(workflowExecution.GetWorkflowID()),
+		tag.WorkflowRunID(common.StringDefault(recordRequest.WorkflowExecution.RunID)),
+		tag.WorkflowScheduleID(recordRequest.GetScheduleID()),
+	)
+
 	if recordRequest.GetDomainUUID() == "" {
 		return nil, h.error(errDomainNotSet, scope, domainID, workflowID)
 	}
@@ -354,11 +364,6 @@ func (h *handlerImpl) RecordDecisionTaskStarted(
 
 	defer log.CapturePanic(h.GetLogger(), &retError)
 	h.startWG.Wait()
-	h.GetLogger().Debug(fmt.Sprintf("RecordDecisionTaskStarted. DomainID: %v, WorkflowID: %v, RunID: %v, ScheduleID: %v",
-		recordRequest.GetDomainUUID(),
-		recordRequest.WorkflowExecution.GetWorkflowID(),
-		common.StringDefault(recordRequest.WorkflowExecution.RunID),
-		recordRequest.GetScheduleID()))
 
 	scope := metrics.HistoryRecordDecisionTaskStartedScope
 	h.GetMetricsClient().IncCounter(scope, metrics.CadenceRequests)
@@ -368,6 +373,16 @@ func (h *handlerImpl) RecordDecisionTaskStarted(
 	domainID := recordRequest.GetDomainUUID()
 	workflowExecution := recordRequest.WorkflowExecution
 	workflowID := workflowExecution.GetWorkflowID()
+
+	h.emitInfoOrDebugLog(
+		domainID,
+		"RecordDecisionTaskStarted",
+		tag.WorkflowDomainID(domainID),
+		tag.WorkflowID(workflowExecution.GetWorkflowID()),
+		tag.WorkflowRunID(common.StringDefault(recordRequest.WorkflowExecution.RunID)),
+		tag.WorkflowScheduleID(recordRequest.GetScheduleID()),
+	)
+
 	if domainID == "" {
 		return nil, h.error(errDomainNotSet, scope, domainID, workflowID)
 	}
@@ -2005,6 +2020,18 @@ func (h *handlerImpl) getLoggerWithTags(
 	}
 
 	return logger
+}
+
+func (h *handlerImpl) emitInfoOrDebugLog(
+	domainID string,
+	msg string,
+	tags ...tag.Tag,
+) {
+	if h.config.EnableDebugMode && h.config.EnableTaskInfoLogByDomainID(domainID) {
+		h.GetLogger().Info(msg, tags...)
+	} else {
+		h.GetLogger().Debug(msg, tags...)
+	}
 }
 
 func validateTaskToken(token *common.TaskToken) error {

--- a/service/history/task/event_logger.go
+++ b/service/history/task/event_logger.go
@@ -77,7 +77,7 @@ func (e *eventLoggerImpl) AddEvent(
 		details:   details,
 	}
 
-	e.nextEventIdx = (e.nextEventIdx + 1) % len(e.events)
+	e.nextEventIdx = (e.nextEventIdx + 1) % e.maxSize
 }
 
 func (e *eventLoggerImpl) FlushEvents(

--- a/service/history/task/event_logger.go
+++ b/service/history/task/event_logger.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2017-2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package task
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+)
+
+type (
+	eventLogger interface {
+		AddEvent(eventMsg string, details ...interface{})
+		FlushEvents(msg string) int
+	}
+
+	event struct {
+		timestamp time.Time
+		message   string
+		details   []interface{}
+	}
+
+	eventLoggerImpl struct {
+		logger     log.Logger
+		timeSource clock.TimeSource
+
+		events       []event
+		nextEventIdx int
+		maxSize      int
+	}
+)
+
+func newEventLogger(
+	logger log.Logger,
+	timeSource clock.TimeSource,
+	maxSize int,
+) eventLogger {
+	return &eventLoggerImpl{
+		logger:     logger,
+		timeSource: timeSource,
+
+		events:       make([]event, maxSize),
+		nextEventIdx: 0,
+		maxSize:      maxSize,
+	}
+}
+
+func (e *eventLoggerImpl) AddEvent(
+	eventMsg string,
+	details ...interface{},
+) {
+	e.events[e.nextEventIdx] = event{
+		timestamp: e.timeSource.Now(),
+		message:   eventMsg,
+		details:   details,
+	}
+
+	e.nextEventIdx = (e.nextEventIdx + 1) % len(e.events)
+}
+
+func (e *eventLoggerImpl) FlushEvents(
+	msg string,
+) int {
+	var builder strings.Builder
+	eventIdx := e.nextEventIdx
+	eventsFlushed := 0
+
+	for i := 0; i != len(e.events); i++ {
+		// dump all events in reverse order
+		eventIdx--
+		if eventIdx < 0 {
+			eventIdx = len(e.events) - 1
+		}
+
+		event := e.events[eventIdx]
+		if event.timestamp.IsZero() {
+			break
+		}
+
+		eventsFlushed++
+		builder.WriteString(fmt.Sprintf("%v, %s, %v\n", event.timestamp, event.message, event.details))
+	}
+
+	e.logger.Info(msg, tag.Key("events"), tag.Value(builder.String()))
+
+	e.events = make([]event, e.maxSize)
+
+	return eventsFlushed
+}

--- a/service/history/task/event_logger_test.go
+++ b/service/history/task/event_logger_test.go
@@ -1,0 +1,92 @@
+// Copyright (c) 2017-2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package task
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log"
+)
+
+type (
+	eventLoggerSuite struct {
+		*require.Assertions
+		suite.Suite
+
+		mockLogger *log.MockLogger
+
+		eventLogger *eventLoggerImpl
+	}
+)
+
+func TestEventLoggerSuite(t *testing.T) {
+	s := new(eventLoggerSuite)
+	suite.Run(t, s)
+}
+
+func (s *eventLoggerSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.mockLogger = &log.MockLogger{}
+
+	s.eventLogger = newEventLogger(
+		s.mockLogger,
+		clock.NewRealTimeSource(),
+		defaultTaskEventLoggerSize,
+	).(*eventLoggerImpl)
+}
+
+func (s *eventLoggerSuite) TearDownTest() {
+	s.mockLogger.AssertExpectations(s.T())
+}
+
+func (s *eventLoggerSuite) TestAddEvent() {
+	for i := 0; i != defaultTaskEventLoggerSize*2; i++ {
+		s.eventLogger.AddEvent("some random event", i)
+		s.Equal((i+1)%defaultTaskEventLoggerSize, s.eventLogger.nextEventIdx)
+	}
+
+	for i := 0; i != defaultTaskEventLoggerSize; i++ {
+		// check if old events got overwritten
+		s.Equal(i+defaultTaskEventLoggerSize, s.eventLogger.events[i].details[0])
+	}
+
+	s.Len(s.eventLogger.events, defaultTaskEventLoggerSize)
+}
+
+func (s *eventLoggerSuite) TestFlushEvents() {
+	for _, numEvents := range []int{0, defaultTaskEventLoggerSize / 2, defaultTaskEventLoggerSize, defaultTaskEventLoggerSize * 2} {
+		for i := 0; i != numEvents; i++ {
+			s.eventLogger.AddEvent("some random event")
+		}
+
+		expectedEventsFlushed := common.MinInt(numEvents, defaultTaskEventLoggerSize)
+		s.mockLogger.On("Info", mock.Anything, mock.Anything, mock.Anything).Times(1)
+
+		s.Equal(expectedEventsFlushed, s.eventLogger.FlushEvents("some random message"))
+	}
+}

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -60,6 +60,10 @@ type (
 		MaxTaskBatchSize                dynamicconfig.IntPropertyFnWithTaskListInfoFilters
 
 		ThrottledLogRPS dynamicconfig.IntPropertyFn
+
+		// debugging configuration
+		EnableDebugMode             bool // note that this value is initialized once on service start
+		EnableTaskInfoLogByDomainID dynamicconfig.BoolPropertyFnWithDomainIDFilter
 	}
 
 	forwarderConfig struct {
@@ -114,6 +118,8 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		ForwarderMaxRatePerSecond:       dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingForwarderMaxRatePerSecond, 10),
 		ForwarderMaxChildrenPerNode:     dc.GetIntPropertyFilteredByTaskListInfo(dynamicconfig.MatchingForwarderMaxChildrenPerNode, 20),
 		ShutdownDrainDuration:           dc.GetDurationProperty(dynamicconfig.MatchingShutdownDrainDuration, 0),
+		EnableDebugMode:                 dc.GetBoolProperty(dynamicconfig.EnableDebugMode, false)(),
+		EnableTaskInfoLogByDomainID:     dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.MatchingEnableTaskInfoLogByDomainID, false),
 	}
 }
 

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -126,6 +126,7 @@ func (h *handlerImpl) newHandlerContext(
 		taskList,
 		h.metricsClient,
 		scope,
+		h.GetLogger(),
 	)
 }
 
@@ -376,6 +377,7 @@ func (h *handlerImpl) ListTaskListPartitions(
 		request.GetTaskList(),
 		h.metricsClient,
 		metrics.MatchingListTaskListPartitionsScope,
+		h.GetLogger(),
 	)
 
 	sw := hCtx.startProfiling(&h.startWG)

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -111,9 +111,10 @@ func (s *matchingEngineSuite) SetupTest() {
 	s.handlerContext = newHandlerContext(
 		context.Background(),
 		matchingTestDomainName,
-		&types.TaskList{common.StringPtr(matchingTestTaskList), &tlKindNormal},
+		&types.TaskList{Name: common.StringPtr(matchingTestTaskList), Kind: &tlKindNormal},
 		metrics.NewClient(tally.NoopScope, metrics.Matching),
 		metrics.MatchingTaskListMgrScope,
+		loggerimpl.NewDevelopmentForTest(s.Suite),
 	)
 
 	s.matchingEngine = s.newMatchingEngine(defaultTestConfig(), s.taskManager)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add event logger for logging for transfer/time task lifecycle events.
- Add logs for recordActivity/DecisionTaskStarted calls in history service.
- Add logs for AddActivity/DecisionTask calls in matching.
- Add logs when matching handler returns an internal service error or an uncategorized error.

<!-- Tell your future self why have you made these changes -->
**Why?**
Help debugging lost task issue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested in staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk when all feature flags are disabled. If enabled, may increase GC pressure due to frequent access of dynamicconfig client for determining if log need to be emitted. 
