### PR TITLE
Drop pointer for forwarded from fields

### DIFF
--- a/common/types/mapper/thrift/matching.go
+++ b/common/types/mapper/thrift/matching.go
@@ -39,7 +39,7 @@ func FromAddActivityTaskRequest(t *types.AddActivityTaskRequest) *matching.AddAc
 		ScheduleId:                    t.ScheduleID,
 		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
 		Source:                        FromTaskSource(t.Source),
-		ForwardedFrom:                 t.ForwardedFrom,
+		ForwardedFrom:                 &t.ForwardedFrom,
 	}
 }
 
@@ -56,7 +56,7 @@ func ToAddActivityTaskRequest(t *matching.AddActivityTaskRequest) *types.AddActi
 		ScheduleID:                    t.ScheduleId,
 		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
 		Source:                        ToTaskSource(t.Source),
-		ForwardedFrom:                 t.ForwardedFrom,
+		ForwardedFrom:                 t.GetForwardedFrom(),
 	}
 }
 
@@ -72,7 +72,7 @@ func FromAddDecisionTaskRequest(t *types.AddDecisionTaskRequest) *matching.AddDe
 		ScheduleId:                    t.ScheduleID,
 		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
 		Source:                        FromTaskSource(t.Source),
-		ForwardedFrom:                 t.ForwardedFrom,
+		ForwardedFrom:                 &t.ForwardedFrom,
 	}
 }
 
@@ -88,7 +88,7 @@ func ToAddDecisionTaskRequest(t *matching.AddDecisionTaskRequest) *types.AddDeci
 		ScheduleID:                    t.ScheduleId,
 		ScheduleToStartTimeoutSeconds: t.ScheduleToStartTimeoutSeconds,
 		Source:                        ToTaskSource(t.Source),
-		ForwardedFrom:                 t.ForwardedFrom,
+		ForwardedFrom:                 t.GetForwardedFrom(),
 	}
 }
 
@@ -605,7 +605,7 @@ func FromMatchingPollForActivityTaskRequest(t *types.MatchingPollForActivityTask
 		DomainUUID:    &t.DomainUUID,
 		PollerID:      t.PollerID,
 		PollRequest:   FromPollForActivityTaskRequest(t.PollRequest),
-		ForwardedFrom: t.ForwardedFrom,
+		ForwardedFrom: &t.ForwardedFrom,
 	}
 }
 
@@ -618,7 +618,7 @@ func ToMatchingPollForActivityTaskRequest(t *matching.PollForActivityTaskRequest
 		DomainUUID:    t.GetDomainUUID(),
 		PollerID:      t.PollerID,
 		PollRequest:   ToPollForActivityTaskRequest(t.PollRequest),
-		ForwardedFrom: t.ForwardedFrom,
+		ForwardedFrom: t.GetForwardedFrom(),
 	}
 }
 
@@ -631,7 +631,7 @@ func FromMatchingPollForDecisionTaskRequest(t *types.MatchingPollForDecisionTask
 		DomainUUID:    &t.DomainUUID,
 		PollerID:      t.PollerID,
 		PollRequest:   FromPollForDecisionTaskRequest(t.PollRequest),
-		ForwardedFrom: t.ForwardedFrom,
+		ForwardedFrom: &t.ForwardedFrom,
 	}
 }
 
@@ -644,7 +644,7 @@ func ToMatchingPollForDecisionTaskRequest(t *matching.PollForDecisionTaskRequest
 		DomainUUID:    t.GetDomainUUID(),
 		PollerID:      t.PollerID,
 		PollRequest:   ToPollForDecisionTaskRequest(t.PollRequest),
-		ForwardedFrom: t.ForwardedFrom,
+		ForwardedFrom: t.GetForwardedFrom(),
 	}
 }
 
@@ -709,7 +709,7 @@ func FromMatchingQueryWorkflowRequest(t *types.MatchingQueryWorkflowRequest) *ma
 		DomainUUID:    &t.DomainUUID,
 		TaskList:      FromTaskList(t.TaskList),
 		QueryRequest:  FromQueryWorkflowRequest(t.QueryRequest),
-		ForwardedFrom: t.ForwardedFrom,
+		ForwardedFrom: &t.ForwardedFrom,
 	}
 }
 
@@ -722,7 +722,7 @@ func ToMatchingQueryWorkflowRequest(t *matching.QueryWorkflowRequest) *types.Mat
 		DomainUUID:    t.GetDomainUUID(),
 		TaskList:      ToTaskList(t.TaskList),
 		QueryRequest:  ToQueryWorkflowRequest(t.QueryRequest),
