### PR TITLE
Replace gRPC port when resolving host address

### DIFF
--- a/common/config/rpc.go
+++ b/common/config/rpc.go
@@ -127,12 +127,12 @@ func (d *RPCFactory) CreateGRPCDispatcherForOutbound(
 	serviceName string,
 	hostName string,
 ) (*yarpc.Dispatcher, error) {
-	grpcAddress, err := d.grpcPorts.GetGRPCAddress(serviceName, hostName)
-	if err != nil {
-		d.logger.Error("Failed to create GRPC outbound dispatcher", tag.Error(err))
-		return nil, err
-	}
-	return d.createOutboundDispatcher(callerName, serviceName, grpcAddress, d.grpc.NewSingleOutbound(grpcAddress))
+	return d.createOutboundDispatcher(callerName, serviceName, hostName, d.grpc.NewSingleOutbound(hostName))
+}
+
+// ReplaceGRPCPort replaces port in the address to grpc for a given service
+func (d *RPCFactory) ReplaceGRPCPort(serviceName, hostAddress string) (string, error) {
+	return d.grpcPorts.GetGRPCAddress(serviceName, hostAddress)
 }
 
 func (d *RPCFactory) createOutboundDispatcher(

--- a/common/rpc.go
+++ b/common/rpc.go
@@ -56,6 +56,7 @@ type (
 		GetDispatcher() *yarpc.Dispatcher
 		CreateDispatcherForOutbound(callerName, serviceName, hostName string) (*yarpc.Dispatcher, error)
 		CreateGRPCDispatcherForOutbound(callerName, serviceName, hostName string) (*yarpc.Dispatcher, error)
+		ReplaceGRPCPort(serviceName, hostAddress string) (string, error)
 	}
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Instead of replacing gRPC port when creating an outbound dispatcher - replace it earlier, when resolving target host address.

<!-- Tell your future self why have you made these changes -->
**Why?**
Otherwise non-replaced ip:thrift port is used as cache key. Which not correct for dynamic grpc ports. For example when host is restarted and assigned different gRPC port, but cache still holds the old dispatcher.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Confirmed on staging2.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
