### PR TITLE
Add new es record for uninitialized workflow

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1513,6 +1513,12 @@ const (
 	// Default value: true
 	// Allowed filters: DomainID, WorkflowID
 	EnableReplicationTaskGeneration
+	// EnableRecordWorkflowExecutionUninitialized enables record workflow execution uninitialized state in ElasticSearch
+	// KeyName: history.EnableRecordWorkflowExecutionUninitialized
+	// Value type: Bool
+	// Default value: true
+	// Allowed filters: N/A
+	EnableRecordWorkflowExecutionUninitialized
 	// AllowArchivingIncompleteHistory will continue on when seeing some error like history mutated(usually caused by database consistency issues)
 	// KeyName: worker.AllowArchivingIncompleteHistory
 	// Value type: Bool
@@ -3330,6 +3336,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "history.emitShardDiffLog",
 		Description:  "EmitShardDiffLog is whether emit the shard diff log",
 		DefaultValue: false,
+	},
+	EnableRecordWorkflowExecutionUninitialized: DynamicBool{
+		KeyName:      "history.enableRecordWorkflowExecutionUninitialized",
+		Description:  "EnableRecordWorkflowExecutionUninitialized enables record workflow execution uninitialized state in ElasticSearch",
+		DefaultValue: true,
 	},
 	DisableListVisibilityByFilter: DynamicBool{
 		KeyName:      "frontend.disableListVisibilityByFilter",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3340,7 +3340,7 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	EnableRecordWorkflowExecutionUninitialized: DynamicBool{
 		KeyName:      "history.enableRecordWorkflowExecutionUninitialized",
 		Description:  "EnableRecordWorkflowExecutionUninitialized enables record workflow execution uninitialized state in ElasticSearch",
-		DefaultValue: true,
+		DefaultValue: false,
 	},
 	DisableListVisibilityByFilter: DynamicBool{
 		KeyName:      "frontend.disableListVisibilityByFilter",

--- a/common/elasticsearch/client_v6.go
+++ b/common/elasticsearch/client_v6.go
@@ -529,20 +529,31 @@ func (v *v6BulkProcessor) Close() error {
 
 func (v *v6BulkProcessor) Add(request *GenericBulkableAddRequest) {
 	var req elastic.BulkableRequest
-	if request.IsDelete {
+	switch request.RequestType {
+	case BulkableDeleteRequest:
 		req = elastic.NewBulkDeleteRequest().
 			Index(request.Index).
 			Type(request.Type).
 			Id(request.ID).
 			VersionType(request.VersionType).
 			Version(request.Version)
-	} else {
+	case BulkableIndexRequest:
 		req = elastic.NewBulkIndexRequest().
 			Index(request.Index).
 			Type(request.Type).
 			Id(request.ID).
 			VersionType(request.VersionType).
 			Version(request.Version).
+			Doc(request.Doc)
+	case BulkableCreateRequest:
+		//for bulk create request still calls the bulk index method
+		//with providing operation type
+		req = elastic.NewBulkIndexRequest().
+			OpType("create").
+			Index(request.Index).
+			Type(request.Type).
+			Id(request.ID).
+			VersionType("internal").
 			Doc(request.Doc)
 	}
 	v.processor.Add(req)

--- a/common/elasticsearch/client_v7.go
+++ b/common/elasticsearch/client_v7.go
@@ -522,20 +522,31 @@ func (v *v7BulkProcessor) Close() error {
 
 func (v *v7BulkProcessor) Add(request *GenericBulkableAddRequest) {
 	var req elastic.BulkableRequest
-	if request.IsDelete {
+	switch request.RequestType {
+	case BulkableDeleteRequest:
 		req = elastic.NewBulkDeleteRequest().
 			Index(request.Index).
 			Type(request.Type).
 			Id(request.ID).
 			VersionType(request.VersionType).
 			Version(request.Version)
-	} else {
+	case BulkableIndexRequest:
 		req = elastic.NewBulkIndexRequest().
 			Index(request.Index).
 			Type(request.Type).
 			Id(request.ID).
 			VersionType(request.VersionType).
 			Version(request.Version).
+			Doc(request.Doc)
+	case BulkableCreateRequest:
+		//for bulk create request still calls the bulk index method
+		//with providing operation type
+		req = elastic.NewBulkIndexRequest().
+			OpType("create").
+			Index(request.Index).
+			Type(request.Type).
+			Id(request.ID).
+			VersionType("internal").
 			Doc(request.Doc)
 	}
 	v.processor.Add(req)

--- a/common/elasticsearch/interfaces.go
+++ b/common/elasticsearch/interfaces.go
@@ -51,6 +51,14 @@ func NewGenericClient(
 	}
 }
 
+type GenericBulkableRequestType int
+
+const (
+	BulkableIndexRequest GenericBulkableRequestType = iota
+	BulkableDeleteRequest
+	BulkableCreateRequest
+)
+
 type (
 	// GenericClient is a generic interface for all versions of ElasticSearch clients
 	GenericClient interface {
@@ -175,8 +183,8 @@ type (
 		ID          string
 		VersionType string
 		Version     int64
-		// true means it's delete, otherwise it's a index request
-		IsDelete bool
+		// request types can be index, delete or create
+		RequestType GenericBulkableRequestType
 		// should be nil if IsDelete is true
 		Doc interface{}
 	}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -243,6 +243,8 @@ const (
 	PersistenceRecordWorkflowExecutionStartedScope
 	// PersistenceRecordWorkflowExecutionClosedScope tracks RecordWorkflowExecutionClosed calls made by service to persistence layer
 	PersistenceRecordWorkflowExecutionClosedScope
+	// PersistenceRecordWorkflowExecutionUninitializedScope tracks RecordWorkflowExecutionUninitialized calls made by service to persistence layer
+	PersistenceRecordWorkflowExecutionUninitializedScope
 	// PersistenceUpsertWorkflowExecutionScope tracks UpsertWorkflowExecution calls made by service to persistence layer
 	PersistenceUpsertWorkflowExecutionScope
 	// PersistenceListOpenWorkflowExecutionsScope tracks ListOpenWorkflowExecutions calls made by service to persistence layer
@@ -664,6 +666,8 @@ const (
 	ElasticsearchRecordWorkflowExecutionStartedScope
 	// ElasticsearchRecordWorkflowExecutionClosedScope tracks RecordWorkflowExecutionClosed calls made by service to persistence layer
 	ElasticsearchRecordWorkflowExecutionClosedScope
+	// ElasticsearchRecordWorkflowExecutionUninitializedScope tracks RecordWorkflowExecutionUninitialized calls made by service to persistence layer
+	ElasticsearchRecordWorkflowExecutionUninitializedScope
 	// ElasticsearchUpsertWorkflowExecutionScope tracks UpsertWorkflowExecution calls made by service to persistence layer
 	ElasticsearchUpsertWorkflowExecutionScope
 	// ElasticsearchListOpenWorkflowExecutionsScope tracks ListOpenWorkflowExecutions calls made by service to persistence layer
@@ -1272,6 +1276,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		PersistenceGetMetadataScope:                              {operation: "GetMetadata"},
 		PersistenceRecordWorkflowExecutionStartedScope:           {operation: "RecordWorkflowExecutionStarted"},
 		PersistenceRecordWorkflowExecutionClosedScope:            {operation: "RecordWorkflowExecutionClosed"},
+		PersistenceRecordWorkflowExecutionUninitializedScope:     {operation: "RecordWorkflowExecutionUninitialized"},
 		PersistenceUpsertWorkflowExecutionScope:                  {operation: "UpsertWorkflowExecution"},
 		PersistenceListOpenWorkflowExecutionsScope:               {operation: "ListOpenWorkflowExecutions"},
 		PersistenceListClosedWorkflowExecutionsScope:             {operation: "ListClosedWorkflowExecutions"},
@@ -1485,6 +1490,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 
 		ElasticsearchRecordWorkflowExecutionStartedScope:           {operation: "RecordWorkflowExecutionStarted"},
 		ElasticsearchRecordWorkflowExecutionClosedScope:            {operation: "RecordWorkflowExecutionClosed"},
+		ElasticsearchRecordWorkflowExecutionUninitializedScope:     {operation: "RecordWorkflowExecutionUninitialized"},
 		ElasticsearchUpsertWorkflowExecutionScope:                  {operation: "UpsertWorkflowExecution"},
 		ElasticsearchListOpenWorkflowExecutionsScope:               {operation: "ListOpenWorkflowExecutions"},
 		ElasticsearchListClosedWorkflowExecutionsScope:             {operation: "ListClosedWorkflowExecutions"},

--- a/common/mocks/VisibilityManager.go
+++ b/common/mocks/VisibilityManager.go
@@ -326,6 +326,20 @@ func (_m *VisibilityManager) RecordWorkflowExecutionStarted(ctx context.Context,
 	return r0
 }
 
+// RecordWorkflowExecutionUninitialized provides a mock function with given fields: ctx, request
+func (_m *VisibilityManager) RecordWorkflowExecutionUninitialized(ctx context.Context, request *persistence.RecordWorkflowExecutionUninitializedRequest) error {
+	ret := _m.Called(ctx, request)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, *persistence.RecordWorkflowExecutionUninitializedRequest) error); ok {
+		r0 = rf(ctx, request)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // ScanWorkflowExecutions provides a mock function with given fields: ctx, request
 func (_m *VisibilityManager) ScanWorkflowExecutions(ctx context.Context, request *persistence.ListWorkflowExecutionsByQueryRequest) (*persistence.ListWorkflowExecutionsResponse, error) {
 	ret := _m.Called(ctx, request)

--- a/common/persistence/dataStoreInterfaces.go
+++ b/common/persistence/dataStoreInterfaces.go
@@ -164,6 +164,7 @@ type (
 		GetName() string
 		RecordWorkflowExecutionStarted(ctx context.Context, request *InternalRecordWorkflowExecutionStartedRequest) error
 		RecordWorkflowExecutionClosed(ctx context.Context, request *InternalRecordWorkflowExecutionClosedRequest) error
+		RecordWorkflowExecutionUninitialized(ctx context.Context, request *InternalRecordWorkflowExecutionUninitializedRequest) error
 		UpsertWorkflowExecution(ctx context.Context, request *InternalUpsertWorkflowExecutionRequest) error
 		ListOpenWorkflowExecutions(ctx context.Context, request *InternalListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error)
 		ListClosedWorkflowExecutions(ctx context.Context, request *InternalListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error)
@@ -719,6 +720,14 @@ type (
 		RetentionPeriod    time.Duration
 		IsCron             bool
 		NumClusters        int16
+	}
+
+	// InternalRecordWorkflowExecutionUninitializedRequest is used to add a record of a newly uninitialized execution
+	InternalRecordWorkflowExecutionUninitializedRequest struct {
+		DomainUUID       string
+		WorkflowID       string
+		RunID            string
+		WorkflowTypeName string
 	}
 
 	// InternalUpsertWorkflowExecutionRequest is request to UpsertWorkflowExecution

--- a/common/persistence/dataVisibilityManagerInterfaces.go
+++ b/common/persistence/dataVisibilityManagerInterfaces.go
@@ -75,6 +75,13 @@ type (
 		SearchAttributes   map[string][]byte
 	}
 
+	// RecordWorkflowExecutionUninitializedRequest is used to add a record of a newly uninitialized execution
+	RecordWorkflowExecutionUninitializedRequest struct {
+		DomainUUID       string
+		Execution        types.WorkflowExecution
+		WorkflowTypeName string
+	}
+
 	// UpsertWorkflowExecutionRequest is used to upsert workflow execution
 	UpsertWorkflowExecutionRequest struct {
 		DomainUUID         string
@@ -187,6 +194,7 @@ type (
 		GetName() string
 		RecordWorkflowExecutionStarted(ctx context.Context, request *RecordWorkflowExecutionStartedRequest) error
 		RecordWorkflowExecutionClosed(ctx context.Context, request *RecordWorkflowExecutionClosedRequest) error
+		RecordWorkflowExecutionUninitialized(ctx context.Context, request *RecordWorkflowExecutionUninitializedRequest) error
 		UpsertWorkflowExecution(ctx context.Context, request *UpsertWorkflowExecutionRequest) error
 		ListOpenWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error)
 		ListClosedWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsRequest) (*ListWorkflowExecutionsResponse, error)

--- a/common/persistence/elasticsearch/esVisibilityMetricClients.go
+++ b/common/persistence/elasticsearch/esVisibilityMetricClients.go
@@ -85,6 +85,23 @@ func (p *visibilityMetricsClient) RecordWorkflowExecutionClosed(
 	return err
 }
 
+func (p *visibilityMetricsClient) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *p.RecordWorkflowExecutionUninitializedRequest,
+) error {
+	p.metricClient.IncCounter(metrics.ElasticsearchRecordWorkflowExecutionUninitializedScope, metrics.ElasticsearchRequests)
+
+	sw := p.metricClient.StartTimer(metrics.ElasticsearchRecordWorkflowExecutionUninitializedScope, metrics.ElasticsearchLatency)
+	err := p.persistence.RecordWorkflowExecutionUninitialized(ctx, request)
+	sw.Stop()
+
+	if err != nil {
+		p.updateErrorMetric(metrics.ElasticsearchRecordWorkflowExecutionUninitializedScope, err)
+	}
+
+	return err
+}
+
 func (p *visibilityMetricsClient) UpsertWorkflowExecution(
 	ctx context.Context,
 	request *p.UpsertWorkflowExecutionRequest,

--- a/common/persistence/nosql/nosqlVisibilityStore.go
+++ b/common/persistence/nosql/nosqlVisibilityStore.go
@@ -128,6 +128,14 @@ func (v *nosqlVisibilityStore) RecordWorkflowExecutionClosed(
 	return nil
 }
 
+func (v *nosqlVisibilityStore) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *p.InternalRecordWorkflowExecutionUninitializedRequest,
+) error {
+	// temporary: not implemented, only implemented for ES
+	return nil
+}
+
 func (v *nosqlVisibilityStore) UpsertWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalUpsertWorkflowExecutionRequest,

--- a/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
@@ -162,6 +162,14 @@ func (s *DBVisibilityPersistenceSuite) TestBasicVisibility() {
 	s.Nil(err4)
 	s.Equal(1, len(resp.Executions))
 	s.assertClosedExecutionEquals(closeReq, resp.Executions[0])
+
+	uninitializedReq := &p.RecordWorkflowExecutionUninitializedRequest{
+		DomainUUID:       testDomainUUID,
+		Execution:        workflowExecution,
+		WorkflowTypeName: "visibility-workflow",
+	}
+	err5 := s.VisibilityMgr.RecordWorkflowExecutionUninitialized(ctx, uninitializedReq)
+	s.Nil(err5)
 }
 
 // TestCronVisibility test

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -1037,6 +1037,16 @@ func (p *visibilityPersistenceClient) RecordWorkflowExecutionClosed(
 	return p.call(metrics.PersistenceRecordWorkflowExecutionClosedScope, op)
 }
 
+func (p *visibilityPersistenceClient) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *RecordWorkflowExecutionUninitializedRequest,
+) error {
+	op := func() error {
+		return p.persistence.RecordWorkflowExecutionUninitialized(ctx, request)
+	}
+	return p.call(metrics.PersistenceRecordWorkflowExecutionUninitializedScope, op)
+}
+
 func (p *visibilityPersistenceClient) UpsertWorkflowExecution(
 	ctx context.Context,
 	request *UpsertWorkflowExecutionRequest,

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -803,6 +803,14 @@ func (p *visibilityRateLimitedPersistenceClient) RecordWorkflowExecutionClosed(
 	return err
 }
 
+func (p *visibilityRateLimitedPersistenceClient) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *RecordWorkflowExecutionUninitializedRequest,
+) error {
+	err := p.persistence.RecordWorkflowExecutionUninitialized(ctx, request)
+	return err
+}
+
 func (p *visibilityRateLimitedPersistenceClient) UpsertWorkflowExecution(
 	ctx context.Context,
 	request *UpsertWorkflowExecutionRequest,

--- a/common/persistence/sql/sqlVisibilityStore.go
+++ b/common/persistence/sql/sqlVisibilityStore.go
@@ -122,6 +122,14 @@ func (s *sqlVisibilityStore) RecordWorkflowExecutionClosed(
 	return nil
 }
 
+func (s *sqlVisibilityStore) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *p.InternalRecordWorkflowExecutionUninitializedRequest,
+) error {
+	// temporary: not implemented, only implemented for ES
+	return nil
+}
+
 func (s *sqlVisibilityStore) UpsertWorkflowExecution(
 	_ context.Context,
 	request *p.InternalUpsertWorkflowExecutionRequest,

--- a/common/persistence/visibilityDualManager.go
+++ b/common/persistence/visibilityDualManager.go
@@ -110,6 +110,21 @@ func (v *visibilityDualManager) RecordWorkflowExecutionClosed(
 	)
 }
 
+func (v *visibilityDualManager) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *RecordWorkflowExecutionUninitializedRequest,
+) error {
+	return v.chooseVisibilityManagerForWrite(
+		ctx,
+		func() error {
+			return v.dbVisibilityManager.RecordWorkflowExecutionUninitialized(ctx, request)
+		},
+		func() error {
+			return v.esVisibilityManager.RecordWorkflowExecutionUninitialized(ctx, request)
+		},
+	)
+}
+
 func (v *visibilityDualManager) DeleteWorkflowExecution(
 	ctx context.Context,
 	request *VisibilityDeleteWorkflowExecutionRequest,

--- a/common/persistence/visibilitySamplingClient.go
+++ b/common/persistence/visibilitySamplingClient.go
@@ -161,6 +161,13 @@ func (p *visibilitySamplingClient) RecordWorkflowExecutionClosed(
 	return nil
 }
 
+func (p *visibilitySamplingClient) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *RecordWorkflowExecutionUninitializedRequest,
+) error {
+	return p.persistence.RecordWorkflowExecutionUninitialized(ctx, request)
+}
+
 func (p *visibilitySamplingClient) UpsertWorkflowExecution(
 	ctx context.Context,
 	request *UpsertWorkflowExecutionRequest,

--- a/common/persistence/visibilitySingleManager.go
+++ b/common/persistence/visibilitySingleManager.go
@@ -108,6 +108,19 @@ func (v *visibilityManagerImpl) RecordWorkflowExecutionClosed(
 	return v.persistence.RecordWorkflowExecutionClosed(ctx, req)
 }
 
+func (v *visibilityManagerImpl) RecordWorkflowExecutionUninitialized(
+	ctx context.Context,
+	request *RecordWorkflowExecutionUninitializedRequest,
+) error {
+	req := &InternalRecordWorkflowExecutionUninitializedRequest{
+		DomainUUID:       request.DomainUUID,
+		WorkflowID:       request.Execution.GetWorkflowID(),
+		RunID:            request.Execution.GetRunID(),
+		WorkflowTypeName: request.WorkflowTypeName,
+	}
+	return v.persistence.RecordWorkflowExecutionUninitialized(ctx, req)
+}
+
 func (v *visibilityManagerImpl) UpsertWorkflowExecution(
 	ctx context.Context,
 	request *UpsertWorkflowExecutionRequest,

--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/lib/pq v1.2.0
 	github.com/m3db/prometheus_client_golang v0.8.1
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/olivere/elastic v6.2.21+incompatible
+	github.com/olivere/elastic v6.2.37+incompatible
 	github.com/olivere/elastic/v7 v7.0.21
 	github.com/opentracing/opentracing-go v1.2.0
 	github.com/otiai10/copy v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -314,8 +314,8 @@ github.com/montanaflynn/stats v0.0.0-20171201202039-1bf9dbcd8cbe/go.mod h1:wL8QJ
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
-github.com/olivere/elastic v6.2.21+incompatible h1:QnTuofzxOCV5FrYLywjkMxOmOWhAeild1VXxKRksK9Y=
-github.com/olivere/elastic v6.2.21+incompatible/go.mod h1:J+q1zQJTgAz9woqsbVRqGeB5G1iqDKVBWLNSYW8yfJ8=
+github.com/olivere/elastic v6.2.37+incompatible h1:UfSGJem5czY+x/LqxgeCBgjDn6St+z8OnsCuxwD3L0U=
+github.com/olivere/elastic v6.2.37+incompatible/go.mod h1:J+q1zQJTgAz9woqsbVRqGeB5G1iqDKVBWLNSYW8yfJ8=
 github.com/olivere/elastic/v7 v7.0.21 h1:58a2pMlLketCsLyKg8kJNJG+OZIFKrSQXX6gJBpqqlg=
 github.com/olivere/elastic/v7 v7.0.21/go.mod h1:Kh7iIsXIBl5qRQOBFoylCsXVTtye3keQU2Y/YbR7HD8=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -279,6 +279,7 @@ type Config struct {
 	ReplicationTaskProcessorShardQPS                   dynamicconfig.FloatPropertyFn
 	ReplicationTaskGenerationQPS                       dynamicconfig.FloatPropertyFn
 	EnableReplicationTaskGeneration                    dynamicconfig.BoolPropertyFnWithDomainIDAndWorkflowIDFilter
+	EnableRecordWorkflowExecutionUninitialized         dynamicconfig.BoolPropertyFn
 
 	// The following are used by consistent query
 	EnableConsistentQuery         dynamicconfig.BoolPropertyFn
@@ -519,6 +520,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ReplicationTaskProcessorShardQPS:                   dc.GetFloat64Property(dynamicconfig.ReplicationTaskProcessorShardQPS),
 		ReplicationTaskGenerationQPS:                       dc.GetFloat64Property(dynamicconfig.ReplicationTaskGenerationQPS),
 		EnableReplicationTaskGeneration:                    dc.GetBoolPropertyFilteredByDomainIDAndWorkflowID(dynamicconfig.EnableReplicationTaskGeneration),
+		EnableRecordWorkflowExecutionUninitialized:         dc.GetBoolProperty(dynamicconfig.EnableRecordWorkflowExecutionUninitialized),
 
 		EnableConsistentQuery:                 dc.GetBoolProperty(dynamicconfig.EnableConsistentQuery),
 		EnableConsistentQueryByDomain:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableConsistentQueryByDomain),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -654,7 +654,7 @@ func (e *historyEngineImpl) startWorkflowHelper(
 		if err != nil {
 			return nil, err
 		}
-	} else if e.shard.GetConfig().EnableRecordWorkflowExecutionUninitialized() {
+	} else if e.shard.GetConfig().EnableRecordWorkflowExecutionUninitialized() && e.visibilityMgr != nil {
 		uninitializedRequest := &persistence.RecordWorkflowExecutionUninitializedRequest{
 			DomainUUID: domainID,
 			Execution: types.WorkflowExecution{

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -654,6 +654,19 @@ func (e *historyEngineImpl) startWorkflowHelper(
 		if err != nil {
 			return nil, err
 		}
+	} else if e.shard.GetConfig().EnableRecordWorkflowExecutionUninitialized() {
+		uninitializedRequest := &persistence.RecordWorkflowExecutionUninitializedRequest{
+			DomainUUID: domainID,
+			Execution: types.WorkflowExecution{
+				WorkflowID: workflowID,
+				RunID:      workflowExecution.RunID,
+			},
+			WorkflowTypeName: request.WorkflowType.Name,
+		}
+
+		if err := e.visibilityMgr.RecordWorkflowExecutionUninitialized(ctx, uninitializedRequest); err != nil {
+			e.logger.Error("Failed to record uninitialized workflow execution", tag.Error(err))
+		}
 	}
 
 	err = e.addStartEventsAndTasks(

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1535,11 +1535,13 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTask()
 	persistenceMutableState, err := test.CreatePersistenceMutableState(mutableState, decisionCompletionID, mutableState.GetCurrentVersion())
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockVisibilityMgr.On(
-		"RecordWorkflowExecutionUninitialized",
-		mock.Anything,
-		createRecordWorkflowExecutionUninitializedRequest(transferTask, mutableState),
-	).Once().Return(nil)
+	if s.mockShard.GetConfig().EnableRecordWorkflowExecutionUninitialized() {
+		s.mockVisibilityMgr.On(
+			"RecordWorkflowExecutionUninitialized",
+			mock.Anything,
+			createRecordWorkflowExecutionUninitializedRequest(transferTask, mutableState),
+		).Once().Return(nil)
+	}
 	s.mockVisibilityMgr.On(
 		"RecordWorkflowExecutionStarted",
 		mock.Anything,

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -788,6 +788,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
 	s.mockVisibilityMgr.On(
+		"RecordWorkflowExecutionUninitialized",
+		mock.Anything,
+		createRecordWorkflowExecutionUninitializedRequest(transferTask, mutableState),
+	).Once().Return(nil)
+	s.mockVisibilityMgr.On(
 		"RecordWorkflowExecutionStarted",
 		mock.Anything,
 		createRecordWorkflowExecutionStartedRequest(

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -787,11 +787,13 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 	persistenceMutableState, err := test.CreatePersistenceMutableState(mutableState, startEvent.ID, startEvent.Version)
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockVisibilityMgr.On(
-		"RecordWorkflowExecutionUninitialized",
-		mock.Anything,
-		createRecordWorkflowExecutionUninitializedRequest(transferTask, mutableState),
-	).Once().Return(nil)
+	if s.mockShard.GetConfig().EnableRecordWorkflowExecutionUninitialized() {
+		s.mockVisibilityMgr.On(
+			"RecordWorkflowExecutionUninitialized",
+			mock.Anything,
+			createRecordWorkflowExecutionUninitializedRequest(transferTask, mutableState),
+		).Once().Return(nil)
+	}
 	s.mockVisibilityMgr.On(
 		"RecordWorkflowExecutionStarted",
 		mock.Anything,

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -188,6 +188,20 @@ func (t *transferTaskExecutorBase) recordWorkflowStarted(
 		SearchAttributes:   searchAttributes,
 	}
 
+	if t.config.EnableRecordWorkflowExecutionUninitialized() {
+		uninitializedRequest := &persistence.RecordWorkflowExecutionUninitializedRequest{
+			DomainUUID: domainID,
+			Execution: types.WorkflowExecution{
+				WorkflowID: workflowID,
+				RunID:      runID,
+			},
+			WorkflowTypeName: workflowTypeName,
+		}
+		if err := t.visibilityMgr.RecordWorkflowExecutionUninitialized(ctx, uninitializedRequest); err != nil {
+			t.logger.Error("Failed to record uninitialized workflow execution", tag.Error(err))
+		}
+	}
+
 	return t.visibilityMgr.RecordWorkflowExecutionStarted(ctx, request)
 }
 

--- a/service/worker/indexer/esProcessor_test.go
+++ b/service/worker/indexer/esProcessor_test.go
@@ -135,7 +135,7 @@ func (s *esProcessorSuite) TestStop() {
 }
 
 func (s *esProcessorSuite) TestAdd() {
-	request := &es.GenericBulkableAddRequest{IsDelete: false}
+	request := &es.GenericBulkableAddRequest{RequestType: es.BulkableIndexRequest}
 	mockKafkaMsg := &msgMocks.Message{}
 	key := "test-key"
 	s.Equal(0, s.esProcessor.mapToKafkaMsg.Len())
@@ -155,7 +155,7 @@ func (s *esProcessorSuite) TestAdd() {
 }
 
 func (s *esProcessorSuite) TestAdd_ConcurrentAdd() {
-	request := &es.GenericBulkableAddRequest{IsDelete: false}
+	request := &es.GenericBulkableAddRequest{RequestType: es.BulkableIndexRequest}
 	mockKafkaMsg := &msgMocks.Message{}
 	key := "test-key"
 

--- a/service/worker/indexer/processor.go
+++ b/service/worker/indexer/processor.go
@@ -212,10 +212,15 @@ func (p *indexProcessor) addMessageToES(indexMsg *indexer.Message, kafkaMsg mess
 		keyToKafkaMsg = fmt.Sprintf("%v-%v", kafkaMsg.Partition(), kafkaMsg.Offset())
 		doc := p.generateESDoc(indexMsg, keyToKafkaMsg)
 		req.Doc = doc
-		req.IsDelete = false
+		req.RequestType = es.BulkableIndexRequest
 	case indexer.MessageTypeDelete:
 		keyToKafkaMsg = docID
-		req.IsDelete = true
+		req.RequestType = es.BulkableDeleteRequest
+	case indexer.MessageTypeCreate:
+		keyToKafkaMsg = fmt.Sprintf("%v-%v", kafkaMsg.Partition(), kafkaMsg.Offset())
+		doc := p.generateESDoc(indexMsg, keyToKafkaMsg)
+		req.Doc = doc
+		req.RequestType = es.BulkableCreateRequest
 	default:
 		logger.Error("Unknown message type")
 		p.metricsClient.IncCounter(metrics.IndexProcessorScope, metrics.IndexProcessorCorruptedData)

--- a/tools/cli/adminElasticSearchCommands.go
+++ b/tools/cli/adminElasticSearchCommands.go
@@ -152,6 +152,13 @@ func AdminIndex(c *cli.Context) {
 				Id(docID).
 				VersionType(versionTypeExternal).
 				Version(message.GetVersion())
+		case indexer.MessageTypeCreate:
+			req = elastic.NewBulkIndexRequest().
+				OpType("create").
+				Index(indexName).
+				Type(elasticsearch.GetESDocType()).
+				Id(docID).
+				VersionType("internal")
 		default:
 			ErrorAndExit("Unknown message type", nil)
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added new visibility record for uninitialized workflow execution to detect stuck workflow.
Added bulk create request to insert the new record so it wouldn't change the status of existing workflows.

<!-- Tell your future self why have you made these changes -->
**Why?**

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test by breaking the start workflow execution process and unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
