### PR TITLE
Fix/default qps

### DIFF
--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -32,7 +32,7 @@ var (
 	// Override values for dynamic configs
 	staticOverrides = map[dynamicconfig.Key]interface{}{
 		dynamicconfig.FrontendRPS:                                   3000,
-		dynamicconfig.FrontendVisibilityListMaxQPS:                  100,
+		dynamicconfig.FrontendVisibilityListMaxQPS:                  200,
 		dynamicconfig.FrontendESIndexMaxResultWindow:                defaultTestValueOfESIndexMaxResultWindow,
 		dynamicconfig.MatchingNumTasklistWritePartitions:            3,
 		dynamicconfig.MatchingNumTasklistReadPartitions:             3,


### PR DESCRIPTION
Since changing https://github.com/uber/cadence-web/pull/239 the workflow list screen will try to call twice (Open & Closed workflows). This effectively means we need to double the default QPS allowed otherwise it will result in the frontend showing QPS error.