### PR TITLE
Automatically adjust task priority and redispatch interval based on attempts

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -780,6 +780,15 @@ const (
 	// Default value: common.ConvertIntMapToDynamicConfigMapProperty(DefaultTaskPriorityWeight)
 	// Allowed filters: N/A
 	TaskSchedulerRoundRobinWeights
+	// TaskCriticalRetryCount is the critical retry count for background tasks
+	// when task attempt exceeds this threshold:
+	// - task attempt metrics and additional error logs will be emitted
+	// - task priority will be lowered
+	// KeyName: history.taskCriticalRetryCount
+	// Value type: Int
+	// Default value: 20
+	// Allowed filters: N/A
+	TaskCriticalRetryCount
 	// ActiveTaskRedispatchInterval is the active task redispatch interval
 	// KeyName: history.activeTaskRedispatchInterval
 	// Value type: Duration
@@ -895,12 +904,6 @@ const (
 	// Default value: 10
 	// Allowed filters: N/A
 	TimerTaskWorkerCount
-	// TimerTaskMaxRetryCount is max retry count for timer processor
-	// KeyName: history.timerTaskMaxRetryCount
-	// Value type: Int
-	// Default value: 100
-	// Allowed filters: N/A
-	TimerTaskMaxRetryCount
 	// TimerProcessorGetFailureRetryCount is retry count for timer processor get failure operation
 	// KeyName: history.timerProcessorGetFailureRetryCount
 	// Value type: Int
@@ -1016,12 +1019,6 @@ const (
 	// Default value: 10
 	// Allowed filters: N/A
 	TransferTaskWorkerCount
-	// TransferTaskMaxRetryCount is max times of retry for transferQueueProcessor
-	// KeyName: history.transferTaskMaxRetryCount
-	// Value type: Int
-	// Default value: 100
-	// Allowed filters: N/A
-	TransferTaskMaxRetryCount
 	// TransferProcessorCompleteTransferFailureRetryCount is times of retry for failure
 	// KeyName: history.transferProcessorCompleteTransferFailureRetryCount
 	// Value type: Int
@@ -1113,12 +1110,6 @@ const (
 	// Default value: 10
 	// Allowed filters: N/A
 	CrossClusterTaskWorkerCount
-	// CrossClusterTaskMaxRetryCount is max times of retry for crossClusterQueueProcessor
-	// KeyName: history.crossClusterTaskMaxRetryCount
-	// Value type: Int
-	// Default value: 100
-	// Allowed filters: N/A
-	CrossClusterTaskMaxRetryCount
 	// CrossClusterProcessorCompleteTaskFailureRetryCount is times of retry for failure
 	// KeyName: history.crossClusterProcessorCompleteTaskFailureRetryCount
 	// Value type: Int
@@ -1210,12 +1201,6 @@ const (
 	// Default value: 3
 	// Allowed filters: N/A
 	ReplicatorReadTaskMaxRetryCount
-	// ReplicatorTaskMaxRetryCount is max times of retry for ReplicatorProcessor
-	// KeyName: history.replicatorTaskMaxRetryCount
-	// Value type: Int
-	// Default value: 100
-	// Allowed filters: N/A
-	ReplicatorTaskMaxRetryCount
 	// ReplicatorProcessorMaxPollRPS is max poll rate per second for ReplicatorProcessor
 	// KeyName: history.replicatorProcessorMaxPollRPS
 	// Value type: Int
@@ -2080,6 +2065,7 @@ var Keys = map[Key]string{
 	TaskSchedulerShardQueueSize:                        "history.taskSchedulerShardQueueSize",
 	TaskSchedulerDispatcherCount:                       "history.taskSchedulerDispatcherCount",
 	TaskSchedulerRoundRobinWeights:                     "history.taskSchedulerRoundRobinWeight",
+	TaskCriticalRetryCount:                             "history.taskCriticalRetryCount",
 	ActiveTaskRedispatchInterval:                       "history.activeTaskRedispatchInterval",
 	StandbyTaskRedispatchInterval:                      "history.standbyTaskRedispatchInterval",
 	TaskRedispatchIntervalJitterCoefficient:            "history.taskRedispatchIntervalJitterCoefficient",
@@ -2100,7 +2086,6 @@ var Keys = map[Key]string{
 
 	TimerTaskBatchSize:                                "history.timerTaskBatchSize",
 	TimerTaskWorkerCount:                              "history.timerTaskWorkerCount",
-	TimerTaskMaxRetryCount:                            "history.timerTaskMaxRetryCount",
 	TimerProcessorGetFailureRetryCount:                "history.timerProcessorGetFailureRetryCount",
 	TimerProcessorCompleteTimerFailureRetryCount:      "history.timerProcessorCompleteTimerFailureRetryCount",
 	TimerProcessorUpdateAckInterval:                   "history.timerProcessorUpdateAckInterval",
@@ -2121,7 +2106,6 @@ var Keys = map[Key]string{
 	TransferProcessorFailoverMaxPollRPS:                  "history.transferProcessorFailoverMaxPollRPS",
 	TransferProcessorMaxPollRPS:                          "history.transferProcessorMaxPollRPS",
 	TransferTaskWorkerCount:                              "history.transferTaskWorkerCount",
-	TransferTaskMaxRetryCount:                            "history.transferTaskMaxRetryCount",
 	TransferProcessorCompleteTransferFailureRetryCount:   "history.transferProcessorCompleteTransferFailureRetryCount",
 	TransferProcessorMaxPollInterval:                     "history.transferProcessorMaxPollInterval",
 	TransferProcessorMaxPollIntervalJitterCoefficient:    "history.transferProcessorMaxPollIntervalJitterCoefficient",
@@ -2138,7 +2122,6 @@ var Keys = map[Key]string{
 	CrossClusterTaskBatchSize:                                "history.crossClusterTaskBatchSize",
 	CrossClusterProcessorMaxPollRPS:                          "history.crossClusterProcessorMaxPollRPS",
 	CrossClusterTaskWorkerCount:                              "history.crossClusterTaskWorkerCount",
-	CrossClusterTaskMaxRetryCount:                            "history.crossClusterTaskMaxRetryCount",
 	CrossClusterProcessorCompleteTaskFailureRetryCount:       "history.crossClusterProcessorCompleteTaskFailureRetryCount",
 	CrossClusterProcessorMaxPollInterval:                     "history.crossClusterProcessorMaxPollInterval",
 	CrossClusterProcessorMaxPollIntervalJitterCoefficient:    "history.crossClusterProcessorMaxPollIntervalJitterCoefficient",
@@ -2155,7 +2138,6 @@ var Keys = map[Key]string{
 	ReplicatorTaskBatchSize:                               "history.replicatorTaskBatchSize",
 	ReplicatorTaskWorkerCount:                             "history.replicatorTaskWorkerCount",
 	ReplicatorReadTaskMaxRetryCount:                       "history.replicatorReadTaskMaxRetryCount",
-	ReplicatorTaskMaxRetryCount:                           "history.replicatorTaskMaxRetryCount",
 	ReplicatorProcessorMaxPollRPS:                         "history.replicatorProcessorMaxPollRPS",
 	ReplicatorProcessorMaxPollInterval:                    "history.replicatorProcessorMaxPollInterval",
 	ReplicatorProcessorMaxPollIntervalJitterCoefficient:   "history.replicatorProcessorMaxPollIntervalJitterCoefficient",

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -94,6 +94,7 @@ type Config struct {
 	TaskSchedulerShardQueueSize             dynamicconfig.IntPropertyFn
 	TaskSchedulerDispatcherCount            dynamicconfig.IntPropertyFn
 	TaskSchedulerRoundRobinWeights          dynamicconfig.MapPropertyFn
+	TaskCriticalRetryCount                  dynamicconfig.IntPropertyFn
 	ActiveTaskRedispatchInterval            dynamicconfig.DurationPropertyFn
 	StandbyTaskRedispatchInterval           dynamicconfig.DurationPropertyFn
 	TaskRedispatchIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
@@ -118,7 +119,6 @@ type Config struct {
 	// TimerQueueProcessor settings
 	TimerTaskBatchSize                                dynamicconfig.IntPropertyFn
 	TimerTaskWorkerCount                              dynamicconfig.IntPropertyFn
-	TimerTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
 	TimerProcessorGetFailureRetryCount                dynamicconfig.IntPropertyFn
 	TimerProcessorCompleteTimerFailureRetryCount      dynamicconfig.IntPropertyFn
 	TimerProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
@@ -138,7 +138,6 @@ type Config struct {
 	// TransferQueueProcessor settings
 	TransferTaskBatchSize                                dynamicconfig.IntPropertyFn
 	TransferTaskWorkerCount                              dynamicconfig.IntPropertyFn
-	TransferTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
 	TransferProcessorCompleteTransferFailureRetryCount   dynamicconfig.IntPropertyFn
 	TransferProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
 	TransferProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
@@ -157,7 +156,6 @@ type Config struct {
 	// CrossClusterQueueProcessor settings
 	CrossClusterTaskBatchSize                                dynamicconfig.IntPropertyFn
 	CrossClusterTaskWorkerCount                              dynamicconfig.IntPropertyFn
-	CrossClusterTaskMaxRetryCount                            dynamicconfig.IntPropertyFn
 	CrossClusterProcessorCompleteTaskFailureRetryCount       dynamicconfig.IntPropertyFn
 	CrossClusterProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
 	CrossClusterProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
@@ -175,7 +173,6 @@ type Config struct {
 	// ReplicatorQueueProcessor settings
 	ReplicatorTaskBatchSize                               dynamicconfig.IntPropertyFn
 	ReplicatorTaskWorkerCount                             dynamicconfig.IntPropertyFn
-	ReplicatorTaskMaxRetryCount                           dynamicconfig.IntPropertyFn
 	ReplicatorReadTaskMaxRetryCount                       dynamicconfig.IntPropertyFn
 	ReplicatorProcessorMaxPollRPS                         dynamicconfig.IntPropertyFn
 	ReplicatorProcessorMaxPollInterval                    dynamicconfig.DurationPropertyFn
@@ -373,6 +370,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		TaskSchedulerShardQueueSize:             dc.GetIntProperty(dynamicconfig.TaskSchedulerShardQueueSize, 200),
 		TaskSchedulerDispatcherCount:            dc.GetIntProperty(dynamicconfig.TaskSchedulerDispatcherCount, 1),
 		TaskSchedulerRoundRobinWeights:          dc.GetMapProperty(dynamicconfig.TaskSchedulerRoundRobinWeights, common.ConvertIntMapToDynamicConfigMapProperty(DefaultTaskPriorityWeight)),
+		TaskCriticalRetryCount:                  dc.GetIntProperty(dynamicconfig.TaskCriticalRetryCount, 50),
 		ActiveTaskRedispatchInterval:            dc.GetDurationProperty(dynamicconfig.ActiveTaskRedispatchInterval, 5*time.Second),
 		StandbyTaskRedispatchInterval:           dc.GetDurationProperty(dynamicconfig.StandbyTaskRedispatchInterval, 30*time.Second),
 		TaskRedispatchIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.TaskRedispatchIntervalJitterCoefficient, 0.15),
@@ -395,7 +393,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 
 		TimerTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.TimerTaskBatchSize, 100),
 		TimerTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.TimerTaskWorkerCount, 10),
-		TimerTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.TimerTaskMaxRetryCount, 100),
 		TimerProcessorGetFailureRetryCount:                dc.GetIntProperty(dynamicconfig.TimerProcessorGetFailureRetryCount, 5),
 		TimerProcessorCompleteTimerFailureRetryCount:      dc.GetIntProperty(dynamicconfig.TimerProcessorCompleteTimerFailureRetryCount, 10),
 		TimerProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicconfig.TimerProcessorUpdateAckInterval, 30*time.Second),
@@ -416,7 +413,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		TransferProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.TransferProcessorFailoverMaxPollRPS, 1),
 		TransferProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollRPS, 20),
 		TransferTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.TransferTaskWorkerCount, 10),
-		TransferTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.TransferTaskMaxRetryCount, 100),
 		TransferProcessorCompleteTransferFailureRetryCount:   dc.GetIntProperty(dynamicconfig.TransferProcessorCompleteTransferFailureRetryCount, 10),
 		TransferProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.TransferProcessorMaxPollInterval, 1*time.Minute),
 		TransferProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.TransferProcessorMaxPollIntervalJitterCoefficient, 0.15),
@@ -433,7 +429,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		CrossClusterTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.CrossClusterTaskBatchSize, 100),
 		CrossClusterProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.CrossClusterProcessorMaxPollRPS, 20),
 		CrossClusterTaskWorkerCount:                              dc.GetIntProperty(dynamicconfig.CrossClusterTaskWorkerCount, 10),
-		CrossClusterTaskMaxRetryCount:                            dc.GetIntProperty(dynamicconfig.CrossClusterTaskMaxRetryCount, 100),
 		CrossClusterProcessorCompleteTaskFailureRetryCount:       dc.GetIntProperty(dynamicconfig.CrossClusterProcessorCompleteTaskFailureRetryCount, 10),
 		CrossClusterProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.CrossClusterProcessorMaxPollInterval, 1*time.Minute),
 		CrossClusterProcessorMaxPollIntervalJitterCoefficient:    dc.GetFloat64Property(dynamicconfig.CrossClusterProcessorMaxPollIntervalJitterCoefficient, 0.15),
@@ -449,7 +444,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 
 		ReplicatorTaskBatchSize:                               dc.GetIntProperty(dynamicconfig.ReplicatorTaskBatchSize, 100),
 		ReplicatorTaskWorkerCount:                             dc.GetIntProperty(dynamicconfig.ReplicatorTaskWorkerCount, 10),
-		ReplicatorTaskMaxRetryCount:                           dc.GetIntProperty(dynamicconfig.ReplicatorTaskMaxRetryCount, 100),
 		ReplicatorReadTaskMaxRetryCount:                       dc.GetIntProperty(dynamicconfig.ReplicatorReadTaskMaxRetryCount, 3),
 		ReplicatorProcessorMaxPollRPS:                         dc.GetIntProperty(dynamicconfig.ReplicatorProcessorMaxPollRPS, 20),
 		ReplicatorProcessorMaxPollInterval:                    dc.GetDurationProperty(dynamicconfig.ReplicatorProcessorMaxPollInterval, 1*time.Minute),

--- a/service/history/queue/cross_cluster_queue_processor_base.go
+++ b/service/history/queue/cross_cluster_queue_processor_base.go
@@ -153,7 +153,7 @@ func newCrossClusterQueueProcessorBaseHelper(
 			func(t task.Task) {
 				_, _ = base.submitTask(t)
 			},
-			shard.GetConfig().CrossClusterTaskMaxRetryCount,
+			shard.GetConfig().TaskCriticalRetryCount,
 		)
 	}
 	return base

