### PR TITLE
add workflow type to signal with start auth

### DIFF
--- a/service/frontend/accessControlledHandler.go
+++ b/service/frontend/accessControlledHandler.go
@@ -632,9 +632,10 @@ func (a *AccessControlledWorkflowHandler) SignalWithStartWorkflowExecution(
 	scope := a.getMetricsScopeWithDomain(metrics.FrontendSignalWithStartWorkflowExecutionScope, request)
 
 	attr := &authorization.Attributes{
-		APIName:    "SignalWithStartWorkflowExecution",
-		DomainName: request.GetDomain(),
-		Permission: authorization.PermissionWrite,
+		APIName:      "SignalWithStartWorkflowExecution",
+		DomainName:   request.GetDomain(),
+		Permission:   authorization.PermissionWrite,
+		WorkflowType: request.WorkflowType,
 	}
 	isAuthorized, err := a.isAuthorized(ctx, attr, scope)
 	if err != nil {


### PR DESCRIPTION
What changed?
follow up on https://github.com/uber/cadence/pull/4299/files

Why?
we need to enable auth by logging only before fully enabling to avoid outages

How did you test it?
locally

Potential risks
No