### PR TITLE
Log replication messages that did not fit

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -704,6 +704,21 @@ func TokenLastEventVersion(version int64) Tag {
 	return newInt64("xdc-token-last-event-version", version)
 }
 
+// ResponseSize returns tag for ResponseSize
+func ResponseSize(size int) Tag {
+	return newInt("response-size", size)
+}
+
+// ResponseTotalSize returns tag for ResponseTotalSize
+func ResponseTotalSize(size int) Tag {
+	return newInt("response-total-size", size)
+}
+
+// ResponseMaxSize returns tag for ResponseMaxSize
+func ResponseMaxSize(size int) Tag {
+	return newInt("response-max-size", size)
+}
+
 ///////////////////  Archival tags defined here: archival- ///////////////////
 // archival request tags
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
During fanout to multiple peers and collection of replication messages we collect responses up until the RPC message size limit. Remaining responses are discarded. They are expected to be picked up with next call.

However, there is not visibility whether (or how often) this is happening.

- Adding additional logging to emit which shards were discarded as well as info about sizes (max size, total size accumulated so far and current size that is out of limits).
- Also, instead of terminating early and returning partial response. Continue the loop and try other peer responses. They may be smaller and could still fit into the response.

<!-- Tell your future self why have you made these changes -->
**Why?**
For better visibility.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Deployed in our staging environment, reduced max rpc limit via dynamic config `system.grpcMaxSizeInByte` and checked that logs are emitted.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
