### PR TITLE
Fix domain updating via grpc

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -4025,7 +4025,6 @@ func ToUpdateDomainRequest(t *apiv1.UpdateDomainRequest) *types.UpdateDomainRequ
 	request := types.UpdateDomainRequest{
 		Name:          t.Name,
 		SecurityToken: t.SecurityToken,
-		EmitMetric:    common.BoolPtr(true), // DEPRECATED - defaults to true
 	}
 	fs := newFieldSet(t.UpdateMask)
 

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -686,7 +686,7 @@ func TestTimerStartedEventAttributes(t *testing.T) {
 	}
 }
 func TestUpdateDomainRequest(t *testing.T) {
-	for _, item := range []*types.UpdateDomainRequest{nil, {EmitMetric: common.BoolPtr(true)}, &testdata.UpdateDomainRequest} {
+	for _, item := range []*types.UpdateDomainRequest{nil, {}, &testdata.UpdateDomainRequest} {
 		assert.Equal(t, item, ToUpdateDomainRequest(FromUpdateDomainRequest(item)))
 	}
 }

--- a/common/types/testdata/service_frontend.go
+++ b/common/types/testdata/service_frontend.go
@@ -69,7 +69,6 @@ var (
 		OwnerEmail:                             common.StringPtr(DomainOwnerEmail),
 		Data:                                   DomainData,
 		WorkflowExecutionRetentionPeriodInDays: common.Int32Ptr(DomainRetention),
-		EmitMetric:                             common.BoolPtr(DomainEmitMetric),
 		BadBinaries:                            &BadBinaries,
 		HistoryArchivalStatus:                  &ArchivalStatus,
 		HistoryArchivalURI:                     common.StringPtr(HistoryArchivalURI),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed deprecated field (`EmitMetric`) update when converting proto request to internal types.

<!-- Tell your future self why have you made these changes -->
**Why?**
As this field is deprecated and is not present in proto request at all, previously it was defaulted to `true` when converting to internal types. This was wrong assumption.

When doing domain failover via grpc, there is a validation that checks whether other fields are set when doing a failover. EmitMetrics is set by default in this case even if client did not provide it. This results in an error when doing a failover via grpc.

Instead - never set this field when updating domain via grpc.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated unit test, and verified locally with multicluster setup and cadence canary.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
