### PR TITLE
Move dispatcher provider to rpc package

### DIFF
--- a/client/clientBean_mock.go
+++ b/client/clientBean_mock.go
@@ -30,7 +30,6 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	yarpc "go.uber.org/yarpc"
 
 	admin "github.com/uber/cadence/client/admin"
 	frontend "github.com/uber/cadence/client/frontend"
@@ -190,57 +189,4 @@ func (m *MockBean) SetRemoteFrontendClient(cluster string, client frontend.Clien
 func (mr *MockBeanMockRecorder) SetRemoteFrontendClient(cluster, client interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetRemoteFrontendClient", reflect.TypeOf((*MockBean)(nil).SetRemoteFrontendClient), cluster, client)
-}
-
-// MockDispatcherProvider is a mock of DispatcherProvider interface
-type MockDispatcherProvider struct {
-	ctrl     *gomock.Controller
-	recorder *MockDispatcherProviderMockRecorder
-}
-
-// MockDispatcherProviderMockRecorder is the mock recorder for MockDispatcherProvider
-type MockDispatcherProviderMockRecorder struct {
-	mock *MockDispatcherProvider
-}
-
-// NewMockDispatcherProvider creates a new mock instance
-func NewMockDispatcherProvider(ctrl *gomock.Controller) *MockDispatcherProvider {
-	mock := &MockDispatcherProvider{ctrl: ctrl}
-	mock.recorder = &MockDispatcherProviderMockRecorder{mock}
-	return mock
-}
-
-// EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockDispatcherProvider) EXPECT() *MockDispatcherProviderMockRecorder {
-	return m.recorder
-}
-
-// GetTChannel mocks base method
-func (m *MockDispatcherProvider) GetTChannel(name, address string, options *DispatcherOptions) (*yarpc.Dispatcher, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetTChannel", name, address, options)
-	ret0, _ := ret[0].(*yarpc.Dispatcher)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetTChannel indicates an expected call of GetTChannel
-func (mr *MockDispatcherProviderMockRecorder) GetTChannel(name, address, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTChannel", reflect.TypeOf((*MockDispatcherProvider)(nil).GetTChannel), name, address, options)
-}
-
-// GetGRPC mocks base method
-func (m *MockDispatcherProvider) GetGRPC(name, address string, options *DispatcherOptions) (*yarpc.Dispatcher, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetGRPC", name, address, options)
-	ret0, _ := ret[0].(*yarpc.Dispatcher)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetGRPC indicates an expected call of GetGRPC
-func (mr *MockDispatcherProviderMockRecorder) GetGRPC(name, address, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGRPC", reflect.TypeOf((*MockDispatcherProvider)(nil).GetGRPC), name, address, options)
 }

--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -52,7 +52,6 @@ const (
 	frontendCaller = "cadence-frontend-client"
 	historyCaller  = "history-service-client"
 	matchingCaller = "matching-service-client"
-	crossDCCaller  = "cadence-xdc-client"
 )
 
 const (

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -26,7 +26,6 @@ import (
 
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 
-	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
@@ -176,7 +175,7 @@ func (s *server) startService() common.Daemon {
 	)
 
 	if s.cfg.PublicClient.HostPort != "" {
-		params.DispatcherProvider = client.NewDNSYarpcDispatcherProvider(params.Logger, s.cfg.PublicClient.RefreshInterval)
+		params.DispatcherProvider = rpc.NewDNSYarpcDispatcherProvider(params.Logger, s.cfg.PublicClient.RefreshInterval)
 	} else {
 		log.Fatalf("need to provide an endpoint config for PublicClient")
 	}
@@ -215,14 +214,14 @@ func (s *server) startService() common.Daemon {
 		}
 	}
 
-	var options *client.DispatcherOptions
+	var options *rpc.DispatcherOptions
 	if s.cfg.Authorization.OAuthAuthorizer.Enable {
 		clusterName := s.cfg.ClusterGroupMetadata.CurrentClusterName
 		authProvider, err := authorization.GetAuthProviderClient(s.cfg.ClusterGroupMetadata.ClusterGroup[clusterName].AuthorizationProvider.PrivateKey)
 		if err != nil {
 			log.Fatalf("failed to create AuthProvider: %v", err.Error())
 		}
-		options = &client.DispatcherOptions{
+		options = &rpc.DispatcherOptions{
 			AuthProvider: authProvider,
 		}
 	}

--- a/common/rpc/dispatcher_provider.go
+++ b/common/rpc/dispatcher_provider.go
@@ -1,0 +1,149 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"context"
+	"time"
+
+	clientworker "go.uber.org/cadence/worker"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/transport"
+	"go.uber.org/yarpc/peer/roundrobin"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/tchannel"
+)
+
+const (
+	defaultRefreshInterval = time.Second * 10
+	crossDCCaller          = "cadence-xdc-client"
+)
+
+type (
+	DispatcherOptions struct {
+		AuthProvider clientworker.AuthorizationProvider
+	}
+
+	// DispatcherProvider provides a dispatcher to a given address
+	DispatcherProvider interface {
+		GetTChannel(name string, address string, options *DispatcherOptions) (*yarpc.Dispatcher, error)
+		GetGRPC(name string, address string, options *DispatcherOptions) (*yarpc.Dispatcher, error)
+	}
+
+	dnsDispatcherProvider struct {
+		interval time.Duration
+		logger   log.Logger
+	}
+)
+
+// NewDNSYarpcDispatcherProvider create a dispatcher provider which handles with IP address
+func NewDNSYarpcDispatcherProvider(logger log.Logger, interval time.Duration) DispatcherProvider {
+	if interval <= 0 {
+		interval = defaultRefreshInterval
+	}
+	return &dnsDispatcherProvider{
+		interval: interval,
+		logger:   logger,
+	}
+}
+
+func (p *dnsDispatcherProvider) GetTChannel(serviceName string, address string, options *DispatcherOptions) (*yarpc.Dispatcher, error) {
+	tchanTransport, err := tchannel.NewTransport(
+		tchannel.ServiceName(serviceName),
+		// this aim to get rid of the annoying popup about accepting incoming network connections
+		tchannel.ListenAddr("127.0.0.1:0"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	peerList := roundrobin.New(tchanTransport)
+	peerListUpdater, err := newDNSUpdater(peerList, address, p.interval, p.logger)
+	if err != nil {
+		return nil, err
+	}
+	peerListUpdater.Start()
+	outbound := tchanTransport.NewOutbound(peerList)
+
+	p.logger.Info("Creating TChannel dispatcher outbound", tag.Address(address))
+	return p.createOutboundDispatcher(serviceName, outbound, options)
+}
+
+func (p *dnsDispatcherProvider) GetGRPC(serviceName string, address string, options *DispatcherOptions) (*yarpc.Dispatcher, error) {
+	grpcTransport := grpc.NewTransport()
+
+	peerList := roundrobin.New(grpcTransport)
+	peerListUpdater, err := newDNSUpdater(peerList, address, p.interval, p.logger)
+	if err != nil {
+		return nil, err
+	}
+	peerListUpdater.Start()
+	outbound := grpcTransport.NewOutbound(peerList)
+
+	p.logger.Info("Creating GRPC dispatcher outbound", tag.Address(address))
+	return p.createOutboundDispatcher(serviceName, outbound, options)
+}
+
+func (p *dnsDispatcherProvider) createOutboundDispatcher(serviceName string, outbound transport.UnaryOutbound, options *DispatcherOptions) (*yarpc.Dispatcher, error) {
+	cfg := yarpc.Config{
+		Name: crossDCCaller,
+		Outbounds: yarpc.Outbounds{
+			serviceName: transport.Outbounds{
+				Unary:       outbound,
+				ServiceName: serviceName,
+			},
+		},
+	}
+	if options != nil && options.AuthProvider != nil {
+		cfg.OutboundMiddleware = yarpc.OutboundMiddleware{
+			Unary: &outboundMiddleware{authProvider: options.AuthProvider},
+		}
+	}
+
+	// Attach the outbound to the dispatcher (this will add middleware/logging/etc)
+	dispatcher := yarpc.NewDispatcher(cfg)
+
+	if err := dispatcher.Start(); err != nil {
+		return nil, err
+	}
+	return dispatcher, nil
+}
+
+type outboundMiddleware struct {
+	authProvider clientworker.AuthorizationProvider
+}
+
+func (om *outboundMiddleware) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
+	if om.authProvider != nil {
+		token, err := om.authProvider.GetAuthToken()
+		if err != nil {
+			return nil, err
+		}
+		request.Headers = request.Headers.
+			With(common.AuthorizationTokenHeaderName, string(token))
+	}
+	return out.Call(ctx, request)
+}

--- a/common/rpc/dns_updater.go
+++ b/common/rpc/dns_updater.go
@@ -52,7 +52,7 @@ type (
 	}
 )
 
-func NewDNSUpdater(list peer.List, dnsPort string, interval time.Duration, logger log.Logger) (*dnsUpdater, error) {
+func newDNSUpdater(list peer.List, dnsPort string, interval time.Duration, logger log.Logger) (*dnsUpdater, error) {
 	ss := strings.Split(dnsPort, ":")
 	if len(ss) != 2 {
 		return nil, fmt.Errorf("incorrect DNS:Port format")

--- a/common/rpc/dns_updater.go
+++ b/common/rpc/dns_updater.go
@@ -1,0 +1,154 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"go.uber.org/yarpc/api/peer"
+
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+)
+
+type (
+	dnsUpdater struct {
+		interval     time.Duration
+		dnsAddress   string
+		port         string
+		currentPeers map[string]struct{}
+		list         peer.List
+		logger       log.Logger
+	}
+	dnsRefreshResult struct {
+		updates  peer.ListUpdates
+		newPeers map[string]struct{}
+		changed  bool
+	}
+	aPeer struct {
+		addrPort string
+	}
+)
+
+func NewDNSUpdater(list peer.List, dnsPort string, interval time.Duration, logger log.Logger) (*dnsUpdater, error) {
+	ss := strings.Split(dnsPort, ":")
+	if len(ss) != 2 {
+		return nil, fmt.Errorf("incorrect DNS:Port format")
+	}
+	return &dnsUpdater{
+		interval:     interval,
+		logger:       logger,
+		list:         list,
+		dnsAddress:   ss[0],
+		port:         ss[1],
+		currentPeers: make(map[string]struct{}),
+	}, nil
+}
+
+func (d *dnsUpdater) Start() {
+	go func() {
+		for {
+			now := time.Now()
+			res, err := d.refresh()
+			if err != nil {
+				d.logger.Error("Failed to update DNS", tag.Error(err), tag.Address(d.dnsAddress))
+			}
+			if res != nil && res.changed {
+				if len(res.updates.Additions) > 0 {
+					d.logger.Info("Add new peers by DNS lookup", tag.Address(d.dnsAddress), tag.Addresses(identifiersToStringList(res.updates.Additions)))
+				}
+				if len(res.updates.Removals) > 0 {
+					d.logger.Info("Remove stale peers by DNS lookup", tag.Address(d.dnsAddress), tag.Addresses(identifiersToStringList(res.updates.Removals)))
+				}
+
+				err := d.list.Update(res.updates)
+				if err != nil {
+					d.logger.Error("Failed to update peerList", tag.Error(err), tag.Address(d.dnsAddress))
+				}
+				d.currentPeers = res.newPeers
+			}
+			sleepDu := now.Add(d.interval).Sub(now)
+			time.Sleep(sleepDu)
+		}
+	}()
+}
+
+func (d *dnsUpdater) refresh() (*dnsRefreshResult, error) {
+	resolver := net.DefaultResolver
+	ips, err := resolver.LookupHost(context.Background(), d.dnsAddress)
+	if err != nil {
+		return nil, err
+	}
+	newPeers := map[string]struct{}{}
+	for _, ip := range ips {
+		adr := fmt.Sprintf("%v:%v", ip, d.port)
+		newPeers[adr] = struct{}{}
+	}
+
+	updates := peer.ListUpdates{
+		Additions: make([]peer.Identifier, 0),
+		Removals:  make([]peer.Identifier, 0),
+	}
+	changed := false
+	// remove if it doesn't exist anymore
+	for addr := range d.currentPeers {
+		if _, ok := newPeers[addr]; !ok {
+			changed = true
+			updates.Removals = append(
+				updates.Removals,
+				aPeer{addrPort: addr},
+			)
+		}
+	}
+
+	// add if it doesn't exist before
+	for addr := range newPeers {
+		if _, ok := d.currentPeers[addr]; !ok {
+			changed = true
+			updates.Additions = append(
+				updates.Additions,
+				aPeer{addrPort: addr},
+			)
+		}
+	}
+
+	return &dnsRefreshResult{
+		updates:  updates,
+		newPeers: newPeers,
+		changed:  changed,
+	}, nil
+}
+
+func (a aPeer) Identifier() string {
+	return a.addrPort
+}
+
+func identifiersToStringList(ids []peer.Identifier) []string {
+	ss := make([]string, 0, len(ids))
+	for _, id := range ids {
+		ss = append(ss, id.Identifier())
+	}
+	return ss
+}

--- a/common/service/service.go
+++ b/common/service/service.go
@@ -47,6 +47,7 @@ import (
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/rpc"
 )
 
 type (
@@ -71,7 +72,7 @@ type (
 		ESClient            es.GenericClient
 		ESConfig            *config.ElasticSearchConfig
 		DynamicConfig       dynamicconfig.Client
-		DispatcherProvider  client.DispatcherProvider
+		DispatcherProvider  rpc.DispatcherProvider
 		DCRedirectionPolicy config.DCRedirectionPolicy
 		PublicClient        workflowserviceclient.Interface
 		ArchivalMetadata    archiver.ArchivalMetadata
@@ -111,7 +112,7 @@ type (
 		messagingClient        messaging.Client
 		blobstoreClient        blobstore.Client
 		dynamicCollection      *dynamicconfig.Collection
-		dispatcherProvider     client.DispatcherProvider
+		dispatcherProvider     rpc.DispatcherProvider
 		archivalMetadata       archiver.ArchivalMetadata
 		archiverProvider       provider.ArchiverProvider
 		serializer             persistence.PayloadSerializer

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -38,7 +38,6 @@ import (
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/transport/tchannel"
 
-	"github.com/uber/cadence/client"
 	adminClient "github.com/uber/cadence/client/admin"
 	frontendClient "github.com/uber/cadence/client/frontend"
 	historyClient "github.com/uber/cadence/client/history"
@@ -59,6 +58,7 @@ import (
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/rpc"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/frontend"
@@ -93,7 +93,7 @@ type (
 		logger                        log.Logger
 		clusterMetadata               cluster.Metadata
 		persistenceConfig             config.Persistence
-		dispatcherProvider            client.DispatcherProvider
+		dispatcherProvider            rpc.DispatcherProvider
 		messagingClient               messaging.Client
 		domainManager                 persistence.DomainManager
 		historyV2Mgr                  persistence.HistoryManager
@@ -128,7 +128,7 @@ type (
 	CadenceParams struct {
 		ClusterMetadata               cluster.Metadata
 		PersistenceConfig             config.Persistence
-		DispatcherProvider            client.DispatcherProvider
+		DispatcherProvider            rpc.DispatcherProvider
 		MessagingClient               messaging.Client
 		DomainManager                 persistence.DomainManager
 		HistoryV2Mgr                  persistence.HistoryManager

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/uber-go/tally"
 
-	"github.com/uber/cadence/client"
 	adminClient "github.com/uber/cadence/client/admin"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/filestore"
@@ -48,6 +47,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql"
 	"github.com/uber/cadence/common/persistence/persistence-tests/testcluster"
+	"github.com/uber/cadence/common/rpc"
 
 	// the import is a test dependency
 	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
@@ -139,7 +139,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger, params persistenc
 	cadenceParams := &CadenceParams{
 		ClusterMetadata:               params.ClusterMetadata,
 		PersistenceConfig:             pConfig,
-		DispatcherProvider:            client.NewDNSYarpcDispatcherProvider(logger, 0),
+		DispatcherProvider:            rpc.NewDNSYarpcDispatcherProvider(logger, 0),
 		MessagingClient:               messagingClient,
 		DomainManager:                 testBase.DomainManager,
 		HistoryV2Mgr:                  testBase.HistoryV2Mgr,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Moved `DispatcherProvider` and dns implementation together with `dnsUpdater` to `rpc` package.

<!-- Tell your future self why have you made these changes -->
**Why?**
To consolidate rpc related functionality in one place, such that it could be further refactored.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
So far, only a mechanical move.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
