### PR TITLE
Provide background context to all scanners

### DIFF
--- a/service/worker/scanner/executions/concrete_execution.go
+++ b/service/worker/scanner/executions/concrete_execution.go
@@ -144,7 +144,7 @@ func FixerManager(_ context.Context, pr persistence.Retryer, _ shardscanner.FixS
 }
 
 // ConcreteExecutionConfig resolves dynamic config for concrete executions scanner.
-func ConcreteExecutionConfig(ctx shardscanner.Context) shardscanner.CustomScannerConfig {
+func ConcreteExecutionConfig(ctx *shardscanner.Context) shardscanner.CustomScannerConfig {
 	res := shardscanner.CustomScannerConfig{}
 
 	if ctx.Config.DynamicCollection.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerInvariantCollectionHistory, true)() {

--- a/service/worker/scanner/executions/concrete_execution.go
+++ b/service/worker/scanner/executions/concrete_execution.go
@@ -100,7 +100,6 @@ func ScannerManager(
 	ctx context.Context,
 	pr persistence.Retryer,
 	params shardscanner.ScanShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) invariant.Manager {
 
 	collections := ParseCollections(params.ScannerConfig)
@@ -118,7 +117,6 @@ func ScannerIterator(
 	ctx context.Context,
 	pr persistence.Retryer,
 	params shardscanner.ScanShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) pagination.Iterator {
 	it := ConcreteExecutionType.ToIterator()
 	return it(ctx, pr, params.PageSize)
@@ -126,12 +124,12 @@ func ScannerIterator(
 }
 
 // FixerIterator provides iterator for concrete execution fixer.
-func FixerIterator(ctx context.Context, client blobstore.Client, keys store.Keys, _ shardscanner.FixShardActivityParams, _ shardscanner.ScannerConfig) store.ScanOutputIterator {
+func FixerIterator(ctx context.Context, client blobstore.Client, keys store.Keys, _ shardscanner.FixShardActivityParams) store.ScanOutputIterator {
 	return store.NewBlobstoreIterator(ctx, client, keys, ConcreteExecutionType.ToBlobstoreEntity())
 }
 
 // FixerManager provides invariant manager for concrete execution fixer.
-func FixerManager(_ context.Context, pr persistence.Retryer, _ shardscanner.FixShardActivityParams, _ shardscanner.ScannerConfig) invariant.Manager {
+func FixerManager(_ context.Context, pr persistence.Retryer, _ shardscanner.FixShardActivityParams) invariant.Manager {
 	var ivs []invariant.Invariant
 	var collections []invariant.Collection
 

--- a/service/worker/scanner/executions/concrete_execution.go
+++ b/service/worker/scanner/executions/concrete_execution.go
@@ -142,7 +142,7 @@ func FixerManager(_ context.Context, pr persistence.Retryer, _ shardscanner.FixS
 }
 
 // ConcreteExecutionConfig resolves dynamic config for concrete executions scanner.
-func ConcreteExecutionConfig(ctx *shardscanner.Context) shardscanner.CustomScannerConfig {
+func ConcreteExecutionConfig(ctx shardscanner.Context) shardscanner.CustomScannerConfig {
 	res := shardscanner.CustomScannerConfig{}
 
 	if ctx.Config.DynamicCollection.GetBoolProperty(dynamicconfig.ConcreteExecutionsScannerInvariantCollectionHistory, true)() {

--- a/service/worker/scanner/executions/concrete_execution_test.go
+++ b/service/worker/scanner/executions/concrete_execution_test.go
@@ -119,7 +119,6 @@ func (s *concreteExectionsWorkflowsSuite) TestScannerWorkflow_Success() {
 		var customc shardscanner.CustomScannerConfig
 		env.OnActivity(shardscanner.ActivityScanShard, mock.Anything, shardscanner.ScanShardActivityParams{
 			Shards:        batch,
-			ContextKey:    "cadence-sys-executions-scanner-workflow",
 			ScannerConfig: customc,
 		}).Return(reports, nil)
 	}

--- a/service/worker/scanner/executions/current_execution.go
+++ b/service/worker/scanner/executions/current_execution.go
@@ -83,7 +83,6 @@ func CurrentExecutionManager(
 	ctx context.Context,
 	pr persistence.Retryer,
 	params shardscanner.ScanShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) invariant.Manager {
 	var ivs []invariant.Invariant
 	collections := ParseCollections(params.ScannerConfig)
@@ -167,7 +166,6 @@ func CurrentExecutionIterator(
 	ctx context.Context,
 	pr persistence.Retryer,
 	params shardscanner.ScanShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) pagination.Iterator {
 	return CurrentExecutionType.ToIterator()(ctx, pr, params.PageSize)
 }
@@ -178,7 +176,6 @@ func CurrentExecutionFixerIterator(
 	client blobstore.Client,
 	keys store.Keys,
 	_ shardscanner.FixShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) store.ScanOutputIterator {
 	return store.NewBlobstoreIterator(ctx, client, keys, CurrentExecutionType.ToBlobstoreEntity())
 }

--- a/service/worker/scanner/executions/current_execution.go
+++ b/service/worker/scanner/executions/current_execution.go
@@ -106,7 +106,7 @@ func CurrentFixerWorkflow(
 }
 
 // CurrentExecutionConfig resolves dynamic config for current executions scanner.
-func CurrentExecutionConfig(ctx shardscanner.Context) shardscanner.CustomScannerConfig {
+func CurrentExecutionConfig(ctx *shardscanner.Context) shardscanner.CustomScannerConfig {
 	res := shardscanner.CustomScannerConfig{}
 
 	if ctx.Config.DynamicCollection.GetBoolProperty(dynamicconfig.CurrentExecutionsScannerInvariantCollectionHistory, true)() {

--- a/service/worker/scanner/executions/current_execution.go
+++ b/service/worker/scanner/executions/current_execution.go
@@ -105,7 +105,7 @@ func CurrentFixerWorkflow(
 }
 
 // CurrentExecutionConfig resolves dynamic config for current executions scanner.
-func CurrentExecutionConfig(ctx *shardscanner.Context) shardscanner.CustomScannerConfig {
+func CurrentExecutionConfig(ctx shardscanner.Context) shardscanner.CustomScannerConfig {
 	res := shardscanner.CustomScannerConfig{}
 
 	if ctx.Config.DynamicCollection.GetBoolProperty(dynamicconfig.CurrentExecutionsScannerInvariantCollectionHistory, true)() {

--- a/service/worker/scanner/scanner_test.go
+++ b/service/worker/scanner/scanner_test.go
@@ -27,11 +27,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/suite"
-	"github.com/uber-go/tally"
-
-	"github.com/uber/cadence/common/metrics"
-	"github.com/uber/cadence/common/resource"
-	"github.com/uber/cadence/service/worker/scanner/shardscanner"
 )
 
 type scannerTestSuite struct {
@@ -45,48 +40,9 @@ func TestScannerSuite(t *testing.T) {
 
 func (s *scannerTestSuite) SetupTest() {
 	s.mockCtrl = gomock.NewController(s.T())
+
 }
 
 func (s *scannerTestSuite) TearDownTest() {
 	s.mockCtrl.Finish()
-}
-
-func (s *scannerTestSuite) TestShardScannerContext() {
-	res := resource.NewTest(s.mockCtrl, metrics.Worker)
-	ctx := scannerContext{
-		Resource:   res,
-		cfg:        Config{},
-		tallyScope: tally.NoopScope,
-	}
-
-	cfg := getShardScannerContext(ctx, &shardscanner.ScannerConfig{
-		ScannerWFTypeName: "test_ScannerWFTypeName",
-		FixerWFTypeName:   "test_FixerWFTypeName",
-		ScannerHooks: func() *shardscanner.ScannerHooks {
-			return nil
-		},
-	})
-	s.Equal(shardscanner.ScannerContextKey("test_ScannerWFTypeName"), cfg.ContextKey)
-	s.NotNil(cfg.Config)
-
-}
-
-func (s *scannerTestSuite) TestShardFixerContext() {
-	res := resource.NewTest(s.mockCtrl, metrics.Worker)
-	ctx := scannerContext{
-		Resource:   res,
-		cfg:        Config{},
-		tallyScope: tally.NoopScope,
-	}
-
-	cfg := getShardFixerContext(ctx, &shardscanner.ScannerConfig{
-		ScannerWFTypeName: "test_ScannerWFTypeName",
-		FixerWFTypeName:   "test_FixerWFTypeName",
-		FixerHooks: func() *shardscanner.FixerHooks {
-			return nil
-		},
-	})
-
-	s.Equal(shardscanner.ScannerContextKey("test_FixerWFTypeName"), cfg.ContextKey)
-	s.NotNil(cfg.Config)
 }

--- a/service/worker/scanner/shardscanner/activities.go
+++ b/service/worker/scanner/shardscanner/activities.go
@@ -58,7 +58,7 @@ func ScannerConfigActivity(
 	activityCtx context.Context,
 	params ScannerConfigActivityParams,
 ) (ResolvedScannerWorkflowConfig, error) {
-	ctx := activityCtx.Value(params.ContextKey).(Context)
+	ctx, _ := GetScannerContext(activityCtx)
 	dc := ctx.Config.DynamicParams
 
 	result := ResolvedScannerWorkflowConfig{
@@ -134,10 +134,15 @@ func scanShard(
 	shardID int,
 	heartbeatDetails ScanShardHeartbeatDetails,
 ) (*ScanReport, error) {
-	ctx := activityCtx.Value(params.ContextKey).(Context)
+	ctx, err := GetScannerContext(activityCtx)
+	if err != nil {
+		return nil, err
+	}
+	info := activity.GetInfo(activityCtx)
+
 	scope := ctx.Scope.Tagged(
 		metrics.ActivityTypeTag(ActivityScanShard),
-		metrics.WorkflowTypeTag(params.ContextKey.String()),
+		metrics.WorkflowTypeTag(info.WorkflowType.Name),
 		metrics.DomainTag(c.SystemLocalDomainName),
 	)
 	sw := scope.StartTimer(metrics.CadenceLatency)
@@ -179,8 +184,12 @@ func FixerCorruptedKeysActivity(
 	activityCtx context.Context,
 	params FixerCorruptedKeysActivityParams,
 ) (*FixerCorruptedKeysActivityResult, error) {
-	resource := activityCtx.Value(params.ContextKey).(FixerContext).Resource
-	client := resource.GetSDKClient()
+	ctx, err := GetFixerContext(activityCtx)
+	if err != nil {
+		return nil, err
+	}
+
+	client := ctx.Resource.GetSDKClient()
 	if params.ScannerWorkflowRunID == "" {
 		listResp, err := client.ListClosedWorkflowExecutions(activityCtx, &shared.ListClosedWorkflowExecutionsRequest{
 			Domain:          c.StringPtr(c.SystemLocalDomainName),
@@ -302,11 +311,15 @@ func fixShard(
 	corruptedKeys store.Keys,
 	heartbeatDetails FixShardHeartbeatDetails,
 ) (*FixReport, error) {
-	ctx := activityCtx.Value(params.ContextKey).(FixerContext)
-	resources := ctx.Resource
+	ctx, err := GetFixerContext(activityCtx)
+	if err != nil {
+		return nil, err
+	}
+	resource := ctx.Resource
+	info := activity.GetInfo(activityCtx)
 	scope := ctx.Scope.Tagged(
 		metrics.ActivityTypeTag(ActivityFixShard),
-		metrics.WorkflowTypeTag(params.ContextKey.String()),
+		metrics.WorkflowTypeTag(info.WorkflowType.Name),
 		metrics.DomainTag(c.SystemLocalDomainName),
 	)
 	sw := scope.StartTimer(metrics.CadenceLatency)
@@ -316,23 +329,23 @@ func fixShard(
 		return nil, cadence.NewCustomError(ErrMissingHooks)
 	}
 
-	execManager, err := resources.GetExecutionManager(shardID)
+	execManager, err := resource.GetExecutionManager(shardID)
 	if err != nil {
 		scope.IncCounter(metrics.CadenceFailures)
 		return nil, err
 	}
 
-	pr := persistence.NewPersistenceRetryer(execManager, resources.GetHistoryManager(), c.CreatePersistenceRetryPolicy())
+	pr := persistence.NewPersistenceRetryer(execManager, resource.GetHistoryManager(), c.CreatePersistenceRetryPolicy())
 
 	fixer := NewFixer(
 		activityCtx,
 		shardID,
 		ctx.Hooks.InvariantManager(activityCtx, pr, params, *ctx.Config),
-		ctx.Hooks.Iterator(activityCtx, resources.GetBlobstoreClient(), corruptedKeys, params, *ctx.Config),
-		resources.GetBlobstoreClient(),
+		ctx.Hooks.Iterator(activityCtx, resource.GetBlobstoreClient(), corruptedKeys, params, *ctx.Config),
+		resource.GetBlobstoreClient(),
 		params.ResolvedFixerWorkflowConfig.BlobstoreFlushThreshold,
 		func() { activity.RecordHeartbeat(activityCtx, heartbeatDetails) },
-		resources.GetDomainCache(),
+		resource.GetDomainCache(),
 		ctx.Config.DynamicParams.AllowDomain,
 	)
 	report := fixer.Fix()
@@ -347,10 +360,11 @@ func ScannerEmitMetricsActivity(
 	activityCtx context.Context,
 	params ScannerEmitMetricsActivityParams,
 ) error {
-	contextKey := params.ContextKey
-	scope := activityCtx.Value(contextKey).(Context).Scope.Tagged(
+	ctx, _ := GetScannerContext(activityCtx)
+	info := activity.GetInfo(activityCtx)
+	scope := ctx.Scope.Tagged(
 		metrics.ActivityTypeTag(ActivityScannerEmitMetrics),
-		metrics.WorkflowTypeTag(contextKey.String()),
+		metrics.WorkflowTypeTag(info.WorkflowType.Name),
 		metrics.DomainTag(c.SystemLocalDomainName),
 	)
 	scope.UpdateGauge(metrics.CadenceShardSuccessGauge, float64(params.ShardSuccessCount))

--- a/service/worker/scanner/shardscanner/fixer_workflow.go
+++ b/service/worker/scanner/shardscanner/fixer_workflow.go
@@ -97,8 +97,6 @@ func NewFixerWorkflow(
 		return nil, errors.New("workflow name is not provided")
 	}
 
-	params.ContextKey = ScannerContextKey(name)
-
 	wf := FixerWorkflow{
 		Params: params,
 	}
@@ -139,7 +137,6 @@ func (fx *FixerWorkflow) Start(ctx workflow.Context) error {
 				if err := workflow.ExecuteActivity(activityCtx, ActivityFixShard, FixShardActivityParams{
 					CorruptedKeysEntries:        batch,
 					ResolvedFixerWorkflowConfig: resolvedConfig,
-					ContextKey:                  fx.Params.ContextKey,
 				}).Get(ctx, &reports); err != nil {
 					errStr := err.Error()
 					shardReportChan.Send(ctx, FixReportError{

--- a/service/worker/scanner/shardscanner/fixer_workflow.go
+++ b/service/worker/scanner/shardscanner/fixer_workflow.go
@@ -47,7 +47,6 @@ type FixerManagerCB func(
 	context.Context,
 	persistence.Retryer,
 	FixShardActivityParams,
-	ScannerConfig,
 ) invariant.Manager
 
 // FixerIteratorCB is a function which returns ScanOutputIterator for fixer.
@@ -56,7 +55,6 @@ type FixerIteratorCB func(
 	blobstore.Client,
 	store.Keys,
 	FixShardActivityParams,
-	ScannerConfig,
 ) store.ScanOutputIterator
 
 // FixerHooks holds callback functions for shard scanner workflow implementation.

--- a/service/worker/scanner/shardscanner/fixer_workflow_test.go
+++ b/service/worker/scanner/shardscanner/fixer_workflow_test.go
@@ -97,7 +97,6 @@ func (s *fixerWorkflowSuite) TestNewFixerHooks() {
 				ctx context.Context,
 				retryer persistence.Retryer,
 				params FixShardActivityParams,
-				config ScannerConfig,
 			) invariant.Manager {
 				return nil
 			},
@@ -110,11 +109,15 @@ func (s *fixerWorkflowSuite) TestNewFixerHooks() {
 				ctx context.Context,
 				retryer persistence.Retryer,
 				params FixShardActivityParams,
-				config ScannerConfig,
 			) invariant.Manager {
 				return nil
 			},
-			iterator: func(ctx context.Context, client blobstore.Client, keys store.Keys, params FixShardActivityParams, config ScannerConfig) store.ScanOutputIterator {
+			iterator: func(
+				ctx context.Context,
+				client blobstore.Client,
+				keys store.Keys,
+				params FixShardActivityParams,
+			) store.ScanOutputIterator {
 				return nil
 			},
 			wantErr: false,

--- a/service/worker/scanner/shardscanner/scanner_workflow.go
+++ b/service/worker/scanner/shardscanner/scanner_workflow.go
@@ -74,7 +74,7 @@ type ScannerWorkflow struct {
 type ScannerHooks struct {
 	Manager          ManagerCB
 	Iterator         IteratorCB
-	GetScannerConfig func(scanner *Context) CustomScannerConfig
+	GetScannerConfig func(scanner Context) CustomScannerConfig
 }
 
 // NewScannerWorkflow creates instance of shard scanner
@@ -169,15 +169,14 @@ func (wf *ScannerWorkflow) Start(ctx workflow.Context) error {
 
 	activityCtx = getShortActivityContext(ctx)
 	summary := wf.Aggregator.GetStatusSummary()
-	if err := workflow.ExecuteActivity(activityCtx, ActivityScannerEmitMetrics, ScannerEmitMetricsActivityParams{
+
+	return workflow.ExecuteActivity(activityCtx, ActivityScannerEmitMetrics, ScannerEmitMetricsActivityParams{
 		ShardSuccessCount:            summary[ShardStatusSuccess],
 		ShardControlFlowFailureCount: summary[ShardStatusControlFlowFailure],
 		AggregateReportResult:        wf.Aggregator.GetAggregateReport(),
 		ShardDistributionStats:       wf.Aggregator.GetShardDistributionStats(),
-	}).Get(ctx, nil); err != nil {
-		return err
-	}
-	return nil
+	}).Get(ctx, nil)
+
 }
 
 func getScanHandlers(aggregator *ShardScanResultAggregator) map[string]interface{} {
@@ -222,7 +221,7 @@ func getShardBatches(
 }
 
 // SetConfig allow to pass optional config resolver hook
-func (sh *ScannerHooks) SetConfig(config func(scanner *Context) CustomScannerConfig) {
+func (sh *ScannerHooks) SetConfig(config func(scanner Context) CustomScannerConfig) {
 	sh.GetScannerConfig = config
 }
 

--- a/service/worker/scanner/shardscanner/scanner_workflow.go
+++ b/service/worker/scanner/shardscanner/scanner_workflow.go
@@ -53,7 +53,6 @@ type ManagerCB func(
 	context.Context,
 	persistence.Retryer,
 	ScanShardActivityParams,
-	ScannerConfig,
 ) invariant.Manager
 
 // IteratorCB is a function which returns iterator for scanner.
@@ -61,7 +60,6 @@ type IteratorCB func(
 	context.Context,
 	persistence.Retryer,
 	ScanShardActivityParams,
-	ScannerConfig,
 ) pagination.Iterator
 
 // ScannerWorkflow is a workflow which scans and checks entities in a shard.

--- a/service/worker/scanner/shardscanner/scanner_workflow_test.go
+++ b/service/worker/scanner/shardscanner/scanner_workflow_test.go
@@ -231,7 +231,6 @@ func (s *fixerWorkflowSuite) TestNewScannerHooks() {
 				ctx context.Context,
 				retryer persistence.Retryer,
 				params ScanShardActivityParams,
-				config ScannerConfig,
 			) pagination.Iterator {
 				return nil
 			},
@@ -244,7 +243,6 @@ func (s *fixerWorkflowSuite) TestNewScannerHooks() {
 				ctx context.Context,
 				retryer persistence.Retryer,
 				params ScanShardActivityParams,
-				config ScannerConfig,
 			) invariant.Manager {
 				return nil
 			},
@@ -257,7 +255,6 @@ func (s *fixerWorkflowSuite) TestNewScannerHooks() {
 				ctx context.Context,
 				retryer persistence.Retryer,
 				params ScanShardActivityParams,
-				config ScannerConfig,
 			) invariant.Manager {
 				return nil
 			},
@@ -265,7 +262,6 @@ func (s *fixerWorkflowSuite) TestNewScannerHooks() {
 				ctx context.Context,
 				retryer persistence.Retryer,
 				params ScanShardActivityParams,
-				config ScannerConfig,
 			) pagination.Iterator {
 				return nil
 			},

--- a/service/worker/scanner/shardscanner/shardscannertest/workflow_test.go
+++ b/service/worker/scanner/shardscanner/shardscannertest/workflow_test.go
@@ -101,8 +101,7 @@ func (s *workflowsSuite) TestScannerWorkflow_Failure_ScanShard() {
 			}
 		}
 		env.OnActivity(shardscanner.ActivityScanShard, mock.Anything, shardscanner.ScanShardActivityParams{
-			ContextKey: "test-workflow",
-			Shards:     batch,
+			Shards: batch,
 		}).Return(reports, err)
 	}
 	env.ExecuteWorkflow(NewTestWorkflow, "test-workflow", shardscanner.ScannerWorkflowParams{
@@ -248,7 +247,6 @@ func (s *workflowsSuite) TestFixerWorkflow_Success() {
 		env.OnActivity(shardscanner.ActivityFixShard, mock.Anything, shardscanner.FixShardActivityParams{
 			CorruptedKeysEntries:        corruptedKeys,
 			ResolvedFixerWorkflowConfig: resolvedFixerWorkflowConfig,
-			ContextKey:                  "test-fixer",
 		}).Return(reports, nil)
 	}
 
@@ -256,7 +254,6 @@ func (s *workflowsSuite) TestFixerWorkflow_Success() {
 		ScannerWorkflowWorkflowID:     "test_wid",
 		ScannerWorkflowRunID:          "test_rid",
 		FixerWorkflowConfigOverwrites: fixerWorkflowConfigOverwrites,
-		ContextKey:                    "test-fixer",
 	})
 	s.True(env.IsWorkflowCompleted())
 	s.NoError(env.GetWorkflowError())

--- a/service/worker/scanner/shardscanner/types.go
+++ b/service/worker/scanner/shardscanner/types.go
@@ -28,10 +28,9 @@ import (
 	"fmt"
 	"time"
 
-	"go.uber.org/cadence/activity"
-
 	"go.uber.org/cadence"
-	cclient "go.uber.org/cadence/client"
+	"go.uber.org/cadence/activity"
+	"go.uber.org/cadence/client"
 	"go.uber.org/cadence/workflow"
 
 	"github.com/uber/cadence/common/metrics"
@@ -254,8 +253,8 @@ type (
 		FixerHooks           func() *FixerHooks
 		DynamicParams        DynamicParams
 		DynamicCollection    *dynamicconfig.Collection
-		StartWorkflowOptions cclient.StartWorkflowOptions
-		StartFixerOptions    cclient.StartWorkflowOptions
+		StartWorkflowOptions client.StartWorkflowOptions
+		StartFixerOptions    client.StartWorkflowOptions
 	}
 
 	// FixerWorkflowConfigOverwrites enables overwriting the default values.
@@ -415,7 +414,11 @@ func (s Shards) Flatten() ([]int, int, int) {
 	return shardList, min, max
 }
 
-func NewShardScannerContext(res resource.Resource, config *ScannerConfig) Context {
+// NewShardScannerContext sets scanner context up
+func NewShardScannerContext(
+	res resource.Resource,
+	config *ScannerConfig,
+) Context {
 	return Context{
 		Resource: res,
 		Scope:    res.GetMetricsClient().Scope(metrics.ExecutionsScannerScope),
@@ -424,7 +427,11 @@ func NewShardScannerContext(res resource.Resource, config *ScannerConfig) Contex
 	}
 }
 
-func NewShardFixerContext(res resource.Resource, config *ScannerConfig) FixerContext {
+// NewShardFixerContext sets fixer context up
+func NewShardFixerContext(
+	res resource.Resource,
+	config *ScannerConfig,
+) FixerContext {
 	return FixerContext{
 		Resource: res,
 		Scope:    res.GetMetricsClient().Scope(metrics.ExecutionsFixerScope),
@@ -433,11 +440,20 @@ func NewShardFixerContext(res resource.Resource, config *ScannerConfig) FixerCon
 	}
 }
 
-func NewContext(ctx context.Context, workflowName string, scannerContext interface{}) context.Context {
+// NewContext provides context to be used as background activity context
+func NewContext(
+	ctx context.Context,
+	workflowName string,
+	scannerContext interface{},
+) context.Context {
 	return context.WithValue(ctx, contextKey(workflowName), scannerContext)
 }
 
-func GetScannerContext(ctx context.Context) (*Context, error) {
+// GetScannerContext extracts scanner context from activity context
+// it uses typed, private key to reduce access scope
+func GetScannerContext(
+	ctx context.Context,
+) (*Context, error) {
 	info := activity.GetInfo(ctx)
 	if info.WorkflowType == nil {
 		return nil, fmt.Errorf("workflowType is nil")
@@ -449,7 +465,11 @@ func GetScannerContext(ctx context.Context) (*Context, error) {
 	return val, nil
 }
 
-func GetFixerContext(ctx context.Context) (*FixerContext, error) {
+// GetFixerContext extracts fixer context from activity context
+// it uses typed, private key to reduce access scope
+func GetFixerContext(
+	ctx context.Context,
+) (*FixerContext, error) {
 	info := activity.GetInfo(ctx)
 	if info.WorkflowType == nil {
 		return nil, fmt.Errorf("workflowType is nil")

--- a/service/worker/scanner/shardscanner/types_test.go
+++ b/service/worker/scanner/shardscanner/types_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package shardscanner
 
 import (

--- a/service/worker/scanner/shardscanner/types_test.go
+++ b/service/worker/scanner/shardscanner/types_test.go
@@ -1,0 +1,18 @@
+package shardscanner
+
+import (
+	"context"
+	"testing"
+)
+
+func TestGetFixerContextPanicsWhenNonActivityContextProvided(t *testing.T) {
+	defer func() { recover() }()
+	GetFixerContext(context.Background())
+	t.Errorf("should have panicked")
+}
+
+func TestGetScannerContextPanicsWhenNonActivityContextProvided(t *testing.T) {
+	defer func() { recover() }()
+	GetScannerContext(context.Background())
+	t.Errorf("should have panicked")
+}

--- a/service/worker/scanner/timers/timers.go
+++ b/service/worker/scanner/timers/timers.go
@@ -110,7 +110,6 @@ func Manager(
 	_ context.Context,
 	pr persistence.Retryer,
 	_ shardscanner.ScanShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) invariant.Manager {
 	return invariant.NewInvariantManager(getInvariants(pr))
 }
@@ -120,7 +119,6 @@ func Iterator(
 	ctx context.Context,
 	pr persistence.Retryer,
 	params shardscanner.ScanShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) pagination.Iterator {
 	start, err := strconv.Atoi(params.ScannerConfig[periodStartKey])
 	if err != nil {
@@ -144,7 +142,6 @@ func FixerIterator(
 	client blobstore.Client,
 	keys store.Keys,
 	_ shardscanner.FixShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) store.ScanOutputIterator {
 	return store.NewBlobstoreIterator(ctx, client, keys, &entity.Timer{})
 }
@@ -154,7 +151,6 @@ func FixerManager(
 	_ context.Context,
 	pr persistence.Retryer,
 	_ shardscanner.FixShardActivityParams,
-	_ shardscanner.ScannerConfig,
 ) invariant.Manager {
 	return invariant.NewInvariantManager(getInvariants(pr))
 }

--- a/service/worker/scanner/timers/timers.go
+++ b/service/worker/scanner/timers/timers.go
@@ -156,7 +156,7 @@ func FixerManager(
 }
 
 // Config resolves dynamic config for timers scanner.
-func Config(ctx *shardscanner.Context) shardscanner.CustomScannerConfig {
+func Config(ctx shardscanner.Context) shardscanner.CustomScannerConfig {
 	res := shardscanner.CustomScannerConfig{}
 	res[periodStartKey] = strconv.Itoa(ctx.Config.DynamicCollection.GetIntProperty(dynamicconfig.TimersScannerPeriodStart, _defaultPeriodStart)())
 	res[periodEndKey] = strconv.Itoa(ctx.Config.DynamicCollection.GetIntProperty(dynamicconfig.TimersScannerPeriodEnd, _defaultPeriodEnd)())

--- a/service/worker/scanner/timers/timers.go
+++ b/service/worker/scanner/timers/timers.go
@@ -160,7 +160,7 @@ func FixerManager(
 }
 
 // Config resolves dynamic config for timers scanner.
-func Config(ctx shardscanner.Context) shardscanner.CustomScannerConfig {
+func Config(ctx *shardscanner.Context) shardscanner.CustomScannerConfig {
 	res := shardscanner.CustomScannerConfig{}
 	res[periodStartKey] = strconv.Itoa(ctx.Config.DynamicCollection.GetIntProperty(dynamicconfig.TimersScannerPeriodStart, _defaultPeriodStart)())
 	res[periodEndKey] = strconv.Itoa(ctx.Config.DynamicCollection.GetIntProperty(dynamicconfig.TimersScannerPeriodEnd, _defaultPeriodEnd)())

--- a/service/worker/scanner/timers/timers_test.go
+++ b/service/worker/scanner/timers/timers_test.go
@@ -135,7 +135,6 @@ func (s *timersWorkflowsSuite) TestScannerWorkflow_Success() {
 		//var customc shardscanner.CustomScannerConfig
 		env.OnActivity(shardscanner.ActivityScanShard, mock.Anything, shardscanner.ScanShardActivityParams{
 			Shards:        batch,
-			ContextKey:    ScannerWFTypeName,
 			ScannerConfig: cconfig,
 		}).Return(reports, nil)
 	}

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -124,24 +124,28 @@ func HistoryScavengerActivity(
 	activityCtx context.Context,
 ) (history.ScavengerHeartbeatDetails, error) {
 
-	ctx, _ := GetScannerContext(activityCtx)
+	ctx, err := GetScannerContext(activityCtx)
+	if err != nil {
+		return history.ScavengerHeartbeatDetails{}, err
+	}
 
 	rps := ctx.cfg.ScannerPersistenceMaxQPS()
+	res := ctx.resource
 
 	hbd := history.ScavengerHeartbeatDetails{}
 	if activity.HasHeartbeatDetails(activityCtx) {
 		if err := activity.GetHeartbeatDetails(activityCtx, &hbd); err != nil {
-			ctx.GetLogger().Error("Failed to recover from last heartbeat, start over from beginning", tag.Error(err))
+			res.GetLogger().Error("Failed to recover from last heartbeat, start over from beginning", tag.Error(err))
 		}
 	}
 
 	scavenger := history.NewScavenger(
-		ctx.GetHistoryManager(),
+		res.GetHistoryManager(),
 		rps,
-		ctx.GetHistoryClient(),
+		res.GetHistoryClient(),
 		hbd,
-		ctx.GetMetricsClient(),
-		ctx.GetLogger(),
+		res.GetMetricsClient(),
+		res.GetLogger(),
 	)
 	return scavenger.Run(activityCtx)
 }
@@ -154,13 +158,14 @@ func TaskListScavengerActivity(
 	if err != nil {
 		return err
 	}
-	scavenger := tasklist.NewScavenger(activityCtx, ctx.GetTaskManager(), ctx.GetMetricsClient(), ctx.GetLogger())
-	ctx.GetLogger().Info("Starting task list scavenger")
+	res := ctx.resource
+	scavenger := tasklist.NewScavenger(activityCtx, res.GetTaskManager(), res.GetMetricsClient(), res.GetLogger())
+	res.GetLogger().Info("Starting task list scavenger")
 	scavenger.Start()
 	for scavenger.Alive() {
 		activity.RecordHeartbeat(activityCtx)
 		if activityCtx.Err() != nil {
-			ctx.GetLogger().Info("activity context error, stopping scavenger", tag.Error(activityCtx.Err()))
+			res.GetLogger().Info("activity context error, stopping scavenger", tag.Error(activityCtx.Err()))
 			scavenger.Stop()
 			return activityCtx.Err()
 		}

--- a/service/worker/scanner/workflow.go
+++ b/service/worker/scanner/workflow.go
@@ -37,8 +37,6 @@ import (
 )
 
 const (
-	scannerContextKey = "scannerContextKey"
-
 	maxConcurrentActivityExecutionSize     = 10
 	maxConcurrentDecisionTaskExecutionSize = 10
 	infiniteDuration                       = 20 * 365 * 24 * time.Hour
@@ -126,7 +124,8 @@ func HistoryScavengerActivity(
 	activityCtx context.Context,
 ) (history.ScavengerHeartbeatDetails, error) {
 
-	ctx := activityCtx.Value(scannerContextKey).(scannerContext)
+	ctx, _ := GetScannerContext(activityCtx)
+
 	rps := ctx.cfg.ScannerPersistenceMaxQPS()
 
 	hbd := history.ScavengerHeartbeatDetails{}
@@ -151,8 +150,10 @@ func HistoryScavengerActivity(
 func TaskListScavengerActivity(
 	activityCtx context.Context,
 ) error {
-
-	ctx := activityCtx.Value(scannerContextKey).(scannerContext)
+	ctx, err := GetScannerContext(activityCtx)
+	if err != nil {
+		return err
+	}
 	scavenger := tasklist.NewScavenger(activityCtx, ctx.GetTaskManager(), ctx.GetMetricsClient(), ctx.GetLogger())
 	ctx.GetLogger().Info("Starting task list scavenger")
 	scavenger.Start()

--- a/service/worker/scanner/workflow_test.go
+++ b/service/worker/scanner/workflow_test.go
@@ -25,12 +25,13 @@ import (
 	"testing"
 	"time"
 
+	"go.uber.org/cadence/worker"
+	"go.uber.org/zap"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/cadence/testsuite"
-	"go.uber.org/cadence/worker"
-	"go.uber.org/zap"
 
 	"github.com/uber/cadence/common/metrics"
 	p "github.com/uber/cadence/common/persistence"
@@ -61,13 +62,13 @@ func (s *scannerWorkflowTestSuite) TestScavengerActivity() {
 	defer mockResource.Finish(s.T())
 
 	mockResource.TaskMgr.On("ListTaskList", mock.Anything, mock.Anything).Return(&p.ListTaskListResponse{}, nil)
-	ctx := scannerContext{
+	ctx := ScannerContext{
 		Resource:  mockResource,
 		zapLogger: zap.NewNop(),
 	}
 	env.SetTestTimeout(time.Second * 5)
 	env.SetWorkerOptions(worker.Options{
-		BackgroundActivityContext: context.WithValue(context.Background(), scannerContextKey, ctx),
+		BackgroundActivityContext: NewScannerContext(context.Background(), "default-test-workflow-type-name", &ctx),
 	})
 	tlScavengerHBInterval = time.Millisecond * 10
 	_, err := env.ExecuteActivity(taskListScavengerActivityName)

--- a/service/worker/scanner/workflow_test.go
+++ b/service/worker/scanner/workflow_test.go
@@ -25,17 +25,17 @@ import (
 	"testing"
 	"time"
 
-	"go.uber.org/cadence/worker"
-	"go.uber.org/zap"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-	"go.uber.org/cadence/testsuite"
 
 	"github.com/uber/cadence/common/metrics"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/resource"
+
+	"go.uber.org/cadence/testsuite"
+	"go.uber.org/cadence/worker"
+	"go.uber.org/zap"
 )
 
 type scannerWorkflowTestSuite struct {
@@ -62,8 +62,8 @@ func (s *scannerWorkflowTestSuite) TestScavengerActivity() {
 	defer mockResource.Finish(s.T())
 
 	mockResource.TaskMgr.On("ListTaskList", mock.Anything, mock.Anything).Return(&p.ListTaskListResponse{}, nil)
-	ctx := ScannerContext{
-		Resource:  mockResource,
+	ctx := scannerContext{
+		resource:  mockResource,
 		zapLogger: zap.NewNop(),
 	}
 	env.SetTestTimeout(time.Second * 5)

--- a/service/worker/scanner/workflow_test.go
+++ b/service/worker/scanner/workflow_test.go
@@ -35,7 +35,6 @@ import (
 
 	"go.uber.org/cadence/testsuite"
 	"go.uber.org/cadence/worker"
-	"go.uber.org/zap"
 )
 
 type scannerWorkflowTestSuite struct {
@@ -63,12 +62,11 @@ func (s *scannerWorkflowTestSuite) TestScavengerActivity() {
 
 	mockResource.TaskMgr.On("ListTaskList", mock.Anything, mock.Anything).Return(&p.ListTaskListResponse{}, nil)
 	ctx := scannerContext{
-		resource:  mockResource,
-		zapLogger: zap.NewNop(),
+		resource: mockResource,
 	}
 	env.SetTestTimeout(time.Second * 5)
 	env.SetWorkerOptions(worker.Options{
-		BackgroundActivityContext: NewScannerContext(context.Background(), "default-test-workflow-type-name", &ctx),
+		BackgroundActivityContext: NewScannerContext(context.Background(), "default-test-workflow-type-name", ctx),
 	})
 	tlScavengerHBInterval = time.Millisecond * 10
 	_, err := env.ExecuteActivity(taskListScavengerActivityName)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -133,7 +133,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			Persistence:              &params.PersistenceConfig,
 			ClusterMetadata:          params.ClusterMetadata,
 			TaskListScannerEnabled:   dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
-			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
+			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, false),
 			ShardScanners: []*shardscanner.ScannerConfig{
 				executions.ConcreteExecutionScannerConfig(dc),
 				executions.CurrentExecutionScannerConfig(dc),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -133,7 +133,7 @@ func NewConfig(params *service.BootstrapParams) *Config {
 			Persistence:              &params.PersistenceConfig,
 			ClusterMetadata:          params.ClusterMetadata,
 			TaskListScannerEnabled:   dc.GetBoolProperty(dynamicconfig.TaskListScannerEnabled, true),
-			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, false),
+			HistoryScannerEnabled:    dc.GetBoolProperty(dynamicconfig.HistoryScannerEnabled, true),
 			ShardScanners: []*shardscanner.ScannerConfig{
 				executions.ConcreteExecutionScannerConfig(dc),
 				executions.CurrentExecutionScannerConfig(dc),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Context keys are now typed and private. Every scanner has context key named after workflow name. Activity context is used to get workflow name. Shardscanner now don't pass workflow name in activity param
Fixes #3963

<!-- Tell your future self why have you made these changes -->
**Why?**
This will reduce possibility to misuse context keys

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests, local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

