### PR TITLE
Generate cross cluster tasks in mutable state task generator

### DIFF
--- a/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // This is to make sure adding new noop method when adding new nosql interfaces
-// Remove it when any other tests are implemented. 
+// Remove it when any other tests are implemented.
 func TestNoopStruct(t *testing.T) {
 	_, _ = dynamodb.NewDynamoDB(config.NoSQL{}, nil)
 }

--- a/service/history/constants/test_constants.go
+++ b/service/history/constants/test_constants.go
@@ -42,6 +42,10 @@ var (
 	TestTargetDomainID = "deadbeef-0123-4567-890a-bcdef0123458"
 	// TestTargetDomainName is the targetDomainName for test
 	TestTargetDomainName = "some random target domain name"
+	// TestRemoteTargetDomainID is the remoteTargetDomainID for test
+	TestRemoteTargetDomainID = "deadbeef-0123-4567-890a-bcdef0123459"
+	// TestRemoteTargetDomainName is the remoteTargetDomainName for test
+	TestRemoteTargetDomainName = "some random remote target domain name"
 	// TestChildDomainID is the childDomainID for test
 	TestChildDomainID = "deadbeef-0123-4567-890a-bcdef0123459"
 	// TestChildDomainName is the childDomainName for test
@@ -51,12 +55,15 @@ var (
 	// TestRunID is the workflow runID for test
 	TestRunID = "0d00698f-08e1-4d36-a3e2-3bf109f5d2d6"
 
+	// TestClusterMetadata is the cluster metadata for test
+	TestClusterMetadata = cluster.GetTestClusterMetadata(true, true)
+
 	// TestLocalDomainEntry is the local domain cache entry for test
 	TestLocalDomainEntry = cache.NewLocalDomainCacheEntryForTest(
 		&persistence.DomainInfo{ID: TestDomainID, Name: TestDomainName},
 		&persistence.DomainConfig{Retention: 1},
 		cluster.TestCurrentClusterName,
-		nil,
+		TestClusterMetadata,
 	)
 
 	// TestGlobalDomainEntry is the global domain cache entry for test
@@ -75,7 +82,7 @@ var (
 			},
 		},
 		TestVersion,
-		nil,
+		TestClusterMetadata,
 	)
 
 	// TestGlobalParentDomainEntry is the global parent domain cache entry for test
@@ -90,7 +97,7 @@ var (
 			},
 		},
 		TestVersion,
-		nil,
+		TestClusterMetadata,
 	)
 
 	// TestGlobalTargetDomainEntry is the global target domain cache entry for test
@@ -105,7 +112,22 @@ var (
 			},
 		},
 		TestVersion,
-		nil,
+		TestClusterMetadata,
+	)
+
+	// TestGlobalRemoteTargetDomainEntry is the global target domain cache entry for test
+	TestGlobalRemoteTargetDomainEntry = cache.NewGlobalDomainCacheEntryForTest(
+		&persistence.DomainInfo{ID: TestRemoteTargetDomainID, Name: TestRemoteTargetDomainName},
+		&persistence.DomainConfig{Retention: 1},
+		&persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestAlternativeClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{ClusterName: cluster.TestCurrentClusterName},
+				{ClusterName: cluster.TestAlternativeClusterName},
+			},
+		},
+		TestVersion,
+		TestClusterMetadata,
 	)
 
 	// TestGlobalChildDomainEntry is the global child domain cache entry for test
@@ -120,6 +142,6 @@ var (
 			},
 		},
 		TestVersion,
-		nil,
+		TestClusterMetadata,
 	)
 )

