### PR TITLE
[WIP] Update OAuth implementation to use domainCache to authorize

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -30,7 +30,6 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
-	"github.com/uber/cadence/common/authorization"
 	"github.com/uber/cadence/common/blobstore/filestore"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/config"
@@ -216,7 +215,7 @@ func (s *server) startService() common.Daemon {
 	params.ArchiverProvider = provider.NewArchiverProvider(s.cfg.Archival.History.Provider, s.cfg.Archival.Visibility.Provider)
 	params.PersistenceConfig.TransactionSizeLimit = dc.GetIntProperty(dynamicconfig.TransactionSizeLimit, common.DefaultTransactionSizeLimit)
 	params.PersistenceConfig.ErrorInjectionRate = dc.GetFloat64Property(dynamicconfig.PersistenceErrorInjectionRate, 0)
-	params.Authorizer = authorization.NewAuthorizer(s.cfg.Authorization, params.Logger)
+	params.AuthorizationConfig = s.cfg.Authorization
 	params.BlobstoreClient, err = filestore.NewFilestoreClient(s.cfg.Blobstore.Filestore)
 	if err != nil {
 		log.Printf("failed to create file blobstore client, will continue startup without it: %v", err)

--- a/common/authorization/factory.go
+++ b/common/authorization/factory.go
@@ -21,14 +21,15 @@
 package authorization
 
 import (
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 )
 
-func NewAuthorizer(authorization config.Authorization, logger log.Logger) Authorizer {
+func NewAuthorizer(authorization config.Authorization, logger log.Logger, domainCache cache.DomainCache) Authorizer {
 	switch true {
 	case authorization.OAuthAuthorizer.Enable:
-		return NewOAuthAuthorizer(authorization.OAuthAuthorizer, logger)
+		return NewOAuthAuthorizer(authorization.OAuthAuthorizer, logger, domainCache)
 	default:
 		return NewNopAuthorizer()
 	}

--- a/common/authorization/factory_test.go
+++ b/common/authorization/factory_test.go
@@ -82,7 +82,7 @@ func (s *factorySuite) TestFactoryNoopAuthorizer() {
 	}
 
 	for _, test := range tests {
-		authorizer := NewAuthorizer(test.cfg, s.logger)
+		authorizer := NewAuthorizer(test.cfg, s.logger, nil)
 		s.Equal(authorizer, test.expected)
 	}
 }

--- a/common/authorization/oauthAuthorizer.go
+++ b/common/authorization/oauthAuthorizer.go
@@ -30,6 +30,7 @@ import (
 	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -37,6 +38,7 @@ import (
 
 type oauthAuthority struct {
 	authorizationCfg config.OAuthAuthorizer
+	domainCache      cache.DomainCache
 	log              log.Logger
 }
 
@@ -53,9 +55,11 @@ type jwtClaims struct {
 func NewOAuthAuthorizer(
 	authorizationCfg config.OAuthAuthorizer,
 	log log.Logger,
+	domainCache cache.DomainCache,
 ) Authorizer {
 	return &oauthAuthority{
 		authorizationCfg: authorizationCfg,
+		domainCache:      domainCache,
 		log:              log,
 	}
 }

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -76,7 +76,8 @@ type (
 		PublicClient        workflowserviceclient.Interface
 		ArchivalMetadata    archiver.ArchivalMetadata
 		ArchiverProvider    provider.ArchiverProvider
-		Authorizer          authorization.Authorizer
+		Authorizer          authorization.Authorizer // NOTE: this can be nil. If nil, AccessControlledHandlerImpl will initiate one with config.Authorization
+		AuthorizationConfig config.Authorization     // NOTE: empty(default) struct will get a authorization.NoopAuthorizer
 	}
 
 	// MembershipMonitorFactory provides a bootstrapped membership monitor

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -409,7 +409,7 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]string, startWG *sync.Wai
 	params.ArchiverProvider = c.archiverProvider
 	params.ESConfig = c.esConfig
 	params.ESClient = c.esClient
-	params.Authorizer = authorization.NewAuthorizer(c.authorizationConfig, params.Logger)
+	params.Authorizer = authorization.NewAuthorizer(c.authorizationConfig, params.Logger, nil)
 
 	var err error
 	params.PersistenceConfig, err = copyPersistenceConfig(c.persistenceConfig)

--- a/service/frontend/accessControlledHandler.go
+++ b/service/frontend/accessControlledHandler.go
@@ -24,6 +24,7 @@ import (
 	"context"
 
 	"github.com/uber/cadence/common/authorization"
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/types"
@@ -42,7 +43,10 @@ type AccessControlledWorkflowHandler struct {
 var _ Handler = (*AccessControlledWorkflowHandler)(nil)
 
 // NewAccessControlledHandlerImpl creates frontend handler with authentication support
-func NewAccessControlledHandlerImpl(wfHandler Handler, resource resource.Resource, authorizer authorization.Authorizer) *AccessControlledWorkflowHandler {
+func NewAccessControlledHandlerImpl(wfHandler Handler, resource resource.Resource, authorizer authorization.Authorizer, cfg config.Authorization) *AccessControlledWorkflowHandler {
+	if authorizer == nil {
+		authorizer = authorization.NewAuthorizer(cfg, resource.GetLogger(), resource.GetDomainCache())
+	}
 	return &AccessControlledWorkflowHandler{
 		Resource:        resource,
 		frontendHandler: wfHandler,

--- a/service/frontend/accessControlledHandler_test.go
+++ b/service/frontend/accessControlledHandler_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common/authorization"
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/mocks"
 	"github.com/uber/cadence/common/resource"
@@ -62,7 +63,7 @@ func (s *accessControlledHandlerSuite) SetupTest() {
 	s.mockFrontendHandler = NewMockHandler(s.controller)
 	s.mockAuthorizer = authorization.NewMockAuthorizer(s.controller)
 	s.mockMetricsScope = &mocks.Scope{}
-	s.handler = NewAccessControlledHandlerImpl(s.mockFrontendHandler, s.mockResource, s.mockAuthorizer)
+	s.handler = NewAccessControlledHandlerImpl(s.mockFrontendHandler, s.mockResource, s.mockAuthorizer, config.Authorization{})
 }
 
 func (s *accessControlledHandlerSuite) TearDownTest() {

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -254,9 +254,7 @@ func (s *Service) Start() {
 	// Additional decorations
 	var handler Handler = s.handler
 	handler = NewDCRedirectionHandler(handler, s, s.config, s.params.DCRedirectionPolicy)
-	if s.params.Authorizer != nil {
-		handler = NewAccessControlledHandlerImpl(handler, s, s.params.Authorizer)
-	}
+	handler = NewAccessControlledHandlerImpl(handler, s, s.params.Authorizer, s.params.AuthorizationConfig)
 
 	// Register the latest (most decorated) handler
 	thriftHandler := NewThriftHandler(handler)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**
Based on discussion with @just-at-uber , we need to make change on the proposal to support multiple domains operation on WebUI with one logging.
The best way to do it is letting OAuthAuthorizer to get the group permission info by domainData. 

Ideally domainCache should be passed in on initialization. However, some implementation may not be able to get the domainCache(especially Uber's internal implementation). So we are changing the Authorizer interface to pass it in so that it will work for all implementation. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
