### PR TITLE
Fill currentCluster RpcAddress with publicClient as default

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -55,6 +55,7 @@ type (
 		// Archival is the config for archival
 		Archival Archival `yaml:"archival"`
 		// PublicClient is config for sys worker service connecting to cadence frontend
+		// Default to currentCluster's RPCAddress in ClusterInformation
 		PublicClient PublicClient `yaml:"publicClient"`
 		// DynamicConfigClient is the config for setting up the file based dynamic config client
 		// Filepath would be relative to the root directory when the path wasn't absolute.
@@ -324,7 +325,6 @@ type (
 		RPCName string `yaml:"rpcName"`
 		// Address indicate the remote service address(Host:Port). Host can be DNS name.
 		// For currentCluster, it's usually the same as publicClient.hostPort
-		// Default to publicClient.hostPort if empty
 		RPCAddress string `yaml:"rpcAddress" validate:"nonzero"`
 	}
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -324,7 +324,7 @@ type (
 		RPCName string `yaml:"rpcName"`
 		// Address indicate the remote service address(Host:Port). Host can be DNS name.
 		// For currentCluster, it's usually the same as publicClient.hostPort
-		// Default to publicClient.hostPort if empty 
+		// Default to publicClient.hostPort if empty
 		RPCAddress string `yaml:"rpcAddress"`
 	}
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -512,8 +512,8 @@ func (c *Config) fillDefaults() error {
 		if cluster.RPCName == "" {
 			// filling RPCName with a default value if empty
 			cluster.RPCName = "cadence-frontend"
+			c.ClusterMetadata.ClusterInformation[name] = cluster
 		}
-		c.ClusterMetadata.ClusterInformation[name] = cluster
 	}
 
 	// filling publicClient with current cluster's RPC address if empty

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -55,7 +55,6 @@ type (
 		// Archival is the config for archival
 		Archival Archival `yaml:"archival"`
 		// PublicClient is config for sys worker service connecting to cadence frontend
-		// Default to currentCluster's RPCAddress in ClusterInformation
 		PublicClient PublicClient `yaml:"publicClient"`
 		// DynamicConfigClient is the config for setting up the file based dynamic config client
 		// Filepath would be relative to the root directory when the path wasn't absolute.
@@ -427,6 +426,7 @@ type (
 	// PublicClient is config for connecting to cadence frontend
 	PublicClient struct {
 		// HostPort is the host port to connect on. Host can be DNS name
+		// Default to currentCluster's RPCAddress in ClusterInformation
 		HostPort string `yaml:"hostPort"`
 		// interval to refresh DNS. Default to 10s
 		RefreshInterval time.Duration `yaml:"RefreshInterval"`

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -51,17 +51,22 @@ func TestFillingDefaultSQLEncodingDecodingTypes(t *testing.T) {
 	assert.Equal(t, []string{string(common.EncodingTypeThriftRW)}, cfg.Persistence.DataStores["sql"].SQL.DecodingTypes)
 }
 
-func TestFillingDefaultRpcName(t *testing.T) {
+func TestFillingDefaultRpcNameAndAddress(t *testing.T) {
 	cfg := &Config{
 		ClusterMetadata: &ClusterMetadata{
+			CurrentClusterName: "clusterA",
 			ClusterInformation: map[string]ClusterInformation{
 				"clusterA": {},
 			},
+		},
+		PublicClient: PublicClient{
+			HostPort: "127.0.0.1:7933",
 		},
 	}
 
 	cfg.fillDefaults()
 	assert.Equal(t, "cadence-frontend", cfg.ClusterMetadata.ClusterInformation["clusterA"].RPCName)
+	assert.Equal(t, "127.0.0.1:7933", cfg.ClusterMetadata.ClusterInformation["clusterA"].RPCAddress)
 }
 
 func TestConfigFallbacks(t *testing.T) {

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -45,6 +45,7 @@ func TestFillingDefaultSQLEncodingDecodingTypes(t *testing.T) {
 				},
 			},
 		},
+		ClusterMetadata: &ClusterMetadata{},
 	}
 	cfg.fillDefaults()
 	assert.Equal(t, string(common.EncodingTypeThriftRW), cfg.Persistence.DataStores["sql"].SQL.EncodingType)
@@ -56,17 +57,19 @@ func TestFillingDefaultRpcNameAndAddress(t *testing.T) {
 		ClusterMetadata: &ClusterMetadata{
 			CurrentClusterName: "clusterA",
 			ClusterInformation: map[string]ClusterInformation{
-				"clusterA": {},
+				"clusterA": {
+					RPCAddress: "127.0.0.1:7933",
+				},
 			},
 		},
 		PublicClient: PublicClient{
-			HostPort: "127.0.0.1:7933",
+			HostPort: "",
 		},
 	}
 
 	cfg.fillDefaults()
 	assert.Equal(t, "cadence-frontend", cfg.ClusterMetadata.ClusterInformation["clusterA"].RPCName)
-	assert.Equal(t, "127.0.0.1:7933", cfg.ClusterMetadata.ClusterInformation["clusterA"].RPCAddress)
+	assert.Equal(t, "127.0.0.1:7933", cfg.PublicClient.HostPort)
 }
 
 func TestConfigFallbacks(t *testing.T) {

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -80,6 +80,7 @@ clusterMetadata:
     active:
       enabled: true
       initialFailoverVersion: 0
+      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "noop"
@@ -111,9 +112,6 @@ domainDefaults:
     visibility:
       status: "enabled"
       URI: "file:///tmp/cadence_vis_archival/development"
-
-publicClient:
-  hostPort: "localhost:7933"
 
 dynamicconfig:
   client: filebased

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -80,7 +80,7 @@ clusterMetadata:
     active:
       enabled: true
       initialFailoverVersion: 0
-      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:7933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -80,8 +80,6 @@ clusterMetadata:
     active:
       enabled: true
       initialFailoverVersion: 0
-      rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933"
 
 dcRedirectionPolicy:
   policy: "noop"

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -78,17 +78,17 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:7933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:8933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:9933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -78,17 +78,17 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933"
+      rpcAddress: "localhost:8933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933"
+      rpcAddress: "localhost:9933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"
@@ -118,9 +118,6 @@ domainDefaults:
     visibility:
       status: "enabled"
       URI: "file:///tmp/cadence_vis_archival/development"
-
-publicClient:
-  hostPort: "localhost:7933"
 
 blobstore:
   filestore:

--- a/config/development_oauth.yaml
+++ b/config/development_oauth.yaml
@@ -1,92 +1,3 @@
-persistence:
-  defaultStore: cass-default
-  visibilityStore: cass-visibility
-  numHistoryShards: 4
-  datastores:
-    cass-default:
-      nosql:
-        pluginName: "cassandra"
-        hosts: "127.0.0.1"
-        keyspace: "cadence"
-    cass-visibility:
-      nosql:
-        pluginName: "cassandra"
-        hosts: "127.0.0.1"
-        keyspace: "cadence_visibility"
-
-ringpop:
-  name: cadence
-  bootstrapMode: hosts
-  bootstrapHosts: [ "127.0.0.1:7933", "127.0.0.1:7934", "127.0.0.1:7935" ]
-  maxJoinDuration: 30s
-
-services:
-  frontend:
-    rpc:
-      port: 7933
-      grpcPort: 7833
-      bindOnLocalHost: true
-      grpcMaxMsgSize: 33554432
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
-    pprof:
-      port: 7936
-
-  matching:
-    rpc:
-      port: 7935
-      grpcPort: 7835
-      bindOnLocalHost: true
-      grpcMaxMsgSize: 33554432
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
-    pprof:
-      port: 7938
-
-  history:
-    rpc:
-      port: 7934
-      grpcPort: 7834
-      bindOnLocalHost: true
-      grpcMaxMsgSize: 33554432
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
-    pprof:
-      port: 7937
-
-  worker:
-    rpc:
-      port: 7939
-      bindOnLocalHost: true
-    metrics:
-      statsd:
-        hostPort: "127.0.0.1:8125"
-        prefix: "cadence"
-    pprof:
-      port: 7940
-
-clusterMetadata:
-  enableGlobalDomain: true
-  failoverVersionIncrement: 10
-  masterClusterName: "active"
-  currentClusterName: "active"
-  clusterInformation:
-    active:
-      enabled: true
-      initialFailoverVersion: 0
-      rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933"
-
-dcRedirectionPolicy:
-  policy: "noop"
-  toDC: ""
-
 archival:
   history:
     status: "disabled"
@@ -103,9 +14,6 @@ domainDefaults:
     visibility:
       status: "disabled"
       URI: ""
-
-publicClient:
-  hostPort: "localhost:7933"
 
 dynamicconfig:
   client: filebased

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -78,17 +78,17 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:7933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:8933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:9933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -78,17 +78,17 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933"
+      rpcAddress: "localhost:8933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933"
+      rpcAddress: "localhost:9933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"
@@ -118,9 +118,6 @@ domainDefaults:
     visibility:
       status: "enabled"
       URI: "file:///tmp/cadence_vis_archival/development"
-
-publicClient:
-  hostPort: "localhost:9933"
 
 blobstore:
   filestore:

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -78,17 +78,17 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:7933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:8933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:9933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -78,17 +78,17 @@ clusterMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933"
+      rpcAddress: "localhost:7933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933"
+      rpcAddress: "localhost:8933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933"
+      rpcAddress: "localhost:9933" # this is to let system worker connected to the fronted end service. In cluster setup, localhost will not work
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"
@@ -118,9 +118,6 @@ domainDefaults:
     visibility:
       status: "enabled"
       URI: "file:///tmp/cadence_vis_archival/development"
-
-publicClient:
-  hostPort: "localhost:8933"
 
 blobstore:
   filestore:

--- a/config/dynamicconfig/development_oauth.yaml
+++ b/config/dynamicconfig/development_oauth.yaml
@@ -19,4 +19,6 @@ system.enableWorkflowShadower:
 system.enableFailoverManager:
   - value: false
     constraints: {}
-
+worker.enableBatcher:
+  - value: false
+    constraints: {}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. Fill currentCluster RpcAddress with publicClient as default
2. Improve config comments 
3. Remove redundant config in development_oauth.yaml

<!-- Tell your future self why have you made these changes -->
**Why?**
Improvement for https://github.com/uber/cadence/issues/3984
It's been a pain for OSS users to configure this value for a long long time. 
Also the Helmchart doesn't have an easy way to make it correct. (see https://github.com/banzaicloud/banzai-charts/pull/1278#discussion_r681587829 )


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
New unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
