### PR TITLE
Allow loading service config for all DB operations

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -22,16 +22,13 @@
 package cli
 
 import (
-	"fmt"
 	"strings"
 	"time"
 
 	"github.com/urfave/cli"
 
-	"github.com/uber/cadence/common/persistence/sql"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/service/worker/scanner/executions"
-	"github.com/uber/cadence/tools/common/flag"
 )
 
 func newAdminWorkflowCommands() []cli.Command {
@@ -117,7 +114,7 @@ func newAdminWorkflowCommands() []cli.Command {
 					Usage: "skip errors when deleting history",
 				},
 				cli.BoolFlag{
-					Name:  FlagRemoteWithAlias,
+					Name:  FlagRemote,
 					Usage: "Executes deletion on server side",
 				}),
 			Action: func(c *cli.Context) {
@@ -261,11 +258,6 @@ func newAdminShardManagementCommands() []cli.Command {
 					Name:  FlagPageSize,
 					Usage: "page size used to query db executions table",
 					Value: 500,
-				},
-				cli.IntFlag{
-					Name:  FlagRPS,
-					Usage: "target rps of database queries",
-					Value: 100,
 				},
 				cli.StringFlag{
 					Name:  FlagStartDate,
@@ -975,91 +967,6 @@ func newDBCommands() []cli.Command {
 			Action: func(c *cli.Context) {
 				AdminDBDataDecodeThrift(c)
 			},
-		},
-	}
-}
-
-func getDBFlags() []cli.Flag {
-	supportedDBs := append(sql.GetRegisteredPluginNames(), "cassandra")
-	return []cli.Flag{
-		cli.StringFlag{
-			Name:  FlagDBType,
-			Value: "cassandra",
-			Usage: fmt.Sprintf("persistence type. Current supported options are %v", supportedDBs),
-		},
-		cli.StringFlag{
-			Name:  FlagDBAddress,
-			Value: "127.0.0.1",
-			Usage: "persistence address (right now only cassandra is fully supported)",
-		},
-		cli.IntFlag{
-			Name:  FlagDBPort,
-			Value: 9042,
-			Usage: "persistence port",
-		},
-		cli.StringFlag{
-			Name:  FlagDBRegion,
-			Usage: "persistence region",
-		},
-		cli.StringFlag{
-			Name:  FlagUsername,
-			Usage: "persistence username",
-		},
-		cli.StringFlag{
-			Name:  FlagPassword,
-			Usage: "persistence password",
-		},
-		cli.StringFlag{
-			Name:  FlagKeyspace,
-			Value: "cadence",
-			Usage: "cassandra keyspace",
-		},
-		cli.StringFlag{
-			Name:  FlagDatabaseName,
-			Value: "cadence",
-			Usage: "sql database name",
-		},
-		cli.StringFlag{
-			Name:  FlagEncodingType,
-			Value: "thriftrw",
-			Usage: "sql database encoding type",
-		},
-		cli.StringSliceFlag{
-			Name: FlagDecodingTypes,
-			Value: &cli.StringSlice{
-				"thriftrw",
-			},
-			Usage: "sql database decoding types",
-		},
-		cli.IntFlag{
-			Name:  FlagProtoVersion,
-			Value: 4,
-			Usage: "cassandra protocol version",
-		},
-		cli.BoolFlag{
-			Name:  FlagEnableTLS,
-			Usage: "enable TLS over cassandra connection",
-		},
-		cli.StringFlag{
-			Name:  FlagTLSCertPath,
-			Usage: "cassandra tls client cert path (tls must be enabled)",
-		},
-		cli.StringFlag{
-			Name:  FlagTLSKeyPath,
-			Usage: "cassandra tls client key path (tls must be enabled)",
-		},
-		cli.StringFlag{
-			Name:  FlagTLSCaPath,
-			Usage: "cassandra tls client ca path (tls must be enabled)",
-		},
-		cli.BoolFlag{
-			Name:  FlagTLSEnableHostVerification,
-			Usage: "cassandra tls verify hostname and server cert (tls must be enabled)",
-		},
-		cli.GenericFlag{
-			Name:  FlagConnectionAttributes,
-			Usage: "a key-value set of sql database connection attributes (must be in key1=value1,key2=value2,...,keyN=valueN format, e.g. cluster=dca or cluster=dca,instance=cadence)",
-			Value: &flag.StringMap{},
 		},
 	}
 }

