### PR TITLE
Log error when fetchHistoryFromRemote fails

### DIFF
--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -606,7 +606,7 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 	_ context.Context,
 	taskInfo Info,
 	postActionInfo interface{},
-	log log.Logger,
+	_ log.Logger,
 ) error {
 
 	if postActionInfo == nil {
@@ -645,7 +645,9 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 			tag.WorkflowDomainID(transferTask.DomainID),
 			tag.WorkflowID(transferTask.WorkflowID),
 			tag.WorkflowRunID(transferTask.RunID),
-			tag.SourceCluster(t.clusterName))
+			tag.SourceCluster(t.clusterName),
+			tag.Error(err),
+		)
 	}
 
 	// return error so task processing logic will retry


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding error tag to expose more details on why the resender has failed

<!-- Tell your future self why have you made these changes -->
**Why?**
It will help to diagnose replication errors better

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
