### PR TITLE
Use common dispatcher for public client outbound #2

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -29,7 +29,6 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/provider"
-	"github.com/uber/cadence/common/authorization"
 	"github.com/uber/cadence/common/blobstore/filestore"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/config"
@@ -151,9 +150,10 @@ func (s *server) startService() common.Daemon {
 		log.Fatalf("error creating rpc factory params: %v", err)
 	}
 	params.RPCFactory = rpc.NewFactory(params.Logger, rpcParams)
+	dispatcher := params.RPCFactory.GetDispatcher()
 
 	params.MembershipFactory, err = s.cfg.Ringpop.NewFactory(
-		params.RPCFactory.GetDispatcher(),
+		dispatcher,
 		params.Name,
 		params.Logger,
 	)
@@ -174,10 +174,6 @@ func (s *server) startService() common.Daemon {
 		clusterGroupMetadata.CurrentClusterName,
 		clusterGroupMetadata.ClusterGroup,
 	)
-
-	if len(s.cfg.PublicClient.HostPort) == 0 {
-		log.Fatalf("need to provide an endpoint config for PublicClient")
-	}
 
 	params.DispatcherProvider = rpc.NewDispatcherProvider(params.Logger, rpc.NewDNSPeerChooserFactory(s.cfg.PublicClient.RefreshInterval, params.Logger))
 
@@ -215,22 +211,7 @@ func (s *server) startService() common.Daemon {
 		}
 	}
 
