### PR TITLE
Bug fix: Declare CloseStatus and HistoryStatus as integers for development dynamicconfig

### DIFF
--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -13,8 +13,8 @@ frontend.validSearchAttributes:
       StartTime: 2
       ExecutionTime: 2
       CloseTime: 2
-      CloseStatus: 2
-      HistoryLength: 2
+      CloseStatus: 1
+      HistoryLength: 1
       TaskList: 1
       CustomStringField: 0
       CustomKeywordField: 1


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Declare CloseStatus and HistoryStatus as integers in the test dynamic config for frontend.

<!-- Tell your future self why have you made these changes -->
**Why?**

Test configs are often used as examples and can cause confusion.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

NA This change affects test code.
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Test breaks, no production effect

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

NA
<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
NA