### PR TITLE
Use global domain by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ You can find a list of previous releases on the [github releases](https://github
 - Bump CLI version to v0.19.0
 - Change `--connect-attributes` in `cadence-sql-tool` from URL encoding to the format of k1=v1,k2=v2...
 - Change `--domain_data` in `cadence domain update/register` from the format of k1:v1,k2:v2... to the format of k1=v1,k2=v2...
+- Deprecate local domains. All new domains should be created as global domains.
 
 ## [0.18.0] - 2021-01-22
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"encoding/json"
+	"log"
 	"time"
 
 	"github.com/uber-go/tally/m3"
@@ -437,6 +438,10 @@ func (c *Config) ValidateAndFillDefaults() error {
 func (c *Config) validate() error {
 	if err := c.Persistence.Validate(); err != nil {
 		return err
+	}
+	if !c.ClusterMetadata.EnableGlobalDomain {
+		log.Println("[WARN] Local domain is now deprecated. Please update config to enable global domain(ClusterMetadata->EnableGlobalDomain)." +
+			"Global domain of single cluster has zero overhead, but only advantages for future migration and fail over. Please check Cadence documentation for more details.")
 	}
 	return c.Archival.Validate(&c.DomainDefaults.Archival)
 }

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"time"
 
@@ -438,6 +439,9 @@ func (c *Config) ValidateAndFillDefaults() error {
 func (c *Config) validate() error {
 	if err := c.Persistence.Validate(); err != nil {
 		return err
+	}
+	if c.ClusterMetadata == nil {
+		return fmt.Errorf("ClusterMetadata cannot be empty")
 	}
 	if !c.ClusterMetadata.EnableGlobalDomain {
 		log.Println("[WARN] Local domain is now deprecated. Please update config to enable global domain(ClusterMetadata->EnableGlobalDomain)." +

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -128,7 +128,7 @@ func (d *handlerImpl) RegisterDomain(
 	if !d.clusterMetadata.IsGlobalDomainEnabled() {
 		if registerRequest.IsGlobalDomain {
 			return &types.BadRequestError{Message: "Cannot register global domain when not enabled. Please update config to enable global domain(recommended), " +
-				"or use \"--global_domain false\" to create legacy local domain. Global domain of single cluster has zero overhead, but only advantages for future migration and fail over. Please check Cadence documentation for more details."}
+				"or specify explicit parameter to create legacy local domain. Global domain of single cluster has zero overhead, but only advantages for future migration and fail over. Please check Cadence documentation for more details."}
 		}
 	} else {
 		// cluster global domain enabled

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -127,7 +127,8 @@ func (d *handlerImpl) RegisterDomain(
 
 	if !d.clusterMetadata.IsGlobalDomainEnabled() {
 		if registerRequest.IsGlobalDomain {
-			return &types.BadRequestError{Message: "Cannot register global domain when not enabled"}
+			return &types.BadRequestError{Message: "Cannot register global domain when not enabled. Please update config to enable global domain(recommended), " +
+				"or use \"--global_domain false\" to create legacy local domain. Global domain of single cluster has zero overhead, but only advantages for future migration and fail over. Please check Cadence documentation for more details."}
 		}
 	} else {
 		// cluster global domain enabled

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -72,7 +72,7 @@ services:
       port: 7940
 
 clusterMetadata:
-  enableGlobalDomain: false
+  enableGlobalDomain: true
   failoverVersionIncrement: 10
   masterClusterName: "active"
   currentClusterName: "active"

--- a/config/development_es.yaml
+++ b/config/development_es.yaml
@@ -71,7 +71,7 @@ services:
       port: 7940
 
 clusterMetadata:
-  enableGlobalDomain: false
+  enableGlobalDomain: true
   failoverVersionIncrement: 10
   primaryClusterName: "active"
   currentClusterName: "active"

--- a/config/development_es_v7.yaml
+++ b/config/development_es_v7.yaml
@@ -72,7 +72,7 @@ services:
       port: 7940
 
 clusterMetadata:
-  enableGlobalDomain: false
+  enableGlobalDomain: true
   failoverVersionIncrement: 10
   primaryClusterName: "active"
   currentClusterName: "active"

--- a/config/development_mysql.yaml
+++ b/config/development_mysql.yaml
@@ -81,7 +81,7 @@ services:
       port: 7940
 
 clusterMetadata:
-  enableGlobalDomain: false
+  enableGlobalDomain: true
   failoverVersionIncrement: 10
   primaryClusterName: "active"
   currentClusterName: "active"

--- a/config/development_postgres.yaml
+++ b/config/development_postgres.yaml
@@ -81,7 +81,7 @@ services:
       port: 7940
 
 clusterMetadata:
-  enableGlobalDomain: false
+  enableGlobalDomain: true
   failoverVersionIncrement: 10
   primaryClusterName: "active"
   currentClusterName: "active"

--- a/config/development_prometheus.yaml
+++ b/config/development_prometheus.yaml
@@ -69,7 +69,7 @@ services:
       port: 7940
 
 clusterMetadata:
-  enableGlobalDomain: false
+  enableGlobalDomain: true
   failoverVersionIncrement: 10
   primaryClusterName: "active"
   currentClusterName: "active"

--- a/config/development_scylla.yaml
+++ b/config/development_scylla.yaml
@@ -69,7 +69,7 @@ services:
       port: 7940
 
 clusterMetadata:
-  enableGlobalDomain: false
+  enableGlobalDomain: true
   failoverVersionIncrement: 10
   primaryClusterName: "active"
   currentClusterName: "active"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -201,7 +201,7 @@ services:
         {{- end }}
 
 clusterMetadata:
-    enableGlobalDomain: {{ default .Env.ENABLE_GLOBAL_DOMAIN "false" }}
+    enableGlobalDomain: {{ default .Env.ENABLE_GLOBAL_DOMAIN "true" }}
     failoverVersionIncrement: 10
     primaryClusterName: "primary"
     {{- if .Env.IS_NOT_PRIMARY }}

--- a/tools/cli/domainCommands.go
+++ b/tools/cli/domainCommands.go
@@ -88,7 +88,7 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) {
 	securityToken := c.String(FlagSecurityToken)
 	var err error
 
-	isGlobalDomain := false
+	isGlobalDomain := true
 	if c.IsSet(FlagIsGlobalDomain) {
 		isGlobalDomain, err = strconv.ParseBool(c.String(FlagIsGlobalDomain))
 		if err != nil {

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -77,7 +77,8 @@ var (
 		},
 		cli.StringFlag{
 			Name:  FlagIsGlobalDomainWithAlias,
-			Usage: "Flag to indicate whether domain is a global domain",
+			Usage: "Flag to indicate whether domain is a global domain. Default to true. Local domain is now legacy.",
+			Value: "true",
 		},
 		cli.GenericFlag{
 			Name:  FlagDomainDataWithAlias,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use global domain by default 

<!-- Tell your future self why have you made these changes -->
**Why?**
Local domain has no more value compared to global domain, even in a single cluster setup. 
It's only limiting users from migrating to new clusters(e.g. for scaling up)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No. It's been used for a very long time.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Need to add release notes for migrating to update config

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
N/A