### PR TITLE
Fix dynamic config collection logValue function

### DIFF
--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -21,7 +21,9 @@
 package dynamicconfig
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -62,35 +64,42 @@ type Collection struct {
 	filterOptions []FilterOption
 }
 
-func (c *Collection) logError(key Key, err error) {
+func (c *Collection) logError(
+	key Key,
+	filters map[Filter]interface{},
+	err error,
+) {
 	errCount := atomic.AddInt64(&c.errCount, 1)
 	if errCount%errCountLogThreshold == 0 {
 		// log only every 'x' errors to reduce mem allocs and to avoid log noise
+		filteredKey := getFilteredKey(key, filters)
 		if _, ok := err.(*types.EntityNotExistsError); ok {
-			c.logger.Info("dynamic config not set, use default value", tag.Key(key.String()))
+			c.logger.Info("dynamic config not set, use default value", tag.Key(filteredKey))
 		} else {
-			c.logger.Warn("Failed to fetch key from dynamic config", tag.Key(key.String()), tag.Error(err))
+			c.logger.Warn("Failed to fetch key from dynamic config", tag.Key(filteredKey), tag.Error(err))
 		}
 	}
 }
 
 func (c *Collection) logValue(
 	key Key,
+	filters map[Filter]interface{},
 	value, defaultValue interface{},
 	cmpValueEquals func(interface{}, interface{}) bool,
 ) {
-	loadedValue, loaded := c.logKeys.LoadOrStore(key, value)
+	filteredKey := getFilteredKey(key, filters)
+	loadedValue, loaded := c.logKeys.LoadOrStore(filteredKey, value)
 	if !loaded {
 		c.logger.Info("First loading dynamic config",
-			tag.Key(key.String()), tag.Value(value), tag.DefaultValue(defaultValue))
+			tag.Key(filteredKey), tag.Value(value), tag.DefaultValue(defaultValue))
 	} else {
 		// it's loaded before, check if the value has changed
 		if !cmpValueEquals(loadedValue, value) {
 			c.logger.Info("Dynamic config has changed",
-				tag.Key(key.String()), tag.Value(value), tag.DefaultValue(loadedValue))
+				tag.Key(filteredKey), tag.Value(value), tag.DefaultValue(loadedValue))
 			// update the logKeys so that we can capture the changes again
 			// (ignore the racing condition here because it's just for logging, we need a lock if really need to solve it)
-			c.logKeys.Store(key, value)
+			c.logKeys.Store(filteredKey, value)
 		}
 	}
 }
@@ -157,53 +166,43 @@ func (c *Collection) GetProperty(key Key, defaultValue interface{}) PropertyFn {
 	return func() interface{} {
 		val, err := c.client.GetValue(key, defaultValue)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, nil, err)
 		}
-		c.logValue(key, val, defaultValue, reflect.DeepEqual)
+		c.logValue(key, nil, val, defaultValue, reflect.DeepEqual)
 		return val
 	}
-}
-
-func getFilterMap(opts ...FilterOption) map[Filter]interface{} {
-	l := len(opts)
-	m := make(map[Filter]interface{}, l)
-	for _, opt := range opts {
-		opt(m)
-	}
-	return m
 }
 
 // GetIntProperty gets property and asserts that it's an integer
 func (c *Collection) GetIntProperty(key Key, defaultValue int) IntPropertyFn {
 	return func(opts ...FilterOption) int {
-		opts = append(opts, c.filterOptions...)
+		filters := c.getFilterMap(opts...)
 		val, err := c.client.GetIntValue(
 			key,
-			getFilterMap(opts...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, intCompareEquals)
+		c.logValue(key, filters, val, defaultValue, intCompareEquals)
 		return val
 	}
 }
 
 // GetIntPropertyFilteredByDomain gets property with domain filter and asserts that it's an integer
 func (c *Collection) GetIntPropertyFilteredByDomain(key Key, defaultValue int) IntPropertyFnWithDomainFilter {
-
 	return func(domain string) int {
-		filters := append([]FilterOption{DomainFilter(domain)}, c.filterOptions...)
+		filters := c.getFilterMap(DomainFilter(domain))
 		val, err := c.client.GetIntValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, intCompareEquals)
+		c.logValue(key, filters, val, defaultValue, intCompareEquals)
 		return val
 	}
 }
