### PR TITLE
Assign CLI version on CLI commands

### DIFF
--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -36,6 +36,7 @@ import (
 	"github.com/uber/cadence/client/admin"
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
+	cc "github.com/uber/cadence/common/client"
 )
 
 const (
@@ -121,6 +122,8 @@ type versionMiddleware struct {
 }
 
 func (vm *versionMiddleware) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
-	request.Headers = request.Headers.With(common.ClientImplHeaderName, "cli")
+	request.Headers = request.Headers.
+		With(common.ClientImplHeaderName, cc.CLI).
+		With(common.FeatureVersionHeaderName, cc.SupportedCLIVersion)
 	return out.Call(ctx, request)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
CLI commands are sent without any version. This means with CLI commands, we always get the most legacy behavior. With this change we will send the current go-client version to get the most updated behavior. If the user's CLI is old, their cli will send their request with their version.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
window1:
~/cadence$ ./cadence-server start

window2: 
~/cadence-samples$ ./bin/helloworld -m worker

window3: 
~/cadence-samples$ ./bin/helloworld -m trigger
<take the worflow id from window3>

window4:
~/cadence$ ./cadence --do samples-domain wf signal --wid helloworld_7d9b5833-d821-4889-9b17-40b2627c6f9d --name signal_test
Error: Signal workflow failed.
Error Details: WorkflowExecutionAlreadyCompletedError{Message: workflow execution already completed}
('export CADENCE_CLI_SHOW_STACKS=1' to see stack traces)

<without versioning we get EntityNotExistsError which is the legacy error type>
```


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
