### PR TITLE
Shift pointer conversions down to thrift encoder

### DIFF
--- a/common/persistence/serialization/getters.go
+++ b/common/persistence/serialization/getters.go
@@ -30,48 +30,48 @@ import (
 
 // GetStolenSinceRenew internal sql blob getter
 func (s *ShardInfo) GetStolenSinceRenew() (o int32) {
-	if s != nil && s.StolenSinceRenew != nil {
-		return *s.StolenSinceRenew
+	if s != nil {
+		return s.StolenSinceRenew
 	}
 	return
 }
 
 // GetUpdatedAt internal sql blob getter
 func (s *ShardInfo) GetUpdatedAt() time.Time {
-	if s != nil && s.UpdatedAt != nil {
-		return *s.UpdatedAt
+	if s != nil {
+		return s.UpdatedAt
 	}
 	return time.Unix(0, 0)
 }
 
 // GetReplicationAckLevel internal sql blob getter
 func (s *ShardInfo) GetReplicationAckLevel() (o int64) {
-	if s != nil && s.ReplicationAckLevel != nil {
-		return *s.ReplicationAckLevel
+	if s != nil {
+		return s.ReplicationAckLevel
 	}
 	return
 }
 
 // GetTransferAckLevel internal sql blob getter
 func (s *ShardInfo) GetTransferAckLevel() (o int64) {
-	if s != nil && s.TransferAckLevel != nil {
-		return *s.TransferAckLevel
+	if s != nil {
+		return s.TransferAckLevel
 	}
 	return
 }
 
 // GetTimerAckLevel internal sql blob getter
 func (s *ShardInfo) GetTimerAckLevel() time.Time {
-	if s != nil && s.TimerAckLevel != nil {
-		return *s.TimerAckLevel
+	if s != nil {
+		return s.TimerAckLevel
 	}
 	return time.Unix(0, 0)
 }
 
 // GetDomainNotificationVersion internal sql blob getter
 func (s *ShardInfo) GetDomainNotificationVersion() (o int64) {
-	if s != nil && s.DomainNotificationVersion != nil {
-		return *s.DomainNotificationVersion
+	if s != nil {
+		return s.DomainNotificationVersion
 	}
 	return
 }
@@ -94,8 +94,8 @@ func (s *ShardInfo) GetClusterTimerAckLevel() (o map[string]time.Time) {
 
 // GetOwner internal sql blob getter
 func (s *ShardInfo) GetOwner() (o string) {
-	if s != nil && s.Owner != nil {
-		return *s.Owner
+	if s != nil {
+		return s.Owner
 	}
 	return
 }
@@ -118,8 +118,8 @@ func (s *ShardInfo) GetPendingFailoverMarkers() (o []byte) {
 
 // GetPendingFailoverMarkersEncoding internal sql blob getter
 func (s *ShardInfo) GetPendingFailoverMarkersEncoding() (o string) {
-	if s != nil && s.PendingFailoverMarkersEncoding != nil {
-		return *s.PendingFailoverMarkersEncoding
+	if s != nil {
+		return s.PendingFailoverMarkersEncoding
 	}
 	return
 }
@@ -142,8 +142,8 @@ func (s *ShardInfo) GetTransferProcessingQueueStates() (o []byte) {
 
 // GetTransferProcessingQueueStatesEncoding internal sql blob getter
 func (s *ShardInfo) GetTransferProcessingQueueStatesEncoding() (o string) {
-	if s != nil && s.TransferProcessingQueueStatesEncoding != nil {
-		return *s.TransferProcessingQueueStatesEncoding
+	if s != nil {
+		return s.TransferProcessingQueueStatesEncoding
 	}
 	return
 }
@@ -158,112 +158,112 @@ func (s *ShardInfo) GetTimerProcessingQueueStates() (o []byte) {
 
 // GetTimerProcessingQueueStatesEncoding internal sql blob getter
 func (s *ShardInfo) GetTimerProcessingQueueStatesEncoding() (o string) {
-	if s != nil && s.TimerProcessingQueueStatesEncoding != nil {
-		return *s.TimerProcessingQueueStatesEncoding
+	if s != nil {
+		return s.TimerProcessingQueueStatesEncoding
 	}
 	return
 }
 
 // GetName internal sql blob getter
 func (d *DomainInfo) GetName() (o string) {
-	if d != nil && d.Name != nil {
-		return *d.Name
+	if d != nil {
+		return d.Name
 	}
 	return
 }
 
 // GetDescription internal sql blob getter
 func (d *DomainInfo) GetDescription() (o string) {
-	if d != nil && d.Description != nil {
-		return *d.Description
+	if d != nil {
+		return d.Description
 	}
 	return
 }
 
 // GetOwner internal sql blob getter
 func (d *DomainInfo) GetOwner() (o string) {
-	if d != nil && d.Owner != nil {
-		return *d.Owner
+	if d != nil {
+		return d.Owner
 	}
 	return
 }
 
 // GetStatus internal sql blob getter
 func (d *DomainInfo) GetStatus() (o int32) {
-	if d != nil && d.Status != nil {
-		return *d.Status
+	if d != nil {
+		return d.Status
 	}
 	return
 }
 
 // GetRetention internal sql blob getter
 func (d *DomainInfo) GetRetention() time.Duration {
-	if d != nil && d.Retention != nil {
-		return *d.Retention
+	if d != nil {
+		return d.Retention
 	}
 	return time.Duration(0)
 }
 
 // GetEmitMetric internal sql blob getter
 func (d *DomainInfo) GetEmitMetric() (o bool) {
-	if d != nil && d.EmitMetric != nil {
-		return *d.EmitMetric
+	if d != nil {
+		return d.EmitMetric
 	}
 	return
 }
 
 // GetArchivalBucket internal sql blob getter
 func (d *DomainInfo) GetArchivalBucket() (o string) {
-	if d != nil && d.ArchivalBucket != nil {
-		return *d.ArchivalBucket
+	if d != nil {
+		return d.ArchivalBucket
 	}
 	return
 }
 
 // GetArchivalStatus internal sql blob getter
 func (d *DomainInfo) GetArchivalStatus() (o int16) {
-	if d != nil && d.ArchivalStatus != nil {
-		return *d.ArchivalStatus
+	if d != nil {
+		return d.ArchivalStatus
 	}
 	return
 }
 
 // GetConfigVersion internal sql blob getter
 func (d *DomainInfo) GetConfigVersion() (o int64) {
-	if d != nil && d.ConfigVersion != nil {
-		return *d.ConfigVersion
+	if d != nil {
+		return d.ConfigVersion
 	}
 	return
 }
 
 // GetNotificationVersion internal sql blob getter
 func (d *DomainInfo) GetNotificationVersion() (o int64) {
-	if d != nil && d.NotificationVersion != nil {
-		return *d.NotificationVersion
+	if d != nil {
+		return d.NotificationVersion
 	}
 	return
 }
 
 // GetFailoverNotificationVersion internal sql blob getter
 func (d *DomainInfo) GetFailoverNotificationVersion() (o int64) {
-	if d != nil && d.FailoverNotificationVersion != nil {
-		return *d.FailoverNotificationVersion
+	if d != nil {
+		return d.FailoverNotificationVersion
 	}
 	return
 }
 
 // GetFailoverVersion internal sql blob getter
 func (d *DomainInfo) GetFailoverVersion() (o int64) {
-	if d != nil && d.FailoverVersion != nil {
-		return *d.FailoverVersion
+	if d != nil {
+		return d.FailoverVersion
 	}
 	return
 }
 
 // GetActiveClusterName internal sql blob getter
 func (d *DomainInfo) GetActiveClusterName() (o string) {
-	if d != nil && d.ActiveClusterName != nil {
-		return *d.ActiveClusterName
+	if d != nil {
+		return d.ActiveClusterName
 	}
 	return
 }
@@ -294,40 +294,40 @@ func (d *DomainInfo) GetBadBinaries() (o []byte) {
 
 // GetBadBinariesEncoding internal sql blob getter
 func (d *DomainInfo) GetBadBinariesEncoding() (o string) {
-	if d != nil && d.BadBinariesEncoding != nil {
-		return *d.BadBinariesEncoding
+	if d != nil {
+		return d.BadBinariesEncoding
 	}
 	return
 }
 
 // GetHistoryArchivalStatus internal sql blob getter
 func (d *DomainInfo) GetHistoryArchivalStatus() (o int16) {
-	if d != nil && d.HistoryArchivalStatus != nil {
-		return *d.HistoryArchivalStatus
+	if d != nil {
+		return d.HistoryArchivalStatus
 	}
 	return
 }
 
 // GetHistoryArchivalURI internal sql blob getter
 func (d *DomainInfo) GetHistoryArchivalURI() (o string) {
-	if d != nil && d.HistoryArchivalURI != nil {
-		return *d.HistoryArchivalURI
+	if d != nil {
+		return d.HistoryArchivalURI
 	}
 	return
 }
 
 // GetVisibilityArchivalStatus internal sql blob getter
 func (d *DomainInfo) GetVisibilityArchivalStatus() (o int16) {
-	if d != nil && d.VisibilityArchivalStatus != nil {
-		return *d.VisibilityArchivalStatus
+	if d != nil {
+		return d.VisibilityArchivalStatus
 	}
 	return
 }
 
 // GetVisibilityArchivalURI internal sql blob getter
 func (d *DomainInfo) GetVisibilityArchivalURI() (o string) {
-	if d != nil && d.VisibilityArchivalURI != nil {
-		return *d.VisibilityArchivalURI
+	if d != nil {
+		return d.VisibilityArchivalURI
 	}
 	return
 }
@@ -342,24 +342,24 @@ func (d *DomainInfo) GetFailoverEndTimestamp() time.Time {
 
 // GetPreviousFailoverVersion internal sql blob getter
 func (d *DomainInfo) GetPreviousFailoverVersion() (o int64) {
-	if d != nil && d.PreviousFailoverVersion != nil {
-		return *d.PreviousFailoverVersion
+	if d != nil {
+		return d.PreviousFailoverVersion
 	}
 	return
 }
 
 // GetLastUpdatedTimestamp internal sql blob getter
 func (d *DomainInfo) GetLastUpdatedTimestamp() time.Time {
-	if d != nil && d.LastUpdatedTimestamp != nil {
-		return *d.LastUpdatedTimestamp
+	if d != nil {
+		return d.LastUpdatedTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetCreatedTimestamp internal sql blob getter
 func (h *HistoryTreeInfo) GetCreatedTimestamp() time.Time {
-	if h != nil && h.CreatedTimestamp != nil {
-		return *h.CreatedTimestamp
+	if h != nil {
+		return h.CreatedTimestamp
 	}
 	return time.Unix(0, 0)
 }
@@ -374,8 +374,8 @@ func (h *HistoryTreeInfo) GetAncestors() (o []*types.HistoryBranchRange) {
 
 // GetInfo internal sql blob getter
 func (h *HistoryTreeInfo) GetInfo() (o string) {
-	if h != nil && h.Info != nil {
-		return *h.Info
+	if h != nil {
+		return h.Info
 	}
 	return
 }
@@ -390,16 +390,16 @@ func (w *WorkflowExecutionInfo) GetParentDomainID() (o []byte) {
 
 // GetRetryBackoffCoefficient internal sql blob getter
 func (w *WorkflowExecutionInfo) GetRetryBackoffCoefficient() (o float64) {
-	if w != nil && w.RetryBackoffCoefficient != nil {
-		return *w.RetryBackoffCoefficient
+	if w != nil {
+		return w.RetryBackoffCoefficient
 	}
 	return
 }
 
 // GetParentWorkflowID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetParentWorkflowID() (o string) {
-	if w != nil && w.ParentWorkflowID != nil {
-		return *w.ParentWorkflowID
+	if w != nil {
+		return w.ParentWorkflowID
 	}
 	return
 }
@@ -414,120 +414,120 @@ func (w *WorkflowExecutionInfo) GetParentRunID() (o []byte) {
 
 // GetCompletionEventEncoding internal sql blob getter
 func (w *WorkflowExecutionInfo) GetCompletionEventEncoding() (o string) {
-	if w != nil && w.CompletionEventEncoding != nil {
-		return *w.CompletionEventEncoding
+	if w != nil {
+		return w.CompletionEventEncoding
 	}
 	return
 }
 
 // GetTaskList internal sql blob getter
 func (w *WorkflowExecutionInfo) GetTaskList() (o string) {
-	if w != nil && w.TaskList != nil {
-		return *w.TaskList
+	if w != nil {
+		return w.TaskList
 	}
 	return
 }
 
 // GetIsCron internal sql blob getter
 func (w *WorkflowExecutionInfo) GetIsCron() (o bool) {
-	if w != nil && w.IsCron != nil {
-		return *w.IsCron
+	if w != nil {
+		return w.IsCron
 	}
 	return
 }
 
 // GetWorkflowTypeName internal sql blob getter
 func (w *WorkflowExecutionInfo) GetWorkflowTypeName() (o string) {
-	if w != nil && w.WorkflowTypeName != nil {
-		return *w.WorkflowTypeName
+	if w != nil {
+		return w.WorkflowTypeName
 	}
 	return
 }
 
 // GetCreateRequestID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetCreateRequestID() (o string) {
-	if w != nil && w.CreateRequestID != nil {
-		return *w.CreateRequestID
+	if w != nil {
+		return w.CreateRequestID
 	}
 	return
 }
 
 // GetDecisionRequestID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionRequestID() (o string) {
-	if w != nil && w.DecisionRequestID != nil {
-		return *w.DecisionRequestID
+	if w != nil {
+		return w.DecisionRequestID
 	}
 	return
 }
 
 // GetCancelRequestID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetCancelRequestID() (o string) {
-	if w != nil && w.CancelRequestID != nil {
-		return *w.CancelRequestID
+	if w != nil {
+		return w.CancelRequestID
 	}
 	return
 }
 
 // GetStickyTaskList internal sql blob getter
 func (w *WorkflowExecutionInfo) GetStickyTaskList() (o string) {
-	if w != nil && w.StickyTaskList != nil {
-		return *w.StickyTaskList
+	if w != nil {
+		return w.StickyTaskList
 	}
 	return
 }
 
 // GetCronSchedule internal sql blob getter
 func (w *WorkflowExecutionInfo) GetCronSchedule() (o string) {
-	if w != nil && w.CronSchedule != nil {
-		return *w.CronSchedule
+	if w != nil {
+		return w.CronSchedule
 	}
 	return
 }
 
 // GetClientLibraryVersion internal sql blob getter
 func (w *WorkflowExecutionInfo) GetClientLibraryVersion() (o string) {
-	if w != nil && w.ClientLibraryVersion != nil {
-		return *w.ClientLibraryVersion
+	if w != nil {
+		return w.ClientLibraryVersion
 	}
 	return
 }
 
 // GetClientFeatureVersion internal sql blob getter
 func (w *WorkflowExecutionInfo) GetClientFeatureVersion() (o string) {
-	if w != nil && w.ClientFeatureVersion != nil {
-		return *w.ClientFeatureVersion
+	if w != nil {
+		return w.ClientFeatureVersion
 	}
 	return
 }
 
 // GetClientImpl internal sql blob getter
 func (w *WorkflowExecutionInfo) GetClientImpl() (o string) {
-	if w != nil && w.ClientImpl != nil {
-		return *w.ClientImpl
+	if w != nil {
+		return w.ClientImpl
 	}
 	return
 }
 
 // GetAutoResetPointsEncoding internal sql blob getter
 func (w *WorkflowExecutionInfo) GetAutoResetPointsEncoding() (o string) {
-	if w != nil && w.AutoResetPointsEncoding != nil {
-		return *w.AutoResetPointsEncoding
+	if w != nil {
+		return w.AutoResetPointsEncoding
 	}
 	return
 }
 
 // GetVersionHistoriesEncoding internal sql blob getter
 func (w *WorkflowExecutionInfo) GetVersionHistoriesEncoding() (o string) {
-	if w != nil && w.VersionHistoriesEncoding != nil {
-		return *w.VersionHistoriesEncoding
+	if w != nil {
+		return w.VersionHistoriesEncoding
 	}
 	return
 }
 
 // GetInitiatedID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetInitiatedID() (o int64) {
-	if w != nil && w.InitiatedID != nil {
-		return *w.InitiatedID
+	if w != nil {
+		return w.InitiatedID
 	}
 	return
 }
@@ -542,8 +542,8 @@ func (w *WorkflowExecutionInfo) GetCompletionEventBatchID() (o int64) {
 
 // GetStartVersion internal sql blob getter
 func (w *WorkflowExecutionInfo) GetStartVersion() (o int64) {
-	if w != nil && w.StartVersion != nil {
-		return *w.StartVersion
+	if w != nil {
+		return w.StartVersion
 	}
 	return
 }
@@ -558,216 +558,216 @@ func (w *WorkflowExecutionInfo) GetLastWriteEventID() (o int64) {
 
 // GetLastEventTaskID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetLastEventTaskID() (o int64) {
-	if w != nil && w.LastEventTaskID != nil {
-		return *w.LastEventTaskID
+	if w != nil {
+		return w.LastEventTaskID
 	}
 	return
 }
 
 // GetLastFirstEventID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetLastFirstEventID() (o int64) {
-	if w != nil && w.LastFirstEventID != nil {
-		return *w.LastFirstEventID
+	if w != nil {
+		return w.LastFirstEventID
 	}
 	return
 }
 
 // GetLastProcessedEvent internal sql blob getter
 func (w *WorkflowExecutionInfo) GetLastProcessedEvent() (o int64) {
-	if w != nil && w.LastProcessedEvent != nil {
-		return *w.LastProcessedEvent
+	if w != nil {
+		return w.LastProcessedEvent
 	}
 	return
 }
 
 // GetDecisionVersion internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionVersion() (o int64) {
-	if w != nil && w.DecisionVersion != nil {
-		return *w.DecisionVersion
+	if w != nil {
+		return w.DecisionVersion
 	}
 	return
 }
 
 // GetDecisionScheduleID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionScheduleID() (o int64) {
-	if w != nil && w.DecisionScheduleID != nil {
-		return *w.DecisionScheduleID
+	if w != nil {
+		return w.DecisionScheduleID
 	}
 	return
 }
 
 // GetDecisionStartedID internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionStartedID() (o int64) {
-	if w != nil && w.DecisionStartedID != nil {
-		return *w.DecisionStartedID
+	if w != nil {
+		return w.DecisionStartedID
 	}
 	return
 }
 
 // GetDecisionAttempt internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionAttempt() (o int64) {
-	if w != nil && w.DecisionAttempt != nil {
-		return *w.DecisionAttempt
+	if w != nil {
+		return w.DecisionAttempt
 	}
 	return
 }
 
 // GetRetryAttempt internal sql blob getter
 func (w *WorkflowExecutionInfo) GetRetryAttempt() (o int64) {
-	if w != nil && w.RetryAttempt != nil {
-		return *w.RetryAttempt
+	if w != nil {
+		return w.RetryAttempt
 	}
 	return
 }
 
 // GetSignalCount internal sql blob getter
 func (w *WorkflowExecutionInfo) GetSignalCount() (o int64) {
-	if w != nil && w.SignalCount != nil {
-		return *w.SignalCount
+	if w != nil {
+		return w.SignalCount
 	}
 	return
 }
 
 // GetHistorySize internal sql blob getter
 func (w *WorkflowExecutionInfo) GetHistorySize() (o int64) {
-	if w != nil && w.HistorySize != nil {
-		return *w.HistorySize
+	if w != nil {
+		return w.HistorySize
 	}
 	return
 }
 
 // GetState internal sql blob getter
 func (w *WorkflowExecutionInfo) GetState() (o int32) {
-	if w != nil && w.State != nil {
-		return *w.State
+	if w != nil {
+		return w.State
 	}
 	return
 }
 
 // GetCloseStatus internal sql blob getter
 func (w *WorkflowExecutionInfo) GetCloseStatus() (o int32) {
-	if w != nil && w.CloseStatus != nil {
-		return *w.CloseStatus
+	if w != nil {
+		return w.CloseStatus
 	}
 	return
 }
 
 // GetRetryMaximumAttempts internal sql blob getter
 func (w *WorkflowExecutionInfo) GetRetryMaximumAttempts() (o int32) {
-	if w != nil && w.RetryMaximumAttempts != nil {
-		return *w.RetryMaximumAttempts
+	if w != nil {
+		return w.RetryMaximumAttempts
 	}
 	return
 }
 
 // GetEventStoreVersion internal sql blob getter
 func (w *WorkflowExecutionInfo) GetEventStoreVersion() (o int32) {
-	if w != nil && w.EventStoreVersion != nil {
-		return *w.EventStoreVersion
+	if w != nil {
+		return w.EventStoreVersion
 	}
 	return
 }
 
 // GetWorkflowTimeout internal sql blob getter
 func (w *WorkflowExecutionInfo) GetWorkflowTimeout() time.Duration {
-	if w != nil && w.WorkflowTimeout != nil {
-		return *w.WorkflowTimeout
+	if w != nil {
+		return w.WorkflowTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetDecisionTaskTimeout internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionTaskTimeout() time.Duration {
-	if w != nil && w.DecisionTaskTimeout != nil {
-		return *w.DecisionTaskTimeout
+	if w != nil {
+		return w.DecisionTaskTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetDecisionTimeout internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionTimeout() time.Duration {
-	if w != nil && w.DecisionTimeout != nil {
-		return *w.DecisionTimeout
+	if w != nil {
+		return w.DecisionTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetStickyScheduleToStartTimeout internal sql blob getter
 func (w *WorkflowExecutionInfo) GetStickyScheduleToStartTimeout() time.Duration {
-	if w != nil && w.StickyScheduleToStartTimeout != nil {
-		return *w.StickyScheduleToStartTimeout
+	if w != nil {
+		return w.StickyScheduleToStartTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetRetryInitialInterval internal sql blob getter
 func (w *WorkflowExecutionInfo) GetRetryInitialInterval() time.Duration {
-	if w != nil && w.RetryInitialInterval != nil {
-		return *w.RetryInitialInterval
+	if w != nil {
+		return w.RetryInitialInterval
 	}
 	return time.Duration(0)
 }
 
 // GetRetryMaximumInterval internal sql blob getter
 func (w *WorkflowExecutionInfo) GetRetryMaximumInterval() time.Duration {
-	if w != nil && w.RetryMaximumInterval != nil {
-		return *w.RetryMaximumInterval
+	if w != nil {
+		return w.RetryMaximumInterval
 	}
 	return time.Duration(0)
 }
 
 // GetRetryExpiration internal sql blob getter
 func (w *WorkflowExecutionInfo) GetRetryExpiration() time.Duration {
-	if w != nil && w.RetryExpiration != nil {
-		return *w.RetryExpiration
+	if w != nil {
+		return w.RetryExpiration
 	}
 	return time.Duration(0)
 }
 
 // GetStartTimestamp internal sql blob getter
 func (w *WorkflowExecutionInfo) GetStartTimestamp() time.Time {
-	if w != nil && w.StartTimestamp != nil {
-		return *w.StartTimestamp
+	if w != nil {
+		return w.StartTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetLastUpdatedTimestamp internal sql blob getter
 func (w *WorkflowExecutionInfo) GetLastUpdatedTimestamp() time.Time {
-	if w != nil && w.LastUpdatedTimestamp != nil {
-		return *w.LastUpdatedTimestamp
+	if w != nil {
+		return w.LastUpdatedTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetDecisionStartedTimestamp internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionStartedTimestamp() time.Time {
-	if w != nil && w.DecisionStartedTimestamp != nil {
-		return *w.DecisionStartedTimestamp
+	if w != nil {
+		return w.DecisionStartedTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetDecisionScheduledTimestamp internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionScheduledTimestamp() time.Time {
-	if w != nil && w.DecisionScheduledTimestamp != nil {
-		return *w.DecisionScheduledTimestamp
+	if w != nil {
+		return w.DecisionScheduledTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetDecisionOriginalScheduledTimestamp internal sql blob getter
 func (w *WorkflowExecutionInfo) GetDecisionOriginalScheduledTimestamp() time.Time {
-	if w != nil && w.DecisionOriginalScheduledTimestamp != nil {
-		return *w.DecisionOriginalScheduledTimestamp
+	if w != nil {
+		return w.DecisionOriginalScheduledTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetRetryExpirationTimestamp internal sql blob getter
 func (w *WorkflowExecutionInfo) GetRetryExpirationTimestamp() time.Time {
-	if w != nil && w.RetryExpirationTimestamp != nil {
-		return *w.RetryExpirationTimestamp
+	if w != nil {
+		return w.RetryExpirationTimestamp
 	}
 	return time.Unix(0, 0)
 }
@@ -838,208 +838,208 @@ func (w *WorkflowExecutionInfo) GetRetryNonRetryableErrors() (o []string) {
 
 // GetCancelRequested internal sql blob getter
 func (w *WorkflowExecutionInfo) GetCancelRequested() (o bool) {
-	if w != nil && w.CancelRequested != nil {
-		return *w.CancelRequested
+	if w != nil {
+		return w.CancelRequested
 	}
 	return
 }
 
 // GetHasRetryPolicy internal sql blob getter
 func (w *WorkflowExecutionInfo) GetHasRetryPolicy() (o bool) {
-	if w != nil && w.HasRetryPolicy != nil {
-		return *w.HasRetryPolicy
+	if w != nil {
+		return w.HasRetryPolicy
 	}
 	return
 }
 
 // GetVersion internal sql blob getter
 func (a *ActivityInfo) GetVersion() (o int64) {
-	if a != nil && a.Version != nil {
-		return *a.Version
+	if a != nil {
+		return a.Version
 	}
 	return
 }
 
 // GetScheduledEventBatchID internal sql blob getter
 func (a *ActivityInfo) GetScheduledEventBatchID() (o int64) {
-	if a != nil && a.ScheduledEventBatchID != nil {
-		return *a.ScheduledEventBatchID
+	if a != nil {
+		return a.ScheduledEventBatchID
 	}
 	return
 }
 
 // GetStartedID internal sql blob getter
 func (a *ActivityInfo) GetStartedID() (o int64) {
-	if a != nil && a.StartedID != nil {
-		return *a.StartedID
+	if a != nil {
+		return a.StartedID
 	}
 	return
 }
 
 // GetCancelRequestID internal sql blob getter
 func (a *ActivityInfo) GetCancelRequestID() (o int64) {
-	if a != nil && a.CancelRequestID != nil {
-		return *a.CancelRequestID
+	if a != nil {
+		return a.CancelRequestID
 	}
 	return
 }
 
 // GetTimerTaskStatus internal sql blob getter
 func (a *ActivityInfo) GetTimerTaskStatus() (o int32) {
-	if a != nil && a.TimerTaskStatus != nil {
-		return *a.TimerTaskStatus
+	if a != nil {
+		return a.TimerTaskStatus
 	}
 	return
 }
 
 // GetScheduledEventEncoding internal sql blob getter
 func (a *ActivityInfo) GetScheduledEventEncoding() (o string) {
-	if a != nil && a.ScheduledEventEncoding != nil {
-		return *a.ScheduledEventEncoding
+	if a != nil {
+		return a.ScheduledEventEncoding
 	}
 	return
 }
 
 // GetStartedIdentity internal sql blob getter
 func (a *ActivityInfo) GetStartedIdentity() (o string) {
-	if a != nil && a.StartedIdentity != nil {
-		return *a.StartedIdentity
+	if a != nil {
+		return a.StartedIdentity
 	}
 	return
 }
 
 // GetRetryLastFailureReason internal sql blob getter
 func (a *ActivityInfo) GetRetryLastFailureReason() (o string) {
-	if a != nil && a.RetryLastFailureReason != nil {
-		return *a.RetryLastFailureReason
+	if a != nil {
+		return a.RetryLastFailureReason
 	}
 	return
 }
 
 // GetRetryLastWorkerIdentity internal sql blob getter
 func (a *ActivityInfo) GetRetryLastWorkerIdentity() (o string) {
-	if a != nil && a.RetryLastWorkerIdentity != nil {
-		return *a.RetryLastWorkerIdentity
+	if a != nil {
+		return a.RetryLastWorkerIdentity
 	}
 	return
 }
 
 // GetTaskList internal sql blob getter
 func (a *ActivityInfo) GetTaskList() (o string) {
-	if a != nil && a.TaskList != nil {
-		return *a.TaskList
+	if a != nil {
+		return a.TaskList
 	}
 	return
 }
 
 // GetStartedEventEncoding internal sql blob getter
 func (a *ActivityInfo) GetStartedEventEncoding() (o string) {
-	if a != nil && a.StartedEventEncoding != nil {
-		return *a.StartedEventEncoding
+	if a != nil {
+		return a.StartedEventEncoding
 	}
 	return
 }
 
 // GetActivityID internal sql blob getter
 func (a *ActivityInfo) GetActivityID() (o string) {
-	if a != nil && a.ActivityID != nil {
-		return *a.ActivityID
+	if a != nil {
+		return a.ActivityID
 	}
 	return
 }
 
 // GetRequestID internal sql blob getter
 func (a *ActivityInfo) GetRequestID() (o string) {
-	if a != nil && a.RequestID != nil {
-		return *a.RequestID
+	if a != nil {
+		return a.RequestID
 	}
 	return
 }
 
 // GetAttempt internal sql blob getter
 func (a *ActivityInfo) GetAttempt() (o int32) {
-	if a != nil && a.Attempt != nil {
-		return *a.Attempt
+	if a != nil {
+		return a.Attempt
 	}
 	return
 }
 
 // GetRetryMaximumAttempts internal sql blob getter
 func (a *ActivityInfo) GetRetryMaximumAttempts() (o int32) {
-	if a != nil && a.RetryMaximumAttempts != nil {
-		return *a.RetryMaximumAttempts
+	if a != nil {
+		return a.RetryMaximumAttempts
 	}
 	return
 }
 
 // GetScheduledTimestamp internal sql blob getter
 func (a *ActivityInfo) GetScheduledTimestamp() time.Time {
-	if a != nil && a.ScheduledTimestamp != nil {
-		return *a.ScheduledTimestamp
+	if a != nil {
+		return a.ScheduledTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetStartedTimestamp internal sql blob getter
 func (a *ActivityInfo) GetStartedTimestamp() time.Time {
-	if a != nil && a.StartedTimestamp != nil {
-		return *a.StartedTimestamp
+	if a != nil {
+		return a.StartedTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetRetryExpirationTimestamp internal sql blob getter
 func (a *ActivityInfo) GetRetryExpirationTimestamp() time.Time {
-	if a != nil && a.RetryExpirationTimestamp != nil {
-		return *a.RetryExpirationTimestamp
+	if a != nil {
+		return a.RetryExpirationTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetScheduleToStartTimeout internal sql blob getter
 func (a *ActivityInfo) GetScheduleToStartTimeout() time.Duration {
-	if a != nil && a.ScheduleToStartTimeout != nil {
-		return *a.ScheduleToStartTimeout
+	if a != nil {
+		return a.ScheduleToStartTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetScheduleToCloseTimeout internal sql blob getter
 func (a *ActivityInfo) GetScheduleToCloseTimeout() time.Duration {
-	if a != nil && a.ScheduleToCloseTimeout != nil {
-		return *a.ScheduleToCloseTimeout
+	if a != nil {
+		return a.ScheduleToCloseTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetStartToCloseTimeout internal sql blob getter
 func (a *ActivityInfo) GetStartToCloseTimeout() time.Duration {
-	if a != nil && a.StartToCloseTimeout != nil {
-		return *a.StartToCloseTimeout
+	if a != nil {
+		return a.StartToCloseTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetHeartbeatTimeout internal sql blob getter
 func (a *ActivityInfo) GetHeartbeatTimeout() time.Duration {
-	if a != nil && a.HeartbeatTimeout != nil {
-		return *a.HeartbeatTimeout
+	if a != nil {
+		return a.HeartbeatTimeout
 	}
 	return time.Duration(0)
 }
 
 // GetRetryInitialInterval internal sql blob getter
 func (a *ActivityInfo) GetRetryInitialInterval() time.Duration {
-	if a != nil && a.RetryInitialInterval != nil {
-		return *a.RetryInitialInterval
+	if a != nil {
+		return a.RetryInitialInterval
 	}
 	return time.Duration(0)
 }
 
 // GetRetryMaximumInterval internal sql blob getter
 func (a *ActivityInfo) GetRetryMaximumInterval() time.Duration {
-	if a != nil && a.RetryMaximumInterval != nil {
-		return *a.RetryMaximumInterval
+	if a != nil {
+		return a.RetryMaximumInterval
 	}
 	return time.Duration(0)
 }
@@ -1070,24 +1070,24 @@ func (a *ActivityInfo) GetRetryLastFailureDetails() (o []byte) {
 
 // GetCancelRequested internal sql blob getter
 func (a *ActivityInfo) GetCancelRequested() (o bool) {
-	if a != nil && a.CancelRequested != nil {
-		return *a.CancelRequested
+	if a != nil {
+		return a.CancelRequested
 	}
 	return
 }
 
 // GetHasRetryPolicy internal sql blob getter
 func (a *ActivityInfo) GetHasRetryPolicy() (o bool) {
-	if a != nil && a.HasRetryPolicy != nil {
-		return *a.HasRetryPolicy
+	if a != nil {
+		return a.HasRetryPolicy
 	}
 	return
 }
 
 // GetRetryBackoffCoefficient internal sql blob getter
 func (a *ActivityInfo) GetRetryBackoffCoefficient() (o float64) {
-	if a != nil && a.RetryBackoffCoefficient != nil {
-		return *a.RetryBackoffCoefficient
+	if a != nil {
+		return a.RetryBackoffCoefficient
 	}
 	return
 }
@@ -1102,48 +1102,48 @@ func (a *ActivityInfo) GetRetryNonRetryableErrors() (o []string) {
 
 // GetVersion internal sql blob getter
 func (c *ChildExecutionInfo) GetVersion() (o int64) {
-	if c != nil && c.Version != nil {
-		return *c.Version
+	if c != nil {
+		return c.Version
 	}
 	return
 }
 
 // GetInitiatedEventBatchID internal sql blob getter
 func (c *ChildExecutionInfo) GetInitiatedEventBatchID() (o int64) {
-	if c != nil && c.InitiatedEventBatchID != nil {
-		return *c.InitiatedEventBatchID
+	if c != nil {
+		return c.InitiatedEventBatchID
 	}
 	return
 }
 
 // GetStartedID internal sql blob getter
 func (c *ChildExecutionInfo) GetStartedID() (o int64) {
-	if c != nil && c.StartedID != nil {
-		return *c.StartedID
+	if c != nil {
+		return c.StartedID
 	}
 	return
 }
 
 // GetParentClosePolicy internal sql blob getter
 func (c *ChildExecutionInfo) GetParentClosePolicy() (o int32) {
-	if c != nil && c.ParentClosePolicy != nil {
-		return *c.ParentClosePolicy
+	if c != nil {
+		return c.ParentClosePolicy
 	}
 	return
 }
 
 // GetInitiatedEventEncoding internal sql blob getter
 func (c *ChildExecutionInfo) GetInitiatedEventEncoding() (o string) {
-	if c != nil && c.InitiatedEventEncoding != nil {
-		return *c.InitiatedEventEncoding
+	if c != nil {
+		return c.InitiatedEventEncoding
 	}
 	return
 }
 
 // GetStartedWorkflowID internal sql blob getter
 func (c *ChildExecutionInfo) GetStartedWorkflowID() (o string) {
-	if c != nil && c.StartedWorkflowID != nil {
-		return *c.StartedWorkflowID
+	if c != nil {
+		return c.StartedWorkflowID
 	}
 	return
 }
@@ -1158,32 +1158,32 @@ func (c *ChildExecutionInfo) GetStartedRunID() (o []byte) {
 
 // GetStartedEventEncoding internal sql blob getter
 func (c *ChildExecutionInfo) GetStartedEventEncoding() (o string) {
-	if c != nil && c.StartedEventEncoding != nil {
-		return *c.StartedEventEncoding
+	if c != nil {
+		return c.StartedEventEncoding
 	}
 	return
 }
 
 // GetCreateRequestID internal sql blob getter
 func (c *ChildExecutionInfo) GetCreateRequestID() (o string) {
-	if c != nil && c.CreateRequestID != nil {
-		return *c.CreateRequestID
+	if c != nil {
+		return c.CreateRequestID
 	}
 	return
 }
 
 // GetDomainName internal sql blob getter
 func (c *ChildExecutionInfo) GetDomainName() (o string) {
-	if c != nil && c.DomainName != nil {
-		return *c.DomainName
+	if c != nil {
+		return c.DomainName
 	}
 	return
 }
 
 // GetWorkflowTypeName internal sql blob getter
 func (c *ChildExecutionInfo) GetWorkflowTypeName() (o string) {
-	if c != nil && c.WorkflowTypeName != nil {
-		return *c.WorkflowTypeName
+	if c != nil {
+		return c.WorkflowTypeName
 	}
 	return
 }
@@ -1206,32 +1206,32 @@ func (c *ChildExecutionInfo) GetStartedEvent() (o []byte) {
 
 // GetVersion internal sql blob getter
 func (s *SignalInfo) GetVersion() (o int64) {
-	if s != nil && s.Version != nil {
-		return *s.Version
+	if s != nil {
+		return s.Version
 	}
 	return
 }
 
 // GetInitiatedEventBatchID internal sql blob getter
 func (s *SignalInfo) GetInitiatedEventBatchID() (o int64) {
-	if s != nil && s.InitiatedEventBatchID != nil {
-		return *s.InitiatedEventBatchID
+	if s != nil {
+		return s.InitiatedEventBatchID
 	}
 	return
 }
 
 // GetRequestID internal sql blob getter
 func (s *SignalInfo) GetRequestID() (o string) {
-	if s != nil && s.RequestID != nil {
-		return *s.RequestID
+	if s != nil {
+		return s.RequestID
 	}
 	return
 }
 
 // GetName internal sql blob getter
 func (s *SignalInfo) GetName() (o string) {
-	if s != nil && s.Name != nil {
-		return *s.Name
+	if s != nil {
+		return s.Name
 	}
 	return
 }
@@ -1254,64 +1254,64 @@ func (s *SignalInfo) GetControl() (o []byte) {
 
 // GetVersion internal sql blob getter
 func (r *RequestCancelInfo) GetVersion() (o int64) {
-	if r != nil && r.Version != nil {
-		return *r.Version
+	if r != nil {
+		return r.Version
 	}
 	return
 }
 
 // GetInitiatedEventBatchID internal sql blob getter
 func (r *RequestCancelInfo) GetInitiatedEventBatchID() (o int64) {
-	if r != nil && r.InitiatedEventBatchID != nil {
-		return *r.InitiatedEventBatchID
+	if r != nil {
+		return r.InitiatedEventBatchID
 	}
 	return
 }
 
 // GetCancelRequestID internal sql blob getter
 func (r *RequestCancelInfo) GetCancelRequestID() (o string) {
-	if r != nil && r.CancelRequestID != nil {
-		return *r.CancelRequestID
+	if r != nil {
+		return r.CancelRequestID
 	}
 	return
 }
 
 // GetVersion internal sql blob getter
 func (t *TimerInfo) GetVersion() (o int64) {
-	if t != nil && t.Version != nil {
-		return *t.Version
+	if t != nil {
+		return t.Version
 	}
 	return
 }
 
 // GetStartedID internal sql blob getter
 func (t *TimerInfo) GetStartedID() (o int64) {
-	if t != nil && t.StartedID != nil {
-		return *t.StartedID
+	if t != nil {
+		return t.StartedID
 	}
 	return
 }
 
 // GetTaskID internal sql blob getter
 func (t *TimerInfo) GetTaskID() (o int64) {
-	if t != nil && t.TaskID != nil {
-		return *t.TaskID
+	if t != nil {
+		return t.TaskID
 	}
 	return
 }
 
 // GetExpiryTimestamp internal sql blob getter
 func (t *TimerInfo) GetExpiryTimestamp() (o time.Time) {
-	if t != nil && t.ExpiryTimestamp != nil {
-		return *t.ExpiryTimestamp
+	if t != nil {
+		return t.ExpiryTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetWorkflowID internal sql blob getter
 func (t *TaskInfo) GetWorkflowID() (o string) {
-	if t != nil && t.WorkflowID != nil {
-		return *t.WorkflowID
+	if t != nil {
+		return t.WorkflowID
 	}
 	return
 }
@@ -1326,56 +1326,56 @@ func (t *TaskInfo) GetRunID() (o []byte) {
 
 // GetScheduleID internal sql blob getter
 func (t *TaskInfo) GetScheduleID() (o int64) {
-	if t != nil && t.ScheduleID != nil {
-		return *t.ScheduleID
+	if t != nil {
+		return t.ScheduleID
 	}
 	return
 }
 
 // GetExpiryTimestamp internal sql blob getter
 func (t *TaskInfo) GetExpiryTimestamp() time.Time {
-	if t != nil && t.ExpiryTimestamp != nil {
-		return *t.ExpiryTimestamp
+	if t != nil {
+		return t.ExpiryTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetCreatedTimestamp internal sql blob getter
 func (t *TaskInfo) GetCreatedTimestamp() time.Time {
-	if t != nil && t.CreatedTimestamp != nil {
-		return *t.CreatedTimestamp
+	if t != nil {
+		return t.CreatedTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetKind internal sql blob getter
 func (t *TaskListInfo) GetKind() (o int16) {
-	if t != nil && t.Kind != nil {
-		return *t.Kind
+	if t != nil {
+		return t.Kind
 	}
 	return
 }
 
 // GetAckLevel internal sql blob getter
 func (t *TaskListInfo) GetAckLevel() (o int64) {
-	if t != nil && t.AckLevel != nil {
-		return *t.AckLevel
+	if t != nil {
+		return t.AckLevel
 	}
 	return
 }
 
 // GetExpiryTimestamp internal sql blob getter
 func (t *TaskListInfo) GetExpiryTimestamp() time.Time {
-	if t != nil && t.ExpiryTimestamp != nil {
-		return *t.ExpiryTimestamp
+	if t != nil {
+		return t.ExpiryTimestamp
 	}
 	return time.Unix(0, 0)
 }
 
 // GetLastUpdated internal sql blob getter
 func (t *TaskListInfo) GetLastUpdated() time.Time {
-	if t != nil && t.LastUpdated != nil {
-		return *t.LastUpdated
+	if t != nil {
+		return t.LastUpdated
 	}
 	return time.Unix(0, 0)
 }
@@ -1390,8 +1390,8 @@ func (t *TransferTaskInfo) GetDomainID() (o []byte) {
 
 // GetWorkflowID internal sql blob getter
 func (t *TransferTaskInfo) GetWorkflowID() (o string) {
-	if t != nil && t.WorkflowID != nil {
-		return *t.WorkflowID
+	if t != nil {
+		return t.WorkflowID
 	}
 	return
 }
@@ -1406,8 +1406,8 @@ func (t *TransferTaskInfo) GetRunID() (o []byte) {
 
 // GetTaskType internal sql blob getter
 func (t *TransferTaskInfo) GetTaskType() (o int16) {
-	if t != nil && t.TaskType != nil {
-		return *t.TaskType
+	if t != nil {
+		return t.TaskType
 	}
 	return
 }
@@ -1422,8 +1422,8 @@ func (t *TransferTaskInfo) GetTargetDomainID() (o []byte) {
 
 // GetTargetWorkflowID internal sql blob getter
 func (t *TransferTaskInfo) GetTargetWorkflowID() (o string) {
-	if t != nil && t.TargetWorkflowID != nil {
-		return *t.TargetWorkflowID
+	if t != nil {
+		return t.TargetWorkflowID
 	}
 	return
 }
@@ -1438,40 +1438,40 @@ func (t *TransferTaskInfo) GetTargetRunID() (o []byte) {
 
 // GetTaskList internal sql blob getter
 func (t *TransferTaskInfo) GetTaskList() (o string) {
-	if t != nil && t.TaskList != nil {
-		return *t.TaskList
+	if t != nil {
+		return t.TaskList
 	}
 	return
 }
 
 // GetTargetChildWorkflowOnly internal sql blob getter
 func (t *TransferTaskInfo) GetTargetChildWorkflowOnly() (o bool) {
-	if t != nil && t.TargetChildWorkflowOnly != nil {
-		return *t.TargetChildWorkflowOnly
+	if t != nil {
+		return t.TargetChildWorkflowOnly
 	}
 	return
 }
 
 // GetScheduleID internal sql blob getter
 func (t *TransferTaskInfo) GetScheduleID() (o int64) {
-	if t != nil && t.ScheduleID != nil {
-		return *t.ScheduleID
+	if t != nil {
+		return t.ScheduleID
 	}
 	return
 }
 
 // GetVersion internal sql blob getter
 func (t *TransferTaskInfo) GetVersion() (o int64) {
-	if t != nil && t.Version != nil {
-		return *t.Version
+	if t != nil {
+		return t.Version
 	}
 	return
 }
 
 // GetVisibilityTimestamp internal sql blob getter
 func (t *TransferTaskInfo) GetVisibilityTimestamp() time.Time {
-	if t != nil && t.VisibilityTimestamp != nil {
-		return *t.VisibilityTimestamp
+	if t != nil {
+		return t.VisibilityTimestamp
 	}
 	return time.Unix(0, 0)
 }
@@ -1486,15 +1486,15 @@ func (t *TimerTaskInfo) GetDomainID() (o []byte) {
 
 // GetWorkflowID internal sql blob getter
 func (t *TimerTaskInfo) GetWorkflowID() (o string) {
-	if t != nil && t.WorkflowID != nil {
-		return *t.WorkflowID
+	if t != nil {
+		return t.WorkflowID
 	}
 	return
 }
 
 // GetRunID internal sql blob getter
 func (t *TimerTaskInfo) GetRunID() (o []byte) {
-	if t != nil && t.RunID != nil {
+	if t != nil {
 		return t.RunID
 	}
 	return
@@ -1502,8 +1502,8 @@ func (t *TimerTaskInfo) GetRunID() (o []byte) {
 
 // GetTaskType internal sql blob getter
 func (t *TimerTaskInfo) GetTaskType() (o int16) {
-	if t != nil && t.TaskType != nil {
-		return *t.TaskType
+	if t != nil {
+		return t.TaskType
 	}
 	return
 }
@@ -1518,24 +1518,24 @@ func (t *TimerTaskInfo) GetTimeoutType() (o int16) {
 
 // GetVersion internal sql blob getter
 func (t *TimerTaskInfo) GetVersion() (o int64) {
-	if t != nil && t.Version != nil {
-		return *t.Version
+	if t != nil {
+		return t.Version
 	}
 	return
 }
 
 // GetScheduleAttempt internal sql blob getter
 func (t *TimerTaskInfo) GetScheduleAttempt() (o int64) {
-	if t != nil && t.ScheduleAttempt != nil {
-		return *t.ScheduleAttempt
+	if t != nil {
+		return t.ScheduleAttempt
 	}
 	return
 }
 
 // GetEventID internal sql blob getter
 func (t *TimerTaskInfo) GetEventID() (o int64) {
-	if t != nil && t.EventID != nil {
-		return *t.EventID
+	if t != nil {
+		return t.EventID
 	}
 	return
 }
@@ -1550,8 +1550,8 @@ func (t *ReplicationTaskInfo) GetDomainID() (o []byte) {
 
 // GetWorkflowID internal sql blob getter
 func (t *ReplicationTaskInfo) GetWorkflowID() (o string) {
-	if t != nil && t.WorkflowID != nil {
-		return *t.WorkflowID
+	if t != nil {
+		return t.WorkflowID
 	}
 	return
 }
@@ -1566,56 +1566,56 @@ func (t *ReplicationTaskInfo) GetRunID() (o []byte) {
 
 // GetTaskType internal sql blob getter
 func (t *ReplicationTaskInfo) GetTaskType() (o int16) {
-	if t != nil && t.TaskType != nil {
-		return *t.TaskType
+	if t != nil {
+		return t.TaskType
 	}
 	return
 }
 
 // GetVersion internal sql blob getter
 func (t *ReplicationTaskInfo) GetVersion() (o int64) {
-	if t != nil && t.Version != nil {
-		return *t.Version
+	if t != nil {
+		return t.Version
 	}
 	return
 }
 
 // GetFirstEventID internal sql blob getter
 func (t *ReplicationTaskInfo) GetFirstEventID() (o int64) {
-	if t != nil && t.FirstEventID != nil {
-		return *t.FirstEventID
+	if t != nil {
+		return t.FirstEventID
 	}
 	return
 }
 
 // GetNextEventID internal sql blob getter
 func (t *ReplicationTaskInfo) GetNextEventID() (o int64) {
-	if t != nil && t.NextEventID != nil {
-		return *t.NextEventID
+	if t != nil {
+		return t.NextEventID
 	}
 	return
 }
 
 // GetScheduledID internal sql blob getter
 func (t *ReplicationTaskInfo) GetScheduledID() (o int64) {
-	if t != nil && t.ScheduledID != nil {
-		return *t.ScheduledID
+	if t != nil {
+		return t.ScheduledID
 	}
 	return
 }
 
 // GetEventStoreVersion internal sql blob getter
 func (t *ReplicationTaskInfo) GetEventStoreVersion() (o int32) {
-	if t != nil && t.EventStoreVersion != nil {
-		return *t.EventStoreVersion
+	if t != nil {
+		return t.EventStoreVersion
 	}
 	return
 }
 
 // GetNewRunEventStoreVersion internal sql blob getter
 func (t *ReplicationTaskInfo) GetNewRunEventStoreVersion() (o int32) {
-	if t != nil && t.NewRunEventStoreVersion != nil {
-		return *t.NewRunEventStoreVersion
+	if t != nil {
+		return t.NewRunEventStoreVersion
 	}
 	return
 }
@@ -1638,8 +1638,8 @@ func (t *ReplicationTaskInfo) GetNewRunBranchToken() (o []byte) {
 
 // GetCreationTimestamp internal sql blob getter
 func (t *ReplicationTaskInfo) GetCreationTimestamp() time.Time {
-	if t != nil && t.CreationTimestamp != nil {
-		return *t.CreationTimestamp
+	if t != nil {
+		return t.CreationTimestamp
 	}
 	return time.Unix(0, 0)
 }

--- a/common/persistence/serialization/interfaces.go
+++ b/common/persistence/serialization/interfaces.go
@@ -35,267 +35,267 @@ import (
 type (
 	// ShardInfo blob in a serialization agnostic format
 	ShardInfo struct {
-		StolenSinceRenew                      *int32
-		UpdatedAt                             *time.Time
-		ReplicationAckLevel                   *int64
-		TransferAckLevel                      *int64
-		TimerAckLevel                         *time.Time
-		DomainNotificationVersion             *int64
+		StolenSinceRenew                      int32
+		UpdatedAt                             time.Time
+		ReplicationAckLevel                   int64
+		TransferAckLevel                      int64
+		TimerAckLevel                         time.Time
+		DomainNotificationVersion             int64
 		ClusterTransferAckLevel               map[string]int64
 		ClusterTimerAckLevel                  map[string]time.Time
-		Owner                                 *string
+		Owner                                 string
 		ClusterReplicationLevel               map[string]int64
 		PendingFailoverMarkers                []byte
-		PendingFailoverMarkersEncoding        *string
+		PendingFailoverMarkersEncoding        string
 		ReplicationDlqAckLevel                map[string]int64
 		TransferProcessingQueueStates         []byte
-		TransferProcessingQueueStatesEncoding *string
+		TransferProcessingQueueStatesEncoding string
 		TimerProcessingQueueStates            []byte
-		TimerProcessingQueueStatesEncoding    *string
+		TimerProcessingQueueStatesEncoding    string
 	}
 
 	// DomainInfo blob in a serialization agnostic format
 	DomainInfo struct {
-		Name                        *string
-		Description                 *string
-		Owner                       *string
-		Status                      *int32
-		Retention                   *time.Duration
-		EmitMetric                  *bool
-		ArchivalBucket              *string
-		ArchivalStatus              *int16
-		ConfigVersion               *int64
-		NotificationVersion         *int64
-		FailoverNotificationVersion *int64
-		FailoverVersion             *int64
-		ActiveClusterName           *string
+		Name                        string // TODO: This field seems not to be required. We already store domain name in another column.
+		Description                 string
+		Owner                       string
+		Status                      int32
+		Retention                   time.Duration
+		EmitMetric                  bool
+		ArchivalBucket              string
+		ArchivalStatus              int16
+		ConfigVersion               int64
+		NotificationVersion         int64
+		FailoverNotificationVersion int64
+		FailoverVersion             int64
+		ActiveClusterName           string
 		Clusters                    []string
 		Data                        map[string]string
 		BadBinaries                 []byte
-		BadBinariesEncoding         *string
-		HistoryArchivalStatus       *int16
-		HistoryArchivalURI          *string
-		VisibilityArchivalStatus    *int16
-		VisibilityArchivalURI       *string
-		FailoverEndTimestamp        *time.Time
-		PreviousFailoverVersion     *int64
-		LastUpdatedTimestamp        *time.Time
+		BadBinariesEncoding         string
+		HistoryArchivalStatus       int16
+		HistoryArchivalURI          string
+		VisibilityArchivalStatus    int16
+		VisibilityArchivalURI       string
+		FailoverEndTimestamp        *time.Time // TODO: There is logic checking if it's nil, should revisit this
+		PreviousFailoverVersion     int64
+		LastUpdatedTimestamp        time.Time
 	}
 
 	// HistoryBranchRange blob in a serialization agnostic format
 	HistoryBranchRange struct {
-		BranchID    *string
-		BeginNodeID *int64
-		EndNodeID   *int64
+		BranchID    string
+		BeginNodeID int64
+		EndNodeID   int64
 	}
 
 	// HistoryTreeInfo blob in a serialization agnostic format
 	HistoryTreeInfo struct {
-		CreatedTimestamp *time.Time
+		CreatedTimestamp time.Time
 		Ancestors        []*types.HistoryBranchRange
-		Info             *string
+		Info             string
 	}
 
 	// WorkflowExecutionInfo blob in a serialization agnostic format
 	WorkflowExecutionInfo struct {
 		ParentDomainID                     UUID
-		ParentWorkflowID                   *string
+		ParentWorkflowID                   string
 		ParentRunID                        UUID
-		InitiatedID                        *int64
-		CompletionEventBatchID             *int64
+		InitiatedID                        int64
+		CompletionEventBatchID             *int64 // TODO: This is not updated because of backward compatibility issue. Should revisit it later.
 		CompletionEvent                    []byte
-		CompletionEventEncoding            *string
-		TaskList                           *string
-		IsCron                             *bool
-		WorkflowTypeName                   *string
-		WorkflowTimeout                    *time.Duration
-		DecisionTaskTimeout                *time.Duration
+		CompletionEventEncoding            string
+		TaskList                           string
+		IsCron                             bool
+		WorkflowTypeName                   string
+		WorkflowTimeout                    time.Duration
+		DecisionTaskTimeout                time.Duration
 		ExecutionContext                   []byte
-		State                              *int32
-		CloseStatus                        *int32
-		StartVersion                       *int64
-		LastWriteEventID                   *int64
-		LastEventTaskID                    *int64
-		LastFirstEventID                   *int64
-		LastProcessedEvent                 *int64
-		StartTimestamp                     *time.Time
-		LastUpdatedTimestamp               *time.Time
-		DecisionVersion                    *int64
-		DecisionScheduleID                 *int64
-		DecisionStartedID                  *int64
-		DecisionTimeout                    *time.Duration
-		DecisionAttempt                    *int64
-		DecisionStartedTimestamp           *time.Time
-		DecisionScheduledTimestamp         *time.Time
-		CancelRequested                    *bool
-		DecisionOriginalScheduledTimestamp *time.Time
-		CreateRequestID                    *string
-		DecisionRequestID                  *string
-		CancelRequestID                    *string
-		StickyTaskList                     *string
-		StickyScheduleToStartTimeout       *time.Duration
-		RetryAttempt                       *int64
-		RetryInitialInterval               *time.Duration
-		RetryMaximumInterval               *time.Duration
-		RetryMaximumAttempts               *int32
-		RetryExpiration                    *time.Duration
-		RetryBackoffCoefficient            *float64
-		RetryExpirationTimestamp           *time.Time
+		State                              int32
+		CloseStatus                        int32
+		StartVersion                       int64
+		LastWriteEventID                   *int64 // TODO: We have logic checking if LastWriteEventID != nil. The field seems to be deprecated. Should revisit it later.
+		LastEventTaskID                    int64
+		LastFirstEventID                   int64
+		LastProcessedEvent                 int64
+		StartTimestamp                     time.Time
+		LastUpdatedTimestamp               time.Time
+		DecisionVersion                    int64
+		DecisionScheduleID                 int64
+		DecisionStartedID                  int64
+		DecisionTimeout                    time.Duration
+		DecisionAttempt                    int64
+		DecisionStartedTimestamp           time.Time
+		DecisionScheduledTimestamp         time.Time
+		CancelRequested                    bool
+		DecisionOriginalScheduledTimestamp time.Time
+		CreateRequestID                    string
+		DecisionRequestID                  string
+		CancelRequestID                    string
+		StickyTaskList                     string
+		StickyScheduleToStartTimeout       time.Duration
+		RetryAttempt                       int64
+		RetryInitialInterval               time.Duration
+		RetryMaximumInterval               time.Duration
+		RetryMaximumAttempts               int32
+		RetryExpiration                    time.Duration
+		RetryBackoffCoefficient            float64
+		RetryExpirationTimestamp           time.Time
 		RetryNonRetryableErrors            []string
-		HasRetryPolicy                     *bool
-		CronSchedule                       *string
-		EventStoreVersion                  *int32
+		HasRetryPolicy                     bool
+		CronSchedule                       string
+		EventStoreVersion                  int32
 		EventBranchToken                   []byte
-		SignalCount                        *int64
-		HistorySize                        *int64
-		ClientLibraryVersion               *string
-		ClientFeatureVersion               *string
-		ClientImpl                         *string
+		SignalCount                        int64
+		HistorySize                        int64
+		ClientLibraryVersion               string
+		ClientFeatureVersion               string
+		ClientImpl                         string
 		AutoResetPoints                    []byte
-		AutoResetPointsEncoding            *string
+		AutoResetPointsEncoding            string
 		SearchAttributes                   map[string][]byte
 		Memo                               map[string][]byte
 		VersionHistories                   []byte
-		VersionHistoriesEncoding           *string
+		VersionHistoriesEncoding           string
 	}
 
 	// ActivityInfo blob in a serialization agnostic format
 	ActivityInfo struct {
-		Version                  *int64
-		ScheduledEventBatchID    *int64
+		Version                  int64
+		ScheduledEventBatchID    int64
 		ScheduledEvent           []byte
-		ScheduledEventEncoding   *string
-		ScheduledTimestamp       *time.Time
-		StartedID                *int64
+		ScheduledEventEncoding   string
+		ScheduledTimestamp       time.Time
+		StartedID                int64
 		StartedEvent             []byte
-		StartedEventEncoding     *string
-		StartedTimestamp         *time.Time
-		ActivityID               *string
-		RequestID                *string
-		ScheduleToStartTimeout   *time.Duration
-		ScheduleToCloseTimeout   *time.Duration
-		StartToCloseTimeout      *time.Duration
-		HeartbeatTimeout         *time.Duration
-		CancelRequested          *bool
-		CancelRequestID          *int64
-		TimerTaskStatus          *int32
-		Attempt                  *int32
-		TaskList                 *string
-		StartedIdentity          *string
-		HasRetryPolicy           *bool
-		RetryInitialInterval     *time.Duration
-		RetryMaximumInterval     *time.Duration
-		RetryMaximumAttempts     *int32
-		RetryExpirationTimestamp *time.Time
-		RetryBackoffCoefficient  *float64
+		StartedEventEncoding     string
+		StartedTimestamp         time.Time
+		ActivityID               string
+		RequestID                string
+		ScheduleToStartTimeout   time.Duration
+		ScheduleToCloseTimeout   time.Duration
+		StartToCloseTimeout      time.Duration
+		HeartbeatTimeout         time.Duration
+		CancelRequested          bool
+		CancelRequestID          int64
+		TimerTaskStatus          int32
+		Attempt                  int32
+		TaskList                 string
+		StartedIdentity          string
+		HasRetryPolicy           bool
+		RetryInitialInterval     time.Duration
+		RetryMaximumInterval     time.Duration
+		RetryMaximumAttempts     int32
+		RetryExpirationTimestamp time.Time
+		RetryBackoffCoefficient  float64
 		RetryNonRetryableErrors  []string
-		RetryLastFailureReason   *string
-		RetryLastWorkerIdentity  *string
+		RetryLastFailureReason   string
+		RetryLastWorkerIdentity  string
 		RetryLastFailureDetails  []byte
 	}
 
 	// ChildExecutionInfo blob in a serialization agnostic format
 	ChildExecutionInfo struct {
-		Version                *int64
-		InitiatedEventBatchID  *int64
-		StartedID              *int64
+		Version                int64
+		InitiatedEventBatchID  int64
+		StartedID              int64
 		InitiatedEvent         []byte
-		InitiatedEventEncoding *string
-		StartedWorkflowID      *string
+		InitiatedEventEncoding string
+		StartedWorkflowID      string
 		StartedRunID           UUID
 		StartedEvent           []byte
-		StartedEventEncoding   *string
-		CreateRequestID        *string
-		DomainName             *string
-		WorkflowTypeName       *string
-		ParentClosePolicy      *int32
+		StartedEventEncoding   string
+		CreateRequestID        string
+		DomainName             string
+		WorkflowTypeName       string
+		ParentClosePolicy      int32
 	}
 
 	// SignalInfo blob in a serialization agnostic format
 	SignalInfo struct {
-		Version               *int64
-		InitiatedEventBatchID *int64
-		RequestID             *string
-		Name                  *string
+		Version               int64
+		InitiatedEventBatchID int64
+		RequestID             string
+		Name                  string
 		Input                 []byte
 		Control               []byte
 	}
 
 	// RequestCancelInfo blob in a serialization agnostic format
 	RequestCancelInfo struct {
-		Version               *int64
-		InitiatedEventBatchID *int64
-		CancelRequestID       *string
+		Version               int64
+		InitiatedEventBatchID int64
+		CancelRequestID       string
 	}
 
 	// TimerInfo blob in a serialization agnostic format
 	TimerInfo struct {
-		Version         *int64
-		StartedID       *int64
-		ExpiryTimestamp *time.Time
-		TaskID          *int64
+		Version         int64
+		StartedID       int64
+		ExpiryTimestamp time.Time
+		TaskID          int64
 	}
 
 	// TaskInfo blob in a serialization agnostic format
 	TaskInfo struct {
-		WorkflowID       *string
+		WorkflowID       string
 		RunID            UUID
-		ScheduleID       *int64
-		ExpiryTimestamp  *time.Time
-		CreatedTimestamp *time.Time
+		ScheduleID       int64
+		ExpiryTimestamp  time.Time
+		CreatedTimestamp time.Time
 	}
 
 	// TaskListInfo blob in a serialization agnostic format
 	TaskListInfo struct {
-		Kind            *int16
-		AckLevel        *int64
-		ExpiryTimestamp *time.Time
-		LastUpdated     *time.Time
+		Kind            int16
+		AckLevel        int64
+		ExpiryTimestamp time.Time
+		LastUpdated     time.Time
 	}
 
 	// TransferTaskInfo blob in a serialization agnostic format
 	TransferTaskInfo struct {
 		DomainID                UUID
-		WorkflowID              *string
+		WorkflowID              string
 		RunID                   UUID
-		TaskType                *int16
+		TaskType                int16
 		TargetDomainID          UUID
-		TargetWorkflowID        *string
+		TargetWorkflowID        string
 		TargetRunID             UUID
-		TaskList                *string
-		TargetChildWorkflowOnly *bool
-		ScheduleID              *int64
-		Version                 *int64
-		VisibilityTimestamp     *time.Time
+		TaskList                string
+		TargetChildWorkflowOnly bool
+		ScheduleID              int64
+		Version                 int64
+		VisibilityTimestamp     time.Time
 	}
 
 	// TimerTaskInfo blob in a serialization agnostic format
 	TimerTaskInfo struct {
 		DomainID        UUID
-		WorkflowID      *string
+		WorkflowID      string
 		RunID           UUID
-		TaskType        *int16
-		TimeoutType     *int16
-		Version         *int64
-		ScheduleAttempt *int64
-		EventID         *int64
+		TaskType        int16
+		TimeoutType     *int16 // TODO: The default value for TimeoutType doesn't make sense. No equivalent value for nil.
+		Version         int64
+		ScheduleAttempt int64
+		EventID         int64
 	}
 
 	// ReplicationTaskInfo blob in a serialization agnostic format
 	ReplicationTaskInfo struct {
 		DomainID                UUID
-		WorkflowID              *string
+		WorkflowID              string
 		RunID                   UUID
-		TaskType                *int16
-		Version                 *int64
-		FirstEventID            *int64
-		NextEventID             *int64
-		ScheduledID             *int64
-		EventStoreVersion       *int32
-		NewRunEventStoreVersion *int32
+		TaskType                int16
+		Version                 int64
+		FirstEventID            int64
+		NextEventID             int64
+		ScheduledID             int64
+		EventStoreVersion       int32
+		NewRunEventStoreVersion int32
 		BranchToken             []byte
 		NewRunBranchToken       []byte
-		CreationTimestamp       *time.Time
+		CreationTimestamp       time.Time
 	}
 )
 

--- a/common/persistence/serialization/parser_test.go
+++ b/common/persistence/serialization/parser_test.go
@@ -34,7 +34,7 @@ func TestParse(t *testing.T) {
 	thriftParser, err := NewParser(common.EncodingTypeThriftRW, common.EncodingTypeThriftRW)
 	assert.NoError(t, err)
 	domainInfo := &DomainInfo{
-		Name: common.StringPtr("test_name"),
+		Name: "test_name",
 		Data: map[string]string{"test_key": "test_value"},
 	}
 	db, err := thriftParser.DomainInfoToBlob(domainInfo)
@@ -42,5 +42,5 @@ func TestParse(t *testing.T) {
 	assert.NotNil(t, db.Data)
 	decodedDomainInfo, err := thriftParser.DomainInfoFromBlob(db.Data, string(db.Encoding))
 	assert.NoError(t, err)
-	assert.Equal(t, decodedDomainInfo, domainInfo)
+	assert.Equal(t, domainInfo, decodedDomainInfo)
 }

--- a/common/persistence/serialization/thrift_mapper.go
+++ b/common/persistence/serialization/thrift_mapper.go
@@ -36,22 +36,22 @@ func shardInfoToThrift(info *ShardInfo) *sqlblobs.ShardInfo {
 		return nil
 	}
 	result := &sqlblobs.ShardInfo{
-		StolenSinceRenew:                      info.StolenSinceRenew,
-		ReplicationAckLevel:                   info.ReplicationAckLevel,
-		TransferAckLevel:                      info.TransferAckLevel,
-		DomainNotificationVersion:             info.DomainNotificationVersion,
+		StolenSinceRenew:                      &info.StolenSinceRenew,
+		ReplicationAckLevel:                   &info.ReplicationAckLevel,
+		TransferAckLevel:                      &info.TransferAckLevel,
+		DomainNotificationVersion:             &info.DomainNotificationVersion,
 		ClusterTransferAckLevel:               info.ClusterTransferAckLevel,
-		Owner:                                 info.Owner,
+		Owner:                                 &info.Owner,
 		ClusterReplicationLevel:               info.ClusterReplicationLevel,
 		PendingFailoverMarkers:                info.PendingFailoverMarkers,
-		PendingFailoverMarkersEncoding:        info.PendingFailoverMarkersEncoding,
+		PendingFailoverMarkersEncoding:        &info.PendingFailoverMarkersEncoding,
 		ReplicationDlqAckLevel:                info.ReplicationDlqAckLevel,
 		TransferProcessingQueueStates:         info.TransferProcessingQueueStates,
-		TransferProcessingQueueStatesEncoding: info.TransferProcessingQueueStatesEncoding,
+		TransferProcessingQueueStatesEncoding: &info.TransferProcessingQueueStatesEncoding,
 		TimerProcessingQueueStates:            info.TimerProcessingQueueStates,
-		TimerProcessingQueueStatesEncoding:    info.TimerProcessingQueueStatesEncoding,
-		UpdatedAtNanos:                        unixNanoPtr(info.UpdatedAt),
-		TimerAckLevelNanos:                    unixNanoPtr(info.TimerAckLevel),
+		TimerProcessingQueueStatesEncoding:    &info.TimerProcessingQueueStatesEncoding,
+		UpdatedAtNanos:                        timeToUnixNanoPtr(info.UpdatedAt),
+		TimerAckLevelNanos:                    timeToUnixNanoPtr(info.TimerAckLevel),
 	}
 	if info.ClusterTimerAckLevel != nil {
 		result.ClusterTimerAckLevel = make(map[string]int64, len(info.ClusterTimerAckLevel))
@@ -68,22 +68,22 @@ func shardInfoFromThrift(info *sqlblobs.ShardInfo) *ShardInfo {
 	}
 
 	result := &ShardInfo{
-		StolenSinceRenew:                      info.StolenSinceRenew,
-		ReplicationAckLevel:                   info.ReplicationAckLevel,
-		TransferAckLevel:                      info.TransferAckLevel,
-		DomainNotificationVersion:             info.DomainNotificationVersion,
+		StolenSinceRenew:                      info.GetStolenSinceRenew(),
+		ReplicationAckLevel:                   info.GetReplicationAckLevel(),
+		TransferAckLevel:                      info.GetTransferAckLevel(),
+		DomainNotificationVersion:             info.GetDomainNotificationVersion(),
 		ClusterTransferAckLevel:               info.ClusterTransferAckLevel,
-		Owner:                                 info.Owner,
+		Owner:                                 info.GetOwner(),
 		ClusterReplicationLevel:               info.ClusterReplicationLevel,
 		PendingFailoverMarkers:                info.PendingFailoverMarkers,
-		PendingFailoverMarkersEncoding:        info.PendingFailoverMarkersEncoding,
+		PendingFailoverMarkersEncoding:        info.GetPendingFailoverMarkersEncoding(),
 		ReplicationDlqAckLevel:                info.ReplicationDlqAckLevel,
 		TransferProcessingQueueStates:         info.TransferProcessingQueueStates,
-		TransferProcessingQueueStatesEncoding: info.TransferProcessingQueueStatesEncoding,
+		TransferProcessingQueueStatesEncoding: info.GetTransferProcessingQueueStatesEncoding(),
 		TimerProcessingQueueStates:            info.TimerProcessingQueueStates,
-		TimerProcessingQueueStatesEncoding:    info.TimerProcessingQueueStatesEncoding,
-		UpdatedAt:                             timePtr(info.UpdatedAtNanos),
-		TimerAckLevel:                         timePtr(info.TimerAckLevelNanos),
+		TimerProcessingQueueStatesEncoding:    info.GetTimerProcessingQueueStatesEncoding(),
+		UpdatedAt:                             timeFromUnixNano(info.GetUpdatedAtNanos()),
+		TimerAckLevel:                         timeFromUnixNano(info.GetTimerAckLevelNanos()),
 	}
 	if info.ClusterTimerAckLevel != nil {
 		result.ClusterTimerAckLevel = make(map[string]time.Time, len(info.ClusterTimerAckLevel))
@@ -99,30 +99,30 @@ func domainInfoToThrift(info *DomainInfo) *sqlblobs.DomainInfo {
 		return nil
 	}
 	return &sqlblobs.DomainInfo{
-		Name:                        info.Name,
-		Description:                 info.Description,
-		Owner:                       info.Owner,
-		Status:                      info.Status,
-		EmitMetric:                  info.EmitMetric,
-		ArchivalBucket:              info.ArchivalBucket,
-		ArchivalStatus:              info.ArchivalStatus,
-		ConfigVersion:               info.ConfigVersion,
-		NotificationVersion:         info.NotificationVersion,
-		FailoverNotificationVersion: info.FailoverNotificationVersion,
-		FailoverVersion:             info.FailoverVersion,
-		ActiveClusterName:           info.ActiveClusterName,
+		Name:                        &info.Name,
+		Description:                 &info.Description,
+		Owner:                       &info.Owner,
+		Status:                      &info.Status,
+		EmitMetric:                  &info.EmitMetric,
+		ArchivalBucket:              &info.ArchivalBucket,
+		ArchivalStatus:              &info.ArchivalStatus,
+		ConfigVersion:               &info.ConfigVersion,
+		NotificationVersion:         &info.NotificationVersion,
+		FailoverNotificationVersion: &info.FailoverNotificationVersion,
+		FailoverVersion:             &info.FailoverVersion,
+		ActiveClusterName:           &info.ActiveClusterName,
 		Clusters:                    info.Clusters,
 		Data:                        info.Data,
 		BadBinaries:                 info.BadBinaries,
-		BadBinariesEncoding:         info.BadBinariesEncoding,
-		HistoryArchivalStatus:       info.HistoryArchivalStatus,
-		HistoryArchivalURI:          info.HistoryArchivalURI,
-		VisibilityArchivalStatus:    info.VisibilityArchivalStatus,
-		VisibilityArchivalURI:       info.VisibilityArchivalURI,
-		PreviousFailoverVersion:     info.PreviousFailoverVersion,
-		RetentionDays:               durationToDays(info.Retention),
+		BadBinariesEncoding:         &info.BadBinariesEncoding,
+		HistoryArchivalStatus:       &info.HistoryArchivalStatus,
+		HistoryArchivalURI:          &info.HistoryArchivalURI,
+		VisibilityArchivalStatus:    &info.VisibilityArchivalStatus,
+		VisibilityArchivalURI:       &info.VisibilityArchivalURI,
+		PreviousFailoverVersion:     &info.PreviousFailoverVersion,
+		RetentionDays:               durationToDaysInt16Ptr(info.Retention),
 		FailoverEndTime:             unixNanoPtr(info.FailoverEndTimestamp),
-		LastUpdatedTime:             unixNanoPtr(info.LastUpdatedTimestamp),
+		LastUpdatedTime:             timeToUnixNanoPtr(info.LastUpdatedTimestamp),
 	}
 }
 
@@ -131,30 +131,30 @@ func domainInfoFromThrift(info *sqlblobs.DomainInfo) *DomainInfo {
 		return nil
 	}
 	return &DomainInfo{
-		Name:                        info.Name,
-		Description:                 info.Description,
-		Owner:                       info.Owner,
-		Status:                      info.Status,
-		EmitMetric:                  info.EmitMetric,
-		ArchivalBucket:              info.ArchivalBucket,
-		ArchivalStatus:              info.ArchivalStatus,
-		ConfigVersion:               info.ConfigVersion,
-		NotificationVersion:         info.NotificationVersion,
-		FailoverNotificationVersion: info.FailoverNotificationVersion,
-		FailoverVersion:             info.FailoverVersion,
-		ActiveClusterName:           info.ActiveClusterName,
+		Name:                        info.GetName(),
+		Description:                 info.GetDescription(),
+		Owner:                       info.GetOwner(),
+		Status:                      info.GetStatus(),
+		EmitMetric:                  info.GetEmitMetric(),
+		ArchivalBucket:              info.GetArchivalBucket(),
+		ArchivalStatus:              info.GetArchivalStatus(),
+		ConfigVersion:               info.GetConfigVersion(),
+		NotificationVersion:         info.GetNotificationVersion(),
+		FailoverNotificationVersion: info.GetFailoverNotificationVersion(),
+		FailoverVersion:             info.GetFailoverVersion(),
+		ActiveClusterName:           info.GetActiveClusterName(),
 		Clusters:                    info.Clusters,
 		Data:                        info.Data,
 		BadBinaries:                 info.BadBinaries,
-		BadBinariesEncoding:         info.BadBinariesEncoding,
-		HistoryArchivalStatus:       info.HistoryArchivalStatus,
-		HistoryArchivalURI:          info.HistoryArchivalURI,
-		VisibilityArchivalStatus:    info.VisibilityArchivalStatus,
-		VisibilityArchivalURI:       info.VisibilityArchivalURI,
-		PreviousFailoverVersion:     info.PreviousFailoverVersion,
-		Retention:                   daysToDuration(info.RetentionDays),
+		BadBinariesEncoding:         info.GetBadBinariesEncoding(),
+		HistoryArchivalStatus:       info.GetHistoryArchivalStatus(),
+		HistoryArchivalURI:          info.GetHistoryArchivalURI(),
+		VisibilityArchivalStatus:    info.GetVisibilityArchivalStatus(),
+		VisibilityArchivalURI:       info.GetVisibilityArchivalURI(),
+		PreviousFailoverVersion:     info.GetPreviousFailoverVersion(),
+		Retention:                   common.DaysToDuration(int32(info.GetRetentionDays())),
 		FailoverEndTimestamp:        timePtr(info.FailoverEndTime),
-		LastUpdatedTimestamp:        timePtr(info.LastUpdatedTime),
+		LastUpdatedTimestamp:        timeFromUnixNano(info.GetLastUpdatedTime()),
 	}
 }
 
@@ -163,8 +163,8 @@ func historyTreeInfoToThrift(info *HistoryTreeInfo) *sqlblobs.HistoryTreeInfo {
 		return nil
 	}
 	result := &sqlblobs.HistoryTreeInfo{
-		CreatedTimeNanos: unixNanoPtr(info.CreatedTimestamp),
-		Info:             info.Info,
+		CreatedTimeNanos: timeToUnixNanoPtr(info.CreatedTimestamp),
+		Info:             &info.Info,
 	}
 	if info.Ancestors != nil {
 		result.Ancestors = make([]*shared.HistoryBranchRange, len(info.Ancestors), len(info.Ancestors))
@@ -184,8 +184,8 @@ func historyTreeInfoFromThrift(info *sqlblobs.HistoryTreeInfo) *HistoryTreeInfo 
 		return nil
 	}
 	result := &HistoryTreeInfo{
-		CreatedTimestamp: timePtr(info.CreatedTimeNanos),
-		Info:             info.Info,
+		CreatedTimestamp: timeFromUnixNano(info.GetCreatedTimeNanos()),
+		Info:             info.GetInfo(),
 	}
 	if info.Ancestors != nil {
 		result.Ancestors = make([]*types.HistoryBranchRange, len(info.Ancestors), len(info.Ancestors))
@@ -206,63 +206,63 @@ func workflowExecutionInfoToThrift(info *WorkflowExecutionInfo) *sqlblobs.Workfl
 	}
 	return &sqlblobs.WorkflowExecutionInfo{
 		ParentDomainID:                          info.ParentDomainID,
-		ParentWorkflowID:                        info.ParentWorkflowID,
+		ParentWorkflowID:                        &info.ParentWorkflowID,
 		ParentRunID:                             info.ParentRunID,
-		InitiatedID:                             info.InitiatedID,
+		InitiatedID:                             &info.InitiatedID,
 		CompletionEventBatchID:                  info.CompletionEventBatchID,
 		CompletionEvent:                         info.CompletionEvent,
-		CompletionEventEncoding:                 info.CompletionEventEncoding,
-		TaskList:                                info.TaskList,
-		WorkflowTypeName:                        info.WorkflowTypeName,
-		WorkflowTimeoutSeconds:                  durationToSeconds(info.WorkflowTimeout),
-		DecisionTaskTimeoutSeconds:              durationToSeconds(info.DecisionTaskTimeout),
+		CompletionEventEncoding:                 &info.CompletionEventEncoding,
+		TaskList:                                &info.TaskList,
+		WorkflowTypeName:                        &info.WorkflowTypeName,
+		WorkflowTimeoutSeconds:                  durationToSecondsInt32Ptr(info.WorkflowTimeout),
+		DecisionTaskTimeoutSeconds:              durationToSecondsInt32Ptr(info.DecisionTaskTimeout),
 		ExecutionContext:                        info.ExecutionContext,
-		State:                                   info.State,
-		CloseStatus:                             info.CloseStatus,
-		StartVersion:                            info.StartVersion,
+		State:                                   &info.State,
+		CloseStatus:                             &info.CloseStatus,
+		StartVersion:                            &info.StartVersion,
 		LastWriteEventID:                        info.LastWriteEventID,
-		LastEventTaskID:                         info.LastEventTaskID,
-		LastFirstEventID:                        info.LastFirstEventID,
-		LastProcessedEvent:                      info.LastProcessedEvent,
-		StartTimeNanos:                          unixNanoPtr(info.StartTimestamp),
-		LastUpdatedTimeNanos:                    unixNanoPtr(info.LastUpdatedTimestamp),
-		DecisionVersion:                         info.DecisionVersion,
-		DecisionScheduleID:                      info.DecisionScheduleID,
-		DecisionStartedID:                       info.DecisionStartedID,
-		DecisionTimeout:                         durationToSeconds(info.DecisionTimeout),
-		DecisionAttempt:                         info.DecisionAttempt,
-		DecisionStartedTimestampNanos:           unixNanoPtr(info.DecisionStartedTimestamp),
-		DecisionScheduledTimestampNanos:         unixNanoPtr(info.DecisionScheduledTimestamp),
-		CancelRequested:                         info.CancelRequested,
-		DecisionOriginalScheduledTimestampNanos: unixNanoPtr(info.DecisionOriginalScheduledTimestamp),
-		CreateRequestID:                         info.CreateRequestID,
-		DecisionRequestID:                       info.DecisionRequestID,
-		CancelRequestID:                         info.CancelRequestID,
-		StickyTaskList:                          info.StickyTaskList,
-		StickyScheduleToStartTimeout:            durationToSecondsInt64(info.StickyScheduleToStartTimeout),
-		RetryAttempt:                            info.RetryAttempt,
-		RetryInitialIntervalSeconds:             durationToSeconds(info.RetryInitialInterval),
-		RetryMaximumIntervalSeconds:             durationToSeconds(info.RetryMaximumInterval),
-		RetryMaximumAttempts:                    info.RetryMaximumAttempts,
-		RetryExpirationSeconds:                  durationToSeconds(info.RetryExpiration),
-		RetryBackoffCoefficient:                 info.RetryBackoffCoefficient,
-		RetryExpirationTimeNanos:                unixNanoPtr(info.RetryExpirationTimestamp),
+		LastEventTaskID:                         &info.LastEventTaskID,
+		LastFirstEventID:                        &info.LastFirstEventID,
+		LastProcessedEvent:                      &info.LastProcessedEvent,
+		StartTimeNanos:                          timeToUnixNanoPtr(info.StartTimestamp),
+		LastUpdatedTimeNanos:                    timeToUnixNanoPtr(info.LastUpdatedTimestamp),
+		DecisionVersion:                         &info.DecisionVersion,
+		DecisionScheduleID:                      &info.DecisionScheduleID,
+		DecisionStartedID:                       &info.DecisionStartedID,
+		DecisionTimeout:                         durationToSecondsInt32Ptr(info.DecisionTimeout),
+		DecisionAttempt:                         &info.DecisionAttempt,
+		DecisionStartedTimestampNanos:           timeToUnixNanoPtr(info.DecisionStartedTimestamp),
+		DecisionScheduledTimestampNanos:         timeToUnixNanoPtr(info.DecisionScheduledTimestamp),
+		CancelRequested:                         &info.CancelRequested,
+		DecisionOriginalScheduledTimestampNanos: timeToUnixNanoPtr(info.DecisionOriginalScheduledTimestamp),
+		CreateRequestID:                         &info.CreateRequestID,
+		DecisionRequestID:                       &info.DecisionRequestID,
+		CancelRequestID:                         &info.CancelRequestID,
+		StickyTaskList:                          &info.StickyTaskList,
+		StickyScheduleToStartTimeout:            durationToSecondsInt64Ptr(info.StickyScheduleToStartTimeout),
+		RetryAttempt:                            &info.RetryAttempt,
+		RetryInitialIntervalSeconds:             durationToSecondsInt32Ptr(info.RetryInitialInterval),
+		RetryMaximumIntervalSeconds:             durationToSecondsInt32Ptr(info.RetryMaximumInterval),
+		RetryMaximumAttempts:                    &info.RetryMaximumAttempts,
+		RetryExpirationSeconds:                  durationToSecondsInt32Ptr(info.RetryExpiration),
+		RetryBackoffCoefficient:                 &info.RetryBackoffCoefficient,
+		RetryExpirationTimeNanos:                timeToUnixNanoPtr(info.RetryExpirationTimestamp),
 		RetryNonRetryableErrors:                 info.RetryNonRetryableErrors,
-		HasRetryPolicy:                          info.HasRetryPolicy,
-		CronSchedule:                            info.CronSchedule,
-		EventStoreVersion:                       info.EventStoreVersion,
+		HasRetryPolicy:                          &info.HasRetryPolicy,
+		CronSchedule:                            &info.CronSchedule,
+		EventStoreVersion:                       &info.EventStoreVersion,
 		EventBranchToken:                        info.EventBranchToken,
-		SignalCount:                             info.SignalCount,
-		HistorySize:                             info.HistorySize,
-		ClientLibraryVersion:                    info.ClientLibraryVersion,
-		ClientFeatureVersion:                    info.ClientFeatureVersion,
-		ClientImpl:                              info.ClientImpl,
+		SignalCount:                             &info.SignalCount,
+		HistorySize:                             &info.HistorySize,
+		ClientLibraryVersion:                    &info.ClientLibraryVersion,
+		ClientFeatureVersion:                    &info.ClientFeatureVersion,
+		ClientImpl:                              &info.ClientImpl,
 		AutoResetPoints:                         info.AutoResetPoints,
-		AutoResetPointsEncoding:                 info.AutoResetPointsEncoding,
+		AutoResetPointsEncoding:                 &info.AutoResetPointsEncoding,
 		SearchAttributes:                        info.SearchAttributes,
 		Memo:                                    info.Memo,
 		VersionHistories:                        info.VersionHistories,
-		VersionHistoriesEncoding:                info.VersionHistoriesEncoding,
+		VersionHistoriesEncoding:                &info.VersionHistoriesEncoding,
 	}
 }
 
@@ -272,63 +272,63 @@ func workflowExecutionInfoFromThrift(info *sqlblobs.WorkflowExecutionInfo) *Work
 	}
 	return &WorkflowExecutionInfo{
 		ParentDomainID:                     info.ParentDomainID,
-		ParentWorkflowID:                   info.ParentWorkflowID,
+		ParentWorkflowID:                   info.GetParentWorkflowID(),
 		ParentRunID:                        info.ParentRunID,
-		InitiatedID:                        info.InitiatedID,
+		InitiatedID:                        info.GetInitiatedID(),
 		CompletionEventBatchID:             info.CompletionEventBatchID,
 		CompletionEvent:                    info.CompletionEvent,
-		CompletionEventEncoding:            info.CompletionEventEncoding,
-		TaskList:                           info.TaskList,
-		WorkflowTypeName:                   info.WorkflowTypeName,
-		WorkflowTimeout:                    secondsToDuration(info.WorkflowTimeoutSeconds),
-		DecisionTaskTimeout:                secondsToDuration(info.DecisionTaskTimeoutSeconds),
+		CompletionEventEncoding:            info.GetCompletionEventEncoding(),
+		TaskList:                           info.GetTaskList(),
+		WorkflowTypeName:                   info.GetWorkflowTypeName(),
+		WorkflowTimeout:                    common.SecondsToDuration(int64(info.GetWorkflowTimeoutSeconds())),
+		DecisionTaskTimeout:                common.SecondsToDuration(int64(info.GetDecisionTaskTimeoutSeconds())),
 		ExecutionContext:                   info.ExecutionContext,
-		State:                              info.State,
-		CloseStatus:                        info.CloseStatus,
-		StartVersion:                       info.StartVersion,
+		State:                              info.GetState(),
+		CloseStatus:                        info.GetCloseStatus(),
+		StartVersion:                       info.GetStartVersion(),
 		LastWriteEventID:                   info.LastWriteEventID,
-		LastEventTaskID:                    info.LastEventTaskID,
-		LastFirstEventID:                   info.LastFirstEventID,
-		LastProcessedEvent:                 info.LastProcessedEvent,
-		StartTimestamp:                     timePtr(info.StartTimeNanos),
-		LastUpdatedTimestamp:               timePtr(info.LastUpdatedTimeNanos),
-		DecisionVersion:                    info.DecisionVersion,
-		DecisionScheduleID:                 info.DecisionScheduleID,
-		DecisionStartedID:                  info.DecisionStartedID,
-		DecisionTimeout:                    secondsToDuration(info.DecisionTimeout),
-		DecisionAttempt:                    info.DecisionAttempt,
-		DecisionStartedTimestamp:           timePtr(info.DecisionStartedTimestampNanos),
-		DecisionScheduledTimestamp:         timePtr(info.DecisionScheduledTimestampNanos),
-		CancelRequested:                    info.CancelRequested,
-		DecisionOriginalScheduledTimestamp: timePtr(info.DecisionOriginalScheduledTimestampNanos),
-		CreateRequestID:                    info.CreateRequestID,
-		DecisionRequestID:                  info.DecisionRequestID,
-		CancelRequestID:                    info.CancelRequestID,
-		StickyTaskList:                     info.StickyTaskList,
-		StickyScheduleToStartTimeout:       secondsInt64ToDuration(info.StickyScheduleToStartTimeout),
-		RetryAttempt:                       info.RetryAttempt,
-		RetryInitialInterval:               secondsToDuration(info.RetryInitialIntervalSeconds),
-		RetryMaximumInterval:               secondsToDuration(info.RetryMaximumIntervalSeconds),
-		RetryMaximumAttempts:               info.RetryMaximumAttempts,
-		RetryExpiration:                    secondsToDuration(info.RetryExpirationSeconds),
-		RetryBackoffCoefficient:            info.RetryBackoffCoefficient,
-		RetryExpirationTimestamp:           timePtr(info.RetryExpirationTimeNanos),
+		LastEventTaskID:                    info.GetLastEventTaskID(),
+		LastFirstEventID:                   info.GetLastFirstEventID(),
+		LastProcessedEvent:                 info.GetLastProcessedEvent(),
+		StartTimestamp:                     timeFromUnixNano(info.GetStartTimeNanos()),
+		LastUpdatedTimestamp:               timeFromUnixNano(info.GetLastUpdatedTimeNanos()),
+		DecisionVersion:                    info.GetDecisionVersion(),
+		DecisionScheduleID:                 info.GetDecisionScheduleID(),
+		DecisionStartedID:                  info.GetDecisionStartedID(),
+		DecisionTimeout:                    common.SecondsToDuration(int64(info.GetDecisionTimeout())),
+		DecisionAttempt:                    info.GetDecisionAttempt(),
+		DecisionStartedTimestamp:           timeFromUnixNano(info.GetDecisionStartedTimestampNanos()),
+		DecisionScheduledTimestamp:         timeFromUnixNano(info.GetDecisionScheduledTimestampNanos()),
+		CancelRequested:                    info.GetCancelRequested(),
+		DecisionOriginalScheduledTimestamp: timeFromUnixNano(info.GetDecisionOriginalScheduledTimestampNanos()),
+		CreateRequestID:                    info.GetCreateRequestID(),
+		DecisionRequestID:                  info.GetDecisionRequestID(),
+		CancelRequestID:                    info.GetCancelRequestID(),
+		StickyTaskList:                     info.GetStickyTaskList(),
+		StickyScheduleToStartTimeout:       common.SecondsToDuration(info.GetStickyScheduleToStartTimeout()),
+		RetryAttempt:                       info.GetRetryAttempt(),
+		RetryInitialInterval:               common.SecondsToDuration(int64(info.GetRetryInitialIntervalSeconds())),
+		RetryMaximumInterval:               common.SecondsToDuration(int64(info.GetRetryMaximumIntervalSeconds())),
+		RetryMaximumAttempts:               info.GetRetryMaximumAttempts(),
+		RetryExpiration:                    common.SecondsToDuration(int64(info.GetRetryExpirationSeconds())),
+		RetryBackoffCoefficient:            info.GetRetryBackoffCoefficient(),
+		RetryExpirationTimestamp:           timeFromUnixNano(info.GetRetryExpirationTimeNanos()),
 		RetryNonRetryableErrors:            info.RetryNonRetryableErrors,
-		HasRetryPolicy:                     info.HasRetryPolicy,
-		CronSchedule:                       info.CronSchedule,
-		EventStoreVersion:                  info.EventStoreVersion,
+		HasRetryPolicy:                     info.GetHasRetryPolicy(),
+		CronSchedule:                       info.GetCronSchedule(),
+		EventStoreVersion:                  info.GetEventStoreVersion(),
 		EventBranchToken:                   info.EventBranchToken,
-		SignalCount:                        info.SignalCount,
-		HistorySize:                        info.HistorySize,
-		ClientLibraryVersion:               info.ClientLibraryVersion,
-		ClientFeatureVersion:               info.ClientFeatureVersion,
-		ClientImpl:                         info.ClientImpl,
+		SignalCount:                        info.GetSignalCount(),
+		HistorySize:                        info.GetHistorySize(),
+		ClientLibraryVersion:               info.GetClientLibraryVersion(),
+		ClientFeatureVersion:               info.GetClientFeatureVersion(),
+		ClientImpl:                         info.GetClientImpl(),
 		AutoResetPoints:                    info.AutoResetPoints,
-		AutoResetPointsEncoding:            info.AutoResetPointsEncoding,
+		AutoResetPointsEncoding:            info.GetAutoResetPointsEncoding(),
 		SearchAttributes:                   info.SearchAttributes,
 		Memo:                               info.Memo,
 		VersionHistories:                   info.VersionHistories,
-		VersionHistoriesEncoding:           info.VersionHistoriesEncoding,
+		VersionHistoriesEncoding:           info.GetVersionHistoriesEncoding(),
 	}
 }
 
@@ -337,36 +337,36 @@ func activityInfoToThrift(info *ActivityInfo) *sqlblobs.ActivityInfo {
 		return nil
 	}
 	return &sqlblobs.ActivityInfo{
-		Version:                       info.Version,
-		ScheduledEventBatchID:         info.ScheduledEventBatchID,
+		Version:                       &info.Version,
+		ScheduledEventBatchID:         &info.ScheduledEventBatchID,
 		ScheduledEvent:                info.ScheduledEvent,
-		ScheduledEventEncoding:        info.ScheduledEventEncoding,
-		ScheduledTimeNanos:            unixNanoPtr(info.ScheduledTimestamp),
-		StartedID:                     info.StartedID,
+		ScheduledEventEncoding:        &info.ScheduledEventEncoding,
+		ScheduledTimeNanos:            timeToUnixNanoPtr(info.ScheduledTimestamp),
+		StartedID:                     &info.StartedID,
 		StartedEvent:                  info.StartedEvent,
-		StartedEventEncoding:          info.StartedEventEncoding,
-		StartedTimeNanos:              unixNanoPtr(info.StartedTimestamp),
-		ActivityID:                    info.ActivityID,
-		RequestID:                     info.RequestID,
-		ScheduleToStartTimeoutSeconds: durationToSeconds(info.ScheduleToStartTimeout),
-		ScheduleToCloseTimeoutSeconds: durationToSeconds(info.ScheduleToCloseTimeout),
-		StartToCloseTimeoutSeconds:    durationToSeconds(info.StartToCloseTimeout),
-		HeartbeatTimeoutSeconds:       durationToSeconds(info.HeartbeatTimeout),
-		CancelRequested:               info.CancelRequested,
-		CancelRequestID:               info.CancelRequestID,
-		TimerTaskStatus:               info.TimerTaskStatus,
-		Attempt:                       info.Attempt,
-		TaskList:                      info.TaskList,
-		StartedIdentity:               info.StartedIdentity,
-		HasRetryPolicy:                info.HasRetryPolicy,
-		RetryInitialIntervalSeconds:   durationToSeconds(info.RetryInitialInterval),
-		RetryMaximumIntervalSeconds:   durationToSeconds(info.RetryMaximumInterval),
-		RetryMaximumAttempts:          info.RetryMaximumAttempts,
-		RetryExpirationTimeNanos:      unixNanoPtr(info.RetryExpirationTimestamp),
-		RetryBackoffCoefficient:       info.RetryBackoffCoefficient,
+		StartedEventEncoding:          &info.StartedEventEncoding,
+		StartedTimeNanos:              timeToUnixNanoPtr(info.StartedTimestamp),
+		ActivityID:                    &info.ActivityID,
+		RequestID:                     &info.RequestID,
+		ScheduleToStartTimeoutSeconds: durationToSecondsInt32Ptr(info.ScheduleToStartTimeout),
+		ScheduleToCloseTimeoutSeconds: durationToSecondsInt32Ptr(info.ScheduleToCloseTimeout),
+		StartToCloseTimeoutSeconds:    durationToSecondsInt32Ptr(info.StartToCloseTimeout),
+		HeartbeatTimeoutSeconds:       durationToSecondsInt32Ptr(info.HeartbeatTimeout),
+		CancelRequested:               &info.CancelRequested,
+		CancelRequestID:               &info.CancelRequestID,
+		TimerTaskStatus:               &info.TimerTaskStatus,
+		Attempt:                       &info.Attempt,
+		TaskList:                      &info.TaskList,
+		StartedIdentity:               &info.StartedIdentity,
+		HasRetryPolicy:                &info.HasRetryPolicy,
+		RetryInitialIntervalSeconds:   durationToSecondsInt32Ptr(info.RetryInitialInterval),
+		RetryMaximumIntervalSeconds:   durationToSecondsInt32Ptr(info.RetryMaximumInterval),
+		RetryMaximumAttempts:          &info.RetryMaximumAttempts,
+		RetryExpirationTimeNanos:      timeToUnixNanoPtr(info.RetryExpirationTimestamp),
+		RetryBackoffCoefficient:       &info.RetryBackoffCoefficient,
 		RetryNonRetryableErrors:       info.RetryNonRetryableErrors,
-		RetryLastFailureReason:        info.RetryLastFailureReason,
-		RetryLastWorkerIdentity:       info.RetryLastWorkerIdentity,
+		RetryLastFailureReason:        &info.RetryLastFailureReason,
+		RetryLastWorkerIdentity:       &info.RetryLastWorkerIdentity,
 		RetryLastFailureDetails:       info.RetryLastFailureDetails,
 	}
 }
@@ -376,36 +376,36 @@ func activityInfoFromThrift(info *sqlblobs.ActivityInfo) *ActivityInfo {
 		return nil
 	}
 	return &ActivityInfo{
-		Version:                  info.Version,
-		ScheduledEventBatchID:    info.ScheduledEventBatchID,
+		Version:                  info.GetVersion(),
+		ScheduledEventBatchID:    info.GetScheduledEventBatchID(),
 		ScheduledEvent:           info.ScheduledEvent,
-		ScheduledEventEncoding:   info.ScheduledEventEncoding,
-		ScheduledTimestamp:       timePtr(info.ScheduledTimeNanos),
-		StartedID:                info.StartedID,
+		ScheduledEventEncoding:   info.GetScheduledEventEncoding(),
+		ScheduledTimestamp:       timeFromUnixNano(info.GetScheduledTimeNanos()),
+		StartedID:                info.GetStartedID(),
 		StartedEvent:             info.StartedEvent,
-		StartedEventEncoding:     info.StartedEventEncoding,
-		StartedTimestamp:         timePtr(info.StartedTimeNanos),
-		ActivityID:               info.ActivityID,
-		RequestID:                info.RequestID,
-		ScheduleToStartTimeout:   secondsToDuration(info.ScheduleToStartTimeoutSeconds),
-		ScheduleToCloseTimeout:   secondsToDuration(info.ScheduleToCloseTimeoutSeconds),
-		StartToCloseTimeout:      secondsToDuration(info.StartToCloseTimeoutSeconds),
-		HeartbeatTimeout:         secondsToDuration(info.HeartbeatTimeoutSeconds),
-		CancelRequested:          info.CancelRequested,
-		CancelRequestID:          info.CancelRequestID,
-		TimerTaskStatus:          info.TimerTaskStatus,
-		Attempt:                  info.Attempt,
-		TaskList:                 info.TaskList,
-		StartedIdentity:          info.StartedIdentity,
-		HasRetryPolicy:           info.HasRetryPolicy,
-		RetryInitialInterval:     secondsToDuration(info.RetryInitialIntervalSeconds),
-		RetryMaximumInterval:     secondsToDuration(info.RetryMaximumIntervalSeconds),
-		RetryMaximumAttempts:     info.RetryMaximumAttempts,
-		RetryExpirationTimestamp: timePtr(info.RetryExpirationTimeNanos),
-		RetryBackoffCoefficient:  info.RetryBackoffCoefficient,
+		StartedEventEncoding:     info.GetStartedEventEncoding(),
+		StartedTimestamp:         timeFromUnixNano(info.GetStartedTimeNanos()),
+		ActivityID:               info.GetActivityID(),
+		RequestID:                info.GetRequestID(),
+		ScheduleToStartTimeout:   common.SecondsToDuration(int64(info.GetScheduleToStartTimeoutSeconds())),
+		ScheduleToCloseTimeout:   common.SecondsToDuration(int64(info.GetScheduleToCloseTimeoutSeconds())),
+		StartToCloseTimeout:      common.SecondsToDuration(int64(info.GetStartToCloseTimeoutSeconds())),
+		HeartbeatTimeout:         common.SecondsToDuration(int64(info.GetHeartbeatTimeoutSeconds())),
+		CancelRequested:          info.GetCancelRequested(),
+		CancelRequestID:          info.GetCancelRequestID(),
+		TimerTaskStatus:          info.GetTimerTaskStatus(),
+		Attempt:                  info.GetAttempt(),
+		TaskList:                 info.GetTaskList(),
+		StartedIdentity:          info.GetStartedIdentity(),
+		HasRetryPolicy:           info.GetHasRetryPolicy(),
+		RetryInitialInterval:     common.SecondsToDuration(int64(info.GetRetryInitialIntervalSeconds())),
+		RetryMaximumInterval:     common.SecondsToDuration(int64(info.GetRetryMaximumIntervalSeconds())),
+		RetryMaximumAttempts:     info.GetRetryMaximumAttempts(),
+		RetryExpirationTimestamp: timeFromUnixNano(info.GetRetryExpirationTimeNanos()),
+		RetryBackoffCoefficient:  info.GetRetryBackoffCoefficient(),
 		RetryNonRetryableErrors:  info.RetryNonRetryableErrors,
-		RetryLastFailureReason:   info.RetryLastFailureReason,
-		RetryLastWorkerIdentity:  info.RetryLastWorkerIdentity,
+		RetryLastFailureReason:   info.GetRetryLastFailureReason(),
+		RetryLastWorkerIdentity:  info.GetRetryLastWorkerIdentity(),
 		RetryLastFailureDetails:  info.RetryLastFailureDetails,
 	}
 }
@@ -415,19 +415,19 @@ func childExecutionInfoToThrift(info *ChildExecutionInfo) *sqlblobs.ChildExecuti
 		return nil
 	}
 	return &sqlblobs.ChildExecutionInfo{
-		Version:                info.Version,
-		InitiatedEventBatchID:  info.InitiatedEventBatchID,
-		StartedID:              info.StartedID,
+		Version:                &info.Version,
+		InitiatedEventBatchID:  &info.InitiatedEventBatchID,
+		StartedID:              &info.StartedID,
 		InitiatedEvent:         info.InitiatedEvent,
-		InitiatedEventEncoding: info.InitiatedEventEncoding,
-		StartedWorkflowID:      info.StartedWorkflowID,
+		InitiatedEventEncoding: &info.InitiatedEventEncoding,
+		StartedWorkflowID:      &info.StartedWorkflowID,
 		StartedRunID:           info.StartedRunID,
 		StartedEvent:           info.StartedEvent,
-		StartedEventEncoding:   info.StartedEventEncoding,
-		CreateRequestID:        info.CreateRequestID,
-		DomainName:             info.DomainName,
-		WorkflowTypeName:       info.WorkflowTypeName,
-		ParentClosePolicy:      info.ParentClosePolicy,
+		StartedEventEncoding:   &info.StartedEventEncoding,
+		CreateRequestID:        &info.CreateRequestID,
+		DomainName:             &info.DomainName,
+		WorkflowTypeName:       &info.WorkflowTypeName,
+		ParentClosePolicy:      &info.ParentClosePolicy,
 	}
 }
 
@@ -436,19 +436,19 @@ func childExecutionInfoFromThrift(info *sqlblobs.ChildExecutionInfo) *ChildExecu
 		return nil
 	}
 	return &ChildExecutionInfo{
-		Version:                info.Version,
-		InitiatedEventBatchID:  info.InitiatedEventBatchID,
-		StartedID:              info.StartedID,
+		Version:                info.GetVersion(),
+		InitiatedEventBatchID:  info.GetInitiatedEventBatchID(),
+		StartedID:              info.GetStartedID(),
 		InitiatedEvent:         info.InitiatedEvent,
-		InitiatedEventEncoding: info.InitiatedEventEncoding,
-		StartedWorkflowID:      info.StartedWorkflowID,
-		StartedRunID:           info.StartedRunID,
+		InitiatedEventEncoding: info.GetInitiatedEventEncoding(),
+		StartedWorkflowID:      info.GetStartedWorkflowID(),
+		StartedRunID:           info.GetStartedRunID(),
 		StartedEvent:           info.StartedEvent,
-		StartedEventEncoding:   info.StartedEventEncoding,
-		CreateRequestID:        info.CreateRequestID,
-		DomainName:             info.DomainName,
-		WorkflowTypeName:       info.WorkflowTypeName,
-		ParentClosePolicy:      info.ParentClosePolicy,
+		StartedEventEncoding:   info.GetStartedEventEncoding(),
+		CreateRequestID:        info.GetCreateRequestID(),
+		DomainName:             info.GetDomainName(),
+		WorkflowTypeName:       info.GetWorkflowTypeName(),
+		ParentClosePolicy:      info.GetParentClosePolicy(),
 	}
 }
 
@@ -457,10 +457,10 @@ func signalInfoToThrift(info *SignalInfo) *sqlblobs.SignalInfo {
 		return nil
 	}
 	return &sqlblobs.SignalInfo{
-		Version:               info.Version,
-		InitiatedEventBatchID: info.InitiatedEventBatchID,
-		RequestID:             info.RequestID,
-		Name:                  info.Name,
+		Version:               &info.Version,
+		InitiatedEventBatchID: &info.InitiatedEventBatchID,
+		RequestID:             &info.RequestID,
+		Name:                  &info.Name,
 		Input:                 info.Input,
 		Control:               info.Control,
 	}
@@ -471,10 +471,10 @@ func signalInfoFromThrift(info *sqlblobs.SignalInfo) *SignalInfo {
 		return nil
 	}
 	return &SignalInfo{
-		Version:               info.Version,
-		InitiatedEventBatchID: info.InitiatedEventBatchID,
-		RequestID:             info.RequestID,
-		Name:                  info.Name,
+		Version:               info.GetVersion(),
+		InitiatedEventBatchID: info.GetInitiatedEventBatchID(),
+		RequestID:             info.GetRequestID(),
+		Name:                  info.GetName(),
 		Input:                 info.Input,
 		Control:               info.Control,
 	}
@@ -485,9 +485,9 @@ func requestCancelInfoToThrift(info *RequestCancelInfo) *sqlblobs.RequestCancelI
 		return nil
 	}
 	return &sqlblobs.RequestCancelInfo{
-		Version:               info.Version,
-		InitiatedEventBatchID: info.InitiatedEventBatchID,
-		CancelRequestID:       info.CancelRequestID,
+		Version:               &info.Version,
+		InitiatedEventBatchID: &info.InitiatedEventBatchID,
+		CancelRequestID:       &info.CancelRequestID,
 	}
 }
 
@@ -496,9 +496,9 @@ func requestCancelInfoFromThrift(info *sqlblobs.RequestCancelInfo) *RequestCance
 		return nil
 	}
 	return &RequestCancelInfo{
-		Version:               info.Version,
-		InitiatedEventBatchID: info.InitiatedEventBatchID,
-		CancelRequestID:       info.CancelRequestID,
+		Version:               info.GetVersion(),
+		InitiatedEventBatchID: info.GetInitiatedEventBatchID(),
+		CancelRequestID:       info.GetCancelRequestID(),
 	}
 }
 
@@ -507,10 +507,10 @@ func timerInfoToThrift(info *TimerInfo) *sqlblobs.TimerInfo {
 		return nil
 	}
 	return &sqlblobs.TimerInfo{
-		Version:         info.Version,
-		StartedID:       info.StartedID,
-		ExpiryTimeNanos: unixNanoPtr(info.ExpiryTimestamp),
-		TaskID:          info.TaskID,
+		Version:         &info.Version,
+		StartedID:       &info.StartedID,
+		ExpiryTimeNanos: timeToUnixNanoPtr(info.ExpiryTimestamp),
+		TaskID:          &info.TaskID,
 	}
 }
 
@@ -519,10 +519,10 @@ func timerInfoFromThrift(info *sqlblobs.TimerInfo) *TimerInfo {
 		return nil
 	}
 	return &TimerInfo{
-		Version:         info.Version,
-		StartedID:       info.StartedID,
-		ExpiryTimestamp: timePtr(info.ExpiryTimeNanos),
-		TaskID:          info.TaskID,
+		Version:         info.GetVersion(),
+		StartedID:       info.GetStartedID(),
+		ExpiryTimestamp: timeFromUnixNano(info.GetExpiryTimeNanos()),
+		TaskID:          info.GetTaskID(),
 	}
 }
 
@@ -531,11 +531,11 @@ func taskInfoToThrift(info *TaskInfo) *sqlblobs.TaskInfo {
 		return nil
 	}
 	return &sqlblobs.TaskInfo{
-		WorkflowID:       info.WorkflowID,
+		WorkflowID:       &info.WorkflowID,
 		RunID:            info.RunID,
-		ScheduleID:       info.ScheduleID,
-		ExpiryTimeNanos:  unixNanoPtr(info.ExpiryTimestamp),
-		CreatedTimeNanos: unixNanoPtr(info.CreatedTimestamp),
+		ScheduleID:       &info.ScheduleID,
+		ExpiryTimeNanos:  timeToUnixNanoPtr(info.ExpiryTimestamp),
+		CreatedTimeNanos: timeToUnixNanoPtr(info.CreatedTimestamp),
 	}
 }
 
@@ -544,11 +544,11 @@ func taskInfoFromThrift(info *sqlblobs.TaskInfo) *TaskInfo {
 		return nil
 	}
 	return &TaskInfo{
-		WorkflowID:       info.WorkflowID,
+		WorkflowID:       info.GetWorkflowID(),
 		RunID:            info.RunID,
-		ScheduleID:       info.ScheduleID,
-		ExpiryTimestamp:  timePtr(info.ExpiryTimeNanos),
-		CreatedTimestamp: timePtr(info.CreatedTimeNanos),
+		ScheduleID:       info.GetScheduleID(),
+		ExpiryTimestamp:  timeFromUnixNano(info.GetExpiryTimeNanos()),
+		CreatedTimestamp: timeFromUnixNano(info.GetCreatedTimeNanos()),
 	}
 }
 
@@ -557,10 +557,10 @@ func taskListInfoToThrift(info *TaskListInfo) *sqlblobs.TaskListInfo {
 		return nil
 	}
 	return &sqlblobs.TaskListInfo{
-		Kind:             info.Kind,
-		AckLevel:         info.AckLevel,
-		ExpiryTimeNanos:  unixNanoPtr(info.ExpiryTimestamp),
-		LastUpdatedNanos: unixNanoPtr(info.LastUpdated),
+		Kind:             &info.Kind,
+		AckLevel:         &info.AckLevel,
+		ExpiryTimeNanos:  timeToUnixNanoPtr(info.ExpiryTimestamp),
+		LastUpdatedNanos: timeToUnixNanoPtr(info.LastUpdated),
 	}
 }
 
@@ -569,10 +569,10 @@ func taskListInfoFromThrift(info *sqlblobs.TaskListInfo) *TaskListInfo {
 		return nil
 	}
 	return &TaskListInfo{
-		Kind:            info.Kind,
-		AckLevel:        info.AckLevel,
-		ExpiryTimestamp: timePtr(info.ExpiryTimeNanos),
-		LastUpdated:     timePtr(info.LastUpdatedNanos),
+		Kind:            info.GetKind(),
+		AckLevel:        info.GetAckLevel(),
+		ExpiryTimestamp: timeFromUnixNano(info.GetExpiryTimeNanos()),
+		LastUpdated:     timeFromUnixNano(info.GetLastUpdatedNanos()),
 	}
 }
 
@@ -582,17 +582,17 @@ func transferTaskInfoToThrift(info *TransferTaskInfo) *sqlblobs.TransferTaskInfo
 	}
 	return &sqlblobs.TransferTaskInfo{
 		DomainID:                 info.DomainID,
-		WorkflowID:               info.WorkflowID,
+		WorkflowID:               &info.WorkflowID,
 		RunID:                    info.RunID,
-		TaskType:                 info.TaskType,
+		TaskType:                 &info.TaskType,
 		TargetDomainID:           info.TargetDomainID,
-		TargetWorkflowID:         info.TargetWorkflowID,
+		TargetWorkflowID:         &info.TargetWorkflowID,
 		TargetRunID:              info.TargetRunID,
-		TaskList:                 info.TaskList,
-		TargetChildWorkflowOnly:  info.TargetChildWorkflowOnly,
-		ScheduleID:               info.ScheduleID,
-		Version:                  info.Version,
-		VisibilityTimestampNanos: unixNanoPtr(info.VisibilityTimestamp),
+		TaskList:                 &info.TaskList,
+		TargetChildWorkflowOnly:  &info.TargetChildWorkflowOnly,
+		ScheduleID:               &info.ScheduleID,
+		Version:                  &info.Version,
+		VisibilityTimestampNanos: timeToUnixNanoPtr(info.VisibilityTimestamp),
 	}
 }
 
@@ -602,17 +602,17 @@ func transferTaskInfoFromThrift(info *sqlblobs.TransferTaskInfo) *TransferTaskIn
 	}
 	return &TransferTaskInfo{
 		DomainID:                info.DomainID,
-		WorkflowID:              info.WorkflowID,
+		WorkflowID:              info.GetWorkflowID(),
 		RunID:                   info.RunID,
-		TaskType:                info.TaskType,
+		TaskType:                info.GetTaskType(),
 		TargetDomainID:          info.TargetDomainID,
-		TargetWorkflowID:        info.TargetWorkflowID,
+		TargetWorkflowID:        info.GetTargetWorkflowID(),
 		TargetRunID:             info.TargetRunID,
-		TaskList:                info.TaskList,
-		TargetChildWorkflowOnly: info.TargetChildWorkflowOnly,
-		ScheduleID:              info.ScheduleID,
-		Version:                 info.Version,
-		VisibilityTimestamp:     timePtr(info.VisibilityTimestampNanos),
+		TaskList:                info.GetTaskList(),
+		TargetChildWorkflowOnly: info.GetTargetChildWorkflowOnly(),
+		ScheduleID:              info.GetScheduleID(),
+		Version:                 info.GetVersion(),
+		VisibilityTimestamp:     timeFromUnixNano(info.GetVisibilityTimestampNanos()),
 	}
 }
 
@@ -622,13 +622,13 @@ func timerTaskInfoToThrift(info *TimerTaskInfo) *sqlblobs.TimerTaskInfo {
 	}
 	return &sqlblobs.TimerTaskInfo{
 		DomainID:        info.DomainID,
-		WorkflowID:      info.WorkflowID,
+		WorkflowID:      &info.WorkflowID,
 		RunID:           info.RunID,
-		TaskType:        info.TaskType,
+		TaskType:        &info.TaskType,
 		TimeoutType:     info.TimeoutType,
-		Version:         info.Version,
-		ScheduleAttempt: info.ScheduleAttempt,
-		EventID:         info.EventID,
+		Version:         &info.Version,
+		ScheduleAttempt: &info.ScheduleAttempt,
+		EventID:         &info.EventID,
 	}
 }
 
@@ -638,13 +638,13 @@ func timerTaskInfoFromThrift(info *sqlblobs.TimerTaskInfo) *TimerTaskInfo {
 	}
 	return &TimerTaskInfo{
 		DomainID:        info.DomainID,
-		WorkflowID:      info.WorkflowID,
+		WorkflowID:      info.GetWorkflowID(),
 		RunID:           info.RunID,
-		TaskType:        info.TaskType,
+		TaskType:        info.GetTaskType(),
 		TimeoutType:     info.TimeoutType,
-		Version:         info.Version,
-		ScheduleAttempt: info.ScheduleAttempt,
-		EventID:         info.EventID,
+		Version:         info.GetVersion(),
+		ScheduleAttempt: info.GetScheduleAttempt(),
+		EventID:         info.GetEventID(),
 	}
 }
 
@@ -654,18 +654,18 @@ func replicationTaskInfoToThrift(info *ReplicationTaskInfo) *sqlblobs.Replicatio
 	}
 	return &sqlblobs.ReplicationTaskInfo{
 		DomainID:                info.DomainID,
-		WorkflowID:              info.WorkflowID,
+		WorkflowID:              &info.WorkflowID,
 		RunID:                   info.RunID,
-		TaskType:                info.TaskType,
-		Version:                 info.Version,
-		FirstEventID:            info.FirstEventID,
-		NextEventID:             info.NextEventID,
-		ScheduledID:             info.ScheduledID,
-		EventStoreVersion:       info.EventStoreVersion,
-		NewRunEventStoreVersion: info.NewRunEventStoreVersion,
+		TaskType:                &info.TaskType,
+		Version:                 &info.Version,
+		FirstEventID:            &info.FirstEventID,
+		NextEventID:             &info.NextEventID,
+		ScheduledID:             &info.ScheduledID,
+		EventStoreVersion:       &info.EventStoreVersion,
+		NewRunEventStoreVersion: &info.NewRunEventStoreVersion,
 		BranchToken:             info.BranchToken,
 		NewRunBranchToken:       info.NewRunBranchToken,
-		CreationTime:            unixNanoPtr(info.CreationTimestamp),
+		CreationTime:            timeToUnixNanoPtr(info.CreationTimestamp),
 	}
 }
 
@@ -675,18 +675,18 @@ func replicationTaskInfoFromThrift(info *sqlblobs.ReplicationTaskInfo) *Replicat
 	}
 	return &ReplicationTaskInfo{
 		DomainID:                info.DomainID,
-		WorkflowID:              info.WorkflowID,
+		WorkflowID:              info.GetWorkflowID(),
 		RunID:                   info.RunID,
-		TaskType:                info.TaskType,
-		Version:                 info.Version,
-		FirstEventID:            info.FirstEventID,
-		NextEventID:             info.NextEventID,
-		ScheduledID:             info.ScheduledID,
-		EventStoreVersion:       info.EventStoreVersion,
-		NewRunEventStoreVersion: info.NewRunEventStoreVersion,
+		TaskType:                info.GetTaskType(),
+		Version:                 info.GetVersion(),
+		FirstEventID:            info.GetFirstEventID(),
+		NextEventID:             info.GetNextEventID(),
+		ScheduledID:             info.GetScheduledID(),
+		EventStoreVersion:       info.GetEventStoreVersion(),
+		NewRunEventStoreVersion: info.GetNewRunEventStoreVersion(),
 		BranchToken:             info.BranchToken,
 		NewRunBranchToken:       info.NewRunBranchToken,
-		CreationTimestamp:       timePtr(info.CreationTime),
+		CreationTimestamp:       timeFromUnixNano(info.GetCreationTime()),
 	}
 }
 
@@ -696,6 +696,10 @@ func unixNanoPtr(t *time.Time) *int64 {
 	if t == nil {
 		return nil
 	}
+	return common.Int64Ptr(t.UnixNano())
+}
+
+func timeToUnixNanoPtr(t time.Time) *int64 {
 	return common.Int64Ptr(t.UnixNano())
 }
 
@@ -711,44 +715,23 @@ func timePtr(t *int64) *time.Time {
 	return common.TimePtr(time.Unix(0, *t))
 }
 
-func durationToSeconds(t *time.Duration) *int32 {
-	if t == nil {
-		return nil
+func timeFromUnixNano(t int64) time.Time {
+	// Calling UnixNano() on zero time is undefined an results in a number that is converted back to 1754-08-30T22:43:41Z
+	// Handle such case explicitly
+	if t == zeroTimeNanos {
+		return time.Time{}
 	}
-	return common.Int32Ptr(int32(common.DurationToSeconds(*t)))
+	return time.Unix(0, t)
 }
 
-func durationToSecondsInt64(t *time.Duration) *int64 {
-	if t == nil {
-		return nil
-	}
-	return common.Int64Ptr(common.DurationToSeconds(*t))
+func durationToSecondsInt32Ptr(t time.Duration) *int32 {
+	return common.Int32Ptr(int32(common.DurationToSeconds(t)))
 }
 
-func secondsInt64ToDuration(t *int64) *time.Duration {
-	if t == nil {
-		return nil
-	}
-	return common.DurationPtr(common.SecondsToDuration(*t))
+func durationToSecondsInt64Ptr(t time.Duration) *int64 {
+	return common.Int64Ptr(common.DurationToSeconds(t))
 }
 
-func secondsToDuration(t *int32) *time.Duration {
-	if t == nil {
-		return nil
-	}
-	return common.DurationPtr(common.SecondsToDuration(int64(*t)))
-}
-
-func durationToDays(t *time.Duration) *int16 {
-	if t == nil {
-		return nil
-	}
-	return common.Int16Ptr(int16(common.DurationToDays(*t)))
-}
-
-func daysToDuration(t *int16) *time.Duration {
-	if t == nil {
-		return nil
-	}
-	return common.DurationPtr(common.DaysToDuration(int32(*t)))
+func durationToDaysInt16Ptr(t time.Duration) *int16 {
+	return common.Int16Ptr(int16(common.DurationToDays(t)))
 }

--- a/common/persistence/serialization/thrift_mapper_test.go
+++ b/common/persistence/serialization/thrift_mapper_test.go
@@ -37,30 +37,30 @@ import (
 
 func TestShardInfo(t *testing.T) {
 	expected := &ShardInfo{
-		StolenSinceRenew:                      common.Int32Ptr(int32(rand.Intn(1000))),
-		UpdatedAt:                             common.TimePtr(time.Now()),
-		ReplicationAckLevel:                   common.Int64Ptr(int64(rand.Intn(1000))),
-		TransferAckLevel:                      common.Int64Ptr(int64(rand.Intn(1000))),
-		TimerAckLevel:                         common.TimePtr(time.Now()),
-		DomainNotificationVersion:             common.Int64Ptr(int64(rand.Intn(1000))),
+		StolenSinceRenew:                      int32(rand.Intn(1000)),
+		UpdatedAt:                             time.Now(),
+		ReplicationAckLevel:                   int64(rand.Intn(1000)),
+		TransferAckLevel:                      int64(rand.Intn(1000)),
+		TimerAckLevel:                         time.Now(),
+		DomainNotificationVersion:             int64(rand.Intn(1000)),
 		ClusterTransferAckLevel:               map[string]int64{"key_1": int64(rand.Intn(1000)), "key_2": int64(rand.Intn(1000))},
 		ClusterTimerAckLevel:                  map[string]time.Time{"key_1": time.Now(), "key_2": time.Now()},
-		Owner:                                 common.StringPtr("test_owner"),
+		Owner:                                 "test_owner",
 		ClusterReplicationLevel:               map[string]int64{"key_1": int64(rand.Intn(1000)), "key_2": int64(rand.Intn(1000))},
 		PendingFailoverMarkers:                []byte("PendingFailoverMarkers"),
-		PendingFailoverMarkersEncoding:        common.StringPtr("PendingFailoverMarkersEncoding"),
+		PendingFailoverMarkersEncoding:        "PendingFailoverMarkersEncoding",
 		ReplicationDlqAckLevel:                map[string]int64{"key_1": int64(rand.Intn(1000)), "key_2": int64(rand.Intn(1000))},
 		TransferProcessingQueueStates:         []byte("TransferProcessingQueueStates"),
-		TransferProcessingQueueStatesEncoding: common.StringPtr("TransferProcessingQueueStatesEncoding"),
+		TransferProcessingQueueStatesEncoding: "TransferProcessingQueueStatesEncoding",
 		TimerProcessingQueueStates:            []byte("TimerProcessingQueueStates"),
-		TimerProcessingQueueStatesEncoding:    common.StringPtr("TimerProcessingQueueStatesEncoding"),
+		TimerProcessingQueueStatesEncoding:    "TimerProcessingQueueStatesEncoding",
 	}
 	actual := shardInfoFromThrift(shardInfoToThrift(expected))
 	assert.Equal(t, expected.StolenSinceRenew, actual.StolenSinceRenew)
-	assert.Equal(t, expected.UpdatedAt.Sub(*actual.UpdatedAt), time.Duration(0))
+	assert.Equal(t, expected.UpdatedAt.Sub(actual.UpdatedAt), time.Duration(0))
 	assert.Equal(t, expected.ReplicationAckLevel, actual.ReplicationAckLevel)
 	assert.Equal(t, expected.TransferAckLevel, actual.TransferAckLevel)
-	assert.Equal(t, expected.TimerAckLevel.Sub(*actual.TimerAckLevel), time.Duration(0))
+	assert.Equal(t, expected.TimerAckLevel.Sub(actual.TimerAckLevel), time.Duration(0))
 	assert.Equal(t, expected.DomainNotificationVersion, actual.DomainNotificationVersion)
 	assert.Equal(t, expected.ClusterTransferAckLevel, actual.ClusterTransferAckLevel)
 	assert.Equal(t, expected.Owner, actual.Owner)
@@ -81,37 +81,37 @@ func TestShardInfo(t *testing.T) {
 
 func TestDomainInfo(t *testing.T) {
 	expected := &DomainInfo{
-		Name:                        common.StringPtr("domain_name"),
-		Description:                 common.StringPtr("description"),
-		Owner:                       common.StringPtr("owner"),
-		Status:                      common.Int32Ptr(int32(rand.Intn(1000))),
-		Retention:                   common.DurationPtr(time.Duration(int64(rand.Intn(1000)))),
-		EmitMetric:                  common.BoolPtr(true),
-		ArchivalBucket:              common.StringPtr("archival_bucket"),
-		ArchivalStatus:              common.Int16Ptr(int16(rand.Intn(1000))),
-		ConfigVersion:               common.Int64Ptr(int64(rand.Intn(1000))),
-		NotificationVersion:         common.Int64Ptr(int64(rand.Intn(1000))),
-		FailoverNotificationVersion: common.Int64Ptr(int64(rand.Intn(1000))),
-		FailoverVersion:             common.Int64Ptr(int64(rand.Intn(1000))),
-		ActiveClusterName:           common.StringPtr("ActiveClusterName"),
+		Name:                        "domain_name",
+		Description:                 "description",
+		Owner:                       "owner",
+		Status:                      int32(rand.Intn(1000)),
+		Retention:                   time.Duration(int64(rand.Intn(1000))),
+		EmitMetric:                  true,
+		ArchivalBucket:              "archival_bucket",
+		ArchivalStatus:              int16(rand.Intn(1000)),
+		ConfigVersion:               int64(rand.Intn(1000)),
+		NotificationVersion:         int64(rand.Intn(1000)),
+		FailoverNotificationVersion: int64(rand.Intn(1000)),
+		FailoverVersion:             int64(rand.Intn(1000)),
+		ActiveClusterName:           "ActiveClusterName",
 		Clusters:                    []string{"cluster_a", "cluster_b"},
 		Data:                        map[string]string{"key_1": "value_1", "key_2": "value_2"},
 		BadBinaries:                 []byte("BadBinaries"),
-		BadBinariesEncoding:         common.StringPtr("BadBinariesEncoding"),
-		HistoryArchivalStatus:       common.Int16Ptr(int16(rand.Intn(1000))),
-		HistoryArchivalURI:          common.StringPtr("HistoryArchivalURI"),
-		VisibilityArchivalStatus:    common.Int16Ptr(int16(rand.Intn(1000))),
-		VisibilityArchivalURI:       common.StringPtr("VisibilityArchivalURI"),
+		BadBinariesEncoding:         "BadBinariesEncoding",
+		HistoryArchivalStatus:       int16(rand.Intn(1000)),
+		HistoryArchivalURI:          "HistoryArchivalURI",
+		VisibilityArchivalStatus:    int16(rand.Intn(1000)),
+		VisibilityArchivalURI:       "VisibilityArchivalURI",
 		FailoverEndTimestamp:        common.TimePtr(time.Now()),
-		PreviousFailoverVersion:     common.Int64Ptr(int64(rand.Intn(1000))),
-		LastUpdatedTimestamp:        common.TimePtr(time.Now()),
+		PreviousFailoverVersion:     int64(rand.Intn(1000)),
+		LastUpdatedTimestamp:        time.Now(),
 	}
 	actual := domainInfoFromThrift(domainInfoToThrift(expected))
 	assert.Equal(t, expected.Name, actual.Name)
 	assert.Equal(t, expected.Description, actual.Description)
 	assert.Equal(t, expected.Owner, actual.Owner)
 	assert.Equal(t, expected.Status, actual.Status)
-	assert.True(t, (*expected.Retention-*actual.Retention) < time.Second)
+	assert.True(t, (expected.Retention-actual.Retention) < time.Second)
 	assert.Equal(t, expected.EmitMetric, actual.EmitMetric)
 	assert.Equal(t, expected.ArchivalBucket, actual.ArchivalBucket)
 	assert.Equal(t, expected.ArchivalStatus, actual.ArchivalStatus)
@@ -129,12 +129,12 @@ func TestDomainInfo(t *testing.T) {
 	assert.Equal(t, expected.VisibilityArchivalURI, actual.VisibilityArchivalURI)
 	assert.Equal(t, expected.FailoverEndTimestamp.Sub(*actual.FailoverEndTimestamp), time.Duration(0))
 	assert.Equal(t, expected.PreviousFailoverVersion, actual.PreviousFailoverVersion)
-	assert.Equal(t, expected.LastUpdatedTimestamp.Sub(*actual.LastUpdatedTimestamp), time.Duration(0))
+	assert.Equal(t, expected.LastUpdatedTimestamp.Sub(actual.LastUpdatedTimestamp), time.Duration(0))
 }
 
 func TestHistoryTreeInfo(t *testing.T) {
 	expected := &HistoryTreeInfo{
-		CreatedTimestamp: common.TimePtr(time.Now()),
+		CreatedTimestamp: time.Now(),
 		Ancestors: []*types.HistoryBranchRange{
 			{
 				BranchID:    common.StringPtr("branch_id"),
@@ -147,10 +147,10 @@ func TestHistoryTreeInfo(t *testing.T) {
 				EndNodeID:   common.Int64Ptr(int64(rand.Intn(1000))),
 			},
 		},
-		Info: common.StringPtr("info"),
+		Info: "info",
 	}
 	actual := historyTreeInfoFromThrift(historyTreeInfoToThrift(expected))
-	assert.Equal(t, expected.CreatedTimestamp.Sub(*actual.CreatedTimestamp), time.Duration(0))
+	assert.Equal(t, expected.CreatedTimestamp.Sub(actual.CreatedTimestamp), time.Duration(0))
 	assert.Equal(t, expected.Ancestors, actual.Ancestors)
 	assert.Equal(t, expected.Info, actual.Info)
 }
@@ -158,63 +158,63 @@ func TestHistoryTreeInfo(t *testing.T) {
 func TestWorkflowExecutionInfo(t *testing.T) {
 	expected := &WorkflowExecutionInfo{
 		ParentDomainID:                     UUID(uuid.New()),
-		ParentWorkflowID:                   common.StringPtr("ParentWorkflowID"),
+		ParentWorkflowID:                   "ParentWorkflowID",
 		ParentRunID:                        UUID(uuid.New()),
-		InitiatedID:                        common.Int64Ptr(int64(rand.Intn(1000))),
+		InitiatedID:                        int64(rand.Intn(1000)),
 		CompletionEventBatchID:             common.Int64Ptr(int64(rand.Intn(1000))),
 		CompletionEvent:                    []byte("CompletionEvent"),
-		CompletionEventEncoding:            common.StringPtr("CompletionEventEncoding"),
-		TaskList:                           common.StringPtr("TaskList"),
-		WorkflowTypeName:                   common.StringPtr("WorkflowTypeName"),
-		WorkflowTimeout:                    common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		DecisionTaskTimeout:                common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
+		CompletionEventEncoding:            "CompletionEventEncoding",
+		TaskList:                           "TaskList",
+		WorkflowTypeName:                   "WorkflowTypeName",
+		WorkflowTimeout:                    time.Minute * time.Duration(rand.Intn(10)),
+		DecisionTaskTimeout:                time.Minute * time.Duration(rand.Intn(10)),
 		ExecutionContext:                   []byte("ExecutionContext"),
-		State:                              common.Int32Ptr(int32(rand.Intn(1000))),
-		CloseStatus:                        common.Int32Ptr(int32(rand.Intn(1000))),
-		StartVersion:                       common.Int64Ptr(int64(rand.Intn(1000))),
+		State:                              int32(rand.Intn(1000)),
+		CloseStatus:                        int32(rand.Intn(1000)),
+		StartVersion:                       int64(rand.Intn(1000)),
 		LastWriteEventID:                   common.Int64Ptr(int64(rand.Intn(1000))),
-		LastEventTaskID:                    common.Int64Ptr(int64(rand.Intn(1000))),
-		LastFirstEventID:                   common.Int64Ptr(int64(rand.Intn(1000))),
-		LastProcessedEvent:                 common.Int64Ptr(int64(rand.Intn(1000))),
-		StartTimestamp:                     common.TimePtr(time.Now()),
-		LastUpdatedTimestamp:               common.TimePtr(time.Now()),
-		DecisionVersion:                    common.Int64Ptr(int64(rand.Intn(1000))),
-		DecisionScheduleID:                 common.Int64Ptr(int64(rand.Intn(1000))),
-		DecisionStartedID:                  common.Int64Ptr(int64(rand.Intn(1000))),
-		DecisionTimeout:                    common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		DecisionAttempt:                    common.Int64Ptr(int64(rand.Intn(1000))),
-		DecisionStartedTimestamp:           common.TimePtr(time.Now()),
-		DecisionScheduledTimestamp:         common.TimePtr(time.Now()),
-		CancelRequested:                    common.BoolPtr(true),
-		DecisionOriginalScheduledTimestamp: common.TimePtr(time.Now()),
-		CreateRequestID:                    common.StringPtr("CreateRequestID"),
-		DecisionRequestID:                  common.StringPtr("DecisionRequestID"),
-		CancelRequestID:                    common.StringPtr("CancelRequestID"),
-		StickyTaskList:                     common.StringPtr("StickyTaskList"),
-		StickyScheduleToStartTimeout:       common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		RetryAttempt:                       common.Int64Ptr(int64(rand.Intn(1000))),
-		RetryInitialInterval:               common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		RetryMaximumInterval:               common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		RetryMaximumAttempts:               common.Int32Ptr(int32(rand.Intn(1000))),
-		RetryExpiration:                    common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		RetryBackoffCoefficient:            common.Float64Ptr(rand.Float64() * 1000),
-		RetryExpirationTimestamp:           common.TimePtr(time.Now()),
+		LastEventTaskID:                    int64(rand.Intn(1000)),
+		LastFirstEventID:                   int64(rand.Intn(1000)),
+		LastProcessedEvent:                 int64(rand.Intn(1000)),
+		StartTimestamp:                     time.Now(),
+		LastUpdatedTimestamp:               time.Now(),
+		DecisionVersion:                    int64(rand.Intn(1000)),
+		DecisionScheduleID:                 int64(rand.Intn(1000)),
+		DecisionStartedID:                  int64(rand.Intn(1000)),
+		DecisionTimeout:                    time.Minute * time.Duration(rand.Intn(10)),
+		DecisionAttempt:                    int64(rand.Intn(1000)),
+		DecisionStartedTimestamp:           time.Now(),
+		DecisionScheduledTimestamp:         time.Now(),
+		CancelRequested:                    true,
+		DecisionOriginalScheduledTimestamp: time.Now(),
+		CreateRequestID:                    "CreateRequestID",
+		DecisionRequestID:                  "DecisionRequestID",
+		CancelRequestID:                    "CancelRequestID",
+		StickyTaskList:                     "StickyTaskList",
+		StickyScheduleToStartTimeout:       time.Minute * time.Duration(rand.Intn(10)),
+		RetryAttempt:                       int64(rand.Intn(1000)),
+		RetryInitialInterval:               time.Minute * time.Duration(rand.Intn(10)),
+		RetryMaximumInterval:               time.Minute * time.Duration(rand.Intn(10)),
+		RetryMaximumAttempts:               int32(rand.Intn(1000)),
+		RetryExpiration:                    time.Minute * time.Duration(rand.Intn(10)),
+		RetryBackoffCoefficient:            rand.Float64() * 1000,
+		RetryExpirationTimestamp:           time.Now(),
 		RetryNonRetryableErrors:            []string{"RetryNonRetryableErrors"},
-		HasRetryPolicy:                     common.BoolPtr(true),
-		CronSchedule:                       common.StringPtr("CronSchedule"),
-		EventStoreVersion:                  common.Int32Ptr(int32(rand.Intn(1000))),
+		HasRetryPolicy:                     true,
+		CronSchedule:                       "CronSchedule",
+		EventStoreVersion:                  int32(rand.Intn(1000)),
 		EventBranchToken:                   []byte("EventBranchToken"),
-		SignalCount:                        common.Int64Ptr(int64(rand.Intn(1000))),
-		HistorySize:                        common.Int64Ptr(int64(rand.Intn(1000))),
-		ClientLibraryVersion:               common.StringPtr("ClientLibraryVersion"),
-		ClientFeatureVersion:               common.StringPtr("ClientFeatureVersion"),
-		ClientImpl:                         common.StringPtr("ClientImpl"),
+		SignalCount:                        int64(rand.Intn(1000)),
+		HistorySize:                        int64(rand.Intn(1000)),
+		ClientLibraryVersion:               "ClientLibraryVersion",
+		ClientFeatureVersion:               "ClientFeatureVersion",
+		ClientImpl:                         "ClientImpl",
 		AutoResetPoints:                    []byte("AutoResetPoints"),
-		AutoResetPointsEncoding:            common.StringPtr("AutoResetPointsEncoding"),
+		AutoResetPointsEncoding:            "AutoResetPointsEncoding",
 		SearchAttributes:                   map[string][]byte{"key_1": []byte("SearchAttributes")},
 		Memo:                               map[string][]byte{"key_1": []byte("Memo")},
 		VersionHistories:                   []byte("VersionHistories"),
-		VersionHistoriesEncoding:           common.StringPtr("VersionHistoriesEncoding"),
+		VersionHistoriesEncoding:           "VersionHistoriesEncoding",
 	}
 	actual := workflowExecutionInfoFromThrift(workflowExecutionInfoToThrift(expected))
 	assert.Equal(t, expected.ParentDomainID, actual.ParentDomainID)
@@ -226,8 +226,8 @@ func TestWorkflowExecutionInfo(t *testing.T) {
 	assert.Equal(t, expected.CompletionEventEncoding, actual.CompletionEventEncoding)
 	assert.Equal(t, expected.TaskList, actual.TaskList)
 	assert.Equal(t, expected.WorkflowTypeName, actual.WorkflowTypeName)
-	assert.True(t, (*expected.WorkflowTimeout-*actual.WorkflowTimeout) < time.Second)
-	assert.True(t, (*expected.DecisionTaskTimeout-*actual.DecisionTaskTimeout) < time.Second)
+	assert.True(t, (expected.WorkflowTimeout-actual.WorkflowTimeout) < time.Second)
+	assert.True(t, (expected.DecisionTaskTimeout-actual.DecisionTaskTimeout) < time.Second)
 	assert.Equal(t, expected.ExecutionContext, actual.ExecutionContext)
 	assert.Equal(t, expected.State, actual.State)
 	assert.Equal(t, expected.CloseStatus, actual.CloseStatus)
@@ -236,16 +236,16 @@ func TestWorkflowExecutionInfo(t *testing.T) {
 	assert.Equal(t, expected.LastEventTaskID, actual.LastEventTaskID)
 	assert.Equal(t, expected.LastFirstEventID, actual.LastFirstEventID)
 	assert.Equal(t, expected.LastProcessedEvent, actual.LastProcessedEvent)
-	assert.Equal(t, expected.StartTimestamp.Sub(*actual.StartTimestamp), time.Duration(0))
-	assert.Equal(t, expected.LastUpdatedTimestamp.Sub(*actual.LastUpdatedTimestamp), time.Duration(0))
+	assert.Equal(t, expected.StartTimestamp.Sub(actual.StartTimestamp), time.Duration(0))
+	assert.Equal(t, expected.LastUpdatedTimestamp.Sub(actual.LastUpdatedTimestamp), time.Duration(0))
 	assert.Equal(t, expected.DecisionVersion, actual.DecisionVersion)
 	assert.Equal(t, expected.DecisionScheduleID, actual.DecisionScheduleID)
 	assert.Equal(t, expected.DecisionStartedID, actual.DecisionStartedID)
-	assert.True(t, (*expected.DecisionTimeout-*actual.DecisionTimeout) < time.Second)
+	assert.True(t, (expected.DecisionTimeout-actual.DecisionTimeout) < time.Second)
 	assert.Equal(t, expected.DecisionAttempt, actual.DecisionAttempt)
-	assert.Equal(t, expected.DecisionStartedTimestamp.Sub(*actual.DecisionStartedTimestamp), time.Duration(0))
-	assert.Equal(t, expected.DecisionScheduledTimestamp.Sub(*actual.DecisionScheduledTimestamp), time.Duration(0))
-	assert.Equal(t, expected.DecisionOriginalScheduledTimestamp.Sub(*actual.DecisionOriginalScheduledTimestamp), time.Duration(0))
+	assert.Equal(t, expected.DecisionStartedTimestamp.Sub(actual.DecisionStartedTimestamp), time.Duration(0))
+	assert.Equal(t, expected.DecisionScheduledTimestamp.Sub(actual.DecisionScheduledTimestamp), time.Duration(0))
+	assert.Equal(t, expected.DecisionOriginalScheduledTimestamp.Sub(actual.DecisionOriginalScheduledTimestamp), time.Duration(0))
 	assert.Equal(t, expected.CancelRequested, actual.CancelRequested)
 	assert.Equal(t, expected.DecisionRequestID, actual.DecisionRequestID)
 	assert.Equal(t, expected.CancelRequestID, actual.CancelRequestID)
@@ -269,45 +269,45 @@ func TestWorkflowExecutionInfo(t *testing.T) {
 	assert.Equal(t, expected.Memo, actual.Memo)
 	assert.Equal(t, expected.VersionHistories, actual.VersionHistories)
 	assert.Equal(t, expected.VersionHistoriesEncoding, actual.VersionHistoriesEncoding)
-	assert.Equal(t, expected.RetryExpirationTimestamp.Sub(*actual.RetryExpirationTimestamp), time.Duration(0))
-	assert.True(t, (*expected.StickyScheduleToStartTimeout-*actual.StickyScheduleToStartTimeout) < time.Second)
-	assert.True(t, (*expected.RetryInitialInterval-*actual.RetryInitialInterval) < time.Second)
-	assert.True(t, (*expected.RetryMaximumInterval-*actual.RetryMaximumInterval) < time.Second)
-	assert.True(t, (*expected.RetryExpiration-*actual.RetryExpiration) < time.Second)
+	assert.Equal(t, expected.RetryExpirationTimestamp.Sub(actual.RetryExpirationTimestamp), time.Duration(0))
+	assert.True(t, (expected.StickyScheduleToStartTimeout-actual.StickyScheduleToStartTimeout) < time.Second)
+	assert.True(t, (expected.RetryInitialInterval-actual.RetryInitialInterval) < time.Second)
+	assert.True(t, (expected.RetryMaximumInterval-actual.RetryMaximumInterval) < time.Second)
+	assert.True(t, (expected.RetryExpiration-actual.RetryExpiration) < time.Second)
 }
 
 func TestActivityInfo(t *testing.T) {
 	expected := &ActivityInfo{
-		Version:                  common.Int64Ptr(int64(rand.Intn(1000))),
-		ScheduledEventBatchID:    common.Int64Ptr(int64(rand.Intn(1000))),
+		Version:                  int64(rand.Intn(1000)),
+		ScheduledEventBatchID:    int64(rand.Intn(1000)),
 		ScheduledEvent:           []byte("ScheduledEvent"),
-		ScheduledEventEncoding:   common.StringPtr("ScheduledEventEncoding"),
-		ScheduledTimestamp:       common.TimePtr(time.Now()),
-		StartedID:                common.Int64Ptr(int64(rand.Intn(1000))),
+		ScheduledEventEncoding:   "ScheduledEventEncoding",
+		ScheduledTimestamp:       time.Now(),
+		StartedID:                int64(rand.Intn(1000)),
 		StartedEvent:             []byte("StartedEvent"),
-		StartedEventEncoding:     common.StringPtr("StartedEventEncoding"),
-		StartedTimestamp:         common.TimePtr(time.Now()),
-		ActivityID:               common.StringPtr("ActivityID"),
-		RequestID:                common.StringPtr("RequestID"),
-		ScheduleToStartTimeout:   common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		ScheduleToCloseTimeout:   common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		StartToCloseTimeout:      common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		HeartbeatTimeout:         common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		CancelRequested:          common.BoolPtr(true),
-		CancelRequestID:          common.Int64Ptr(int64(rand.Intn(1000))),
-		TimerTaskStatus:          common.Int32Ptr(int32(rand.Intn(1000))),
-		Attempt:                  common.Int32Ptr(int32(rand.Intn(1000))),
-		TaskList:                 common.StringPtr("TaskList"),
-		StartedIdentity:          common.StringPtr("StartedIdentity"),
-		HasRetryPolicy:           common.BoolPtr(true),
-		RetryInitialInterval:     common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		RetryMaximumInterval:     common.DurationPtr(time.Minute * time.Duration(rand.Intn(10))),
-		RetryMaximumAttempts:     common.Int32Ptr(int32(rand.Intn(1000))),
-		RetryExpirationTimestamp: common.TimePtr(time.Time{}),
-		RetryBackoffCoefficient:  common.Float64Ptr(rand.Float64() * 1000),
+		StartedEventEncoding:     "StartedEventEncoding",
+		StartedTimestamp:         time.Now(),
+		ActivityID:               "ActivityID",
+		RequestID:                "RequestID",
+		ScheduleToStartTimeout:   time.Minute * time.Duration(rand.Intn(10)),
+		ScheduleToCloseTimeout:   time.Minute * time.Duration(rand.Intn(10)),
+		StartToCloseTimeout:      time.Minute * time.Duration(rand.Intn(10)),
+		HeartbeatTimeout:         time.Minute * time.Duration(rand.Intn(10)),
+		CancelRequested:          true,
+		CancelRequestID:          int64(rand.Intn(1000)),
+		TimerTaskStatus:          int32(rand.Intn(1000)),
+		Attempt:                  int32(rand.Intn(1000)),
+		TaskList:                 "TaskList",
+		StartedIdentity:          "StartedIdentity",
+		HasRetryPolicy:           true,
+		RetryInitialInterval:     time.Minute * time.Duration(rand.Intn(10)),
+		RetryMaximumInterval:     time.Minute * time.Duration(rand.Intn(10)),
+		RetryMaximumAttempts:     int32(rand.Intn(1000)),
+		RetryExpirationTimestamp: time.Time{},
+		RetryBackoffCoefficient:  rand.Float64() * 1000,
 		RetryNonRetryableErrors:  []string{"RetryNonRetryableErrors"},
-		RetryLastFailureReason:   common.StringPtr("RetryLastFailureReason"),
-		RetryLastWorkerIdentity:  common.StringPtr("RetryLastWorkerIdentity"),
+		RetryLastFailureReason:   "RetryLastFailureReason",
+		RetryLastWorkerIdentity:  "RetryLastWorkerIdentity",
 		RetryLastFailureDetails:  []byte("RetryLastFailureDetails"),
 	}
 	actual := activityInfoFromThrift(activityInfoToThrift(expected))
@@ -333,32 +333,32 @@ func TestActivityInfo(t *testing.T) {
 	assert.Equal(t, expected.RetryLastFailureReason, actual.RetryLastFailureReason)
 	assert.Equal(t, expected.RetryLastWorkerIdentity, actual.RetryLastWorkerIdentity)
 	assert.Equal(t, expected.RetryLastFailureDetails, actual.RetryLastFailureDetails)
-	assert.True(t, (*expected.ScheduleToStartTimeout-*actual.ScheduleToStartTimeout) < time.Second)
-	assert.True(t, (*expected.ScheduleToCloseTimeout-*actual.ScheduleToCloseTimeout) < time.Second)
-	assert.True(t, (*expected.StartToCloseTimeout-*actual.StartToCloseTimeout) < time.Second)
-	assert.True(t, (*expected.HeartbeatTimeout-*actual.HeartbeatTimeout) < time.Second)
-	assert.True(t, (*expected.RetryInitialInterval-*actual.RetryInitialInterval) < time.Second)
-	assert.True(t, (*expected.RetryMaximumInterval-*actual.RetryMaximumInterval) < time.Second)
-	assert.Equal(t, expected.ScheduledTimestamp.Sub(*actual.ScheduledTimestamp), time.Duration(0))
-	assert.Equal(t, expected.StartedTimestamp.Sub(*actual.StartedTimestamp), time.Duration(0))
-	assert.Equal(t, expected.RetryExpirationTimestamp.Sub(*actual.RetryExpirationTimestamp), time.Duration(0))
+	assert.True(t, (expected.ScheduleToStartTimeout-actual.ScheduleToStartTimeout) < time.Second)
+	assert.True(t, (expected.ScheduleToCloseTimeout-actual.ScheduleToCloseTimeout) < time.Second)
+	assert.True(t, (expected.StartToCloseTimeout-actual.StartToCloseTimeout) < time.Second)
+	assert.True(t, (expected.HeartbeatTimeout-actual.HeartbeatTimeout) < time.Second)
+	assert.True(t, (expected.RetryInitialInterval-actual.RetryInitialInterval) < time.Second)
+	assert.True(t, (expected.RetryMaximumInterval-actual.RetryMaximumInterval) < time.Second)
+	assert.Equal(t, expected.ScheduledTimestamp.Sub(actual.ScheduledTimestamp), time.Duration(0))
+	assert.Equal(t, expected.StartedTimestamp.Sub(actual.StartedTimestamp), time.Duration(0))
+	assert.Equal(t, expected.RetryExpirationTimestamp.Sub(actual.RetryExpirationTimestamp), time.Duration(0))
 }
 
 func TestChildExecutionInfo(t *testing.T) {
 	expected := &ChildExecutionInfo{
-		Version:                common.Int64Ptr(int64(rand.Intn(1000))),
-		InitiatedEventBatchID:  common.Int64Ptr(int64(rand.Intn(1000))),
-		StartedID:              common.Int64Ptr(int64(rand.Intn(1000))),
+		Version:                int64(rand.Intn(1000)),
+		InitiatedEventBatchID:  int64(rand.Intn(1000)),
+		StartedID:              int64(rand.Intn(1000)),
 		InitiatedEvent:         []byte("InitiatedEvent"),
-		InitiatedEventEncoding: common.StringPtr("InitiatedEventEncoding"),
-		StartedWorkflowID:      common.StringPtr("InitiatedEventEncoding"),
+		InitiatedEventEncoding: "InitiatedEventEncoding",
+		StartedWorkflowID:      "InitiatedEventEncoding",
 		StartedRunID:           UUID(uuid.New()),
 		StartedEvent:           []byte("StartedEvent"),
-		StartedEventEncoding:   common.StringPtr("StartedEventEncoding"),
-		CreateRequestID:        common.StringPtr("CreateRequestID"),
-		DomainName:             common.StringPtr("DomainName"),
-		WorkflowTypeName:       common.StringPtr("WorkflowTypeName"),
-		ParentClosePolicy:      common.Int32Ptr(int32(rand.Intn(1000))),
+		StartedEventEncoding:   "StartedEventEncoding",
+		CreateRequestID:        "CreateRequestID",
+		DomainName:             "DomainName",
+		WorkflowTypeName:       "WorkflowTypeName",
+		ParentClosePolicy:      int32(rand.Intn(1000)),
 	}
 	actual := childExecutionInfoFromThrift(childExecutionInfoToThrift(expected))
 	assert.Equal(t, expected, actual)
@@ -366,10 +366,10 @@ func TestChildExecutionInfo(t *testing.T) {
 
 func TestSignalInfo(t *testing.T) {
 	expected := &SignalInfo{
-		Version:               common.Int64Ptr(int64(rand.Intn(1000))),
-		InitiatedEventBatchID: common.Int64Ptr(int64(rand.Intn(1000))),
-		RequestID:             common.StringPtr("RequestID"),
-		Name:                  common.StringPtr("Name"),
+		Version:               int64(rand.Intn(1000)),
+		InitiatedEventBatchID: int64(rand.Intn(1000)),
+		RequestID:             "RequestID",
+		Name:                  "Name",
 		Input:                 []byte("Input"),
 		Control:               []byte("Control"),
 	}
@@ -379,9 +379,9 @@ func TestSignalInfo(t *testing.T) {
 
 func TestRequestCancelInfo(t *testing.T) {
 	expected := &RequestCancelInfo{
-		Version:               common.Int64Ptr(int64(rand.Intn(1000))),
-		InitiatedEventBatchID: common.Int64Ptr(int64(rand.Intn(1000))),
-		CancelRequestID:       common.StringPtr("CancelRequestID"),
+		Version:               int64(rand.Intn(1000)),
+		InitiatedEventBatchID: int64(rand.Intn(1000)),
+		CancelRequestID:       "CancelRequestID",
 	}
 	actual := requestCancelInfoFromThrift(requestCancelInfoToThrift(expected))
 	assert.Equal(t, expected, actual)
@@ -389,61 +389,61 @@ func TestRequestCancelInfo(t *testing.T) {
 
 func TestTimerInfo(t *testing.T) {
 	expected := &TimerInfo{
-		Version:         common.Int64Ptr(int64(rand.Intn(1000))),
-		StartedID:       common.Int64Ptr(int64(rand.Intn(1000))),
-		ExpiryTimestamp: common.TimePtr(time.Now()),
-		TaskID:          common.Int64Ptr(int64(rand.Intn(1000))),
+		Version:         int64(rand.Intn(1000)),
+		StartedID:       int64(rand.Intn(1000)),
+		ExpiryTimestamp: time.Now(),
+		TaskID:          int64(rand.Intn(1000)),
 	}
 	actual := timerInfoFromThrift(timerInfoToThrift(expected))
 	assert.Equal(t, expected.Version, actual.Version)
 	assert.Equal(t, expected.StartedID, actual.StartedID)
 	assert.Equal(t, expected.TaskID, actual.TaskID)
-	assert.Equal(t, expected.ExpiryTimestamp.Sub(*actual.ExpiryTimestamp), time.Duration(0))
+	assert.Equal(t, expected.ExpiryTimestamp.Sub(actual.ExpiryTimestamp), time.Duration(0))
 }
 
 func TestTaskInfo(t *testing.T) {
 	expected := &TaskInfo{
-		WorkflowID:       common.StringPtr("WorkflowID"),
+		WorkflowID:       "WorkflowID",
 		RunID:            UUID(uuid.New()),
-		ScheduleID:       common.Int64Ptr(int64(rand.Intn(1000))),
-		ExpiryTimestamp:  common.TimePtr(time.Now()),
-		CreatedTimestamp: common.TimePtr(time.Now()),
+		ScheduleID:       int64(rand.Intn(1000)),
+		ExpiryTimestamp:  time.Now(),
+		CreatedTimestamp: time.Now(),
 	}
 	actual := taskInfoFromThrift(taskInfoToThrift(expected))
 	assert.Equal(t, expected.WorkflowID, actual.WorkflowID)
 	assert.Equal(t, expected.RunID, actual.RunID)
 	assert.Equal(t, expected.ScheduleID, actual.ScheduleID)
-	assert.Equal(t, expected.ExpiryTimestamp.Sub(*actual.ExpiryTimestamp), time.Duration(0))
-	assert.Equal(t, expected.CreatedTimestamp.Sub(*actual.CreatedTimestamp), time.Duration(0))
+	assert.Equal(t, expected.ExpiryTimestamp.Sub(actual.ExpiryTimestamp), time.Duration(0))
+	assert.Equal(t, expected.CreatedTimestamp.Sub(actual.CreatedTimestamp), time.Duration(0))
 }
 
 func TestTaskListInfo(t *testing.T) {
 	expected := &TaskListInfo{
-		Kind:            common.Int16Ptr(int16(rand.Intn(1000))),
-		AckLevel:        common.Int64Ptr(int64(rand.Intn(1000))),
-		ExpiryTimestamp: common.TimePtr(time.Now()),
-		LastUpdated:     common.TimePtr(time.Now()),
+		Kind:            int16(rand.Intn(1000)),
+		AckLevel:        int64(rand.Intn(1000)),
+		ExpiryTimestamp: time.Now(),
+		LastUpdated:     time.Now(),
 	}
 	actual := taskListInfoFromThrift(taskListInfoToThrift(expected))
 	assert.Equal(t, expected.Kind, actual.Kind)
 	assert.Equal(t, expected.AckLevel, actual.AckLevel)
-	assert.Equal(t, expected.LastUpdated.Sub(*actual.LastUpdated), time.Duration(0))
-	assert.Equal(t, expected.ExpiryTimestamp.Sub(*actual.ExpiryTimestamp), time.Duration(0))
+	assert.Equal(t, expected.LastUpdated.Sub(actual.LastUpdated), time.Duration(0))
+	assert.Equal(t, expected.ExpiryTimestamp.Sub(actual.ExpiryTimestamp), time.Duration(0))
 }
 
 func TestTransferTaskInfo(t *testing.T) {
 	expected := &TransferTaskInfo{
 		DomainID:                UUID(uuid.New()),
-		WorkflowID:              common.StringPtr("WorkflowID"),
+		WorkflowID:              "WorkflowID",
 		RunID:                   UUID(uuid.New()),
-		TaskType:                common.Int16Ptr(int16(rand.Intn(1000))),
+		TaskType:                int16(rand.Intn(1000)),
 		TargetDomainID:          UUID(uuid.New()),
-		TargetWorkflowID:        common.StringPtr("TargetWorkflowID"),
+		TargetWorkflowID:        "TargetWorkflowID",
 		TargetRunID:             UUID(uuid.New()),
-		TaskList:                common.StringPtr("TaskList"),
-		TargetChildWorkflowOnly: common.BoolPtr(true),
-		ScheduleID:              common.Int64Ptr(int64(rand.Intn(1000))),
-		Version:                 common.Int64Ptr(int64(rand.Intn(1000))),
+		TaskList:                "TaskList",
+		TargetChildWorkflowOnly: true,
+		ScheduleID:              int64(rand.Intn(1000)),
+		Version:                 int64(rand.Intn(1000)),
 	}
 	actual := transferTaskInfoFromThrift(transferTaskInfoToThrift(expected))
 	assert.Equal(t, expected, actual)
@@ -452,13 +452,13 @@ func TestTransferTaskInfo(t *testing.T) {
 func TestTimerTaskInfo(t *testing.T) {
 	expected := &TimerTaskInfo{
 		DomainID:        UUID(uuid.New()),
-		WorkflowID:      common.StringPtr("WorkflowID"),
+		WorkflowID:      "WorkflowID",
 		RunID:           UUID(uuid.New()),
-		TaskType:        common.Int16Ptr(int16(rand.Intn(1000))),
+		TaskType:        int16(rand.Intn(1000)),
 		TimeoutType:     common.Int16Ptr(int16(rand.Intn(1000))),
-		Version:         common.Int64Ptr(int64(rand.Intn(1000))),
-		ScheduleAttempt: common.Int64Ptr(int64(rand.Intn(1000))),
-		EventID:         common.Int64Ptr(int64(rand.Intn(1000))),
+		Version:         int64(rand.Intn(1000)),
+		ScheduleAttempt: int64(rand.Intn(1000)),
+		EventID:         int64(rand.Intn(1000)),
 	}
 	actual := timerTaskInfoFromThrift(timerTaskInfoToThrift(expected))
 	assert.Equal(t, expected, actual)
@@ -467,15 +467,15 @@ func TestTimerTaskInfo(t *testing.T) {
 func TestReplicationTaskInfo(t *testing.T) {
 	expected := &ReplicationTaskInfo{
 		DomainID:                UUID(uuid.New()),
-		WorkflowID:              common.StringPtr("WorkflowID"),
+		WorkflowID:              "WorkflowID",
 		RunID:                   UUID(uuid.New()),
-		TaskType:                common.Int16Ptr(int16(rand.Intn(1000))),
-		Version:                 common.Int64Ptr(int64(rand.Intn(1000))),
-		FirstEventID:            common.Int64Ptr(int64(rand.Intn(1000))),
-		NextEventID:             common.Int64Ptr(int64(rand.Intn(1000))),
-		ScheduledID:             common.Int64Ptr(int64(rand.Intn(1000))),
-		EventStoreVersion:       common.Int32Ptr(int32(rand.Intn(1000))),
-		NewRunEventStoreVersion: common.Int32Ptr(int32(rand.Intn(1000))),
+		TaskType:                int16(rand.Intn(1000)),
+		Version:                 int64(rand.Intn(1000)),
+		FirstEventID:            int64(rand.Intn(1000)),
+		NextEventID:             int64(rand.Intn(1000)),
+		ScheduledID:             int64(rand.Intn(1000)),
+		EventStoreVersion:       int32(rand.Intn(1000)),
+		NewRunEventStoreVersion: int32(rand.Intn(1000)),
 		BranchToken:             []byte("BranchToken"),
 		NewRunBranchToken:       []byte("NewRunBranchToken"),
 	}

--- a/common/persistence/sql/sqlExecutionManager.go
+++ b/common/persistence/sql/sqlExecutionManager.go
@@ -1239,16 +1239,19 @@ func (m *sqlExecutionManager) PutReplicationTaskToDLQ(
 ) error {
 	replicationTask := request.TaskInfo
 	blob, err := m.parser.ReplicationTaskInfoToBlob(&serialization.ReplicationTaskInfo{
-		DomainID:          serialization.MustParseUUID(replicationTask.DomainID),
-		WorkflowID:        &replicationTask.WorkflowID,
-		RunID:             serialization.MustParseUUID(replicationTask.RunID),
-		TaskType:          common.Int16Ptr(int16(replicationTask.TaskType)),
-		FirstEventID:      &replicationTask.FirstEventID,
-		NextEventID:       &replicationTask.NextEventID,
-		Version:           &replicationTask.Version,
-		ScheduledID:       &replicationTask.ScheduledID,
-		BranchToken:       replicationTask.BranchToken,
-		NewRunBranchToken: replicationTask.NewRunBranchToken,
+		DomainID:                serialization.MustParseUUID(replicationTask.DomainID),
+		WorkflowID:              replicationTask.WorkflowID,
+		RunID:                   serialization.MustParseUUID(replicationTask.RunID),
+		TaskType:                int16(replicationTask.TaskType),
+		FirstEventID:            replicationTask.FirstEventID,
+		NextEventID:             replicationTask.NextEventID,
+		Version:                 replicationTask.Version,
+		ScheduledID:             replicationTask.ScheduledID,
+		EventStoreVersion:       p.EventStoreVersion,
+		NewRunEventStoreVersion: p.EventStoreVersion,
+		BranchToken:             replicationTask.BranchToken,
+		NewRunBranchToken:       replicationTask.NewRunBranchToken,
+		CreationTimestamp:       replicationTask.CreationTime,
 	})
 	if err != nil {
 		return err
@@ -1352,9 +1355,7 @@ func (m *sqlExecutionManager) populateWorkflowMutableState(
 		state.ExecutionInfo.ParentWorkflowID = info.GetParentWorkflowID()
 		state.ExecutionInfo.ParentRunID = info.ParentRunID.String()
 		state.ExecutionInfo.InitiatedID = info.GetInitiatedID()
-		if state.ExecutionInfo.CompletionEvent != nil {
-			state.ExecutionInfo.CompletionEvent = nil
-		}
+		state.ExecutionInfo.CompletionEvent = nil
 	}
 
 	if info.GetCancelRequested() {

--- a/common/persistence/sql/sqlHistoryManager.go
+++ b/common/persistence/sql/sqlHistoryManager.go
@@ -94,8 +94,8 @@ func (m *sqlHistoryV2Manager) AppendHistoryNodes(
 
 		treeInfo := &serialization.HistoryTreeInfo{
 			Ancestors:        ancestors,
-			Info:             &request.Info,
-			CreatedTimestamp: common.TimePtr(time.Now()),
+			Info:             request.Info,
+			CreatedTimestamp: time.Now(),
 		}
 
 		blob, err := m.parser.HistoryTreeInfoToBlob(treeInfo)
@@ -338,8 +338,8 @@ func (m *sqlHistoryV2Manager) ForkHistoryBranch(
 
 	treeInfo := &serialization.HistoryTreeInfo{
 		Ancestors:        newAncestors,
-		Info:             &request.Info,
-		CreatedTimestamp: common.TimePtr(time.Now()),
+		Info:             request.Info,
+		CreatedTimestamp: time.Now(),
 	}
 
 	blob, err := m.parser.HistoryTreeInfoToBlob(treeInfo)

--- a/common/persistence/sql/sqlMetadataManagerV2.go
+++ b/common/persistence/sql/sqlMetadataManagerV2.go
@@ -98,33 +98,34 @@ func (m *sqlMetadataManagerV2) CreateDomain(
 	}
 
 	var badBinaries []byte
-	var badBinariesEncoding *string
+	badBinariesEncoding := string(common.EncodingTypeEmpty)
 	if request.Config.BadBinaries != nil {
 		badBinaries = request.Config.BadBinaries.Data
-		badBinariesEncoding = common.StringPtr(string(request.Config.BadBinaries.GetEncoding()))
+		badBinariesEncoding = string(request.Config.BadBinaries.GetEncoding())
 	}
 
 	domainInfo := &serialization.DomainInfo{
-		Status:                      common.Int32Ptr(int32(request.Info.Status)),
-		Description:                 &request.Info.Description,
-		Owner:                       &request.Info.OwnerEmail,
+		Name:                        request.Info.Name,
+		Status:                      int32(request.Info.Status),
+		Description:                 request.Info.Description,
+		Owner:                       request.Info.OwnerEmail,
 		Data:                        request.Info.Data,
-		Retention:                   &request.Config.Retention,
-		EmitMetric:                  &request.Config.EmitMetric,
-		ArchivalBucket:              &request.Config.ArchivalBucket,
-		ArchivalStatus:              common.Int16Ptr(int16(request.Config.ArchivalStatus)),
-		HistoryArchivalStatus:       common.Int16Ptr(int16(request.Config.HistoryArchivalStatus)),
-		HistoryArchivalURI:          &request.Config.HistoryArchivalURI,
-		VisibilityArchivalStatus:    common.Int16Ptr(int16(request.Config.VisibilityArchivalStatus)),
-		VisibilityArchivalURI:       &request.Config.VisibilityArchivalURI,
-		ActiveClusterName:           &request.ReplicationConfig.ActiveClusterName,
+		Retention:                   request.Config.Retention,
+		EmitMetric:                  request.Config.EmitMetric,
+		ArchivalBucket:              request.Config.ArchivalBucket,
+		ArchivalStatus:              int16(request.Config.ArchivalStatus),
+		HistoryArchivalStatus:       int16(request.Config.HistoryArchivalStatus),
+		HistoryArchivalURI:          request.Config.HistoryArchivalURI,
+		VisibilityArchivalStatus:    int16(request.Config.VisibilityArchivalStatus),
+		VisibilityArchivalURI:       request.Config.VisibilityArchivalURI,
+		ActiveClusterName:           request.ReplicationConfig.ActiveClusterName,
 		Clusters:                    clusters,
-		ConfigVersion:               common.Int64Ptr(request.ConfigVersion),
-		FailoverVersion:             common.Int64Ptr(request.FailoverVersion),
-		NotificationVersion:         common.Int64Ptr(metadata.NotificationVersion),
-		FailoverNotificationVersion: common.Int64Ptr(persistence.InitialFailoverNotificationVersion),
-		PreviousFailoverVersion:     common.Int64Ptr(common.InitialPreviousFailoverVersion),
-		LastUpdatedTimestamp:        &request.LastUpdatedTime,
+		ConfigVersion:               request.ConfigVersion,
+		FailoverVersion:             request.FailoverVersion,
+		NotificationVersion:         metadata.NotificationVersion,
+		FailoverNotificationVersion: persistence.InitialFailoverNotificationVersion,
+		PreviousFailoverVersion:     common.InitialPreviousFailoverVersion,
+		LastUpdatedTimestamp:        request.LastUpdatedTime,
 		BadBinaries:                 badBinaries,
 		BadBinariesEncoding:         badBinariesEncoding,
 	}
@@ -221,7 +222,7 @@ func (m *sqlMetadataManagerV2) domainRowToGetDomainResponse(row *sqlplugin.Domai
 
 	var badBinaries *persistence.DataBlob
 	if domainInfo.BadBinaries != nil {
-		badBinaries = persistence.NewDataBlob(domainInfo.BadBinaries, common.EncodingType(*domainInfo.BadBinariesEncoding))
+		badBinaries = persistence.NewDataBlob(domainInfo.BadBinaries, common.EncodingType(domainInfo.GetBadBinariesEncoding()))
 	}
 
 	return &persistence.InternalGetDomainResponse{
@@ -237,10 +238,10 @@ func (m *sqlMetadataManagerV2) domainRowToGetDomainResponse(row *sqlplugin.Domai
 			Retention:                domainInfo.GetRetention(),
 			EmitMetric:               domainInfo.GetEmitMetric(),
 			ArchivalBucket:           domainInfo.GetArchivalBucket(),
-			ArchivalStatus:           types.ArchivalStatus(*domainInfo.ArchivalStatus),
-			HistoryArchivalStatus:    types.ArchivalStatus(*domainInfo.HistoryArchivalStatus),
+			ArchivalStatus:           types.ArchivalStatus(domainInfo.GetArchivalStatus()),
+			HistoryArchivalStatus:    types.ArchivalStatus(domainInfo.GetHistoryArchivalStatus()),
 			HistoryArchivalURI:       domainInfo.GetHistoryArchivalURI(),
-			VisibilityArchivalStatus: types.ArchivalStatus(*domainInfo.VisibilityArchivalStatus),
+			VisibilityArchivalStatus: types.ArchivalStatus(domainInfo.GetVisibilityArchivalStatus()),
 			VisibilityArchivalURI:    domainInfo.GetVisibilityArchivalURI(),
 			BadBinaries:              badBinaries,
 		},
@@ -270,34 +271,34 @@ func (m *sqlMetadataManagerV2) UpdateDomain(
 	}
 
 	var badBinaries []byte
-	var badBinariesEncoding *string
+	badBinariesEncoding := string(common.EncodingTypeEmpty)
 	if request.Config.BadBinaries != nil {
 		badBinaries = request.Config.BadBinaries.Data
-		badBinariesEncoding = common.StringPtr(string(request.Config.BadBinaries.GetEncoding()))
+		badBinariesEncoding = string(request.Config.BadBinaries.GetEncoding())
 	}
 
 	domainInfo := &serialization.DomainInfo{
-		Status:                      common.Int32Ptr(int32(request.Info.Status)),
-		Description:                 &request.Info.Description,
-		Owner:                       &request.Info.OwnerEmail,
+		Status:                      int32(request.Info.Status),
+		Description:                 request.Info.Description,
+		Owner:                       request.Info.OwnerEmail,
 		Data:                        request.Info.Data,
-		Retention:                   &request.Config.Retention,
-		EmitMetric:                  &request.Config.EmitMetric,
-		ArchivalBucket:              &request.Config.ArchivalBucket,
-		ArchivalStatus:              common.Int16Ptr(int16(request.Config.ArchivalStatus)),
-		HistoryArchivalStatus:       common.Int16Ptr(int16(request.Config.HistoryArchivalStatus)),
-		HistoryArchivalURI:          &request.Config.HistoryArchivalURI,
-		VisibilityArchivalStatus:    common.Int16Ptr(int16(request.Config.VisibilityArchivalStatus)),
-		VisibilityArchivalURI:       &request.Config.VisibilityArchivalURI,
-		ActiveClusterName:           &request.ReplicationConfig.ActiveClusterName,
+		Retention:                   request.Config.Retention,
+		EmitMetric:                  request.Config.EmitMetric,
+		ArchivalBucket:              request.Config.ArchivalBucket,
+		ArchivalStatus:              int16(request.Config.ArchivalStatus),
+		HistoryArchivalStatus:       int16(request.Config.HistoryArchivalStatus),
+		HistoryArchivalURI:          request.Config.HistoryArchivalURI,
+		VisibilityArchivalStatus:    int16(request.Config.VisibilityArchivalStatus),
+		VisibilityArchivalURI:       request.Config.VisibilityArchivalURI,
+		ActiveClusterName:           request.ReplicationConfig.ActiveClusterName,
 		Clusters:                    clusters,
-		ConfigVersion:               common.Int64Ptr(request.ConfigVersion),
-		FailoverVersion:             common.Int64Ptr(request.FailoverVersion),
-		NotificationVersion:         common.Int64Ptr(request.NotificationVersion),
-		FailoverNotificationVersion: common.Int64Ptr(request.FailoverNotificationVersion),
-		PreviousFailoverVersion:     common.Int64Ptr(request.PreviousFailoverVersion),
+		ConfigVersion:               request.ConfigVersion,
+		FailoverVersion:             request.FailoverVersion,
+		NotificationVersion:         request.NotificationVersion,
+		FailoverNotificationVersion: request.FailoverNotificationVersion,
+		PreviousFailoverVersion:     request.PreviousFailoverVersion,
 		FailoverEndTimestamp:        request.FailoverEndTime,
-		LastUpdatedTimestamp:        &request.LastUpdatedTime,
+		LastUpdatedTimestamp:        request.LastUpdatedTime,
 		BadBinaries:                 badBinaries,
 		BadBinariesEncoding:         badBinariesEncoding,
 	}

--- a/common/persistence/sql/sqlShardManager.go
+++ b/common/persistence/sql/sqlShardManager.go
@@ -232,44 +232,44 @@ func readLockShard(ctx context.Context, tx sqlplugin.Tx, shardID int, oldRangeID
 
 func shardInfoToShardsRow(s persistence.InternalShardInfo, parser serialization.Parser) (*sqlplugin.ShardsRow, error) {
 	var markerData []byte
-	var markerEncoding string
+	markerEncoding := string(common.EncodingTypeEmpty)
 	if s.PendingFailoverMarkers != nil {
 		markerData = s.PendingFailoverMarkers.Data
 		markerEncoding = string(s.PendingFailoverMarkers.Encoding)
 	}
 
 	var transferPQSData []byte
-	var transferPQSEncoding string
+	transferPQSEncoding := string(common.EncodingTypeEmpty)
 	if s.TransferProcessingQueueStates != nil {
 		transferPQSData = s.TransferProcessingQueueStates.Data
 		transferPQSEncoding = string(s.TransferProcessingQueueStates.Encoding)
 	}
 
 	var timerPQSData []byte
-	var timerPQSEncoding string
+	timerPQSEncoding := string(common.EncodingTypeEmpty)
 	if s.TimerProcessingQueueStates != nil {
 		timerPQSData = s.TimerProcessingQueueStates.Data
 		timerPQSEncoding = string(s.TimerProcessingQueueStates.Encoding)
 	}
 
 	shardInfo := &serialization.ShardInfo{
-		StolenSinceRenew:                      common.Int32Ptr(int32(s.StolenSinceRenew)),
-		UpdatedAt:                             &s.UpdatedAt,
-		ReplicationAckLevel:                   common.Int64Ptr(s.ReplicationAckLevel),
-		TransferAckLevel:                      common.Int64Ptr(s.TransferAckLevel),
-		TimerAckLevel:                         &s.TimerAckLevel,
+		StolenSinceRenew:                      int32(s.StolenSinceRenew),
+		UpdatedAt:                             s.UpdatedAt,
+		ReplicationAckLevel:                   s.ReplicationAckLevel,
+		TransferAckLevel:                      s.TransferAckLevel,
+		TimerAckLevel:                         s.TimerAckLevel,
 		ClusterTransferAckLevel:               s.ClusterTransferAckLevel,
 		ClusterTimerAckLevel:                  s.ClusterTimerAckLevel,
 		TransferProcessingQueueStates:         transferPQSData,
-		TransferProcessingQueueStatesEncoding: common.StringPtr(transferPQSEncoding),
+		TransferProcessingQueueStatesEncoding: transferPQSEncoding,
 		TimerProcessingQueueStates:            timerPQSData,
-		TimerProcessingQueueStatesEncoding:    common.StringPtr(timerPQSEncoding),
-		DomainNotificationVersion:             common.Int64Ptr(s.DomainNotificationVersion),
-		Owner:                                 &s.Owner,
+		TimerProcessingQueueStatesEncoding:    timerPQSEncoding,
+		DomainNotificationVersion:             s.DomainNotificationVersion,
+		Owner:                                 s.Owner,
 		ClusterReplicationLevel:               s.ClusterReplicationLevel,
 		ReplicationDlqAckLevel:                s.ReplicationDLQAckLevel,
 		PendingFailoverMarkers:                markerData,
-		PendingFailoverMarkersEncoding:        common.StringPtr(markerEncoding),
+		PendingFailoverMarkersEncoding:        markerEncoding,
 	}
 
 	blob, err := parser.ShardInfoToBlob(shardInfo)

--- a/common/persistence/sql/sqlTaskManager.go
+++ b/common/persistence/sql/sqlTaskManager.go
@@ -80,10 +80,10 @@ func (m *sqlTaskManager) LeaseTaskList(
 	if err != nil {
 		if err == sql.ErrNoRows {
 			tlInfo := &serialization.TaskListInfo{
-				AckLevel:        &ackLevel,
-				Kind:            common.Int16Ptr(int16(request.TaskListKind)),
-				ExpiryTimestamp: common.TimePtr(time.Unix(0, 0)),
-				LastUpdated:     common.TimePtr(time.Now()),
+				AckLevel:        ackLevel,
+				Kind:            int16(request.TaskListKind),
+				ExpiryTimestamp: time.Unix(0, 0),
+				LastUpdated:     time.Now(),
 			}
 			blob, err := m.parser.TaskListInfoToBlob(tlInfo)
 			if err != nil {
@@ -141,7 +141,7 @@ func (m *sqlTaskManager) LeaseTaskList(
 			return err1
 		}
 		now := time.Now()
-		tlInfo.LastUpdated = common.TimePtr(now)
+		tlInfo.LastUpdated = now
 		blob, err1 := m.parser.TaskListInfoToBlob(tlInfo)
 		if err1 != nil {
 			return err1
@@ -195,13 +195,13 @@ func (m *sqlTaskManager) UpdateTaskList(
 	shardID := m.shardID(request.TaskListInfo.DomainID, request.TaskListInfo.Name)
 	domainID := serialization.MustParseUUID(request.TaskListInfo.DomainID)
 	tlInfo := &serialization.TaskListInfo{
-		AckLevel:        common.Int64Ptr(request.TaskListInfo.AckLevel),
-		Kind:            common.Int16Ptr(int16(request.TaskListInfo.Kind)),
-		ExpiryTimestamp: common.TimePtr(time.Unix(0, 0)),
-		LastUpdated:     common.TimePtr(time.Now()),
+		AckLevel:        request.TaskListInfo.AckLevel,
+		Kind:            int16(request.TaskListInfo.Kind),
+		ExpiryTimestamp: time.Unix(0, 0),
+		LastUpdated:     time.Now(),
 	}
 	if request.TaskListInfo.Kind == persistence.TaskListKindSticky {
-		tlInfo.ExpiryTimestamp = common.TimePtr(stickyTaskListExpiry())
+		tlInfo.ExpiryTimestamp = stickyTaskListExpiry()
 	}
 
 	var resp *persistence.UpdateTaskListResponse
@@ -385,11 +385,11 @@ func (m *sqlTaskManager) CreateTasks(
 			expiryTime = time.Now().Add(ttl)
 		}
 		blob, err := m.parser.TaskInfoToBlob(&serialization.TaskInfo{
-			WorkflowID:       &v.Data.WorkflowID,
+			WorkflowID:       v.Data.WorkflowID,
 			RunID:            serialization.MustParseUUID(v.Data.RunID),
-			ScheduleID:       &v.Data.ScheduleID,
-			ExpiryTimestamp:  &expiryTime,
-			CreatedTimestamp: common.TimePtr(time.Now()),
+			ScheduleID:       v.Data.ScheduleID,
+			ExpiryTimestamp:  expiryTime,
+			CreatedTimestamp: time.Now(),
 		})
 		if err != nil {
 			return nil, err

--- a/common/persistence/sql/workflowStateMaps.go
+++ b/common/persistence/sql/workflowStateMaps.go
@@ -51,36 +51,36 @@ func updateActivityInfos(
 			startEvent, startEncoding := persistence.FromDataBlob(activityInfo.StartedEvent)
 
 			info := &serialization.ActivityInfo{
-				Version:                  &activityInfo.Version,
-				ScheduledEventBatchID:    &activityInfo.ScheduledEventBatchID,
+				Version:                  activityInfo.Version,
+				ScheduledEventBatchID:    activityInfo.ScheduledEventBatchID,
 				ScheduledEvent:           scheduledEvent,
-				ScheduledEventEncoding:   common.StringPtr(scheduledEncoding),
-				ScheduledTimestamp:       &activityInfo.ScheduledTime,
-				StartedID:                &activityInfo.StartedID,
+				ScheduledEventEncoding:   scheduledEncoding,
+				ScheduledTimestamp:       activityInfo.ScheduledTime,
+				StartedID:                activityInfo.StartedID,
 				StartedEvent:             startEvent,
-				StartedEventEncoding:     common.StringPtr(startEncoding),
-				StartedTimestamp:         &activityInfo.StartedTime,
-				ActivityID:               &activityInfo.ActivityID,
-				RequestID:                &activityInfo.RequestID,
-				ScheduleToStartTimeout:   &activityInfo.ScheduleToStartTimeout,
-				ScheduleToCloseTimeout:   &activityInfo.ScheduleToCloseTimeout,
-				StartToCloseTimeout:      &activityInfo.StartToCloseTimeout,
-				HeartbeatTimeout:         &activityInfo.HeartbeatTimeout,
-				CancelRequested:          &activityInfo.CancelRequested,
-				CancelRequestID:          &activityInfo.CancelRequestID,
-				TimerTaskStatus:          &activityInfo.TimerTaskStatus,
-				Attempt:                  &activityInfo.Attempt,
-				TaskList:                 &activityInfo.TaskList,
-				StartedIdentity:          &activityInfo.StartedIdentity,
-				HasRetryPolicy:           &activityInfo.HasRetryPolicy,
-				RetryInitialInterval:     &activityInfo.InitialInterval,
-				RetryBackoffCoefficient:  &activityInfo.BackoffCoefficient,
-				RetryMaximumInterval:     &activityInfo.MaximumInterval,
-				RetryExpirationTimestamp: &activityInfo.ExpirationTime,
-				RetryMaximumAttempts:     &activityInfo.MaximumAttempts,
+				StartedEventEncoding:     startEncoding,
+				StartedTimestamp:         activityInfo.StartedTime,
+				ActivityID:               activityInfo.ActivityID,
+				RequestID:                activityInfo.RequestID,
+				ScheduleToStartTimeout:   activityInfo.ScheduleToStartTimeout,
+				ScheduleToCloseTimeout:   activityInfo.ScheduleToCloseTimeout,
+				StartToCloseTimeout:      activityInfo.StartToCloseTimeout,
+				HeartbeatTimeout:         activityInfo.HeartbeatTimeout,
+				CancelRequested:          activityInfo.CancelRequested,
+				CancelRequestID:          activityInfo.CancelRequestID,
+				TimerTaskStatus:          activityInfo.TimerTaskStatus,
+				Attempt:                  activityInfo.Attempt,
+				TaskList:                 activityInfo.TaskList,
+				StartedIdentity:          activityInfo.StartedIdentity,
+				HasRetryPolicy:           activityInfo.HasRetryPolicy,
+				RetryInitialInterval:     activityInfo.InitialInterval,
+				RetryBackoffCoefficient:  activityInfo.BackoffCoefficient,
+				RetryMaximumInterval:     activityInfo.MaximumInterval,
+				RetryExpirationTimestamp: activityInfo.ExpirationTime,
+				RetryMaximumAttempts:     activityInfo.MaximumAttempts,
 				RetryNonRetryableErrors:  activityInfo.NonRetriableErrors,
-				RetryLastFailureReason:   &activityInfo.LastFailureReason,
-				RetryLastWorkerIdentity:  &activityInfo.LastWorkerIdentity,
+				RetryLastFailureReason:   activityInfo.LastFailureReason,
+				RetryLastWorkerIdentity:  activityInfo.LastWorkerIdentity,
 				RetryLastFailureDetails:  activityInfo.LastFailureDetails,
 			}
 			blob, err := parser.ActivityInfoToBlob(info)
@@ -225,13 +225,13 @@ func updateTimerInfos(
 		rows := make([]sqlplugin.TimerInfoMapsRow, len(timerInfos))
 		for i, timerInfo := range timerInfos {
 			blob, err := parser.TimerInfoToBlob(&serialization.TimerInfo{
-				Version:         &timerInfo.Version,
-				StartedID:       &timerInfo.StartedID,
-				ExpiryTimestamp: &timerInfo.ExpiryTime,
+				Version:         timerInfo.Version,
+				StartedID:       timerInfo.StartedID,
+				ExpiryTimestamp: timerInfo.ExpiryTime,
 				// TaskID is a misleading variable, it actually serves
 				// the purpose of indicating whether a timer task is
 				// generated for this timer info
-				TaskID: &timerInfo.TaskStatus,
+				TaskID: timerInfo.TaskStatus,
 			})
 			if err != nil {
 				return err
@@ -345,19 +345,19 @@ func updateChildExecutionInfos(
 			startEvent, startEncoding := persistence.FromDataBlob(childExecutionInfo.StartedEvent)
 
 			info := &serialization.ChildExecutionInfo{
-				Version:                &childExecutionInfo.Version,
-				InitiatedEventBatchID:  &childExecutionInfo.InitiatedEventBatchID,
+				Version:                childExecutionInfo.Version,
+				InitiatedEventBatchID:  childExecutionInfo.InitiatedEventBatchID,
 				InitiatedEvent:         initiateEvent,
-				InitiatedEventEncoding: &initiateEncoding,
+				InitiatedEventEncoding: initiateEncoding,
 				StartedEvent:           startEvent,
-				StartedEventEncoding:   &startEncoding,
-				StartedID:              &childExecutionInfo.StartedID,
-				StartedWorkflowID:      &childExecutionInfo.StartedWorkflowID,
+				StartedEventEncoding:   startEncoding,
+				StartedID:              childExecutionInfo.StartedID,
+				StartedWorkflowID:      childExecutionInfo.StartedWorkflowID,
 				StartedRunID:           serialization.MustParseUUID(childExecutionInfo.StartedRunID),
-				CreateRequestID:        &childExecutionInfo.CreateRequestID,
-				DomainName:             &childExecutionInfo.DomainName,
-				WorkflowTypeName:       &childExecutionInfo.WorkflowTypeName,
-				ParentClosePolicy:      common.Int32Ptr(int32(childExecutionInfo.ParentClosePolicy)),
+				CreateRequestID:        childExecutionInfo.CreateRequestID,
+				DomainName:             childExecutionInfo.DomainName,
+				WorkflowTypeName:       childExecutionInfo.WorkflowTypeName,
+				ParentClosePolicy:      int32(childExecutionInfo.ParentClosePolicy),
 			}
 			blob, err := parser.ChildExecutionInfoToBlob(info)
 			if err != nil {
@@ -479,9 +479,9 @@ func updateRequestCancelInfos(
 		rows := make([]sqlplugin.RequestCancelInfoMapsRow, len(requestCancelInfos))
 		for i, requestCancelInfo := range requestCancelInfos {
 			blob, err := parser.RequestCancelInfoToBlob(&serialization.RequestCancelInfo{
-				Version:               &requestCancelInfo.Version,
-				InitiatedEventBatchID: &requestCancelInfo.InitiatedEventBatchID,
-				CancelRequestID:       &requestCancelInfo.CancelRequestID,
+				Version:               requestCancelInfo.Version,
+				InitiatedEventBatchID: requestCancelInfo.InitiatedEventBatchID,
+				CancelRequestID:       requestCancelInfo.CancelRequestID,
 			})
 			if err != nil {
 				return err
@@ -590,10 +590,10 @@ func updateSignalInfos(
 		rows := make([]sqlplugin.SignalInfoMapsRow, len(signalInfos))
 		for i, signalInfo := range signalInfos {
 			blob, err := parser.SignalInfoToBlob(&serialization.SignalInfo{
-				Version:               &signalInfo.Version,
-				InitiatedEventBatchID: &signalInfo.InitiatedEventBatchID,
-				RequestID:             &signalInfo.SignalRequestID,
-				Name:                  &signalInfo.SignalName,
+				Version:               signalInfo.Version,
+				InitiatedEventBatchID: signalInfo.InitiatedEventBatchID,
+				RequestID:             signalInfo.SignalRequestID,
+				Name:                  signalInfo.SignalName,
 				Input:                 signalInfo.Input,
 				Control:               signalInfo.Control,
 			})


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactored persistence serialization to shift pointer conversions down to thrift encoder.

<!-- Tell your future self why have you made these changes -->
**Why?**
Some encoders don't need to shift pointers, so original pointer conversion in common path for all encoders will be shifted back if the encoder don't need to shift pointers.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
For cassandra, there is no risk. For SQL, we need to make sure the read path is compatible with old data.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
For cassandra, there is nothing to be worried.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
