### PR TITLE
Only update maxReadLevel after successful re-acquire of shard

### DIFF
--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -74,6 +74,7 @@ type (
 		historyEngine    *historyEngineImpl
 		mockExecutionMgr *mocks.ExecutionManager
 		mockHistoryV2Mgr *mocks.HistoryV2Manager
+		mockShardManager *mocks.ShardManager
 
 		config *config.Config
 		logger log.Logger
@@ -115,6 +116,7 @@ func (s *engine2Suite) SetupTest() {
 	s.mockDomainCache = s.mockShard.Resource.DomainCache
 	s.mockExecutionMgr = s.mockShard.Resource.ExecutionMgr
 	s.mockHistoryV2Mgr = s.mockShard.Resource.HistoryMgr
+	s.mockShardManager = s.mockShard.Resource.ShardMgr
 	s.mockClusterMetadata = s.mockShard.Resource.ClusterMetadata
 	s.mockEventsCache = s.mockShard.MockEventsCache
 	testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
@@ -1300,6 +1302,7 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_CreateTimeout() {
 	s.mockExecutionMgr.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(nil, notExistErr).Once()
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&p.AppendHistoryNodesResponse{Size: 0}, nil).Once()
 	s.mockExecutionMgr.On("CreateWorkflowExecution", mock.Anything, mock.Anything).Return(nil, &p.TimeoutError{}).Once()
+	s.mockShardManager.On("UpdateShard", mock.Anything, mock.Anything).Return(nil).Once()
 
 	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.True(p.IsTimeoutError(err))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
cherry pick https://github.com/temporalio/temporal/pull/2272 from temporal

> we shouldn't update maxReadLevel immediately when we attempt to reacquire the rangeid lock in the background, we should do it only after a successful re-acquisition (which on cassandra implies that the previous unknown transaction definitively succeeded or failed).

<!-- Tell your future self why have you made these changes -->
**Why?**
see https://github.com/temporalio/temporal/pull/2272

> If maxReadLevel is updated, readers catch up to it, and then the original transaction actually gets applied and becomes visible later, then we'd lose tasks.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
