### PR TITLE
Add source_cluster tag when emitting DLQ size

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -33,6 +33,7 @@ const (
 
 	instance               = "instance"
 	domain                 = "domain"
+	sourceCluster          = "source_cluster"
 	targetCluster          = "target_cluster"
 	activeCluster          = "active_cluster"
 	taskList               = "tasklist"
@@ -90,6 +91,11 @@ func DomainUnknownTag() Tag {
 // InstanceTag returns a new instance tag
 func InstanceTag(value string) Tag {
 	return simpleMetric{key: instance, value: value}
+}
+
+// SourceClusterTag returns a new source cluster tag.
+func SourceClusterTag(value string) Tag {
+	return metricWithUnknown(sourceCluster, value)
 }
 
 // TargetClusterTag returns a new target cluster tag.

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -629,6 +629,7 @@ func (p *taskProcessorImpl) emitDLQSizeMetricsLoop() {
 			} else {
 				p.metricsClient.Scope(
 					metrics.ReplicationDLQStatsScope,
+					metrics.SourceClusterTag(p.sourceCluster),
 					metrics.InstanceTag(strconv.Itoa(p.shard.GetShardID())),
 				).UpdateGauge(metrics.ReplicationDLQSize, float64(resp.Size))
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added `source_cluster` tag when emitting DLQ size.

<!-- Tell your future self why have you made these changes -->
**Why?**
With multi cluster setup, DLQ messages can come from more than one source cluster. Each have its own pump to periodically emit dlq size. They keep emitting sizes on the same gauge value, causing to be "jumpy".

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
