### PR TITLE
Add inbound header forwarding middleware

### DIFF
--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -26,7 +26,6 @@ import (
 
 	"go.uber.org/yarpc"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -64,7 +63,6 @@ func (c *clientImpl) AddSearchAttribute(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.AddSearchAttribute(ctx, request, opts...)
@@ -76,7 +74,6 @@ func (c *clientImpl) DescribeShardDistribution(
 	opts ...yarpc.CallOption,
 ) (*types.DescribeShardDistributionResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeShardDistribution(ctx, request, opts...)
@@ -88,7 +85,6 @@ func (c *clientImpl) DescribeHistoryHost(
 	opts ...yarpc.CallOption,
 ) (*types.DescribeHistoryHostResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeHistoryHost(ctx, request, opts...)
@@ -100,7 +96,6 @@ func (c *clientImpl) RemoveTask(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RemoveTask(ctx, request, opts...)
@@ -112,7 +107,6 @@ func (c *clientImpl) CloseShard(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.CloseShard(ctx, request, opts...)
@@ -124,7 +118,6 @@ func (c *clientImpl) ResetQueue(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ResetQueue(ctx, request, opts...)
@@ -136,7 +129,6 @@ func (c *clientImpl) DescribeQueue(
 	opts ...yarpc.CallOption,
 ) (*types.DescribeQueueResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeQueue(ctx, request, opts...)
@@ -148,7 +140,6 @@ func (c *clientImpl) DescribeWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) (*types.AdminDescribeWorkflowExecutionResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeWorkflowExecution(ctx, request, opts...)
@@ -160,7 +151,6 @@ func (c *clientImpl) GetWorkflowExecutionRawHistoryV2(
 	opts ...yarpc.CallOption,
 ) (*types.GetWorkflowExecutionRawHistoryV2Response, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetWorkflowExecutionRawHistoryV2(ctx, request, opts...)
@@ -170,7 +160,6 @@ func (c *clientImpl) DescribeCluster(
 	ctx context.Context,
 	opts ...yarpc.CallOption,
 ) (*types.DescribeClusterResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeCluster(ctx, opts...)
@@ -181,7 +170,6 @@ func (c *clientImpl) GetReplicationMessages(
 	request *types.GetReplicationMessagesRequest,
 	opts ...yarpc.CallOption,
 ) (*types.GetReplicationMessagesResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContextWithLargeTimeout(ctx)
 	defer cancel()
 	return c.client.GetReplicationMessages(ctx, request, opts...)
@@ -192,7 +180,6 @@ func (c *clientImpl) GetDomainReplicationMessages(
 	request *types.GetDomainReplicationMessagesRequest,
 	opts ...yarpc.CallOption,
 ) (*types.GetDomainReplicationMessagesResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetDomainReplicationMessages(ctx, request, opts...)
@@ -203,7 +190,6 @@ func (c *clientImpl) GetDLQReplicationMessages(
 	request *types.GetDLQReplicationMessagesRequest,
 	opts ...yarpc.CallOption,
 ) (*types.GetDLQReplicationMessagesResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetDLQReplicationMessages(ctx, request, opts...)
@@ -215,7 +201,6 @@ func (c *clientImpl) ReapplyEvents(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ReapplyEvents(ctx, request, opts...)
@@ -227,7 +212,6 @@ func (c *clientImpl) ReadDLQMessages(
 	opts ...yarpc.CallOption,
 ) (*types.ReadDLQMessagesResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ReadDLQMessages(ctx, request, opts...)
@@ -239,7 +223,6 @@ func (c *clientImpl) PurgeDLQMessages(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.PurgeDLQMessages(ctx, request, opts...)
@@ -251,7 +234,6 @@ func (c *clientImpl) MergeDLQMessages(
 	opts ...yarpc.CallOption,
 ) (*types.MergeDLQMessagesResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.MergeDLQMessages(ctx, request, opts...)
@@ -264,7 +246,6 @@ func (c *clientImpl) RefreshWorkflowTasks(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RefreshWorkflowTasks(ctx, request, opts...)
@@ -276,7 +257,6 @@ func (c *clientImpl) ResendReplicationTasks(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ResendReplicationTasks(ctx, request, opts...)
@@ -287,7 +267,6 @@ func (c *clientImpl) GetCrossClusterTasks(
 	request *types.GetCrossClusterTasksRequest,
 	opts ...yarpc.CallOption,
 ) (*types.GetCrossClusterTasksResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContextWithLargeTimeout(ctx)
 	defer cancel()
 	return c.client.GetCrossClusterTasks(ctx, request, opts...)
@@ -298,7 +277,6 @@ func (c *clientImpl) RespondCrossClusterTasksCompleted(
 	request *types.RespondCrossClusterTasksCompletedRequest,
 	opts ...yarpc.CallOption,
 ) (*types.RespondCrossClusterTasksCompletedResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondCrossClusterTasksCompleted(ctx, request, opts...)
@@ -309,7 +287,6 @@ func (c *clientImpl) GetDynamicConfig(
 	request *types.GetDynamicConfigRequest,
 	opts ...yarpc.CallOption,
 ) (*types.GetDynamicConfigResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetDynamicConfig(ctx, request, opts...)
@@ -320,7 +297,6 @@ func (c *clientImpl) UpdateDynamicConfig(
 	request *types.UpdateDynamicConfigRequest,
 	opts ...yarpc.CallOption,
 ) error {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.UpdateDynamicConfig(ctx, request, opts...)
@@ -331,7 +307,6 @@ func (c *clientImpl) RestoreDynamicConfig(
 	request *types.RestoreDynamicConfigRequest,
 	opts ...yarpc.CallOption,
 ) error {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RestoreDynamicConfig(ctx, request, opts...)
@@ -342,7 +317,6 @@ func (c *clientImpl) ListDynamicConfig(
 	request *types.ListDynamicConfigRequest,
 	opts ...yarpc.CallOption,
 ) (*types.ListDynamicConfigResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ListDynamicConfig(ctx, request, opts...)

--- a/client/frontend/client.go
+++ b/client/frontend/client.go
@@ -26,7 +26,6 @@ import (
 
 	"go.uber.org/yarpc"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -64,7 +63,6 @@ func (c *clientImpl) DeprecateDomain(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DeprecateDomain(ctx, request, opts...)
@@ -76,7 +74,6 @@ func (c *clientImpl) DescribeDomain(
 	opts ...yarpc.CallOption,
 ) (*types.DescribeDomainResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeDomain(ctx, request, opts...)
@@ -88,7 +85,6 @@ func (c *clientImpl) DescribeTaskList(
 	opts ...yarpc.CallOption,
 ) (*types.DescribeTaskListResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeTaskList(ctx, request, opts...)
@@ -100,7 +96,6 @@ func (c *clientImpl) DescribeWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) (*types.DescribeWorkflowExecutionResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.DescribeWorkflowExecution(ctx, request, opts...)
@@ -112,7 +107,6 @@ func (c *clientImpl) GetWorkflowExecutionHistory(
 	opts ...yarpc.CallOption,
 ) (*types.GetWorkflowExecutionHistoryResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetWorkflowExecutionHistory(ctx, request, opts...)
@@ -124,7 +118,6 @@ func (c *clientImpl) ListArchivedWorkflowExecutions(
 	opts ...yarpc.CallOption,
 ) (*types.ListArchivedWorkflowExecutionsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createLongPollContext(ctx)
 	defer cancel()
 	return c.client.ListArchivedWorkflowExecutions(ctx, request, opts...)
@@ -136,7 +129,6 @@ func (c *clientImpl) ListClosedWorkflowExecutions(
 	opts ...yarpc.CallOption,
 ) (*types.ListClosedWorkflowExecutionsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ListClosedWorkflowExecutions(ctx, request, opts...)
@@ -148,7 +140,6 @@ func (c *clientImpl) ListDomains(
 	opts ...yarpc.CallOption,
 ) (*types.ListDomainsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ListDomains(ctx, request, opts...)
@@ -160,7 +151,6 @@ func (c *clientImpl) ListOpenWorkflowExecutions(
 	opts ...yarpc.CallOption,
 ) (*types.ListOpenWorkflowExecutionsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ListOpenWorkflowExecutions(ctx, request, opts...)
@@ -172,7 +162,6 @@ func (c *clientImpl) ListWorkflowExecutions(
 	opts ...yarpc.CallOption,
 ) (*types.ListWorkflowExecutionsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ListWorkflowExecutions(ctx, request, opts...)
@@ -184,7 +173,6 @@ func (c *clientImpl) ScanWorkflowExecutions(
 	opts ...yarpc.CallOption,
 ) (*types.ListWorkflowExecutionsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ScanWorkflowExecutions(ctx, request, opts...)
@@ -196,7 +184,6 @@ func (c *clientImpl) CountWorkflowExecutions(
 	opts ...yarpc.CallOption,
 ) (*types.CountWorkflowExecutionsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.CountWorkflowExecutions(ctx, request, opts...)
@@ -207,7 +194,6 @@ func (c *clientImpl) GetSearchAttributes(
 	opts ...yarpc.CallOption,
 ) (*types.GetSearchAttributesResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetSearchAttributes(ctx, opts...)
@@ -219,7 +205,6 @@ func (c *clientImpl) PollForActivityTask(
 	opts ...yarpc.CallOption,
 ) (*types.PollForActivityTaskResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createLongPollContext(ctx)
 	defer cancel()
 	return c.client.PollForActivityTask(ctx, request, opts...)
@@ -231,7 +216,6 @@ func (c *clientImpl) PollForDecisionTask(
 	opts ...yarpc.CallOption,
 ) (*types.PollForDecisionTaskResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createLongPollContext(ctx)
 	defer cancel()
 	return c.client.PollForDecisionTask(ctx, request, opts...)
@@ -243,7 +227,6 @@ func (c *clientImpl) QueryWorkflow(
 	opts ...yarpc.CallOption,
 ) (*types.QueryWorkflowResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.QueryWorkflow(ctx, request, opts...)
@@ -255,7 +238,6 @@ func (c *clientImpl) RecordActivityTaskHeartbeat(
 	opts ...yarpc.CallOption,
 ) (*types.RecordActivityTaskHeartbeatResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RecordActivityTaskHeartbeat(ctx, request, opts...)
@@ -267,7 +249,6 @@ func (c *clientImpl) RecordActivityTaskHeartbeatByID(
 	opts ...yarpc.CallOption,
 ) (*types.RecordActivityTaskHeartbeatResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RecordActivityTaskHeartbeatByID(ctx, request, opts...)
@@ -279,7 +260,6 @@ func (c *clientImpl) RegisterDomain(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RegisterDomain(ctx, request, opts...)
@@ -291,7 +271,6 @@ func (c *clientImpl) RequestCancelWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RequestCancelWorkflowExecution(ctx, request, opts...)
@@ -303,7 +282,6 @@ func (c *clientImpl) ResetStickyTaskList(
 	opts ...yarpc.CallOption,
 ) (*types.ResetStickyTaskListResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ResetStickyTaskList(ctx, request, opts...)
@@ -315,7 +293,6 @@ func (c *clientImpl) ResetWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) (*types.ResetWorkflowExecutionResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.ResetWorkflowExecution(ctx, request, opts...)
@@ -327,7 +304,6 @@ func (c *clientImpl) RespondActivityTaskCanceled(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondActivityTaskCanceled(ctx, request, opts...)
@@ -339,7 +315,6 @@ func (c *clientImpl) RespondActivityTaskCanceledByID(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondActivityTaskCanceledByID(ctx, request, opts...)
@@ -351,7 +326,6 @@ func (c *clientImpl) RespondActivityTaskCompleted(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondActivityTaskCompleted(ctx, request, opts...)
@@ -363,7 +337,6 @@ func (c *clientImpl) RespondActivityTaskCompletedByID(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondActivityTaskCompletedByID(ctx, request, opts...)
@@ -375,7 +348,6 @@ func (c *clientImpl) RespondActivityTaskFailed(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondActivityTaskFailed(ctx, request, opts...)
@@ -387,7 +359,6 @@ func (c *clientImpl) RespondActivityTaskFailedByID(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondActivityTaskFailedByID(ctx, request, opts...)
@@ -399,7 +370,6 @@ func (c *clientImpl) RespondDecisionTaskCompleted(
 	opts ...yarpc.CallOption,
 ) (*types.RespondDecisionTaskCompletedResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondDecisionTaskCompleted(ctx, request, opts...)
@@ -411,7 +381,6 @@ func (c *clientImpl) RespondDecisionTaskFailed(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondDecisionTaskFailed(ctx, request, opts...)
@@ -423,7 +392,6 @@ func (c *clientImpl) RespondQueryTaskCompleted(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.RespondQueryTaskCompleted(ctx, request, opts...)
@@ -435,7 +403,6 @@ func (c *clientImpl) SignalWithStartWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) (*types.StartWorkflowExecutionResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.SignalWithStartWorkflowExecution(ctx, request, opts...)
@@ -447,7 +414,6 @@ func (c *clientImpl) SignalWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.SignalWorkflowExecution(ctx, request, opts...)
@@ -459,7 +425,6 @@ func (c *clientImpl) StartWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) (*types.StartWorkflowExecutionResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.StartWorkflowExecution(ctx, request, opts...)
@@ -471,7 +436,6 @@ func (c *clientImpl) TerminateWorkflowExecution(
 	opts ...yarpc.CallOption,
 ) error {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.TerminateWorkflowExecution(ctx, request, opts...)
@@ -483,7 +447,6 @@ func (c *clientImpl) UpdateDomain(
 	opts ...yarpc.CallOption,
 ) (*types.UpdateDomainResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.UpdateDomain(ctx, request, opts...)
@@ -508,7 +471,6 @@ func (c *clientImpl) GetClusterInfo(
 	opts ...yarpc.CallOption,
 ) (*types.ClusterInfo, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 	return c.client.GetClusterInfo(ctx, opts...)
@@ -520,7 +482,6 @@ func (c *clientImpl) ListTaskListPartitions(
 	opts ...yarpc.CallOption,
 ) (*types.ListTaskListPartitionsResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 
@@ -533,7 +494,6 @@ func (c *clientImpl) GetTaskListsByDomain(
 	opts ...yarpc.CallOption,
 ) (*types.GetTaskListsByDomainResponse, error) {
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	ctx, cancel := c.createContext(ctx)
 	defer cancel()
 

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -89,7 +89,6 @@ func (c *clientImpl) StartWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.StartWorkflowExecutionResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -114,7 +113,6 @@ func (c *clientImpl) GetMutableState(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.GetMutableStateResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -139,7 +137,6 @@ func (c *clientImpl) PollMutableState(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.PollMutableStateResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -175,7 +172,6 @@ func (c *clientImpl) DescribeHistoryHost(
 		return nil, err
 	}
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.DescribeHistoryHostResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -200,7 +196,6 @@ func (c *clientImpl) RemoveTask(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		var err error
 		ctx, cancel := c.createContext(ctx)
@@ -222,7 +217,6 @@ func (c *clientImpl) CloseShard(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		var err error
 		ctx, cancel := c.createContext(ctx)
@@ -247,7 +241,6 @@ func (c *clientImpl) ResetQueue(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		var err error
 		ctx, cancel := c.createContext(ctx)
@@ -272,7 +265,6 @@ func (c *clientImpl) DescribeQueue(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.DescribeQueueResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -298,7 +290,6 @@ func (c *clientImpl) DescribeMutableState(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.DescribeMutableStateResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -323,7 +314,6 @@ func (c *clientImpl) ResetStickyTaskList(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.HistoryResetStickyTaskListResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -348,7 +338,6 @@ func (c *clientImpl) DescribeWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.DescribeWorkflowExecutionResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -373,7 +362,6 @@ func (c *clientImpl) RecordDecisionTaskStarted(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.RecordDecisionTaskStartedResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -398,7 +386,6 @@ func (c *clientImpl) RecordActivityTaskStarted(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.RecordActivityTaskStartedResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -427,7 +414,6 @@ func (c *clientImpl) RespondDecisionTaskCompleted(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.HistoryRespondDecisionTaskCompletedResponse
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
@@ -452,7 +438,6 @@ func (c *clientImpl) RespondDecisionTaskFailed(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -475,7 +460,6 @@ func (c *clientImpl) RespondActivityTaskCompleted(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -498,7 +482,6 @@ func (c *clientImpl) RespondActivityTaskFailed(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -521,7 +504,6 @@ func (c *clientImpl) RespondActivityTaskCanceled(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -544,7 +526,6 @@ func (c *clientImpl) RecordActivityTaskHeartbeat(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.RecordActivityTaskHeartbeatResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -569,7 +550,6 @@ func (c *clientImpl) RequestCancelWorkflowExecution(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -587,7 +567,6 @@ func (c *clientImpl) SignalWorkflowExecution(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -607,7 +586,6 @@ func (c *clientImpl) SignalWithStartWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.StartWorkflowExecutionResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -652,7 +630,6 @@ func (c *clientImpl) TerminateWorkflowExecution(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -671,7 +648,6 @@ func (c *clientImpl) ResetWorkflowExecution(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.ResetWorkflowExecutionResponse
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
@@ -695,7 +671,6 @@ func (c *clientImpl) ScheduleDecisionTask(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -714,7 +689,6 @@ func (c *clientImpl) RecordChildExecutionCompleted(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -733,7 +707,6 @@ func (c *clientImpl) ReplicateEventsV2(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -755,7 +728,6 @@ func (c *clientImpl) SyncShardStatus(
 		return err
 	}
 
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -775,7 +747,6 @@ func (c *clientImpl) SyncActivity(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -794,7 +765,6 @@ func (c *clientImpl) QueryWorkflow(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	var response *types.HistoryQueryWorkflowResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error
@@ -917,7 +887,6 @@ func (c *clientImpl) ReapplyEvents(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	op := func(ctx context.Context, peer string) error {
 		ctx, cancel := c.createContext(ctx)
 		defer cancel()
@@ -937,7 +906,6 @@ func (c *clientImpl) ReadDLQMessages(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	return c.client.ReadDLQMessages(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -951,7 +919,6 @@ func (c *clientImpl) PurgeDLQMessages(
 	if err != nil {
 		return err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	return c.client.PurgeDLQMessages(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -965,7 +932,6 @@ func (c *clientImpl) MergeDLQMessages(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	return c.client.MergeDLQMessages(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -1108,7 +1074,6 @@ func (c *clientImpl) RespondCrossClusterTasksCompleted(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 
 	var response *types.RespondCrossClusterTasksCompletedResponse
 	op := func(ctx context.Context, peer string) error {
@@ -1135,7 +1100,6 @@ func (c *clientImpl) GetFailoverInfo(
 	if err != nil {
 		return nil, err
 	}
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	return c.client.GetFailoverInfo(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -26,7 +26,6 @@ import (
 
 	"go.uber.org/yarpc"
 
-	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/future"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
@@ -71,7 +70,6 @@ func (c *clientImpl) AddActivityTask(
 	request *types.AddActivityTaskRequest,
 	opts ...yarpc.CallOption,
 ) error {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	partition := c.loadBalancer.PickWritePartition(
 		request.GetDomainUUID(),
 		*request.GetTaskList(),
@@ -93,7 +91,6 @@ func (c *clientImpl) AddDecisionTask(
 	request *types.AddDecisionTaskRequest,
 	opts ...yarpc.CallOption,
 ) error {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	partition := c.loadBalancer.PickWritePartition(
 		request.GetDomainUUID(),
 		*request.GetTaskList(),
@@ -115,7 +112,6 @@ func (c *clientImpl) PollForActivityTask(
 	request *types.MatchingPollForActivityTaskRequest,
 	opts ...yarpc.CallOption,
 ) (*types.PollForActivityTaskResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	partition := c.loadBalancer.PickReadPartition(
 		request.GetDomainUUID(),
 		*request.PollRequest.GetTaskList(),
@@ -137,7 +133,6 @@ func (c *clientImpl) PollForDecisionTask(
 	request *types.MatchingPollForDecisionTaskRequest,
 	opts ...yarpc.CallOption,
 ) (*types.MatchingPollForDecisionTaskResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	partition := c.loadBalancer.PickReadPartition(
 		request.GetDomainUUID(),
 		*request.PollRequest.GetTaskList(),
@@ -159,7 +154,6 @@ func (c *clientImpl) QueryWorkflow(
 	request *types.MatchingQueryWorkflowRequest,
 	opts ...yarpc.CallOption,
 ) (*types.QueryWorkflowResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	partition := c.loadBalancer.PickReadPartition(
 		request.GetDomainUUID(),
 		*request.GetTaskList(),
@@ -181,7 +175,6 @@ func (c *clientImpl) RespondQueryTaskCompleted(
 	request *types.MatchingRespondQueryTaskCompletedRequest,
 	opts ...yarpc.CallOption,
 ) error {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	peer, err := c.peerResolver.FromTaskList(request.TaskList.GetName())
 	if err != nil {
 		return err
@@ -196,7 +189,6 @@ func (c *clientImpl) CancelOutstandingPoll(
 	request *types.CancelOutstandingPollRequest,
 	opts ...yarpc.CallOption,
 ) error {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	peer, err := c.peerResolver.FromTaskList(request.TaskList.GetName())
 	if err != nil {
 		return err
@@ -211,7 +203,6 @@ func (c *clientImpl) DescribeTaskList(
 	request *types.MatchingDescribeTaskListRequest,
 	opts ...yarpc.CallOption,
 ) (*types.DescribeTaskListResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	peer, err := c.peerResolver.FromTaskList(request.DescRequest.TaskList.GetName())
 	if err != nil {
 		return nil, err
@@ -226,7 +217,6 @@ func (c *clientImpl) ListTaskListPartitions(
 	request *types.MatchingListTaskListPartitionsRequest,
 	opts ...yarpc.CallOption,
 ) (*types.ListTaskListPartitionsResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	peer, err := c.peerResolver.FromTaskList(request.TaskList.GetName())
 	if err != nil {
 		return nil, err
@@ -241,7 +231,6 @@ func (c *clientImpl) GetTaskListsByDomain(
 	request *types.GetTaskListsByDomainRequest,
 	opts ...yarpc.CallOption,
 ) (*types.GetTaskListsByDomainResponse, error) {
-	opts = common.AggregateYarpcOptions(ctx, opts...)
 	peers, err := c.peerResolver.GetAllPeers()
 	if err != nil {
 		return nil, err

--- a/common/rpc.go
+++ b/common/rpc.go
@@ -21,8 +21,6 @@
 package common
 
 import (
-	"context"
-
 	"go.uber.org/yarpc"
 )
 
@@ -59,17 +57,3 @@ type (
 		GetMaxMessageSize() int
 	}
 )
-
-// AggregateYarpcOptions aggregate the header information from context to existing yarpc call options
-func AggregateYarpcOptions(ctx context.Context, opts ...yarpc.CallOption) []yarpc.CallOption {
-	var result []yarpc.CallOption
-	if ctx != nil {
-		call := yarpc.CallFromContext(ctx)
-		for _, key := range call.HeaderNames() {
-			value := call.Header(key)
-			result = append(result, yarpc.WithHeader(key, value))
-		}
-	}
-	result = append(result, opts...)
-	return result
-}

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -101,6 +101,9 @@ func NewParams(serviceName string, config *config.Config, dc *dynamicconfig.Coll
 		InboundMiddleware: yarpc.InboundMiddleware{
 			Unary: &inboundMetricsMiddleware{},
 		},
+		OutboundMiddleware: yarpc.OutboundMiddleware{
+			Unary: &HeaderForwardingMiddleware{},
+		},
 	}, nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added middleware to forward ongoing inbound call header when making new outbound call.
Previously we did this on every call within client.
This can can be made transparent with the use of middleware that forwards existing inbound headers to the new outbound request.

<!-- Tell your future self why have you made these changes -->
**Why?**
To simplify and reduce boilerplate code.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Covered new middleware with unit tests.
Tested locally with cadence-canary.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
