### PR TITLE
Add persistence info to DescribeCluster API call

### DIFF
--- a/common/persistence/visibilityWrapper.go
+++ b/common/persistence/visibilityWrapper.go
@@ -65,7 +65,10 @@ func (v *visibilityManagerWrapper) Close() {
 }
 
 func (v *visibilityManagerWrapper) GetName() string {
-	return "visibilityManagerWrapper"
+	if v.esVisibilityManager != nil {
+		return v.esVisibilityManager.GetName()
+	}
+	return v.visibilityManager.GetName()
 }
 
 func (v *visibilityManagerWrapper) RecordWorkflowExecutionStarted(

--- a/common/types/admin.go
+++ b/common/types/admin.go
@@ -46,6 +46,7 @@ func (v *AddSearchAttributeRequest) GetSecurityToken() (o string) {
 type DescribeClusterResponse struct {
 	SupportedClientVersions *SupportedClientVersions `json:"supportedClientVersions,omitempty"`
 	MembershipInfo          *MembershipInfo          `json:"membershipInfo,omitempty"`
+	PersistenceInfo         *PersistenceInfo         `json:"persistenceInfo,omitempty"`
 }
 
 // GetSupportedClientVersions is an internal getter (TBD...)
@@ -275,6 +276,12 @@ func (v *MembershipInfo) GetRings() (o []*RingInfo) {
 		return v.Rings
 	}
 	return
+}
+
+// PersistenceInfo is an internal type which exposes persistence configuration
+type PersistenceInfo struct {
+	Name                      *string `json:"name,omitempty"`
+	AdvancedVisibilityEnabled *bool   `json:"advancedVisibilityEnabled,omitempty"`
 }
 
 // ResendReplicationTasksRequest is an internal type (TBD...)

--- a/common/types/admin.go
+++ b/common/types/admin.go
@@ -44,9 +44,9 @@ func (v *AddSearchAttributeRequest) GetSecurityToken() (o string) {
 
 // DescribeClusterResponse is an internal type (TBD...)
 type DescribeClusterResponse struct {
-	SupportedClientVersions *SupportedClientVersions `json:"supportedClientVersions,omitempty"`
-	MembershipInfo          *MembershipInfo          `json:"membershipInfo,omitempty"`
-	PersistenceInfo         *PersistenceInfo         `json:"persistenceInfo,omitempty"`
+	SupportedClientVersions *SupportedClientVersions    `json:"supportedClientVersions,omitempty"`
+	MembershipInfo          *MembershipInfo             `json:"membershipInfo,omitempty"`
+	PersistenceInfo         map[string]*PersistenceInfo `json:"persistenceInfo,omitempty"`
 }
 
 // GetSupportedClientVersions is an internal getter (TBD...)
@@ -278,10 +278,24 @@ func (v *MembershipInfo) GetRings() (o []*RingInfo) {
 	return
 }
 
-// PersistenceInfo is an internal type which exposes persistence configuration
+// PersistenceSetting is used to expose persistence engine settings
+type PersistenceSetting struct {
+	Key   string `json:"key,omitempty"`
+	Value string `json:"value,omitempty"`
+}
+
+// PersistenceFeature is used to expose store specific feature.
+// Feature can be cadence or store specific.
+type PersistenceFeature struct {
+	Key     string `json:"key,omitempty"`
+	Enabled bool   `json:"enabled,omitempty"`
+}
+
+// PersistenceInfo is used to expose store configuration
 type PersistenceInfo struct {
-	Name                      *string `json:"name,omitempty"`
-	AdvancedVisibilityEnabled *bool   `json:"advancedVisibilityEnabled,omitempty"`
+	Backend  string                `json:"backend,omitempty"`
+	Settings []*PersistenceSetting `json:"settings,omitempty"`
+	Features []*PersistenceFeature `json:"features,omitempty"`
 }
 
 // ResendReplicationTasksRequest is an internal type (TBD...)

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -513,7 +513,14 @@ func (adh *adminHandlerImpl) DescribeCluster(
 	scope, sw := adh.startRequestProfile(metrics.AdminGetWorkflowExecutionRawHistoryV2Scope)
 	defer sw.Stop()
 
-	membershipInfo := &types.MembershipInfo{}
+	persistenceName := adh.Resource.GetVisibilityManager().GetName()
+	advancedVisibilityEnabled := adh.params.ESConfig != nil
+	persistenceInfo := types.PersistenceInfo{
+		Name:                      &persistenceName,
+		AdvancedVisibilityEnabled: &advancedVisibilityEnabled,
+	}
+
+	membershipInfo := types.MembershipInfo{}
 	if monitor := adh.GetMembershipMonitor(); monitor != nil {
 		currentHost, err := monitor.WhoAmI()
 		if err != nil {
@@ -559,7 +566,8 @@ func (adh *adminHandlerImpl) DescribeCluster(
 			GoSdk:   client.SupportedGoSDKVersion,
 			JavaSdk: client.SupportedJavaSDKVersion,
 		},
-		MembershipInfo: membershipInfo,
+		MembershipInfo:  &membershipInfo,
+		PersistenceInfo: &persistenceInfo,
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`DescribeCluster` API call will add `PersistenceInfo` to response.
To fully implement this feature, will update IDL and handler accordingly.

<!-- Tell your future self why have you made these changes -->
**Why?**
If we expose available persistence capabilities, it helps to decide if advanced UI features can be enabled.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
