### PR TITLE
Remove unused PayloadSerializer param

### DIFF
--- a/common/ndc/history_resender_test.go
+++ b/common/ndc/history_resender_test.go
@@ -71,13 +71,6 @@ func TestHistoryResenderSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func (s *historyResenderSuite) SetupSuite() {
-}
-
-func (s *historyResenderSuite) TearDownSuite() {
-
-}
-
 func (s *historyResenderSuite) SetupTest() {
 	s.Assertions = require.New(s.T())
 
@@ -339,7 +332,7 @@ func (s *historyResenderSuite) TestGetHistory() {
 
 	out, err := s.rereplicator.getHistory(
 		context.Background(),
-		s.domainID,
+		s.domainName,
 		workflowID,
 		runID,
 		&startEventID,

--- a/common/ndc/history_resender_test.go
+++ b/common/ndc/history_resender_test.go
@@ -115,7 +115,6 @@ func (s *historyResenderSuite) SetupTest() {
 		func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 			return s.mockHistoryClient.ReplicateEventsV2(ctx, request)
 		},
-		persistence.NewPayloadSerializer(),
 		nil,
 		nil,
 		s.logger,
@@ -365,7 +364,6 @@ func (s *historyResenderSuite) TestCurrentExecutionCheck() {
 		func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 			return s.mockHistoryClient.ReplicateEventsV2(ctx, request)
 		},
-		persistence.NewPayloadSerializer(),
 		nil,
 		invariantMock,
 		s.logger,

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -1319,7 +1319,6 @@ func (adh *adminHandlerImpl) ResendReplicationTasks(
 		func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 			return adh.GetHistoryClient().ReplicateEventsV2(ctx, request)
 		},
-		adh.eventSerializer,
 		nil,
 		nil,
 		adh.GetLogger(),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -302,7 +302,6 @@ func NewEngineWithShardContext(
 			shard.GetDomainCache(),
 			adminRetryableClient,
 			resendFunc,
-			shard.GetService().GetPayloadSerializer(),
 			nil,
 			openExecutionCheck,
 			shard.GetLogger(),

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -117,10 +117,9 @@ func NewTimerQueueProcessor(
 			func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 				return historyEngine.ReplicateEventsV2(ctx, request)
 			},
-			shard.GetService().GetPayloadSerializer(),
 			config.StandbyTaskReReplicationContextTimeout,
 			executionCheck,
-			shard.GetLogger().WithTags(tag.ComponentHistoryResender),
+			shard.GetLogger(),
 		)
 		standbyTaskExecutor := task.NewTimerStandbyTaskExecutor(
 			shard,

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -128,10 +128,9 @@ func NewTransferQueueProcessor(
 			func(ctx context.Context, request *types.ReplicateEventsV2Request) error {
 				return historyEngine.ReplicateEventsV2(ctx, request)
 			},
-			shard.GetService().GetPayloadSerializer(),
 			config.StandbyTaskReReplicationContextTimeout,
 			executionCheck,
-			shard.GetLogger().WithTags(tag.ComponentHistoryResender),
+			shard.GetLogger(),
 		)
 		standbyTaskExecutor := task.NewTransferStandbyTaskExecutor(
 			shard,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
PayloadSerializer has been removed.

Additionally, getting domain name is moved up and done once. Fixed logger tagging.