-	var options *rpc.DispatcherOptions
-	if s.cfg.Authorization.OAuthAuthorizer.Enable {
-		clusterName := s.cfg.ClusterGroupMetadata.CurrentClusterName
-		authProvider, err := authorization.GetAuthProviderClient(s.cfg.ClusterGroupMetadata.ClusterGroup[clusterName].AuthorizationProvider.PrivateKey)
-		if err != nil {
-			log.Fatalf("failed to create AuthProvider: %v", err.Error())
-		}
-		options = &rpc.DispatcherOptions{
-			AuthProvider: authProvider,
-		}
-	}
-	dispatcher, err := params.DispatcherProvider.GetTChannel(service.Frontend, s.cfg.PublicClient.HostPort, options)
-	if err != nil {
-		log.Fatalf("failed to construct dispatcher: %v", err)
-	}
-	params.PublicClient = workflowserviceclient.New(dispatcher.ClientConfig(service.Frontend))
+	params.PublicClient = workflowserviceclient.New(dispatcher.ClientConfig(rpc.OutboundPublicClient))
 
 	params.ArchivalMetadata = archiver.NewArchivalMetadata(
 		dc,

--- a/common/rpc/outbounds.go
+++ b/common/rpc/outbounds.go
@@ -43,6 +43,11 @@ type OutboundsBuilder interface {
 	Build(*grpc.Transport, *tchannel.Transport) (yarpc.Outbounds, error)
 }
 
+type publicClientOutbound struct {
+	address        string
+	authMiddleware middleware.UnaryOutbound
+}
+
 func newPublicClientOutbound(config *config.Config) (publicClientOutbound, error) {
 	if len(config.PublicClient.HostPort) == 0 {
 		return publicClientOutbound{}, fmt.Errorf("need to provide an endpoint config for PublicClient")
@@ -60,11 +65,6 @@ func newPublicClientOutbound(config *config.Config) (publicClientOutbound, error
 	}
 
 	return publicClientOutbound{config.PublicClient.HostPort, authMiddleware}, nil
-}
-
-type publicClientOutbound struct {
-	address        string
-	authMiddleware middleware.UnaryOutbound
 }
 
 func (b publicClientOutbound) Build(_ *grpc.Transport, tchannel *tchannel.Transport) (yarpc.Outbounds, error) {

--- a/common/rpc/outbounds.go
+++ b/common/rpc/outbounds.go
@@ -48,7 +48,7 @@ func newPublicClientOutbound(config *config.Config) (publicClientOutbound, error
 		return publicClientOutbound{}, fmt.Errorf("need to provide an endpoint config for PublicClient")
 	}
 
-	var authMiddleware *authOutboundMiddleware
+	var authMiddleware middleware.UnaryOutbound
 	if config.Authorization.OAuthAuthorizer.Enable {
 		clusterName := config.ClusterGroupMetadata.CurrentClusterName
 		clusterInfo := config.ClusterGroupMetadata.ClusterGroup[clusterName]
@@ -64,7 +64,7 @@ func newPublicClientOutbound(config *config.Config) (publicClientOutbound, error
 
 type publicClientOutbound struct {
 	address        string
-	authMiddleware *authOutboundMiddleware
+	authMiddleware middleware.UnaryOutbound
 }
 
 func (b publicClientOutbound) Build(_ *grpc.Transport, tchannel *tchannel.Transport) (yarpc.Outbounds, error) {

--- a/common/rpc/outbounds.go
+++ b/common/rpc/outbounds.go
@@ -21,12 +21,57 @@
 package rpc
 
 import (
+	"fmt"
+
+	"github.com/uber/cadence/common/authorization"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/service"
+
 	"go.uber.org/yarpc"
+	"go.uber.org/yarpc/api/middleware"
 	"go.uber.org/yarpc/transport/grpc"
 	"go.uber.org/yarpc/transport/tchannel"
+)
+
+const (
+	// OutboundPublicClient is the name of configured public client outbound
+	OutboundPublicClient = "public-client"
 )
 
 // OutboundsBuilder allows defining outbounds for the dispatcher
 type OutboundsBuilder interface {
 	Build(*grpc.Transport, *tchannel.Transport) (yarpc.Outbounds, error)
+}
+
+func newPublicClientOutbound(config *config.Config) (publicClientOutbound, error) {
+	if len(config.PublicClient.HostPort) == 0 {
+		return publicClientOutbound{}, fmt.Errorf("need to provide an endpoint config for PublicClient")
+	}
+
+	var authMiddleware *authOutboundMiddleware
+	if config.Authorization.OAuthAuthorizer.Enable {
+		clusterName := config.ClusterGroupMetadata.CurrentClusterName
+		clusterInfo := config.ClusterGroupMetadata.ClusterGroup[clusterName]
+		authProvider, err := authorization.GetAuthProviderClient(clusterInfo.AuthorizationProvider.PrivateKey)
+		if err != nil {
+			return publicClientOutbound{}, fmt.Errorf("failed to create AuthProvider: %v", err)
+		}
+		authMiddleware = &authOutboundMiddleware{authProvider}
+	}
+
+	return publicClientOutbound{config.PublicClient.HostPort, authMiddleware}, nil
+}
+
+type publicClientOutbound struct {
+	address        string
+	authMiddleware *authOutboundMiddleware
+}
+
+func (b publicClientOutbound) Build(_ *grpc.Transport, tchannel *tchannel.Transport) (yarpc.Outbounds, error) {
+	return yarpc.Outbounds{
+		OutboundPublicClient: {
+			ServiceName: service.Frontend,
+			Unary:       middleware.ApplyUnaryOutbound(tchannel.NewSingleOutbound(b.address), b.authMiddleware),
+		},
+	}, nil
 }

--- a/common/rpc/outbounds.go
+++ b/common/rpc/outbounds.go
@@ -54,7 +54,7 @@ func newPublicClientOutbound(config *config.Config) (publicClientOutbound, error
 		clusterInfo := config.ClusterGroupMetadata.ClusterGroup[clusterName]
 		authProvider, err := authorization.GetAuthProviderClient(clusterInfo.AuthorizationProvider.PrivateKey)
 		if err != nil {
-			return publicClientOutbound{}, fmt.Errorf("failed to create AuthProvider: %v", err)
+			return publicClientOutbound{}, fmt.Errorf("create AuthProvider: %v", err)
 		}
 		authMiddleware = &authOutboundMiddleware{authProvider}
 	}

--- a/common/rpc/outbounds_test.go
+++ b/common/rpc/outbounds_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package rpc
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/service"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/yarpc/transport/grpc"
+	"go.uber.org/yarpc/transport/tchannel"
+)
+
+func TestPublicClientOutbound(t *testing.T) {
+	makeConfig := func(hostPort string, enableAuth bool, keyPath string) *config.Config {
+		return &config.Config{
+			PublicClient:  config.PublicClient{HostPort: hostPort},
+			Authorization: config.Authorization{OAuthAuthorizer: config.OAuthAuthorizer{Enable: enableAuth}},
+			ClusterGroupMetadata: &config.ClusterGroupMetadata{
+				CurrentClusterName: "cluster-A",
+				ClusterGroup: map[string]config.ClusterInformation{
+					"cluster-A": {
+						AuthorizationProvider: config.AuthorizationProvider{
+							PrivateKey: keyPath,
+						},
+					},
+				},
+			},
+		}
+	}
+
+	_, err := newPublicClientOutbound(&config.Config{})
+	require.EqualError(t, err, "need to provide an endpoint config for PublicClient")
+
+	builder, err := newPublicClientOutbound(makeConfig("localhost:1234", false, ""))
+	require.NoError(t, err)
+	require.NotNil(t, builder)
+	require.Equal(t, "localhost:1234", builder.address)
+	require.Nil(t, builder.authMiddleware)
+
+	builder, err = newPublicClientOutbound(makeConfig("localhost:1234", true, "invalid"))
+	require.EqualError(t, err, "failed to create AuthProvider: invalid private key path invalid")
+
+	builder, err = newPublicClientOutbound(makeConfig("localhost:1234", true, tempFile(t, "private-key")))
+	require.NoError(t, err)
+	require.NotNil(t, builder)
+	require.Equal(t, "localhost:1234", builder.address)
+	require.NotNil(t, builder.authMiddleware)
+
+	grpc := &grpc.Transport{}
+	tchannel := &tchannel.Transport{}
+	outbounds, err := builder.Build(grpc, tchannel)
+	assert.Equal(t, outbounds[OutboundPublicClient].ServiceName, service.Frontend)
+	assert.NotNil(t, outbounds[OutboundPublicClient].Unary)
+}
+
+func tempFile(t *testing.T, content string) string {
+	f, err := ioutil.TempFile("", "")
+	require.NoError(t, err)
+
+	f.Write([]byte(content))
+	require.NoError(t, err)
+
+	err = f.Close()
+	require.NoError(t, err)
+
+	return f.Name()
+}

--- a/common/rpc/outbounds_test.go
+++ b/common/rpc/outbounds_test.go
@@ -58,7 +58,7 @@ func TestPublicClientOutbound(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, builder)
 	require.Equal(t, "localhost:1234", builder.address)
-	require.Nil(t, builder.authMiddleware)
+	require.Equal(t, nil, builder.authMiddleware)
 
 	builder, err = newPublicClientOutbound(makeConfig("localhost:1234", true, "invalid"))
 	require.EqualError(t, err, "create AuthProvider: invalid private key path invalid")
@@ -72,6 +72,7 @@ func TestPublicClientOutbound(t *testing.T) {
 	grpc := &grpc.Transport{}
 	tchannel := &tchannel.Transport{}
 	outbounds, err := builder.Build(grpc, tchannel)
+	require.NoError(t, err)
 	assert.Equal(t, outbounds[OutboundPublicClient].ServiceName, service.Frontend)
 	assert.NotNil(t, outbounds[OutboundPublicClient].Unary)
 }

--- a/common/rpc/outbounds_test.go
+++ b/common/rpc/outbounds_test.go
@@ -61,7 +61,7 @@ func TestPublicClientOutbound(t *testing.T) {
 	require.Nil(t, builder.authMiddleware)
 
 	builder, err = newPublicClientOutbound(makeConfig("localhost:1234", true, "invalid"))
-	require.EqualError(t, err, "failed to create AuthProvider: invalid private key path invalid")
+	require.EqualError(t, err, "create AuthProvider: invalid private key path invalid")
 
 	builder, err = newPublicClientOutbound(makeConfig("localhost:1234", true, tempFile(t, "private-key")))
 	require.NoError(t, err)

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -52,12 +52,12 @@ func NewParams(serviceName string, config *config.Config) (Params, error) {
 
 	listenIP, err := getListenIP(serviceConfig.RPC)
 	if err != nil {
-		return Params{}, fmt.Errorf("failed to get listen IP: %v", err)
+		return Params{}, fmt.Errorf("get listen IP: %v", err)
 	}
 
 	publicClientOutbound, err := newPublicClientOutbound(config)
 	if err != nil {
-		return Params{}, fmt.Errorf("failed to create public client outbound: %v", err)
+		return Params{}, fmt.Errorf("public client outbound: %v", err)
 	}
 
 	return Params{

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -54,12 +54,19 @@ func NewParams(serviceName string, config *config.Config) (Params, error) {
 	if err != nil {
 		return Params{}, fmt.Errorf("failed to get listen IP: %v", err)
 	}
+
+	publicClientOutbound, err := newPublicClientOutbound(config)
+	if err != nil {
+		return Params{}, fmt.Errorf("failed to create public client outbound: %v", err)
+	}
+
 	return Params{
 		ServiceName:       serviceName,
 		TChannelAddress:   fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.Port),
 		GRPCAddress:       fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.GRPCPort),
 		GRPCMaxMsgSize:    serviceConfig.RPC.GRPCMaxMsgSize,
 		HostAddressMapper: NewGRPCPorts(config),
+		OutboundsBuilder:  publicClientOutbound,
 	}, nil
 }
 

--- a/common/rpc/params_test.go
+++ b/common/rpc/params_test.go
@@ -33,7 +33,9 @@ import (
 func TestNewParams(t *testing.T) {
 	serviceName := service.Frontend
 	makeConfig := func(svc config.Service) *config.Config {
-		return &config.Config{Services: map[string]config.Service{"frontend": svc}}
+		return &config.Config{
+			PublicClient: config.PublicClient{HostPort: "localhost:9999"},
+			Services:     map[string]config.Service{"frontend": svc}}
 	}
 
 	_, err := NewParams(serviceName, &config.Config{})
@@ -44,6 +46,9 @@ func TestNewParams(t *testing.T) {
 
 	_, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnIP: "invalidIP"}}))
 	assert.EqualError(t, err, "failed to get listen IP: unable to parse bindOnIP value or it is not an IPv4 address: invalidIP")
+
+	_, err = NewParams(serviceName, &config.Config{Services: map[string]config.Service{"frontend": {}}})
+	assert.EqualError(t, err, "failed to create public client outbound: need to provide an endpoint config for PublicClient")
 
 	params, err := NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnLocalHost: true, Port: 1111, GRPCPort: 2222, GRPCMaxMsgSize: 3333}}))
 	assert.NoError(t, err)

--- a/common/rpc/params_test.go
+++ b/common/rpc/params_test.go
@@ -42,13 +42,13 @@ func TestNewParams(t *testing.T) {
 	assert.EqualError(t, err, "no config section for service: frontend")
 
 	_, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnLocalHost: true, BindOnIP: "1.2.3.4"}}))
