### PR TITLE
Expose max message size config for gRPC

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -94,6 +94,8 @@ type (
 		DisableLogging bool `yaml:"disableLogging"`
 		// LogLevel is the desired log level
 		LogLevel string `yaml:"logLevel"`
+		// GRPCMaxMsgSize allows overriding default (4MB) message size for gRPC
+		GRPCMaxMsgSize int `yaml:"grpcMaxMsgSize"`
 	}
 
 	// Blobstore contains the config for blobstore

--- a/common/config/rpc.go
+++ b/common/config/rpc.go
@@ -89,7 +89,12 @@ func (d *RPCFactory) createInboundDispatcher() *yarpc.Dispatcher {
 	inbounds = append(inbounds, d.ch.NewInbound())
 	d.logger.Info("Listening for TChannel requests", tag.Address(hostAddress))
 
-	d.grpc = grpc.NewTransport()
+	var options []grpc.TransportOption
+	if d.config.GRPCMaxMsgSize > 0 {
+		options = append(options, grpc.ServerMaxRecvMsgSize(d.config.GRPCMaxMsgSize))
+		options = append(options, grpc.ClientMaxRecvMsgSize(d.config.GRPCMaxMsgSize))
+	}
+	d.grpc = grpc.NewTransport(options...)
 	if d.config.GRPCPort > 0 {
 		grpcAddress := fmt.Sprintf("%v:%v", d.getListenIP(), d.config.GRPCPort)
 		listener, err := net.Listen("tcp", grpcAddress)

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -24,6 +24,7 @@ services:
       port: 7933
       grpcPort: 7833
       bindOnLocalHost: true
+      grpcMaxMsgSize: 33554432
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"
@@ -36,6 +37,7 @@ services:
       port: 7935
       grpcPort: 7835
       bindOnLocalHost: true
+      grpcMaxMsgSize: 33554432
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"
@@ -48,6 +50,7 @@ services:
       port: 7934
       grpcPort: 7834
       bindOnLocalHost: true
+      grpcMaxMsgSize: 33554432
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Expose configuration for setting max message size for gRPC. If specified it overrides the 4MB default.

<!-- Tell your future self why have you made these changes -->
**Why?**
In same cases Cadence may send big messages. Large page sizes combines with big blobs, can result in big messages.
This exposes a configuration to tune it if necessary.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Locally run cadence samples with high blob sizes, and checked how it reacts with this setting.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
