### PR TITLE
Fallback to zero value for non-present parent execution fields

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -4558,25 +4558,17 @@ func FromParentExecutionInfoFields(domainID, domainName *string, we *types.Workf
 	if domainID == nil && domainName == nil && we == nil && initiatedID == nil {
 		return nil
 	}
-	if domainName == nil || we == nil || initiatedID == nil {
-		panic("either all or none parent execution info must be set")
-	}
 
-	// Domain ID was added to unify parent execution info in several places.
-	// However it may not be present:
+	// ParentExecutionInfo wrapper was added to unify parent related fields.
+	// However some fields may not be present:
 	// - on older histories
 	// - if conversion involves thrift data types
-	// Fallback to empty string in those cases
-	parentDomainID := ""
-	if domainID != nil {
-		parentDomainID = *domainID
-	}
-
+	// Fallback to zero values in those cases
 	return &apiv1.ParentExecutionInfo{
-		DomainId:          parentDomainID,
-		DomainName:        *domainName,
+		DomainId:          common.StringDefault(domainID),
+		DomainName:        common.StringDefault(domainName),
 		WorkflowExecution: FromWorkflowExecution(we),
-		InitiatedId:       *initiatedID,
+		InitiatedId:       common.Int64Default(initiatedID),
 	}
 }
 

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -769,12 +769,17 @@ func TestParentExecutionInfo(t *testing.T) {
 }
 func TestParentExecutionInfoFields(t *testing.T) {
 	assert.Nil(t, FromParentExecutionInfoFields(nil, nil, nil, nil))
-	assert.Panics(t, func() { FromParentExecutionInfoFields(nil, &testdata.ParentExecutionInfo.Domain, nil, nil) })
-	info := FromParentExecutionInfoFields(nil,
+	info := FromParentExecutionInfoFields(nil, nil, testdata.ParentExecutionInfo.Execution, nil)
+	assert.Equal(t, "", *ToParentDomainID(info))
+	assert.Equal(t, "", *ToParentDomainName(info))
+	assert.Equal(t, testdata.ParentExecutionInfo.Execution, ToParentWorkflowExecution(info))
+	assert.Equal(t, int64(0), *ToParentInitiatedID(info))
+	info = FromParentExecutionInfoFields(
+		&testdata.ParentExecutionInfo.DomainUUID,
 		&testdata.ParentExecutionInfo.Domain,
 		testdata.ParentExecutionInfo.Execution,
 		&testdata.ParentExecutionInfo.InitiatedID)
-	assert.Equal(t, "", *ToParentDomainID(info))
+	assert.Equal(t, testdata.ParentExecutionInfo.DomainUUID, *ToParentDomainID(info))
 	assert.Equal(t, testdata.ParentExecutionInfo.Domain, *ToParentDomainName(info))
 	assert.Equal(t, testdata.ParentExecutionInfo.Execution, ToParentWorkflowExecution(info))
 	assert.Equal(t, testdata.ParentExecutionInfo.InitiatedID, *ToParentInitiatedID(info))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Do not panic if some fields are missing when mapping `ParentExecutionInfo`. Instead fallback to zero values.

<!-- Tell your future self why have you made these changes -->
**Why?**
Cadence canary (and potentially other workflows with parent relationship) fail when type conversions involve both tchannel and grpc.
For this particular case: cadence canary -> grpc -> frontend -> tchannel -> history

Parent related fields were wrapped under `ParentExecutionInfo` to unify their usage. Not all fields are present in older Thrift IDLs, and they get dropped along the way. When converting back to grpc, we get panic which is not expected under normal flow, but is possible in this scenario.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
To reproduce issue started local Cadence server with tchannel internally and canary with grpc.
Made a fix and checked that canary no longer produces errors.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
