### PR TITLE
Add conn_attrs flag to admin db commands

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/service/worker/scanner/executions"
+	"github.com/uber/cadence/tools/common/flag"
 )
 
 func newAdminWorkflowCommands() []cli.Command {
@@ -1001,6 +1002,11 @@ func getDBFlags() []cli.Flag {
 		cli.BoolFlag{
 			Name:  FlagTLSEnableHostVerification,
 			Usage: "cassandra tls verify hostname and server cert (tls must be enabled)",
+		},
+		cli.GenericFlag{
+			Name:  FlagConnectionAttributes,
+			Usage: "a key-value set of sql database connection attributes (must be in key1=value1,key2=value2,...,keyN=valueN format, e.g. cluster=dca or cluster=dca,instance=cadence)",
+			Value: &flag.StringMap{},
 		},
 	}
 }

--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -43,6 +43,7 @@ import (
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/types/mapper/thrift"
+	"github.com/uber/cadence/tools/common/flag"
 )
 
 const (
@@ -327,18 +328,20 @@ func connectToSQL(c *cli.Context) sqlplugin.DB {
 	}
 	encodingType := c.String(FlagEncodingType)
 	decodingTypesStr := c.StringSlice(FlagDecodingTypes)
+	connectAttributes := c.Generic(FlagConnectionAttributes).(*flag.StringMap)
 
 	sqlConfig := &config.SQL{
 		ConnectAddr: net.JoinHostPort(
 			host,
 			c.String(FlagDBPort),
 		),
-		PluginName:    c.String(FlagDBType),
-		User:          c.String(FlagUsername),
-		Password:      c.String(FlagPassword),
-		DatabaseName:  getRequiredOption(c, FlagDatabaseName),
-		EncodingType:  encodingType,
-		DecodingTypes: decodingTypesStr,
+		PluginName:        c.String(FlagDBType),
+		User:              c.String(FlagUsername),
+		Password:          c.String(FlagPassword),
+		DatabaseName:      getRequiredOption(c, FlagDatabaseName),
+		EncodingType:      encodingType,
+		DecodingTypes:     decodingTypesStr,
+		ConnectAttributes: connectAttributes.Value(),
 	}
 
 	if c.Bool(FlagEnableTLS) {

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -273,6 +273,7 @@ const (
 	FlagShardMultiplier                   = "shard_multiplier"
 	FlagBucketSize                        = "bucket_size"
 	DelayStartSeconds                     = "delay_start_seconds"
+	FlagConnectionAttributes              = "conn_attrs"
 )
 
 var flagsForExecution = []cli.Flag{

--- a/tools/common/flag/flag.go
+++ b/tools/common/flag/flag.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package flag
+
+import (
+	"fmt"
+	"strings"
+)
+
+type (
+	StringMap map[string]string
+)
+
+func (m *StringMap) Set(value string) error {
+	if m == nil {
+		return fmt.Errorf("StringMap is nil")
+	}
+	if *m == nil {
+		*m = make(map[string]string)
+	}
+	for _, s := range strings.Split(value, ",") {
+		kv := strings.Split(s, "=")
+		if len(kv) != 2 {
+			return fmt.Errorf("should be in 'key1=value1,key2=value2,...,keyN=valueN' format")
+		}
+		(*m)[kv[0]] = kv[1]
+	}
+	return nil
+}
+
+func (m *StringMap) String() string {
+	if m == nil {
+		return fmt.Sprintf("%v", map[string]string(nil))
+	}
+	return fmt.Sprintf("%v", *m)
+}
+
+func (m *StringMap) Value() map[string]string {
+	if m == nil {
+		return nil
+	}
+	return *m
+}

--- a/tools/common/flag/flag_test.go
+++ b/tools/common/flag/flag_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package flag
+
+import (
+	"os"
+	"reflect"
+	"testing"
+
+	"github.com/urfave/cli"
+)
+
+func TestParseMultiStringMap(t *testing.T) {
+	_ = (&cli.App{
+		Flags: []cli.Flag{
+			cli.GenericFlag{Name: "serve, s", Value: &StringMap{}},
+		},
+		Action: func(ctx *cli.Context) error {
+			if !reflect.DeepEqual(ctx.Generic("serve"), &StringMap{"a": "b", "c": "d"}) {
+				t.Errorf("main name not set")
+			}
+			if !reflect.DeepEqual(ctx.Generic("s"), &StringMap{"a": "b", "c": "d"}) {
+				t.Errorf("short name not set")
+			}
+			return nil
+		},
+	}).Run([]string{"run", "-s", "a=b", "-s", "c=d"})
+}
+
+func TestParseMultiStringMapFromEnv(t *testing.T) {
+	os.Clearenv()
+	_ = os.Setenv("APP_SERVE", "x=y,w=v")
+	_ = (&cli.App{
+		Flags: []cli.Flag{
+			cli.GenericFlag{Name: "serve, s", Value: &StringMap{}, EnvVar: "APP_SERVE"},
+		},
+		Action: func(ctx *cli.Context) error {
+			if !reflect.DeepEqual(ctx.Generic("serve"), &StringMap{"x": "y", "w": "v"}) {
+				t.Errorf("main name not set from env")
+			}
+			if !reflect.DeepEqual(ctx.Generic("s"), &StringMap{"x": "y", "w": "v"}) {
+				t.Errorf("short name not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}
+
+func TestParseMultiStringMapFromEnvCascade(t *testing.T) {
+	os.Clearenv()
+	_ = os.Setenv("APP_FOO", "u=t,r=s")
+	_ = (&cli.App{
+		Flags: []cli.Flag{
+			cli.GenericFlag{Name: "foos", Value: &StringMap{}, EnvVar: "COMPAT_FOO,APP_FOO"},
+		},
+		Action: func(ctx *cli.Context) error {
+			if !reflect.DeepEqual(ctx.Generic("foos"), &StringMap{"u": "t", "r": "s"}) {
+				t.Errorf("value not set from env")
+			}
+			return nil
+		},
+	}).Run([]string{"run"})
+}

--- a/tools/sql/handler.go
+++ b/tools/sql/handler.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"net/url"
 
 	"github.com/urfave/cli"
 
@@ -33,6 +32,7 @@ import (
 	postgres_db "github.com/uber/cadence/common/persistence/sql/sqlplugin/postgres"
 	"github.com/uber/cadence/schema/mysql"
 	"github.com/uber/cadence/schema/postgres"
+	cliflag "github.com/uber/cadence/tools/common/flag"
 	"github.com/uber/cadence/tools/common/schema"
 )
 
@@ -163,23 +163,8 @@ func parseConnectConfig(cli *cli.Context) (*config.SQL, error) {
 	cfg.DatabaseName = cli.GlobalString(schema.CLIOptDatabase)
 	cfg.PluginName = cli.GlobalString(schema.CLIOptPluginName)
 
-	if cfg.ConnectAttributes == nil {
-		cfg.ConnectAttributes = map[string]string{}
-	}
-	connectAttributesQueryString := cli.GlobalString(schema.CLIOptConnectAttributes)
-	if connectAttributesQueryString != "" {
-		values, err := url.ParseQuery(connectAttributesQueryString)
-		if err != nil {
-			return nil, fmt.Errorf("invalid connect attributes: %v", err)
-		}
-		for key, vals := range values {
-			// check to ensure only one value is provider per key
-			if len(vals) > 1 {
-				return nil, fmt.Errorf("invalid connect attribute %v, only 1 value allowed: %v", key, vals)
-			}
-			cfg.ConnectAttributes[key] = vals[0]
-		}
-	}
+	connectAttributes := cli.GlobalGeneric(schema.CLIOptConnectAttributes).(*cliflag.StringMap)
+	cfg.ConnectAttributes = connectAttributes.Value()
 
 	if cli.GlobalBool(schema.CLIFlagEnableTLS) {
 		cfg.TLS = &config.TLS{

--- a/tools/sql/main.go
+++ b/tools/sql/main.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/urfave/cli"
 
+	cliflag "github.com/uber/cadence/tools/common/flag"
 	"github.com/uber/cadence/tools/common/schema"
 )
 
@@ -94,9 +95,10 @@ func BuildCLIOptions() *cli.App {
 			Name:  schema.CLIFlagQuiet,
 			Usage: "Don't set exit status to 1 on error",
 		},
-		cli.StringFlag{
+		cli.GenericFlag{
 			Name:   schema.CLIFlagConnectAttributes,
-			Usage:  "sql connect attributes",
+			Value:  &cliflag.StringMap{},
+			Usage:  "sql connect attributes (must be in key1=value1,key2=value2,...,keyN=valueN format, e.g. cluster=dca or cluster=dca,instance=cadence)",
 			EnvVar: "SQL_CONNECT_ATTRIBUTES",
 		},
 		cli.BoolFlag{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Introduce StringMap type to parse `key=val` CLI input into string map
- Add `conn_attrs` flag to admin db commands and use it for SQL database connection

<!-- Tell your future self why have you made these changes -->
**Why?**
To address #2777. Docstore will use `conn_attrs` for database connection.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local test, new unit test

```
zijian@zijian-C02XW43AJGH6 cli % ./cli adm shard d --conn_attrs "a=b" --shard_id 0 --db_port 9042 --conn_attrs cd --db_type mysql 
Incorrect Usage: invalid value "cd" for flag -conn_attrs: should be in 'key=value' format

NAME:
   cadence admin shard describe - Describe shard by Id

USAGE:
   cadence admin shard describe [command options] [arguments...]

OPTIONS:
   --db_type value                 persistence type. Current supported options are [mysql postgres cassandra] (default: "cassandra")
   --db_address value              persistence address (right now only cassandra is fully supported) (default: "127.0.0.1")
   --db_port value                 persistence port (default: 9042)
   --db_region value               persistence region
   --username value                persistence username
   --password value                persistence password
   --keyspace value                cassandra keyspace (default: "cadence")
   --db_name value                 sql database name (default: "cadence")
   --encoding_type value           sql database encoding type (default: "thriftrw")
   --decoding_types value          sql database decoding types (default: "thriftrw")
   --tls                           enable TLS over cassandra connection
   --tls_cert_path value           cassandra tls client cert path (tls must be enabled)
   --tls_key_path value            cassandra tls client key path (tls must be enabled)
   --tls_ca_path value             cassandra tls client ca path (tls must be enabled)
   --tls_enable_host_verification  cassandra tls verify hostname and server cert (tls must be enabled)
   --conn_attrs value              a key-value set of sql database connection attributes (must be in key=value format) (default: map[a:b])
   --shard_id value                The Id of the shard to describe (default: 0)
   
invalid value "cd" for flag -conn_attrs: should be in 'key=value' format
```
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
