### PR TITLE
Update auto-forwarding to work for global domains with 1 cluster

### DIFF
--- a/service/frontend/clusterRedirectionPolicy.go
+++ b/service/frontend/clusterRedirectionPolicy.go
@@ -172,11 +172,8 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) isDomainNotActiveErr
 // return two values: the target cluster name, and whether or not forwarding to the active cluster
 func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) getTargetClusterAndIsDomainNotActiveAutoForwarding(ctx context.Context, domainEntry *cache.DomainCacheEntry, apiName string) (string, bool) {
 	if !domainEntry.IsGlobalDomain() {
-		return policy.currentClusterName, false
-	}
-
-	if len(domainEntry.GetReplicationConfig().Clusters) == 1 {
-		// do not do dc redirection if domain is only targeting at 1 dc (effectively local domain)
+		// do not do dc redirection if domain is local domain,
+		// for global domains with 1 dc, it's still useful to do auto-forwarding during cluster migration
 		return policy.currentClusterName, false
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update auto-forwarding to work for global domains with 1 cluster
- Improve/Fix unit test coverage

<!-- Tell your future self why have you made these changes -->
**Why?**
It's useful to forward requests to global domains with 1 cluster during cluster migration.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
