### PR TITLE
Start enabled shardscanner fixers

### DIFF
--- a/service/worker/scanner/executions/concrete_execution.go
+++ b/service/worker/scanner/executions/concrete_execution.go
@@ -47,6 +47,7 @@ const (
 
 	// ConcreteExecutionsFixerWFTypeName defines workflow type name for concrete executions fixer
 	ConcreteExecutionsFixerWFTypeName   = "cadence-sys-executions-fixer-workflow"
+	concreteExecutionsFixerWFID         = "cadence-sys-executions-fixer"
 	concreteExecutionsFixerTaskListName = "cadence-sys-executions-fixer-tasklist-0"
 )
 
@@ -173,10 +174,16 @@ func ConcreteExecutionScannerConfig(dc *dynamicconfig.Collection) *shardscanner.
 		DynamicCollection: dc,
 		ScannerHooks:      ConcreteExecutionHooks,
 		FixerHooks:        ConcreteExecutionFixerHooks,
-		FixerTLName:       concreteExecutionsFixerTaskListName,
 		StartWorkflowOptions: cclient.StartWorkflowOptions{
 			ID:                           concreteExecutionsScannerWFID,
 			TaskList:                     concreteExecutionsScannerTaskListName,
+			ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour,
+			WorkflowIDReusePolicy:        cclient.WorkflowIDReusePolicyAllowDuplicate,
+			CronSchedule:                 "* * * * *",
+		},
+		StartFixerOptions: cclient.StartWorkflowOptions{
+			ID:                           concreteExecutionsFixerWFID,
+			TaskList:                     concreteExecutionsFixerTaskListName,
 			ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour,
 			WorkflowIDReusePolicy:        cclient.WorkflowIDReusePolicyAllowDuplicate,
 			CronSchedule:                 "* * * * *",

--- a/service/worker/scanner/executions/current_execution.go
+++ b/service/worker/scanner/executions/current_execution.go
@@ -40,8 +40,8 @@ import (
 )
 
 const (
-	// CurrentExecutionsScannerWFID is the current execution scanner workflow ID
-	CurrentExecutionsScannerWFID = "cadence-sys-current-executions-scanner"
+	// currentExecutionsScannerWFID is the current execution scanner workflow ID
+	currentExecutionsScannerWFID = "cadence-sys-current-executions-scanner"
 	// CurrentExecutionsScannerWFTypeName is the current execution scanner workflow type
 	CurrentExecutionsScannerWFTypeName = "cadence-sys-current-executions-scanner-workflow"
 	// CurrentExecutionsScannerTaskListName is the current execution scanner workflow tasklist
@@ -49,6 +49,7 @@ const (
 
 	// CurrentExecutionsFixerWFTypeName is the current execution fixer workflow ID
 	CurrentExecutionsFixerWFTypeName = "cadence-sys-current-executions-fixer-workflow"
+	currentExecutionsFixerWFID       = "cadence-sys-current-executions-fixer"
 	// CurrentExecutionsFixerTaskListName is the current execution fixer workflow tasklist
 	CurrentExecutionsFixerTaskListName = "cadence-sys-current-executions-fixer-tasklist-0"
 )
@@ -144,10 +145,16 @@ func CurrentExecutionScannerConfig(dc *dynamicconfig.Collection) *shardscanner.S
 		},
 		ScannerHooks: CurrentExecutionsHooks,
 		FixerHooks:   CurrentExecutionFixerHooks,
-		FixerTLName:  CurrentExecutionsFixerTaskListName,
 		StartWorkflowOptions: cclient.StartWorkflowOptions{
-			ID:                           CurrentExecutionsScannerWFID,
+			ID:                           currentExecutionsScannerWFID,
 			TaskList:                     CurrentExecutionsScannerTaskListName,
+			ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour,
+			WorkflowIDReusePolicy:        cclient.WorkflowIDReusePolicyAllowDuplicate,
+			CronSchedule:                 "* * * * *",
+		},
+		StartFixerOptions: cclient.StartWorkflowOptions{
+			ID:                           currentExecutionsFixerWFID,
+			TaskList:                     CurrentExecutionsFixerTaskListName,
 			ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour,
 			WorkflowIDReusePolicy:        cclient.WorkflowIDReusePolicyAllowDuplicate,
 			CronSchedule:                 "* * * * *",

--- a/service/worker/scanner/scanner.go
+++ b/service/worker/scanner/scanner.go
@@ -181,20 +181,31 @@ func (s *Scanner) startShardScanner(
 			getShardFixerContext(s.context, config),
 		)
 
-		workerTaskListNames = append(workerTaskListNames, config.FixerTLName)
+		go s.startWorkflowWithRetry(
+			config.StartFixerOptions,
+			config.FixerWFTypeName,
+			shardscanner.FixerWorkflowParams{
+				ScannerWorkflowWorkflowID: config.StartWorkflowOptions.ID,
+			},
+		)
+
+		workerTaskListNames = append(workerTaskListNames, config.StartFixerOptions.TaskList)
 	}
 
 	if config.DynamicParams.ScannerEnabled() {
 		workerTaskListNames = append(workerTaskListNames, config.StartWorkflowOptions.TaskList)
 
-		go s.startWorkflowWithRetry(config.StartWorkflowOptions, config.ScannerWFTypeName, shardscanner.ScannerWorkflowParams{
-			Shards: shardscanner.Shards{
-				Range: &shardscanner.ShardRange{
-					Min: 0,
-					Max: s.context.cfg.Persistence.NumHistoryShards,
+		go s.startWorkflowWithRetry(
+			config.StartWorkflowOptions,
+			config.ScannerWFTypeName,
+			shardscanner.ScannerWorkflowParams{
+				Shards: shardscanner.Shards{
+					Range: &shardscanner.ShardRange{
+						Min: 0,
+						Max: s.context.cfg.Persistence.NumHistoryShards,
+					},
 				},
-			},
-		})
+			})
 	}
 
 	return backgroundActivityContext, workerTaskListNames

--- a/service/worker/scanner/shardscanner/activities_test.go
+++ b/service/worker/scanner/shardscanner/activities_test.go
@@ -26,7 +26,9 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
+	"github.com/pborman/uuid"
 	"github.com/uber-go/tally"
 
 	"github.com/golang/mock/gomock"
@@ -75,7 +77,10 @@ func (s *activitiesSuite) SetupSuite() {
 func (s *activitiesSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockResource = resource.NewTest(s.controller, metrics.Worker)
-	defer s.controller.Finish()
+}
+
+func (s *activitiesSuite) TearDownTest() {
+	s.controller.Finish()
 }
 
 func (s *activitiesSuite) TestScanShardActivity() {
@@ -404,7 +409,26 @@ func (s *activitiesSuite) TestFixerCorruptedKeysActivity() {
 		},
 	}
 	queryResultData, err := json.Marshal(queryResult)
+	response := &shared.ListClosedWorkflowExecutionsResponse{
+		Executions: []*shared.WorkflowExecutionInfo{
+			{
+				Execution: &shared.WorkflowExecution{
+					WorkflowId: common.StringPtr("test-list-workflow-id"),
+					RunId:      common.StringPtr(uuid.New()),
+				},
+				Type: &shared.WorkflowType{
+					Name: common.StringPtr("test-list-workflow-type"),
+				},
+				StartTime:     common.Int64Ptr(time.Now().UnixNano()),
+				CloseTime:     common.Int64Ptr(time.Now().Add(time.Hour).UnixNano()),
+				CloseStatus:   shared.WorkflowExecutionCloseStatusCompleted.Ptr(),
+				HistoryLength: common.Int64Ptr(12),
+			},
+		},
+	}
 	s.NoError(err)
+	s.mockResource.SDKClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(response, nil)
+
 	s.mockResource.SDKClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(&shared.QueryWorkflowResponse{
 		QueryResult: queryResultData,
 	}, nil)

--- a/service/worker/scanner/shardscanner/types.go
+++ b/service/worker/scanner/shardscanner/types.go
@@ -251,7 +251,6 @@ type (
 
 	// ScannerConfig is the  config for ShardScanner workflow
 	ScannerConfig struct {
-		FixerTLName          string
 		ScannerWFTypeName    string
 		FixerWFTypeName      string
 		ScannerHooks         func() *ScannerHooks
@@ -259,6 +258,7 @@ type (
 		DynamicParams        DynamicParams
 		DynamicCollection    *dynamicconfig.Collection
 		StartWorkflowOptions cclient.StartWorkflowOptions
+		StartFixerOptions    cclient.StartWorkflowOptions
 	}
 
 	// FixerWorkflowConfigOverwrites enables overwriting the default values.

--- a/service/worker/scanner/timers/timers.go
+++ b/service/worker/scanner/timers/timers.go
@@ -50,6 +50,7 @@ const (
 	// FixerWFTypeName defines workflow type name for timers fixer
 	FixerWFTypeName   = "cadence-sys-timers-fixer-workflow"
 	fixerTaskListName = "cadence-sys-timers-fixer-tasklist-0"
+	fixerwfid         = "cadence-sys-timers-fixer"
 	periodStartKey    = "period_start"
 	periodEndKey      = "period_end"
 
@@ -183,10 +184,17 @@ func ScannerConfig(dc *dynamicconfig.Collection) *shardscanner.ScannerConfig {
 		DynamicCollection: dc,
 		ScannerHooks:      ScannerHooks,
 		FixerHooks:        FixerHooks,
-		FixerTLName:       fixerTaskListName,
+
 		StartWorkflowOptions: client.StartWorkflowOptions{
 			ID:                           wfid,
 			TaskList:                     scannerTaskListName,
+			ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour,
+			WorkflowIDReusePolicy:        client.WorkflowIDReusePolicyAllowDuplicate,
+			CronSchedule:                 "* * * * *",
+		},
+		StartFixerOptions: client.StartWorkflowOptions{
+			ID:                           fixerwfid,
+			TaskList:                     fixerTaskListName,
 			ExecutionStartToCloseTimeout: 20 * 365 * 24 * time.Hour,
 			WorkflowIDReusePolicy:        client.WorkflowIDReusePolicyAllowDuplicate,
 			CronSchedule:                 "* * * * *",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Start enabled fixers automatically; Fix activity for getting corrupted keys.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is fix for a functional regression.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests
Local test:
```
   1  WorkflowExecutionStarted         {WorkflowType:{Name:cadence-sys-current-executions-fixer-workflow},
                                       TaskList:{Name:cadence-sys-current-executions-fixer-tasklist-0},
                                       Input:[{"ScannerWorkflowWorkflowID":"cadence-sys-current-executions-scanner","ScannerWorkflowRunID":"","ContextKey":"","FixerW
                                       orkflowConfigOverwrites":{"Concurrency":null,"BlobstoreFlushThreshold":null,"ActivityBatchSize":null}}],
                                       ExecutionStartToCloseTimeoutSeconds:630720000, TaskStartToCloseTimeoutSeconds:10,
                                       ContinuedExecutionRunId:0f0bc50f-ecc6-45ef-b30d-6d17a2e705ec, Initiator:CronSchedule,
                                       ContinuedFailureReason:cadenceInternal:Generic, ContinuedFailureDetails:[corrupted keys not found], LastCompletionResult:[],
                                       OriginalExecutionRunId:7bd93da6-0a99-40a5-b7b6-092402977677, FirstExecutionRunId:0f0bc50f-ecc6-45ef-b30d-6d17a2e705ec,
                                       Attempt:0, CronSchedule:* * * * *, FirstDecisionTaskBackoffSeconds:60, PrevAutoResetPoints:{Points:[len=1]},
                                       Header:{Fields:map{}}}
   2  DecisionTaskScheduled            {TaskList:{Name:cadence-sys-current-executions-fixer-tasklist-0},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
   3  DecisionTaskStarted              {ScheduledEventId:2,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       RequestId:ae2c84fe-1779-4063-81b5-5a8d06450709}
   4  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:2, StartedEventId:3,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       BinaryChecksum:f30736e2dc8f37300c501e4bb771260e}
   5  ActivityTaskScheduled            {ActivityId:0, ActivityType:{Name:cadence-sys-shardscanner-corruptedkeys-activity},
                                       TaskList:{Name:cadence-sys-current-executions-fixer-tasklist-0},
                                       Input:[{"ContextKey":"cadence-sys-current-executions-fixer-workflow","ScannerWorkflowWorkflowID":"cadence-sys-current-executio
                                       ns-scanner","ScannerWorkflowRunID":"","StartingShardID":null}], ScheduleToCloseTimeoutSeconds:600,
                                       ScheduleToStartTimeoutSeconds:600, StartToCloseTimeoutSeconds:300, HeartbeatTimeoutSeconds:0, DecisionTaskCompletedEventId:4,
                                       RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7, MaximumIntervalInSeconds:100, MaximumAttempts:0,
                                       NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:600}, Header:{Fields:map{}}}
   6  ActivityTaskStarted              {ScheduledEventId:5,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       RequestId:aa15c0a4-2c85-4cf0-affa-edcdfb13881b, Attempt:0, LastFailureDetails:[]}
   7  ActivityTaskCompleted            {Result:[{"CorruptedKeys":[{"ShardID":3,"CorruptedKeys":{"UUID":"03f9341b-9050-46ce-83b9-9b5bd9dda272","MinPage":0,"MaxPage":0,"
                                       Extension":"corrupted"}}],"MinShard":3,"MaxShard":3,"ShardQueryPaginationToken":{"NextShardID":null,"IsDone":true}}],
                                       ScheduledEventId:5, StartedEventId:6, Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0}
   8  DecisionTaskScheduled            {TaskList:{Name:mantas:cb29c3ed-5655-4511-abd0-1f2607ceca4a},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
   9  DecisionTaskStarted              {ScheduledEventId:8,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       RequestId:0a94425f-9b80-47ca-b015-2c26d8f4a2ee}
  10  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:8, StartedEventId:9,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       BinaryChecksum:f30736e2dc8f37300c501e4bb771260e}
  11  ActivityTaskScheduled            {ActivityId:1, ActivityType:{Name:cadence-sys-shardscanner-fixshard-activity},
                                       TaskList:{Name:cadence-sys-current-executions-fixer-tasklist-0},
                                       Input:[{"CorruptedKeysEntries":[{"ShardID":3,"CorruptedKeys":{"UUID":"03f9341b-9050-46ce-83b9-9b5bd9dda272","MinPage":0,"MaxPa
                                       ge":0,"Extension":"corrupted"}}],"ResolvedFixerWorkflowConfig":{"Concurrency":25,"BlobstoreFlushThreshold":1000,"Activit
                                       yBatchSize":200},"ContextKey":"cadence-sys-current-executions-fixer-workflow"}], ScheduleToCloseTimeoutSeconds:172860,
                                       ScheduleToStartTimeoutSeconds:1800, StartToCloseTimeoutSeconds:172800, HeartbeatTimeoutSeconds:60,
                                       DecisionTaskCompletedEventId:10, RetryPolicy:{InitialIntervalInSeconds:1, BackoffCoefficient:1.7,
                                       MaximumIntervalInSeconds:100, MaximumAttempts:0, NonRetriableErrorReasons:[len=3], ExpirationIntervalInSeconds:172800},
                                       Header:{Fields:map{}}}
  12  ActivityTaskStarted              {ScheduledEventId:11,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       RequestId:ceef52a3-079e-4209-bbad-d685d67c3d70, Attempt:0, LastFailureDetails:[]}
  13  ActivityTaskCompleted            {Result:[[{"ShardID":3,"Stats":{"EntitiesCount":2,"FixedCount":0,"SkippedCount":2,"FailedCount":0},"Result":{"ShardFixKeys":{"Sk
                                       ipped":{"UUID":"390aaaf9-1310-4795-8a73-661e4fa11884","MinPage":0,"MaxPage":0,"Extension":"skipped"},"Failed":null,"Fixe
                                       d":null},"ControlFlowFailure":null}}]], ScheduledEventId:11, StartedEventId:12,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0}
  14  DecisionTaskScheduled            {TaskList:{Name:mantas:cb29c3ed-5655-4511-abd0-1f2607ceca4a},
                                       StartToCloseTimeoutSeconds:10, Attempt:0}
  15  DecisionTaskStarted              {ScheduledEventId:14,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       RequestId:c970c914-b8e8-4e95-9aa5-59168a0fb948}
  16  DecisionTaskCompleted            {ExecutionContext:[], ScheduledEventId:14, StartedEventId:15,
                                       Identity:25828@mantas@cadence-sys-current-executions-fixer-tasklist-0,
                                       BinaryChecksum:f30736e2dc8f37300c501e4bb771260e}
  17  WorkflowExecutionContinuedAsNew  {NewExecutionRunId:9ec668ec-6faa-48f9-97df-aa052c1ca6fc, WorkflowType:{Name:cadence-sys-current-executions-fixer-workflow},
                                       TaskList:{Name:cadence-sys-current-executions-fixer-tasklist-0},
                                       Input:[{"ScannerWorkflowWorkflowID":"cadence-sys-current-executions-scanner","ScannerWorkflowRunID":"","ContextKey":"","FixerW
                                       orkflowConfigOverwrites":{"Concurrency":null,"BlobstoreFlushThreshold":null,"ActivityBatchSize":null}}],
                                       ExecutionStartToCloseTimeoutSeconds:630720000, TaskStartToCloseTimeoutSeconds:10, DecisionTaskCompletedEventId:16,
                                       BackoffStartIntervalInSeconds:60, Initiator:CronSchedule, FailureDetails:[], LastCompletionResult:[], Header:{Fields:map{}}}
```
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

