### PR TITLE
Emit metrics during shardscanner fix and scan activities

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2163,8 +2163,8 @@ const (
 	ScannerShardSizeSeventyFiveGauge
 	ScannerShardSizeTwentyFiveGauge
 	ScannerShardSizeTenGauge
-	ShardscannerScan
-	ShardscannerFix
+	ShardScannerScan
+	ShardScannerFix
 
 	NumWorkerMetrics
 )
@@ -2664,8 +2664,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ScannerShardSizeSeventyFiveGauge:              {metricName: "scanner_shard_size_seventy_five", metricType: Gauge},
 		ScannerShardSizeTwentyFiveGauge:               {metricName: "scanner_shard_size_twenty_five", metricType: Gauge},
 		ScannerShardSizeTenGauge:                      {metricName: "scanner_shard_size_ten", metricType: Gauge},
-		ShardscannerScan:                              {metricName: "shardscanner_scan", metricType: Counter},
-		ShardscannerFix:                               {metricName: "shardscanner_fix", metricType: Counter},
+		ShardScannerScan:                              {metricName: "shardscanner_scan", metricType: Counter},
+		ShardScannerFix:                               {metricName: "shardscanner_fix", metricType: Counter},
 	},
 }
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2163,6 +2163,8 @@ const (
 	ScannerShardSizeSeventyFiveGauge
 	ScannerShardSizeTwentyFiveGauge
 	ScannerShardSizeTenGauge
+	ShardscannerScan
+	ShardscannerFix
 
 	NumWorkerMetrics
 )
@@ -2662,6 +2664,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ScannerShardSizeSeventyFiveGauge:              {metricName: "scanner_shard_size_seventy_five", metricType: Gauge},
 		ScannerShardSizeTwentyFiveGauge:               {metricName: "scanner_shard_size_twenty_five", metricType: Gauge},
 		ScannerShardSizeTenGauge:                      {metricName: "scanner_shard_size_ten", metricType: Gauge},
