### PR TITLE
CLI: Differentiate local and global in describe domain

### DIFF
--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -411,8 +411,12 @@ func (d *domainCLIImpl) DescribeDomain(c *cli.Context) {
 		ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)
 	}
 
+	clusters := "N/A, Not a global domain"
+	if resp.IsGlobalDomain {
+		clusters = clustersToString(resp.ReplicationConfiguration.Clusters)
+	}
 	var formatStr = "Name: %v\nUUID: %v\nDescription: %v\nOwnerEmail: %v\nDomainData: %v\nStatus: %v\nRetentionInDays: %v\n" +
-		"EmitMetrics: %v\nActiveClusterName: %v\nClusters: %v\nHistoryArchivalStatus: %v\n"
+		"EmitMetrics: %v\nIsGlobal(XDC)Domain: %v\nActiveClusterName: %v\nClusters: %v\nHistoryArchivalStatus: %v\n"
 	descValues := []interface{}{
 		resp.DomainInfo.GetName(),
 		resp.DomainInfo.GetUUID(),
@@ -422,8 +426,9 @@ func (d *domainCLIImpl) DescribeDomain(c *cli.Context) {
 		resp.DomainInfo.GetStatus(),
 		resp.Configuration.GetWorkflowExecutionRetentionPeriodInDays(),
 		resp.Configuration.GetEmitMetric(),
+		resp.IsGlobalDomain,
 		resp.ReplicationConfiguration.GetActiveClusterName(),
-		clustersToString(resp.ReplicationConfiguration.Clusters),
+		clusters,
 		resp.Configuration.GetHistoryArchivalStatus().String(),
 	}
 	if resp.Configuration.GetHistoryArchivalURI() != "" {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Differentiate local and global in describe domain

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/4228

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
./cadence --do samples-domain-local d desc
Name: samples-domain-local
UUID: 6a0b7d8d-ec33-4820-8a61-84ae83f58fc9
Description:
OwnerEmail:
DomainData: map[]
Status: REGISTERED
RetentionInDays: 3
EmitMetrics: true
IsGlobal(XDC)Domain: false
ActiveClusterName: primary
Clusters: N/A, Not a global domain
...
qlong@~/cadence:
(qlong-cli-global)$./cadence --do samples-domain-global d desc
Name: samples-domain-global
UUID: 5ac45494-581f-4a86-890f-007bcab7feea
Description:
OwnerEmail:
DomainData: map[]
Status: REGISTERED
RetentionInDays: 3
EmitMetrics: true
IsGlobal(XDC)Domain: true
ActiveClusterName: primary
Clusters: primary, secondary
...
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
No