### PR TITLE
Add task processing workflow busy metric

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1731,6 +1731,7 @@ const (
 	TaskRequestsPerDomain
 	TaskLatencyPerDomain
 	TaskFailuresPerDomain
+	TaskWorkflowBusyPerDomain
 	TaskDiscardedPerDomain
 	TaskUnsupportedPerDomain
 	TaskAttemptTimerPerDomain
@@ -2218,6 +2219,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskLatencyPerDomain:                     {metricName: "task_latency_per_domain", metricRollupName: "task_latency", metricType: Timer},
 		TaskAttemptTimerPerDomain:                {metricName: "task_attempt_per_domain", metricRollupName: "task_attempt", metricType: Timer},
 		TaskFailuresPerDomain:                    {metricName: "task_errors_per_domain", metricRollupName: "task_errors", metricType: Counter},
+		TaskWorkflowBusyPerDomain:                {metricName: "task_errors_workflow_busy_per_domain", metricRollupName: "task_errors_workflow_busy", metricType: Counter},
 		TaskDiscardedPerDomain:                   {metricName: "task_errors_discarded_per_domain", metricRollupName: "task_errors_discarded", metricType: Counter},
 		TaskUnsupportedPerDomain:                 {metricName: "task_errors_unsupported_per_domain", metricRollupName: "task_errors_discarded", metricType: Counter},
 		TaskStandbyRetryCounterPerDomain:         {metricName: "task_errors_standby_retry_counter_per_domain", metricRollupName: "task_errors_standby_retry_counter", metricType: Counter},

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -330,6 +330,11 @@ func (t *taskBase) HandleErr(
 		return nil
 	}
 
+	if err == errWorkflowBusy {
+		t.scope.IncCounter(metrics.TaskWorkflowBusyPerDomain)
+		return err
+	}
+
 	// this is a transient error
 	if err == ErrTaskRedispatch {
 		t.scope.IncCounter(metrics.TaskStandbyRetryCounterPerDomain)
@@ -386,7 +391,7 @@ func (t *taskBase) HandleErr(
 func (t *taskBase) RetryErr(
 	err error,
 ) bool {
-	if err == ErrTaskRedispatch || err == ErrTaskPendingActive || common.IsContextTimeoutError(err) {
+	if err == errWorkflowBusy || err == ErrTaskRedispatch || err == ErrTaskPendingActive || common.IsContextTimeoutError(err) {
 		return false
 	}
 

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -111,6 +111,9 @@ func (t *timerActiveTaskExecutor) executeUserTimerTimeoutTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -166,6 +169,9 @@ func (t *timerActiveTaskExecutor) executeActivityTimeoutTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -280,6 +286,9 @@ func (t *timerActiveTaskExecutor) executeDecisionTimeoutTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -355,6 +364,9 @@ func (t *timerActiveTaskExecutor) executeWorkflowBackoffTimerTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -393,6 +405,9 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -480,6 +495,9 @@ func (t *timerActiveTaskExecutor) executeWorkflowTimeoutTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -420,6 +420,9 @@ func (t *timerStandbyTaskExecutor) processTimer(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() {

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -59,6 +59,7 @@ var (
 
 var (
 	errUnknownTransferTask = errors.New("Unknown transfer task")
+	errWorkflowBusy        = errors.New("Unable to get workflow execution lock within specified timeout")
 )
 
 type (
@@ -154,6 +155,9 @@ func (t *transferActiveTaskExecutor) processActivityTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -194,6 +198,9 @@ func (t *transferActiveTaskExecutor) processDecisionTask(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -252,6 +259,9 @@ func (t *transferActiveTaskExecutor) processCloseExecution(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -368,6 +378,9 @@ func (t *transferActiveTaskExecutor) processCancelExecution(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -459,6 +472,9 @@ func (t *transferActiveTaskExecutor) processSignalExecution(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -575,6 +591,9 @@ func (t *transferActiveTaskExecutor) processStartChildExecution(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -700,6 +719,9 @@ func (t *transferActiveTaskExecutor) processRecordWorkflowStartedOrUpsertHelper(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { release(retError) }()
@@ -784,6 +806,9 @@ func (t *transferActiveTaskExecutor) processResetWorkflow(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() { currentRelease(retError) }()
@@ -867,6 +892,9 @@ func (t *transferActiveTaskExecutor) processResetWorkflow(
 			baseExecution,
 			taskGetExecutionContextTimeout,
 		)
+		if err != nil {
+			return err
+		}
 
 		defer func() { baseRelease(retError) }()
 		baseMutableState, err = loadMutableStateForTransferTask(ctx, baseContext, task, t.metricsClient, t.logger)

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -507,6 +507,9 @@ func (t *transferStandbyTaskExecutor) processTransfer(
 		taskGetExecutionContextTimeout,
 	)
 	if err != nil {
+		if err == context.DeadlineExceeded {
+			return errWorkflowBusy
+		}
 		return err
 	}
 	defer func() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Emit task processing workflow busy metric instead of task error metrics when failed to get workflow execution lock within timeout during task processing.

<!-- Tell your future self why have you made these changes -->
**Why?**
If a workflow schedules a large number of childworkflows or activities in a single decision batch, most of tasks will fail due to timeout error when getting the execution lock, and we will backoff the execution based on this error. This is an expected behavior so we should not emit task error metrics and cause the alert to fire in this case. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, only metrics changes.
