### PR TITLE
Improve archival history mutated error logs and add option to allow archiving incomplete history

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -222,7 +222,8 @@ func (s *server) startService() common.Daemon {
 		&s.cfg.DomainDefaults.Archival,
 	)
 
-	params.ArchiverProvider = provider.NewArchiverProvider(s.cfg.Archival.History.Provider, s.cfg.Archival.Visibility.Provider)
+	archiveIncompleteHistory := dc.GetBoolProperty(dynamicconfig.AllowArchivingIncompleteHistory, false)
+	params.ArchiverProvider = provider.NewArchiverProvider(s.cfg.Archival.History.Provider, s.cfg.Archival.Visibility.Provider, archiveIncompleteHistory())
 	params.PersistenceConfig.TransactionSizeLimit = dc.GetIntProperty(dynamicconfig.TransactionSizeLimit, common.DefaultTransactionSizeLimit)
 	params.PersistenceConfig.ErrorInjectionRate = dc.GetFloat64Property(dynamicconfig.PersistenceErrorInjectionRate, 0)
 	params.AuthorizationConfig = s.cfg.Authorization

--- a/common/archiver/filestore/historyArchiver.go
+++ b/common/archiver/filestore/historyArchiver.go
@@ -163,8 +163,7 @@ func (h *historyArchiver) Archive(
 			return err
 		}
 
-		if historyMutated(request, historyBlob.Body, *historyBlob.Header.IsLast) {
-			logger.Error(archiver.ArchiveNonRetriableErrorMsg, tag.ArchivalArchiveFailReason(archiver.ErrReasonHistoryMutated))
+		if archiver.IsHistoryMutated(request, historyBlob.Body, *historyBlob.Header.IsLast, logger) {
 			return archiver.ErrHistoryMutated
 		}
 

--- a/common/archiver/filestore/util.go
+++ b/common/archiver/filestore/util.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/dgryski/go-farm"
 
-	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
@@ -131,21 +130,6 @@ func extractCloseFailoverVersion(filename string) (int64, error) {
 		return -1, errors.New("unknown filename structure")
 	}
 	return strconv.ParseInt(filenameParts[1], 10, 64)
-}
-
-func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*types.History, isLast bool) bool {
-	lastBatch := historyBatches[len(historyBatches)-1].Events
-	lastEvent := lastBatch[len(lastBatch)-1]
-	lastFailoverVersion := lastEvent.GetVersion()
-	if lastFailoverVersion > request.CloseFailoverVersion {
-		return true
-	}
-
-	if !isLast {
-		return false
-	}
-	lastEventID := lastEvent.GetEventID()
-	return lastFailoverVersion != request.CloseFailoverVersion || lastEventID+1 != request.NextEventID
 }
 
 func contextExpired(ctx context.Context) bool {

--- a/common/archiver/filestore/util_test.go
+++ b/common/archiver/filestore/util_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/util"
 )
@@ -192,106 +191,6 @@ func (s *UtilSuite) TestExtractCloseFailoverVersion() {
 			s.NoError(err)
 			s.Equal(tc.expectedVersion, version)
 		}
-	}
-}
-
-func (s *UtilSuite) TestHistoryMutated() {
-	testCases := []struct {
-		historyBatches []*types.History
-		request        *archiver.ArchiveHistoryRequest
-		isLast         bool
-		isMutated      bool
-	}{
-		{
-			historyBatches: []*types.History{
-				{
-					Events: []*types.HistoryEvent{
-						{
-							Version: 15,
-						},
-					},
-				},
-			},
-			request: &archiver.ArchiveHistoryRequest{
-				CloseFailoverVersion: 3,
-			},
-			isMutated: true,
-		},
-		{
-			historyBatches: []*types.History{
-				{
-					Events: []*types.HistoryEvent{
-						{
-							EventID: 33,
-							Version: 10,
-						},
-					},
-				},
-				{
-					Events: []*types.HistoryEvent{
-						{
-							EventID: 49,
-							Version: 10,
-						},
-						{
-							EventID: 50,
-							Version: 10,
-						},
-					},
-				},
-			},
-			request: &archiver.ArchiveHistoryRequest{
-				CloseFailoverVersion: 10,
-				NextEventID:          34,
-			},
-			isLast:    true,
-			isMutated: true,
-		},
-		{
-			historyBatches: []*types.History{
-				{
-					Events: []*types.HistoryEvent{
-						{
-							Version: 9,
-						},
-					},
-				},
-			},
-			request: &archiver.ArchiveHistoryRequest{
-				CloseFailoverVersion: 10,
-			},
-			isLast:    true,
-			isMutated: true,
-		},
-		{
-			historyBatches: []*types.History{
-				{
-					Events: []*types.HistoryEvent{
-						{
-							EventID: 20,
-							Version: 10,
-						},
-					},
-				},
-				{
-					Events: []*types.HistoryEvent{
-						{
-							EventID: 33,
-							Version: 10,
-						},
-					},
-				},
-			},
-			request: &archiver.ArchiveHistoryRequest{
-				CloseFailoverVersion: 10,
-				NextEventID:          34,
-			},
-			isLast:    true,
-			isMutated: false,
-		},
-	}
-	for _, tc := range testCases {
-		s.Equal(tc.isMutated, historyMutated(tc.request, tc.historyBatches, tc.isLast))
 	}
 }
 

