### PR TITLE
Fix domain registration to default with current cluster name for local domain

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -154,7 +154,7 @@ func (d *handlerImpl) RegisterDomain(
 
 	activeClusterName := d.clusterMetadata.GetCurrentClusterName()
 	// input validation on cluster names
-	if registerRequest.ActiveClusterName != nil {
+	if registerRequest.ActiveClusterName != nil && *registerRequest.ActiveClusterName != "" {
 		activeClusterName = registerRequest.GetActiveClusterName()
 	}
 	clusters := []*persistence.ClusterReplicationConfig{}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix domain registration to default with current cluster name for local domain
This is for patch release 0.18.2 ONLY.

<!-- Tell your future self why have you made these changes -->
**Why?**
I tried to patch https://github.com/uber/cadence/pull/3972 but there are too many conflict. 
So I made this one line fix as the mitigation for 0.18 release. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
