### PR TITLE
Allow decoding thrift from base64 string via CLI

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -936,12 +936,16 @@ func newDBCommands() []cli.Command {
 		},
 		{
 			Name:  "decode_thrift",
-			Usage: "decode thrift object of HEX, print into JSON if the HEX data is matching with any supported struct",
+			Usage: "decode thrift object, print into JSON if the data is matching with any supported struct",
 			Flags: []cli.Flag{
 				cli.StringFlag{
 					Name:   FlagInputWithAlias,
 					EnvVar: "Input",
-					Usage:  "HEX input of the binary data, you may get from database query like SELECT HEX(...) FROM ...",
+					Usage:  "Input of Thrift encoded data structure.",
+				},
+				cli.StringFlag{
+					Name:  FlagInputEncodingWithAlias,
+					Usage: "Encoding of the input: [hex|base64] (Default: hex)",
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -82,6 +82,8 @@ const (
 	FlagInputWithAlias                    = FlagInput + ", i"
 	FlagInputFile                         = "input_file"
 	FlagInputFileWithAlias                = FlagInputFile + ", if"
+	FlagInputEncoding                     = "encoding"
+	FlagInputEncodingWithAlias            = FlagInputEncoding + ", enc"
 	FlagSignalInput                       = "signal_input"
 	FlagSignalInputWithAlias              = FlagSignalInput + ", si"
 	FlagSignalInputFile                   = "signal_input_file"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added additional option to decode Thrift data structure from base64 string (instead of hex encoded).

<!-- Tell your future self why have you made these changes -->
**Why?**
Encoded thrift payload is often represented as base64 string (instead of hex). This will allow decoding such strings easier.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tried running `./cadence admin db decode_thrift -enc base64 -i ...`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
