### PR TITLE
feat: Fixing RPC to allow bindOnIP for IPv6

### DIFF
--- a/common/rpc/grpc.go
+++ b/common/rpc/grpc.go
@@ -22,8 +22,8 @@ package rpc
 
 import (
 	"errors"
-	"fmt"
-	"strings"
+	"net"
+	"strconv"
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/service"
@@ -55,9 +55,9 @@ func (p GRPCPorts) GetGRPCAddress(service, hostAddress string) (string, error) {
 	}
 
 	// Drop port if provided
-	if index := strings.Index(hostAddress, ":"); index > 0 {
-		hostAddress = hostAddress[:index]
+	if newHostAddress, _, err := net.SplitHostPort(hostAddress); err == nil {
+		hostAddress = newHostAddress
 	}
 
-	return fmt.Sprintf("%s:%d", hostAddress, port), nil
+	return net.JoinHostPort(hostAddress, strconv.Itoa(port)), nil
 }

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net"
+	"strconv"
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/service"
@@ -83,8 +84,8 @@ func NewParams(serviceName string, config *config.Config) (Params, error) {
 
 	return Params{
 		ServiceName:       serviceName,
-		TChannelAddress:   fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.Port),
-		GRPCAddress:       fmt.Sprintf("%v:%v", listenIP, serviceConfig.RPC.GRPCPort),
+		TChannelAddress:   net.JoinHostPort(listenIP.String(), strconv.Itoa(serviceConfig.RPC.Port)),
+		GRPCAddress:       net.JoinHostPort(listenIP.String(), strconv.Itoa(serviceConfig.RPC.GRPCPort)),
 		GRPCMaxMsgSize:    serviceConfig.RPC.GRPCMaxMsgSize,
 		HostAddressMapper: NewGRPCPorts(config),
 		OutboundsBuilder:  publicClientOutbound,
@@ -110,7 +111,10 @@ func getListenIP(config config.RPC) (net.IP, error) {
 		if ip != nil && ip.To4() != nil {
 			return ip.To4(), nil
 		}
-		return nil, fmt.Errorf("unable to parse bindOnIP value or it is not an IPv4 address: %s", config.BindOnIP)
+		if ip != nil && ip.To16() != nil {
+			return ip.To16(), nil
+		}
+		return nil, fmt.Errorf("unable to parse bindOnIP value or it is not an IPv4 or IPv6 address: %s", config.BindOnIP)
 	}
 	return ListenIP()
 }

--- a/common/rpc/params_test.go
+++ b/common/rpc/params_test.go
@@ -45,7 +45,7 @@ func TestNewParams(t *testing.T) {
 	assert.EqualError(t, err, "get listen IP: bindOnLocalHost and bindOnIP are mutually exclusive")
 
 	_, err = NewParams(serviceName, makeConfig(config.Service{RPC: config.RPC{BindOnIP: "invalidIP"}}))
-	assert.EqualError(t, err, "get listen IP: unable to parse bindOnIP value or it is not an IPv4 address: invalidIP")
+	assert.EqualError(t, err, "get listen IP: unable to parse bindOnIP value or it is not an IPv4 or IPv6 address: invalidIP")
 
 	_, err = NewParams(serviceName, &config.Config{Services: map[string]config.Service{"frontend": {}}})
 	assert.EqualError(t, err, "public client outbound: need to provide an endpoint config for PublicClient")


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Supporting IPv6 bindOnIP in config and RPC as discussed in #4613 .

Basically it means replacing strings package functions by net package functions.

<!-- Tell your future self why have you made these changes -->
Supporting IPv6 bindOnIP in config and RPC.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
It was tested locally on a cluster with two cadence server nodes. Deployed in production with similar patch for older cadence version.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Reviewer must verify that it does not break IP address binding

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
IPv6 must be mentioned in changelog

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
bindOnIP supports IPv6 must be mentioned in doc
