### PR TITLE
Move membership providers to common/membership

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -154,11 +154,11 @@ func (s *server) startService() common.Daemon {
 		rpcParams.OutboundsBuilder,
 		rpc.NewCrossDCOutbounds(clusterGroupMetadata.ClusterGroup, rpc.NewDNSPeerChooserFactory(s.cfg.PublicClient.RefreshInterval, params.Logger)),
 	)
-	params.RPCFactory = rpc.NewFactory(params.Logger, rpcParams)
-	dispatcher := params.RPCFactory.GetDispatcher()
+	rpcFactory := rpc.NewFactory(params.Logger, rpcParams)
 
+	params.RPCFactory = rpcFactory
 	params.MembershipFactory, err = ringpop.NewFactory(s.cfg.Ringpop,
-		dispatcher,
+		rpcFactory.GetChannel(),
 		params.Name,
 		params.Logger,
 	)
@@ -214,7 +214,7 @@ func (s *server) startService() common.Daemon {
 		}
 	}
 
-	params.PublicClient = workflowserviceclient.New(dispatcher.ClientConfig(rpc.OutboundPublicClient))
+	params.PublicClient = workflowserviceclient.New(params.RPCFactory.GetDispatcher().ClientConfig(rpc.OutboundPublicClient))
 
 	params.ArchivalMetadata = archiver.NewArchivalMetadata(
 		dc,

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -29,10 +29,10 @@ import (
 
 	"github.com/uber-go/tally/m3"
 	"github.com/uber-go/tally/prometheus"
-	"github.com/uber/ringpop-go/discovery"
 
 	"github.com/uber/cadence/common/dynamicconfig"
 	c "github.com/uber/cadence/common/dynamicconfig/configstore/config"
+	"github.com/uber/cadence/common/membership/ringpop"
 	"github.com/uber/cadence/common/service"
 )
 
@@ -40,7 +40,7 @@ type (
 	// Config contains the configuration for a set of cadence services
 	Config struct {
 		// Ringpop is the ringpop related configuration
-		Ringpop Ringpop `yaml:"ringpop"`
+		Ringpop ringpop.Config `yaml:"ringpop"`
 		// Persistence contains the configuration for cadence datastores
 		Persistence Persistence `yaml:"persistence"`
 		// Log is the logging config
@@ -149,22 +149,6 @@ type (
 	// FileBlobstore contains the config for a file backed blobstore
 	FileBlobstore struct {
 		OutputDirectory string `yaml:"outputDirectory"`
-	}
-
-	// Ringpop contains the ringpop config items
-	Ringpop struct {
-		// Name to be used in ringpop advertisement
-		Name string `yaml:"name" validate:"nonzero"`
-		// BootstrapMode is a enum that defines the ringpop bootstrap method
-		BootstrapMode BootstrapMode `yaml:"bootstrapMode"`
-		// BootstrapHosts is a list of seed hosts to be used for ringpop bootstrap
-		BootstrapHosts []string `yaml:"bootstrapHosts"`
-		// BootstrapFile is the file path to be used for ringpop bootstrap
-		BootstrapFile string `yaml:"bootstrapFile"`
-		// MaxJoinDuration is the max wait time to join the ring
-		MaxJoinDuration time.Duration `yaml:"maxJoinDuration"`
-		// Custom discovery provider, cannot be specified through yaml
-		DiscoveryProvider discovery.DiscoverProvider `yaml:"-"`
 	}
 
 	// Persistence contains the configuration for data store / persistence layer
@@ -508,9 +492,6 @@ type (
 		// URI is the domain default URI for visibility archiver
 		URI string `yaml:"URI"`
 	}
-
-	// BootstrapMode is an enum type for ringpop bootstrap mode
-	BootstrapMode int
 )
 
 // ValidateAndFillDefaults validates this config and fills default values if needed

--- a/common/membership/interfaces.go
+++ b/common/membership/interfaces.go
@@ -23,20 +23,16 @@
 package membership
 
 import (
-	"errors"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 )
 
-// ErrUnknownService is thrown for a service that is not tracked by this instance
-var ErrUnknownService = errors.New("Service not tracked by Monitor")
-
 // ErrInsufficientHosts is thrown when there are not enough hosts to serve the request
 var ErrInsufficientHosts = &types.InternalServiceError{Message: "Not enough hosts to serve the request"}
 
-// ErrListenerAlreadyExist is thrown on a duplicate AddListener call from the same listener
-var ErrListenerAlreadyExist = errors.New("Listener already exist for the service")
+// RoleKey label is set by every single service as soon as it bootstraps its
+// ringpop instance. The data for this key is the service name
+const RoleKey = "serviceName"
 
 type (
 

--- a/common/membership/ringpop/config_test.go
+++ b/common/membership/ringpop/config_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package config
+package ringpop
 
 import (
 	"context"
@@ -48,7 +48,7 @@ func (s *RingpopSuite) SetupTest() {
 }
 
 func (s *RingpopSuite) TestHostsMode() {
-	var cfg Ringpop
+	var cfg Config
 	err := yaml.Unmarshal([]byte(getHostsConfig()), &cfg)
 	s.Nil(err)
 	s.Equal("test", cfg.Name)
@@ -57,13 +57,13 @@ func (s *RingpopSuite) TestHostsMode() {
 	s.Equal(time.Second*30, cfg.MaxJoinDuration)
 	err = cfg.validate()
 	s.Nil(err)
-	f, err := cfg.NewFactory(nil, "test", loggerimpl.NewNopLogger())
+	f, err := NewFactory(cfg, nil, "test", loggerimpl.NewNopLogger())
 	s.Nil(err)
 	s.NotNil(f)
 }
 
 func (s *RingpopSuite) TestFileMode() {
-	var cfg Ringpop
+	var cfg Config
 	err := yaml.Unmarshal([]byte(getJSONConfig()), &cfg)
 	s.Nil(err)
 	s.Equal("test", cfg.Name)
@@ -72,13 +72,13 @@ func (s *RingpopSuite) TestFileMode() {
 	s.Equal(time.Second*30, cfg.MaxJoinDuration)
 	err = cfg.validate()
 	s.Nil(err)
-	f, err := cfg.NewFactory(nil, "test", loggerimpl.NewNopLogger())
+	f, err := NewFactory(cfg, nil, "test", loggerimpl.NewNopLogger())
 	s.Nil(err)
 	s.NotNil(f)
 }
 
 func (s *RingpopSuite) TestCustomMode() {
-	var cfg Ringpop
+	var cfg Config
 	err := yaml.Unmarshal([]byte(getCustomConfig()), &cfg)
 	s.Nil(err)
 	s.Equal("test", cfg.Name)
@@ -86,7 +86,7 @@ func (s *RingpopSuite) TestCustomMode() {
 	s.NotNil(cfg.validate())
 	cfg.DiscoveryProvider = statichosts.New("127.0.0.1")
 	s.Nil(cfg.validate())
-	f, err := cfg.NewFactory(nil, "test", loggerimpl.NewNopLogger())
+	f, err := NewFactory(cfg, nil, "test", loggerimpl.NewNopLogger())
 	s.Nil(err)
 	s.NotNil(f)
 }
@@ -104,14 +104,14 @@ func (resolver *mockResolver) LookupHost(ctx context.Context, host string) ([]st
 }
 
 func (s *RingpopSuite) TestDNSMode() {
-	var cfg Ringpop
+	var cfg Config
 	err := yaml.Unmarshal([]byte(getDNSConfig()), &cfg)
 	s.Nil(err)
 	s.Equal("test", cfg.Name)
 	s.Equal(BootstrapModeDNS, cfg.BootstrapMode)
 	s.Nil(cfg.validate())
 	logger := loggerimpl.NewNopLogger()
-	f, err := cfg.NewFactory(nil, "test", logger)
+	f, err := NewFactory(cfg, nil, "test", logger)
 	s.Nil(err)
 	s.NotNil(f)
 
@@ -166,7 +166,7 @@ func (s *RingpopSuite) TestDNSMode() {
 }
 
 func (s *RingpopSuite) TestInvalidConfig() {
-	var cfg Ringpop
+	var cfg Config
 	s.NotNil(cfg.validate())
 	cfg.Name = "test"
 	s.NotNil(cfg.validate())

--- a/common/membership/ringpop/factory.go
+++ b/common/membership/ringpop/factory.go
@@ -1,0 +1,157 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package ringpop
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sync"
+
+	"github.com/uber/ringpop-go"
+	"github.com/uber/ringpop-go/swim"
+	"github.com/uber/tchannel-go"
+	tchannel2 "go.uber.org/yarpc/transport/tchannel"
+
+	"github.com/uber/cadence/common/service"
+
+	"go.uber.org/yarpc"
+
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/membership"
+)
+
+// Factory implements the Factory interface
+type Factory struct {
+	config      Config
+	dispatcher  *yarpc.Dispatcher
+	serviceName string
+	logger      log.Logger
+
+	sync.Mutex
+	ringPop           *RingPop
+	membershipMonitor membership.Monitor
+}
+
+func NewFactory(
+	config Config,
+	dispatcher *yarpc.Dispatcher,
+	serviceName string,
+	logger log.Logger,
+) (*Factory, error) {
+
+	if err := config.validate(); err != nil {
+		return nil, err
+	}
+	if config.MaxJoinDuration == 0 {
+		config.MaxJoinDuration = defaultMaxJoinDuration
+	}
+	return &Factory{
+		config:      config,
+		dispatcher:  dispatcher,
+		serviceName: serviceName,
+		logger:      logger,
+	}, nil
+}
+
+// GetMembershipMonitor return a membership monitor
+func (factory *Factory) GetMembershipMonitor() (membership.Monitor, error) {
+	factory.Lock()
+	defer factory.Unlock()
+
+	return factory.getMembership()
+}
+
+func (factory *Factory) getMembership() (membership.Monitor, error) {
+	if factory.membershipMonitor != nil {
+		return factory.membershipMonitor, nil
+	}
+
+	membershipMonitor, err := factory.createMembership()
+	if err != nil {
+		return nil, err
+	}
+	factory.membershipMonitor = membershipMonitor
+	return membershipMonitor, nil
+}
+
+func (factory *Factory) createMembership() (membership.Monitor, error) {
+	// use actual listen port (in case service is bound to :0 or 0.0.0.0:0)
+	rp, err := factory.getRingpop()
+	if err != nil {
+		return nil, fmt.Errorf("ringpop creation failed: %v", err)
+	}
+
+	return NewMonitor(factory.serviceName, service.List, rp, factory.logger), nil
+}
+
+func (factory *Factory) getRingpop() (*RingPop, error) {
+	if factory.ringPop != nil {
+		return factory.ringPop, nil
+	}
+
+	ringPop, err := factory.createRingpop()
+	if err != nil {
+		return nil, err
+	}
+	factory.ringPop = ringPop
+	return ringPop, nil
+}
+
+func (factory *Factory) createRingpop() (*RingPop, error) {
+
+	var ch *tchannel.Channel
+	var err error
+	if ch, err = factory.getChannel(factory.dispatcher); err != nil {
+		return nil, err
+	}
+
+	rp, err := ringpop.New(factory.config.Name, ringpop.Channel(ch))
+	if err != nil {
+		return nil, err
+	}
+
+	discoveryProvider, err := newDiscoveryProvider(factory.config, factory.logger)
+	if err != nil {
+		return nil, err
+	}
+	bootstrapOpts := &swim.BootstrapOptions{
+		MaxJoinDuration:  factory.config.MaxJoinDuration,
+		DiscoverProvider: discoveryProvider,
+	}
+	return NewRingPop(rp, bootstrapOpts, factory.logger), nil
+}
+
+func (factory *Factory) getChannel(
+	dispatcher *yarpc.Dispatcher,
+) (*tchannel.Channel, error) {
+
+	t := dispatcher.Inbounds()[0].Transports()[0].(*tchannel2.ChannelTransport)
+	ty := reflect.ValueOf(t.Channel())
+	var ch *tchannel.Channel
+	var ok bool
+	if ch, ok = ty.Interface().(*tchannel.Channel); !ok {
+		return nil, errors.New("unable to get tchannel out of the dispatcher")
+	}
+	return ch, nil
+}

--- a/common/membership/ringpop/monitor.go
+++ b/common/membership/ringpop/monitor.go
@@ -80,7 +80,7 @@ func (rpo *monitor) Start() {
 		rpo.logger.Fatal("unable to get ringpop labels", tag.Error(err))
 	}
 
-	if err = labels.Set(membership.RoleKey, rpo.serviceName); err != nil {
+	if err := labels.Set(membership.RoleKey, rpo.serviceName); err != nil {
 		rpo.logger.Fatal("unable to set ringpop labels", tag.Error(err))
 	}
 

--- a/common/membership/ringpop/monitor_test.go
+++ b/common/membership/ringpop/monitor_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package membership
+package ringpop
 
 import (
 	"testing"
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/membership"
 )
 
 type RpoSuite struct {
@@ -53,13 +54,13 @@ func (s *RpoSuite) TestRingpopMonitor() {
 
 	time.Sleep(time.Second)
 
-	listenCh := make(chan *ChangedEvent, 5)
+	listenCh := make(chan *membership.ChangedEvent, 5)
 	err := rpm.AddListener("rpm-test", "test-listener", listenCh)
 	s.Nil(err, "AddListener failed")
 
 	host, err := rpm.Lookup("rpm-test", "key")
-	s.Nil(err, "Ringpop monitor failed to find host for key")
-	s.NotNil(host, "Ringpop monitor returned a nil host")
+	s.Nil(err, "Config monitor failed to find host for key")
+	s.NotNil(host, "Config monitor returned a nil host")
 
 	logger.Info("Killing host 1")
 	testService.KillHost(testService.hostUUIDs[1])
@@ -75,8 +76,8 @@ func (s *RpoSuite) TestRingpopMonitor() {
 	}
 
 	host, err = rpm.Lookup("rpm-test", "key")
-	s.Nil(err, "Ringpop monitor failed to find host for key")
-	s.NotEqual(testService.hostAddrs[1], host.GetAddress(), "Ringpop monitor assigned key to dead host")
+	s.Nil(err, "Config monitor failed to find host for key")
+	s.NotEqual(testService.hostAddrs[1], host.GetAddress(), "Config monitor assigned key to dead host")
 
 	err = rpm.RemoveListener("rpm-test", "test-listener")
 	s.Nil(err, "RemoveListener() failed")

--- a/common/membership/ringpop/ringpop.go
+++ b/common/membership/ringpop/ringpop.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package membership
+package ringpop
 
 import (
 	"sync/atomic"
@@ -34,8 +34,8 @@ import (
 type (
 	// RingPop is a simple wrapper
 	RingPop struct {
-		status int32
-		*ringpop.Ringpop
+		status     int32
+		ringpop    *ringpop.Ringpop
 		bootParams *swim.BootstrapOptions
 		logger     log.Logger
 	}
@@ -49,7 +49,7 @@ func NewRingPop(
 ) *RingPop {
 	return &RingPop{
 		status:     common.DaemonStatusInitialized,
-		Ringpop:    ringPop,
+		ringpop:    ringPop,
 		bootParams: bootParams,
 		logger:     logger,
 	}
@@ -65,7 +65,7 @@ func (r *RingPop) Start() {
 		return
 	}
 
-	_, err := r.Ringpop.Bootstrap(r.bootParams)
+	_, err := r.ringpop.Bootstrap(r.bootParams)
 	if err != nil {
 		r.logger.Fatal("unable to bootstrap ringpop", tag.Error(err))
 	}
@@ -81,5 +81,5 @@ func (r *RingPop) Stop() {
 		return
 	}
 
-	r.Destroy()
+	r.ringpop.Destroy()
 }

--- a/common/membership/simple/simpleMonitor.go
+++ b/common/membership/simple/simpleMonitor.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package host
+package simple
 
 import (
 	"fmt"
@@ -31,8 +31,8 @@ type simpleMonitor struct {
 	resolvers map[string]membership.ServiceResolver
 }
 
-// NewSimpleMonitor returns a simple monitor interface
-func newSimpleMonitor(serviceName string, hosts map[string][]string) membership.Monitor {
+// NewMonitor returns a simple monitor interface
+func NewMonitor(serviceName string, hosts map[string][]string) membership.Monitor {
 	resolvers := make(map[string]membership.ServiceResolver, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newSimpleResolver(service, hostList)

--- a/common/membership/simple/simpleServiceResolver.go
+++ b/common/membership/simple/simpleServiceResolver.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package host
+package simple
 
 import (
 	"github.com/dgryski/go-farm"

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -55,6 +55,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/membership/simple"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
@@ -765,7 +766,7 @@ func newMembershipFactory(serviceName string, hosts map[string][]string) resourc
 }
 
 func (p *membershipFactoryImpl) GetMembershipMonitor() (membership.Monitor, error) {
-	return newSimpleMonitor(p.serviceName, p.hosts), nil
+	return simple.NewMonitor(p.serviceName, p.hosts), nil
 }
 
 func newPProfInitializerImpl(logger log.Logger, port int) common.PProfInitializer {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ringpop and simple monitor is placed under common/membership

<!-- Tell your future self why have you made these changes -->
**Why?**
This is prep work for introducing configurable membership providers.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