+		ShardscannerScan:                              {metricName: "shardscanner_scan", metricType: Counter},
+		ShardscannerFix:                               {metricName: "shardscanner_fix", metricType: Counter},
 	},
 }
 

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -31,19 +31,21 @@ const (
 	buildVersionTag = "build_version"
 	goVersionTag    = "go_version"
 
-	instance       = "instance"
-	domain         = "domain"
-	targetCluster  = "target_cluster"
-	activeCluster  = "active_cluster"
-	taskList       = "tasklist"
-	taskListType   = "tasklistType"
-	workflowType   = "workflowType"
-	activityType   = "activityType"
-	decisionType   = "decisionType"
-	invariantType  = "invariantType"
-	kafkaPartition = "kafkaPartition"
-	transport      = "transport"
-	signalName     = "signalName"
+	instance               = "instance"
+	domain                 = "domain"
+	targetCluster          = "target_cluster"
+	activeCluster          = "active_cluster"
+	taskList               = "tasklist"
+	taskListType           = "tasklistType"
+	workflowType           = "workflowType"
+	activityType           = "activityType"
+	decisionType           = "decisionType"
+	invariantType          = "invariantType"
+	shardscannerScanResult = "shardscanner_scan_result"
+	shardscannerFixResult  = "shardscanner_fix_result"
+	kafkaPartition         = "kafkaPartition"
+	transport              = "transport"
+	signalName             = "signalName"
 
 	allValue     = "all"
 	unknownValue = "_unknown_"
@@ -133,6 +135,16 @@ func ActivityTypeTag(value string) Tag {
 // DecisionTypeTag returns a new decision type tag.
 func DecisionTypeTag(value string) Tag {
 	return metricWithUnknown(decisionType, value)
+}
+
+// ShardscannerScanResult returns a new shardscanner scan result type tag.
+func ShardscannerScanResult(value string) Tag {
+	return metricWithUnknown(shardscannerScanResult, value)
+}
+
+// ShardscannerFixResult returns a new shardscanner fix result type tag.
+func ShardscannerFixResult(value string) Tag {
+	return metricWithUnknown(shardscannerFixResult, value)
 }
 
 // InvariantTypeTag returns a new invariant type tag.

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -41,8 +41,8 @@ const (
 	activityType           = "activityType"
 	decisionType           = "decisionType"
 	invariantType          = "invariantType"
-	shardscannerScanResult = "shardscanner_scan_result"
-	shardscannerFixResult  = "shardscanner_fix_result"
+	shardScannerScanResult = "shardscanner_scan_result"
+	shardScannerFixResult  = "shardscanner_fix_result"
 	kafkaPartition         = "kafkaPartition"
 	transport              = "transport"
 	signalName             = "signalName"
@@ -137,14 +137,14 @@ func DecisionTypeTag(value string) Tag {
 	return metricWithUnknown(decisionType, value)
 }
 
-// ShardscannerScanResult returns a new shardscanner scan result type tag.
-func ShardscannerScanResult(value string) Tag {
-	return metricWithUnknown(shardscannerScanResult, value)
+// ShardScannerScanResult returns a new shardscanner scan result type tag.
+func ShardScannerScanResult(value string) Tag {
+	return metricWithUnknown(shardScannerScanResult, value)
 }
 
-// ShardscannerFixResult returns a new shardscanner fix result type tag.
-func ShardscannerFixResult(value string) Tag {
-	return metricWithUnknown(shardscannerFixResult, value)
+// ShardScannerFixResult returns a new shardscanner fix result type tag.
+func ShardScannerFixResult(value string) Tag {
+	return metricWithUnknown(shardScannerFixResult, value)
 }
 
 // InvariantTypeTag returns a new invariant type tag.

--- a/service/worker/scanner/shardscanner/activities.go
+++ b/service/worker/scanner/shardscanner/activities.go
@@ -179,6 +179,8 @@ func scanShard(
 		params.BlobstoreFlushThreshold,
 		ctx.Hooks.Manager(activityCtx, pr, params),
 		func() { activity.RecordHeartbeat(activityCtx, heartbeatDetails) },
+		scope,
+		resources.GetDomainCache(),
 	)
 	report := scanner.Scan(activityCtx)
 	if report.Result.ControlFlowFailure != nil {
@@ -373,6 +375,7 @@ func fixShard(
 		func() { activity.RecordHeartbeat(activityCtx, heartbeatDetails) },
 		resource.GetDomainCache(),
 		ctx.Config.DynamicParams.AllowDomain,
+		scope,
 	)
 	report := fixer.Fix()
 	if report.Result.ControlFlowFailure != nil {

--- a/service/worker/scanner/shardscanner/activities_test.go
+++ b/service/worker/scanner/shardscanner/activities_test.go
@@ -74,6 +74,9 @@ func (s *activitiesSuite) SetupSuite() {
 func (s *activitiesSuite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockResource = resource.NewTest(s.controller, metrics.Worker)
+	domainCache := cache.NewMockDomainCache(s.controller)
+	domainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain", nil).AnyTimes()
+	s.mockResource.DomainCache = domainCache
 }
 
 func (s *activitiesSuite) TearDownTest() {

--- a/service/worker/scanner/shardscanner/fixer.go
+++ b/service/worker/scanner/shardscanner/fixer.go
@@ -31,6 +31,7 @@ import (
 	"github.com/uber/cadence/common/blobstore"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/reconciliation/entity"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/common/reconciliation/store"
@@ -59,6 +60,7 @@ type (
 		progressReportFn func()
 		domainCache      cache.DomainCache
 		allowDomain      dynamicconfig.BoolPropertyFnWithDomainFilter
+		scope            metrics.Scope
 	}
 )
 
@@ -73,6 +75,7 @@ func NewFixer(
 	progressReportFn func(),
 	domainCache cache.DomainCache,
 	allowDomain dynamicconfig.BoolPropertyFnWithDomainFilter,
+	scope metrics.Scope,
 ) *ShardFixer {
 	id := uuid.New()
 
@@ -87,6 +90,7 @@ func NewFixer(
 		progressReportFn: progressReportFn,
 		domainCache:      domainCache,
 		allowDomain:      allowDomain,
+		scope:            scope,
 	}
 }
 
@@ -138,6 +142,18 @@ func (f *ShardFixer) Fix() FixReport {
 			Input:     *soe,
 			Result:    fixResult,
 		}
+
+		invariantName := ""
+		if fixResult.DeterminingInvariantName != nil {
+			invariantName = string(*fixResult.DeterminingInvariantName)
+		}
+
+		f.scope.Tagged(
+			metrics.DomainTag(domainName),
+			metrics.InvariantTypeTag(invariantName),
+			metrics.ShardscannerFixResult(string(fixResult.FixResultType)),
+		).IncCounter(metrics.ShardscannerFix)
+
 		switch fixResult.FixResultType {
 		case invariant.FixResultTypeFixed:
 			if err := f.fixedWriter.Add(foe); err != nil {

--- a/service/worker/scanner/shardscanner/fixer.go
+++ b/service/worker/scanner/shardscanner/fixer.go
@@ -151,8 +151,8 @@ func (f *ShardFixer) Fix() FixReport {
 		f.scope.Tagged(
 			metrics.DomainTag(domainName),
 			metrics.InvariantTypeTag(invariantName),
-			metrics.ShardscannerFixResult(string(fixResult.FixResultType)),
-		).IncCounter(metrics.ShardscannerFix)
+			metrics.ShardScannerFixResult(string(fixResult.FixResultType)),
+		).IncCounter(metrics.ShardScannerFix)
 
 		switch fixResult.FixResultType {
 		case invariant.FixResultTypeFixed:

--- a/service/worker/scanner/shardscanner/fixer_test.go
+++ b/service/worker/scanner/shardscanner/fixer_test.go
@@ -33,16 +33,20 @@ import (
 
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/reconciliation/entity"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/common/reconciliation/store"
+	"github.com/uber/cadence/common/resource"
 )
 
 type FixerSuite struct {
 	*require.Assertions
 	suite.Suite
-	controller *gomock.Controller
+
+	mockResource *resource.Test
+	controller   *gomock.Controller
 }
 
 func TestFixerSuite(t *testing.T) {
@@ -52,6 +56,7 @@ func TestFixerSuite(t *testing.T) {
 func (s *FixerSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 	s.controller = gomock.NewController(s.T())
+	s.mockResource = resource.NewTest(s.controller, metrics.Worker)
 }
 
 func (s *FixerSuite) TearDownTest() {
@@ -117,6 +122,7 @@ func (s *FixerSuite) TestFix_Failure_NonFirstError() {
 		progressReportFn: func() {},
 		domainCache:      domainCache,
 		allowDomain:      dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
+		scope:            metrics.NoopScope(metrics.Worker),
 	}
 	result := fixer.Fix()
 	s.Equal(FixReport{
@@ -168,6 +174,7 @@ func (s *FixerSuite) TestFix_Failure_SkippedWriterError() {
 		progressReportFn: func() {},
 		domainCache:      domainCache,
 		allowDomain:      dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
+		scope:            metrics.NoopScope(metrics.Worker),
 	}
 	result := fixer.Fix()
 	s.Equal(FixReport{
@@ -218,6 +225,7 @@ func (s *FixerSuite) TestFix_Failure_FailedWriterError() {
 		progressReportFn: func() {},
 		domainCache:      domainCache,
 		allowDomain:      dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
+		scope:            metrics.NoopScope(metrics.Worker),
 	}
 	result := fixer.Fix()
 	s.Equal(FixReport{
@@ -268,6 +276,7 @@ func (s *FixerSuite) TestFix_Failure_FixedWriterError() {
 		progressReportFn: func() {},
 		domainCache:      domainCache,
 		allowDomain:      dynamicconfig.GetBoolPropertyFnFilteredByDomain(true),
+		scope:            metrics.NoopScope(metrics.Worker),
 	}
 	result := fixer.Fix()
 	s.Equal(FixReport{
@@ -708,6 +717,7 @@ func (s *FixerSuite) TestFix_Success() {
 		progressReportFn: func() {},
 		domainCache:      domainCache,
 		allowDomain:      allowDomain,
+		scope:            metrics.NoopScope(metrics.Worker),
 	}
 	result := fixer.Fix()
 	s.Equal(FixReport{

--- a/service/worker/scanner/shardscanner/scanner.go
+++ b/service/worker/scanner/shardscanner/scanner.go
@@ -29,6 +29,8 @@ import (
 	"github.com/pborman/uuid"
 
 	"github.com/uber/cadence/common/blobstore"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/pagination"
 	"github.com/uber/cadence/common/reconciliation/entity"
 	"github.com/uber/cadence/common/reconciliation/invariant"
@@ -53,6 +55,8 @@ type (
 		corruptedWriter  store.ExecutionWriter
 		invariantManager invariant.Manager
 		progressReportFn func()
+		scope            metrics.Scope
+		domainCache      cache.DomainCache
 	}
 )
 
@@ -64,6 +68,8 @@ func NewScanner(
 	blobstoreFlushThreshold int,
 	manager invariant.Manager,
 	progressReportFn func(),
+	scope metrics.Scope,
+	domainCache cache.DomainCache,
 ) *ShardScanner {
 	id := uuid.New()
 
@@ -74,6 +80,8 @@ func NewScanner(
 		corruptedWriter:  store.NewBlobstoreWriter(id, store.CorruptedExtension, blobstoreClient, blobstoreFlushThreshold),
 		invariantManager: manager,
 		progressReportFn: progressReportFn,
+		scope:            scope,
+		domainCache:      domainCache,
 	}
 }
 
@@ -88,7 +96,7 @@ func (s *ShardScanner) Scan(ctx context.Context) ScanReport {
 	}
 	for s.itr.HasNext() {
 		s.progressReportFn()
-		entity, err := s.itr.Next()
+		execution, err := s.itr.Next()
 		if err != nil {
 			result.Result.ControlFlowFailure = &ControlFlowFailure{
 				Info:        "persistence iterator returned error",
@@ -96,8 +104,8 @@ func (s *ShardScanner) Scan(ctx context.Context) ScanReport {
 			}
 			return result
 		}
-		checkResult := s.invariantManager.RunChecks(ctx, entity)
-		domainID, err := s.getDomainIDFromEntity(entity)
+		checkResult := s.invariantManager.RunChecks(ctx, execution)
+		domainID, err := s.getDomainIDFromEntity(execution)
 		if err != nil {
 			result.Result.ControlFlowFailure = &ControlFlowFailure{
 				Info:        "failed to get domainID from entity",
@@ -105,6 +113,15 @@ func (s *ShardScanner) Scan(ctx context.Context) ScanReport {
 			}
 			return result
 		}
+		domainName, err := s.domainCache.GetDomainName(*domainID)
+		if err != nil {
+			result.Result.ControlFlowFailure = &ControlFlowFailure{
+				Info:        "failed to get domain name from cache",
+				InfoDetails: err.Error(),
+			}
+			return result
+		}
+
 		if _, ok := result.DomainStats[*domainID]; !ok {
 			result.DomainStats[*domainID] = &ScanStats{
 				CorruptionByType: make(map[invariant.Name]int64),
@@ -112,12 +129,22 @@ func (s *ShardScanner) Scan(ctx context.Context) ScanReport {
 		}
 		result.DomainStats[*domainID].EntitiesCount++
 		result.Stats.EntitiesCount++
+		invariantName := ""
+		if checkResult.DeterminingInvariantType != nil {
+			invariantName = string(*checkResult.DeterminingInvariantType)
+		}
+		s.scope.Tagged(
+			metrics.DomainTag(domainName),
+			metrics.InvariantTypeTag(invariantName),
+			metrics.ShardscannerScanResult(string(checkResult.CheckResultType)),
+		).IncCounter(metrics.ShardscannerScan)
+
 		switch checkResult.CheckResultType {
 		case invariant.CheckResultTypeHealthy:
 			// do nothing if execution is healthy
 		case invariant.CheckResultTypeCorrupted:
 			if err := s.corruptedWriter.Add(store.ScanOutputEntity{
-				Execution: entity,
+				Execution: execution,
 				Result:    checkResult,
 			}); err != nil {
 				result.Result.ControlFlowFailure = &ControlFlowFailure{
@@ -132,7 +159,7 @@ func (s *ShardScanner) Scan(ctx context.Context) ScanReport {
 			result.DomainStats[*domainID].CorruptionByType[*checkResult.DeterminingInvariantType]++
 		case invariant.CheckResultTypeFailed:
 			if err := s.failedWriter.Add(store.ScanOutputEntity{
-				Execution: entity,
+				Execution: execution,
 				Result:    checkResult,
 			}); err != nil {
 				result.Result.ControlFlowFailure = &ControlFlowFailure{

--- a/service/worker/scanner/shardscanner/scanner.go
+++ b/service/worker/scanner/shardscanner/scanner.go
@@ -136,8 +136,8 @@ func (s *ShardScanner) Scan(ctx context.Context) ScanReport {
 		s.scope.Tagged(
 			metrics.DomainTag(domainName),
 			metrics.InvariantTypeTag(invariantName),
-			metrics.ShardscannerScanResult(string(checkResult.CheckResultType)),
-		).IncCounter(metrics.ShardscannerScan)
+			metrics.ShardScannerScanResult(string(checkResult.CheckResultType)),
+		).IncCounter(metrics.ShardScannerScan)
 
 		switch checkResult.CheckResultType {
 		case invariant.CheckResultTypeHealthy:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Tagged shardscanner metrics will be emitted during every scan/fix. 
Tags include: 
* domain name
* Invariant name
* Operation
* Result

<!-- Tell your future self why have you made these changes -->
**Why?**
This should replace all aggregated metrics for shards. Aggregated metrics are emitted only after workflow is finished and must be queried to extract specific stats for a domain.

Using tagged metrics can answer all questions from metric aggregation side (ex: group invariants by domain name, etc.) 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
