### PR TITLE
[WIP] Use outbound middleware to set max timeouts on clients.

### DIFF
--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -20,318 +20,43 @@
 
 package admin
 
-import (
-	"context"
-	"time"
+import "time"
 
-	"go.uber.org/yarpc"
-
-	"github.com/uber/cadence/common/types"
-)
-
-var _ Client = (*clientImpl)(nil)
-
-const (
+var (
 	// DefaultTimeout is the default timeout used to make calls
 	DefaultTimeout = 10 * time.Second
 	// DefaultLargeTimeout is the default timeout used to make calls
 	DefaultLargeTimeout = time.Minute
+
+	// MaxTimeouts specify a max allowed duration for each method on the client.
+	// It it used to override context deadline, shortening it when it is too far in the future.
+	// If the value is nil, additional max timeout is not enforced and current context deadline is untouched.
+	// We use it as a safeguard to prevent service exhaustion, when upstream timeout is too large.
+	MaxTimeouts = map[string]*time.Duration{
+		"AddSearchAttribute":                &DefaultTimeout,
+		"DescribeShardDistribution":         &DefaultTimeout,
+		"DescribeHistoryHost":               &DefaultTimeout,
+		"RemoveTask":                        &DefaultTimeout,
+		"CloseShard":                        &DefaultTimeout,
+		"ResetQueue":                        &DefaultTimeout,
+		"DescribeQueue":                     &DefaultTimeout,
+		"DescribeWorkflowExecution":         &DefaultTimeout,
+		"GetWorkflowExecutionRawHistoryV2":  &DefaultTimeout,
+		"DescribeCluster":                   &DefaultTimeout,
+		"GetReplicationMessages":            &DefaultLargeTimeout,
+		"GetDomainReplicationMessages":      &DefaultTimeout,
+		"GetDLQReplicationMessages":         &DefaultTimeout,
+		"ReapplyEvents":                     &DefaultTimeout,
+		"ReadDLQMessages":                   &DefaultTimeout,
+		"PurgeDLQMessages":                  &DefaultTimeout,
+		"MergeDLQMessages":                  &DefaultTimeout,
+		"RefreshWorkflowTasks":              &DefaultTimeout,
+		"ResendReplicationTasks":            &DefaultTimeout,
+		"GetCrossClusterTasks":              &DefaultLargeTimeout,
+		"RespondCrossClusterTasksCompleted": &DefaultTimeout,
+		"GetDynamicConfig":                  &DefaultTimeout,
+		"UpdateDynamicConfig":               &DefaultTimeout,
+		"RestoreDynamicConfig":              &DefaultTimeout,
+		"ListDynamicConfig":                 &DefaultTimeout,
+	}
 )
-
-type clientImpl struct {
-	timeout      time.Duration
-	largeTimeout time.Duration
-	client       Client
-}
-
-// NewClient creates a new admin service TChannel client
-func NewClient(
-	timeout time.Duration,
-	largeTimeout time.Duration,
-	client Client,
-) Client {
-	return &clientImpl{
-		timeout:      timeout,
-		largeTimeout: largeTimeout,
-		client:       client,
-	}
-}
-
-func (c *clientImpl) AddSearchAttribute(
-	ctx context.Context,
-	request *types.AddSearchAttributeRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.AddSearchAttribute(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeShardDistribution(
-	ctx context.Context,
-	request *types.DescribeShardDistributionRequest,
-	opts ...yarpc.CallOption,
-) (*types.DescribeShardDistributionResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeShardDistribution(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeHistoryHost(
-	ctx context.Context,
-	request *types.DescribeHistoryHostRequest,
-	opts ...yarpc.CallOption,
-) (*types.DescribeHistoryHostResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeHistoryHost(ctx, request, opts...)
-}
-
-func (c *clientImpl) RemoveTask(
-	ctx context.Context,
-	request *types.RemoveTaskRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RemoveTask(ctx, request, opts...)
-}
-
-func (c *clientImpl) CloseShard(
-	ctx context.Context,
-	request *types.CloseShardRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.CloseShard(ctx, request, opts...)
-}
-
-func (c *clientImpl) ResetQueue(
-	ctx context.Context,
-	request *types.ResetQueueRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ResetQueue(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeQueue(
-	ctx context.Context,
-	request *types.DescribeQueueRequest,
-	opts ...yarpc.CallOption,
-) (*types.DescribeQueueResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeQueue(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeWorkflowExecution(
-	ctx context.Context,
-	request *types.AdminDescribeWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) (*types.AdminDescribeWorkflowExecutionResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetWorkflowExecutionRawHistoryV2(
-	ctx context.Context,
-	request *types.GetWorkflowExecutionRawHistoryV2Request,
-	opts ...yarpc.CallOption,
-) (*types.GetWorkflowExecutionRawHistoryV2Response, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetWorkflowExecutionRawHistoryV2(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeCluster(
-	ctx context.Context,
-	opts ...yarpc.CallOption,
-) (*types.DescribeClusterResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeCluster(ctx, opts...)
-}
-
-func (c *clientImpl) GetReplicationMessages(
-	ctx context.Context,
-	request *types.GetReplicationMessagesRequest,
-	opts ...yarpc.CallOption,
-) (*types.GetReplicationMessagesResponse, error) {
-	ctx, cancel := c.createContextWithLargeTimeout(ctx)
-	defer cancel()
-	return c.client.GetReplicationMessages(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetDomainReplicationMessages(
-	ctx context.Context,
-	request *types.GetDomainReplicationMessagesRequest,
-	opts ...yarpc.CallOption,
-) (*types.GetDomainReplicationMessagesResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetDomainReplicationMessages(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetDLQReplicationMessages(
-	ctx context.Context,
-	request *types.GetDLQReplicationMessagesRequest,
-	opts ...yarpc.CallOption,
-) (*types.GetDLQReplicationMessagesResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetDLQReplicationMessages(ctx, request, opts...)
-}
-
-func (c *clientImpl) ReapplyEvents(
-	ctx context.Context,
-	request *types.ReapplyEventsRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ReapplyEvents(ctx, request, opts...)
-}
-
-func (c *clientImpl) ReadDLQMessages(
-	ctx context.Context,
-	request *types.ReadDLQMessagesRequest,
-	opts ...yarpc.CallOption,
-) (*types.ReadDLQMessagesResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ReadDLQMessages(ctx, request, opts...)
-}
-
-func (c *clientImpl) PurgeDLQMessages(
-	ctx context.Context,
-	request *types.PurgeDLQMessagesRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.PurgeDLQMessages(ctx, request, opts...)
-}
-
-func (c *clientImpl) MergeDLQMessages(
-	ctx context.Context,
-	request *types.MergeDLQMessagesRequest,
-	opts ...yarpc.CallOption,
-) (*types.MergeDLQMessagesResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.MergeDLQMessages(ctx, request, opts...)
-
-}
-
-func (c *clientImpl) RefreshWorkflowTasks(
-	ctx context.Context,
-	request *types.RefreshWorkflowTasksRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RefreshWorkflowTasks(ctx, request, opts...)
-}
-
-func (c *clientImpl) ResendReplicationTasks(
-	ctx context.Context,
-	request *types.ResendReplicationTasksRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ResendReplicationTasks(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetCrossClusterTasks(
-	ctx context.Context,
-	request *types.GetCrossClusterTasksRequest,
-	opts ...yarpc.CallOption,
-) (*types.GetCrossClusterTasksResponse, error) {
-	ctx, cancel := c.createContextWithLargeTimeout(ctx)
-	defer cancel()
-	return c.client.GetCrossClusterTasks(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondCrossClusterTasksCompleted(
-	ctx context.Context,
-	request *types.RespondCrossClusterTasksCompletedRequest,
-	opts ...yarpc.CallOption,
-) (*types.RespondCrossClusterTasksCompletedResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondCrossClusterTasksCompleted(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetDynamicConfig(
-	ctx context.Context,
-	request *types.GetDynamicConfigRequest,
-	opts ...yarpc.CallOption,
-) (*types.GetDynamicConfigResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetDynamicConfig(ctx, request, opts...)
-}
-
-func (c *clientImpl) UpdateDynamicConfig(
-	ctx context.Context,
-	request *types.UpdateDynamicConfigRequest,
-	opts ...yarpc.CallOption,
-) error {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.UpdateDynamicConfig(ctx, request, opts...)
-}
-
-func (c *clientImpl) RestoreDynamicConfig(
-	ctx context.Context,
-	request *types.RestoreDynamicConfigRequest,
-	opts ...yarpc.CallOption,
-) error {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RestoreDynamicConfig(ctx, request, opts...)
-}
-
-func (c *clientImpl) ListDynamicConfig(
-	ctx context.Context,
-	request *types.ListDynamicConfigRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListDynamicConfigResponse, error) {
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ListDynamicConfig(ctx, request, opts...)
-}
-
-func (c *clientImpl) createContext(parent context.Context) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		return context.WithTimeout(context.Background(), c.timeout)
-	}
-	return context.WithTimeout(parent, c.timeout)
-}
-
-func (c *clientImpl) createContextWithLargeTimeout(parent context.Context) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		return context.WithTimeout(context.Background(), c.largeTimeout)
-	}
-	return context.WithTimeout(parent, c.largeTimeout)
-}

--- a/client/admin/client_test.go
+++ b/client/admin/client_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package admin
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxTimeouts(t *testing.T) {
+	// Since MaxTimeouts list every method by string
+	// Here we ensure that they reflect all actual methods.
+	// We test both ways: the map must contain all client methods and do not contain any other keys.
+	c := grpcClient{}
+	client := reflect.TypeOf(c)
+	for i := 0; i < client.NumMethod(); i++ {
+		require.Contains(t, MaxTimeouts, client.Method(i).Name)
+	}
+	for method := range MaxTimeouts {
+		_, exists := client.MethodByName(method)
+		require.True(t, exists, "MaxTimeouts contains unknown method %s", method)
+	}
+}

--- a/client/clientBean.go
+++ b/client/clientBean.go
@@ -75,20 +75,12 @@ func NewClientBean(factory Factory, dispatcher *yarpc.Dispatcher, clusterMetadat
 
 		clientConfig := dispatcher.ClientConfig(clusterName)
 
-		adminClient, err := factory.NewAdminClientWithTimeoutAndConfig(
-			clientConfig,
-			admin.DefaultTimeout,
-			admin.DefaultLargeTimeout,
-		)
+		adminClient, err := factory.NewAdminClient(clientConfig)
 		if err != nil {
 			return nil, err
 		}
 
-		frontendClient, err := factory.NewFrontendClientWithTimeoutAndConfig(
-			clientConfig,
-			frontend.DefaultTimeout,
-			frontend.DefaultLongPollTimeout,
-		)
+		frontendClient, err := factory.NewFrontendClient(clientConfig)
 		if err != nil {
 			return nil, err
 		}

--- a/client/frontend/client.go
+++ b/client/frontend/client.go
@@ -20,482 +20,57 @@
 
 package frontend
 
-import (
-	"context"
-	"time"
+import "time"
 
-	"go.uber.org/yarpc"
-
-	"github.com/uber/cadence/common/types"
-)
-
-var _ Client = (*clientImpl)(nil)
-
-const (
+var (
 	// DefaultTimeout is the default timeout used to make calls
 	DefaultTimeout = 10 * time.Second
 	// DefaultLongPollTimeout is the long poll default timeout used to make calls
 	DefaultLongPollTimeout = time.Minute * 3
+
+	// MaxTimeouts specify a max allowed duration for each method on the client.
+	// It it used to override context deadline, shortening it when it is too far in the future.
+	// If the value is nil, additional max timeout is not enforced and current context deadline is untouched.
+	// We use it as a safeguard to prevent service exhaustion, when upstream timeout is too large.
+	MaxTimeouts = map[string]*time.Duration{
+		"DeprecateDomain":                  &DefaultTimeout,
+		"DescribeDomain":                   &DefaultTimeout,
+		"DescribeTaskList":                 &DefaultTimeout,
+		"DescribeWorkflowExecution":        &DefaultTimeout,
+		"GetWorkflowExecutionHistory":      &DefaultTimeout,
+		"ListArchivedWorkflowExecutions":   &DefaultLongPollTimeout,
+		"ListClosedWorkflowExecutions":     &DefaultTimeout,
+		"ListDomains":                      &DefaultTimeout,
+		"ListOpenWorkflowExecutions":       &DefaultTimeout,
+		"ListWorkflowExecutions":           &DefaultTimeout,
+		"ScanWorkflowExecutions":           &DefaultTimeout,
+		"CountWorkflowExecutions":          &DefaultTimeout,
+		"GetSearchAttributes":              &DefaultTimeout,
+		"PollForActivityTask":              &DefaultLongPollTimeout,
+		"PollForDecisionTask":              &DefaultLongPollTimeout,
+		"QueryWorkflow":                    &DefaultTimeout,
+		"RecordActivityTaskHeartbeat":      &DefaultTimeout,
+		"RecordActivityTaskHeartbeatByID":  &DefaultTimeout,
+		"RegisterDomain":                   &DefaultTimeout,
+		"RequestCancelWorkflowExecution":   &DefaultTimeout,
+		"ResetStickyTaskList":              &DefaultTimeout,
+		"ResetWorkflowExecution":           &DefaultTimeout,
+		"RespondActivityTaskCanceled":      &DefaultTimeout,
+		"RespondActivityTaskCanceledByID":  &DefaultTimeout,
+		"RespondActivityTaskCompleted":     &DefaultTimeout,
+		"RespondActivityTaskCompletedByID": &DefaultTimeout,
+		"RespondActivityTaskFailed":        &DefaultTimeout,
+		"RespondActivityTaskFailedByID":    &DefaultTimeout,
+		"RespondDecisionTaskCompleted":     &DefaultTimeout,
+		"RespondDecisionTaskFailed":        &DefaultTimeout,
+		"RespondQueryTaskCompleted":        &DefaultTimeout,
+		"SignalWithStartWorkflowExecution": &DefaultTimeout,
+		"SignalWorkflowExecution":          &DefaultTimeout,
+		"StartWorkflowExecution":           &DefaultTimeout,
+		"TerminateWorkflowExecution":       &DefaultTimeout,
+		"UpdateDomain":                     &DefaultTimeout,
+		"GetClusterInfo":                   &DefaultTimeout,
+		"ListTaskListPartitions":           &DefaultTimeout,
+		"GetTaskListsByDomain":             &DefaultTimeout,
+	}
 )
-
-type clientImpl struct {
-	timeout         time.Duration
-	longPollTimeout time.Duration
-	client          Client
-}
-
-// NewClient creates a new frontend service TChannel client
-func NewClient(
-	timeout time.Duration,
-	longPollTimeout time.Duration,
-	client Client,
-) Client {
-	return &clientImpl{
-		timeout:         timeout,
-		longPollTimeout: longPollTimeout,
-		client:          client,
-	}
-}
-
-func (c *clientImpl) DeprecateDomain(
-	ctx context.Context,
-	request *types.DeprecateDomainRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DeprecateDomain(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeDomain(
-	ctx context.Context,
-	request *types.DescribeDomainRequest,
-	opts ...yarpc.CallOption,
-) (*types.DescribeDomainResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeDomain(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeTaskList(
-	ctx context.Context,
-	request *types.DescribeTaskListRequest,
-	opts ...yarpc.CallOption,
-) (*types.DescribeTaskListResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeTaskList(ctx, request, opts...)
-}
-
-func (c *clientImpl) DescribeWorkflowExecution(
-	ctx context.Context,
-	request *types.DescribeWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) (*types.DescribeWorkflowExecutionResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.DescribeWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetWorkflowExecutionHistory(
-	ctx context.Context,
-	request *types.GetWorkflowExecutionHistoryRequest,
-	opts ...yarpc.CallOption,
-) (*types.GetWorkflowExecutionHistoryResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetWorkflowExecutionHistory(ctx, request, opts...)
-}
-
-func (c *clientImpl) ListArchivedWorkflowExecutions(
-	ctx context.Context,
-	request *types.ListArchivedWorkflowExecutionsRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListArchivedWorkflowExecutionsResponse, error) {
-
-	ctx, cancel := c.createLongPollContext(ctx)
-	defer cancel()
-	return c.client.ListArchivedWorkflowExecutions(ctx, request, opts...)
-}
-
-func (c *clientImpl) ListClosedWorkflowExecutions(
-	ctx context.Context,
-	request *types.ListClosedWorkflowExecutionsRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListClosedWorkflowExecutionsResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ListClosedWorkflowExecutions(ctx, request, opts...)
-}
-
-func (c *clientImpl) ListDomains(
-	ctx context.Context,
-	request *types.ListDomainsRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListDomainsResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ListDomains(ctx, request, opts...)
-}
-
-func (c *clientImpl) ListOpenWorkflowExecutions(
-	ctx context.Context,
-	request *types.ListOpenWorkflowExecutionsRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListOpenWorkflowExecutionsResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ListOpenWorkflowExecutions(ctx, request, opts...)
-}
-
-func (c *clientImpl) ListWorkflowExecutions(
-	ctx context.Context,
-	request *types.ListWorkflowExecutionsRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListWorkflowExecutionsResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ListWorkflowExecutions(ctx, request, opts...)
-}
-
-func (c *clientImpl) ScanWorkflowExecutions(
-	ctx context.Context,
-	request *types.ListWorkflowExecutionsRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListWorkflowExecutionsResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ScanWorkflowExecutions(ctx, request, opts...)
-}
-
-func (c *clientImpl) CountWorkflowExecutions(
-	ctx context.Context,
-	request *types.CountWorkflowExecutionsRequest,
-	opts ...yarpc.CallOption,
-) (*types.CountWorkflowExecutionsResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.CountWorkflowExecutions(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetSearchAttributes(
-	ctx context.Context,
-	opts ...yarpc.CallOption,
-) (*types.GetSearchAttributesResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetSearchAttributes(ctx, opts...)
-}
-
-func (c *clientImpl) PollForActivityTask(
-	ctx context.Context,
-	request *types.PollForActivityTaskRequest,
-	opts ...yarpc.CallOption,
-) (*types.PollForActivityTaskResponse, error) {
-
-	ctx, cancel := c.createLongPollContext(ctx)
-	defer cancel()
-	return c.client.PollForActivityTask(ctx, request, opts...)
-}
-
-func (c *clientImpl) PollForDecisionTask(
-	ctx context.Context,
-	request *types.PollForDecisionTaskRequest,
-	opts ...yarpc.CallOption,
-) (*types.PollForDecisionTaskResponse, error) {
-
-	ctx, cancel := c.createLongPollContext(ctx)
-	defer cancel()
-	return c.client.PollForDecisionTask(ctx, request, opts...)
-}
-
-func (c *clientImpl) QueryWorkflow(
-	ctx context.Context,
-	request *types.QueryWorkflowRequest,
-	opts ...yarpc.CallOption,
-) (*types.QueryWorkflowResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.QueryWorkflow(ctx, request, opts...)
-}
-
-func (c *clientImpl) RecordActivityTaskHeartbeat(
-	ctx context.Context,
-	request *types.RecordActivityTaskHeartbeatRequest,
-	opts ...yarpc.CallOption,
-) (*types.RecordActivityTaskHeartbeatResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RecordActivityTaskHeartbeat(ctx, request, opts...)
-}
-
-func (c *clientImpl) RecordActivityTaskHeartbeatByID(
-	ctx context.Context,
-	request *types.RecordActivityTaskHeartbeatByIDRequest,
-	opts ...yarpc.CallOption,
-) (*types.RecordActivityTaskHeartbeatResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RecordActivityTaskHeartbeatByID(ctx, request, opts...)
-}
-
-func (c *clientImpl) RegisterDomain(
-	ctx context.Context,
-	request *types.RegisterDomainRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RegisterDomain(ctx, request, opts...)
-}
-
-func (c *clientImpl) RequestCancelWorkflowExecution(
-	ctx context.Context,
-	request *types.RequestCancelWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RequestCancelWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) ResetStickyTaskList(
-	ctx context.Context,
-	request *types.ResetStickyTaskListRequest,
-	opts ...yarpc.CallOption,
-) (*types.ResetStickyTaskListResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ResetStickyTaskList(ctx, request, opts...)
-}
-
-func (c *clientImpl) ResetWorkflowExecution(
-	ctx context.Context,
-	request *types.ResetWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) (*types.ResetWorkflowExecutionResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.ResetWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondActivityTaskCanceled(
-	ctx context.Context,
-	request *types.RespondActivityTaskCanceledRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondActivityTaskCanceled(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondActivityTaskCanceledByID(
-	ctx context.Context,
-	request *types.RespondActivityTaskCanceledByIDRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondActivityTaskCanceledByID(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondActivityTaskCompleted(
-	ctx context.Context,
-	request *types.RespondActivityTaskCompletedRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondActivityTaskCompleted(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondActivityTaskCompletedByID(
-	ctx context.Context,
-	request *types.RespondActivityTaskCompletedByIDRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondActivityTaskCompletedByID(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondActivityTaskFailed(
-	ctx context.Context,
-	request *types.RespondActivityTaskFailedRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondActivityTaskFailed(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondActivityTaskFailedByID(
-	ctx context.Context,
-	request *types.RespondActivityTaskFailedByIDRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondActivityTaskFailedByID(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondDecisionTaskCompleted(
-	ctx context.Context,
-	request *types.RespondDecisionTaskCompletedRequest,
-	opts ...yarpc.CallOption,
-) (*types.RespondDecisionTaskCompletedResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondDecisionTaskCompleted(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondDecisionTaskFailed(
-	ctx context.Context,
-	request *types.RespondDecisionTaskFailedRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondDecisionTaskFailed(ctx, request, opts...)
-}
-
-func (c *clientImpl) RespondQueryTaskCompleted(
-	ctx context.Context,
-	request *types.RespondQueryTaskCompletedRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.RespondQueryTaskCompleted(ctx, request, opts...)
-}
-
-func (c *clientImpl) SignalWithStartWorkflowExecution(
-	ctx context.Context,
-	request *types.SignalWithStartWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) (*types.StartWorkflowExecutionResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.SignalWithStartWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) SignalWorkflowExecution(
-	ctx context.Context,
-	request *types.SignalWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.SignalWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) StartWorkflowExecution(
-	ctx context.Context,
-	request *types.StartWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) (*types.StartWorkflowExecutionResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.StartWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) TerminateWorkflowExecution(
-	ctx context.Context,
-	request *types.TerminateWorkflowExecutionRequest,
-	opts ...yarpc.CallOption,
-) error {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.TerminateWorkflowExecution(ctx, request, opts...)
-}
-
-func (c *clientImpl) UpdateDomain(
-	ctx context.Context,
-	request *types.UpdateDomainRequest,
-	opts ...yarpc.CallOption,
-) (*types.UpdateDomainResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.UpdateDomain(ctx, request, opts...)
-}
-
-func (c *clientImpl) createContext(parent context.Context) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		return context.WithTimeout(context.Background(), c.timeout)
-	}
-	return context.WithTimeout(parent, c.timeout)
-}
-
-func (c *clientImpl) createLongPollContext(parent context.Context) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		return context.WithTimeout(context.Background(), c.longPollTimeout)
-	}
-	return context.WithTimeout(parent, c.longPollTimeout)
-}
-
-func (c *clientImpl) GetClusterInfo(
-	ctx context.Context,
-	opts ...yarpc.CallOption,
-) (*types.ClusterInfo, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-	return c.client.GetClusterInfo(ctx, opts...)
-}
-
-func (c *clientImpl) ListTaskListPartitions(
-	ctx context.Context,
-	request *types.ListTaskListPartitionsRequest,
-	opts ...yarpc.CallOption,
-) (*types.ListTaskListPartitionsResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-
-	return c.client.ListTaskListPartitions(ctx, request, opts...)
-}
-
-func (c *clientImpl) GetTaskListsByDomain(
-	ctx context.Context,
-	request *types.GetTaskListsByDomainRequest,
-	opts ...yarpc.CallOption,
-) (*types.GetTaskListsByDomainResponse, error) {
-
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
-
-	return c.client.GetTaskListsByDomain(ctx, request, opts...)
-}

--- a/client/frontend/client_test.go
+++ b/client/frontend/client_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package frontend
+
+import (
+	reflect "reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxTimeouts(t *testing.T) {
+	// Since MaxTimeouts list every method by string
+	// Here we ensure that they reflect all actual methods.
+	// We test both ways: the map must contain all client methods and do not contain any other keys.
+	c := grpcClient{}
+	client := reflect.TypeOf(c)
+	for i := 0; i < client.NumMethod(); i++ {
+		require.Contains(t, MaxTimeouts, client.Method(i).Name)
+	}
+	for method := range MaxTimeouts {
+		_, exists := client.MethodByName(method)
+		require.True(t, exists, "MaxTimeouts contains unknown method %s", method)
+	}
+}

--- a/client/history/client_test.go
+++ b/client/history/client_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package history
+
+import (
+	reflect "reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxTimeouts(t *testing.T) {
+	// Since MaxTimeouts list every method by string
+	// Here we ensure that they reflect all actual methods.
+	// We test both ways: the map must contain all client methods and do not contain any other keys.
+	c := grpcClient{}
+	client := reflect.TypeOf(c)
+	for i := 0; i < client.NumMethod(); i++ {
+		require.Contains(t, MaxTimeouts, client.Method(i).Name)
+	}
+	for method := range MaxTimeouts {
+		_, exists := client.MethodByName(method)
+		require.True(t, exists, "MaxTimeouts contains unknown method %s", method)
+	}
+}

--- a/client/matching/client.go
+++ b/client/matching/client.go
@@ -33,35 +33,46 @@ import (
 
 var _ Client = (*clientImpl)(nil)
 
-const (
+var (
 	// DefaultTimeout is the default timeout used to make calls
 	DefaultTimeout = time.Minute
 	// DefaultLongPollTimeout is the long poll default timeout used to make calls
 	DefaultLongPollTimeout = time.Minute * 2
+
+	// MaxTimeouts specify a max allowed duration for each method on the client.
+	// It it used to override context deadline, shortening it when it is too far in the future.
+	// If the value is nil, additional max timeout is not enforced and current context deadline is untouched.
+	// We use it as a safeguard to prevent service exhaustion, when upstream timeout is too large.
+	MaxTimeouts = map[string]*time.Duration{
+		"AddActivityTask":           &DefaultTimeout,
+		"AddDecisionTask":           &DefaultTimeout,
+		"CancelOutstandingPoll":     &DefaultTimeout,
+		"DescribeTaskList":          &DefaultTimeout,
+		"ListTaskListPartitions":    &DefaultTimeout,
+		"GetTaskListsByDomain":      nil,
+		"PollForActivityTask":       &DefaultLongPollTimeout,
+		"PollForDecisionTask":       &DefaultLongPollTimeout,
+		"QueryWorkflow":             &DefaultTimeout,
+		"RespondQueryTaskCompleted": &DefaultTimeout,
+	}
 )
 
 type clientImpl struct {
-	timeout         time.Duration
-	longPollTimeout time.Duration
-	client          Client
-	peerResolver    PeerResolver
-	loadBalancer    LoadBalancer
+	client       Client
+	peerResolver PeerResolver
+	loadBalancer LoadBalancer
 }
 
 // NewClient creates a new history service TChannel client
 func NewClient(
-	timeout time.Duration,
-	longPollTimeout time.Duration,
 	client Client,
 	peerResolver PeerResolver,
 	lb LoadBalancer,
 ) Client {
 	return &clientImpl{
-		timeout:         timeout,
-		longPollTimeout: longPollTimeout,
-		client:          client,
-		peerResolver:    peerResolver,
-		loadBalancer:    lb,
+		client:       client,
+		peerResolver: peerResolver,
+		loadBalancer: lb,
 	}
 }
 
@@ -81,8 +92,6 @@ func (c *clientImpl) AddActivityTask(
 	if err != nil {
 		return err
 	}
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
 	return c.client.AddActivityTask(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -102,8 +111,6 @@ func (c *clientImpl) AddDecisionTask(
 	if err != nil {
 		return err
 	}
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
 	return c.client.AddDecisionTask(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -123,8 +130,6 @@ func (c *clientImpl) PollForActivityTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.createLongPollContext(ctx)
-	defer cancel()
 	return c.client.PollForActivityTask(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -144,8 +149,6 @@ func (c *clientImpl) PollForDecisionTask(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.createLongPollContext(ctx)
-	defer cancel()
 	return c.client.PollForDecisionTask(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -165,8 +168,6 @@ func (c *clientImpl) QueryWorkflow(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
 	return c.client.QueryWorkflow(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -179,8 +180,6 @@ func (c *clientImpl) RespondQueryTaskCompleted(
 	if err != nil {
 		return err
 	}
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
 	return c.client.RespondQueryTaskCompleted(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -193,8 +192,6 @@ func (c *clientImpl) CancelOutstandingPoll(
 	if err != nil {
 		return err
 	}
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
 	return c.client.CancelOutstandingPoll(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -207,8 +204,6 @@ func (c *clientImpl) DescribeTaskList(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
 	return c.client.DescribeTaskList(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -221,8 +216,6 @@ func (c *clientImpl) ListTaskListPartitions(
 	if err != nil {
 		return nil, err
 	}
-	ctx, cancel := c.createContext(ctx)
-	defer cancel()
 	return c.client.ListTaskListPartitions(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 }
 
@@ -270,22 +263,4 @@ func (c *clientImpl) GetTaskListsByDomain(
 		DecisionTaskListMap: decisionTaskListMap,
 		ActivityTaskListMap: activityTaskListMap,
 	}, nil
-}
-
-func (c *clientImpl) createContext(
-	parent context.Context,
-) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		return context.WithTimeout(context.Background(), c.timeout)
-	}
-	return context.WithTimeout(parent, c.timeout)
-}
-
-func (c *clientImpl) createLongPollContext(
-	parent context.Context,
-) (context.Context, context.CancelFunc) {
-	if parent == nil {
-		return context.WithTimeout(context.Background(), c.longPollTimeout)
-	}
-	return context.WithTimeout(parent, c.longPollTimeout)
 }

--- a/client/matching/client_test.go
+++ b/client/matching/client_test.go
@@ -1,0 +1,43 @@
+// Copyright (c) 2021 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package matching
+
+import (
+	reflect "reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaxTimeouts(t *testing.T) {
+	// Since MaxTimeouts list every method by string
+	// Here we ensure that they reflect all actual methods.
+	// We test both ways: the map must contain all client methods and do not contain any other keys.
+	c := grpcClient{}
+	client := reflect.TypeOf(c)
+	for i := 0; i < client.NumMethod(); i++ {
+		require.Contains(t, MaxTimeouts, client.Method(i).Name)
+	}
+	for method := range MaxTimeouts {
+		_, exists := client.MethodByName(method)
+		require.True(t, exists, "MaxTimeouts contains unknown method %s", method)
+	}
+}


### PR DESCRIPTION
<!-- Tell your future self why have you made these changes -->
**Why?**

We have lots of boilerplate code within our clients and handler, where we decorate the interface with some orthogonal functionality. This results in code explosion as we have to do it for every single API method.

Some of those decorators rely on actual types (or error types) being used. Those could only be simplified with the help of generics.

However others can be expressed as transport level middleware. 

This is an example how we could simplify our clients by moving cross cutting concerns to transport layer middleware.
If this seems acceptable, we could similarly simplify some other areas as well.

<!-- Describe what has changed in this PR -->
**What changed?**
- Removed helpers that set default timeouts on outgoing calls. For admin and frontend client this was the only thing left there, thus removing the implementation all together.

- Added outbound middleware that sets the context timeout override based on outbound method name.

- Added mapping between method name and default (max) timeout value. This also revealed some interesting cases where we do not set any default timeouts. Left those as is, as this is purely refactoring. However concise mapping reveals such things at a quick glance.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Added unit tests to check that string based mapping is up to date. If API is changed without updating the map, unit test will fail to remind it.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
