### PR TITLE
Add Signal Name to Signal Metrics

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -43,6 +43,7 @@ const (
 	invariantType  = "invariantType"
 	kafkaPartition = "kafkaPartition"
 	transport      = "transport"
+	signalName     = "signalName"
 
 	domainAllValue = "all"
 	unknownValue   = "_unknown_"
@@ -152,4 +153,9 @@ func ThriftTransportTag() Tag {
 // GPRCTransportTag returns a new GRPC transport type tag.
 func GPRCTransportTag() Tag {
 	return simpleMetric{key: transport, value: transportGRPC}
+}
+
+// SignalNameTag returns a new SignalName tag
+func SignalNameTag(value string) Tag {
+	return metricWithUnknown(signalName, value)
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2108,6 +2108,10 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 	}, nil
 }
 
+func withSignalName(ctx context.Context, signalName string) context.Context {
+	return metrics.TagContext(ctx, metrics.SignalNameTag(signalName))
+}
+
 // SignalWorkflowExecution is used to send a signal event to running workflow execution.  This results in
 // WorkflowExecutionSignaled event recorded in the history and a decision task being created for the execution.
 func (wh *WorkflowHandler) SignalWorkflowExecution(
@@ -2116,6 +2120,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(
 ) (retError error) {
 	defer log.CapturePanic(wh.GetLogger(), &retError)
 
+	ctx = withSignalName(ctx, signalRequest.GetSignalName())
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendSignalWorkflowExecutionScope, signalRequest)
 	defer sw.Stop()
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding signalName as a tag to the signal metrics. This will help filtering signal metrics by signal name and create alerts. 

See https://t3.uberinternal.com/browse/CDNC-1232 for more details. 

Original ask was to include workflowType in the metric name but that doesn't seem to be accessible within the SignalWorkflowExecution requests. Instead of the workflowType signalName seems to be a good candidate. This approach needs to be discussed before landing, sending the changes first as the intro of the discussion.

<!-- Tell your future self why have you made these changes -->
**Why?**
This PR is from [this task](https://t3.uberinternal.com/browse/CDNC-1232) as a followup to the incident [here](https://incidents.uberinternal.com/incident/27d9dec4-a849-4242-b948-106f6dabf738)

The customer wants to trigger an alert whenwhen the signal metric shows abnormally. (e.g too much error, no signal, and signal spike abnormally)


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
