### PR TITLE
Improve error handling for SQL persistence implementation

### DIFF
--- a/common/persistence/sql/sqlExecutionManagerUtil.go
+++ b/common/persistence/sql/sqlExecutionManagerUtil.go
@@ -61,14 +61,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runID,
 		workflowMutation.Condition); err != nil {
-		switch err.(type) {
-		case *p.ConditionFailedError:
-			return err
-		default:
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("applyWorkflowMutationTx failed. Failed to lock executions row. Error: %v", err),
-			}
-		}
+		return err
 	}
 
 	if err := updateExecution(
@@ -80,9 +73,7 @@ func applyWorkflowMutationTx(
 		lastWriteVersion,
 		shardID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Failed to update executions row. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := applyTasks(
@@ -111,9 +102,7 @@ func applyWorkflowMutationTx(
 		runID,
 		parser,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateTimerInfos(
@@ -127,9 +116,7 @@ func applyWorkflowMutationTx(
 		runID,
 		parser,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateChildExecutionInfos(
@@ -143,9 +130,7 @@ func applyWorkflowMutationTx(
 		runID,
 		parser,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateRequestCancelInfos(
@@ -159,9 +144,7 @@ func applyWorkflowMutationTx(
 		runID,
 		parser,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateSignalInfos(
@@ -175,9 +158,7 @@ func applyWorkflowMutationTx(
 		runID,
 		parser,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateSignalsRequested(
@@ -190,9 +171,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runID,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-		}
+		return err
 	}
 
 	if workflowMutation.ClearBufferedEvents {
@@ -204,9 +183,7 @@ func applyWorkflowMutationTx(
 			workflowID,
 			runID,
 		); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-			}
+			return err
 		}
 	}
 
@@ -219,9 +196,7 @@ func applyWorkflowMutationTx(
 		workflowID,
 		runID,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowMutationTx failed. Error: %v", err),
-		}
+		return err
 	}
 	return nil
 }
@@ -251,14 +226,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID,
 		workflowSnapshot.Condition); err != nil {
-		switch err.(type) {
-		case *p.ConditionFailedError:
-			return err
-		default:
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to lock executions row. Error: %v", err),
-			}
-		}
+		return err
 	}
 
 	if err := updateExecution(
@@ -270,9 +238,7 @@ func applyWorkflowSnapshotTxAsReset(
 		lastWriteVersion,
 		shardID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to update executions row. Erorr: %v", err),
-		}
+		return err
 	}
 
 	if err := applyTasks(
@@ -297,9 +263,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear activity info map. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateActivityInfos(
@@ -312,9 +276,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := deleteTimerInfoMap(
@@ -324,9 +286,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear timer info map. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateTimerInfos(
@@ -339,9 +299,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into timer info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := deleteChildExecutionInfoMap(
@@ -351,9 +309,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear child execution info map. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateChildExecutionInfos(
@@ -366,9 +322,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into activity info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := deleteRequestCancelInfoMap(
@@ -378,9 +332,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear request cancel info map. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateRequestCancelInfos(
@@ -393,9 +345,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into request cancel info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := deleteSignalInfoMap(
@@ -405,9 +355,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signal info map. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateSignalInfos(
@@ -420,9 +368,7 @@ func applyWorkflowSnapshotTxAsReset(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signal info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := deleteSignalsRequestedSet(
@@ -432,9 +378,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear signals requested set. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateSignalsRequested(
@@ -446,9 +390,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to insert into signals requested set after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := deleteBufferedEvents(
@@ -458,9 +400,7 @@ func applyWorkflowSnapshotTxAsReset(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsReset failed. Failed to clear buffered events. Error: %v", err),
-		}
+		return err
 	}
 	return nil
 }
@@ -518,9 +458,7 @@ func (m *sqlExecutionManager) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateTimerInfos(
@@ -533,9 +471,7 @@ func (m *sqlExecutionManager) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into timer info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateChildExecutionInfos(
@@ -548,9 +484,7 @@ func (m *sqlExecutionManager) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into activity info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateRequestCancelInfos(
@@ -563,9 +497,7 @@ func (m *sqlExecutionManager) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into request cancel info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateSignalInfos(
@@ -578,9 +510,7 @@ func (m *sqlExecutionManager) applyWorkflowSnapshotTxAsNew(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signal info map after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := updateSignalsRequested(
@@ -592,9 +522,7 @@ func (m *sqlExecutionManager) applyWorkflowSnapshotTxAsNew(
 		domainID,
 		workflowID,
 		runID); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyWorkflowSnapshotTxAsNew failed. Failed to insert into signals requested set after clearing. Error: %v", err),
-		}
+		return err
 	}
 
 	return nil
@@ -622,9 +550,7 @@ func applyTasks(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyTasks failed. Failed to create transfer tasks. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := createReplicationTasks(
@@ -637,9 +563,7 @@ func applyTasks(
 		runID,
 		parser,
 	); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyTasks failed. Failed to create replication tasks. Error: %v", err),
-		}
+		return err
 	}
 
 	if err := createTimerTasks(
@@ -651,9 +575,7 @@ func applyTasks(
 		workflowID,
 		runID,
 		parser); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("applyTasks failed. Failed to create timer tasks. Error: %v", err),
-		}
+		return err
 	}
 
 	return nil
@@ -676,9 +598,7 @@ func lockCurrentExecutionIfExists(
 	})
 	if err != nil {
 		if err != sql.ErrNoRows {
-			return nil, &types.InternalServiceError{
-				Message: fmt.Sprintf("lockCurrentExecutionIfExists failed. Failed to get current_executions row for (shard,domain,workflow) = (%v, %v, %v). Error: %v", shardID, domainID, workflowID, err),
-			}
+			return nil, convertCommonErrors(tx, "lockCurrentExecutionIfExists", fmt.Sprintf("Failed to get current_executions row for (shard,domain,workflow) = (%v, %v, %v).", shardID, domainID, workflowID), err)
 		}
 	}
 	size := len(rows)
@@ -734,9 +654,7 @@ func createOrUpdateCurrentExecution(
 			closeStatus,
 			row.StartVersion,
 			row.LastWriteVersion); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to continue as new. Error: %v", err),
-			}
+			return err
 		}
 	case p.CreateWorkflowModeWorkflowIDReuse:
 		if err := updateCurrentExecution(
@@ -751,15 +669,11 @@ func createOrUpdateCurrentExecution(
 			closeStatus,
 			row.StartVersion,
 			row.LastWriteVersion); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to reuse workflow ID. Error: %v", err),
-			}
+			return err
 		}
 	case p.CreateWorkflowModeBrandNew:
 		if _, err := tx.InsertIntoCurrentExecutions(ctx, &row); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("createOrUpdateCurrentExecution failed. Failed to insert into current_executions table. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "createOrUpdateCurrentExecution", "Failed to insert into current_executions table.", err)
 		}
 	case p.CreateWorkflowModeZombie:
 		// noop
@@ -827,9 +741,7 @@ func lockNextEventID(
 				),
 			}
 		}
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("lockNextEventID failed. Error: %v", err),
-		}
+		return nil, convertCommonErrors(tx, "lockNextEventID", "", err)
 	}
 	result := int64(nextEventID)
 	return &result, nil
@@ -924,9 +836,7 @@ func createTransferTasks(
 
 	result, err := tx.InsertIntoTransferTasks(ctx, transferTasksRows)
 	if err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("createTransferTasks failed. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "createTransferTasks", "", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
@@ -1022,9 +932,7 @@ func createReplicationTasks(
 
 	result, err := tx.InsertIntoReplicationTasks(ctx, replicationTasksRows)
 	if err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("createReplicationTasks failed. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "createReplicationTasks", "", err)
 	}
 
 	rowsAffected, err := result.RowsAffected()
@@ -1116,9 +1024,7 @@ func createTimerTasks(
 
 	result, err := tx.InsertIntoTimerTasks(ctx, timerTasksRows)
 	if err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("createTimerTasks failed. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "createTimerTasks", "", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -1154,9 +1060,7 @@ func assertNotCurrentExecution(
 			// allow bypassing no current record
 			return nil
 		}
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "assertCurrentExecution", "Unable to load current record.", err)
 	}
 	return assertRunIDMismatch(runID, currentRow.RunID)
 }
@@ -1256,9 +1160,7 @@ func assertCurrentExecution(
 		WorkflowID: workflowID,
 	})
 	if err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("assertCurrentExecution failed. Unable to load current record. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "assertCurrentExecution", "Unable to load current record.", err)
 	}
 	return assertFn(currentRow)
 }
@@ -1301,9 +1203,7 @@ func updateCurrentExecution(
 		LastWriteVersion: lastWriteVersion,
 	})
 	if err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("updateCurrentExecution failed. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "updateCurrentExecution", "", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -1466,9 +1366,7 @@ func (m *sqlExecutionManager) createExecution(
 				LastWriteVersion: row.LastWriteVersion,
 			}
 		}
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("createExecution failed. Erorr: %v", err),
-		}
+		return convertCommonErrors(tx, "createExecution", "", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
@@ -1519,9 +1417,7 @@ func updateExecution(
 	}
 	result, err := tx.UpdateExecutions(ctx, row)
 	if err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("updateExecution failed. Erorr: %v", err),
-		}
+		return convertCommonErrors(tx, "updateExecution", "", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -143,7 +143,7 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 		if m.db.IsDupEntryError(err) {
 			return &p.ConditionFailedError{Msg: fmt.Sprintf("AppendHistoryNodes: row already exist: %v", err)}
 		}
-		return &types.InternalServiceError{Message: fmt.Sprintf("AppendHistoryEvents: %v", err)}
+		return convertCommonErrors(m.db, "AppendHistoryEvents", "", err)
 	}
 	return nil
 }
@@ -353,14 +353,14 @@ func (m *sqlHistoryV2Manager) ForkHistoryBranch(
 	}
 	result, err := m.db.InsertIntoHistoryTree(ctx, row)
 	if err != nil {
-		return nil, err
+		return nil, convertCommonErrors(m.db, "ForkHistoryBranch", "", err)
 	}
 	rowsAffected, err := result.RowsAffected()
 	if err != nil {
 		return nil, err
 	}
 	if rowsAffected != 1 {
-		return nil, fmt.Errorf("expected 1 row to be affected for tree table, got %v", rowsAffected)
+		return nil, types.InternalServiceError{Message: fmt.Sprintf("expected 1 row to be affected for tree table, got %v", rowsAffected)}
 	}
 	return resp, nil
 }

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -781,6 +781,8 @@ type (
 	// Tx defines the API for a SQL transaction
 	Tx interface {
 		tableCRUD
+		ErrorChecker
+
 		Commit() error
 		Rollback() error
 	}
@@ -788,10 +790,10 @@ type (
 	// DB defines the API for regular SQL operations of a Cadence server
 	DB interface {
 		tableCRUD
+		ErrorChecker
 
 		BeginTx(ctx context.Context) (Tx, error)
 		PluginName() string
-		IsDupEntryError(err error) bool
 		Close() error
 	}
 
@@ -800,5 +802,12 @@ type (
 		adminCRUD
 		PluginName() string
 		Close() error
+	}
+
+	ErrorChecker interface {
+		IsDupEntryError(err error) bool
+		IsNotFoundError(err error) bool
+		IsTimeoutError(err error) bool
+		IsThrottlingError(err error) bool
 	}
 )

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -24,7 +24,6 @@ package sql
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
@@ -102,9 +101,7 @@ func updateActivityInfos(
 		}
 
 		if _, err := tx.ReplaceIntoActivityInfoMaps(ctx, rows); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update activity info. Failed to execute update query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateActivityInfos", "Failed to execute update query.", err)
 		}
 	}
 
@@ -116,9 +113,7 @@ func updateActivityInfos(
 			RunID:      runID,
 			ScheduleID: &deleteInfo,
 		}); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update activity info. Failed to execute delete query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateActivityInfos", "Failed to execute delete query.", err)
 		}
 	}
 
@@ -142,9 +137,7 @@ func getActivityInfoMap(
 		RunID:      runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to get activity info. Error: %v", err),
-		}
+		return nil, convertCommonErrors(db, "getActivityInfoMap", "", err)
 	}
 
 	ret := make(map[int64]*persistence.InternalActivityInfo)
@@ -211,9 +204,7 @@ func deleteActivityInfoMap(
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to delete activity info map. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "deleteActivityInfoMap", "", err)
 	}
 	return nil
 }
