### PR TITLE
Refactor PeerChooserFactory out of DispatcherProvider

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -175,7 +175,7 @@ func (s *server) startService() common.Daemon {
 	)
 
 	if s.cfg.PublicClient.HostPort != "" {
-		params.DispatcherProvider = rpc.NewDNSYarpcDispatcherProvider(params.Logger, s.cfg.PublicClient.RefreshInterval)
+		params.DispatcherProvider = rpc.NewDispatcherProvider(params.Logger, rpc.NewDNSPeerChooserFactory(s.cfg.PublicClient.RefreshInterval, params.Logger))
 	} else {
 		log.Fatalf("need to provide an endpoint config for PublicClient")
 	}

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -174,11 +174,11 @@ func (s *server) startService() common.Daemon {
 		clusterGroupMetadata.ClusterGroup,
 	)
 
-	if s.cfg.PublicClient.HostPort != "" {
-		params.DispatcherProvider = rpc.NewDispatcherProvider(params.Logger, rpc.NewDNSPeerChooserFactory(s.cfg.PublicClient.RefreshInterval, params.Logger))
-	} else {
+	if len(s.cfg.PublicClient.HostPort) == 0 {
 		log.Fatalf("need to provide an endpoint config for PublicClient")
 	}
+
+	params.DispatcherProvider = rpc.NewDispatcherProvider(params.Logger, rpc.NewDNSPeerChooserFactory(s.cfg.PublicClient.RefreshInterval, params.Logger))
 
 	advancedVisMode := dc.GetStringProperty(
 		dynamicconfig.AdvancedVisibilityWritingMode,

--- a/common/rpc/peer_chooser.go
+++ b/common/rpc/peer_chooser.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"time"
+
+	"github.com/uber/cadence/common/log"
+
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/peer/roundrobin"
+)
+
+const defaultDNSRefreshInterval = time.Second * 10
+
+type (
+	PeerChooserFactory interface {
+		CreatePeerChooser(transport peer.Transport, address string) (peer.Chooser, error)
+	}
+	dnsPeerChooserFactory struct {
+		interval time.Duration
+		logger   log.Logger
+	}
+)
+
+func NewDNSPeerChooserFactory(interval time.Duration, logger log.Logger) *dnsPeerChooserFactory {
+	if interval <= 0 {
+		interval = defaultDNSRefreshInterval
+	}
+
+	return &dnsPeerChooserFactory{interval, logger}
+}
+
+func (f *dnsPeerChooserFactory) CreatePeerChooser(transport peer.Transport, address string) (peer.Chooser, error) {
+	peerList := roundrobin.New(transport)
+	peerListUpdater, err := newDNSUpdater(peerList, address, f.interval, f.logger)
+	if err != nil {
+		return nil, err
+	}
+	peerListUpdater.Start()
+	return peerList, nil
+}

--- a/common/rpc/peer_chooser_test.go
+++ b/common/rpc/peer_chooser_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/cadence/common/log"
+	"go.uber.org/yarpc/api/peer"
+	"go.uber.org/yarpc/api/transport"
+)
+
+func TestDNSPeerChooserFactory(t *testing.T) {
+	logger := log.NewNoop()
+	ctx := context.Background()
+	interval := 100 * time.Millisecond
+
+	// Ensure default interval is set
+	factory := NewDNSPeerChooserFactory(0, logger)
+	assert.Equal(t, defaultDNSRefreshInterval, factory.interval)
+
+	factory = NewDNSPeerChooserFactory(interval, logger)
+	peerTransport := &fakePeerTransport{}
+
+	// Ensure invalid address returns error
+	_, err := factory.CreatePeerChooser(peerTransport, "invalid address")
+	assert.EqualError(t, err, "incorrect DNS:Port format")
+
+	chooser, err := factory.CreatePeerChooser(peerTransport, "localhost:1234")
+	require.NoError(t, err)
+
+	require.NoError(t, chooser.Start())
+	require.True(t, chooser.IsRunning())
+
+	// Wait for refresh
+	time.Sleep(interval)
+
+	peer, _, err := chooser.Choose(ctx, &transport.Request{})
+	require.NoError(t, err)
+	require.NotNil(t, peer)
+	assert.Equal(t, "fakePeer", peer.Identifier())
+}
+
+type (
+	fakePeerTransport struct{}
+	fakePeer          struct{}
+)
+
+func (t *fakePeerTransport) RetainPeer(peer.Identifier, peer.Subscriber) (peer.Peer, error) {
+	return &fakePeer{}, nil
+}
+func (t *fakePeerTransport) ReleasePeer(peer.Identifier, peer.Subscriber) error {
+	return nil
+}
+
+func (p *fakePeer) Identifier() string  { return "fakePeer" }
+func (p *fakePeer) Status() peer.Status { return peer.Status{ConnectionStatus: peer.Available} }
+func (p *fakePeer) StartRequest()       {}
+func (p *fakePeer) EndRequest()         {}

--- a/common/rpc/peer_chooser_test.go
+++ b/common/rpc/peer_chooser_test.go
@@ -27,9 +27,10 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/uber/cadence/common/log"
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
+
+	"github.com/uber/cadence/common/log"
 )
 
 func TestDNSPeerChooserFactory(t *testing.T) {

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -139,7 +139,7 @@ func NewCluster(options *TestClusterConfig, logger log.Logger, params persistenc
 	cadenceParams := &CadenceParams{
 		ClusterMetadata:               params.ClusterMetadata,
 		PersistenceConfig:             pConfig,
-		DispatcherProvider:            rpc.NewDNSYarpcDispatcherProvider(logger, 0),
+		DispatcherProvider:            rpc.NewDispatcherProvider(logger, rpc.NewDNSPeerChooserFactory(0, logger)),
 		MessagingClient:               messagingClient,
 		DomainManager:                 testBase.DomainManager,
 		HistoryV2Mgr:                  testBase.HistoryV2Mgr,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactored DNS peer chooser functionality out of `DispatcherProvider`.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a preparation step before merging `DispatcherProvider` into `rpc.Factory`.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.
+ Added unit tests for the refactored part.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
