### PR TITLE
Fix ndc reset workflow replication bug

### DIFF
--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -683,6 +683,613 @@ func (s *NDCIntegrationTestSuite) TestHandcraftedMultipleBranches() {
 	)
 }
 
+func (s *NDCIntegrationTestSuite) TestHandcraftedResetWorkflow_Zombie() {
+
+	s.setupRemoteFrontendClients()
+	workflowID := "ndc-handcrafted-reset-workflow-test" + uuid.New()
+	runID := uuid.New()
+	newRunID := uuid.New()
+
+	workflowType := "event-generator-workflow-type"
+	tasklist := "event-generator-taskList"
+	identity := "worker-identity"
+
+	// active has initial version 0
+	historyClient := s.active.GetHistoryClient()
+
+	eventsBatch1 := []*types.History{
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   1,
+				Version:   21,
+				EventType: types.EventTypeWorkflowExecutionStarted.Ptr(),
+				WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+					WorkflowType:                        &types.WorkflowType{Name: workflowType},
+					TaskList:                            &types.TaskList{Name: tasklist},
+					Input:                               nil,
+					ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1000),
+					FirstDecisionTaskBackoffSeconds:     common.Int32Ptr(100),
+				},
+			},
+			{
+				EventID:   2,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   3,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 2,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   4,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+				DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+					ScheduledEventID: 2,
+					StartedEventID:   3,
+					Identity:         identity,
+				},
+			},
+			{
+				EventID:   5,
+				Version:   21,
+				EventType: types.EventTypeMarkerRecorded.Ptr(),
+				MarkerRecordedEventAttributes: &types.MarkerRecordedEventAttributes{
+					MarkerName:                   "some marker name",
+					Details:                      []byte("some marker details"),
+					DecisionTaskCompletedEventID: 4,
+				},
+			},
+			{
+				EventID:   6,
+				Version:   21,
+				EventType: types.EventTypeActivityTaskScheduled.Ptr(),
+				ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+					DecisionTaskCompletedEventID:  4,
+					ActivityID:                    "0",
+					ActivityType:                  &types.ActivityType{Name: "activity-type"},
+					TaskList:                      &types.TaskList{Name: tasklist},
+					Input:                         nil,
+					ScheduleToCloseTimeoutSeconds: common.Int32Ptr(20),
+					ScheduleToStartTimeoutSeconds: common.Int32Ptr(20),
+					StartToCloseTimeoutSeconds:    common.Int32Ptr(20),
+					HeartbeatTimeoutSeconds:       common.Int32Ptr(20),
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   7,
+				Version:   21,
+				EventType: types.EventTypeActivityTaskStarted.Ptr(),
+				ActivityTaskStartedEventAttributes: &types.ActivityTaskStartedEventAttributes{
+					ScheduledEventID: 6,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+					Attempt:          0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   8,
+				Version:   21,
+				EventType: types.EventTypeWorkflowExecutionSignaled.Ptr(),
+				WorkflowExecutionSignaledEventAttributes: &types.WorkflowExecutionSignaledEventAttributes{
+					SignalName: "some signal name 1",
+					Input:      []byte("some signal details 1"),
+					Identity:   identity,
+				},
+			},
+			{
+				EventID:   9,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   10,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 9,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   11,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+				DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+					ScheduledEventID: 9,
+					StartedEventID:   10,
+					Identity:         identity,
+				},
+			},
+			{
+				EventID:   12,
+				Version:   21,
+				EventType: types.EventTypeWorkflowExecutionSignaled.Ptr(),
+				WorkflowExecutionSignaledEventAttributes: &types.WorkflowExecutionSignaledEventAttributes{
+					SignalName: "some signal name 2",
+					Input:      []byte("some signal details 2"),
+					Identity:   identity,
+				},
+			},
+			{
+				EventID:   13,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+			{
+				EventID:   14,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 13,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+	}
+
+	eventsBatch2 := []*types.History{
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   15,
+				Version:   30,
+				EventType: types.EventTypeDecisionTaskTimedOut.Ptr(),
+				DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
+					ScheduledEventID: 13,
+					StartedEventID:   14,
+					TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
+				},
+			},
+			{
+				EventID:   16,
+				Version:   30,
+				EventType: types.EventTypeActivityTaskTimedOut.Ptr(),
+				ActivityTaskTimedOutEventAttributes: &types.ActivityTaskTimedOutEventAttributes{
+					ScheduledEventID: 6,
+					StartedEventID:   7,
+					TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
+				},
+			},
+			{
+				EventID:   17,
+				Version:   30,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   18,
+				Version:   30,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 17,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+	}
+
+	resetCause := types.DecisionTaskFailedCauseResetWorkflow
+	dtFailedReason := "events-reapplication"
+	eventsBatch3 := []*types.History{
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   11,
+				Version:   22,
+				EventType: types.EventTypeDecisionTaskFailed.Ptr(),
+				DecisionTaskFailedEventAttributes: &types.DecisionTaskFailedEventAttributes{
+					ScheduledEventID: 9,
+					StartedEventID:   10,
+					Identity:         identity,
+					Cause:            &resetCause,
+					Reason:           &dtFailedReason,
+					BaseRunID:        runID,
+					NewRunID:         newRunID,
+					ForkEventVersion: 21,
+				},
+			},
+		}},
+	}
+
+	versionHistory1 := s.eventBatchesToVersionHistory(nil, eventsBatch1)
+
+	versionHistory2, err := versionHistory1.DuplicateUntilLCAItem(
+		persistence.NewVersionHistoryItem(14, 21),
+	)
+	s.NoError(err)
+	versionHistory2 = s.eventBatchesToVersionHistory(versionHistory2, eventsBatch2)
+
+	versionHistory3, err := versionHistory1.DuplicateUntilLCAItem(
+		persistence.NewVersionHistoryItem(10, 21),
+	)
+	s.NoError(err)
+	versionHistory3 = s.eventBatchesToVersionHistory(versionHistory3, eventsBatch3)
+
+	s.applyEvents(
+		workflowID,
+		runID,
+		workflowType,
+		tasklist,
+		versionHistory1,
+		eventsBatch1,
+		historyClient,
+	)
+	s.applyEvents(
+		workflowID,
+		runID,
+		workflowType,
+		tasklist,
+		versionHistory2,
+		eventsBatch2,
+		historyClient,
+	)
+	s.applyEvents(
+		workflowID,
+		newRunID,
+		workflowType,
+		tasklist,
+		versionHistory3,
+		eventsBatch3,
+		historyClient,
+	)
+}
+func (s *NDCIntegrationTestSuite) TestHandcraftedResetWorkflow() {
+
+	s.setupRemoteFrontendClients()
+	workflowID := "ndc-handcrafted-reset-workflow-test" + uuid.New()
+	runID := uuid.New()
+	newRunID := uuid.New()
+
+	workflowType := "event-generator-workflow-type"
+	tasklist := "event-generator-taskList"
+	identity := "worker-identity"
+
+	// active has initial version 0
+	historyClient := s.active.GetHistoryClient()
+
+	eventsBatch1 := []*types.History{
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   1,
+				Version:   21,
+				EventType: types.EventTypeWorkflowExecutionStarted.Ptr(),
+				WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+					WorkflowType:                        &types.WorkflowType{Name: workflowType},
+					TaskList:                            &types.TaskList{Name: tasklist},
+					Input:                               nil,
+					ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1000),
+					FirstDecisionTaskBackoffSeconds:     common.Int32Ptr(100),
+				},
+			},
+			{
+				EventID:   2,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   3,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 2,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   4,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+				DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+					ScheduledEventID: 2,
+					StartedEventID:   3,
+					Identity:         identity,
+				},
+			},
+			{
+				EventID:   5,
+				Version:   21,
+				EventType: types.EventTypeMarkerRecorded.Ptr(),
+				MarkerRecordedEventAttributes: &types.MarkerRecordedEventAttributes{
+					MarkerName:                   "some marker name",
+					Details:                      []byte("some marker details"),
+					DecisionTaskCompletedEventID: 4,
+				},
+			},
+			{
+				EventID:   6,
+				Version:   21,
+				EventType: types.EventTypeActivityTaskScheduled.Ptr(),
+				ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+					DecisionTaskCompletedEventID:  4,
+					ActivityID:                    "0",
+					ActivityType:                  &types.ActivityType{Name: "activity-type"},
+					TaskList:                      &types.TaskList{Name: tasklist},
+					Input:                         nil,
+					ScheduleToCloseTimeoutSeconds: common.Int32Ptr(20),
+					ScheduleToStartTimeoutSeconds: common.Int32Ptr(20),
+					StartToCloseTimeoutSeconds:    common.Int32Ptr(20),
+					HeartbeatTimeoutSeconds:       common.Int32Ptr(20),
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   7,
+				Version:   21,
+				EventType: types.EventTypeActivityTaskStarted.Ptr(),
+				ActivityTaskStartedEventAttributes: &types.ActivityTaskStartedEventAttributes{
+					ScheduledEventID: 6,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+					Attempt:          0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   8,
+				Version:   21,
+				EventType: types.EventTypeWorkflowExecutionSignaled.Ptr(),
+				WorkflowExecutionSignaledEventAttributes: &types.WorkflowExecutionSignaledEventAttributes{
+					SignalName: "some signal name 1",
+					Input:      []byte("some signal details 1"),
+					Identity:   identity,
+				},
+			},
+			{
+				EventID:   9,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   10,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 9,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   11,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+				DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+					ScheduledEventID: 9,
+					StartedEventID:   10,
+					Identity:         identity,
+				},
+			},
+			{
+				EventID:   12,
+				Version:   21,
+				EventType: types.EventTypeWorkflowExecutionSignaled.Ptr(),
+				WorkflowExecutionSignaledEventAttributes: &types.WorkflowExecutionSignaledEventAttributes{
+					SignalName: "some signal name 2",
+					Input:      []byte("some signal details 2"),
+					Identity:   identity,
+				},
+			},
+			{
+				EventID:   13,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+			{
+				EventID:   14,
+				Version:   21,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 13,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+	}
+
+	eventsBatch2 := []*types.History{
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   15,
+				Version:   30,
+				EventType: types.EventTypeDecisionTaskTimedOut.Ptr(),
+				DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
+					ScheduledEventID: 13,
+					StartedEventID:   14,
+					TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
+				},
+			},
+			{
+				EventID:   16,
+				Version:   30,
+				EventType: types.EventTypeActivityTaskTimedOut.Ptr(),
+				ActivityTaskTimedOutEventAttributes: &types.ActivityTaskTimedOutEventAttributes{
+					ScheduledEventID: 6,
+					StartedEventID:   7,
+					TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
+				},
+			},
+			{
+				EventID:   17,
+				Version:   30,
+				EventType: types.EventTypeDecisionTaskScheduled.Ptr(),
+				DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+					TaskList:                   &types.TaskList{Name: tasklist},
+					StartToCloseTimeoutSeconds: common.Int32Ptr(1000),
+					Attempt:                    0,
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   18,
+				Version:   30,
+				EventType: types.EventTypeDecisionTaskStarted.Ptr(),
+				DecisionTaskStartedEventAttributes: &types.DecisionTaskStartedEventAttributes{
+					ScheduledEventID: 17,
+					Identity:         identity,
+					RequestID:        uuid.New(),
+				},
+			},
+		}},
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   19,
+				Version:   30,
+				EventType: types.EventTypeDecisionTaskCompleted.Ptr(),
+				DecisionTaskCompletedEventAttributes: &types.DecisionTaskCompletedEventAttributes{
+					ScheduledEventID: 8,
+					StartedEventID:   9,
+					Identity:         identity,
+				},
+			},
+			{
+				EventID:   20,
+				Version:   30,
+				EventType: types.EventTypeWorkflowExecutionFailed.Ptr(),
+				WorkflowExecutionFailedEventAttributes: &types.WorkflowExecutionFailedEventAttributes{
+					DecisionTaskCompletedEventID: 19,
+					Reason:                       common.StringPtr("some random reason"),
+					Details:                      nil,
+				},
+			},
+		}},
+	}
+
+	resetCause := types.DecisionTaskFailedCauseResetWorkflow
+	dtFailedReason := "events-reapplication"
+	eventsBatch3 := []*types.History{
+		{Events: []*types.HistoryEvent{
+			{
+				EventID:   11,
+				Version:   22,
+				EventType: types.EventTypeDecisionTaskFailed.Ptr(),
+				DecisionTaskFailedEventAttributes: &types.DecisionTaskFailedEventAttributes{
+					ScheduledEventID: 9,
+					StartedEventID:   10,
+					Identity:         identity,
+					Cause:            &resetCause,
+					Reason:           &dtFailedReason,
+					BaseRunID:        runID,
+					NewRunID:         newRunID,
+					ForkEventVersion: 21,
+				},
+			},
+		}},
+	}
+
+	versionHistory1 := s.eventBatchesToVersionHistory(nil, eventsBatch1)
+
+	versionHistory2, err := versionHistory1.DuplicateUntilLCAItem(
+		persistence.NewVersionHistoryItem(14, 21),
+	)
+	s.NoError(err)
+	versionHistory2 = s.eventBatchesToVersionHistory(versionHistory2, eventsBatch2)
+
+	versionHistory3, err := versionHistory1.DuplicateUntilLCAItem(
+		persistence.NewVersionHistoryItem(10, 21),
+	)
+	s.NoError(err)
+	versionHistory3 = s.eventBatchesToVersionHistory(versionHistory3, eventsBatch3)
+
+	s.applyEvents(
+		workflowID,
+		runID,
+		workflowType,
+		tasklist,
+		versionHistory1,
+		eventsBatch1,
+		historyClient,
+	)
+	s.applyEvents(
+		workflowID,
+		runID,
+		workflowType,
+		tasklist,
+		versionHistory2,
+		eventsBatch2,
+		historyClient,
+	)
+	s.applyEvents(
+		workflowID,
+		newRunID,
+		workflowType,
+		tasklist,
+		versionHistory3,
+		eventsBatch3,
+		historyClient,
+	)
+}
+
 func (s *NDCIntegrationTestSuite) TestHandcraftedMultipleBranchesWithZombieContinueAsNew() {
 
 	s.setupRemoteFrontendClients()

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -74,11 +74,11 @@ type (
 			eventBatches []*persistence.WorkflowEvents,
 		) error
 
-		PersistFirstWorkflowEvents(
+		PersistStartWorkflowBatchEvents(
 			ctx context.Context,
 			workflowEvents *persistence.WorkflowEvents,
 		) (int64, error)
-		PersistNonFirstWorkflowEvents(
+		PersistNonStartWorkflowBatchEvents(
 			ctx context.Context,
 			workflowEvents *persistence.WorkflowEvents,
 		) (int64, error)
@@ -458,7 +458,7 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 	}
 	resetHistorySize := c.GetHistorySize()
 	for _, workflowEvents := range resetWorkflowEventsSeq {
-		eventsSize, err := c.PersistNonFirstWorkflowEvents(ctx, workflowEvents)
+		eventsSize, err := c.PersistNonStartWorkflowBatchEvents(ctx, workflowEvents)
 		if err != nil {
 			return err
 		}
@@ -488,7 +488,7 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 		}
 		newWorkflowSizeSize := newContext.GetHistorySize()
 		startEvents := newWorkflowEventsSeq[0]
-		eventsSize, err := c.PersistFirstWorkflowEvents(ctx, startEvents)
+		eventsSize, err := c.PersistStartWorkflowBatchEvents(ctx, startEvents)
 		if err != nil {
 			return err
 		}
@@ -518,7 +518,7 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 		}
 		currentWorkflowSize := currentContext.GetHistorySize()
 		for _, workflowEvents := range currentWorkflowEventsSeq {
-			eventsSize, err := c.PersistNonFirstWorkflowEvents(ctx, workflowEvents)
+			eventsSize, err := c.PersistNonStartWorkflowBatchEvents(ctx, workflowEvents)
 			if err != nil {
 				return err
 			}
@@ -697,7 +697,7 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 
 	currentWorkflowSize := c.GetHistorySize()
 	for _, workflowEvents := range currentWorkflowEventsSeq {
-		eventsSize, err := c.PersistNonFirstWorkflowEvents(ctx, workflowEvents)
+		eventsSize, err := c.PersistNonStartWorkflowBatchEvents(ctx, workflowEvents)
 		if err != nil {
 			return err
 		}
@@ -730,13 +730,13 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 		firstEventID := startEvents.Events[0].GetEventID()
 		var eventsSize int64
 		if firstEventID == common.FirstEventID {
-			eventsSize, err = c.PersistFirstWorkflowEvents(ctx, startEvents)
+			eventsSize, err = c.PersistStartWorkflowBatchEvents(ctx, startEvents)
 			if err != nil {
 				return err
 			}
 		} else {
 			// NOTE: This is the case for reset workflow, reset workflow already inserted a branch record
-			eventsSize, err = c.PersistNonFirstWorkflowEvents(ctx, startEvents)
+			eventsSize, err = c.PersistNonStartWorkflowBatchEvents(ctx, startEvents)
 			if err != nil {
 				return err
 			}
@@ -920,7 +920,7 @@ func (c *contextImpl) mergeContinueAsNewReplicationTasks(
 	return nil
 }
 
-func (c *contextImpl) PersistFirstWorkflowEvents(
+func (c *contextImpl) PersistStartWorkflowBatchEvents(
 	ctx context.Context,
 	workflowEvents *persistence.WorkflowEvents,
 ) (int64, error) {
@@ -956,7 +956,7 @@ func (c *contextImpl) PersistFirstWorkflowEvents(
 	return int64(size), err
 }
 
-func (c *contextImpl) PersistNonFirstWorkflowEvents(
+func (c *contextImpl) PersistNonStartWorkflowBatchEvents(
 	ctx context.Context,
 	workflowEvents *persistence.WorkflowEvents,
 ) (int64, error) {

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -251,34 +251,34 @@ func (mr *MockContextMockRecorder) ReapplyEvents(eventBatches interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReapplyEvents", reflect.TypeOf((*MockContext)(nil).ReapplyEvents), eventBatches)
 }
 
-// PersistFirstWorkflowEvents mocks base method
-func (m *MockContext) PersistFirstWorkflowEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (int64, error) {
+// PersistStartWorkflowBatchEvents mocks base method
+func (m *MockContext) PersistStartWorkflowBatchEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PersistFirstWorkflowEvents", ctx, workflowEvents)
+	ret := m.ctrl.Call(m, "PersistStartWorkflowBatchEvents", ctx, workflowEvents)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PersistFirstWorkflowEvents indicates an expected call of PersistFirstWorkflowEvents
-func (mr *MockContextMockRecorder) PersistFirstWorkflowEvents(ctx, workflowEvents interface{}) *gomock.Call {
+// PersistStartWorkflowBatchEvents indicates an expected call of PersistStartWorkflowBatchEvents
+func (mr *MockContextMockRecorder) PersistStartWorkflowBatchEvents(ctx, workflowEvents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistFirstWorkflowEvents", reflect.TypeOf((*MockContext)(nil).PersistFirstWorkflowEvents), ctx, workflowEvents)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistStartWorkflowBatchEvents", reflect.TypeOf((*MockContext)(nil).PersistStartWorkflowBatchEvents), ctx, workflowEvents)
 }
 
-// PersistNonFirstWorkflowEvents mocks base method
-func (m *MockContext) PersistNonFirstWorkflowEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (int64, error) {
+// PersistNonStartWorkflowBatchEvents mocks base method
+func (m *MockContext) PersistNonStartWorkflowBatchEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (int64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PersistNonFirstWorkflowEvents", ctx, workflowEvents)
+	ret := m.ctrl.Call(m, "PersistNonStartWorkflowBatchEvents", ctx, workflowEvents)
 	ret0, _ := ret[0].(int64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// PersistNonFirstWorkflowEvents indicates an expected call of PersistNonFirstWorkflowEvents
-func (mr *MockContextMockRecorder) PersistNonFirstWorkflowEvents(ctx, workflowEvents interface{}) *gomock.Call {
+// PersistNonStartWorkflowBatchEvents indicates an expected call of PersistNonStartWorkflowBatchEvents
+func (mr *MockContextMockRecorder) PersistNonStartWorkflowBatchEvents(ctx, workflowEvents interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistNonFirstWorkflowEvents", reflect.TypeOf((*MockContext)(nil).PersistNonFirstWorkflowEvents), ctx, workflowEvents)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PersistNonStartWorkflowBatchEvents", reflect.TypeOf((*MockContext)(nil).PersistNonStartWorkflowBatchEvents), ctx, workflowEvents)
 }
 
 // CreateWorkflowExecution mocks base method

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -639,7 +639,7 @@ func (e *historyEngineImpl) startWorkflowHelper(
 	if err != nil {
 		return nil, err
 	}
-	historySize, err := wfContext.PersistFirstWorkflowEvents(ctx, newWorkflowEventsSeq[0])
+	historySize, err := wfContext.PersistStartWorkflowBatchEvents(ctx, newWorkflowEventsSeq[0])
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/ndc/new_workflow_transaction_manager.go
+++ b/service/history/ndc/new_workflow_transaction_manager.go
@@ -157,10 +157,20 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 		return err
 	}
 
-	targetWorkflowHistorySize, err := targetWorkflow.GetContext().PersistFirstWorkflowEvents(
-		ctx,
-		targetWorkflowEventsSeq[0],
-	)
+	var targetWorkflowHistorySize int64
+	if len(targetWorkflowEventsSeq[0].Events) > 0 {
+		if targetWorkflowEventsSeq[0].Events[0].GetEventType() == types.EventTypeWorkflowExecutionStarted {
+			targetWorkflowHistorySize, err = targetWorkflow.GetContext().PersistStartWorkflowBatchEvents(
+				ctx,
+				targetWorkflowEventsSeq[0],
+			)
+		} else { // reset workflows fall into else branch
+			targetWorkflowHistorySize, err = targetWorkflow.GetContext().PersistNonStartWorkflowBatchEvents(
+				ctx,
+				targetWorkflowEventsSeq[0],
+			)
+		}
+	}
 	if err != nil {
 		return err
 	}
@@ -227,10 +237,20 @@ func (r *transactionManagerForNewWorkflowImpl) createAsZombie(
 		return err
 	}
 
-	targetWorkflowHistorySize, err := targetWorkflow.GetContext().PersistFirstWorkflowEvents(
-		ctx,
-		targetWorkflowEventsSeq[0],
-	)
+	var targetWorkflowHistorySize int64
+	if len(targetWorkflowEventsSeq[0].Events) > 0 {
+		if targetWorkflowEventsSeq[0].Events[0].GetEventType() == types.EventTypeWorkflowExecutionStarted {
+			targetWorkflowHistorySize, err = targetWorkflow.GetContext().PersistStartWorkflowBatchEvents(
+				ctx,
+				targetWorkflowEventsSeq[0],
+			)
+		} else { // reset workflows fall into else branch
+			targetWorkflowHistorySize, err = targetWorkflow.GetContext().PersistNonStartWorkflowBatchEvents(
+				ctx,
+				targetWorkflowEventsSeq[0],
+			)
+		}
+	}
 	if err != nil {
 		return err
 	}

--- a/service/history/ndc/new_workflow_transaction_manager_test.go
+++ b/service/history/ndc/new_workflow_transaction_manager_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/execution"
 )
 
@@ -108,7 +109,16 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Brand
 	workflow.EXPECT().GetReleaseFn().Return(releaseFn).AnyTimes()
 
 	workflowSnapshot := &persistence.WorkflowSnapshot{}
-	workflowEventsSeq := []*persistence.WorkflowEvents{&persistence.WorkflowEvents{}}
+	workflowStartedType := types.EventTypeWorkflowExecutionStarted
+	workflowEventsSeq := []*persistence.WorkflowEvents{
+		&persistence.WorkflowEvents{
+			Events: []*types.HistoryEvent{
+				{
+					EventType: &workflowStartedType,
+				},
+			},
+		},
+	}
 	workflowHistorySize := int64(12345)
 	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
@@ -123,7 +133,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Brand
 		ctx, domainID, workflowID,
 	).Return("", nil).Times(1)
 
-	context.EXPECT().PersistFirstWorkflowEvents(
+	context.EXPECT().PersistStartWorkflowBatchEvents(
 		gomock.Any(),
 		workflowEventsSeq[0],
 	).Return(workflowHistorySize, nil).Times(1)
@@ -170,7 +180,16 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 	currentWorkflow.EXPECT().GetReleaseFn().Return(currentReleaseFn).AnyTimes()
 
 	targetWorkflowSnapshot := &persistence.WorkflowSnapshot{}
-	targetWorkflowEventsSeq := []*persistence.WorkflowEvents{&persistence.WorkflowEvents{}}
+	workflowNonStartedType := types.EventTypeDecisionTaskScheduled // non workflow started event
+	targetWorkflowEventsSeq := []*persistence.WorkflowEvents{
+		&persistence.WorkflowEvents{
+			Events: []*types.HistoryEvent{
+				{
+					EventType: &workflowNonStartedType,
+				},
+			},
+		},
+	}
 	targetWorkflowHistorySize := int64(12345)
 	targetMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
@@ -193,7 +212,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 	}).AnyTimes()
 	currentWorkflow.EXPECT().GetVectorClock().Return(currentLastWriteVersion, int64(0), nil)
 
-	targetContext.EXPECT().PersistFirstWorkflowEvents(
+	targetContext.EXPECT().PersistNonStartWorkflowBatchEvents(
 		gomock.Any(),
 		targetWorkflowEventsSeq[0],
 	).Return(targetWorkflowHistorySize, nil).Times(1)
@@ -243,7 +262,16 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 			WorkflowID: workflowID,
 		},
 	}
-	targetWorkflowEventsSeq := []*persistence.WorkflowEvents{&persistence.WorkflowEvents{}}
+	workflowStartedType := types.EventTypeWorkflowExecutionStarted
+	targetWorkflowEventsSeq := []*persistence.WorkflowEvents{
+		&persistence.WorkflowEvents{
+			Events: []*types.HistoryEvent{
+				{
+					EventType: &workflowStartedType,
+				},
+			},
+		},
+	}
 	targetWorkflowHistorySize := int64(12345)
 	targetMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
@@ -260,7 +288,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
 	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(execution.TransactionPolicyPassive, nil).Times(1)
 
-	targetContext.EXPECT().PersistFirstWorkflowEvents(
+	targetContext.EXPECT().PersistStartWorkflowBatchEvents(
 		gomock.Any(),
 		targetWorkflowEventsSeq[0],
 	).Return(targetWorkflowHistorySize, nil).Times(1)
@@ -311,7 +339,16 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 			WorkflowID: workflowID,
 		},
 	}
-	targetWorkflowEventsSeq := []*persistence.WorkflowEvents{&persistence.WorkflowEvents{}}
+	workflowNonStartedType := types.EventTypeDecisionTaskScheduled // non workflow started event
+	targetWorkflowEventsSeq := []*persistence.WorkflowEvents{
+		&persistence.WorkflowEvents{
+			Events: []*types.HistoryEvent{
+				{
+					EventType: &workflowNonStartedType,
+				},
+			},
+		},
+	}
 	targetWorkflowHistorySize := int64(12345)
 	targetMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
@@ -328,7 +365,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 	targetWorkflow.EXPECT().HappensAfter(currentWorkflow).Return(false, nil)
 	targetWorkflow.EXPECT().SuppressBy(currentWorkflow).Return(execution.TransactionPolicyPassive, nil).Times(1)
 
-	targetContext.EXPECT().PersistFirstWorkflowEvents(
+	targetContext.EXPECT().PersistNonStartWorkflowBatchEvents(
 		gomock.Any(),
 		targetWorkflowEventsSeq[0],
 	).Return(targetWorkflowHistorySize, nil).Times(1)

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -240,7 +240,7 @@ func (r *transactionManagerImpl) backfillWorkflow(
 		}
 	}()
 
-	if _, err := targetWorkflow.GetContext().PersistNonFirstWorkflowEvents(
+	if _, err := targetWorkflow.GetContext().PersistNonStartWorkflowBatchEvents(
 		ctx,
 		targetWorkflowEvents,
 	); err != nil {

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -164,7 +164,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Op
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetDomainEntry().Return(s.domainEntry).AnyTimes()
 	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{RunID: runID}).Times(1)
-	context.EXPECT().PersistNonFirstWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyActive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -238,7 +238,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Cl
 		WorkflowID: workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil).Once()
 
-	context.EXPECT().PersistNonFirstWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -273,7 +273,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_O
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetDomainEntry().Return(s.domainEntry).AnyTimes()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonFirstWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -320,7 +320,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_C
 		WorkflowID: workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonFirstWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -375,7 +375,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active
 		WorkflowID: workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonFirstWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -429,7 +429,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passiv
 		WorkflowID: workflowID,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonFirstWorkflowEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)

--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -292,7 +292,7 @@ func (r *workflowResetterImpl) persistToDB(
 	}
 
 	// reset workflow with decision task failed or timed out
-	resetHistorySize, err = resetWorkflow.GetContext().PersistNonFirstWorkflowEvents(ctx, resetWorkflowEventsSeq[0])
+	resetHistorySize, err = resetWorkflow.GetContext().PersistNonStartWorkflowBatchEvents(ctx, resetWorkflowEventsSeq[0])
 	if err != nil {
 		return err
 	}

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -193,7 +193,7 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 		gomock.Any(),
 		execution.TransactionPolicyActive,
 	).Return(resetSnapshot, resetEventsSeq, nil).Times(1)
-	resetContext.EXPECT().PersistNonFirstWorkflowEvents(gomock.Any(), resetEventsSeq[0]).Return(resetEventsSize, nil).Times(1)
+	resetContext.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), resetEventsSeq[0]).Return(resetEventsSize, nil).Times(1)
 	resetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
 		resetSnapshot,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

1. ndc transaction manager calls `PersistNonStartWorkflowBatchEvents` when the workflow is a reset workflow
2. rename `PersistFirstWorkflowEvents` to `PersistStartWorkflowBatchEvents` and `PersistNonFirstWorkflowEvents` to `PersistNonStartWorkflowBatchEvents`

<!-- Tell your future self why have you made these changes -->
**Why?**
for reset workflows, we forked a branch in existing history, and don't need to create a new branch

rename the functions to make it less confusing for reset workflows

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test & new integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
