### PR TITLE
Introduce rpc.Params

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -82,9 +82,6 @@ func startHandler(c *cli.Context) {
 	sigc := make(chan os.Signal, 1)
 	signal.Notify(sigc, syscall.SIGTERM)
 	for _, svc := range services {
-		if _, ok := cfg.Services[svc]; !ok {
-			log.Fatalf("`%v` service missing config", svc)
-		}
 		server := newServer(svc, &cfg)
 		daemons = append(daemons, server)
 		server.Start()

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -22,6 +22,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"time"
 
@@ -31,6 +32,7 @@ import (
 
 	"github.com/uber/cadence/common/dynamicconfig"
 	c "github.com/uber/cadence/common/dynamicconfig/configstore/config"
+	"github.com/uber/cadence/common/service"
 )
 
 type (
@@ -479,4 +481,13 @@ func (c *Config) fillDefaults() {
 func (c *Config) String() string {
 	out, _ := json.MarshalIndent(c, "", "    ")
 	return string(out)
+}
+
+func (c *Config) GetServiceConfig(serviceName string) (Service, error) {
+	shortName := service.ShortName(serviceName)
+	serviceConfig, ok := c.Services[shortName]
+	if !ok {
+		return Service{}, fmt.Errorf("no config section for service: %s", shortName)
+	}
+	return serviceConfig, nil
 }

--- a/common/config/config_test.go
+++ b/common/config/config_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/service"
 )
 
 func TestToString(t *testing.T) {
@@ -101,4 +102,15 @@ func TestConfigErrorInAuthorizationConfig(t *testing.T) {
 
 	err := cfg.ValidateAndFillDefaults()
 	require.Error(t, err)
+}
+
+func TestGetServiceConfig(t *testing.T) {
+	cfg := Config{}
+	_, err := cfg.GetServiceConfig(service.Frontend)
+	assert.EqualError(t, err, "no config section for service: frontend")
+
+	cfg = Config{Services: map[string]Service{"frontend": {RPC: RPC{GRPCPort: 123}}}}
+	svc, err := cfg.GetServiceConfig(service.Frontend)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, svc)
 }

--- a/common/config/tls.go
+++ b/common/config/tls.go
@@ -21,7 +21,7 @@
 package config
 
 type (
-	// TLS describe TLS configuration 
+	// TLS describe TLS configuration
 	TLS struct {
 		Enabled bool `yaml:"enabled"`
 

--- a/common/rpc/factory.go
+++ b/common/rpc/factory.go
@@ -34,11 +34,11 @@ import (
 
 // Factory is an implementation of common.RPCFactory interface
 type Factory struct {
-	logger           log.Logger
-	grpcPortResolver GRPCPortResolver
-	tchannel         *tchannel.Transport
-	grpc             *grpc.Transport
-	dispatcher       *yarpc.Dispatcher
+	logger            log.Logger
+	hostAddressMapper HostAddressMapper
+	tchannel          *tchannel.Transport
+	grpc              *grpc.Transport
+	dispatcher        *yarpc.Dispatcher
 }
 
 // NewFactory builds a new rpc.Factory
@@ -97,11 +97,11 @@ func NewFactory(logger log.Logger, p Params) *Factory {
 	})
 
 	return &Factory{
-		logger:           logger,
-		grpcPortResolver: p.GRPCPortResolver,
-		tchannel:         tchannel,
-		grpc:             grpc,
-		dispatcher:       dispatcher,
+		logger:            logger,
+		hostAddressMapper: p.HostAddressMapper,
+		tchannel:          tchannel,
+		grpc:              grpc,
+		dispatcher:        dispatcher,
 	}
 }
 
@@ -130,7 +130,7 @@ func (d *Factory) CreateGRPCDispatcherForOutbound(
 
 // ReplaceGRPCPort replaces port in the address to grpc for a given service
 func (d *Factory) ReplaceGRPCPort(serviceName, hostAddress string) (string, error) {
-	return d.grpcPortResolver.GetGRPCAddress(serviceName, hostAddress)
+	return d.hostAddressMapper.GetGRPCAddress(serviceName, hostAddress)
 }
 
 func (d *Factory) createOutboundDispatcher(

--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -30,7 +30,7 @@ import (
 )
 
 type (
-	GRPCPortResolver interface {
+	HostAddressMapper interface {
 		GetGRPCAddress(service, hostAddress string) (string, error)
 	}
 

--- a/common/rpc/outbounds.go
+++ b/common/rpc/outbounds.go
@@ -21,43 +21,12 @@
 package rpc
 
 import (
-	"errors"
-	"fmt"
-	"strings"
-
-	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/service"
+	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/tchannel"
 )
 
-type (
-	GRPCPortResolver interface {
-		GetGRPCAddress(service, hostAddress string) (string, error)
-	}
-
-	GRPCPorts map[string]int
-)
-
-func NewGRPCPorts(c *config.Config) GRPCPorts {
-	grpcPorts := map[string]int{}
-	for name, config := range c.Services {
-		grpcPorts[service.FullName(name)] = config.RPC.GRPCPort
-	}
-	return grpcPorts
-}
-
-func (p GRPCPorts) GetGRPCAddress(service, hostAddress string) (string, error) {
-	port, ok := p[service]
-	if !ok {
-		return hostAddress, errors.New("unknown service: " + service)
-	}
-	if port == 0 {
-		return hostAddress, errors.New("GRPC port not configured for service: " + service)
-	}
-
-	// Drop port if provided
-	if index := strings.Index(hostAddress, ":"); index > 0 {
-		hostAddress = hostAddress[:index]
-	}
-
-	return fmt.Sprintf("%s:%d", hostAddress, port), nil
+// OutboundsBuilder allows defining outbounds for the dispatcher
+type OutboundsBuilder interface {
+	Build(*grpc.Transport, *tchannel.Transport) (yarpc.Outbounds, error)
 }

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -1,0 +1,83 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/uber/cadence/common/config"
+
+	"go.uber.org/yarpc"
+)
+
+// Params allows to configure rpc.Factory
+type Params struct {
+	ServiceName      string
+	TChannelAddress  string
+	GRPCAddress      string
+	GRPCMaxMsgSize   int
+	GRPCPortResolver GRPCPortResolver
+
+	InboundMiddleware  yarpc.InboundMiddleware
+	OutboundMiddleware yarpc.OutboundMiddleware
+
+	OutboundsBuilder OutboundsBuilder
+}
+
+// NewParams creates parameters for rpc.Factory from the given config
+func NewParams(serviceName string, config *config.Config) (Params, error) {
+	serviceConfig, err := config.GetServiceConfig(serviceName)
+	if err != nil {
+		return Params{}, err
+	}
+
+	listenIP, err := getListenIP(serviceConfig.RPC)
+	if err != nil {
+		return Params{}, fmt.Errorf("failed to get listen IP: %v", err)
+	}
+	return Params{
+		ServiceName:      serviceName,
+		TChannelAddress:  fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.Port),
+		GRPCAddress:      fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.GRPCPort),
+		GRPCMaxMsgSize:   serviceConfig.RPC.GRPCMaxMsgSize,
+		GRPCPortResolver: NewGRPCPorts(config),
+	}, nil
+}
+
+func getListenIP(config config.RPC) (net.IP, error) {
+	if config.BindOnLocalHost && len(config.BindOnIP) > 0 {
+		return nil, fmt.Errorf("bindOnLocalHost and bindOnIP are mutually exclusive")
+	}
+
+	if config.BindOnLocalHost {
+		return net.IPv4(127, 0, 0, 1), nil
+	}
+
+	if len(config.BindOnIP) > 0 {
+		ip := net.ParseIP(config.BindOnIP)
+		if ip != nil && ip.To4() != nil {
+			return ip.To4(), nil
+		}
+		return nil, fmt.Errorf("unable to parse bindOnIP value or it is not an IPv4 address: %s", config.BindOnIP)
+	}
+	return ListenIP()
+}

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -31,11 +31,11 @@ import (
 
 // Params allows to configure rpc.Factory
 type Params struct {
-	ServiceName      string
-	TChannelAddress  string
-	GRPCAddress      string
-	GRPCMaxMsgSize   int
-	GRPCPortResolver GRPCPortResolver
+	ServiceName       string
+	TChannelAddress   string
+	GRPCAddress       string
+	GRPCMaxMsgSize    int
+	HostAddressMapper HostAddressMapper
 
 	InboundMiddleware  yarpc.InboundMiddleware
 	OutboundMiddleware yarpc.OutboundMiddleware
@@ -55,11 +55,11 @@ func NewParams(serviceName string, config *config.Config) (Params, error) {
 		return Params{}, fmt.Errorf("failed to get listen IP: %v", err)
 	}
 	return Params{
-		ServiceName:      serviceName,
-		TChannelAddress:  fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.Port),
-		GRPCAddress:      fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.GRPCPort),
-		GRPCMaxMsgSize:   serviceConfig.RPC.GRPCMaxMsgSize,
-		GRPCPortResolver: NewGRPCPorts(config),
+		ServiceName:       serviceName,
+		TChannelAddress:   fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.Port),
+		GRPCAddress:       fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.GRPCPort),
+		GRPCMaxMsgSize:    serviceConfig.RPC.GRPCMaxMsgSize,
+		HostAddressMapper: NewGRPCPorts(config),
 	}, nil
 }
 

--- a/common/rpc/params_test.go
+++ b/common/rpc/params_test.go
@@ -50,7 +50,7 @@ func TestNewParams(t *testing.T) {
 	assert.Equal(t, "127.0.0.1:1111", params.TChannelAddress)
 	assert.Equal(t, "127.0.0.1:2222", params.GRPCAddress)
 	assert.Equal(t, 3333, params.GRPCMaxMsgSize)
-	assert.IsType(t, GRPCPorts{}, params.GRPCPortResolver)
+	assert.IsType(t, GRPCPorts{}, params.HostAddressMapper)
 
 	params, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnIP: "1.2.3.4", GRPCPort: 2222}}))
 	assert.NoError(t, err)

