### PR TITLE
Support delaying cron workflows

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -103,7 +103,6 @@ var (
 	ErrContextTimeoutTooShort = &types.BadRequestError{Message: "Context timeout is too short."}
 	// ErrContextTimeoutNotSet is error for not setting a context timeout when calling a long poll API
 	ErrContextTimeoutNotSet = &types.BadRequestError{Message: "Context timeout is not set."}
-	ErrDelayStartSeconds    = &types.BadRequestError{Message: "Conflicting inputs: both DelayStartSeconds and Cron schedule is set"}
 )
 
 // AwaitWaitGroup calls Wait on the given wait
@@ -428,20 +427,22 @@ func CreateHistoryStartWorkflowRequest(
 	domainID string,
 	startRequest *types.StartWorkflowExecutionRequest,
 	now time.Time,
-) (*types.HistoryStartWorkflowExecutionRequest, error) {
+) *types.HistoryStartWorkflowExecutionRequest {
 	histRequest := &types.HistoryStartWorkflowExecutionRequest{
 		DomainUUID:   domainID,
 		StartRequest: startRequest,
 	}
 
-	firstDecisionTaskBackoffSeconds := backoff.GetBackoffForNextScheduleInSeconds(
-		startRequest.GetCronSchedule(), now, now)
 	delayStartSeconds := startRequest.GetDelayStartSeconds()
-	if delayStartSeconds > 0 && firstDecisionTaskBackoffSeconds > 0 {
-		return nil, ErrDelayStartSeconds
-	}
-	if delayStartSeconds > 0 {
-		firstDecisionTaskBackoffSeconds = delayStartSeconds
+	firstDecisionTaskBackoffSeconds := delayStartSeconds
+	if len(startRequest.GetCronSchedule()) > 0 {
+		delayedStartTime := now.Add(time.Second * time.Duration(delayStartSeconds))
+		firstDecisionTaskBackoffSeconds = backoff.GetBackoffForNextScheduleInSeconds(
+			startRequest.GetCronSchedule(), delayedStartTime, delayedStartTime)
+
+		// backoff seconds was calculated based on delayed start time, so we need to
+		// add the delayStartSeconds to that backoff.
+		firstDecisionTaskBackoffSeconds += delayStartSeconds
 	}
 
 	histRequest.FirstDecisionTaskBackoffSeconds = Int32Ptr(firstDecisionTaskBackoffSeconds)
@@ -453,7 +454,7 @@ func CreateHistoryStartWorkflowRequest(
 		histRequest.ExpirationTimestamp = Int64Ptr(deadline.Round(time.Millisecond).UnixNano())
 	}
 
-	return histRequest, nil
+	return histRequest
 }
 
 // CheckEventBlobSizeLimit checks if a blob data exceeds limits. It logs a warning if it exceeds warnLimit,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1838,11 +1838,8 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	}
 
 	wh.GetLogger().Debug("Start workflow execution request domainID", tag.WorkflowDomainID(domainID))
-	historyRequest, err := common.CreateHistoryStartWorkflowRequest(
+	historyRequest := common.CreateHistoryStartWorkflowRequest(
 		domainID, startRequest, time.Now())
-	if err != nil {
-		return nil, wh.error(err, scope)
-	}
 
 	resp, err = wh.GetHistoryClient().StartWorkflowExecution(ctx, historyRequest)
 	if err != nil {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2801,10 +2801,7 @@ func getStartRequest(
 		DelayStartSeconds:                   request.DelayStartSeconds,
 	}
 
-	startRequest, err := common.CreateHistoryStartWorkflowRequest(domainID, req, time.Now())
-	if err != nil {
-		return nil, err
-	}
+	startRequest := common.CreateHistoryStartWorkflowRequest(domainID, req, time.Now())
 
 	return startRequest, nil
 }

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1308,10 +1308,7 @@ func (t *transferActiveTaskExecutor) startWorkflowWithRetry(
 	}
 
 	now := t.shard.GetTimeSource().Now()
-	historyStartReq, historyReqError := common.CreateHistoryStartWorkflowRequest(task.TargetDomainID, frontendStartReq, now)
-	if historyReqError != nil {
-		return "", historyReqError
-	}
+	historyStartReq := common.CreateHistoryStartWorkflowRequest(task.TargetDomainID, frontendStartReq, now)
 
 	historyStartReq.ParentExecutionInfo = &types.ParentExecutionInfo{
 		DomainUUID: task.DomainID,

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -2269,11 +2269,8 @@ func (s *transferActiveTaskExecutorSuite) createChildWorkflowExecutionRequest(
 		InitiatedID: task.ScheduleID,
 	}
 
-	historyStartReq, err := common.CreateHistoryStartWorkflowRequest(
+	historyStartReq := common.CreateHistoryStartWorkflowRequest(
 		task.TargetDomainID, frontendStartReq, now)
-	if err != nil {
-		return nil, err
-	}
 
 	historyStartReq.ParentExecutionInfo = parentInfo
 	return historyStartReq, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
About a month ago, we added delaying workflow feature which wasn't supporting delaying cron workflows. There was a customer ask to see if we could delay starting cron workflows too; this PR does that. 


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- TestCreateHistoryStartWorkflowRequest_DelayStart
- TestCreateHistoryStartWorkflowRequest_DelayStartWithCron

```
./cadence --do samples-domain workflow start --tl cronGroup --wt main.sampleCronWorkflow --et 60 -i '"cadence"' --delay_start_seconds 5 --cron "@every 10s"
```
Verified that the first run starts after 15s and every subsequent one fires after 10 seconds

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
