### PR TITLE
Expose invalid timer value in the error message

### DIFF
--- a/service/history/decision/checker.go
+++ b/service/history/decision/checker.go
@@ -363,7 +363,9 @@ func (v *attrValidator) validateTimerScheduleAttributes(
 		return &types.BadRequestError{Message: "TimerId exceeds length limit."}
 	}
 	if attributes.GetStartToFireTimeoutSeconds() <= 0 {
-		return &types.BadRequestError{Message: "A valid StartToFireTimeoutSeconds is not set on decision."}
+		return &types.BadRequestError{
+			Message: fmt.Sprintf("Invalid StartToFireTimeoutSeconds: %v", attributes.GetStartToFireTimeoutSeconds()),
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Currently, if the timer has an invalid value; the error just says it's invalid. With this change, it will also tell the value of it.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
