### PR TITLE
Improve task re-dispatch error logging

### DIFF
--- a/common/ndc/history_resender.go
+++ b/common/ndc/history_resender.go
@@ -25,6 +25,7 @@ package ndc
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	adminClient "github.com/uber/cadence/client/admin"
@@ -141,13 +142,9 @@ func (n *HistoryResenderImpl) SendSingleWorkflowHistory(
 	for historyIterator.HasNext() {
 		result, err := historyIterator.Next()
 		if err != nil {
-			n.logger.Error("failed to get history events",
-				tag.WorkflowDomainID(domainID),
-				tag.WorkflowID(workflowID),
-				tag.WorkflowRunID(runID),
-				tag.Error(err))
-			return err
+			return fmt.Errorf("history iterator: %w", err)
 		}
+
 		historyBatch := result.(*historyBatch)
 		replicationRequest := n.createReplicationRawRequest(
 			domainID,
@@ -164,22 +161,12 @@ func (n *HistoryResenderImpl) SendSingleWorkflowHistory(
 		case *types.EntityNotExistsError:
 			// Case 1: the workflow pass the retention period
 			// Case 2: the workflow is corrupted
-			if skipTask := n.fixCurrentExecution(
-				ctx,
-				domainID,
-				workflowID,
-				runID,
-			); skipTask {
+			if skipTask := n.fixCurrentExecution(ctx, domainID, workflowID, runID); skipTask {
 				return ErrSkipTask
 			}
 			return err
 		default:
-			n.logger.Error("failed to replicate events",
-				tag.WorkflowDomainID(domainID),
-				tag.WorkflowID(workflowID),
-				tag.WorkflowRunID(runID),
-				tag.Error(err))
-			return err
+			return fmt.Errorf("sending replication request: %w", err)
 		}
 	}
 	return nil
@@ -270,12 +257,9 @@ func (n *HistoryResenderImpl) getHistory(
 	pageSize int32,
 ) (*types.GetWorkflowExecutionRawHistoryV2Response, error) {
 
-	logger := n.logger.WithTags(tag.WorkflowRunID(runID))
-
 	domainName, err := n.domainCache.GetDomainName(domainID)
 	if err != nil {
-		logger.Error("error getting domain", tag.Error(err))
-		return nil, err
+		return nil, fmt.Errorf("getting domain: %w", err)
 	}
 
 	ctx, cancel := context.WithTimeout(ctx, resendContextTimeout)
@@ -294,7 +278,7 @@ func (n *HistoryResenderImpl) getHistory(
 		NextPageToken:     token,
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("getting history: %w", err)
 	}
 
 	return response, nil

--- a/common/ndc/history_resender.go
+++ b/common/ndc/history_resender.go
@@ -294,7 +294,6 @@ func (n *HistoryResenderImpl) getHistory(
 		NextPageToken:     token,
 	})
 	if err != nil {
-		logger.Error("error getting history", tag.Error(err))
 		return nil, err
 	}
 

--- a/common/persistence/versionHistory.go
+++ b/common/persistence/versionHistory.go
@@ -303,7 +303,7 @@ func (v *VersionHistory) GetFirstItem() (*VersionHistoryItem, error) {
 func (v *VersionHistory) GetLastItem() (*VersionHistoryItem, error) {
 
 	if len(v.Items) == 0 {
-		return nil, &types.BadRequestError{Message: "version history is empty."}
+		return nil, &types.BadRequestError{Message: "version history is empty"}
 	}
 
 	return v.Items[len(v.Items)-1].Duplicate(), nil
@@ -440,7 +440,7 @@ func (h *VersionHistories) GetVersionHistory(
 ) (*VersionHistory, error) {
 
 	if branchIndex < 0 || branchIndex >= len(h.Histories) {
-		return nil, &types.BadRequestError{Message: "invalid branch index."}
+		return nil, &types.BadRequestError{Message: fmt.Sprintf("getting branch index: %d, available branch count: %d", branchIndex, len(h.Histories))}
 	}
 
 	return h.Histories[branchIndex], nil

--- a/service/history/task/standby_task_util.go
+++ b/service/history/task/standby_task_util.go
@@ -53,7 +53,7 @@ func standbyTaskPostActionNoOp(
 	}
 
 	// return error so task processing logic will retry
-	return &RedispatchError{Reason: fmt.Sprintf("post action is %T", postActionInfo)}
+	return &redispatchError{Reason: fmt.Sprintf("post action is %T", postActionInfo)}
 }
 
 func standbyTransferTaskPostActionTaskDiscarded(

--- a/service/history/task/standby_task_util.go
+++ b/service/history/task/standby_task_util.go
@@ -22,9 +22,11 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/uber/cadence/common"
+
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
@@ -43,7 +45,7 @@ func standbyTaskPostActionNoOp(
 	ctx context.Context,
 	taskInfo Info,
 	postActionInfo interface{},
-	logger log.Logger,
+	_ log.Logger,
 ) error {
 
 	if postActionInfo == nil {
@@ -51,7 +53,7 @@ func standbyTaskPostActionNoOp(
 	}
 
 	// return error so task processing logic will retry
-	return ErrTaskRedispatch
+	return &RedispatchError{Reason: fmt.Sprintf("post action is %T", postActionInfo)}
 }
 
 func standbyTransferTaskPostActionTaskDiscarded(
@@ -120,16 +122,6 @@ type (
 	}
 )
 
-func newHistoryResendInfo(
-	lastEventID int64,
-	lastEventVersion int64,
-) *historyResendInfo {
-	return &historyResendInfo{
-		lastEventID:      common.Int64Ptr(lastEventID),
-		lastEventVersion: common.Int64Ptr(lastEventVersion),
-	}
-}
-
 func newPushActivityToMatchingInfo(
 	activityScheduleToStartTimeout int32,
 ) *pushActivityToMatchingInfo {
@@ -166,7 +158,10 @@ func getHistoryResendInfo(
 	if err != nil {
 		return nil, err
 	}
-	return newHistoryResendInfo(lastItem.EventID, lastItem.Version), nil
+	return &historyResendInfo{
+		lastEventID:      common.Int64Ptr(lastItem.EventID),
+		lastEventVersion: common.Int64Ptr(lastItem.Version),
+	}, nil
 }
 
 func getStandbyPostActionFn(

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -51,18 +51,18 @@ const (
 	stickyTaskMaxRetryCount = 100
 )
 
-// RedispatchError is the error indicating that the timer / transfer task should be redispatched and retried.
-type RedispatchError struct {
+// redispatchError is the error indicating that the timer / transfer task should be redispatched and retried.
+type redispatchError struct {
 	Reason string
 }
 
 // Error explains why this task should be redispatched
-func (r *RedispatchError) Error() string {
+func (r *redispatchError) Error() string {
 	return fmt.Sprintf("Redispatch reason: %q", r.Reason)
 }
 
 func isRedispatchErr(err error) bool {
-	var redispatchErr *RedispatchError
+	var redispatchErr *redispatchError
 	return errors.As(err, &redispatchErr)
 }
 

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -22,6 +22,7 @@ package task
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 
@@ -50,11 +51,24 @@ const (
 	stickyTaskMaxRetryCount = 100
 )
 
+// RedispatchError is the error indicating that the timer / transfer task should be redispatched and retried.
+type RedispatchError struct {
+	Reason string
+}
+
+// Error explains why this task should be redispatched
+func (r *RedispatchError) Error() string {
+	return fmt.Sprintf("Redispatch reason: %q", r.Reason)
+}
+
+func isRedispatchErr(err error) bool {
+	var redispatchErr *RedispatchError
+	return errors.As(err, &redispatchErr)
+}
+
 var (
 	// ErrTaskDiscarded is the error indicating that the timer / transfer task is pending for too long and discarded.
 	ErrTaskDiscarded = errors.New("passive task pending for too long")
-	// ErrTaskRedispatch is the error indicating that the timer / transfer task should be re0dispatched and retried.
-	ErrTaskRedispatch = errors.New("passive task should be redispatched due to condition in mutable state is not met")
 	// ErrTaskPendingActive is the error indicating that the task should be re-dispatched
 	ErrTaskPendingActive = errors.New("redispatch the task while the domain is pending-active")
 )
@@ -241,7 +255,11 @@ func (t *taskImpl) HandleErr(
 			if t.attempt > t.criticalRetryCount() {
 				t.scope.RecordTimer(metrics.TaskAttemptTimerPerDomain, time.Duration(t.attempt))
 				t.logger.Error("Critical error processing task, retrying.",
-					tag.Error(err), tag.OperationCritical, tag.TaskType(t.GetTaskType()))
+					tag.Error(err),
+					tag.OperationCritical,
+					tag.TaskType(t.GetTaskType()),
+				)
+
 				t.reportCorruptWorkflowToWatchDog()
 			}
 		}
@@ -274,7 +292,7 @@ func (t *taskImpl) HandleErr(
 	}
 
 	// this is a transient error
-	if err == ErrTaskRedispatch {
+	if isRedispatchErr(err) {
 		t.scope.IncCounter(metrics.TaskStandbyRetryCounterPerDomain)
 		return err
 	}
@@ -336,7 +354,7 @@ func (t *taskImpl) HandleErr(
 func (t *taskImpl) RetryErr(
 	err error,
 ) bool {
-	if err == errWorkflowBusy || err == ErrTaskRedispatch || err == ErrTaskPendingActive || common.IsContextTimeoutError(err) {
+	if err == errWorkflowBusy || isRedispatchErr(err) || err == ErrTaskPendingActive || common.IsContextTimeoutError(err) {
 		return false
 	}
 

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -137,7 +137,7 @@ func (s *taskSuite) TestHandleErr_ErrTaskRetry() {
 		return true, nil
 	}, nil)
 
-	err := &RedispatchError{Reason: "random-reason"}
+	err := &redispatchError{Reason: "random-reason"}
 	s.Equal(err, taskBase.HandleErr(err))
 }
 

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -137,8 +137,8 @@ func (s *taskSuite) TestHandleErr_ErrTaskRetry() {
 		return true, nil
 	}, nil)
 
-	err := ErrTaskRedispatch
-	s.Equal(ErrTaskRedispatch, taskBase.HandleErr(err))
+	err := &RedispatchError{Reason: "random-reason"}
+	s.Equal(err, taskBase.HandleErr(err))
 }
 
 func (s *taskSuite) TestHandleErr_ErrTaskDiscarded() {

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -496,7 +496,7 @@ func (t *timerStandbyTaskExecutor) fetchHistoryFromRemote(
 	}
 
 	// return error so task processing logic will retry
-	return &RedispatchError{Reason: "fetchHistoryFromRemote"}
+	return &redispatchError{Reason: "fetchHistoryFromRemote"}
 }
 
 func (t *timerStandbyTaskExecutor) getCurrentTime() time.Time {

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -272,7 +272,7 @@ func (t *timerStandbyTaskExecutor) executeDecisionTimeoutTask(
 	timerTask *persistence.TimerTaskInfo,
 ) error {
 
-	// decision schedule to start timer won't be generate for sticky decision,
+	// decision schedule to start timer won't be generated for sticky decision,
 	// since sticky is cleared when applying events on passive.
 	// for normal decision, we don't know if a schedule to start timeout timer
 	// is generated or not since it's based on a dynamicconfig. On passive cluster,
@@ -418,7 +418,7 @@ func (t *timerStandbyTaskExecutor) processTimer(
 		return err
 	}
 	defer func() {
-		if retError == ErrTaskRedispatch {
+		if isRedispatchErr(retError) {
 			release(nil)
 		} else {
 			release(retError)
@@ -451,14 +451,14 @@ func (t *timerStandbyTaskExecutor) fetchHistoryFromRemote(
 	_ context.Context,
 	taskInfo Info,
 	postActionInfo interface{},
-	log log.Logger,
+	_ log.Logger,
 ) error {
 
 	if postActionInfo == nil {
 		return nil
 	}
 
-	timerTask := taskInfo.(*persistence.TimerTaskInfo)
+	task := taskInfo.(*persistence.TimerTaskInfo)
 	resendInfo := postActionInfo.(*historyResendInfo)
 
 	t.metricsClient.IncCounter(metrics.HistoryRereplicationByTimerTaskScope, metrics.CadenceClientRequests)
@@ -470,9 +470,9 @@ func (t *timerStandbyTaskExecutor) fetchHistoryFromRemote(
 		// note history resender doesn't take in a context parameter, there's a separate dynamicconfig for
 		// controlling the timeout for resending history.
 		err = t.historyResender.SendSingleWorkflowHistory(
-			timerTask.DomainID,
-			timerTask.WorkflowID,
-			timerTask.RunID,
+			task.DomainID,
+			task.WorkflowID,
+			task.RunID,
 			resendInfo.lastEventID,
 			resendInfo.lastEventVersion,
 			nil,
@@ -480,21 +480,23 @@ func (t *timerStandbyTaskExecutor) fetchHistoryFromRemote(
 		)
 	} else {
 		err = &types.InternalServiceError{
-			Message: "timerQueueStandbyProcessor encounter empty historyResendInfo",
+			Message: fmt.Sprintf("incomplete historyResendInfo: %v", resendInfo),
 		}
 	}
 
 	if err != nil {
 		t.logger.Error("Error re-replicating history from remote.",
 			tag.ShardID(t.shard.GetShardID()),
-			tag.WorkflowDomainID(timerTask.DomainID),
-			tag.WorkflowID(timerTask.WorkflowID),
-			tag.WorkflowRunID(timerTask.RunID),
-			tag.ClusterName(t.clusterName))
+			tag.WorkflowDomainID(task.DomainID),
+			tag.WorkflowID(task.WorkflowID),
+			tag.WorkflowRunID(task.RunID),
+			tag.SourceCluster(t.clusterName),
+			tag.Error(err),
+		)
 	}
 
 	// return error so task processing logic will retry
-	return ErrTaskRedispatch
+	return &RedispatchError{Reason: "fetchHistoryFromRemote"}
 }
 
 func (t *timerStandbyTaskExecutor) getCurrentTime() time.Time {

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -190,7 +190,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -204,7 +204,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessUserTimerTimeout_Pending() {
 	).Return(nil).Times(1)
 
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.discardDuration))
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
@@ -337,7 +337,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -350,7 +350,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Pending() {
 		nil,
 	).Return(nil).Times(1)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.discardDuration))
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
@@ -575,7 +575,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -588,7 +588,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessDecisionTimeout_Pending() {
 		nil,
 	).Return(nil).Times(1)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.discardDuration))
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
@@ -670,7 +670,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pending(
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -683,7 +683,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowBackoffTimer_Pending(
 		nil,
 	).Return(nil).Times(1)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, time.Now().Add(s.discardDuration))
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
@@ -740,7 +740,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -753,7 +753,7 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessWorkflowTimeout_Pending() {
 		nil,
 	).Return(nil).Times(1)
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, s.now.Add(s.discardDuration))
 	err = s.timerStandbyTaskExecutor.Execute(timerTask, true)

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -22,6 +22,7 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -73,7 +74,6 @@ func (t *transferStandbyTaskExecutor) Execute(
 	task Task,
 	shouldProcessTask bool,
 ) error {
-
 	transferTask, ok := task.GetInfo().(*persistence.TransferTaskInfo)
 	if !ok {
 		return errUnexpectedTask
@@ -535,7 +535,7 @@ func (t *transferStandbyTaskExecutor) processTransfer(
 		return err
 	}
 	defer func() {
-		if retError == ErrTaskRedispatch {
+		if isRedispatchErr(err) {
 			release(nil)
 		} else {
 			release(retError)
@@ -613,7 +613,7 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 		return nil
 	}
 
-	transferTask := taskInfo.(*persistence.TransferTaskInfo)
+	task := taskInfo.(*persistence.TransferTaskInfo)
 	resendInfo := postActionInfo.(*historyResendInfo)
 
 	t.metricsClient.IncCounter(metrics.HistoryRereplicationByTransferTaskScope, metrics.CadenceClientRequests)
@@ -625,9 +625,9 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 		// note history resender doesn't take in a context parameter, there's a separate dynamicconfig for
 		// controlling the timeout for resending history.
 		err = t.historyResender.SendSingleWorkflowHistory(
-			transferTask.DomainID,
-			transferTask.WorkflowID,
-			transferTask.RunID,
+			task.DomainID,
+			task.WorkflowID,
+			task.RunID,
 			resendInfo.lastEventID,
 			resendInfo.lastEventVersion,
 			nil,
@@ -635,23 +635,23 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 		)
 	} else {
 		err = &types.InternalServiceError{
-			Message: "transferQueueStandbyProcessor encounter empty historyResendInfo",
+			Message: fmt.Sprintf("incomplete historyResendInfo: %v", resendInfo),
 		}
 	}
 
 	if err != nil {
 		t.logger.Error("Error re-replicating history from remote.",
 			tag.ShardID(t.shard.GetShardID()),
-			tag.WorkflowDomainID(transferTask.DomainID),
-			tag.WorkflowID(transferTask.WorkflowID),
-			tag.WorkflowRunID(transferTask.RunID),
+			tag.WorkflowDomainID(task.DomainID),
+			tag.WorkflowID(task.WorkflowID),
+			tag.WorkflowRunID(task.RunID),
 			tag.SourceCluster(t.clusterName),
 			tag.Error(err),
 		)
 	}
 
 	// return error so task processing logic will retry
-	return ErrTaskRedispatch
+	return &RedispatchError{Reason: "fetchHistoryFromRemote"}
 }
 
 func (t *transferStandbyTaskExecutor) getCurrentTime() time.Time {

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -651,7 +651,7 @@ func (t *transferStandbyTaskExecutor) fetchHistoryFromRemote(
 	}
 
 	// return error so task processing logic will retry
-	return &RedispatchError{Reason: "fetchHistoryFromRemote"}
+	return &redispatchError{Reason: "fetchHistoryFromRemote"}
 }
 
 func (t *transferStandbyTaskExecutor) getCurrentTime() time.Time {

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -205,7 +205,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 }
 
 func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending_PushToMatching() {
@@ -310,7 +310,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Pending() {
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 }
 
 func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Pending_PushToMatching() {
@@ -487,7 +487,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Pending() 
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -500,7 +500,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessCancelExecution_Pending() 
 		nil,
 	).Return(nil).Times(1)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
@@ -594,7 +594,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Pending() 
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -607,7 +607,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessSignalExecution_Pending() 
 		nil,
 	).Return(nil).Times(1)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
@@ -701,7 +701,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Pendin
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.fetchHistoryDuration))
 	s.mockNDCHistoryResender.EXPECT().SendSingleWorkflowHistory(
@@ -714,7 +714,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessStartChildExecution_Pendin
 		nil,
 	).Return(nil).Times(1)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
-	s.Equal(ErrTaskRedispatch, err)
+	s.True(isRedispatchErr(err))
 
 	s.mockShard.SetCurrentTime(s.clusterName, now.Add(s.discardDuration))
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding custom error type for task re-dispatching. 


<!-- Tell your future self why have you made these changes -->
**Why?**
Current logs are not exposing enough information to understand, why particular task was re-dispatched.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
