### PR TITLE
Parallelize GetWorkflowExecution SQL calls

### DIFF
--- a/common/persistence/sql/sqlExecutionStore.go
+++ b/common/persistence/sql/sqlExecutionStore.go
@@ -342,8 +342,13 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 
 	err := g.Wait()
 	if err != nil {
-		return nil, &types.InternalServiceError{
-			Message: fmt.Sprintf("GetWorkflowExecution: failed. Error: %v", err),
+		switch err := err.(type) {
+		case *types.EntityNotExistsError:
+			return nil, err
+		default:
+			return nil, &types.InternalServiceError{
+				Message: fmt.Sprintf("GetWorkflowExecution: failed. Error: %v", err),
+			}
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -69,6 +69,7 @@ require (
 	go.uber.org/zap v1.13.0
 	golang.org/x/net v0.0.0-20201031054903-ff519b6c9102
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	golang.org/x/text v0.3.4 // indirect
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 	golang.org/x/tools v0.1.0
@@ -76,7 +77,7 @@ require (
 	google.golang.org/api v0.26.0
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20201201144952-b05cb90ed32e // indirect
-	google.golang.org/grpc v1.29.1
+	google.golang.org/grpc v1.29.1 // indirect
 	google.golang.org/protobuf v1.25.0 // indirect
 	gopkg.in/jcmturner/goidentity.v3 v3.0.0 // indirect
 	gopkg.in/jcmturner/gokrb5.v7 v7.3.0 // indirect


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
During DocStore migration we realized that GetWorkflowExecution API calls are the slowest (3x-4x slower at best). With this PR I'm parallelizing the SQL calls so we can save some latency for this API

This API makes GetWorkflowExecution 2.6 times faster (decreased sql latency by 62%) for SQL plugins based on bench test runs. Even though, it's still slightly slower compared to nosql, the difference is ignorable: <5ms.

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve SQL performance


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Current unit tests should pass. This PR doesn't change any functionality

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
