### PR TITLE
Release/0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find a list of previous releases on the [github releases](https://github.com/uber/cadence/releases) page.
 
 ## [Unreleased]
+
+
+## [0.21.0] - 2021-05-07
 ### Added
 - Added GRPC support. Cadence server will accept requests on both TChannel and GRPC. With dynamic config flag `system.enableGRPCOutbound` it will also switch to GRPC communication internally between server components.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ You can find a list of previous releases on the [github releases](https://github
 - Fixed a bug where an error message is always displayed in Cadence UI `persistence max qps reached for list operations` on the workflow list screen (#3958)
 
 ### Changed
-- Bump CLI version to v0.18.3 (#3959)
+- Bump CLI version to v0.18.4 (#4150)
 
 ## [0.18.0] - 2021-01-22
 

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -33,7 +33,7 @@ services:
     environment:
       - discovery.type=single-node
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -60,7 +60,7 @@ services:
       - kafka
       - elasticsearch
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -33,7 +33,7 @@ services:
     environment:
       - discovery.type=single-node
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -59,7 +59,7 @@ services:
       - kafka
       - elasticsearch
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:

--- a/docker/docker-compose-multiclusters.yml
+++ b/docker/docker-compose-multiclusters.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - '9090:9090'
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -41,7 +41,7 @@ services:
       - cassandra
       - prometheus
   cadence-secondary:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
       - "9000:9000"
       - "9001:9001"
@@ -70,7 +70,7 @@ services:
       - cassandra
       - prometheus
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:
@@ -78,7 +78,7 @@ services:
     depends_on:
       - cadence
   cadence-web-secondary:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence-secondary:7933"
     ports:

--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -15,7 +15,7 @@ services:
     ports:
       - '9090:9090'
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -39,7 +39,7 @@ services:
       - mysql
       - prometheus
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - '9090:9090'
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -41,7 +41,7 @@ services:
       - postgres
       - prometheus
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:

--- a/docker/docker-compose-scylla.yml
+++ b/docker/docker-compose-scylla.yml
@@ -16,7 +16,7 @@ services:
     ports:
       - '9090:9090'
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
       - "8000:8000"
       - "8001:8001"
@@ -38,7 +38,7 @@ services:
       - scylla
       - prometheus
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:

--- a/docker/docker-compose-statsd.yml
+++ b/docker/docker-compose-statsd.yml
@@ -12,7 +12,7 @@ services:
       - "8125:8125"
       - "8126:8126"
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
      - "7933:7933"
      - "7934:7934"
@@ -26,7 +26,7 @@ services:
       - cassandra
       - statsd
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - '9100:9100'
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.21.0-auto-setup
     ports:
      - "8000:8000"
      - "8001:8001"
@@ -38,7 +38,7 @@ services:
       - cassandra
       - prometheus
   cadence-web:
-    image: ubercadence/web:latest
+    image: ubercadence/web:v3.25.0
     environment:
       - "CADENCE_TCHANNEL_PEERS=cadence:7933"
     ports:


### PR DESCRIPTION
### Added
- Added GRPC support. Cadence server will accept requests on both TChannel and GRPC. With dynamic config flag system.enableGRPCOutbound it will also switch to GRPC communication internally between server components.

### Fixed
- Fixed a bug where an error message is always displayed in Cadence UI persistence max qps reached for list operations on the workflow list screen (#3958)

### Changed
- Bump CLI version to v0.18.4 (#4150)