### PR TITLE
Update SQL task manager to support sharded SQL DB

### DIFF
--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -401,6 +401,7 @@ func (m *sqlTaskManager) CreateTasks(
 			return nil, err
 		}
 		currTasksRow := sqlplugin.TasksRow{
+			ShardID:      m.shardID(v.Data.DomainID, request.TaskListInfo.Name),
 			DomainID:     serialization.MustParseUUID(v.Data.DomainID),
 			TaskListName: request.TaskListInfo.Name,
 			TaskType:     int64(request.TaskListInfo.TaskType),
@@ -453,6 +454,7 @@ func (m *sqlTaskManager) GetTasks(
 	request *persistence.GetTasksRequest,
 ) (*persistence.InternalGetTasksResponse, error) {
 	rows, err := m.db.SelectFromTasks(ctx, &sqlplugin.TasksFilter{
+		ShardID:      m.shardID(request.DomainID, request.TaskList),
 		DomainID:     serialization.MustParseUUID(request.DomainID),
 		TaskListName: request.TaskList,
 		TaskType:     int64(request.TaskType),
@@ -493,6 +495,7 @@ func (m *sqlTaskManager) CompleteTask(
 	taskID := request.TaskID
 	taskList := request.TaskList
 	_, err := m.db.DeleteFromTasks(ctx, &sqlplugin.TasksFilter{
+		ShardID:      m.shardID(taskList.DomainID, taskList.Name),
 		DomainID:     serialization.MustParseUUID(taskList.DomainID),
 		TaskListName: taskList.Name,
 		TaskType:     int64(taskList.TaskType),
@@ -508,6 +511,7 @@ func (m *sqlTaskManager) CompleteTasksLessThan(
 	request *persistence.CompleteTasksLessThanRequest,
 ) (int, error) {
 	result, err := m.db.DeleteFromTasks(ctx, &sqlplugin.TasksFilter{
+		ShardID:              m.shardID(request.DomainID, request.TaskListName),
 		DomainID:             serialization.MustParseUUID(request.DomainID),
 		TaskListName:         request.TaskListName,
 		TaskType:             int64(request.TaskType),

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -170,6 +170,7 @@ type (
 
 	// TasksRow represents a row in tasks table
 	TasksRow struct {
+		ShardID      int
 		DomainID     serialization.UUID
 		TaskType     int64
 		TaskID       int64
@@ -198,6 +199,7 @@ type (
 	// TasksFilter contains the column names within tasks table that
 	// can be used to filter results through a WHERE clause
 	TasksFilter struct {
+		ShardID              int
 		DomainID             serialization.UUID
 		TaskListName         string
 		TaskType             int64


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update sql task manager to set shard ID for task and pass it down to sql plugins

<!-- Tell your future self why have you made these changes -->
**Why?**
When creating new tasks, we need to perform transactions across `tasks` and `task_lists` table.
In sharded SQL case, we need a shard id to ensure the transaction is within a shard.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
