### PR TITLE
Add version check for JavaConsistentQuery

### DIFF
--- a/common/client/versionChecker.go
+++ b/common/client/versionChecker.go
@@ -45,7 +45,7 @@ const (
 	// SupportedGoSDKVersion indicates the highest go sdk version server will accept requests from
 	SupportedGoSDKVersion = "1.7.0"
 	// SupportedJavaSDKVersion indicates the highest java sdk version server will accept requests from
-	SupportedJavaSDKVersion = "1.4.0"
+	SupportedJavaSDKVersion = "1.5.0"
 	// SupportedCLIVersion indicates the highest cli version server will accept requests from
 	SupportedCLIVersion = "1.7.0"
 
@@ -59,8 +59,8 @@ const (
 	GoWorkerConsistentQueryVersion = "1.5.0"
 	// JavaWorkerRawHistoryQueryVersion indicates the minimum client version of the java worker which supports RawHistoryQuery
 	JavaWorkerRawHistoryQueryVersion = "1.3.0"
-	// JavaWorkerConsistentQueryVersion indicates the minimum client version of the java worker which supports RawHistoryQuery
-	JavaWorkerConsistentQueryVersion = "1.4.0"
+	// JavaWorkerConsistentQueryVersion indicates the minimum client version of the java worker which supports ConsistentQuery
+	JavaWorkerConsistentQueryVersion = "1.5.0"
 	// GoWorkerRawHistoryQueryVersion indicates the minimum client version of the go worker which supports RawHistoryQuery
 	GoWorkerRawHistoryQueryVersion = "1.6.0"
 	// CLIRawHistoryQueryVersion indicates the minimum CLI version of the go worker which supports RawHistoryQuery

--- a/common/client/versionChecker.go
+++ b/common/client/versionChecker.go
@@ -59,6 +59,8 @@ const (
 	GoWorkerConsistentQueryVersion = "1.5.0"
 	// JavaWorkerRawHistoryQueryVersion indicates the minimum client version of the java worker which supports RawHistoryQuery
 	JavaWorkerRawHistoryQueryVersion = "1.3.0"
+	// JavaWorkerConsistentQueryVersion indicates the minimum client version of the java worker which supports RawHistoryQuery
+	JavaWorkerConsistentQueryVersion = "1.4.0"
 	// GoWorkerRawHistoryQueryVersion indicates the minimum client version of the go worker which supports RawHistoryQuery
 	GoWorkerRawHistoryQueryVersion = "1.6.0"
 	// CLIRawHistoryQueryVersion indicates the minimum CLI version of the go worker which supports RawHistoryQuery
@@ -161,6 +163,7 @@ func NewVersionChecker() VersionChecker {
 		},
 		JavaSDK: {
 			stickyQuery:                   mustNewConstraint(fmt.Sprintf(">=%v", JavaWorkerStickyQueryVersion)),
+			consistentQuery:               mustNewConstraint(fmt.Sprintf(">=%v", JavaWorkerConsistentQueryVersion)),
 			rawHistoryQuery:               mustNewConstraint(fmt.Sprintf(">=%v", JavaWorkerRawHistoryQueryVersion)),
 			workflowAlreadyCompletedError: mustNewConstraint(fmt.Sprintf(">=%v", JavaWorkflowAlreadyCompletedVersion)),
 		},

--- a/common/client/versionChecker_test.go
+++ b/common/client/versionChecker_test.go
@@ -225,7 +225,7 @@ func (s *VersionCheckerSuite) TestSupportsConsistentQuery() {
 		},
 		{
 			clientImpl:           JavaSDK,
-			clientFeatureVersion: "1.5.0",
+			clientFeatureVersion: "1.4.0",
 			expectErr:            true,
 		},
 		{

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -769,7 +769,7 @@ func TestParentExecutionInfo(t *testing.T) {
 }
 func TestParentExecutionInfoFields(t *testing.T) {
 	assert.Nil(t, FromParentExecutionInfoFields(nil, nil, nil, nil))
-	assert.Panics(t, func() { FromParentExecutionInfoFields(nil, &testdata.ParentExecutionInfo.Domain, nil, nil)} )
+	assert.Panics(t, func() { FromParentExecutionInfoFields(nil, &testdata.ParentExecutionInfo.Domain, nil, nil) })
 	info := FromParentExecutionInfoFields(nil,
 		&testdata.ParentExecutionInfo.Domain,
 		testdata.ParentExecutionInfo.Execution,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add version check for JavaConsistentQuery

<!-- Tell your future self why have you made these changes -->
**Why?**
Will merge after https://github.com/uber/cadence-java-client/pull/530 is merged

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No test needed

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
