### PR TITLE
Bugfix: write changes back to *Persistence.DataStores

### DIFF
--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/uber/cadence/common"
 )
@@ -61,4 +62,36 @@ func TestFillingDefaultRpcName(t *testing.T) {
 
 	cfg.fillDefaults()
 	assert.Equal(t, "cadence-frontend", cfg.ClusterMetadata.ClusterInformation["clusterA"].RPCName)
+}
+
+func TestConfigFallbacks(t *testing.T) {
+	cfg := &Config{
+		Persistence: Persistence{
+			DefaultStore:    "default",
+			VisibilityStore: "cass",
+			DataStores: map[string]DataStore{
+				"default": {
+					SQL: &SQL{
+						PluginName:      "fake",
+						ConnectProtocol: "tcp",
+						ConnectAddr:     "192.168.0.1:3306",
+						DatabaseName:    "db1",
+						NumShards:       0, // default value, should be changed
+					},
+				},
+				"cass": {
+					Cassandra: &NoSQL{
+						Hosts: "127.0.0.1",
+					},
+					// no sql or nosql, should be populated from cassandra
+				},
+			},
+		},
+	}
+	err := cfg.ValidateAndFillDefaults()
+	require.NoError(t, err) // sanity check, must be valid or the later tests are potentially useless
+
+	assert.NotEmpty(t, cfg.Persistence.DataStores["cass"].Cassandra, "cassandra config should remain after update")
+	assert.NotEmpty(t, cfg.Persistence.DataStores["cass"].NoSQL, "nosql config should contain cassandra config / not be empty")
+	assert.NotZero(t, cfg.Persistence.DataStores["default"].SQL.NumShards, "num shards should be nonzero")
 }

--- a/common/config/persistence.go
+++ b/common/config/persistence.go
@@ -71,6 +71,8 @@ func (c *Persistence) Validate() error {
 		if ds.SQL != nil && ds.SQL.NumShards == 0 {
 			ds.SQL.NumShards = 1
 		}
+		// write changes back to DataStores, as ds is a value object
+		c.DataStores[st] = ds
 	}
 	return nil
 }


### PR DESCRIPTION
Since DataStores is a `map[string]DataStore`, `ds` is a copy of the data in the map, and changes are made only to that copy.
So this change writes the (possibly)-changed value back to the map, so it actually takes effect.

I added a test because why not.  Prior to this fix it fails with:
```
--- FAIL: TestConfigFallbacks (0.00s)
    config_test.go:95: 
                Error Trace:    config_test.go:95
                Error:          Should NOT be empty, but was <nil>
                Test:           TestConfigFallbacks
                Messages:       nosql config should contain cassandra config / not be empty
```
and now it passes.

The NumShards update worked before because it's modifying a `*SQL`, but I've included an assertion for it to serve as a counter-example / to guard against a bug if it ever becomes a value object as well.  Plus I assume we have other "fill in defaults / backfill legacy stuff" values, or we will eventually, and bundling all the simple ones into one test is fairly reasonable.