### PR TITLE
Fix startTime in workflow task refresher

### DIFF
--- a/service/history/execution/mutable_state_task_refresher.go
+++ b/service/history/execution/mutable_state_task_refresher.go
@@ -41,7 +41,7 @@ var emptyTasks = []persistence.Task{}
 type (
 	// MutableStateTaskRefresher refreshes workflow transfer and timer tasks
 	MutableStateTaskRefresher interface {
-		RefreshTasks(ctx context.Context, mutableState MutableState) error
+		RefreshTasks(ctx context.Context, startTime time.Time, mutableState MutableState) error
 	}
 
 	mutableStateTaskRefresherImpl struct {
@@ -76,6 +76,7 @@ func NewMutableStateTaskRefresher(
 
 func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 	ctx context.Context,
+	startTime time.Time,
 	mutableState MutableState,
 ) error {
 
@@ -88,6 +89,7 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 	if err := r.refreshTasksForWorkflowStart(
 		ctx,
+		startTime,
 		mutableState,
 		taskGenerator,
 	); err != nil {
@@ -173,6 +175,7 @@ func (r *mutableStateTaskRefresherImpl) RefreshTasks(
 
 func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowStart(
 	ctx context.Context,
+	startTime time.Time,
 	mutableState MutableState,
 	taskGenerator MutableStateTaskGenerator,
 ) error {
@@ -183,7 +186,7 @@ func (r *mutableStateTaskRefresherImpl) refreshTasksForWorkflowStart(
 	}
 
 	if err := taskGenerator.GenerateWorkflowStartTasks(
-		time.Unix(0, startEvent.GetTimestamp()),
+		startTime,
 		startEvent,
 	); err != nil {
 		return err

--- a/service/history/execution/mutable_state_task_refresher_mock.go
+++ b/service/history/execution/mutable_state_task_refresher_mock.go
@@ -29,6 +29,7 @@ package execution
 import (
 	context "context"
 	reflect "reflect"
+	time "time"
 
 	gomock "github.com/golang/mock/gomock"
 )
@@ -57,15 +58,15 @@ func (m *MockMutableStateTaskRefresher) EXPECT() *MockMutableStateTaskRefresherM
 }
 
 // RefreshTasks mocks base method
-func (m *MockMutableStateTaskRefresher) RefreshTasks(ctx context.Context, mutableState MutableState) error {
+func (m *MockMutableStateTaskRefresher) RefreshTasks(ctx context.Context, startTime time.Time, mutableState MutableState) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RefreshTasks", ctx, mutableState)
+	ret := m.ctrl.Call(m, "RefreshTasks", ctx, startTime, mutableState)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // RefreshTasks indicates an expected call of RefreshTasks
-func (mr *MockMutableStateTaskRefresherMockRecorder) RefreshTasks(ctx, mutableState interface{}) *gomock.Call {
+func (mr *MockMutableStateTaskRefresherMockRecorder) RefreshTasks(ctx, startTime, mutableState interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTasks", reflect.TypeOf((*MockMutableStateTaskRefresher)(nil).RefreshTasks), ctx, mutableState)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshTasks", reflect.TypeOf((*MockMutableStateTaskRefresher)(nil).RefreshTasks), ctx, startTime, mutableState)
 }

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -185,7 +185,7 @@ func (r *stateRebuilderImpl) Rebuild(
 	}
 
 	// refresh tasks to be generated
-	if err := r.taskRefresher.RefreshTasks(ctx, rebuiltMutableState); err != nil {
+	if err := r.taskRefresher.RefreshTasks(ctx, now, rebuiltMutableState); err != nil {
 		return nil, 0, err
 	}
 

--- a/service/history/execution/state_rebuilder_test.go
+++ b/service/history/execution/state_rebuilder_test.go
@@ -304,7 +304,7 @@ func (s *stateRebuilderSuite) TestRebuild() {
 		1234,
 		s.mockClusterMetadata,
 	), nil).AnyTimes()
-	s.mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.mockTaskRefresher.EXPECT().RefreshTasks(gomock.Any(), now, gomock.Any()).Return(nil).Times(1)
 
 	rebuildMutableState, rebuiltHistorySize, err := s.nDCStateRebuilder.Rebuild(
 		context.Background(),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -3276,7 +3276,7 @@ func (e *historyEngineImpl) RefreshWorkflowTasks(
 		e.shard.GetShardID(),
 	)
 
-	err = mutableStateTaskRefresher.RefreshTasks(ctx, mutableState)
+	err = mutableStateTaskRefresher.RefreshTasks(ctx, mutableState.GetExecutionInfo().StartTimestamp, mutableState)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix workflow refresh start time value for scheduling workflow timeout timer

<!-- Tell your future self why have you made these changes -->
**Why?**
- Start event time is not the actual start time if the workflow has been reset before.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- reverted change in unit test to assert the correct behavior

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
