### PR TITLE
Add domain queries to scanner and fixer, and skip terminated scans

### DIFF
--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -7,3 +7,18 @@ system.minRetentionDays:
 history.EnableConsistentQueryByDomain:
 - value: true
   constraints: {}
+worker.executionsScannerEnabled:
+  - value: true
+    constraints: {}
+worker.executionsScannerInvariantCollectionMutableState:
+  - value: true
+    constraints: {}
+worker.executionsScannerInvariantCollectionHistory:
+  - value: true
+    constraints: {}
+worker.concreteExecutionFixerEnabled:
+  - value: true
+    constraints: {}
+worker.concreteExecutionFixerDomainAllow:
+  - value: true
+    constraints: {}

--- a/service/worker/scanner/shardscanner/activities_test.go
+++ b/service/worker/scanner/shardscanner/activities_test.go
@@ -400,6 +400,9 @@ func (s *activitiesSuite) TestFixerCorruptedKeysActivity() {
 	response := &shared.ListClosedWorkflowExecutionsResponse{
 		Executions: []*shared.WorkflowExecutionInfo{
 			{
+				CloseStatus: shared.WorkflowExecutionCloseStatusCompleted.Ptr(),
+			},
+			{
 				Execution: &shared.WorkflowExecution{
 					WorkflowId: common.StringPtr("test-list-workflow-id"),
 					RunId:      common.StringPtr(uuid.New()),
@@ -409,7 +412,7 @@ func (s *activitiesSuite) TestFixerCorruptedKeysActivity() {
 				},
 				StartTime:     common.Int64Ptr(time.Now().UnixNano()),
 				CloseTime:     common.Int64Ptr(time.Now().Add(time.Hour).UnixNano()),
-				CloseStatus:   shared.WorkflowExecutionCloseStatusCompleted.Ptr(),
+				CloseStatus:   shared.WorkflowExecutionCloseStatusContinuedAsNew.Ptr(),
 				HistoryLength: common.Int64Ptr(12),
 			},
 		},
@@ -420,19 +423,7 @@ func (s *activitiesSuite) TestFixerCorruptedKeysActivity() {
 	s.mockResource.SDKClient.EXPECT().QueryWorkflow(gomock.Any(), gomock.Any()).Return(&shared.QueryWorkflowResponse{
 		QueryResult: queryResultData,
 	}, nil)
-	env := s.NewTestActivityEnvironment()
-	cfg := &ScannerConfig{
-		DynamicParams: DynamicParams{
-			AllowDomain: dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
-		},
-		FixerHooks: func() *FixerHooks {
-			return &FixerHooks{}
-		},
-	}
-	fc := NewShardFixerContext(s.mockResource, cfg)
-	env.SetWorkerOptions(worker.Options{
-		BackgroundActivityContext: NewFixerContext(context.Background(), testWorkflowName, fc),
-	})
+	env := s.getFixerActivityEnvironment()
 	fixerResultValue, err := env.ExecuteActivity(FixerCorruptedKeysActivity, FixerCorruptedKeysActivityParams{})
 	s.NoError(err)
 	fixerResult := &FixerCorruptedKeysActivityResult{}
@@ -461,4 +452,49 @@ func (s *activitiesSuite) TestFixerCorruptedKeysActivity() {
 			UUID: "third",
 		},
 	})
+}
+
+func (s *activitiesSuite) TestFixerCorruptedKeysActivity_Fails_WhenNoSuitableExecutionsAreFound() {
+	response := &shared.ListClosedWorkflowExecutionsResponse{
+		Executions: []*shared.WorkflowExecutionInfo{
+			{
+				CloseStatus: shared.WorkflowExecutionCloseStatusCompleted.Ptr(),
+			},
+			{
+				CloseStatus: shared.WorkflowExecutionCloseStatusCanceled.Ptr(),
+			},
+			{
+				CloseStatus: shared.WorkflowExecutionCloseStatusTimedOut.Ptr(),
+			},
+			{
+				CloseStatus: shared.WorkflowExecutionCloseStatusTerminated.Ptr(),
+			},
+			{
+				CloseStatus: shared.WorkflowExecutionCloseStatusFailed.Ptr(),
+			},
+		},
+	}
+	s.mockResource.SDKClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(response, nil)
+
+	env := s.getFixerActivityEnvironment()
+	fixerResultValue, err := env.ExecuteActivity(FixerCorruptedKeysActivity, FixerCorruptedKeysActivityParams{})
+	s.Nil(fixerResultValue)
+	s.EqualError(err, "failed to find a recent scanner workflow execution with ContinuedAsNew status")
+}
+
+func (s *activitiesSuite) getFixerActivityEnvironment() *testsuite.TestActivityEnvironment {
+	env := s.NewTestActivityEnvironment()
+	cfg := &ScannerConfig{
+		DynamicParams: DynamicParams{
+			AllowDomain: dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
+		},
+		FixerHooks: func() *FixerHooks {
+			return &FixerHooks{}
+		},
+	}
+	fc := NewShardFixerContext(s.mockResource, cfg)
+	env.SetWorkerOptions(worker.Options{
+		BackgroundActivityContext: NewFixerContext(context.Background(), testWorkflowName, fc),
+	})
+	return env
 }

--- a/service/worker/scanner/shardscanner/fixer.go
+++ b/service/worker/scanner/shardscanner/fixer.go
@@ -94,7 +94,8 @@ func NewFixer(
 func (f *ShardFixer) Fix() FixReport {
 
 	result := FixReport{
-		ShardID: f.shardID,
+		ShardID:     f.shardID,
+		DomainStats: map[string]*FixStats{},
 	}
 
 	for f.itr.HasNext() {
@@ -108,13 +109,17 @@ func (f *ShardFixer) Fix() FixReport {
 			return result
 		}
 
-		domainName, err := f.domainCache.GetDomainName(soe.Execution.(entity.Entity).GetDomainID())
+		domainID := soe.Execution.(entity.Entity).GetDomainID()
+		domainName, err := f.domainCache.GetDomainName(domainID)
 		if err != nil {
 			result.Result.ControlFlowFailure = &ControlFlowFailure{
 				Info:        "failed to get domain name",
 				InfoDetails: err.Error(),
 			}
 			return result
+		}
+		if _, ok := result.DomainStats[domainID]; !ok {
+			result.DomainStats[domainID] = &FixStats{}
 		}
 
 		var fixResult invariant.ManagerFixResult
@@ -127,6 +132,7 @@ func (f *ShardFixer) Fix() FixReport {
 			}
 		}
 		result.Stats.EntitiesCount++
+		result.DomainStats[domainID].EntitiesCount++
 		foe := store.FixOutputEntity{
 			Execution: soe.Execution,
 			Input:     *soe,
@@ -142,6 +148,7 @@ func (f *ShardFixer) Fix() FixReport {
 				return result
 			}
 			result.Stats.FixedCount++
+			result.DomainStats[domainID].FixedCount++
 		case invariant.FixResultTypeSkipped:
 			if err := f.skippedWriter.Add(foe); err != nil {
 				result.Result.ControlFlowFailure = &ControlFlowFailure{
@@ -151,6 +158,7 @@ func (f *ShardFixer) Fix() FixReport {
 				return result
 			}
 			result.Stats.SkippedCount++
+			result.DomainStats[domainID].SkippedCount++
 		case invariant.FixResultTypeFailed:
 			if err := f.failedWriter.Add(foe); err != nil {
 				result.Result.ControlFlowFailure = &ControlFlowFailure{
@@ -160,6 +168,7 @@ func (f *ShardFixer) Fix() FixReport {
 				return result
 			}
 			result.Stats.FailedCount++
+			result.DomainStats[domainID].FailedCount++
 		default:
 			panic(fmt.Sprintf("unknown FixResultType: %v", fixResult.FixResultType))
 		}

--- a/service/worker/scanner/shardscanner/fixer_test.go
+++ b/service/worker/scanner/shardscanner/fixer_test.go
@@ -76,6 +76,7 @@ func (s *FixerSuite) TestFix_Failure_FirstIteratorError() {
 				InfoDetails: "iterator error",
 			},
 		},
+		DomainStats: map[string]*FixStats{},
 	}, result)
 }
 
@@ -130,6 +131,14 @@ func (s *FixerSuite) TestFix_Failure_NonFirstError() {
 				InfoDetails: "iterator got error on: 4",
 			},
 		},
+		DomainStats: map[string]*FixStats{
+			"test_domain": {
+				EntitiesCount: 4,
+				FixedCount:    4,
+				SkippedCount:  0,
+				FailedCount:   0,
+			},
+		},
 	}, result)
 }
 