-	assert.EqualError(t, err, "failed to get listen IP: bindOnLocalHost and bindOnIP are mutually exclusive")
+	assert.EqualError(t, err, "get listen IP: bindOnLocalHost and bindOnIP are mutually exclusive")
 
 	_, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnIP: "invalidIP"}}))
-	assert.EqualError(t, err, "failed to get listen IP: unable to parse bindOnIP value or it is not an IPv4 address: invalidIP")
+	assert.EqualError(t, err, "get listen IP: unable to parse bindOnIP value or it is not an IPv4 address: invalidIP")
 
 	_, err = NewParams(serviceName, &config.Config{Services: map[string]config.Service{"frontend": {}}})
-	assert.EqualError(t, err, "failed to create public client outbound: need to provide an endpoint config for PublicClient")
+	assert.EqualError(t, err, "public client outbound: need to provide an endpoint config for PublicClient")
 
 	params, err := NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnLocalHost: true, Port: 1111, GRPCPort: 2222, GRPCMaxMsgSize: 3333}}))
 	assert.NoError(t, err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Same as #4523, but with fixed middleware pointer, which required the revert #4534.

authMiddleware was stored as a pointer, which is not equal to nil which is checked when wrapping a middleware here: https://github.com/yarpc/yarpc-go/blob/dev/api/middleware/outbound.go#L59

Also updated unit test to ensure true nil is used when auth is not configured.

---

Stop using `DispatcherProvider` for creating public client. Instead use common dispatcher from rpc.Factory.

Builder for public client outbound was created which also includes auth middleware initialization. It was previously located within server.go itself. Moving it here allows consolidating all logic related logic in one place and covering it with unit tests.

<!-- Tell your future self why have you made these changes -->
**Why?**
To eventually delete `DispatcherProvider` entirely.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests and new unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