-		ForwardedFrom: t.ForwardedFrom,
+		ForwardedFrom: t.GetForwardedFrom(),
 	}
 }
 

--- a/common/types/matching.go
+++ b/common/types/matching.go
@@ -35,7 +35,7 @@ type AddActivityTaskRequest struct {
 	ScheduleID                    *int64             `json:"scheduleId,omitempty"`
 	ScheduleToStartTimeoutSeconds *int32             `json:"scheduleToStartTimeoutSeconds,omitempty"`
 	Source                        *TaskSource        `json:"source,omitempty"`
-	ForwardedFrom                 *string            `json:"forwardedFrom,omitempty"`
+	ForwardedFrom                 string             `json:"forwardedFrom,omitempty"`
 }
 
 // GetDomainUUID is an internal getter (TBD...)
@@ -96,8 +96,8 @@ func (v *AddActivityTaskRequest) GetSource() (o TaskSource) {
 
 // GetForwardedFrom is an internal getter (TBD...)
 func (v *AddActivityTaskRequest) GetForwardedFrom() (o string) {
-	if v != nil && v.ForwardedFrom != nil {
-		return *v.ForwardedFrom
+	if v != nil {
+		return v.ForwardedFrom
 	}
 	return
 }
@@ -110,7 +110,7 @@ type AddDecisionTaskRequest struct {
 	ScheduleID                    *int64             `json:"scheduleId,omitempty"`
 	ScheduleToStartTimeoutSeconds *int32             `json:"scheduleToStartTimeoutSeconds,omitempty"`
 	Source                        *TaskSource        `json:"source,omitempty"`
-	ForwardedFrom                 *string            `json:"forwardedFrom,omitempty"`
+	ForwardedFrom                 string             `json:"forwardedFrom,omitempty"`
 }
 
 // GetDomainUUID is an internal getter (TBD...)
@@ -163,8 +163,8 @@ func (v *AddDecisionTaskRequest) GetSource() (o TaskSource) {
 
 // GetForwardedFrom is an internal getter (TBD...)
 func (v *AddDecisionTaskRequest) GetForwardedFrom() (o string) {
-	if v != nil && v.ForwardedFrom != nil {
-		return *v.ForwardedFrom
+	if v != nil {
+		return v.ForwardedFrom
 	}
 	return
 }
@@ -825,7 +825,7 @@ type MatchingPollForActivityTaskRequest struct {
 	DomainUUID    string                      `json:"domainUUID,omitempty"`
 	PollerID      *string                     `json:"pollerID,omitempty"`
 	PollRequest   *PollForActivityTaskRequest `json:"pollRequest,omitempty"`
-	ForwardedFrom *string                     `json:"forwardedFrom,omitempty"`
+	ForwardedFrom string                      `json:"forwardedFrom,omitempty"`
 }
 
 // GetDomainUUID is an internal getter (TBD...)
@@ -854,8 +854,8 @@ func (v *MatchingPollForActivityTaskRequest) GetPollRequest() (o *PollForActivit
 
 // GetForwardedFrom is an internal getter (TBD...)
 func (v *MatchingPollForActivityTaskRequest) GetForwardedFrom() (o string) {
-	if v != nil && v.ForwardedFrom != nil {
-		return *v.ForwardedFrom
+	if v != nil {
+		return v.ForwardedFrom
 	}
 	return
 }
@@ -865,7 +865,7 @@ type MatchingPollForDecisionTaskRequest struct {
 	DomainUUID    string                      `json:"domainUUID,omitempty"`
 	PollerID      *string                     `json:"pollerID,omitempty"`
 	PollRequest   *PollForDecisionTaskRequest `json:"pollRequest,omitempty"`
-	ForwardedFrom *string                     `json:"forwardedFrom,omitempty"`
+	ForwardedFrom string                      `json:"forwardedFrom,omitempty"`
 }
 
 // GetDomainUUID is an internal getter (TBD...)
@@ -894,8 +894,8 @@ func (v *MatchingPollForDecisionTaskRequest) GetPollRequest() (o *PollForDecisio
 
 // GetForwardedFrom is an internal getter (TBD...)
 func (v *MatchingPollForDecisionTaskRequest) GetForwardedFrom() (o string) {
-	if v != nil && v.ForwardedFrom != nil {
-		return *v.ForwardedFrom
+	if v != nil {
+		return v.ForwardedFrom
 	}
 	return
 }
@@ -1062,7 +1062,7 @@ type MatchingQueryWorkflowRequest struct {
 	DomainUUID    string                `json:"domainUUID,omitempty"`
 	TaskList      *TaskList             `json:"taskList,omitempty"`
 	QueryRequest  *QueryWorkflowRequest `json:"queryRequest,omitempty"`
-	ForwardedFrom *string               `json:"forwardedFrom,omitempty"`
+	ForwardedFrom string                `json:"forwardedFrom,omitempty"`
 }
 
 // GetDomainUUID is an internal getter (TBD...)
@@ -1091,8 +1091,8 @@ func (v *MatchingQueryWorkflowRequest) GetQueryRequest() (o *QueryWorkflowReques
 
 // GetForwardedFrom is an internal getter (TBD...)
 func (v *MatchingQueryWorkflowRequest) GetForwardedFrom() (o string) {
-	if v != nil && v.ForwardedFrom != nil {
-		return *v.ForwardedFrom
+	if v != nil {
+		return v.ForwardedFrom
 	}
 	return
 }

--- a/service/matching/forwarder.go
+++ b/service/matching/forwarder.go
@@ -136,7 +136,7 @@ func (fwdr *Forwarder) ForwardTask(ctx context.Context, task *internalTask) erro
 			ScheduleID:                    &task.event.ScheduleID,
 			ScheduleToStartTimeoutSeconds: &task.event.ScheduleToStartTimeout,
 			Source:                        &task.source,
-			ForwardedFrom:                 &fwdr.taskListID.name,
+			ForwardedFrom:                 fwdr.taskListID.name,
 		})
 	case persistence.TaskListTypeActivity:
 		err = fwdr.client.AddActivityTask(ctx, &types.AddActivityTaskRequest{
@@ -150,7 +150,7 @@ func (fwdr *Forwarder) ForwardTask(ctx context.Context, task *internalTask) erro
 			ScheduleID:                    &task.event.ScheduleID,
 			ScheduleToStartTimeoutSeconds: &task.event.ScheduleToStartTimeout,
 			Source:                        &task.source,
-			ForwardedFrom:                 &fwdr.taskListID.name,
+			ForwardedFrom:                 fwdr.taskListID.name,
 		})
 	default:
 		return errInvalidTaskListType
@@ -181,7 +181,7 @@ func (fwdr *Forwarder) ForwardQueryTask(
 			Kind: &fwdr.taskListKind,
 		},
 		QueryRequest:  task.query.request.QueryRequest,
-		ForwardedFrom: &fwdr.taskListID.name,
+		ForwardedFrom: fwdr.taskListID.name,
 	})
 
 	return resp, fwdr.handleErr(err)
@@ -213,7 +213,7 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context) (*internalTask, error) {
 				},
 				Identity: identity,
 			},
-			ForwardedFrom: &fwdr.taskListID.name,
+			ForwardedFrom: fwdr.taskListID.name,
 		})
 		if err != nil {
 			return nil, fwdr.handleErr(err)
@@ -230,7 +230,7 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context) (*internalTask, error) {
 				},
 				Identity: identity,
 			},
-			ForwardedFrom: &fwdr.taskListID.name,
+			ForwardedFrom: fwdr.taskListID.name,
 		})
 		if err != nil {
 			return nil, fwdr.handleErr(err)

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -367,7 +367,7 @@ func (s *matchingEngineSuite) AddTasksTest(taskType int, isForwarded bool) {
 				ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
 			}
 			if isForwarded {
-				addRequest.ForwardedFrom = &forwardedFrom
+				addRequest.ForwardedFrom = forwardedFrom
 			}
 			_, err = s.matchingEngine.AddActivityTask(s.handlerContext, &addRequest)
 		} else {
@@ -379,7 +379,7 @@ func (s *matchingEngineSuite) AddTasksTest(taskType int, isForwarded bool) {
 				ScheduleToStartTimeoutSeconds: common.Int32Ptr(1),
 			}
 			if isForwarded {
-				addRequest.ForwardedFrom = &forwardedFrom
+				addRequest.ForwardedFrom = forwardedFrom
 			}
 			_, err = s.matchingEngine.AddDecisionTask(s.handlerContext, &addRequest)
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Drop pointer for forwarded from fields within internal types.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is one of PRs planned to drop pointers for always required fields in internal types. It will make them more idiomatic and easier to use. These pointer are legacy of Thrift types that were used previously through our codebase. This will also allow safer migration to grpc, as proto primitive types don't have nils by default.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Passing build and existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

