### PR TITLE
Purge un-hydrated replication tasks when doing DLQ merge

### DIFF
--- a/service/history/replication/dlq_handler.go
+++ b/service/history/replication/dlq_handler.go
@@ -197,7 +197,7 @@ func (r *dlqHandlerImpl) MergeMessages(
 		return nil, errInvalidCluster
 	}
 
-	tasks, _, token, err := r.readMessagesWithAckLevel(
+	tasks, rawTasks, token, err := r.readMessagesWithAckLevel(
 		ctx,
 		sourceCluster,
 		lastMessageID,
@@ -208,17 +208,23 @@ func (r *dlqHandlerImpl) MergeMessages(
 		return nil, err
 	}
 
-	lastMessageID = defaultBeginningMessageID
+	replicationTasks := map[int64]*types.ReplicationTask{}
 	for _, task := range tasks {
-		if _, err := r.taskExecutors[sourceCluster].execute(
-			task,
-			true,
-		); err != nil {
-			return nil, err
+		replicationTasks[task.SourceTaskID] = task
+	}
+
+	lastMessageID = defaultBeginningMessageID
+	for _, raw := range rawTasks {
+		if task, ok := replicationTasks[raw.TaskID]; ok {
+			if _, err := r.taskExecutors[sourceCluster].execute(task, true); err != nil {
+				return nil, err
+			}
 		}
 
-		if lastMessageID < task.GetSourceTaskID() {
-			lastMessageID = task.GetSourceTaskID()
+		// If hydrated replication task does not exists in remote cluster - continue merging
+		// Record lastMessageID with raw task id, so that they can be purged after.
+		if lastMessageID < raw.TaskID {
+			lastMessageID = raw.TaskID
 		}
 	}
 

--- a/service/history/replication/dlq_handler_test.go
+++ b/service/history/replication/dlq_handler_test.go
@@ -170,7 +170,7 @@ func (s *dlqHandlerSuite) TestPurgeMessages_OK() {
 
 func (s *dlqHandlerSuite) TestMergeMessages_OK() {
 	ctx := context.Background()
-	lastMessageID := int64(1)
+	lastMessageID := int64(2)
 	pageSize := 1
 	pageToken := []byte{}
 
@@ -182,6 +182,13 @@ func (s *dlqHandlerSuite) TestMergeMessages_OK() {
 				RunID:      uuid.New(),
 				TaskType:   0,
 				TaskID:     1,
+			},
+			{
+				DomainID:   uuid.New(),
+				WorkflowID: uuid.New(),
+				RunID:      uuid.New(),
+				TaskType:   0,
+				TaskID:     2,
 			},
 		},
 	}
@@ -198,7 +205,7 @@ func (s *dlqHandlerSuite) TestMergeMessages_OK() {
 	s.mockClientBean.EXPECT().GetRemoteAdminClient(s.sourceCluster).Return(s.adminClient).AnyTimes()
 	replicationTask := &types.ReplicationTask{
 		TaskType:     types.ReplicationTaskTypeHistory.Ptr(),
-		SourceTaskID: lastMessageID,
+		SourceTaskID: 1,
 	}
 	s.adminClient.EXPECT().
 		GetDLQReplicationMessages(ctx, gomock.Any()).


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use raw replication tasks to find last message ID when deleting DLQ messages. 

<!-- Tell your future self why have you made these changes -->
**Why?**
When merging DLQs with workflows that are already finished and deleted in source cluster - they do not get hydrated.

In the target cluster we receive less of those (or none) hydrated replication tasks and iterate over when merging. This does not increment lastMessageID which is later used to delete merged messages.

Then end result - when trying to merge DLQs from CLI we get response `Successfully merged all messages in shard ...` but after reading DLQs again we can see that they are still there. In the end we purge them anyway, since they are gone in the source cluster.

Now we will increment lastMessageID based on raw task id, to delete those as part of merging process.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Added unit test.
- Tested on staging2.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
