### PR TITLE
Fix time convertion to nanos

### DIFF
--- a/common/persistence/serialization/thrift_mapper.go
+++ b/common/persistence/serialization/thrift_mapper.go
@@ -690,6 +690,8 @@ func replicationTaskInfoFromThrift(info *sqlblobs.ReplicationTaskInfo) *Replicat
 	}
 }
 
+var zeroTimeNanos = time.Time{}.UnixNano()
+
 func unixNanoPtr(t *time.Time) *int64 {
 	if t == nil {
 		return nil
@@ -700,6 +702,11 @@ func unixNanoPtr(t *time.Time) *int64 {
 func timePtr(t *int64) *time.Time {
 	if t == nil {
 		return nil
+	}
+	// Calling UnixNano() on zero time is undefined an results in a number that is converted back to 1754-08-30T22:43:41Z
+	// Handle such case explicitly
+	if *t == zeroTimeNanos {
+		return common.TimePtr(time.Time{})
 	}
 	return common.TimePtr(time.Unix(0, *t))
 }

--- a/common/persistence/serialization/thrift_mapper_test.go
+++ b/common/persistence/serialization/thrift_mapper_test.go
@@ -303,7 +303,7 @@ func TestActivityInfo(t *testing.T) {
 		RetryInitialInterval:     common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
 		RetryMaximumInterval:     common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
 		RetryMaximumAttempts:     common.Int32Ptr(int32(rand.Intn(1000))),
-		RetryExpirationTimestamp: common.TimePtr(time.Now()),
+		RetryExpirationTimestamp: common.TimePtr(time.Time{}),
 		RetryBackoffCoefficient:  common.Float64Ptr(rand.Float64() * 1000),
 		RetryNonRetryableErrors:  []string{"RetryNonRetryableErrors"},
 		RetryLastFailureReason:   common.StringPtr("RetryLastFailureReason"),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Trying to handle zero value of `time.Time{}` conversion.

<!-- Tell your future self why have you made these changes -->
**Why?**
Converting zero value of `time.Time{}` to nanos and back does not result in the same value. It is documented that calling `UnixNano()` on zero value is undefined. It returns weird number which converted back to time results in `1754-08-30T22:43:41Z`. Repro: https://play.golang.org/p/qvhsG0_S6Vs

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated unit tests with such case.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

