### PR TITLE
Lock membership keys after peer provider call

### DIFF
--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -221,9 +221,6 @@ func (r *ring) Members() []HostInfo {
 }
 
 func (r *ring) refresh() error {
-	r.members.Lock()
-	defer r.members.Unlock()
-
 	if r.members.refreshed.After(time.Now().Add(-minRefreshInternal)) {
 		// refreshed too frequently
 		return nil
@@ -234,6 +231,8 @@ func (r *ring) refresh() error {
 		return fmt.Errorf("getting members from peer provider: %w", err)
 	}
 
+	r.members.Lock()
+	defer r.members.Unlock()
 	newMembersMap, changed := r.compareMembers(members)
 	if !changed {
 		return nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Membership keys locking is done later

<!-- Tell your future self why have you made these changes -->
**Why?**
Depending on Peer Provider implementation, locking at the begging is a risk to block for too long

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
