### PR TITLE
Use RenderTable for the remaining CLI commands

### DIFF
--- a/tools/cli/adminCommands.go
+++ b/tools/cli/adminCommands.go
@@ -30,7 +30,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 
 	"github.com/uber/cadence/.gen/go/shared"
@@ -550,6 +549,11 @@ func AdminCloseShard(c *cli.Context) {
 	}
 }
 
+type ShardRow struct {
+	ShardID  int32  `header:"ShardID"`
+	Identity string `header:"Identity"`
+}
+
 // AdminDescribeShardDistribution describes shard distribution
 func AdminDescribeShardDistribution(c *cli.Context) {
 	adminClient := cFactory.ServerAdminClient(c)
@@ -574,31 +578,23 @@ func AdminDescribeShardDistribution(c *cli.Context) {
 		return
 	}
 
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetBorder(false)
-	table.SetColumnSeparator("|")
-	header := []string{"ShardID", "Identity"}
-	headerColor := []tablewriter.Colors{tableHeaderBlue, tableHeaderBlue}
-	table.SetHeader(header)
-	table.SetHeaderColor(headerColor...)
-	table.SetHeaderLine(false)
-
+	table := []ShardRow{}
+	opts := TableOptions{Color: true}
 	outputPageSize := tableRenderSize
 	for shardID, identity := range resp.Shards {
 		if outputPageSize == 0 {
-			table.Render()
-			table.ClearRows()
+			RenderTable(os.Stdout, table, opts)
+			table = []ShardRow{}
 			if !showNextPage() {
 				break
 			}
 			outputPageSize = tableRenderSize
 		}
-		table.Append([]string{strconv.Itoa(int(shardID)), identity})
+		table = append(table, ShardRow{ShardID: shardID, Identity: identity})
 		outputPageSize--
 	}
 	// output the remaining rows
-	table.Render()
-	table.ClearRows()
+	RenderTable(os.Stdout, table, opts)
 }
 
 // AdminDescribeHistoryHost describes history host

--- a/tools/cli/adminElasticSearchCommands.go
+++ b/tools/cli/adminElasticSearchCommands.go
@@ -71,6 +71,18 @@ func timeValProcess(timeStr string) (string, error) {
 	return fmt.Sprintf("%v", parsedTime.UnixNano()), nil
 }
 
+type ESIndexRow struct {
+	Health             string `header:"Health"`
+	Status             string `header:"Status"`
+	Index              string `header:"Index"`
+	PrimaryShards      int    `header:"Pri"`
+	ReplicaShards      int    `header:"Rep"`
+	DocsCount          int    `header:"Docs Count"`
+	DocsDeleted        int    `header:"Docs Deleted"`
+	StorageSize        string `header:"Store Size"`
+	PrimaryStorageSize string `header:"Pri Store Size"`
+}
+
 // AdminCatIndices cat indices for ES cluster
 func AdminCatIndices(c *cli.Context) {
 	esClient := cFactory.ElasticSearchClient(c)
@@ -81,23 +93,21 @@ func AdminCatIndices(c *cli.Context) {
 		ErrorAndExit("Unable to cat indices", err)
 	}
 
-	table := tablewriter.NewWriter(os.Stdout)
-	header := []string{"health", "status", "index", "pri", "rep", "docs.count", "docs.deleted", "store.size", "pri.store.size"}
-	table.SetHeader(header)
+	table := []ESIndexRow{}
 	for _, row := range resp {
-		data := make([]string, len(header))
-		data[0] = row.Health
-		data[1] = row.Status
-		data[2] = row.Index
-		data[3] = strconv.Itoa(row.Pri)
-		data[4] = strconv.Itoa(row.Rep)
-		data[5] = strconv.Itoa(row.DocsCount)
-		data[6] = strconv.Itoa(row.DocsDeleted)
-		data[7] = row.StoreSize
-		data[8] = row.PriStoreSize
-		table.Append(data)
+		table = append(table, ESIndexRow{
+			Health:             row.Health,
+			Status:             row.Status,
+			Index:              row.Index,
+			PrimaryShards:      row.Pri,
+			ReplicaShards:      row.Rep,
+			DocsCount:          row.DocsCount,
+			DocsDeleted:        row.DocsDeleted,
+			StorageSize:        row.StoreSize,
+			PrimaryStorageSize: row.PriStoreSize,
+		})
 	}
-	table.Render()
+	RenderTable(os.Stdout, table, TableOptions{Color: true, Border: true})
 }
 
 // AdminIndex used to bulk insert message from kafka parse
