### PR TITLE
YARPC error mapping

### DIFF
--- a/common/types/mapper/proto/errors.go
+++ b/common/types/mapper/proto/errors.go
@@ -23,8 +23,8 @@ package proto
 import (
 	"errors"
 
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
+	"go.uber.org/yarpc/encoding/protobuf"
+	"go.uber.org/yarpc/yarpcerrors"
 
 	apiv1 "github.com/uber/cadence/.gen/proto/api/v1"
 	sharedv1 "github.com/uber/cadence/.gen/proto/shared/v1"
@@ -32,132 +32,124 @@ import (
 )
 
 func FromError(err error) error {
-	st, conversionErr := errorToStatus(err)
-	if conversionErr != nil {
-		return conversionErr
-	}
-	return st.Err()
-}
-
-func errorToStatus(err error) (*status.Status, error) {
 	if err == nil {
-		return status.New(codes.OK, ""), nil
+		return protobuf.NewError(yarpcerrors.CodeOK, "")
 	}
 
 	switch e := err.(type) {
-	case types.AccessDeniedError:
-		return status.New(codes.PermissionDenied, e.Message), nil
-	case types.InternalServiceError:
-		return status.New(codes.Internal, e.Message), nil
-	case types.EntityNotExistsError:
-		return status.New(codes.NotFound, e.Message).WithDetails(&apiv1.EntityNotExistsError{
+	case *types.AccessDeniedError:
+		return protobuf.NewError(yarpcerrors.CodePermissionDenied, e.Message)
+	case *types.InternalServiceError:
+		return protobuf.NewError(yarpcerrors.CodeInternal, e.Message)
+	case *types.EntityNotExistsError:
+		return protobuf.NewError(yarpcerrors.CodeNotFound, e.Message, protobuf.WithErrorDetails(&apiv1.EntityNotExistsError{
 			CurrentCluster: e.CurrentCluster,
 			ActiveCluster:  e.ActiveCluster,
-		})
-	case types.BadRequestError:
-		return status.New(codes.InvalidArgument, e.Message), nil
-	case types.QueryFailedError:
-		return status.New(codes.InvalidArgument, e.Message).WithDetails(&apiv1.QueryFailedError{})
-	case types.ShardOwnershipLostError:
-		return status.New(codes.Aborted, e.Message).WithDetails(&sharedv1.ShardOwnershipLostError{
+		}))
+	case *types.BadRequestError:
+		return protobuf.NewError(yarpcerrors.CodeInvalidArgument, e.Message)
+	case *types.QueryFailedError:
+		return protobuf.NewError(yarpcerrors.CodeInvalidArgument, e.Message, protobuf.WithErrorDetails(&apiv1.QueryFailedError{}))
+	case *types.ShardOwnershipLostError:
+		return protobuf.NewError(yarpcerrors.CodeAborted, e.Message, protobuf.WithErrorDetails(&sharedv1.ShardOwnershipLostError{
 			Owner: e.Owner,
-		})
-	case types.CurrentBranchChangedError:
-		return status.New(codes.Aborted, e.Message).WithDetails(&sharedv1.CurrentBranchChangedError{
+		}))
+	case *types.CurrentBranchChangedError:
+		return protobuf.NewError(yarpcerrors.CodeAborted, e.Message, protobuf.WithErrorDetails(&sharedv1.CurrentBranchChangedError{
 			CurrentBranchToken: e.GetCurrentBranchToken(),
-		})
-	case types.RetryTaskV2Error:
-		return status.New(codes.Aborted, e.Message).WithDetails(&sharedv1.RetryTaskV2Error{
+		}))
+	case *types.RetryTaskV2Error:
+		return protobuf.NewError(yarpcerrors.CodeAborted, e.Message, protobuf.WithErrorDetails(&sharedv1.RetryTaskV2Error{
 			DomainId:          e.DomainID,
 			WorkflowExecution: FromWorkflowRunPair(e.WorkflowID, e.RunID),
 			StartEvent:        FromEventIDVersionPair(e.StartEventID, e.StartEventVersion),
 			EndEvent:          FromEventIDVersionPair(e.EndEventID, e.EndEventVersion),
-		})
-	case types.CancellationAlreadyRequestedError:
-		return status.New(codes.AlreadyExists, e.Message).WithDetails(&apiv1.CancellationAlreadyRequestedError{})
-	case types.DomainAlreadyExistsError:
-		return status.New(codes.AlreadyExists, e.Message).WithDetails(&apiv1.DomainAlreadyExistsError{})
-	case types.EventAlreadyStartedError:
-		return status.New(codes.AlreadyExists, e.Message).WithDetails(&sharedv1.EventAlreadyStartedError{})
-	case types.WorkflowExecutionAlreadyStartedError:
-		return status.New(codes.AlreadyExists, e.Message).WithDetails(&apiv1.WorkflowExecutionAlreadyStartedError{
+		}))
+	case *types.CancellationAlreadyRequestedError:
+		return protobuf.NewError(yarpcerrors.CodeAlreadyExists, e.Message, protobuf.WithErrorDetails(&apiv1.CancellationAlreadyRequestedError{}))
+	case *types.DomainAlreadyExistsError:
+		return protobuf.NewError(yarpcerrors.CodeAlreadyExists, e.Message, protobuf.WithErrorDetails(&apiv1.DomainAlreadyExistsError{}))
+	case *types.EventAlreadyStartedError:
+		return protobuf.NewError(yarpcerrors.CodeAlreadyExists, e.Message, protobuf.WithErrorDetails(&sharedv1.EventAlreadyStartedError{}))
+	case *types.WorkflowExecutionAlreadyStartedError:
+		return protobuf.NewError(yarpcerrors.CodeAlreadyExists, e.Message, protobuf.WithErrorDetails(&apiv1.WorkflowExecutionAlreadyStartedError{
 			StartRequestId: e.StartRequestID,
 			RunId:          e.RunID,
-		})
-	case types.ClientVersionNotSupportedError:
-		return status.New(codes.FailedPrecondition, "Client version not supported").WithDetails(&apiv1.ClientVersionNotSupportedError{
+		}))
+	case *types.ClientVersionNotSupportedError:
+		return protobuf.NewError(yarpcerrors.CodeFailedPrecondition, "Client version not supported", protobuf.WithErrorDetails(&apiv1.ClientVersionNotSupportedError{
 			FeatureVersion:    e.FeatureVersion,
 			ClientImpl:        e.ClientImpl,
 			SupportedVersions: e.SupportedVersions,
-		})
-	case types.DomainNotActiveError:
-		return status.New(codes.FailedPrecondition, e.Message).WithDetails(&apiv1.DomainNotActiveError{
+		}))
+	case *types.DomainNotActiveError:
+		return protobuf.NewError(yarpcerrors.CodeFailedPrecondition, e.Message, protobuf.WithErrorDetails(&apiv1.DomainNotActiveError{
 			Domain:         e.DomainName,
 			CurrentCluster: e.CurrentCluster,
 			ActiveCluster:  e.ActiveCluster,
-		})
-	case types.InternalDataInconsistencyError:
-		return status.New(codes.DataLoss, e.Message).WithDetails(&sharedv1.InternalDataInconsistencyError{})
-	case types.LimitExceededError:
-		return status.New(codes.ResourceExhausted, e.Message).WithDetails(&apiv1.LimitExceededError{})
-	case types.ServiceBusyError:
-		return status.New(codes.ResourceExhausted, e.Message).WithDetails(&apiv1.ServiceBusyError{})
-	case types.RemoteSyncMatchedError:
-		return status.New(codes.Unavailable, e.Message).WithDetails(&sharedv1.RemoteSyncMatchedError{})
+		}))
+	case *types.InternalDataInconsistencyError:
+		return protobuf.NewError(yarpcerrors.CodeDataLoss, e.Message, protobuf.WithErrorDetails(&sharedv1.InternalDataInconsistencyError{}))
+	case *types.LimitExceededError:
+		return protobuf.NewError(yarpcerrors.CodeResourceExhausted, e.Message, protobuf.WithErrorDetails(&apiv1.LimitExceededError{}))
+	case *types.ServiceBusyError:
+		return protobuf.NewError(yarpcerrors.CodeResourceExhausted, e.Message, protobuf.WithErrorDetails(&apiv1.ServiceBusyError{}))
+	case *types.RemoteSyncMatchedError:
+		return protobuf.NewError(yarpcerrors.CodeUnavailable, e.Message, protobuf.WithErrorDetails(&sharedv1.RemoteSyncMatchedError{}))
 	}
 
-	return status.New(codes.Unknown, err.Error()), nil
+	return protobuf.NewError(yarpcerrors.CodeUnknown, err.Error())
 }
 
 func ToError(err error) error {
-	status := status.Convert(err)
-	if status == nil || status.Code() == codes.OK {
+	status := yarpcerrors.FromError(err)
+	if status == nil || status.Code() == yarpcerrors.CodeOK {
 		return nil
 	}
 
 	switch status.Code() {
-	case codes.PermissionDenied:
-		return types.AccessDeniedError{
+	case yarpcerrors.CodePermissionDenied:
+		return &types.AccessDeniedError{
 			Message: status.Message(),
 		}
-	case codes.Internal:
-		return types.InternalServiceError{
+	case yarpcerrors.CodeInternal:
+		return &types.InternalServiceError{
 			Message: status.Message(),
 		}
-	case codes.NotFound:
-		switch details := getErrorDetails(status).(type) {
+	case yarpcerrors.CodeNotFound:
+		switch details := getErrorDetails(err).(type) {
 		case *apiv1.EntityNotExistsError:
-			return types.EntityNotExistsError{
+			return &types.EntityNotExistsError{
 				Message:        status.Message(),
 				CurrentCluster: details.CurrentCluster,
 				ActiveCluster:  details.ActiveCluster,
 			}
 		}
-	case codes.InvalidArgument:
-		switch getErrorDetails(status).(type) {
+	case yarpcerrors.CodeInvalidArgument:
+		switch getErrorDetails(err).(type) {
 		case nil:
-			return types.BadRequestError{
+			return &types.BadRequestError{
 				Message: status.Message(),
 			}
 		case *apiv1.QueryFailedError:
-			return types.QueryFailedError{
+			return &types.QueryFailedError{
 				Message: status.Message(),
 			}
 		}
-	case codes.Aborted:
-		switch details := getErrorDetails(status).(type) {
+	case yarpcerrors.CodeAborted:
+		switch details := getErrorDetails(err).(type) {
 		case *sharedv1.ShardOwnershipLostError:
-			return types.ShardOwnershipLostError{
+			return &types.ShardOwnershipLostError{
 				Message: status.Message(),
 				Owner:   details.Owner,
 			}
 		case *sharedv1.CurrentBranchChangedError:
-			return types.CurrentBranchChangedError{
+			return &types.CurrentBranchChangedError{
 				Message:            status.Message(),
 				CurrentBranchToken: details.CurrentBranchToken,
 			}
 		case *sharedv1.RetryTaskV2Error:
-			return types.RetryTaskV2Error{
+			return &types.RetryTaskV2Error{
 				Message:           status.Message(),
 				DomainID:          details.DomainId,
 				WorkflowID:        ToWorkflowID(details.WorkflowExecution),
@@ -168,62 +160,62 @@ func ToError(err error) error {
 				EndEventVersion:   ToEventVersion(details.EndEvent),
 			}
 		}
-	case codes.AlreadyExists:
-		switch details := getErrorDetails(status).(type) {
+	case yarpcerrors.CodeAlreadyExists:
+		switch details := getErrorDetails(err).(type) {
 		case *apiv1.CancellationAlreadyRequestedError:
-			return types.CancellationAlreadyRequestedError{
+			return &types.CancellationAlreadyRequestedError{
 				Message: status.Message(),
 			}
 		case *apiv1.DomainAlreadyExistsError:
-			return types.DomainAlreadyExistsError{
+			return &types.DomainAlreadyExistsError{
 				Message: status.Message(),
 			}
 		case *sharedv1.EventAlreadyStartedError:
-			return types.EventAlreadyStartedError{
+			return &types.EventAlreadyStartedError{
 				Message: status.Message(),
 			}
 		case *apiv1.WorkflowExecutionAlreadyStartedError:
-			return types.WorkflowExecutionAlreadyStartedError{
+			return &types.WorkflowExecutionAlreadyStartedError{
 				Message:        status.Message(),
 				StartRequestID: details.StartRequestId,
 				RunID:          details.RunId,
 			}
 		}
-	case codes.DataLoss:
-		return types.InternalDataInconsistencyError{
+	case yarpcerrors.CodeDataLoss:
+		return &types.InternalDataInconsistencyError{
 			Message: status.Message(),
 		}
-	case codes.FailedPrecondition:
-		switch details := getErrorDetails(status).(type) {
+	case yarpcerrors.CodeFailedPrecondition:
+		switch details := getErrorDetails(err).(type) {
 		case *apiv1.ClientVersionNotSupportedError:
-			return types.ClientVersionNotSupportedError{
+			return &types.ClientVersionNotSupportedError{
 				FeatureVersion:    details.FeatureVersion,
 				ClientImpl:        details.ClientImpl,
 				SupportedVersions: details.SupportedVersions,
 			}
 		case *apiv1.DomainNotActiveError:
-			return types.DomainNotActiveError{
+			return &types.DomainNotActiveError{
 				Message:        status.Message(),
 				DomainName:     details.Domain,
 				CurrentCluster: details.CurrentCluster,
 				ActiveCluster:  details.ActiveCluster,
 			}
 		}
-	case codes.ResourceExhausted:
-		switch getErrorDetails(status).(type) {
+	case yarpcerrors.CodeResourceExhausted:
+		switch getErrorDetails(err).(type) {
 		case *apiv1.LimitExceededError:
-			return types.LimitExceededError{
+			return &types.LimitExceededError{
 				Message: status.Message(),
 			}
 		case *apiv1.ServiceBusyError:
-			return types.ServiceBusyError{
+			return &types.ServiceBusyError{
 				Message: status.Message(),
 			}
 		}
-	case codes.Unavailable:
-		switch getErrorDetails(status).(type) {
+	case yarpcerrors.CodeUnavailable:
+		switch getErrorDetails(err).(type) {
 		case *sharedv1.RemoteSyncMatchedError:
-			return types.RemoteSyncMatchedError{
+			return &types.RemoteSyncMatchedError{
 				Message: status.Message(),
 			}
 		}
@@ -232,8 +224,8 @@ func ToError(err error) error {
 	return errors.New(status.Message())
 }
 
-func getErrorDetails(status *status.Status) interface{} {
-	details := status.Details()
+func getErrorDetails(err error) interface{} {
+	details := protobuf.GetErrorDetails(err)
 	if len(details) > 0 {
 		return details[0]
 	}

--- a/common/types/mapper/proto/errors_test.go
+++ b/common/types/mapper/proto/errors_test.go
@@ -33,29 +33,29 @@ import (
 func TestErrors(t *testing.T) {
 	for _, err := range []error{
 		nil, // OK - no error
-		testdata.AccessDeniedError,
-		testdata.BadRequestError,
-		testdata.CancellationAlreadyRequestedError,
-		testdata.ClientVersionNotSupportedError,
-		testdata.CurrentBranchChangedError,
-		testdata.DomainAlreadyExistsError,
-		testdata.DomainNotActiveError,
-		testdata.EntityNotExistsError,
-		testdata.EventAlreadyStartedError,
-		testdata.InternalDataInconsistencyError,
-		testdata.InternalServiceError,
-		testdata.LimitExceededError,
-		testdata.QueryFailedError,
-		testdata.RemoteSyncMatchedError,
-		testdata.RetryTaskV2Error,
-		testdata.ServiceBusyError,
-		testdata.ShardOwnershipLostError,
-		testdata.WorkflowExecutionAlreadyStartedError,
+		&testdata.AccessDeniedError,
+		&testdata.BadRequestError,
+		&testdata.CancellationAlreadyRequestedError,
+		&testdata.ClientVersionNotSupportedError,
+		&testdata.CurrentBranchChangedError,
+		&testdata.DomainAlreadyExistsError,
+		&testdata.DomainNotActiveError,
+		&testdata.EntityNotExistsError,
+		&testdata.EventAlreadyStartedError,
+		&testdata.InternalDataInconsistencyError,
+		&testdata.InternalServiceError,
+		&testdata.LimitExceededError,
+		&testdata.QueryFailedError,
+		&testdata.RemoteSyncMatchedError,
+		&testdata.RetryTaskV2Error,
+		&testdata.ServiceBusyError,
+		&testdata.ShardOwnershipLostError,
+		&testdata.WorkflowExecutionAlreadyStartedError,
 		errors.New("unknown error"),
 	} {
 		name := "OK"
 		if err != nil {
-			name = reflect.TypeOf(err).Name()
+			name = reflect.TypeOf(err).Elem().Name()
 		}
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, err, ToError(FromError(err)))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use YARPC error model instead of vanilla grpc errors. As we use YARPC framework, errors needs to use it as well, to get properly serialized and deserialized. Otherwise all errors gets mapped to Unknown category and breaks logic for the caller which expect specific errors to be returned.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a prerequisite for https://github.com/uber/cadence/pull/4057. Splitting it off here for easier review.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

