### PR TITLE
Fix proto mapper for Payload

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -5149,6 +5149,13 @@ func ToPayload(p *apiv1.Payload) []byte {
 	if p == nil {
 		return nil
 	}
+	if p.Data == nil {
+		// FromPayload will not generate this case
+		// however, Data field will be dropped by the encoding if it's empty
+		// and receiver side will see nil for the Data field
+		// since we already know p is not nil, Data field must be an empty byte array
+		return []byte{}
+	}
 	return p.Data
 }
 

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -896,6 +896,10 @@ func TestPayload(t *testing.T) {
 	for _, item := range [][]byte{nil, {}, testdata.Payload1} {
 		assert.Equal(t, item, ToPayload(FromPayload(item)))
 	}
+
+	assert.Equal(t, []byte{}, ToPayload(&apiv1.Payload{
+		Data: nil,
+	}))
 }
 func TestPayloadMap(t *testing.T) {
 	for _, item := range []map[string][]byte{nil, {}, testdata.PayloadMap} {

--- a/host/integrationTest.go
+++ b/host/integrationTest.go
@@ -87,6 +87,12 @@ func (s *IntegrationSuite) TestStartWorkflowExecution() {
 		ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(100),
 		TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 		Identity:                            identity,
+		Header: &types.Header{
+			Fields: map[string][]byte{
+				"test-key":    []byte("test-value"),
+				"empty-value": {},
+			},
+		},
 	}
 
 	we0, err0 := s.engine.StartWorkflowExecution(createContext(), request)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
If payload is not nil, but payload.Data is nil, then return []byte{} instead of nil afs

<!-- Tell your future self why have you made these changes -->
**Why?**
Empty payload.Data field after transferring on the wire becomes a nil field. And when payload is used as map value, thriftrw is not able to handle the case as the map value becomes nil.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally and integration test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
N/A
