### PR TITLE
Fix parsing domain_id in child_info_maps for backward compatibility

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/workflowParsingUtils.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflowParsingUtils.go
@@ -24,6 +24,8 @@ package cassandra
 import (
 	"time"
 
+	cql "github.com/gocql/gocql"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/checksum"
 	"github.com/uber/cadence/common/persistence"
@@ -31,6 +33,8 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"github.com/uber/cadence/common/types"
 )
+
+var _emptyUUID = cql.UUID{}
 
 func parseWorkflowExecutionInfo(
 	result map[string]interface{},
@@ -362,6 +366,10 @@ func parseChildExecutionInfo(
 			encoding = common.EncodingType(v.(string))
 		case "domain_id":
 			info.DomainID = v.(gocql.UUID).String()
+			if info.DomainID == _emptyUUID.String() {
+				// for backward compatibility, the gocql library doesn't handle the null uuid correectly https://github.com/gocql/gocql/blob/master/marshal.go#L1807
+				info.DomainID = ""
+			}
 		case "domain_name":
 			info.DomainNameDEPRECATED = v.(string)
 		case "workflow_type_name":


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
If domain_id from child_info_maps is empty UUID, we convert it to an empty string.

<!-- Tell your future self why have you made these changes -->
**Why?**
For backward compatibility. null uuids loaded from DB are converted to empty UUID, which is a breaking change for us, because the domain_id field is a new field.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test, verify with child workflows created from 0.23.2 release

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
