### PR TITLE
Fix race condition in task re-dispatcher test

### DIFF
--- a/service/history/task/redispatcher_test.go
+++ b/service/history/task/redispatcher_test.go
@@ -90,7 +90,7 @@ func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
 			close(stopDoneCh)
 		}()
 
-		<-stopDoneCh
+		<-s.redispatcher.shutdownCh
 		return false, errors.New("processor shutdown")
 	}).Times(1)
 
@@ -101,6 +101,7 @@ func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
 	}
 
 	s.Equal(numTasks, s.redispatcher.Size())
+	<-s.redispatcher.shutdownCh
 	<-stopDoneCh
 
 	s.Equal(numTasks-successfullyRedispatched-1, s.redispatcher.Size())

--- a/service/history/task/redispatcher_test.go
+++ b/service/history/task/redispatcher_test.go
@@ -90,7 +90,7 @@ func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
 			close(stopDoneCh)
 		}()
 
-		<-s.redispatcher.shutdownCh
+		<-stopDoneCh
 		return false, errors.New("processor shutdown")
 	}).Times(1)
 
@@ -101,7 +101,6 @@ func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
 	}
 
 	s.Equal(numTasks, s.redispatcher.Size())
-	<-s.redispatcher.shutdownCh
 	<-stopDoneCh
 
 	s.Equal(numTasks-successfullyRedispatched-1, s.redispatcher.Size())

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -453,4 +453,3 @@ func getConfigDir(c *cli.Context) string {
 	}
 	return dirPath
 }
-


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix race condition in task re-dispatcher test

<!-- Tell your future self why have you made these changes -->
**Why?**
```
=== RUN   TestRedispatcherSuite/TestRedispatch_ProcessorShutDown

==================

WARNING: DATA RACE

Read at 0x00c000b50443 by goroutine 33:

  testing.(*common).logDepth()

      /usr/local/go/src/testing/testing.go:665 +0xa1

  testing.(*common).Logf()

      /usr/local/go/src/testing/testing.go:658 +0x8f

  testing.(*T).Logf()

      <autogenerated>:1 +0x75

  go.uber.org/zap/zaptest.testingWriter.Write()

      /go/pkg/mod/go.uber.org/zap@v1.13.0/zaptest/logger.go:130 +0x11f

  go.uber.org/zap/zaptest.(*testingWriter).Write()

      <autogenerated>:1 +0xa9

  go.uber.org/zap/zapcore.(*ioCore).Write()

      /go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/core.go:90 +0x1c3

  go.uber.org/zap/zapcore.(*CheckedEntry).Write()

      /go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/entry.go:216 +0x1e7

  go.uber.org/zap.(*Logger).Info()

      /go/pkg/mod/go.uber.org/zap@v1.13.0/logger.go:187 +0x95

  github.com/uber/cadence/common/log/loggerimpl.(*loggerImpl).Info()

      /cadence/common/log/loggerimpl/logger.go:119 +0xfb

  github.com/uber/cadence/service/history/task.(*redispatcherImpl).Stop()

      /cadence/service/history/task/redispatcher.go:118 +0x253

  github.com/uber/cadence/service/history/task.(*redispatcherSuite).TestRedispatch_ProcessorShutDown.func1.1()

      /cadence/service/history/task/redispatcher_test.go:88 +0x50



Previous write at 0x00c000b50443 by goroutine 30:

  testing.tRunner.func1()

      /usr/local/go/src/testing/testing.go:900 +0x353

  testing.tRunner()

      /usr/local/go/src/testing/testing.go:913 +0x1bb
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`go test -run TestRedispatcherSuite -race -count=100`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
