### PR TITLE
Switch canary to gRPC

### DIFF
--- a/config/canary/development.yaml
+++ b/config/canary/development.yaml
@@ -4,4 +4,4 @@ canary:
 
 cadence:
   service: "cadence-frontend"
-  host: "127.0.0.1:7933"
+  host: "127.0.0.1:7833"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Switched cadence-canary to gRPC via compatibility adapter

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Locally `./cadence-canary start -m all`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
