### PR TITLE
Treat persistence timeout as transient error

### DIFF
--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -144,7 +144,7 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 
 		if err != nil {
 			logger := logger.WithTags(tag.ArchivalArchiveFailReason(archiver.ErrReasonReadHistory), tag.Error(err))
-			if !common.IsPersistenceTransientError(err) {
+			if !persistence.IsTransientError(err) {
 				logger.Error(archiver.ArchiveNonRetriableErrorMsg)
 				return errUploadNonRetriable
 			}
@@ -305,10 +305,10 @@ func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIte
 		if contextExpired(ctx) {
 			return nil, archiver.ErrContextTimeout
 		}
-		if !common.IsPersistenceTransientError(err) {
+		if !persistence.IsTransientError(err) {
 			return nil, err
 		}
-		err = backoff.Retry(op, common.CreatePersistenceRetryPolicy(), common.IsPersistenceTransientError)
+		err = backoff.Retry(op, common.CreatePersistenceRetryPolicy(), persistence.IsTransientError)
 	}
 	return historyBlob, nil
 }

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -128,7 +128,7 @@ func (h *historyArchiver) Archive(
 	defer func() {
 		sw.Stop()
 		if err != nil {
-			if common.IsPersistenceTransientError(err) || isRetryableError(err) {
+			if persistence.IsTransientError(err) || isRetryableError(err) {
 				scope.IncCounter(metrics.HistoryArchiverArchiveTransientErrorCount)
 			} else {
 				scope.IncCounter(metrics.HistoryArchiverArchiveNonRetryableErrorCount)
@@ -160,7 +160,7 @@ func (h *historyArchiver) Archive(
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 		if err != nil {
 			logger := logger.WithTags(tag.ArchivalArchiveFailReason(archiver.ErrReasonReadHistory), tag.Error(err))
-			if common.IsPersistenceTransientError(err) {
+			if persistence.IsTransientError(err) {
 				logger.Error(archiver.ArchiveTransientErrorMsg)
 			} else {
 				logger.Error(archiver.ArchiveNonRetriableErrorMsg)
@@ -355,10 +355,10 @@ func getNextHistoryBlob(ctx context.Context, historyIterator archiver.HistoryIte
 		if contextExpired(ctx) {
 			return nil, archiver.ErrContextTimeout
 		}
-		if !common.IsPersistenceTransientError(err) {
+		if !persistence.IsTransientError(err) {
 			return nil, err
 		}
-		err = backoff.Retry(op, common.CreatePersistenceRetryPolicy(), common.IsPersistenceTransientError)
+		err = backoff.Retry(op, common.CreatePersistenceRetryPolicy(), persistence.IsTransientError)
 	}
 	return historyBlob, nil
 }

--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -2616,3 +2616,13 @@ func NewGetReplicationTasksFromDLQRequest(
 		},
 	}
 }
+
+// IsTransientError checks if the error is a transient persistence error
+func IsTransientError(err error) bool {
+	switch err.(type) {
+	case *types.InternalServiceError, *types.ServiceBusyError, *TimeoutError:
+		return true
+	}
+
+	return false
+}

--- a/common/persistence/datainterfaces_test.go
+++ b/common/persistence/datainterfaces_test.go
@@ -21,9 +21,13 @@
 package persistence
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/types"
 )
 
 func TestClusterReplicationConfigGetCopy(t *testing.T) {
@@ -32,4 +36,25 @@ func TestClusterReplicationConfigGetCopy(t *testing.T) {
 	}
 	assert.Equal(t, config, config.GetCopy()) // deep equal
 	assert.Equal(t, true, config != config.GetCopy())
+}
+
+func TestIsTransientError(t *testing.T) {
+	transientErrors := []error{
+		&types.ServiceBusyError{},
+		&types.InternalServiceError{},
+		&TimeoutError{},
+	}
+	for _, err := range transientErrors {
+		require.True(t, IsTransientError(err))
+	}
+
+	nonRetryableErrors := []error{
+		&types.EntityNotExistsError{},
+		&types.DomainAlreadyExistsError{},
+		&WorkflowExecutionAlreadyStartedError{},
+		errors.New("some unknown error"),
+	}
+	for _, err := range nonRetryableErrors {
+		require.False(t, IsTransientError(err))
+	}
 }

--- a/common/persistence/datainterfaces_test.go
+++ b/common/persistence/datainterfaces_test.go
@@ -24,7 +24,7 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/bmizerany/assert"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/cadence/common/types"

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/cassandra"
 	"github.com/uber/cadence/common/persistence/client"
@@ -1908,7 +1909,7 @@ func (s *TestBase) Publish(
 		},
 		retryPolicy,
 		func(e error) bool {
-			return common.IsPersistenceTransientError(e) || isMessageIDConflictError(e)
+			return persistence.IsTransientError(e) || isMessageIDConflictError(e)
 		})
 }
 
@@ -1960,7 +1961,7 @@ func (s *TestBase) PublishToDomainDLQ(
 		},
 		retryPolicy,
 		func(e error) bool {
-			return common.IsPersistenceTransientError(e) || isMessageIDConflictError(e)
+			return persistence.IsTransientError(e) || isMessageIDConflictError(e)
 		})
 }
 

--- a/common/persistence/retryer.go
+++ b/common/persistence/retryer.go
@@ -25,7 +25,6 @@ package persistence
 import (
 	"context"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 )
 
@@ -77,7 +76,7 @@ func (pr *persistenceRetryer) ListConcreteExecutions(
 		return err
 	}
 	var err error
-	err = backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	err = backoff.Retry(op, pr.policy, IsTransientError)
 	if err == nil {
 		return resp, nil
 	}
@@ -95,7 +94,7 @@ func (pr *persistenceRetryer) GetWorkflowExecution(
 		resp, err = pr.execManager.GetWorkflowExecution(ctx, req)
 		return err
 	}
-	err := backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, pr.policy, IsTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +112,7 @@ func (pr *persistenceRetryer) GetCurrentExecution(
 		resp, err = pr.execManager.GetCurrentExecution(ctx, req)
 		return err
 	}
-	err := backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, pr.policy, IsTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +131,7 @@ func (pr *persistenceRetryer) ListCurrentExecutions(
 		return err
 	}
 	var err error
-	err = backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	err = backoff.Retry(op, pr.policy, IsTransientError)
 	if err == nil {
 		return resp, nil
 	}
@@ -150,7 +149,7 @@ func (pr *persistenceRetryer) IsWorkflowExecutionExists(
 		resp, err = pr.execManager.IsWorkflowExecutionExists(ctx, req)
 		return err
 	}
-	err := backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, pr.policy, IsTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +167,7 @@ func (pr *persistenceRetryer) ReadHistoryBranch(
 		resp, err = pr.historyManager.ReadHistoryBranch(ctx, req)
 		return err
 	}
-	err := backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, pr.policy, IsTransientError)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +182,7 @@ func (pr *persistenceRetryer) DeleteWorkflowExecution(
 	op := func() error {
 		return pr.execManager.DeleteWorkflowExecution(ctx, req)
 	}
-	return backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, pr.policy, IsTransientError)
 }
 
 // DeleteCurrentWorkflowExecution retries DeleteCurrentWorkflowExecution
@@ -194,7 +193,7 @@ func (pr *persistenceRetryer) DeleteCurrentWorkflowExecution(
 	op := func() error {
 		return pr.execManager.DeleteCurrentWorkflowExecution(ctx, req)
 	}
-	return backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, pr.policy, IsTransientError)
 }
 
 // GetShardID return shard id
