### PR TITLE
Security fix: Update PROPOSALS.md to not reference google groups

### DIFF
--- a/PROPOSALS.md
+++ b/PROPOSALS.md
@@ -21,7 +21,6 @@ The design process for changes to Cadence is modeled on the [proposal process us
   - The design doc should be linked from the opened GitHub issue.
   - The design doc should only allow edit access to authors of the document.
   - Do not create the document from a corporate G Suite account. If you want to edit from a corporate G Suite account then first create the document from a personal Google account and grant edit access to your corporate G Suite account.
-  - Comment access should be granted explicitly to [cadence-discussion@googlegroups.com](https://groups.google.com/d/forum/cadence-discussion) so that users viewing the document display under their account names rather than anonymous users.
   - Comment access should also be accessible by the public. Make sure this is the case by clicking "Share" and "Get shareable link" ensuring you select "Anyone with the link can comment".
   
 - Once comments and revisions on the design doc wind down, there is a final discussion about the proposal.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removing link to google group that has been compromised.

<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid phishing from hackers

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
