### PR TITLE
Support is_cron field for SQL/Cassandra/Postgres

### DIFF
--- a/common/persistence/dataInterfaces.go
+++ b/common/persistence/dataInterfaces.go
@@ -340,6 +340,7 @@ type (
 		BranchToken        []byte
 		// Cron
 		CronSchedule      string
+		IsCron            bool
 		ExpirationSeconds int32 // TODO: is this field useful?
 	}
 

--- a/common/persistence/executionStore.go
+++ b/common/persistence/executionStore.go
@@ -141,6 +141,7 @@ func (m *executionManagerImpl) DeserializeExecutionInfo(
 		InitiatedID:                        info.InitiatedID,
 		CompletionEventBatchID:             info.CompletionEventBatchID,
 		TaskList:                           info.TaskList,
+		IsCron:                             len(info.CronSchedule) > 0,
 		WorkflowTypeName:                   info.WorkflowTypeName,
 		WorkflowTimeout:                    int32(info.WorkflowTimeout.Seconds()),
 		DecisionStartToCloseTimeout:        int32(info.DecisionStartToCloseTimeout.Seconds()),

--- a/common/persistence/serialization/getters.go
+++ b/common/persistence/serialization/getters.go
@@ -428,6 +428,14 @@ func (w *WorkflowExecutionInfo) GetTaskList() (o string) {
 	return
 }
 
+// GetIsCron internal sql blob getter
+func (w *WorkflowExecutionInfo) GetIsCron() (o bool) {
+	if w != nil && w.IsCron != nil {
+		return *w.IsCron
+	}
+	return
+}
+
 // GetWorkflowTypeName internal sql blob getter
 func (w *WorkflowExecutionInfo) GetWorkflowTypeName() (o string) {
 	if w != nil && w.WorkflowTypeName != nil {

--- a/common/persistence/serialization/interfaces.go
+++ b/common/persistence/serialization/interfaces.go
@@ -106,6 +106,7 @@ type (
 		CompletionEvent                    []byte
 		CompletionEventEncoding            *string
 		TaskList                           *string
+		IsCron                             *bool
 		WorkflowTypeName                   *string
 		WorkflowTimeout                    *time.Duration
 		DecisionTaskTimeout                *time.Duration

--- a/common/persistence/sql/sqlVisibilityStore.go
+++ b/common/persistence/sql/sqlVisibilityStore.go
@@ -75,6 +75,7 @@ func (s *sqlVisibilityStore) RecordWorkflowExecutionStarted(
 		WorkflowTypeName: request.WorkflowTypeName,
 		Memo:             request.Memo.Data,
 		Encoding:         string(request.Memo.GetEncoding()),
+		IsCron:           request.IsCron,
 	})
 
 	if err != nil {
@@ -100,6 +101,7 @@ func (s *sqlVisibilityStore) RecordWorkflowExecutionClosed(
 		HistoryLength:    &request.HistoryLength,
 		Memo:             request.Memo.Data,
 		Encoding:         string(request.Memo.GetEncoding()),
+		IsCron:           request.IsCron,
 	})
 	if err != nil {
 		return convertCommonErrors(s.db, "RecordWorkflowExecutionClosed", "", err)
@@ -319,6 +321,7 @@ func (s *sqlVisibilityStore) rowToInfo(row *sqlplugin.VisibilityRow) *p.Internal
 		TypeName:      row.WorkflowTypeName,
 		StartTime:     row.StartTime,
 		ExecutionTime: row.ExecutionTime,
+		IsCron:        row.IsCron,
 		Memo:          p.NewDataBlob(row.Memo, common.EncodingType(row.Encoding)),
 	}
 	if row.CloseStatus != nil {

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -515,6 +515,7 @@ type (
 		HistoryLength    *int64
 		Memo             []byte
 		Encoding         string
+		IsCron           bool
 	}
 
 	// VisibilityFilter contains the column names within executions_visibility table that

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -26,4 +26,4 @@ package cassandra
 const Version = "0.30"
 
 // VisibilityVersion is the Cassandra visibility database release version
-const VisibilityVersion = "0.5"
+const VisibilityVersion = "0.6"

--- a/schema/cassandra/visibility/schema.cql
+++ b/schema/cassandra/visibility/schema.cql
@@ -9,6 +9,7 @@ CREATE TABLE open_executions (
   memo                 blob,
   encoding             text,
   task_list            text,
+  is_cron              boolean,
   PRIMARY KEY  ((domain_id, domain_partition), start_time, run_id)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
   AND COMPACTION = {
@@ -35,6 +36,7 @@ CREATE TABLE closed_executions (
   memo                 blob,
   encoding             text,
   task_list            text,
+  is_cron              boolean,
   PRIMARY KEY  ((domain_id, domain_partition), start_time, run_id)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
   AND COMPACTION = {
@@ -62,6 +64,7 @@ CREATE TABLE closed_executions_v2 (
   memo                 blob,
   encoding             text,
   task_list            text,
+  is_cron              boolean,
   PRIMARY KEY  ((domain_id, domain_partition), close_time, run_id)
 ) WITH CLUSTERING ORDER BY (close_time DESC)
   AND COMPACTION = {

--- a/schema/cassandra/visibility/versioned/v0.6/add_is_cron.cql
+++ b/schema/cassandra/visibility/versioned/v0.6/add_is_cron.cql
@@ -1,0 +1,3 @@
+ALTER TABLE open_executions ADD is_cron boolean;
+ALTER TABLE closed_executions ADD is_cron boolean;
+ALTER TABLE closed_executions_v2 ADD is_cron boolean;

--- a/schema/cassandra/visibility/versioned/v0.6/manifest.json
+++ b/schema/cassandra/visibility/versioned/v0.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.6",
+  "MinCompatibleVersion": "0.6",
+  "Description": "add is_cron field to visibility",
+  "SchemaUpdateCqlFiles": [
+    "add_is_cron.cql"
+  ]
+}

--- a/schema/mysql/v57/visibility/schema.sql
+++ b/schema/mysql/v57/visibility/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE executions_visibility (
   memo                 BLOB,
   encoding             VARCHAR(64) NOT NULL,
   task_list            VARCHAR(255) DEFAULT '' NOT NULL,
+  is_cron              BOOLEAN DEFAULT false NOT NULL,
 
   PRIMARY KEY  (domain_id, run_id)
 );

--- a/schema/mysql/v57/visibility/versioned/v0.4/add_is_cron.sql
+++ b/schema/mysql/v57/visibility/versioned/v0.4/add_is_cron.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions_visibility ADD is_cron BOOLEAN DEFAULT false;

--- a/schema/mysql/v57/visibility/versioned/v0.4/manifest.json
+++ b/schema/mysql/v57/visibility/versioned/v0.4/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.4",
+  "MinCompatibleVersion": "0.4",
+  "Description": "add is_cron field to visibility",
+  "SchemaUpdateCqlFiles": [
+    "add_is_cron.sql"
+  ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -26,4 +26,4 @@ package mysql
 const Version = "0.4"
 
 // VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "0.3"
+const VisibilityVersion = "0.4"

--- a/schema/postgres/version.go
+++ b/schema/postgres/version.go
@@ -28,4 +28,4 @@ const Version = "0.3"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Cadence supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const VisibilityVersion = "0.3"
+const VisibilityVersion = "0.4"

--- a/schema/postgres/visibility/schema.sql
+++ b/schema/postgres/visibility/schema.sql
@@ -11,6 +11,7 @@ CREATE TABLE executions_visibility (
   memo                 BYTEA,
   encoding             VARCHAR(64) NOT NULL,
   task_list            VARCHAR(255) DEFAULT '' NOT NULL,
+  is_cron              BOOLEAN DEFAULT false NOT NULL,
 
   PRIMARY KEY  (domain_id, run_id)
 );

--- a/schema/postgres/visibility/versioned/v0.4/add_is_cron.sql
+++ b/schema/postgres/visibility/versioned/v0.4/add_is_cron.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions_visibility ADD is_cron boolean DEFAULT false;

--- a/schema/postgres/visibility/versioned/v0.4/manifest.json
+++ b/schema/postgres/visibility/versioned/v0.4/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.4",
+  "MinCompatibleVersion": "0.4",
+  "Description": "add is_cron field to visibility",
+  "SchemaUpdateCqlFiles": [
+    "add_is_cron.sql"
+  ]
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This visibility field was supported for ElasticSearch in this PR: https://github.com/uber/cadence/pull/4176 It will be supported for SQL, Postgres and Cassandra with this diff.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go test -v github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql
go test -v github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/tests
go test -v github.com/uber/cadence/common/persistence/sql/sqlplugin/postgres
```


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
