### PR TITLE
Improve close execution task for cross cluster situation

### DIFF
--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -315,7 +315,9 @@ func (t *transferActiveTaskExecutor) processCloseExecution(
 	children := mutableState.GetPendingChildExecutionInfos()
 
 	// generate cross cluster task for applying parent close policy
-	crossClusterTaskGenerators, sameClusterChildDomainIDs, signalParentClosePolicyWorker, err := t.applyParentClosePolicyDomainActiveCheck(
+	crossClusterTaskGenerators,
+		sameClusterChildDomainIDs,
+		signalParentClosePolicyWorker, err := t.applyParentClosePolicyDomainActiveCheck(
 		task,
 		domainName,
 		children,

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -456,6 +456,8 @@ func (s *transferActiveTaskExecutorSuite) TestProcessCloseExecution_HasParent_Fa
 			mutableState execution.MutableState,
 			workflowExecution, targetExecution types.WorkflowExecution,
 		) {
+			s.mockVisibilityMgr.On("RecordWorkflowExecutionClosed", mock.Anything, mock.Anything).Return(nil).Once()
+			s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewDisabledArchvialConfig())
 		},
 		true,
 	)
@@ -595,7 +597,15 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.domainName,
 		},
 		func() {
-			s.expectCrossClusterApplyParentPolicyCalls()
+			// s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
+			// 	func(request parentclosepolicy.Request) bool {
+			// 		fmt.Println(request.Executions)
+			// 		return len(request.Executions) == 3
+			// 	},
+			// )).Return(nil).Times(1)
+			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
+			// cross cluster apply parent close task is fixed
+			// s.expectCrossClusterApplyParentPolicyCalls()
 			s.expectCancelRequest(s.domainName)
 			s.expectTerminateRequest(s.domainName)
 		},
@@ -610,8 +620,15 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.childDomainName,
 		},
 		func() {
-			s.expectCrossClusterApplyParentPolicyCalls()
-			s.expectCancelRequest(s.childDomainName)
+			s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
+				func(request parentclosepolicy.Request) bool {
+					return len(request.Executions) == 2
+				},
+			)).Return(nil).Times(1)
+			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
+			// cross cluster apply parent close task is fixed
+			// s.expectCrossClusterApplyParentPolicyCalls()
+			// s.expectCancelRequest(s.childDomainName)
 		},
 	)
 }
@@ -624,8 +641,15 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.remoteTargetDomainName,
 		},
 		func() {
-			s.expectCrossClusterApplyParentPolicyCalls()
-			s.expectTerminateRequest(s.domainName)
+			s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
+				func(request parentclosepolicy.Request) bool {
+					return len(request.Executions) == 2
+				},
+			)).Return(nil).Times(1)
+			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
+			// cross cluster apply parent close task is fixed
+			// s.expectCrossClusterApplyParentPolicyCalls()
+			// s.expectTerminateRequest(s.domainName)
 		},
 	)
 }
@@ -638,7 +662,14 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.remoteTargetDomainName,
 		},
 		func() {
-			s.expectCrossClusterApplyParentPolicyCalls()
+			s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
+				func(request parentclosepolicy.Request) bool {
+					return len(request.Executions) == 2
+				},
+			)).Return(nil).Times(1)
+			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
+			// cross cluster apply parent close task is fixed
+			// s.expectCrossClusterApplyParentPolicyCalls()
 		},
 	)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Send signal to parent close policy workflow if possible
- Release mutable state lock as early as possible

<!-- Tell your future self why have you made these changes -->
**Why?**
- Current cross cluster parent close policy task is buggy. Use system workflow to process them as a short term solution
- Release mutable state lock as early as possible (before any rpc calls) by deciding how task should be processed first.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
