### PR TITLE
Release current workflow lock on create as zombie

### DIFF
--- a/service/history/ndc/new_workflow_transaction_manager.go
+++ b/service/history/ndc/new_workflow_transaction_manager.go
@@ -235,6 +235,11 @@ func (r *transactionManagerForNewWorkflowImpl) createAsZombie(
 		return err
 	}
 
+	// release lock on current workflow, since current cluster maybe the active cluster
+	//  and events maybe reapplied to current workflow
+	currentWorkflow.GetReleaseFn()(nil)
+	currentWorkflow = nil
+
 	if err := targetWorkflow.GetContext().ReapplyEvents(
 		targetWorkflowEventsSeq,
 	); err != nil {

--- a/service/history/ndc/new_workflow_transaction_manager.go
+++ b/service/history/ndc/new_workflow_transaction_manager.go
@@ -236,7 +236,8 @@ func (r *transactionManagerForNewWorkflowImpl) createAsZombie(
 	}
 
 	// release lock on current workflow, since current cluster maybe the active cluster
-	//  and events maybe reapplied to current workflow
+	// and events maybe reapplied to current workflow
+	// TODO: add functional test for this case.
 	currentWorkflow.GetReleaseFn()(nil)
 	currentWorkflow = nil
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Release current workflow lock on create as zombie

<!-- Tell your future self why have you made these changes -->
**Why?**
When creating workflow as zombie, the zombie wf may trigger event reapply to the current workflow run. It requires releasing the lock to avoid dead lock.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test, a functional test will be add to cover this case.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

