### PR TITLE
Refactor service naming constants

### DIFF
--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -46,6 +46,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/membership"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/service"
 )
 
 const (
@@ -143,7 +144,7 @@ func (cf *rpcClientFactory) createKeyResolver(serviceName string) (func(key stri
 }
 
 func (cf *rpcClientFactory) NewHistoryClientWithTimeout(timeout time.Duration) (history.Client, error) {
-	keyResolver, err := cf.createKeyResolver(common.HistoryServiceName)
+	keyResolver, err := cf.createKeyResolver(service.History)
 	if err != nil {
 		return nil, err
 	}
@@ -175,7 +176,7 @@ func (cf *rpcClientFactory) NewMatchingClientWithTimeout(
 	timeout time.Duration,
 	longPollTimeout time.Duration,
 ) (matching.Client, error) {
-	keyResolver, err := cf.createKeyResolver(common.MatchingServiceName)
+	keyResolver, err := cf.createKeyResolver(service.Matching)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +189,7 @@ func (cf *rpcClientFactory) NewMatchingClientWithTimeout(
 	}
 
 	clientFetcher := func() ([]matching.Client, error) {
-		resolver, err := cf.monitor.GetResolver(common.MatchingServiceName)
+		resolver, err := cf.monitor.GetResolver(service.Matching)
 		if err != nil {
 			return nil, err
 		}
@@ -197,7 +198,7 @@ func (cf *rpcClientFactory) NewMatchingClientWithTimeout(
 		for _, host := range resolver.Members() {
 			hostAddress := host.GetAddress()
 			if cf.enableGRPCOutbound {
-				hostAddress, err = cf.rpcFactory.ReplaceGRPCPort(common.MatchingServiceName, hostAddress)
+				hostAddress, err = cf.rpcFactory.ReplaceGRPCPort(service.Matching, hostAddress)
 				if err != nil {
 					return nil, err
 				}
@@ -232,7 +233,7 @@ func (cf *rpcClientFactory) NewFrontendClientWithTimeout(
 	timeout time.Duration,
 	longPollTimeout time.Duration,
 ) (frontend.Client, error) {
-	keyResolver, err := cf.createKeyResolver(common.FrontendServiceName)
+	keyResolver, err := cf.createKeyResolver(service.Frontend)
 	if err != nil {
 		return nil, err
 	}
@@ -316,51 +317,51 @@ func (cf *rpcClientFactory) NewFrontendClientWithTimeoutAndDispatcher(
 }
 
 func (cf *rpcClientFactory) newHistoryThriftClient(hostAddress string) (history.Client, error) {
-	dispatcher, err := cf.rpcFactory.CreateDispatcherForOutbound(historyCaller, common.HistoryServiceName, hostAddress)
+	dispatcher, err := cf.rpcFactory.CreateDispatcherForOutbound(historyCaller, service.History, hostAddress)
 	if err != nil {
 		return nil, err
 	}
-	return history.NewThriftClient(historyserviceclient.New(dispatcher.ClientConfig(common.HistoryServiceName))), nil
+	return history.NewThriftClient(historyserviceclient.New(dispatcher.ClientConfig(service.History))), nil
 }
 
 func (cf *rpcClientFactory) newMatchingThriftClient(hostAddress string) (matching.Client, error) {
-	dispatcher, err := cf.rpcFactory.CreateDispatcherForOutbound(matchingCaller, common.MatchingServiceName, hostAddress)
+	dispatcher, err := cf.rpcFactory.CreateDispatcherForOutbound(matchingCaller, service.Matching, hostAddress)
 	if err != nil {
 		return nil, err
 	}
-	return matching.NewThriftClient(matchingserviceclient.New(dispatcher.ClientConfig(common.MatchingServiceName))), nil
+	return matching.NewThriftClient(matchingserviceclient.New(dispatcher.ClientConfig(service.Matching))), nil
 }
 
 func (cf *rpcClientFactory) newFrontendThriftClient(hostAddress string) (frontend.Client, error) {
-	dispatcher, err := cf.rpcFactory.CreateDispatcherForOutbound(frontendCaller, common.FrontendServiceName, hostAddress)
+	dispatcher, err := cf.rpcFactory.CreateDispatcherForOutbound(frontendCaller, service.Frontend, hostAddress)
 	if err != nil {
 		return nil, err
 	}
-	return frontend.NewThriftClient(workflowserviceclient.New(dispatcher.ClientConfig(common.FrontendServiceName))), nil
+	return frontend.NewThriftClient(workflowserviceclient.New(dispatcher.ClientConfig(service.Frontend))), nil
 }
 
 func (cf *rpcClientFactory) newHistoryGRPCClient(hostAddress string) (history.Client, error) {
-	dispatcher, err := cf.rpcFactory.CreateGRPCDispatcherForOutbound(historyCaller, common.HistoryServiceName, hostAddress)
+	dispatcher, err := cf.rpcFactory.CreateGRPCDispatcherForOutbound(historyCaller, service.History, hostAddress)
 	if err != nil {
 		return nil, err
 	}
-	return history.NewGRPCClient(historyv1.NewHistoryAPIYARPCClient(dispatcher.ClientConfig(common.HistoryServiceName))), nil
+	return history.NewGRPCClient(historyv1.NewHistoryAPIYARPCClient(dispatcher.ClientConfig(service.History))), nil
 }
 
 func (cf *rpcClientFactory) newMatchingGRPCClient(hostAddress string) (matching.Client, error) {
-	dispatcher, err := cf.rpcFactory.CreateGRPCDispatcherForOutbound(matchingCaller, common.MatchingServiceName, hostAddress)
+	dispatcher, err := cf.rpcFactory.CreateGRPCDispatcherForOutbound(matchingCaller, service.Matching, hostAddress)
 	if err != nil {
 		return nil, err
 	}
-	return matching.NewGRPCClient(matchingv1.NewMatchingAPIYARPCClient(dispatcher.ClientConfig(common.MatchingServiceName))), nil
+	return matching.NewGRPCClient(matchingv1.NewMatchingAPIYARPCClient(dispatcher.ClientConfig(service.Matching))), nil
 }
 
 func (cf *rpcClientFactory) newFrontendGRPCClient(hostAddress string) (frontend.Client, error) {
-	dispatcher, err := cf.rpcFactory.CreateGRPCDispatcherForOutbound(frontendCaller, common.FrontendServiceName, hostAddress)
+	dispatcher, err := cf.rpcFactory.CreateGRPCDispatcherForOutbound(frontendCaller, service.Frontend, hostAddress)
 	if err != nil {
 		return nil, err
 	}
-	config := dispatcher.ClientConfig(common.FrontendServiceName)
+	config := dispatcher.ClientConfig(service.Frontend)
 	return frontend.NewGRPCClient(
 		apiv1.NewDomainAPIYARPCClient(config),
 		apiv1.NewWorkflowAPIYARPCClient(config),

--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -34,12 +34,13 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/tools/cassandra"
 	"github.com/uber/cadence/tools/sql"
 )
 
 // validServices is the list of all valid cadence services
-var validServices = []string{frontendService, historyService, matchingService, workerService}
+var validServices = service.ShortNames(service.List)
 
 // startHandler is the handler for the cli start command
 func startHandler(c *cli.Context) {

--- a/common/cluster/metadataTest.go
+++ b/common/cluster/metadataTest.go
@@ -21,10 +21,10 @@
 package cluster
 
 import (
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/service"
 )
 
 const (
@@ -56,13 +56,13 @@ var (
 		TestCurrentClusterName: {
 			Enabled:                true,
 			InitialFailoverVersion: TestCurrentClusterInitialFailoverVersion,
-			RPCName:                common.FrontendServiceName,
+			RPCName:                service.Frontend,
 			RPCAddress:             TestCurrentClusterFrontendAddress,
 		},
 		TestAlternativeClusterName: {
 			Enabled:                true,
 			InitialFailoverVersion: TestAlternativeClusterInitialFailoverVersion,
-			RPCName:                common.FrontendServiceName,
+			RPCName:                service.Frontend,
 			RPCAddress:             TestAlternativeClusterFrontendAddress,
 		},
 		TestDisabledClusterName: {
@@ -78,7 +78,7 @@ var (
 		TestCurrentClusterName: {
 			Enabled:                true,
 			InitialFailoverVersion: TestCurrentClusterInitialFailoverVersion,
-			RPCName:                common.FrontendServiceName,
+			RPCName:                service.Frontend,
 			RPCAddress:             TestCurrentClusterFrontendAddress,
 		},
 	}

--- a/common/config/ringpop.go
+++ b/common/config/ringpop.go
@@ -39,10 +39,10 @@ import (
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/transport/tchannel"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/service"
 )
 
 const (
@@ -62,14 +62,6 @@ const (
 const (
 	defaultMaxJoinDuration = 10 * time.Second
 )
-
-// CadenceServices indicate the list of cadence services
-var CadenceServices = []string{
-	common.FrontendServiceName,
-	common.HistoryServiceName,
-	common.MatchingServiceName,
-	common.WorkerServiceName,
-}
 
 // RingpopFactory implements the RingpopFactory interface
 type RingpopFactory struct {
@@ -206,7 +198,7 @@ func (factory *RingpopFactory) createMembership() (membership.Monitor, error) {
 		return nil, fmt.Errorf("ringpop creation failed: %v", err)
 	}
 
-	membershipMonitor := membership.NewRingpopMonitor(factory.serviceName, CadenceServices, rp, factory.logger)
+	membershipMonitor := membership.NewRingpopMonitor(factory.serviceName, service.List, rp, factory.logger)
 	return membershipMonitor, nil
 }
 

--- a/common/constants.go
+++ b/common/constants.go
@@ -58,17 +58,6 @@ const (
 	EmptyUUID = "emptyUuid"
 )
 
-const (
-	// FrontendServiceName is the name of the frontend service
-	FrontendServiceName = "cadence-frontend"
-	// HistoryServiceName is the name of the history service
-	HistoryServiceName = "cadence-history"
-	// MatchingServiceName is the name of the matching service
-	MatchingServiceName = "cadence-matching"
-	// WorkerServiceName is the name of the worker service
-	WorkerServiceName = "cadence-worker"
-)
-
 // Data encoding types
 const (
 	EncodingTypeJSON     EncodingType = "json"

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -38,6 +38,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -761,7 +762,7 @@ func (d *handlerImpl) validateHistoryArchivalURI(URIString string) error {
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme(), common.FrontendServiceName)
+	archiver, err := d.archiverProvider.GetHistoryArchiver(URI.Scheme(), service.Frontend)
 	if err != nil {
 		return err
 	}
@@ -775,7 +776,7 @@ func (d *handlerImpl) validateVisibilityArchivalURI(URIString string) error {
 		return err
 	}
 
-	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), common.FrontendServiceName)
+	archiver, err := d.archiverProvider.GetVisibilityArchiver(URI.Scheme(), service.Frontend)
 	if err != nil {
 		return err
 	}

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -179,8 +179,8 @@ func (s *TestBase) Setup() {
 	s.DefaultTestCluster.SetupTestDatabase()
 
 	cfg := s.DefaultTestCluster.Config()
-	scope := tally.NewTestScope(common.HistoryServiceName, make(map[string]string))
-	metricsClient := metrics.NewClient(scope, service.GetMetricsServiceIdx(common.HistoryServiceName, s.Logger))
+	scope := tally.NewTestScope(service.History, make(map[string]string))
+	metricsClient := metrics.NewClient(scope, service.GetMetricsServiceIdx(service.History, s.Logger))
 	factory := client.NewFactory(&cfg, nil, clusterName, metricsClient, s.Logger)
 
 	s.TaskMgr, err = factory.NewTaskManager()

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -174,22 +174,22 @@ func New(
 		return nil, err
 	}
 
-	frontendServiceResolver, err := membershipMonitor.GetResolver(common.FrontendServiceName)
+	frontendServiceResolver, err := membershipMonitor.GetResolver(service.Frontend)
 	if err != nil {
 		return nil, err
 	}
 
-	matchingServiceResolver, err := membershipMonitor.GetResolver(common.MatchingServiceName)
+	matchingServiceResolver, err := membershipMonitor.GetResolver(service.Matching)
 	if err != nil {
 		return nil, err
 	}
 
-	historyServiceResolver, err := membershipMonitor.GetResolver(common.HistoryServiceName)
+	historyServiceResolver, err := membershipMonitor.GetResolver(service.History)
 	if err != nil {
 		return nil, err
 	}
 
-	workerServiceResolver, err := membershipMonitor.GetResolver(common.WorkerServiceName)
+	workerServiceResolver, err := membershipMonitor.GetResolver(service.Worker)
 	if err != nil {
 		return nil, err
 	}

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -32,7 +32,6 @@ import (
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/blobstore"
@@ -48,6 +47,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	persistenceClient "github.com/uber/cadence/common/persistence/client"
+	"github.com/uber/cadence/common/service"
 
 	"go.uber.org/yarpc"
 	"go.uber.org/zap"
@@ -159,10 +159,10 @@ func NewTest(
 	matchingServiceResolver := membership.NewMockServiceResolver(controller)
 	historyServiceResolver := membership.NewMockServiceResolver(controller)
 	workerServiceResolver := membership.NewMockServiceResolver(controller)
-	membershipMonitor.EXPECT().GetResolver(common.FrontendServiceName).Return(frontendServiceResolver, nil).AnyTimes()
-	membershipMonitor.EXPECT().GetResolver(common.MatchingServiceName).Return(matchingServiceResolver, nil).AnyTimes()
-	membershipMonitor.EXPECT().GetResolver(common.HistoryServiceName).Return(historyServiceResolver, nil).AnyTimes()
-	membershipMonitor.EXPECT().GetResolver(common.WorkerServiceName).Return(workerServiceResolver, nil).AnyTimes()
+	membershipMonitor.EXPECT().GetResolver(service.Frontend).Return(frontendServiceResolver, nil).AnyTimes()
+	membershipMonitor.EXPECT().GetResolver(service.Matching).Return(matchingServiceResolver, nil).AnyTimes()
+	membershipMonitor.EXPECT().GetResolver(service.History).Return(historyServiceResolver, nil).AnyTimes()
+	membershipMonitor.EXPECT().GetResolver(service.Worker).Return(workerServiceResolver, nil).AnyTimes()
 
 	scope := tally.NewTestScope("test", nil)
 

--- a/common/rpc/grpc_test.go
+++ b/common/rpc/grpc_test.go
@@ -23,8 +23,8 @@ package rpc
 import (
 	"testing"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/service"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -41,14 +41,14 @@ func TestGRPCPorts(t *testing.T) {
 	_, err := grpcPorts.GetGRPCAddress("some-service", "1.2.3.4")
 	assert.EqualError(t, err, "unknown service: some-service")
 
-	_, err = grpcPorts.GetGRPCAddress(common.HistoryServiceName, "1.2.3.4")
+	_, err = grpcPorts.GetGRPCAddress(service.History, "1.2.3.4")
 	assert.EqualError(t, err, "GRPC port not configured for service: cadence-history")
 
-	grpcAddress, err := grpcPorts.GetGRPCAddress(common.FrontendServiceName, "1.2.3.4")
+	grpcAddress, err := grpcPorts.GetGRPCAddress(service.Frontend, "1.2.3.4")
 	assert.Nil(t, err)
 	assert.Equal(t, grpcAddress, "1.2.3.4:9999")
 
-	grpcAddress, err = grpcPorts.GetGRPCAddress(common.FrontendServiceName, "1.2.3.4:8888")
+	grpcAddress, err = grpcPorts.GetGRPCAddress(service.Frontend, "1.2.3.4:8888")
 	assert.Nil(t, err)
 	assert.Equal(t, grpcAddress, "1.2.3.4:9999")
 }

--- a/common/service/name.go
+++ b/common/service/name.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2017 Uber Technologies, Inc.
+// Copyright (c) 2021 Uber Technologies, Inc.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,27 +20,41 @@
 
 package service
 
-import (
-	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/metrics"
+import "strings"
+
+const (
+	_servicePrefix = "cadence-"
+
+	// Frontend is the name of the frontend service
+	Frontend = "cadence-frontend"
+	// History is the name of the history service
+	History = "cadence-history"
+	// Matching is the name of the matching service
+	Matching = "cadence-matching"
+	// Worker is the name of the worker service
+	Worker = "cadence-worker"
 )
 
-// GetMetricsServiceIdx returns the metrics name
-func GetMetricsServiceIdx(serviceName string, logger log.Logger) metrics.ServiceIdx {
-	switch serviceName {
-	case common.FrontendServiceName:
-		return metrics.Frontend
-	case common.HistoryServiceName:
-		return metrics.History
-	case common.MatchingServiceName:
-		return metrics.Matching
-	case common.WorkerServiceName:
-		return metrics.Worker
-	default:
-		logger.Fatal("Unknown service name for metrics!")
-	}
+// List contains the list of all cadence services
+var List = []string{Frontend, History, Matching, Worker}
 
-	// this should never happen!
-	return metrics.NumServices
+// ShortName returns cadence service name without "cadence-" prefix
+func ShortName(name string) string {
+	return strings.TrimPrefix(name, _servicePrefix)
+}
+
+// FullName returns cadence service name with "cadence-" prefix
+func FullName(name string) string {
+	if strings.HasPrefix(name, _servicePrefix) {
+		return name
+	}
+	return _servicePrefix + name
+}
+
+func ShortNames(names []string) []string {
+	result := make([]string, len(names))
+	for i := range names {
+		result[i] = ShortName(names[i])
+	}
+	return result
 }

--- a/common/service/name_test.go
+++ b/common/service/name_test.go
@@ -18,40 +18,24 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package rpc
+package service
 
 import (
-	"errors"
-	"fmt"
-	"strings"
+	"testing"
 
-	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/service"
+	"github.com/stretchr/testify/assert"
 )
 
-type GRPCPorts map[string]int
+func TestServiceNames(t *testing.T) {
+	shortName := "frontend"
+	fullName := "cadence-frontend"
 
-func NewGRPCPorts(c *config.Config) GRPCPorts {
-	grpcPorts := map[string]int{}
-	for name, config := range c.Services {
-		grpcPorts[service.FullName(name)] = config.RPC.GRPCPort
-	}
-	return grpcPorts
-}
+	assert.Equal(t, shortName, ShortName(shortName))
+	assert.Equal(t, shortName, ShortName(fullName))
 
-func (p GRPCPorts) GetGRPCAddress(service, hostAddress string) (string, error) {
-	port, ok := p[service]
-	if !ok {
-		return hostAddress, errors.New("unknown service: " + service)
-	}
-	if port == 0 {
-		return hostAddress, errors.New("GRPC port not configured for service: " + service)
-	}
+	assert.Equal(t, fullName, FullName(shortName))
+	assert.Equal(t, fullName, FullName(fullName))
 
-	// Drop port if provided
-	if index := strings.Index(hostAddress, ":"); index > 0 {
-		hostAddress = hostAddress[:index]
-	}
-
-	return fmt.Sprintf("%s:%d", hostAddress, port), nil
+	assert.Equal(t, []string{"cadence-frontend", "cadence-history", "cadence-matching", "cadence-worker"}, List)
+	assert.Equal(t, []string{"frontend", "history", "matching", "worker"}, ShortNames(List))
 }

--- a/host/client.go
+++ b/host/client.go
@@ -29,7 +29,7 @@ import (
 	"github.com/uber/cadence/client/admin"
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/client/history"
-	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/service"
 )
 
 // AdminClient is the interface exposed by admin service client
@@ -49,15 +49,15 @@ type HistoryClient interface {
 
 // NewAdminClient creates a client to cadence admin client
 func NewAdminClient(d *yarpc.Dispatcher) AdminClient {
-	return admin.NewThriftClient(adminserviceclient.New(d.ClientConfig(common.FrontendServiceName)))
+	return admin.NewThriftClient(adminserviceclient.New(d.ClientConfig(service.Frontend)))
 }
 
 // NewFrontendClient creates a client to cadence frontend client
 func NewFrontendClient(d *yarpc.Dispatcher) FrontendClient {
-	return frontend.NewThriftClient(workflowserviceclient.New(d.ClientConfig(common.FrontendServiceName)))
+	return frontend.NewThriftClient(workflowserviceclient.New(d.ClientConfig(service.Frontend)))
 }
 
 // NewHistoryClient creates a client to cadence history service client
 func NewHistoryClient(d *yarpc.Dispatcher) HistoryClient {
-	return history.NewThriftClient(historyserviceclient.New(d.ClientConfig(common.HistoryServiceName)))
+	return history.NewThriftClient(historyserviceclient.New(d.ClientConfig(service.History)))
 }

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -46,8 +46,8 @@ import (
 	"go.uber.org/yarpc/transport/tchannel"
 	"go.uber.org/zap"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/service"
 )
 
 func init() {
@@ -99,7 +99,7 @@ func (s *ClientIntegrationSuite) TearDownSuite() {
 
 func (s *ClientIntegrationSuite) buildServiceClient() (workflowserviceclient.Interface, error) {
 	cadenceClientName := "cadence-client"
-	cadenceFrontendService := common.FrontendServiceName
+	cadenceFrontendService := service.Frontend
 	hostPort := "127.0.0.1:7104"
 	if TestFlags.FrontendAddr != "" {
 		hostPort = TestFlags.FrontendAddr

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -187,11 +187,11 @@ func (c *cadenceImpl) enableWorker() bool {
 
 func (c *cadenceImpl) Start() error {
 	hosts := make(map[string][]string)
-	hosts[common.FrontendServiceName] = []string{c.FrontendAddress()}
-	hosts[common.MatchingServiceName] = []string{c.MatchingServiceAddress()}
-	hosts[common.HistoryServiceName] = c.HistoryServiceAddress()
+	hosts[service.Frontend] = []string{c.FrontendAddress()}
+	hosts[service.Matching] = []string{c.MatchingServiceAddress()}
+	hosts[service.History] = c.HistoryServiceAddress()
 	if c.enableWorker() {
-		hosts[common.WorkerServiceName] = []string{c.WorkerServiceAddress()}
+		hosts[service.Worker] = []string{c.WorkerServiceAddress()}
 	}
 
 	// create cadence-system domain, this must be created before starting
@@ -393,13 +393,13 @@ func (c *cadenceImpl) GetHistoryClient() historyClient.Client {
 func (c *cadenceImpl) startFrontend(hosts map[string][]string, startWG *sync.WaitGroup) {
 	params := new(resource.Params)
 	params.DCRedirectionPolicy = config.DCRedirectionPolicy{}
-	params.Name = common.FrontendServiceName
+	params.Name = service.Frontend
 	params.Logger = c.logger
 	params.ThrottledLogger = c.logger
-	params.UpdateLoggerWithServiceName(common.FrontendServiceName)
+	params.UpdateLoggerWithServiceName(service.Frontend)
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.FrontendPProfPort())
-	params.RPCFactory = newRPCFactoryImpl(common.FrontendServiceName, c.FrontendAddress(), c.logger)
-	params.MetricScope = tally.NewTestScope(common.FrontendServiceName, make(map[string]string))
+	params.RPCFactory = newRPCFactoryImpl(service.Frontend, c.FrontendAddress(), c.logger)
+	params.MetricScope = tally.NewTestScope(service.Frontend, make(map[string]string))
 	params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 	params.ClusterMetadata = c.clusterMetadata
 	params.DispatcherProvider = c.dispatcherProvider
@@ -460,13 +460,13 @@ func (c *cadenceImpl) startHistory(
 	pprofPorts := c.HistoryPProfPort()
 	for i, hostport := range c.HistoryServiceAddress() {
 		params := new(resource.Params)
-		params.Name = common.HistoryServiceName
+		params.Name = service.History
 		params.Logger = c.logger
 		params.ThrottledLogger = c.logger
-		params.UpdateLoggerWithServiceName(common.HistoryServiceName)
+		params.UpdateLoggerWithServiceName(service.History)
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
-		params.RPCFactory = newRPCFactoryImpl(common.HistoryServiceName, hostport, c.logger)
-		params.MetricScope = tally.NewTestScope(common.HistoryServiceName, make(map[string]string))
+		params.RPCFactory = newRPCFactoryImpl(service.History, hostport, c.logger)
+		params.MetricScope = tally.NewTestScope(service.History, make(map[string]string))
 		params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 		params.ClusterMetadata = c.clusterMetadata
 		params.DispatcherProvider = c.dispatcherProvider
@@ -475,11 +475,11 @@ func (c *cadenceImpl) startHistory(
 		integrationClient := newIntegrationConfigClient(dynamicconfig.NewNopClient())
 		c.overrideHistoryDynamicConfig(integrationClient)
 		params.DynamicConfig = integrationClient
-		dispatcher, err := params.DispatcherProvider.GetTChannel(common.FrontendServiceName, c.FrontendAddress(), nil)
+		dispatcher, err := params.DispatcherProvider.GetTChannel(service.Frontend, c.FrontendAddress(), nil)
 		if err != nil {
 			c.logger.Fatal("Failed to get dispatcher for history", tag.Error(err))
 		}
-		params.PublicClient = cwsc.New(dispatcher.ClientConfig(common.FrontendServiceName))
+		params.PublicClient = cwsc.New(dispatcher.ClientConfig(service.Frontend))
 		params.ArchivalMetadata = c.archiverMetadata
 		params.ArchiverProvider = c.archiverProvider
 		params.ESConfig = c.esConfig
@@ -530,13 +530,13 @@ func (c *cadenceImpl) startHistory(
 func (c *cadenceImpl) startMatching(hosts map[string][]string, startWG *sync.WaitGroup) {
 
 	params := new(resource.Params)
-	params.Name = common.MatchingServiceName
+	params.Name = service.Matching
 	params.Logger = c.logger
 	params.ThrottledLogger = c.logger
-	params.UpdateLoggerWithServiceName(common.MatchingServiceName)
+	params.UpdateLoggerWithServiceName(service.Matching)
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.MatchingPProfPort())
-	params.RPCFactory = newRPCFactoryImpl(common.MatchingServiceName, c.MatchingServiceAddress(), c.logger)
-	params.MetricScope = tally.NewTestScope(common.MatchingServiceName, make(map[string]string))
+	params.RPCFactory = newRPCFactoryImpl(service.Matching, c.MatchingServiceAddress(), c.logger)
+	params.MetricScope = tally.NewTestScope(service.Matching, make(map[string]string))
 	params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 	params.ClusterMetadata = c.clusterMetadata
 	params.DispatcherProvider = c.dispatcherProvider
@@ -573,13 +573,13 @@ func (c *cadenceImpl) startMatching(hosts map[string][]string, startWG *sync.Wai
 
 func (c *cadenceImpl) startWorker(hosts map[string][]string, startWG *sync.WaitGroup) {
 	params := new(resource.Params)
-	params.Name = common.WorkerServiceName
+	params.Name = service.Worker
 	params.Logger = c.logger
 	params.ThrottledLogger = c.logger
-	params.UpdateLoggerWithServiceName(common.WorkerServiceName)
+	params.UpdateLoggerWithServiceName(service.Worker)
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.WorkerPProfPort())
-	params.RPCFactory = newRPCFactoryImpl(common.WorkerServiceName, c.WorkerServiceAddress(), c.logger)
-	params.MetricScope = tally.NewTestScope(common.WorkerServiceName, make(map[string]string))
+	params.RPCFactory = newRPCFactoryImpl(service.Worker, c.WorkerServiceAddress(), c.logger)
+	params.MetricScope = tally.NewTestScope(service.Worker, make(map[string]string))
 	params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 	params.ClusterMetadata = c.clusterMetadata
 	params.DispatcherProvider = c.dispatcherProvider
@@ -593,11 +593,11 @@ func (c *cadenceImpl) startWorker(hosts map[string][]string, startWG *sync.WaitG
 	if err != nil {
 		c.logger.Fatal("Failed to copy persistence config for worker", tag.Error(err))
 	}
-	dispatcher, err := params.DispatcherProvider.GetTChannel(common.FrontendServiceName, c.FrontendAddress(), nil)
+	dispatcher, err := params.DispatcherProvider.GetTChannel(service.Frontend, c.FrontendAddress(), nil)
 	if err != nil {
 		c.logger.Fatal("Failed to get dispatcher for worker", tag.Error(err))
 	}
-	params.PublicClient = cwsc.New(dispatcher.ClientConfig(common.FrontendServiceName))
+	params.PublicClient = cwsc.New(dispatcher.ClientConfig(service.Frontend))
 	service := NewService(params)
 	service.Start()
 
@@ -632,17 +632,17 @@ func (c *cadenceImpl) startWorker(hosts map[string][]string, startWG *sync.WaitG
 	c.shutdownWG.Done()
 }
 
-func (c *cadenceImpl) startWorkerReplicator(params *resource.Params, service Service, domainCache cache.DomainCache) {
-	serviceResolver, err := service.GetMembershipMonitor().GetResolver(common.WorkerServiceName)
+func (c *cadenceImpl) startWorkerReplicator(params *resource.Params, svc Service, domainCache cache.DomainCache) {
+	serviceResolver, err := svc.GetMembershipMonitor().GetResolver(service.Worker)
 	if err != nil {
 		c.logger.Fatal("Fail to start replicator when start worker", tag.Error(err))
 	}
 	c.replicator = replicator.NewReplicator(
 		c.clusterMetadata,
-		service.GetClientBean(),
+		svc.GetClientBean(),
 		c.logger,
-		service.GetMetricsClient(),
-		service.GetHostInfo(),
+		svc.GetMetricsClient(),
+		svc.GetHostInfo(),
 		serviceResolver,
 		c.domainReplicationQueue,
 		c.domainReplicationTaskExecutor,
@@ -654,24 +654,24 @@ func (c *cadenceImpl) startWorkerReplicator(params *resource.Params, service Ser
 	}
 }
 
-func (c *cadenceImpl) startWorkerClientWorker(params *resource.Params, service Service, domainCache cache.DomainCache) {
+func (c *cadenceImpl) startWorkerClientWorker(params *resource.Params, svc Service, domainCache cache.DomainCache) {
 	workerConfig := worker.NewConfig(params)
 	workerConfig.ArchiverConfig.ArchiverConcurrency = dynamicconfig.GetIntPropertyFn(10)
 	historyArchiverBootstrapContainer := &carchiver.HistoryBootstrapContainer{
 		HistoryV2Manager: c.historyV2Mgr,
 		Logger:           c.logger,
-		MetricsClient:    service.GetMetricsClient(),
+		MetricsClient:    svc.GetMetricsClient(),
 		ClusterMetadata:  c.clusterMetadata,
 		DomainCache:      domainCache,
 	}
-	err := c.archiverProvider.RegisterBootstrapContainer(common.WorkerServiceName, historyArchiverBootstrapContainer, &carchiver.VisibilityBootstrapContainer{})
+	err := c.archiverProvider.RegisterBootstrapContainer(service.Worker, historyArchiverBootstrapContainer, &carchiver.VisibilityBootstrapContainer{})
 	if err != nil {
 		c.logger.Fatal("Failed to register archiver bootstrap container for worker service", tag.Error(err))
 	}
 
 	bc := &archiver.BootstrapContainer{
 		PublicClient:     params.PublicClient,
-		MetricsClient:    service.GetMetricsClient(),
+		MetricsClient:    svc.GetMetricsClient(),
 		Logger:           c.logger,
 		HistoryV2Manager: c.historyV2Mgr,
 		DomainCache:      domainCache,

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -46,6 +46,7 @@ import (
 	"github.com/uber/cadence/common/ndc"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -265,7 +266,7 @@ func (adh *adminHandlerImpl) DescribeWorkflowExecution(
 	shardIDstr := string(rune(shardID)) // originally `string(int_shard_id)`, but changing it will change the ring hashing
 	shardIDForOutput := strconv.Itoa(shardID)
 
-	historyHost, err := adh.GetMembershipMonitor().Lookup(common.HistoryServiceName, shardIDstr)
+	historyHost, err := adh.GetMembershipMonitor().Lookup(service.History, shardIDstr)
 	if err != nil {
 		return nil, adh.error(err, scope)
 	}
@@ -596,7 +597,7 @@ func (adh *adminHandlerImpl) DescribeCluster(
 		membershipInfo.ReachableMembers = members
 
 		var rings []*types.RingInfo
-		for _, role := range []string{common.FrontendServiceName, common.HistoryServiceName, common.MatchingServiceName, common.WorkerServiceName} {
+		for _, role := range service.List {
 			resolver, err := monitor.GetResolver(role)
 			if err != nil {
 				return nil, adh.error(err, scope)

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -207,7 +207,7 @@ func NewService(
 
 	serviceResource, err := resource.New(
 		params,
-		common.FrontendServiceName,
+		service.Frontend,
 		&service.Config{
 			PersistenceMaxQPS:       serviceConfig.PersistenceMaxQPS,
 			PersistenceGlobalMaxQPS: serviceConfig.PersistenceGlobalMaxQPS,

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -49,6 +49,7 @@ import (
 	persistenceutils "github.com/uber/cadence/common/persistence/persistence-utils"
 	"github.com/uber/cadence/common/quotas"
 	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/types/mapper/thrift"
 )
@@ -165,7 +166,7 @@ func NewWorkflowHandler(
 			},
 			func(domain string) float64 {
 				if monitor := resource.GetMembershipMonitor(); monitor != nil && config.GlobalDomainRPS(domain) > 0 {
-					ringSize, err := monitor.GetMemberCount(common.FrontendServiceName)
+					ringSize, err := monitor.GetMemberCount(service.Frontend)
 					if err == nil && ringSize > 0 {
 						avgQuota := common.MaxInt(config.GlobalDomainRPS(domain)/ringSize, 1)
 						return float64(common.MinInt(avgQuota, config.MaxDomainRPSPerInstance(domain)))
@@ -2916,7 +2917,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(
 		return nil, wh.error(err, scope)
 	}
 
-	visibilityArchiver, err := wh.GetArchiverProvider().GetVisibilityArchiver(URI.Scheme(), common.FrontendServiceName)
+	visibilityArchiver, err := wh.GetArchiverProvider().GetVisibilityArchiver(URI.Scheme(), service.Frontend)
 	if err != nil {
 		return nil, wh.error(err, scope)
 	}
@@ -4168,7 +4169,7 @@ func (wh *WorkflowHandler) getArchivedHistory(
 		return nil, wh.error(err, scope, tags...)
 	}
 
-	historyArchiver, err := wh.GetArchiverProvider().GetHistoryArchiver(URI.Scheme(), common.FrontendServiceName)
+	historyArchiver, err := wh.GetArchiverProvider().GetHistoryArchiver(URI.Scheme(), service.Frontend)
 	if err != nil {
 		return nil, wh.error(err, scope, tags...)
 	}

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -122,7 +123,7 @@ func (s *workflowHandlerSuite) SetupTest() {
 	s.mockVersionChecker = client.NewMockVersionChecker(s.controller)
 
 	mockMonitor := s.mockResource.MembershipMonitor
-	mockMonitor.EXPECT().GetMemberCount(common.FrontendServiceName).Return(5, nil).AnyTimes()
+	mockMonitor.EXPECT().GetMemberCount(service.Frontend).Return(5, nil).AnyTimes()
 	s.mockVersionChecker.EXPECT().ClientSupported(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 }

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -28,6 +28,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/tag"
 	commonResource "github.com/uber/cadence/common/resource"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/resource"
 )
@@ -61,7 +62,7 @@ func NewService(
 
 	serviceResource, err := resource.New(
 		params,
-		common.HistoryServiceName,
+		service.History,
 		serviceConfig,
 	)
 	if err != nil {

--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/execution"
@@ -176,7 +177,7 @@ func (t *timerTaskExecutorBase) archiveWorkflow(
 			BranchToken:          branchToken,
 			CloseFailoverVersion: closeFailoverVersion,
 		},
-		CallerService:        common.HistoryServiceName,
+		CallerService:        service.History,
 		AttemptArchiveInline: false, // archive in workflow by default
 	}
 	executionStats, err := workflowContext.LoadExecutionStats(ctx)

--- a/service/history/task/timer_task_executor_base_test.go
+++ b/service/history/task/timer_task_executor_base_test.go
@@ -31,11 +31,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/execution"
@@ -153,7 +153,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_NoErr_InlineArchiva
 	s.mockVisibilityManager.On("DeleteWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
 
 	s.mockArchivalClient.On("Archive", mock.Anything, mock.MatchedBy(func(req *archiver.ClientRequest) bool {
-		return req.CallerService == common.HistoryServiceName && req.AttemptArchiveInline && req.ArchiveRequest.Targets[0] == archiver.ArchiveTargetHistory
+		return req.CallerService == service.History && req.AttemptArchiveInline && req.ArchiveRequest.Targets[0] == archiver.ArchiveTargetHistory
 	})).Return(&archiver.ClientResponse{
 		HistoryArchivedInline: false,
 	}, nil)
@@ -187,7 +187,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TestArchiveHistory_SendSignalErr() {
 	s.mockMutableState.EXPECT().GetNextEventID().Return(int64(101)).Times(1)
 
 	s.mockArchivalClient.On("Archive", mock.Anything, mock.MatchedBy(func(req *archiver.ClientRequest) bool {
-		return req.CallerService == common.HistoryServiceName && !req.AttemptArchiveInline && req.ArchiveRequest.Targets[0] == archiver.ArchiveTargetHistory
+		return req.CallerService == service.History && !req.AttemptArchiveInline && req.ArchiveRequest.Targets[0] == archiver.ArchiveTargetHistory
 	})).Return(nil, errors.New("failed to send signal"))
 
 	domainCacheEntry := cache.NewDomainCacheEntryForTest(

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/execution"
@@ -317,7 +318,7 @@ func (t *transferTaskExecutorBase) recordWorkflowClosed(
 				URI:                domainEntry.GetConfig().HistoryArchivalURI,
 				Targets:            []archiver.ArchivalTarget{archiver.ArchiveTargetVisibility},
 			},
-			CallerService:        common.HistoryServiceName,
+			CallerService:        service.History,
 			AttemptArchiveInline: true, // archive visibility inline by default
 		})
 		return err

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -55,7 +55,7 @@ func NewService(
 
 	serviceResource, err := resource.New(
 		params,
-		common.MatchingServiceName,
+		service.Matching,
 		&service.Config{
 			PersistenceMaxQPS:       serviceConfig.PersistenceMaxQPS,
 			PersistenceGlobalMaxQPS: serviceConfig.PersistenceGlobalMaxQPS,

--- a/service/worker/archiver/activities.go
+++ b/service/worker/archiver/activities.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/service"
 )
 
 const (
@@ -68,7 +69,7 @@ func uploadHistoryActivity(ctx context.Context, request ArchiveRequest) (err err
 		logger.Error(carchiver.ArchiveNonRetriableErrorMsg, tag.ArchivalArchiveFailReason("failed to get history archival uri"), tag.ArchivalURI(request.URI), tag.Error(err))
 		return errUploadNonRetriable
 	}
-	historyArchiver, err := container.ArchiverProvider.GetHistoryArchiver(URI.Scheme(), common.WorkerServiceName)
+	historyArchiver, err := container.ArchiverProvider.GetHistoryArchiver(URI.Scheme(), service.Worker)
 	if err != nil {
 		logger.Error(carchiver.ArchiveNonRetriableErrorMsg, tag.ArchivalArchiveFailReason("failed to get history archiver"), tag.Error(err))
 		return errUploadNonRetriable
@@ -141,7 +142,7 @@ func archiveVisibilityActivity(ctx context.Context, request ArchiveRequest) (err
 		logger.Error(carchiver.ArchiveNonRetriableErrorMsg, tag.ArchivalArchiveFailReason("failed to get visibility archival uri"), tag.ArchivalURI(request.VisibilityURI), tag.Error(err))
 		return errArchiveVisibilityNonRetriable
 	}
-	visibilityArchiver, err := container.ArchiverProvider.GetVisibilityArchiver(URI.Scheme(), common.WorkerServiceName)
+	visibilityArchiver, err := container.ArchiverProvider.GetVisibilityArchiver(URI.Scheme(), service.Worker)
 	if err != nil {
 		logger.Error(carchiver.ArchiveNonRetriableErrorMsg, tag.ArchivalArchiveFailReason("failed to get visibility archiver"), tag.Error(err))
 		return errArchiveVisibilityNonRetriable

--- a/service/worker/archiver/activities_test.go
+++ b/service/worker/archiver/activities_test.go
@@ -31,7 +31,6 @@ import (
 	"go.uber.org/cadence/worker"
 	"go.uber.org/zap"
 
-	"github.com/uber/cadence/common"
 	carchiver "github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/log"
@@ -39,6 +38,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	mmocks "github.com/uber/cadence/common/metrics/mocks"
 	"github.com/uber/cadence/common/mocks"
+	"github.com/uber/cadence/common/service"
 )
 
 const (
@@ -122,7 +122,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_InvalidURI() {
 func (s *activitiesSuite) TestUploadHistory_Fail_GetArchiverError() {
 	s.metricsClient.On("Scope", metrics.ArchiverUploadHistoryActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	s.metricsScope.On("IncCounter", metrics.ArchiverNonRetryableErrorCount).Once()
-	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, common.WorkerServiceName).Return(nil, errors.New("failed to get archiver"))
+	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, service.Worker).Return(nil, errors.New("failed to get archiver"))
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,
@@ -150,7 +150,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveNonRetriableError() {
 	s.metricsClient.On("Scope", metrics.ArchiverUploadHistoryActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	s.metricsScope.On("IncCounter", metrics.ArchiverNonRetryableErrorCount).Once()
 	s.historyArchiver.On("Archive", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errUploadNonRetriable)
-	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, common.WorkerServiceName).Return(s.historyArchiver, nil)
+	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, service.Worker).Return(s.historyArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,
@@ -178,7 +178,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveRetriableError() {
 	s.metricsClient.On("Scope", metrics.ArchiverUploadHistoryActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	testArchiveErr := errors.New("some transient error")
 	s.historyArchiver.On("Archive", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(testArchiveErr)
-	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, common.WorkerServiceName).Return(s.historyArchiver, nil)
+	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, service.Worker).Return(s.historyArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,
@@ -205,7 +205,7 @@ func (s *activitiesSuite) TestUploadHistory_Fail_ArchiveRetriableError() {
 func (s *activitiesSuite) TestUploadHistory_Success() {
 	s.metricsClient.On("Scope", metrics.ArchiverUploadHistoryActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	s.historyArchiver.On("Archive", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, common.WorkerServiceName).Return(s.historyArchiver, nil)
+	s.archiverProvider.On("GetHistoryArchiver", mock.Anything, service.Worker).Return(s.historyArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,
@@ -282,7 +282,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_InvalidURI() {
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_GetArchiverError() {
 	s.metricsClient.On("Scope", metrics.ArchiverArchiveVisibilityActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	s.metricsScope.On("IncCounter", metrics.ArchiverNonRetryableErrorCount).Once()
-	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, common.WorkerServiceName).Return(nil, errors.New("failed to get archiver"))
+	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, service.Worker).Return(nil, errors.New("failed to get archiver"))
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,
@@ -307,7 +307,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveNonRetriable
 	s.metricsClient.On("Scope", metrics.ArchiverArchiveVisibilityActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	s.metricsScope.On("IncCounter", metrics.ArchiverNonRetryableErrorCount).Once()
 	s.visibilityArchiver.On("Archive", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errArchiveVisibilityNonRetriable)
-	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, common.WorkerServiceName).Return(s.visibilityArchiver, nil)
+	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, service.Worker).Return(s.visibilityArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,
@@ -332,7 +332,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveRetriableErr
 	s.metricsClient.On("Scope", metrics.ArchiverArchiveVisibilityActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	testArchiveErr := errors.New("some transient error")
 	s.visibilityArchiver.On("Archive", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(testArchiveErr)
-	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, common.WorkerServiceName).Return(s.visibilityArchiver, nil)
+	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, service.Worker).Return(s.visibilityArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,
@@ -356,7 +356,7 @@ func (s *activitiesSuite) TestArchiveVisibilityActivity_Fail_ArchiveRetriableErr
 func (s *activitiesSuite) TestArchiveVisibilityActivity_Success() {
 	s.metricsClient.On("Scope", metrics.ArchiverArchiveVisibilityActivityScope, []metrics.Tag{metrics.DomainTag(testDomainName)}).Return(s.metricsScope).Once()
 	s.visibilityArchiver.On("Archive", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
-	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, common.WorkerServiceName).Return(s.visibilityArchiver, nil)
+	s.archiverProvider.On("GetVisibilityArchiver", mock.Anything, service.Worker).Return(s.visibilityArchiver, nil)
 	container := &BootstrapContainer{
 		Logger:           s.logger,
 		MetricsClient:    s.metricsClient,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -93,7 +93,7 @@ func NewService(
 
 	serviceResource, err := resource.New(
 		params,
-		common.WorkerServiceName,
+		service.Worker,
 		&service.Config{
 			PersistenceMaxQPS:       serviceConfig.PersistenceMaxQPS,
 			PersistenceGlobalMaxQPS: serviceConfig.PersistenceGlobalMaxQPS,

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -30,7 +30,6 @@ import (
 	"github.com/urfave/cli"
 
 	"github.com/uber/cadence/client/frontend"
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
 	"github.com/uber/cadence/common/clock"
@@ -44,6 +43,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/client"
+	"github.com/uber/cadence/common/service"
 )
 
 const (
@@ -395,7 +395,7 @@ func initializeArchivalProvider(
 	}
 
 	err := archiverProvider.RegisterBootstrapContainer(
-		common.FrontendServiceName,
+		service.Frontend,
 		historyArchiverBootstrapContainer,
 		visibilityArchiverBootstrapContainer,
 	)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Gathered all service naming related constants, lists and `cadence-` prefix related functionality in one place under `service` package.

<!-- Tell your future self why have you made these changes -->
**Why?**
To prevent duplication, keep everything in one place.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Additional unit tests to cover prefix functionlity.
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
