### PR TITLE
Removed TaskID from types.HistoryTaskV2Attributes

### DIFF
--- a/common/types/mapper/proto/shared.go
+++ b/common/types/mapper/proto/shared.go
@@ -592,7 +592,6 @@ func FromHistoryTaskV2Attributes(t *types.HistoryTaskV2Attributes) *adminv1.Hist
 		return nil
 	}
 	return &adminv1.HistoryTaskV2Attributes{
-		TaskId:              t.TaskID,
 		DomainId:            t.DomainID,
 		WorkflowExecution:   FromWorkflowRunPair(t.WorkflowID, t.RunID),
 		VersionHistoryItems: FromVersionHistoryItemArray(t.VersionHistoryItems),
@@ -606,7 +605,6 @@ func ToHistoryTaskV2Attributes(t *adminv1.HistoryTaskV2Attributes) *types.Histor
 		return nil
 	}
 	return &types.HistoryTaskV2Attributes{
-		TaskID:              t.TaskId,
 		DomainID:            t.DomainId,
 		WorkflowID:          ToWorkflowID(t.WorkflowExecution),
 		RunID:               ToRunID(t.WorkflowExecution),

--- a/common/types/mapper/thrift/replicator.go
+++ b/common/types/mapper/thrift/replicator.go
@@ -300,7 +300,6 @@ func FromHistoryTaskV2Attributes(t *types.HistoryTaskV2Attributes) *replicator.H
 		return nil
 	}
 	return &replicator.HistoryTaskV2Attributes{
-		TaskId:              &t.TaskID,
 		DomainId:            &t.DomainID,
 		WorkflowId:          &t.WorkflowID,
 		RunId:               &t.RunID,
@@ -316,7 +315,6 @@ func ToHistoryTaskV2Attributes(t *replicator.HistoryTaskV2Attributes) *types.His
 		return nil
 	}
 	return &types.HistoryTaskV2Attributes{
-		TaskID:              t.GetTaskId(),
 		DomainID:            t.GetDomainId(),
 		WorkflowID:          t.GetWorkflowId(),
 		RunID:               t.GetRunId(),

--- a/common/types/replicator.go
+++ b/common/types/replicator.go
@@ -307,7 +307,6 @@ func (v *GetReplicationMessagesResponse) GetMessagesByShard() (o map[int32]*Repl
 
 // HistoryTaskV2Attributes is an internal type (TBD...)
 type HistoryTaskV2Attributes struct {
-	TaskID              int64                 `json:"taskId,omitempty"`
 	DomainID            string                `json:"domainId,omitempty"`
 	WorkflowID          string                `json:"workflowId,omitempty"`
 	RunID               string                `json:"runId,omitempty"`

--- a/common/types/testdata/replication.go
+++ b/common/types/testdata/replication.go
@@ -129,7 +129,6 @@ var (
 		VersionHistory:     &VersionHistory,
 	}
 	HistoryTaskV2Attributes = types.HistoryTaskV2Attributes{
-		TaskID:              TaskID,
 		DomainID:            DomainID,
 		WorkflowID:          WorkflowID,
 		RunID:               RunID,

--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -2406,7 +2406,6 @@ func (s *NDCIntegrationTestSuite) applyEventsThroughFetcher(
 			TaskType:     &taskType,
 			SourceTaskID: 1,
 			HistoryTaskV2Attributes: &types.HistoryTaskV2Attributes{
-				TaskID:              1,
 				DomainID:            s.domainID,
 				WorkflowID:          workflowID,
 				RunID:               runID,

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -529,7 +529,6 @@ func (t *taskAckManagerImpl) generateHistoryReplicationTask(
 			replicationTask := &types.ReplicationTask{
 				TaskType: types.ReplicationTaskType.Ptr(types.ReplicationTaskTypeHistoryV2),
 				HistoryTaskV2Attributes: &types.HistoryTaskV2Attributes{
-					TaskID:              task.FirstEventID,
 					DomainID:            task.DomainID,
 					WorkflowID:          task.WorkflowID,
 					RunID:               task.RunID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed `TaskID` field from `types.HistoryTaskV2Attributes`

<!-- Tell your future self why have you made these changes -->
**Why?**
Not actually used anywhere. Instead we have another `SourceTaskID` field which is set on `types.ReplicationTask` that is actually used. It caught my attention as this was set to suspicious value in TaskAckManager:
```
    TaskID:              task.FirstEventID,
```
After checking, it looks like do not care about this field in the other side of replication stack.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
