### PR TITLE
Increase archival initial retry interval

### DIFF
--- a/service/worker/archiver/handler.go
+++ b/service/worker/archiver/handler.go
@@ -138,7 +138,7 @@ func (h *handler) handleHistoryRequest(ctx workflow.Context, request *ArchiveReq
 		ScheduleToStartTimeout: 1 * time.Minute,
 		StartToCloseTimeout:    1 * time.Minute,
 		RetryPolicy: &cadence.RetryPolicy{
-			InitialInterval:          time.Second,
+			InitialInterval:          5 * time.Second,
 			BackoffCoefficient:       2.0,
 			ExpirationInterval:       5 * time.Minute,
 			NonRetriableErrorReasons: uploadHistoryActivityNonRetryableErrors,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Increased the initial retry interval for history archival request. 


<!-- Tell your future self why have you made these changes -->
**Why?**
Current retries were exhausting the storage we use for archival.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
