### PR TITLE
Drop pointers on internal history branch types

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/events.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/events.go
@@ -26,7 +26,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/uber/cadence/common"
 	p "github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
@@ -66,7 +65,7 @@ func (db *cdb) InsertIntoHistoryTreeAndNode(ctx context.Context, treeRow *nosqlp
 	if treeRow != nil {
 		for _, an := range treeRow.Ancestors {
 			value := make(map[string]interface{})
-			value["end_node_id"] = *an.EndNodeID
+			value["end_node_id"] = an.EndNodeID
 			value["branch_id"] = an.BranchID
 			ancs = append(ancs, value)
 		}
@@ -220,9 +219,9 @@ func parseBranchAncestors(
 		for k, v := range e {
 			switch k {
 			case "branch_id":
-				an.BranchID = common.StringPtr(v.(gocql.UUID).String())
+				an.BranchID = v.(gocql.UUID).String()
 			case "end_node_id":
-				an.EndNodeID = common.Int64Ptr(v.(int64))
+				an.EndNodeID = v.(int64)
 			}
 		}
 		ans = append(ans, an)
@@ -230,8 +229,8 @@ func parseBranchAncestors(
 
 	if len(ans) > 0 {
 		// sort ans based onf EndNodeID so that we can set BeginNodeID
-		sort.Slice(ans, func(i, j int) bool { return *ans[i].EndNodeID < *ans[j].EndNodeID })
-		ans[0].BeginNodeID = common.Int64Ptr(int64(1))
+		sort.Slice(ans, func(i, j int) bool { return ans[i].EndNodeID < ans[j].EndNodeID })
+		ans[0].BeginNodeID = int64(1)
 		for i := 1; i < len(ans); i++ {
 			ans[i].BeginNodeID = ans[i-1].EndNodeID
 		}

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -731,7 +731,7 @@ func (s *HistoryV2PersistenceSuite) deleteHistoryBranch(ctx context.Context, bra
 	beginNodeID := persistenceutils.GetBeginNodeID(*branch)
 	brsToDelete := append(branch.Ancestors, &types.HistoryBranchRange{
 		BranchID:    branch.BranchID,
-		BeginNodeID: common.Int64Ptr(beginNodeID),
+		BeginNodeID: beginNodeID,
 	})
 
 	branches := s.descTreeByToken(ctx, branchToken)
@@ -745,12 +745,12 @@ func (s *HistoryV2PersistenceSuite) deleteHistoryBranch(ctx context.Context, bra
 	minNodeID := beginNodeID
 	for i := len(brsToDelete) - 1; i >= 0; i-- {
 		br := brsToDelete[i]
-		maxReferredEndNodeID, ok := validBRsMaxEndNode[*br.BranchID]
+		maxReferredEndNodeID, ok := validBRsMaxEndNode[br.BranchID]
 		if ok {
 			minNodeID = maxReferredEndNodeID
 			break
 		} else {
-			minNodeID = *br.BeginNodeID
+			minNodeID = br.BeginNodeID
 		}
 	}
 

--- a/common/persistence/persistence-utils/historyManagerUtil.go
+++ b/common/persistence/persistence-utils/historyManagerUtil.go
@@ -86,7 +86,7 @@ func GetBeginNodeID(bi types.HistoryBranch) int64 {
 		return 1
 	}
 	idx := len(bi.Ancestors) - 1
-	return *bi.Ancestors[idx].EndNodeID
+	return bi.Ancestors[idx].EndNodeID
 }
 
 // PaginateHistory return paged history
@@ -146,9 +146,9 @@ func GetBranchesMaxReferredNodeIDs(branches []*types.HistoryBranch) map[string]i
 	validBRsMaxEndNode := map[string]int64{}
 	for _, b := range branches {
 		for _, br := range b.Ancestors {
-			curr, ok := validBRsMaxEndNode[*br.BranchID]
-			if !ok || curr < *br.EndNodeID {
-				validBRsMaxEndNode[*br.BranchID] = *br.EndNodeID
+			curr, ok := validBRsMaxEndNode[br.BranchID]
+			if !ok || curr < br.EndNodeID {
+				validBRsMaxEndNode[br.BranchID] = br.EndNodeID
 			}
 		}
 	}

--- a/common/persistence/serialization/thrift_mapper.go
+++ b/common/persistence/serialization/thrift_mapper.go
@@ -25,10 +25,9 @@ package serialization
 import (
 	"time"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/.gen/go/sqlblobs"
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 func shardInfoToThrift(info *ShardInfo) *sqlblobs.ShardInfo {
@@ -166,42 +165,22 @@ func historyTreeInfoToThrift(info *HistoryTreeInfo) *sqlblobs.HistoryTreeInfo {
 	if info == nil {
 		return nil
 	}
-	result := &sqlblobs.HistoryTreeInfo{
+	return &sqlblobs.HistoryTreeInfo{
 		CreatedTimeNanos: timeToUnixNanoPtr(info.CreatedTimestamp),
 		Info:             &info.Info,
+		Ancestors:        thrift.FromHistoryBranchRangeArray(info.Ancestors),
 	}
-	if info.Ancestors != nil {
-		result.Ancestors = make([]*shared.HistoryBranchRange, len(info.Ancestors), len(info.Ancestors))
-		for i, a := range info.Ancestors {
-			result.Ancestors[i] = &shared.HistoryBranchRange{
-				BranchID:    a.BranchID,
-				BeginNodeID: a.BeginNodeID,
-				EndNodeID:   a.EndNodeID,
-			}
-		}
-	}
-	return result
 }
 
 func historyTreeInfoFromThrift(info *sqlblobs.HistoryTreeInfo) *HistoryTreeInfo {
 	if info == nil {
 		return nil
 	}
-	result := &HistoryTreeInfo{
+	return &HistoryTreeInfo{
 		CreatedTimestamp: timeFromUnixNano(info.GetCreatedTimeNanos()),
 		Info:             info.GetInfo(),
+		Ancestors:        thrift.ToHistoryBranchRangeArray(info.Ancestors),
 	}
-	if info.Ancestors != nil {
-		result.Ancestors = make([]*types.HistoryBranchRange, len(info.Ancestors), len(info.Ancestors))
-		for i, a := range info.Ancestors {
-			result.Ancestors[i] = &types.HistoryBranchRange{
-				BranchID:    a.BranchID,
-				BeginNodeID: a.BeginNodeID,
-				EndNodeID:   a.EndNodeID,
-			}
-		}
-	}
-	return result
 }
 
 func workflowExecutionInfoToThrift(info *WorkflowExecutionInfo) *sqlblobs.WorkflowExecutionInfo {

--- a/common/persistence/serialization/thrift_mapper_test.go
+++ b/common/persistence/serialization/thrift_mapper_test.go
@@ -136,14 +136,14 @@ func TestHistoryTreeInfo(t *testing.T) {
 		CreatedTimestamp: time.Now(),
 		Ancestors: []*types.HistoryBranchRange{
 			{
-				BranchID:    common.StringPtr("branch_id"),
-				BeginNodeID: common.Int64Ptr(int64(rand.Intn(1000))),
-				EndNodeID:   common.Int64Ptr(int64(rand.Intn(1000))),
+				BranchID:    "branch_id",
+				BeginNodeID: int64(rand.Intn(1000)),
+				EndNodeID:   int64(rand.Intn(1000)),
 			},
 			{
-				BranchID:    common.StringPtr("branch_id"),
-				BeginNodeID: common.Int64Ptr(int64(rand.Intn(1000))),
-				EndNodeID:   common.Int64Ptr(int64(rand.Intn(1000))),
+				BranchID:    "branch_id",
+				BeginNodeID: int64(rand.Intn(1000)),
+				EndNodeID:   int64(rand.Intn(1000)),
 			},
 		},
 		Info: "info",

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -2554,8 +2554,8 @@ func FromHistoryBranch(t *types.HistoryBranch) *shared.HistoryBranch {
 		return nil
 	}
 	return &shared.HistoryBranch{
-		TreeID:    t.TreeID,
-		BranchID:  t.BranchID,
+		TreeID:    &t.TreeID,
+		BranchID:  &t.BranchID,
 		Ancestors: FromHistoryBranchRangeArray(t.Ancestors),
 	}
 }
@@ -2566,8 +2566,8 @@ func ToHistoryBranch(t *shared.HistoryBranch) *types.HistoryBranch {
 		return nil
 	}
 	return &types.HistoryBranch{
-		TreeID:    t.TreeID,
-		BranchID:  t.BranchID,
+		TreeID:    *t.TreeID,
+		BranchID:  *t.BranchID,
 		Ancestors: ToHistoryBranchRangeArray(t.Ancestors),
 	}
 }
@@ -2578,9 +2578,9 @@ func FromHistoryBranchRange(t *types.HistoryBranchRange) *shared.HistoryBranchRa
 		return nil
 	}
 	return &shared.HistoryBranchRange{
-		BranchID:    t.BranchID,
-		BeginNodeID: t.BeginNodeID,
-		EndNodeID:   t.EndNodeID,
+		BranchID:    &t.BranchID,
+		BeginNodeID: &t.BeginNodeID,
+		EndNodeID:   &t.EndNodeID,
 	}
 }
 
@@ -2590,9 +2590,9 @@ func ToHistoryBranchRange(t *shared.HistoryBranchRange) *types.HistoryBranchRang
 		return nil
 	}
 	return &types.HistoryBranchRange{
-		BranchID:    t.BranchID,
-		BeginNodeID: t.BeginNodeID,
-		EndNodeID:   t.EndNodeID,
+		BranchID:    *t.BranchID,
+		BeginNodeID: *t.BeginNodeID,
+		EndNodeID:   *t.EndNodeID,
 	}
 }
 

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -3646,64 +3646,16 @@ func (v *History) GetEvents() (o []*HistoryEvent) {
 
 // HistoryBranch is an internal type (TBD...)
 type HistoryBranch struct {
-	TreeID    *string               `json:"treeID,omitempty"`
-	BranchID  *string               `json:"branchID,omitempty"`
-	Ancestors []*HistoryBranchRange `json:"ancestors,omitempty"`
-}
-
-// GetTreeID is an internal getter (TBD...)
-func (v *HistoryBranch) GetTreeID() (o string) {
-	if v != nil && v.TreeID != nil {
-		return *v.TreeID
-	}
-	return
-}
-
-// GetBranchID is an internal getter (TBD...)
-func (v *HistoryBranch) GetBranchID() (o string) {
-	if v != nil && v.BranchID != nil {
-		return *v.BranchID
-	}
-	return
-}
-
-// GetAncestors is an internal getter (TBD...)
-func (v *HistoryBranch) GetAncestors() (o []*HistoryBranchRange) {
-	if v != nil && v.Ancestors != nil {
-		return v.Ancestors
-	}
-	return
+	TreeID    string
+	BranchID  string
+	Ancestors []*HistoryBranchRange
 }
 
 // HistoryBranchRange is an internal type (TBD...)
 type HistoryBranchRange struct {
-	BranchID    *string `json:"branchID,omitempty"`
-	BeginNodeID *int64  `json:"beginNodeID,omitempty"`
-	EndNodeID   *int64  `json:"endNodeID,omitempty"`
-}
-
-// GetBranchID is an internal getter (TBD...)
-func (v *HistoryBranchRange) GetBranchID() (o string) {
-	if v != nil && v.BranchID != nil {
-		return *v.BranchID
-	}
-	return
-}
-
-// GetBeginNodeID is an internal getter (TBD...)
-func (v *HistoryBranchRange) GetBeginNodeID() (o int64) {
-	if v != nil && v.BeginNodeID != nil {
-		return *v.BeginNodeID
-	}
-	return
-}
-
-// GetEndNodeID is an internal getter (TBD...)
-func (v *HistoryBranchRange) GetEndNodeID() (o int64) {
-	if v != nil && v.EndNodeID != nil {
-		return *v.EndNodeID
-	}
-	return
+	BranchID    string
+	BeginNodeID int64
+	EndNodeID   int64
 }
 
 // HistoryEvent is an internal type (TBD...)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Drop pointers with internal types: `types.HistoryBranch` and `types.HistoryBranchRange`
- Drop json annotations for them. Those types are never serialized directly.
- Drop helper functions for them. We can use fields directly once pointers are gone.
- Within persistence layer reuse `thrift.[To/From]HistoryBranchRangeArray`
- Within thrift mapper deserialize fields directly with `*` (no zero values fallback). I did this to preserve current functionality - we would get NPE for those cases as it is currently. Although they should never be nil.

<!-- Tell your future self why have you made these changes -->
**Why?**
To simplify and drop unused code

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
