### PR TITLE
Feature/cdnc 2263 Add toggle which can block domain failovers

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2193,11 +2193,11 @@ const (
 	// Default value: false
 	CorruptWorkflowWatchdogPause
 
-	// SystemLockdown defines if we want to allow failovers of domains to this cluster
-	// KeyName: system.SystemLockdown
+	// Lockdown defines if we want to allow failovers of domains to this cluster
+	// KeyName: system.Lockdown
 	// Value type: bool
 	// Default value: false
-	SystemLockdown
+	Lockdown
 
 	// LastKeyForTest must be the last one in this const group for testing purpose
 	LastKeyForTest
@@ -2251,7 +2251,7 @@ var Keys = map[Key]string{
 	EnableGRPCOutbound:                  "system.enableGRPCOutbound",
 	GRPCMaxSizeInByte:                   "system.grpcMaxSizeInByte",
 	EnableWatchDog:                      "system.EnableWatchDog",
-	SystemLockdown:                      "system.lockdown",
+	Lockdown:                            "system.Lockdown",
 
 	// size limit
 	BlobSizeLimitError:     "limit.blobSize.error",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2193,6 +2193,12 @@ const (
 	// Default value: false
 	CorruptWorkflowWatchdogPause
 
+	// SystemLockdown defines if we want to allow failovers of domains to this cluster
+	// KeyName: worker.SystemLockdown
+	// Value type: bool
+	// Default value: false
+	SystemLockdown
+
 	// LastKeyForTest must be the last one in this const group for testing purpose
 	LastKeyForTest
 )
@@ -2245,6 +2251,7 @@ var Keys = map[Key]string{
 	EnableGRPCOutbound:                  "system.enableGRPCOutbound",
 	GRPCMaxSizeInByte:                   "system.grpcMaxSizeInByte",
 	EnableWatchDog:                      "system.EnableWatchDog",
+	SystemLockdown:                      "system.lockdown",
 
 	// size limit
 	BlobSizeLimitError:     "limit.blobSize.error",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2194,7 +2194,7 @@ const (
 	CorruptWorkflowWatchdogPause
 
 	// SystemLockdown defines if we want to allow failovers of domains to this cluster
-	// KeyName: worker.SystemLockdown
+	// KeyName: system.SystemLockdown
 	// Value type: bool
 	// Default value: false
 	SystemLockdown

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -59,6 +59,7 @@ type Config struct {
 	EnableClientVersionCheck        dynamicconfig.BoolPropertyFn
 	DisallowQuery                   dynamicconfig.BoolPropertyFnWithDomainFilter
 	ShutdownDrainDuration           dynamicconfig.DurationPropertyFn
+	SystemLockdown                  dynamicconfig.BoolPropertyFnWithDomainFilter
 
 	// id length limits
 	MaxIDLengthWarnLimit  dynamicconfig.IntPropertyFn
@@ -160,6 +161,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		SendRawWorkflowHistory:                      dc.GetBoolPropertyFilteredByDomain(dynamicconfig.SendRawWorkflowHistory, sendRawWorkflowHistory),
 		DecisionResultCountLimit:                    dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendDecisionResultCountLimit, 0),
 		EmitSignalNameMetricsTag:                    dc.GetBoolPropertyFilteredByDomain(dynamicconfig.FrontendEmitSignalNameMetricsTag, false),
+		SystemLockdown:                              dc.GetBoolPropertyFilteredByDomain(dynamicconfig.SystemLockdown, false),
 		domainConfig: domain.Config{
 			MaxBadBinaryCount:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries, domain.MaxBadBinaries),
 			MinRetentionDays:       dc.GetIntProperty(dynamicconfig.MinRetentionDays, domain.DefaultMinWorkflowRetentionInDays),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -59,7 +59,7 @@ type Config struct {
 	EnableClientVersionCheck        dynamicconfig.BoolPropertyFn
 	DisallowQuery                   dynamicconfig.BoolPropertyFnWithDomainFilter
 	ShutdownDrainDuration           dynamicconfig.DurationPropertyFn
-	SystemLockdown                  dynamicconfig.BoolPropertyFnWithDomainFilter
+	Lockdown                        dynamicconfig.BoolPropertyFnWithDomainFilter
 
 	// id length limits
 	MaxIDLengthWarnLimit  dynamicconfig.IntPropertyFn
@@ -161,7 +161,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		SendRawWorkflowHistory:                      dc.GetBoolPropertyFilteredByDomain(dynamicconfig.SendRawWorkflowHistory, sendRawWorkflowHistory),
 		DecisionResultCountLimit:                    dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendDecisionResultCountLimit, 0),
 		EmitSignalNameMetricsTag:                    dc.GetBoolPropertyFilteredByDomain(dynamicconfig.FrontendEmitSignalNameMetricsTag, false),
-		SystemLockdown:                              dc.GetBoolPropertyFilteredByDomain(dynamicconfig.SystemLockdown, false),
+		Lockdown:                                    dc.GetBoolPropertyFilteredByDomain(dynamicconfig.Lockdown, false),
 		domainConfig: domain.Config{
 			MaxBadBinaryCount:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries, domain.MaxBadBinaries),
 			MinRetentionDays:       dc.GetIntProperty(dynamicconfig.MinRetentionDays, domain.DefaultMinWorkflowRetentionInDays),

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -133,6 +133,7 @@ var (
 	errClusterNameNotSet                          = &types.BadRequestError{Message: "Cluster name is not set."}
 	errEmptyReplicationInfo                       = &types.BadRequestError{Message: "Replication task info is not set."}
 	errEmptyQueueType                             = &types.BadRequestError{Message: "Queue type is not set."}
+	errDomainInLockdown                           = &types.BadRequestError{Message: "Domain is not accepting fail overs at this time."}
 	errShuttingDown                               = &types.InternalServiceError{Message: "Shutting down"}
 
 	// err for archival
@@ -407,6 +408,11 @@ func (wh *WorkflowHandler) UpdateDomain(
 	// don't require permission for failover request
 	if !isFailoverRequest(updateRequest) {
 		if err := checkPermission(wh.config, updateRequest.SecurityToken); err != nil {
+			return nil, err
+		}
+	} else {
+		// reject the failover if the cluster is in lockdown
+		if err := checkFailOverPermission(wh.config, updateRequest.Name); err != nil {
 			return nil, err
 		}
 	}
@@ -4383,6 +4389,13 @@ func checkPermission(
 		if securityToken != requiredToken {
 			return errNoPermission
 		}
+	}
+	return nil
+}
+
+func checkFailOverPermission(config *Config, domainName string) error {
+	if config.SystemLockdown(domainName) {
+		return errDomainInLockdown
 	}
 	return nil
 }

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -4394,7 +4394,7 @@ func checkPermission(
 }
 
 func checkFailOverPermission(config *Config, domainName string) error {
-	if config.SystemLockdown(domainName) {
+	if config.Lockdown(domainName) {
 		return errDomainInLockdown
 	}
 	return nil

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -133,7 +133,7 @@ var (
 	errClusterNameNotSet                          = &types.BadRequestError{Message: "Cluster name is not set."}
 	errEmptyReplicationInfo                       = &types.BadRequestError{Message: "Replication task info is not set."}
 	errEmptyQueueType                             = &types.BadRequestError{Message: "Queue type is not set."}
-	errDomainInLockdown                           = &types.BadRequestError{Message: "Domain is not accepting fail overs at this time."}
+	errDomainInLockdown                           = &types.BadRequestError{Message: "Domain is not accepting fail overs at this time due to lockdown."}
 	errShuttingDown                               = &types.InternalServiceError{Message: "Shutting down"}
 
 	// err for archival

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -927,7 +927,7 @@ func (s *workflowHandlerSuite) TestUpdateDomain_Success_GracefulFailOver() {
 func (s *workflowHandlerSuite) TestUpdateDomain_Failure_FailoverLockdown() {
 
 	dynamicClient := dc.NewInMemoryClient()
-	dynamicClient.UpdateValue(dc.SystemLockdown, map[string]interface{}{"SystemLockdown": true})
+	dynamicClient.UpdateValue(dc.Lockdown, map[string]interface{}{"Lockdown": true})
 	wh := s.getWorkflowHandler(s.newConfig(dynamicClient))
 
 	updateReq := updateFailoverRequest(

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -886,7 +886,7 @@ func (s *workflowHandlerSuite) TestUpdateDomain_Success_ArchivalNeverEnabledToEn
 	s.Equal(types.ArchivalStatusEnabled, result.Configuration.GetVisibilityArchivalStatus())
 	s.Equal(testVisibilityArchivalURI, result.Configuration.GetVisibilityArchivalURI())
 }
-func (s *workflowHandlerSuite) TestUpdateDomain_Success_GracefulFailOver() {
+func (s *workflowHandlerSuite) TestUpdateDomain_Success_FailOver() {
 	s.mockMetadataMgr.On("GetMetadata", mock.Anything).Return(&persistence.GetMetadataResponse{
 		NotificationVersion: int64(0),
 	}, nil)

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -927,7 +927,7 @@ func (s *workflowHandlerSuite) TestUpdateDomain_Success_GracefulFailOver() {
 func (s *workflowHandlerSuite) TestUpdateDomain_Failure_FailoverLockdown() {
 
 	dynamicClient := dc.NewInMemoryClient()
-	dynamicClient.UpdateValue(dc.SystemLockdown, map[string]interface{}{"SystemLockdown": "system.lockdown"})
+	dynamicClient.UpdateValue(dc.SystemLockdown, map[string]interface{}{"SystemLockdown": true})
 	wh := s.getWorkflowHandler(s.newConfig(dynamicClient))
 
 	updateReq := updateFailoverRequest(
@@ -938,8 +938,8 @@ func (s *workflowHandlerSuite) TestUpdateDomain_Failure_FailoverLockdown() {
 		common.Int32Ptr(1),
 		common.StringPtr(cluster.TestAlternativeClusterName),
 	)
-	_, err := wh.UpdateDomain(context.Background(), updateReq)
-
+	resp, err := wh.UpdateDomain(context.Background(), updateReq)
+	s.Nil(resp)
 	s.Error(err)
 }
 

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -886,6 +886,62 @@ func (s *workflowHandlerSuite) TestUpdateDomain_Success_ArchivalNeverEnabledToEn
 	s.Equal(types.ArchivalStatusEnabled, result.Configuration.GetVisibilityArchivalStatus())
 	s.Equal(testVisibilityArchivalURI, result.Configuration.GetVisibilityArchivalURI())
 }
+func (s *workflowHandlerSuite) TestUpdateDomain_Success_GracefulFailOver() {
+	s.mockMetadataMgr.On("GetMetadata", mock.Anything).Return(&persistence.GetMetadataResponse{
+		NotificationVersion: int64(0),
+	}, nil)
+	getDomainResp := persistenceGetDomainResponseForFailoverTest(
+		&domain.ArchivalState{Status: types.ArchivalStatusDisabled, URI: ""},
+		&domain.ArchivalState{Status: types.ArchivalStatusDisabled, URI: ""},
+	)
+
+	s.mockMetadataMgr.On("GetDomain", mock.Anything, mock.Anything).Return(getDomainResp, nil)
+	s.mockMetadataMgr.On("UpdateDomain", mock.Anything, mock.Anything).Return(nil)
+	s.mockClusterMetadata.EXPECT().GetAllClusterInfo().Return(cluster.TestAllClusterInfo).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetCurrentClusterName().Return(cluster.TestAlternativeClusterName).AnyTimes()
+	s.mockClusterMetadata.EXPECT().GetNextFailoverVersion(gomock.Any(), gomock.Any()).Return(int64(123)).AnyTimes()
+	s.mockArchivalMetadata.On("GetHistoryConfig").Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("disabled"), dc.GetBoolPropertyFn(false), "disabled", "some random URI"))
+	s.mockArchivalMetadata.On("GetVisibilityConfig").Return(archiver.NewArchivalConfig("enabled", dc.GetStringPropertyFn("disabled"), dc.GetBoolPropertyFn(false), "disabled", "some random URI"))
+	s.mockProducer.On("Publish", mock.Anything, mock.Anything).Return(nil).Once()
+	s.mockResource.RemoteFrontendClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any()).
+		Return(describeDomainResponseServer, nil).AnyTimes()
+
+	wh := s.getWorkflowHandler(s.newConfig(dc.NewInMemoryClient()))
+
+	updateReq := updateFailoverRequest(
+		common.StringPtr(testHistoryArchivalURI),
+		types.ArchivalStatusEnabled.Ptr(),
+		common.StringPtr(testVisibilityArchivalURI),
+		types.ArchivalStatusEnabled.Ptr(),
+		common.Int32Ptr(1),
+		common.StringPtr(cluster.TestAlternativeClusterName),
+	)
+	result, err := wh.UpdateDomain(context.Background(), updateReq)
+
+	s.NoError(err)
+	s.NotNil(result)
+	s.NotNil(result.Configuration)
+	s.Equal(result.ReplicationConfiguration.ActiveClusterName, cluster.TestAlternativeClusterName)
+}
+
+func (s *workflowHandlerSuite) TestUpdateDomain_Failure_FailoverLockdown() {
+
+	dynamicClient := dc.NewInMemoryClient()
+	dynamicClient.UpdateValue(dc.SystemLockdown, map[string]interface{}{"SystemLockdown": "system.lockdown"})
+	wh := s.getWorkflowHandler(s.newConfig(dynamicClient))
+
+	updateReq := updateFailoverRequest(
+		common.StringPtr(testHistoryArchivalURI),
+		types.ArchivalStatusEnabled.Ptr(),
+		common.StringPtr(testVisibilityArchivalURI),
+		types.ArchivalStatusEnabled.Ptr(),
+		common.Int32Ptr(1),
+		common.StringPtr(cluster.TestAlternativeClusterName),
+	)
+	_, err := wh.UpdateDomain(context.Background(), updateReq)
+
+	s.Error(err)
+}
 
 func (s *workflowHandlerSuite) TestHistoryArchived() {
 	wh := s.getWorkflowHandler(s.newConfig(dc.NewInMemoryClient()))
@@ -1488,6 +1544,25 @@ func updateRequest(
 	}
 }
 
+func updateFailoverRequest(
+	historyArchivalURI *string,
+	historyArchivalStatus *types.ArchivalStatus,
+	visibilityArchivalURI *string,
+	visibilityArchivalStatus *types.ArchivalStatus,
+	failoverTimeoutInSeconds *int32,
+	activeClusterName *string,
+) *types.UpdateDomainRequest {
+	return &types.UpdateDomainRequest{
+		Name:                     "test-name",
+		HistoryArchivalStatus:    historyArchivalStatus,
+		HistoryArchivalURI:       historyArchivalURI,
+		VisibilityArchivalStatus: visibilityArchivalStatus,
+		VisibilityArchivalURI:    visibilityArchivalURI,
+		FailoverTimeoutInSeconds: failoverTimeoutInSeconds,
+		ActiveClusterName:        activeClusterName,
+	}
+}
+
 func persistenceGetDomainResponse(historyArchivalState, visibilityArchivalState *domain.ArchivalState) *persistence.GetDomainResponse {
 	return &persistence.GetDomainResponse{
 		Info: &persistence.DomainInfo{
@@ -1515,6 +1590,40 @@ func persistenceGetDomainResponse(historyArchivalState, visibilityArchivalState 
 			},
 		},
 		IsGlobalDomain:              false,
+		ConfigVersion:               0,
+		FailoverVersion:             0,
+		FailoverNotificationVersion: 0,
+		NotificationVersion:         0,
+	}
+}
+
+func persistenceGetDomainResponseForFailoverTest(historyArchivalState, visibilityArchivalState *domain.ArchivalState) *persistence.GetDomainResponse {
+	return &persistence.GetDomainResponse{
+		Info: &persistence.DomainInfo{
+			ID:          "test-id",
+			Name:        "test-name",
+			Status:      0,
+			Description: "test-description",
+			OwnerEmail:  "test-owner-email",
+			Data:        make(map[string]string),
+		},
+		Config: &persistence.DomainConfig{
+			Retention:                1,
+			EmitMetric:               true,
+			HistoryArchivalStatus:    historyArchivalState.Status,
+			HistoryArchivalURI:       historyArchivalState.URI,
+			VisibilityArchivalStatus: visibilityArchivalState.Status,
+			VisibilityArchivalURI:    visibilityArchivalState.URI,
+		},
+		ReplicationConfig: &persistence.DomainReplicationConfig{
+			ActiveClusterName: cluster.TestCurrentClusterName,
+			Clusters: []*persistence.ClusterReplicationConfig{
+				{
+					ClusterName: cluster.TestAlternativeClusterName,
+				},
+			},
+		},
+		IsGlobalDomain:              true,
 		ConfigVersion:               0,
 		FailoverVersion:             0,
 		FailoverNotificationVersion: 0,
@@ -1566,4 +1675,27 @@ func listArchivedWorkflowExecutionsTestRequest() *types.ListArchivedWorkflowExec
 		PageSize: 10,
 		Query:    "some random query string",
 	}
+}
+
+var describeDomainResponseServer = &types.DescribeDomainResponse{
+	DomainInfo: &types.DomainInfo{
+		Name:        "test-domain",
+		Description: "a test domain",
+		OwnerEmail:  "test@uber.com",
+	},
+	Configuration: &types.DomainConfiguration{
+		WorkflowExecutionRetentionPeriodInDays: 3,
+		EmitMetric:                             true,
+	},
+	ReplicationConfiguration: &types.DomainReplicationConfiguration{
+		ActiveClusterName: cluster.TestCurrentClusterName,
+		Clusters: []*types.ClusterReplicationConfiguration{
+			{
+				ClusterName: cluster.TestCurrentClusterName,
+			},
+			{
+				ClusterName: cluster.TestAlternativeClusterName,
+			},
+		},
+	},
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What Changed?**
Added support for locking down a cluster when we don't want to allow domains to be failed over to it if the cluster is already at capacity


<!-- Tell your future self why have you made these changes -->
**Why?**
In certain cases where clusters are already running at capacity failing over additional traffic can have harmful effects.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests for both a successful failover when cluster isn't in lockdown and unit tests for failed when cluster is in lockdown.
Was also able to spin up 2 clusters using docker ui voodoo to verify end to end on local machine.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential Risks**
Nothing should happen initially since default value is false and the blocking code will never be reached.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
