### PR TITLE
Improve error message when a workflow's decision is rejected due to concurrent changes

### DIFF
--- a/service/history/decision/task_handler.go
+++ b/service/history/decision/task_handler.go
@@ -394,7 +394,10 @@ func (handler *taskHandlerImpl) handleDecisionCompleteWorkflow(
 	)
 
 	if handler.hasUnhandledEventsBeforeDecisions {
-		return handler.handlerFailDecision(types.DecisionTaskFailedCauseUnhandledDecision, "")
+		return handler.handlerFailDecision(
+			types.DecisionTaskFailedCauseUnhandledDecision,
+			"cannot complete workflow, new pending decisions were scheduled while this decision was processing",
+		)
 	}
 
 	if err := handler.validateDecisionAttr(
@@ -472,7 +475,10 @@ func (handler *taskHandlerImpl) handleDecisionFailWorkflow(
 	)
 
 	if handler.hasUnhandledEventsBeforeDecisions {
-		return handler.handlerFailDecision(types.DecisionTaskFailedCauseUnhandledDecision, "")
+		return handler.handlerFailDecision(
+			types.DecisionTaskFailedCauseUnhandledDecision,
+			"cannot complete workflow, new pending decisions were scheduled while this decision was processing",
+		)
 	}
 
 	if err := handler.validateDecisionAttr(
@@ -602,7 +608,10 @@ func (handler *taskHandlerImpl) handleDecisionCancelWorkflow(
 		metrics.DecisionTypeCancelWorkflowCounter)
 
 	if handler.hasUnhandledEventsBeforeDecisions {
-		return handler.handlerFailDecision(types.DecisionTaskFailedCauseUnhandledDecision, "")
+		return handler.handlerFailDecision(
+			types.DecisionTaskFailedCauseUnhandledDecision,
+			"cannot process cancellation, new pending decisions were scheduled while this decision was processing",
+		)
 	}
 
 	if err := handler.validateDecisionAttr(
@@ -723,7 +732,10 @@ func (handler *taskHandlerImpl) handleDecisionContinueAsNewWorkflow(
 	)
 
 	if handler.hasUnhandledEventsBeforeDecisions {
-		return handler.handlerFailDecision(types.DecisionTaskFailedCauseUnhandledDecision, "")
+		return handler.handlerFailDecision(
+			types.DecisionTaskFailedCauseUnhandledDecision,
+			"cannot complete workflow, new pending decisions were scheduled while this decision was processing",
+		)
 	}
 
 	executionInfo := handler.mutableState.GetExecutionInfo()


### PR DESCRIPTION
When a workflow e.g. receives a signal while processing a decision task, the task's result
will not be applied, and an 'Unhandled decision' error will be returned.  The next decision
task will (hopefully) produce a new set of decisions that take that signal into account.

When this error is returned, in the UI it currently shows as a decision-task-failed with
these details:
```
cause   UNHANDLED_DECISION
details []
```
which is extremely unclear to users.  After this change, hopefully it will be easier to
understand.