### PR TITLE
Rollback workflow already completed error

### DIFF
--- a/common/client/versionChecker.go
+++ b/common/client/versionChecker.go
@@ -176,6 +176,7 @@ func (vc *versionChecker) SupportsRawHistoryQuery(clientImpl string, clientFeatu
 
 // Returns error if workflowAlreadyCompletedError is not supported otherwise nil.
 // In case client version lookup fails assume the client does not support feature.
+// NOTE: Enabling this error will break customer code handling the workflow errors in their workflow
 func (vc *versionChecker) SupportsWorkflowAlreadyCompletedError(clientImpl string, clientFeatureVersion string) error {
 	return vc.featureSupported(clientImpl, clientFeatureVersion, workflowAlreadyCompletedError)
 }

--- a/host/signalworkflowTest.go
+++ b/host/signalworkflowTest.go
@@ -225,7 +225,7 @@ func (s *IntegrationSuite) TestSignalWorkflow() {
 		Identity:   identity,
 	})
 	s.NotNil(err)
-	s.IsType(&types.WorkflowExecutionAlreadyCompletedError{}, err)
+	s.IsType(&types.EntityNotExistsError{}, err)
 }
 
 func (s *IntegrationSuite) TestSignalWorkflow_DuplicateRequest() {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -4040,6 +4040,8 @@ func checkRequiredDomainDataKVs(requiredDomainDataKeys map[string]interface{}, d
 func (wh *WorkflowHandler) normalizeVersionedErrors(ctx context.Context, err error) error {
 	switch err.(type) {
 	case *types.WorkflowExecutionAlreadyCompletedError:
+		return &types.EntityNotExistsError{Message: "Workflow execution already completed."}
+		/* TODO: re-enable the block below once we can rollout this *breaking* change
 		call := yarpc.CallFromContext(ctx)
 		clientFeatureVersion := call.Header(common.FeatureVersionHeaderName)
 		clientImpl := call.Header(common.ClientImplHeaderName)
@@ -4049,6 +4051,7 @@ func (wh *WorkflowHandler) normalizeVersionedErrors(ctx context.Context, err err
 		} else {
 			return &types.EntityNotExistsError{Message: "Workflow execution already completed."}
 		}
+		*/
 	default:
 		return err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Earlier we introduced a new error type for the actions on recently finished workflows (https://github.com/uber/cadence/commit/12579bd153360679f8442a3589f35f279f19ec6b). We were returning WorkflowExecutionAlreadyCompleted error. However, there are customers depending on the previous error type. If their code doesn't support the new error type, their workflows might be broken. 

That change is going to be a breaking change anyway but it wasn't planned to be breaking today. We will release that feature again once we are ready. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
go test -run TestIntegrationSuite github.com/uber/cadence/host -testify.m TestSignalWorkflow$ -v
go test -v github.com/uber/cadence/service/history -run engine2Suite -testify.m TestRequestCancelWorkflowExecutionFail
go test -v github.com/uber/cadence/service/history -run TestEngineSuite -testify.m TestSignalWorkflowExecution_Failed

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
