### PR TITLE
Fix remote sync match for standby domains and task creation time

### DIFF
--- a/common/persistence/nosql/nosqlTaskStore.go
+++ b/common/persistence/nosql/nosqlTaskStore.go
@@ -226,6 +226,7 @@ func (t *nosqlTaskStore) CreateTasks(
 	ctx context.Context,
 	request *p.InternalCreateTasksRequest,
 ) (*p.CreateTasksResponse, error) {
+	now := time.Now()
 	var tasks []*nosqlplugin.TaskRowForInsert
 	for _, t := range request.Tasks {
 		task := &nosqlplugin.TaskRow{
@@ -236,7 +237,7 @@ func (t *nosqlTaskStore) CreateTasks(
 			WorkflowID:   t.Execution.GetWorkflowID(),
 			RunID:        t.Execution.GetRunID(),
 			ScheduledID:  t.Data.ScheduleID,
-			CreatedTime:  t.Data.CreatedTime,
+			CreatedTime:  now,
 		}
 		ttl := int(t.Data.ScheduleToStartTimeout.Seconds())
 		tasks = append(tasks, &nosqlplugin.TaskRowForInsert{

--- a/common/persistence/nosql/nosqlTaskStore.go
+++ b/common/persistence/nosql/nosqlTaskStore.go
@@ -226,7 +226,6 @@ func (t *nosqlTaskStore) CreateTasks(
 	ctx context.Context,
 	request *p.InternalCreateTasksRequest,
 ) (*p.CreateTasksResponse, error) {
-	now := time.Now()
 	var tasks []*nosqlplugin.TaskRowForInsert
 	for _, t := range request.Tasks {
 		task := &nosqlplugin.TaskRow{
@@ -237,7 +236,7 @@ func (t *nosqlTaskStore) CreateTasks(
 			WorkflowID:   t.Execution.GetWorkflowID(),
 			RunID:        t.Execution.GetRunID(),
 			ScheduledID:  t.Data.ScheduleID,
-			CreatedTime:  now,
+			CreatedTime:  t.Data.CreatedTime,
 		}
 		ttl := int(t.Data.ScheduleToStartTimeout.Seconds())
 		tasks = append(tasks, &nosqlplugin.TaskRowForInsert{

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -373,7 +373,7 @@ func (db *cdb) InsertTasks(
 				task.WorkflowID,
 				task.RunID,
 				scheduleID,
-				tasklistCondition.LastUpdatedTime,
+				task.CreatedTime,
 				ttl)
 		}
 	}

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1604,18 +1604,20 @@ func (s *TestBase) CreateDecisionTask(ctx context.Context, domainID string, work
 		return 0, err
 	}
 
+	// clearing this field since when creating task in matching we don't have the LastUpdate information
+	leaseResponse.TaskListInfo.LastUpdated = time.Time{}
+
 	taskID := s.GetNextSequenceNumber()
 	tasks := []*p.CreateTaskInfo{
 		{
 			TaskID:    taskID,
 			Execution: workflowExecution,
 			Data: &p.TaskInfo{
-				DomainID:    domainID,
-				WorkflowID:  workflowExecution.WorkflowID,
-				RunID:       workflowExecution.RunID,
-				TaskID:      taskID,
-				ScheduleID:  decisionScheduleID,
-				CreatedTime: time.Now(),
+				DomainID:   domainID,
+				WorkflowID: workflowExecution.WorkflowID,
+				RunID:      workflowExecution.RunID,
+				TaskID:     taskID,
+				ScheduleID: decisionScheduleID,
 			},
 		},
 	}
@@ -1647,6 +1649,8 @@ func (s *TestBase) CreateActivityTasks(ctx context.Context, domainID string, wor
 				return []int64{}, err
 			}
 			taskLists[tl] = resp.TaskListInfo
+			// clearing this field since when creating task in matching we don't have the LastUpdate information
+			taskLists[tl].LastUpdated = time.Time{}
 		}
 	}
 
@@ -1664,7 +1668,6 @@ func (s *TestBase) CreateActivityTasks(ctx context.Context, domainID string, wor
 					TaskID:                 taskID,
 					ScheduleID:             activityScheduleID,
 					ScheduleToStartTimeout: defaultScheduleToStartTimeout,
-					CreatedTime:            time.Now(),
 				},
 			},
 		}

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -1610,11 +1610,12 @@ func (s *TestBase) CreateDecisionTask(ctx context.Context, domainID string, work
 			TaskID:    taskID,
 			Execution: workflowExecution,
 			Data: &p.TaskInfo{
-				DomainID:   domainID,
-				WorkflowID: workflowExecution.WorkflowID,
-				RunID:      workflowExecution.RunID,
-				TaskID:     taskID,
-				ScheduleID: decisionScheduleID,
+				DomainID:    domainID,
+				WorkflowID:  workflowExecution.WorkflowID,
+				RunID:       workflowExecution.RunID,
+				TaskID:      taskID,
+				ScheduleID:  decisionScheduleID,
+				CreatedTime: time.Now(),
 			},
 		},
 	}
@@ -1663,6 +1664,7 @@ func (s *TestBase) CreateActivityTasks(ctx context.Context, domainID string, wor
 					TaskID:                 taskID,
 					ScheduleID:             activityScheduleID,
 					ScheduleToStartTimeout: defaultScheduleToStartTimeout,
+					CreatedTime:            time.Now(),
 				},
 			},
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix remote sync match check for standby domains
- Fix persisted task creation time for cassandra

<!-- Tell your future self why have you made these changes -->
**Why?**
- Currently, for standby domains, matching will persist the task no matter it's forwarded from child partition or not. But forwarded tasks has no TTL (since they are not supposed to be persisted) and if we persist them in the standby tasklist, they will live in DB forever if the user never does domain failover. This will cause the tasklist partition to grow infinitely and incur high db latency.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