@@ -213,7 +212,7 @@ func (pr *persistenceRetryer) GetTimerIndexTasks(
 		resp, err = pr.execManager.GetTimerIndexTasks(ctx, req)
 		return err
 	}
-	err := backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, pr.policy, IsTransientError)
 
 	if err != nil {
 		return nil, err
@@ -231,5 +230,5 @@ func (pr *persistenceRetryer) CompleteTimerTask(
 		return pr.execManager.CompleteTimerTask(ctx, request)
 	}
 
-	return backoff.Retry(op, pr.policy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, pr.policy, IsTransientError)
 }

--- a/common/util.go
+++ b/common/util.go
@@ -203,16 +203,6 @@ func CreateReplicationServiceBusyRetryPolicy() backoff.RetryPolicy {
 	return policy
 }
 
-// IsPersistenceTransientError checks if the error is a transient persistence error
-func IsPersistenceTransientError(err error) bool {
-	switch err.(type) {
-	case *types.InternalServiceError, *types.ServiceBusyError:
-		return true
-	}
-
-	return false
-}
-
 // IsServiceTransientError checks if the error is a transient error.
 func IsServiceTransientError(err error) bool {
 	switch err.(type) {

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/apache/thrift v0.13.0
 	github.com/aws/aws-sdk-go v1.34.13
 	github.com/benbjohnson/clock v0.0.0-20161215174838-7dc76406b6d3 // indirect
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/cactus/go-statsd-client/statsd v0.0.0-20191106001114-12b4e2b38748
 	github.com/cch123/elasticsql v0.0.0-20190321073543-a1a440758eb9
 	github.com/davecgh/go-spew v1.1.1
@@ -23,7 +22,7 @@ require (
 	github.com/gocql/gocql v0.0.0-20191126110522-1982a06ad6b9
 	github.com/gogo/protobuf v1.3.1
 	github.com/golang/mock v1.4.4
-	github.com/golang/protobuf v1.4.3
+	github.com/golang/protobuf v1.4.3 // indirect
 	github.com/google/go-cmp v0.5.4 // indirect
 	github.com/google/uuid v1.1.2
 	github.com/hashicorp/go-version v1.2.0
@@ -74,7 +73,7 @@ require (
 	google.golang.org/api v0.26.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e // indirect
-	google.golang.org/grpc v1.29.1
+	google.golang.org/grpc v1.29.1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/pborman/uuid"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/definition"
@@ -316,7 +315,7 @@ func (c *Cache) getCurrentExecutionWithRetry(
 		return err
 	}
 
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, persistence.IsTransientError)
 	if err != nil {
 		c.metricsClient.IncCounter(metrics.HistoryCacheGetCurrentExecutionScope, metrics.CacheFailures)
 		return nil, err

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -973,7 +973,7 @@ func (c *contextImpl) appendHistoryV2EventsWithRetry(
 	err := backoff.Retry(
 		op,
 		persistenceOperationRetryPolicy,
-		common.IsPersistenceTransientError,
+		persistence.IsTransientError,
 	)
 	return int64(resp), err
 }
@@ -993,7 +993,7 @@ func (c *contextImpl) createWorkflowExecutionWithRetry(
 	err := backoff.Retry(
 		op,
 		persistenceOperationRetryPolicy,
-		common.IsPersistenceTransientError,
+		persistence.IsTransientError,
 	)
 	switch err.(type) {
 	case nil:
@@ -1031,7 +1031,7 @@ func (c *contextImpl) getWorkflowExecutionWithRetry(
 	err := backoff.Retry(
 		op,
 		persistenceOperationRetryPolicy,
-		common.IsPersistenceTransientError,
+		persistence.IsTransientError,
 	)
 	switch err.(type) {
 	case nil:
@@ -1066,7 +1066,7 @@ func (c *contextImpl) updateWorkflowExecutionWithRetry(
 
 	err := backoff.Retry(
 		op, persistenceOperationRetryPolicy,
-		common.IsPersistenceTransientError,
+		persistence.IsTransientError,
 	)
 	switch err.(type) {
 	case nil:

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -458,7 +458,7 @@ func (t *transferQueueProcessorBase) readTasks(
 		return err
 	}
 
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, persistence.IsTransientError)
 	if err != nil {
 		return nil, false, err
 	}

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -173,7 +173,7 @@ TaskInfoLoop:
 			replicationTask, err = t.toReplicationTask(ctx, taskInfo)
 			return err
 		}
-		err = backoff.Retry(op, t.retryPolicy, common.IsPersistenceTransientError)
+		err = backoff.Retry(op, t.retryPolicy, persistence.IsTransientError)
 		switch err.(type) {
 		case nil:
 			// No action

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1463,7 +1463,7 @@ func acquireShard(
 	retryPolicy.SetExpirationInterval(5 * time.Second)
 
 	retryPredicate := func(err error) bool {
-		if common.IsPersistenceTransientError(err) {
+		if persistence.IsTransientError(err) {
 			return true
 		}
 		_, ok := err.(*persistence.ShardAlreadyExistError)

--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -227,7 +227,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowExecution(
 			RunID:      task.RunID,
 		})
 	}
-	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, persistence.IsTransientError)
 }
 
 func (t *timerTaskExecutorBase) deleteCurrentWorkflowExecution(
@@ -242,7 +242,7 @@ func (t *timerTaskExecutorBase) deleteCurrentWorkflowExecution(
 			RunID:      task.RunID,
 		})
 	}
-	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, persistence.IsTransientError)
 }
 
 func (t *timerTaskExecutorBase) deleteWorkflowHistory(
@@ -262,7 +262,7 @@ func (t *timerTaskExecutorBase) deleteWorkflowHistory(
 		})
 
 	}
-	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, persistence.IsTransientError)
 }
 
 func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
@@ -280,5 +280,5 @@ func (t *timerTaskExecutorBase) deleteWorkflowVisibility(
 		// TODO: expose GetVisibilityManager method on shardContext interface
 		return t.shard.GetService().GetVisibilityManager().DeleteWorkflowExecution(ctx, request) // delete from db
 	}
-	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, persistence.IsTransientError)
 }

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1223,7 +1223,7 @@ func (t *transferActiveTaskExecutor) requestCancelExternalExecutionWithRetry(
 		return t.historyClient.RequestCancelWorkflowExecution(requestCancelCtx, request)
 	}
 