@@ -256,9 +247,7 @@ func updateTimerInfos(
 			}
 		}
 		if _, err := tx.ReplaceIntoTimerInfoMaps(ctx, rows); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update timer info. Failed to execute update query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateTimerInfos", "Failed to execute update query.", err)
 		}
 	}
 
@@ -270,9 +259,7 @@ func updateTimerInfos(
 			RunID:      runID,
 			TimerID:    &deleteInfo,
 		}); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update timer info. Failed to execute delete query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateTimerInfos", "Failed to execute delete query.", err)
 		}
 	}
 
@@ -296,9 +283,7 @@ func getTimerInfoMap(
 		RunID:      runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to get timer info. Error: %v", err),
-		}
+		return nil, convertCommonErrors(db, "getTimerInfoMap", "", err)
 	}
 	ret := make(map[string]*persistence.TimerInfo)
 	for _, row := range rows {
@@ -336,9 +321,7 @@ func deleteTimerInfoMap(
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to delete timer info map. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "deleteTimerInfoMap", "", err)
 	}
 	return nil
 }
@@ -391,9 +374,7 @@ func updateChildExecutionInfos(
 			}
 		}
 		if _, err := tx.ReplaceIntoChildExecutionInfoMaps(ctx, rows); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update child execution info. Failed to execute update query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateChildExecutionInfos", "Failed to execute update query.", err)
 		}
 	}
 
