### PR TITLE
Disable basic(db) visibility sampling by default

### DIFF
--- a/common/domain/failover_watcher_test.go
+++ b/common/domain/failover_watcher_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -62,10 +62,10 @@ const (
 	// Default value: FALSE
 	// Allowed filters: N/A
 	EnableGlobalDomain
-	// EnableVisibilitySampling is key for enable visibility sampling
+	// EnableVisibilitySampling is key for enable visibility sampling for basic(DB based) visibility
 	// KeyName: system.enableVisibilitySampling
 	// Value type: Bool
-	// Default value: TRUE
+	// Default value: FALSE
 	// Allowed filters: N/A
 	EnableVisibilitySampling
 	// EnableReadFromClosedExecutionV2 is key for enable read from cadence_visibility.closed_executions_v2

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -341,7 +341,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		PersistenceMaxQPS:                    dc.GetIntProperty(dynamicconfig.HistoryPersistenceMaxQPS, 9000),
 		PersistenceGlobalMaxQPS:              dc.GetIntProperty(dynamicconfig.HistoryPersistenceGlobalMaxQPS, 0),
 		ShutdownDrainDuration:                dc.GetDurationProperty(dynamicconfig.HistoryShutdownDrainDuration, 0),
-		EnableVisibilitySampling:             dc.GetBoolProperty(dynamicconfig.EnableVisibilitySampling, true),
+		EnableVisibilitySampling:             dc.GetBoolProperty(dynamicconfig.EnableVisibilitySampling, false),
 		EnableReadFromClosedExecutionV2:      dc.GetBoolProperty(dynamicconfig.EnableReadFromClosedExecutionV2, false),
 		VisibilityOpenMaxQPS:                 dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryVisibilityOpenMaxQPS, 300),
 		VisibilityClosedMaxQPS:               dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryVisibilityClosedMaxQPS, 300),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Disable basic(db) visibility sampling by default

<!-- Tell your future self why have you made these changes -->
**Why?**
Enabling this by default is very confusing. It's causing more issues than the benefits. 
From most users pov, the workflow listing results are wrong. 

Perf optimization should be an option, especially lower prioritized than the correctness.  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
No test needed

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
