### PR TITLE
Fix flaky Cron integration test

### DIFF
--- a/host/integrationTest.go
+++ b/host/integrationTest.go
@@ -1244,7 +1244,7 @@ func (s *IntegrationSuite) TestCronWorkflow() {
 		// However, it's difficult to guarantee accuracy within a second, we allows 1s as buffering...
 		backoffSeconds := int(time.Duration(expectedBackoff - executionTimeDiff).Round(time.Second).Seconds())
 		targetBackoffSeconds := int(targetBackoffDuration.Seconds())
-		targetDiff := math.Abs(float64(backoffSeconds%targetBackoffSeconds - 3))
+		targetDiff := int(math.Abs(float64(backoffSeconds%targetBackoffSeconds-3))) % 3
 
 		s.True(
 			targetDiff <= 1,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix flaky Cron integration test

<!-- Tell your future self why have you made these changes -->
**Why?**
for https://github.com/uber/cadence/issues/3540 
Unfortunatley, it's now also failing for Cassandra(probably builkite is a little overloaded)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
na

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
na -- I released the assertion but I think it's still in a safe range.  one second buffering is quite normal I think 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
