### PR TITLE
Drop pointer for poller id fields

### DIFF
--- a/common/types/mapper/thrift/matching.go
+++ b/common/types/mapper/thrift/matching.go
@@ -101,7 +101,7 @@ func FromCancelOutstandingPollRequest(t *types.CancelOutstandingPollRequest) *ma
 		DomainUUID:   &t.DomainUUID,
 		TaskListType: t.TaskListType,
 		TaskList:     FromTaskList(t.TaskList),
-		PollerID:     t.PollerID,
+		PollerID:     &t.PollerID,
 	}
 }
 
@@ -114,7 +114,7 @@ func ToCancelOutstandingPollRequest(t *matching.CancelOutstandingPollRequest) *t
 		DomainUUID:   t.GetDomainUUID(),
 		TaskListType: t.TaskListType,
 		TaskList:     ToTaskList(t.TaskList),
-		PollerID:     t.PollerID,
+		PollerID:     t.GetPollerID(),
 	}
 }
 
@@ -603,7 +603,7 @@ func FromMatchingPollForActivityTaskRequest(t *types.MatchingPollForActivityTask
 	}
 	return &matching.PollForActivityTaskRequest{
 		DomainUUID:    &t.DomainUUID,
-		PollerID:      t.PollerID,
+		PollerID:      &t.PollerID,
 		PollRequest:   FromPollForActivityTaskRequest(t.PollRequest),
 		ForwardedFrom: t.ForwardedFrom,
 	}
@@ -616,7 +616,7 @@ func ToMatchingPollForActivityTaskRequest(t *matching.PollForActivityTaskRequest
 	}
 	return &types.MatchingPollForActivityTaskRequest{
 		DomainUUID:    t.GetDomainUUID(),
-		PollerID:      t.PollerID,
+		PollerID:      t.GetPollerID(),
 		PollRequest:   ToPollForActivityTaskRequest(t.PollRequest),
 		ForwardedFrom: t.ForwardedFrom,
 	}
@@ -629,7 +629,7 @@ func FromMatchingPollForDecisionTaskRequest(t *types.MatchingPollForDecisionTask
 	}
 	return &matching.PollForDecisionTaskRequest{
 		DomainUUID:    &t.DomainUUID,
-		PollerID:      t.PollerID,
+		PollerID:      &t.PollerID,
 		PollRequest:   FromPollForDecisionTaskRequest(t.PollRequest),
 		ForwardedFrom: t.ForwardedFrom,
 	}
@@ -642,7 +642,7 @@ func ToMatchingPollForDecisionTaskRequest(t *matching.PollForDecisionTaskRequest
 	}
 	return &types.MatchingPollForDecisionTaskRequest{
 		DomainUUID:    t.GetDomainUUID(),
-		PollerID:      t.PollerID,
+		PollerID:      t.GetPollerID(),
 		PollRequest:   ToPollForDecisionTaskRequest(t.PollRequest),
 		ForwardedFrom: t.ForwardedFrom,
 	}

--- a/common/types/matching.go
+++ b/common/types/matching.go
@@ -174,7 +174,7 @@ type CancelOutstandingPollRequest struct {
 	DomainUUID   string    `json:"domainUUID,omitempty"`
 	TaskListType *int32    `json:"taskListType,omitempty"`
 	TaskList     *TaskList `json:"taskList,omitempty"`
-	PollerID     *string   `json:"pollerID,omitempty"`
+	PollerID     string    `json:"pollerID,omitempty"`
 }
 
 // GetDomainUUID is an internal getter (TBD...)
