### PR TITLE
Reuse rate limiter collection functionality

### DIFF
--- a/common/quotas/collection.go
+++ b/common/quotas/collection.go
@@ -1,0 +1,63 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package quotas
+
+import "sync"
+
+// LimiterCollection stores a map of limiters by key
+type LimiterCollection struct {
+	sync.RWMutex
+	factory  func(string) Limiter
+	limiters map[string]Limiter
+}
+
+// NewLimiterCollection create a new limiter collection.
+// Given factory is called to create new individual limiter.
+func NewLimiterCollection(factory func(string) Limiter) *LimiterCollection {
+	return &LimiterCollection{
+		factory:  factory,
+		limiters: make(map[string]Limiter),
+	}
+}
+
+// For retrieves limiter by a given key.
+// If limiter for such key does not exists, it creates new one with via factory.
+func (c *LimiterCollection) For(key string) Limiter {
+	c.RLock()
+	limiter, ok := c.limiters[key]
+	c.RUnlock()
+
+	if !ok {
+		// create a new limiter
+		newLimiter := c.factory(key)
+
+		// verify that it is needed and add to map
+		c.Lock()
+		limiter, ok = c.limiters[key]
+		if !ok {
+			c.limiters[key] = newLimiter
+			limiter = newLimiter
+		}
+		c.Unlock()
+	}
+
+	return limiter
+}

--- a/common/quotas/interfaces.go
+++ b/common/quotas/interfaces.go
@@ -20,13 +20,22 @@
 
 package quotas
 
-import "context"
+import (
+	"context"
+
+	"golang.org/x/time/rate"
+)
 
 // RPSFunc returns a float64 as the RPS
 type RPSFunc func() float64
 
 // RPSKeyFunc returns a float64 as the RPS for the given key
 type RPSKeyFunc func(key string) float64
+
+// Apply applies given key to return regular RPS function
+func (f RPSKeyFunc) Apply(key string) RPSFunc {
+	return func() float64 { return f(key) }
+}
 
 // Info corresponds to information required to determine rate limits
 type Info struct {
@@ -43,6 +52,9 @@ type Limiter interface {
 	// Wait waits till the deadline for a rate limit token to allow the request
 	// to go through.
 	Wait(ctx context.Context) error
+
+	// Reserve reserves a rate limit token
+	Reserve() *rate.Reservation
 }
 
 // Policy corresponds to a quota policy. A policy allows implementing layered

--- a/service/history/task/priority_assigner.go
+++ b/service/history/task/priority_assigner.go
@@ -48,7 +48,7 @@ type (
 		config             *config.Config
 		logger             log.Logger
 		scope              metrics.Scope
-		rateLimiters       map[string]quotas.Limiter
+		rateLimiters       *quotas.LimiterCollection
 	}
 )
 
@@ -68,7 +68,9 @@ func NewPriorityAssigner(
 		config:             config,
 		logger:             logger,
 		scope:              metricClient.Scope(metrics.TaskPriorityAssignerScope),
-		rateLimiters:       make(map[string]quotas.Limiter),
+		rateLimiters: quotas.NewLimiterCollection(func(domain string) quotas.Limiter {
+			return quotas.NewDynamicRateLimiter(config.TaskProcessRPS.AsFloat64(domain))
+		}),
 	}
 }
 
@@ -113,7 +115,7 @@ func (a *priorityAssignerImpl) Assign(
 	// for case 2 and 3 the task will be a no-op in most cases, also give it a high priority so that
 	// it can be quickly verified/acked and won't prevent the ack level in the processor from advancing
 	// (especially for active processor)
-	if !a.getRateLimiter(domainName).Allow() {
+	if !a.rateLimiters.For(domainName).Allow() {
 		queueTask.SetPriority(defaultTaskPriority)
 		taggedScope := a.scope.Tagged(metrics.DomainTag(domainName))
 		switch queueType {
@@ -154,26 +156,4 @@ func (a *priorityAssignerImpl) getDomainInfo(
 		return domainEntry.GetInfo().Name, false, nil
 	}
 	return domainEntry.GetInfo().Name, true, nil
-}
-
-func (a *priorityAssignerImpl) getRateLimiter(
-	domainName string,
-) quotas.Limiter {
-	a.RLock()
-	if limiter, ok := a.rateLimiters[domainName]; ok {
-		a.RUnlock()
-		return limiter
-	}
-	a.RUnlock()
-
-	limiter := quotas.NewDynamicRateLimiter(a.config.TaskProcessRPS.AsFloat64(domainName))
-
-	a.Lock()
-	defer a.Unlock()
-	if existingLimiter, ok := a.rateLimiters[domainName]; ok {
-		return existingLimiter
-	}
-
-	a.rateLimiters[domainName] = limiter
-	return limiter
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Created `LimiterCollection` 

<!-- Tell your future self why have you made these changes -->
**Why?**
To reuse generic rate limiter collection functionality in both `multistageratelimiter.go` and `priority_assigner.go`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
