### PR TITLE
Refactor: move errorChecker to nosqlplugin pkg

### DIFF
--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/checksum"
 	p "github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/common/types"
 )
@@ -2200,7 +2201,7 @@ func createChecksum(result map[string]interface{}) checksum.Checksum {
 }
 
 func convertCommonErrors(
-	errChecker gocql.ErrorChecker,
+	errChecker nosqlplugin.ErrorChecker,
 	operation string,
 	err error,
 ) error {

--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -2201,7 +2201,7 @@ func createChecksum(result map[string]interface{}) checksum.Checksum {
 }
 
 func convertCommonErrors(
-	errChecker nosqlplugin.ErrorChecker,
+	errChecker nosqlplugin.ClientErrorChecker,
 	operation string,
 	err error,
 ) error {

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
@@ -40,7 +40,7 @@ type (
 	Client interface {
 		CreateSession(ClusterConfig) (Session, error)
 
-		nosqlplugin.ErrorChecker
+		nosqlplugin.ClientErrorChecker
 	}
 
 	// Session is the interface for interacting with the database.

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 )
 
 // Note: this file defines the minimal interface that is needed by Cadence's cassandra
@@ -39,7 +40,7 @@ type (
 	Client interface {
 		CreateSession(ClusterConfig) (Session, error)
 
-		ErrorChecker
+		nosqlplugin.ErrorChecker
 	}
 
 	// Session is the interface for interacting with the database.
@@ -85,13 +86,6 @@ type (
 	// UUID represents a universally unique identifier
 	UUID interface {
 		String() string
-	}
-
-	// ErrorChecker checks for common gocql errors
-	ErrorChecker interface {
-		IsTimeoutError(error) bool
-		IsNotFoundError(error) bool
-		IsThrottlingError(error) bool
 	}
 
 	// BatchType is the type of the Batch operation

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -36,7 +35,7 @@ type (
 		Close()
 
 		IsConditionFailedError(err error) bool
-		gocql.ErrorChecker
+		ErrorChecker
 
 		tableCRUD
 	}
@@ -46,6 +45,13 @@ type (
 		historyEventsCRUD
 		messageQueueCRUD
 		domainCRUD
+	}
+
+	// ErrorChecker checks for common nosql errors
+	ErrorChecker interface {
+		IsTimeoutError(error) bool
+		IsNotFoundError(error) bool
+		IsThrottlingError(error) bool
 	}
 
 	// historyEventsCRUD is for History events storage system

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -34,9 +34,7 @@ type (
 		PluginName() string
 		Close()
 
-		IsConditionFailedError(err error) bool
-		ErrorChecker
-
+		NoSQLErrorChecker
 		tableCRUD
 	}
 	// tableCRUD defines the API for interacting with the database tables
@@ -47,8 +45,14 @@ type (
 		domainCRUD
 	}
 
-	// ErrorChecker checks for common nosql errors
-	ErrorChecker interface {
+	// NoSQLErrorChecker checks for common nosql errors
+	NoSQLErrorChecker interface {
+		IsConditionFailedError(err error) bool
+		ClientErrorChecker
+	}
+
+	// ClientErrorChecker checks for common nosql errors on client
+	ClientErrorChecker interface {
 		IsTimeoutError(error) bool
 		IsNotFoundError(error) bool
 		IsThrottlingError(error) bool


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Move ErrorChecker to nosqlplugin pkg
It will make the work of https://github.com/uber/cadence/issues/3514 easier
<!-- Tell your future self why have you made these changes -->
**Why?**
For consistency in the interfaces. Nosqlplugin.interfaces shouldn't depend on gocql interfaces of Cassandra. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
