### PR TITLE
Fixing typos in README.md File

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -26,7 +26,7 @@ docker pull ubercadence/server:master-auto-setup
 
 Using different docker-compose files
 -----------------------
-By default `docker-compose up` will run with `docker-compose.yaml` in this folder.
+By default `docker-compose up` will run with `docker-compose.yml` in this folder.
 This compose file is running with Cassandra, with basic visibility, 
 using Prometheus for emitting metric, with Grafana access. 
 
@@ -36,7 +36,7 @@ We also provide several other compose files for different features/modes:
 * docker-compose-es.yml enables advanced visibility with ElasticSearch 6.x
 * docker-compose-es-v7.yml enables advanced visibility with ElasticSearch 7.x
 * docker-compose-mysql.yml uses MySQL as persistence storage
-* docker-compose-postgres.yml uses PosstgreSQL as persistence storage
+* docker-compose-postgres.yml uses PostgreSQL as persistence storage
 * docker-compose-statsd.yaml runs with Statsd+Graphite
 * docker-compose-multiclusters.yaml runs with 2 cadence clusters
 

--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -291,7 +291,7 @@ func (d *domainCLIImpl) DeprecateDomain(c *cli.Context) {
 	defer cancel()
 
 	if !force {
-	// check if there is any workflow in this domain, if exists, do not deprecate
+		// check if there is any workflow in this domain, if exists, do not deprecate
 		wfs, _ := listClosedWorkflow(getWorkflowClient(c), 1, 0, time.Now().UnixNano(), "", "", workflowStatusNotSet, nil, c)
 		if len(wfs) > 0 {
 			ErrorAndExit("Operation DeprecateDomain failed.", errors.New("Workflow history not cleared in this domain."))

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -180,7 +180,7 @@ var (
 			Usage: "Optional token for security check",
 		},
 		cli.BoolFlag{
-			Name: FlagForce,
+			Name:  FlagForce,
 			Usage: "Deprecate domain regardless of domain history.",
 		},
 	}

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -453,3 +453,4 @@ func getConfigDir(c *cli.Context) string {
 	}
 	return dirPath
 }
+


### PR DESCRIPTION
**Describe what has changed in this PR** 
`README.md` was modified, 2 words typos were fixed. The first one, the `docker-compose.yaml` file doesn't match with the actual filename and the second one, `PosstgreSQL`, was fixed (an extra s in the name)

Also, the linter modified to files so I commited them too.

**Tell your future self why have you made these changes**
To point to the right file and to have the right database name.


**How have you verified this change? Tested locally? Added a unit test? Checked in staging env?** 
No need to verified this change, it's a readme file


**Assuming the worst case, what can be broken when deploying this change to production?**
Nothing

**Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md**
No

**Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs**
No
