### PR TITLE
Fix queue diff metric for disabled clusters

### DIFF
--- a/service/history/failover/marker_notifier_test.go
+++ b/service/history/failover/marker_notifier_test.go
@@ -79,6 +79,7 @@ func (s *markerNotifierSuite) SetupTest() {
 	)
 	s.mockClusterMetadata = s.mockShard.Resource.ClusterMetadata
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	mockShardManager := s.mockShard.Resource.ShardMgr
 	mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 	s.mockDomainCache = s.mockShard.Resource.DomainCache

--- a/service/history/replication/task_ack_manager_test.go
+++ b/service/history/replication/task_ack_manager_test.go
@@ -103,6 +103,7 @@ func (s *taskAckManagerSuite) SetupTest() {
 	s.mockClusterMetadata = s.mockShard.Resource.ClusterMetadata
 	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestCurrentClusterName).AnyTimes()
 	s.mockClusterMetadata.EXPECT().IsGlobalDomainEnabled().Return(true).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 
 	s.logger = s.mockShard.GetLogger()
 	executionCache := execution.NewCache(s.mockShard)

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1185,10 +1185,15 @@ func (s *contextImpl) persistShardInfoLocked(
 
 func (s *contextImpl) emitShardInfoMetricsLogsLocked() {
 	currentCluster := s.GetClusterMetadata().GetCurrentClusterName()
+	clusterInfo := s.GetClusterMetadata().GetAllClusterInfo()
 
 	minTransferLevel := s.shardInfo.ClusterTransferAckLevel[currentCluster]
 	maxTransferLevel := s.shardInfo.ClusterTransferAckLevel[currentCluster]
-	for _, v := range s.shardInfo.ClusterTransferAckLevel {
+	for clusterName, v := range s.shardInfo.ClusterTransferAckLevel {
+		if !clusterInfo[clusterName].Enabled {
+			continue
+		}
+
 		if v < minTransferLevel {
 			minTransferLevel = v
 		}
@@ -1200,7 +1205,11 @@ func (s *contextImpl) emitShardInfoMetricsLogsLocked() {
 
 	minTimerLevel := s.shardInfo.ClusterTimerAckLevel[currentCluster]
 	maxTimerLevel := s.shardInfo.ClusterTimerAckLevel[currentCluster]
-	for _, v := range s.shardInfo.ClusterTimerAckLevel {
+	for clusterName, v := range s.shardInfo.ClusterTimerAckLevel {
+		if !clusterInfo[clusterName].Enabled {
+			continue
+		}
+
 		if v.Before(minTimerLevel) {
 			minTimerLevel = v
 		}

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -179,6 +179,7 @@ func (s *contextTestSuite) TestGetAndUpdateProcessingQueueStates() {
 
 	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil)
 	s.mockResource.ClusterMetadata.EXPECT().GetCurrentClusterName().Return(clusterName).AnyTimes()
+	s.mockResource.ClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
 	updatedTransferQueueStates := []*types.ProcessingQueueState{
 		{
 			Level:    common.Int32Ptr(0),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Ignore ack level for disabled clusters when calculating transfer/timer queue ack level diff metric

<!-- Tell your future self why have you made these changes -->
**Why?**
- Ack level for disabled clusters won't be updated. If they are included in the calculated, the metric will become meaningless and the value will only keep increasing

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A, only changing how metric values are calculated

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
