### PR TITLE
Provide Channel for Ringpop

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -153,9 +153,10 @@ func (s *server) startService() common.Daemon {
 		rpcParams.OutboundsBuilder,
 		rpc.NewCrossDCOutbounds(clusterGroupMetadata.ClusterGroup, rpc.NewDNSPeerChooserFactory(s.cfg.PublicClient.RefreshInterval, params.Logger)),
 	)
-	params.RPCFactory = rpc.NewFactory(params.Logger, rpcParams)
+	rpcFactory := rpc.NewFactory(params.Logger, rpcParams)
+	params.RPCFactory = rpcFactory
 	params.MembershipFactory, err = s.cfg.Ringpop.NewFactory(
-		params.RPCFactory,
+		rpcFactory.GetChannel(),
 		params.Name,
 		params.Logger,
 	)

--- a/common/rpc.go
+++ b/common/rpc.go
@@ -24,7 +24,6 @@ import (
 	"context"
 
 	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/transport/tchannel"
 )
 
 const (
@@ -56,7 +55,6 @@ type (
 	// RPCFactory Creates a dispatcher that knows how to transport requests.
 	RPCFactory interface {
 		GetDispatcher() *yarpc.Dispatcher
-		GetChannel() tchannel.Channel
 		CreateDispatcherForOutbound(callerName, serviceName, hostName string) (*yarpc.Dispatcher, error)
 		CreateGRPCDispatcherForOutbound(callerName, serviceName, hostName string) (*yarpc.Dispatcher, error)
 		ReplaceGRPCPort(serviceName, hostAddress string) (string, error)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
RPC factory provides Tchannel Channel

<!-- Tell your future self why have you made these changes -->
**Why?**
Ringpop doesn't need dispatcher anymore. Channel is retrieved from RPC factory without interface assertion

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
