### PR TITLE
Improve docker-compose local unit-test, minor cleanup

### DIFF
--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -3,8 +3,8 @@ version: "3.5"
 services:
   cassandra:
     image: cassandra:3.11
-    ports:
-      - "9042:9042"
+    expose:
+      - "9042"
     networks:
       services-network:
         aliases:
@@ -17,8 +17,8 @@ services:
       MYSQL_ROOT_PASSWORD: uber
     volumes:
       - ./mysql-init:/docker-entrypoint-initdb.d
-    ports:
-      - "3306:3306"
+    expose:
+      - "3306"
     networks:
       services-network:
         aliases:
@@ -28,8 +28,9 @@ services:
     image: postgres:12
     environment:
       POSTGRES_PASSWORD: cadence
-    ports:
-      - "5432:5432"
+      POSTGRES_USER: cadence
+    expose:
+      - "5432"
     networks:
       services-network:
         aliases:
@@ -37,8 +38,8 @@ services:
 
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
-    ports:
-      - "2181:2181"
+    expose:
+      - "2181"
     networks:
       services-network:
         aliases:
@@ -48,8 +49,8 @@ services:
     image: wurstmeister/kafka:2.12-2.1.1
     depends_on:
       - zookeeper
-    ports:
-      - "9092:9092"
+    expose:
+      - "9092"
     networks:
       services-network:
         aliases:
@@ -61,8 +62,8 @@ services:
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.1
-    ports:
-      - "9200:9200"
+    expose:
+      - "9200"
     networks:
       services-network:
         aliases:
@@ -74,20 +75,13 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command:
-      - /bin/sh
-      - -e
-      - -c
-      - |
-        make cover_profile
-    ports:
-      - "7933:7933"
-      - "7934:7934"
-      - "7935:7935"
-      - "7939:7939"
+    command: make cover_profile
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "MYSQL_SEEDS=mysql"
+      - "POSTGRES_SEEDS=postgres"
+      - "POSTGRES_USER=cadence"
+      - "POSTGRES_PASSWORD=cadence"
     depends_on:
       - cassandra
       - mysql
@@ -103,17 +97,7 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command:
-      - /bin/sh
-      - -e
-      - -c
-      - |
-        make cover_integration_profile
-    ports:
-      - "7933:7933"
-      - "7934:7934"
-      - "7935:7935"
-      - "7939:7939"
+    command: make cover_integration_profile
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
@@ -134,17 +118,7 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command:
-      - /bin/sh
-      - -e
-      - -c
-      - |
-        make cover_integration_profile
-    ports:
-      - "7933:7933"
-      - "7934:7934"
-      - "7935:7935"
-      - "7939:7939"
+    command: make cover_integration_profile
     environment:
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
@@ -166,17 +140,7 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command:
-      - /bin/sh
-      - -e
-      - -c
-      - |
-        make cover_integration_profile
-    ports:
-      - "7933:7933"
-      - "7934:7934"
-      - "7935:7935"
-      - "7939:7939"
+    command: make cover_integration_profile
     environment:
       - "POSTGRES_SEEDS=postgres"
       - "PERSISTENCE_PLUGIN=postgres"
@@ -199,17 +163,7 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command:
-      - /bin/sh
-      - -e
-      - -c
-      - |
-        make cover_integration_profile EVENTSV2=true
-    ports:
-      - "7933:7933"
-      - "7934:7934"
-      - "7935:7935"
-      - "7939:7939"
+    command: make cover_integration_profile EVENTSV2=true
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
@@ -230,17 +184,7 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command:
-      - /bin/sh
-      - -e
-      - -c
-      - |
-        make cover_ndc_profile
-    ports:
-      - "7933:7933"
-      - "7934:7934"
-      - "7935:7935"
-      - "7939:7939"
+    command: make cover_ndc_profile
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
@@ -261,17 +205,7 @@ services:
     build:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
-    command:
-      - /bin/sh
-      - -e
-      - -c
-      - |
-        make cover_ndc_profile
-    ports:
-      - "7933:7933"
-      - "7934:7934"
-      - "7935:7935"
-      - "7939:7939"
+    command: make cover_ndc_profile
     environment:
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"


### PR DESCRIPTION
Unfortunately the "unit-test" isn't much of a unit test, clearly connecting to the database containers...
... but after these changes, it at least starts up on my machine, and doesn't collide with other instances / port use / etc.
It also finally connects to postgres, though that should still be fixed eventually.

To summarize the changes:
- `ports` -> `expose` to keep networking internal.  ports are no longer publicly mapped, so you can run other things without colliding.
- `command` array -> a string.  because wow was that verbose.
- adding postgres connection info to unit-test, as it was using the wrong host + username previously.

---

Unfortunately tests still don't pass locally, I have not yet traced down the reason.
They stop here for me, on a few errors like this:
```
--- FAIL: TestSQLHistoryV2PersistenceSuite (3.70s)
    --- PASS: TestSQLHistoryV2PersistenceSuite/TestConcurrentlyCreateAndAppendBranches (1.23s)
    --- FAIL: TestSQLHistoryV2PersistenceSuite/TestConcurrentlyForkAndAppendBranches (0.61s)
        historyV2PersistenceTest.go:752:
            	Error Trace:	historyV2PersistenceTest.go:752
				historyV2PersistenceTest.go:570
				asm_amd64.s:1357
            	Error:      	Expected nil, but got: &types.InternalDataInconsistencyError{Message:"corrupted history event batch, eventID is not continouous"}
            	Test:       	TestSQLHistoryV2PersistenceSuite/TestConcurrentlyForkAndAppendBranches
```

Still, it's progress.