### PR TITLE
Fix get replication task read level update issue

### DIFF
--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -177,6 +177,7 @@ TaskInfoLoop:
 			return nil, err
 		}
 		if skipTask(pollingCluster, domainEntity) {
+			readLevel = taskInfo.GetTaskID()
 			continue
 		}
 
@@ -234,6 +235,7 @@ TaskInfoLoop:
 	}
 	t.lastTaskCreationTime.Store(lastTaskCreationTime)
 
+	t.logger.Debug("Get replication tasks", tag.SourceCluster(pollingCluster), tag.ShardReplicationAck(lastReadTaskID), tag.ReadLevel(readLevel))
 	return &types.ReplicationMessages{
 		ReplicationTasks:       replicationTasks,
 		HasMore:                hasMore,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update replication read level for skipped tasks 

<!-- Tell your future self why have you made these changes -->
**Why?**
If the replication tasks read in a batch belong to a domain which isn't replicated to the polling cluster, the read level won't be updated and the polling cluster will try to fetch the same replication tasks and the replication of polling cluster will get stuck and the replication tasks from the source cluster won't be cleaned up.
We didn't hit this issue because we only have 2 replicas, and that branch is never hit in this situation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
