### PR TITLE
Forward activity responses and heartbeats on failover as well

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -343,12 +343,15 @@ type (
 		// 6. QueryWorkflow
 		// 7. ResetWorkflow
 		//
-		// Both "selected-apis-forwarding" and "all-domain-apis-forwarding" can work with EnableDomainNotActiveAutoForwarding dynamicconfig to select certain domains using the policy.
+		// 4) "selected-apis-forwarding-v2" will forward all of "selected-apis-forwarding", and also activity responses
+		// and heartbeats, but not other worker APIs.
 		//
-		// Usage recommendation: when enabling XDC(global domain) feature, either "all-domain-apis-forwarding" or "selected-apis-forwarding" should be used to ensure seamless domain failover(high availability)
-		// Depending on the cost of cross cluster calls :
+		// "selected-apis-forwarding(-v2)" and "all-domain-apis-forwarding" can work with EnableDomainNotActiveAutoForwarding dynamicconfig to select certain domains using the policy.
 		//
-		// 1) If the network communication overhead is high(e.g., clusters are in remote datacenters of different region), then should use "selected-apis-forwarding".
+		// Usage recommendation: when enabling XDC(global domain) feature, either "all-domain-apis-forwarding" or "selected-apis-forwarding(-v2)" should be used to ensure seamless domain failover(high availability)
+		// Depending on the cost of cross cluster calls:
+		//
+		// 1) If the network communication overhead is high(e.g., clusters are in remote datacenters of different region), then should use "selected-apis-forwarding(-v2)".
 		// But you must ensure a different set of workers with the same workflow & activity code are connected to each Cadence cluster.
 		//
 		// 2) If the network communication overhead is low (e.g. in the same datacenter, mostly for cluster migration usage), then you can use "all-domain-apis-forwarding". Then only one set of

--- a/service/frontend/clusterRedirectionHandler_test.go
+++ b/service/frontend/clusterRedirectionHandler_test.go
@@ -65,7 +65,10 @@ type (
 
 func TestForwardingPolicyV2ContainsV1(t *testing.T) {
 	require.NotEqual(t, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, selectedAPIsForwardingRedirectionPolicyAPIAllowlist)
-	require.Subset(t, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, selectedAPIsForwardingRedirectionPolicyAPIAllowlist)
+	for k := range selectedAPIsForwardingRedirectionPolicyAPIAllowlist {
+		_, ok := selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2[k]
+		require.True(t, ok, "v2 does not contain a key that is in v1: %v", k)
+	}
 }
 
 func TestClusterRedirectionHandlerSuite(t *testing.T) {

--- a/service/frontend/clusterRedirectionHandler_test.go
+++ b/service/frontend/clusterRedirectionHandler_test.go
@@ -63,6 +63,11 @@ type (
 	}
 )
 
+func TestForwardingPolicyV2ContainsV1(t *testing.T) {
+	require.NotEqual(t, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, selectedAPIsForwardingRedirectionPolicyAPIAllowlist)
+	require.Subset(t, selectedAPIsForwardingRedirectionPolicyAPIAllowlistV2, selectedAPIsForwardingRedirectionPolicyAPIAllowlist)
+}
+
 func TestClusterRedirectionHandlerSuite(t *testing.T) {
 	s := new(clusterRedirectionHandlerSuite)
 	suite.Run(t, s)

--- a/service/frontend/clusterRedirectionPolicy_test.go
+++ b/service/frontend/clusterRedirectionPolicy_test.go
@@ -149,6 +149,7 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) SetupTest() {
 		s.mockConfig,
 		s.mockDomainCache,
 		false,
+		selectedAPIsForwardingRedirectionPolicyAPIAllowlist,
 		"",
 	)
 }


### PR DESCRIPTION
We have a user desiring this, and in general it seems like a good idea.
Activities are generally assumed to be "high cost" to lose, or at least potentially.

Longer term, we should probably consider making this a per-domain config,
rather than something that is hardcoded for a whole cluster.  Nothing
about this seems like it would be cluster-bound.  For the current planned use
though, that's fine.