--- a/common/rpc/params_test.go
+++ b/common/rpc/params_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"net"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/service"
+)
+
+func TestNewParams(t *testing.T) {
+	serviceName := service.Frontend
+	makeConfig := func(svc config.Service) *config.Config {
+		return &config.Config{Services: map[string]config.Service{"frontend": svc}}
+	}
+
+	_, err := NewParams(serviceName, &config.Config{})
+	assert.EqualError(t, err, "no config section for service: frontend")
+
+	_, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnLocalHost: true, BindOnIP: "1.2.3.4"}}))
+	assert.EqualError(t, err, "failed to get listen IP: bindOnLocalHost and bindOnIP are mutually exclusive")
+
+	_, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnIP: "invalidIP"}}))
+	assert.EqualError(t, err, "failed to get listen IP: unable to parse bindOnIP value or it is not an IPv4 address: invalidIP")
+
+	params, err := NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnLocalHost: true, Port: 1111, GRPCPort: 2222, GRPCMaxMsgSize: 3333}}))
+	assert.NoError(t, err)
+	assert.Equal(t, "127.0.0.1:1111", params.TChannelAddress)
+	assert.Equal(t, "127.0.0.1:2222", params.GRPCAddress)
+	assert.Equal(t, 3333, params.GRPCMaxMsgSize)
+	assert.IsType(t, GRPCPorts{}, params.GRPCPortResolver)
+
+	params, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnIP: "1.2.3.4", GRPCPort: 2222}}))
+	assert.NoError(t, err)
+	assert.Equal(t, "1.2.3.4:2222", params.GRPCAddress)
+
+	params, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{GRPCPort: 2222}}))
+	assert.NoError(t, err)
+	ip, port, err := net.SplitHostPort(params.GRPCAddress)
+	assert.NoError(t, err)
+	assert.Equal(t, "2222", port)
+	assert.NotNil(t, net.ParseIP(ip))
+}

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -799,10 +799,10 @@ func newRPCFactory(serviceName string, tchannelHostPort string, logger log.Logge
 	}
 
 	return rpc.NewFactory(logger, rpc.Params{
-		ServiceName:      serviceName,
-		TChannelAddress:  tchannelHostPort,
-		GRPCAddress:      grpcHostPort,
-		GRPCPortResolver: &grpcPortResolver,
+		ServiceName:       serviceName,
+		TChannelAddress:   tchannelHostPort,
+		GRPCAddress:       grpcHostPort,
+		HostAddressMapper: &grpcPortResolver,
 		InboundMiddleware: yarpc.InboundMiddleware{
 			Unary: &versionMiddleware{},
 		},

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -398,7 +398,7 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]string, startWG *sync.Wai
 	params.ThrottledLogger = c.logger
 	params.UpdateLoggerWithServiceName(service.Frontend)
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.FrontendPProfPort())
-	params.RPCFactory = newRPCFactoryImpl(service.Frontend, c.FrontendAddress(), c.logger)
+	params.RPCFactory = newRPCFactory(service.Frontend, c.FrontendAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(service.Frontend, make(map[string]string))
 	params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 	params.ClusterMetadata = c.clusterMetadata
@@ -465,7 +465,7 @@ func (c *cadenceImpl) startHistory(
 		params.ThrottledLogger = c.logger
 		params.UpdateLoggerWithServiceName(service.History)
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
-		params.RPCFactory = newRPCFactoryImpl(service.History, hostport, c.logger)
+		params.RPCFactory = newRPCFactory(service.History, hostport, c.logger)
 		params.MetricScope = tally.NewTestScope(service.History, make(map[string]string))
 		params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 		params.ClusterMetadata = c.clusterMetadata
@@ -535,7 +535,7 @@ func (c *cadenceImpl) startMatching(hosts map[string][]string, startWG *sync.Wai
 	params.ThrottledLogger = c.logger
 	params.UpdateLoggerWithServiceName(service.Matching)
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.MatchingPProfPort())
-	params.RPCFactory = newRPCFactoryImpl(service.Matching, c.MatchingServiceAddress(), c.logger)
+	params.RPCFactory = newRPCFactory(service.Matching, c.MatchingServiceAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(service.Matching, make(map[string]string))
 	params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 	params.ClusterMetadata = c.clusterMetadata
@@ -578,7 +578,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]string, startWG *sync.WaitG
 	params.ThrottledLogger = c.logger
 	params.UpdateLoggerWithServiceName(service.Worker)
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.WorkerPProfPort())
-	params.RPCFactory = newRPCFactoryImpl(service.Worker, c.WorkerServiceAddress(), c.logger)
+	params.RPCFactory = newRPCFactory(service.Worker, c.WorkerServiceAddress(), c.logger)
 	params.MetricScope = tally.NewTestScope(service.Worker, make(map[string]string))
 	params.MembershipFactory = newMembershipFactory(params.Name, hosts)
 	params.ClusterMetadata = c.clusterMetadata
@@ -791,70 +791,38 @@ func newPProfInitializerImpl(logger log.Logger, port int) common.PProfInitialize
 	}
 }
 
