### PR TITLE
Update batcher to support replicating workflows

### DIFF
--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -476,6 +476,14 @@ func newBatchCommands() []cli.Command {
 					Name:  FlagInputWithAlias,
 					Usage: "Optional input of signal",
 				},
+				cli.StringFlag{
+					Name:  FlagSourceClusterWithAlias,
+					Usage: "Required for batch replicate",
+				},
+				cli.StringFlag{
+					Name:  FlagTargetClusterWithAlias,
+					Usage: "Required for batch replicate",
+				},
 				cli.IntFlag{
 					Name:  FlagRPS,
 					Value: batcher.DefaultRPS,

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -147,6 +147,11 @@ func StartBatchJob(c *cli.Context) {
 		sigName = getRequiredOption(c, FlagSignalName)
 		sigVal = getRequiredOption(c, FlagInput)
 	}
+	var sourceCluster, targetCluster string
+	if batchType == batcher.BatchTypeReplicate {
+		sourceCluster = getRequiredOption(c, FlagSourceCluster)
+		targetCluster = getRequiredOption(c, FlagTargetCluster)
+	}
 	rps := c.Int(FlagRPS)
 
 	svcClient := cFactory.ClientFrontendClient(c)
@@ -199,6 +204,10 @@ func StartBatchJob(c *cli.Context) {
 		SignalParams: batcher.SignalParams{
 			SignalName: sigName,
 			Input:      sigVal,
+		},
+		ReplicateParams: batcher.ReplicateParams{
+			SourceCluster: sourceCluster,
+			TargetCluster: targetCluster,
 		},
 		RPS: rps,
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Update batcher to support replicating workflows
- Update CLI to support starting batch replicating workflow

To replicate workflows in batch from a source cluster to a target cluster, use the CLI command:
```
cadence --ad <source cluster address> --do <domain to replicate> wf batch start --re 'migrate workflows' --bt replicate --sc <source cluster> --tc <target cluster> --query <workflow query expr>
```

<!-- Tell your future self why have you made these changes -->
**Why?**
It's useful to replicate closed workflows to a new cluster when we're doing cluster migration.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