@@ -291,7 +301,6 @@ func toTimeStr(s interface{}) string {
 // GenerateReport generate report for an aggregation query to ES
 func GenerateReport(c *cli.Context) {
 	// use url command argument to create client
-	url := getRequiredOption(c, FlagURL)
 	index := getRequiredOption(c, FlagIndex)
 	sql := getRequiredOption(c, FlagListQuery)
 	var reportFormat, reportFilePath string
@@ -303,10 +312,7 @@ func GenerateReport(c *cli.Context) {
 	} else {
 		reportFilePath = "./report." + reportFormat
 	}
-	esClient, err := elastic.NewClient(elastic.SetURL(url))
-	if err != nil {
-		ErrorAndExit("Fail to create elastic client", err)
-	}
+	esClient := cFactory.ElasticSearchClient(c)
 	ctx := context.Background()
 
 	// convert sql to dsl

--- a/tools/cli/adminTaskListCommands.go
+++ b/tools/cli/adminTaskListCommands.go
@@ -23,13 +23,26 @@ package cli
 import (
 	"fmt"
 	"os"
-	"strconv"
 	"strings"
 
-	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 
 	"github.com/uber/cadence/common/types"
+)
+
+type (
+	TaskListRow struct {
+		Name        string `header:"Task List Name"`
+		Type        string `header:"Type"`
+		PollerCount int    `header:"Poller Count"`
+	}
+	TaskListStatusRow struct {
+		ReadLevel int64 `header:"Read Level"`
+		AckLevel  int64 `header:"Ack Level"`
+		Backlog   int64 `header:"Backlog"`
+		StartID   int64 `header:"Lease Start TaskID"`
+		EndID     int64 `header:"Lease End TaskID"`
+	}
 )
 
 // AdminDescribeTaskList displays poller and status information of task list.
@@ -67,7 +80,7 @@ func AdminDescribeTaskList(c *cli.Context) {
 	if len(pollers) == 0 {
 		ErrorAndExit(colorMagenta("No poller for tasklist: "+taskList), nil)
 	}
-	printPollerInfo(pollers, taskListType)
+	printTaskListPollers(pollers, taskListType)
 }
 
 // AdminListTaskList displays all task lists under a domain.
@@ -87,51 +100,23 @@ func AdminListTaskList(c *cli.Context) {
 	}
 
 	fmt.Println("Task Lists for domain " + domain + ":")
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetBorder(true)
-	table.SetColumnSeparator("|")
-	table.SetHeader([]string{"Task List Name", "Type", "Poller Count"})
-	table.SetHeaderLine(true)
-	table.SetHeaderColor(tableHeaderBlue, tableHeaderBlue, tableHeaderBlue)
+	table := []TaskListRow{}
 	for name, taskList := range response.GetDecisionTaskListMap() {
-		table.Append([]string{name, strconv.Itoa(len(taskList.GetPollers()))})
+		table = append(table, TaskListRow{name, "Decision", len(taskList.GetPollers())})
 	}
 	for name, taskList := range response.GetActivityTaskListMap() {
-		table.Append([]string{name, strconv.Itoa(len(taskList.GetPollers()))})
+		table = append(table, TaskListRow{name, "Activity", len(taskList.GetPollers())})
 	}
-	table.Render()
+	RenderTable(os.Stdout, table, TableOptions{Color: true, Border: true})
 }
 
 func printTaskListStatus(taskListStatus *types.TaskListStatus) {
-	taskIDBlock := taskListStatus.GetTaskIDBlock()
-
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetBorder(false)
-	table.SetColumnSeparator("|")
-	table.SetHeader([]string{"Read Level", "Ack Level", "Backlog", "Lease Start TaskID", "Lease End TaskID"})
-	table.SetHeaderLine(false)
-	table.SetHeaderColor(tableHeaderBlue, tableHeaderBlue, tableHeaderBlue, tableHeaderBlue, tableHeaderBlue)
-	table.Append([]string{strconv.FormatInt(taskListStatus.GetReadLevel(), 10),
-		strconv.FormatInt(taskListStatus.GetAckLevel(), 10),
-		strconv.FormatInt(taskListStatus.GetBacklogCountHint(), 10),
-		strconv.FormatInt(taskIDBlock.GetStartID(), 10),
-		strconv.FormatInt(taskIDBlock.GetEndID(), 10)})
-	table.Render()
-}
-
-func printPollerInfo(pollers []*types.PollerInfo, taskListType types.TaskListType) {
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetBorder(false)
-	table.SetColumnSeparator("|")
-	if taskListType == types.TaskListTypeActivity {
-		table.SetHeader([]string{"Activity Poller Identity", "Last Access Time"})
-	} else {
-		table.SetHeader([]string{"Decision Poller Identity", "Last Access Time"})
-	}
-	table.SetHeaderLine(false)
-	table.SetHeaderColor(tableHeaderBlue, tableHeaderBlue)
-	for _, poller := range pollers {
-		table.Append([]string{poller.GetIdentity(), convertTime(poller.GetLastAccessTime(), false)})
-	}
-	table.Render()
+	table := []TaskListStatusRow{{
+		ReadLevel: taskListStatus.GetReadLevel(),
+		AckLevel:  taskListStatus.GetAckLevel(),
+		Backlog:   taskListStatus.GetBacklogCountHint(),
+		StartID:   taskListStatus.GetTaskIDBlock().GetStartID(),
+		EndID:     taskListStatus.GetTaskIDBlock().GetEndID(),
+	}}
+	RenderTable(os.Stdout, table, TableOptions{Color: true})
 }

--- a/tools/cli/clusterCommands.go
+++ b/tools/cli/clusterCommands.go
@@ -24,9 +24,26 @@ import (
 	"os"
 	"sort"
 
-	"github.com/olekukonko/tablewriter"
 	"github.com/urfave/cli"
 )
+
+type (
+	SearchAttributesRow struct {
+		Key       string `header:"Key"`
+		ValueType string `header:"Value type"`
+	}
+	SearchAttributesTable []SearchAttributesRow
+)
+
+func (s SearchAttributesTable) Len() int {
+	return len(s)
+}
+func (s SearchAttributesTable) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+func (s SearchAttributesTable) Less(i, j int) bool {
+	return s[i].Key < s[j].Key
+}
 
 // GetSearchAttributes get valid search attributes
 func GetSearchAttributes(c *cli.Context) {
@@ -39,15 +56,10 @@ func GetSearchAttributes(c *cli.Context) {
 		ErrorAndExit("Failed to get search attributes.", err)
 	}
 
-	table := tablewriter.NewWriter(os.Stdout)
-	header := []string{"Key", "Value type"}
-	table.SetHeader(header)
-	table.SetHeaderColor(tableHeaderBlue, tableHeaderBlue)
-	rows := [][]string{}
+	table := SearchAttributesTable{}
 	for k, v := range resp.Keys {
-		rows = append(rows, []string{k, v.String()})
+		table = append(table, SearchAttributesRow{Key: k, ValueType: v.String()})
 	}
-	sort.Sort(byKey(rows))
-	table.AppendBulk(rows)
-	table.Render()
+	sort.Sort(table)
+	RenderTable(os.Stdout, table, TableOptions{Color: true, Border: true})
 }

--- a/tools/cli/defs.go
+++ b/tools/cli/defs.go
@@ -25,7 +25,6 @@ import (
 	"time"
 
 	"github.com/fatih/color"
-	"github.com/olekukonko/tablewriter"
 
 	"github.com/uber/cadence/common/types"
 )
@@ -115,7 +114,6 @@ var (
 	colorMagenta = color.New(color.FgMagenta).SprintFunc()
 	colorGreen   = color.New(color.FgGreen).SprintFunc()
 
-	tableHeaderBlue         = tablewriter.Colors{tablewriter.FgHiBlueColor}
 	optionErr               = "there is something wrong with your command options"
 	osExit                  = os.Exit
 	workflowClosedStatusMap = map[string]types.WorkflowExecutionCloseStatus{

--- a/tools/cli/table.go
+++ b/tools/cli/table.go
@@ -35,6 +35,8 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+var tableHeaderBlue = tablewriter.Colors{tablewriter.FgHiBlueColor}
+
 // TableOptions allows passing optional flags for altering rendered table
 type TableOptions struct {
 	// OptionalColumns may contain column header names which can be hidden

--- a/tools/cli/table.go
+++ b/tools/cli/table.go
@@ -72,7 +72,7 @@ func RenderTable(w io.Writer, slice interface{}, opts TableOptions) {
 	table := tablewriter.NewWriter(w)
 	table.SetBorder(opts.Border)
 	table.SetColumnSeparator("|")
-	table.SetHeaderLine(false)
+	table.SetHeaderLine(opts.Border)
 
 	for r := 0; r < sliceValue.Len(); r++ {
 		var row []string

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -766,26 +766,28 @@ func describeWorkflowHelper(c *cli.Context, wid, rid string) {
 	prettyPrintJSONObject(o)
 }
 
+type AutoResetPointRow struct {
+	BinaryChecksum string    `header:"Binary Checksum"`
+	CreateTime     time.Time `header:"Create Time"`
+	RunID          string    `header:"RunID"`
+	EventID        int64     `header:"EventID"`
+}
+
 func printAutoResetPoints(resp *types.DescribeWorkflowExecutionResponse) {
 	fmt.Println("Auto Reset Points:")
-	table := tablewriter.NewWriter(os.Stdout)
-	table.SetBorder(true)
-	table.SetColumnSeparator("|")
-	header := []string{"Binary Checksum", "Create Time", "RunID", "EventID"}
-	headerColor := []tablewriter.Colors{tableHeaderBlue, tableHeaderBlue, tableHeaderBlue, tableHeaderBlue}
-	table.SetHeader(header)
-	table.SetHeaderColor(headerColor...)
-	if resp.WorkflowExecutionInfo.AutoResetPoints != nil && len(resp.WorkflowExecutionInfo.AutoResetPoints.Points) > 0 {
-		for _, pt := range resp.WorkflowExecutionInfo.AutoResetPoints.Points {
-			var row []string
-			row = append(row, pt.GetBinaryChecksum())
-			row = append(row, time.Unix(0, pt.GetCreatedTimeNano()).String())
-			row = append(row, pt.GetRunID())
-			row = append(row, strconv.FormatInt(pt.GetFirstDecisionCompletedID(), 10))
-			table.Append(row)
-		}
+	table := []AutoResetPointRow{}
+	if resp.WorkflowExecutionInfo.AutoResetPoints == nil || len(resp.WorkflowExecutionInfo.AutoResetPoints.Points) == 0 {
+		return
 	}
-	table.Render()
+	for _, pt := range resp.WorkflowExecutionInfo.AutoResetPoints.Points {
+		table = append(table, AutoResetPointRow{
+			BinaryChecksum: pt.GetBinaryChecksum(),
+			CreateTime:     time.Unix(0, pt.GetCreatedTimeNano()),
+			RunID:          pt.GetRunID(),
+			EventID:        pt.GetFirstDecisionCompletedID(),
+		})
+	}
+	RenderTable(os.Stdout, table, TableOptions{Color: true, Border: true, PrintDateTime: true})
 }
 
 // describeWorkflowExecutionResponse is used to print datetime instead of print raw time

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -1590,19 +1590,6 @@ func loadWorkflowIDsFromFile(excludeFileName, separator string) map[string]bool 
 	return excludeWIDs
 }
 
-// sort helper for search attributes
-type byKey [][]string
-
-func (s byKey) Len() int {
-	return len(s)
-}
-func (s byKey) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-func (s byKey) Less(i, j int) bool {
-	return s[i][0] < s[j][0]
-}
-
 func printErrorAndReturn(msg string, err error) error {
 	fmt.Println(msg)
 	return err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use generic table rendering function `RenderTable` for the remaining CLI commands.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a continuation for https://github.com/uber/cadence/pull/4773

Currently CLI commands are sprinkled with table rendering logic which makes it difficult add additional output formats or pipe cadence commands together.

This is part of a larger effort to separate CLI logic from presentation layer.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally affected commands.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
