### PR TITLE
Generate parentClosePolicy task for x-cluster child

### DIFF
--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -606,7 +606,7 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_SameClusterChild
 	)
 }
 
-func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChild_Abandon() {
+func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterAbandonedChild_Abandon() {
 	s.testProcessCloseExecutionNoParentHasFewChildren(
 		map[string]string{
 			"child_abandon":   s.remoteTargetDomainName,
@@ -614,15 +614,6 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.domainName,
 		},
 		func() {
-			// s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
-			// 	func(request parentclosepolicy.Request) bool {
-			// 		fmt.Println(request.Executions)
-			// 		return len(request.Executions) == 3
-			// 	},
-			// )).Return(nil).Times(1)
-			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
-			// cross cluster apply parent close task is fixed
-			// s.expectCrossClusterApplyParentPolicyCalls()
 			s.expectCancelRequest(s.domainName)
 			s.expectTerminateRequest(s.domainName)
 		},
@@ -637,15 +628,8 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.childDomainName,
 		},
 		func() {
-			s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
-				func(request parentclosepolicy.Request) bool {
-					return len(request.Executions) == 2
-				},
-			)).Return(nil).Times(1)
-			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
-			// cross cluster apply parent close task is fixed
-			// s.expectCrossClusterApplyParentPolicyCalls()
-			// s.expectCancelRequest(s.childDomainName)
+			s.expectCrossClusterApplyParentPolicyCalls()
+			s.expectCancelRequest(s.childDomainName)
 		},
 	)
 }
@@ -658,15 +642,8 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.remoteTargetDomainName,
 		},
 		func() {
-			s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
-				func(request parentclosepolicy.Request) bool {
-					return len(request.Executions) == 2
-				},
-			)).Return(nil).Times(1)
-			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
-			// cross cluster apply parent close task is fixed
-			// s.expectCrossClusterApplyParentPolicyCalls()
-			// s.expectTerminateRequest(s.domainName)
+			s.expectCrossClusterApplyParentPolicyCalls()
+			s.expectTerminateRequest(s.domainName)
 		},
 	)
 }
@@ -679,14 +656,7 @@ func (s *transferActiveTaskExecutorSuite) TestApplyParentPolicy_CrossClusterChil
 			"child_cancel":    s.remoteTargetDomainName,
 		},
 		func() {
-			s.mockParentClosePolicyClient.On("SendParentClosePolicyRequest", mock.Anything, mock.MatchedBy(
-				func(request parentclosepolicy.Request) bool {
-					return len(request.Executions) == 2
-				},
-			)).Return(nil).Times(1)
-			// TODO: uncomment the following and remove ParentClosePolicyClient mock after
-			// cross cluster apply parent close task is fixed
-			// s.expectCrossClusterApplyParentPolicyCalls()
+			s.expectCrossClusterApplyParentPolicyCalls()
 		},
 	)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Instead of always signaling system workflow for applying parent close policy for x-cluster child, generate x-cluster parent close policy task now that the bugs in that task implementation have been fixed.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Revert temp workaround for x-cluster parent close policy task bug

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
