### PR TITLE
Support prefix match for list domain command

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -415,6 +415,11 @@ func newAdminDomainCommands() []cli.Command {
 					Name:  FlagDeprecatedWithAlias,
 					Usage: "List deprecated domains only, by default only domains in REGISTERED status are listed",
 				},
+				cli.StringFlag{
+					Name:  FlagPrefix,
+					Usage: "List domains that are matching to the given prefix",
+					Value: "",
+				},
 				cli.BoolFlag{
 					Name:  FlagPrintFullyDetailWithAlias,
 					Usage: "Print full domain detail",

--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -458,6 +458,7 @@ func (d *domainCLIImpl) DescribeDomain(c *cli.Context) {
 
 func (d *domainCLIImpl) ListDomains(c *cli.Context) {
 	pageSize := c.Int(FlagPageSize)
+	prefix := c.String(FlagPrefix)
 	printAll := c.Bool(FlagAll)
 	printDeprecated := c.Bool(FlagDeprecated)
 	printFull := c.Bool(FlagPrintFullyDetail)
@@ -469,6 +470,18 @@ func (d *domainCLIImpl) ListDomains(c *cli.Context) {
 
 	domains := d.getAllDomains(c)
 	var filteredDomains []*types.DescribeDomainResponse
+
+	// Only list domains that are matching to the prefix if prefix is provided
+	if len(prefix) > 0 {
+		var prefixDomains []*types.DescribeDomainResponse
+		for _, domain := range domains {
+			if strings.Index(domain.DomainInfo.Name, prefix) == 0 {
+				prefixDomains = append(prefixDomains, domain)
+			}
+		}
+		domains = prefixDomains
+	}
+
 	if printAll {
 		filteredDomains = domains
 	} else {

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -112,6 +112,7 @@ const (
 	FlagMore                              = "more"
 	FlagMoreWithAlias                     = FlagMore + ", m"
 	FlagAll                               = "all"
+	FlagPrefix                            = "prefix"
 	FlagAllWithAlias                      = FlagAll + ", a"
 	FlagDeprecated                        = "deprecated"
 	FlagDeprecatedWithAlias               = FlagDeprecated + ", dep"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
With this change list domains results can be filtered by a given prefix


<!-- Tell your future self why have you made these changes -->
**Why?**
If we have this change, we can build a typeahead for cadence-web when people are searching domains


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
enderd[06/15 08:34]:~/cadence$ ./cadence admin domain list --help
NAME:
   cadence admin domain list - List all domains in the cluster

USAGE:
   cadence admin domain list [command options] [arguments...]

OPTIONS:
   --pagesize value, --ps value  Result page size (default: 10)
   --all, -a                     List all domains, by default only domains in REGISTERED status are listed
   --deprecated, --dep           List deprecated domains only, by default only domains in REGISTERED status are listed
   --prefix value                List domains that are matching to the given prefix
   --print_full, --pf            Print full domain detail
   --print_json, --pjson         Print in raw json format

enderd[06/15 08:35]:~/cadence$ ./cadence admin domain list
           NAME           |                 UUID                 | DOMAIN DATA | IS GLOBAL DOMAIN | ACTIVE CLUSTER
  cadence-shadower        | 59c51119-1b41-4a28-986d-d6e377716f82 |             | false            | active
  cadence-system          | 32049b68-7872-4094-8e63-d0dd59896a83 |             | false            | active
  integration-test-domain | 81343532-fa83-4476-9b6e-16b762aeb526 |             | false            | active
  samples-domain          | d186133d-82cf-41bb-abd1-de4b26396c71 |             | false            | active
enderd[06/15 08:35]:~/cadence$ ./cadence admin domain list --prefix ca
        NAME       |                 UUID                 | DOMAIN DATA | IS GLOBAL DOMAIN | ACTIVE CLUSTER
  cadence-shadower | 59c51119-1b41-4a28-986d-d6e377716f82 |             | false            | active
  cadence-system   | 32049b68-7872-4094-8e63-d0dd59896a83 |             | false            | active
enderd[06/15 08:35]:~/cadence$ ./cadence admin domain list --prefix s
       NAME      |                 UUID                 | DOMAIN DATA | IS GLOBAL DOMAIN | ACTIVE CLUSTER
  samples-domain | d186133d-82cf-41bb-abd1-de4b26396c71 |             | false            | active
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
