### PR TITLE
Expand workflowCompleted error to other APIs

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -737,7 +737,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 			FailedRequest: failRequest,
 		})
 		if err != nil {
-			return nil, wh.error(err, scope)
+			return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 		resp = &types.RecordActivityTaskHeartbeatResponse{CancelRequested: true}
 	} else {
@@ -746,7 +746,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 			HeartbeatRequest: heartbeatRequest,
 		})
 		if err != nil {
-			return nil, wh.error(err, scope)
+			return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	}
 
@@ -843,7 +843,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 			FailedRequest: failRequest,
 		})
 		if err != nil {
-			return nil, wh.error(err, scope)
+			return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 		resp = &types.RecordActivityTaskHeartbeatResponse{CancelRequested: true}
 	} else {
@@ -858,7 +858,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 			HeartbeatRequest: req,
 		})
 		if err != nil {
-			return nil, wh.error(err, scope)
+			return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	}
 
@@ -942,7 +942,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 			FailedRequest: failRequest,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	} else {
 		err = wh.GetHistoryClient().RespondActivityTaskCompleted(ctx, &types.HistoryRespondActivityTaskCompletedRequest{
@@ -950,7 +950,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 			CompleteRequest: completeRequest,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	}
 
@@ -1050,7 +1050,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 			FailedRequest: failRequest,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	} else {
 		req := &types.RespondActivityTaskCompletedRequest{
@@ -1064,7 +1064,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 			CompleteRequest: req,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	}
 
@@ -1147,7 +1147,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 		FailedRequest: failedRequest,
 	})
 	if err != nil {
-		return wh.error(err, scope)
+		return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 	}
 	return nil
 }
@@ -1249,7 +1249,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 		FailedRequest: req,
 	})
 	if err != nil {
-		return wh.error(err, scope)
+		return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 	}
 	return nil
 }
@@ -1332,7 +1332,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 			FailedRequest: failRequest,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	} else {
 		err = wh.GetHistoryClient().RespondActivityTaskCanceled(ctx, &types.HistoryRespondActivityTaskCanceledRequest{
@@ -1340,7 +1340,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 			CancelRequest: cancelRequest,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	}
 
@@ -1439,7 +1439,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 			FailedRequest: failRequest,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	} else {
 		req := &types.RespondActivityTaskCanceledRequest{
@@ -1453,7 +1453,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 			CancelRequest: req,
 		})
 		if err != nil {
-			return wh.error(err, scope)
+			return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 		}
 	}
 
@@ -1517,7 +1517,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 	}
 
 	if !wh.validIDLength(completeRequest.GetIdentity(), scope, domainName) {
-		return nil, wh.error(errIdentityTooLong, scope)
+		return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 	}
 
 	completedResp := &types.RespondDecisionTaskCompletedResponse{}
@@ -1622,7 +1622,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 		FailedRequest: failedRequest,
 	})
 	if err != nil {
-		return wh.error(err, scope)
+		return wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 	}
 	return nil
 }
@@ -3105,7 +3105,7 @@ func (wh *WorkflowHandler) ResetStickyTaskList(
 		Execution:  resetRequest.Execution,
 	})
 	if err != nil {
-		return nil, wh.error(err, scope)
+		return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 	}
 	return &types.ResetStickyTaskListResponse{}, nil
 }

--- a/service/history/decision/handler.go
+++ b/service/history/decision/handler.go
@@ -266,7 +266,7 @@ func (handler *handlerImpl) HandleDecisionTaskFailed(
 	return workflow.UpdateWithAction(ctx, handler.executionCache, domainID, workflowExecution, true, handler.timeSource.Now(),
 		func(context execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return workflow.ErrNotExists
+				return workflow.ErrAlreadyCompleted
 			}
 
 			scheduleID := token.ScheduleID
@@ -321,7 +321,7 @@ Update_History_Loop:
 			return nil, err
 		}
 		if !msBuilder.IsWorkflowExecutionRunning() {
-			return nil, workflow.ErrNotExists
+			return nil, workflow.ErrAlreadyCompleted
 		}
 		executionStats, err := wfContext.LoadExecutionStats(ctx)
 		if err != nil {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -1416,7 +1416,7 @@ func (e *historyEngineImpl) ResetStickyTaskList(
 	err := workflow.UpdateWithAction(ctx, e.executionCache, domainID, *resetRequest.Execution, false, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return workflow.ErrNotExists
+				return workflow.ErrAlreadyCompleted
 			}
 			mutableState.ClearStickyness()
 			return nil
@@ -1740,7 +1740,7 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(
 	err = workflow.UpdateWithAction(ctx, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return workflow.ErrNotExists
+				return workflow.ErrAlreadyCompleted
 			}
 
 			scheduleID := token.ScheduleID
@@ -1826,7 +1826,7 @@ func (e *historyEngineImpl) RespondActivityTaskFailed(
 		e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) (*workflow.UpdateAction, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return nil, workflow.ErrNotExists
+				return nil, workflow.ErrAlreadyCompleted
 			}
 
 			scheduleID := token.ScheduleID
@@ -1918,7 +1918,7 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(
 	err = workflow.UpdateWithAction(ctx, e.executionCache, domainID, workflowExecution, true, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
-				return workflow.ErrNotExists
+				return workflow.ErrAlreadyCompleted
 			}
 
 			scheduleID := token.ScheduleID
@@ -2007,7 +2007,7 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
 		func(wfContext execution.Context, mutableState execution.MutableState) error {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				e.logger.Debug("Heartbeat failed")
-				return workflow.ErrNotExists
+				return workflow.ErrAlreadyCompleted
 			}
 
 			scheduleID := token.ScheduleID


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Expand WorkflowExecutionAlreadyCompletedError across the other APIs that might return for consistency.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Will update here with some integration tests.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
