### PR TITLE
Use frontend client in parentClosePolicy workflow to allow auto-forwarding

### DIFF
--- a/service/worker/parentclosepolicy/processor.go
+++ b/service/worker/parentclosepolicy/processor.go
@@ -28,7 +28,7 @@ import (
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/worker"
 
-	"github.com/uber/cadence/client"
+	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -47,28 +47,28 @@ type (
 		Logger        log.Logger
 		// TallyScope is an instance of tally metrics scope
 		TallyScope tally.Scope
-		// ClientBean is an instance of client.Bean for a collection of clients
-		ClientBean client.Bean
+		// FrontendClient is an instance of frontend.Client for talking to frontend service
+		FrontendClient frontend.Client
 	}
 
 	// Processor is the background sub-system that execute workflow for ParentClosePolicy
 	Processor struct {
-		svcClient     workflowserviceclient.Interface
-		clientBean    client.Bean
-		metricsClient metrics.Client
-		tallyScope    tally.Scope
-		logger        log.Logger
+		svcClient      workflowserviceclient.Interface
+		frontendClient frontend.Client
+		metricsClient  metrics.Client
+		tallyScope     tally.Scope
+		logger         log.Logger
 	}
 )
 
 // New returns a new instance as daemon
 func New(params *BootstrapParams) *Processor {
 	return &Processor{
-		svcClient:     params.ServiceClient,
-		metricsClient: params.MetricsClient,
-		tallyScope:    params.TallyScope,
-		logger:        params.Logger.WithTags(tag.ComponentBatcher),
-		clientBean:    params.ClientBean,
+		svcClient:      params.ServiceClient,
+		metricsClient:  params.MetricsClient,
+		tallyScope:     params.TallyScope,
+		logger:         params.Logger.WithTags(tag.ComponentBatcher),
+		frontendClient: params.FrontendClient,
 	}
 }
 

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -103,7 +103,6 @@ func ProcessorWorkflow(ctx workflow.Context) error {
 
 // ProcessorActivity is activity for processing batch operation
 func ProcessorActivity(ctx context.Context, request Request) error {
-	time.Sleep(2 * time.Minute)
 	processor := ctx.Value(processorContextKey).(*Processor)
 	for _, execution := range request.Executions {
 		var err error

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -103,8 +103,8 @@ func ProcessorWorkflow(ctx workflow.Context) error {
 
 // ProcessorActivity is activity for processing batch operation
 func ProcessorActivity(ctx context.Context, request Request) error {
+	time.Sleep(2 * time.Minute)
 	processor := ctx.Value(processorContextKey).(*Processor)
-	client := processor.clientBean.GetHistoryClient()
 	for _, execution := range request.Executions {
 		var err error
 		switch execution.Policy {
@@ -112,29 +112,23 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 			//no-op
 			continue
 		case types.ParentClosePolicyTerminate:
-			err = client.TerminateWorkflowExecution(nil, &types.HistoryTerminateWorkflowExecutionRequest{
-				DomainUUID: request.DomainUUID,
-				TerminateRequest: &types.TerminateWorkflowExecutionRequest{
-					Domain: request.DomainName,
-					WorkflowExecution: &types.WorkflowExecution{
-						WorkflowID: execution.WorkflowID,
-						RunID:      execution.RunID,
-					},
-					Reason:   "by parent close policy",
-					Identity: processorWFTypeName,
+			err = processor.frontendClient.TerminateWorkflowExecution(ctx, &types.TerminateWorkflowExecutionRequest{
+				Domain: request.DomainName,
+				WorkflowExecution: &types.WorkflowExecution{
+					WorkflowID: execution.WorkflowID,
+					RunID:      execution.RunID,
 				},
+				Reason:   "by parent close policy",
+				Identity: processorWFTypeName,
 			})
 		case types.ParentClosePolicyRequestCancel:
-			err = client.RequestCancelWorkflowExecution(nil, &types.HistoryRequestCancelWorkflowExecutionRequest{
-				DomainUUID: request.DomainUUID,
-				CancelRequest: &types.RequestCancelWorkflowExecutionRequest{
-					Domain: request.DomainName,
-					WorkflowExecution: &types.WorkflowExecution{
-						WorkflowID: execution.WorkflowID,
-						RunID:      execution.RunID,
-					},
-					Identity: processorWFTypeName,
+			err = processor.frontendClient.RequestCancelWorkflowExecution(ctx, &types.RequestCancelWorkflowExecutionRequest{
+				Domain: request.DomainName,
+				WorkflowExecution: &types.WorkflowExecution{
+					WorkflowID: execution.WorkflowID,
+					RunID:      execution.RunID,
 				},
+				Identity: processorWFTypeName,
 			})
 		}
 

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -239,11 +239,11 @@ func (s *Service) Stop() {
 
 func (s *Service) startParentClosePolicyProcessor() {
 	params := &parentclosepolicy.BootstrapParams{
-		ServiceClient: s.params.PublicClient,
-		MetricsClient: s.GetMetricsClient(),
-		Logger:        s.GetLogger(),
-		TallyScope:    s.params.MetricScope,
-		ClientBean:    s.GetClientBean(),
+		ServiceClient:  s.params.PublicClient,
+		MetricsClient:  s.GetMetricsClient(),
+		Logger:         s.GetLogger(),
+		TallyScope:     s.params.MetricScope,
+		FrontendClient: s.GetFrontendClient(), // frontend client with retry
 	}
 	processor := parentclosepolicy.New(params)
 	if err := processor.Start(); err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use frontend client in parentClosePolicy workflow

<!-- Tell your future self why have you made these changes -->
**Why?**
If workflow domain failovered to another cluster after parent close policy workflow receives the request, the request will keeping retrying as the domain is no-long active in the current cluster and there's no auto-forwarding for history client, which is currently used.

Switch to frontend client so that the request can be auto-forwarded to the new active cluster.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally with samples

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the worst case, parent close policy workflow may stop working.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
