### PR TITLE
Fix docker-compose bug: publicClient is not valid and error

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -267,7 +267,7 @@ kafka:
             dlq-topic: {{ default .Env.VISIBILITY_NAME "cadence-visibility-dev" }}-dlq
 
 publicClient:
-    hostPort: {{ default .Env.FRONTEND_SERVICE "127.0.0.1" }}:{{ default .Env.FRONTEND_PORT "7933" }}
+    hostPort: {{ default .Env.FRONTEND_SERVICE "cadence" }}:{{ default .Env.FRONTEND_PORT "7933" }}
 
 dynamicConfigClient:
     filepath: {{ default .Env.DYNAMIC_CONFIG_FILE_PATH "/etc/cadence/config/dynamicconfig/development.yaml" }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix docker-compose bug: publicClient is not valid and error

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/4121

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test.
The error is gone after this change. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
