### PR TITLE
Fix a racy read in test

### DIFF
--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -357,7 +357,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 	).Return(nil)
 
 	// Poll needs to happen before MustOffer, or else it goes into the non-blocking path.
-	ensureAsyncReady(time.Second, func(ctx context.Context) {
+	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
 		task, err := t.matcher.Poll(ctx)
 		t.Nil(err)
 		t.NotNil(task)
@@ -365,6 +365,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 
 	t.NoError(t.matcher.MustOffer(ctx, task))
 	cancel()
+	wait()
 	t.NotNil(req)
 	t.NoError(err)
 	t.True(remoteSyncMatch)


### PR DESCRIPTION
Unfortunately I seem to have missed this `wait()` call in #3975, and it decided to assert itself recently:
https://buildkite.com/uberopensource/cadence-server/builds/11015#bf06bca6-2ad3-49fd-a063-de1dd67655b9
(races between line 363 and the suite's `SetT()` method)

This should fix it.  There aren't any other missing-`wait()`s AFAICT.