@@ -170,6 +179,14 @@ func (s *FixerSuite) TestFix_Failure_SkippedWriterError() {
 			ControlFlowFailure: &ControlFlowFailure{
 				Info:        "blobstore add failed for skipped execution fix",
 				InfoDetails: "skipped writer error",
+			},
+		},
+		DomainStats: map[string]*FixStats{
+			"test_domain": {
+				EntitiesCount: 1,
+				FixedCount:    0,
+				SkippedCount:  0,
+				FailedCount:   0,
 			},
 		},
 	}, result)
@@ -214,6 +231,14 @@ func (s *FixerSuite) TestFix_Failure_FailedWriterError() {
 				InfoDetails: "failed writer error",
 			},
 		},
+		DomainStats: map[string]*FixStats{
+			"test_domain": {
+				EntitiesCount: 1,
+				FixedCount:    0,
+				SkippedCount:  0,
+				FailedCount:   0,
+			},
+		},
 	}, result)
 }
 
@@ -256,6 +281,14 @@ func (s *FixerSuite) TestFix_Failure_FixedWriterError() {
 				InfoDetails: "fixed writer error",
 			},
 		},
+		DomainStats: map[string]*FixStats{
+			"test_domain": {
+				EntitiesCount: 1,
+				FixedCount:    0,
+				SkippedCount:  0,
+				FailedCount:   0,
+			},
+		},
 	}, result)
 }
 
