### PR TITLE
Close shard on service busy error

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -761,7 +761,6 @@ Update_Loop:
 		if err != nil {
 			switch err.(type) {
 			case *persistence.ConditionFailedError,
-				*types.ServiceBusyError,
 				*types.LimitExceededError:
 				// No special handling required for these errors
 			case *persistence.ShardOwnershipLostError:
@@ -890,7 +889,6 @@ Conflict_Resolve_Loop:
 		if err != nil {
 			switch err.(type) {
 			case *persistence.ConditionFailedError,
-				*types.ServiceBusyError,
 				*types.LimitExceededError:
 				// No special handling required for these errors
 			case *persistence.ShardOwnershipLostError:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
If update/conflictresolveworkflow fails with ServiceBusyError, we close the shard and update rangeID.

<!-- Tell your future self why have you made these changes -->
**Why?**
ServiceBusyError is not created by our own logic, but also depends on database. If the dependency has some bug in error type, it can cause critical issue for cadence.
To address https://github.com/uber/cadence/issues/4316

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
