### PR TITLE
Version goveralls, remove unused go bins from docker setup

### DIFF
--- a/cmd/server/tools.go
+++ b/cmd/server/tools.go
@@ -40,4 +40,6 @@ import (
 	_ "github.com/dmarkham/enumer"
 	// golint - functional, but worth replacing with something less problematic and abandoned
 	_ "golang.org/x/lint/golint"
+	// coverage reporting
+	_ "github.com/dmetzgar/goveralls"
 )

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -21,10 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl https://bootstrap.pypa.io/get-pip.py | python
 RUN pip install PyYAML==3.13 cqlsh==5.0.4
 
-RUN go get github.com/axw/gocov/gocov
-RUN go get github.com/dmetzgar/goveralls
-RUN go get golang.org/x/tools/cmd/cover
-
 # https://github.com/docker-library/golang/blob/c1baf037d71331eb0b8d4c70cff4c29cf124c5e0/1.4/Dockerfile
 RUN mkdir -p /cadence
 WORKDIR /cadence

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1
 	github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2
 	github.com/dmarkham/enumer v1.5.1
+	github.com/dmetzgar/goveralls v0.0.3
 	github.com/eapache/go-resiliency v1.2.0 // indirect
 	github.com/emirpasic/gods v0.0.0-20190624094223-e689965507ab
 	github.com/fatih/color v0.0.0-20181010231311-3f9d52f7176a

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczC
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUnsFjfmXRMNPybcSiG0BgUW2AuFH8PAnS2iTw=
 github.com/dmarkham/enumer v1.5.1 h1:wu5fRfgGALOeMiwo9m5JnBnXOdNOi38j0Bq86Ap6rEQ=
 github.com/dmarkham/enumer v1.5.1/go.mod h1:jZ3PNbNJDEkFGx54MlkSjnDQUo7445l7/guoKdh9cY8=
+github.com/dmetzgar/goveralls v0.0.3 h1:PFQ5jBL6PXbgTeDyogIszCqtvbzOI+T9RTgiYMzXySk=
+github.com/dmetzgar/goveralls v0.0.3/go.mod h1:kSS2IYY6FaFQKx7FSMVmA2g1SEwoNO5KaNVMJjTtmjs=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-resiliency v1.2.0 h1:v7g92e/KSN71Rq7vSThKaWIq68fL4YHvWyiUKorFR1Q=
 github.com/eapache/go-resiliency v1.2.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=

--- a/scripts/buildkite/gocov.sh
+++ b/scripts/buildkite/gocov.sh
@@ -2,9 +2,6 @@
 
 set -ex
 
-# fetch codecov reporting tool
-go get github.com/dmetzgar/goveralls
-
 # download cover files from all the tests
 mkdir -p .build/coverage
 buildkite-agent artifact download ".build/coverage/unit_cover.out" . --step ":golang: unit test" --build "$BUILDKITE_BUILD_ID"
@@ -14,7 +11,6 @@ buildkite-agent artifact download ".build/coverage/integ_sql_mysql_cover.out" . 
 buildkite-agent artifact download ".build/coverage/integ_ndc_sql_mysql_cover.out" . --step ":golang: integration ndc test with mysql" --build "$BUILDKITE_BUILD_ID"
 buildkite-agent artifact download ".build/coverage/integ_sql_postgres_cover.out" . --step ":golang: integration test with postgres" --build "$BUILDKITE_BUILD_ID"
 buildkite-agent artifact download ".build/coverage/integ_ndc_sql_postgres_cover.out" . --step ":golang: integration ndc test with postgres" --build "$BUILDKITE_BUILD_ID"
-
 
 echo "download complete"
 


### PR DESCRIPTION
A few things seem unused / unnecessary to bake into scripts / docker, as now these are versioned by the makefile.

I also noticed that the "host" folder has code-being-tested and tests, but wasn't included in coverage.
So that's now included.