@@ -279,6 +312,7 @@ func (s *FixerSuite) TestFix_Failure_FixedWriterFlushError() {
 				InfoDetails: "fix writer flush failed",
 			},
 		},
+		DomainStats: map[string]*FixStats{},
 	}, result)
 }
 
@@ -305,6 +339,7 @@ func (s *FixerSuite) TestFix_Failure_SkippedWriterFlushError() {
 				InfoDetails: "skip writer flush failed",
 			},
 		},
+		DomainStats: map[string]*FixStats{},
 	}, result)
 }
 
@@ -334,6 +369,7 @@ func (s *FixerSuite) TestFix_Failure_FailedWriterFlushError() {
 				InfoDetails: "fail writer flush failed",
 			},
 		},
+		DomainStats: map[string]*FixStats{},
 	}, result)
 }
 
@@ -687,6 +723,44 @@ func (s *FixerSuite) TestFix_Success() {
 				Fixed:   &store.Keys{UUID: "fixed_keys_uuid"},
 				Failed:  &store.Keys{UUID: "failed_keys_uuid"},
 				Skipped: &store.Keys{UUID: "skipped_keys_uuid"},
+			},
+		},
+		DomainStats: map[string]*FixStats{
+			"disallow_domain": {
+				EntitiesCount: 2,
+				FixedCount:    0,
+				SkippedCount:  2,
+				FailedCount:   0,
+			},
+			"failed": {
+				EntitiesCount: 2,
+				FixedCount:    0,
+				SkippedCount:  0,
+				FailedCount:   2,
+			},
+			"first_history_event": {
+				EntitiesCount: 1,
+				FixedCount:    1,
+				SkippedCount:  0,
+				FailedCount:   0,
+			},
+			"history_missing": {
+				EntitiesCount: 2,
+				FixedCount:    2,
+				SkippedCount:  0,
+				FailedCount:   0,
+			},
+			"orphan_execution": {
+				EntitiesCount: 1,
+				FixedCount:    1,
+				SkippedCount:  0,
+				FailedCount:   0,
+			},
+			"skipped": {
+				EntitiesCount: 4,
+				FixedCount:    0,
+				SkippedCount:  4,
+				FailedCount:   0,
 			},
 		},
 	}, result)

