### PR TITLE
break if adminClient returns error

### DIFF
--- a/tools/cli/adminDLQCommands.go
+++ b/tools/cli/adminDLQCommands.go
@@ -186,10 +186,11 @@ func AdminMergeDLQMessages(c *cli.Context) {
 		for {
 			response, err := adminClient.MergeDLQMessages(ctx, request)
 			if err != nil {
-				ErrorAndExit(fmt.Sprintf("Failed to merge DLQ message in shard %v.", shardID), err)
+				fmt.Printf("Failed to merge DLQ message in shard %v with error: %v.\n", shardID, err)
+				break
 			}
 
-			if response == nil || len(response.NextPageToken) == 0 {
+			if len(response.NextPageToken) == 0 {
 				break
 			}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Instead of breaking when `response` is nil, we will break when operation returns an error.

<!-- Tell your future self why have you made these changes -->
**Why?**
When no error is returned, we always assume that response is valid, in we will face panic due `response.NextPageToken` is being nil, then something is not right and it needs to be investigated

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

