### PR TITLE
Not allow more than one types of metric reporters

### DIFF
--- a/common/config/metrics.go
+++ b/common/config/metrics.go
@@ -77,9 +77,15 @@ func (c *Metrics) NewScope(logger log.Logger, service string) tally.Scope {
 		rootScope = c.newM3Scope(logger)
 	}
 	if c.Statsd != nil {
+		if rootScope != tally.NoopScope {
+			logger.Fatal("error creating metric reporter: cannot have more than one types of metric configuration")
+		}
 		rootScope = c.newStatsdScope(logger)
 	}
 	if c.Prometheus != nil {
+		if rootScope != tally.NoopScope {
+			logger.Fatal("error creating metric reporter: cannot have more than one types of metric configuration")
+		}
 		rootScope = c.newPrometheusScope(logger)
 	}
 	rootScope = rootScope.Tagged(map[string]string{metrics.CadenceServiceTagName: service})

--- a/common/config/metrics.go
+++ b/common/config/metrics.go
@@ -63,14 +63,8 @@ var (
 	}
 )
 
-// NewScope builds a new tally scope
-// for this metrics configuration
-//
-// If the underlying configuration is
-// valid for multiple reporter types,
-// only one of them will be used for
-// reporting. Currently, m3 is preferred
-// over statsd
+// NewScope builds a new tally scope for this metrics configuration
+// Only one reporter type is allowed
 func (c *Metrics) NewScope(logger log.Logger, service string) tally.Scope {
 	rootScope := tally.NoopScope
 	if c.M3 != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Panic when more than one types of metric reporters

<!-- Tell your future self why have you made these changes -->
**Why?**
From a convo with a Cadence user: https://uber-cadence.slack.com/archives/CJW5MM9TJ/p1620057538026800?thread_ts=1613850452.000200&cid=CJW5MM9TJ

Allowing overriding is making things super hard to troubleshot today. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test with modified config:
```
(qlong-metric-override)$./cadence-server start
2021/05/06 14:37:02 Loading config; env=development,zone=,configDir=./config
2021/05/06 14:37:02 Loading configFiles=[./config/base.yaml ./config/development.yaml]
{"level":"info","ts":"2021-05-06T14:37:02.674-0700","msg":"Updated dynamic config","service":"cadence-frontend","logging-call-at":"file_based_client.go:258"}
{"level":"fatal","ts":"2021-05-06T14:37:02.675-0700","msg":"error creating metric reporter: cannot have more than one types of metric configuration","service":"cadence-frontend","logging-call-at":"metrics.go:87","stacktrace":"github.com/uber/cadence/common/log/loggerimpl.(*loggerImpl).Fatal\n\t/Users/qlong/cadence/common/log/loggerimpl/logger.go:137\ngithub.com/uber/cadence/common/config.(*Metrics).NewScope\n\t/Users/qlong/cadence/common/config/metrics.go:87\ngithub.com/uber/cadence/cmd/server/cadence.(*server).startService\n\t/Users/qlong/cadence/cmd/server/cadence/server.go:129\ngithub.com/uber/cadence/cmd/server/cadence.(*server).Start\n\t/Users/qlong/cadence/cmd/server/cadence/server.go:81\ngithub.com/uber/cadence/cmd/server/cadence.startHandler\n\t/Users/qlong/cadence/cmd/server/cadence/cadence.go:83\ngithub.com/uber/cadence/cmd/server/cadence.BuildCLI.func1\n\t/Users/qlong/cadence/cmd/server/cadence/cadence.go:208\ngithub.com/urfave/cli.HandleAction\n\t/Users/qlong/go/pkg/mod/github.com/urfave/cli@v1.22.4/app.go:528\ngithub.com/urfave/cli.Command.Run\n\t/Users/qlong/go/pkg/mod/github.com/urfave/cli@v1.22.4/command.go:174\ngithub.com/urfave/cli.(*App).Run\n\t/Users/qlong/go/pkg/mod/github.com/urfave/cli@v1.22.4/app.go:279\nmain.main\n\t/Users/qlong/cadence/cmd/server/main.go:36\nruntime.main\n\t/usr/local/Cellar/go/1.16.3/libexec/src/runtime/proc.go:225"}
```


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
No

Also created issue in hemlchart: https://github.com/banzaicloud/banzai-charts/issues/1250