### PR TITLE
Checkout idls if folder is empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ THRIFT_GEN := $(subst idls/thrift/,.build/,$(THRIFT_FILES))
 
 # thrift is done when all sub-thrifts are done
 $(BUILD)/thrift: $(THRIFT_GEN) | $(BUILD)
+	$(if $(THRIFT_GEN),,$(error "idls directory is empty, please use 'git submodule update idls/' to checkout submodule and retry"))  # thrift_gen or thrift_files, either should work fine
 	@touch $@
 
 # how to generate each thrift book-keeping file.

--- a/Makefile
+++ b/Makefile
@@ -254,6 +254,7 @@ $(BUILD)/protoc: $(PROTO_FILES) $(BIN)/$(PROTOC_VERSION_BIN) $(BIN)/protoc-gen-g
 .fake-thrift: | $(BIN) $(BUILD)
 	touch $(BIN)/thriftrw $(BIN)/thriftrw-plugin-yarpc
 	$(if $(THRIFT_GEN),touch $(THRIFT_GEN),) # maybe ignoring empty idl folder
+	touch $(BUILD)/thrift #skip thrift too
 
 # ====================================
 # other intermediates


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Checkout idls if folder is empty

<!-- Tell your future self why have you made these changes -->
**Why?**

After this https://github.com/uber/cadence/pull/4152 , the development is broken for people who start development on Cadence. 
The errors is:
```
proto/public: warning: directory does not exist.
uber/cadence/api/v1/history.proto: File not found.
uber/cadence/shared/v1/history.proto:27:1: Import "uber/cadence/api/v1/history.proto" was not found or had errors.
uber/cadence/shared/v1/history.proto:30:3: "api.v1.HistoryEvent" is not defined.
uber/cadence/shared/v1/history.proto:31:3: "api.v1.HistoryEvent" is not defined.
make: *** [.build/protoc] Error 1
```
If you checkout Cadence from beginning you will see it. 
This should be safe enough because if your idls is already checked out, this target won't do anything.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test

```
(qlong-make-check-idl)$make cadence-bench
if [ -z "" ]; then \
		git submodule update idls/; \
	fi
Submodule path 'idls': checked out '9cc53eec153e97be0868ece127be8b34e31866ee'
protoc...
.bin/copyright --verifyOnly
goimports...
...
```
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
na

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
na

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
na