### PR TITLE
Support refreshing long running workflows based on user config

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -203,6 +203,8 @@ const (
 	DefaultESAnalyzerMinNumWorkflowsForAvg = 100
 	// DefaultESAnalyzerLimitToTypes controls if we want to limit ESAnalyzer only to some workflow types
 	DefaultESAnalyzerLimitToTypes = ""
+	// DefaultESAnalyzerEnableAvgDurationBasedChecks controls if we want to enable avg duration based refreshes
+	DefaultESAnalyzerEnableAvgDurationBasedChecks = false
 	// DefaultESAnalyzerLimitToDomains controls if we want to limit ESAnalyzer only to some domains
 	DefaultESAnalyzerLimitToDomains = ""
 	// DefaultESAnalyzerWorkflowDurationWarnThreshold defines warning threshold for a workflow duration

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2171,6 +2171,11 @@ const (
 	// Value type: Int
 	// Default value: "" => means no limitation
 	ESAnalyzerLimitToTypes
+	// ESAnalyzerEnableAvgDurationBasedChecks controls if we want to enable avg duration based task refreshes
+	// KeyName: worker.ESAnalyzerEnableAvgDurationBasedChecks
+	// Value type: Bool
+	// Default value: false
+	ESAnalyzerEnableAvgDurationBasedChecks
 	// ESAnalyzerLimitToDomains controls if we want to limit ESAnalyzer only to some domains
 	// KeyName: worker.ESAnalyzerLimitToDomains
 	// Value type: Int
@@ -2178,7 +2183,7 @@ const (
 	ESAnalyzerLimitToDomains
 	// ESAnalyzerWorkflowDurationWarnThresholds defines the warning execution thresholds for workflow types
 	// KeyName: worker.ESAnalyzerWorkflowDurationWarnThresholds
-	// Value type: string (json of a dictionary {"<domainName>/<workflowType>":<value>,...})
+	// Value type: string [{"domainName":"<domain>", "wfType":"<workflowType>", "threshold":"<duration>", "refresh":<shouldRefresh>}]
 	// Default value: ""
 	ESAnalyzerWorkflowDurationWarnThresholds
 
@@ -2581,6 +2586,7 @@ var Keys = map[Key]string{
 	ESAnalyzerBufferWaitTime:                 "worker.ESAnalyzerBufferWaitTime",
 	ESAnalyzerMinNumWorkflowsForAvg:          "worker.ESAnalyzerMinNumWorkflowsForAvg",
 	ESAnalyzerLimitToTypes:                   "worker.ESAnalyzerLimitToTypes",
+	ESAnalyzerEnableAvgDurationBasedChecks:   "worker.ESAnalyzerEnableAvgDurationBasedChecks",
 	ESAnalyzerLimitToDomains:                 "worker.ESAnalyzerLimitToDomains",
 	ESAnalyzerWorkflowDurationWarnThresholds: "worker.ESAnalyzerWorkflowDurationWarnThresholds",
 

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2183,7 +2183,7 @@ const (
 	ESAnalyzerLimitToDomains
 	// ESAnalyzerWorkflowDurationWarnThresholds defines the warning execution thresholds for workflow types
 	// KeyName: worker.ESAnalyzerWorkflowDurationWarnThresholds
-	// Value type: string [{"domainName":"<domain>", "wfType":"<workflowType>", "threshold":"<duration>", "refresh":<shouldRefresh>}]
+	// Value type: string [{"DomainName":"<domain>", "WorkflowType":"<workflowType>", "Threshold":"<duration>", "Refresh":<shouldRefresh>, "MaxNumWorkflows":<maxNumber>}]
 	// Default value: ""
 	ESAnalyzerWorkflowDurationWarnThresholds
 

--- a/service/worker/esanalyzer/analyzer.go
+++ b/service/worker/esanalyzer/analyzer.go
@@ -68,6 +68,7 @@ type (
 		ESAnalyzerMaxNumDomains                  dynamicconfig.IntPropertyFn
 		ESAnalyzerMaxNumWorkflowTypes            dynamicconfig.IntPropertyFn
 		ESAnalyzerLimitToTypes                   dynamicconfig.StringPropertyFn
+		ESAnalyzerEnableAvgDurationBasedChecks   dynamicconfig.BoolPropertyFn
 		ESAnalyzerLimitToDomains                 dynamicconfig.StringPropertyFn
 		ESAnalyzerNumWorkflowsToRefresh          dynamicconfig.IntPropertyFnWithWorkflowTypeFilter
 		ESAnalyzerBufferWaitTime                 dynamicconfig.DurationPropertyFnWithWorkflowTypeFilter

--- a/service/worker/esanalyzer/analyzer_test.go
+++ b/service/worker/esanalyzer/analyzer_test.go
@@ -399,12 +399,13 @@ func (s *esanalyzerWorkflowTestSuite) TestGetLongRunCheckEntriesSingleEntry() {
 	s.Equal("SomeDomain", longRunningWorkflows[0].DomainName)
 	s.Equal("SomeWFType", longRunningWorkflows[0].WorkflowType)
 	s.Equal(2*time.Minute, longRunningWorkflows[0].Threshold)
+	s.Equal(0, longRunningWorkflows[0].MaxNumWorkflows)
 	s.Equal(true, longRunningWorkflows[0].Refresh)
 }
 
 func (s *esanalyzerWorkflowTestSuite) TestGetLongRunCheckEntriesMultipleEntries() {
 	s.config.ESAnalyzerWorkflowDurationWarnThresholds = dynamicconfig.GetStringPropertyFn(
-		`[{"DomainName":"d1", "WorkflowType":"t1", "Threshold":"2m", "Refresh":true},{"DomainName":"d2", "WorkflowType":"t2", "Threshold":"3m", "Refresh":false}]`,
+		`[{"DomainName":"d1", "WorkflowType":"t1", "Threshold":"2m", "Refresh":true},{"DomainName":"d2", "WorkflowType":"t2", "Threshold":"3m", "Refresh":false, "MaxNumWorkflows":1000000}]`,
 	)
 
 	actFuture, err := s.activityEnv.ExecuteActivity(s.workflow.getLongRunCheckEntries)
@@ -416,11 +417,13 @@ func (s *esanalyzerWorkflowTestSuite) TestGetLongRunCheckEntriesMultipleEntries(
 	s.Equal("d1", longRunningWorkflows[0].DomainName)
 	s.Equal("t1", longRunningWorkflows[0].WorkflowType)
 	s.Equal(2*time.Minute, longRunningWorkflows[0].Threshold)
+	s.Equal(0, longRunningWorkflows[0].MaxNumWorkflows)
 	s.Equal(true, longRunningWorkflows[0].Refresh)
 
 	s.Equal("d2", longRunningWorkflows[1].DomainName)
 	s.Equal("t2", longRunningWorkflows[1].WorkflowType)
 	s.Equal(3*time.Minute, longRunningWorkflows[1].Threshold)
+	s.Equal(1000000, longRunningWorkflows[1].MaxNumWorkflows)
 	s.Equal(false, longRunningWorkflows[1].Refresh)
 }
 

--- a/service/worker/esanalyzer/analyzer_test.go
+++ b/service/worker/esanalyzer/analyzer_test.go
@@ -166,6 +166,10 @@ func (s *esanalyzerWorkflowTestSuite) SetupTest() {
 		s.workflow.findLongRunningWorkflows,
 		activity.RegisterOptions{Name: findLongRunningWorkflowsActivity},
 	)
+	s.workflowEnv.RegisterActivityWithOptions(
+		s.workflow.getLongRunCheckEntries,
+		activity.RegisterOptions{Name: getLongRunCheckEntriesActivity},
+	)
 
 	s.activityEnv.RegisterActivityWithOptions(
 		s.workflow.getWorkflowTypes,
@@ -180,6 +184,10 @@ func (s *esanalyzerWorkflowTestSuite) SetupTest() {
 	s.activityEnv.RegisterActivityWithOptions(
 		s.workflow.findLongRunningWorkflows,
 		activity.RegisterOptions{Name: findLongRunningWorkflowsActivity},
+	)
+	s.activityEnv.RegisterActivityWithOptions(
+		s.workflow.getLongRunCheckEntries,
+		activity.RegisterOptions{Name: getLongRunCheckEntriesActivity},
 	)
 }
 
@@ -210,10 +218,21 @@ func (s *esanalyzerWorkflowTestSuite) TestExecuteWorkflow() {
 	}
 	s.workflowEnv.OnActivity(findStuckWorkflowsActivity, mock.Anything, workflowTypeInfos[0]).
 		Return(workflows, nil).Times(1)
-	s.workflowEnv.OnActivity(findLongRunningWorkflowsActivity, mock.Anything).
-		Return(nil).Times(1)
 
-	s.workflowEnv.OnActivity(refreshStuckWorkflowsActivity, mock.Anything, workflows).Return(nil).Times(1)
+	longRunningWorkflows := []LongRunCheckEntry{
+		{
+			DomainName:   s.DomainName,
+			WorkflowType: s.WorkflowType,
+			Threshold:    time.Hour,
+			Refresh:      true,
+		},
+	}
+	s.workflowEnv.OnActivity(getLongRunCheckEntriesActivity, mock.Anything).
+		Return(longRunningWorkflows, nil).Times(1)
+	s.workflowEnv.OnActivity(findLongRunningWorkflowsActivity, mock.Anything, longRunningWorkflows[0]).
+		Return(workflows, nil).Times(1)
+
+	s.workflowEnv.OnActivity(refreshStuckWorkflowsActivity, mock.Anything, workflows).Return(nil).Times(2)
 
 	s.workflowEnv.ExecuteWorkflow(esanalyzerWFTypeName)
 	err := s.workflowEnv.GetWorkflowResult(nil)
@@ -254,8 +273,8 @@ func (s *esanalyzerWorkflowTestSuite) TestExecuteWorkflowMultipleWorkflowTypes()
 		Return(workflows1, nil).Times(1)
 	s.workflowEnv.OnActivity(findStuckWorkflowsActivity, mock.Anything, workflowTypeInfos[1]).
 		Return(workflows2, nil).Times(1)
-	s.workflowEnv.OnActivity(findLongRunningWorkflowsActivity, mock.Anything).
-		Return(nil).Times(1)
+	s.workflowEnv.OnActivity(getLongRunCheckEntriesActivity, mock.Anything).
+		Return(nil, nil).Times(1)
 
 	s.workflowEnv.OnActivity(refreshStuckWorkflowsActivity, mock.Anything, workflows1).Return(nil).Times(1)
 	s.workflowEnv.OnActivity(refreshStuckWorkflowsActivity, mock.Anything, workflows2).Return(nil).Times(1)
@@ -366,6 +385,45 @@ func (s *esanalyzerWorkflowTestSuite) TestRefreshStuckWorkflowsFromSameWorkflowI
 	s.EqualError(err, "InternalServiceError{Message: Inconsistent worklow. Expected domainID: deadbeef-0123-4567-890a-bcdef0123460, actual: another-domain-id}")
 }
 
+func (s *esanalyzerWorkflowTestSuite) TestGetLongRunCheckEntriesSingleEntry() {
+	s.config.ESAnalyzerWorkflowDurationWarnThresholds = dynamicconfig.GetStringPropertyFn(
+		`[{"DomainName":"SomeDomain", "WorkflowType":"SomeWFType", "Threshold":"2m", "Refresh":true}]`,
+	)
+
+	actFuture, err := s.activityEnv.ExecuteActivity(s.workflow.getLongRunCheckEntries)
+	s.NoError(err)
+	var longRunningWorkflows []LongRunCheckEntry
+	err = actFuture.Get(&longRunningWorkflows)
+	s.NoError(err)
+	s.Equal(1, len(longRunningWorkflows))
+	s.Equal("SomeDomain", longRunningWorkflows[0].DomainName)
+	s.Equal("SomeWFType", longRunningWorkflows[0].WorkflowType)
+	s.Equal(2*time.Minute, longRunningWorkflows[0].Threshold)
+	s.Equal(true, longRunningWorkflows[0].Refresh)
+}
+
+func (s *esanalyzerWorkflowTestSuite) TestGetLongRunCheckEntriesMultipleEntries() {
+	s.config.ESAnalyzerWorkflowDurationWarnThresholds = dynamicconfig.GetStringPropertyFn(
+		`[{"DomainName":"d1", "WorkflowType":"t1", "Threshold":"2m", "Refresh":true},{"DomainName":"d2", "WorkflowType":"t2", "Threshold":"3m", "Refresh":false}]`,
+	)
+
+	actFuture, err := s.activityEnv.ExecuteActivity(s.workflow.getLongRunCheckEntries)
+	s.NoError(err)
+	var longRunningWorkflows []LongRunCheckEntry
+	err = actFuture.Get(&longRunningWorkflows)
+	s.NoError(err)
+	s.Equal(2, len(longRunningWorkflows))
+	s.Equal("d1", longRunningWorkflows[0].DomainName)
+	s.Equal("t1", longRunningWorkflows[0].WorkflowType)
+	s.Equal(2*time.Minute, longRunningWorkflows[0].Threshold)
+	s.Equal(true, longRunningWorkflows[0].Refresh)
+
+	s.Equal("d2", longRunningWorkflows[1].DomainName)
+	s.Equal("t2", longRunningWorkflows[1].WorkflowType)
+	s.Equal(3*time.Minute, longRunningWorkflows[1].Threshold)
+	s.Equal(false, longRunningWorkflows[1].Refresh)
+}
+
 func (s *esanalyzerWorkflowTestSuite) TestFindLongRunningWorkflows() {
 	s.mockESClient.On("SearchRaw", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(
 		&elasticsearch.RawResponse{
@@ -382,8 +440,15 @@ func (s *esanalyzerWorkflowTestSuite) TestFindLongRunningWorkflows() {
 		int64(1234),
 	).Return().Times(1)
 
-	s.config.ESAnalyzerWorkflowDurationWarnThresholds = dynamicconfig.GetStringPropertyFn(`{"test-domain/workflow1":"1m"}`)
-	_, err := s.activityEnv.ExecuteActivity(s.workflow.findLongRunningWorkflows)
+	longRunningWorkflows := []LongRunCheckEntry{
+		{
+			DomainName:   s.DomainName,
+			WorkflowType: s.WorkflowType,
+			Threshold:    time.Hour,
+			Refresh:      true,
+		},
+	}
+	_, err := s.activityEnv.ExecuteActivity(s.workflow.findLongRunningWorkflows, longRunningWorkflows[0])
 	s.NoError(err)
 }
 
@@ -470,7 +535,15 @@ func (s *esanalyzerWorkflowTestSuite) TestFindStuckWorkflowsMinNumWorkflowValida
 	s.Equal(0, len(results))
 }
 
-func (s *esanalyzerWorkflowTestSuite) TestGetWorkflowTypes() {
+func (s *esanalyzerWorkflowTestSuite) TestGetWorkflowTypesEnabled() {
+	s.testGetWorkflowTypes(true)
+}
+func (s *esanalyzerWorkflowTestSuite) TestGetWorkflowTypesDisabled() {
+	s.testGetWorkflowTypes(false)
+}
+
+func (s *esanalyzerWorkflowTestSuite) testGetWorkflowTypes(enabled bool) {
+	s.config.ESAnalyzerEnableAvgDurationBasedChecks = dynamicconfig.GetBoolPropertyFn(enabled)
 	esResult := struct {
 		Buckets []DomainInfo `json:"buckets"`
 	}{
@@ -512,11 +585,16 @@ func (s *esanalyzerWorkflowTestSuite) TestGetWorkflowTypes() {
 	var results []WorkflowTypeInfo
 	err = actFuture.Get(&results)
 	s.NoError(err)
-	s.Equal(2, len(results))
-	s.Equal(normalizeDomainInfos(esResult.Buckets), results)
+	if enabled {
+		s.Equal(2, len(results))
+		s.Equal(normalizeDomainInfos(esResult.Buckets), results)
+	} else {
+		s.Equal(0, len(results))
+	}
 }
 
 func (s *esanalyzerWorkflowTestSuite) TestGetWorkflowTypesFromConfig() {
+	s.config.ESAnalyzerEnableAvgDurationBasedChecks = dynamicconfig.GetBoolPropertyFn(true)
 	workflowTypes := []WorkflowTypeInfo{
 		{DomainID: s.DomainID, Name: "workflow1"},
 		{DomainID: s.DomainID, Name: "workflow2"},

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -33,6 +33,7 @@ import (
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
 
+	"github.com/uber/cadence/common/elasticsearch"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
 )
@@ -49,6 +50,7 @@ const (
 	findStuckWorkflowsActivity       = "cadence-sys-es-analyzer-find-stuck-workflows"
 	refreshStuckWorkflowsActivity    = "cadence-sys-es-analyzer-refresh-stuck-workflows"
 	findLongRunningWorkflowsActivity = "cadence-sys-es-analyzer-find-long-running-workflows"
+	getLongRunCheckEntriesActivity   = "cadence-sys-es-analyzer-get-long-run-check-entries"
 )
 
 type (
@@ -81,6 +83,13 @@ type (
 		WorkflowID string `json:"WorkflowID"`
 		RunID      string `json:"RunID"`
 	}
+
+	LongRunCheckEntry struct {
+		DomainName   string
+		WorkflowType string
+		Threshold    time.Duration
+		Refresh      bool
+	}
 )
 
 var (
@@ -111,6 +120,11 @@ var (
 		StartToCloseTimeout:    15 * time.Minute,
 		RetryPolicy:            &retryPolicy,
 	}
+	getLongRunCheckEntriesOptions = workflow.ActivityOptions{
+		ScheduleToStartTimeout: time.Minute,
+		StartToCloseTimeout:    1 * time.Minute,
+		RetryPolicy:            &retryPolicy,
+	}
 
 	wfOptions = cclient.StartWorkflowOptions{
 		ID:                           esAnalyzerWFID,
@@ -131,6 +145,9 @@ func initWorkflow(a *Analyzer) {
 	activity.RegisterWithOptions(
 		w.findLongRunningWorkflows,
 		activity.RegisterOptions{Name: findLongRunningWorkflowsActivity})
+	activity.RegisterWithOptions(
+		w.getLongRunCheckEntries,
+		activity.RegisterOptions{Name: getLongRunCheckEntriesActivity})
 }
 
 // workflowFunc queries ElasticSearch to detect issues and mitigates them
@@ -175,10 +192,39 @@ func (w *Workflow) workflowFunc(ctx workflow.Context) error {
 		}
 	}
 
+	var longRunChecks []LongRunCheckEntry
 	err = workflow.ExecuteActivity(
-		workflow.WithActivityOptions(ctx, findLongRunningWorkflowsOptions),
-		findLongRunningWorkflowsActivity,
-	).Get(ctx, nil)
+		workflow.WithActivityOptions(ctx, getLongRunCheckEntriesOptions),
+		getLongRunCheckEntriesActivity,
+	).Get(ctx, &longRunChecks)
+	if err != nil {
+		return err
+	}
+
+	for _, checkInfo := range longRunChecks {
+		var longRunningWorkflows []WorkflowInfo
+		err = workflow.ExecuteActivity(
+			workflow.WithActivityOptions(ctx, findLongRunningWorkflowsOptions),
+			findLongRunningWorkflowsActivity,
+			checkInfo,
+		).Get(ctx, &longRunningWorkflows)
+
+		if err != nil {
+			return err
+		}
+		if len(longRunningWorkflows) == 0 {
+			continue
+		}
+
+		err = workflow.ExecuteActivity(
+			workflow.WithActivityOptions(ctx, refreshStuckWorkflowsOptions),
+			refreshStuckWorkflowsActivity,
+			longRunningWorkflows,
+		).Get(ctx, nil)
+		if err != nil {
+			return err
+		}
+	}
 
 	return err
 }
@@ -187,6 +233,7 @@ func getLongRunningWorkflowsQuery(
 	maxWorkflowStartTime int64,
 	domainID string,
 	workflowType string,
+	maxNumWorkflows int,
 ) (string, error) {
 	wfTypeMarshaled, err := json.Marshal(workflowType)
 	if err != nil {
@@ -223,86 +270,102 @@ func getLongRunningWorkflowsQuery(
               }
           }
       },
-      "size": 0
+      "size": %d
     }
-    `, maxWorkflowStartTime, domainID, string(wfTypeMarshaled)), nil
+    `, maxWorkflowStartTime, domainID, string(wfTypeMarshaled), maxNumWorkflows), nil
 }
 
-// findLongRunningWorkflows is activity to find long running workflows
-func (w *Workflow) findLongRunningWorkflows(ctx context.Context) error {
+func (w *Workflow) getLongRunCheckEntries(ctx context.Context) ([]LongRunCheckEntry, error) {
 	logger := activity.GetLogger(ctx)
 
 	workflowThresholds := w.analyzer.config.ESAnalyzerWorkflowDurationWarnThresholds()
 	if len(workflowThresholds) == 0 {
 		logger.Info("No workflow execution time thresholds defined")
-		return nil
+		return nil, nil
 	}
 
-	var entries map[string]string
+	var entries []struct {
+		DomainName   string
+		WorkflowType string
+		Threshold    string
+		Refresh      bool
+	}
 	err := json.Unmarshal([]byte(workflowThresholds), &entries)
 	if err != nil {
-		return err
+		logger.Error("Error while unmarshaling long workflow thresholds", zap.Error(err))
+		return nil, err
 	}
 
-	domainNameToID := map[string]string{}
-	for domainWFTypePair, threshold := range entries {
-		index := strings.Index(domainWFTypePair, "/")
-		// -1 no delimiter, 0 means the entry starts with /
-		if index < 1 || len(domainWFTypePair) <= (index+1) {
-			return types.InternalServiceError{
-				Message: fmt.Sprintf("Bad Workflow type entry %q", domainWFTypePair),
-			}
-		}
-		domainName := domainWFTypePair[:index]
-		wfType := domainWFTypePair[index+1:]
-		var domainID string
-		if _, ok := domainNameToID[domainName]; !ok {
-			domainEntry, err := w.analyzer.domainCache.GetDomain(domainName)
-			if err != nil {
-				logger.Error("Failed to get domain entry",
-					zap.Error(err),
-					zap.String("DomainName", domainName))
-				return err
-			}
-			domainID = domainEntry.GetInfo().ID
-			domainNameToID[domainName] = domainID
-		}
+	if len(entries) == 0 {
+		return nil, nil
+	}
 
-		durVal, err := time.ParseDuration(threshold)
+	result := []LongRunCheckEntry{}
+	for _, entry := range entries {
+		threshold, err := time.ParseDuration(entry.Threshold)
 		if err != nil {
-			return err
+			logger.Error(fmt.Sprintf("Error while parsing threshold %v ", entry.Threshold), zap.Error(err))
+			continue
 		}
-		maxWorkflowStartTime := time.Now().Add(-durVal).UnixNano()
+		result = append(result, LongRunCheckEntry{
+			DomainName:   entry.DomainName,
+			WorkflowType: entry.WorkflowType,
+			Threshold:    threshold,
+			Refresh:      entry.Refresh,
+		})
+	}
 
-		query, err := getLongRunningWorkflowsQuery(maxWorkflowStartTime, domainID, wfType)
-		if err != nil {
-			return err
-		}
-		response, err := w.analyzer.esClient.SearchRaw(ctx, w.analyzer.visibilityIndexName, query)
-		if err != nil {
-			logger.Error("Failed to query ElasticSearch for stuck workflows",
-				zap.Error(err),
-				zap.String("VisibilityQuery", query),
-			)
-			return err
-		}
+	return result, nil
+}
 
-		if response.Hits.TotalHits > 0 {
-			logger.Warn("Slow running workflows detected",
-				zap.String("DomainName", domainName),
-				zap.String("WorkflowType", wfType))
-		}
+// findLongRunningWorkflows is activity to find long running workflows
+func (w *Workflow) findLongRunningWorkflows(ctx context.Context, entry LongRunCheckEntry) ([]WorkflowInfo, error) {
+	logger := activity.GetLogger(ctx)
 
-		tagged := w.analyzer.scopedMetricClient.Tagged(
-			metrics.DomainTag(domainName),
-			metrics.WorkflowTypeTag(wfType),
+	domainEntry, err := w.analyzer.domainCache.GetDomain(entry.DomainName)
+	if err != nil {
+		logger.Error("Failed to get domain entry",
+			zap.Error(err),
+			zap.String("DomainName", entry.DomainName))
+		return nil, err
+	}
+	domainID := domainEntry.GetInfo().ID
+
+	maxWorkflowStartTime := time.Now().Add(-entry.Threshold).UnixNano()
+
+	maxNumWorkflows := 0
+	if entry.Refresh {
+		maxNumWorkflows = w.analyzer.config.ESAnalyzerNumWorkflowsToRefresh(entry.DomainName, entry.WorkflowType)
+	}
+	query, err := getLongRunningWorkflowsQuery(maxWorkflowStartTime, domainID, entry.WorkflowType, maxNumWorkflows)
+	if err != nil {
+		return nil, err
+	}
+	response, err := w.analyzer.esClient.SearchRaw(ctx, w.analyzer.visibilityIndexName, query)
+	if err != nil {
+		logger.Error("Failed to query ElasticSearch for stuck workflows",
+			zap.Error(err),
+			zap.String("VisibilityQuery", query),
 		)
-		tagged.AddCounter(
-			metrics.ESAnalyzerNumLongRunningWorkflows,
-			response.Hits.TotalHits)
+		return nil, err
 	}
 
-	return nil
+	if response.Hits.TotalHits > 0 {
+		logger.Warn("Slow running workflows detected",
+			zap.String("DomainName", entry.DomainName),
+			zap.String("WorkflowType", entry.WorkflowType))
+	}
+
+	tagged := w.analyzer.scopedMetricClient.Tagged(
+		metrics.DomainTag(entry.DomainName),
+		metrics.WorkflowTypeTag(entry.WorkflowType),
+	)
+	tagged.AddCounter(
+		metrics.ESAnalyzerNumLongRunningWorkflows,
+		response.Hits.TotalHits)
+
+	workflows := w.ESResponseToWorkflowInfo(response)
+	return workflows, nil
 }
 
 // refreshStuckWorkflowsFromSameWorkflowType is activity to refresh stuck workflows from the same domain
@@ -410,6 +473,20 @@ func getFindStuckWorkflowsQuery(
     `, startDateTime, endTime, domainID, string(wfTypeMarshaled), maxNumWorkflows), nil
 }
 
+func (w *Workflow) ESResponseToWorkflowInfo(response *elasticsearch.RawResponse) []WorkflowInfo {
+	workflows := []WorkflowInfo{}
+	if response.Hits.Hits != nil {
+		for _, hit := range response.Hits.Hits {
+			workflows = append(workflows, WorkflowInfo{
+				DomainID:   hit.DomainID,
+				WorkflowID: hit.WorkflowID,
+				RunID:      hit.RunID,
+			})
+		}
+	}
+	return workflows
+}
+
 // findStuckWorkflows is activity to find open workflows that are live significantly longer than average
 func (w *Workflow) findStuckWorkflows(ctx context.Context, info WorkflowTypeInfo) ([]WorkflowInfo, error) {
 	logger := activity.GetLogger(ctx)
@@ -469,16 +546,7 @@ func (w *Workflow) findStuckWorkflows(ctx context.Context, info WorkflowTypeInfo
 	}
 
 	// Return a simpler structure to reduce activity output size
-	workflows := []WorkflowInfo{}
-	if response.Hits.Hits != nil {
-		for _, hit := range response.Hits.Hits {
-			workflows = append(workflows, WorkflowInfo{
-				DomainID:   hit.DomainID,
-				WorkflowID: hit.WorkflowID,
-				RunID:      hit.RunID,
-			})
-		}
-	}
+	workflows := w.ESResponseToWorkflowInfo(response)
 
 	if len(workflows) > 0 {
 		w.analyzer.scopedMetricClient.AddCounter(
@@ -638,6 +706,11 @@ func normalizeDomainInfos(infos []DomainInfo) []WorkflowTypeInfo {
 // getWorkflowTypes is activity to get workflow type list from ElasticSearch
 func (w *Workflow) getWorkflowTypes(ctx context.Context) ([]WorkflowTypeInfo, error) {
 	logger := activity.GetLogger(ctx)
+
+	enabled := w.analyzer.config.ESAnalyzerEnableAvgDurationBasedChecks()
+	if !enabled {
+		return nil, nil
+	}
 
 	limitToTypes := w.analyzer.config.ESAnalyzerLimitToTypes()
 	if len(limitToTypes) > 0 {

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -168,6 +168,7 @@ func NewConfig(params *resource.Params) *Config {
 			ESAnalyzerMaxNumDomains:                  dc.GetIntProperty(dynamicconfig.ESAnalyzerMaxNumDomains, common.DefaultESAnalyzerMaxNumDomains),
 			ESAnalyzerMaxNumWorkflowTypes:            dc.GetIntProperty(dynamicconfig.ESAnalyzerMaxNumWorkflowTypes, common.DefaultESAnalyzerMaxNumWorkflowTypes),
 			ESAnalyzerLimitToTypes:                   dc.GetStringProperty(dynamicconfig.ESAnalyzerLimitToTypes, common.DefaultESAnalyzerLimitToTypes),
+			ESAnalyzerEnableAvgDurationBasedChecks:   dc.GetBoolProperty(dynamicconfig.ESAnalyzerEnableAvgDurationBasedChecks, common.DefaultESAnalyzerEnableAvgDurationBasedChecks),
 			ESAnalyzerLimitToDomains:                 dc.GetStringProperty(dynamicconfig.ESAnalyzerLimitToDomains, common.DefaultESAnalyzerLimitToDomains),
 			ESAnalyzerNumWorkflowsToRefresh:          dc.GetIntPropertyFilteredByWorkflowType(dynamicconfig.ESAnalyzerNumWorkflowsToRefresh, common.DefaultESAnalyzerNumWorkflowsToRefresh),
 			ESAnalyzerBufferWaitTime:                 dc.GetDurationPropertyFilteredByWorkflowType(dynamicconfig.ESAnalyzerBufferWaitTime, common.DefaultESAnalyzerBufferWaitTime),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Due to Cassandra issues tasks might be lost. Some users want to automatically refresh the tasks if their workflows are taking longer than user specified time. This will help mitigate the issue.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go test -v github.com/uber/cadence/service/worker/esanalyzer -run TestESAnalyzerWorkflowTestSuite
```


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
