### PR TITLE
Kafka TLS: allow CA(RootCAs) or cert/key(certificate chains) only

### DIFF
--- a/common/messaging/kafka/clientImpl.go
+++ b/common/messaging/kafka/clientImpl.go
@@ -169,7 +169,7 @@ func (c *clientImpl) initAuth(saramaConfig *sarama.Config) error {
 	return nil
 }
 
-// convertTLSConfig convert tls config
+// convertTLSConfig converts tls config
 func convertTLSConfig(authConfig auth.TLS) (*tls.Config, error) {
 	if !authConfig.Enabled {
 		return nil, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow allow CA or cert/key only to enable TLS for Kafka

<!-- Tell your future self why have you made these changes -->
**Why?**
Because TLS doesn't require both. Only one of them is also enough for TLS. 
See comment in https://github.com/uber/cadence/pull/3862/files#r573369803

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
User will test it. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It's backward compatible with the existing TLS experience(less strict). 
