### PR TITLE
Use errgroup.Group for fanout style workfloads

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -25,15 +25,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/pborman/uuid"
 	"go.uber.org/yarpc"
 	"go.uber.org/yarpc/yarpcerrors"
+	"golang.org/x/sync/errgroup"
 
-	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/backoff"
@@ -4205,36 +4204,20 @@ func (wh *WorkflowHandler) checkOngoingFailover(
 
 	clusterMetadata := wh.GetClusterMetadata()
 	respChan := make(chan *types.DescribeDomainResponse, len(clusterMetadata.GetAllClusterInfo()))
-	wg := &sync.WaitGroup{}
 
-	describeDomain := func(
-		ctx context.Context,
-		client frontend.Client,
-		domainName *string,
-	) {
-		defer wg.Done()
-		resp, _ := client.DescribeDomain(
-			ctx,
-			&types.DescribeDomainRequest{
-				Name: domainName,
-			},
-		)
-		respChan <- resp
-	}
-
+	g := &errgroup.Group{}
 	for clusterName, cluster := range clusterMetadata.GetAllClusterInfo() {
 		if !cluster.Enabled {
 			continue
 		}
 		frontendClient := wh.GetRemoteFrontendClient(clusterName)
-		wg.Add(1)
-		go describeDomain(
-			ctx,
-			frontendClient,
-			domainName,
-		)
+		g.Go(func() error {
+			resp, _ := frontendClient.DescribeDomain(ctx, &types.DescribeDomainRequest{Name: domainName})
+			respChan <- resp
+			return nil
+		})
 	}
-	wg.Wait()
+	g.Wait()
 	close(respChan)
 
 	var failoverVersion *int64


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use `errgroup.Group` for places where some kind of parallel fanout is used.

<!-- Tell your future self why have you made these changes -->
**Why?**
Simplifies code for running go routines and handling first error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
