### PR TITLE
Add logic in replication stack to handle different shard number

### DIFF
--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -509,8 +509,13 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 
 // NewForTest create new history service config for test
 func NewForTest() *Config {
+	return NewForTestByShardNumber(1)
+}
+
+// NewForTestByShardNumber create new history service config for test
+func NewForTestByShardNumber(shardNumber int) *Config {
 	dc := dynamicconfig.NewNopCollection()
-	config := New(dc, 1, config.StoreTypeCassandra, false)
+	config := New(dc, shardNumber, config.StoreTypeCassandra, false)
 	// reduce the duration of long poll to increase test speed
 	config.LongPollExpirationInterval = dc.GetDurationPropertyFilteredByDomain(dynamicconfig.HistoryLongPollExpirationInterval, 10*time.Second)
 	config.EnableConsistentQueryByDomain = dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableConsistentQueryByDomain, true)

--- a/service/history/replication/task_executor_test.go
+++ b/service/history/replication/task_executor_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
-
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/client/admin"
+	historyClient "github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/metrics"
@@ -52,6 +52,7 @@ type (
 
 		mockShard          *shard.TestContext
 		mockEngine         *engine.MockEngine
+		historyClient      *historyClient.MockClient
 		config             *config.Config
 		mockDomainCache    *cache.MockDomainCache
 		mockClientBean     *client.MockBean
@@ -79,7 +80,7 @@ func (s *taskExecutorSuite) TearDownSuite() {
 
 func (s *taskExecutorSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
-	s.config = config.NewForTest()
+	s.config = config.NewForTestByShardNumber(2)
 	s.controller = gomock.NewController(s.T())
 	s.mockShard = shard.NewTestContext(
 		s.controller,
@@ -98,10 +99,9 @@ func (s *taskExecutorSuite) SetupTest() {
 	s.clusterMetadata = s.mockShard.Resource.ClusterMetadata
 	s.executionManager = s.mockShard.Resource.ExecutionMgr
 	s.nDCHistoryResender = ndc.NewMockHistoryResender(s.controller)
-
 	s.mockEngine = engine.NewMockEngine(s.controller)
+	s.historyClient = s.mockShard.Resource.HistoryClient
 
-	metricsClient := metrics.NewClient(tally.NoopScope, metrics.History)
 	s.clusterMetadata.EXPECT().GetCurrentClusterName().Return("active").AnyTimes()
 
 	s.taskHandler = NewTaskExecutor(
@@ -109,7 +109,7 @@ func (s *taskExecutorSuite) SetupTest() {
 		s.mockDomainCache,
 		s.nDCHistoryResender,
 		s.mockEngine,
-		metricsClient,
+		metrics.NewClient(tally.NoopScope, metrics.History),
 		s.mockShard.GetLogger(),
 	).(*taskExecutorImpl)
 }
@@ -169,9 +169,9 @@ func (s *taskExecutorSuite) TestFilterTask_EnforceApply() {
 	s.True(ok)
 }
 
-func (s *taskExecutorSuite) TestProcessTaskOnce_SyncActivityReplicationTask() {
+func (s *taskExecutorSuite) TestProcessTask_SyncActivityReplicationTask_SameShardID() {
 	domainID := uuid.New()
-	workflowID := uuid.New()
+	workflowID := "6d89f939-e6a4-4c26-a0ed-626ce27bcc9c" // belong to shard 0
 	runID := uuid.New()
 	task := &types.ReplicationTask{
 		TaskType: types.ReplicationTaskTypeSyncActivity.Ptr(),
@@ -192,9 +192,9 @@ func (s *taskExecutorSuite) TestProcessTaskOnce_SyncActivityReplicationTask() {
 	s.NoError(err)
 }
 
-func (s *taskExecutorSuite) TestProcess_HistoryV2ReplicationTask() {
+func (s *taskExecutorSuite) TestProcessTask_HistoryV2ReplicationTask_SameShardID() {
 	domainID := uuid.New()
-	workflowID := uuid.New()
+	workflowID := "6d89f939-e6a4-4c26-a0ed-626ce27bcc9c" // belong to shard 0
 	runID := uuid.New()
 	task := &types.ReplicationTask{
 		TaskType: types.ReplicationTaskTypeHistoryV2.Ptr(),
@@ -213,6 +213,56 @@ func (s *taskExecutorSuite) TestProcess_HistoryV2ReplicationTask() {
 	}
 
 	s.mockEngine.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(nil).Times(1)
+	_, err := s.taskHandler.execute(task, true)
+	s.NoError(err)
+}
+
+func (s *taskExecutorSuite) TestProcess_HistoryV2ReplicationTask_DifferentShardID() {
+	domainID := uuid.New()
+	workflowID := "abc" // belong to shard 1
+	runID := uuid.New()
+	task := &types.ReplicationTask{
+		TaskType: types.ReplicationTaskTypeHistoryV2.Ptr(),
+		HistoryTaskV2Attributes: &types.HistoryTaskV2Attributes{
+			DomainID:   domainID,
+			WorkflowID: workflowID,
+			RunID:      runID,
+		},
+	}
+	request := &types.ReplicateEventsV2Request{
+		DomainUUID: domainID,
+		WorkflowExecution: &types.WorkflowExecution{
+			WorkflowID: workflowID,
+			RunID:      runID,
+		},
+	}
+
+	s.mockEngine.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(nil).Times(0)
+	s.historyClient.EXPECT().ReplicateEventsV2(gomock.Any(), request).Return(nil).Times(1)
+	_, err := s.taskHandler.execute(task, true)
+	s.NoError(err)
+}
+
+func (s *taskExecutorSuite) TestProcess_SyncActivityReplicationTask_DifferentShardID() {
+	domainID := uuid.New()
+	workflowID := "abc" // belong to shard 1
+	runID := uuid.New()
+	task := &types.ReplicationTask{
+		TaskType: types.ReplicationTaskTypeSyncActivity.Ptr(),
+		SyncActivityTaskAttributes: &types.SyncActivityTaskAttributes{
+			DomainID:   domainID,
+			WorkflowID: workflowID,
+			RunID:      runID,
+		},
+	}
+	request := &types.SyncActivityRequest{
+		DomainID:   domainID,
+		WorkflowID: workflowID,
+		RunID:      runID,
+	}
+
+	s.mockEngine.EXPECT().SyncActivity(gomock.Any(), request).Return(nil).Times(0)
+	s.historyClient.EXPECT().SyncActivity(gomock.Any(), request).Return(nil).Times(2)
 	_, err := s.taskHandler.execute(task, true)
 	s.NoError(err)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add logic in replication stack to handle different shard number

<!-- Tell your future self why have you made these changes -->
**Why?**
When a cluster increase the shard numbers, the replication should route the request to the correct history engine.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
In the worst case, if the request routed to the incorrect shard. The replication request will be failed.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
