### PR TITLE
Update cadence batch command to receive more input

### DIFF
--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -253,6 +253,8 @@ const (
 	FlagFailoverTypeWithAlias             = FlagFailoverType + ", ft"
 	FlagFailoverTimeout                   = "failover_timeout_seconds"
 	FlagFailoverTimeoutWithAlias          = FlagFailoverTimeout + ", fts"
+	FlagActivityHeartBeatTimeout          = "heart_beat_timeout_seconds"
+	FlagActivityHeartBeatTimeoutWithAlias = FlagActivityHeartBeatTimeout + ", hbts"
 	FlagFailoverWaitTime                  = "failover_wait_time_second"
 	FlagFailoverWaitTimeWithAlias         = FlagFailoverWaitTime + ", fwts"
 	FlagFailoverBatchSize                 = "failover_batch_size"

--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -22,6 +22,7 @@ package cli
 
 import (
 	"strings"
+	"time"
 
 	"github.com/urfave/cli"
 
@@ -510,6 +511,26 @@ func newBatchCommands() []cli.Command {
 				cli.BoolFlag{
 					Name:  FlagYes,
 					Usage: "Optional flag to disable confirmation prompt",
+				},
+				cli.IntFlag{
+					Name:  FlagPageSize,
+					Value: batcher.DefaultPageSize,
+					Usage: "PageSize of processiing",
+				},
+				cli.IntFlag{
+					Name:  FlagRetryAttempts,
+					Value: batcher.DefaultAttemptsOnRetryableError,
+					Usage: "Retry attempts for retriable errors",
+				},
+				cli.IntFlag{
+					Name:  FlagActivityHeartBeatTimeoutWithAlias,
+					Value: int(batcher.DefaultActivityHeartBeatTimeout / time.Second),
+					Usage: "Heartbeat timeout for batcher activity in seconds",
+				},
+				cli.IntFlag{
+					Name:  FlagConcurrency,
+					Value: batcher.DefaultConcurrency,
+					Usage: "Concurrency of batch activity",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/workflowBatchCommands.go
+++ b/tools/cli/workflowBatchCommands.go
@@ -26,6 +26,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/pborman/uuid"
 	"github.com/urfave/cli"
@@ -172,6 +173,10 @@ func StartBatchJob(c *cli.Context) {
 		targetCluster = getRequiredOption(c, FlagTargetCluster)
 	}
 	rps := c.Int(FlagRPS)
+	pageSize := c.Int(FlagPageSize)
+	concurrency := c.Int(FlagConcurrency)
+	retryAttempt := c.Int(FlagRetryAttempts)
+	heartBeatTimeout := time.Duration(c.Int(FlagActivityHeartBeatTimeout)) * time.Second
 
 	svcClient := cFactory.ServerFrontendClient(c)
 	tcCtx, cancel := newContext(c)
@@ -221,7 +226,11 @@ func StartBatchJob(c *cli.Context) {
 			SourceCluster: sourceCluster,
 			TargetCluster: targetCluster,
 		},
-		RPS: rps,
+		RPS:                      rps,
+		Concurrency:              concurrency,
+		PageSize:                 pageSize,
+		AttemptsOnRetryableError: retryAttempt,
+		ActivityHeartBeatTimeout: heartBeatTimeout,
 	}
 	input, err := json.Marshal(params)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update cadence batch command to receive more input

<!-- Tell your future self why have you made these changes -->
**Why?**
To make batch activity more configurable
Currently, if we have lots of workflows to process in the batch activity, the activity frequently times out and we have no way to change the default heart beat timeout via CLI.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual local test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