@@ -405,9 +386,7 @@ func updateChildExecutionInfos(
 			RunID:       runID,
 			InitiatedID: common.Int64Ptr(deleteInfo),
 		}); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update child execution info. Failed to execute delete query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateChildExecutionInfos", "Failed to execute delete query.", err)
 		}
 	}
 
@@ -431,9 +410,7 @@ func getChildExecutionInfoMap(
 		RunID:      runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to get timer info. Error: %v", err),
-		}
+		return nil, convertCommonErrors(db, "getChildExecutionInfoMap", "", err)
 	}
 
 	ret := make(map[int64]*persistence.InternalChildExecutionInfo)
@@ -481,9 +458,7 @@ func deleteChildExecutionInfoMap(
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to delete timer info map. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "deleteChildExecutionInfoMap", "", err)
 	}
 	return nil
 }
@@ -523,9 +498,7 @@ func updateRequestCancelInfos(
 		}
 
 		if _, err := tx.ReplaceIntoRequestCancelInfoMaps(ctx, rows); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update request cancel info. Failed to execute update query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateRequestCancelInfos", "Failed to execute update query.", err)
 		}
 	}
 
@@ -537,9 +510,7 @@ func updateRequestCancelInfos(
 			RunID:       runID,
 			InitiatedID: common.Int64Ptr(deleteInfo),
 		}); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update request cancel info. Failed to execute delete query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateRequestCancelInfos", "Failed to execute delete query.", err)
 		}
 	}
 