-	err := backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, taskRetryPolicy, persistence.IsTransientError)
 
 	if _, ok := err.(*types.CancellationAlreadyRequestedError); ok {
 		// err is CancellationAlreadyRequestedError
@@ -1269,7 +1269,7 @@ func (t *transferActiveTaskExecutor) signalExternalExecutionWithRetry(
 		return t.historyClient.SignalWorkflowExecution(signalCtx, request)
 	}
 
-	return backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
+	return backoff.Retry(op, taskRetryPolicy, persistence.IsTransientError)
 }
 
 func (t *transferActiveTaskExecutor) startWorkflowWithRetry(
@@ -1321,7 +1321,7 @@ func (t *transferActiveTaskExecutor) startWorkflowWithRetry(
 		return err
 	}
 
-	err = backoff.Retry(op, taskRetryPolicy, common.IsPersistenceTransientError)
+	err = backoff.Retry(op, taskRetryPolicy, persistence.IsTransientError)
 	if err != nil {
 		return "", err
 	}

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -449,7 +449,7 @@ func (c *taskListManagerImpl) renewLeaseWithRetry() (taskListState, error) {
 		return
 	}
 	c.metricScope().IncCounter(metrics.LeaseRequestPerTaskListCounter)
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, common.IsPersistenceTransientError)
+	err := backoff.Retry(op, persistenceOperationRetryPolicy, persistence.IsTransientError)
 	if err != nil {
 		c.metricScope().IncCounter(metrics.LeaseFailurePerTaskListCounter)
 		c.engine.unloadTaskList(c.taskListID)
@@ -492,7 +492,7 @@ func (c *taskListManagerImpl) executeWithRetry(
 		if _, ok := err.(*persistence.ConditionFailedError); ok {
 			return false
 		}
-		return common.IsPersistenceTransientError(err)
+		return persistence.IsTransientError(err)
 	})
 
 	if _, ok := err.(*persistence.ConditionFailedError); ok {

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -116,7 +116,7 @@ func deleteHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 	}
 	logger := tagLoggerWithHistoryRequest(tagLoggerWithActivityInfo(container.Logger, activity.GetInfo(ctx)), &request)
 	logger.Error("failed to delete history events", tag.Error(err))
