### PR TITLE
Fix xdc failover integration test

### DIFF
--- a/host/xdc/integration_failover_test.go
+++ b/host/xdc/integration_failover_test.go
@@ -158,10 +158,8 @@ func (s *integrationClustersTestSuite) TestDomainFailover() {
 
 	// update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -412,10 +410,8 @@ func (s *integrationClustersTestSuite) TestSimpleWorkflowFailover() {
 
 	// update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -638,10 +634,8 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 
 	// Update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -671,10 +665,8 @@ func (s *integrationClustersTestSuite) TestStickyDecisionFailover() {
 
 	// Update domain to fail over back
 	updateReq = &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[0]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[0]),
 	}
 	updateResp, err = client2.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -783,10 +775,8 @@ func (s *integrationClustersTestSuite) TestStartWorkflowExecution_Failover_Workf
 
 	// update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -928,10 +918,8 @@ func (s *integrationClustersTestSuite) TestTerminateFailover() {
 
 	// update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -1120,10 +1108,8 @@ func (s *integrationClustersTestSuite) TestContinueAsNewFailover() {
 
 	// update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -1260,10 +1246,8 @@ func (s *integrationClustersTestSuite) TestSignalFailover() {
 
 	// Update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -1478,10 +1462,8 @@ func (s *integrationClustersTestSuite) TestUserTimerFailover() {
 
 	// Update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -1653,10 +1635,8 @@ func (s *integrationClustersTestSuite) TestActivityHeartbeatFailover() {
 
 	// Update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -1810,10 +1790,8 @@ func (s *integrationClustersTestSuite) TestTransientDecisionFailover() {
 
 	// Update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -1903,10 +1881,8 @@ func (s *integrationClustersTestSuite) TestCronWorkflowFailover() {
 	// Failover during backoff
 	// Update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)
@@ -2012,10 +1988,8 @@ func (s *integrationClustersTestSuite) TestWorkflowRetryFailover() {
 
 	// Update domain to fail over
 	updateReq := &types.UpdateDomainRequest{
-		Name: common.StringPtr(domainName),
-		ReplicationConfiguration: &types.DomainReplicationConfiguration{
-			ActiveClusterName: common.StringPtr(clusterName[1]),
-		},
+		Name: domainName,
+		ActiveClusterName: common.StringPtr(clusterName[1]),
 	}
 	updateResp, err := client1.UpdateDomain(createContext(), updateReq)
 	s.NoError(err)


### PR DESCRIPTION
I have just noticed that after #3954 xdc integration test was not updated. My IDE started showing errors for this.

I fixed what was missing, but the bigger question is why is this not included in the build?