@@ -563,9 +534,7 @@ func getRequestCancelInfoMap(
 		RunID:      runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to get request cancel info. Error: %v", err),
-		}
+		return nil, convertCommonErrors(db, "getRequestCancelInfoMap", "", err)
 	}
 
 	ret := make(map[int64]*persistence.RequestCancelInfo)
@@ -600,9 +569,7 @@ func deleteRequestCancelInfoMap(
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to delete request cancel info map. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "deleteRequestCancelInfoMap", "", err)
 	}
 	return nil
 }
@@ -645,9 +612,7 @@ func updateSignalInfos(
 		}
 
 		if _, err := tx.ReplaceIntoSignalInfoMaps(ctx, rows); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update signal info. Failed to execute update query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateSignalInfos", "Failed to execute update query.", err)
 		}
 	}
 
@@ -659,9 +624,7 @@ func updateSignalInfos(
 			RunID:       runID,
 			InitiatedID: common.Int64Ptr(deleteInfo),
 		}); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update signal info. Failed to execute delete query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateSignalInfos", "Failed to execute delete query.", err)
 		}
 	}
 
@@ -685,9 +648,7 @@ func getSignalInfoMap(
 		RunID:      runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to get signal info. Error: %v", err),
-		}
+		return nil, convertCommonErrors(db, "getSignalInfoMap", "", err)
 	}
 
 	ret := make(map[int64]*persistence.SignalInfo)
@@ -725,9 +686,7 @@ func deleteSignalInfoMap(
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to delete signal info map. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "deleteSignalInfoMap", "", err)
 	}
 	return nil
 }

