### PR TITLE
Revert "Drop pointer on ActivityTaskScheduledEventAttributes.Domain (#4009)"

### DIFF
--- a/common/testing/history_event_util.go
+++ b/common/testing/history_event_util.go
@@ -388,7 +388,7 @@ func InitializeHistoryEventGenerator(
 			ActivityType: &types.ActivityType{
 				Name: "activity",
 			},
-			Domain: domain,
+			Domain: common.StringPtr(domain),
 			TaskList: &types.TaskList{
 				Name: taskList,
 				Kind: types.TaskListKindNormal.Ptr(),

--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -154,7 +154,7 @@ func FromActivityTaskScheduledEventAttributes(t *types.ActivityTaskScheduledEven
 	return &apiv1.ActivityTaskScheduledEventAttributes{
 		ActivityId:                   t.ActivityID,
 		ActivityType:                 FromActivityType(t.ActivityType),
-		Domain:                       t.Domain,
+		Domain:                       t.GetDomain(),
 		TaskList:                     FromTaskList(t.TaskList),
 		Input:                        FromPayload(t.Input),
 		ScheduleToCloseTimeout:       secondsToDuration(t.ScheduleToCloseTimeoutSeconds),
@@ -174,7 +174,7 @@ func ToActivityTaskScheduledEventAttributes(t *apiv1.ActivityTaskScheduledEventA
 	return &types.ActivityTaskScheduledEventAttributes{
 		ActivityID:                    t.ActivityId,
 		ActivityType:                  ToActivityType(t.ActivityType),
-		Domain:                        t.Domain,
+		Domain:                        &t.Domain,
 		TaskList:                      ToTaskList(t.TaskList),
 		Input:                         ToPayload(t.Input),
 		ScheduleToCloseTimeoutSeconds: durationToSeconds(t.ScheduleToCloseTimeout),

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -57,7 +57,9 @@ func TestActivityTaskFailedEventAttributes(t *testing.T) {
 	}
 }
 func TestActivityTaskScheduledEventAttributes(t *testing.T) {
-	for _, item := range []*types.ActivityTaskScheduledEventAttributes{nil, {}, &testdata.ActivityTaskScheduledEventAttributes} {
+	// since proto definition for Domain field doesn't have pointer, To(From(item)) won't be equal to item when item's Domain is a nil pointer
+	// this is fine as the code using this field will check both if the field is a nil pointer and if it's a pointer to an empty string.
+	for _, item := range []*types.ActivityTaskScheduledEventAttributes{nil, {Domain: common.StringPtr("")}, &testdata.ActivityTaskScheduledEventAttributes} {
 		assert.Equal(t, item, ToActivityTaskScheduledEventAttributes(FromActivityTaskScheduledEventAttributes(item)))
 	}
 }

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -186,7 +186,7 @@ func FromActivityTaskScheduledEventAttributes(t *types.ActivityTaskScheduledEven
 	return &shared.ActivityTaskScheduledEventAttributes{
 		ActivityId:                    &t.ActivityID,
 		ActivityType:                  FromActivityType(t.ActivityType),
-		Domain:                        &t.Domain,
+		Domain:                        t.Domain,
 		TaskList:                      FromTaskList(t.TaskList),
 		Input:                         t.Input,
 		ScheduleToCloseTimeoutSeconds: t.ScheduleToCloseTimeoutSeconds,
@@ -207,7 +207,7 @@ func ToActivityTaskScheduledEventAttributes(t *shared.ActivityTaskScheduledEvent
 	return &types.ActivityTaskScheduledEventAttributes{
 		ActivityID:                    t.GetActivityId(),
 		ActivityType:                  ToActivityType(t.ActivityType),
-		Domain:                        t.GetDomain(),
+		Domain:                        t.Domain,
 		TaskList:                      ToTaskList(t.TaskList),
 		Input:                         t.Input,
 		ScheduleToCloseTimeoutSeconds: t.ScheduleToCloseTimeoutSeconds,

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -252,7 +252,7 @@ func (v *ActivityTaskFailedEventAttributes) GetIdentity() (o string) {
 type ActivityTaskScheduledEventAttributes struct {
 	ActivityID                    string        `json:"activityId,omitempty"`
 	ActivityType                  *ActivityType `json:"activityType,omitempty"`
-	Domain                        string        `json:"domain,omitempty"`
+	Domain                        *string       `json:"domain,omitempty"`
 	TaskList                      *TaskList     `json:"taskList,omitempty"`
 	Input                         []byte        `json:"input,omitempty"`
 	ScheduleToCloseTimeoutSeconds *int32        `json:"scheduleToCloseTimeoutSeconds,omitempty"`
@@ -282,8 +282,8 @@ func (v *ActivityTaskScheduledEventAttributes) GetActivityType() (o *ActivityTyp
 
 // GetDomain is an internal getter (TBD...)
 func (v *ActivityTaskScheduledEventAttributes) GetDomain() (o string) {
-	if v != nil {
-		return v.Domain
+	if v != nil && v.Domain != nil {
+		return *v.Domain
 	}
 	return
 }

--- a/common/types/testdata/history.go
+++ b/common/types/testdata/history.go
@@ -326,7 +326,7 @@ var (
 	ActivityTaskScheduledEventAttributes = types.ActivityTaskScheduledEventAttributes{
 		ActivityID:                    ActivityID,
 		ActivityType:                  &ActivityType,
-		Domain:                        DomainName,
+		Domain:                        &DomainName,
 		TaskList:                      &TaskList,
 		Input:                         Payload1,
 		ScheduleToCloseTimeoutSeconds: &Duration1,

--- a/common/types/testdata/history.go
+++ b/common/types/testdata/history.go
@@ -326,7 +326,7 @@ var (
 	ActivityTaskScheduledEventAttributes = types.ActivityTaskScheduledEventAttributes{
 		ActivityID:                    ActivityID,
 		ActivityType:                  &ActivityType,
-		Domain:                        &DomainName,
+		Domain:                        common.StringPtr(DomainName),
 		TaskList:                      &TaskList,
 		Input:                         Payload1,
 		ScheduleToCloseTimeoutSeconds: &Duration1,

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -2150,7 +2150,7 @@ func (e *mutableStateBuilder) ReplicateActivityTaskScheduledEvent(
 
 	attributes := event.ActivityTaskScheduledEventAttributes
 	targetDomainID := e.executionInfo.DomainID
-	if attributes.Domain != nil {
+	if attributes.GetDomain() != "" {
 		targetDomainEntry, err := e.shard.GetDomainCache().GetDomain(attributes.GetDomain())
 		if err != nil {
 			return nil, err

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -2150,7 +2150,7 @@ func (e *mutableStateBuilder) ReplicateActivityTaskScheduledEvent(
 
 	attributes := event.ActivityTaskScheduledEventAttributes
 	targetDomainID := e.executionInfo.DomainID
-	if attributes.Domain != "" {
+	if attributes.Domain != nil {
 		targetDomainEntry, err := e.shard.GetDomainCache().GetDomain(attributes.GetDomain())
 		if err != nil {
 			return nil, err

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -136,7 +136,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 			// as ParentWorkflowDomainID will not be present on older histories.
 			if attributes.ParentWorkflowDomainID != nil {
 				parentDomainID = attributes.ParentWorkflowDomainID
-			} else if attributes.ParentWorkflowDomain != nil {
+			} else if attributes.GetParentWorkflowDomain() != "" {
 				parentDomainEntry, err := b.domainCache.GetDomain(
 					attributes.GetParentWorkflowDomain(),
 				)

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -455,7 +455,7 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 		if err != nil {
 			return err
 		}
-		if scheduledEvent.ActivityTaskScheduledEventAttributes.Domain != nil {
+		if scheduledEvent.ActivityTaskScheduledEventAttributes.GetDomain() != "" {
 			domainEntry, err := t.shard.GetDomainCache().GetDomain(scheduledEvent.ActivityTaskScheduledEventAttributes.GetDomain())
 			if err != nil {
 				return &types.InternalServiceError{Message: "unable to re-schedule activity across domain."}

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -455,7 +455,7 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 		if err != nil {
 			return err
 		}
-		if scheduledEvent.ActivityTaskScheduledEventAttributes.Domain != "" {
+		if scheduledEvent.ActivityTaskScheduledEventAttributes.Domain != nil {
 			domainEntry, err := t.shard.GetDomainCache().GetDomain(scheduledEvent.ActivityTaskScheduledEventAttributes.GetDomain())
 			if err != nil {
 				return &types.InternalServiceError{Message: "unable to re-schedule activity across domain."}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This reverts commit 4cd869c49a3ea3d1abd405d53be9cd9f8ac8db22. as it's not compatible with 0.19 and previous releases.

Since logic in our previous releases assumes if this field is not nil then it's also not an empty string, the solution is:
- For internal types, added the pointer back for domain field, otherwise the history persisted will be viewed as a pointer to empty string by previous releases and cause issues.
- For thrift types, nothing changes, it always has the pointer. When converting to internal types, domain field will never be a pointer to empty string (technically it can, but there's no code path lead to it).
- For proto, nothing changes, it **DOES NOT** have the pointer. When converting to internal types, domain field **will be** a pointer to empty string. The logic for checking that field has been updated to check if the string is empty or not instead of if just a nil pointer. Since proto is will not be production ready soon, it's unlikely user are still using 0.19 server when it's ready.

<!-- Tell your future self why have you made these changes -->
**Why?**
Domain field in ActivityScheduledEvent is an optional field for scheduling activity in a different domain.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local canary.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
