### PR TITLE
Update the default values of dynamic config to not depend on static config

### DIFF
--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -117,7 +117,7 @@ func (cf *rpcClientFactory) NewHistoryClientWithTimeout(timeout time.Duration) (
 	peerResolver := history.NewPeerResolver(cf.numberOfHistoryShards, cf.resolver, namedPort)
 
 	supportedMessageSize := cf.rpcFactory.GetMaxMessageSize()
-	maxSizeConfig := cf.dynConfig.GetIntProperty(dynamicconfig.GRPCMaxSizeInByte, supportedMessageSize)
+	maxSizeConfig := cf.dynConfig.GetIntProperty(dynamicconfig.GRPCMaxSizeInByte, 4*1024*1024)
 	if maxSizeConfig() > supportedMessageSize {
 		return nil, fmt.Errorf(
 			"GRPCMaxSizeInByte dynamic config value %v is larger than supported value %v",

--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -198,7 +198,7 @@ func (s *server) startService() common.Daemon {
 
 	advancedVisMode := dc.GetStringProperty(
 		dynamicconfig.AdvancedVisibilityWritingMode,
-		common.GetDefaultAdvancedVisibilityWritingMode(params.PersistenceConfig.IsAdvancedVisibilityConfigExist()),
+		common.AdvancedVisibilityWritingModeOn,
 	)()
 	isAdvancedVisEnabled := common.IsAdvancedVisibilityWritingEnabled(advancedVisMode, params.PersistenceConfig.IsAdvancedVisibilityConfigExist())
 	if isAdvancedVisEnabled {

--- a/common/archiver/archivalMetadata.go
+++ b/common/archiver/archivalMetadata.go
@@ -86,18 +86,18 @@ func NewArchivalMetadata(
 ) ArchivalMetadata {
 	historyConfig := NewArchivalConfig(
 		historyStatus,
-		dc.GetStringProperty(dynamicconfig.HistoryArchivalStatus, historyStatus),
+		dc.GetStringProperty(dynamicconfig.HistoryArchivalStatus, common.ArchivalEnabled),
 		historyReadEnabled,
-		dc.GetBoolProperty(dynamicconfig.EnableReadFromHistoryArchival, historyReadEnabled),
+		dc.GetBoolProperty(dynamicconfig.EnableReadFromHistoryArchival, true),
 		domainDefaults.History.Status,
 		domainDefaults.History.URI,
 	)
 
 	visibilityConfig := NewArchivalConfig(
 		visibilityStatus,
-		dc.GetStringProperty(dynamicconfig.VisibilityArchivalStatus, visibilityStatus),
+		dc.GetStringProperty(dynamicconfig.VisibilityArchivalStatus, common.ArchivalEnabled),
 		visibilityReadEnabled,
-		dc.GetBoolProperty(dynamicconfig.EnableReadFromVisibilityArchival, visibilityReadEnabled),
+		dc.GetBoolProperty(dynamicconfig.EnableReadFromVisibilityArchival, true),
 		domainDefaults.Visibility.Status,
 		domainDefaults.Visibility.URI,
 	)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -82,13 +82,13 @@ const (
 	// AdvancedVisibilityWritingMode is key for how to write to advanced visibility. The most useful option is "dual", which can be used for seamless migration from db visibility to advanced visibility, usually using with EnableReadVisibilityFromES
 	// KeyName: system.advancedVisibilityWritingMode
 	// Value type: String enum: "on"(means writing to advancedVisibility only, "off" (means writing to db visibility only), or "dual" (means writing to both)
-	// Default value: "on" if advanced visibility persistence is configured, otherwise "off" (see common.GetDefaultAdvancedVisibilityWritingMode(isAdvancedVisConfigExist))
+	// Default value: "on"
 	// Allowed filters: N/A
 	AdvancedVisibilityWritingMode
 	// EnableReadVisibilityFromES is key for enable read from elastic search or db visibility, usually using with AdvancedVisibilityWritingMode for seamless migration from db visibility to advanced visibility
 	// KeyName: system.enableReadVisibilityFromES
 	// Value type: Bool
-	// Default value: true if advanced visibility persistence is configured, otherwise false
+	// Default value: true
 	// Allowed filters: DomainName
 	EnableReadVisibilityFromES
 	// EmitShardDiffLog is whether emit the shard diff log
@@ -106,25 +106,25 @@ const (
 	// HistoryArchivalStatus is key for the status of history archival to override the value from static config.
 	// KeyName: system.historyArchivalStatus
 	// Value type: string enum: "enabled" or "disabled"
-	// Default value: the value in static config: common.Config.Archival.History.Status
+	// Default value: "enabled"
 	// Allowed filters: N/A
 	HistoryArchivalStatus
 	// EnableReadFromHistoryArchival is key for enabling reading history from archival store
 	// KeyName: system.enableReadFromHistoryArchival
-	// Value type: string enum: "enabled" or "disabled"
-	// Default value: the value in static config: common.Config.Archival.History.EnableRead
+	// Value type: Bool
+	// Default value: true
 	// Allowed filters: N/A
 	EnableReadFromHistoryArchival
 	// VisibilityArchivalStatus is key for the status of visibility archival to override the value from static config.
 	// KeyName: system.visibilityArchivalStatus
 	// Value type: string enum: "enabled" or "disabled"
-	// Default value: the value in static config: common.Config.Archival.Visibility.Status
+	// Default value: "enabled"
 	// Allowed filters: N/A
 	VisibilityArchivalStatus
 	// EnableReadFromVisibilityArchival is key for enabling reading visibility from archival store to override the value from static config.
 	// KeyName: system.enableReadFromVisibilityArchival
-	// Value type: string enum: "enabled" or "disabled"
-	// Default value: the value in static config: common.Config.Archival.Visibility.EnableRead
+	// Value type: Bool
+	// Default value: true
 	// Allowed filters: N/A
 	EnableReadFromVisibilityArchival
 	// EnableDomainNotActiveAutoForwarding decides requests form which domain will be forwarded to active cluster if domain is not active in current cluster.

--- a/common/util.go
+++ b/common/util.go
@@ -842,15 +842,6 @@ func DeserializeSearchAttributeValue(value []byte, valueType workflow.IndexedVal
 	}
 }
 
-// GetDefaultAdvancedVisibilityWritingMode get default advancedVisibilityWritingMode based on
-// whether related config exists in static config file.
-func GetDefaultAdvancedVisibilityWritingMode(isAdvancedVisConfigExist bool) string {
-	if isAdvancedVisConfigExist {
-		return AdvancedVisibilityWritingModeOn
-	}
-	return AdvancedVisibilityWritingModeOff
-}
-
 // IsAdvancedVisibilityWritingEnabled returns true if we should write to advanced visibility
 func IsAdvancedVisibilityWritingEnabled(advancedVisibilityWritingMode string, isAdvancedVisConfigExist bool) bool {
 	return advancedVisibilityWritingMode != AdvancedVisibilityWritingModeOff && isAdvancedVisConfigExist

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -123,7 +123,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		EnableReadFromClosedExecutionV2:             dc.GetBoolProperty(dynamicconfig.EnableReadFromClosedExecutionV2, false),
 		VisibilityListMaxQPS:                        dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendVisibilityListMaxQPS, defaultVisibilityListMaxQPS()),
 		ESVisibilityListMaxQPS:                      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendESVisibilityListMaxQPS, 30),
-		EnableReadVisibilityFromES:                  dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableReadVisibilityFromES, isAdvancedVisConfigExist),
+		EnableReadVisibilityFromES:                  dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableReadVisibilityFromES, true),
 		ESIndexMaxResultWindow:                      dc.GetIntProperty(dynamicconfig.FrontendESIndexMaxResultWindow, 10000),
 		HistoryMaxPageSize:                          dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, common.GetHistoryMaxPageSize),
 		UserRPS:                                     dc.GetIntProperty(dynamicconfig.FrontendUserRPS, 1200),

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -366,7 +366,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		VisibilityClosedMaxQPS:               dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryVisibilityClosedMaxQPS, 300),
 		MaxAutoResetPoints:                   dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryMaxAutoResetPoints, DefaultHistoryMaxAutoResetPoints),
 		MaxDecisionStartToCloseSeconds:       dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaxDecisionStartToCloseSeconds, 240),
