### PR TITLE
Fix dryrun option for SQL/Cassandra schema update command

### DIFF
--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -154,20 +154,6 @@ func doCreateKeyspace(cfg CQLClientConfig, name string) error {
 	return client.createKeyspace(name)
 }
 
-func doDropKeyspace(cfg CQLClientConfig, name string) {
-	cfg.Keyspace = systemKeyspace
-	client, err := newCQLClient(&cfg)
-	if err != nil {
-		logErr(fmt.Errorf("error creating client: %v", err))
-		return
-	}
-	err = client.dropKeyspace(name)
-	if err != nil {
-		logErr(fmt.Errorf("error dropping keyspace %v: %v", name, err))
-	}
-	client.Close()
-}
-
 func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 	config := new(CQLClientConfig)
 	config.Hosts = cli.GlobalString(schema.CLIOptEndpoint)
@@ -188,14 +174,13 @@ func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 		}
 	}
 
-	isDryRun := cli.Bool(schema.CLIOptDryrun)
-	if err := validateCQLClientConfig(config, isDryRun); err != nil {
+	if err := validateCQLClientConfig(config); err != nil {
 		return nil, err
 	}
 	return config, nil
 }
 
-func validateCQLClientConfig(config *CQLClientConfig, isDryRun bool) error {
+func validateCQLClientConfig(config *CQLClientConfig) error {
 	if len(config.Hosts) == 0 {
 		return schema.NewConfigError("missing cassandra endpoint argument " + flag(schema.CLIOptEndpoint))
 	}

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -116,13 +116,6 @@ func updateSchema(cli *cli.Context) error {
 	if err != nil {
 		return handleErr(schema.NewConfigError(err.Error()))
 	}
-	if config.Keyspace == schema.DryrunDBName {
-		cfg := *config
-		if err := doCreateKeyspace(cfg, cfg.Keyspace); err != nil {
-			return handleErr(fmt.Errorf("error creating dryrun Keyspace: %v", err))
-		}
-		defer doDropKeyspace(cfg, cfg.Keyspace)
-	}
 	client, err := newCQLClient(config)
 	if err != nil {
 		return handleErr(err)
@@ -207,10 +200,7 @@ func validateCQLClientConfig(config *CQLClientConfig, isDryRun bool) error {
 		return schema.NewConfigError("missing cassandra endpoint argument " + flag(schema.CLIOptEndpoint))
 	}
 	if config.Keyspace == "" {
-		if !isDryRun {
-			return schema.NewConfigError("missing " + flag(schema.CLIOptKeyspace) + " argument ")
-		}
-		config.Keyspace = schema.DryrunDBName
+		return schema.NewConfigError("missing " + flag(schema.CLIOptKeyspace) + " argument ")
 	}
 	if config.Port == 0 {
 		config.Port = defaultCassandraPort

--- a/tools/cassandra/handler_test.go
+++ b/tools/cassandra/handler_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/environment"
-	"github.com/uber/cadence/tools/common/schema"
 )
 
 type (
@@ -52,8 +51,6 @@ func (s *HandlerTestSuite) TestValidateCQLClientConfig() {
 
 	config.Hosts = environment.GetCassandraAddress()
 	s.NotNil(validateCQLClientConfig(config, false))
-	s.Nil(validateCQLClientConfig(config, true))
-	s.Equal(schema.DryrunDBName, config.Keyspace)
 
 	config.Keyspace = "foobar"
 	s.Nil(validateCQLClientConfig(config, false))

--- a/tools/cassandra/handler_test.go
+++ b/tools/cassandra/handler_test.go
@@ -46,13 +46,11 @@ func (s *HandlerTestSuite) SetupTest() {
 
 func (s *HandlerTestSuite) TestValidateCQLClientConfig() {
 	config := new(CQLClientConfig)
-	s.NotNil(validateCQLClientConfig(config, false))
-	s.NotNil(validateCQLClientConfig(config, true))
+	s.NotNil(validateCQLClientConfig(config))
 
 	config.Hosts = environment.GetCassandraAddress()
-	s.NotNil(validateCQLClientConfig(config, false))
+	s.NotNil(validateCQLClientConfig(config))
 
 	config.Keyspace = "foobar"
-	s.Nil(validateCQLClientConfig(config, false))
-	s.Nil(validateCQLClientConfig(config, true))
+	s.Nil(validateCQLClientConfig(config))
 }

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -36,7 +36,7 @@ func RunTool(args []string) error {
 
 // SetupSchema setups the cassandra schema
 func SetupSchema(config *SetupSchemaConfig) error {
-	if err := validateCQLClientConfig(&config.CQLClientConfig, false); err != nil {
+	if err := validateCQLClientConfig(&config.CQLClientConfig); err != nil {
 		return err
 	}
 	db, err := newCQLClient(&config.CQLClientConfig)

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -154,9 +154,6 @@ const (
 	CLIFlagTLSEnableHostVerification = "tls-enable-host-verification"
 )
 
-// DryrunDBName is the db name used for dryrun
-const DryrunDBName = "_cadence_dryrun_"
-
 var rmspaceRegex = regexp.MustCompile(`\s+`)
 
 // NewConfigError creates and returns an instance of ConfigError

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -134,7 +134,7 @@ const (
 	// CLIFlagTargetVersion is the cli flag for target version
 	CLIFlagTargetVersion = CLIOptTargetVersion + ", v"
 	// CLIFlagDryrun is the cli flag for dryrun
-	CLIFlagDryrun = CLIOptDryrun + ", y"
+	CLIFlagDryrun = CLIOptDryrun
 	// CLIFlagSchemaDir is the cli flag for schema directory
 	CLIFlagSchemaDir = CLIOptSchemaDir + ", d"
 	// CLIFlagReplicationFactor is the cli flag for replication factor

--- a/tools/common/schema/updatetask.go
+++ b/tools/common/schema/updatetask.go
@@ -98,12 +98,6 @@ func (task *UpdateTask) Run() error {
 
 	log.Printf("UpdateSchemeTask started, config=%+v\n", config)
 
-	if config.IsDryRun {
-		if err := task.setupDryrunDatabase(); err != nil {
-			return fmt.Errorf("error creating dryrun database:%v", err.Error())
-		}
-	}
-
 	currVer, err := task.db.ReadSchemaVersion()
 	if err != nil {
 		return fmt.Errorf("error reading current schema version:%v", err.Error())
@@ -114,11 +108,23 @@ func (task *UpdateTask) Run() error {
 		return err
 	}
 
-	err = task.executeUpdates(currVer, updates)
-	if err != nil {
-		return err
+	if config.IsDryRun {
+		log.Println("In DryRun mode, this command will only print queries without executing....")
+		if len(updates) == 0 {
+			log.Println("Found zero updates to run")
+		}
+		for _, upd := range updates {
+			log.Printf("DryRun of updating to version: %s, manifest: %s \n", upd.version, upd.manifest)
+			for _, stmt := range upd.cqlStmts {
+				log.Printf("DryRun query:%s \n", stmt)
+			}
+		}
+	} else {
+		err = task.executeUpdates(currVer, updates)
+		if err != nil {
+			return err
+		}
 	}
-
 	log.Printf("UpdateSchemeTask done\n")
 
 	return nil
@@ -415,17 +421,6 @@ func filterDirectories(dirNames []string, startVer string, endVer string) ([]str
 	sort.Sort(byVersion(result))
 
 	return result, squashes, nil
-}
-
-// sets up a temporary dryrun database for
-// executing the cassandra schema update
-func (task *UpdateTask) setupDryrunDatabase() error {
-	setupConfig := &SetupConfig{
-		Overwrite:      true,
-		InitialVersion: "0.0",
-	}
-	setupTask := newSetupSchemaTask(task.db, setupConfig)
-	return setupTask.Run()
 }
 
 func dirToVersion(dir string) string {

--- a/tools/common/schema/updatetask.go
+++ b/tools/common/schema/updatetask.go
@@ -109,7 +109,7 @@ func (task *UpdateTask) Run() error {
 	}
 
 	if config.IsDryRun {
-		log.Println("In DryRun mode, this command will only print queries without executing....")
+		log.Println("In DryRun mode, this command will only print queries without executing.....")
 		if len(updates) == 0 {
 			log.Println("Found zero updates to run")
 		}

--- a/tools/sql/README.md
+++ b/tools/sql/README.md
@@ -41,10 +41,10 @@ SQL_USER=$USERNAME SQL_PASSWORD=$PASSWD make install-schema-mysql
 You can only upgrade to a new version after the initial setup done above.
 
 ```
-./cadence-sql-tool --ep $SQL_HOST_ADDR -p $port --plugin mysql --db cadence update-schema -d ./schema/mysql/v57/cadence/versioned -v x.x -y -- executes a dryrun of upgrade to version x.x
+./cadence-sql-tool --ep $SQL_HOST_ADDR -p $port --plugin mysql --db cadence update-schema -d ./schema/mysql/v57/cadence/versioned -v x.x --dryrun -- executes a dryrun of upgrade to version x.x
 ./cadence-sql-tool --ep $SQL_HOST_ADDR -p $port --plugin mysql --db cadence update-schema -d ./schema/mysql/v57/cadence/versioned -v x.x    -- actually executes the upgrade to version x.x
 
-./cadence-sql-tool --ep $SQL_HOST_ADDR -p $port --plugin mysql --db cadence_visibility update-schema -d ./schema/mysql/v57/cadence/versioned -v x.x -y -- executes a dryrun of upgrade to version x.x
+./cadence-sql-tool --ep $SQL_HOST_ADDR -p $port --plugin mysql --db cadence_visibility update-schema -d ./schema/mysql/v57/cadence/versioned -v x.x --dryrun -- executes a dryrun of upgrade to version x.x
 ./cadence-sql-tool --ep $SQL_HOST_ADDR -p $port --plugin mysql --db cadence_visibility update-schema -d ./schema/mysql/v57/cadence/versioned -v x.x    -- actually executes the upgrade to version x.x
 ```
 

--- a/tools/sql/clitest/handlerTest.go
+++ b/tools/sql/clitest/handlerTest.go
@@ -58,40 +58,33 @@ func (s *HandlerTestSuite) SetupTest() {
 func (s *HandlerTestSuite) TestValidateConnectConfig() {
 	cfg := new(config.SQL)
 
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.NotNil(sql.ValidateConnectConfig(cfg, true))
+	s.NotNil(sql.ValidateConnectConfig(cfg))
 
 	cfg.ConnectAddr = net.JoinHostPort(
 		environment.GetMySQLAddress(),
 		strconv.Itoa(environment.GetMySQLPort()),
 	)
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
+	s.NotNil(sql.ValidateConnectConfig(cfg))
 
 	cfg.DatabaseName = "foobar"
-	s.Nil(sql.ValidateConnectConfig(cfg, false))
-	s.Nil(sql.ValidateConnectConfig(cfg, true))
+	s.Nil(sql.ValidateConnectConfig(cfg))
 
 	cfg.TLS = &auth.TLS{}
 	cfg.TLS.Enabled = true
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.NotNil(sql.ValidateConnectConfig(cfg, true))
+	s.NotNil(sql.ValidateConnectConfig(cfg))
 
 	cfg.TLS.CaFile = "ca.pem"
-	s.Nil(sql.ValidateConnectConfig(cfg, false))
-	s.Nil(sql.ValidateConnectConfig(cfg, true))
+	s.Nil(sql.ValidateConnectConfig(cfg))
 
 	cfg.TLS.KeyFile = "key_file"
 	cfg.TLS.CertFile = ""
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.NotNil(sql.ValidateConnectConfig(cfg, true))
+	s.NotNil(sql.ValidateConnectConfig(cfg))
 
 	cfg.TLS.KeyFile = ""
 	cfg.TLS.CertFile = "cert_file"
-	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.NotNil(sql.ValidateConnectConfig(cfg, true))
+	s.NotNil(sql.ValidateConnectConfig(cfg))
 
 	cfg.TLS.KeyFile = "key_file"
 	cfg.TLS.CertFile = "cert_file"
-	s.Nil(sql.ValidateConnectConfig(cfg, false))
-	s.Nil(sql.ValidateConnectConfig(cfg, true))
+	s.Nil(sql.ValidateConnectConfig(cfg))
 }

--- a/tools/sql/clitest/handlerTest.go
+++ b/tools/sql/clitest/handlerTest.go
@@ -30,7 +30,6 @@ import (
 	"github.com/uber/cadence/common/auth"
 	"github.com/uber/cadence/common/service/config"
 	"github.com/uber/cadence/environment"
-	"github.com/uber/cadence/tools/common/schema"
 	"github.com/uber/cadence/tools/sql"
 )
 
@@ -67,8 +66,6 @@ func (s *HandlerTestSuite) TestValidateConnectConfig() {
 		strconv.Itoa(environment.GetMySQLPort()),
 	)
 	s.NotNil(sql.ValidateConnectConfig(cfg, false))
-	s.Nil(sql.ValidateConnectConfig(cfg, true))
-	s.Equal(schema.DryrunDBName, cfg.DatabaseName)
 
 	cfg.DatabaseName = "foobar"
 	s.Nil(sql.ValidateConnectConfig(cfg, false))

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -115,12 +115,6 @@ func updateSchema(cli *cli.Context) error {
 	if err != nil {
 		return handleErr(schema.NewConfigError(err.Error()))
 	}
-	if cfg.DatabaseName == schema.DryrunDBName {
-		if err := doCreateDatabase(cfg, cfg.DatabaseName); err != nil {
-			return handleErr(fmt.Errorf("error creating dryrun database: %v", err))
-		}
-		defer doDropDatabase(cfg, cfg.DatabaseName)
-	}
 	conn, err := NewConnection(cfg)
 	if err != nil {
 		return handleErr(err)
@@ -230,10 +224,7 @@ func ValidateConnectConfig(cfg *config.SQL, isDryRun bool) error {
 		return schema.NewConfigError("missing sql endpoint argument " + flag(schema.CLIOptEndpoint))
 	}
 	if cfg.DatabaseName == "" {
-		if !isDryRun {
-			return schema.NewConfigError("missing " + flag(schema.CLIOptDatabase) + " argument")
-		}
-		cfg.DatabaseName = schema.DryrunDBName
+		return schema.NewConfigError("missing " + flag(schema.CLIOptDatabase) + " argument")
 	}
 	if cfg.TLS != nil && cfg.TLS.Enabled {
 		enabledCaFile := cfg.TLS.CaFile != ""

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -153,20 +153,6 @@ func doCreateDatabase(cfg *config.SQL, name string) error {
 	return conn.CreateDatabase(name)
 }
 
-func doDropDatabase(cfg *config.SQL, name string) {
-	cfg.DatabaseName = ""
-	conn, err := NewConnection(cfg)
-	if err != nil {
-		logErr(err)
-		return
-	}
-	err = conn.DropDatabase(name)
-	if err != nil {
-		logErr(err)
-	}
-	conn.Close()
-}
-
 func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 	cfg := new(config.SQL)
 
@@ -177,7 +163,6 @@ func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 	cfg.Password = cli.GlobalString(schema.CLIOptPassword)
 	cfg.DatabaseName = cli.GlobalString(schema.CLIOptDatabase)
 	cfg.PluginName = cli.GlobalString(schema.CLIOptPluginName)
-	isDryRun := cli.Bool(schema.CLIOptDryrun)
 
 	if cfg.ConnectAttributes == nil {
 		cfg.ConnectAttributes = map[string]string{}
@@ -207,7 +192,7 @@ func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 		}
 	}
 
-	if err := ValidateConnectConfig(cfg, isDryRun); err != nil {
+	if err := ValidateConnectConfig(cfg); err != nil {
 		return nil, err
 	}
 
@@ -215,7 +200,7 @@ func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 }
 
 // ValidateConnectConfig validates params
-func ValidateConnectConfig(cfg *config.SQL, isDryRun bool) error {
+func ValidateConnectConfig(cfg *config.SQL) error {
 	host, _, err := net.SplitHostPort(cfg.ConnectAddr)
 	if err != nil {
 		return schema.NewConfigError("invalid host and port " + cfg.ConnectAddr)

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -168,7 +168,7 @@ func BuildCLIOptions() *cli.App {
 				},
 				cli.BoolFlag{
 					Name:  schema.CLIFlagDryrun,
-					Usage: "do a dryrun",
+					Usage: "do a dryrun, which will print queries only without executing them",
 				},
 			},
 			Action: func(c *cli.Context) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix dryrun option for SQL/Cassandra schema update command.
The current dryrun is not really "dry", it will:
1. If not providing a database, it will create a new database to perform the operation. It's not useful because this will not simulating what will happen without dryrun.
2. If providing a database, it will DROP all the tables in the database, which is DANGEROUS to do. 
3. Remove "-y" as dryrun option. I believe this is a mistake at the early time. "-y" seems to be for skipping prompt confirmation. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Cadence users complaint about this and it has caused database to drop.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test
```
--user uber --password uber --plugin mysql --db cadence_visibility update-schema -d ./schema/mysql/v57/visibility/versioned/ --dryrun
2021/02/17 13:58:45 UpdateSchemeTask started, config=&{DBName: TargetVersion: SchemaDir:./schema/mysql/v57/visibility/versioned/ IsDryRun:true}
2021/02/17 13:58:45 In DryRun mode, this command will only print queries without executing...
2021/02/17 13:58:45 DryRun of updating to version: 0.1, manifest: &{0.1 0.1 base version of visibility schema [base.sql] 11a94c94f6e45a2dbea217c014db8939} 
2021/02/17 13:58:45 DryRun query:CREATE TABLE executions_visibility (domain_id            CHAR(64) NOT NULL,run_id               CHAR(64) NOT NULL,start_time           DATETIME(6) NOT NULL,execution_time       DATETIME(6) NOT NULL,workflow_id          VARCHAR(255) NOT NULL,workflow_type_name   VARCHAR(255) NOT NULL,close_status         INT,  close_time           DATETIME(6) NULL,history_length       BIGINT,memo                 BLOB,encoding             VARCHAR(64) NOT NULL,PRIMARY KEY  (domain_id, run_id)); 
2021/02/17 13:58:45 DryRun query:CREATE INDEX by_type_start_time ON executions_visibility (domain_id, workflow_type_name, close_status, start_time DESC, run_id); 
2021/02/17 13:58:45 DryRun query:CREATE INDEX by_workflow_id_start_time ON executions_visibility (domain_id, workflow_id, close_status, start_time DESC, run_id); 
2021/02/17 13:58:45 DryRun query:CREATE INDEX by_status_by_close_time ON executions_visibility (domain_id, close_status, start_time DESC, run_id); 
2021/02/17 13:58:45 DryRun of updating to version: 0.2, manifest: &{0.2 0.2 add task_list field to visibility [add_task_list.sql] 75ca3e95da717fdc00b05b55b563532a} 
2021/02/17 13:58:45 DryRun query:ALTER TABLE executions_visibility ADD task_list varchar(255) DEFAULT ''; 
2021/02/17 13:58:45 DryRun of updating to version: 0.3, manifest: &{0.3 0.2 add close time and closed state index [vs_index.sql] 5c0df1a919b33cdb1902180ab189c7f8} 
2021/02/17 13:58:45 DryRun query:CREATE INDEX by_close_time_by_status ON executions_visibility (domain_id, close_time DESC, run_id, close_status); 
2021/02/17 13:58:45 UpdateSchemeTask done



```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
NO