### PR TITLE
Magically speed up NDC integration tests

### DIFF
--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -182,7 +182,6 @@ services:
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
       - "TEST_TAG=esintegration"
-      - "TEST_RUN_COUNT=10"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -210,7 +209,6 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_PLUGIN=mysql"
       - "TEST_TAG=esintegration"
-      - "TEST_RUN_COUNT=10"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID
@@ -238,7 +236,6 @@ services:
       - "PERSISTENCE_TYPE=sql"
       - "PERSISTENCE_PLUGIN=postgres"
       - "TEST_TAG=esintegration"
-      - "TEST_RUN_COUNT=10"
       - BUILDKITE_AGENT_ACCESS_TOKEN
       - BUILDKITE_JOB_ID
       - BUILDKITE_BUILD_ID


### PR DESCRIPTION
Delete 3 lines -> cut test suite time significantly!
I feel productive.

At this point, the biggest time cost seems to be coming from installing cqlsh, which is
a bit longer than other portions of "build stuff so we can run stuff".

---

These "run integration tests 10x" lines date back to when buildkite was first enabled
in PR #2626, but I don't see any explanation as to *why*... so I'm going to assume it
was intended as like a stress-test or to make troubleshooting easier or something.

Regardless, it seems.... undesirable?  Extra insurance of stability is indeed nice,
but I'm not sure it's something we desire to be running all the time.

---

AFAICT the coverage changes are due to these E2E tests being inherently
non-deterministic (which seems entirely natural / fine), and possibly revealing that
we do not have some of the "may be used in E2E tests" branches covered by stable
unit tests. It might be worth exploring which lines are flapping, and covering or ignoring
them somehow.  I haven't looked into that yet.

Or we could just not collect coverage from E2E tests.
But that seems.... somewhat incorrect too.  It's code covered by tests.