### PR TITLE
Improve standby task processing

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -862,6 +862,16 @@ func (entry *DomainCacheEntry) GetDomainNotActiveErr() error {
 	)
 }
 
+// HasReplicationCluster returns true if the domain has replication in the cluster
+func (entry *DomainCacheEntry) HasReplicationCluster(clusterName string) bool {
+	for _, cluster := range entry.GetReplicationConfig().Clusters {
+		if cluster.ClusterName == clusterName {
+			return true
+		}
+	}
+	return false
+}
+
 // Len return length
 func (t DomainCacheEntries) Len() int {
 	return len(t)

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -519,6 +519,11 @@ func newTimerQueueStandbyProcessor(
 		if !ok {
 			return false, errUnexpectedQueueTask
 		}
+		if timer.TaskType == persistence.TaskTypeWorkflowTimeout ||
+			timer.TaskType == persistence.TaskTypeDeleteHistoryEvent {
+			// guarantee the processing of workflow execution history deletion
+			return true, nil
+		}
 		return taskAllocator.VerifyStandbyTask(clusterName, timer.DomainID, timer)
 	}
 

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -529,6 +529,11 @@ func newTransferQueueStandbyProcessor(
 		if !ok {
 			return false, errUnexpectedQueueTask
 		}
+		if task.TaskType == persistence.TransferTaskTypeCloseExecution ||
+			task.TaskType == persistence.TransferTaskTypeRecordChildExecutionCompleted {
+			// guarantee the processing of workflow execution close
+			return true, nil
+		}
 		return taskAllocator.VerifyStandbyTask(clusterName, task.DomainID, task)
 	}
 

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -530,9 +530,23 @@ func newTransferQueueStandbyProcessor(
 			return false, errUnexpectedQueueTask
 		}
 		if task.TaskType == persistence.TransferTaskTypeCloseExecution ||
-			task.TaskType == persistence.TransferTaskTypeRecordChildExecutionCompleted {
-			// guarantee the processing of workflow execution close
-			return true, nil
+			task.TaskType == persistence.TransferTaskTypeRecordWorkflowClosed {
+			domainEntry, err := shard.GetDomainCache().GetDomainByID(task.DomainID)
+			if err == nil {
+				if domainEntry.HasReplicationCluster(clusterName) {
+					// guarantee the processing of workflow execution close
+					return true, nil
+				}
+			} else {
+				if _, ok := err.(*types.EntityNotExistsError); !ok {
+					// retry the task if failed to find the domain
+					logger.Warn("Cannot find domain", tag.WorkflowDomainID(task.DomainID))
+					return false, err
+				} else {
+					logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(task.DomainID), tag.Value(task))
+					return false, nil
+				}
+			}
 		}
 		return taskAllocator.VerifyStandbyTask(clusterName, task.DomainID, task)
 	}

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -87,10 +87,7 @@ func (t *timerStandbyTaskExecutor) Execute(
 		return errUnexpectedTask
 	}
 
-	if !shouldProcessTask &&
-		timerTask.TaskType != persistence.TaskTypeWorkflowTimeout &&
-		timerTask.TaskType != persistence.TaskTypeDeleteHistoryEvent {
-		// guarantee the processing of workflow execution history deletion
+	if !shouldProcessTask {
 		return nil
 	}
 

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -79,10 +79,7 @@ func (t *transferStandbyTaskExecutor) Execute(
 		return errUnexpectedTask
 	}
 
-	if !shouldProcessTask &&
-		transferTask.TaskType != persistence.TransferTaskTypeCloseExecution &&
-		transferTask.TaskType != persistence.TransferTaskTypeRecordWorkflowClosed {
-		// guarantee the processing of workflow execution close
+	if !shouldProcessTask {
 		return nil
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Refactor standby task filter logic to move the special cases handling logic to task filter
- Improve standby task processing for the special cases to only process those tasks if the domain is replicated to that cluster
- Fix task_requests metrics

<!-- Tell your future self why have you made these changes -->
**Why?**
It's not necessary to process standby tasks if the domain is not replicated to the cluster. And it will reduce load to ES and history archival.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Standby task which is supposed to be processed is not processed causing workflow not closed in visibility and history not deleted.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
