### PR TITLE
Sanitize common metrics tag values, allow dashes

### DIFF
--- a/common/metrics/interfaces.go
+++ b/common/metrics/interfaces.go
@@ -69,10 +69,3 @@ type (
 		Tagged(tags ...Tag) Scope
 	}
 )
-
-var sanitizer = tally.NewSanitizer(tally.SanitizeOptions{
-	NameCharacters:       tally.ValidCharacters{tally.AlphanumericRange, tally.UnderscoreCharacters},
-	KeyCharacters:        tally.ValidCharacters{tally.AlphanumericRange, tally.UnderscoreCharacters},
-	ValueCharacters:      tally.ValidCharacters{tally.AlphanumericRange, tally.UnderscoreCharacters},
-	ReplacementCharacter: '_',
-})


### PR DESCRIPTION
The existence of a sanitizer implies that there are *un*safe values, so we should probably always sanitize.  Many of these values are user-controllable anyway, leaving them untouched may not be a good idea.
So now everything's sanitized.  I've excluded the kafka one simply because the current builder + sanitizer are guaranteed to not have any effect.

Of note:
- `sanitizer` was only used in this file, so I've moved it.
- `-` may be reasonable to allow for values, but it's a slightly larger semantic change and is not necessarily desirable.
- `.` I'm *intentionally excluding*, as it's used as a conceptual-group separator, e.g. as in canary/metrics.go.
  Since these tag APIs seem more focused on single-"thing" values, separators don't seem like they should be allowed.
  I've left a comment in code for this, for future potential-modifiers.

The main risk here is that some stats could change, e.g. domains / instances / etc with `.`s or other blocked characters in their names will now have underscores there.  Double-sanitizing is harmless / a no-op as there's no escaping sequence, just outright replacement.