### PR TITLE
Set grpc ports in docker config template

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -112,6 +112,7 @@ services:
     frontend:
         rpc:
             port: {{ default .Env.FRONTEND_PORT "7933" }}
+            grpcPort: {{ default .Env.GRPC_FRONTEND_PORT "7833" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
         {{- if .Env.STATSD_ENDPOINT }}
         metrics:
@@ -133,6 +134,7 @@ services:
     matching:
         rpc:
             port: {{ default .Env.MATCHING_PORT "7935" }}
+            grpcPort: {{ default .Env.GRPC_MATCHING_PORT "7835" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
         {{- if .Env.STATSD_ENDPOINT }}
         metrics:
@@ -154,6 +156,7 @@ services:
     history:
         rpc:
             port: {{ default .Env.HISTORY_PORT "7934" }}
+            grpcPort: {{ default .Env.GRPC_HISTORY_PORT "7834" }}
             bindOnIP: {{ default .Env.BIND_ON_IP "127.0.0.1" }}
         {{- if .Env.STATSD_ENDPOINT }}
         metrics:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set grpc ports in docker config template

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix `GRPC port not configured for service` error

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