@@ -203,8 +203,8 @@ func (v *CancelOutstandingPollRequest) GetTaskList() (o *TaskList) {
 
 // GetPollerID is an internal getter (TBD...)
 func (v *CancelOutstandingPollRequest) GetPollerID() (o string) {
-	if v != nil && v.PollerID != nil {
-		return *v.PollerID
+	if v != nil {
+		return v.PollerID
 	}
 	return
 }
@@ -823,7 +823,7 @@ func (v *MatchingServiceRespondQueryTaskCompletedResult) GetServiceBusyError() (
 // MatchingPollForActivityTaskRequest is an internal type (TBD...)
 type MatchingPollForActivityTaskRequest struct {
 	DomainUUID    string                      `json:"domainUUID,omitempty"`
-	PollerID      *string                     `json:"pollerID,omitempty"`
+	PollerID      string                      `json:"pollerID,omitempty"`
 	PollRequest   *PollForActivityTaskRequest `json:"pollRequest,omitempty"`
 	ForwardedFrom *string                     `json:"forwardedFrom,omitempty"`
 }
@@ -838,8 +838,8 @@ func (v *MatchingPollForActivityTaskRequest) GetDomainUUID() (o string) {
 
 // GetPollerID is an internal getter (TBD...)
 func (v *MatchingPollForActivityTaskRequest) GetPollerID() (o string) {
-	if v != nil && v.PollerID != nil {
-		return *v.PollerID
+	if v != nil {
+		return v.PollerID
 	}
 	return
 }
@@ -863,7 +863,7 @@ func (v *MatchingPollForActivityTaskRequest) GetForwardedFrom() (o string) {
 // MatchingPollForDecisionTaskRequest is an internal type (TBD...)
 type MatchingPollForDecisionTaskRequest struct {
 	DomainUUID    string                      `json:"domainUUID,omitempty"`
-	PollerID      *string                     `json:"pollerID,omitempty"`
+	PollerID      string                      `json:"pollerID,omitempty"`
 	PollRequest   *PollForDecisionTaskRequest `json:"pollRequest,omitempty"`
 	ForwardedFrom *string                     `json:"forwardedFrom,omitempty"`
 }
@@ -878,8 +878,8 @@ func (v *MatchingPollForDecisionTaskRequest) GetDomainUUID() (o string) {
 
 // GetPollerID is an internal getter (TBD...)
 func (v *MatchingPollForDecisionTaskRequest) GetPollerID() (o string) {
-	if v != nil && v.PollerID != nil {
-		return *v.PollerID
+	if v != nil {
+		return v.PollerID
 	}
 	return
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -488,7 +488,7 @@ func (wh *WorkflowHandler) PollForActivityTask(
 	op := func() error {
 		resp, err = wh.GetMatchingClient().PollForActivityTask(ctx, &types.MatchingPollForActivityTaskRequest{
 			DomainUUID:  domainID,
-			PollerID:    common.StringPtr(pollerID),
+			PollerID:    pollerID,
 			PollRequest: pollRequest,
 		})
 		return err
@@ -580,7 +580,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 	op := func() error {
 		matchingResp, err = wh.GetMatchingClient().PollForDecisionTask(ctx, &types.MatchingPollForDecisionTaskRequest{
 			DomainUUID:  domainID,
-			PollerID:    common.StringPtr(pollerID),
+			PollerID:    pollerID,
 			PollRequest: pollRequest,
 		})
 		return err
@@ -641,7 +641,7 @@ func (wh *WorkflowHandler) cancelOutstandingPoll(ctx context.Context, err error,
 			DomainUUID:   domainID,
 			TaskListType: common.Int32Ptr(taskListType),
 			TaskList:     taskList,
-			PollerID:     common.StringPtr(pollerID),
+			PollerID:     pollerID,
 		})
 		// We can not do much if this call fails.  Just log the error and move on
 		if err != nil {

--- a/service/matching/forwarder.go
+++ b/service/matching/forwarder.go
@@ -205,7 +205,7 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context) (*internalTask, error) {
 	case persistence.TaskListTypeDecision:
 		resp, err := fwdr.client.PollForDecisionTask(ctx, &types.MatchingPollForDecisionTaskRequest{
 			DomainUUID: fwdr.taskListID.domainID,
-			PollerID:   &pollerID,
+			PollerID:   pollerID,
 			PollRequest: &types.PollForDecisionTaskRequest{
 				TaskList: &types.TaskList{
 					Name: name,
@@ -222,7 +222,7 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context) (*internalTask, error) {
 	case persistence.TaskListTypeActivity:
 		resp, err := fwdr.client.PollForActivityTask(ctx, &types.MatchingPollForActivityTaskRequest{
 			DomainUUID: fwdr.taskListID.domainID,
-			PollerID:   &pollerID,
+			PollerID:   pollerID,
 			PollRequest: &types.PollForActivityTaskRequest{
 				TaskList: &types.TaskList{
 					Name: name,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Drop pointer for poller id fields within internal types.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is one of PRs planned to drop pointers for always required fields in internal types. It will make them more idiomatic and easier to use. These pointer are legacy of Thrift types that were used previously through our codebase. This will also allow safer migration to grpc, as proto primitive types don't have nils by default.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Passing build and existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