--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -131,6 +131,7 @@ func newProcessorBase(
 		taskProcessor: taskProcessor,
 		redispatcher: task.NewRedispatcher(
 			taskProcessor,
+			shard.GetTimeSource(),
 			&task.RedispatcherOptions{
 				TaskRedispatchInterval:                  options.RedispatchInterval,
 				TaskRedispatchIntervalJitterCoefficient: options.RedispatchIntervalJitterCoefficient,

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -128,7 +128,7 @@ func newTimerQueueProcessorBase(
 				taskExecutor,
 				taskProcessor,
 				processorBase.redispatcher.AddTask,
-				shard.GetConfig().TimerTaskMaxRetryCount,
+				shard.GetConfig().TaskCriticalRetryCount,
 			)
 		},
 

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -121,7 +121,7 @@ func newTransferQueueProcessorBase(
 				taskExecutor,
 				taskProcessor,
 				processorBase.redispatcher.AddTask,
-				shard.GetConfig().TransferTaskMaxRetryCount,
+				shard.GetConfig().TaskCriticalRetryCount,
 			)
 		},
 

--- a/service/history/task/cross_cluster_task_processor.go
+++ b/service/history/task/cross_cluster_task_processor.go
@@ -133,6 +133,7 @@ func newCrossClusterTaskProcessor(
 		taskFetcher: taskFetcher,
 		redispatcher: NewRedispatcher(
 			taskProcessor,
+			shard.GetTimeSource(),
 			&RedispatcherOptions{
 				TaskRedispatchInterval:                  options.TaskRedispatchInterval,
 				TaskRedispatchIntervalJitterCoefficient: options.TimerJitterCoefficient,

--- a/service/history/task/priority_assigner.go
+++ b/service/history/task/priority_assigner.go
@@ -33,6 +33,12 @@ import (
 	"github.com/uber/cadence/service/history/config"
 )
 
+var (
+	highTaskPriority    = task.GetTaskPriority(task.HighPriorityClass, task.DefaultPrioritySubclass)
+	defaultTaskPriority = task.GetTaskPriority(task.DefaultPriorityClass, task.DefaultPrioritySubclass)
+	lowTaskPriority     = task.GetTaskPriority(task.LowPriorityClass, task.DefaultPrioritySubclass)
+)
+
 type (
 	priorityAssignerImpl struct {
 		sync.RWMutex
@@ -69,19 +75,23 @@ func NewPriorityAssigner(
 func (a *priorityAssignerImpl) Assign(
 	queueTask Task,
 ) error {
-	if queueTask.Priority() != task.NoPriority {
+	if priority := queueTask.Priority(); priority != task.NoPriority {
+		if priority != lowTaskPriority && queueTask.GetAttempt() > a.config.TaskCriticalRetryCount() {
+			// automatically lower the priority if task attempt exceeds certain threshold
+			queueTask.SetPriority(lowTaskPriority)
+		}
 		return nil
 	}
 
 	queueType := queueTask.GetQueueType()
 
 	if queueType == QueueTypeReplication {
-		queueTask.SetPriority(task.GetTaskPriority(task.LowPriorityClass, task.DefaultPrioritySubclass))
+		queueTask.SetPriority(lowTaskPriority)
 		return nil
 	}
 
 	// timer or transfer task, first check if task is active or not and if domain is active or not
-	isActiveTask := queueType == QueueTypeActiveTimer || queueType == QueueTypeActiveTransfer
+	isActiveTask := queueType == QueueTypeActiveTimer || queueType == QueueTypeActiveTransfer || queueType == QueueTypeCrossCluster
 	domainName, isActiveDomain, err := a.getDomainInfo(queueTask.GetDomainID())
 	if err != nil {
 		return err
@@ -95,7 +105,7 @@ func (a *priorityAssignerImpl) Assign(
 
 	if !isActiveTask && !isActiveDomain {
 		// only assign low priority to tasks in the fourth case
-		queueTask.SetPriority(task.GetTaskPriority(task.LowPriorityClass, task.DefaultPrioritySubclass))
+		queueTask.SetPriority(lowTaskPriority)
 		return nil
 	}
 
@@ -104,7 +114,7 @@ func (a *priorityAssignerImpl) Assign(
 	// it can be quickly verified/acked and won't prevent the ack level in the processor from advancing
 	// (especially for active processor)
 	if !a.getRateLimiter(domainName).Allow() {
-		queueTask.SetPriority(task.GetTaskPriority(task.DefaultPriorityClass, task.DefaultPrioritySubclass))
+		queueTask.SetPriority(defaultTaskPriority)
 		taggedScope := a.scope.Tagged(metrics.DomainTag(domainName))
 		if queueType == QueueTypeActiveTransfer || queueType == QueueTypeStandbyTransfer {
 			taggedScope.IncCounter(metrics.TransferTaskThrottledCounter)
@@ -114,7 +124,7 @@ func (a *priorityAssignerImpl) Assign(
 		return nil
 	}
 
-	queueTask.SetPriority(task.GetTaskPriority(task.HighPriorityClass, task.DefaultPrioritySubclass))
+	queueTask.SetPriority(highTaskPriority)
 	return nil
 }
 

--- a/service/history/task/redispatcher.go
+++ b/service/history/task/redispatcher.go
@@ -21,12 +21,14 @@
 package task
 
 import (
+	"sort"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -35,6 +37,9 @@ import (
 
 const (
 	defaultBufferSize = 200
+
+	redispatchBackoffCoefficient  = 1.2
+	redispatchMaxBackoffInternval = 2 * time.Minute
 )
 
 type (
@@ -53,6 +58,7 @@ type (
 		sync.Mutex
 
 		taskProcessor Processor
+		timeSource    clock.TimeSource
 		options       *RedispatcherOptions
 		logger        log.Logger
 		metricsScope  metrics.Scope
@@ -62,19 +68,33 @@ type (
 		shutdownWG      sync.WaitGroup
 		redispatchCh    chan redispatchNotification
 		redispatchTimer *time.Timer
-		taskQueues      map[int][]Task // priority -> redispatch queue
+		backoffPolicy   backoff.RetryPolicy
+		taskQueues      map[int][]redispatchTask // priority -> redispatch queue
+		taskChFull      map[int]bool             // priority -> if taskCh is full
+	}
+
+	redispatchTask struct {
+		task           Task
+		redispatchTime time.Time
 	}
 )
 
 // NewRedispatcher creates a new task Redispatcher
 func NewRedispatcher(
 	taskProcessor Processor,
+	timeSource clock.TimeSource,
 	options *RedispatcherOptions,
 	logger log.Logger,
 	metricsScope metrics.Scope,
 ) Redispatcher {
+	backoffPolicy := backoff.NewExponentialRetryPolicy(options.TaskRedispatchInterval())
+	backoffPolicy.SetBackoffCoefficient(redispatchBackoffCoefficient)
+	backoffPolicy.SetMaximumInterval(redispatchMaxBackoffInternval)
+	backoffPolicy.SetExpirationInterval(backoff.NoInterval)
+
 	return &redispatcherImpl{
 		taskProcessor:   taskProcessor,
+		timeSource:      timeSource,
 		options:         options,
 		logger:          logger,
 		metricsScope:    metricsScope,
@@ -82,7 +102,9 @@ func NewRedispatcher(
 		shutdownCh:      make(chan struct{}),
 		redispatchCh:    make(chan redispatchNotification, 1),
 		redispatchTimer: nil,
-		taskQueues:      make(map[int][]Task),
+		backoffPolicy:   backoffPolicy,
+		taskQueues:      make(map[int][]redispatchTask),
+		taskChFull:      make(map[int]bool),
 	}
 }
 
@@ -121,15 +143,19 @@ func (r *redispatcherImpl) Stop() {
 func (r *redispatcherImpl) AddTask(
 	task Task,
 ) {
+	priority := task.Priority()
+	attempt := task.GetAttempt()
+
 	r.Lock()
 	defer r.Unlock()
-
-	priority := task.Priority()
 	queue, ok := r.taskQueues[priority]
 	if !ok {
-		queue = make([]Task, 0)
+		queue = make([]redispatchTask, 0)
 	}
-	r.taskQueues[priority] = append(queue, task)
+	r.taskQueues[priority] = append(queue, redispatchTask{
+		task:           task,
+		redispatchTime: r.getRedispatchTime(attempt),
+	})
 
 	r.setupTimerLocked()
 }
@@ -203,43 +229,58 @@ func (r *redispatcherImpl) redispatchTasks(
 	}
 
 	totalRedispatched := 0
+	now := r.timeSource.Now()
+	for priority := range r.taskQueues {
+		r.taskChFull[priority] = false
+	}
+
 	for priority, queue := range r.taskQueues {
-		queueLen := len(queue)
-		for i := 0; i != queueLen; i++ {
-			if totalRedispatched >= targetRedispatched {
+		// sort by redispatch time
+		sort.Slice(queue, func(i, j int) bool {
+			return queue[i].redispatchTime.Before(queue[j].redispatchTime)
+		})
+
+		newStartIdx := 0
+		for _, redispatchTask := range queue {
+			if totalRedispatched >= targetRedispatched ||
+				r.taskChFull[priority] ||
+				redispatchTask.redispatchTime.After(now) {
+				// Note the second condition regarding taskChFull is not 100% accurate
+				// since task may get a new, lower priority upon redispatch, and
+				// the taskCh for the new priority may not be full.
+				// But the current estimation should be good enough as task with
+				// lower priority should be executed after high priority ones,
+				// so it's ok to leave them in the queue
 				break
 			}
 
-			task := queue[0]
-			queue[0] = nil
-			queue = queue[1:]
-
-			submitted, err := r.taskProcessor.TrySubmit(task)
+			submitted, err := r.taskProcessor.TrySubmit(redispatchTask.task)
 			if err != nil {
 				if r.isStopped() {
 					// if error is due to shard shutdown
 					break
-				} else {
-					// otherwise it might be error from domain cache etc, add
-					// the task to redispatch queue so that it can be retried
-					r.logger.Error("Failed to redispatch task", tag.Error(err))
 				}
+				// otherwise it might be error from domain cache etc, add
+				// the task to redispatch queue so that it can be retried
+				r.logger.Error("Failed to redispatch task", tag.Error(err))
 			}
 
+			newStartIdx++ // task will be either redispatched or enqueued again at here
+			newPriority := redispatchTask.task.Priority()
 			if err != nil || !submitted {
 				// failed to submit, enqueue again
-				queue = append(queue, task)
+				r.taskQueues[newPriority] = append(r.taskQueues[newPriority], redispatchTask)
 			}
-
 			if err == nil && !submitted {
-				// task chan is full for this priority, continue to next priority
-				break
+				// task chan is full for the new priority
+				r.taskChFull[newPriority] = true
 			}
-
-			totalRedispatched++
+			if submitted {
+				totalRedispatched++
+			}
 		}
 
-		r.taskQueues[priority] = queue
+		r.taskQueues[priority] = r.taskQueues[priority][newStartIdx:]
 
 		if r.isStopped() {
 			return
@@ -282,4 +323,10 @@ func (r *redispatcherImpl) sizeLocked() int {
 
 func (r *redispatcherImpl) isStopped() bool {
 	return atomic.LoadInt32(&r.status) == common.DaemonStatusStopped
+}
+
+func (r *redispatcherImpl) getRedispatchTime(attempt int) time.Time {
+	// note that elapsedTime (the first parameter) is not relevant when
+	// the retry policy has not expiration interval
+	return r.timeSource.Now().Add(r.backoffPolicy.ComputeNextDelay(0, attempt))
 }

--- a/service/history/task/redispatcher_test.go
+++ b/service/history/task/redispatcher_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
 
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/loggerimpl"
@@ -42,8 +43,9 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller    *gomock.Controller
-		mockProcessor *MockProcessor
+		controller     *gomock.Controller
+		mockProcessor  *MockProcessor
+		mockTimeSource *clock.EventTimeSource
 
 		metricsScope metrics.Scope
 		logger       log.Logger
@@ -62,12 +64,12 @@ func (s *redispatcherSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 	s.mockProcessor = NewMockProcessor(s.controller)
+	s.mockTimeSource = clock.NewEventTimeSource()
 
 	s.metricsScope = metrics.NewClient(tally.NoopScope, metrics.History).Scope(0)
 	s.logger = loggerimpl.NewLoggerForTest(s.Suite)
 
 	s.redispatcher = s.newTestRedispatcher()
-	s.redispatcher.Start()
 }
 
 func (s *redispatcherSuite) TearDownTest() {
@@ -97,14 +99,17 @@ func (s *redispatcherSuite) TestRedispatch_ProcessorShutDown() {
 	for i := 0; i != numTasks; i++ {
 		mockTask := NewMockTask(s.controller)
 		mockTask.EXPECT().Priority().Return(rand.Intn(5)).AnyTimes()
+		mockTask.EXPECT().GetAttempt().Return(0).Times(1)
 		s.redispatcher.AddTask(mockTask)
 	}
 
 	s.Equal(numTasks, s.redispatcher.Size())
+	s.mockTimeSource.Update(s.mockTimeSource.Now().Add(2 * s.redispatcher.options.TaskRedispatchInterval()))
+	s.redispatcher.Start()
 	<-s.redispatcher.shutdownCh
 	<-stopDoneCh
 
-	s.Equal(numTasks-successfullyRedispatched-1, s.redispatcher.Size())
+	s.Equal(numTasks-successfullyRedispatched, s.redispatcher.Size())
 }
 
 func (s *redispatcherSuite) TestRedispatch_WithTargetSize() {
@@ -114,10 +119,13 @@ func (s *redispatcherSuite) TestRedispatch_WithTargetSize() {
 	for i := 0; i != numTasks; i++ {
 		mockTask := NewMockTask(s.controller)
 		mockTask.EXPECT().Priority().Return(rand.Intn(5)).AnyTimes()
+		mockTask.EXPECT().GetAttempt().Return(0).Times(1)
 		s.redispatcher.AddTask(mockTask)
 		s.mockProcessor.EXPECT().TrySubmit(gomock.Any()).Return(true, nil).MaxTimes(1)
 	}
 
+	s.mockTimeSource.Update(s.mockTimeSource.Now().Add(2 * s.redispatcher.options.TaskRedispatchInterval()))
+	s.redispatcher.Start()
 	s.redispatcher.Redispatch(targetSize)
 
 	// implementation can choose to redispatch more tasks than needed
@@ -125,22 +133,57 @@ func (s *redispatcherSuite) TestRedispatch_WithTargetSize() {
 	s.True(s.redispatcher.Size() > 0)
 }
 
+func (s *redispatcherSuite) TestRedispatch_Backoff() {
+	numTasks := 50
+	numLowAttemptTasks := 0
+	numHighAttemptTasks := 0
+	for i := 0; i != numTasks; i++ {
+		attempt := 100
+		if rand.Intn(2) == 0 {
+			numLowAttemptTasks++
+			attempt = 0
+		} else {
+			numHighAttemptTasks++
+		}
+
+		mockTask := NewMockTask(s.controller)
+		mockTask.EXPECT().Priority().Return(rand.Intn(5)).AnyTimes()
+		mockTask.EXPECT().GetAttempt().Return(attempt).Times(1)
+		s.redispatcher.AddTask(mockTask)
+		s.mockProcessor.EXPECT().TrySubmit(NewMockTaskMatcher(mockTask)).Return(true, nil).MaxTimes(1)
+	}
+
+	s.mockTimeSource.Update(s.mockTimeSource.Now().Add(2 * s.redispatcher.options.TaskRedispatchInterval()))
+	s.redispatcher.Start()
+	s.redispatcher.Redispatch(0)
+
+	s.Equal(numHighAttemptTasks, s.redispatcher.Size())
+}
+
 func (s *redispatcherSuite) TestRedispatch_Random() {
-	numTasks := 10
+	numTasks := 100
 	dispatched := 0
 
 	for i := 0; i != numTasks; i++ {
-		mockTask := NewMockTask(s.controller)
-		mockTask.EXPECT().Priority().Return(rand.Intn(5)).AnyTimes()
-		s.redispatcher.AddTask(mockTask)
 		submitted := false
+		attempt := 100
 		if rand.Intn(2) == 0 {
 			submitted = true
-			dispatched++
+			if rand.Intn(2) == 0 {
+				dispatched++
+				attempt = 0
+			}
 		}
+
+		mockTask := NewMockTask(s.controller)
+		mockTask.EXPECT().Priority().Return(rand.Intn(5)).AnyTimes()
+		mockTask.EXPECT().GetAttempt().Return(attempt).Times(1)
+		s.redispatcher.AddTask(mockTask)
 		s.mockProcessor.EXPECT().TrySubmit(NewMockTaskMatcher(mockTask)).Return(submitted, nil).MaxTimes(1)
 	}
 
+	s.mockTimeSource.Update(s.mockTimeSource.Now().Add(2 * s.redispatcher.options.TaskRedispatchInterval()))
+	s.redispatcher.Start()
 	s.redispatcher.Redispatch(0)
 
 	// implementation can choose to stop redispatch for a certain priority when previous submit has failed
@@ -150,6 +193,7 @@ func (s *redispatcherSuite) TestRedispatch_Random() {
 func (s *redispatcherSuite) newTestRedispatcher() *redispatcherImpl {
 	return NewRedispatcher(
 		s.mockProcessor,
+		s.mockTimeSource,
 		&RedispatcherOptions{
 			TaskRedispatchInterval:                  dynamicconfig.GetDurationPropertyFn(time.Millisecond * 50),
 			TaskRedispatchIntervalJitterCoefficient: dynamicconfig.GetFloatPropertyFn(0.15),

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -45,6 +45,8 @@ const (
 	activeTaskResubmitMaxAttempts = 10
 
 	defaultTaskEventLoggerSize = 100
+
+	stickyTaskMaxRetryCount = 100
 )
 
 var (
@@ -61,20 +63,20 @@ type (
 		sync.Mutex
 		Info
 
-		shard         shard.Context
-		state         ctask.State
-		priority      int
-		attempt       int
-		timeSource    clock.TimeSource
-		submitTime    time.Time
-		logger        log.Logger
-		eventLogger   eventLogger
-		scopeIdx      int
-		scope         metrics.Scope // initialized when processing task to make the initialization parallel
-		taskExecutor  Executor
-		taskProcessor Processor
-		redispatchFn  func(task Task)
-		maxRetryCount dynamicconfig.IntPropertyFn
+		shard              shard.Context
+		state              ctask.State
+		priority           int
+		attempt            int
+		timeSource         clock.TimeSource
+		submitTime         time.Time
+		logger             log.Logger
+		eventLogger        eventLogger
+		scopeIdx           int
+		scope              metrics.Scope // initialized when processing task to make the initialization parallel
+		taskExecutor       Executor
+		taskProcessor      Processor
+		redispatchFn       func(task Task)
+		criticalRetryCount dynamicconfig.IntPropertyFn
 
 		// TODO: following three fields should be removed after new task lifecycle is implemented
 		taskFilter        Filter
@@ -93,7 +95,7 @@ func NewTimerTask(
 	taskExecutor Executor,
 	taskProcessor Processor,
 	redispatchFn func(task Task),
-	maxRetryCount dynamicconfig.IntPropertyFn,
+	criticalRetryCount dynamicconfig.IntPropertyFn,
 ) Task {
 	return newTask(
 		shard,
@@ -104,7 +106,7 @@ func NewTimerTask(
 		taskFilter,
 		taskExecutor,
 		taskProcessor,
-		maxRetryCount,
+		criticalRetryCount,
 		redispatchFn,
 	)
 }
@@ -119,7 +121,7 @@ func NewTransferTask(
 	taskExecutor Executor,
 	taskProcessor Processor,
 	redispatchFn func(task Task),
-	maxRetryCount dynamicconfig.IntPropertyFn,
+	criticalRetryCount dynamicconfig.IntPropertyFn,
 ) Task {
 	return newTask(
 		shard,
@@ -130,7 +132,7 @@ func NewTransferTask(
 		taskFilter,
 		taskExecutor,
 		taskProcessor,
-		maxRetryCount,
+		criticalRetryCount,
 		redispatchFn,
 	)
 }
@@ -144,7 +146,7 @@ func newTask(
 	taskFilter Filter,
 	taskExecutor Executor,
 	taskProcessor Processor,
-	maxRetryCount dynamicconfig.IntPropertyFn,
+	criticalRetryCount dynamicconfig.IntPropertyFn,
 	redispatchFn func(task Task),
 ) *taskImpl {
 	timeSource := shard.GetTimeSource()
@@ -157,23 +159,23 @@ func newTask(
 	}
 
 	return &taskImpl{
-		Info:          taskInfo,
-		shard:         shard,
-		state:         ctask.TaskStatePending,
-		priority:      ctask.NoPriority,
-		queueType:     queueType,
-		scopeIdx:      scopeIdx,
-		scope:         nil,
-		logger:        logger,
-		eventLogger:   eventLogger,
-		attempt:       0,
-		submitTime:    timeSource.Now(),
-		timeSource:    timeSource,
-		maxRetryCount: maxRetryCount,
-		redispatchFn:  redispatchFn,
-		taskFilter:    taskFilter,
-		taskExecutor:  taskExecutor,
-		taskProcessor: taskProcessor,
+		Info:               taskInfo,
+		shard:              shard,
+		state:              ctask.TaskStatePending,
+		priority:           ctask.NoPriority,
+		queueType:          queueType,
+		scopeIdx:           scopeIdx,
+		scope:              nil,
+		logger:             logger,
+		eventLogger:        eventLogger,
+		attempt:            0,
+		submitTime:         timeSource.Now(),
+		timeSource:         timeSource,
+		criticalRetryCount: criticalRetryCount,
+		redispatchFn:       redispatchFn,
+		taskFilter:         taskFilter,
+		taskExecutor:       taskExecutor,
+		taskProcessor:      taskProcessor,
 	}
 }
 
@@ -218,7 +220,7 @@ func (t *taskImpl) HandleErr(
 			defer t.Unlock()
 
 			t.attempt++
-			if t.attempt > t.maxRetryCount() {
+			if t.attempt > t.criticalRetryCount() {
 				t.scope.RecordTimer(metrics.TaskAttemptTimerPerDomain, time.Duration(t.attempt))
 				t.logger.Error("Critical error processing task, retrying.",
 					tag.Error(err), tag.OperationCritical, tag.TaskType(t.GetTaskType()))
@@ -294,7 +296,7 @@ func (t *taskImpl) HandleErr(
 		return nil
 	}
 
-	if t.GetAttempt() > t.maxRetryCount() && common.IsStickyTaskConditionError(err) {
+	if t.GetAttempt() > stickyTaskMaxRetryCount && common.IsStickyTaskConditionError(err) {
 		// sticky task could end up into endless loop in rare cases and
 		// cause worker to keep getting decision timeout unless restart.
 		// return nil here to break the endless loop


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Automatically adjust task priority to low when task is keep retrying
- Assign different redispatch backoff interval for different tasks based on number of attempts

<!-- Tell your future self why have you made these changes -->
**Why?**
- Reducing the impact of tasks that are keep retrying.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
