### PR TITLE
Log more tags while putting to replication task to dlq

### DIFF
--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -115,6 +115,7 @@ func NewTaskProcessor(
 	taskExecutor TaskExecutor,
 ) TaskProcessor {
 	shardID := shard.GetShardID()
+	sourceCluster := taskFetcher.GetSourceCluster()
 	firstRetryPolicy := backoff.NewExponentialRetryPolicy(config.ReplicationTaskProcessorErrorRetryWait(shardID))
 	firstRetryPolicy.SetMaximumAttempts(config.ReplicationTaskProcessorErrorRetryMaxAttempts(shardID))
 	secondRetryPolicy := backoff.NewExponentialRetryPolicy(config.ReplicationTaskProcessorErrorSecondRetryWait(shardID))
@@ -131,14 +132,14 @@ func NewTaskProcessor(
 	noTaskRetrier := backoff.NewRetrier(noTaskBackoffPolicy, backoff.SystemClock)
 	return &taskProcessorImpl{
 		currentCluster:         shard.GetClusterMetadata().GetCurrentClusterName(),
-		sourceCluster:          taskFetcher.GetSourceCluster(),
+		sourceCluster:          sourceCluster,
 		status:                 common.DaemonStatusInitialized,
 		shard:                  shard,
 		historyEngine:          historyEngine,
 		historySerializer:      persistence.NewPayloadSerializer(),
 		config:                 config,
 		metricsClient:          metricsClient,
-		logger:                 shard.GetLogger(),
+		logger:                 shard.GetLogger().WithTags(tag.SourceCluster(sourceCluster), tag.ShardID(shardID)),
 		taskExecutor:           taskExecutor,
 		hostRateLimiter:        taskFetcher.GetRateLimiter(),
 		shardRateLimiter:       quotas.NewDynamicRateLimiter(config.ReplicationTaskProcessorShardQPS.AsFloat64()),
@@ -426,9 +427,18 @@ func (p *taskProcessorImpl) processSingleTask(replicationTask *types.Replication
 		p.logger.Warn("Skip adding new messages to DLQ.", tag.Error(err))
 		return err
 	default:
-		p.logger.Error(
-			"Failed to apply replication task after retry. Putting task into DLQ.",
-			tag.TaskID(replicationTask.GetSourceTaskID()),
+		request, err := p.generateDLQRequest(replicationTask)
+		if err != nil {
+			p.logger.Error("Failed to generate DLQ replication task.", tag.Error(err))
+			// We cannot deserialize the task. Dropping it.
+			return nil
+		}
+		p.logger.Error("Failed to apply replication task after retry. Putting task into DLQ.",
+			tag.WorkflowDomainID(request.TaskInfo.GetDomainID()),
+			tag.WorkflowID(request.TaskInfo.GetWorkflowID()),
+			tag.WorkflowRunID(request.TaskInfo.GetRunID()),
+			tag.TaskID(request.TaskInfo.GetTaskID()),
+			tag.TaskType(request.TaskInfo.GetTaskType()),
 			tag.Error(err),
 		)
 		//TODO: uncomment this when the execution fixer workflow is ready
@@ -436,7 +446,7 @@ func (p *taskProcessorImpl) processSingleTask(replicationTask *types.Replication
 		//	p.logger.Warn("Failed to trigger data scan", tag.Error(err))
 		//	p.metricsClient.IncCounter(metrics.ReplicationDLQStatsScope, metrics.ReplicationDLQValidationFailed)
 		//}
-		return p.putReplicationTaskToDLQ(replicationTask)
+		return p.putReplicationTaskToDLQ(request)
 	}
 }
 
@@ -466,21 +476,7 @@ func (p *taskProcessorImpl) processTaskOnce(replicationTask *types.ReplicationTa
 	return err
 }
 
-func (p *taskProcessorImpl) putReplicationTaskToDLQ(replicationTask *types.ReplicationTask) error {
-	request, err := p.generateDLQRequest(replicationTask)
-	if err != nil {
-		p.logger.Error("Failed to generate DLQ replication task.", tag.Error(err))
-		// We cannot deserialize the task. Dropping it.
-		return nil
-	}
-	p.logger.Info("Put history replication to DLQ",
-		tag.WorkflowDomainID(request.TaskInfo.GetDomainID()),
-		tag.WorkflowID(request.TaskInfo.GetWorkflowID()),
-		tag.WorkflowRunID(request.TaskInfo.GetRunID()),
-		tag.TaskID(request.TaskInfo.GetTaskID()),
-		tag.ShardID(p.shard.GetShardID()),
-	)
-
+func (p *taskProcessorImpl) putReplicationTaskToDLQ(request *persistence.PutReplicationTaskToDLQRequest) error {
 	p.metricsClient.Scope(
 		metrics.ReplicationDLQStatsScope,
 		metrics.TargetClusterTag(p.sourceCluster),

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -176,62 +176,27 @@ func (s *taskProcessorSuite) TestHandleSyncShardStatus() {
 }
 
 func (s *taskProcessorSuite) TestPutReplicationTaskToDLQ_SyncActivityReplicationTask() {
-	domainID := uuid.New()
-	workflowID := uuid.New()
-	runID := uuid.New()
-	task := &types.ReplicationTask{
-		TaskType: types.ReplicationTaskTypeSyncActivity.Ptr(),
-		SyncActivityTaskAttributes: &types.SyncActivityTaskAttributes{
-			DomainID:   domainID,
-			WorkflowID: workflowID,
-			RunID:      runID,
-		},
-	}
 	request := &persistence.PutReplicationTaskToDLQRequest{
 		SourceClusterName: "standby",
 		TaskInfo: &persistence.ReplicationTaskInfo{
-			DomainID:   domainID,
-			WorkflowID: workflowID,
-			RunID:      runID,
+			DomainID:   uuid.New(),
+			WorkflowID: uuid.New(),
+			RunID:      uuid.New(),
 			TaskType:   persistence.ReplicationTaskTypeSyncActivity,
 		},
 	}
 	s.executionManager.On("PutReplicationTaskToDLQ", mock.Anything, request).Return(nil)
-	err := s.taskProcessor.putReplicationTaskToDLQ(task)
+	err := s.taskProcessor.putReplicationTaskToDLQ(request)
 	s.NoError(err)
 }
 
 func (s *taskProcessorSuite) TestPutReplicationTaskToDLQ_HistoryV2ReplicationTask() {
-	domainID := uuid.New()
-	workflowID := uuid.New()
-	runID := uuid.New()
-	events := []*types.HistoryEvent{
-		{
-			EventID: 1,
-			Version: 1,
-		},
-	}
-	serializer := s.mockShard.GetPayloadSerializer()
-	data, err := serializer.SerializeBatchEvents(events, common.EncodingTypeThriftRW)
-	s.NoError(err)
-	task := &types.ReplicationTask{
-		TaskType: types.ReplicationTaskTypeHistoryV2.Ptr(),
-		HistoryTaskV2Attributes: &types.HistoryTaskV2Attributes{
-			DomainID:   domainID,
-			WorkflowID: workflowID,
-			RunID:      runID,
-			Events: &types.DataBlob{
-				EncodingType: types.EncodingTypeThriftRW.Ptr(),
-				Data:         data.Data,
-			},
-		},
-	}
 	request := &persistence.PutReplicationTaskToDLQRequest{
 		SourceClusterName: "standby",
 		TaskInfo: &persistence.ReplicationTaskInfo{
-			DomainID:     domainID,
-			WorkflowID:   workflowID,
-			RunID:        runID,
+			DomainID:     uuid.New(),
+			WorkflowID:   uuid.New(),
+			RunID:        uuid.New(),
 			TaskType:     persistence.ReplicationTaskTypeHistory,
 			FirstEventID: 1,
 			NextEventID:  2,
@@ -239,7 +204,7 @@ func (s *taskProcessorSuite) TestPutReplicationTaskToDLQ_HistoryV2ReplicationTas
 		},
 	}
 	s.executionManager.On("PutReplicationTaskToDLQ", mock.Anything, request).Return(nil)
-	err = s.taskProcessor.putReplicationTaskToDLQ(task)
+	err := s.taskProcessor.putReplicationTaskToDLQ(request)
 	s.NoError(err)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
After all replication retries we emit two log messages:
- Error: `Failed to apply replication task after retry. Putting task into DLQ.` with attached error message
- Info: `Put history replication to DLQ` immediately after with tags for domainId / workflowId / runId ...

Having two different log entries makes it harder to correlate errors with domains / workflows being affected.
Therefore this PR collapse them into one error log entry with all the info.

Additionally move common logger tags (sourceCluster, shardId) to entire "sub" logger when initializing in the constructor.

<!-- Tell your future self why have you made these changes -->
**Why?**
To have single log entry for DLQ messages, that are easier to search for.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