--- a/service/worker/scanner/shardscanner/fixer_workflow.go
+++ b/service/worker/scanner/shardscanner/fixer_workflow.go
@@ -209,6 +209,12 @@ func setHandlers(aggregator *ShardFixResultAggregator) map[string]interface{} {
 			}
 			return aggregator.GetAggregation(), nil
 		},
+		DomainReportQuery: func(req DomainReportQueryRequest) (*DomainFixReportQueryResult, error) {
+			if aggregator == nil {
+				return nil, errQueryNotReady
+			}
+			return aggregator.GetDomainStatus(req)
+		},
 	}
 }
 

--- a/service/worker/scanner/shardscanner/scanner_workflow.go
+++ b/service/worker/scanner/shardscanner/scanner_workflow.go
@@ -44,6 +44,8 @@ const (
 	AggregateReportQuery = "aggregate_report"
 	// ShardSizeQuery is the query name for the query used to get the number of executions per shard in sorted order
 	ShardSizeQuery = "shard_size"
+	// DomainReportQuery is the query name for the query used to get the reports per domains for all finished shards
+	DomainReportQuery = "domain_report"
 
 	scanShardReportChan = "scanShardReportChan"
 )
@@ -198,6 +200,9 @@ func getScanHandlers(aggregator *ShardScanResultAggregator) map[string]interface
 		},
 		ShardSizeQuery: func(req ShardSizeQueryRequest) (ShardSizeQueryResult, error) {
 			return aggregator.GetShardSizeQueryResult(req)
+		},
+		DomainReportQuery: func(req DomainReportQueryRequest) (*DomainScanReportQueryResult, error) {
+			return aggregator.GetDomainStatus(req)
 		},
 	}
 }

--- a/service/worker/scanner/shardscanner/types.go
+++ b/service/worker/scanner/shardscanner/types.go
@@ -114,11 +114,25 @@ type (
 		ScannerWorkflowRunID          string
 		FixerWorkflowConfigOverwrites FixerWorkflowConfigOverwrites
 	}
+
 	// ScanReport is the report of running Scan on a single shard.
 	ScanReport struct {
-		ShardID int
-		Stats   ScanStats
-		Result  ScanResult
+		ShardID     int
+		Stats       ScanStats
+		Result      ScanResult
+		DomainStats map[string]*ScanStats
+	}
+
+	// DomainStats is the report of stats for one domain
+	DomainScanStats struct {
+		DomainID string
+		Stats    ScanStats
+	}
+
+	// DomainStats is the report of stats for one domain
+	DomainFixStats struct {
+		DomainID string
+		Stats    FixStats
 	}
 
 	// ScanStats indicates the stats of entities which were handled by shard Scan.
@@ -145,9 +159,10 @@ type (
 
 	// FixReport is the report of running Fix on a single shard
 	FixReport struct {
-		ShardID int
-		Stats   FixStats
-		Result  FixResult
+		ShardID     int
+		Stats       FixStats
+		Result      FixResult
+		DomainStats map[string]*FixStats
 	}
 
 	// FixStats indicates the stats of executions that were handled by shard Fix.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
- Added `domain_report` query handlers to both Scanner and Fixer workflows
- Updated the Fixer workflow to ensure it only picks up the `continued_as_new` scanner executions by default


<!-- Tell your future self why have you made these changes -->
- Domain queries are useful for troubleshooting and fixer rollouts. 
- Picking the latest `continued_as_new` scanner execution is important to avoid picking up a terminated or failed execution which could provide an incomplete/incorrect report. This only affects the default behavior, and operators can still run the fixer with a specific Scanner execution as they wish.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
- Unit testing
- Manual e2e testing with intentionally created corruptions


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
In the worst case, the availability of Scanner or Fixer could be impacted such that they may just stop working or fail to serve data through the query handlers. 

