### PR TITLE
Support allowed authenticators in tool

### DIFF
--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -176,6 +176,7 @@ func newCQLClientConfig(cli *cli.Context) (*CQLClientConfig, error) {
 	cqlConfig.Port = cli.GlobalInt(schema.CLIOptPort)
 	cqlConfig.User = cli.GlobalString(schema.CLIOptUser)
 	cqlConfig.Password = cli.GlobalString(schema.CLIOptPassword)
+	cqlConfig.AllowedAuthenticators = cli.GlobalStringSlice(schema.CLIOptAllowedAuthenticators)
 	cqlConfig.Timeout = cli.GlobalInt(schema.CLIOptTimeout)
 	cqlConfig.Keyspace = cli.GlobalString(schema.CLIOptKeyspace)
 	cqlConfig.NumReplicas = cli.Int(schema.CLIOptReplicationFactor)

--- a/tools/cassandra/main.go
+++ b/tools/cassandra/main.go
@@ -87,6 +87,11 @@ func BuildCLIOptions() *cli.App {
 			Usage:  "Password used for authentication for connecting to cassandra host",
 			EnvVar: "CASSANDRA_PASSWORD",
 		},
+		cli.StringSliceFlag{
+			Name:  schema.CLIFlagAllowedAuthenticators,
+			Value: &cli.StringSlice{""},
+			Usage: "Set allowed authenticators for servers with custom authenticators",
+		},
 		cli.IntFlag{
 			Name:   schema.CLIFlagTimeout,
 			Value:  DefaultTimeout,

--- a/tools/common/schema/types.go
+++ b/tools/common/schema/types.go
@@ -76,6 +76,8 @@ const (
 	CLIOptUser = "user"
 	// CLIOptPassword is the cli option for password
 	CLIOptPassword = "password"
+	// CLIOptAllowedAuthenticatorsis the cli option for cassandra allowed authenticators
+	CLIOptAllowedAuthenticators = "allowed-authenticators"
 	// CLIOptTimeout is the cli option for timeout
 	CLIOptTimeout = "timeout"
 	// CLIOptKeyspace is the cli option for keyspace
@@ -115,6 +117,8 @@ const (
 	CLIFlagUser = CLIOptUser + ", u"
 	// CLIFlagPassword is the cli flag for password
 	CLIFlagPassword = CLIOptPassword + ", pw"
+	// CLIFlagAllowedAuthenticators is the cli flag for whitelisting custom authenticators
+	CLIFlagAllowedAuthenticators = CLIOptAllowedAuthenticators + ", aa"
 	// CLIFlagTimeout is the cli flag for timeout
 	CLIFlagTimeout = CLIOptTimeout + ", t"
 	// CLIFlagKeyspace is the cli flag for keyspace


### PR DESCRIPTION
**What changed?**
As part of #4676 we added support for custom authenticators in cassandra but didn't propagate the change to the cadence-cassandra-tool cli options.

This commit fixes that.

**Why?**
So cadence-cassandra-tool can work on clusters with custom authenticators.

**How did you test it?**
Tested locally, against a cluster with a custom authenticator, and one without.

**Potential risks**
If you set the wrong value, the tool will not run and throw an `unexpected authenticator` error

**Release notes**
Added support for custom cassandra authenticator in cadence-cassandra-tool

**Documentation Changes**
