### PR TITLE
Protect membership member keys concurrent access

### DIFF
--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -68,7 +68,7 @@ type ring struct {
 	value atomic.Value // this stores the current hashring
 
 	members struct {
-		sync.Mutex
+		sync.RWMutex
 		refreshed time.Time
 		keys      map[string]HostInfo // for mapping ip:port to HostInfo
 	}
@@ -160,6 +160,8 @@ func (r *ring) Lookup(
 		}
 		return HostInfo{}, ErrInsufficientHosts
 	}
+	r.members.RLock()
+	defer r.members.RUnlock()
 	host, ok := r.members.keys[addr]
 	if !ok {
 		return HostInfo{}, fmt.Errorf("host not found in member keys, host: %q", addr)
@@ -204,6 +206,8 @@ func (r *ring) Members() []HostInfo {
 	servers := r.ring().Servers()
 
 	var hosts = make([]HostInfo, 0, len(servers))
+	r.members.RLock()
+	defer r.members.RUnlock()
 	for _, s := range servers {
 		host, ok := r.members.keys[s]
 		if !ok {
@@ -239,7 +243,6 @@ func (r *ring) refresh() error {
 	for _, member := range members {
 		ring.AddMembers(member)
 	}
-
 	r.members.keys = newMembersMap
 	r.members.refreshed = time.Now()
 	r.value.Store(ring)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding read lock for member keys

<!-- Tell your future self why have you made these changes -->
**Why?**
There was a race condition when `Lookup` is called during periodic member `Refresh`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Wrote a separate test case to be checked with -race flag 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
