### PR TITLE
Fix error type returned from GetWorkflowExecution and DeleteWorkflowExecution

### DIFF
--- a/common/persistence/sql/sqlExecutionStore.go
+++ b/common/persistence/sql/sqlExecutionStore.go
@@ -344,14 +344,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 
 	err := g.Wait()
 	if err != nil {
-		switch err := err.(type) {
-		case *types.EntityNotExistsError:
-			return nil, err
-		default:
-			return nil, &types.InternalServiceError{
-				Message: fmt.Sprintf("GetWorkflowExecution: failed. Error: %v", err),
-			}
-		}
+		return nil, err
 	}
 
 	state, err := m.populateWorkflowMutableState(executions[0])
@@ -707,13 +700,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 		})
 		return e
 	})
-	err := g.Wait()
-	if err != nil {
-		return &types.InternalServiceError{
-			Message: fmt.Sprintf("DeleteWorkflowExecution: failed. Error: %v", err),
-		}
-	}
-	return nil
+	return g.Wait()
 }
 
 // its possible for a new run of the same workflow to have started after the run we are deleting


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Do not convert error returned from GetWorkflowExecution and DeleteWorkflowExecution to InternalServiceError

<!-- Tell your future self why have you made these changes -->
**Why?**
We have logic check error type from persistence layer and converting those errors to InternalServiceError results in unexpected behavior such as incorrect retry policy

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
