### PR TITLE
Pretty-simple "find dependency updates" helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -442,8 +442,37 @@ start-mysql: bins
 start-postgres: bins
 	./cadence-server --zone postgres start
 
+# broken up into multiple += so I can interleave comments.
+# this all becomes a single line of output.
+# you must not use single-quotes within the string in this var.
+JQ_DEPS_AGE = jq '
+# only deal with things with updates
+JQ_DEPS_AGE += select(.Update)
+# allow additional filtering, e.g. DEPS_FILTER='$(JQ_DEPS_ONLY_DIRECT)'
+JQ_DEPS_AGE += $(DEPS_FILTER)
+# add "days between current version and latest version"
+JQ_DEPS_AGE += | . + {Age:(((.Update.Time | fromdate) - (.Time | fromdate))/60/60/24 | floor)}
+# add "days between latest version and now"
+JQ_DEPS_AGE += | . + {Available:((now - (.Update.Time | fromdate))/60/60/24 | floor)}
+# 123 days: library 	old_version -> new_version
+JQ_DEPS_AGE += | ([.Age, .Available] | max | tostring) + " days: " + .Path + "  \t" + .Version + " -> " + .Update.Version
+JQ_DEPS_AGE += '
+# remove surrounding quotes from output
+JQ_DEPS_AGE += --raw-output
+
+# exclude `"Indirect": true` dependencies.  direct ones have no "Indirect" key at all.
+JQ_DEPS_ONLY_DIRECT = | select(has("Indirect") | not)
+
+deps: ## Check for dependency updates, for things that are directly imported
+	@make --no-print-directory DEPS_FILTER='$(JQ_DEPS_ONLY_DIRECT)' deps-all
+
+deps-all: ## Check for all dependency updates
+	@go list -u -m -json all \
+		| $(JQ_DEPS_AGE) \
+		| sort -n
+
 help:
 	@# print help first, so it's visible
 	@printf "\033[36m%-20s\033[0m %s\n" 'help' 'Prints a help message showing any specially-commented targets'
 	@# then everything matching "target: ## magic comments"
-	@cat $(MAKEFILE_LIST) | grep -e "^[a-zA-Z_\-]*:.* ## .*" | sort | awk 'BEGIN {FS = ":.*? ## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+	@cat $(MAKEFILE_LIST) | grep -e "^[a-zA-Z_\-]*:.* ## .*" | awk 'BEGIN {FS = ":.*? ## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}' | sort


### PR DESCRIPTION
While building github.com/uber-go/cadence-client/pull/1060, I realized I kinda missed the out-of-date warnings.
So here's something kinda similar.

An alternative option is to use something like https://github.com/psampaz/go-mod-outdated, but unfortunately that one will just tell you _what_ updates are available, not how old they are. It's pretty good otherwise though.

It may be worth adding e.g. a "nothing > 100 days" check to `make lint` and/or CI?  Otherwise I tend to see dependencies go un-upgraded for huge lengths of time.

---

The output currently shows the maximum of these two values, as it feels like a pretty good "badness" metric:
- how much time has passed between the current version and the latest version
- how much time has passed since the latest version was released

Either alone produces some non-great edge cases:
- with only the first:
    - a long-stable library with a fix today looks 100s of days old
    - a release -> immediate bugfix release looks 0 days old (e.g. `rsc.io/sampler`)
- with only the second:
    - a consistently-releasing library always looks "recent-ish".  e.g. prior to them using tags, golang.org/x/tools would usually look <7 days old, as `master` is updated frequently... even though we were a few months behind.

Ideally, IMO, this would check for both:
- how old is our current version? (which this does)
- how long have we ignored _any_ update?

But AFAICT that'd require custom requests to a goproxy, as we cannot get "current+1" versions, only "current" and "latest".