### PR TITLE
Handle workflow not exist error when archiving history

### DIFF
--- a/common/archiver/README.md
+++ b/common/archiver/README.md
@@ -30,6 +30,8 @@ type HistoryArchiver interface {
 	// to interact with these retries including giving the implementor the ability to cancel retries and record progress
   // between retry attempts. 
   // This method will be invoked after a workflow passes its retention period.
+  // It's possible that this method will be invoked for one workflow multiple times and potentially concurrently,
+  // implementation should correctly handle the workflow not exist case and return nil error.
     Archive(context.Context, URI, *ArchiveHistoryRequest, ...ArchiveOption) error
     
     // Get is used to access an archived history. When context expires method should stop trying to fetch history.

--- a/common/archiver/constants.go
+++ b/common/archiver/constants.go
@@ -29,6 +29,8 @@ const (
 	ArchiveNonRetriableErrorMsg = "Archive method encountered an non-retriable error."
 	// ArchiveTransientErrorMsg is the log message when the Archive() method encounters a transient error
 	ArchiveTransientErrorMsg = "Archive method encountered a transient error."
+	// ArchiveSkippedInfoMsg is the log messsage when the Archive() method encounter an entity not exists error
+	ArchiveSkippedInfoMsg = "Archive method encountered entity not exists error and skipped the archival"
 
 	// ErrReasonInvalidURI is the error reason for invalid URI
 	ErrReasonInvalidURI = "URI is invalid"

--- a/common/archiver/gcloud/historyArchiver.go
+++ b/common/archiver/gcloud/historyArchiver.go
@@ -143,6 +143,14 @@ func (h *historyArchiver) Archive(ctx context.Context, URI archiver.URI, request
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 
 		if err != nil {
+			if common.IsEntityNotExistsError(err) {
+				// workflow history no longer exists, may due to duplicated archival signal
+				// this may happen even in the middle of iterating history as two archival signals
+				// can be processed concurrently.
+				logger.Info(archiver.ArchiveSkippedInfoMsg)
+				return nil
+			}
+
 			logger := logger.WithTags(tag.ArchivalArchiveFailReason(archiver.ErrReasonReadHistory), tag.Error(err))
 			if !persistence.IsTransientError(err) {
 				logger.Error(archiver.ArchiveNonRetriableErrorMsg)

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -159,6 +159,14 @@ func (h *historyArchiver) Archive(
 	for historyIterator.HasNext() {
 		historyBlob, err := getNextHistoryBlob(ctx, historyIterator)
 		if err != nil {
+			if common.IsEntityNotExistsError(err) {
+				// workflow history no longer exists, may due to duplicated archival signal
+				// this may happen even in the middle of iterating history as two archival signals
+				// can be processed concurrently.
+				logger.Info(archiver.ArchiveSkippedInfoMsg)
+				return nil
+			}
+
 			logger := logger.WithTags(tag.ArchivalArchiveFailReason(archiver.ErrReasonReadHistory), tag.Error(err))
 			if persistence.IsTransientError(err) {
 				logger.Error(archiver.ArchiveTransientErrorMsg)

--- a/common/archiver/s3store/historyArchiver_test.go
+++ b/common/archiver/s3store/historyArchiver_test.go
@@ -391,6 +391,52 @@ func (s *historyArchiverSuite) TestArchive_Fail_NonRetriableErrorOption() {
 	s.Equal(nonRetryableErr, err)
 }
 
+func (s *historyArchiverSuite) TestArchive_Skip() {
+	mockCtrl := gomock.NewController(s.T())
+	defer mockCtrl.Finish()
+	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
+	historyBlob := &archiver.HistoryBlob{
+		Header: &archiver.HistoryBlobHeader{
+			IsLast: common.BoolPtr(false),
+		},
+		Body: []*types.History{
+			{
+				Events: []*types.HistoryEvent{
+					{
+						EventID:   common.FirstEventID,
+						Timestamp: common.Int64Ptr(time.Now().UnixNano()),
+						Version:   testCloseFailoverVersion,
+					},
+				},
+			},
+		},
+	}
+	gomock.InOrder(
+		historyIterator.EXPECT().HasNext().Return(true),
+		historyIterator.EXPECT().Next().Return(historyBlob, nil),
+		historyIterator.EXPECT().HasNext().Return(true),
+		historyIterator.EXPECT().Next().Return(nil, &types.EntityNotExistsError{Message: "workflow not found"}),
+	)
+
+	historyArchiver := s.newTestHistoryArchiver(historyIterator)
+	request := &archiver.ArchiveHistoryRequest{
+		DomainID:             testDomainID,
+		DomainName:           testDomainName,
+		WorkflowID:           testWorkflowID,
+		RunID:                testRunID,
+		BranchToken:          testBranchToken,
+		NextEventID:          testNextEventID,
+		CloseFailoverVersion: testCloseFailoverVersion,
+	}
+	URI, err := archiver.NewURI(testBucketURI + "/TestArchive_Skip")
+	s.NoError(err)
+	err = historyArchiver.Archive(context.Background(), URI, request)
+	s.NoError(err)
+
+	expectedkey := constructHistoryKey("", testDomainID, testWorkflowID, testRunID, testCloseFailoverVersion, 0)
+	s.assertKeyExists(expectedkey)
+}
+
 func (s *historyArchiverSuite) TestArchive_Success() {
 	mockCtrl := gomock.NewController(s.T())
 	defer mockCtrl.Finish()

--- a/common/util.go
+++ b/common/util.go
@@ -226,6 +226,12 @@ func IsServiceTransientError(err error) bool {
 	return false
 }
 
+// IsEntityNotExistsError checks if the error is an entity not exists error.
+func IsEntityNotExistsError(err error) bool {
+	_, ok := err.(*types.EntityNotExistsError)
+	return ok
+}
+
 // IsServiceBusyError checks if the error is a service busy error.
 func IsServiceBusyError(err error) bool {
 	switch err.(type) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Skip archival if workflow history does not exist.

<!-- Tell your future self why have you made these changes -->
**Why?**
Skip archival if workflow history does not exist. If workflow does not exist, we currently return an non-retryable error immediately. It's the same as just return from the Archive method with nil error in terms of behavior since workflow don't retry the non-retryable error. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
N/A