### PR TITLE
Add more default Prometheus histogram buckets for non-latency timer metrics like history_size

### DIFF
--- a/common/metrics/tally/prometheus/buckets.go
+++ b/common/metrics/tally/prometheus/buckets.go
@@ -1,0 +1,72 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package prometheus
+
+import (
+	"time"
+
+	"github.com/uber-go/tally/prometheus"
+)
+
+// DefaultHistogramBuckets is the default histogram buckets used when
+// creating a new Histogram in the prometheus registry.
+// Cadence uses Histogram to report both latency and non-latency metrics(like history_count/history_size).
+// The buckets need to set correct boundary for both.
+// See more in https://github.com/uber/cadence/issues/4006
+func DefaultHistogramBuckets() []prometheus.HistogramObjective {
+
+	// For latency metrics, this is a nanoSecond.
+	// For non-latency metrics, this is ONE.
+	// divided by Second because of https://github.com/uber-go/tally/blob/04828d51c63b1d09b46824d7c0d7904b5eb1b3b6/prometheus/reporter.go#L183
+	OneOrNanoSecond := float64(time.Nanosecond) / float64(time.Second)
+
+	// convenient units
+	microSecOr1K := OneOrNanoSecond * 1000
+	milliSecOr1M := OneOrNanoSecond * 1000000
+
+	return []prometheus.HistogramObjective{
+		{Upper: 5 * OneOrNanoSecond},
+		{Upper: 10 * OneOrNanoSecond},
+		{Upper: 50 * OneOrNanoSecond},
+		{Upper: 100 * OneOrNanoSecond},
+
+		{Upper: microSecOr1K},
+		{Upper: 10 * microSecOr1K},
+		{Upper: 50 * microSecOr1K},
+		{Upper: 200 * microSecOr1K},
+
+		// Below are exactly the same as https://github.com/uber-go/tally/blob/04828d51c63b1d09b46824d7c0d7904b5eb1b3b6/prometheus/reporter.go#L51
+		// to ensure backward compatibility
+		{Upper: milliSecOr1M},
+		{Upper: 2 * milliSecOr1M},
+		{Upper: 5 * milliSecOr1M},
+		{Upper: 10 * milliSecOr1M},
+		{Upper: 20 * milliSecOr1M},
+		{Upper: 50 * milliSecOr1M},
+		{Upper: 100 * milliSecOr1M},
+		{Upper: 200 * milliSecOr1M},
+		{Upper: 500 * milliSecOr1M},
+		{Upper: 1000 * milliSecOr1M},
+		{Upper: 2000 * milliSecOr1M},
+		{Upper: 5000 * milliSecOr1M},
+		{Upper: 10000 * milliSecOr1M},
+	}
+}

--- a/common/service/config/metrics.go
+++ b/common/service/config/metrics.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
+	mprom "github.com/uber/cadence/common/metrics/tally/prometheus"
 	statsdreporter "github.com/uber/cadence/common/metrics/tally/statsd"
 )
 
@@ -127,6 +128,9 @@ func (c *Metrics) newStatsdScope(logger log.Logger) tally.Scope {
 // newPrometheusScope returns a new prometheus scope with
 // a default reporting interval of a second
 func (c *Metrics) newPrometheusScope(logger log.Logger) tally.Scope {
+	if len(c.Prometheus.DefaultHistogramBuckets) == 0 {
+		c.Prometheus.DefaultHistogramBuckets = mprom.DefaultHistogramBuckets()
+	}
 	reporter, err := c.Prometheus.NewReporter(
 		prometheus.ConfigurationOptions{
 			Registry: prom.NewRegistry(),


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Add more default Prometheus histogram buckets for non-latency timer metrics like history_size

<!-- Tell your future self why have you made these changes -->
**Why?**
The default buckets from tally won't work for Cadence's non-latency metrics
See more: https://github.com/uber/cadence/issues/4006

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No.
