### PR TITLE
Fix flaky integration test

### DIFF
--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -1208,15 +1208,26 @@ func (s *integrationSuite) TestCronWorkflow() {
 	}
 	for i := 1; i != 4; i++ {
 		executionInfo := closedExecutions[i]
-		// Roundup to compare on the precision of seconds
-		expectedBackoff := executionInfo.GetExecutionTime()/1000000000 - lastExecution.GetExecutionTime()/1000000000
+		expectedBackoff := executionInfo.GetExecutionTime() - lastExecution.GetExecutionTime()
 		// The execution time calculate based on last execution close time
 		// However, the current execution time is based on the current start time
 		// This code is to remove the diff between current start time and last execution close time
 		// TODO: Remove this line once we unify the time source
-		executionTimeDiff := executionInfo.GetStartTime()/1000000000 - lastExecution.GetCloseTime()/1000000000
+		executionTimeDiff := executionInfo.GetStartTime() - lastExecution.GetCloseTime()
 		// The backoff between any two executions should be multiplier of the target backoff duration which is 3 in this test
-		s.Equal(int64(0), int64(expectedBackoff-executionTimeDiff)%(targetBackoffDuration.Nanoseconds()/1000000000))
+		backoffSeconds := int(time.Duration(expectedBackoff-executionTimeDiff).Round(time.Second).Seconds())
+		targetBackoffSeconds := int(targetBackoffDuration.Seconds())
+		s.Equal(
+			0,
+			backoffSeconds % targetBackoffSeconds,
+			"Still Flaky?: backoffSeconds: %v ((%v-%v) - (%v-%v)), targetBackoffSeconds: %v",
+			backoffSeconds,
+			executionInfo.GetExecutionTime(),
+			lastExecution.GetExecutionTime(),
+			executionInfo.GetStartTime(),
+			lastExecution.GetCloseTime(),
+			targetBackoffSeconds,
+		)
 		lastExecution = executionInfo
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Attempt to fix flaky integration test that seems to be failing due to time precisions affecting timestamp math. Also added some extra logs to help with the investigation if the test continues being flaky.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**



<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

