### PR TITLE
Update ElasticSearch version to fix log4j issues

### DIFF
--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -61,7 +61,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22
     expose:
       - "9200"
     networks:

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22
     networks:
       services-network:
         aliases:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -27,7 +27,7 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.5.1
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22
     ports:
       - "9200:9200"
     environment:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
ElasticSearch had a log4j vulnerability which was fixed in 6.8.22; we are upgrading the ES version to that in our docker compose files.

Closes #4690 


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
