### PR TITLE
Rewrite makefile to be reliable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 .tmp/
 .vscode/
 .build/
+.bin/
 /vendor
 /_vendor-*
 /cadence

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,8 @@ RUN go mod download
 
 COPY . .
 
+# bypass codegen, use committed files.  must be run separately, before building things.
+RUN make .faux-codegen
 RUN CGO_ENABLED=0 make copyright cadence-cassandra-tool cadence-sql-tool cadence cadence-server
 
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ default: help
 # - Targets should never, EVER be *actual source files*.
 #   Always use book-keeping files in $(BUILD).
 #   Otherwise e.g. changing git branches could confuse Make about what it needs to do.
-# - Simiarly, prerequisites should be those book-keeping files,
+# - Similarly, prerequisites should be those book-keeping files,
 #   not source files that are prerequisites for book-keeping.
 #   e.g. depend on .build/fmt, not $(ALL_SRC), and not both.
 # - Be strict and explicit about prerequisites / order of execution / etc.
@@ -273,7 +273,7 @@ $(BUILD)/lint: $(LINT_SRC) $(BIN)/revive | $(BUILD)
 #
 # this is not fatal, we can just run 2x.
 # to be fancier though, we can detect when *both* are run, and re-touch the book-keeping files to prevent the second run.
-# this STRICTLY REQUIRES that `copyright` and `fmt` are mututally stable, and that copyright runs before fmt.
+# this STRICTLY REQUIRES that `copyright` and `fmt` are mutually stable, and that copyright runs before fmt.
 # if either changes, this will need to change.
 MAYBE_TOUCH_COPYRIGHT=
 

--- a/Makefile
+++ b/Makefile
@@ -414,7 +414,7 @@ test_e2e_xdc: bins
 		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) | tee -a test.log; \
 	done;
 
-cover_profile: clean bins_nothrift
+cover_profile: bins
 	@mkdir -p $(BUILD)
 	@mkdir -p $(COVER_ROOT)
 	@echo "mode: atomic" > $(UNIT_COVER_FILE)
@@ -426,7 +426,7 @@ cover_profile: clean bins_nothrift
 		cat $(BUILD)/"$$dir"/coverage.out | grep -v "^mode: \w\+" >> $(UNIT_COVER_FILE); \
 	done;
 
-cover_integration_profile: clean bins_nothrift
+cover_integration_profile: bins
 	@mkdir -p $(BUILD)
 	@mkdir -p $(COVER_ROOT)
 	@echo "mode: atomic" > $(INTEG_COVER_FILE)
@@ -436,7 +436,7 @@ cover_integration_profile: clean bins_nothrift
 	@time go test $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
 	@cat $(BUILD)/$(INTEG_TEST_DIR)/coverage.out | grep -v "^mode: \w\+" >> $(INTEG_COVER_FILE)
 
-cover_ndc_profile: clean bins_nothrift
+cover_ndc_profile: bins
 	@mkdir -p $(BUILD)
 	@mkdir -p $(COVER_ROOT)
 	@echo "mode: atomic" > $(INTEG_NDC_COVER_FILE)

--- a/cmd/tools/copyright/licensegen.go
+++ b/cmd/tools/copyright/licensegen.go
@@ -158,7 +158,7 @@ func (task *addLicenseHeaderTask) handleFile(path string, fileInfo os.FileInfo, 
 	}
 
 	if fileInfo.IsDir() {
-		if strings.HasPrefix(fileInfo.Name(), "_vendor-") || fileInfo.Name() == ".build" {
+		if strings.HasPrefix(fileInfo.Name(), "_vendor-") || fileInfo.Name() == ".build" || fileInfo.Name() == ".bin" {
 			return filepath.SkipDir
 		}
 		return nil


### PR DESCRIPTION
Phase 2 of makefile cleanups!

I've added some simple docs to the makefile, hopefully they're easy to follow.
For higher-level docs and general Make education (e.g. why, exactly, I recommend so strongly about never "making" source files)... I need to find a location, and it'll take a little longer to write.  I'm kinda fond of a `makefile.md` or `architecture.md` but I'm not yet sure where to put it.

But as a tl;dr, what this PR does is:
- makes the high-level build steps explicit so they're easier to follow (right near the top)
- switches to Make-only book-keeping files, so steps are reliably recalculated in all situations
- moves tool-bins to a .bin folder so they are not deleted by default, and versions them more strictly (you can now switch between versions for "free", great for e.g. trying new protocs)
- adds a _reliable_ way to avoid codegen in buildkite / wherever it's needed or desired

As a bonus, this should now be safe to always run in parallel, which runs about 2x as fast for me:
```
> time make bins
...
make bins  104.18s user 38.68s system 310% cpu 45.941 total

> time make bins -j8
...
make bins -j8  108.43s user 53.00s system 717% cpu 22.489 total
```
I'll change Buildkite to do this in a bit, when it has been battle-tested a bit more.

Next (and final) phase is to make test-running a bit more normal, but that needs a bit more work.

---

As a brief summary about why book-keeping files are important, be aware of these two details:
1. Make _only_ looks at file modification times to determine what to do.  If A depends on B and B is newer than A (or A does not exist), it'll re-build A.
2. Git (and other tools) _do not_ record modification times, to work better with Make.  This is why `touch go.mod` doesn't lead to anything to commit - git doesn't record _when_ you modified it, only what the modifications were.

Because of this, on e.g. a brand new `git clone`, _all_ files are "the same" age... with some randomness about what ones are newer than others, within e.g. milliseconds.  So as far as Make is concerned, a bunch of _random_ files have been modified.  If you had makefile rules like `output.go: input.go \n do codegen`, some of those output files may be newer than their inputs, so they may or may not be re-made.

That's pretty clearly wrong.  The same kind of thing happens when you change branches - depending on what changed between your before/after commits, those files are now "new".

The way out of this madness is to rely on files that e.g. Git does _not_ modify: these book-keeping files.
- When cloning (or clean), they do not exist, so they must all be re-made.
- When changing branches, any changed files are _always_ newer than these book-keeping files, so they will _always_ be re-made (when appropriate).

So that's what this PR does.