### PR TITLE
Emit number of task list managers started

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1960,6 +1960,7 @@ const (
 	RemoteToLocalMatchPerTaskListCounter
 	RemoteToRemoteMatchPerTaskListCounter
 	PollerPerTaskListCounter
+	TaskListManagersGauge
 
 	NumMatchingMetrics
 )
@@ -2441,6 +2442,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		RemoteToLocalMatchPerTaskListCounter:     {metricName: "remote_to_local_matches_per_tl", metricRollupName: "remote_to_local_matches"},
 		RemoteToRemoteMatchPerTaskListCounter:    {metricName: "remote_to_remote_matches_per_tl", metricRollupName: "remote_to_remote_matches"},
 		PollerPerTaskListCounter:                 {metricName: "poller_count_per_tl", metricRollupName: "poller_count"},
+		TaskListManagersGauge:                    {metricName: "tasklist_managers", metricType: Gauge},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -203,6 +203,10 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *taskListID,
 		logger.Info("Task list manager state changed", tag.LifeCycleStartFailed, tag.Error(err))
 		return nil, err
 	}
+	e.metricsClient.Scope(metrics.MatchingTaskListMgrScope).UpdateGauge(
+		metrics.TaskListManagersGauge,
+		float64(len(e.taskLists)),
+	)
 	logger.Info("Task list manager state changed", tag.LifeCycleStarted)
 	return mgr, nil
 }
@@ -218,6 +222,10 @@ func (e *matchingEngineImpl) removeTaskListManager(id *taskListID) {
 	e.taskListsLock.Lock()
 	defer e.taskListsLock.Unlock()
 	delete(e.taskLists, *id)
+	e.metricsClient.Scope(metrics.MatchingTaskListMgrScope).UpdateGauge(
+		metrics.TaskListManagersGauge,
+		float64(len(e.taskLists)),
+	)
 }
 
 // AddDecisionTask either delivers task directly to waiting poller or save it into task list persistence.

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -197,16 +197,16 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *taskListID,
 		return nil, err
 	}
 	e.taskLists[*taskList] = mgr
+	e.metricsClient.Scope(metrics.MatchingTaskListMgrScope).UpdateGauge(
+		metrics.TaskListManagersGauge,
+		float64(len(e.taskLists)),
+	)
 	e.taskListsLock.Unlock()
 	err = mgr.Start()
 	if err != nil {
 		logger.Info("Task list manager state changed", tag.LifeCycleStartFailed, tag.Error(err))
 		return nil, err
 	}
-	e.metricsClient.Scope(metrics.MatchingTaskListMgrScope).UpdateGauge(
-		metrics.TaskListManagersGauge,
-		float64(len(e.taskLists)),
-	)
 	logger.Info("Task list manager state changed", tag.LifeCycleStarted)
 	return mgr, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
During creation and deletion of Task List Manager gauge metric is emitted with a count of Task List Managers active

<!-- Tell your future self why have you made these changes -->
**Why?**
This will expose a number of task list managers created per matching instance

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

