### PR TITLE
Default to non-verbose `make test` output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
-# set a VERBOSE=1 env var for verbose output. VERBOSE=0 (or empty) disables.
+# set a VERBOSE=1 env var for verbose output. VERBOSE=0 (or unset) disables.
 # this is used to make verbose flags, suitable for `$(if $(test_v),...)`.
 VERBOSE ?= 0
 ifneq (0,$(VERBOSE))

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
-# set a V=1 env var for verbose output. V=0 (or empty) disables.
-# this is used to make a verbose flag, suitable for `$(if $(verbose),...)`.
-V ?= 0
-ifneq (0,$(V))
-verbose = 1
+# set a VERBOSE=1 env var for verbose output. VERBOSE=0 (or empty) disables.
+# this is used to make verbose flags, suitable for `$(if $(test_v),...)`.
+VERBOSE ?= 0
+ifneq (0,$(VERBOSE))
+test_v = 1
 else
-verbose =
+test_v =
 endif
 
 # a literal space value, for makefile purposes
@@ -25,7 +25,7 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
 TEST_TIMEOUT = 20m
-TEST_ARG ?= -race $(if $(verbose),-v) -timeout $(TEST_TIMEOUT)
+TEST_ARG ?= -race $(if $(test_v),-v) -timeout $(TEST_TIMEOUT)
 BUILD := .build
 BIN := $(BUILD)/bin
 TOOLS_CMD_ROOT=./cmd/tools

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,15 @@
 MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
+# set a V=1 env var for verbose output. V=0 (or empty) disables.
+# this is used to make a verbose flag, suitable for `$(if $(verbose),...)`.
+V ?= 0
+ifneq (0,$(V))
+verbose = 1
+else
+verbose =
+endif
+
 # a literal space value, for makefile purposes
 SPACE :=
 SPACE +=
@@ -16,7 +25,7 @@ GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
 TEST_TIMEOUT = 20m
-TEST_ARG ?= -race -v -timeout $(TEST_TIMEOUT)
+TEST_ARG ?= -race $(if $(verbose),-v) -timeout $(TEST_TIMEOUT)
 BUILD := .build
 BIN := $(BUILD)/bin
 TOOLS_CMD_ROOT=./cmd/tools

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -22,6 +22,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install -U 'pip<21'
 RUN pip install PyYAML==3.13 cqlsh==5.0.4
 
+# verbose test output from `make`, can be disabled with V=0
+ENV V=1
+
 # https://github.com/docker-library/golang/blob/c1baf037d71331eb0b8d4c70cff4c29cf124c5e0/1.4/Dockerfile
 RUN mkdir -p /cadence
 WORKDIR /cadence

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -22,8 +22,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN pip install -U 'pip<21'
 RUN pip install PyYAML==3.13 cqlsh==5.0.4
 
-# verbose test output from `make`, can be disabled with V=0
-ENV V=1
+# verbose test output from `make`, can be disabled with VERBOSE=0
+ENV VERBOSE=1
 
 # https://github.com/docker-library/golang/blob/c1baf037d71331eb0b8d4c70cff4c29cf124c5e0/1.4/Dockerfile
 RUN mkdir -p /cadence


### PR DESCRIPTION
Test output locally is pretty noisy.  Failed test output is already captured by Go, generally that's good enough.
Buildkite logs can be kinda useful though, so the buildkite dockerfile sets VERBOSE=1 to enable it.
