### PR TITLE
change the cadence-server image for the corresponding version

### DIFF
--- a/docker/docker-compose-multiclusters.yml
+++ b/docker/docker-compose-multiclusters.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - '9090:9090'
   cadence:
-    image: ubercadence/server:master-auto-setup
+    image: ubercadence/server:0.22.4-auto-setup
     ports:
       - "8000:8000"
       - "8001:8001"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
cadence-server image in docker-compose-multiclusters.yml point to master insted the image of this version

<!-- Tell your future self why have you made these changes -->
**Why?**
Docker-compose for multicluster doesn't work properly until this fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
In a local environment, following the guides in https://cadenceworkflow.io/docs/concepts/cross-dc-replication/

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No need for this simple case
<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
No need for this simple case