--- a/common/persistence/sql/workflowStateNonMaps.go
+++ b/common/persistence/sql/workflowStateNonMaps.go
@@ -24,13 +24,11 @@ package sql
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/uber/cadence/common"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/serialization"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
-	"github.com/uber/cadence/common/types"
 )
 
 func updateSignalsRequested(
@@ -56,9 +54,7 @@ func updateSignalsRequested(
 			}
 		}
 		if _, err := tx.InsertIntoSignalsRequestedSets(ctx, rows); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update signals requested. Failed to execute update query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateSignalsRequested", "Failed to execute update query.", err)
 		}
 	}
 
@@ -70,9 +66,7 @@ func updateSignalsRequested(
 			RunID:      runID,
 			SignalID:   common.StringPtr(deldeleteSignalRequestID),
 		}); err != nil {
-			return &types.InternalServiceError{
-				Message: fmt.Sprintf("Failed to update signals requested. Failed to execute delete query. Error: %v", err),
-			}
+			return convertCommonErrors(tx, "updateSignalsRequested", "Failed to execute delete query.", err)
 		}
 	}
 
@@ -95,9 +89,7 @@ func getSignalsRequested(
 		RunID:      runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to get signals requested. Error: %v", err),
-		}
+		return nil, convertCommonErrors(db, "getSignalsRequested", "", err)
 	}
 	var ret = make(map[string]struct{})
 	for _, s := range rows {
@@ -121,9 +113,7 @@ func deleteSignalsRequestedSet(
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("Failed to delete signals requested set. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "deleteSignalsRequestedSet", "", err)
 	}
 	return nil
 }
@@ -151,9 +141,7 @@ func updateBufferedEvents(
 	}
 
 	if _, err := tx.InsertIntoBufferedEvents(ctx, []sqlplugin.BufferedEventsRow{row}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("updateBufferedEvents operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "updateBufferedEvents", "", err)
 	}
 	return nil
 }
@@ -174,9 +162,7 @@ func getBufferedEvents(
 		RunID:      runID,
 	})
 	if err != nil && err != sql.ErrNoRows {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("getBufferedEvents operation failed. Select failed: %v", err),
-		}
+		return nil, convertCommonErrors(db, "getBufferedEvents", "", err)
 	}
 	var result []*p.DataBlob
 	for _, row := range rows {
@@ -200,9 +186,7 @@ func deleteBufferedEvents(
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}); err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("updateBufferedEvents delete operation failed. Error: %v", err),
-		}
+		return convertCommonErrors(tx, "deleteBufferedEvents", "", err)
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	cloud.google.com/go/storage v1.6.0
 	github.com/DataDog/zstd v1.4.0 // indirect
 	github.com/Shopify/sarama v1.23.0
+	github.com/VividCortex/mysqlerr v1.0.0 // indirect
 	github.com/apache/thrift v0.13.0
 	github.com/aws/aws-sdk-go v1.34.13
 	github.com/benbjohnson/clock v0.0.0-20161215174838-7dc76406b6d3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/Shopify/sarama v1.23.0 h1:slvlbm7bxyp7sKQbUwha5BQdZTqurhRoI+zbKorVigQ
 github.com/Shopify/sarama v1.23.0/go.mod h1:XLH1GYJnLVE0XCr6KdJGVJRTwY30moWNJ4sERjXX6fs=
 github.com/Shopify/toxiproxy v2.1.4+incompatible h1:TKdv8HiTLgE5wdJuEML90aBgNWsokNbMijUGhmcoBJc=
 github.com/Shopify/toxiproxy v2.1.4+incompatible/go.mod h1:OXgGpZ6Cli1/URJOF1DMxUHB2q5Ap20/P/eIdh4G0pI=
+github.com/VividCortex/mysqlerr v1.0.0 h1:5pZ2TZA+YnzPgzBfiUWGqWmKDVNBdrkf9g+DNe1Tiq8=
+github.com/VividCortex/mysqlerr v1.0.0/go.mod h1:xERx8E4tBhLvpjzdUyQiSfUxeMcATEQrflDAfXsqcAE=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Convert sqlplugin specific errors to common errors, such as timeout error, service busy error, entity not exists error.

<!-- Tell your future self why have you made these changes -->
**Why?**
Common errors are used to emit metrics in persistence layer. Different error types correspond to different metric names.
Our Cassandra implementation converts the errors to common error types as well. And we can use common errors to more intelligently decide if the call should be retried or not.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
