### PR TITLE
Fix NPE when replicating child started event

### DIFF
--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -3495,16 +3495,13 @@ func (e *mutableStateBuilder) ReplicateChildWorkflowExecutionStartedEvent(
 
 	ci, ok := e.GetChildExecutionInfo(initiatedID)
 	if !ok {
-		err := fmt.Errorf(
-			"unable to find child workflow event ID: %v in mutable state when replicate child execution started",
-			initiatedID,
-		)
 		e.logError(
-			"unable to find child workflow when replicate child execution started",
+			"Unable to find child workflow",
 			tag.ErrorTypeInvalidMutableStateAction,
+			tag.WorkflowEventID(e.GetNextEventID()),
 			tag.WorkflowInitiatedID(initiatedID),
 		)
-		return err
+		return ErrMissingChildWorkflowInfo
 	}
 	ci.StartedID = event.GetEventID()
 	ci.StartedRunID = attributes.GetWorkflowExecution().GetRunID()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**
- If child workflow not exist in mutable when replicating child workflow executed started event, the code will hit an NPE issue and restart.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Hot fix already deployed to production.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
