### PR TITLE
Fix docker-push.sh execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN go install
 # Build Cadence binaries
 FROM golang:1.13.6-alpine AS builder
 
-RUN apk add --update --no-cache ca-certificates make git curl mercurial bzr
+RUN apk add --update --no-cache ca-certificates make git curl mercurial bzr unzip
 
 WORKDIR /cadence
 

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -18,7 +18,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
       unzip \
     && rm -rf /var/lib/apt/lists/*
 
-RUN curl https://bootstrap.pypa.io/get-pip.py | python
+# pip 21+ drops support for python2 entirely, we seem to need at least 19 to build cqlsh
+RUN pip install -U 'pip<21'
 RUN pip install PyYAML==3.13 cqlsh==5.0.4
 
 # https://github.com/docker-library/golang/blob/c1baf037d71331eb0b8d4c70cff4c29cf124c5e0/1.4/Dockerfile


### PR DESCRIPTION
**Why this commit exists:**

"build and push master" buildkite steps are failing, due to both:
- their images not having `unzip` available
- `protoc` failing to run on alpine after adding `unzip`, e.g. `/bin/sh: .build/bin/protoc: not found`
- pip v21 dropped support for python2 entirely, and `cqlsh` hasn't been updated in nearly 4 years and is stuck on 2.7

This fixes that by 1) adding unzip, and 2) not executing thrift/proto codegen during those release builds (and in other locations).

---

**Lots more details:**

Protoc is apparently incompatible with alpine images, it has something to do with musl and (g?)libc incompatibilities.
In the alpine images, `sh` complains `.build/bin/protoc: not found`, but after some more digging you can see `ldd` has more info:
```
ldd .build/bin/protoc
	/lib64/ld-linux-x86-64.so.2 (0x7f9b1f366000)
	libm.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f9b1f366000)
	libpthread.so.0 => /lib64/ld-linux-x86-64.so.2 (0x7f9b1f366000)
	libc.so.6 => /lib64/ld-linux-x86-64.so.2 (0x7f9b1f366000)
Error loading shared library ld-linux-x86-64.so.2: No such file or directory (needed by .build/bin/protoc)
Error relocating .build/bin/protoc: __strftime_l: symbol not found
```

After a bit of experimenting, it seems that the semi-common tricks of "install `libc6-compat` or `gcompat`" do not work for protoc.
I'm not really sure why.

So our options are basically one of:
- Abandon alpine for this build section.  It just builds binaries that are copied to the next step, so it won't affect the final image size anyway.  (this builds successfully, but I have not checked the resulting binaries)
- Keep alpine, build protoc from source, hope it compiles successfully against musl
- Keep alpine, but don't do codegen in this build (this works)

Option 3 seemed worth trying in depth.  After some toying around and (as usual) learning something new about Make, I found this tactic.
It appears to be well-supported and consistent, so I'm OK with using it, though it's rather strange at first glance.
Binaries are still downloaded/built during release builds with this approach, but that seems like a relatively low-risk / low-cost consequence.

This all also means that devs will download and build these tools as part of a normal `make bins`, but similarly will not run codegen unless needed.
Since that kinda helps "prime" the dev environment, that seems totally fine / possibly even a good thing.  Codegen *should* still run when necessary though.