### PR TITLE
Add support for ScyllaDB

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/queue.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue.go
@@ -188,7 +188,7 @@ func (db *cdb) InsertQueueMetadata(
 ) error {
 	clusterAckLevels := map[string]int64{}
 	query := db.session.Query(templateInsertQueueMetadataQuery, queueType, clusterAckLevels, version).WithContext(ctx)
-	_, err := query.ScanCAS()
+	_, err := query.ScanCAS(nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -209,7 +209,7 @@ func (db *cdb) UpdateQueueMetadataCas(
 		row.QueueType,
 		row.Version-1,
 	).WithContext(ctx)
-	applied, err := query.ScanCAS()
+	applied, err := query.ScanCAS(nil, nil, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/queue.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue.go
@@ -188,6 +188,10 @@ func (db *cdb) InsertQueueMetadata(
 ) error {
 	clusterAckLevels := map[string]int64{}
 	query := db.session.Query(templateInsertQueueMetadataQuery, queueType, clusterAckLevels, version).WithContext(ctx)
+	
+	// NOTE: Must pass nils to be compatible with ScyllaDB's LWT behavior
+	// "Scylla always returns the old version of the row, regardless of whether the condition is true or not."
+	// See also https://docs.scylladb.com/kb/lwt-differences/	
 	_, err := query.ScanCAS(nil, nil, nil)
 	if err != nil {
 		return err
@@ -209,6 +213,10 @@ func (db *cdb) UpdateQueueMetadataCas(
 		row.QueueType,
 		row.Version-1,
 	).WithContext(ctx)
+	
+	// NOTE: Must pass nils to be compatible with ScyllaDB's LWT behavior
+	// "Scylla always returns the old version of the row, regardless of whether the condition is true or not."
+	// See also https://docs.scylladb.com/kb/lwt-differences/
 	applied, err := query.ScanCAS(nil, nil, nil, nil)
 	if err != nil {
 		return err

--- a/config/development_scylla.yaml
+++ b/config/development_scylla.yaml
@@ -1,0 +1,118 @@
+persistence:
+  defaultStore: scylla-default
+  visibilityStore: scylla-visibility
+  numHistoryShards: 4
+  datastores:
+    scylla-default:
+      cassandra:
+        hosts: "127.0.0.1"
+        keyspace: "cadence"
+    scylla-visibility:
+      cassandra:
+        hosts: "127.0.0.1"
+        keyspace: "cadence_visibility"
+
+ringpop:
+  name: cadence
+  bootstrapMode: hosts
+  bootstrapHosts: [ "127.0.0.1:7933", "127.0.0.1:7934", "127.0.0.1:7935" ]
+  maxJoinDuration: 30s
+
+services:
+  frontend:
+    rpc:
+      port: 7933
+      bindOnLocalHost: true
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7936
+
+  matching:
+    rpc:
+      port: 7935
+      bindOnLocalHost: true
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7938
+
+  history:
+    rpc:
+      port: 7934
+      bindOnLocalHost: true
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7937
+
+  worker:
+    rpc:
+      port: 7939
+      bindOnLocalHost: true
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7940
+
+clusterMetadata:
+  enableGlobalDomain: false
+  failoverVersionIncrement: 10
+  masterClusterName: "active"
+  currentClusterName: "active"
+  clusterInformation:
+    active:
+      enabled: true
+      initialFailoverVersion: 0
+      rpcName: "cadence-frontend"
+      rpcAddress: "localhost:7933"
+
+dcRedirectionPolicy:
+  policy: "noop"
+  toDC: ""
+
+archival:
+  history:
+    status: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+      gstorage:
+        credentialsPath: "/tmp/gcloud/keyfile.json"
+  visibility:
+    status: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+
+domainDefaults:
+  archival:
+    history:
+      status: "enabled"
+      URI: "file:///tmp/cadence_archival/development"
+    visibility:
+      status: "enabled"
+      URI: "file:///tmp/cadence_vis_archival/development"
+
+publicClient:
+  hostPort: "localhost:7933"
+
+dynamicConfigClient:
+  filepath: "config/dynamicconfig/development.yaml"
+  pollInterval: "10s"
+
+blobstore:
+  filestore:
+    outputDirectory: "/tmp/blobstore"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -12,7 +12,7 @@ persistence:
     {{- end }}
     datastores:
         {{- $db := default .Env.DB "cassandra" | lower -}}
-        {{- if eq $db "cassandra" }}
+        {{- if or (eq $db "cassandra") (eq $db "scylla") }}
         default:
             cassandra:
                 hosts: {{ default .Env.CASSANDRA_SEEDS "" }}

--- a/docker/docker-compose-scylla.yml
+++ b/docker/docker-compose-scylla.yml
@@ -1,0 +1,39 @@
+version: '3'
+services:
+  scylla:
+    image: scylladb/scylla:4.3.1
+    command:
+      - "--smp"
+      - "1"
+    ports:
+      - "9042:9042"
+  statsd:
+    image: graphiteapp/graphite-statsd
+    ports:
+      - "8080:80"
+      - "2003:2003"
+      - "8125:8125"
+      - "8126:8126"
+  cadence:
+    image: ubercadence/server:master-auto-setup
+    ports:
+      - "7933:7933"
+      - "7934:7934"
+      - "7935:7935"
+      - "7939:7939"
+    environment:
+      - "DB=scylla"
+      - "CASSANDRA_SEEDS=scylla"
+      - "STATSD_ENDPOINT=statsd:8125"
+      - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+    depends_on:
+      - scylla
+      - statsd
+  cadence-web:
+    image: ubercadence/web:latest
+    environment:
+      - "CADENCE_TCHANNEL_PEERS=cadence:7933"
+    ports:
+      - "8088:8088"
+    depends_on:
+      - cadence

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -91,6 +91,15 @@ wait_for_cassandra() {
     echo 'cassandra started'
 }
 
+wait_for_scylla() {
+    server=`echo $CASSANDRA_SEEDS | awk -F ',' '{print $1}'`
+    until cqlsh -u $CASSANDRA_USER -p $CASSANDRA_PASSWORD --cqlversion=3.3.1 $server < /dev/null; do
+        echo 'waiting for scylla to start up'
+        sleep 1
+    done
+    echo 'scylla started'
+}
+
 wait_for_mysql() {
     server=`echo $MYSQL_SEEDS | awk -F ',' '{print $1}'`
     nc -z $server $DB_PORT < /dev/null
@@ -131,6 +140,8 @@ wait_for_db() {
         wait_for_mysql
     elif [ "$DB" == "postgres" ]; then
         wait_for_postgres
+    elif [ "$DB" == "scylla" ]; then
+        wait_for_scylla
     else
         wait_for_cassandra
     fi


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This PR adds support for ScyllaDB. The codebase is 99.9% compatible, I needed to change one line.

<!-- Tell your future self why have you made these changes -->
**Why?**

ScyllaDB is an alternative implementation of Cassandra. It was requested in https://github.com/uber/cadence/issues/2607 and a related bug was reported in https://github.com/uber/cadence/issues/3314.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

I tested it locally using docker-compose and running a few tests from https://github.com/uber-common/cadence-samples. using Cassandra and ScyllaDB as persistent stores.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

I don't see any huge risks. Cassandra is still a default database and there was almost no code changes.