### PR TITLE
Raise VisibilityListMaxQPS limit for local docker-compose env

### DIFF
--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -339,3 +339,4 @@ func (s *Service) Stop() {
 	s.Resource.Stop()
 	s.params.Logger.Info("frontend stopped")
 }
+


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Raise VisibilityListMaxQP limit for local docker-compose env

<!-- Tell your future self why have you made these changes -->
**Why?**
For https://github.com/uber/cadence/issues/3900

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local test
```
cadence_1        | {"level":"info","ts":"2021-05-28T23:23:22.427Z","msg":"First loading dynamic config","service":"cadence-frontend","key":"frontend.visibilityListMaxQPS,domainName:samples-domain,clusterName:primary","value":"10000","default-value":"10000","logging-call-at":"config.go:93"}
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
