### PR TITLE
Refactoring Cassandra task persistence manager for NoSQL support

### DIFF
--- a/common/persistence/cassandra/cassandraPersistence.go
+++ b/common/persistence/cassandra/cassandraPersistence.go
@@ -90,7 +90,7 @@ const (
 	rowTypeShardTaskID     = int64(-11)
 	emptyInitiatedID       = int64(-7)
 
-	stickyTaskListTTL = int32(24 * time.Hour / time.Second) // if sticky task_list stopped being updated, remove it in one day
+	stickyTaskListTTL = int64(24 * time.Hour / time.Second) // if sticky task_list stopped being updated, remove it in one day
 )
 
 const (

--- a/common/persistence/cassandra/cassandraPersistenceUtil.go
+++ b/common/persistence/cassandra/cassandraPersistenceUtil.go
@@ -2131,29 +2131,6 @@ func createHistoryEventBatchBlob(
 	return eventBatch
 }
 
-func createTaskInfo(
-	result map[string]interface{},
-) *p.InternalTaskInfo {
-
-	info := &p.InternalTaskInfo{}
-	for k, v := range result {
-		switch k {
-		case "domain_id":
-			info.DomainID = v.(gocql.UUID).String()
-		case "workflow_id":
-			info.WorkflowID = v.(string)
-		case "run_id":
-			info.RunID = v.(gocql.UUID).String()
-		case "schedule_id":
-			info.ScheduleID = v.(int64)
-		case "created_time":
-			info.CreatedTime = v.(time.Time)
-		}
-	}
-
-	return info
-}
-
 func createTimerTaskInfo(
 	result map[string]interface{},
 ) *p.TimerTaskInfo {

--- a/common/persistence/cassandra/cassandraTaskPersistence.go
+++ b/common/persistence/cassandra/cassandraTaskPersistence.go
@@ -24,166 +24,58 @@ package cassandra
 import (
 	"context"
 	"fmt"
-	"strings"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"time"
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra"
-	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/common/types"
 )
 
 type (
 	// Implements TaskManager
-	cassandraTaskPersistence struct {
-		cassandraStore
-		shardID            int
-		currentClusterName string
+	nosqlTaskManager struct {
+		db     nosqlplugin.DB
+		logger log.Logger
 	}
 )
 
 const (
-	// Row types for table tasks
-	rowTypeTask = iota
-	rowTypeTaskList
+	initialRangeID  = 1 // Id of the first range of a new task list
+	initialAckLevel = 0
 )
 
-const (
-	taskListTaskID = -12345
-	initialRangeID = 1 // Id of the first range of a new task list
-)
-
-const (
-	templateTaskListType = `{` +
-		`domain_id: ?, ` +
-		`name: ?, ` +
-		`type: ?, ` +
-		`ack_level: ?, ` +
-		`kind: ?, ` +
-		`last_updated: ? ` +
-		`}`
-
-	templateTaskType = `{` +
-		`domain_id: ?, ` +
-		`workflow_id: ?, ` +
-		`run_id: ?, ` +
-		`schedule_id: ?,` +
-		`created_time: ? ` +
-		`}`
-
-	templateCreateTaskQuery = `INSERT INTO tasks (` +
-		`domain_id, task_list_name, task_list_type, type, task_id, task) ` +
-		`VALUES(?, ?, ?, ?, ?, ` + templateTaskType + `)`
-
-	templateCreateTaskWithTTLQuery = `INSERT INTO tasks (` +
-		`domain_id, task_list_name, task_list_type, type, task_id, task) ` +
-		`VALUES(?, ?, ?, ?, ?, ` + templateTaskType + `) USING TTL ?`
-
-	templateGetTasksQuery = `SELECT task_id, task ` +
-		`FROM tasks ` +
-		`WHERE domain_id = ? ` +
-		`and task_list_name = ? ` +
-		`and task_list_type = ? ` +
-		`and type = ? ` +
-		`and task_id > ? ` +
-		`and task_id <= ?`
-
-	templateCompleteTaskQuery = `DELETE FROM tasks ` +
-		`WHERE domain_id = ? ` +
-		`and task_list_name = ? ` +
-		`and task_list_type = ? ` +
-		`and type = ? ` +
-		`and task_id = ?`
-
-	templateCompleteTasksLessThanQuery = `DELETE FROM tasks ` +
-		`WHERE domain_id = ? ` +
-		`AND task_list_name = ? ` +
-		`AND task_list_type = ? ` +
-		`AND type = ? ` +
-		`AND task_id <= ? `
-
-	templateGetTaskList = `SELECT ` +
-		`range_id, ` +
-		`task_list ` +
-		`FROM tasks ` +
-		`WHERE domain_id = ? ` +
-		`and task_list_name = ? ` +
-		`and task_list_type = ? ` +
-		`and type = ? ` +
-		`and task_id = ?`
-
-	templateInsertTaskListQuery = `INSERT INTO tasks (` +
-		`domain_id, ` +
-		`task_list_name, ` +
-		`task_list_type, ` +
-		`type, ` +
-		`task_id, ` +
-		`range_id, ` +
-		`task_list ` +
-		`) VALUES (?, ?, ?, ?, ?, ?, ` + templateTaskListType + `) IF NOT EXISTS`
-
-	templateUpdateTaskListQuery = `UPDATE tasks SET ` +
-		`range_id = ?, ` +
-		`task_list = ` + templateTaskListType + " " +
-		`WHERE domain_id = ? ` +
-		`and task_list_name = ? ` +
-		`and task_list_type = ? ` +
-		`and type = ? ` +
-		`and task_id = ? ` +
-		`IF range_id = ?`
-
-	templateUpdateTaskListQueryWithTTLPart1 = ` INSERT INTO tasks (` +
-		`domain_id, ` +
-		`task_list_name, ` +
-		`task_list_type, ` +
-		`type, ` +
-		`task_id ` +
-		`) VALUES (?, ?, ?, ?, ?) USING TTL ?`
-
-	templateUpdateTaskListQueryWithTTLPart2 = `UPDATE tasks USING TTL ? SET ` +
-		`range_id = ?, ` +
-		`task_list = ` + templateTaskListType + " " +
-		`WHERE domain_id = ? ` +
-		`and task_list_name = ? ` +
-		`and task_list_type = ? ` +
-		`and type = ? ` +
-		`and task_id = ? ` +
-		`IF range_id = ?`
-
-	templateDeleteTaskListQuery = `DELETE FROM tasks ` +
-		`WHERE domain_id = ? ` +
-		`AND task_list_name = ? ` +
-		`AND task_list_type = ? ` +
-		`AND type = ? ` +
-		`AND task_id = ? ` +
-		`IF range_id = ?`
-)
-
-var _ p.TaskStore = (*cassandraTaskPersistence)(nil)
+var _ p.TaskStore = (*nosqlTaskManager)(nil)
 
 // newTaskPersistence is used to create an instance of TaskManager implementation
 func newTaskPersistence(
 	cfg config.Cassandra,
 	logger log.Logger,
 ) (p.TaskStore, error) {
-	session, err := cassandra.CreateSession(cfg)
+	// TODO hardcoding to Cassandra for now, will switch to dynamically loading later
+	db, err := cassandra.NewCassandraDB(cfg, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	return &cassandraTaskPersistence{
-		cassandraStore: cassandraStore{
-			client:  gocql.NewClient(),
-			session: session,
-			logger:  logger,
-		},
-		shardID: -1,
+	return &nosqlTaskManager{
+		db:     db,
+		logger: logger,
 	}, nil
 }
 
-func (d *cassandraTaskPersistence) GetOrphanTasks(ctx context.Context, request *p.GetOrphanTasksRequest) (*p.GetOrphanTasksResponse, error) {
+func (t *nosqlTaskManager) GetName() string {
+	return t.db.PluginName()
+}
+
+// Close releases the underlying resources held by this object
+func (t *nosqlTaskManager) Close() {
+	t.db.Close()
+}
+
+func (t *nosqlTaskManager) GetOrphanTasks(ctx context.Context, request *p.GetOrphanTasksRequest) (*p.GetOrphanTasksResponse, error) {
 	// TODO: It's unclear if this's necessary or possible for NoSQL
 	return nil, &types.InternalServiceError{
 		Message: "Unimplemented call to GetOrphanTasks for NoSQL",
@@ -191,7 +83,7 @@ func (d *cassandraTaskPersistence) GetOrphanTasks(ctx context.Context, request *
 }
 
 // From TaskManager interface
-func (d *cassandraTaskPersistence) LeaseTaskList(
+func (t *nosqlTaskManager) LeaseTaskList(
 	ctx context.Context,
 	request *p.LeaseTaskListRequest,
 ) (*p.LeaseTaskListResponse, error) {
@@ -201,82 +93,62 @@ func (d *cassandraTaskPersistence) LeaseTaskList(
 		}
 	}
 	now := time.Now()
-	query := d.session.Query(templateGetTaskList,
-		request.DomainID,
-		request.TaskList,
-		request.TaskType,
-		rowTypeTaskList,
-		taskListTaskID,
-	).WithContext(ctx)
-	var rangeID, ackLevel int64
-	var tlDB map[string]interface{}
-	err := query.Scan(&rangeID, &tlDB)
+	tasklist, err := t.db.SelectTaskList(ctx, &nosqlplugin.TaskListFilter{
+		DomainID:     request.DomainID,
+		TaskListName: request.TaskList,
+		TaskListType: request.TaskType,
+	})
 
+	var previous *nosqlplugin.TaskListRow
 	if err != nil {
-		if d.client.IsNotFoundError(err) { // First time task list is used
-			query = d.session.Query(templateInsertTaskListQuery,
-				request.DomainID,
-				request.TaskList,
-				request.TaskType,
-				rowTypeTaskList,
-				taskListTaskID,
-				initialRangeID,
-				request.DomainID,
-				request.TaskList,
-				request.TaskType,
-				0,
-				request.TaskListKind,
-				now,
-			).WithContext(ctx)
+		if t.db.IsNotFoundError(err) { // First time task list is used
+			previous, err = t.db.InsertTaskList(ctx, &nosqlplugin.TaskListRow{
+				DomainID:        request.DomainID,
+				TaskListName:    request.TaskList,
+				TaskListType:    request.TaskType,
+				RangeID:         initialRangeID,
+				TaskListKind:    request.TaskListKind,
+				AckLevel:        initialAckLevel,
+				LastUpdatedTime: now,
+			})
 		} else {
-			return nil, convertCommonErrors(d.client, "LeaseTaskList", err)
+			return nil, convertCommonErrors(t.db, "LeaseTaskList", err)
 		}
 	} else {
 		// if request.RangeID is > 0, we are trying to renew an already existing
 		// lease on the task list. If request.RangeID=0, we are trying to steal
 		// the tasklist from its current owner
-		if request.RangeID > 0 && request.RangeID != rangeID {
+		if request.RangeID > 0 && request.RangeID != tasklist.RangeID {
 			return nil, &p.ConditionFailedError{
 				Msg: fmt.Sprintf("leaseTaskList:renew failed: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",
-					request.TaskList, request.TaskType, request.RangeID, rangeID),
+					request.TaskList, request.TaskType, request.RangeID, tasklist.RangeID),
 			}
 		}
-		ackLevel = tlDB["ack_level"].(int64)
-		taskListKind := tlDB["kind"].(int)
-		query = d.session.Query(templateUpdateTaskListQuery,
-			rangeID+1,
-			request.DomainID,
-			&request.TaskList,
-			request.TaskType,
-			ackLevel,
-			taskListKind,
-			now,
-			request.DomainID,
-			&request.TaskList,
-			request.TaskType,
-			rowTypeTaskList,
-			taskListTaskID,
-			rangeID,
-		).WithContext(ctx)
+		previous, err = t.db.UpdateTaskList(ctx, &nosqlplugin.TaskListRow{
+			DomainID:        request.DomainID,
+			TaskListName:    request.TaskList,
+			TaskListType:    request.TaskType,
+			RangeID:         tasklist.RangeID + 1,
+			TaskListKind:    tasklist.TaskListKind,
+			AckLevel:        tasklist.AckLevel,
+			LastUpdatedTime: now,
+		}, tasklist.RangeID)
 	}
-	previous := make(map[string]interface{})
-	applied, err := query.MapScanCAS(previous)
 	if err != nil {
-		return nil, convertCommonErrors(d.client, "LeaseTaskList", err)
-	}
-	if !applied {
-		previousRangeID := previous["range_id"]
-		return nil, &p.ConditionFailedError{
-			Msg: fmt.Sprintf("leaseTaskList: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",
-				request.TaskList, request.TaskType, rangeID, previousRangeID),
+		if t.db.IsConditionFailedError(err) {
+			return nil, &p.ConditionFailedError{
+				Msg: fmt.Sprintf("leaseTaskList: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",
+					request.TaskList, request.TaskType, tasklist.RangeID, previous.RangeID),
+			}
 		}
+		return nil, convertCommonErrors(t.db, "LeaseTaskList", err)
 	}
 	tli := &p.TaskListInfo{
 		DomainID:    request.DomainID,
 		Name:        request.TaskList,
 		TaskType:    request.TaskType,
-		RangeID:     rangeID + 1,
-		AckLevel:    ackLevel,
+		RangeID:     tasklist.RangeID + 1,
+		AckLevel:    tasklist.AckLevel,
 		Kind:        request.TaskListKind,
 		LastUpdated: now,
 	}
@@ -284,198 +156,128 @@ func (d *cassandraTaskPersistence) LeaseTaskList(
 }
 
 // From TaskManager interface
-func (d *cassandraTaskPersistence) UpdateTaskList(
+func (t *nosqlTaskManager) UpdateTaskList(
 	ctx context.Context,
 	request *p.UpdateTaskListRequest,
 ) (*p.UpdateTaskListResponse, error) {
 	tli := request.TaskListInfo
-
-	var applied bool
 	var err error
-	previous := make(map[string]interface{})
+	var previous *nosqlplugin.TaskListRow
+	taskListToUpdate := &nosqlplugin.TaskListRow{
+		DomainID:        tli.DomainID,
+		TaskListName:    tli.Name,
+		TaskListType:    tli.TaskType,
+		RangeID:         tli.RangeID,
+		TaskListKind:    tli.Kind,
+		AckLevel:        tli.AckLevel,
+		LastUpdatedTime: time.Now(),
+	}
+
 	if tli.Kind == p.TaskListKindSticky { // if task_list is sticky, then update with TTL
-		batch := d.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
-		// part 1 is used to set TTL on primary key as UPDATE can't set TTL for primary key
-		batch.Query(templateUpdateTaskListQueryWithTTLPart1,
-			tli.DomainID,
-			&tli.Name,
-			tli.TaskType,
-			rowTypeTaskList,
-			taskListTaskID,
-			stickyTaskListTTL,
-		)
-		// part 2 is for CAS and setting TTL for the rest of the columns
-		batch.Query(templateUpdateTaskListQueryWithTTLPart2,
-			stickyTaskListTTL,
-			tli.RangeID,
-			tli.DomainID,
-			&tli.Name,
-			tli.TaskType,
-			tli.AckLevel,
-			tli.Kind,
-			time.Now(),
-			tli.DomainID,
-			&tli.Name,
-			tli.TaskType,
-			rowTypeTaskList,
-			taskListTaskID,
-			tli.RangeID,
-		)
-		applied, _, err = d.session.MapExecuteBatchCAS(batch, previous)
+		previous, err = t.db.UpdateTaskListWithTTL(ctx, stickyTaskListTTL, taskListToUpdate, tli.RangeID)
 	} else {
-		query := d.session.Query(templateUpdateTaskListQuery,
-			tli.RangeID,
-			tli.DomainID,
-			&tli.Name,
-			tli.TaskType,
-			tli.AckLevel,
-			tli.Kind,
-			time.Now(),
-			tli.DomainID,
-			&tli.Name,
-			tli.TaskType,
-			rowTypeTaskList,
-			taskListTaskID,
-			tli.RangeID,
-		).WithContext(ctx)
-		applied, err = query.MapScanCAS(previous)
+		previous, err = t.db.UpdateTaskList(ctx, taskListToUpdate, tli.RangeID)
 	}
 
 	if err != nil {
-		return nil, convertCommonErrors(d.client, "UpdateTaskList", err)
-	}
-
-	if !applied {
-		var columns []string
-		for k, v := range previous {
-			columns = append(columns, fmt.Sprintf("%s=%v", k, v))
+		if t.db.IsConditionFailedError(err) {
+			return nil, &p.ConditionFailedError{
+				Msg: fmt.Sprintf("Failed to update task list. name: %v, type: %v, rangeID: %v, columns: (%v)",
+					tli.Name, tli.TaskType, tli.RangeID, previous),
+			}
 		}
-
-		return nil, &p.ConditionFailedError{
-			Msg: fmt.Sprintf("Failed to update task list. name: %v, type: %v, rangeID: %v, columns: (%v)",
-				tli.Name, tli.TaskType, tli.RangeID, strings.Join(columns, ",")),
-		}
+		return nil, convertCommonErrors(t.db, "UpdateTaskList", err)
 	}
 
 	return &p.UpdateTaskListResponse{}, nil
 }
 
-func (d *cassandraTaskPersistence) ListTaskList(
-	ctx context.Context,
-	request *p.ListTaskListRequest,
+func (t *nosqlTaskManager) ListTaskList(
+	_ context.Context,
+	_ *p.ListTaskListRequest,
 ) (*p.ListTaskListResponse, error) {
 	return nil, &types.InternalServiceError{
 		Message: fmt.Sprintf("unsupported operation"),
 	}
 }
 
-func (d *cassandraTaskPersistence) DeleteTaskList(
+func (t *nosqlTaskManager) DeleteTaskList(
 	ctx context.Context,
 	request *p.DeleteTaskListRequest,
 ) error {
-	query := d.session.Query(templateDeleteTaskListQuery,
-		request.DomainID,
-		request.TaskListName,
-		request.TaskListType,
-		rowTypeTaskList,
-		taskListTaskID,
-		request.RangeID,
-	).WithContext(ctx)
-	previous := make(map[string]interface{})
-	applied, err := query.MapScanCAS(previous)
+	previous, err := t.db.DeleteTaskList(ctx, &nosqlplugin.TaskListFilter{
+		DomainID:     request.DomainID,
+		TaskListName: request.TaskListName,
+		TaskListType: request.TaskListType,
+	}, request.RangeID)
+
 	if err != nil {
-		return convertCommonErrors(d.client, "DeleteTaskList", err)
-	}
-	if !applied {
-		return &p.ConditionFailedError{
-			Msg: fmt.Sprintf("DeleteTaskList operation failed: expected_range_id=%v but found %+v", request.RangeID, previous),
+		if t.db.IsConditionFailedError(err) {
+			return &p.ConditionFailedError{
+				Msg: fmt.Sprintf("Failed to delete task list. name: %v, type: %v, rangeID: %v, columns: (%v)",
+					request.TaskListName, request.TaskListType, request.RangeID, previous),
+			}
 		}
+		return convertCommonErrors(t.db, "DeleteTaskList", err)
 	}
+
 	return nil
 }
 
 // From TaskManager interface
-func (d *cassandraTaskPersistence) CreateTasks(
+func (t *nosqlTaskManager) CreateTasks(
 	ctx context.Context,
 	request *p.InternalCreateTasksRequest,
 ) (*p.CreateTasksResponse, error) {
-	batch := d.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
-	domainID := request.TaskListInfo.DomainID
-	taskList := request.TaskListInfo.Name
-	taskListType := request.TaskListInfo.TaskType
-	taskListKind := request.TaskListInfo.Kind
-	ackLevel := request.TaskListInfo.AckLevel
-	cqlNowTimestamp := p.UnixNanoToDBTimestamp(time.Now().UnixNano())
-
-	for _, task := range request.Tasks {
-		scheduleID := task.Data.ScheduleID
-		ttl := int64(task.Data.ScheduleToStartTimeout.Seconds())
-		if ttl <= 0 {
-			batch.Query(templateCreateTaskQuery,
-				domainID,
-				taskList,
-				taskListType,
-				rowTypeTask,
-				task.TaskID,
-				domainID,
-				task.Execution.GetWorkflowID(),
-				task.Execution.GetRunID(),
-				scheduleID,
-				cqlNowTimestamp)
-		} else {
-			if ttl > maxCassandraTTL {
-				ttl = maxCassandraTTL
-			}
-			batch.Query(templateCreateTaskWithTTLQuery,
-				domainID,
-				taskList,
-				taskListType,
-				rowTypeTask,
-				task.TaskID,
-				domainID,
-				task.Execution.GetWorkflowID(),
-				task.Execution.GetRunID(),
-				scheduleID,
-				cqlNowTimestamp,
-				ttl)
+	now := time.Now()
+	var tasks []*nosqlplugin.TaskRowForInsert
+	for _, t := range request.Tasks {
+		task := &nosqlplugin.TaskRow{
+			DomainID:     request.TaskListInfo.DomainID,
+			TaskListName: request.TaskListInfo.Name,
+			TaskListType: request.TaskListInfo.TaskType,
+			TaskID:       t.TaskID,
+			WorkflowID:   t.Execution.GetWorkflowID(),
+			RunID:        t.Execution.GetRunID(),
+			ScheduledID:  t.Data.ScheduleID,
+			CreatedTime:  now,
 		}
+		ttl := int(t.Data.ScheduleToStartTimeout.Seconds())
+		tasks = append(tasks, &nosqlplugin.TaskRowForInsert{
+			TaskRow:    *task,
+			TTLSeconds: ttl,
+		})
 	}
 
-	// The following query is used to ensure that range_id didn't change
-	batch.Query(templateUpdateTaskListQuery,
-		request.TaskListInfo.RangeID,
-		domainID,
-		taskList,
-		taskListType,
-		ackLevel,
-		taskListKind,
-		time.Now(),
-		domainID,
-		taskList,
-		taskListType,
-		rowTypeTaskList,
-		taskListTaskID,
-		request.TaskListInfo.RangeID,
-	)
+	previous, err := t.db.InsertTasks(ctx, tasks, toTaskListRow(request.TaskListInfo))
 
-	previous := make(map[string]interface{})
-	applied, _, err := d.session.MapExecuteBatchCAS(batch, previous)
 	if err != nil {
-		return nil, convertCommonErrors(d.client, "CreateTasks", err)
-	}
-	if !applied {
-		rangeID := previous["range_id"]
-		return nil, &p.ConditionFailedError{
-			Msg: fmt.Sprintf("Failed to create task. TaskList: %v, taskListType: %v, rangeID: %v, db rangeID: %v",
-				taskList, taskListType, request.TaskListInfo.RangeID, rangeID),
+		if t.db.IsConditionFailedError(err) {
+			return nil, &p.ConditionFailedError{
+				Msg: fmt.Sprintf("Failed to insert tasks. name: %v, type: %v, rangeID: %v, columns: (%v)",
+					request.TaskListInfo.Name, request.TaskListInfo.TaskType, request.TaskListInfo.RangeID, previous),
+			}
 		}
+		return nil, convertCommonErrors(t.db, "CreateTasks", err)
 	}
 
 	return &p.CreateTasksResponse{}, nil
 }
 
+func toTaskListRow(info *p.TaskListInfo) *nosqlplugin.TaskListRow {
+	return &nosqlplugin.TaskListRow{
+		DomainID:        info.DomainID,
+		TaskListName:    info.Name,
+		TaskListType:    info.TaskType,
+		TaskListKind:    info.Kind,
+		RangeID:         info.RangeID,
+		AckLevel:        info.AckLevel,
+		LastUpdatedTime: info.LastUpdated,
+	}
+}
+
 // From TaskManager interface
-func (d *cassandraTaskPersistence) GetTasks(
+func (t *nosqlTaskManager) GetTasks(
 	ctx context.Context,
 	request *p.GetTasksRequest,
 ) (*p.InternalGetTasksResponse, error) {
@@ -488,54 +290,62 @@ func (d *cassandraTaskPersistence) GetTasks(
 		return &p.InternalGetTasksResponse{}, nil
 	}
 
-	// Reading tasklist tasks need to be quorum level consistent, otherwise we could loose task
-	query := d.session.Query(templateGetTasksQuery,
-		request.DomainID,
-		request.TaskList,
-		request.TaskType,
-		rowTypeTask,
-		request.ReadLevel,
-		*request.MaxReadLevel,
-	).PageSize(request.BatchSize).WithContext(ctx)
-
-	iter := query.Iter()
-	if iter == nil {
-		return nil, &types.InternalServiceError{
-			Message: "GetTasks operation failed.  Not able to create query iterator.",
-		}
-	}
-
-	response := &p.InternalGetTasksResponse{}
-	task := make(map[string]interface{})
-PopulateTasks:
-	for iter.MapScan(task) {
-		taskID, ok := task["task_id"]
-		if !ok { // no tasks, but static column record returned
-			continue
-		}
-		t := createTaskInfo(task["task"].(map[string]interface{}))
-		t.TaskID = taskID.(int64)
-		response.Tasks = append(response.Tasks, t)
-		if len(response.Tasks) == request.BatchSize {
-			break PopulateTasks
-		}
-		task = make(map[string]interface{}) // Reinitialize map as initialized fails on unmarshalling
-	}
-
-	if err := iter.Close(); err != nil {
-		return nil, convertCommonErrors(d.client, "GetTasks", err)
-	}
+	resp, err := t.db.SelectTasks(ctx, &nosqlplugin.TasksFilter{
+		TaskListFilter: nosqlplugin.TaskListFilter{
+			DomainID:     request.DomainID,
+			TaskListName: request.TaskList,
+			TaskListType: request.TaskType,
+		},
+		MinTaskID: request.ReadLevel,
+	})
+	//	// Reading tasklist tasks need to be quorum level consistent, otherwise we could loose task
+	//	query := t.session.Query(templateGetTasksQuery,
+	//		request.DomainID,
+	//		request.TaskList,
+	//		request.TaskType,
+	//		rowTypeTask,
+	//		request.ReadLevel,
+	//		*request.MaxReadLevel,
+	//	).PageSize(request.BatchSize).WithContext(ctx)
+	//
+	//	iter := query.Iter()
+	//	if iter == nil {
+	//		return nil, &types.InternalServiceError{
+	//			Message: "GetTasks operation failed.  Not able to create query iterator.",
+	//		}
+	//	}
+	//
+	//	response := &p.InternalGetTasksResponse{}
+	//	task := make(map[string]interface{})
+	//PopulateTasks:
+	//	for iter.MapScan(task) {
+	//		taskID, ok := task["task_id"]
+	//		if !ok { // no tasks, but static column record returned
+	//			continue
+	//		}
+	//		t := createTaskInfo(task["task"].(map[string]interface{}))
+	//		t.TaskID = taskID.(int64)
+	//		response.Tasks = append(response.Tasks, t)
+	//		if len(response.Tasks) == request.BatchSize {
+	//			break PopulateTasks
+	//		}
+	//		task = make(map[string]interface{}) // Reinitialize map as initialized fails on unmarshalling
+	//	}
+	//
+	//	if err := iter.Close(); err != nil {
+	//		return nil, convertCommonErrors(t.client, "GetTasks", err)
+	//	}
 
 	return response, nil
 }
 
 // From TaskManager interface
-func (d *cassandraTaskPersistence) CompleteTask(
+func (t *nosqlTaskManager) CompleteTask(
 	ctx context.Context,
 	request *p.CompleteTaskRequest,
 ) error {
 	tli := request.TaskList
-	query := d.session.Query(templateCompleteTaskQuery,
+	query := t.session.Query(templateCompleteTaskQuery,
 		tli.DomainID,
 		tli.Name,
 		tli.TaskType,
@@ -545,7 +355,7 @@ func (d *cassandraTaskPersistence) CompleteTask(
 
 	err := query.Exec()
 	if err != nil {
-		return convertCommonErrors(d.client, "CompleteTask", err)
+		return convertCommonErrors(t.client, "CompleteTask", err)
 	}
 
 	return nil
@@ -554,11 +364,11 @@ func (d *cassandraTaskPersistence) CompleteTask(
 // CompleteTasksLessThan deletes all tasks less than or equal to the given task id. This API ignores the
 // Limit request parameter i.e. either all tasks leq the task_id will be deleted or an error will
 // be returned to the caller
-func (d *cassandraTaskPersistence) CompleteTasksLessThan(
+func (t *nosqlTaskManager) CompleteTasksLessThan(
 	ctx context.Context,
 	request *p.CompleteTasksLessThanRequest,
 ) (int, error) {
-	query := d.session.Query(templateCompleteTasksLessThanQuery,
+	query := t.session.Query(templateCompleteTasksLessThanQuery,
 		request.DomainID,
 		request.TaskListName,
 		request.TaskType,
@@ -567,7 +377,7 @@ func (d *cassandraTaskPersistence) CompleteTasksLessThan(
 	).WithContext(ctx)
 	err := query.Exec()
 	if err != nil {
-		return 0, convertCommonErrors(d.client, "CompleteTasksLessThan", err)
+		return 0, convertCommonErrors(t.client, "CompleteTasksLessThan", err)
 	}
 	return p.UnknownNumRowsAffected, nil
 }

--- a/common/persistence/cassandra/cassandraTaskPersistence.go
+++ b/common/persistence/cassandra/cassandraTaskPersistence.go
@@ -184,9 +184,9 @@ func newTaskPersistence(
 }
 
 func (d *cassandraTaskPersistence) GetOrphanTasks(ctx context.Context, request *p.GetOrphanTasksRequest) (*p.GetOrphanTasksResponse, error) {
-	// TODO: It's unclear if this's necessary or useful for Cassandra
+	// TODO: It's unclear if this's necessary or possible for NoSQL
 	return nil, &types.InternalServiceError{
-		Message: "Unimplemented call to GetOrphanTasks for Cassandra",
+		Message: "Unimplemented call to GetOrphanTasks for NoSQL",
 	}
 }
 
@@ -211,6 +211,7 @@ func (d *cassandraTaskPersistence) LeaseTaskList(
 	var rangeID, ackLevel int64
 	var tlDB map[string]interface{}
 	err := query.Scan(&rangeID, &tlDB)
+
 	if err != nil {
 		if d.client.IsNotFoundError(err) { // First time task list is used
 			query = d.session.Query(templateInsertTaskListQuery,

--- a/common/persistence/cassandra/cassandraTaskPersistence.go
+++ b/common/persistence/cassandra/cassandraTaskPersistence.go
@@ -122,7 +122,7 @@ func (t *nosqlTaskManager) LeaseTaskList(
 	} else {
 		// if request.RangeID is > 0, we are trying to renew an already existing
 		// lease on the task list. If request.RangeID=0, we are trying to steal
-		// the currTL from its current owner
+		// the tasklist from its current owner
 		if request.RangeID > 0 && request.RangeID != currTL.RangeID {
 			return nil, &p.ConditionFailedError{
 				Msg: fmt.Sprintf("leaseTaskList:renew failed: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",

--- a/common/persistence/cassandra/cassandraTaskPersistence.go
+++ b/common/persistence/cassandra/cassandraTaskPersistence.go
@@ -291,11 +291,7 @@ func (t *nosqlTaskManager) GetTasks(
 	request *p.GetTasksRequest,
 ) (*p.InternalGetTasksResponse, error) {
 	if request.MaxReadLevel == nil {
-		request.MaxReadLevel = common.Int64Ptr(math.MaxInt64 - 1)
-	}
-	if *request.MaxReadLevel == math.MaxInt64 {
-		// fix overflow
-		*request.MaxReadLevel -= 1
+		request.MaxReadLevel = common.Int64Ptr(math.MaxInt64)
 	}
 
 	if request.ReadLevel > *request.MaxReadLevel {
@@ -310,10 +306,8 @@ func (t *nosqlTaskManager) GetTasks(
 		},
 		BatchSize: request.BatchSize,
 
-		// Change from exclusive to inclusive
-		MinTaskID: request.ReadLevel + 1,
-		// Change from inclusive to exclusive
-		MaxTaskID: *request.MaxReadLevel + 1,
+		MinTaskID: request.ReadLevel,
+		MaxTaskID: *request.MaxReadLevel,
 	})
 
 	if err != nil {

--- a/common/persistence/cassandra/cassandraVisibilityPersistence.go
+++ b/common/persistence/cassandra/cassandraVisibilityPersistence.go
@@ -37,8 +37,6 @@ import (
 const (
 	defaultCloseTTLSeconds = 86400
 	openExecutionTTLBuffer = int64(86400) // setting it to a day to account for shard going down
-
-	maxCassandraTTL = int64(157680000) // Cassandra max support time is 2038-01-19T03:14:06+00:00. Updated this to 5 years to support until year 2033
 )
 
 type (

--- a/common/persistence/nosql/nosqlplugin/cassandra/constants.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/constants.go
@@ -92,4 +92,5 @@ const (
 	emptyInitiatedID       = int64(-7)
 
 	stickyTaskListTTL = int32(24 * time.Hour / time.Second) // if sticky task_list stopped being updated, remove it in one day
+	maxCassandraTTL   = int64(157680000)
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/constants.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/constants.go
@@ -91,6 +91,5 @@ const (
 	rowTypeShardTaskID     = int64(-11)
 	emptyInitiatedID       = int64(-7)
 
-	stickyTaskListTTL = int32(24 * time.Hour / time.Second) // if sticky task_list stopped being updated, remove it in one day
 	maxCassandraTTL   = int64(157680000)
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/constants.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/constants.go
@@ -91,5 +91,5 @@ const (
 	rowTypeShardTaskID     = int64(-11)
 	emptyInitiatedID       = int64(-7)
 
-	maxCassandraTTL   = int64(157680000)
+	maxCassandraTTL = int64(157680000)
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/constants.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/constants.go
@@ -90,6 +90,4 @@ const (
 	rowTypeExecutionTaskID = int64(-10)
 	rowTypeShardTaskID     = int64(-11)
 	emptyInitiatedID       = int64(-7)
-
-	maxCassandraTTL = int64(157680000)
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -265,7 +265,7 @@ func (db *cdb) UpdateTaskListWithTTL(
 	)
 	// part 2 is for CAS and setting TTL for the rest of the columns
 	batch.Query(templateUpdateTaskListQueryWithTTLPart2,
-		stickyTaskListTTL,
+		ttlSeconds,
 		row.RangeID,
 		row.DomainID,
 		row.TaskListName,

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -1,0 +1,248 @@
+package cassandra
+
+import (
+	"context"
+	p "github.com/uber/cadence/common/persistence"
+	"time"
+
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
+)
+
+const (
+	// Row types for table tasks
+	rowTypeTask = iota
+	rowTypeTaskList
+)
+
+const (
+	taskListTaskID = -12345
+	initialRangeID = 1 // Id of the first range of a new task list
+)
+
+const (
+	templateTaskListType = `{` +
+		`domain_id: ?, ` +
+		`name: ?, ` +
+		`type: ?, ` +
+		`ack_level: ?, ` +
+		`kind: ?, ` +
+		`last_updated: ? ` +
+		`}`
+
+	templateTaskType = `{` +
+		`domain_id: ?, ` +
+		`workflow_id: ?, ` +
+		`run_id: ?, ` +
+		`schedule_id: ?,` +
+		`created_time: ? ` +
+		`}`
+
+	templateCreateTaskQuery = `INSERT INTO tasks (` +
+		`domain_id, task_list_name, task_list_type, type, task_id, task) ` +
+		`VALUES(?, ?, ?, ?, ?, ` + templateTaskType + `)`
+
+	templateCreateTaskWithTTLQuery = `INSERT INTO tasks (` +
+		`domain_id, task_list_name, task_list_type, type, task_id, task) ` +
+		`VALUES(?, ?, ?, ?, ?, ` + templateTaskType + `) USING TTL ?`
+
+	templateGetTasksQuery = `SELECT task_id, task ` +
+		`FROM tasks ` +
+		`WHERE domain_id = ? ` +
+		`and task_list_name = ? ` +
+		`and task_list_type = ? ` +
+		`and type = ? ` +
+		`and task_id > ? ` +
+		`and task_id <= ?`
+
+	templateCompleteTaskQuery = `DELETE FROM tasks ` +
+		`WHERE domain_id = ? ` +
+		`and task_list_name = ? ` +
+		`and task_list_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ?`
+
+	templateCompleteTasksLessThanQuery = `DELETE FROM tasks ` +
+		`WHERE domain_id = ? ` +
+		`AND task_list_name = ? ` +
+		`AND task_list_type = ? ` +
+		`AND type = ? ` +
+		`AND task_id <= ? `
+
+	templateGetTaskList = `SELECT ` +
+		`range_id, ` +
+		`task_list ` +
+		`FROM tasks ` +
+		`WHERE domain_id = ? ` +
+		`and task_list_name = ? ` +
+		`and task_list_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ?`
+
+	templateInsertTaskListQuery = `INSERT INTO tasks (` +
+		`domain_id, ` +
+		`task_list_name, ` +
+		`task_list_type, ` +
+		`type, ` +
+		`task_id, ` +
+		`range_id, ` +
+		`task_list ` +
+		`) VALUES (?, ?, ?, ?, ?, ?, ` + templateTaskListType + `) IF NOT EXISTS`
+
+	templateUpdateTaskListQuery = `UPDATE tasks SET ` +
+		`range_id = ?, ` +
+		`task_list = ` + templateTaskListType + " " +
+		`WHERE domain_id = ? ` +
+		`and task_list_name = ? ` +
+		`and task_list_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ? ` +
+		`IF range_id = ?`
+
+	templateUpdateTaskListQueryWithTTLPart1 = ` INSERT INTO tasks (` +
+		`domain_id, ` +
+		`task_list_name, ` +
+		`task_list_type, ` +
+		`type, ` +
+		`task_id ` +
+		`) VALUES (?, ?, ?, ?, ?) USING TTL ?`
+
+	templateUpdateTaskListQueryWithTTLPart2 = `UPDATE tasks USING TTL ? SET ` +
+		`range_id = ?, ` +
+		`task_list = ` + templateTaskListType + " " +
+		`WHERE domain_id = ? ` +
+		`and task_list_name = ? ` +
+		`and task_list_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ? ` +
+		`IF range_id = ?`
+
+	templateDeleteTaskListQuery = `DELETE FROM tasks ` +
+		`WHERE domain_id = ? ` +
+		`AND task_list_name = ? ` +
+		`AND task_list_type = ? ` +
+		`AND type = ? ` +
+		`AND task_id = ? ` +
+		`IF range_id = ?`
+)
+
+// SelectTaskList returns a single tasklist row.
+// Return IsNotFoundError if the row doesn't exist
+func (db *cdb) SelectTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter) (*nosqlplugin.TaskListRow, error){
+	query := db.session.Query(templateGetTaskList,
+		filter.DomainID,
+		filter.TaskListName,
+		filter.TaskListType,
+		rowTypeTaskList,
+		taskListTaskID,
+	).WithContext(ctx)
+	var rangeID int64
+	var tlDB map[string]interface{}
+	err := query.Scan(&rangeID, &tlDB)
+	if err != nil{
+		return nil, err
+	}
+	ackLevel := tlDB["ack_level"].(int64)
+	taskListKind := tlDB["kind"].(int)
+	lastUpdatedTime := tlDB["last_updated"].(time.Time)
+	return &nosqlplugin.TaskListRow{
+		DomainID: filter.DomainID,
+		TaskListName: filter.TaskListName,
+		TaskListType: filter.TaskListType,
+
+		TaskListKind: taskListKind,
+		LastUpdatedTime: lastUpdatedTime,
+		AckLevel: ackLevel,
+	}, nil
+}
+// InsertTaskList insert a single tasklist row
+// Return IsConditionFailedError if the row already exists, and also the existing row
+func (db *cdb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow) (*nosqlplugin.TaskListRow, error){
+	query := db.session.Query(templateInsertTaskListQuery,
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		rowTypeTaskList,
+		taskListTaskID,
+		initialRangeID,
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		0,
+		row.TaskListKind,
+		time.Now(),
+	).WithContext(ctx)
+
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		return nil, err
+	}
+	if !applied {
+		rangeID := previous["range_id"]
+		taslist := previous["task_list"].(map[string]interface{})
+		ackLevel := taslist["ack_level"].(int64)
+		taskListKind := taslist["kind"].(int)
+		lastUpdatedTime := taslist["last_updated"].(time.Time)
+
+		return nil, &p.ConditionFailedError{
+			Msg: fmt.Sprintf("leaseTaskList: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",
+				request.TaskList, request.TaskType, rangeID, previousRangeID),
+		}
+	}
+	return nil, nil
+}
+
+// UpdateTaskList updates a single tasklist row
+// Return IsConditionFailedError if the condition doesn't meet, and also the previous row
+func (db *cdb) UpdateTaskList(
+	ctx context.Context,
+	row *nosqlplugin.TaskListRow,
+	previousRangeID int64,
+) (*nosqlplugin.TaskListRow, error){
+
+}
+// UpdateTaskList updates a single tasklist row, and set an TTL on the record
+// Return IsConditionFailedError if the condition doesn't meet, and also the existing row
+// Ignore TTL if it's not supported, which becomes exactly the same as UpdateTaskList, but ListTaskList must be
+// implemented for TaskListScavenger
+func (db *cdb) UpdateTaskListWithTTL(
+	ctx context.Context,
+	ttlSeconds int64,
+	row *nosqlplugin.TaskListRow,
+	previousRangeID int64,
+) (*nosqlplugin.TaskListRow, error){
+
+}
+// ListTaskList returns all tasklists.
+// Noop if TTL is already implemented in other methods
+func (db *cdb) ListTaskList(ctx context.Context, pageSize int, nextPageToken []byte) (*nosqlplugin.ListTaskListResult, error){
+
+}
+// DeleteTaskList deletes a single tasklist row
+// Return IsConditionFailedError if the condition doesn't meet, and also the existing row
+func (db *cdb) DeleteTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter) (*nosqlplugin.TaskListRow, error){
+
+}
+// InsertTasks inserts a batch of tasks
+// Return IsConditionFailedError if the condition doesn't meet, and also the previous tasklist row
+func (db *cdb) InsertTasks(
+	ctx context.Context,
+	tasksToInsert []*nosqlplugin.TaskRowForInsert,
+	tasklistCondition *nosqlplugin.TaskListRow,
+) (*nosqlplugin.TaskListRow, error){
+
+}
+// SelectTasks return tasks that associated to a tasklist
+func (db *cdb) SelectTasks(ctx context.Context, filter *nosqlplugin.TasksFilter) ([]*nosqlplugin.TaskRow, error){
+
+}
+// DeleteTask delete a single task
+func (db *cdb) DeleteTask(ctx context.Context, row *nosqlplugin.TaskRowPK) error{
+
+}
+
+// DeleteTask delete a batch tasks that taskIDs less than or equal to the row
+// If TTL is not implemented, then should also return the number of rows deleted, otherwise persistence.UnknownNumRowsAffected
+func (db *cdb) RangeDeleteTasks(ctx context.Context, maxTaskID *nosqlplugin.TaskRowPK) (rowsDeleted int, err error){
+
+}

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -467,7 +467,9 @@ func (db *cdb) DeleteTask(ctx context.Context, row *nosqlplugin.TaskRowPK) error
 
 // DeleteTask delete a batch tasks that taskIDs less than the row
 // If TTL is not implemented, then should also return the number of rows deleted, otherwise persistence.UnknownNumRowsAffected
-func (db *cdb) RangeDeleteTasks(ctx context.Context, maxTaskID *nosqlplugin.TaskRowPK) (rowsDeleted int, err error) {
+// NOTE: This API ignores the `Limit` request parameter i.e. either all tasks leq the task_id will be deleted or an error will
+// be returned to the caller, because rowsDeleted is not supported by Cassandra
+func (db *cdb) RangeDeleteTasks(ctx context.Context, maxTaskID *nosqlplugin.TaskRowPK, _ int) (rowsDeleted int, err error) {
 	query := db.session.Query(templateCompleteTasksLessThanQuery,
 		maxTaskID.DomainID,
 		maxTaskID.TaskListName,

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -1,3 +1,24 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
 package cassandra
 
 import (
@@ -130,7 +151,7 @@ const (
 
 // SelectTaskList returns a single tasklist row.
 // Return IsNotFoundError if the row doesn't exist
-func (db *cdb) SelectTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter) (*nosqlplugin.TaskListRow, error){
+func (db *cdb) SelectTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter) (*nosqlplugin.TaskListRow, error) {
 	query := db.session.Query(templateGetTaskList,
 		filter.DomainID,
 		filter.TaskListName,
@@ -141,7 +162,7 @@ func (db *cdb) SelectTaskList(ctx context.Context, filter *nosqlplugin.TaskListF
 	var rangeID int64
 	var tlDB map[string]interface{}
 	err := query.Scan(&rangeID, &tlDB)
-	if err != nil{
+	if err != nil {
 		return nil, err
 	}
 	ackLevel := tlDB["ack_level"].(int64)
@@ -159,9 +180,10 @@ func (db *cdb) SelectTaskList(ctx context.Context, filter *nosqlplugin.TaskListF
 		RangeID:         rangeID,
 	}, nil
 }
+
 // InsertTaskList insert a single tasklist row
 // Return IsConditionFailedError if the row already exists, and also the existing row
-func (db *cdb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow) (*nosqlplugin.TaskListRow, error){
+func (db *cdb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow) (*nosqlplugin.TaskListRow, error) {
 	query := db.session.Query(templateInsertTaskListQuery,
 		row.DomainID,
 		row.TaskListName,

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -75,8 +75,8 @@ const (
 		`and task_list_name = ? ` +
 		`and task_list_type = ? ` +
 		`and type = ? ` +
-		`and task_id >= ? ` +
-		`and task_id < ?`
+		`and task_id > ? ` +
+		`and task_id <= ?`
 
 	templateCompleteTaskQuery = `DELETE FROM tasks ` +
 		`WHERE domain_id = ? ` +

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -2,10 +2,13 @@ package cassandra
 
 import (
 	"context"
-	p "github.com/uber/cadence/common/persistence"
+	"fmt"
 	"time"
 
+	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"github.com/uber/cadence/common/types"
 )
 
 const (
@@ -51,8 +54,8 @@ const (
 		`and task_list_name = ? ` +
 		`and task_list_type = ? ` +
 		`and type = ? ` +
-		`and task_id > ? ` +
-		`and task_id <= ?`
+		`and task_id >= ? ` +
+		`and task_id < ?`
 
 	templateCompleteTaskQuery = `DELETE FROM tasks ` +
 		`WHERE domain_id = ? ` +
@@ -66,7 +69,7 @@ const (
 		`AND task_list_name = ? ` +
 		`AND task_list_type = ? ` +
 		`AND type = ? ` +
-		`AND task_id <= ? `
+		`AND task_id < ? `
 
 	templateGetTaskList = `SELECT ` +
 		`range_id, ` +
@@ -169,7 +172,7 @@ func (db *cdb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow)
 		row.TaskListType,
 		0,
 		row.TaskListKind,
-		time.Now(),
+		row.LastUpdatedTime,
 	).WithContext(ctx)
 
 	previous := make(map[string]interface{})
@@ -177,19 +180,8 @@ func (db *cdb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow)
 	if err != nil {
 		return nil, err
 	}
-	if !applied {
-		rangeID := previous["range_id"]
-		taslist := previous["task_list"].(map[string]interface{})
-		ackLevel := taslist["ack_level"].(int64)
-		taskListKind := taslist["kind"].(int)
-		lastUpdatedTime := taslist["last_updated"].(time.Time)
 
-		return nil, &p.ConditionFailedError{
-			Msg: fmt.Sprintf("leaseTaskList: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",
-				request.TaskList, request.TaskType, rangeID, previousRangeID),
-		}
-	}
-	return nil, nil
+	return handleTaskListAppliedError(applied, previous)
 }
 
 // UpdateTaskList updates a single tasklist row
@@ -198,9 +190,59 @@ func (db *cdb) UpdateTaskList(
 	ctx context.Context,
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
-) (*nosqlplugin.TaskListRow, error){
+) (*nosqlplugin.TaskListRow, error) {
+	query := db.session.Query(templateUpdateTaskListQuery,
+		row.RangeID,
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		row.AckLevel,
+		row.TaskListKind,
+		row.LastUpdatedTime,
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		rowTypeTaskList,
+		taskListTaskID,
+		previousRangeID,
+	).WithContext(ctx)
 
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		return nil, err
+	}
+
+	return handleTaskListAppliedError(applied, previous)
 }
+
+func handleTaskListAppliedError(applied bool, previous map[string]interface{}) (*nosqlplugin.TaskListRow, error) {
+	if !applied {
+		domainID := previous["domain_id"].(gocql.UUID).String()
+		taskListName := previous["task_list_name"].(string)
+		taskListType := previous["task_list_name"].(int)
+
+		rangeID := previous["range_id"].(int64)
+		taslist := previous["task_list"].(map[string]interface{})
+
+		ackLevel := taslist["ack_level"].(int64)
+		taskListKind := taslist["kind"].(int)
+		lastUpdatedTime := taslist["last_updated"].(time.Time)
+
+		return &nosqlplugin.TaskListRow{
+			DomainID:     domainID,
+			TaskListName: taskListName,
+			TaskListType: taskListType,
+
+			RangeID:         rangeID,
+			AckLevel:        ackLevel,
+			TaskListKind:    taskListKind,
+			LastUpdatedTime: lastUpdatedTime,
+		}, errConditionFailed
+	}
+	return nil, nil
+}
+
 // UpdateTaskList updates a single tasklist row, and set an TTL on the record
 // Return IsConditionFailedError if the condition doesn't meet, and also the existing row
 // Ignore TTL if it's not supported, which becomes exactly the same as UpdateTaskList, but ListTaskList must be
@@ -210,39 +252,229 @@ func (db *cdb) UpdateTaskListWithTTL(
 	ttlSeconds int64,
 	row *nosqlplugin.TaskListRow,
 	previousRangeID int64,
-) (*nosqlplugin.TaskListRow, error){
-
+) (*nosqlplugin.TaskListRow, error) {
+	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	// part 1 is used to set TTL on primary key as UPDATE can't set TTL for primary key
+	batch.Query(templateUpdateTaskListQueryWithTTLPart1,
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		rowTypeTaskList,
+		taskListTaskID,
+		ttlSeconds,
+	)
+	// part 2 is for CAS and setting TTL for the rest of the columns
+	batch.Query(templateUpdateTaskListQueryWithTTLPart2,
+		stickyTaskListTTL,
+		row.RangeID,
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		row.AckLevel,
+		row.TaskListKind,
+		time.Now(),
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		rowTypeTaskList,
+		taskListTaskID,
+		previousRangeID,
+	)
+	previous := make(map[string]interface{})
+	applied, _, err := db.session.MapExecuteBatchCAS(batch, previous)
+	if err != nil {
+		return nil, err
+	}
+	return handleTaskListAppliedError(applied, previous)
 }
+
 // ListTaskList returns all tasklists.
 // Noop if TTL is already implemented in other methods
-func (db *cdb) ListTaskList(ctx context.Context, pageSize int, nextPageToken []byte) (*nosqlplugin.ListTaskListResult, error){
-
+func (db *cdb) ListTaskList(ctx context.Context, pageSize int, nextPageToken []byte) (*nosqlplugin.ListTaskListResult, error) {
+	return nil, &types.InternalServiceError{
+		Message: fmt.Sprintf("unsupported operation"),
+	}
 }
+
 // DeleteTaskList deletes a single tasklist row
 // Return IsConditionFailedError if the condition doesn't meet, and also the existing row
-func (db *cdb) DeleteTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter) (*nosqlplugin.TaskListRow, error){
-
+func (db *cdb) DeleteTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter, previousRangeID int64) (*nosqlplugin.TaskListRow, error) {
+	query := db.session.Query(templateDeleteTaskListQuery,
+		filter.DomainID,
+		filter.TaskListName,
+		filter.TaskListType,
+		rowTypeTaskList,
+		taskListTaskID,
+		previousRangeID,
+	).WithContext(ctx)
+	previous := make(map[string]interface{})
+	applied, err := query.MapScanCAS(previous)
+	if err != nil {
+		return nil, err
+	}
+	return handleTaskListAppliedError(applied, previous)
 }
+
 // InsertTasks inserts a batch of tasks
 // Return IsConditionFailedError if the condition doesn't meet, and also the previous tasklist row
 func (db *cdb) InsertTasks(
 	ctx context.Context,
 	tasksToInsert []*nosqlplugin.TaskRowForInsert,
 	tasklistCondition *nosqlplugin.TaskListRow,
-) (*nosqlplugin.TaskListRow, error){
+) (*nosqlplugin.TaskListRow, error) {
+	batch := db.session.NewBatch(gocql.LoggedBatch).WithContext(ctx)
+	domainID := tasklistCondition.DomainID
+	taskListName := tasklistCondition.TaskListName
+	taskListType := tasklistCondition.TaskListType
+	taskListKind := tasklistCondition.TaskListKind
+	ackLevel := tasklistCondition.AckLevel
 
+	for _, task := range tasksToInsert {
+		scheduleID := task.ScheduledID
+		ttl := int64(task.TTLSeconds)
+		if ttl <= 0 {
+			batch.Query(templateCreateTaskQuery,
+				domainID,
+				taskListName,
+				taskListType,
+				rowTypeTask,
+				task.TaskID,
+				domainID,
+				task.WorkflowID,
+				task.RunID,
+				scheduleID,
+				task.CreatedTime)
+		} else {
+			if ttl > maxCassandraTTL {
+				ttl = maxCassandraTTL
+			}
+			batch.Query(templateCreateTaskWithTTLQuery,
+				domainID,
+				taskListName,
+				taskListType,
+				rowTypeTask,
+				task.TaskID,
+				domainID,
+				task.WorkflowID,
+				task.RunID,
+				scheduleID,
+				tasklistCondition.LastUpdatedTime,
+				ttl)
+		}
+	}
+
+	// The following query is used to ensure that range_id didn't change
+	batch.Query(templateUpdateTaskListQuery,
+		tasklistCondition.RangeID,
+		domainID,
+		taskListName,
+		taskListType,
+		ackLevel,
+		taskListKind,
+		time.Now(),
+		domainID,
+		taskListName,
+		taskListType,
+		rowTypeTaskList,
+		taskListTaskID,
+		tasklistCondition.RangeID,
+	)
+
+	previous := make(map[string]interface{})
+	applied, _, err := db.session.MapExecuteBatchCAS(batch, previous)
+	if err != nil {
+		return nil, err
+	}
+	return handleTaskListAppliedError(applied, previous)
 }
+
 // SelectTasks return tasks that associated to a tasklist
-func (db *cdb) SelectTasks(ctx context.Context, filter *nosqlplugin.TasksFilter) ([]*nosqlplugin.TaskRow, error){
+func (db *cdb) SelectTasks(ctx context.Context, filter *nosqlplugin.TasksFilter) ([]*nosqlplugin.TaskRow, error) {
+	// Reading tasklist tasks need to be quorum level consistent, otherwise we could loose task
+	query := db.session.Query(templateGetTasksQuery,
+		filter.DomainID,
+		filter.TaskListName,
+		filter.TaskListType,
+		rowTypeTask,
+		filter.MinTaskID,
+		filter.MaxTaskID,
+	).PageSize(filter.BatchSize).WithContext(ctx)
 
+	iter := query.Iter()
+	if iter == nil {
+		return nil, fmt.Errorf("GetTasks operation failed.  Not able to create query iterator.")
+	}
+
+	var response []*nosqlplugin.TaskRow
+	task := make(map[string]interface{})
+PopulateTasks:
+	for iter.MapScan(task) {
+		taskID, ok := task["task_id"]
+		if !ok { // no tasks, but static column record returned
+			continue
+		}
+		t := createTaskInfo(task["task"].(map[string]interface{}))
+		t.TaskID = taskID.(int64)
+		response = append(response, t)
+		if len(response) == filter.BatchSize {
+			break PopulateTasks
+		}
+		task = make(map[string]interface{}) // Reinitialize map as initialized fails on unmarshalling
+	}
+
+	if err := iter.Close(); err != nil {
+		return nil, err
+	}
+
+	return response, nil
 }
+
+func createTaskInfo(
+	result map[string]interface{},
+) *nosqlplugin.TaskRow {
+
+	info := &nosqlplugin.TaskRow{}
+	for k, v := range result {
+		switch k {
+		case "domain_id":
+			info.DomainID = v.(gocql.UUID).String()
+		case "workflow_id":
+			info.WorkflowID = v.(string)
+		case "run_id":
+			info.RunID = v.(gocql.UUID).String()
+		case "schedule_id":
+			info.ScheduledID = v.(int64)
+		case "created_time":
+			info.CreatedTime = v.(time.Time)
+		}
+	}
+
+	return info
+}
+
 // DeleteTask delete a single task
-func (db *cdb) DeleteTask(ctx context.Context, row *nosqlplugin.TaskRowPK) error{
+func (db *cdb) DeleteTask(ctx context.Context, row *nosqlplugin.TaskRowPK) error {
+	query := db.session.Query(templateCompleteTaskQuery,
+		row.DomainID,
+		row.TaskListName,
+		row.TaskListType,
+		rowTypeTask,
+		row.TaskID,
+	).WithContext(ctx)
 
+	return query.Exec()
 }
 
-// DeleteTask delete a batch tasks that taskIDs less than or equal to the row
+// DeleteTask delete a batch tasks that taskIDs less than the row
 // If TTL is not implemented, then should also return the number of rows deleted, otherwise persistence.UnknownNumRowsAffected
-func (db *cdb) RangeDeleteTasks(ctx context.Context, maxTaskID *nosqlplugin.TaskRowPK) (rowsDeleted int, err error){
-
+func (db *cdb) RangeDeleteTasks(ctx context.Context, maxTaskID *nosqlplugin.TaskRowPK) (rowsDeleted int, err error) {
+	query := db.session.Query(templateCompleteTasksLessThanQuery,
+		maxTaskID.DomainID,
+		maxTaskID.TaskListName,
+		maxTaskID.TaskListType,
+		rowTypeTask,
+		maxTaskID.TaskID,
+	).WithContext(ctx)
+	err = query.Exec()
+	return p.UnknownNumRowsAffected, err
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -463,19 +463,6 @@ func createTaskInfo(
 	return info
 }
 
-// DeleteTask delete a single task
-func (db *cdb) DeleteTask(ctx context.Context, row *nosqlplugin.TaskRowPK) error {
-	query := db.session.Query(templateCompleteTaskQuery,
-		row.DomainID,
-		row.TaskListName,
-		row.TaskListType,
-		rowTypeTask,
-		row.TaskID,
-	).WithContext(ctx)
-
-	return query.Exec()
-}
-
 // DeleteTask delete a batch tasks that taskIDs less than the row
 // If TTL is not implemented, then should also return the number of rows deleted, otherwise persistence.UnknownNumRowsAffected
 // NOTE: This API ignores the `BatchSize` request parameter i.e. either all tasks leq the task_id will be deleted or an error will

--- a/common/persistence/nosql/nosqlplugin/dynamodb/db.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/db.go
@@ -22,6 +22,7 @@ package dynamodb
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
@@ -46,7 +47,7 @@ var _ nosqlplugin.DB = (*ddb)(nil)
 
 // NewDynamoDB return a new DB
 func NewDynamoDB(cfg config.NoSQL, logger log.Logger) (nosqlplugin.DB, error) {
-	panic("TODO")
+	return nil, fmt.Errorf("TODO")
 }
 
 func (db *ddb) Close() {

--- a/common/persistence/nosql/nosqlplugin/dynamodb/task.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/task.go
@@ -1,0 +1,97 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package dynamodb
+
+import (
+	"context"
+
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
+)
+
+// SelectTaskList returns a single tasklist row.
+// Return IsNotFoundError if the row doesn't exist
+func (db *ddb) SelectTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter) (*nosqlplugin.TaskListRow, error) {
+	panic("TODO")
+}
+
+// InsertTaskList insert a single tasklist row
+// Return IsConditionFailedError if the row already exists, and also the existing row
+func (db *ddb) InsertTaskList(ctx context.Context, row *nosqlplugin.TaskListRow) (*nosqlplugin.TaskListRow, error) {
+	panic("TODO")
+}
+
+// UpdateTaskList updates a single tasklist row
+// Return IsConditionFailedError if the condition doesn't meet, and also the previous row
+func (db *ddb) UpdateTaskList(
+	ctx context.Context,
+	row *nosqlplugin.TaskListRow,
+	previousRangeID int64,
+) (*nosqlplugin.TaskListRow, error) {
+	panic("TODO")
+}
+
+// UpdateTaskList updates a single tasklist row, and set an TTL on the record
+// Return IsConditionFailedError if the condition doesn't meet, and also the existing row
+// Ignore TTL if it's not supported, which becomes exactly the same as UpdateTaskList, but ListTaskList must be
+// implemented for TaskListScavenger
+func (db *ddb) UpdateTaskListWithTTL(
+	ctx context.Context,
+	ttlSeconds int64,
+	row *nosqlplugin.TaskListRow,
+	previousRangeID int64,
+) (*nosqlplugin.TaskListRow, error) {
+	panic("TODO")
+}
+
+// ListTaskList returns all tasklists.
+// Noop if TTL is already implemented in other methods
+func (db *ddb) ListTaskList(ctx context.Context, pageSize int, nextPageToken []byte) (*nosqlplugin.ListTaskListResult, error) {
+	panic("TODO")
+}
+
+// DeleteTaskList deletes a single tasklist row
+// Return IsConditionFailedError if the condition doesn't meet, and also the existing row
+func (db *ddb) DeleteTaskList(ctx context.Context, filter *nosqlplugin.TaskListFilter, previousRangeID int64) (*nosqlplugin.TaskListRow, error) {
+	panic("TODO")
+}
+
+// InsertTasks inserts a batch of tasks
+// Return IsConditionFailedError if the condition doesn't meet, and also the previous tasklist row
+func (db *ddb) InsertTasks(
+	ctx context.Context,
+	tasksToInsert []*nosqlplugin.TaskRowForInsert,
+	tasklistCondition *nosqlplugin.TaskListRow,
+) (*nosqlplugin.TaskListRow, error) {
+	panic("TODO")
+}
+
+// SelectTasks return tasks that associated to a tasklist
+func (db *ddb) SelectTasks(ctx context.Context, filter *nosqlplugin.TasksFilter) ([]*nosqlplugin.TaskRow, error) {
+	panic("TODO")
+}
+
+// DeleteTask delete a batch tasks that taskIDs less than the row
+// If TTL is not implemented, then should also return the number of rows deleted, otherwise persistence.UnknownNumRowsAffected
+// NOTE: This API ignores the `BatchSize` request parameter i.e. either all tasks leq the task_id will be deleted or an error will
+// be returned to the caller, because rowsDeleted is not supported by Cassandra
+func (db *ddb) RangeDeleteTasks(ctx context.Context, filter *nosqlplugin.TasksFilter) (rowsDeleted int, err error) {
+	panic("TODO")
+}

--- a/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
@@ -22,7 +22,14 @@ package tests
 
 import (
 	"testing"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/dynamodb"
 )
+
+func TestNoopStruct(t *testing.T) {
+	_, _ = dynamodb.NewDynamoDB(config.NoSQL{}, nil)
+}
 
 func TestDynamoDBHistoryPersistence(t *testing.T) {
 	//s := new(persistencetests.HistoryV2PersistenceSuite)

--- a/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
@@ -27,6 +27,8 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/dynamodb"
 )
 
+// This is to make sure adding new noop method when adding new nosql interfaces
+// Remove it when any other tests are implemented. 
 func TestNoopStruct(t *testing.T) {
 	_, _ = dynamodb.NewDynamoDB(config.NoSQL{}, nil)
 }

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -344,6 +344,7 @@ type (
 
 	TaskRowForInsert struct {
 		TaskRow
+		// <= 0 means no TTL
 		TTLSeconds int
 	}
 

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -336,9 +336,9 @@ type (
 
 	TasksFilter struct {
 		TaskListFilter
-		// Inclusive
-		MinTaskID int64
 		// Exclusive
+		MinTaskID int64
+		// Inclusive
 		MaxTaskID int64
 		BatchSize int
 	}

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -328,10 +328,9 @@ type (
 		SelectTasks(ctx context.Context, filter *TasksFilter) ([]*TaskRow, error)
 		// DeleteTask delete a single task
 		DeleteTask(ctx context.Context, row *TaskRowPK) error
-		// DeleteTask delete a batch tasks that taskIDs less than the row(exclusive)
-		// Limit is the max number of tasks to delete.
-		// Also return the number of rows deleted -- if it's not supported then ignore the limit, and return persistence.UnknownNumRowsAffected
-		RangeDeleteTasks(ctx context.Context, maxTaskID *TaskRowPK, limit int) (rowsDeleted int, err error)
+		// DeleteTask delete a batch of tasks
+		// Also return the number of rows deleted -- if it's not supported then ignore the batchSize, and return persistence.UnknownNumRowsAffected
+		RangeDeleteTasks(ctx context.Context, filter *TasksFilter) (rowsDeleted int, err error)
 	}
 
 	TasksFilter struct {

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -329,8 +329,9 @@ type (
 		// DeleteTask delete a single task
 		DeleteTask(ctx context.Context, row *TaskRowPK) error
 		// DeleteTask delete a batch tasks that taskIDs less than the row(exclusive)
-		// If TTL is not implemented, then should also return the number of rows deleted, otherwise persistence.UnknownNumRowsAffected
-		RangeDeleteTasks(ctx context.Context, maxTaskID *TaskRowPK) (rowsDeleted int, err error)
+		// Limit is the max number of tasks to delete.
+		// Also return the number of rows deleted -- if it's not supported then ignore the limit, and return persistence.UnknownNumRowsAffected
+		RangeDeleteTasks(ctx context.Context, maxTaskID *TaskRowPK, limit int) (rowsDeleted int, err error)
 	}
 
 	TasksFilter struct {

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -320,7 +320,7 @@ type (
 		ListTaskList(ctx context.Context, pageSize int, nextPageToken []byte) (*ListTaskListResult, error)
 		// DeleteTaskList deletes a single tasklist row
 		// Return IsConditionFailedError if the condition doesn't meet, and also the existing row
-		DeleteTaskList(ctx context.Context, filter *TaskListFilter) (*TaskListRow, error)
+		DeleteTaskList(ctx context.Context, filter *TaskListFilter, previousRangeID int64) (*TaskListRow, error)
 		// InsertTasks inserts a batch of tasks
 		// Return IsConditionFailedError if the condition doesn't meet, and also the previous tasklist row
 		InsertTasks(ctx context.Context, tasksToInsert []*TaskRowForInsert, tasklistCondition *TaskListRow) (previous *TaskListRow, err error)
@@ -328,7 +328,7 @@ type (
 		SelectTasks(ctx context.Context, filter *TasksFilter) ([]*TaskRow, error)
 		// DeleteTask delete a single task
 		DeleteTask(ctx context.Context, row *TaskRowPK) error
-		// DeleteTask delete a batch tasks that taskIDs less than or equal to the row
+		// DeleteTask delete a batch tasks that taskIDs less than the row(exclusive)
 		// If TTL is not implemented, then should also return the number of rows deleted, otherwise persistence.UnknownNumRowsAffected
 		RangeDeleteTasks(ctx context.Context, maxTaskID *TaskRowPK) (rowsDeleted int, err error)
 	}
@@ -356,6 +356,7 @@ type (
 		WorkflowID  string
 		RunID       string
 		ScheduledID int64
+		CreatedTime time.Time
 	}
 
 	TaskRowPK struct {

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -326,8 +326,6 @@ type (
 		InsertTasks(ctx context.Context, tasksToInsert []*TaskRowForInsert, tasklistCondition *TaskListRow) (previous *TaskListRow, err error)
 		// SelectTasks return tasks that associated to a tasklist
 		SelectTasks(ctx context.Context, filter *TasksFilter) ([]*TaskRow, error)
-		// DeleteTask delete a single task
-		DeleteTask(ctx context.Context, row *TaskRowPK) error
 		// DeleteTask delete a batch of tasks
 		// Also return the number of rows deleted -- if it's not supported then ignore the batchSize, and return persistence.UnknownNumRowsAffected
 		RangeDeleteTasks(ctx context.Context, filter *TasksFilter) (rowsDeleted int, err error)
@@ -358,13 +356,6 @@ type (
 		RunID       string
 		ScheduledID int64
 		CreatedTime time.Time
-	}
-
-	TaskRowPK struct {
-		DomainID     string
-		TaskListName string
-		TaskListType int
-		TaskID       int64
 	}
 
 	TaskListFilter struct {

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -141,10 +141,6 @@ func (s *MatchingPersistenceSuite) TestGetTasksWithNoMaxReadLevel() {
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
 	defer cancel()
 
-	if s.TaskMgr.GetName() == "cassandra" {
-		//this test is not applicable for cassandra persistence
-		return
-	}
 	domainID := "f1116985-d1f1-40e0-aba9-83344db915bc"
 	workflowExecution := types.WorkflowExecution{WorkflowID: "complete-decision-task-test",
 		RunID: "2aa0a74e-16ee-4f27-983d-48b07ec1915d"}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Create NoSQL interface for task operation
2. Extract the logic of Cassandra to implement the interface
3. Replace matchingStore with NoSQL plugin db style

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/3514

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Low risks

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
No