### PR TITLE
Drop pointer for page size fields

### DIFF
--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -322,7 +322,7 @@ func (s *domainHandlerCommonSuite) TestListDomain() {
 	var token []byte
 	for doPaging := true; doPaging; doPaging = len(token) > 0 {
 		resp, err := s.handler.ListDomains(context.Background(), &types.ListDomainsRequest{
-			PageSize:      common.Int32Ptr(pagesize),
+			PageSize:      pagesize,
 			NextPageToken: token,
 		})
 		s.Nil(err)

--- a/common/service/config/archival.go
+++ b/common/service/config/archival.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"errors"
+
 	"github.com/uber/cadence/common"
 )
 

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -2344,7 +2344,7 @@ func FromGetWorkflowExecutionHistoryRequest(t *types.GetWorkflowExecutionHistory
 	return &shared.GetWorkflowExecutionHistoryRequest{
 		Domain:                 &t.Domain,
 		Execution:              FromWorkflowExecution(t.Execution),
-		MaximumPageSize:        t.MaximumPageSize,
+		MaximumPageSize:        &t.MaximumPageSize,
 		NextPageToken:          t.NextPageToken,
 		WaitForNewEvent:        t.WaitForNewEvent,
 		HistoryEventFilterType: FromHistoryEventFilterType(t.HistoryEventFilterType),
@@ -2360,7 +2360,7 @@ func ToGetWorkflowExecutionHistoryRequest(t *shared.GetWorkflowExecutionHistoryR
 	return &types.GetWorkflowExecutionHistoryRequest{
 		Domain:                 t.GetDomain(),
 		Execution:              ToWorkflowExecution(t.Execution),
-		MaximumPageSize:        t.MaximumPageSize,
+		MaximumPageSize:        t.GetMaximumPageSize(),
 		NextPageToken:          t.NextPageToken,
 		WaitForNewEvent:        t.WaitForNewEvent,
 		HistoryEventFilterType: ToHistoryEventFilterType(t.HistoryEventFilterType),
@@ -2733,7 +2733,7 @@ func FromListArchivedWorkflowExecutionsRequest(t *types.ListArchivedWorkflowExec
 	}
 	return &shared.ListArchivedWorkflowExecutionsRequest{
 		Domain:        &t.Domain,
-		PageSize:      t.PageSize,
+		PageSize:      &t.PageSize,
 		NextPageToken: t.NextPageToken,
 		Query:         t.Query,
 	}
@@ -2746,7 +2746,7 @@ func ToListArchivedWorkflowExecutionsRequest(t *shared.ListArchivedWorkflowExecu
 	}
 	return &types.ListArchivedWorkflowExecutionsRequest{
 		Domain:        t.GetDomain(),
-		PageSize:      t.PageSize,
+		PageSize:      t.GetPageSize(),
 		NextPageToken: t.NextPageToken,
 		Query:         t.Query,
 	}
@@ -2781,7 +2781,7 @@ func FromListClosedWorkflowExecutionsRequest(t *types.ListClosedWorkflowExecutio
 	}
 	return &shared.ListClosedWorkflowExecutionsRequest{
 		Domain:          &t.Domain,
-		MaximumPageSize: t.MaximumPageSize,
+		MaximumPageSize: &t.MaximumPageSize,
 		NextPageToken:   t.NextPageToken,
 		StartTimeFilter: FromStartTimeFilter(t.StartTimeFilter),
 		ExecutionFilter: FromWorkflowExecutionFilter(t.ExecutionFilter),
@@ -2797,7 +2797,7 @@ func ToListClosedWorkflowExecutionsRequest(t *shared.ListClosedWorkflowExecution
 	}
 	return &types.ListClosedWorkflowExecutionsRequest{
 		Domain:          t.GetDomain(),
-		MaximumPageSize: t.MaximumPageSize,
+		MaximumPageSize: t.GetMaximumPageSize(),
 		NextPageToken:   t.NextPageToken,
 		StartTimeFilter: ToStartTimeFilter(t.StartTimeFilter),
 		ExecutionFilter: ToWorkflowExecutionFilter(t.ExecutionFilter),
@@ -2834,7 +2834,7 @@ func FromListDomainsRequest(t *types.ListDomainsRequest) *shared.ListDomainsRequ
 		return nil
 	}
 	return &shared.ListDomainsRequest{
-		PageSize:      t.PageSize,
+		PageSize:      &t.PageSize,
 		NextPageToken: t.NextPageToken,
 	}
 }
@@ -2845,7 +2845,7 @@ func ToListDomainsRequest(t *shared.ListDomainsRequest) *types.ListDomainsReques
 		return nil
 	}
 	return &types.ListDomainsRequest{
-		PageSize:      t.PageSize,
+		PageSize:      t.GetPageSize(),
 		NextPageToken: t.NextPageToken,
 	}
 }
@@ -2879,7 +2879,7 @@ func FromListOpenWorkflowExecutionsRequest(t *types.ListOpenWorkflowExecutionsRe
 	}
 	return &shared.ListOpenWorkflowExecutionsRequest{
 		Domain:          &t.Domain,
-		MaximumPageSize: t.MaximumPageSize,
+		MaximumPageSize: &t.MaximumPageSize,
 		NextPageToken:   t.NextPageToken,
 		StartTimeFilter: FromStartTimeFilter(t.StartTimeFilter),
 		ExecutionFilter: FromWorkflowExecutionFilter(t.ExecutionFilter),
@@ -2894,7 +2894,7 @@ func ToListOpenWorkflowExecutionsRequest(t *shared.ListOpenWorkflowExecutionsReq
 	}
 	return &types.ListOpenWorkflowExecutionsRequest{
 		Domain:          t.GetDomain(),
-		MaximumPageSize: t.MaximumPageSize,
+		MaximumPageSize: t.GetMaximumPageSize(),
 		NextPageToken:   t.NextPageToken,
 		StartTimeFilter: ToStartTimeFilter(t.StartTimeFilter),
 		ExecutionFilter: ToWorkflowExecutionFilter(t.ExecutionFilter),
@@ -2975,7 +2975,7 @@ func FromListWorkflowExecutionsRequest(t *types.ListWorkflowExecutionsRequest) *
 	}
 	return &shared.ListWorkflowExecutionsRequest{
 		Domain:        &t.Domain,
-		PageSize:      t.PageSize,
+		PageSize:      &t.PageSize,
 		NextPageToken: t.NextPageToken,
 		Query:         t.Query,
 	}
@@ -2988,7 +2988,7 @@ func ToListWorkflowExecutionsRequest(t *shared.ListWorkflowExecutionsRequest) *t
 	}
 	return &types.ListWorkflowExecutionsRequest{
 		Domain:        t.GetDomain(),
-		PageSize:      t.PageSize,
+		PageSize:      t.GetPageSize(),
 		NextPageToken: t.NextPageToken,
 		Query:         t.Query,
 	}

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -3403,7 +3403,7 @@ func (v *GetSearchAttributesResponse) GetKeys() (o map[string]IndexedValueType) 
 type GetWorkflowExecutionHistoryRequest struct {
 	Domain                 string                  `json:"domain,omitempty"`
 	Execution              *WorkflowExecution      `json:"execution,omitempty"`
-	MaximumPageSize        *int32                  `json:"maximumPageSize,omitempty"`
+	MaximumPageSize        int32                   `json:"maximumPageSize,omitempty"`
 	NextPageToken          []byte                  `json:"nextPageToken,omitempty"`
 	WaitForNewEvent        *bool                   `json:"waitForNewEvent,omitempty"`
 	HistoryEventFilterType *HistoryEventFilterType `json:"HistoryEventFilterType,omitempty"`
@@ -3428,8 +3428,8 @@ func (v *GetWorkflowExecutionHistoryRequest) GetExecution() (o *WorkflowExecutio
 
 // GetMaximumPageSize is an internal getter (TBD...)
 func (v *GetWorkflowExecutionHistoryRequest) GetMaximumPageSize() (o int32) {
-	if v != nil && v.MaximumPageSize != nil {
-		return *v.MaximumPageSize
+	if v != nil {
+		return v.MaximumPageSize
 	}
 	return
 }
@@ -4193,7 +4193,7 @@ func (v *LimitExceededError) GetMessage() (o string) {
 // ListArchivedWorkflowExecutionsRequest is an internal type (TBD...)
 type ListArchivedWorkflowExecutionsRequest struct {
 	Domain        string  `json:"domain,omitempty"`
-	PageSize      *int32  `json:"pageSize,omitempty"`
+	PageSize      int32   `json:"pageSize,omitempty"`
 	NextPageToken []byte  `json:"nextPageToken,omitempty"`
 	Query         *string `json:"query,omitempty"`
 }
@@ -4208,8 +4208,8 @@ func (v *ListArchivedWorkflowExecutionsRequest) GetDomain() (o string) {
 
 // GetPageSize is an internal getter (TBD...)
 func (v *ListArchivedWorkflowExecutionsRequest) GetPageSize() (o int32) {
-	if v != nil && v.PageSize != nil {
-		return *v.PageSize
+	if v != nil {
+		return v.PageSize
 	}
 	return
 }
@@ -4255,7 +4255,7 @@ func (v *ListArchivedWorkflowExecutionsResponse) GetNextPageToken() (o []byte) {
 // ListClosedWorkflowExecutionsRequest is an internal type (TBD...)
 type ListClosedWorkflowExecutionsRequest struct {
 	Domain          string                        `json:"domain,omitempty"`
-	MaximumPageSize *int32                        `json:"maximumPageSize,omitempty"`
+	MaximumPageSize int32                         `json:"maximumPageSize,omitempty"`
 	NextPageToken   []byte                        `json:"nextPageToken,omitempty"`
 	StartTimeFilter *StartTimeFilter              `json:"StartTimeFilter,omitempty"`
 	ExecutionFilter *WorkflowExecutionFilter      `json:"executionFilter,omitempty"`
@@ -4273,8 +4273,8 @@ func (v *ListClosedWorkflowExecutionsRequest) GetDomain() (o string) {
 
 // GetMaximumPageSize is an internal getter (TBD...)
 func (v *ListClosedWorkflowExecutionsRequest) GetMaximumPageSize() (o int32) {
-	if v != nil && v.MaximumPageSize != nil {
-		return *v.MaximumPageSize
+	if v != nil {
+		return v.MaximumPageSize
 	}
 	return
 }
@@ -4343,14 +4343,14 @@ func (v *ListClosedWorkflowExecutionsResponse) GetNextPageToken() (o []byte) {
 
 // ListDomainsRequest is an internal type (TBD...)
 type ListDomainsRequest struct {
-	PageSize      *int32 `json:"pageSize,omitempty"`
+	PageSize      int32  `json:"pageSize,omitempty"`
 	NextPageToken []byte `json:"nextPageToken,omitempty"`
 }
 
 // GetPageSize is an internal getter (TBD...)
 func (v *ListDomainsRequest) GetPageSize() (o int32) {
-	if v != nil && v.PageSize != nil {
-		return *v.PageSize
+	if v != nil {
+		return v.PageSize
 	}
 	return
 }
@@ -4388,7 +4388,7 @@ func (v *ListDomainsResponse) GetNextPageToken() (o []byte) {
 // ListOpenWorkflowExecutionsRequest is an internal type (TBD...)
 type ListOpenWorkflowExecutionsRequest struct {
 	Domain          string                   `json:"domain,omitempty"`
-	MaximumPageSize *int32                   `json:"maximumPageSize,omitempty"`
+	MaximumPageSize int32                    `json:"maximumPageSize,omitempty"`
 	NextPageToken   []byte                   `json:"nextPageToken,omitempty"`
 	StartTimeFilter *StartTimeFilter         `json:"StartTimeFilter,omitempty"`
 	ExecutionFilter *WorkflowExecutionFilter `json:"executionFilter,omitempty"`
@@ -4405,8 +4405,8 @@ func (v *ListOpenWorkflowExecutionsRequest) GetDomain() (o string) {
 
 // GetMaximumPageSize is an internal getter (TBD...)
 func (v *ListOpenWorkflowExecutionsRequest) GetMaximumPageSize() (o int32) {
-	if v != nil && v.MaximumPageSize != nil {
-		return *v.MaximumPageSize
+	if v != nil {
+		return v.MaximumPageSize
 	}
 	return
 }
@@ -4512,7 +4512,7 @@ func (v *ListTaskListPartitionsResponse) GetDecisionTaskListPartitions() (o []*T
 // ListWorkflowExecutionsRequest is an internal type (TBD...)
 type ListWorkflowExecutionsRequest struct {
 	Domain        string  `json:"domain,omitempty"`
-	PageSize      *int32  `json:"pageSize,omitempty"`
+	PageSize      int32   `json:"pageSize,omitempty"`
 	NextPageToken []byte  `json:"nextPageToken,omitempty"`
 	Query         *string `json:"query,omitempty"`
 }
@@ -4527,8 +4527,8 @@ func (v *ListWorkflowExecutionsRequest) GetDomain() (o string) {
 
 // GetPageSize is an internal getter (TBD...)
 func (v *ListWorkflowExecutionsRequest) GetPageSize() (o int32) {
-	if v != nil && v.PageSize != nil {
-		return *v.PageSize
+	if v != nil {
+		return v.PageSize
 	}
 	return
 }

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -122,7 +122,7 @@ func (s *integrationSuite) TestVisibilityArchival() {
 		executions = []*types.WorkflowExecutionInfo{}
 		request := &types.ListArchivedWorkflowExecutionsRequest{
 			Domain:   s.archivalDomainName,
-			PageSize: common.Int32Ptr(2),
+			PageSize: 2,
 			Query:    common.StringPtr(fmt.Sprintf("CloseTime >= %v and CloseTime <= %v and WorkflowType = '%s'", startTime, endTime, workflowType)),
 		}
 		for len(executions) == 0 || request.NextPageToken != nil {

--- a/host/elasticsearch_test.go
+++ b/host/elasticsearch_test.go
@@ -114,7 +114,7 @@ func (s *elasticsearchIntegrationSuite) TestListOpenWorkflow() {
 		startFilter.LatestTime = common.Int64Ptr(time.Now().UnixNano())
 		resp, err := s.engine.ListOpenWorkflowExecutions(createContext(), &types.ListOpenWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(defaultTestValueOfESIndexMaxResultWindow),
+			MaximumPageSize: defaultTestValueOfESIndexMaxResultWindow,
 			StartTimeFilter: startFilter,
 			ExecutionFilter: &types.WorkflowExecutionFilter{
 				WorkflowID: common.StringPtr(id),
@@ -227,7 +227,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_SearchAttribute() {
 
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   s.domainName,
-		PageSize: common.Int32Ptr(int32(2)),
+		PageSize: int32(2),
 		Query:    common.StringPtr(fmt.Sprintf(`WorkflowType = '%s' and CloseTime = missing and BinaryChecksums = 'binary-v1'`, wt)),
 	}
 	// verify upsert data is on ES
@@ -309,7 +309,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrQuery() {
 	var openExecution *types.WorkflowExecutionInfo
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   s.domainName,
-		PageSize: common.Int32Ptr(defaultTestValueOfESIndexMaxResultWindow),
+		PageSize: defaultTestValueOfESIndexMaxResultWindow,
 		Query:    common.StringPtr(query1),
 	}
 	for i := 0; i < numOfRetry; i++ {
@@ -398,7 +398,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_MaxWindowSize() {
 
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:        s.domainName,
-		PageSize:      common.Int32Ptr(int32(defaultTestValueOfESIndexMaxResultWindow)),
+		PageSize:      int32(defaultTestValueOfESIndexMaxResultWindow),
 		NextPageToken: nextPageToken,
 		Query:         common.StringPtr(fmt.Sprintf(`WorkflowType = '%s' and CloseTime = missing`, wt)),
 	}
@@ -467,7 +467,7 @@ func (s *elasticsearchIntegrationSuite) TestListWorkflow_OrderBy() {
 	var openExecutions []*types.WorkflowExecutionInfo
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   s.domainName,
-		PageSize: common.Int32Ptr(pageSize),
+		PageSize: pageSize,
 		Query:    common.StringPtr(query1),
 	}
 	for i := 0; i < numOfRetry; i++ {
@@ -574,7 +574,7 @@ func (s *elasticsearchIntegrationSuite) testListWorkflowHelper(numOfWorkflows, p
 
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:        s.domainName,
-		PageSize:      common.Int32Ptr(int32(pageSize)),
+		PageSize:      int32(pageSize),
 		NextPageToken: nextPageToken,
 		Query:         common.StringPtr(fmt.Sprintf(`WorkflowType = '%s' and CloseTime = missing`, wType)),
 	}
@@ -630,7 +630,7 @@ func (s *elasticsearchIntegrationSuite) testHelperForReadOnce(runID, query strin
 	var openExecution *types.WorkflowExecutionInfo
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   s.domainName,
-		PageSize: common.Int32Ptr(defaultTestValueOfESIndexMaxResultWindow),
+		PageSize: defaultTestValueOfESIndexMaxResultWindow,
 		Query:    common.StringPtr(query),
 	}
 	for i := 0; i < numOfRetry; i++ {
@@ -903,7 +903,7 @@ func (s *elasticsearchIntegrationSuite) TestUpsertWorkflowExecution() {
 	// verify upsert data is on ES
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   s.domainName,
-		PageSize: common.Int32Ptr(int32(2)),
+		PageSize: int32(2),
 		Query:    common.StringPtr(fmt.Sprintf(`WorkflowType = '%s' and CloseTime = missing`, wt)),
 	}
 	verified := false

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -1101,7 +1101,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	time.Sleep(2 * time.Second)
 	resp, err := s.engine.ListOpenWorkflowExecutions(createContext(), &types.ListOpenWorkflowExecutionsRequest{
 		Domain:          s.domainName,
-		MaximumPageSize: common.Int32Ptr(100),
+		MaximumPageSize: 100,
 		StartTimeFilter: startFilter,
 		ExecutionFilter: &types.WorkflowExecutionFilter{
 			WorkflowID: common.StringPtr(id),
@@ -1171,7 +1171,7 @@ func (s *integrationSuite) TestCronWorkflow() {
 	for i := 0; i < 10; i++ {
 		resp, err := s.engine.ListClosedWorkflowExecutions(createContext(), &types.ListClosedWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
 			ExecutionFilter: &types.WorkflowExecutionFilter{
 				WorkflowID: common.StringPtr(id),
@@ -1850,7 +1850,7 @@ func (s *integrationSuite) TestVisibility() {
 	for i := 0; i < 10; i++ {
 		resp, err3 := s.engine.ListClosedWorkflowExecutions(createContext(), &types.ListClosedWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
 		})
 		s.Nil(err3)
@@ -1868,7 +1868,7 @@ func (s *integrationSuite) TestVisibility() {
 	for i := 0; i < 10; i++ {
 		resp, err4 := s.engine.ListOpenWorkflowExecutions(createContext(), &types.ListOpenWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
 		})
 		s.Nil(err4)
@@ -2201,7 +2201,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 		startFilter.LatestTime = common.Int64Ptr(time.Now().UnixNano())
 		resp, err := s.engine.ListOpenWorkflowExecutions(createContext(), &types.ListOpenWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
 			ExecutionFilter: &types.WorkflowExecutionFilter{
 				WorkflowID: common.StringPtr(childID),
@@ -2244,7 +2244,7 @@ func (s *integrationSuite) TestCronChildWorkflowExecution() {
 	for i := 0; i < 10; i++ {
 		resp, err := s.engine.ListClosedWorkflowExecutions(createContext(), &types.ListClosedWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
 		})
 		s.Nil(err)
@@ -2343,7 +2343,7 @@ ListClosedLoop:
 	for i := 0; i < 10; i++ {
 		resp, err3 := s.engine.ListClosedWorkflowExecutions(createContext(), &types.ListClosedWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: startFilter,
 		})
 		s.Nil(err3)
@@ -3731,7 +3731,7 @@ func (s *integrationSuite) TestCancelTimer() {
 		resp, err := s.engine.GetWorkflowExecutionHistory(createContext(), &types.GetWorkflowExecutionHistoryRequest{
 			Domain:          s.domainName,
 			Execution:       workflowExecution,
-			MaximumPageSize: common.Int32Ptr(200),
+			MaximumPageSize: 200,
 		})
 		s.Nil(err)
 		for _, event := range resp.History.Events {
@@ -3799,7 +3799,7 @@ func (s *integrationSuite) TestCancelTimer() {
 	resp, err := s.engine.GetWorkflowExecutionHistory(createContext(), &types.GetWorkflowExecutionHistoryRequest{
 		Domain:          s.domainName,
 		Execution:       workflowExecution,
-		MaximumPageSize: common.Int32Ptr(200),
+		MaximumPageSize: 200,
 	})
 	s.Nil(err)
 	for _, event := range resp.History.Events {
@@ -3868,7 +3868,7 @@ func (s *integrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
 		resp, err := s.engine.GetWorkflowExecutionHistory(createContext(), &types.GetWorkflowExecutionHistoryRequest{
 			Domain:          s.domainName,
 			Execution:       workflowExecution,
-			MaximumPageSize: common.Int32Ptr(200),
+			MaximumPageSize: 200,
 		})
 		s.Nil(err)
 		for _, event := range resp.History.Events {
@@ -3937,7 +3937,7 @@ func (s *integrationSuite) TestCancelTimer_CancelFiredAndBuffered() {
 	resp, err := s.engine.GetWorkflowExecutionHistory(createContext(), &types.GetWorkflowExecutionHistoryRequest{
 		Domain:          s.domainName,
 		Execution:       workflowExecution,
-		MaximumPageSize: common.Int32Ptr(200),
+		MaximumPageSize: 200,
 	})
 	s.Nil(err)
 	for _, event := range resp.History.Events {
@@ -3986,7 +3986,7 @@ func (s *integrationSuite) startWithMemoHelper(startFn startFunc, id string, tas
 	for i := 0; i < 10; i++ {
 		resp, err1 := s.engine.ListOpenWorkflowExecutions(createContext(), &types.ListOpenWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: &types.StartTimeFilter{
 				EarliestTime: common.Int64Ptr(0),
 				LatestTime:   common.Int64Ptr(time.Now().UnixNano()),
@@ -4041,7 +4041,7 @@ func (s *integrationSuite) startWithMemoHelper(startFn startFunc, id string, tas
 	for i := 0; i < 10; i++ {
 		resp, err1 := s.engine.ListClosedWorkflowExecutions(createContext(), &types.ListClosedWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: &types.StartTimeFilter{
 				EarliestTime: common.Int64Ptr(0),
 				LatestTime:   common.Int64Ptr(time.Now().UnixNano()),

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -190,7 +190,7 @@ func (s *IntegrationBase) getHistory(domain string, execution *types.WorkflowExe
 	historyResponse, err := s.engine.GetWorkflowExecutionHistory(createContext(), &types.GetWorkflowExecutionHistoryRequest{
 		Domain:          domain,
 		Execution:       execution,
-		MaximumPageSize: common.Int32Ptr(5), // Use small page size to force pagination code path
+		MaximumPageSize: 5, // Use small page size to force pagination code path
 	})
 	s.Require().NoError(err)
 

--- a/host/ndc/nDC_integration_test.go
+++ b/host/ndc/nDC_integration_test.go
@@ -240,7 +240,7 @@ func (s *nDCIntegrationTestSuite) verifyEventHistory(
 				WorkflowID: workflowID,
 				RunID:      runID,
 			},
-			MaximumPageSize:        common.Int32Ptr(1000),
+			MaximumPageSize:        1000,
 			NextPageToken:          nil,
 			WaitForNewEvent:        common.BoolPtr(false),
 			HistoryEventFilterType: types.HistoryEventFilterTypeAllEvent.Ptr(),

--- a/host/signalworkflow_test.go
+++ b/host/signalworkflow_test.go
@@ -1357,7 +1357,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 	// Assert visibility is correct
 	listOpenRequest := &types.ListOpenWorkflowExecutionsRequest{
 		Domain:          s.domainName,
-		MaximumPageSize: common.Int32Ptr(100),
+		MaximumPageSize: 100,
 		StartTimeFilter: &types.StartTimeFilter{
 			EarliestTime: common.Int64Ptr(0),
 			LatestTime:   common.Int64Ptr(time.Now().UnixNano()),
@@ -1394,7 +1394,7 @@ func (s *integrationSuite) TestSignalWithStartWorkflow() {
 
 	listClosedRequest := &types.ListClosedWorkflowExecutionsRequest{
 		Domain:          s.domainName,
-		MaximumPageSize: common.Int32Ptr(100),
+		MaximumPageSize: 100,
 		StartTimeFilter: &types.StartTimeFilter{
 			EarliestTime: common.Int64Ptr(0),
 			LatestTime:   common.Int64Ptr(time.Now().UnixNano()),

--- a/host/sizelimit_test.go
+++ b/host/sizelimit_test.go
@@ -177,7 +177,7 @@ func (s *sizeLimitIntegrationSuite) TestTerminateWorkflowCausedBySizeLimit() {
 	for i := 0; i < 10; i++ {
 		resp, err1 := s.engine.ListClosedWorkflowExecutions(createContext(), &types.ListClosedWorkflowExecutionsRequest{
 			Domain:          s.domainName,
-			MaximumPageSize: common.Int32Ptr(100),
+			MaximumPageSize: 100,
 			StartTimeFilter: &types.StartTimeFilter{
 				EarliestTime: common.Int64Ptr(0),
 				LatestTime:   common.Int64Ptr(time.Now().UnixNano()),

--- a/host/xdc/elasticsearch_test.go
+++ b/host/xdc/elasticsearch_test.go
@@ -204,7 +204,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 	query := fmt.Sprintf(`WorkflowID = "%s" and %s = "%s"`, id, s.testSearchAttributeKey, s.testSearchAttributeVal)
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   domainName,
-		PageSize: common.Int32Ptr(5),
+		PageSize: 5,
 		Query:    common.StringPtr(query),
 	}
 
@@ -268,7 +268,7 @@ func (s *esCrossDCTestSuite) TestSearchAttributes() {
 
 	listRequest = &types.ListWorkflowExecutionsRequest{
 		Domain:   domainName,
-		PageSize: common.Int32Ptr(int32(2)),
+		PageSize: int32(2),
 		Query:    common.StringPtr(fmt.Sprintf(`WorkflowType = '%s' and CloseTime = missing`, wt)),
 	}
 

--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -2052,7 +2052,7 @@ func (s *integrationClustersTestSuite) getHistory(client host.FrontendClient, do
 	historyResponse, err := client.GetWorkflowExecutionHistory(createContext(), &types.GetWorkflowExecutionHistoryRequest{
 		Domain:          domain,
 		Execution:       execution,
-		MaximumPageSize: common.Int32Ptr(5), // Use small page size to force pagination code path
+		MaximumPageSize: 5, // Use small page size to force pagination code path
 	})
 	s.Nil(err)
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1871,7 +1871,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 	}
 
 	if getRequest.GetMaximumPageSize() <= 0 {
-		getRequest.MaximumPageSize = common.Int32Ptr(int32(wh.config.HistoryMaxPageSize(getRequest.GetDomain())))
+		getRequest.MaximumPageSize = int32(wh.config.HistoryMaxPageSize(getRequest.GetDomain()))
 	}
 	// force limit page size if exceed
 	if getRequest.GetMaximumPageSize() > common.GetHistoryMaxPageSize {
@@ -1880,7 +1880,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 			tag.WorkflowRunID(getRequest.Execution.GetRunID()),
 			tag.WorkflowDomainID(domainID),
 			tag.WorkflowSize(int64(getRequest.GetMaximumPageSize())))
-		getRequest.MaximumPageSize = common.Int32Ptr(common.GetHistoryMaxPageSize)
+		getRequest.MaximumPageSize = common.GetHistoryMaxPageSize
 	}
 
 	if !getRequest.GetSkipArchival() {
@@ -2527,7 +2527,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(
 	}
 
 	if listRequest.GetMaximumPageSize() <= 0 {
-		listRequest.MaximumPageSize = common.Int32Ptr(int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain())))
+		listRequest.MaximumPageSize = int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain()))
 	}
 
 	if wh.isListRequestPageSizeTooLarge(listRequest.GetMaximumPageSize(), listRequest.GetDomain()) {
@@ -2623,7 +2623,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(
 	}
 
 	if listRequest.GetPageSize() <= 0 {
-		listRequest.PageSize = common.Int32Ptr(int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain())))
+		listRequest.PageSize = int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain()))
 	}
 
 	maxPageSize := wh.config.VisibilityArchivalQueryMaxPageSize()
@@ -2744,7 +2744,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(
 	} // If ExecutionFilter is provided with one of TypeFilter or StatusFilter, use ExecutionFilter and ignore other filter
 
 	if listRequest.GetMaximumPageSize() <= 0 {
-		listRequest.MaximumPageSize = common.Int32Ptr(int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain())))
+		listRequest.MaximumPageSize = int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain()))
 	}
 
 	if wh.isListRequestPageSizeTooLarge(listRequest.GetMaximumPageSize(), listRequest.GetDomain()) {
@@ -2855,7 +2855,7 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(
 	}
 
 	if listRequest.GetPageSize() <= 0 {
-		listRequest.PageSize = common.Int32Ptr(int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain())))
+		listRequest.PageSize = int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain()))
 	}
 
 	if wh.isListRequestPageSizeTooLarge(listRequest.GetPageSize(), listRequest.GetDomain()) {
@@ -2923,7 +2923,7 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(
 	}
 
 	if listRequest.GetPageSize() <= 0 {
-		listRequest.PageSize = common.Int32Ptr(int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain())))
+		listRequest.PageSize = int32(wh.config.VisibilityMaxPageSize(listRequest.GetDomain()))
 	}
 
 	if wh.isListRequestPageSizeTooLarge(listRequest.GetPageSize(), listRequest.GetDomain()) {

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -1187,7 +1187,7 @@ func (s *workflowHandlerSuite) TestListWorkflowExecutions() {
 
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   s.testDomain,
-		PageSize: common.Int32Ptr(int32(config.ESIndexMaxResultWindow())),
+		PageSize: int32(config.ESIndexMaxResultWindow()),
 	}
 	ctx := context.Background()
 
@@ -1202,7 +1202,7 @@ func (s *workflowHandlerSuite) TestListWorkflowExecutions() {
 	_, err = wh.ListWorkflowExecutions(ctx, listRequest)
 	s.NotNil(err)
 
-	listRequest.PageSize = common.Int32Ptr(int32(config.ESIndexMaxResultWindow() + 1))
+	listRequest.PageSize = int32(config.ESIndexMaxResultWindow() + 1)
 	_, err = wh.ListWorkflowExecutions(ctx, listRequest)
 	s.NotNil(err)
 }
@@ -1216,7 +1216,7 @@ func (s *workflowHandlerSuite) TestScantWorkflowExecutions() {
 
 	listRequest := &types.ListWorkflowExecutionsRequest{
 		Domain:   s.testDomain,
-		PageSize: common.Int32Ptr(int32(config.ESIndexMaxResultWindow())),
+		PageSize: int32(config.ESIndexMaxResultWindow()),
 	}
 	ctx := context.Background()
 
@@ -1231,7 +1231,7 @@ func (s *workflowHandlerSuite) TestScantWorkflowExecutions() {
 	_, err = wh.ScanWorkflowExecutions(ctx, listRequest)
 	s.NotNil(err)
 
-	listRequest.PageSize = common.Int32Ptr(int32(config.ESIndexMaxResultWindow() + 1))
+	listRequest.PageSize = int32(config.ESIndexMaxResultWindow() + 1)
 	_, err = wh.ListWorkflowExecutions(ctx, listRequest)
 	s.NotNil(err)
 }
@@ -1464,7 +1464,7 @@ func getHistoryRequest(nextPageToken []byte) *types.GetWorkflowExecutionHistoryR
 func listArchivedWorkflowExecutionsTestRequest() *types.ListArchivedWorkflowExecutionsRequest {
 	return &types.ListArchivedWorkflowExecutionsRequest{
 		Domain:   "some random domain name",
-		PageSize: common.Int32Ptr(10),
+		PageSize: 10,
 		Query:    common.StringPtr("some random query string"),
 	}
 }

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -270,7 +270,7 @@ func BatchActivity(ctx context.Context, batchParams BatchParams) (HeartBeatDetai
 		//  And we can't use list API because terminate / reset will mutate the result.
 		resp, err := client.ScanWorkflowExecutions(ctx, &types.ListWorkflowExecutionsRequest{
 			Domain:        batchParams.DomainName,
-			PageSize:      common.Int32Ptr(int32(pageSize)),
+			PageSize:      int32(pageSize),
 			NextPageToken: hbd.PageToken,
 			Query:         common.StringPtr(batchParams.Query),
 		})

--- a/service/worker/failovermanager/workflow.go
+++ b/service/worker/failovermanager/workflow.go
@@ -354,7 +354,7 @@ func getAllDomains(ctx context.Context, targetDomains []string) ([]*types.Descri
 	var token []byte
 	for more := true; more; more = len(token) > 0 {
 		listRequest := &types.ListDomainsRequest{
-			PageSize:      common.Int32Ptr(pagesize),
+			PageSize:      pagesize,
 			NextPageToken: token,
 		}
 		listResp, err := feClient.ListDomains(ctx, listRequest)

--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -338,7 +338,7 @@ func (d *domainCLIImpl) getAllDomains(c *cli.Context) []*types.DescribeDomainRes
 	defer cancel()
 	for more := true; more; more = len(token) > 0 {
 		listRequest := &types.ListDomainsRequest{
-			PageSize:      common.Int32Ptr(pagesize),
+			PageSize:      pagesize,
 			NextPageToken: token,
 		}
 		listResp, err := d.listDomains(ctx, listRequest)

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -1826,7 +1826,7 @@ func isLastEventDecisionTaskFailedWithNonDeterminism(ctx context.Context, domain
 			WorkflowID: wid,
 			RunID:      rid,
 		},
-		MaximumPageSize: common.Int32Ptr(1000),
+		MaximumPageSize: 1000,
 		NextPageToken:   nil,
 	}
 
@@ -1939,7 +1939,7 @@ func getFirstDecisionTaskByType(
 			WorkflowID: workflowID,
 			RunID:      runID,
 		},
-		MaximumPageSize: common.Int32Ptr(1000),
+		MaximumPageSize: 1000,
 		NextPageToken:   nil,
 	}
 
@@ -2023,7 +2023,7 @@ func getLastDecisionTaskByType(
 			WorkflowID: workflowID,
 			RunID:      runID,
 		},
-		MaximumPageSize: common.Int32Ptr(1000),
+		MaximumPageSize: 1000,
 		NextPageToken:   nil,
 	}
 
@@ -2059,7 +2059,7 @@ func getLastContinueAsNewID(ctx context.Context, domain, wid, rid string, fronte
 			WorkflowID: wid,
 			RunID:      rid,
 		},
-		MaximumPageSize: common.Int32Ptr(1),
+		MaximumPageSize: 1,
 		NextPageToken:   nil,
 	}
 	resp, err := frontendClient.GetWorkflowExecutionHistory(ctx, req)
@@ -2078,7 +2078,7 @@ func getLastContinueAsNewID(ctx context.Context, domain, wid, rid string, fronte
 			WorkflowID: wid,
 			RunID:      resetBaseRunID,
 		},
-		MaximumPageSize: common.Int32Ptr(1000),
+		MaximumPageSize: 1000,
 		NextPageToken:   nil,
 	}
 	for {
@@ -2191,7 +2191,7 @@ func getEarliestDecisionID(
 			WorkflowID: wid,
 			RunID:      rid,
 		},
-		MaximumPageSize: common.Int32Ptr(1000),
+		MaximumPageSize: 1000,
 		NextPageToken:   nil,
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Drop pointer for page size fields in internal types. Those are checked `<= 0` condition everywhere and are assigned some default value if it is true.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is one of PRs planned to drop pointers for always required fields in internal types. It will make them more idiomatic and easier to use. These pointer are legacy of Thrift types that were used previously through our codebase. This will also allow safer migration to grpc, as proto primitive types don't have nils by default.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Passing build and existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

