### PR TITLE
Change domain data CLI parameter for consistency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ You can find a list of previous releases on the [github releases](https://github
 - This change contains breaking change on user config. The masterClusterName config key is deprecated and is replaced with primaryClusterName key. (#4185)
 
 ### Changed
-- Bump CLI version to v0.18.3 (#3959)
+- Bump CLI version to v0.19.0
+- Change `--connect-attributes` in `cadence-sql-tool` from URL encoding to the format of k1=v1,k2=v2...
+- Change `--domain_data` in `cadence domain update/register` from the format of k1:v1,k2:v2... to the format of k1=v1,k2=v2...
 
 ## [0.18.0] - 2021-01-22
 

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -27,7 +27,7 @@ import (
 const (
 	// Version is the controlled version string. It should be updated every time
 	// before we release a new version.
-	Version = "0.18.4"
+	Version = "0.19.0"
 )
 
 // SetFactory is used to set the ClientFactory global

--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -22,7 +22,6 @@ package cli
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/urfave/cli"
 )
@@ -44,22 +43,6 @@ func checkRequiredDomainDataKVs(domainData map[string]string) error {
 		}
 	}
 	return nil
-}
-
-func parseDomainDataKVs(domainDataStr string) (map[string]string, error) {
-	kvstrs := strings.Split(domainDataStr, ",")
-	kvMap := map[string]string{}
-	for _, kvstr := range kvstrs {
-		kv := strings.Split(kvstr, ":")
-		if len(kv) != 2 {
-			return kvMap, fmt.Errorf("domain data format error. It must be k1:v2,k2:v2,...,kn:vn")
-		}
-		k := strings.TrimSpace(kv[0])
-		v := strings.TrimSpace(kv[1])
-		kvMap[k] = v
-	}
-
-	return kvMap, nil
 }
 
 func newDomainCommands() []cli.Command {

--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -30,6 +30,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/uber/cadence/tools/common/flag"
+
 	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 
@@ -94,16 +96,12 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) {
 		}
 	}
 
-	domainData := map[string]string{}
+	var domainData *flag.StringMap
 	if c.IsSet(FlagDomainData) {
-		domainDataStr := getRequiredOption(c, FlagDomainData)
-		domainData, err = parseDomainDataKVs(domainDataStr)
-		if err != nil {
-			ErrorAndExit(fmt.Sprintf("Option %s format is invalid.", FlagDomainData), err)
-		}
+		domainData = c.Generic(FlagDomainData).(*flag.StringMap)
 	}
 	if len(requiredDomainDataKeys) > 0 {
-		err = checkRequiredDomainDataKVs(domainData)
+		err = checkRequiredDomainDataKVs(domainData.Value())
 		if err != nil {
 			ErrorAndExit("Domain data missed required data.", err)
 		}
@@ -131,7 +129,7 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) {
 		Name:                                   domainName,
 		Description:                            description,
 		OwnerEmail:                             ownerEmail,
-		Data:                                   domainData,
+		Data:                                   domainData.Value(),
 		WorkflowExecutionRetentionPeriodInDays: int32(retentionDays),
 		Clusters:                               clusters,
 		ActiveClusterName:                      activeClusterName,
@@ -205,13 +203,9 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) {
 		if c.IsSet(FlagOwnerEmail) {
 			ownerEmail = c.String(FlagOwnerEmail)
 		}
-		domainData := map[string]string{}
+		var domainData *flag.StringMap
 		if c.IsSet(FlagDomainData) {
-			domainDataStr := c.String(FlagDomainData)
-			domainData, err = parseDomainDataKVs(domainDataStr)
-			if err != nil {
-				ErrorAndExit("Domain data format is invalid.", err)
-			}
+			domainData = c.Generic(FlagDomainData).(*flag.StringMap)
 		}
 		if c.IsSet(FlagRetentionDays) {
 			retentionDays = int32(c.Int(FlagRetentionDays))
@@ -255,7 +249,7 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) {
 			Name:                                   domainName,
 			Description:                            common.StringPtr(description),
 			OwnerEmail:                             common.StringPtr(ownerEmail),
-			Data:                                   domainData,
+			Data:                                   domainData.Value(),
 			WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(retentionDays),
 			EmitMetric:                             common.BoolPtr(emitMetric),
 			HistoryArchivalStatus:                  archivalStatus(c, FlagHistoryArchivalStatus),

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -79,9 +79,10 @@ var (
 			Name:  FlagIsGlobalDomainWithAlias,
 			Usage: "Flag to indicate whether domain is a global domain",
 		},
-		cli.StringFlag{
+		cli.GenericFlag{
 			Name:  FlagDomainDataWithAlias,
-			Usage: "Domain data of key value pairs, in format of k1:v1,k2:v2,k3:v3",
+			Usage: "Domain data of key value pairs (must be in key1=value1,key2=value2,...,keyN=valueN format, e.g. cluster=dca or cluster=dca,instance=cadence)",
+			Value: &flag.StringMap{},
 		},
 		cli.StringFlag{
 			Name:  FlagSecurityTokenWithAlias,

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -23,6 +23,8 @@ package cli
 import (
 	"strings"
 
+	"github.com/uber/cadence/tools/common/flag"
+
 	"github.com/stretchr/testify/mock"
 	"github.com/uber-go/tally"
 	"github.com/urfave/cli"
@@ -127,9 +129,10 @@ var (
 			Name:  FlagClustersWithAlias,
 			Usage: "Clusters",
 		},
-		cli.StringFlag{
+		cli.GenericFlag{
 			Name:  FlagDomainDataWithAlias,
-			Usage: "Domain data of key value pairs, in format of k1:v1,k2:v2,k3:v3 ",
+			Usage: "Domain data of key value pairs (must be in key1=value1,key2=value2,...,keyN=valueN format, e.g. cluster=dca or cluster=dca,instance=cadence)",
+			Value: &flag.StringMap{},
 		},
 		cli.StringFlag{
 			Name:  FlagSecurityTokenWithAlias,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change domain data CLI parameter for consistency

<!-- Tell your future self why have you made these changes -->
**Why?**
A followup to https://github.com/uber/cadence/pull/4226 
This is to unify all map paramter in CLI for consistency. This will be much easier for users using CLI.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local tested 
```
qlong@~/cadence:
(qlong-cli-map-consistence)$./cadence --do test-do-data d re --domain_data k1=v1,k2=v2
Domain test-do-data successfully registered.
qlong@~/cadence:
(qlong-cli-map-consistence)$./cadence --do test-do-data d desc
Name: test-do-data
UUID: 8ec4f4e8-cd7b-4aa0-8064-9575f06f64d0
Description:
OwnerEmail:
DomainData: map[k1:v1 k2:v2]
...

(qlong-cli-map-consistence)$./cadence --do test-do-data d up --domain_data k1=v11,k2=v22
Domain test-do-data successfully updated.
qlong@~/cadence:
(qlong-cli-map-consistence)$./cadence --do test-do-data d desc
Name: test-do-data
UUID: 8ec4f4e8-cd7b-4aa0-8064-9575f06f64d0
Description:
OwnerEmail:
DomainData: map[k1:v11 k2:v22]
...
```
<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Updated

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
