### PR TITLE
Support AWS signing for ElasticSearch client

### DIFF
--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -132,7 +132,7 @@ func NewV6Client(
 	}, nil
 }
 
-// Refer to https://github.com/olivere/elastic/blob/release-branch.v6/recipes/aws-connect-v4/main.go
+// Refer to https://github.com/olivere/elastic/blob/release-branch.v6/recipes/aws-connect-v4/main.go 
 func buildSigningHTTPClientFromStaticCredentialV6(credentialConfig config.AWSStaticCredential) (*http.Client, error) {
 	awsCredentials := credentials.NewStaticCredentials(
 		credentialConfig.AccessKey,

--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -111,7 +111,7 @@ func NewV6Client(
 		var signingClient *http.Client
 		var err error
 		if connectConfig.AWSSigning.EnvironmentCredential != nil {
-			signingClient, err = buildSigningHTTPClientFromDefaultCredentialV6(*connectConfig.AWSSigning.EnvironmentCredential)
+			signingClient, err = buildSigningHTTPClientFromEnvironmentCredentialV6(*connectConfig.AWSSigning.EnvironmentCredential)
 		} else {
 			signingClient, err = buildSigningHTTPClientFromStaticCredentialV6(*connectConfig.AWSSigning.StaticCredential)
 		}
@@ -142,7 +142,7 @@ func buildSigningHTTPClientFromStaticCredentialV6(credentialConfig config.AWSSta
 	return esaws.NewV4SigningClient(awsCredentials, credentialConfig.Region), nil
 }
 
-func buildSigningHTTPClientFromDefaultCredentialV6(credentialConfig config.AWSEnvironmentCredential) (*http.Client, error) {
+func buildSigningHTTPClientFromEnvironmentCredentialV6(credentialConfig config.AWSEnvironmentCredential) (*http.Client, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(credentialConfig.Region)},
 	)

--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -26,12 +26,15 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/olivere/elastic"
-	aws "github.com/olivere/elastic/aws/v4"
+	esaws "github.com/olivere/elastic/aws/v4"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
@@ -102,13 +105,19 @@ func NewV6Client(
 		clientOptFuncs = append(clientOptFuncs, elastic.SetHealthcheck(false))
 	}
 	if connectConfig.AWSSigning.Enable {
-		// Refer to https://github.com/olivere/elastic/blob/release-branch.v6/recipes/aws-connect-v4/main.go
-		awsCredentials := credentials.NewStaticCredentials(
-			connectConfig.AWSSigning.AccessKey,
-			connectConfig.AWSSigning.SecretKey,
-			connectConfig.AWSSigning.SessionToken,
-		)
-		signingClient := aws.NewV4SigningClient(awsCredentials, connectConfig.AWSSigning.Region)
+		if err := config.CheckAWSSigningConfig(connectConfig.AWSSigning); err != nil {
+			return nil, err
+		}
+		var signingClient *http.Client
+		var err error
+		if connectConfig.AWSSigning.EnvironmentCredential != nil {
+			signingClient, err = buildSigningHTTPClientFromDefaultCredentialV6(*connectConfig.AWSSigning.EnvironmentCredential)
+		} else {
+			signingClient, err = buildSigningHTTPClientFromStaticCredentialV6(*connectConfig.AWSSigning.StaticCredential)
+		}
+		if err != nil {
+			return nil, err
+		}
 		clientOptFuncs = append(clientOptFuncs, elastic.SetHttpClient(signingClient))
 	}
 	client, err := elastic.NewClient(clientOptFuncs...)
@@ -121,6 +130,26 @@ func NewV6Client(
 		logger:     logger,
 		serializer: p.NewPayloadSerializer(),
 	}, nil
+}
+
+// Refer to https://github.com/olivere/elastic/blob/release-branch.v6/recipes/aws-connect-v4/main.go
+func buildSigningHTTPClientFromStaticCredentialV6(credentialConfig config.AWSStaticCredential) (*http.Client, error) {
+	awsCredentials := credentials.NewStaticCredentials(
+		credentialConfig.AccessKey,
+		credentialConfig.SecretKey,
+		credentialConfig.SessionToken,
+	)
+	return esaws.NewV4SigningClient(awsCredentials, credentialConfig.Region), nil
+}
+
+func buildSigningHTTPClientFromDefaultCredentialV6(credentialConfig config.AWSEnvironmentCredential) (*http.Client, error) {
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(credentialConfig.Region)},
+	)
+	if err != nil {
+		return nil, err
+	}
+	return esaws.NewV4SigningClient(sess.Config.Credentials, credentialConfig.Region), nil
 }
 
 // root is for nested object like Attr property for search attributes.

