### PR TITLE
Update generating close event to use event version

### DIFF
--- a/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // This is to make sure adding new noop method when adding new nosql interfaces
-// Remove it when any other tests are implemented. 
+// Remove it when any other tests are implemented.
 func TestNoopStruct(t *testing.T) {
 	_, _ = dynamodb.NewDynamoDB(config.NoSQL{}, nil)
 }

--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -177,7 +177,8 @@ func (e *cacheImpl) GetEvent(
 	shardID int,
 	domainID string,
 	workflowID string,
-	runID string, firstEventID int64,
+	runID string,
+	firstEventID int64,
 	eventID int64,
 	branchToken []byte,
 ) (*types.HistoryEvent, error) {
@@ -228,7 +229,7 @@ func (e *cacheImpl) PutEvent(
 
 func (e *cacheImpl) getHistoryEventFromStore(
 	ctx context.Context,
-	firstEventID,
+	firstEventID int64,
 	eventID int64,
 	branchToken []byte,
 	shardID int,

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -124,6 +124,7 @@ type (
 		GetDecisionInfo(int64) (*DecisionInfo, bool)
 		GetDomainEntry() *cache.DomainCacheEntry
 		GetStartEvent(context.Context) (*types.HistoryEvent, error)
+		GetCloseEvent(context.Context) (*types.HistoryEvent, error)
 		GetCurrentBranchToken() ([]byte, error)
 		GetVersionHistories() *persistence.VersionHistories
 		GetCurrentVersion() int64

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -1055,6 +1055,21 @@ func (mr *MockMutableStateMockRecorder) GetStartEvent(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStartEvent", reflect.TypeOf((*MockMutableState)(nil).GetStartEvent), arg0)
 }
 
+// GetCloseEvent mocks base method
+func (m *MockMutableState) GetCloseEvent(arg0 context.Context) (*types.HistoryEvent, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCloseEvent", arg0)
+	ret0, _ := ret[0].(*types.HistoryEvent)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCloseEvent indicates an expected call of GetCloseEvent
+func (mr *MockMutableStateMockRecorder) GetCloseEvent(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloseEvent", reflect.TypeOf((*MockMutableState)(nil).GetCloseEvent), arg0)
+}
+
 // GetCurrentBranchToken mocks base method
 func (m *MockMutableState) GetCurrentBranchToken() ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -44,6 +44,7 @@ type (
 		) error
 		GenerateWorkflowCloseTasks(
 			now time.Time,
+			closeEvent *types.HistoryEvent,
 		) error
 		GenerateRecordWorkflowStartedTasks(
 			startEvent *types.HistoryEvent,
@@ -145,14 +146,13 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowStartTasks(
 
 func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowCloseTasks(
 	now time.Time,
+	closeEvent *types.HistoryEvent,
 ) error {
 
-	currentVersion := r.mutableState.GetCurrentVersion()
 	executionInfo := r.mutableState.GetExecutionInfo()
-
 	r.mutableState.AddTransferTasks(&persistence.CloseExecutionTask{
 		// TaskID and VisibilityTimestamp are set by shard context
-		Version: currentVersion,
+		Version: closeEvent.GetVersion(),
 	})
 
 	retentionInDays := defaultWorkflowRetentionInDays
@@ -170,7 +170,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowCloseTasks(
 	r.mutableState.AddTimerTasks(&persistence.DeleteHistoryEventTask{
 		// TaskID is set by shard
 		VisibilityTimestamp: now.Add(retentionDuration),
-		Version:             currentVersion,
+		Version:             closeEvent.GetVersion(),
 	})
 
 	return nil

--- a/service/history/execution/mutable_state_task_generator_mock.go
+++ b/service/history/execution/mutable_state_task_generator_mock.go
@@ -73,17 +73,17 @@ func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowStartTasks(
 }
 
 // GenerateWorkflowCloseTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateWorkflowCloseTasks(now time.Time) error {
+func (m *MockMutableStateTaskGenerator) GenerateWorkflowCloseTasks(now time.Time, closeEvent *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateWorkflowCloseTasks", now)
+	ret := m.ctrl.Call(m, "GenerateWorkflowCloseTasks", now, closeEvent)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateWorkflowCloseTasks indicates an expected call of GenerateWorkflowCloseTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowCloseTasks(now interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowCloseTasks(now, closeEvent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowCloseTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowCloseTasks), now)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowCloseTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowCloseTasks), now, closeEvent)
 }
 
 // GenerateRecordWorkflowStartedTasks mocks base method

--- a/service/history/execution/mutable_state_task_refresher.go
+++ b/service/history/execution/mutable_state_task_refresher.go
@@ -218,10 +218,14 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowClose(
 ) error {
 
 	executionInfo := mutableState.GetExecutionInfo()
-
 	if executionInfo.CloseStatus != persistence.WorkflowCloseStatusNone {
+		closeEvent, err := mutableState.GetCloseEvent(ctx)
+		if err != nil {
+			return err
+		}
 		return taskGenerator.GenerateWorkflowCloseTasks(
 			now,
+			closeEvent,
 		)
 	}
 

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -525,6 +525,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				b.unixNanoToTime(event.GetTimestamp()),
+				event,
 			); err != nil {
 				return nil, err
 			}
@@ -539,6 +540,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				b.unixNanoToTime(event.GetTimestamp()),
+				event,
 			); err != nil {
 				return nil, err
 			}
@@ -553,6 +555,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				b.unixNanoToTime(event.GetTimestamp()),
+				event,
 			); err != nil {
 				return nil, err
 			}
@@ -567,6 +570,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				b.unixNanoToTime(event.GetTimestamp()),
+				event,
 			); err != nil {
 				return nil, err
 			}
@@ -581,6 +585,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				b.unixNanoToTime(event.GetTimestamp()),
+				event,
 			); err != nil {
 				return nil, err
 			}
@@ -623,6 +628,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
 				b.unixNanoToTime(event.GetTimestamp()),
+				event,
 			); err != nil {
 				return nil, err
 			}

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -268,6 +268,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
+		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
 
@@ -298,6 +299,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
+		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
 	_, err := s.stateBuilder.ApplyEvents(constants.TestDomainID, requestID, workflowExecution, s.toHistory(event), nil)
@@ -327,6 +329,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed() {
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
+		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
 
@@ -357,6 +360,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted(
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
+		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
 
@@ -387,6 +391,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCanceled()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
+		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
 
@@ -481,6 +486,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		s.stateBuilder.unixNanoToTime(continueAsNewEvent.GetTimestamp()),
+		continueAsNewEvent,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
 
@@ -540,6 +546,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
 		s.stateBuilder.unixNanoToTime(continueAsNewEvent.GetTimestamp()),
+		continueAsNewEvent,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
 

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -81,21 +81,6 @@ type (
 		queueType         QueueType
 		shouldProcessTask bool
 	}
-
-	crossClusterTaskImpl struct {
-		sync.Mutex
-		Info
-		shard         shard.Context
-		priority      int
-		attempt       int
-		timeSource    clock.TimeSource
-		submitTime    time.Time
-		logger        log.Logger
-		eventLogger   eventLogger
-		scopeIdx      int
-		scope         metrics.Scope
-		maxRetryCount dynamicconfig.IntPropertyFn
-	}
 )
 
 // NewTimerTask creates a new timer task
@@ -152,36 +137,6 @@ func NewTransferTask(
 		maxRetryCount,
 		redispatchFn,
 	)
-}
-
-func NewCrossClusterTask(
-	shard shard.Context,
-	taskInfo Info,
-	scopeIdx int,
-	logger log.Logger,
-	timeSource clock.TimeSource,
-	maxRetryCount dynamicconfig.IntPropertyFn,
-) Task {
-	var eventLogger eventLogger
-	if shard.GetConfig().EnableDebugMode &&
-		shard.GetConfig().EnableTaskInfoLogByDomainID(taskInfo.GetDomainID()) {
-		eventLogger = newEventLogger(logger, timeSource, defaultTaskEventLoggerSize)
-		eventLogger.AddEvent("Created task")
-	}
-
-	return &crossClusterTaskImpl{
-		Info:          taskInfo,
-		shard:         shard,
-		priority:      ctask.NoPriority,
-		attempt:       0,
-		timeSource:    timeSource,
-		submitTime:    timeSource.Now(),
-		logger:        logger,
-		eventLogger:   eventLogger,
-		scopeIdx:      scopeIdx,
-		scope:         nil,
-		maxRetryCount: maxRetryCount,
-	}
 }
 
 func newTask(

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -81,6 +81,21 @@ type (
 		queueType         QueueType
 		shouldProcessTask bool
 	}
+
+	crossClusterTaskImpl struct {
+		sync.Mutex
+		Info
+		shard         shard.Context
+		priority      int
+		attempt       int
+		timeSource    clock.TimeSource
+		submitTime    time.Time
+		logger        log.Logger
+		eventLogger   eventLogger
+		scopeIdx      int
+		scope         metrics.Scope
+		maxRetryCount dynamicconfig.IntPropertyFn
+	}
 )
 
 // NewTimerTask creates a new timer task
@@ -137,6 +152,36 @@ func NewTransferTask(
 		maxRetryCount,
 		redispatchFn,
 	)
+}
+
+func NewCrossClusterTask(
+	shard shard.Context,
+	taskInfo Info,
+	scopeIdx int,
+	logger log.Logger,
+	timeSource clock.TimeSource,
+	maxRetryCount dynamicconfig.IntPropertyFn,
+) Task {
+	var eventLogger eventLogger
+	if shard.GetConfig().EnableDebugMode &&
+		shard.GetConfig().EnableTaskInfoLogByDomainID(taskInfo.GetDomainID()) {
+		eventLogger = newEventLogger(logger, timeSource, defaultTaskEventLoggerSize)
+		eventLogger.AddEvent("Created task")
+	}
+
+	return &crossClusterTaskImpl{
+		Info:          taskInfo,
+		shard:         shard,
+		priority:      ctask.NoPriority,
+		attempt:       0,
+		timeSource:    timeSource,
+		submitTime:    timeSource.Now(),
+		logger:        logger,
+		eventLogger:   eventLogger,
+		scopeIdx:      scopeIdx,
+		scope:         nil,
+		maxRetryCount: maxRetryCount,
+	}
 }
 
 func newTask(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update generating close event to use event version

<!-- Tell your future self why have you made these changes -->
**Why?**
The task refresher may generate a task with newer version and gets ignored later

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there is bugs with this change, there could be race condition in handling closed event

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
