### PR TITLE
add enable service auth logging key

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1934,6 +1934,11 @@ const (
 	// Default value: N/A
 	// TODO: https://github.com/uber/cadence/issues/3861
 	EnableServiceAuthorization
+	// EnableServiceAuthorizationLogOnly is the key to enable authorization logging for a service, only for extension binary:
+	// KeyName: N/A
+	// Default value: N/A
+	// TODO: https://github.com/uber/cadence/issues/3861
+	EnableServiceAuthorizationLogOnly
 	// Usage: VisibilityArchivalQueryMaxRangeInDays is the maximum number of days for a visibility archival query
 	// KeyName: N/A
 	// Default value: N/A
@@ -2313,6 +2318,7 @@ var Keys = map[Key]string{
 	// TODO https://github.com/uber/cadence/issues/3861
 	EnableAuthorization:                             "system.enableAuthorization",
 	EnableServiceAuthorization:                      "system.enableServiceAuthorization",
+	EnableServiceAuthorizationLogOnly:               "system.enableServiceAuthorizationLogOnly",
 	VisibilityArchivalQueryMaxRangeInDays:           "frontend.visibilityArchivalQueryMaxRangeInDays",
 	VisibilityArchivalQueryMaxQPS:                   "frontend.visibilityArchivalQueryMaxQPS",
 	EnableArchivalCompression:                       "worker.EnableArchivalCompression",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
follow up on https://github.com/uber/cadence/pull/4299/files

<!-- Tell your future self why have you made these changes -->
**Why?**
we need to enable auth by logging only before fully enabling to avoid outages

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
