### PR TITLE
Fix prometheus metric error for dual emitting

### DIFF
--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -97,7 +97,7 @@ func (m *metricsScope) RecordTimer(id int, d time.Duration) {
 	case !def.metricRollupName.Empty():
 		m.rootScope.Timer(def.metricRollupName.String()).Record(d)
 	case m.isDomainTagged:
-		// N.B. - Dual emit here makes sense so that we can see aggregate timer stats across all
+		// N.B. - Dual emit here so that we can see aggregate timer stats across all
 		// domains along with the individual domains stats
 		m.scope.Tagged(map[string]string{domain: domainAllValue}).Timer(def.metricName.String()).Record(d)
 	}

--- a/common/metrics/scope.go
+++ b/common/metrics/scope.go
@@ -97,6 +97,8 @@ func (m *metricsScope) RecordTimer(id int, d time.Duration) {
 	case !def.metricRollupName.Empty():
 		m.rootScope.Timer(def.metricRollupName.String()).Record(d)
 	case m.isDomainTagged:
+		// N.B. - Dual emit here makes sense so that we can see aggregate timer stats across all
+		// domains along with the individual domains stats
 		m.scope.Tagged(map[string]string{domain: domainAllValue}).Timer(def.metricName.String()).Record(d)
 	}
 }

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -480,9 +480,6 @@ func (adh *adminHandlerImpl) GetWorkflowExecutionRawHistoryV2(
 
 	pageToken.PersistenceToken = rawHistoryResponse.NextPageToken
 	size := rawHistoryResponse.Size
-	// N.B. - Dual emit is required here so that we can see aggregate timer stats across all
-	// domains along with the individual domains stats
-	adh.GetMetricsClient().RecordTimer(metrics.AdminGetWorkflowExecutionRawHistoryScope, metrics.HistorySize, time.Duration(size))
 	scope.RecordTimer(metrics.HistorySize, time.Duration(size))
 
 	rawBlobs := rawHistoryResponse.HistoryEventBlobs

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -948,10 +948,8 @@ func (s *contextImpl) AppendHistoryV2Events(
 
 	size := 0
 	defer func() {
-		// N.B. - Dual emit here makes sense so that we can see aggregate timer stats across all
-		// domains along with the individual domains stats
-		s.GetMetricsClient().RecordTimer(metrics.SessionSizeStatsScope, metrics.HistorySize, time.Duration(size))
-		s.GetMetricsClient().Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(domainName)).RecordTimer(metrics.HistorySize, time.Duration(size))
+		s.GetMetricsClient().Scope(metrics.SessionSizeStatsScope, metrics.DomainTag(domainName)).
+			RecordTimer(metrics.HistorySize, time.Duration(size))
 		if size >= historySizeLogThreshold {
 			s.throttledLogger.Warn("history size threshold breached",
 				tag.WorkflowID(execution.GetWorkflowID()),

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -389,7 +389,7 @@ func newAdminDomainCommands() []cli.Command {
 					Usage: "List all domains, by default only domains in REGISTERED status are listed",
 				},
 				cli.BoolFlag{
-					Name: FlagDeprecatedWithAlias,
+					Name:  FlagDeprecatedWithAlias,
 					Usage: "List deprecated domains only, by default only domains in REGISTERED status are listed",
 				},
 				cli.BoolFlag{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix metric error for dual emitting. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The scope is already doing dual emitting. 
After emitting without domain tag,
Emitting with domain tag is not allowed in prometheus. As a result, the metric is lost.  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
However, the code runs well for M3. So it's possible that Uber internal cluster is relying on this behavior (emitting with+without domain tag). After this change, Uber's dashboard may need a small change to filter by `domin="all"`.
