### PR TITLE
Check identity length before RespondDecisionTaskCompleted to history

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -1564,20 +1564,20 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 		return nil, errShuttingDown
 	}
 
-	histResp, err := wh.GetHistoryClient().RespondDecisionTaskCompleted(ctx, &types.HistoryRespondDecisionTaskCompletedRequest{
-		DomainUUID:      taskToken.DomainID,
-		CompleteRequest: completeRequest},
-	)
-	if err != nil {
-		return nil, wh.error(err, scope)
-	}
-
 	if !common.ValidIDLength(
 		completeRequest.GetIdentity(),
 		scope,
 		wh.config.MaxIDLengthWarnLimit(),
 		wh.config.IdentityMaxLength(domainName),
 		metrics.CadenceErrIdentityExceededWarnLimit) {
+		return nil, wh.error(errIdentityTooLong, scope)
+	}
+
+	histResp, err := wh.GetHistoryClient().RespondDecisionTaskCompleted(ctx, &types.HistoryRespondDecisionTaskCompletedRequest{
+		DomainUUID:      taskToken.DomainID,
+		CompleteRequest: completeRequest},
+	)
+	if err != nil {
 		return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope))
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Check identity length before RespondDecisionTaskCompleted to history
- Apply error normalization for the error returned by GetHistoryClient().RespondDecisionTaskCompleted() call.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
