### PR TITLE
Fix remaining server lint warnings and make lint error by default.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ $(BUILD)/proto-lint: $(PROTO_FILES) $(BIN)/$(BUF_VERSION_BIN) | $(BUILD)
 # it's a coarse "you probably don't need to re-lint" filter, nothing more.
 $(BUILD)/lint: $(LINT_SRC) $(BIN)/revive | $(BUILD)
 	$Q echo "lint..."
-	$Q $(BIN)/revive -config revive.toml -exclude './canary/...' -exclude './vendor/...' -formatter unix ./... | sort
+	$Q $(BIN)/revive -config revive.toml -exclude './vendor/...' -formatter stylish ./...
 	$Q touch $@
 
 # fmt and copyright are mutually cyclic with their inputs, so if a copyright header is modified:

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -59,7 +59,7 @@ func (m *sqlStore) useAsyncTransaction() bool {
 }
 
 func (m *sqlStore) txExecute(ctx context.Context, dbShardID int, operation string, f func(tx sqlplugin.Tx) error) error {
-	tx, err := m.db.BeginTx(dbShardID, ctx)
+	tx, err := m.db.BeginTx(ctx, dbShardID)
 	if err != nil {
 		return convertCommonErrors(m.db, operation, "Failed to start transaction.", err)
 	}

--- a/common/persistence/sql/sqlExecutionStore.go
+++ b/common/persistence/sql/sqlExecutionStore.go
@@ -76,8 +76,8 @@ func NewSQLExecutionStore(
 
 // txExecuteShardLocked executes f under transaction and with read lock on shard row
 func (m *sqlExecutionStore) txExecuteShardLocked(
-	dbShardID int,
 	ctx context.Context,
+	dbShardID int,
 	operation string,
 	rangeID int64,
 	fn func(tx sqlplugin.Tx) error,
@@ -105,7 +105,7 @@ func (m *sqlExecutionStore) CreateWorkflowExecution(
 ) (response *p.CreateWorkflowExecutionResponse, err error) {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
 
-	err = m.txExecuteShardLocked(dbShardID, ctx, "CreateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+	err = m.txExecuteShardLocked(ctx, dbShardID, "CreateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
 		response, err = m.createWorkflowExecutionTx(ctx, tx, request)
 		return err
 	})
@@ -372,7 +372,7 @@ func (m *sqlExecutionStore) UpdateWorkflowExecution(
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLocked(dbShardID, ctx, "UpdateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+	return m.txExecuteShardLocked(ctx, dbShardID, "UpdateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
 		return m.updateWorkflowExecutionTx(ctx, tx, request)
 	})
 }
@@ -499,7 +499,7 @@ func (m *sqlExecutionStore) ConflictResolveWorkflowExecution(
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLocked(dbShardID, ctx, "ConflictResolveWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+	return m.txExecuteShardLocked(ctx, dbShardID, "ConflictResolveWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
 		return m.conflictResolveWorkflowExecutionTx(ctx, tx, request)
 	})
 }
@@ -1235,7 +1235,7 @@ func (m *sqlExecutionStore) CreateFailoverMarkerTasks(
 	request *p.CreateFailoverMarkersRequest,
 ) error {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLocked(dbShardID, ctx, "CreateFailoverMarkerTasks", request.RangeID, func(tx sqlplugin.Tx) error {
+	return m.txExecuteShardLocked(ctx, dbShardID, "CreateFailoverMarkerTasks", request.RangeID, func(tx sqlplugin.Tx) error {
 		for _, task := range request.Markers {
 			t := []p.Task{task}
 			if err := createReplicationTasks(

--- a/common/persistence/sql/sqlExecutionStoreUtil.go
+++ b/common/persistence/sql/sqlExecutionStoreUtil.go
@@ -422,6 +422,7 @@ func applyWorkflowMutationAsyncTx(
 	runID := serialization.MustParseUUID(executionInfo.RunID)
 
 	recoverPanic := func(err *error) {
+		// revive:disable-next-line:defer Func is being called using defer().
 		if r := recover(); r != nil {
 			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
 		}
@@ -769,6 +770,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	runID := serialization.MustParseUUID(executionInfo.RunID)
 
 	recoverPanic := func(err *error) {
+		// revive:disable-next-line:defer Func is being called using defer().
 		if r := recover(); r != nil {
 			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
 		}

--- a/common/persistence/sql/sqldriver/sharded.go
+++ b/common/persistence/sql/sqldriver/sharded.go
@@ -162,6 +162,6 @@ func (s *sharded) Rollback() error {
 	return s.tx.Rollback()
 }
 
-func getUnmatchedTxnError(requestShardID, startedShardId int) error {
-	return fmt.Errorf("requested dbShardID %v doesn't match with started transaction shardID %v, must be a bug", requestShardID, startedShardId)
+func getUnmatchedTxnError(requestShardID, startedShardID int) error {
+	return fmt.Errorf("requested dbShardID %v doesn't match with started transaction shardID %v, must be a bug", requestShardID, startedShardID)
 }

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -834,7 +834,7 @@ type (
 		ErrorChecker
 
 		GetTotalNumDBShards() int
-		BeginTx(dbShardID int, ctx context.Context) (Tx, error)
+		BeginTx(ctx context.Context, dbShardID int) (Tx, error)
 		PluginName() string
 		Close() error
 	}

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -113,7 +113,7 @@ func newDB(xdbs []*sqlx.DB, tx *sqlx.Tx, dbShardID int, numDBShards int) (*db, e
 }
 
 // BeginTx starts a new transaction and returns a reference to the Tx object
-func (mdb *db) BeginTx(dbShardID int, ctx context.Context) (sqlplugin.Tx, error) {
+func (mdb *db) BeginTx(ctx context.Context, dbShardID int) (sqlplugin.Tx, error) {
 	xtx, err := mdb.driver.BeginTxx(ctx, dbShardID, nil)
 	if err != nil {
 		return nil, err

--- a/common/persistence/sql/sqlplugin/postgres/db.go
+++ b/common/persistence/sql/sqlplugin/postgres/db.go
@@ -98,7 +98,7 @@ func newDB(xdbs []*sqlx.DB, tx *sqlx.Tx, dbShardID int, numDBShards int) (*db, e
 }
 
 // BeginTx starts a new transaction and returns a reference to the Tx object
-func (pdb *db) BeginTx(dbShardID int, ctx context.Context) (sqlplugin.Tx, error) {
+func (pdb *db) BeginTx(ctx context.Context, dbShardID int) (sqlplugin.Tx, error) {
 	xtx, err := pdb.driver.BeginTxx(ctx, dbShardID, nil)
 	if err != nil {
 		return nil, err

--- a/common/persistence/sql/sqlplugin/postgres/db.go
+++ b/common/persistence/sql/sqlplugin/postgres/db.go
@@ -137,6 +137,6 @@ func (pdb *db) MaxAllowedTTL() (*time.Duration, error) {
 }
 
 // SupportsTTL returns weather Postgre supports Asynchronous transaction
-func (mdb *db) SupportsAsyncTransaction() bool {
+func (pdb *db) SupportsAsyncTransaction() bool {
 	return false
 }

--- a/common/persistence/visibilityDualManager.go
+++ b/common/persistence/visibilityDualManager.go
@@ -183,17 +183,15 @@ func (v *visibilityDualManager) chooseVisibilityManagerForWrite(ctx context.Cont
 	case common.AdvancedVisibilityWritingModeOff:
 		if v.dbVisibilityManager != nil {
 			return dbVisFunc()
-		} else {
-			v.logger.Warn("basic visibility is not available to write, fall back to advanced visibility")
-			return esVisFunc()
 		}
+		v.logger.Warn("basic visibility is not available to write, fall back to advanced visibility")
+		return esVisFunc()
 	case common.AdvancedVisibilityWritingModeOn:
 		if v.esVisibilityManager != nil {
 			return esVisFunc()
-		} else {
-			v.logger.Warn("advanced visibility is not available to write, fall back to basic visibility")
-			return dbVisFunc()
 		}
+		v.logger.Warn("advanced visibility is not available to write, fall back to basic visibility")
+		return dbVisFunc()
 	case common.AdvancedVisibilityWritingModeDual:
 		if v.esVisibilityManager != nil {
 			if err := esVisFunc(); err != nil {
@@ -201,14 +199,12 @@ func (v *visibilityDualManager) chooseVisibilityManagerForWrite(ctx context.Cont
 			}
 			if v.dbVisibilityManager != nil {
 				return dbVisFunc()
-			} else {
-				v.logger.Warn("basic visibility is not available to write")
-				return nil
 			}
-		} else {
-			v.logger.Warn("advanced visibility is not available to write")
-			return dbVisFunc()
+			v.logger.Warn("basic visibility is not available to write")
+			return nil
 		}
+		v.logger.Warn("advanced visibility is not available to write")
+		return dbVisFunc()
 	default:
 		return &types.InternalServiceError{
 			Message: fmt.Sprintf("Unknown visibility writing mode: %s", writeMode),

--- a/common/rpc/peer_chooser.go
+++ b/common/rpc/peer_chooser.go
@@ -41,7 +41,7 @@ type (
 	}
 )
 
-func NewDNSPeerChooserFactory(interval time.Duration, logger log.Logger) *dnsPeerChooserFactory {
+func NewDNSPeerChooserFactory(interval time.Duration, logger log.Logger) PeerChooserFactory {
 	if interval <= 0 {
 		interval = defaultDNSRefreshInterval
 	}

--- a/common/rpc/peer_chooser_test.go
+++ b/common/rpc/peer_chooser_test.go
@@ -38,11 +38,7 @@ func TestDNSPeerChooserFactory(t *testing.T) {
 	ctx := context.Background()
 	interval := 100 * time.Millisecond
 
-	// Ensure default interval is set
-	factory := NewDNSPeerChooserFactory(0, logger)
-	assert.Equal(t, defaultDNSRefreshInterval, factory.interval)
-
-	factory = NewDNSPeerChooserFactory(interval, logger)
+	factory := NewDNSPeerChooserFactory(interval, logger)
 	peerTransport := &fakePeerTransport{}
 
 	// Ensure invalid address returns error

--- a/docs/non-deterministic-error.md
+++ b/docs/non-deterministic-error.md
@@ -37,13 +37,13 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * The decision state machine must be **Scheduled->Started->Closed** 
 
-* The first decision task is triggered by server. Starting from that, the rest decision task is triggered by some events of workflow itself -- when those events mean something the workflow could be waiting for. For example, Signaled, ActivityClosed, ChildWorkflowClosed, TimerFired events. Events like ActivityStarted won’t trigger decisions.  
+* The first decision task is triggered by server. Starting from that, the rest of the decision tasks are triggered by some events of the workflow itself -- when those events mean something the workflow could be waiting for. For example, Signaled, ActivityClosed, ChildWorkflowClosed, TimerFired events. Events like ActivityStarted won’t trigger decisions.
 
 * When a decision is started(internally called in flight), there cannot be any other events written into history before a decision is closed. Those events will be put into a buffer until the decision is closed -- flush buffer will write the events into history.
 
 * **In executing mode**, a decision task will try to complete with some entities: Activities/Timers/Childworkflows/etc Scheduled. 
 
-* **In history replay mode**, decisions use all of those above to rebuild a stack. **Activities/ChildWorkflows/Timers/etc will not be re-executed during history replay.** 
+* **In history replay mode**, decisions use all of those above to rebuild a stack. **Activities/Timers/ChildWorkflows/etc will not be re-executed during history replay.** 
 
 ### Activity 
 
@@ -51,11 +51,11 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * Activity is scheduled by DecisionCompleted
 
-* Activity started by worker. Normally ActivityStartedEvent can be put at any place in history except for the between of DecisionStarted and DecisionClose. 
+* Activity started by worker. Normally, ActivityStartedEvent can be put at any place in history except for in between DecisionStarted and DecisionClose. 
 
 * But Activity with RetryPolicy is a special case. Cadence will only write down Started event when Activity is finally closed. 
 
-* Activity completed/failed by worker, or timeouted by server -- they all consider activity closed, and it will trigger a decision task if no decision task on going. 
+* Activity completed/failed by worker, or timed out by server -- they all consider activity closed, and it will trigger a decision task if no decision task is ongoing. 
 
 * Like in the above, only ActivityClose events could trigger a decision.
 
@@ -65,7 +65,7 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * Local activity is only recorded with DecisionCompleted -- no state machine needed.
 
-* Local activity completed with trigger another decision
+* Local activity completed will trigger another decision
 
 ### Timer
 
@@ -93,7 +93,7 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * State machine is **Initiated->Closed**
 
-* They both initiated by DecisionCompleted, 
+* They are both initiated by DecisionCompleted.
 
 * Closed(completed/failed) by server, it could trigger a decision.
 
@@ -120,16 +120,14 @@ func Workflow(ctx workflow.Context) error {
 	if err != nil {
 		return err
 	}
-      workflow.Sleep(time.Hour)
+	workflow.Sleep(time.Hour)
 	return nil
 }
 ```
 
 The workflow will execute activityA, then wait for 1 minute, then execute activityB, finally waits for 1 hour to complete. 
 
-The history will be the follow if everything runs smoothly (no errors, timeouts, retries, etc):
-
-		
+The history will be as follows if everything runs smoothly (no errors, timeouts, retries, etc):
 
 ```
 ID:1		Workflow Started

--- a/revive.toml
+++ b/revive.toml
@@ -1,9 +1,10 @@
 # config for https://github.com/mgechev/revive
 ignoreGeneratedHeader = false
-severity = "warning"
+severity = "error"
 confidence = 0.8
-errorCode = 0
+errorCode = 1
 warningCode = 0
+
 [directive.specify-disable-reason]
     severity = "error"
 

--- a/service/frontend/clusterRedirectionPolicy.go
+++ b/service/frontend/clusterRedirectionPolicy.go
@@ -242,12 +242,11 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) getTargetClusterAndI
 	if policy.allDomainAPIs {
 		if policy.targetCluster == "" {
 			return currentActiveCluster, true
-		} else {
-			if policy.targetCluster == currentActiveCluster {
-				return currentActiveCluster, true
-			}
-			// fallback to selected APIs if targetCluster is not empty and not the same as currentActiveCluster
 		}
+		if policy.targetCluster == currentActiveCluster {
+			return currentActiveCluster, true
+		}
+		// fallback to selected APIs if targetCluster is not empty and not the same as currentActiveCluster
 	}
 
 	_, ok := policy.selectedAPIs[apiName]

--- a/service/history/decision/task_handler.go
+++ b/service/history/decision/task_handler.go
@@ -259,7 +259,7 @@ func (handler *taskHandlerImpl) handleDecisionScheduleActivity(
 	}
 
 	event, ai, activityDispatchInfo, dispatched, started, err := handler.mutableState.AddActivityTaskScheduledEvent(
-		handler.decisionTaskCompletedID, attr, ctx, handler.activityCountToDispatch > 0)
+		ctx, handler.decisionTaskCompletedID, attr, handler.activityCountToDispatch > 0)
 	if dispatched {
 		handler.activityCountToDispatch--
 	}

--- a/service/history/execution/history_builder_test.go
+++ b/service/history/execution/history_builder_test.go
@@ -1039,7 +1039,7 @@ func (s *historyBuilderSuite) addActivityTaskScheduledEvent(
 	retryPolicy *types.RetryPolicy,
 	requestLocalDispatch bool,
 ) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo) {
-	event, ai, activityDispatchInfo, _, _, err := s.msBuilder.AddActivityTaskScheduledEvent(decisionCompletedID,
+	event, ai, activityDispatchInfo, _, _, err := s.msBuilder.AddActivityTaskScheduledEvent(nil, decisionCompletedID,
 		&types.ScheduleActivityTaskDecisionAttributes{
 			ActivityID:                    activityID,
 			ActivityType:                  &types.ActivityType{Name: activityType},
@@ -1052,7 +1052,7 @@ func (s *historyBuilderSuite) addActivityTaskScheduledEvent(
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(1),
 			RetryPolicy:                   retryPolicy,
 			RequestLocalDispatch:          requestLocalDispatch,
-		}, nil, false,
+		}, false,
 	)
 	s.Nil(err)
 	if domain == "" {

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -61,7 +61,7 @@ type (
 		AddActivityTaskCanceledEvent(int64, int64, int64, []uint8, string) (*types.HistoryEvent, error)
 		AddActivityTaskCompletedEvent(int64, int64, *types.RespondActivityTaskCompletedRequest) (*types.HistoryEvent, error)
 		AddActivityTaskFailedEvent(int64, int64, *types.RespondActivityTaskFailedRequest) (*types.HistoryEvent, error)
-		AddActivityTaskScheduledEvent(int64, *types.ScheduleActivityTaskDecisionAttributes, context.Context, bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error)
+		AddActivityTaskScheduledEvent(context.Context, int64, *types.ScheduleActivityTaskDecisionAttributes, bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error)
 		AddActivityTaskStartedEvent(*persistence.ActivityInfo, int64, string, string) (*types.HistoryEvent, error)
 		AddActivityTaskTimedOutEvent(int64, int64, types.TimeoutType, []uint8) (*types.HistoryEvent, error)
 		AddCancelTimerFailedEvent(int64, *types.CancelTimerDecisionAttributes, string) (*types.HistoryEvent, error)

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -4421,12 +4421,11 @@ func (e *mutableStateBuilder) updateWithLastFirstEvent(
 func (e *mutableStateBuilder) canReplicateEvents() bool {
 	if e.domainEntry.GetReplicationPolicy() == cache.ReplicationPolicyOneCluster {
 		return false
-	} else {
-		// ReplicationPolicyMultiCluster
-		domainID := e.domainEntry.GetInfo().ID
-		workflowID := e.GetExecutionInfo().WorkflowID
-		return e.shard.GetConfig().EnableReplicationTaskGeneration(domainID, workflowID)
 	}
+	// ReplicationPolicyMultiCluster
+	domainID := e.domainEntry.GetInfo().ID
+	workflowID := e.GetExecutionInfo().WorkflowID
+	return e.shard.GetConfig().EnableReplicationTaskGeneration(domainID, workflowID)
 }
 
 // validateNoEventsAfterWorkflowFinish perform check on history event batch

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -2113,9 +2113,9 @@ func (e *mutableStateBuilder) ReplicateDecisionTaskFailedEvent() error {
 }
 
 func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
+	ctx context.Context,
 	decisionCompletedEventID int64,
 	attributes *types.ScheduleActivityTaskDecisionAttributes,
-	ctx context.Context,
 	dispatch bool,
 ) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
 
@@ -2154,7 +2154,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 	}
 	started := false
 	if dispatch {
-		started = e.tryDispatchActivityTask(event, ai, ctx)
+		started = e.tryDispatchActivityTask(ctx, event, ai)
 	}
 	if started {
 		activityStartedScope.IncCounter(metrics.CadenceRequests)
@@ -2171,9 +2171,9 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 }
 
 func (e *mutableStateBuilder) tryDispatchActivityTask(
+	ctx context.Context,
 	scheduledEvent *types.HistoryEvent,
 	ai *persistence.ActivityInfo,
-	ctx context.Context,
 ) bool {
 	taggedScope := e.metricsClient.Scope(metrics.HistoryScheduleDecisionTaskScope).Tagged(
 		metrics.DomainTag(e.domainEntry.GetInfo().Name),

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -125,7 +125,7 @@ func (mr *MockMutableStateMockRecorder) AddActivityTaskFailedEvent(arg0, arg1, a
 }
 
 // AddActivityTaskScheduledEvent mocks base method.
-func (m *MockMutableState) AddActivityTaskScheduledEvent(arg0 int64, arg1 *types.ScheduleActivityTaskDecisionAttributes, arg2 context.Context, arg3 bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
+func (m *MockMutableState) AddActivityTaskScheduledEvent(arg0 context.Context, arg1 int64, arg2 *types.ScheduleActivityTaskDecisionAttributes, arg3 bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddActivityTaskScheduledEvent", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.HistoryEvent)

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -523,10 +523,9 @@ func newTimerQueueStandbyProcessor(
 					// retry the task if failed to find the domain
 					logger.Warn("Cannot find domain", tag.WorkflowDomainID(timer.DomainID))
 					return false, err
-				} else {
-					logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(timer.DomainID), tag.Value(timer))
-					return false, nil
 				}
+				logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(timer.DomainID), tag.Value(timer))
+				return false, nil
 			}
 		}
 		return taskAllocator.VerifyStandbyTask(clusterName, timer.DomainID, timer)

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -533,10 +533,9 @@ func newTransferQueueStandbyProcessor(
 					// retry the task if failed to find the domain
 					logger.Warn("Cannot find domain", tag.WorkflowDomainID(task.DomainID))
 					return false, err
-				} else {
-					logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(task.DomainID), tag.Value(task))
-					return false, nil
 				}
+				logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(task.DomainID), tag.Value(task))
+				return false, nil
 			}
 		}
 		return taskAllocator.VerifyStandbyTask(clusterName, task.DomainID, task)

--- a/service/history/testing/events_util.go
+++ b/service/history/testing/events_util.go
@@ -145,7 +145,7 @@ func AddActivityTaskScheduledEvent(
 ) (*types.HistoryEvent,
 	*persistence.ActivityInfo) {
 
-	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(nil, decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    activityID,
 		ActivityType:                  &types.ActivityType{Name: activityType},
 		TaskList:                      &types.TaskList{Name: taskList},
@@ -154,7 +154,7 @@ func AddActivityTaskScheduledEvent(
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(scheduleToStartTimeout),
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(startToCloseTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
-	}, nil, false,
+	}, false,
 	)
 
 	return event, ai
@@ -175,7 +175,7 @@ func AddActivityTaskScheduledEventWithRetry(
 	retryPolicy *types.RetryPolicy,
 ) (*types.HistoryEvent, *persistence.ActivityInfo) {
 
-	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(nil, decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    activityID,
 		ActivityType:                  &types.ActivityType{Name: activityType},
 		TaskList:                      &types.TaskList{Name: taskList},
@@ -185,7 +185,7 @@ func AddActivityTaskScheduledEventWithRetry(
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(startToCloseTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
 		RetryPolicy:                   retryPolicy,
-	}, nil, false,
+	}, false,
 	)
 
 	return event, ai


### PR DESCRIPTION
- Minor text changes while reading this file
- Ignore lint warning: [defer] recover must be called inside a deferred function
- Fix lint warning: [var-naming] func parameter startedShardId should be startedShardID
- Fix lint warnings: [context-as-argument] context.Context should be the first parameter of a function
- Fix lint warning: [receiver-naming] receiver name mdb should be consistent with previous receiver name pdb for db
- Fix lint warning: [indent-error-flow] if block ends with a return statement, so drop this else and outdent its block
- Fix lint warning: [context-as-argument] context.Context should be the first parameter of a function
- Fix lint warning: [unexported-return] exported func NewDNSPeerChooserFactory returns unexported type rpc.dnsPeerChooserFactory, which can be annoying to use
- Make lint (revive) error by default.
