### PR TITLE
Fix oauth yaml config

### DIFF
--- a/config/development_oauth.yaml
+++ b/config/development_oauth.yaml
@@ -90,10 +90,19 @@ dcRedirectionPolicy:
 archival:
   history:
     status: "disabled"
-
+    enableRead: false
   visibility:
     status: "disabled"
+    enableRead: false
 
+domainDefaults:
+  archival:
+    history:
+      status: "disabled"
+      URI: ""
+    visibility:
+      status: "disabled"
+      URI: ""
 
 publicClient:
   hostPort: "localhost:7933"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix oauth yaml config

<!-- Tell your future self why have you made these changes -->
**Why?**
Without the change, service start will fail due to invalid config. Since `development_oauth.yaml` will be deep merged with `development.yaml` and cause archival config to be invalid.
```
➜  cadence (fix-oauth-config) ✗ ./cadence-server --zone oauth start
2021/08/13 15:17:20 Loading config; env=development,zone=oauth,configDir=./config
2021/08/13 15:17:20 Loading configFiles=[./config/base.yaml ./config/development.yaml ./config/development_oauth.yaml]
2021/08/13 15:17:20 config validation failed: Invalid history archival config
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally. With the change, server can pass the config validation phase.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
