### PR TITLE
Delete corrupt workflows when detected in frontend

### DIFF
--- a/common/persistence/historyManager.go
+++ b/common/persistence/historyManager.go
@@ -54,7 +54,7 @@ const (
 )
 
 var (
-	ErrCorruptedHistory = &types.InternalDataInconsistencyError{Message: "corrupted history event batch, eventID is not continouous"}
+	ErrCorruptedHistory = &types.InternalDataInconsistencyError{Message: "corrupted history event batch, eventID is not continuous"}
 )
 
 var _ HistoryManager = (*historyV2ManagerImpl)(nil)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
During polls corrupt workflow is detected. This change deletes corrupt runs to avoid polls to corrupt workflows

<!-- Tell your future self why have you made these changes -->
**Why?**
Having a lot of such workflows can cause availability issues.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