--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -153,7 +153,7 @@ func fixExecution(
 	invariants []executions.InvariantFactory,
 	execution *store.ScanOutputEntity,
 ) invariant.ManagerFixResult {
-	execManager := initializeExecutionStore(c, execution.Execution.(entity.Entity).GetShardID(), 0)
+	execManager := initializeExecutionStore(c, execution.Execution.(entity.Entity).GetShardID())
 	defer execManager.Close()
 
 	historyV2Mgr := initializeHistoryManager(c)

--- a/tools/cli/adminDBScanCommand.go
+++ b/tools/cli/adminDBScanCommand.go
@@ -34,14 +34,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/collection"
-	"github.com/uber/cadence/common/dynamicconfig"
-	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/nosql"
-	"github.com/uber/cadence/common/persistence/serialization"
-	"github.com/uber/cadence/common/persistence/sql"
-	"github.com/uber/cadence/common/quotas"
 	"github.com/uber/cadence/common/reconciliation/fetcher"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/common/reconciliation/store"
@@ -125,7 +118,7 @@ func checkExecution(
 	invariants []executions.InvariantFactory,
 	fetcher executions.ExecutionFetcher,
 ) (interface{}, invariant.ManagerCheckResult) {
-	execManager := initializeExecutionStore(c, common.WorkflowIDToHistoryShard(req.WorkflowID, numberOfShards), 0)
+	execManager := initializeExecutionStore(c, common.WorkflowIDToHistoryShard(req.WorkflowID, numberOfShards))
 	defer execManager.Close()
 
 	historyV2Mgr := initializeHistoryManager(c)
@@ -157,14 +150,13 @@ func checkExecution(
 
 // AdminDBScanUnsupportedWorkflow is to scan DB for unsupported workflow for a new release
 func AdminDBScanUnsupportedWorkflow(c *cli.Context) {
-	rps := c.Int(FlagRPS)
 	outputFile := getOutputFile(c.String(FlagOutputFilename))
 	startShardID := c.Int(FlagLowerShardBound)
 	endShardID := c.Int(FlagUpperShardBound)
 
 	defer outputFile.Close()
 	for i := startShardID; i <= endShardID; i++ {
-		listExecutionsByShardID(c, i, rps, outputFile)
+		listExecutionsByShardID(c, i, outputFile)
 		fmt.Printf("Shard %v scan operation is completed.\n", i)
 	}
 }
@@ -172,11 +164,10 @@ func AdminDBScanUnsupportedWorkflow(c *cli.Context) {
 func listExecutionsByShardID(
 	c *cli.Context,
 	shardID int,
-	rps int,
 	outputFile *os.File,
 ) {
 
-	client := initializeExecutionStore(c, shardID, rps)
+	client := initializeExecutionStore(c, shardID)
 	defer client.Close()
 
 	paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
@@ -223,178 +214,4 @@ func listExecutionsByShardID(
 			}
 		}
 	}
-}
-
-func initializeExecutionStore(
-	c *cli.Context,
-	shardID int,
-	rps int,
-) persistence.ExecutionManager {
-
-	var execStore persistence.ExecutionStore
-	dbType := c.String(FlagDBType)
-	if !isDBTypeSupported(dbType) {
-		supportedDBs := append(sql.GetRegisteredPluginNames(), "cassandra")
-		ErrorAndExit(fmt.Sprintf("The DB type is not supported. Options are: %s.", supportedDBs), nil)
-	}
-	logger := loggerimpl.NewNopLogger()
-	switch dbType {
-	case "cassandra":
-		execStore = initializeCassandraExecutionClient(c, shardID, logger)
-	default:
-		execStore = initializeSQLExecutionStore(c, shardID, logger)
-	}
-
-	executionManager := persistence.NewExecutionManagerImpl(execStore, logger)
-	if rps == 0 {
-		return executionManager
-	}
-	rateLimiter := quotas.NewSimpleRateLimiter(rps)
-	return persistence.NewWorkflowExecutionPersistenceRateLimitedClient(executionManager, rateLimiter, logger)
-}
-
-func initializeCassandraExecutionClient(
-	c *cli.Context,
-	shardID int,
-	logger log.Logger,
-) persistence.ExecutionStore {
-
-	db, _ := connectToCassandra(c)
-	execStore, err := nosql.NewExecutionStore(
-		shardID,
-		db,
-		logger,
-	)
-	if err != nil {
-		ErrorAndExit("Failed to get execution store from cassandra config", err)
-	}
-	return execStore
-}
-
-func initializeSQLExecutionStore(
-	c *cli.Context,
-	shardID int,
-	logger log.Logger,
-) persistence.ExecutionStore {
-
-	sqlDB := connectToSQL(c)
-	encodingType := c.String(FlagEncodingType)
-	decodingTypesStr := c.StringSlice(FlagDecodingTypes)
-	var decodingTypes []common.EncodingType
-	for _, dt := range decodingTypesStr {
-		decodingTypes = append(decodingTypes, common.EncodingType(dt))
-	}
-	execStore, err := sql.NewSQLExecutionStore(sqlDB, logger, shardID, getSQLParser(common.EncodingType(encodingType), decodingTypes...))
-	if err != nil {
-		ErrorAndExit("Failed to get execution store from sql config", err)
-	}
-	return execStore
-}
-
-func initializeHistoryManager(c *cli.Context) persistence.HistoryManager {
-	var historyV2Mgr persistence.HistoryStore
-	dbType := c.String(FlagDBType)
-	if !isDBTypeSupported(dbType) {
-		supportedDBs := append(sql.GetRegisteredPluginNames(), "cassandra")
-		ErrorAndExit(fmt.Sprintf("The DB type is not supported. Options are: %s.", supportedDBs), nil)
-	}
-	logger := loggerimpl.NewNopLogger()
-	switch dbType {
-	case "cassandra":
-		historyV2Mgr = initializeCassandraHistoryStore(c, logger)
-	default:
-		historyV2Mgr = initializeSQLHistoryStore(c, logger)
-	}
-	historyStore := persistence.NewHistoryV2ManagerImpl(
-		historyV2Mgr,
-		logger,
-		dynamicconfig.GetIntPropertyFn(common.DefaultTransactionSizeLimit),
-	)
-	return historyStore
-}
-
-func initializeShardManager(c *cli.Context) persistence.ShardManager {
-	var shardStore persistence.ShardStore
-	dbType := c.String(FlagDBType)
-	if !isDBTypeSupported(dbType) {
-		supportedDBs := append(sql.GetRegisteredPluginNames(), "cassandra")
-		ErrorAndExit(fmt.Sprintf("The DB type is not supported. Options are: %s.", supportedDBs), nil)
-	}
-	logger := loggerimpl.NewNopLogger()
-	switch dbType {
-	case "cassandra":
-		shardStore = initializeCassandraShardStore(c, "current-cluster", logger)
-	default:
-		shardStore = initializeSQLShardStore(c, "current-cluster", logger)
-	}
-	return persistence.NewShardManager(shardStore)
-}
-
-func initializeCassandraHistoryStore(
-	c *cli.Context,
-	logger log.Logger,
-) persistence.HistoryStore {
-	db, _ := connectToCassandra(c)
-	return nosql.NewNoSQLHistoryStoreFromSession(db, logger)
-}
-
-func initializeSQLHistoryStore(
-	c *cli.Context,
-	logger log.Logger,
-) persistence.HistoryStore {
-	sqlDB := connectToSQL(c)
-	encodingType := c.String(FlagEncodingType)
-	decodingTypesStr := c.StringSlice(FlagDecodingTypes)
-	var decodingTypes []common.EncodingType
-	for _, dt := range decodingTypesStr {
-		decodingTypes = append(decodingTypes, common.EncodingType(dt))
-	}
-	historyV2Mgr, err := sql.NewHistoryV2Persistence(sqlDB, logger, getSQLParser(common.EncodingType(encodingType), decodingTypes...))
-	if err != nil {
-		ErrorAndExit("Failed to get history store from sql config", err)
-	}
-	return historyV2Mgr
-}
-
-func getSQLParser(encodingType common.EncodingType, decodingTypes ...common.EncodingType) serialization.Parser {
-	parser, err := serialization.NewParser(encodingType, decodingTypes...)
-	if err != nil {
-		ErrorAndExit("failed to initialize sql parser", err)
-	}
-	return parser
-}
-
-func initializeCassandraShardStore(
-	c *cli.Context,
-	currentClusterName string,
-	logger log.Logger,
-) persistence.ShardStore {
-	db, _ := connectToCassandra(c)
-	return nosql.NewNoSQLShardStoreFromSession(db, currentClusterName, logger)
-}
-
-func initializeSQLShardStore(
-	c *cli.Context,
-	currentClusterName string,
-	logger log.Logger,
-) persistence.ShardStore {
-	sqlDB := connectToSQL(c)
-	encodingType := c.String(FlagEncodingType)
-	decodingTypesStr := c.StringSlice(FlagDecodingTypes)
-	var decodingTypes []common.EncodingType
-	for _, dt := range decodingTypesStr {
-		decodingTypes = append(decodingTypes, common.EncodingType(dt))
-	}
-	shardStore, err := sql.NewShardPersistence(sqlDB, currentClusterName, logger, getSQLParser(common.EncodingType(encodingType), decodingTypes...))
-	if err != nil {
-		ErrorAndExit("Failed to get shard store from sql config", err)
-	}
-	return shardStore
-}
-
-func isDBTypeSupported(dbType string) bool {
-	if sql.PluginRegistered(dbType) || dbType == "cassandra" {
-		return true
-	}
-	return false
 }

--- a/tools/cli/adminTimers.go
+++ b/tools/cli/adminTimers.go
@@ -75,9 +75,8 @@ type jsonPrinter struct {
 
 // NewDBLoadCloser creates a new LoadCloser to load timer task information from database
 func NewDBLoadCloser(c *cli.Context) LoadCloser {
-	rps := c.Int(FlagRPS)
 	shardID := getRequiredIntOption(c, FlagShardID)
-	executionManager := initializeExecutionStore(c, shardID, rps)
+	executionManager := initializeExecutionStore(c, shardID)
 	return &dbLoadCloser{
 		ctx:              c,
 		executionManager: executionManager,

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/client/admin"
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -60,6 +61,10 @@ func (m *clientFactoryMock) ServerAdminClient(c *cli.Context) admin.Client {
 }
 
 func (m *clientFactoryMock) ElasticSearchClient(c *cli.Context) *elastic.Client {
+	panic("not implemented")
+}
+
+func (m *clientFactoryMock) ServerConfig(c *cli.Context) (*config.Config, error) {
 	panic("not implemented")
 }
 

--- a/tools/cli/database.go
+++ b/tools/cli/database.go
@@ -1,0 +1,341 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"fmt"
+	"net"
+
+	"github.com/urfave/cli"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/persistence/client"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra"
+	"github.com/uber/cadence/common/persistence/sql"
+	"github.com/uber/cadence/tools/common/flag"
+)
+
+var supportedDBs = append(sql.GetRegisteredPluginNames(), "cassandra")
+
+func getDBFlags() []cli.Flag {
+	return []cli.Flag{
+		cli.StringFlag{
+			Name:   FlagServiceConfigDirWithAlias,
+			Value:  "config",
+			Usage:  "service configuration dir",
+			EnvVar: config.EnvKeyConfigDir,
+		},
+		cli.StringFlag{
+			Name:   FlagServiceEnvWithAlias,
+			Usage:  "service env for loading service configuration",
+			EnvVar: config.EnvKeyEnvironment,
+		},
+		cli.StringFlag{
+			Name:   FlagServiceZoneWithAlias,
+			Usage:  "service zone for loading service configuration",
+			EnvVar: config.EnvKeyAvailabilityZone,
+		},
+		cli.StringFlag{
+			Name:  FlagDBType,
+			Value: "cassandra",
+			Usage: fmt.Sprintf("persistence type. Current supported options are %v", supportedDBs),
+		},
+		cli.StringFlag{
+			Name:  FlagDBAddress,
+			Value: "127.0.0.1",
+			Usage: "persistence address (right now only cassandra is fully supported)",
+		},
+		cli.IntFlag{
+			Name:  FlagDBPort,
+			Value: 9042,
+			Usage: "persistence port",
+		},
+		cli.StringFlag{
+			Name:  FlagDBRegion,
+			Usage: "persistence region",
+		},
+		cli.StringFlag{
+			Name:  FlagUsername,
+			Usage: "persistence username",
+		},
+		cli.StringFlag{
+			Name:  FlagPassword,
+			Usage: "persistence password",
+		},
+		cli.StringFlag{
+			Name:  FlagKeyspace,
+			Value: "cadence",
+			Usage: "cassandra keyspace",
+		},
+		cli.StringFlag{
+			Name:  FlagDatabaseName,
+			Value: "cadence",
+			Usage: "sql database name",
+		},
+		cli.StringFlag{
+			Name:  FlagEncodingType,
+			Value: "thriftrw",
+			Usage: "sql database encoding type",
+		},
+		cli.StringSliceFlag{
+			Name: FlagDecodingTypes,
+			Value: &cli.StringSlice{
+				"thriftrw",
+			},
+			Usage: "sql database decoding types",
+		},
+		cli.IntFlag{
+			Name:  FlagProtoVersion,
+			Value: 4,
+			Usage: "cassandra protocol version",
+		},
+		cli.BoolFlag{
+			Name:  FlagEnableTLS,
+			Usage: "enable TLS over cassandra connection",
+		},
+		cli.StringFlag{
+			Name:  FlagTLSCertPath,
+			Usage: "cassandra tls client cert path (tls must be enabled)",
+		},
+		cli.StringFlag{
+			Name:  FlagTLSKeyPath,
+			Usage: "cassandra tls client key path (tls must be enabled)",
+		},
+		cli.StringFlag{
+			Name:  FlagTLSCaPath,
+			Usage: "cassandra tls client ca path (tls must be enabled)",
+		},
+		cli.BoolFlag{
+			Name:  FlagTLSEnableHostVerification,
+			Usage: "cassandra tls verify hostname and server cert (tls must be enabled)",
+		},
+		cli.GenericFlag{
+			Name:  FlagConnectionAttributes,
+			Usage: "a key-value set of sql database connection attributes (must be in key1=value1,key2=value2,...,keyN=valueN format, e.g. cluster=dca or cluster=dca,instance=cadence)",
+			Value: &flag.StringMap{},
+		},
+		cli.IntFlag{
+			Name:  FlagRPS,
+			Usage: "target rps of database queries",
+			Value: 100,
+		},
+	}
+}
+
+func initializeExecutionStore(c *cli.Context, shardID int) persistence.ExecutionManager {
+	factory := getPersistenceFactory(c)
+	historyManager, err := factory.NewExecutionManager(shardID)
+	if err != nil {
+		ErrorAndExit("Failed to initialize history manager", err)
+	}
+	return historyManager
+}
+
+func initializeHistoryManager(c *cli.Context) persistence.HistoryManager {
+	factory := getPersistenceFactory(c)
+	historyManager, err := factory.NewHistoryManager()
+	if err != nil {
+		ErrorAndExit("Failed to initialize history manager", err)
+	}
+	return historyManager
+}
+
+func initializeShardManager(c *cli.Context) persistence.ShardManager {
+	factory := getPersistenceFactory(c)
+	shardManager, err := factory.NewShardManager()
+	if err != nil {
+		ErrorAndExit("Failed to initialize shard manager", err)
+	}
+	return shardManager
+}
+
+func initializeDomainManager(c *cli.Context) persistence.DomainManager {
+	factory := getPersistenceFactory(c)
+	domainManager, err := factory.NewDomainManager()
+	if err != nil {
+		ErrorAndExit("Failed to initialize domain manager", err)
+	}
+	return domainManager
+}
+
+var persistenceFactory client.Factory
+
+func getPersistenceFactory(c *cli.Context) client.Factory {
+	if persistenceFactory == nil {
+		persistenceFactory = initPersistenceFactory(c)
+	}
+	return persistenceFactory
+}
+
+func initPersistenceFactory(c *cli.Context) client.Factory {
+	cfg, err := cFactory.ServerConfig(c)
+
+	if err != nil {
+		cfg = &config.Config{
+			Persistence: config.Persistence{
+				DefaultStore: "default",
+				DataStores: map[string]config.DataStore{
+					"default": {NoSQL: &config.NoSQL{PluginName: cassandra.PluginName}},
+				},
+			},
+			ClusterGroupMetadata: &config.ClusterGroupMetadata{
+				CurrentClusterName: "current-cluster",
+			},
+		}
+	}
+
+	// If there are any overrides provided via CLI flags, apply them here
+	defaultStore := cfg.Persistence.DataStores[cfg.Persistence.DefaultStore]
+	defaultStore = overrideDataStore(c, defaultStore)
+	cfg.Persistence.DataStores[cfg.Persistence.DefaultStore] = defaultStore
+
+	cfg.Persistence.TransactionSizeLimit = dynamicconfig.GetIntPropertyFn(common.DefaultTransactionSizeLimit)
+	cfg.Persistence.ErrorInjectionRate = dynamicconfig.GetFloatPropertyFn(0.0)
+
+	rps := c.Float64(FlagRPS)
+
+	return client.NewFactory(
+		&cfg.Persistence,
+		func() float64 { return rps },
+		cfg.ClusterGroupMetadata.CurrentClusterName,
+		metrics.NewNoopMetricsClient(),
+		log.NewNoop(),
+	)
+}
+
+func overrideDataStore(c *cli.Context, ds config.DataStore) config.DataStore {
+	if c.IsSet(FlagDBType) {
+		// overriding DBType will wipe out all settings, everything will be set from flags only
+		ds = createDataStore(c)
+	}
+
+	if ds.NoSQL != nil {
+		overrideNoSQLDataStore(c, ds.NoSQL)
+	}
+	if ds.SQL != nil {
+		overrideSQLDataStore(c, ds.SQL)
+	}
+
+	return ds
+}
+
+func createDataStore(c *cli.Context) config.DataStore {
+	dbType := c.String(FlagDBType)
+	switch dbType {
+	case cassandra.PluginName:
+		return config.DataStore{NoSQL: &config.NoSQL{PluginName: cassandra.PluginName}}
+	default:
+		if sql.PluginRegistered(dbType) {
+			return config.DataStore{SQL: &config.SQL{PluginName: dbType}}
+		}
+	}
+	ErrorAndExit(fmt.Sprintf("The DB type is not supported. Options are: %s.", supportedDBs), nil)
+	return config.DataStore{}
+}
+
+func overrideNoSQLDataStore(c *cli.Context, cfg *config.NoSQL) {
+	if c.IsSet(FlagDBAddress) || cfg.Hosts == "" {
+		cfg.Hosts = c.String(FlagDBAddress)
+	}
+	if c.IsSet(FlagDBPort) || cfg.Port == 0 {
+		cfg.Port = c.Int(FlagDBPort)
+	}
+	if c.IsSet(FlagDBRegion) || cfg.Region == "" {
+		cfg.Region = c.String(FlagDBRegion)
+	}
+	if c.IsSet(FlagUsername) || cfg.User == "" {
+		cfg.User = c.String(FlagUsername)
+	}
+	if c.IsSet(FlagPassword) || cfg.Password == "" {
+		cfg.Password = c.String(FlagPassword)
+	}
+	if c.IsSet(FlagKeyspace) || cfg.Keyspace == "" {
+		cfg.Keyspace = c.String(FlagKeyspace)
+	}
+	if c.IsSet(FlagProtoVersion) || cfg.ProtoVersion == 0 {
+		cfg.ProtoVersion = c.Int(FlagProtoVersion)
+	}
+
+	if cfg.TLS == nil {
+		cfg.TLS = &config.TLS{}
+	}
+	overrideTLS(c, cfg.TLS)
+}
+
+func overrideSQLDataStore(c *cli.Context, cfg *config.SQL) {
+	host, port, _ := net.SplitHostPort(cfg.ConnectAddr)
+	if c.IsSet(FlagDBAddress) || cfg.ConnectAddr == "" {
+		host = c.String(FlagDBAddress)
+	}
+	if c.IsSet(FlagDBPort) || cfg.ConnectAddr == "" {
+		port = c.String(FlagDBPort)
+	}
+	cfg.ConnectAddr = net.JoinHostPort(host, port)
+
+	if c.IsSet(FlagDBType) || cfg.PluginName == "" {
+		cfg.PluginName = c.String(FlagDBType)
+	}
+	if c.IsSet(FlagUsername) || cfg.User == "" {
+		cfg.User = c.String(FlagUsername)
+	}
+	if c.IsSet(FlagPassword) || cfg.Password == "" {
+		cfg.Password = c.String(FlagPassword)
+	}
+	if c.IsSet(FlagDatabaseName) || cfg.DatabaseName == "" {
+		cfg.DatabaseName = c.String(FlagDatabaseName)
+	}
+	if c.IsSet(FlagEncodingType) || cfg.EncodingType == "" {
+		cfg.EncodingType = c.String(FlagEncodingType)
+	}
+	if c.IsSet(FlagDecodingTypes) || len(cfg.DecodingTypes) == 0 {
+		cfg.DecodingTypes = c.StringSlice(FlagDecodingTypes)
+	}
+	if c.IsSet(FlagConnectionAttributes) || cfg.ConnectAttributes == nil {
+		cfg.ConnectAttributes = c.Generic(FlagConnectionAttributes).(*flag.StringMap).Value()
+	}
+
+	if cfg.TLS == nil {
+		cfg.TLS = &config.TLS{}
+	}
+	overrideTLS(c, cfg.TLS)
+}
+
+func overrideTLS(c *cli.Context, tls *config.TLS) {
+	tls.Enabled = c.Bool(FlagEnableTLS)
+
+	if c.IsSet(FlagTLSCertPath) {
+		tls.CertFile = c.String(FlagTLSCertPath)
+	}
+	if c.IsSet(FlagTLSKeyPath) {
+		tls.KeyFile = c.String(FlagTLSKeyPath)
+	}
+	if c.IsSet(FlagTLSCaPath) {
+		tls.CaFile = c.String(FlagTLSCaPath)
+	}
+	if c.IsSet(FlagTLSEnableHostVerification) {
+		tls.EnableHostVerification = c.Bool(FlagTLSEnableHostVerification)
+	}
+}

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -42,6 +42,7 @@ import (
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
 	cc "github.com/uber/cadence/common/client"
+	"github.com/uber/cadence/common/config"
 )
 
 const (
@@ -63,6 +64,8 @@ type ClientFactory interface {
 	ServerAdminClient(c *cli.Context) admin.Client
 
 	ElasticSearchClient(c *cli.Context) *elastic.Client
+
+	ServerConfig(c *cli.Context) (*config.Config, error)
 }
 
 type clientFactory struct {
@@ -81,6 +84,18 @@ func NewClientFactory() ClientFactory {
 	return &clientFactory{
 		logger: logger,
 	}
+}
+
+// ServerConfig returns Cadence server configs.
+// Use in some CLI admin operations (e.g. accessing DB directly)
+func (b *clientFactory) ServerConfig(c *cli.Context) (*config.Config, error) {
+	env := c.String(FlagServiceEnv)
+	zone := c.String(FlagServiceZone)
+	configDir := c.String(FlagServiceConfigDir)
+
+	var cfg config.Config
+	err := config.Load(env, configDir, zone, &cfg)
+	return &cfg, err
 }
 
 // ServerFrontendClient builds a frontend client (based on server side thrift interface)

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -188,7 +188,6 @@ const (
 	FlagRemote                            = "remote"
 	FlagTimerType                         = "timer_type"
 	FlagSkipErrorModeWithAlias            = FlagSkipErrorMode + ", serr"
-	FlagRemoteWithAlias                   = FlagRemote + ", r"
 	FlagHeadersMode                       = "headers"
 	FlagHeadersModeWithAlias              = FlagHeadersMode + ", he"
 	FlagMessageType                       = "message_type"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
For all CLI commands operating directly with database, allow loading server config file with connection info for persistence.

All existing flags still works and can be use in conjunction with config file. Specifying all (or a subset of flags) will override config fields.

Additionally:
- Fixed `AdminGetDomainIDOrName`. Now works for all DB backends, not just cassandra.
- Moved `FlagRPS` to common DB flags. As this is relevant for all db operations.
- Removed alias `r` for `--remote` - clashes with runid for some commands.

<!-- Tell your future self why have you made these changes -->
**Why?**
1. Simplify usage of CLI commands. One can provide `--service_config_dir` instead of specifying a dozen of db related parameters as flags.
2. Reuse existing persistence client Factory.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested:
- Locally with cassandra based server.
- Locally with Uber specific CLI overriding `clientFactory.ServerConfig` for cassandra and docstore setups.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