@@ -211,23 +210,20 @@ func (c *Collection) GetIntPropertyFilteredByDomain(key Key, defaultValue int) I
 // GetIntPropertyFilteredByTaskListInfo gets property with taskListInfo as filters and asserts that it's an integer
 func (c *Collection) GetIntPropertyFilteredByTaskListInfo(key Key, defaultValue int) IntPropertyFnWithTaskListInfoFilters {
 	return func(domain string, taskList string, taskType int) int {
-		filters := append(
-			[]FilterOption{
-				DomainFilter(domain),
-				TaskListFilter(taskList),
-				TaskTypeFilter(taskType),
-			},
-			c.filterOptions...,
+		filters := c.getFilterMap(
+			DomainFilter(domain),
+			TaskListFilter(taskList),
+			TaskTypeFilter(taskType),
 		)
 		val, err := c.client.GetIntValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, intCompareEquals)
+		c.logValue(key, filters, val, defaultValue, intCompareEquals)
 		return val
 	}
 }
@@ -235,16 +231,16 @@ func (c *Collection) GetIntPropertyFilteredByTaskListInfo(key Key, defaultValue 
 // GetIntPropertyFilteredByShardID gets property with shardID as filter and asserts that it's an integer
 func (c *Collection) GetIntPropertyFilteredByShardID(key Key, defaultValue int) IntPropertyFnWithShardIDFilter {
 	return func(shardID int) int {
-		filters := append([]FilterOption{ShardIDFilter(shardID)}, c.filterOptions...)
+		filters := c.getFilterMap(ShardIDFilter(shardID))
 		val, err := c.client.GetIntValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, intCompareEquals)
+		c.logValue(key, filters, val, defaultValue, intCompareEquals)
 		return val
 	}
 }
@@ -252,16 +248,16 @@ func (c *Collection) GetIntPropertyFilteredByShardID(key Key, defaultValue int) 
 // GetFloat64Property gets property and asserts that it's a float64
 func (c *Collection) GetFloat64Property(key Key, defaultValue float64) FloatPropertyFn {
 	return func(opts ...FilterOption) float64 {
-		opts = append(opts, c.filterOptions...)
+		filters := c.getFilterMap(opts...)
 		val, err := c.client.GetFloatValue(
 			key,
-			getFilterMap(opts...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, float64CompareEquals)
+		c.logValue(key, filters, val, defaultValue, float64CompareEquals)
 		return val
 	}
 }
@@ -269,16 +265,16 @@ func (c *Collection) GetFloat64Property(key Key, defaultValue float64) FloatProp
 // GetFloat64PropertyFilteredByShardID gets property with shardID filter and asserts that it's a float64
 func (c *Collection) GetFloat64PropertyFilteredByShardID(key Key, defaultValue float64) FloatPropertyFnWithShardIDFilter {
 	return func(shardID int) float64 {
-		filters := append([]FilterOption{ShardIDFilter(shardID)}, c.filterOptions...)
+		filters := c.getFilterMap(ShardIDFilter(shardID))
 		val, err := c.client.GetFloatValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, float64CompareEquals)
+		c.logValue(key, filters, val, defaultValue, float64CompareEquals)
 		return val
 	}
 }
