### PR TITLE
Fix workflow refresh for closed workflows

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -953,6 +953,9 @@ func (c *clientImpl) RefreshWorkflowTasks(
 	opts ...yarpc.CallOption,
 ) error {
 	client, err := c.getClientForWorkflowID(request.GetRequest().GetExecution().GetWorkflowID())
+	if err != nil {
+		return err
+	}
 	op := func(ctx context.Context, client Client) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()

--- a/common/log/panic.go
+++ b/common/log/panic.go
@@ -33,19 +33,18 @@ var errDefaultPanic = fmt.Errorf("panic object is not error")
 // If the panic value is not error then a default error is returned
 // We have to use pointer is because in golang: "recover return nil if was not called directly by a deferred function."
 // And we have to set the returned error otherwise our handler will return nil as error which is incorrect
+// NOTE: this function MUST be called in a deferred function
 func CapturePanic(logger Logger, retError *error) {
-	defer func() {
-		if errPanic := recover(); errPanic != nil {
-			err, ok := errPanic.(error)
-			if !ok {
-				err = errDefaultPanic
-			}
-
-			st := string(debug.Stack())
-
-			logger.Error("Panic is captured", tag.SysStackTrace(st), tag.Error(err))
-
-			*retError = err
+	if errPanic := recover(); errPanic != nil {
+		err, ok := errPanic.(error)
+		if !ok {
+			err = errDefaultPanic
 		}
-	}()
+
+		st := string(debug.Stack())
+
+		logger.Error("Panic is captured", tag.SysStackTrace(st), tag.Error(err))
+
+		*retError = err
+	}
 }

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -126,7 +126,6 @@ type (
 		GetDecisionInfo(int64) (*DecisionInfo, bool)
 		GetDomainEntry() *cache.DomainCacheEntry
 		GetStartEvent(context.Context) (*types.HistoryEvent, error)
-		GetCloseEvent(context.Context) (*types.HistoryEvent, error)
 		GetCurrentBranchToken() ([]byte, error)
 		GetVersionHistories() *persistence.VersionHistories
 		GetCurrentVersion() int64

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1700,6 +1700,7 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
 
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowStartTasks(
+		e.unixNanoToTime(event.GetTimestamp()),
 		event,
 	); err != nil {
 		return nil, err
@@ -1753,6 +1754,7 @@ func (e *mutableStateBuilder) AddWorkflowExecutionStartedEvent(
 	}
 	// TODO merge active & passive task generation
 	if err := e.taskGenerator.GenerateWorkflowStartTasks(
+		e.unixNanoToTime(event.GetTimestamp()),
 		event,
 	); err != nil {
 		return nil, err

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1161,36 +1161,6 @@ func (e *mutableStateBuilder) GetStartEvent(
 	return startEvent, nil
 }
 
-// GetCloseEvent returns the last event in history
-func (e *mutableStateBuilder) GetCloseEvent(
-	ctx context.Context,
-) (*types.HistoryEvent, error) {
-
-	if e.GetExecutionInfo().CloseStatus == persistence.WorkflowCloseStatusNone {
-		return nil, ErrMissingWorkflowCloseEvent
-	}
-
-	currentBranchToken, err := e.GetCurrentBranchToken()
-	if err != nil {
-		return nil, err
-	}
-
-	closeEvent, err := e.eventsCache.GetEvent(
-		ctx,
-		e.shard.GetShardID(),
-		e.executionInfo.DomainID,
-		e.executionInfo.WorkflowID,
-		e.executionInfo.RunID,
-		common.FirstEventID,
-		e.GetNextEventID()-1,
-		currentBranchToken,
-	)
-	if err != nil {
-		return nil, err
-	}
-	return closeEvent, nil
-}
-
 // DeletePendingChildExecution deletes details about a ChildExecutionInfo.
 func (e *mutableStateBuilder) DeletePendingChildExecution(
 	initiatedEventID int64,

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -21,8 +21,6 @@
 package execution
 
 import (
-	"context"
-	"fmt"
 	"testing"
 	"time"
 
@@ -787,60 +785,6 @@ func (s *mutableStateSuite) prepareTransientDecisionCompletionFirstBatchReplicat
 	s.NotNil(di)
 
 	return newDecisionScheduleEvent, newDecisionStartedEvent
-}
-
-func (s *mutableStateSuite) TestGetCloseEvent_WorkflowIsOpen() {
-	mutableState := s.buildWorkflowMutableState()
-
-	s.msBuilder.Load(mutableState)
-
-	closeEvent, err := s.msBuilder.GetCloseEvent(context.Background())
-	s.Error(err)
-	s.Nil(closeEvent)
-}
-
-func (s *mutableStateSuite) TestGetCloseEvent_WorkflowIsClose() {
-	mutableState := s.buildWorkflowMutableState()
-	mutableState.ExecutionInfo.State = persistence.WorkflowStateCompleted
-	mutableState.ExecutionInfo.CloseStatus = persistence.WorkflowCloseStatusCompleted
-	s.msBuilder.Load(mutableState)
-
-	expectedCloseEvent := &types.HistoryEvent{}
-
-	s.mockEventsCache.EXPECT().GetEvent(
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		common.FirstEventID,
-		s.msBuilder.GetNextEventID()-1,
-		gomock.Any(),
-	).Return(expectedCloseEvent, nil)
-	closeEvent, err := s.msBuilder.GetCloseEvent(context.Background())
-	s.NoError(err)
-	s.Equal(expectedCloseEvent, closeEvent)
-}
-
-func (s *mutableStateSuite) TestGetCloseEvent_Error() {
-	mutableState := s.buildWorkflowMutableState()
-	mutableState.ExecutionInfo.State = persistence.WorkflowStateCompleted
-	mutableState.ExecutionInfo.CloseStatus = persistence.WorkflowCloseStatusCompleted
-	s.msBuilder.Load(mutableState)
-
-	s.mockEventsCache.EXPECT().GetEvent(
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		gomock.Any(),
-		common.FirstEventID,
-		s.msBuilder.GetNextEventID()-1,
-		gomock.Any(),
-	).Return(nil, fmt.Errorf("test"))
-	closeEvent, err := s.msBuilder.GetCloseEvent(context.Background())
-	s.Error(err)
-	s.Nil(closeEvent)
 }
 
 func (s *mutableStateSuite) TestUpdateCurrentVersion_WorkflowOpen() {

--- a/service/history/execution/mutable_state_decision_task_manager.go
+++ b/service/history/execution/mutable_state_decision_task_manager.go
@@ -444,7 +444,6 @@ func (m *mutableStateDecisionTaskManagerImpl) AddFirstDecisionTaskScheduled(
 	var err error
 	if decisionBackoffDuration != 0 {
 		if err = m.msb.taskGenerator.GenerateDelayedDecisionTasks(
-			m.msb.unixNanoToTime(startEvent.GetTimestamp()),
 			startEvent,
 		); err != nil {
 			return err

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -1083,21 +1083,6 @@ func (mr *MockMutableStateMockRecorder) GetStartEvent(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetStartEvent", reflect.TypeOf((*MockMutableState)(nil).GetStartEvent), arg0)
 }
 
-// GetCloseEvent mocks base method
-func (m *MockMutableState) GetCloseEvent(arg0 context.Context) (*types.HistoryEvent, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCloseEvent", arg0)
-	ret0, _ := ret[0].(*types.HistoryEvent)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetCloseEvent indicates an expected call of GetCloseEvent
-func (mr *MockMutableStateMockRecorder) GetCloseEvent(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCloseEvent", reflect.TypeOf((*MockMutableState)(nil).GetCloseEvent), arg0)
-}
-
 // GetCurrentBranchToken mocks base method
 func (m *MockMutableState) GetCurrentBranchToken() ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -40,6 +40,7 @@ type (
 	// MutableStateTaskGenerator generates workflow transfer and timer tasks
 	MutableStateTaskGenerator interface {
 		GenerateWorkflowStartTasks(
+			now time.Time,
 			startEvent *types.HistoryEvent,
 		) error
 		GenerateWorkflowCloseTasks(
@@ -131,6 +132,7 @@ func NewMutableStateTaskGenerator(
 }
 
 func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowStartTasks(
+	now time.Time,
 	startEvent *types.HistoryEvent,
 ) error {
 
@@ -139,11 +141,10 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowStartTasks(
 
 	executionInfo := r.mutableState.GetExecutionInfo()
 	startVersion := startEvent.GetVersion()
-	startTimestamp := time.Unix(0, startEvent.GetTimestamp())
 
 	workflowTimeoutDuration := time.Duration(executionInfo.WorkflowTimeout) * time.Second
 	workflowTimeoutDuration = workflowTimeoutDuration + firstDecisionDelayDuration
-	workflowTimeoutTimestamp := startTimestamp.Add(workflowTimeoutDuration)
+	workflowTimeoutTimestamp := now.Add(workflowTimeoutDuration)
 	if !executionInfo.ExpirationTime.IsZero() && workflowTimeoutTimestamp.After(executionInfo.ExpirationTime) {
 		workflowTimeoutTimestamp = executionInfo.ExpirationTime
 	}

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -39,8 +39,11 @@ import (
 type (
 	// MutableStateTaskGenerator generates workflow transfer and timer tasks
 	MutableStateTaskGenerator interface {
+		// for workflow reset startTime should be the reset time instead of
+		// the startEvent time, so that workflow timeout timestamp can be
+		// re-calculated.
 		GenerateWorkflowStartTasks(
-			now time.Time,
+			startTime time.Time,
 			startEvent *types.HistoryEvent,
 		) error
 		GenerateWorkflowCloseTasks(
@@ -132,7 +135,7 @@ func NewMutableStateTaskGenerator(
 }
 
 func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowStartTasks(
-	now time.Time,
+	startTime time.Time,
 	startEvent *types.HistoryEvent,
 ) error {
 
@@ -144,7 +147,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowStartTasks(
 
 	workflowTimeoutDuration := time.Duration(executionInfo.WorkflowTimeout) * time.Second
 	workflowTimeoutDuration = workflowTimeoutDuration + firstDecisionDelayDuration
-	workflowTimeoutTimestamp := now.Add(workflowTimeoutDuration)
+	workflowTimeoutTimestamp := startTime.Add(workflowTimeoutDuration)
 	if !executionInfo.ExpirationTime.IsZero() && workflowTimeoutTimestamp.After(executionInfo.ExpirationTime) {
 		workflowTimeoutTimestamp = executionInfo.ExpirationTime
 	}

--- a/service/history/execution/mutable_state_task_generator_mock.go
+++ b/service/history/execution/mutable_state_task_generator_mock.go
@@ -28,7 +28,6 @@ package execution
 
 import (
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 
@@ -60,31 +59,31 @@ func (m *MockMutableStateTaskGenerator) EXPECT() *MockMutableStateTaskGeneratorM
 }
 
 // GenerateWorkflowStartTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateWorkflowStartTasks(now time.Time, startEvent *types.HistoryEvent) error {
+func (m *MockMutableStateTaskGenerator) GenerateWorkflowStartTasks(startEvent *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateWorkflowStartTasks", now, startEvent)
+	ret := m.ctrl.Call(m, "GenerateWorkflowStartTasks", startEvent)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateWorkflowStartTasks indicates an expected call of GenerateWorkflowStartTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowStartTasks(now, startEvent interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowStartTasks(startEvent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowStartTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowStartTasks), now, startEvent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowStartTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowStartTasks), startEvent)
 }
 
 // GenerateWorkflowCloseTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateWorkflowCloseTasks(now time.Time, closeEvent *types.HistoryEvent) error {
+func (m *MockMutableStateTaskGenerator) GenerateWorkflowCloseTasks(closeEvent *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateWorkflowCloseTasks", now, closeEvent)
+	ret := m.ctrl.Call(m, "GenerateWorkflowCloseTasks", closeEvent)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateWorkflowCloseTasks indicates an expected call of GenerateWorkflowCloseTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowCloseTasks(now, closeEvent interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowCloseTasks(closeEvent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowCloseTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowCloseTasks), now, closeEvent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowCloseTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowCloseTasks), closeEvent)
 }
 
 // GenerateRecordWorkflowStartedTasks mocks base method
@@ -102,17 +101,17 @@ func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateRecordWorkflowStart
 }
 
 // GenerateDelayedDecisionTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateDelayedDecisionTasks(now time.Time, startEvent *types.HistoryEvent) error {
+func (m *MockMutableStateTaskGenerator) GenerateDelayedDecisionTasks(startEvent *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateDelayedDecisionTasks", now, startEvent)
+	ret := m.ctrl.Call(m, "GenerateDelayedDecisionTasks", startEvent)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateDelayedDecisionTasks indicates an expected call of GenerateDelayedDecisionTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateDelayedDecisionTasks(now, startEvent interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateDelayedDecisionTasks(startEvent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDelayedDecisionTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateDelayedDecisionTasks), now, startEvent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateDelayedDecisionTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateDelayedDecisionTasks), startEvent)
 }
 
 // GenerateDecisionScheduleTasks mocks base method
@@ -270,29 +269,29 @@ func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateCrossClusterApplyPa
 }
 
 // GenerateActivityTimerTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateActivityTimerTasks(now time.Time) error {
+func (m *MockMutableStateTaskGenerator) GenerateActivityTimerTasks() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateActivityTimerTasks", now)
+	ret := m.ctrl.Call(m, "GenerateActivityTimerTasks")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateActivityTimerTasks indicates an expected call of GenerateActivityTimerTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateActivityTimerTasks(now interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateActivityTimerTasks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateActivityTimerTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateActivityTimerTasks), now)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateActivityTimerTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateActivityTimerTasks))
 }
 
 // GenerateUserTimerTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateUserTimerTasks(now time.Time) error {
+func (m *MockMutableStateTaskGenerator) GenerateUserTimerTasks() error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateUserTimerTasks", now)
+	ret := m.ctrl.Call(m, "GenerateUserTimerTasks")
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateUserTimerTasks indicates an expected call of GenerateUserTimerTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateUserTimerTasks(now interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateUserTimerTasks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateUserTimerTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateUserTimerTasks), now)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateUserTimerTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateUserTimerTasks))
 }

--- a/service/history/execution/mutable_state_task_generator_mock.go
+++ b/service/history/execution/mutable_state_task_generator_mock.go
@@ -60,17 +60,17 @@ func (m *MockMutableStateTaskGenerator) EXPECT() *MockMutableStateTaskGeneratorM
 }
 
 // GenerateWorkflowStartTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateWorkflowStartTasks(now time.Time, startEvent *types.HistoryEvent) error {
+func (m *MockMutableStateTaskGenerator) GenerateWorkflowStartTasks(startTime time.Time, startEvent *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateWorkflowStartTasks", now, startEvent)
+	ret := m.ctrl.Call(m, "GenerateWorkflowStartTasks", startTime, startEvent)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateWorkflowStartTasks indicates an expected call of GenerateWorkflowStartTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowStartTasks(now, startEvent interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowStartTasks(startTime, startEvent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowStartTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowStartTasks), now, startEvent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowStartTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowStartTasks), startTime, startEvent)
 }
 
 // GenerateWorkflowCloseTasks mocks base method

--- a/service/history/execution/mutable_state_task_generator_mock.go
+++ b/service/history/execution/mutable_state_task_generator_mock.go
@@ -28,6 +28,7 @@ package execution
 
 import (
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 
@@ -59,17 +60,17 @@ func (m *MockMutableStateTaskGenerator) EXPECT() *MockMutableStateTaskGeneratorM
 }
 
 // GenerateWorkflowStartTasks mocks base method
-func (m *MockMutableStateTaskGenerator) GenerateWorkflowStartTasks(startEvent *types.HistoryEvent) error {
+func (m *MockMutableStateTaskGenerator) GenerateWorkflowStartTasks(now time.Time, startEvent *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GenerateWorkflowStartTasks", startEvent)
+	ret := m.ctrl.Call(m, "GenerateWorkflowStartTasks", now, startEvent)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // GenerateWorkflowStartTasks indicates an expected call of GenerateWorkflowStartTasks
-func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowStartTasks(startEvent interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskGeneratorMockRecorder) GenerateWorkflowStartTasks(now, startEvent interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowStartTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowStartTasks), startEvent)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GenerateWorkflowStartTasks", reflect.TypeOf((*MockMutableStateTaskGenerator)(nil).GenerateWorkflowStartTasks), now, startEvent)
 }
 
 // GenerateWorkflowCloseTasks mocks base method

--- a/service/history/execution/mutable_state_task_refresher.go
+++ b/service/history/execution/mutable_state_task_refresher.go
@@ -24,11 +24,9 @@ package execution
 
 import (
 	"context"
-	"time"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
@@ -42,7 +40,7 @@ var emptyTasks = []persistence.Task{}
 type (
 	// MutableStateTaskRefresher refreshes workflow transfer and timer tasks
 	MutableStateTaskRefresher interface {
-		RefreshTasks(ctx context.Context, now time.Time, mutableState MutableState) error
+		RefreshTasks(ctx context.Context, mutableState MutableState) error
 	}
 
 	mutableStateTaskRefresherImpl struct {
@@ -77,7 +75,6 @@ func NewMutableStateTaskRefresher(
 
 func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 ) error {
 
@@ -90,7 +87,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForWorkflowStart(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -99,7 +95,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForWorkflowClose(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -108,7 +103,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForRecordWorkflowStarted(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -117,7 +111,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForDecision(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -126,7 +119,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForActivity(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -135,7 +127,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForTimer(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -144,7 +135,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForChildWorkflow(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -153,7 +143,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForRequestCancelExternalWorkflow(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -162,7 +151,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForSignalExternalWorkflow(
 		ctx,
-		now,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -172,7 +160,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 	if r.config.AdvancedVisibilityWritingMode() != common.AdvancedVisibilityWritingModeOff {
 		if err := r.refreshTasksForWorkflowSearchAttr(
 			ctx,
-			now,
 			mutableState,
 			taskGenerator,
 		); err != nil {
@@ -185,7 +172,6 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowStart(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -196,7 +182,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowStart(
 	}
 
 	if err := taskGenerator.GenerateWorkflowStartTasks(
-		now,
 		startEvent,
 	); err != nil {
 		return err
@@ -205,7 +190,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowStart(
 	startAttr := startEvent.WorkflowExecutionStartedEventAttributes
 	if !mutableState.HasProcessedOrPendingDecision() && startAttr.GetFirstDecisionTaskBackoffSeconds() > 0 {
 		if err := taskGenerator.GenerateDelayedDecisionTasks(
-			now,
 			startEvent,
 		); err != nil {
 			return err
@@ -217,7 +201,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowStart(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowClose(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -229,7 +212,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowClose(
 			return err
 		}
 		return taskGenerator.GenerateWorkflowCloseTasks(
-			now,
 			closeEvent,
 		)
 	}
@@ -239,7 +221,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowClose(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForRecordWorkflowStarted(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -262,7 +243,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForRecordWorkflowStarted(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForDecision(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -292,7 +272,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForDecision(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForActivity(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -343,7 +322,6 @@ Loop:
 	}
 
 	if _, err := NewTimerSequence(
-		r.getTimeSource(now),
 		mutableState,
 	).CreateNextActivityTimer(); err != nil {
 		return err
@@ -354,7 +332,6 @@ Loop:
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForTimer(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -374,7 +351,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForTimer(
 	}
 
 	if _, err := NewTimerSequence(
-		r.getTimeSource(now),
 		mutableState,
 	).CreateNextUserTimer(); err != nil {
 		return err
@@ -385,7 +361,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForTimer(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForChildWorkflow(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -430,7 +405,6 @@ Loop:
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForRequestCancelExternalWorkflow(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -470,7 +444,6 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForRequestCancelExternalWork
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForSignalExternalWorkflow(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -510,19 +483,9 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForSignalExternalWorkflow(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowSearchAttr(
 	ctx context.Context,
-	now time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
 
 	return taskGenerator.GenerateWorkflowSearchAttrTasks()
-}
-
-func (r *mutableStateTaskRefresherImpl) getTimeSource(
-	now time.Time,
-) clock.TimeSource {
-
-	timeSource := clock.NewEventTimeSource()
-	timeSource.Update(now)
-	return timeSource
 }

--- a/service/history/execution/mutable_state_task_refresher.go
+++ b/service/history/execution/mutable_state_task_refresher.go
@@ -224,7 +224,7 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowClose(
 
 	executionInfo := mutableState.GetExecutionInfo()
 	if executionInfo.CloseStatus != persistence.WorkflowCloseStatusNone {
-		closeEvent, err := mutableState.GetCloseEvent(ctx)
+		closeEvent, err := mutableState.GetCompletionEvent(ctx)
 		if err != nil {
 			return err
 		}

--- a/service/history/execution/mutable_state_task_refresher.go
+++ b/service/history/execution/mutable_state_task_refresher.go
@@ -24,6 +24,7 @@ package execution
 
 import (
 	"context"
+	"time"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
@@ -182,6 +183,7 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowStart(
 	}
 
 	if err := taskGenerator.GenerateWorkflowStartTasks(
+		time.Unix(0, startEvent.GetTimestamp()),
 		startEvent,
 	); err != nil {
 		return err

--- a/service/history/execution/mutable_state_task_refresher_mock.go
+++ b/service/history/execution/mutable_state_task_refresher_mock.go
@@ -29,7 +29,6 @@ package execution
 import (
 	context "context"
 	reflect "reflect"
-	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -58,15 +57,15 @@ func (m *MockMutableStateTaskRefresher) EXPECT() *MockMutableStateTaskRefresherM
 }
 
 // RefreshTasks mocks base method
-func (m *MockMutableStateTaskRefresher) RefreshTasks(ctx context.Context, now time.Time, mutableState MutableState) error {
+func (m *MockMutableStateTaskRefresher) RefreshTasks(ctx context.Context, mutableState MutableState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshTasks", ctx, now, mutableState)
+	ret := m.ctrl.Call(m, "RefreshTasks", ctx, mutableState)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RefreshTasks indicates an expected call of RefreshTasks
-func (mr *MockMutableStateTaskRefresherMockRecorder) RefreshTasks(ctx, now, mutableState interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskRefresherMockRecorder) RefreshTasks(ctx, mutableState interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTasks", reflect.TypeOf((*MockMutableStateTaskRefresher)(nil).RefreshTasks), ctx, now, mutableState)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTasks", reflect.TypeOf((*MockMutableStateTaskRefresher)(nil).RefreshTasks), ctx, mutableState)
 }

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -162,7 +162,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowStartTasks(
-				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err
@@ -170,7 +169,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			if attributes.GetFirstDecisionTaskBackoffSeconds() > 0 {
 				if err := taskGenerator.GenerateDelayedDecisionTasks(
-					b.unixNanoToTime(event.GetTimestamp()),
 					event,
 				); err != nil {
 					return nil, err
@@ -524,7 +522,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
-				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err
@@ -539,7 +536,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
-				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err
@@ -554,7 +550,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
-				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err
@@ -569,7 +564,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
-				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err
@@ -584,7 +578,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
-				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err
@@ -627,7 +620,6 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowCloseTasks(
-				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err
@@ -639,14 +631,10 @@ func (b *stateBuilderImpl) ApplyEvents(
 	}
 
 	// must generate the activity timer / user timer at the very end
-	if err := taskGenerator.GenerateActivityTimerTasks(
-		b.unixNanoToTime(lastEvent.GetTimestamp()),
-	); err != nil {
+	if err := taskGenerator.GenerateActivityTimerTasks(); err != nil {
 		return nil, err
 	}
-	if err := taskGenerator.GenerateUserTimerTasks(
-		b.unixNanoToTime(lastEvent.GetTimestamp()),
-	); err != nil {
+	if err := taskGenerator.GenerateUserTimerTasks(); err != nil {
 		return nil, err
 	}
 

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -162,6 +162,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 			if err := taskGenerator.GenerateWorkflowStartTasks(
+				b.unixNanoToTime(event.GetTimestamp()),
 				event,
 			); err != nil {
 				return nil, err

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -176,6 +176,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_No
 		event,
 	).Return(nil).Times(1)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowStartTasks(
+		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -226,6 +227,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_Wi
 		event,
 	).Return(nil).Times(1)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowStartTasks(
+		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockTaskGenerator.EXPECT().GenerateDelayedDecisionTasks(
@@ -484,6 +486,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 		newRunStartedEvent,
 	).Return(nil).Times(1)
 	s.mockTaskGeneratorForNew.EXPECT().GenerateWorkflowStartTasks(
+		s.stateBuilder.unixNanoToTime(newRunStartedEvent.GetTimestamp()),
 		newRunStartedEvent,
 	).Return(nil).Times(1)
 	s.mockTaskGeneratorForNew.EXPECT().GenerateDecisionScheduleTasks(

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -129,12 +129,8 @@ func (s *stateBuilderSuite) mockUpdateVersion(events ...*types.HistoryEvent) {
 	for _, event := range events {
 		s.mockMutableState.EXPECT().UpdateCurrentVersion(event.GetVersion(), true).Times(1)
 	}
-	s.mockTaskGenerator.EXPECT().GenerateActivityTimerTasks(
-		s.stateBuilder.unixNanoToTime(events[len(events)-1].GetTimestamp()),
-	).Return(nil).Times(1)
-	s.mockTaskGenerator.EXPECT().GenerateUserTimerTasks(
-		s.stateBuilder.unixNanoToTime(events[len(events)-1].GetTimestamp()),
-	).Return(nil).Times(1)
+	s.mockTaskGenerator.EXPECT().GenerateActivityTimerTasks().Return(nil).Times(1)
+	s.mockTaskGenerator.EXPECT().GenerateUserTimerTasks().Return(nil).Times(1)
 	s.mockMutableState.EXPECT().SetHistoryBuilder(NewHistoryBuilderFromEvents(events, s.logger)).Times(1)
 }
 
@@ -180,7 +176,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_No
 		event,
 	).Return(nil).Times(1)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowStartTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -231,11 +226,9 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionStarted_Wi
 		event,
 	).Return(nil).Times(1)
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowStartTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockTaskGenerator.EXPECT().GenerateDelayedDecisionTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -267,7 +260,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTimedOut()
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -298,7 +290,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionTerminated
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -328,7 +319,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionFailed() {
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -359,7 +349,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCompleted(
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -390,7 +379,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionCanceled()
 	s.mockUpdateVersion(event)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
-		s.stateBuilder.unixNanoToTime(event.GetTimestamp()),
 		event,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -485,7 +473,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	s.mockUpdateVersion(continueAsNewEvent)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
-		s.stateBuilder.unixNanoToTime(continueAsNewEvent.GetTimestamp()),
 		continueAsNewEvent,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)
@@ -497,18 +484,13 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 		newRunStartedEvent,
 	).Return(nil).Times(1)
 	s.mockTaskGeneratorForNew.EXPECT().GenerateWorkflowStartTasks(
-		s.stateBuilder.unixNanoToTime(newRunStartedEvent.GetTimestamp()),
 		newRunStartedEvent,
 	).Return(nil).Times(1)
 	s.mockTaskGeneratorForNew.EXPECT().GenerateDecisionScheduleTasks(
 		newRunDecisionEvent.GetEventID(),
 	).Return(nil).Times(1)
-	s.mockTaskGeneratorForNew.EXPECT().GenerateActivityTimerTasks(
-		s.stateBuilder.unixNanoToTime(newRunEvents[len(newRunEvents)-1].GetTimestamp()),
-	).Return(nil).Times(1)
-	s.mockTaskGeneratorForNew.EXPECT().GenerateUserTimerTasks(
-		s.stateBuilder.unixNanoToTime(newRunEvents[len(newRunEvents)-1].GetTimestamp()),
-	).Return(nil).Times(1)
+	s.mockTaskGeneratorForNew.EXPECT().GenerateActivityTimerTasks().Return(nil).Times(1)
+	s.mockTaskGeneratorForNew.EXPECT().GenerateUserTimerTasks().Return(nil).Times(1)
 
 	newRunStateBuilder, err := s.stateBuilder.ApplyEvents(constants.TestDomainID, requestID, workflowExecution, s.toHistory(continueAsNewEvent), newRunEvents)
 	s.Nil(err)
@@ -545,7 +527,6 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeWorkflowExecutionContinuedA
 	s.mockUpdateVersion(continueAsNewEvent)
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{}).AnyTimes()
 	s.mockTaskGenerator.EXPECT().GenerateWorkflowCloseTasks(
-		s.stateBuilder.unixNanoToTime(continueAsNewEvent.GetTimestamp()),
 		continueAsNewEvent,
 	).Return(nil).Times(1)
 	s.mockMutableState.EXPECT().ClearStickyness().Times(1)

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -169,7 +169,7 @@ func (r *stateRebuilderImpl) Rebuild(
 			return nil, 0, &types.BadRequestError{Message: fmt.Sprintf(
 				"nDCStateRebuilder unable to rebuild mutable state to event ID: %v, version: %v, "+
 					"baseLastEventID + baseLastEventVersion is not the same as the last event of the last "+
-					"batch, event ID: %v, version :%v ,typicaly because of attemptting to rebuild to a middle of a batch",
+					"batch, event ID: %v, version :%v ,typically because of attemptting to rebuild to a middle of a batch",
 				baseLastEventID,
 				baseLastEventVersion,
 				lastItem.EventID,
@@ -185,7 +185,7 @@ func (r *stateRebuilderImpl) Rebuild(
 	}
 
 	// refresh tasks to be generated
-	if err := r.taskRefresher.RefreshTasks(ctx, now, rebuiltMutableState); err != nil {
+	if err := r.taskRefresher.RefreshTasks(ctx, rebuiltMutableState); err != nil {
 		return nil, 0, err
 	}
 

--- a/service/history/execution/state_rebuilder_test.go
+++ b/service/history/execution/state_rebuilder_test.go
@@ -304,7 +304,7 @@ func (s *stateRebuilderSuite) TestRebuild() {
 		1234,
 		s.mockClusterMetadata,
 	), nil).AnyTimes()
-	s.mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), now, gomock.Any()).Return(nil).Times(1)
+	s.mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 
 	rebuildMutableState, rebuiltHistorySize, err := s.nDCStateRebuilder.Rebuild(
 		context.Background(),

--- a/service/history/execution/timer_sequence.go
+++ b/service/history/execution/timer_sequence.go
@@ -28,7 +28,6 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
@@ -92,7 +91,6 @@ type (
 	}
 
 	timerSequenceImpl struct {
-		timeSource   clock.TimeSource
 		mutableState MutableState
 	}
 )
@@ -101,11 +99,9 @@ var _ TimerSequence = (*timerSequenceImpl)(nil)
 
 // NewTimerSequence creates a new timer sequence
 func NewTimerSequence(
-	timeSource clock.TimeSource,
 	mutableState MutableState,
 ) TimerSequence {
 	return &timerSequenceImpl{
-		timeSource:   timeSource,
 		mutableState: mutableState,
 	}
 }

--- a/service/history/execution/timer_sequence_test.go
+++ b/service/history/execution/timer_sequence_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
@@ -39,9 +38,8 @@ type (
 		suite.Suite
 		*require.Assertions
 
-		controller          *gomock.Controller
-		mockMutableState    *MockMutableState
-		mockEventTimeSource clock.TimeSource
+		controller       *gomock.Controller
+		mockMutableState *MockMutableState
 
 		timerSequence *timerSequenceImpl
 	}
@@ -65,9 +63,8 @@ func (s *timerSequenceSuite) SetupTest() {
 
 	s.controller = gomock.NewController(s.T())
 	s.mockMutableState = NewMockMutableState(s.controller)
-	s.mockEventTimeSource = clock.NewEventTimeSource()
 
-	s.timerSequence = NewTimerSequence(s.mockEventTimeSource, s.mockMutableState).(*timerSequenceImpl)
+	s.timerSequence = NewTimerSequence(s.mockMutableState).(*timerSequenceImpl)
 }
 
 func (s *timerSequenceSuite) TearDownTest() {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -3276,14 +3276,12 @@ func (e *historyEngineImpl) RefreshWorkflowTasks(
 		e.shard.GetShardID(),
 	)
 
-	now := e.shard.GetTimeSource().Now()
-
-	err = mutableStateTaskRefresher.RefreshTasks(ctx, now, mutableState)
+	err = mutableStateTaskRefresher.RefreshTasks(ctx, mutableState)
 	if err != nil {
 		return err
 	}
 
-	err = wfContext.UpdateWorkflowExecutionAsActive(ctx, now)
+	err = wfContext.UpdateWorkflowExecutionAsActive(ctx, e.shard.GetTimeSource().Now())
 	if err != nil {
 		return err
 	}

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -3250,7 +3250,6 @@ func (e *historyEngineImpl) RefreshWorkflowTasks(
 	domainUUID string,
 	workflowExecution types.WorkflowExecution,
 ) (retError error) {
-
 	domainEntry, err := e.shard.GetDomainCache().GetActiveDomainByID(domainUUID)
 	if err != nil {
 		return err
@@ -3266,10 +3265,6 @@ func (e *historyEngineImpl) RefreshWorkflowTasks(
 	mutableState, err := wfContext.LoadWorkflowExecution(ctx)
 	if err != nil {
 		return err
-	}
-
-	if !mutableState.IsWorkflowExecutionRunning() {
-		return nil
 	}
 
 	mutableStateTaskRefresher := execution.NewMutableStateTaskRefresher(

--- a/service/history/ndc/activity_replicator.go
+++ b/service/history/ndc/activity_replicator.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -187,7 +186,6 @@ func (r *activityReplicatorImpl) SyncActivity(
 	// passive logic need to explicitly call create timer
 	now := time.Unix(0, eventTime)
 	if _, err := execution.NewTimerSequence(
-		clock.NewEventTimeSource().Update(now),
 		mutableState,
 	).CreateNextActivityTimer(); err != nil {
 		return err

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -133,7 +133,7 @@ func (t *timerActiveTaskExecutor) executeUserTimerTimeoutTask(
 		return nil
 	}
 
-	timerSequence := t.getTimerSequence(mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	referenceTime := t.shard.GetTimeSource().Now()
 	resurrectionCheckMinDelay := t.config.ResurrectionCheckMinDelay()
 	updateMutableState := false
@@ -235,7 +235,7 @@ func (t *timerActiveTaskExecutor) executeActivityTimeoutTask(
 		return nil
 	}
 
-	timerSequence := t.getTimerSequence(mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	referenceTime := t.shard.GetTimeSource().Now()
 	resurrectionCheckMinDelay := t.config.ResurrectionCheckMinDelay()
 	updateMutableState := false
@@ -687,14 +687,6 @@ func (t *timerActiveTaskExecutor) executeWorkflowTimeoutTask(
 		),
 		newMutableState,
 	)
-}
-
-func (t *timerActiveTaskExecutor) getTimerSequence(
-	mutableState execution.MutableState,
-) execution.TimerSequence {
-
-	timeSource := t.shard.GetTimeSource()
-	return execution.NewTimerSequence(timeSource, mutableState)
 }
 
 func (t *timerActiveTaskExecutor) getResurrectedTimer(

--- a/service/history/task/timer_active_task_executor_test.go
+++ b/service/history/task/timer_active_task_executor_test.go
@@ -190,7 +190,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Fire() {
 	timerTimeout := 2 * time.Second
 	event, _ = test.AddTimerStartedEvent(mutableState, event.GetEventID(), timerID, int64(timerTimeout.Seconds()))
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextUserTimer()
 	s.NoError(err)
@@ -260,7 +260,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Noop() {
 	timerTimeout := 2 * time.Second
 	event, _ = test.AddTimerStartedEvent(mutableState, event.GetEventID(), timerID, int64(timerTimeout.Seconds()))
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextUserTimer()
 	s.NoError(err)
@@ -338,7 +338,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessUserTimerTimeout_Resurrected()
 	// omitted here to make the test easier to read
 
 	// create timer task for timer2
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks() // remove existing timer task for timerID1
 	modified, err := timerSequence.CreateNextUserTimer()
 	s.NoError(err)
@@ -445,7 +445,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 		int32(timerTimeout.Seconds()),
 	)
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -530,7 +530,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_NoRetryPolicy_
 	)
 	startedEvent := test.AddActivityTaskStartedEvent(mutableState, scheduledEvent.GetEventID(), identity)
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -622,7 +622,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 	startedEvent := test.AddActivityTaskStartedEvent(mutableState, scheduledEvent.GetEventID(), identity)
 	s.Nil(startedEvent)
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -716,7 +716,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_Re
 		},
 	)
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -812,7 +812,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_RetryPolicy_No
 	startedEvent := test.AddActivityTaskStartedEvent(mutableState, scheduledEvent.GetEventID(), identity)
 	s.Nil(startedEvent)
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -904,7 +904,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_Heartbeat_Noop
 	startedEvent := test.AddActivityTaskStartedEvent(mutableState, scheduledEvent.GetEventID(), identity)
 	s.Nil(startedEvent)
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -1003,7 +1003,7 @@ func (s *timerActiveTaskExecutorSuite) TestProcessActivityTimeout_Resurrected() 
 	// there should be a decision scheduled event after activity1 is completed
 	// omitted here to make the test easier to read
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -196,7 +196,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 	event, _ = test.AddTimerStartedEvent(mutableState, event.GetEventID(), timerID, int64(timerTimeout.Seconds()))
 	nextEventID := event.GetEventID()
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextUserTimer()
 	s.NoError(err)
@@ -279,7 +279,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Success() {
 	timerTimeout := 2 * time.Second
 	event, _ = test.AddTimerStartedEvent(mutableState, event.GetEventID(), timerID, int64(timerTimeout.Seconds()))
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextUserTimer()
 	s.NoError(err)
@@ -351,7 +351,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Multiple() {
 	timerTimeout2 := 50 * time.Second
 	_, _ = test.AddTimerStartedEvent(mutableState, event.GetEventID(), timerID2, int64(timerTimeout2.Seconds()))
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextUserTimer()
 	s.NoError(err)
@@ -423,7 +423,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 		int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()))
 	nextEventID := scheduledEvent.GetEventID()
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -510,7 +510,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Success() {
 		int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()), int32(timerTimeout.Seconds()))
 	startedEvent := test.AddActivityTaskStartedEvent(mutableState, scheduledEvent.GetEventID(), identity)
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -584,7 +584,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Heartbeat_Noo
 	startedEvent := test.AddActivityTaskStartedEvent(mutableState, scheduledEvent.GetEventID(), identity)
 	mutableState.FlushBufferedEvents()
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)
@@ -665,7 +665,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple_CanU
 	activityInfo2.TimerTaskStatus |= execution.TimerTaskStatusCreatedHeartbeat
 	activityInfo2.LastHeartBeatUpdatedTime = time.Now()
 
-	timerSequence := execution.NewTimerSequence(s.timeSource, mutableState)
+	timerSequence := execution.NewTimerSequence(mutableState)
 	mutableState.DeleteTimerTasks()
 	modified, err := timerSequence.CreateNextActivityTimer()
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Allow workflow refresh for closed workflows
- Remove duplicated/buggy GetCloseEvent() method in mutableState
- Remove unused parameter from workflow refresher, task generator, mutableState and timerSequence
- Handle get history client error when calling RefreshWorkflowTask 
- Remove defer() in CapturePanic() as this function is already called in defer

<!-- Tell your future self why have you made these changes -->
**Why?**
- Bug fix for refresh closed workflows

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
