### PR TITLE
Add jitter for starting failover queue

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -966,6 +966,15 @@ const (
 	// Default value: 60s (60*time.Second)
 	// Allowed filters: N/A
 	TimerProcessorCompleteTimerInterval
+	// TimerProcessorFailoverMaxStartJitterInterval is the max jitter interval for starting timer
+	// failover queue processing. The actual jitter interval used will be a random duration between
+	// 0 and the max interval so that timer failover queue across different shards won't start at
+	// the same time
+	// KeyName: history.timerProcessorFailoverMaxStartJitterInterval
+	// Value type: Duration
+	// Default value: 0s (0*time.Second)
+	// Allowed filters: N/A
+	TimerProcessorFailoverMaxStartJitterInterval
 	// TimerProcessorFailoverMaxPollRPS is max poll rate per second for timer processor
 	// KeyName: history.timerProcessorFailoverMaxPollRPS
 	// Value type: Int
@@ -1039,6 +1048,15 @@ const (
 	// Default value: 4000
 	// Allowed filters: N/A
 	TransferTaskDeleteBatchSize
+	// TransferProcessorFailoverMaxStartJitterInterval is the max jitter interval for starting transfer
+	// failover queue processing. The actual jitter interval used will be a random duration between
+	// 0 and the max interval so that timer failover queue across different shards won't start at
+	// the same time
+	// KeyName: history.transferProcessorFailoverMaxStartJitterInterval
+	// Value type: Duration
+	// Default value: 0s (0*time.Second)
+	// Allowed filters: N/A
+	TransferProcessorFailoverMaxStartJitterInterval
 	// TransferProcessorFailoverMaxPollRPS is max poll rate per second for transferQueueProcessor
 	// KeyName: history.transferProcessorFailoverMaxPollRPS
 	// Value type: Int
@@ -2278,6 +2296,7 @@ var Keys = map[Key]string{
 	TimerProcessorUpdateAckInterval:                   "history.timerProcessorUpdateAckInterval",
 	TimerProcessorUpdateAckIntervalJitterCoefficient:  "history.timerProcessorUpdateAckIntervalJitterCoefficient",
 	TimerProcessorCompleteTimerInterval:               "history.timerProcessorCompleteTimerInterval",
+	TimerProcessorFailoverMaxStartJitterInterval:      "history.timerProcessorFailoverMaxStartJitterInterval",
 	TimerProcessorFailoverMaxPollRPS:                  "history.timerProcessorFailoverMaxPollRPS",
 	TimerProcessorMaxPollRPS:                          "history.timerProcessorMaxPollRPS",
 	TimerProcessorMaxPollInterval:                     "history.timerProcessorMaxPollInterval",
@@ -2291,6 +2310,7 @@ var Keys = map[Key]string{
 
 	TransferTaskBatchSize:                                "history.transferTaskBatchSize",
 	TransferTaskDeleteBatchSize:                          "history.transferTaskDeleteBatchSize",
+	TransferProcessorFailoverMaxStartJitterInterval:      "history.transferProcessorFailoverMaxStartJitterInterval",
 	TransferProcessorFailoverMaxPollRPS:                  "history.transferProcessorFailoverMaxPollRPS",
 	TransferProcessorMaxPollRPS:                          "history.transferProcessorMaxPollRPS",
 	TransferProcessorCompleteTransferFailureRetryCount:   "history.transferProcessorCompleteTransferFailureRetryCount",

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -125,6 +125,7 @@ type Config struct {
 	TimerProcessorUpdateAckInterval                   dynamicconfig.DurationPropertyFn
 	TimerProcessorUpdateAckIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
 	TimerProcessorCompleteTimerInterval               dynamicconfig.DurationPropertyFn
+	TimerProcessorFailoverMaxStartJitterInterval      dynamicconfig.DurationPropertyFn
 	TimerProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
 	TimerProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
 	TimerProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
@@ -140,6 +141,7 @@ type Config struct {
 	TransferTaskBatchSize                                dynamicconfig.IntPropertyFn
 	TransferTaskDeleteBatchSize                          dynamicconfig.IntPropertyFn
 	TransferProcessorCompleteTransferFailureRetryCount   dynamicconfig.IntPropertyFn
+	TransferProcessorFailoverMaxStartJitterInterval      dynamicconfig.DurationPropertyFn
 	TransferProcessorFailoverMaxPollRPS                  dynamicconfig.IntPropertyFn
 	TransferProcessorMaxPollRPS                          dynamicconfig.IntPropertyFn
 	TransferProcessorMaxPollInterval                     dynamicconfig.DurationPropertyFn
@@ -417,6 +419,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		TimerProcessorUpdateAckInterval:                   dc.GetDurationProperty(dynamicconfig.TimerProcessorUpdateAckInterval, 30*time.Second),
 		TimerProcessorUpdateAckIntervalJitterCoefficient:  dc.GetFloat64Property(dynamicconfig.TimerProcessorUpdateAckIntervalJitterCoefficient, 0.15),
 		TimerProcessorCompleteTimerInterval:               dc.GetDurationProperty(dynamicconfig.TimerProcessorCompleteTimerInterval, 60*time.Second),
+		TimerProcessorFailoverMaxStartJitterInterval:      dc.GetDurationProperty(dynamicconfig.TimerProcessorFailoverMaxStartJitterInterval, 0),
 		TimerProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.TimerProcessorFailoverMaxPollRPS, 1),
 		TimerProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.TimerProcessorMaxPollRPS, 20),
 		TimerProcessorMaxPollInterval:                     dc.GetDurationProperty(dynamicconfig.TimerProcessorMaxPollInterval, 5*time.Minute),
@@ -430,6 +433,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 
 		TransferTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.TransferTaskBatchSize, 100),
 		TransferTaskDeleteBatchSize:                          dc.GetIntProperty(dynamicconfig.TransferTaskDeleteBatchSize, 4000),
+		TransferProcessorFailoverMaxStartJitterInterval:      dc.GetDurationProperty(dynamicconfig.TransferProcessorFailoverMaxStartJitterInterval, 0),
 		TransferProcessorFailoverMaxPollRPS:                  dc.GetIntProperty(dynamicconfig.TransferProcessorFailoverMaxPollRPS, 1),
 		TransferProcessorMaxPollRPS:                          dc.GetIntProperty(dynamicconfig.TransferProcessorMaxPollRPS, 20),
 		TransferProcessorCompleteTransferFailureRetryCount:   dc.GetIntProperty(dynamicconfig.TransferProcessorCompleteTransferFailureRetryCount, 10),

--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -57,6 +57,7 @@ type (
 		RedispatchInterval                   dynamicconfig.DurationPropertyFn
 		RedispatchIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
 		MaxRedispatchQueueSize               dynamicconfig.IntPropertyFn
+		MaxStartJitterInterval               dynamicconfig.DurationPropertyFn
 		SplitQueueInterval                   dynamicconfig.DurationPropertyFn
 		SplitQueueIntervalJitterCoefficient  dynamicconfig.FloatPropertyFn
 		EnableSplit                          dynamicconfig.BoolPropertyFn


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add some jitter for starting failover queue processing

<!-- Tell your future self why have you made these changes -->
**Why?**
- on domain failover, we will create a failover timer/transfer queue for every shard and all of them will start to load tasks at almost the same time. This caused a spike load and CAS latency in our underlying DB to become very high. As a short-term fix, added some jitter so that those failover queues won't start at the same time. 
- By default, there's no jitter for failover queue. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