--- a/common/archiver/s3store/historyArchiver.go
+++ b/common/archiver/s3store/historyArchiver.go
@@ -177,8 +177,7 @@ func (h *historyArchiver) Archive(
 			return err
 		}
 
-		if historyMutated(request, historyBlob.Body, *historyBlob.Header.IsLast) {
-			logger.Error(archiver.ArchiveNonRetriableErrorMsg, tag.ArchivalArchiveFailReason(archiver.ErrReasonHistoryMutated))
+		if archiver.IsHistoryMutated(request, historyBlob.Body, *historyBlob.Header.IsLast, logger) {
 			return archiver.ErrHistoryMutated
 		}
 

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -236,21 +236,6 @@ func download(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key st
 	return body, nil
 }
 
-func historyMutated(request *archiver.ArchiveHistoryRequest, historyBatches []*types.History, isLast bool) bool {
-	lastBatch := historyBatches[len(historyBatches)-1].Events
-	lastEvent := lastBatch[len(lastBatch)-1]
-	lastFailoverVersion := lastEvent.GetVersion()
-	if lastFailoverVersion > request.CloseFailoverVersion {
-		return true
-	}
-
-	if !isLast {
-		return false
-	}
-	lastEventID := lastEvent.GetEventID()
-	return lastFailoverVersion != request.CloseFailoverVersion || lastEventID+1 != request.NextEventID
-}
-
 func contextExpired(ctx context.Context) bool {
 	select {
 	case <-ctx.Done():

--- a/common/archiver/util.go
+++ b/common/archiver/util.go
@@ -158,7 +158,8 @@ func IsHistoryMutated(request *ArchiveHistoryRequest, historyBatches []*types.Hi
 	lastFailoverVersion := lastEvent.GetVersion()
 	defer func() {
 		if mutated {
-			logger.Warn("history is mutated when during archival with detailed info",
+			logger.Warn(ArchiveNonRetriableErrorMsg+":history is mutated when during archival",
+				tag.ArchivalArchiveFailReason(ErrReasonHistoryMutated),
 				tag.FailoverVersion(lastFailoverVersion),
 				tag.TokenLastEventID(lastEvent.GetEventID()))
 		}

--- a/common/archiver/util.go
+++ b/common/archiver/util.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/types"
 )
 
 var (
@@ -149,4 +150,26 @@ func ConvertSearchAttrToBytes(searchAttrStr map[string]string) map[string][]byte
 		searchAttr[k] = []byte(v)
 	}
 	return searchAttr
+}
+
+func IsHistoryMutated(request *ArchiveHistoryRequest, historyBatches []*types.History, isLast bool, logger log.Logger) (mutated bool) {
+	lastBatch := historyBatches[len(historyBatches)-1].Events
+	lastEvent := lastBatch[len(lastBatch)-1]
+	lastFailoverVersion := lastEvent.GetVersion()
+	defer func() {
+		if mutated {
+			logger.Warn("history is mutated when during archival with detailed info",
+				tag.FailoverVersion(lastFailoverVersion),
+				tag.TokenLastEventID(lastEvent.GetEventID()))
+		}
+	}()
+	if lastFailoverVersion > request.CloseFailoverVersion {
+		return true
+	}
+
+	if !isLast {
+		return false
+	}
+	lastEventID := lastEvent.GetEventID()
+	return lastFailoverVersion != request.CloseFailoverVersion || lastEventID+1 != request.NextEventID
 }

--- a/common/archiver/util_test.go
+++ b/common/archiver/util_test.go
@@ -1,0 +1,144 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package archiver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/types"
+)
+
+type UtilSuite struct {
+	*require.Assertions
+	suite.Suite
+}
+
+func TestUtilSuite(t *testing.T) {
+	suite.Run(t, new(UtilSuite))
+}
+
+func (s *UtilSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *UtilSuite) TestHistoryMutated() {
+	testCases := []struct {
+		historyBatches []*types.History
+		request        *ArchiveHistoryRequest
+		isLast         bool
+		isMutated      bool
+	}{
+		{
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							Version: 15,
+						},
+					},
+				},
+			},
+			request: &ArchiveHistoryRequest{
+				CloseFailoverVersion: 3,
+			},
+			isMutated: true,
+		},
+		{
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: 33,
+							Version: 10,
+						},
+					},
+				},
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: 49,
+							Version: 10,
+						},
+						{
+							EventID: 50,
+							Version: 10,
+						},
+					},
+				},
+			},
+			request: &ArchiveHistoryRequest{
+				CloseFailoverVersion: 10,
+				NextEventID:          34,
+			},
+			isLast:    true,
+			isMutated: true,
+		},
+		{
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							Version: 9,
+						},
+					},
+				},
+			},
+			request: &ArchiveHistoryRequest{
+				CloseFailoverVersion: 10,
+			},
+			isLast:    true,
+			isMutated: true,
+		},
+		{
+			historyBatches: []*types.History{
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: 20,
+							Version: 10,
+						},
+					},
+				},
+				{
+					Events: []*types.HistoryEvent{
+						{
+							EventID: 33,
+							Version: 10,
+						},
+					},
+				},
+			},
+			request: &ArchiveHistoryRequest{
+				CloseFailoverVersion: 10,
+				NextEventID:          34,
+			},
+			isLast:    true,
+			isMutated: false,
+		},
+	}
+	for _, tc := range testCases {
+		s.Equal(tc.isMutated, IsHistoryMutated(tc.request, tc.historyBatches, tc.isLast, loggerimpl.NewNopLogger()))
+	}
+}

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -122,6 +122,12 @@ const (
 	// Default value: the value in static config: common.Config.Archival.Visibility.EnableRead
 	// Allowed filters: N/A
 	EnableReadFromVisibilityArchival
+	// AllowArchivingIncompleteHistory will continue on when seeing some error like history mutated(usually caused by database consistency issues)
+	// KeyName: system.allowArchivingIncompleteHistory
+	// Value type: Bool
+	// Default value: FALSE
+	// Allowed filters: N/A
+	AllowArchivingIncompleteHistory
 	// EnableDomainNotActiveAutoForwarding is whether enabling DC auto forwarding to active cluster for signal / start / signal with start API if domain is not active
 	// KeyName: system.enableDomainNotActiveAutoForwarding
 	// Value type: Bool
@@ -2011,6 +2017,7 @@ var Keys = map[Key]string{
 	EnableReadFromHistoryArchival:       "system.enableReadFromHistoryArchival",
 	VisibilityArchivalStatus:            "system.visibilityArchivalStatus",
 	EnableReadFromVisibilityArchival:    "system.enableReadFromVisibilityArchival",
+	AllowArchivingIncompleteHistory:     "system.allowArchivingIncompleteHistory",
 	EnableDomainNotActiveAutoForwarding: "system.enableDomainNotActiveAutoForwarding",
 	EnableGracefulFailover:              "system.enableGracefulFailover",
 	TransactionSizeLimit:                "system.transactionSizeLimit",

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -240,7 +240,7 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 	if !enabled {
 		return &ArchiverBase{
 			metadata: archiver.NewArchivalMetadata(dcCollection, "", false, "", false, &config.ArchivalDomainDefaults{}),
-			provider: provider.NewArchiverProvider(nil, nil),
+			provider: provider.NewArchiverProvider(nil, nil, false),
 		}
 	}
 
@@ -263,6 +263,7 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 		&config.VisibilityArchiverProvider{
 			Filestore: cfg,
 		},
+		false,
 	)
 	return &ArchiverBase{
 		metadata: archiver.NewArchivalMetadata(dcCollection, "enabled", true, "enabled", true, &config.ArchivalDomainDefaults{

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -378,6 +378,7 @@ func initializeArchivalProvider(
 	archiverProvider := provider.NewArchiverProvider(
 		serviceConfig.Archival.History.Provider,
 		serviceConfig.Archival.Visibility.Provider,
+		false,
 	)
 
 	historyArchiverBootstrapContainer := &archiver.HistoryBootstrapContainer{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. add more logs when history mutated error is emitted 
2. add option to allow continue on archiving the history 

<!-- Tell your future self why have you made these changes -->
**Why?**
1. it's hard to know why 
2. Very likely users will still need the in-complete history -- better than nothing. It's also better if we have a bug in XDC failover which may cause history being lost. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing and new tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Very low. All behavior is the same 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
