### PR TITLE
Ringpop: filter out unhealthy nodes

### DIFF
--- a/common/peerprovider/ringpopprovider/provider.go
+++ b/common/peerprovider/ringpopprovider/provider.go
@@ -189,11 +189,16 @@ func (r *Provider) GetMembers(service string) ([]membership.HostInfo, error) {
 
 	// filter member by service name, add port info to Hostinfo if they are present
 	memberData := func(member swim.Member) bool {
-		portMap := make(membership.PortMap)
 		if v, ok := member.Label(roleKey); !ok || v != service {
 			return false
 		}
 
+		// replicating swim member isReachable() method here as we are skipping other predicates
+		if member.Status != swim.Alive || member.Status != swim.Suspect {
+			return false
+		}
+
+		portMap := make(membership.PortMap)
 		if v, ok := member.Label(membership.PortTchannel); ok {
 			port, err := labelToPort(v)
 			if err != nil {

--- a/common/peerprovider/ringpopprovider/provider.go
+++ b/common/peerprovider/ringpopprovider/provider.go
@@ -194,7 +194,7 @@ func (r *Provider) GetMembers(service string) ([]membership.HostInfo, error) {
 		}
 
 		// replicating swim member isReachable() method here as we are skipping other predicates
-		if member.Status != swim.Alive || member.Status != swim.Suspect {
+		if member.Status != swim.Alive && member.Status != swim.Suspect {
 			return false
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ringpop provider will not include unhealthy ring nodes 

<!-- Tell your future self why have you made these changes -->
**Why?**
As ringpop keeps information about past members, it is needed to check node health status before node can be included to the ring

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