-		AdvancedVisibilityWritingMode:        dc.GetStringProperty(dynamicconfig.AdvancedVisibilityWritingMode, common.GetDefaultAdvancedVisibilityWritingMode(isAdvancedVisConfigExist)),
+		AdvancedVisibilityWritingMode:        dc.GetStringProperty(dynamicconfig.AdvancedVisibilityWritingMode, common.AdvancedVisibilityWritingModeOn),
 		EmitShardDiffLog:                     dc.GetBoolProperty(dynamicconfig.EmitShardDiffLog, false),
 		HistoryCacheInitialSize:              dc.GetIntProperty(dynamicconfig.HistoryCacheInitialSize, 128),
 		HistoryCacheMaxSize:                  dc.GetIntProperty(dynamicconfig.HistoryCacheMaxSize, 512),

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -192,7 +192,7 @@ func NewConfig(params *resource.Params) *Config {
 	}
 	advancedVisWritingMode := dc.GetStringProperty(
 		dynamicconfig.AdvancedVisibilityWritingMode,
-		common.GetDefaultAdvancedVisibilityWritingMode(params.PersistenceConfig.IsAdvancedVisibilityConfigExist()),
+		common.AdvancedVisibilityWritingModeOn,
 	)
 	if common.IsAdvancedVisibilityWritingEnabled(advancedVisWritingMode(), params.PersistenceConfig.IsAdvancedVisibilityConfigExist()) {
 		config.IndexerCfg = &indexer.Config{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Update the default values of dynamic config to be static values, and to not depend on values read from static config file

<!-- Tell your future self why have you made these changes -->
**Why?**

- Dynamic config and static config should be independent of each other
- With this change we can create a source of truth to store the default values of dynamic config

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
If there is no `system.grpcMaxSizeInByte` config, it needs to be created. And the value should be the same as the `maxPayloadSize` in the static config.


<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
