### PR TITLE
Simplify tags

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -46,160 +46,58 @@ const (
 )
 
 // Tag is an interface to define metrics tags
-type Tag interface {
-	Key() string
-	Value() string
-}
-
 type (
-	domainTag struct {
-		value string
+	Tag interface {
+		Key() string
+		Value() string
 	}
 
-	domainUnknownTag struct{}
-
-	taskListUnknownTag struct{}
-
-	instanceTag struct {
-		value string
-	}
-
-	targetClusterTag struct {
-		value string
-	}
-
-	activeClusterTag struct {
-		value string
-	}
-
-	taskListTag struct {
-		value string
-	}
-
-	taskListTypeTag struct {
-		value string
-	}
-
-	workflowTypeTag struct {
-		value string
-	}
-
-	activityTypeTag struct {
-		value string
-	}
-
-	decisionTypeTag struct {
-		value string
-	}
-
-	invariantTypeTag struct {
-		value string
-	}
-
-	kafkaPartitionTag struct {
+	simple struct {
+		key   string
 		value string
 	}
 )
+
+func (s simple) Key() string   { return s.key }
+func (s simple) Value() string { return s.value }
+
+func simpleWithUnknown(key, value string) Tag {
+	if len(value) == 0 {
+		value = unknownValue
+	}
+	return simple{key: key, value: value}
+}
 
 // DomainTag returns a new domain tag. For timers, this also ensures that we
 // dual emit the metric with the all tag. If a blank domain is provided then
 // this converts that to an unknown domain.
 func DomainTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return domainTag{value}
-}
-
-// Key returns the key of the domain tag
-func (d domainTag) Key() string {
-	return domain
-}
-
-// Value returns the value of a domain tag
-func (d domainTag) Value() string {
-	return d.value
+	return simpleWithUnknown(domain, value)
 }
 
 // DomainUnknownTag returns a new domain:unknown tag-value
 func DomainUnknownTag() Tag {
-	return domainUnknownTag{}
-}
-
-// Key returns the key of the domain unknown tag
-func (d taskListUnknownTag) Key() string {
-	return domain
-}
-
-// Value returns the value of the domain unknown tag
-func (d taskListUnknownTag) Value() string {
-	return unknownValue
+	return DomainTag("")
 }
 
 // TaskListUnknownTag returns a new tasklist:unknown tag-value
 func TaskListUnknownTag() Tag {
-	return taskListUnknownTag{}
-}
-
-// Key returns the key of the domain unknown tag
-func (d domainUnknownTag) Key() string {
-	return domain
-}
-
-// Value returns the value of the domain unknown tag
-func (d domainUnknownTag) Value() string {
-	return unknownValue
+	return simple{key: taskList, value: unknownValue}
 }
 
 // InstanceTag returns a new instance tag
 func InstanceTag(value string) Tag {
-	return instanceTag{value}
-}
-
-// Key returns the key of the instance tag
-func (i instanceTag) Key() string {
-	return instance
-}
-
-// Value returns the value of a instance tag
-func (i instanceTag) Value() string {
-	return i.value
+	return simple{key: instance, value: value}
 }
 
 // TargetClusterTag returns a new target cluster tag.
 func TargetClusterTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return targetClusterTag{value}
-}
-
-// Key returns the key of the target cluster tag
-func (d targetClusterTag) Key() string {
-	return targetCluster
-}
-
-// Key returns the key of the active cluster tag
-func (ac activeClusterTag) Key() string {
-	return activeCluster
-}
-
-// Value returns the value of the active cluster tag
-func (ac activeClusterTag) Value() string {
-	return ac.value
+	return simpleWithUnknown(targetCluster, value)
 }
 
 // ActiveClusterTag returns a new active cluster type tag.
 func ActiveClusterTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return activeClusterTag{value}
-}
-
-// Value returns the value of a target cluster tag
-func (d targetClusterTag) Value() string {
-	return d.value
+	return simpleWithUnknown(activeCluster, value)
 }
 
 // TaskListTag returns a new task list tag.
@@ -207,120 +105,35 @@ func TaskListTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return taskListTag{sanitizer.Value(value)}
-}
-
-// Key returns the key of the task list tag
-func (d taskListTag) Key() string {
-	return taskList
-}
-
-// Value returns the value of the task list tag
-func (d taskListTag) Value() string {
-	return d.value
+	return simple{key: taskList, value: sanitizer.Value(value)}
 }
 
 // TaskListTypeTag returns a new task list type tag.
 func TaskListTypeTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return taskListTypeTag{value}
-}
-
-// Key returns the key of the task list type tag
-func (d taskListTypeTag) Key() string {
-	return taskListType
-}
-
-// Value returns the value of the task list type tag
-func (d taskListTypeTag) Value() string {
-	return d.value
+	return simpleWithUnknown(taskListType, value)
 }
 
 // WorkflowTypeTag returns a new workflow type tag.
 func WorkflowTypeTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return workflowTypeTag{value}
-}
-
-// Key returns the key of the workflow type tag
-func (d workflowTypeTag) Key() string {
-	return workflowType
-}
-
-// Value returns the value of the workflow type tag
-func (d workflowTypeTag) Value() string {
-	return d.value
+	return simpleWithUnknown(workflowType, value)
 }
 
 // ActivityTypeTag returns a new activity type tag.
 func ActivityTypeTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return activityTypeTag{value}
-}
-
-// Key returns the key of the activity type tag
-func (d activityTypeTag) Key() string {
-	return activityType
-}
-
-// Value returns the value of the activity type tag
-func (d activityTypeTag) Value() string {
-	return d.value
+	return simpleWithUnknown(activityType, value)
 }
 
 // DecisionTypeTag returns a new decision type tag.
 func DecisionTypeTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return decisionTypeTag{value}
