### PR TITLE
Return Hostinfo identity if set

### DIFF
--- a/common/membership/hostinfo.go
+++ b/common/membership/hostinfo.go
@@ -69,8 +69,12 @@ func (hi HostInfo) GetAddress() string {
 
 // Identity implements ringpop's Membership interface
 func (hi HostInfo) Identity() string {
-	// for now we just use the address as the identity
-	return hi.addr
+	// if identity is not set, return address
+	if hi.identity == "" {
+		return hi.addr
+	}
+
+	return hi.identity
 }
 
 // Label is a noop function to conform to ringpop hashring member interface


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When `Hostinfo{}` has identity set, return identity instead of address

<!-- Tell your future self why have you made these changes -->
**Why?**
Peer provider, depending on implementation, can provide host identity which is not related to actual host address. 
This allows to use to run multiple peer providers at the same time. The only requirement is to have the same host identity returned from different peer providers

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
