### PR TITLE
Use gRPC outbound by default for internal traffic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 You can find a list of previous releases on the [github releases](https://github.com/uber/cadence/releases) page.
 
 ## [Unreleased]
+### Changed
+- Default outbound between internal server components are now switched to gRPC. There is still an option to switch back to TChannel by setting dynamic config `system.enableGRPCOutbound` to `false`. However this is now considered deprecated and will be removed in the future release.
+
+## [0.23.0] - TBD
 ### Added
 - Added gRPC support for cross domain traffic. This can be enabled in `ClusterGroupMetadata` config section with `rpcTransport: "grpc"` option. By default, tchannel is used. (#4390)
 

--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -97,7 +97,7 @@ func NewRPCClientFactory(
 	numberOfHistoryShards int,
 	logger log.Logger,
 ) Factory {
-	enableGRPCOutbound := dc.GetBoolProperty(dynamicconfig.EnableGRPCOutbound, false)()
+	enableGRPCOutbound := dc.GetBoolProperty(dynamicconfig.EnableGRPCOutbound, true)()
 	return &rpcClientFactory{
 		rpcFactory:            rpcFactory,
 		monitor:               monitor,

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -185,7 +185,7 @@ const (
 	// EnableGRPCOutbound is the key for enabling outbound GRPC traffic
 	// KeyName: system.enableGRPCOutbound
 	// Value type: Bool
-	// Default value: FALSE
+	// Default value: TRUE
 	// Allowed filters: N/A
 	EnableGRPCOutbound
 	// BlobSizeLimitError is the per event blob size limit

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -7,6 +7,3 @@ system.minRetentionDays:
 history.EnableConsistentQueryByDomain:
 - value: true
   constraints: {}
-system.enableGRPCOutbound:
-- value: true
-  constraints: {}

--- a/config/dynamicconfig/development_es.yaml
+++ b/config/dynamicconfig/development_es.yaml
@@ -37,6 +37,3 @@ frontend.validSearchAttributes:
       Passed: 4
 system.minRetentionDays:
     - value: 0
-system.enableGRPCOutbound:
-    - value: true
-      constraints: {}

--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -45,7 +45,6 @@ var (
 		dynamicconfig.ReplicationTaskFetcherErrorRetryWait:          50 * time.Millisecond,
 		dynamicconfig.ReplicationTaskProcessorErrorRetryWait:        time.Millisecond,
 		dynamicconfig.EnableConsistentQueryByDomain:                 true,
-		dynamicconfig.EnableGRPCOutbound:                            true,
 		dynamicconfig.MinRetentionDays:                              0,
 	}
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Cadence server will use gRPC outbound for internal traffic by default.

User can still opt-out by setting dynamic config `system.enableGRPCOutbound` to `false`.
However we should consider TChannel for internal communication deprecated and will work towards removing it in the future.

<!-- Tell your future self why have you made these changes -->
**Why?**
Another step in gRPC migration. We have been running gRPC internally for the last few months, it looks stable to be used by default.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Updated changelog.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