--- a/service/history/execution/history_builder_test.go
+++ b/service/history/execution/history_builder_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
@@ -100,6 +101,7 @@ func (s *historyBuilderSuite) SetupTest() {
 	s.mockDomainCache.EXPECT().GetDomainID(s.targetDomainName).Return(s.targetDomainID, nil).AnyTimes()
 	s.mockDomainCache.EXPECT().GetDomainByID(s.targetDomainID).Return(s.targetDomainEntry, nil).AnyTimes()
 	s.mockEventsCache.EXPECT().PutEvent(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockShard.Resource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 
 	s.msBuilder = NewMutableStateBuilder(s.mockShard, s.logger, s.domainEntry)
 	s.builder = NewHistoryBuilder(s.msBuilder, s.logger)

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -217,10 +217,13 @@ type (
 		UpdateWorkflowStateCloseStatus(state int, closeStatus int) error
 
 		AddTransferTasks(transferTasks ...persistence.Task)
+		AddCrossClusterTasks(crossClusterTasks ...persistence.Task)
 		AddTimerTasks(timerTasks ...persistence.Task)
 		GetTransferTasks() []persistence.Task
+		GetCrossClusterTasks() []persistence.Task
 		GetTimerTasks() []persistence.Task
 		DeleteTransferTasks()
+		DeleteCrossClusterTasks()
 		DeleteTimerTasks()
 
 		SetUpdateCondition(int64)

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -2351,6 +2351,22 @@ func (mr *MockMutableStateMockRecorder) AddTransferTasks(transferTasks ...interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTransferTasks", reflect.TypeOf((*MockMutableState)(nil).AddTransferTasks), transferTasks...)
 }
 
+// AddCrossClusterTasks mocks base method
+func (m *MockMutableState) AddCrossClusterTasks(crossClusterTasks ...persistence.Task) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range crossClusterTasks {
+		varargs = append(varargs, a)
+	}
+	m.ctrl.Call(m, "AddCrossClusterTasks", varargs...)
+}
+
+// AddCrossClusterTasks indicates an expected call of AddCrossClusterTasks
+func (mr *MockMutableStateMockRecorder) AddCrossClusterTasks(crossClusterTasks ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddCrossClusterTasks", reflect.TypeOf((*MockMutableState)(nil).AddCrossClusterTasks), crossClusterTasks...)
+}
+
 // AddTimerTasks mocks base method
 func (m *MockMutableState) AddTimerTasks(timerTasks ...persistence.Task) {
 	m.ctrl.T.Helper()
@@ -2381,6 +2397,20 @@ func (mr *MockMutableStateMockRecorder) GetTransferTasks() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransferTasks", reflect.TypeOf((*MockMutableState)(nil).GetTransferTasks))
 }
 
+// GetCrossClusterTasks mocks base method
+func (m *MockMutableState) GetCrossClusterTasks() []persistence.Task {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCrossClusterTasks")
+	ret0, _ := ret[0].([]persistence.Task)
+	return ret0
+}
+
+// GetCrossClusterTasks indicates an expected call of GetCrossClusterTasks
+func (mr *MockMutableStateMockRecorder) GetCrossClusterTasks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCrossClusterTasks", reflect.TypeOf((*MockMutableState)(nil).GetCrossClusterTasks))
+}
+
 // GetTimerTasks mocks base method
 func (m *MockMutableState) GetTimerTasks() []persistence.Task {
 	m.ctrl.T.Helper()
@@ -2405,6 +2435,18 @@ func (m *MockMutableState) DeleteTransferTasks() {
 func (mr *MockMutableStateMockRecorder) DeleteTransferTasks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteTransferTasks", reflect.TypeOf((*MockMutableState)(nil).DeleteTransferTasks))
+}
+
+// DeleteCrossClusterTasks mocks base method
+func (m *MockMutableState) DeleteCrossClusterTasks() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "DeleteCrossClusterTasks")
+}
+
+// DeleteCrossClusterTasks indicates an expected call of DeleteCrossClusterTasks
+func (mr *MockMutableStateMockRecorder) DeleteCrossClusterTasks() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteCrossClusterTasks", reflect.TypeOf((*MockMutableState)(nil).DeleteCrossClusterTasks))
 }
 
 // DeleteTimerTasks mocks base method

