### PR TITLE
Fix CLI rendering long workflow types

### DIFF
--- a/tools/cli/render.go
+++ b/tools/cli/render.go
@@ -292,7 +292,7 @@ func trimString(str string, maxLength int) string {
 
 	items := strings.Split(str, "/")
 	lastItem := items[len(items)-1]
-	if len(str) < maxLength {
+	if len(lastItem) < maxLength {
 		return ".../" + lastItem
 	}
 

--- a/tools/cli/render_test.go
+++ b/tools/cli/render_test.go
@@ -71,7 +71,7 @@ func Test_RenderTable(t *testing.T) {
 			expectOutput: "" +
 				"        STRING        | INTEGER | BOOL  |   TIME   |    MAP     |  SLICE   \n" +
 				"  text                |     123 | true  | 03:04:05 | A:AA, B:BB | 1, 2, 3  \n" +
-				"  ...g long long long |     456 | false | 13:14:15 |            |          \n",
+				"  .../ string this is |     456 | false | 13:14:15 |            |          \n",
 		},
 		{
 			name: "a slice with rendering options",
@@ -80,7 +80,7 @@ func Test_RenderTable(t *testing.T) {
 			expectOutput: "" +
 				"        STRING        | INTEGER | BOOL  |         TIME         |    MAP      \n" +
 				"  text                |     123 | true  | 2000-01-02T03:04:05Z | A:AA, B:BB  \n" +
-				"  ...g long long long |     456 | false | 2000-11-12T13:14:15Z |             \n",
+				"  .../ string this is |     456 | false | 2000-11-12T13:14:15Z |             \n",
 		},
 		{
 			name:      "non-struct element",
@@ -136,7 +136,7 @@ func Test_RenderTemplate(t *testing.T) {
 			expectOutput: "" +
 				"        STRING        | INTEGER | BOOL  |   TIME   |    MAP     |  SLICE   \n" +
 				"  text                |     123 | true  | 03:04:05 | A:AA, B:BB | 1, 2, 3  \n" +
-				"  ...g long long long |     456 | false | 13:14:15 |            |          \n",
+				"  .../ string this is |     456 | false | 13:14:15 |            |          \n",
 		},
 		{
 			name:      "invalid template",
@@ -179,7 +179,7 @@ var testTable = []testRow{
 		SliceField:  []int{1, 2, 3},
 	},
 	{
-		StringField: "long long long long long long",
+		StringField: "very long/ string this is",
 		IntField:    456,
 		BoolField:   false,
 		TimeField:   time.Date(2000, 11, 12, 13, 14, 15, 16, time.Local),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed long workflow type rendering in CLI.

<!-- Tell your future self why have you made these changes -->
**Why?**
For certain strings it was panic'ing with `error calling table: runtime error: slice bounds out of range [-9:]`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test & locally to verify it is fixed

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
