### PR TITLE
Update domain deprecation command to fail if workflow exists

### DIFF
--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -211,20 +211,57 @@ func (s *cliAppSuite) TestDomainUpdate_Failed() {
 }
 
 func (s *cliAppSuite) TestDomainDeprecate() {
+	s.clientFrontendClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.ListClosedWorkflowExecutionsResponse{}, nil)
+	s.clientFrontendClient.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.ListOpenWorkflowExecutionsResponse{}, nil)
 	s.serverFrontendClient.EXPECT().DeprecateDomain(gomock.Any(), gomock.Any()).Return(nil)
 	err := s.app.Run([]string{"", "--do", domainName, "domain", "deprecate"})
 	s.Nil(err)
 }
 
 func (s *cliAppSuite) TestDomainDeprecate_DomainNotExist() {
+	s.clientFrontendClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.ListClosedWorkflowExecutionsResponse{}, nil)
+	s.clientFrontendClient.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.ListOpenWorkflowExecutionsResponse{}, nil)
 	s.serverFrontendClient.EXPECT().DeprecateDomain(gomock.Any(), gomock.Any()).Return(&types.EntityNotExistsError{})
 	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "deprecate"})
 	s.Equal(1, errorCode)
 }
 
 func (s *cliAppSuite) TestDomainDeprecate_Failed() {
+	s.clientFrontendClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.ListClosedWorkflowExecutionsResponse{}, nil)
+	s.clientFrontendClient.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.ListOpenWorkflowExecutionsResponse{}, nil)
 	s.serverFrontendClient.EXPECT().DeprecateDomain(gomock.Any(), gomock.Any()).Return(&types.BadRequestError{"faked error"})
 	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "deprecate"})
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestDomainDeprecate_ClosedWorkflowsExist() {
+	s.clientFrontendClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(listClosedWorkflowExecutionsResponse, nil)
+	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "deprecate"})
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestDomainDeprecate_OpenWorkflowsExist() {
+	s.clientFrontendClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(&shared.ListClosedWorkflowExecutionsResponse{}, nil)
+	s.clientFrontendClient.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), gomock.Any(), callOptions...).Return(listOpenWorkflowExecutionsResponse, nil)
+	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "deprecate"})
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestDomainDeprecate_Force() {
+	s.serverFrontendClient.EXPECT().DeprecateDomain(gomock.Any(), gomock.Any()).Return(nil)
+	err := s.app.Run([]string{"", "--do", domainName, "domain", "deprecate", "--force"})
+	s.Nil(err)
+}
+
+func (s *cliAppSuite) TestDomainDeprecate_DomainNotExist_Force() {
+	s.serverFrontendClient.EXPECT().DeprecateDomain(gomock.Any(), gomock.Any()).Return(&types.EntityNotExistsError{})
+	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "deprecate", "--force"})
+	s.Equal(1, errorCode)
+}
+
+func (s *cliAppSuite) TestDomainDeprecate_Failed_Force() {
+	s.serverFrontendClient.EXPECT().DeprecateDomain(gomock.Any(), gomock.Any()).Return(&types.BadRequestError{"faked error"})
+	errorCode := s.RunErrorExitCode([]string{"", "--do", domainName, "domain", "deprecate", "--force"})
 	s.Equal(1, errorCode)
 }
 

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -179,6 +179,10 @@ var (
 			Name:  FlagSecurityTokenWithAlias,
 			Usage: "Optional token for security check",
 		},
+		cli.BoolFlag{
+			Name: FlagForce,
+			Usage: "Deprecate domain regardless of domain history.",
+		},
 	}
 
 	describeDomainFlags = []cli.Flag{

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -114,6 +114,7 @@ const (
 	FlagAllWithAlias                      = FlagAll + ", a"
 	FlagDeprecated                        = "deprecated"
 	FlagDeprecatedWithAlias               = FlagDeprecated + ", dep"
+	FlagForce                             = "force"
 	FlagPageSize                          = "pagesize"
 	FlagPageSizeWithAlias                 = FlagPageSize + ", ps"
 	FlagEarliestTime                      = "earliest_time"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update the domain deprecation command to check if there exists any workflow history in that domain before deprecating the domain by default. And also add a new flag '--force' to allow user to skip the workflow history check.

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to be cautious when deprecating a domain, so the default behavior is not to do anything if workflow history exists. We also want to keep the original behavior to deprecate a domain when we don't care workflow history in that domain.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
