### PR TITLE
gRPC for cross DC traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find a list of previous releases on the [github releases](https://github.com/uber/cadence/releases) page.
 
 ## [Unreleased]
+### Added
+- Added gRPC support for cross domain traffic. This can be enabled in `ClusterGroupMetadata` config section with `rpcTransport: "grpc"` option. By default, tchannel is used. (#4390)
 
 ## [0.21.3] - 2021-07-17
 ### Added

--- a/client/clientBean.go
+++ b/client/clientBean.go
@@ -119,7 +119,14 @@ func NewClientBean(factory Factory, dispatcherProvider DispatcherProvider, clust
 			continue
 		}
 
-		dispatcher, err := dispatcherProvider.Get(info.RPCName, info.RPCAddress)
+		var dispatcher *yarpc.Dispatcher
+		var err error
+		switch info.RPCTransport {
+		case tchannel.TransportName:
+			dispatcher, err = dispatcherProvider.Get(info.RPCName, info.RPCAddress)
+		case grpc.TransportName:
+			dispatcher, err = dispatcherProvider.GetGRPC(info.RPCName, info.RPCAddress)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/client/clientBean.go
+++ b/client/clientBean.go
@@ -68,7 +68,7 @@ type (
 
 	// DispatcherProvider provides a dispatcher to a given address
 	DispatcherProvider interface {
-		Get(name string, address string) (*yarpc.Dispatcher, error)
+		GetTChannel(name string, address string) (*yarpc.Dispatcher, error)
 		GetGRPC(name string, address string) (*yarpc.Dispatcher, error)
 	}
 
@@ -123,7 +123,7 @@ func NewClientBean(factory Factory, dispatcherProvider DispatcherProvider, clust
 		var err error
 		switch info.RPCTransport {
 		case tchannel.TransportName:
-			dispatcher, err = dispatcherProvider.Get(info.RPCName, info.RPCAddress)
+			dispatcher, err = dispatcherProvider.GetTChannel(info.RPCName, info.RPCAddress)
 		case grpc.TransportName:
 			dispatcher, err = dispatcherProvider.GetGRPC(info.RPCName, info.RPCAddress)
 		}
@@ -265,7 +265,7 @@ func NewDNSYarpcDispatcherProvider(logger log.Logger, interval time.Duration) Di
 	}
 }
 
-func (p *dnsDispatcherProvider) Get(serviceName string, address string) (*yarpc.Dispatcher, error) {
+func (p *dnsDispatcherProvider) GetTChannel(serviceName string, address string) (*yarpc.Dispatcher, error) {
 	tchanTransport, err := tchannel.NewTransport(
 		tchannel.ServiceName(serviceName),
 		// this aim to get rid of the annoying popup about accepting incoming network connections

--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -377,5 +377,9 @@ func (cf *rpcClientFactory) newFrontendGRPCClient(hostAddress string) (frontend.
 
 func isGRPCOutbound(config transport.ClientConfig) bool {
 	namer, ok := config.GetUnaryOutbound().(transport.Namer)
-	return ok && namer.TransportName() == grpc.TransportName
+	if !ok {
+		// This should not happen, unless yarpc older than v1.43.0 is used
+		panic("Outbound does not implement transport.Namer")
+	}
+	return namer.TransportName() == grpc.TransportName
 }

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -213,7 +213,7 @@ func (s *server) startService() common.Daemon {
 		}
 	}
 
-	dispatcher, err := params.DispatcherProvider.Get(common.FrontendServiceName, s.cfg.PublicClient.HostPort)
+	dispatcher, err := params.DispatcherProvider.GetTChannel(common.FrontendServiceName, s.cfg.PublicClient.HostPort)
 	if err != nil {
 		log.Fatalf("failed to construct dispatcher: %v", err)
 	}

--- a/common/config/cluster.go
+++ b/common/config/cluster.go
@@ -23,9 +23,10 @@ package config
 import (
 	"errors"
 	"fmt"
+	"log"
+
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/transport/tchannel"
-	"log"
 
 	"go.uber.org/multierr"
 )

--- a/common/config/cluster.go
+++ b/common/config/cluster.go
@@ -23,6 +23,8 @@ package config
 import (
 	"errors"
 	"fmt"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/tchannel"
 	"log"
 
 	"go.uber.org/multierr"
@@ -59,6 +61,10 @@ type (
 		// Address indicate the remote service address(Host:Port). Host can be DNS name.
 		// For currentCluster, it's usually the same as publicClient.hostPort
 		RPCAddress string `yaml:"rpcAddress" validate:"nonzero"`
+		// RPCTransport specifies transport to use for replication traffic.
+		// Allowed values: tchannel|grpc
+		// Default: tchannel
+		RPCTransport string `yaml:"rpcTransport"`
 	}
 )
 
@@ -112,6 +118,10 @@ func (m *ClusterGroupMetadata) validate() error {
 		if info.Enabled && (len(info.RPCName) == 0 || len(info.RPCAddress) == 0) {
 			errs = multierr.Append(errs, fmt.Errorf("cluster %v: rpc name / address is empty", clusterName))
 		}
+		if info.RPCTransport != tchannel.TransportName && info.RPCTransport != grpc.TransportName {
+			errs = multierr.Append(errs, fmt.Errorf("cluster %v: rpc transport must %v or %v",
+				clusterName, tchannel.TransportName, grpc.TransportName))
+		}
 	}
 	if len(versionToClusterName) != len(m.ClusterGroup) {
 		errs = multierr.Append(errs, errors.New("initial versions of the cluster group have duplicates"))
@@ -141,7 +151,10 @@ func (m *ClusterGroupMetadata) fillDefaults() {
 		if cluster.RPCName == "" {
 			// filling RPCName with a default value if empty
 			cluster.RPCName = "cadence-frontend"
-			m.ClusterGroup[name] = cluster
 		}
+		if cluster.RPCTransport == "" {
+			cluster.RPCTransport = tchannel.TransportName
+		}
+		m.ClusterGroup[name] = cluster
 	}
 }

--- a/common/config/cluster_test.go
+++ b/common/config/cluster_test.go
@@ -38,6 +38,7 @@ func TestClusterGroupMetadataDefaults(t *testing.T) {
 
 	assert.Equal(t, "active", config.PrimaryClusterName)
 	assert.Equal(t, "cadence-frontend", config.ClusterGroup["active"].RPCName)
+	assert.Equal(t, "tchannel", config.ClusterGroup["active"].RPCTransport)
 }
 
 func TestClusterGroupMetadataValidate(t *testing.T) {
@@ -135,6 +136,15 @@ func TestClusterGroupMetadataValidate(t *testing.T) {
 			err: "cluster active: rpc name / address is empty",
 		},
 		{
+			msg: "invalid rpc transport",
+			config: modify(validClusterGroupMetadata(), func(m *ClusterGroupMetadata) {
+				active := m.ClusterGroup["active"]
+				active.RPCTransport = "invalid"
+				m.ClusterGroup["active"] = active
+			}),
+			err: "cluster active: rpc transport must tchannel or grpc",
+		},
+		{
 			msg: "initial version duplicated",
 			config: modify(validClusterGroupMetadata(), func(m *ClusterGroupMetadata) {
 				standby := m.ClusterGroup["standby"]
@@ -176,12 +186,14 @@ func validClusterGroupMetadata() *ClusterGroupMetadata {
 				InitialFailoverVersion: 0,
 				RPCName:                "cadence-frontend",
 				RPCAddress:             "localhost:7933",
+				RPCTransport:           "grpc",
 			},
 			"standby": {
 				Enabled:                true,
 				InitialFailoverVersion: 2,
 				RPCName:                "cadence-frontend",
 				RPCAddress:             "localhost:7933",
+				RPCTransport:           "grpc",
 			},
 		},
 	}

--- a/config/development_active.yaml
+++ b/config/development_active.yaml
@@ -78,17 +78,20 @@ clusterGroupMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:7833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:8833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:9833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development_other.yaml
+++ b/config/development_other.yaml
@@ -78,17 +78,20 @@ clusterGroupMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:7833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:8833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:9833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/config/development_standby.yaml
+++ b/config/development_standby.yaml
@@ -78,17 +78,20 @@ clusterGroupMetadata:
       enabled: true
       initialFailoverVersion: 1
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:7933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:7833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
     standby:
       enabled: true
       initialFailoverVersion: 0
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:8933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:8833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
     other:
       enabled: true
       initialFailoverVersion: 2
       rpcName: "cadence-frontend"
-      rpcAddress: "localhost:9933" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcAddress: "localhost:9833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
 
 dcRedirectionPolicy:
   policy: "selected-apis-forwarding"

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -214,13 +214,15 @@ clusterGroupMetadata:
             enabled: true
             initialFailoverVersion: 0
             rpcName: "cadence-frontend"
-            rpcAddress: {{ default .Env.PRIMARY_FRONTEND_SERVICE "cadence" }}:{{ default .Env.FRONTEND_PORT "7933" }}
+            rpcAddress: {{ default .Env.PRIMARY_FRONTEND_SERVICE "cadence" }}:{{ default .Env.FRONTEND_PORT "7833" }}
+            rpcTransport: "grpc"
         {{- if .Env.ENABLE_GLOBAL_DOMAIN }}
         secondary:
             enabled: true
             initialFailoverVersion: 2
             rpcName: "cadence-frontend"
-            rpcAddress: {{ default .Env.SECONDARY_FRONTEND_SERVICE "cadence-secondary" }}:{{ default .Env.FRONTEND_PORT "7933" }}
+            rpcAddress: {{ default .Env.SECONDARY_FRONTEND_SERVICE "cadence-secondary" }}:{{ default .Env.FRONTEND_PORT "7833" }}
+            rpcTransport: "grpc"
         {{- end }}
 
 

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -471,7 +471,7 @@ func (c *cadenceImpl) startHistory(
 		integrationClient := newIntegrationConfigClient(dynamicconfig.NewNopClient())
 		c.overrideHistoryDynamicConfig(integrationClient)
 		params.DynamicConfig = integrationClient
-		dispatcher, err := params.DispatcherProvider.Get(common.FrontendServiceName, c.FrontendAddress())
+		dispatcher, err := params.DispatcherProvider.GetTChannel(common.FrontendServiceName, c.FrontendAddress())
 		if err != nil {
 			c.logger.Fatal("Failed to get dispatcher for history", tag.Error(err))
 		}
@@ -590,7 +590,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]string, startWG *sync.WaitG
 		c.logger.Fatal("Failed to copy persistence config for worker", tag.Error(err))
 	}
 
-	dispatcher, err := params.DispatcherProvider.Get(common.FrontendServiceName, c.FrontendAddress())
+	dispatcher, err := params.DispatcherProvider.GetTChannel(common.FrontendServiceName, c.FrontendAddress())
 	if err != nil {
 		c.logger.Fatal("Failed to get dispatcher for worker", tag.Error(err))
 	}

--- a/host/testdata/ndc_integration_test_clusters.yaml
+++ b/host/testdata/ndc_integration_test_clusters.yaml
@@ -10,17 +10,20 @@
         enabled: true
         initialFailoverVersion: 0
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:7104"
+        rpcAddress: "127.0.0.1:7114"
+        rpcTransport: "grpc"
       standby:
         enabled: true
         initialFailoverVersion: 1
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:8104"
+        rpcAddress: "127.0.0.1:8114"
+        rpcTransport: "grpc"
       other:
         enabled: true
         initialFailoverVersion: 2
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:9104"
+        rpcAddress: "127.0.0.1:9114"
+        rpcTransport: "grpc"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -73,17 +76,20 @@
         enabled: true
         initialFailoverVersion: 0
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:7104"
+        rpcAddress: "127.0.0.1:7114"
+        rpcTransport: "grpc"
       standby:
         enabled: true
         initialFailoverVersion: 1
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:8104"
+        rpcAddress: "127.0.0.1:8114"
+        rpcTransport: "grpc"
       other:
         enabled: true
         initialFailoverVersion: 2
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:9104"
+        rpcAddress: "127.0.0.1:9114"
+        rpcTransport: "grpc"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -136,17 +142,20 @@
         enabled: true
         initialFailoverVersion: 0
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:7104"
+        rpcAddress: "127.0.0.1:7114"
+        rpcTransport: "grpc"
       standby:
         enabled: true
         initialFailoverVersion: 1
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:8104"
+        rpcAddress: "127.0.0.1:8114"
+        rpcTransport: "grpc"
       other:
         enabled: true
         initialFailoverVersion: 2
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:9104"
+        rpcAddress: "127.0.0.1:9114"
+        rpcTransport: "grpc"
   enablearchival: false
   workerconfig:
     enablearchiver: false

--- a/host/testdata/xdc_integration_es_clusters.yaml
+++ b/host/testdata/xdc_integration_es_clusters.yaml
@@ -10,12 +10,14 @@
         enabled: true
         initialFailoverVersion: 0
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:9104"
+        rpcAddress: "127.0.0.1:9114"
+        rpcTransport: "grpc"
       standby-es:
         enabled: true
         initialFailoverVersion: 1
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:10104"
+        rpcAddress: "127.0.0.1:10114"
+        rpcTransport: "grpc"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -75,12 +77,14 @@
         enabled: true
         initialFailoverVersion: 0
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:9104"
+        rpcAddress: "127.0.0.1:9114"
+        rpcTransport: "grpc"
       standby-es:
         enabled: true
         initialFailoverVersion: 1
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:10104"
+        rpcAddress: "127.0.0.1:10114"
+        rpcTransport: "grpc"
   enablearchival: false
   workerconfig:
     enablearchiver: false

--- a/host/testdata/xdc_integration_test_clusters.yaml
+++ b/host/testdata/xdc_integration_test_clusters.yaml
@@ -10,12 +10,14 @@
         enabled: true
         initialFailoverVersion: 0
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:7104"
+        rpcAddress: "127.0.0.1:7114"
+        rpcTransport: "grpc"
       standby:
         enabled: true
         initialFailoverVersion: 1
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:8104"
+        rpcAddress: "127.0.0.1:8114"
+        rpcTransport: "grpc"
   enablearchival: false
   workerconfig:
     enablearchiver: false
@@ -61,12 +63,14 @@
         enabled: true
         initialFailoverVersion: 0
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:7104"
+        rpcAddress: "127.0.0.1:7114"
+        rpcTransport: "grpc"
       standby:
         enabled: true
         initialFailoverVersion: 1
         rpcName: "cadence-frontend"
-        rpcAddress: "127.0.0.1:8104"
+        rpcAddress: "127.0.0.1:8114"
+        rpcTransport: "grpc"
   enablearchival: false
   workerconfig:
     enablearchiver: false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Updated `DispatcherProvider` interface to support creating dispatchers for gRPC. Updated `dnsDispatcherProvider` implementation to accordingly.
- Client factory will instantiate either Thrift or GRPC client based on the given dispatcher. These clients are used for:
  - admin client: for cross dc replication
  - frontend client: for request forwarding
- Updated config section within `ClusterGroupMetadata` to allow configuring cross DC transport. If not specified, it defaults to `tchannel`, as currently used.

<!-- Tell your future self why have you made these changes -->
**Why?**
To support gRPC for cross DC traffic.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Integration tests for cross DC replication.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
TChannel is still used by default, and gRPC is currently opt in to minimize risk.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Updated CHANGELOG.md

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