-}
-
-// Key returns the key of the decision type tag
-func (d decisionTypeTag) Key() string {
-	return decisionType
-}
-
-// Value returns the value of the decision type tag
-func (d decisionTypeTag) Value() string {
-	return d.value
+	return simpleWithUnknown(decisionType, value)
 }
 
 // InvariantTypeTag returns a new invariant type tag.
 func InvariantTypeTag(value string) Tag {
-	if len(value) == 0 {
-		value = unknownValue
-	}
-	return invariantTypeTag{value}
-}
-
-// Key returns the key of invariant type tag
-func (d invariantTypeTag) Key() string {
-	return invariantType
-}
-
-// Value returns the value of invariant type tag
-func (d invariantTypeTag) Value() string {
-	return d.value
+	return simpleWithUnknown(invariantType, value)
 }
 
 // KafkaPartitionTag returns a new KafkaPartition type tag.
 func KafkaPartitionTag(value int32) Tag {
-	return kafkaPartitionTag{strconv.Itoa(int(value))}
-}
-
-// Key returns the key of the decision type tag
-func (d kafkaPartitionTag) Key() string {
-	return kafkaPartition
-}
-
-// Value returns the value of the decision type tag
-func (d kafkaPartitionTag) Value() string {
-	return d.value
+	return simple{key: kafkaPartition, value: strconv.Itoa(int(value))}
 }

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -52,27 +52,27 @@ type (
 		Value() string
 	}
 
-	simple struct {
+	simpleMetric struct {
 		key   string
 		value string
 	}
 )
 
-func (s simple) Key() string   { return s.key }
-func (s simple) Value() string { return s.value }
+func (s simpleMetric) Key() string   { return s.key }
+func (s simpleMetric) Value() string { return s.value }
 
-func simpleWithUnknown(key, value string) Tag {
+func metricWithUnknown(key, value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return simple{key: key, value: value}
+	return simpleMetric{key: key, value: value}
 }
 
 // DomainTag returns a new domain tag. For timers, this also ensures that we
 // dual emit the metric with the all tag. If a blank domain is provided then
 // this converts that to an unknown domain.
 func DomainTag(value string) Tag {
-	return simpleWithUnknown(domain, value)
+	return metricWithUnknown(domain, value)
 }
 
 // DomainUnknownTag returns a new domain:unknown tag-value
@@ -80,24 +80,19 @@ func DomainUnknownTag() Tag {
 	return DomainTag("")
 }
 
-// TaskListUnknownTag returns a new tasklist:unknown tag-value
-func TaskListUnknownTag() Tag {
-	return simple{key: taskList, value: unknownValue}
-}
-
 // InstanceTag returns a new instance tag
 func InstanceTag(value string) Tag {
-	return simple{key: instance, value: value}
+	return simpleMetric{key: instance, value: value}
 }
 
 // TargetClusterTag returns a new target cluster tag.
 func TargetClusterTag(value string) Tag {
-	return simpleWithUnknown(targetCluster, value)
+	return metricWithUnknown(targetCluster, value)
 }
 
 // ActiveClusterTag returns a new active cluster type tag.
 func ActiveClusterTag(value string) Tag {
-	return simpleWithUnknown(activeCluster, value)
+	return metricWithUnknown(activeCluster, value)
 }
 
 // TaskListTag returns a new task list tag.
@@ -105,35 +100,40 @@ func TaskListTag(value string) Tag {
 	if len(value) == 0 {
 		value = unknownValue
 	}
-	return simple{key: taskList, value: sanitizer.Value(value)}
+	return simpleMetric{key: taskList, value: sanitizer.Value(value)}
+}
+
+// TaskListUnknownTag returns a new tasklist:unknown tag-value
+func TaskListUnknownTag() Tag {
+	return simpleMetric{key: taskList, value: unknownValue}
 }
 
 // TaskListTypeTag returns a new task list type tag.
 func TaskListTypeTag(value string) Tag {
-	return simpleWithUnknown(taskListType, value)
+	return metricWithUnknown(taskListType, value)
 }
 
 // WorkflowTypeTag returns a new workflow type tag.
 func WorkflowTypeTag(value string) Tag {
-	return simpleWithUnknown(workflowType, value)
+	return metricWithUnknown(workflowType, value)
 }
 
 // ActivityTypeTag returns a new activity type tag.
 func ActivityTypeTag(value string) Tag {
-	return simpleWithUnknown(activityType, value)
+	return metricWithUnknown(activityType, value)
 }
 
 // DecisionTypeTag returns a new decision type tag.
 func DecisionTypeTag(value string) Tag {
-	return simpleWithUnknown(decisionType, value)
+	return metricWithUnknown(decisionType, value)
 }
 
 // InvariantTypeTag returns a new invariant type tag.
 func InvariantTypeTag(value string) Tag {
-	return simpleWithUnknown(invariantType, value)
+	return metricWithUnknown(invariantType, value)
 }
 
 // KafkaPartitionTag returns a new KafkaPartition type tag.
 func KafkaPartitionTag(value int32) Tag {
-	return simple{key: kafkaPartition, value: strconv.Itoa(int(value))}
+	return simpleMetric{key: kafkaPartition, value: strconv.Itoa(int(value))}
 }


### PR DESCRIPTION
Just noticed while skimming that this file seemed drastically over-complicated.
As the keys are all consts, this should mean that the net change for all this is that these take one slice pointer more space per instance.  And binary size is slightly smaller due to fewer types / a smaller type->interface lookup table.

Separately, now that it's simpler, some of the variations are more noticeable.
It may be worth standardizing further, e.g.:
- sanitizing everything (except perhaps the kafka partition)
- get rid of the "unknown" constructors?  I can see them having some use, but it seems kinda random what has it and what doesn't.