### PR TITLE
Revert changing HistoryLength and CloseStatus to string

### DIFF
--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -13,8 +13,8 @@ frontend.validSearchAttributes:
       StartTime: 2
       ExecutionTime: 2
       CloseTime: 2
-      CloseStatus: 1
-      HistoryLength: 1
+      CloseStatus: 2
+      HistoryLength: 2
       TaskList: 1
       CustomStringField: 0
       CustomKeywordField: 1


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Reverted previous change 

<!-- Tell your future self why have you made these changes -->
**Why?**

The change happened due to a bad understanding of the dynamic config mappings. The underlying issue is that these search attributes are defined as integers in ES and most of the code but the FrontEnd does not have `integer` defined so `long` is used instead. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

NA
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

NA
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
NA