--- a/service/history/execution/mutable_state_task_generator_test.go
+++ b/service/history/execution/mutable_state_task_generator_test.go
@@ -24,11 +24,105 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/service/history/constants"
 )
 
-func TestGetNextDecisionTimeout(t *testing.T) {
-	a := assert.New(t)
+type (
+	mutableStateTaskGeneratorSuite struct {
+		suite.Suite
+		*require.Assertions
+
+		controller       *gomock.Controller
+		mockDomainCache  *cache.MockDomainCache
+		mockMutableState *MockMutableState
+
+		taskGenerator *mutableStateTaskGeneratorImpl
+	}
+)
+
+func TestMutableStateTaskGeneratorSuite(t *testing.T) {
+	s := new(mutableStateTaskGeneratorSuite)
+	suite.Run(t, s)
+}
+
+func (s *mutableStateTaskGeneratorSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	s.controller = gomock.NewController(s.T())
+	s.mockDomainCache = cache.NewMockDomainCache(s.controller)
+	s.mockMutableState = NewMockMutableState(s.controller)
+
+	s.mockDomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(constants.TestGlobalDomainEntry, nil).AnyTimes()
+	s.mockDomainCache.EXPECT().GetDomainByID(constants.TestTargetDomainID).Return(constants.TestGlobalTargetDomainEntry, nil).AnyTimes()
+	s.mockDomainCache.EXPECT().GetDomainByID(constants.TestRemoteTargetDomainID).Return(constants.TestGlobalRemoteTargetDomainEntry, nil).AnyTimes()
+
+	s.taskGenerator = NewMutableStateTaskGenerator(
+		constants.TestClusterMetadata,
+		s.mockDomainCache,
+		loggerimpl.NewLoggerForTest(s.Suite),
+		s.mockMutableState,
+	).(*mutableStateTaskGeneratorImpl)
+}
+
+func (s *mutableStateTaskGeneratorSuite) TearDownTest() {
+	s.controller.Finish()
+}
+
+func (s *mutableStateTaskGeneratorSuite) TestIsCrossClusterTask() {
+	testCases := []struct {
+		sourceDomainID string
+		targetDomainID string
+		isCrossCluster bool
+		targetCluster  string
+	}{
+		{
+			sourceDomainID: constants.TestDomainID,
+			targetDomainID: constants.TestDomainID,
+			isCrossCluster: false,
+			targetCluster:  "",
+		},
+		{
+			// source domain is passive in the current cluster
+			sourceDomainID: constants.TestRemoteTargetDomainID,
+			targetDomainID: constants.TestDomainID,
+			isCrossCluster: false,
+			targetCluster:  "",
+		},
+		{
+			sourceDomainID: constants.TestDomainID,
+			targetDomainID: constants.TestTargetDomainID,
+			isCrossCluster: false,
+			targetCluster:  "",
+		},
+		{
+			sourceDomainID: constants.TestDomainID,
+			targetDomainID: constants.TestRemoteTargetDomainID,
+			isCrossCluster: true,
+			targetCluster:  cluster.TestAlternativeClusterName,
+		},
+	}
+
+	for _, tc := range testCases {
+		s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
+			DomainID: constants.TestDomainID,
+		})
+
+		targetCluster, isCrossCluster, err := s.taskGenerator.isCrossClusterTask(tc.targetDomainID)
+		s.NoError(err)
+		s.Equal(tc.isCrossCluster, isCrossCluster)
+		s.Equal(tc.targetCluster, targetCluster)
+	}
+}
+
+func (s *mutableStateTaskGeneratorSuite) TestGetNextDecisionTimeout() {
 	defaultStartToCloseTimeout := 10 * time.Second
 	expectedResult := []time.Duration{
 		defaultStartToCloseTimeout,
@@ -43,10 +137,9 @@ func TestGetNextDecisionTimeout(t *testing.T) {
 	for i := 0; i < len(expectedResult); i++ {
 		next := getNextDecisionTimeout(int64(i), defaultStartToCloseTimeout)
 		expected := expectedResult[i]
-		//print("Iter: ", i, ", Next Backoff: ", next.String(), "\n")
 		min, max := getNextBackoffRange(expected)
-		a.True(next >= min, "NextBackoff too low: actual: %v, expected: %v", next, expected)
-		a.True(next <= max, "NextBackoff too high: actual: %v, expected: %v", next, expected)
+		s.True(next >= min, "NextBackoff too low: actual: %v, expected: %v", next, expected)
+		s.True(next <= max, "NextBackoff too high: actual: %v, expected: %v", next, expected)
 	}
 }
 

--- a/service/history/execution/mutable_state_task_refresher.go
+++ b/service/history/execution/mutable_state_task_refresher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
@@ -45,17 +46,19 @@ type (
 	}
 
 	mutableStateTaskRefresherImpl struct {
-		config      *config.Config
-		domainCache cache.DomainCache
-		eventsCache events.Cache
-		logger      log.Logger
-		shardID     int
+		config          *config.Config
+		clusterMetadata cluster.Metadata
+		domainCache     cache.DomainCache
+		eventsCache     events.Cache
+		logger          log.Logger
+		shardID         int
 	}
 )
 
 // NewMutableStateTaskRefresher creates a new task refresher for mutable state
 func NewMutableStateTaskRefresher(
 	config *config.Config,
+	clusterMetadata cluster.Metadata,
 	domainCache cache.DomainCache,
 	eventsCache events.Cache,
 	logger log.Logger,
@@ -63,11 +66,12 @@ func NewMutableStateTaskRefresher(
 ) MutableStateTaskRefresher {
 
 	return &mutableStateTaskRefresherImpl{
-		config:      config,
-		domainCache: domainCache,
-		eventsCache: eventsCache,
-		logger:      logger,
-		shardID:     shardID,
+		config:          config,
+		clusterMetadata: clusterMetadata,
+		domainCache:     domainCache,
+		eventsCache:     eventsCache,
+		logger:          logger,
+		shardID:         shardID,
 	}
 }
 
@@ -78,6 +82,7 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 ) error {
 
 	taskGenerator := NewMutableStateTaskGenerator(
+		r.clusterMetadata,
 		r.domainCache,
 		r.logger,
 		mutableState,

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -88,6 +88,7 @@ func NewStateRebuilder(
 		historyV2Mgr:    shard.GetHistoryManager(),
 		taskRefresher: NewMutableStateTaskRefresher(
 			shard.GetConfig(),
+			shard.GetClusterMetadata(),
 			shard.GetDomainCache(),
 			shard.GetEventsCache(),
 			logger,
@@ -205,7 +206,7 @@ func (r *stateRebuilderImpl) initializeBuilders(
 		r.logger,
 		resetMutableStateBuilder,
 		func(mutableState MutableState) MutableStateTaskGenerator {
-			return NewMutableStateTaskGenerator(r.shard.GetDomainCache(), r.logger, mutableState)
+			return NewMutableStateTaskGenerator(r.shard.GetClusterMetadata(), r.shard.GetDomainCache(), r.logger, mutableState)
 		},
 	)
 	return resetMutableStateBuilder, stateBuilder

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -3187,6 +3187,7 @@ func (e *historyEngineImpl) RefreshWorkflowTasks(
 
 	mutableStateTaskRefresher := execution.NewMutableStateTaskRefresher(
 		e.shard.GetConfig(),
+		e.shard.GetClusterMetadata(),
 		e.shard.GetDomainCache(),
 		e.shard.GetEventsCache(),
 		e.shard.GetLogger(),

--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -161,7 +161,7 @@ func NewHistoryReplicator(
 				logger,
 				state,
 				func(mutableState execution.MutableState) execution.MutableStateTaskGenerator {
-					return execution.NewMutableStateTaskGenerator(shard.GetDomainCache(), logger, mutableState)
+					return execution.NewMutableStateTaskGenerator(shard.GetClusterMetadata(), shard.GetDomainCache(), logger, mutableState)
 				},
 			)
 		},

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -627,6 +627,7 @@ func (s *contextImpl) CreateWorkflowExecution(
 		domainEntry,
 		workflowID,
 		request.NewWorkflowSnapshot.TransferTasks,
+		request.NewWorkflowSnapshot.CrossClusterTasks,
 		request.NewWorkflowSnapshot.ReplicationTasks,
 		request.NewWorkflowSnapshot.TimerTasks,
 		&transferMaxReadLevel,
@@ -730,6 +731,7 @@ func (s *contextImpl) UpdateWorkflowExecution(
 		domainEntry,
 		workflowID,
 		request.UpdateWorkflowMutation.TransferTasks,
+		request.UpdateWorkflowMutation.CrossClusterTasks,
 		request.UpdateWorkflowMutation.ReplicationTasks,
 		request.UpdateWorkflowMutation.TimerTasks,
 		&transferMaxReadLevel,
@@ -741,6 +743,7 @@ func (s *contextImpl) UpdateWorkflowExecution(
 			domainEntry,
 			workflowID,
 			request.NewWorkflowSnapshot.TransferTasks,
+			request.NewWorkflowSnapshot.CrossClusterTasks,
 			request.NewWorkflowSnapshot.ReplicationTasks,
 			request.NewWorkflowSnapshot.TimerTasks,
 			&transferMaxReadLevel,
@@ -839,6 +842,7 @@ func (s *contextImpl) ConflictResolveWorkflowExecution(
 			domainEntry,
 			workflowID,
 			request.CurrentWorkflowMutation.TransferTasks,
+			request.CurrentWorkflowMutation.CrossClusterTasks,
 			request.CurrentWorkflowMutation.ReplicationTasks,
 			request.CurrentWorkflowMutation.TimerTasks,
 			&transferMaxReadLevel,
@@ -850,6 +854,7 @@ func (s *contextImpl) ConflictResolveWorkflowExecution(
 		domainEntry,
 		workflowID,
 		request.ResetWorkflowSnapshot.TransferTasks,
+		request.ResetWorkflowSnapshot.CrossClusterTasks,
 		request.ResetWorkflowSnapshot.ReplicationTasks,
 		request.ResetWorkflowSnapshot.TimerTasks,
 		&transferMaxReadLevel,
@@ -861,6 +866,7 @@ func (s *contextImpl) ConflictResolveWorkflowExecution(
 			domainEntry,
 			workflowID,
 			request.NewWorkflowSnapshot.TransferTasks,
+			request.NewWorkflowSnapshot.CrossClusterTasks,
 			request.NewWorkflowSnapshot.ReplicationTasks,
 			request.NewWorkflowSnapshot.TimerTasks,
 			&transferMaxReadLevel,
@@ -1228,6 +1234,7 @@ func (s *contextImpl) allocateTaskIDsLocked(
 	domainEntry *cache.DomainCacheEntry,
 	workflowID string,
 	transferTasks []persistence.Task,
+	crossClusterTasks []persistence.Task,
 	replicationTasks []persistence.Task,
 	timerTasks []persistence.Task,
 	transferMaxReadLevel *int64,
@@ -1235,6 +1242,12 @@ func (s *contextImpl) allocateTaskIDsLocked(
 
 	if err := s.allocateTransferIDsLocked(
 		transferTasks,
+		transferMaxReadLevel,
+	); err != nil {
+		return err
+	}
+	if err := s.allocateTransferIDsLocked(
+		crossClusterTasks,
 		transferMaxReadLevel,
 	); err != nil {
 		return err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Generate cross cluster tasks in mutable state task generator
- Allocate cross cluster taskID and timestamp in shardContext

<!-- Tell your future self why have you made these changes -->
**Why?**
- For supporting cross-domain operations

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, currently cross-domain/cluster operation is not allowed in decision checker.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
