### PR TITLE
Fix CLI admin domain bug that didn't load Cassandra plugin

### DIFF
--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 
+	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra"              // needed to load cassandra plugin
 	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public" // needed to load the default gocql client
 	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"                      // needed to load mysql plugin
 	_ "github.com/uber/cadence/common/persistence/sql/sqlplugin/postgres"                   // needed to load postgres plugin


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add loading Cassandra plugin for the binary

<!-- Tell your future self why have you made these changes -->
**Why?**
A bug introduced from https://github.com/uber/cadence/pull/4311

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
