### PR TITLE
Allow skipping optional tests for optional methods in plugins

### DIFF
--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -115,6 +115,9 @@ func (s *HistoryV2PersistenceSuite) TestGenUUIDs() {
 
 // TestScanAllTrees test
 func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
+	if os.Getenv("SKIP_SCAN_HISTORY") != "" {
+		s.T().Skipf("GetAllHistoryTreeBranches not supported in %v", s.TaskMgr.GetName())
+	}
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
 	defer cancel()
 

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -552,6 +552,9 @@ func (s *MatchingPersistenceSuite) TestListWithMultipleTaskList() {
 }
 
 func (s *MatchingPersistenceSuite) TestGetOrphanTasks() {
+	if os.Getenv("SKIP_GET_ORPHAN_TASKS") != "" {
+		s.T().Skipf("GetOrphanTasks not supported in %v", s.TaskMgr.GetName())
+	}
 	if s.TaskMgr.GetName() == "cassandra" {
 		// GetOrphanTasks API is currently not supported in cassandra"
 		return


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Allow user to skip GetOrphanTasksTest and ScanHistoryTest 

<!-- Tell your future self why have you made these changes -->
**Why?**

- Database supporting TTL doesn't need to implement GetOrphanTasks
- GetAllHistoryTreeBranches doesn't work for sharded SQL
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
