### PR TITLE
Allow updating ElasticSearch only when adding new search attributes 

### DIFF
--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -187,23 +187,29 @@ func (adh *adminHandlerImpl) AddSearchAttribute(
 	}
 
 	searchAttr := request.GetSearchAttribute()
-	currentValidAttr, _ := adh.params.DynamicConfig.GetMapValue(
+	currentValidAttr, err := adh.params.DynamicConfig.GetMapValue(
 		dynamicconfig.ValidSearchAttributes, nil, definition.GetDefaultIndexedKeys())
-	for k, v := range searchAttr {
-		if definition.IsSystemIndexedKey(k) {
-			return adh.error(&types.BadRequestError{Message: fmt.Sprintf("Key [%s] is reserved by system", k)}, scope)
-		}
-		if _, exist := currentValidAttr[k]; exist {
-			return adh.error(&types.BadRequestError{Message: fmt.Sprintf("Key [%s] is already whitelist", k)}, scope)
-		}
-
-		currentValidAttr[k] = int(v)
+	if err != nil {
+		return adh.error(&types.InternalServiceError{Message: fmt.Sprintf("Failed to get dynamic config, err: %v", err)}, scope)
 	}
 
-	// update dynamic config
-	err := adh.params.DynamicConfig.UpdateValue(dynamicconfig.ValidSearchAttributes, currentValidAttr)
+	for keyName, valueType := range searchAttr {
+		if definition.IsSystemIndexedKey(keyName) {
+			return adh.error(&types.BadRequestError{Message: fmt.Sprintf("Key [%s] is reserved by system", keyName)}, scope)
+		}
+		if currValType, exist := currentValidAttr[keyName]; exist {
+			if currValType != int(valueType) {
+				return adh.error(&types.BadRequestError{Message: fmt.Sprintf("Key [%s] is already whitelisted as a different type", keyName)}, scope)
+			}
+			adh.GetLogger().Warn("Adding a search attribute that is already existing in dynamicconfig, it's probably a noop if ElasticSearch is already added. Here will re-do it on ElasticSearch.")
+		}
+		currentValidAttr[keyName] = int(valueType)
+	}
+
+	// update dynamic config. Until the DB based dynamic config is implemented, we shouldn't fail the updating.
+	err = adh.params.DynamicConfig.UpdateValue(dynamicconfig.ValidSearchAttributes, currentValidAttr)
 	if err != nil {
-		return adh.error(&types.InternalServiceError{Message: fmt.Sprintf("Failed to update dynamic config, err: %v", err)}, scope)
+		adh.GetLogger().Warn("Failed to update dynamicconfig. This is only useful in local dev environment. Please ignore this warn if this is in a real Cluster, because you dynamicconfig MUST be updated separately")
 	}
 
 	// update elasticsearch mapping, new added field will not be able to remove or update

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -495,7 +495,7 @@ func (s *adminHandlerSuite) Test_AddSearchAttribute_Validate() {
 					"testkey": 1,
 				},
 			},
-			Expected: &types.BadRequestError{Message: "Key [testkey] is already whitelist"},
+			Expected: &types.BadRequestError{Message: "Key [testkey] is already whitelisted as a different type"},
 		},
 	}
 	for _, testCase := range testCases2 {
@@ -506,16 +506,17 @@ func (s *adminHandlerSuite) Test_AddSearchAttribute_Validate() {
 		Name: "dynamic config update failed",
 		Request: &types.AddSearchAttributeRequest{
 			SearchAttribute: map[string]types.IndexedValueType{
-				"testkey2": 1,
+				"testkey2": -1,
 			},
 		},
-		Expected: &types.InternalServiceError{Message: "Failed to update dynamic config, err: error"},
+		Expected: &types.BadRequestError{Message: "Unknown value type, IndexedValueType(-1)"},
 	}
 	dynamicConfig.EXPECT().UpdateValue(dynamicconfig.ValidSearchAttributes, map[string]interface{}{
 		"testkey":  types.IndexedValueTypeKeyword,
-		"testkey2": 1,
+		"testkey2": -1,
 	}).Return(errors.New("error"))
-	s.Equal(dcUpdateTest.Expected, handler.AddSearchAttribute(ctx, dcUpdateTest.Request))
+	err := handler.AddSearchAttribute(ctx, dcUpdateTest.Request)
+	s.Equal(dcUpdateTest.Expected, err)
 
 	// ES operations tests
 	dynamicConfig.EXPECT().UpdateValue(gomock.Any(), gomock.Any()).Return(nil).Times(2)

--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -59,7 +59,7 @@ func AdminAddSearchAttribute(c *cli.Context) {
 	if err != nil {
 		ErrorAndExit("Add search attribute failed.", err)
 	}
-	fmt.Println("Success")
+	fmt.Println("Success. Note that for a multil-node Cadence cluster, DynamicConfig MUST be updated separately to whitelist the new attributes.")
 }
 
 // AdminDescribeCluster is used to dump information about the cluster


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow updating ElasticSearch only when adding new search attributes 


<!-- Tell your future self why have you made these changes -->
**Why?**
1. For https://github.com/uber/cadence/issues/4158 always attempting to update dynamic config doesn't work(like my K8s cluster doesn't allow it)
2. More Importantly! In a multi-node cluster, file based dynamic config will never work!! 

This has been a confusing part because LOTS of Cadence users thought that running this command is enough to add new search attributes. We should make it clear that they must update the dynamic config accordingly, unless it's a onebox env like docker-compose. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test

```
qlong@~/cadence:
(qlong-add-sattr)$./cadence adm cluster add-search-attr --search_attr_key user --search_attr_type 0
Are you trying to add key [user] with Type [String]? Y/N
y
Error: Add search attribute failed.
Error Details: BadRequestError{Message: Key [user] is already whitelisted as a different type}
('export CADENCE_CLI_SHOW_STACKS=1' to see stack traces)
qlong@~/cadence:
(qlong-add-sattr)$./cadence adm cluster add-search-attr --search_attr_key user --search_attr_type 1
Are you trying to add key [user] with Type [Keyword]? Y/N
y
Success. Note that for a multil-node Cadence cluster, DynamicConfig MUST be updated separately to whitelist the new attributes.
qlong@~/cadence:
(qlong-add-sattr)$./cadence adm cluster add-search-attr --search_attr_key user2 --search_attr_type 1
Are you trying to add key [user2] with Type [Keyword]? Y/N
y
Success. Note that for a multil-node Cadence cluster, DynamicConfig MUST be updated separately to whitelist the new attributes.
qlong@~/cadence:
(qlong-add-sattr)$./cadence adm cluster add-search-attr --search_attr_key user2 --search_attr_type 1
Are you trying to add key [user2] with Type [Keyword]? Y/N
y
Success. Note that for a multil-node Cadence cluster, DynamicConfig MUST be updated separately to whitelist the new attributes.
```
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**


<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
Will work on https://github.com/uber/cadence-docs/issues/34 after this changed is released