--- a/common/elasticsearch/client_v7.go
+++ b/common/elasticsearch/client_v7.go
@@ -104,9 +104,9 @@ func NewV7Client(
 		var signingClient *http.Client
 		var err error
 		if connectConfig.AWSSigning.EnvironmentCredential != nil {
-			signingClient, err = buildSigningHTTPClientFromDefaultCredentialV6(*connectConfig.AWSSigning.EnvironmentCredential)
+			signingClient, err = buildSigningHTTPClientFromEnvironmentCredentialV7(*connectConfig.AWSSigning.EnvironmentCredential)
 		} else {
-			signingClient, err = buildSigningHTTPClientFromStaticCredentialV6(*connectConfig.AWSSigning.StaticCredential)
+			signingClient, err = buildSigningHTTPClientFromStaticCredentialV7(*connectConfig.AWSSigning.StaticCredential)
 		}
 		if err != nil {
 			return nil, err
@@ -135,7 +135,7 @@ func buildSigningHTTPClientFromStaticCredentialV7(credentialConfig config.AWSSta
 	return esaws.NewV4SigningClient(awsCredentials, credentialConfig.Region), nil
 }
 
-func buildSigningHTTPClientFromDefaultCredentialV7(credentialConfig config.AWSEnvironmentCredential) (*http.Client, error) {
+func buildSigningHTTPClientFromEnvironmentCredentialV7(credentialConfig config.AWSEnvironmentCredential) (*http.Client, error) {
 	sess, err := session.NewSession(&aws.Config{
 		Region: aws.String(credentialConfig.Region)},
 	)

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -42,6 +42,21 @@ type (
 		DisableSniff bool `yaml:"disableSniff"`
 		// optional to disable health check
 		DisableHealthCheck bool `yaml:"disableHealthCheck"`
+		// optional to use AWS signing client
+		// See more info https://github.com/olivere/elastic/wiki/Using-with-AWS-Elasticsearch-Service
+		AWSSigning AWSSigning `yaml:"awsSigning"`
+	}
+
+	// AWSSigning contains config to create a static credentials value provider.
+	// SessionToken is only required for temporary security credentials retrieved via STS,
+	// otherwise an empty string can be passed for this parameter.
+	// See more in https://github.com/aws/aws-sdk-go/blob/master/aws/credentials/static_provider.go#L21
+	AWSSigning struct {
+		Enable       bool   `yaml:"enable"`
+		AccessKey    string `yaml:"accessKey"`
+		SecretKey    string `yaml:"secretKey"`
+		Region       string `yaml:"region"`
+		SessionToken string `yaml:"sessionToken"`
 	}
 )
 

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -91,6 +91,7 @@ func (cfg *ElasticSearchConfig) SetUsernamePassword() {
 	}
 }
 
+// CheckAWSSigningConfig checks if the AWSSigning configuration is valid
 func CheckAWSSigningConfig(config AWSSigning) error {
 	if config.EnvironmentCredential == nil && config.StaticCredential == nil {
 		return errAWSSigningCredential

--- a/common/service/config/elasticsearch.go
+++ b/common/service/config/elasticsearch.go
@@ -55,7 +55,7 @@ type (
 	AWSSigning struct {
 		Enable                bool                      `yaml:"enable"`
 		StaticCredential      *AWSStaticCredential      `yaml:"staticCredential"`
-		EnvironmentCredential *AWSEnvironmentCredential `yaml:"defaultCredential"`
+		EnvironmentCredential *AWSEnvironmentCredential `yaml:"environmentCredential"`
 	}
 
 	// AWSStaticCredential to create a static credentials value provider.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add optional support for AWS signing 
following https://github.com/olivere/elastic/wiki/Using-with-AWS-Elasticsearch-Service
https://github.com/olivere/elastic/blob/release-branch.v7/recipes/aws-connect-v4/main.go

<!-- Tell your future self why have you made these changes -->
**Why?**
From a Cadence user:
```
If turn on protections for ES
We use IAM to ensure only cadence has read/write access to our ES
in order for that to work properly you have to enable the signing of the requests
the client itself has the support baked in, but you have to turn it on
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
User will test it. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Very low/minimum risk as it's optional. 
