### PR TITLE
Add debug info when List API is hititng ratelimiting/sampling

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -274,6 +274,7 @@ const (
 	// Value type: Int
 	// Default value: 1
 	// Allowed filters: DomainName
+	// Default value: 10
 	FrontendVisibilityListMaxQPS
 	// FrontendESVisibilityListMaxQPS is max qps frontend can list open/close workflows from ElasticSearch
 	// KeyName: frontend.esVisibilityListMaxQPS

--- a/common/persistence/visibilitySamplingClient.go
+++ b/common/persistence/visibilitySamplingClient.go
@@ -22,8 +22,6 @@ package persistence
 
 import (
 	"context"
-	"fmt"
-	"path/filepath"
 	"runtime"
 	"sync"
 
@@ -325,14 +323,15 @@ func getRequestPriority(request *RecordWorkflowExecutionClosedRequest) int {
 }
 
 func (p *visibilitySamplingClient) returnServiceBusyErrorForList(domainName string) error {
-	p.logger.Debug("List API request is being sampled", tag.WorkflowDomainName(domainName), tag.Name(caller(1)))
+	p.logger.Debug("List API request is being sampled", tag.WorkflowDomainName(domainName), tag.Name(callerFuncName(2)))
 	return errPersistenceLimitExceededForList
 }
 
-func caller(skip int) string {
-	_, path, lineno, ok := runtime.Caller(skip)
-	if !ok {
-		return ""
+func callerFuncName(skip int) string {
+	pc, _, _, ok := runtime.Caller(skip)
+	details := runtime.FuncForPC(pc)
+	if ok && details != nil {
+		return details.Name()
 	}
-	return fmt.Sprintf("%v:%v", filepath.Base(path), lineno)
+	return ""
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add debug info when List API is hititng ratelimiting/sampling

<!-- Tell your future self why have you made these changes -->
**Why?**
This has been an ongoing forever complaining from Cadence users: https://github.com/uber/cadence/issues/3900#issuecomment-765246025

Even though we have increased the default to 10.

I need a better way to help users to debug it. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test(reduce the default maxQPS to 1 and enable debug logs:
```
{"level":"debug","ts":"2021-04-15T23:30:50.086-0700","msg":"List API request consumed QPS token","service":"cadence-frontend","wf-domain-name":"samples-domain","name":"github.com/uber/cadence/common/persistence.(*visibilitySamplingClient).ListClosedWorkflowExecutions","logging-call-at":"visibilitySamplingClient.go:328"}
```
and
```
{"level":"debug","ts":"2021-04-15T19:00:21.956-0700","msg":"List API request is being sampled","service":"cadence-frontend","wf-domain-name":"samples-domain","name":"github.com/uber/cadence/common/persistence.(*visibilitySamplingClient).ListClosedWorkflowExecutions","logging-call-at":"visibilitySamplingClient.go:326"}
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
