### PR TITLE
Move tcheck to go.mod, get rid of glide dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,23 +6,10 @@ ARG GOPROXY
 # Build tcheck binary
 FROM golang:1.13.6-alpine AS tcheck
 
-RUN apk add --update --no-cache ca-certificates git curl
-
-ENV GO111MODULE=off
-
-RUN curl https://glide.sh/get | sh
-
-ENV TCHECK_VERSION=v1.1.0
-
-RUN go get -d github.com/uber/tcheck
-RUN cd /go/src/github.com/uber/tcheck && git checkout ${TCHECK_VERSION}
-
 WORKDIR /go/src/github.com/uber/tcheck
 
-RUN glide install
-
-RUN go install
-
+COPY go.* ./
+RUN go build -mod=readonly -o /go/bin/tcheck github.com/uber/tcheck
 
 # Build Cadence binaries
 FROM golang:1.13.6-alpine AS builder

--- a/cmd/server/tools.go
+++ b/cmd/server/tools.go
@@ -42,4 +42,7 @@ import (
 	_ "github.com/mgechev/revive"
 	// coverage reporting
 	_ "github.com/dmetzgar/goveralls"
+
+	// health check for docker containers
+	_ "github.com/uber/tcheck"
 )

--- a/go.mod
+++ b/go.mod
@@ -51,6 +51,7 @@ require (
 	github.com/uber-go/tally v3.3.15+incompatible
 	github.com/uber/ringpop-go v0.8.5
 	github.com/uber/tchannel-go v1.16.0
+	github.com/uber/tcheck v1.1.0
 	github.com/urfave/cli v1.22.4
 	github.com/valyala/fastjson v1.4.1
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c

--- a/go.sum
+++ b/go.sum
@@ -403,6 +403,8 @@ github.com/uber/ringpop-go v0.8.5/go.mod h1:zVI6eGO6L7pG14GkntHsSOfmUAWQ7B4lvmzl
 github.com/uber/tchannel-go v1.14.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
 github.com/uber/tchannel-go v1.16.0 h1:B7dirDs15/vJJYDeoHpv3xaEUjuRZ38Rvt1qq9g7pSo=
 github.com/uber/tchannel-go v1.16.0/go.mod h1:Rrgz1eL8kMjW/nEzZos0t+Heq0O4LhnUJVA32OvWKHo=
+github.com/uber/tcheck v1.1.0 h1:Sf5jbtsSg03DZNe8vECLPtFCflAJVg/IYwIxyM9qL/o=
+github.com/uber/tcheck v1.1.0/go.mod h1:ytWRjtMoI4Rb/0aZxYeLQHhGyv3uxJk8UR39lq5RqNc=
 github.com/urfave/cli v1.22.4 h1:u7tSpNPPswAFymm8IehJhy4uJMlUuU/GmqSkvJ1InXA=
 github.com/urfave/cli v1.22.4/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtXRu0=
 github.com/valyala/fastjson v1.4.1 h1:hrltpHpIpkaxll8QltMU8c3QZ5+qIiCL8yKqPFJI/yE=


### PR DESCRIPTION
[glide.sh is down](https://github.com/Masterminds/glide/issues/1077), breaking our pipelines, and glide is abandonware anyway.
It's well past time to migrate off.

I don't believe `tcheck` is actually used for anything, nor is it mentioned in any documentation... but it _does_ work, it'll tell you if e.g. cadence-frontend is running and could be useful for scripting.  Though in that case a relevant `cadence ...` command would be as good or better anyway.

It may be worth removing this entirely?  It's not particularly large nor pulling in any new dependencies, but it may just be old cruft.