-type rpcFactoryImpl struct {
-	ch          *tchannel.ChannelTransport
-	grpc        *grpc.Transport
-	serviceName string
-	hostPort    string
-	logger      log.Logger
-
-	sync.Mutex
-	dispatcher *yarpc.Dispatcher
-}
-
-func newRPCFactoryImpl(sName string, hostPort string, logger log.Logger) common.RPCFactory {
-	return &rpcFactoryImpl{
-		serviceName: sName,
-		hostPort:    hostPort,
-		logger:      logger,
-	}
-}
-
-func (c *rpcFactoryImpl) GetDispatcher() *yarpc.Dispatcher {
-	c.Lock()
-	defer c.Unlock()
-
-	if c.dispatcher != nil {
-		return c.dispatcher
-	}
-
-	c.dispatcher = c.createDispatcher()
-	return c.dispatcher
-}
-
-func (c *rpcFactoryImpl) createDispatcher() *yarpc.Dispatcher {
-	// Setup dispatcher for onebox
-	inbounds := yarpc.Inbounds{}
-	var err error
-	c.ch, err = tchannel.NewChannelTransport(
-		tchannel.ServiceName(c.serviceName), tchannel.ListenAddr(c.hostPort))
+func newRPCFactory(serviceName string, tchannelHostPort string, logger log.Logger) common.RPCFactory {
+	grpcPortResolver := grpcPortResolver{}
+	grpcHostPort, err := grpcPortResolver.GetGRPCAddress("", tchannelHostPort)
 	if err != nil {
-		c.logger.Fatal("Failed to create transport channel", tag.Error(err))
+		logger.Fatal("Failed to obtain GRPC address", tag.Error(err))
 	}
-	inbounds = append(inbounds, c.ch.NewInbound())
 
-	grpcHostPort, err := c.ReplaceGRPCPort("", c.hostPort)
-	if err != nil {
-		c.logger.Fatal("Failed to obtain GRPC address", tag.Error(err))
-	}
-	c.grpc = grpc.NewTransport()
-	listener, err := net.Listen("tcp", grpcHostPort)
-	if err != nil {
-		c.logger.Fatal("Failed to listen for GRPC request", tag.Error(err))
-	}
-	inbounds = append(inbounds, c.grpc.NewInbound(listener))
-
-	return yarpc.NewDispatcher(yarpc.Config{
-		Name:     c.serviceName,
-		Inbounds: inbounds,
-		// For integration tests to generate client out of the same outbound.
-		Outbounds: yarpc.Outbounds{
-			c.serviceName: {Unary: c.ch.NewSingleOutbound(c.hostPort)},
-		},
+	return rpc.NewFactory(logger, rpc.Params{
+		ServiceName:      serviceName,
+		TChannelAddress:  tchannelHostPort,
+		GRPCAddress:      grpcHostPort,
+		GRPCPortResolver: &grpcPortResolver,
 		InboundMiddleware: yarpc.InboundMiddleware{
 			Unary: &versionMiddleware{},
 		},
+		// For integration tests to generate client out of the same outbound.
+		OutboundsBuilder: &singleTChannelOutbound{serviceName, tchannelHostPort},
 	})
+}
+
+type singleTChannelOutbound struct {
+	serviceName string
+	address     string
+}
+
+func (b singleTChannelOutbound) Build(_ *grpc.Transport, tchannel *tchannel.Transport) (yarpc.Outbounds, error) {
+	return yarpc.Outbounds{
+		b.serviceName: {
+			ServiceName: b.serviceName,
+			Unary:       tchannel.NewSingleOutbound(b.address),
+		},
+	}, nil
 }
 
 type versionMiddleware struct {
@@ -868,42 +836,11 @@ func (vm *versionMiddleware) Handle(ctx context.Context, req *transport.Request,
 	return h.Handle(ctx, req, resw)
 }
 
-func (c *rpcFactoryImpl) CreateDispatcherForOutbound(
-	callerName, serviceName, hostName string) (*yarpc.Dispatcher, error) {
-	// Setup dispatcher(outbound) for onebox
-	d := yarpc.NewDispatcher(yarpc.Config{
-		Name: callerName,
-		Outbounds: yarpc.Outbounds{
-			serviceName: {Unary: c.ch.NewSingleOutbound(hostName)},
-		},
-	})
-	if err := d.Start(); err != nil {
-		c.logger.Error("Failed to create outbound transport channel", tag.Error(err))
-		return nil, err
-	}
-	return d, nil
-}
-
-func (c *rpcFactoryImpl) CreateGRPCDispatcherForOutbound(
-	callerName, serviceName, hostName string) (*yarpc.Dispatcher, error) {
-
-	// Setup dispatcher(outbound) for onebox
-	d := yarpc.NewDispatcher(yarpc.Config{
-		Name: callerName,
-		Outbounds: yarpc.Outbounds{
-			serviceName: {Unary: c.grpc.NewSingleOutbound(hostName)},
-		},
-	})
-	if err := d.Start(); err != nil {
-		c.logger.Error("Failed to create outbound GRPC", tag.Error(err))
-		return nil, err
-	}
-	return d, nil
-}
-
 const grpcPortOffset = 10
 
-func (c *rpcFactoryImpl) ReplaceGRPCPort(_, hostPort string) (string, error) {
+type grpcPortResolver struct{}
+
+func (p *grpcPortResolver) GetGRPCAddress(_, hostPort string) (string, error) {
 	host, port, err := net.SplitHostPort(hostPort)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Introduced `rpc.Params` structure that contains required parameters to initialize `rpc.Factory`.
This decouples Factory from using config directly. It is beneficial for 2 reasons:
- Allows unit test config part easier
- Allows reusing the same `rpc.Factory` in integration tests. Before we had a separate implementation there, with minor differences. Now we can pass those differences via Params.

Also refactored service config retrieval into a function. This is now used in couple of places.

<!-- Tell your future self why have you made these changes -->
**Why?**
To reduce code duplication and increase test coverage.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Additional unit tests for refactored code.
Existing tests.
Starting server locally with removed config section.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
