### PR TITLE
Drop unused flags for cli rereplicate command

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -487,14 +487,10 @@ func newAdminKafkaCommands() []cli.Command {
 			Name:    "rereplicate",
 			Aliases: []string{"rrp"},
 			Usage:   "Rereplicate replication tasks from history tables",
-			Flags: append(getDBFlags(),
+			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:  FlagSourceCluster,
 					Usage: "Name of source cluster to resend the replication task",
-				},
-				cli.IntFlag{
-					Name:  FlagNumberOfShards,
-					Usage: "NumberOfShards is required to calculate shardID. (see server config for numHistoryShards)",
 				},
 				cli.StringFlag{
 					Name:  FlagDomainID,
@@ -515,7 +511,7 @@ func newAdminKafkaCommands() []cli.Command {
 				cli.StringFlag{
 					Name:  FlagEndEventVersion,
 					Usage: "Workflow end event version, required if MaxEventID is specified",
-				}),
+				}},
 			Action: func(c *cli.Context) {
 				AdminRereplicate(c)
 			},

--- a/tools/cli/adminKafkaCommands.go
+++ b/tools/cli/adminKafkaCommands.go
@@ -479,11 +479,6 @@ func doRereplicate(
 
 // AdminRereplicate parses will re-publish replication tasks to topic
 func AdminRereplicate(c *cli.Context) {
-	numberOfShards := c.Int(FlagNumberOfShards)
-	if numberOfShards <= 0 {
-		ErrorAndExit("numberOfShards is must be > 0", nil)
-		return
-	}
 	sourceCluster := getRequiredOption(c, FlagSourceCluster)
 
 	adminClient := cFactory.ServerAdminClient(c)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Dropped unused flags for rereplicate command in CLI.
- `FlagNumberOfShards` not used anywhere. It is annoying as it requires this flag to be present and > 0.
- All database flags. This command does not connect to DB directly. It uses admin client.

<!-- Tell your future self why have you made these changes -->
**Why?**
Cleanup.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
