### PR TITLE
Reduce API scope for membership.Monitor

### DIFF
--- a/common/membership/resolver.go
+++ b/common/membership/resolver.go
@@ -34,7 +34,11 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/types"
 )
+
+// ErrInsufficientHosts is thrown when there are not enough hosts to serve the request
+var ErrInsufficientHosts = &types.InternalServiceError{Message: "Not enough hosts to serve the request"}
 
 const (
 	// RoleKey label is set by every single service as soon as it bootstraps its

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -194,9 +194,9 @@ func New(
 		&params.PersistenceConfig,
 		func(...dynamicconfig.FilterOption) int {
 			if serviceConfig.PersistenceGlobalMaxQPS() > 0 {
-				ringSize, err := membershipMonitor.GetMemberCount(serviceName)
-				if err == nil && ringSize > 0 {
-					avgQuota := common.MaxInt(serviceConfig.PersistenceGlobalMaxQPS()/ringSize, 1)
+				resolver, err := membershipMonitor.GetResolver(serviceName)
+				if err == nil && resolver.MemberCount() > 0 {
+					avgQuota := common.MaxInt(serviceConfig.PersistenceGlobalMaxQPS()/resolver.MemberCount(), 1)
 					return common.MinInt(avgQuota, serviceConfig.PersistenceMaxQPS())
 				}
 			}

--- a/host/simpleMonitor.go
+++ b/host/simpleMonitor.go
@@ -21,8 +21,6 @@
 package host
 
 import (
-	"fmt"
-
 	"github.com/uber/cadence/common/membership"
 )
 
@@ -57,28 +55,4 @@ func (s *simpleMonitor) WhoAmI() (*membership.HostInfo, error) {
 
 func (s *simpleMonitor) GetResolver(service string) (membership.ServiceResolver, error) {
 	return s.resolvers[service], nil
-}
-
-func (s *simpleMonitor) Lookup(service string, key string) (*membership.HostInfo, error) {
-	resolver, ok := s.resolvers[service]
-	if !ok {
-		return nil, fmt.Errorf("cannot lookup host for service %v", service)
-	}
-	return resolver.Lookup(key)
-}
-
-func (s *simpleMonitor) AddListener(service string, name string, notifyChannel chan<- *membership.ChangedEvent) error {
-	return nil
-}
-
-func (s *simpleMonitor) RemoveListener(service string, name string) error {
-	return nil
-}
-
-func (s *simpleMonitor) GetReachableMembers() ([]string, error) {
-	return nil, nil
-}
-
-func (s *simpleMonitor) GetMemberCount(service string) (int, error) {
-	return 0, nil
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -166,10 +166,9 @@ func NewWorkflowHandler(
 				return float64(config.RPS())
 			},
 			func(domain string) float64 {
-				if monitor := resource.GetMembershipMonitor(); monitor != nil && config.GlobalDomainRPS(domain) > 0 {
-					ringSize, err := monitor.GetMemberCount(service.Frontend)
-					if err == nil && ringSize > 0 {
-						avgQuota := common.MaxInt(config.GlobalDomainRPS(domain)/ringSize, 1)
+				if resolver := resource.GetFrontendServiceResolver(); resolver != nil && config.GlobalDomainRPS(domain) > 0 {
+					if resolver.MemberCount() > 0 {
+						avgQuota := common.MaxInt(config.GlobalDomainRPS(domain)/resolver.MemberCount(), 1)
 						return float64(common.MinInt(avgQuota, config.MaxDomainRPSPerInstance(domain)))
 					}
 				}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removing duplicate methods from Monitor

<!-- Tell your future self why have you made these changes -->
**Why?**
Monitor is responsible for creating and returning resolvers. 
Service resolver is used to return membership information for a specific key. 



<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