-	if !common.IsPersistenceTransientError(err) {
+	if !persistence.IsTransientError(err) {
 		return errDeleteNonRetriable
 	}
 	return err

--- a/tools/cli/adminClusterCommands_test.go
+++ b/tools/cli/adminClusterCommands_test.go
@@ -26,8 +26,8 @@ import (
 	"flag"
 	"testing"
 
-	"github.com/bmizerany/assert"
 	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
 	"github.com/urfave/cli"
 
 	"github.com/uber/cadence/client/frontend"

--- a/tools/cli/adminTimers.go
+++ b/tools/cli/adminTimers.go
@@ -266,7 +266,7 @@ func (cl *cassandraLoader) Load() []*persistence.TimerTaskInfo {
 		}
 
 		isRetryable := func(err error) bool {
-			return common.IsPersistenceTransientError(err) || common.IsContextTimeoutError(err)
+			return persistence.IsTransientError(err) || common.IsContextTimeoutError(err)
 		}
 
 		err = backoff.Retry(op, common.CreatePersistenceRetryPolicy(), isRetryable)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Treat persistence timeout as transient error
- Move `IsPersistenceTransientError` to persistence package to avoid cycle dependencies between `common` and `persistence` package.

<!-- Tell your future self why have you made these changes -->
**Why?**
Persistence timeout is a transient error and operation should be retried when encountering that error

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If timeout is due to high number of requests, retry will result in more requests and make the situation worse.
