### PR TITLE
Remove unnecessary nonzero requirements in some fields of NoSQL config struct

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -170,7 +170,7 @@ type (
 	// NoSQL contains configuration to connect to NoSQL Database cluster
 	NoSQL struct {
 		// PluginName is the name of NoSQL plugin, default is "cassandra". Supported values: cassandra
-		PluginName string `yaml:"pluginName" validate:"nonzero"`
+		PluginName string `yaml:"pluginName"`
 		// Hosts is a csv of cassandra endpoints
 		Hosts string `yaml:"hosts" validate:"nonzero"`
 		// Port is the cassandra port used for connection by gocql client
@@ -180,7 +180,7 @@ type (
 		// Password is the cassandra password used for authentication by gocql client
 		Password string `yaml:"password"`
 		// Keyspace is the cassandra keyspace
-		Keyspace string `yaml:"keyspace" validate:"nonzero"`
+		Keyspace string `yaml:"keyspace"`
 		// Region is the region filter arg for cassandra
 		Region string `yaml:"region"`
 		// Datacenter is the data center filter arg for cassandra


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove unnecessary nonzero fields in NoSQL config struct

<!-- Tell your future self why have you made these changes -->
**Why?**
1. PluginName requirement will break existing users
2. Keyspace will not be generically applicable for all NoSQL DBs

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
