### PR TITLE
Fix regression introduced by integration test refactoring

### DIFF
--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -179,6 +179,10 @@ func NewClusterMetadata(options *TestClusterConfig, logger log.Logger) cluster.M
 }
 
 func NewPersistenceTestCluster(clusterConfig *TestClusterConfig) persistencetests.PersistenceTestCluster {
+	// NOTE: Override here to keep consistent. clusterConfig will be used in the test for some purposes.
+	clusterConfig.Persistence.StoreType = TestFlags.PersistenceType
+	clusterConfig.Persistence.SQLDBPluginName = TestFlags.SQLPluginName
+
 	var testCluster persistencetests.PersistenceTestCluster
 	if TestFlags.PersistenceType == config.StoreTypeCassandra {
 		testCluster = cassandra.NewTestCluster(clusterConfig.Persistence.DBName, clusterConfig.Persistence.DBUsername, clusterConfig.Persistence.DBPassword, clusterConfig.Persistence.DBHost, clusterConfig.Persistence.DBPort, clusterConfig.Persistence.SchemaDir)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix regression introduced by integration test refactoring

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/4103
Previous integ test refactor changed the behavior https://github.com/uber/cadence/pull/4091

https://github.com/uber/cadence/blob/7bd91051360214181464b87325615631a1712bb7/host/integrationTest.go#L1237
That assertion is not working for postgres, which should be fixed in https://github.com/uber/cadence/issues/3540

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
