### PR TITLE
Rename dockers default cluster name to match the other config files.

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -109,6 +109,17 @@ docker-compose down
 docker-compose up
 ```
 
+DIY: Running a custom cadence server locally alongside cadence requirements
+---------------------------------------------------------------------------
+If you want to test out a custom-built cadence server, while running all the normal cadence dependencies, there's a simple workflow to do that:
+
+Make your cadence server changes and build using "make bins". Then start everything, stop cadence server, and run your own cadence-server:
+```
+docker-compose up
+docker stop docker-cadence-1
+./cadence-server start
+```
+
 Using docker image for production
 =========================
 In a typical production setting, dependencies (cassandra / statsd server) are

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -204,14 +204,14 @@ clusterGroupMetadata:
     clusterRedirectionPolicy:
         policy: {{ default .Env.CLUSTER_REDIRECT_POLICY "all-domain-apis-forwarding" }}
     failoverVersionIncrement: 10
-    primaryClusterName: "primary"
+    primaryClusterName: "cluster0"
     {{- if .Env.IS_NOT_PRIMARY }}
-    currentClusterName: "secondary"
+    currentClusterName: "cluster1"
     {{- else }}
-    currentClusterName: "primary"
+    currentClusterName: "cluster0"
     {{- end }}
     clusterGroup:
-        primary:
+        cluster0:
             enabled: true
             initialFailoverVersion: 0
             rpcName: "cadence-frontend"
@@ -222,7 +222,7 @@ clusterGroupMetadata:
                 type: "OAuthAuthorization"
                 privateKey: {{ default .Env.OAUTH_PRIVATE_KEY "" }}
         {{- if .Env.ENABLE_GLOBAL_DOMAIN }}
-        secondary:
+        cluster1:
             enabled: true
             initialFailoverVersion: 2
             rpcName: "cadence-frontend"


### PR DESCRIPTION
This allows an easy workflow for building/running a custom cadence server: docker-compose up, docker stop cadence, cadence-server start.

Also add documentation of this workflow.

<!-- Describe what has changed in this PR -->
**What changed?**

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran the workflow and ensured it ran as expected.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
