### PR TITLE
Enforce context timeout for retry policies in execution context and cache

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -141,7 +141,7 @@ func CreatePersistenceRetryPolicy() backoff.RetryPolicy {
 }
 
 // CreatePersistenceRetryPolicyWithContext create a retry policy for persistence layer operations
-// with expires when the context expires
+// which has an expiration interval computed based on the context's deadline
 func CreatePersistenceRetryPolicyWithContext(ctx context.Context) backoff.RetryPolicy {
 	if ctx == nil {
 		return CreatePersistenceRetryPolicy()

--- a/common/util.go
+++ b/common/util.go
@@ -140,6 +140,23 @@ func CreatePersistenceRetryPolicy() backoff.RetryPolicy {
 	return policy
 }
 
+// CreatePersistenceRetryPolicyWithContext create a retry policy for persistence layer operations
+// with expires when the context expires
+func CreatePersistenceRetryPolicyWithContext(ctx context.Context) backoff.RetryPolicy {
+	if ctx == nil {
+		return CreatePersistenceRetryPolicy()
+	}
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return CreatePersistenceRetryPolicy()
+	}
+
+	policy := backoff.NewExponentialRetryPolicy(retryPersistenceOperationInitialInterval)
+	policy.SetMaximumInterval(retryPersistenceOperationMaxInterval)
+	policy.SetExpirationInterval(deadline.Sub(time.Now()))
+	return policy
+}
+
 // CreateHistoryServiceRetryPolicy creates a retry policy for calls to history service
 func CreateHistoryServiceRetryPolicy() backoff.RetryPolicy {
 	policy := backoff.NewExponentialRetryPolicy(historyServiceOperationInitialInterval)

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/pborman/uuid"
 
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/definition"
@@ -315,7 +316,11 @@ func (c *Cache) getCurrentExecutionWithRetry(
 		return err
 	}
 
-	err := backoff.Retry(op, persistenceOperationRetryPolicy, persistence.IsTransientError)
+	err := backoff.Retry(
+		op,
+		common.CreatePersistenceRetryPolicyWithContext(ctx),
+		persistence.IsTransientError,
+	)
 	if err != nil {
 		c.metricsClient.IncCounter(metrics.HistoryCacheGetCurrentExecutionScope, metrics.CacheFailures)
 		return nil, err

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -153,10 +153,6 @@ type (
 
 var _ Context = (*contextImpl)(nil)
 
-var (
-	persistenceOperationRetryPolicy = common.CreatePersistenceRetryPolicy()
-)
-
 // NewContext creates a new workflow execution context
 func NewContext(
 	domainID string,
@@ -1003,7 +999,7 @@ func (c *contextImpl) appendHistoryV2EventsWithRetry(
 
 	err := backoff.Retry(
 		op,
-		persistenceOperationRetryPolicy,
+		common.CreatePersistenceRetryPolicyWithContext(ctx),
 		persistence.IsTransientError,
 	)
 	return int64(resp), err
@@ -1033,7 +1029,7 @@ func (c *contextImpl) createWorkflowExecutionWithRetry(
 
 	err := backoff.Retry(
 		op,
-		persistenceOperationRetryPolicy,
+		common.CreatePersistenceRetryPolicyWithContext(ctx),
 		isRetryable,
 	)
 	switch err.(type) {
@@ -1071,7 +1067,7 @@ func (c *contextImpl) getWorkflowExecutionWithRetry(
 
 	err := backoff.Retry(
 		op,
-		persistenceOperationRetryPolicy,
+		common.CreatePersistenceRetryPolicyWithContext(ctx),
 		persistence.IsTransientError,
 	)
 	switch err.(type) {
@@ -1114,7 +1110,8 @@ func (c *contextImpl) updateWorkflowExecutionWithRetry(
 	}
 
 	err := backoff.Retry(
-		op, persistenceOperationRetryPolicy,
+		op,
+		common.CreatePersistenceRetryPolicyWithContext(ctx),
 		isRetryable,
 	)
 	switch err.(type) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Enforce context timeout for retry policies in execution context and cache

<!-- Tell your future self why have you made these changes -->
**Why?**
- When the context times out, persistence layer will retry persistence.Timeout error which is considered as a retryable error

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