@@ -286,16 +282,16 @@ func (c *Collection) GetFloat64PropertyFilteredByShardID(key Key, defaultValue f
 // GetDurationProperty gets property and asserts that it's a duration
 func (c *Collection) GetDurationProperty(key Key, defaultValue time.Duration) DurationPropertyFn {
 	return func(opts ...FilterOption) time.Duration {
-		opts = append(opts, c.filterOptions...)
+		filters := c.getFilterMap(opts...)
 		val, err := c.client.GetDurationValue(
 			key,
-			getFilterMap(opts...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, durationCompareEquals)
+		c.logValue(key, filters, val, defaultValue, durationCompareEquals)
 		return val
 	}
 }
@@ -303,16 +299,16 @@ func (c *Collection) GetDurationProperty(key Key, defaultValue time.Duration) Du
 // GetDurationPropertyFilteredByDomain gets property with domain filter and asserts that it's a duration
 func (c *Collection) GetDurationPropertyFilteredByDomain(key Key, defaultValue time.Duration) DurationPropertyFnWithDomainFilter {
 	return func(domain string) time.Duration {
-		filters := append([]FilterOption{DomainFilter(domain)}, c.filterOptions...)
+		filters := c.getFilterMap(DomainFilter(domain))
 		val, err := c.client.GetDurationValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, durationCompareEquals)
+		c.logValue(key, filters, val, defaultValue, durationCompareEquals)
 		return val
 	}
 }
@@ -320,16 +316,16 @@ func (c *Collection) GetDurationPropertyFilteredByDomain(key Key, defaultValue t
 // GetDurationPropertyFilteredByDomainID gets property with domainID filter and asserts that it's a duration
 func (c *Collection) GetDurationPropertyFilteredByDomainID(key Key, defaultValue time.Duration) DurationPropertyFnWithDomainIDFilter {
 	return func(domainID string) time.Duration {
-		filters := append([]FilterOption{DomainIDFilter(domainID)}, c.filterOptions...)
+		filters := c.getFilterMap(DomainIDFilter(domainID))
 		val, err := c.client.GetDurationValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, durationCompareEquals)
+		c.logValue(key, filters, val, defaultValue, durationCompareEquals)
 		return val
 	}
 }
@@ -337,23 +333,20 @@ func (c *Collection) GetDurationPropertyFilteredByDomainID(key Key, defaultValue
 // GetDurationPropertyFilteredByTaskListInfo gets property with taskListInfo as filters and asserts that it's a duration
 func (c *Collection) GetDurationPropertyFilteredByTaskListInfo(key Key, defaultValue time.Duration) DurationPropertyFnWithTaskListInfoFilters {
 	return func(domain string, taskList string, taskType int) time.Duration {
-		filters := append(
-			[]FilterOption{
-				DomainFilter(domain),
-				TaskListFilter(taskList),
-				TaskTypeFilter(taskType),
-			},
-			c.filterOptions...,
+		filters := c.getFilterMap(
+			DomainFilter(domain),
+			TaskListFilter(taskList),
+			TaskTypeFilter(taskType),
 		)
 		val, err := c.client.GetDurationValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, durationCompareEquals)
+		c.logValue(key, filters, val, defaultValue, durationCompareEquals)
 		return val
 	}
 }
@@ -361,16 +354,16 @@ func (c *Collection) GetDurationPropertyFilteredByTaskListInfo(key Key, defaultV
 // GetDurationPropertyFilteredByShardID gets property with shardID id as filter and asserts that it's a duration
 func (c *Collection) GetDurationPropertyFilteredByShardID(key Key, defaultValue time.Duration) DurationPropertyFnWithShardIDFilter {
 	return func(shardID int) time.Duration {
-		filters := append([]FilterOption{ShardIDFilter(shardID)}, c.filterOptions...)
+		filters := c.getFilterMap(ShardIDFilter(shardID))
 		val, err := c.client.GetDurationValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, durationCompareEquals)
+		c.logValue(key, filters, val, defaultValue, durationCompareEquals)
 		return val
 	}
 }
@@ -378,16 +371,17 @@ func (c *Collection) GetDurationPropertyFilteredByShardID(key Key, defaultValue 
 // GetBoolProperty gets property and asserts that it's an bool
 func (c *Collection) GetBoolProperty(key Key, defaultValue bool) BoolPropertyFn {
 	return func(opts ...FilterOption) bool {
+		filters := c.getFilterMap(opts...)
 		opts = append(opts, c.filterOptions...)
 		val, err := c.client.GetBoolValue(
 			key,
-			getFilterMap(opts...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, boolCompareEquals)
+		c.logValue(key, filters, val, defaultValue, boolCompareEquals)
 		return val
 	}
 }
@@ -395,16 +389,16 @@ func (c *Collection) GetBoolProperty(key Key, defaultValue bool) BoolPropertyFn 
 // GetStringProperty gets property and asserts that it's an string
 func (c *Collection) GetStringProperty(key Key, defaultValue string) StringPropertyFn {
 	return func(opts ...FilterOption) string {
-		opts = append(opts, c.filterOptions...)
+		filters := c.getFilterMap(opts...)
 		val, err := c.client.GetStringValue(
 			key,
-			getFilterMap(opts...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, stringCompareEquals)
+		c.logValue(key, filters, val, defaultValue, stringCompareEquals)
 		return val
 	}
 }
@@ -412,16 +406,16 @@ func (c *Collection) GetStringProperty(key Key, defaultValue string) StringPrope
 // GetMapProperty gets property and asserts that it's a map
 func (c *Collection) GetMapProperty(key Key, defaultValue map[string]interface{}) MapPropertyFn {
 	return func(opts ...FilterOption) map[string]interface{} {
-		opts = append(opts, c.filterOptions...)
+		filters := c.getFilterMap(opts...)
 		val, err := c.client.GetMapValue(
 			key,
-			getFilterMap(opts...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, reflect.DeepEqual)
+		c.logValue(key, filters, val, defaultValue, reflect.DeepEqual)
 		return val
 	}
 }
@@ -429,16 +423,16 @@ func (c *Collection) GetMapProperty(key Key, defaultValue map[string]interface{}
 // GetStringPropertyFilteredByDomain gets property with domain filter and asserts that it's a string
 func (c *Collection) GetStringPropertyFilteredByDomain(key Key, defaultValue string) StringPropertyFnWithDomainFilter {
 	return func(domain string) string {
-		filters := append([]FilterOption{DomainFilter(domain)}, c.filterOptions...)
+		filters := c.getFilterMap(DomainFilter(domain))
 		val, err := c.client.GetStringValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, stringCompareEquals)
+		c.logValue(key, filters, val, defaultValue, stringCompareEquals)
 		return val
 	}
 }
@@ -446,16 +440,16 @@ func (c *Collection) GetStringPropertyFilteredByDomain(key Key, defaultValue str
 // GetBoolPropertyFilteredByDomain gets property with domain filter and asserts that it's a bool
 func (c *Collection) GetBoolPropertyFilteredByDomain(key Key, defaultValue bool) BoolPropertyFnWithDomainFilter {
 	return func(domain string) bool {
-		filters := append([]FilterOption{DomainFilter(domain)}, c.filterOptions...)
+		filters := c.getFilterMap(DomainFilter(domain))
 		val, err := c.client.GetBoolValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, boolCompareEquals)
+		c.logValue(key, filters, val, defaultValue, boolCompareEquals)
 		return val
 	}
 }
@@ -463,16 +457,16 @@ func (c *Collection) GetBoolPropertyFilteredByDomain(key Key, defaultValue bool)
 // GetBoolPropertyFilteredByDomainID gets property with domainID filter and asserts that it's a bool
 func (c *Collection) GetBoolPropertyFilteredByDomainID(key Key, defaultValue bool) BoolPropertyFnWithDomainIDFilter {
 	return func(domainID string) bool {
-		filters := append([]FilterOption{DomainIDFilter(domainID)}, c.filterOptions...)
+		filters := c.getFilterMap(DomainIDFilter(domainID))
 		val, err := c.client.GetBoolValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, boolCompareEquals)
+		c.logValue(key, filters, val, defaultValue, boolCompareEquals)
 		return val
 	}
 }
@@ -480,23 +474,44 @@ func (c *Collection) GetBoolPropertyFilteredByDomainID(key Key, defaultValue boo
 // GetBoolPropertyFilteredByTaskListInfo gets property with taskListInfo as filters and asserts that it's an bool
 func (c *Collection) GetBoolPropertyFilteredByTaskListInfo(key Key, defaultValue bool) BoolPropertyFnWithTaskListInfoFilters {
 	return func(domain string, taskList string, taskType int) bool {
-		filters := append(
-			[]FilterOption{
-				DomainFilter(domain),
-				TaskListFilter(taskList),
-				TaskTypeFilter(taskType),
-			},
-			c.filterOptions...,
+		filters := c.getFilterMap(
+			DomainFilter(domain),
+			TaskListFilter(taskList),
+			TaskTypeFilter(taskType),
 		)
 		val, err := c.client.GetBoolValue(
 			key,
-			getFilterMap(filters...),
+			filters,
 			defaultValue,
 		)
 		if err != nil {
-			c.logError(key, err)
+			c.logError(key, filters, err)
 		}
-		c.logValue(key, val, defaultValue, boolCompareEquals)
+		c.logValue(key, filters, val, defaultValue, boolCompareEquals)
 		return val
 	}
+}
+
+func (c *Collection) getFilterMap(opts ...FilterOption) map[Filter]interface{} {
+	l := len(opts)
+	m := make(map[Filter]interface{}, l)
+	for _, opt := range opts {
+		opt(m)
+	}
+	for _, opt := range c.filterOptions {
+		opt(m)
+	}
+	return m
+}
+
+func getFilteredKey(
+	key Key,
+	filters map[Filter]interface{},
+) string {
+	var sb strings.Builder
+	sb.WriteString(key.String())
+	for _, value := range filters {
+		sb.WriteString(fmt.Sprintf(",%v", value))
+	}
+	return sb.String()
 }

--- a/common/service/dynamicconfig/config.go
+++ b/common/service/dynamicconfig/config.go
@@ -510,8 +510,10 @@ func getFilteredKey(
 ) string {
 	var sb strings.Builder
 	sb.WriteString(key.String())
-	for _, value := range filters {
-		sb.WriteString(fmt.Sprintf(",%v", value))
+	for filter := unknownFilter + 1; filter < lastFilterTypeForTest; filter++ {
+		if value, ok := filters[filter]; ok {
+			sb.WriteString(fmt.Sprintf(",%v:%v", filter.String(), value))
+		}
 	}
 	return sb.String()
 }

--- a/common/service/dynamicconfig/config_test.go
+++ b/common/service/dynamicconfig/config_test.go
@@ -206,6 +206,10 @@ func BenchmarkLogValue(b *testing.B) {
 		0.1,
 		30 * time.Second,
 	}
+	filters := map[Filter]interface{}{
+		ClusterName: "development",
+		DomainName:  "domainName",
+	}
 	cmpFuncs := []func(interface{}, interface{}) bool{
 		intCompareEquals,
 		float64CompareEquals,
@@ -215,12 +219,12 @@ func BenchmarkLogValue(b *testing.B) {
 	collection := NewCollection(NewInMemoryClient(), log.NewNoop())
 	// pre-warm the collection logValue map
 	for i := range keys {
-		collection.logValue(keys[i], values[i], values[i], cmpFuncs[i])
+		collection.logValue(keys[i], filters, values[i], values[i], cmpFuncs[i])
 	}
 
 	for i := 0; i < b.N; i++ {
 		for i := range keys {
-			collection.logValue(keys[i], values[i], values[i], cmpFuncs[i])
+			collection.logValue(keys[i], filters, values[i], values[i], cmpFuncs[i])
 		}
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add filter to dynamicconfig key when storing, comparing and emitting logs for retrieved values.

<!-- Tell your future self why have you made these changes -->
**Why?**
Current logValue function emit a log whenever the value for a dynamicconfig key changes. However, each key may have a set of filters associated with it when retrieving the values (for example domain filter or shardID filter), and the value is expected to be different when the filter values are different and we should not emit the log in this case.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Increase memory cost as we need to store more values. Also each access to dynamicconfig collection will be more expensive as we need to construct the filtered key. But we will also emit much less logs, which will improve the performance. 
