### PR TITLE
Add metrics for empty reads

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -297,6 +297,8 @@ const (
 	PersistenceFetchDynamicConfigScope
 	// PersistenceUpdateDynamicConfigScope tracks UpdateDynamicConfig calls made by service to persistence layer
 	PersistenceUpdateDynamicConfigScope
+	// PersistenceEmptyResponseScope tracks empty read calls made by service to persistence layer
+	PersistenceEmptyResponseScope
 	// HistoryClientStartWorkflowExecutionScope tracks RPC calls to history service
 	HistoryClientStartWorkflowExecutionScope
 	// HistoryClientDescribeHistoryHostScope tracks RPC calls to history service
@@ -1306,6 +1308,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceGetDLQSizeScope:                               {operation: "GetDLQSize"},
 		PersistenceFetchDynamicConfigScope:                       {operation: "FetchDynamicConfig"},
 		PersistenceUpdateDynamicConfigScope:                      {operation: "UpdateDynamicConfig"},
+		PersistenceEmptyResponseScope:                            {operation: "EmptyServiceCallResponse"},
 
 		ClusterMetadataArchivalConfigScope: {operation: "ArchivalConfig"},
 
@@ -1811,6 +1814,7 @@ const (
 	PersistenceErrDomainAlreadyExistsCounter
 	PersistenceErrBadRequestCounter
 	PersistenceSampledCounter
+	PersistenceEmptyResponseCounter
 
 	CadenceClientRequests
 	CadenceClientFailures
@@ -2341,6 +2345,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PersistenceErrDomainAlreadyExistsCounter:            {metricName: "persistence_errors_domain_already_exists", metricType: Counter},
 		PersistenceErrBadRequestCounter:                     {metricName: "persistence_errors_bad_request", metricType: Counter},
 		PersistenceSampledCounter:                           {metricName: "persistence_sampled", metricType: Counter},
+		PersistenceEmptyResponseCounter:                     {metricName: "persistence_empty_response", metricType: Counter},
 		CadenceClientRequests:                               {metricName: "cadence_client_requests", metricType: Counter},
 		CadenceClientFailures:                               {metricName: "cadence_client_errors", metricType: Counter},
 		CadenceClientLatency:                                {metricName: "cadence_client_latency", metricType: Timer},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -297,8 +297,6 @@ const (
 	PersistenceFetchDynamicConfigScope
 	// PersistenceUpdateDynamicConfigScope tracks UpdateDynamicConfig calls made by service to persistence layer
 	PersistenceUpdateDynamicConfigScope
-	// PersistenceEmptyResponseScope tracks empty read calls made by service to persistence layer
-	PersistenceEmptyResponseScope
 	// HistoryClientStartWorkflowExecutionScope tracks RPC calls to history service
 	HistoryClientStartWorkflowExecutionScope
 	// HistoryClientDescribeHistoryHostScope tracks RPC calls to history service
@@ -1308,7 +1306,6 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceGetDLQSizeScope:                               {operation: "GetDLQSize"},
 		PersistenceFetchDynamicConfigScope:                       {operation: "FetchDynamicConfig"},
 		PersistenceUpdateDynamicConfigScope:                      {operation: "UpdateDynamicConfig"},
-		PersistenceEmptyResponseScope:                            {operation: "EmptyServiceCallResponse"},
 
 		ClusterMetadataArchivalConfigScope: {operation: "ArchivalConfig"},
 

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -33,7 +33,6 @@ const (
 
 	instance               = "instance"
 	domain                 = "domain"
-	operation              = "operation"
 	sourceCluster          = "source_cluster"
 	targetCluster          = "target_cluster"
 	activeCluster          = "active_cluster"
@@ -82,10 +81,6 @@ func metricWithUnknown(key, value string) Tag {
 // this converts that to an unknown domain.
 func DomainTag(value string) Tag {
 	return metricWithUnknown(domain, value)
-}
-
-func OperationTag(value string) Tag {
-	return metricWithUnknown(operation, value)
 }
 
 // DomainUnknownTag returns a new domain:unknown tag-value

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -33,6 +33,7 @@ const (
 
 	instance               = "instance"
 	domain                 = "domain"
+	operation              = "operation"
 	sourceCluster          = "source_cluster"
 	targetCluster          = "target_cluster"
 	activeCluster          = "active_cluster"
@@ -81,6 +82,10 @@ func metricWithUnknown(key, value string) Tag {
 // this converts that to an unknown domain.
 func DomainTag(value string) Tag {
 	return metricWithUnknown(domain, value)
+}
+
+func OperationTag(value string) Tag {
+	return metricWithUnknown(operation, value)
 }
 
 // DomainUnknownTag returns a new domain:unknown tag-value

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -437,8 +437,7 @@ func (p *workflowExecutionPersistenceClient) ListCurrentExecutions(
 		var err error
 		resp, err = p.persistence.ListCurrentExecutions(ctx, request)
 		if err == nil && len(resp.Executions) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("ListCurrentExecutions")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceListCurrentExecutionsScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -492,8 +491,7 @@ func (p *workflowExecutionPersistenceClient) GetTransferTasks(
 		var err error
 		resp, err = p.persistence.GetTransferTasks(ctx, request)
 		if err == nil && len(resp.Tasks) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("GetTransferTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceGetTransferTasksScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -513,8 +511,7 @@ func (p *workflowExecutionPersistenceClient) GetCrossClusterTasks(
 		var err error
 		resp, err = p.persistence.GetCrossClusterTasks(ctx, request)
 		if err == nil && len(resp.Tasks) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("GetCrossClusterTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceGetCrossClusterTasksScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -534,8 +531,7 @@ func (p *workflowExecutionPersistenceClient) GetReplicationTasks(
 		var err error
 		resp, err = p.persistence.GetReplicationTasks(ctx, request)
 		if err == nil && len(resp.Tasks) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("GetReplicationTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceGetReplicationTasksScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -646,8 +642,7 @@ func (p *workflowExecutionPersistenceClient) GetReplicationTasksFromDLQ(
 		var err error
 		resp, err = p.persistence.GetReplicationTasksFromDLQ(ctx, request)
 		if err == nil && len(resp.Tasks) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("GetReplicationTasksFromDLQ")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceGetReplicationTasksFromDLQScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -721,8 +716,7 @@ func (p *workflowExecutionPersistenceClient) GetTimerIndexTasks(
 		var err error
 		resp, err = p.persistence.GetTimerIndexTasks(ctx, request)
 		if err == nil && len(resp.Timers) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("GetTimerIndexTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceGetTimerIndexTasksScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -794,8 +788,7 @@ func (p *taskPersistenceClient) GetTasks(
 		var err error
 		resp, err = p.persistence.GetTasks(ctx, request)
 		if err == nil && len(resp.Tasks) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("GetTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceGetTasksScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -989,8 +982,7 @@ func (p *metadataPersistenceClient) ListDomains(
 		var err error
 		resp, err = p.persistence.ListDomains(ctx, request)
 		if err == nil && len(resp.Domains) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("ListDomains")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceListDomainScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -1292,8 +1284,7 @@ func (p *historyPersistenceClient) ReadHistoryBranch(
 		var err error
 		resp, err = p.persistence.ReadHistoryBranch(ctx, request)
 		if err == nil && len(resp.HistoryEvents) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("ReadHistoryBranch")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceReadHistoryBranchScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -1378,8 +1369,7 @@ func (p *historyPersistenceClient) GetAllHistoryTreeBranches(
 		var err error
 		resp, err = p.persistence.GetAllHistoryTreeBranches(ctx, request)
 		if err == nil && len(resp.Branches) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("GetAllHistoryTreeBranches")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceGetAllHistoryTreeBranchesScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}
@@ -1428,8 +1418,7 @@ func (p *queuePersistenceClient) ReadMessages(
 		var err error
 		resp, err = p.persistence.ReadMessages(ctx, lastMessageID, maxCount)
 		if err == nil && len(resp) == 0 {
-			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
-				metrics.OperationTag("ReadMessages")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+			p.metricClient.IncCounter(metrics.PersistenceReadQueueMessagesScope, metrics.PersistenceEmptyResponseCounter)
 		}
 		return err
 	}

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -487,6 +487,10 @@ func (p *workflowExecutionPersistenceClient) GetTransferTasks(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.GetTransferTasks(ctx, request)
+		if err == nil && len(resp.Tasks) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("GetTransferTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceGetTransferTasksScope, op)
@@ -504,6 +508,10 @@ func (p *workflowExecutionPersistenceClient) GetCrossClusterTasks(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.GetCrossClusterTasks(ctx, request)
+		if err == nil && len(resp.Tasks) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("GetCrossClusterTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceGetCrossClusterTasksScope, op)
@@ -521,6 +529,10 @@ func (p *workflowExecutionPersistenceClient) GetReplicationTasks(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.GetReplicationTasks(ctx, request)
+		if err == nil && len(resp.Tasks) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("GetReplicationTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceGetReplicationTasksScope, op)
@@ -700,6 +712,10 @@ func (p *workflowExecutionPersistenceClient) GetTimerIndexTasks(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.GetTimerIndexTasks(ctx, request)
+		if err == nil && len(resp.Timers) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("GetTimerIndexTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceGetTimerIndexTasksScope, op)
@@ -769,6 +785,10 @@ func (p *taskPersistenceClient) GetTasks(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.GetTasks(ctx, request)
+		if err == nil && len(resp.Tasks) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("GetTasks")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceGetTasksScope, op)
@@ -1259,6 +1279,10 @@ func (p *historyPersistenceClient) ReadHistoryBranch(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.ReadHistoryBranch(ctx, request)
+		if err == nil && len(resp.HistoryEvents) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("ReadHistoryBranch")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceReadHistoryBranchScope, op)

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -436,6 +436,10 @@ func (p *workflowExecutionPersistenceClient) ListCurrentExecutions(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.ListCurrentExecutions(ctx, request)
+		if err == nil && len(resp.Executions) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("ListCurrentExecutions")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceListCurrentExecutionsScope, op)
@@ -641,6 +645,10 @@ func (p *workflowExecutionPersistenceClient) GetReplicationTasksFromDLQ(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.GetReplicationTasksFromDLQ(ctx, request)
+		if err == nil && len(resp.Tasks) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("GetReplicationTasksFromDLQ")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceGetReplicationTasksFromDLQScope, op)
@@ -980,6 +988,10 @@ func (p *metadataPersistenceClient) ListDomains(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.ListDomains(ctx, request)
+		if err == nil && len(resp.Domains) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("ListDomains")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceListDomainScope, op)
@@ -1365,6 +1377,10 @@ func (p *historyPersistenceClient) GetAllHistoryTreeBranches(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.GetAllHistoryTreeBranches(ctx, request)
+		if err == nil && len(resp.Branches) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("GetAllHistoryTreeBranches")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceGetAllHistoryTreeBranchesScope, op)
@@ -1411,6 +1427,10 @@ func (p *queuePersistenceClient) ReadMessages(
 	op := func() error {
 		var err error
 		resp, err = p.persistence.ReadMessages(ctx, lastMessageID, maxCount)
+		if err == nil && len(resp) == 0 {
+			p.metricClient.Scope(metrics.PersistenceEmptyResponseScope,
+				metrics.OperationTag("ReadMessages")).IncCounter(metrics.PersistenceEmptyResponseCounter)
+		}
 		return err
 	}
 	err := p.call(metrics.PersistenceReadQueueMessagesScope, op)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added new empty response metrics for persistence operation read calls, also added new counter and scope for empty response.


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
