### PR TITLE
Fix error conversion for WorkflowExecutionAlreadyStartedError

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2061,7 +2061,7 @@ func (h *handlerImpl) convertError(err error) error {
 
 		return shard.CreateShardOwnershipLostError(h.GetHostInfo(), info)
 	case *persistence.WorkflowExecutionAlreadyStartedError:
-		return &types.InternalServiceError{Message: err.Msg}
+		return &types.WorkflowExecutionAlreadyStartedError{Message: err.Msg}
 	case *persistence.CurrentWorkflowConditionFailedError:
 		return &types.InternalServiceError{Message: err.Msg}
 	case *persistence.TransactionSizeLimitError:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Convert perisistence.WorkflowExecutionAlreadyStartedError to types.WorkflowExecutionAlreadyStartedError instead of types.InternalServiceError

<!-- Tell your future self why have you made these changes -->
**Why?**
We treat types.InternalServiceError as a server error in frontend, but WorkflowExecutionAlreadyStartedError should be an application error. And this affects our availability when customers keeps retrying on WorkflowExecutionAlreadyStartedError

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
It's possible that customers at client side check the error type, and since this change changes the error type, it could be a breaking change for the customers.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
