### PR TITLE
Replace unsafe usage of recover() in helper functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -333,7 +333,7 @@ $(BUILD)/proto-lint: $(PROTO_FILES) $(BIN)/$(BUF_VERSION_BIN) | $(BUILD)
 # it's a coarse "you probably don't need to re-lint" filter, nothing more.
 $(BUILD)/lint: $(LINT_SRC) $(BIN)/revive | $(BUILD)
 	$Q echo "lint..."
-	$Q $(BIN)/revive -config revive.toml -exclude './canary/...' -exclude './vendor/...' -formatter unix ./... | sort
+	$Q $(BIN)/revive -config revive.toml -exclude './vendor/...' -formatter stylish ./...
 	$Q touch $@
 
 # fmt and copyright are mutually cyclic with their inputs, so if a copyright header is modified:

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -813,7 +813,7 @@ func (c *clientImpl) GetReplicationMessages(
 	for peer, req := range requestsByPeer {
 		peer, req := peer, req
 		g.Go(func() (e error) {
-			defer log.CapturePanic(c.logger, &e)
+			defer log.CapturePanic(recover(), c.logger, &e)
 
 			requestContext, cancel := common.CreateChildContext(ctx, 0.05)
 			defer cancel()
@@ -939,7 +939,7 @@ func (c *clientImpl) CountDLQMessages(
 	for _, peer := range peers {
 		peer := peer
 		g.Go(func() (e error) {
-			defer log.CapturePanic(c.logger, &e)
+			defer log.CapturePanic(recover(), c.logger, &e)
 
 			response, err := c.client.CountDLQMessages(ctx, request, append(opts, yarpc.WithShardKey(peer))...)
 			if err == nil {
@@ -1047,7 +1047,7 @@ func (c *clientImpl) NotifyFailoverMarkers(
 	for peer, req := range requestsByPeer {
 		peer, req := peer, req
 		g.Go(func() (e error) {
-			defer log.CapturePanic(c.logger, &e)
+			defer log.CapturePanic(recover(), c.logger, &e)
 
 			ctx, cancel := c.createContext(ctx)
 			defer cancel()

--- a/common/log/panic.go
+++ b/common/log/panic.go
@@ -31,10 +31,9 @@ import (
 // If the panic value is not error then a default error is returned
 // We have to use pointer is because in golang: "recover return nil if was not called directly by a deferred function."
 // And we have to set the returned error otherwise our handler will return nil as error which is incorrect
-// NOTE: this function MUST be called in a deferred function
-func CapturePanic(logger Logger, retError *error) {
-	// revive:disable-next-line:defer Caller must call from a deferred function
-	if errPanic := recover(); errPanic != nil {
+// errPanic MUST be the result from calling recover()
+func CapturePanic(errPanic interface{}, logger Logger, retError *error) {
+	if errPanic != nil {
 		err, ok := errPanic.(error)
 		if !ok {
 			err = fmt.Errorf("panic object is not error: %#v", errPanic)

--- a/common/persistence/sql/common.go
+++ b/common/persistence/sql/common.go
@@ -59,7 +59,7 @@ func (m *sqlStore) useAsyncTransaction() bool {
 }
 
 func (m *sqlStore) txExecute(ctx context.Context, dbShardID int, operation string, f func(tx sqlplugin.Tx) error) error {
-	tx, err := m.db.BeginTx(dbShardID, ctx)
+	tx, err := m.db.BeginTx(ctx, dbShardID)
 	if err != nil {
 		return convertCommonErrors(m.db, operation, "Failed to start transaction.", err)
 	}

--- a/common/persistence/sql/sqlExecutionStore.go
+++ b/common/persistence/sql/sqlExecutionStore.go
@@ -268,10 +268,9 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	ctx context.Context,
 	request *p.InternalGetWorkflowExecutionRequest,
 ) (resp *p.InternalGetWorkflowExecutionResponse, e error) {
-	recoverPanic := func(err *error) {
-		// revive:disable-next-line:defer Func is being called using defer().
-		if r := recover(); r != nil {
-			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
+	recoverPanic := func(recovered interface{}, err *error) {
+		if recovered != nil {
+			*err = fmt.Errorf("DB operation panicked: %v %s", recovered, debug.Stack())
 		}
 	}
 
@@ -291,55 +290,55 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		executions, e = m.getExecutions(ctx, request, domainID, wfID, runID)
 		return e
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		activityInfos, e = getActivityInfoMap(
 			ctx, m.db, m.shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		timerInfos, e = getTimerInfoMap(
 			ctx, m.db, m.shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		childExecutionInfos, e = getChildExecutionInfoMap(
 			ctx, m.db, m.shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		requestCancelInfos, e = getRequestCancelInfoMap(
 			ctx, m.db, m.shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		signalInfos, e = getSignalInfoMap(
 			ctx, m.db, m.shardID, domainID, wfID, runID, m.parser)
 		return e
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		bufferedEvents, e = getBufferedEvents(
 			ctx, m.db, m.shardID, domainID, wfID, runID)
 		return e
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		signalsRequested, e = getSignalsRequested(
 			ctx, m.db, m.shardID, domainID, wfID, runID)
 		return e
@@ -619,10 +618,9 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	ctx context.Context,
 	request *p.DeleteWorkflowExecutionRequest,
 ) error {
-	recoverPanic := func(err *error) {
-		// revive:disable-next-line:defer Func is being called using defer().
-		if r := recover(); r != nil {
-			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
+	recoverPanic := func(recovered interface{}, err *error) {
+		if recovered != nil {
+			*err = fmt.Errorf("DB operation panicked: %v %s", recovered, debug.Stack())
 		}
 	}
 	domainID := serialization.MustParseUUID(request.DomainID)
@@ -631,7 +629,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromExecutions(ctx, &sqlplugin.ExecutionsFilter{
 			ShardID:    m.shardID,
 			DomainID:   domainID,
@@ -642,7 +640,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromActivityInfoMaps(ctx, &sqlplugin.ActivityInfoMapsFilter{
 			ShardID:    int64(m.shardID),
 			DomainID:   domainID,
@@ -653,7 +651,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromTimerInfoMaps(ctx, &sqlplugin.TimerInfoMapsFilter{
 			ShardID:    int64(m.shardID),
 			DomainID:   domainID,
@@ -664,7 +662,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromChildExecutionInfoMaps(ctx, &sqlplugin.ChildExecutionInfoMapsFilter{
 			ShardID:    int64(m.shardID),
 			DomainID:   domainID,
@@ -675,7 +673,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromRequestCancelInfoMaps(ctx, &sqlplugin.RequestCancelInfoMapsFilter{
 			ShardID:    int64(m.shardID),
 			DomainID:   domainID,
@@ -686,7 +684,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromSignalInfoMaps(ctx, &sqlplugin.SignalInfoMapsFilter{
 			ShardID:    int64(m.shardID),
 			DomainID:   domainID,
@@ -697,7 +695,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromBufferedEvents(ctx, &sqlplugin.BufferedEventsFilter{
 			ShardID:    m.shardID,
 			DomainID:   domainID,
@@ -708,7 +706,7 @@ func (m *sqlExecutionStore) DeleteWorkflowExecution(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		_, e = m.db.DeleteFromSignalsRequestedSets(ctx, &sqlplugin.SignalsRequestedSetsFilter{
 			ShardID:    int64(m.shardID),
 			DomainID:   domainID,

--- a/common/persistence/sql/sqlExecutionStore.go
+++ b/common/persistence/sql/sqlExecutionStore.go
@@ -76,8 +76,8 @@ func NewSQLExecutionStore(
 
 // txExecuteShardLocked executes f under transaction and with read lock on shard row
 func (m *sqlExecutionStore) txExecuteShardLocked(
-	dbShardID int,
 	ctx context.Context,
+	dbShardID int,
 	operation string,
 	rangeID int64,
 	fn func(tx sqlplugin.Tx) error,
@@ -105,7 +105,7 @@ func (m *sqlExecutionStore) CreateWorkflowExecution(
 ) (response *p.CreateWorkflowExecutionResponse, err error) {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
 
-	err = m.txExecuteShardLocked(dbShardID, ctx, "CreateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+	err = m.txExecuteShardLocked(ctx, dbShardID, "CreateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
 		response, err = m.createWorkflowExecutionTx(ctx, tx, request)
 		return err
 	})
@@ -372,7 +372,7 @@ func (m *sqlExecutionStore) UpdateWorkflowExecution(
 	request *p.InternalUpdateWorkflowExecutionRequest,
 ) error {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLocked(dbShardID, ctx, "UpdateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+	return m.txExecuteShardLocked(ctx, dbShardID, "UpdateWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
 		return m.updateWorkflowExecutionTx(ctx, tx, request)
 	})
 }
@@ -499,7 +499,7 @@ func (m *sqlExecutionStore) ConflictResolveWorkflowExecution(
 	request *p.InternalConflictResolveWorkflowExecutionRequest,
 ) error {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLocked(dbShardID, ctx, "ConflictResolveWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
+	return m.txExecuteShardLocked(ctx, dbShardID, "ConflictResolveWorkflowExecution", request.RangeID, func(tx sqlplugin.Tx) error {
 		return m.conflictResolveWorkflowExecutionTx(ctx, tx, request)
 	})
 }
@@ -1235,7 +1235,7 @@ func (m *sqlExecutionStore) CreateFailoverMarkerTasks(
 	request *p.CreateFailoverMarkersRequest,
 ) error {
 	dbShardID := sqlplugin.GetDBShardIDFromHistoryShardID(m.shardID, m.db.GetTotalNumDBShards())
-	return m.txExecuteShardLocked(dbShardID, ctx, "CreateFailoverMarkerTasks", request.RangeID, func(tx sqlplugin.Tx) error {
+	return m.txExecuteShardLocked(ctx, dbShardID, "CreateFailoverMarkerTasks", request.RangeID, func(tx sqlplugin.Tx) error {
 		for _, task := range request.Markers {
 			t := []p.Task{task}
 			if err := createReplicationTasks(

--- a/common/persistence/sql/sqlExecutionStoreUtil.go
+++ b/common/persistence/sql/sqlExecutionStoreUtil.go
@@ -421,10 +421,10 @@ func applyWorkflowMutationAsyncTx(
 	workflowID := executionInfo.WorkflowID
 	runID := serialization.MustParseUUID(executionInfo.RunID)
 
-	recoverPanic := func(err *error) {
+	recoverPanic := func(recovered interface{}, err *error) {
 		// revive:disable-next-line:defer Func is being called using defer().
-		if r := recover(); r != nil {
-			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
+		if recovered != nil {
+			*err = fmt.Errorf("DB operation panicked: %v %s", recovered, debug.Stack())
 		}
 	}
 
@@ -455,7 +455,7 @@ func applyWorkflowMutationAsyncTx(
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createTransferTasks(
 			ctx,
 			tx,
@@ -469,7 +469,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createCrossClusterTasks(
 			ctx,
 			tx,
@@ -483,7 +483,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createReplicationTasks(
 			ctx,
 			tx,
@@ -497,7 +497,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createTimerTasks(
 			ctx,
 			tx,
@@ -511,7 +511,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateActivityInfos(
 			ctx,
 			tx,
@@ -526,7 +526,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateTimerInfos(
 			ctx,
 			tx,
@@ -542,7 +542,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateChildExecutionInfos(
 			ctx,
 			tx,
@@ -558,7 +558,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateRequestCancelInfos(
 			ctx,
 			tx,
@@ -574,7 +574,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateSignalInfos(
 			ctx,
 			tx,
@@ -590,7 +590,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateSignalsRequested(
 			ctx,
 			tx,
@@ -605,7 +605,7 @@ func applyWorkflowMutationAsyncTx(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		if workflowMutation.ClearBufferedEvents {
 			if e = deleteBufferedEvents(
 				ctx,
@@ -769,16 +769,15 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	workflowID := executionInfo.WorkflowID
 	runID := serialization.MustParseUUID(executionInfo.RunID)
 
-	recoverPanic := func(err *error) {
-		// revive:disable-next-line:defer Func is being called using defer().
-		if r := recover(); r != nil {
-			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
+	recoverPanic := func(recovered interface{}, err *error) {
+		if recovered != nil {
+			*err = fmt.Errorf("DB operation panicked: %v %s", recovered, debug.Stack())
 		}
 	}
 	g, ctx := errgroup.WithContext(ctx)
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = m.createExecution(
 			ctx,
 			tx,
@@ -792,7 +791,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createTransferTasks(
 			ctx,
 			tx,
@@ -806,7 +805,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createCrossClusterTasks(
 			ctx,
 			tx,
@@ -820,7 +819,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createReplicationTasks(
 			ctx,
 			tx,
@@ -834,7 +833,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = createTimerTasks(
 			ctx,
 			tx,
@@ -848,7 +847,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateActivityInfos(
 			ctx,
 			tx,
@@ -863,7 +862,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateTimerInfos(
 			ctx,
 			tx,
@@ -878,7 +877,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateChildExecutionInfos(
 			ctx,
 			tx,
@@ -893,7 +892,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateRequestCancelInfos(
 			ctx,
 			tx,
@@ -908,7 +907,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateSignalInfos(
 			ctx,
 			tx,
@@ -923,7 +922,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	})
 
 	g.Go(func() (e error) {
-		defer recoverPanic(&e)
+		defer recoverPanic(recover(), &e)
 		e = updateSignalsRequested(
 			ctx,
 			tx,

--- a/common/persistence/sql/sqlExecutionStoreUtil.go
+++ b/common/persistence/sql/sqlExecutionStoreUtil.go
@@ -422,6 +422,7 @@ func applyWorkflowMutationAsyncTx(
 	runID := serialization.MustParseUUID(executionInfo.RunID)
 
 	recoverPanic := func(err *error) {
+		// revive:disable-next-line:defer Func is being called using defer().
 		if r := recover(); r != nil {
 			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
 		}
@@ -769,6 +770,7 @@ func (m *sqlExecutionStore) applyWorkflowSnapshotAsyncTxAsNew(
 	runID := serialization.MustParseUUID(executionInfo.RunID)
 
 	recoverPanic := func(err *error) {
+		// revive:disable-next-line:defer Func is being called using defer().
 		if r := recover(); r != nil {
 			*err = fmt.Errorf("DB operation panicked: %v %s", r, debug.Stack())
 		}

--- a/common/persistence/sql/sqldriver/sharded.go
+++ b/common/persistence/sql/sqldriver/sharded.go
@@ -162,6 +162,6 @@ func (s *sharded) Rollback() error {
 	return s.tx.Rollback()
 }
 
-func getUnmatchedTxnError(requestShardID, startedShardId int) error {
-	return fmt.Errorf("requested dbShardID %v doesn't match with started transaction shardID %v, must be a bug", requestShardID, startedShardId)
+func getUnmatchedTxnError(requestShardID, startedShardID int) error {
+	return fmt.Errorf("requested dbShardID %v doesn't match with started transaction shardID %v, must be a bug", requestShardID, startedShardID)
 }

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -834,7 +834,7 @@ type (
 		ErrorChecker
 
 		GetTotalNumDBShards() int
-		BeginTx(dbShardID int, ctx context.Context) (Tx, error)
+		BeginTx(ctx context.Context, dbShardID int) (Tx, error)
 		PluginName() string
 		Close() error
 	}

--- a/common/persistence/sql/sqlplugin/mysql/db.go
+++ b/common/persistence/sql/sqlplugin/mysql/db.go
@@ -113,7 +113,7 @@ func newDB(xdbs []*sqlx.DB, tx *sqlx.Tx, dbShardID int, numDBShards int) (*db, e
 }
 
 // BeginTx starts a new transaction and returns a reference to the Tx object
-func (mdb *db) BeginTx(dbShardID int, ctx context.Context) (sqlplugin.Tx, error) {
+func (mdb *db) BeginTx(ctx context.Context, dbShardID int) (sqlplugin.Tx, error) {
 	xtx, err := mdb.driver.BeginTxx(ctx, dbShardID, nil)
 	if err != nil {
 		return nil, err

--- a/common/persistence/sql/sqlplugin/postgres/db.go
+++ b/common/persistence/sql/sqlplugin/postgres/db.go
@@ -98,7 +98,7 @@ func newDB(xdbs []*sqlx.DB, tx *sqlx.Tx, dbShardID int, numDBShards int) (*db, e
 }
 
 // BeginTx starts a new transaction and returns a reference to the Tx object
-func (pdb *db) BeginTx(dbShardID int, ctx context.Context) (sqlplugin.Tx, error) {
+func (pdb *db) BeginTx(ctx context.Context, dbShardID int) (sqlplugin.Tx, error) {
 	xtx, err := pdb.driver.BeginTxx(ctx, dbShardID, nil)
 	if err != nil {
 		return nil, err

--- a/common/persistence/sql/sqlplugin/postgres/db.go
+++ b/common/persistence/sql/sqlplugin/postgres/db.go
@@ -137,6 +137,6 @@ func (pdb *db) MaxAllowedTTL() (*time.Duration, error) {
 }
 
 // SupportsTTL returns weather Postgre supports Asynchronous transaction
-func (mdb *db) SupportsAsyncTransaction() bool {
+func (pdb *db) SupportsAsyncTransaction() bool {
 	return false
 }

--- a/common/persistence/visibilityDualManager.go
+++ b/common/persistence/visibilityDualManager.go
@@ -183,17 +183,15 @@ func (v *visibilityDualManager) chooseVisibilityManagerForWrite(ctx context.Cont
 	case common.AdvancedVisibilityWritingModeOff:
 		if v.dbVisibilityManager != nil {
 			return dbVisFunc()
-		} else {
-			v.logger.Warn("basic visibility is not available to write, fall back to advanced visibility")
-			return esVisFunc()
 		}
+		v.logger.Warn("basic visibility is not available to write, fall back to advanced visibility")
+		return esVisFunc()
 	case common.AdvancedVisibilityWritingModeOn:
 		if v.esVisibilityManager != nil {
 			return esVisFunc()
-		} else {
-			v.logger.Warn("advanced visibility is not available to write, fall back to basic visibility")
-			return dbVisFunc()
 		}
+		v.logger.Warn("advanced visibility is not available to write, fall back to basic visibility")
+		return dbVisFunc()
 	case common.AdvancedVisibilityWritingModeDual:
 		if v.esVisibilityManager != nil {
 			if err := esVisFunc(); err != nil {
@@ -201,14 +199,12 @@ func (v *visibilityDualManager) chooseVisibilityManagerForWrite(ctx context.Cont
 			}
 			if v.dbVisibilityManager != nil {
 				return dbVisFunc()
-			} else {
-				v.logger.Warn("basic visibility is not available to write")
-				return nil
 			}
-		} else {
-			v.logger.Warn("advanced visibility is not available to write")
-			return dbVisFunc()
+			v.logger.Warn("basic visibility is not available to write")
+			return nil
 		}
+		v.logger.Warn("advanced visibility is not available to write")
+		return dbVisFunc()
 	default:
 		return &types.InternalServiceError{
 			Message: fmt.Sprintf("Unknown visibility writing mode: %s", writeMode),

--- a/common/rpc/peer_chooser.go
+++ b/common/rpc/peer_chooser.go
@@ -41,7 +41,7 @@ type (
 	}
 )
 
-func NewDNSPeerChooserFactory(interval time.Duration, logger log.Logger) *dnsPeerChooserFactory {
+func NewDNSPeerChooserFactory(interval time.Duration, logger log.Logger) PeerChooserFactory {
 	if interval <= 0 {
 		interval = defaultDNSRefreshInterval
 	}

--- a/common/rpc/peer_chooser_test.go
+++ b/common/rpc/peer_chooser_test.go
@@ -38,11 +38,7 @@ func TestDNSPeerChooserFactory(t *testing.T) {
 	ctx := context.Background()
 	interval := 100 * time.Millisecond
 
-	// Ensure default interval is set
-	factory := NewDNSPeerChooserFactory(0, logger)
-	assert.Equal(t, defaultDNSRefreshInterval, factory.interval)
-
-	factory = NewDNSPeerChooserFactory(interval, logger)
+	factory := NewDNSPeerChooserFactory(interval, logger)
 	peerTransport := &fakePeerTransport{}
 
 	// Ensure invalid address returns error

--- a/docs/non-deterministic-error.md
+++ b/docs/non-deterministic-error.md
@@ -37,13 +37,13 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * The decision state machine must be **Scheduled->Started->Closed** 
 
-* The first decision task is triggered by server. Starting from that, the rest decision task is triggered by some events of workflow itself -- when those events mean something the workflow could be waiting for. For example, Signaled, ActivityClosed, ChildWorkflowClosed, TimerFired events. Events like ActivityStarted won’t trigger decisions.  
+* The first decision task is triggered by server. Starting from that, the rest of the decision tasks are triggered by some events of the workflow itself -- when those events mean something the workflow could be waiting for. For example, Signaled, ActivityClosed, ChildWorkflowClosed, TimerFired events. Events like ActivityStarted won’t trigger decisions.
 
 * When a decision is started(internally called in flight), there cannot be any other events written into history before a decision is closed. Those events will be put into a buffer until the decision is closed -- flush buffer will write the events into history.
 
 * **In executing mode**, a decision task will try to complete with some entities: Activities/Timers/Childworkflows/etc Scheduled. 
 
-* **In history replay mode**, decisions use all of those above to rebuild a stack. **Activities/ChildWorkflows/Timers/etc will not be re-executed during history replay.** 
+* **In history replay mode**, decisions use all of those above to rebuild a stack. **Activities/Timers/ChildWorkflows/etc will not be re-executed during history replay.** 
 
 ### Activity 
 
@@ -51,11 +51,11 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * Activity is scheduled by DecisionCompleted
 
-* Activity started by worker. Normally ActivityStartedEvent can be put at any place in history except for the between of DecisionStarted and DecisionClose. 
+* Activity started by worker. Normally, ActivityStartedEvent can be put at any place in history except for in between DecisionStarted and DecisionClose. 
 
 * But Activity with RetryPolicy is a special case. Cadence will only write down Started event when Activity is finally closed. 
 
-* Activity completed/failed by worker, or timeouted by server -- they all consider activity closed, and it will trigger a decision task if no decision task on going. 
+* Activity completed/failed by worker, or timed out by server -- they all consider activity closed, and it will trigger a decision task if no decision task is ongoing. 
 
 * Like in the above, only ActivityClose events could trigger a decision.
 
@@ -65,7 +65,7 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * Local activity is only recorded with DecisionCompleted -- no state machine needed.
 
-* Local activity completed with trigger another decision
+* Local activity completed will trigger another decision
 
 ### Timer
 
@@ -93,7 +93,7 @@ In Cadence, we use "close" to describe the opposite status of “open”. For ac
 
 * State machine is **Initiated->Closed**
 
-* They both initiated by DecisionCompleted, 
+* They are both initiated by DecisionCompleted.
 
 * Closed(completed/failed) by server, it could trigger a decision.
 
@@ -120,16 +120,14 @@ func Workflow(ctx workflow.Context) error {
 	if err != nil {
 		return err
 	}
-      workflow.Sleep(time.Hour)
+	workflow.Sleep(time.Hour)
 	return nil
 }
 ```
 
 The workflow will execute activityA, then wait for 1 minute, then execute activityB, finally waits for 1 hour to complete. 
 
-The history will be the follow if everything runs smoothly (no errors, timeouts, retries, etc):
-
-		
+The history will be as follows if everything runs smoothly (no errors, timeouts, retries, etc):
 
 ```
 ID:1		Workflow Started

--- a/revive.toml
+++ b/revive.toml
@@ -1,9 +1,10 @@
 # config for https://github.com/mgechev/revive
 ignoreGeneratedHeader = false
-severity = "warning"
+severity = "error"
 confidence = 0.8
-errorCode = 0
+errorCode = 1
 warningCode = 0
+
 [directive.specify-disable-reason]
     severity = "error"
 

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -202,7 +202,7 @@ func (adh *adminHandlerImpl) AddSearchAttribute(
 	request *types.AddSearchAttributeRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminAddSearchAttributeScope)
 	defer sw.Stop()
 
@@ -274,7 +274,7 @@ func (adh *adminHandlerImpl) DescribeWorkflowExecution(
 	request *types.AdminDescribeWorkflowExecutionRequest,
 ) (resp *types.AdminDescribeWorkflowExecutionResponse, retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminDescribeWorkflowExecutionScope)
 	defer sw.Stop()
 
@@ -322,7 +322,7 @@ func (adh *adminHandlerImpl) RemoveTask(
 	request *types.RemoveTaskRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminRemoveTaskScope)
 	defer sw.Stop()
 
@@ -619,7 +619,7 @@ func (adh *adminHandlerImpl) CloseShard(
 	request *types.CloseShardRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminCloseShardScope)
 	defer sw.Stop()
 
@@ -638,7 +638,7 @@ func (adh *adminHandlerImpl) ResetQueue(
 	request *types.ResetQueueRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminResetQueueScope)
 	defer sw.Stop()
 
@@ -661,7 +661,7 @@ func (adh *adminHandlerImpl) DescribeQueue(
 	request *types.DescribeQueueRequest,
 ) (resp *types.DescribeQueueResponse, retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminDescribeQueueScope)
 	defer sw.Stop()
 
@@ -681,7 +681,7 @@ func (adh *adminHandlerImpl) DescribeShardDistribution(
 	request *types.DescribeShardDistributionRequest,
 ) (resp *types.DescribeShardDistributionResponse, retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	_, sw := adh.startRequestProfile(ctx, metrics.AdminDescribeShardDistributionScope)
 	defer sw.Stop()
 
@@ -710,7 +710,7 @@ func (adh *adminHandlerImpl) DescribeHistoryHost(
 	request *types.DescribeHistoryHostRequest,
 ) (resp *types.DescribeHistoryHostResponse, retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminDescribeHistoryHostScope)
 	defer sw.Stop()
 
@@ -733,7 +733,7 @@ func (adh *adminHandlerImpl) GetWorkflowExecutionRawHistoryV2(
 	request *types.GetWorkflowExecutionRawHistoryV2Request,
 ) (resp *types.GetWorkflowExecutionRawHistoryV2Response, retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminGetWorkflowExecutionRawHistoryV2Scope)
 	defer sw.Stop()
 
@@ -864,7 +864,7 @@ func (adh *adminHandlerImpl) DescribeCluster(
 	ctx context.Context,
 ) (resp *types.DescribeClusterResponse, retError error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminGetWorkflowExecutionRawHistoryV2Scope)
 	defer sw.Stop()
 
@@ -937,7 +937,7 @@ func (adh *adminHandlerImpl) GetReplicationMessages(
 	request *types.GetReplicationMessagesRequest,
 ) (resp *types.GetReplicationMessagesResponse, err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminGetReplicationMessagesScope)
 	defer sw.Stop()
 
@@ -961,7 +961,7 @@ func (adh *adminHandlerImpl) GetDomainReplicationMessages(
 	request *types.GetDomainReplicationMessagesRequest,
 ) (resp *types.GetDomainReplicationMessagesResponse, err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminGetDomainReplicationMessagesScope)
 	defer sw.Stop()
 
@@ -1020,7 +1020,7 @@ func (adh *adminHandlerImpl) GetDLQReplicationMessages(
 	request *types.GetDLQReplicationMessagesRequest,
 ) (resp *types.GetDLQReplicationMessagesResponse, err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminGetDLQReplicationMessagesScope)
 	defer sw.Stop()
 
@@ -1044,7 +1044,7 @@ func (adh *adminHandlerImpl) ReapplyEvents(
 	request *types.ReapplyEventsRequest,
 ) (err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminReapplyEventsScope)
 	defer sw.Stop()
 
@@ -1084,7 +1084,7 @@ func (adh *adminHandlerImpl) ReadDLQMessages(
 	request *types.ReadDLQMessagesRequest,
 ) (resp *types.ReadDLQMessagesResponse, err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminReadDLQMessagesScope)
 	defer sw.Stop()
 
@@ -1145,7 +1145,7 @@ func (adh *adminHandlerImpl) PurgeDLQMessages(
 	request *types.PurgeDLQMessagesRequest,
 ) (err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminPurgeDLQMessagesScope)
 	defer sw.Stop()
 
@@ -1192,7 +1192,7 @@ func (adh *adminHandlerImpl) CountDLQMessages(
 	ctx context.Context,
 	request *types.CountDLQMessagesRequest,
 ) (resp *types.CountDLQMessagesResponse, err error) {
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminCountDLQMessagesScope)
 	defer sw.Stop()
@@ -1219,7 +1219,7 @@ func (adh *adminHandlerImpl) MergeDLQMessages(
 	request *types.MergeDLQMessagesRequest,
 ) (resp *types.MergeDLQMessagesResponse, err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminMergeDLQMessagesScope)
 	defer sw.Stop()
 
@@ -1275,7 +1275,7 @@ func (adh *adminHandlerImpl) RefreshWorkflowTasks(
 	ctx context.Context,
 	request *types.RefreshWorkflowTasksRequest,
 ) (err error) {
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminRefreshWorkflowTasksScope)
 	defer sw.Stop()
 
@@ -1305,7 +1305,7 @@ func (adh *adminHandlerImpl) ResendReplicationTasks(
 	ctx context.Context,
 	request *types.ResendReplicationTasksRequest,
 ) (err error) {
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminResendReplicationTasksScope)
 	defer sw.Stop()
 
@@ -1338,7 +1338,7 @@ func (adh *adminHandlerImpl) GetCrossClusterTasks(
 	request *types.GetCrossClusterTasksRequest,
 ) (resp *types.GetCrossClusterTasksResponse, err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminGetCrossClusterTasksScope)
 	defer sw.Stop()
 
@@ -1361,7 +1361,7 @@ func (adh *adminHandlerImpl) RespondCrossClusterTasksCompleted(
 	request *types.RespondCrossClusterTasksCompletedRequest,
 ) (resp *types.RespondCrossClusterTasksCompletedResponse, err error) {
 
-	defer log.CapturePanic(adh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &err)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminRespondCrossClusterTasksCompletedScope)
 	defer sw.Stop()
 
@@ -1590,7 +1590,7 @@ func deserializeRawHistoryToken(bytes []byte) (*getWorkflowRawHistoryV2Token, er
 }
 
 func (adh *adminHandlerImpl) GetDynamicConfig(ctx context.Context, request *types.GetDynamicConfigRequest) (_ *types.GetDynamicConfigResponse, retError error) {
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminGetDynamicConfigScope)
 	defer sw.Stop()
 
@@ -1634,7 +1634,7 @@ func (adh *adminHandlerImpl) GetDynamicConfig(ctx context.Context, request *type
 }
 
 func (adh *adminHandlerImpl) UpdateDynamicConfig(ctx context.Context, request *types.UpdateDynamicConfigRequest) (retError error) {
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminUpdateDynamicConfigScope)
 	defer sw.Stop()
 
@@ -1651,7 +1651,7 @@ func (adh *adminHandlerImpl) UpdateDynamicConfig(ctx context.Context, request *t
 }
 
 func (adh *adminHandlerImpl) RestoreDynamicConfig(ctx context.Context, request *types.RestoreDynamicConfigRequest) (retError error) {
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminRestoreDynamicConfigScope)
 	defer sw.Stop()
 
@@ -1678,7 +1678,7 @@ func (adh *adminHandlerImpl) RestoreDynamicConfig(ctx context.Context, request *
 }
 
 func (adh *adminHandlerImpl) ListDynamicConfig(ctx context.Context, request *types.ListDynamicConfigRequest) (_ *types.ListDynamicConfigResponse, retError error) {
-	defer log.CapturePanic(adh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), adh.GetLogger(), &retError)
 	scope, sw := adh.startRequestProfile(ctx, metrics.AdminListDynamicConfigScope)
 	defer sw.Stop()
 

--- a/service/frontend/clusterRedirectionHandler.go
+++ b/service/frontend/clusterRedirectionHandler.go
@@ -86,7 +86,7 @@ func (handler *ClusterRedirectionHandlerImpl) DeprecateDomain(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionDeprecateDomainScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	return handler.frontendHandler.DeprecateDomain(ctx, request)
@@ -102,7 +102,7 @@ func (handler *ClusterRedirectionHandlerImpl) DescribeDomain(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionDescribeDomainScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	return handler.frontendHandler.DescribeDomain(ctx, request)
@@ -118,7 +118,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListDomains(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionListDomainsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	return handler.frontendHandler.ListDomains(ctx, request)
@@ -134,7 +134,7 @@ func (handler *ClusterRedirectionHandlerImpl) RegisterDomain(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRegisterDomainScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	return handler.frontendHandler.RegisterDomain(ctx, request)
@@ -150,7 +150,7 @@ func (handler *ClusterRedirectionHandlerImpl) UpdateDomain(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionUpdateDomainScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	return handler.frontendHandler.UpdateDomain(ctx, request)
@@ -170,7 +170,7 @@ func (handler *ClusterRedirectionHandlerImpl) DescribeTaskList(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionDescribeTaskListScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -200,7 +200,7 @@ func (handler *ClusterRedirectionHandlerImpl) DescribeWorkflowExecution(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionDescribeWorkflowExecutionScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -230,7 +230,7 @@ func (handler *ClusterRedirectionHandlerImpl) GetWorkflowExecutionHistory(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionGetWorkflowExecutionHistoryScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -260,7 +260,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListArchivedWorkflowExecutions(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionListArchivedWorkflowExecutionsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -290,7 +290,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListClosedWorkflowExecutions(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionListClosedWorkflowExecutionsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -320,7 +320,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListOpenWorkflowExecutions(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionListOpenWorkflowExecutionsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -350,7 +350,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListWorkflowExecutions(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionListWorkflowExecutionsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -380,7 +380,7 @@ func (handler *ClusterRedirectionHandlerImpl) ScanWorkflowExecutions(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionScanWorkflowExecutionsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
 		cluster = targetDC
@@ -409,7 +409,7 @@ func (handler *ClusterRedirectionHandlerImpl) CountWorkflowExecutions(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionCountWorkflowExecutionsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -436,7 +436,7 @@ func (handler *ClusterRedirectionHandlerImpl) GetSearchAttributes(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionGetSearchAttributesScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	return handler.frontendHandler.GetSearchAttributes(ctx)
@@ -454,7 +454,7 @@ func (handler *ClusterRedirectionHandlerImpl) PollForActivityTask(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionPollForActivityTaskScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -484,7 +484,7 @@ func (handler *ClusterRedirectionHandlerImpl) PollForDecisionTask(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionPollForDecisionTaskScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -520,7 +520,7 @@ func (handler *ClusterRedirectionHandlerImpl) QueryWorkflow(
 	}
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionQueryWorkflowScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -550,7 +550,7 @@ func (handler *ClusterRedirectionHandlerImpl) RecordActivityTaskHeartbeat(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRecordActivityTaskHeartbeatScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -585,7 +585,7 @@ func (handler *ClusterRedirectionHandlerImpl) RecordActivityTaskHeartbeatByID(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRecordActivityTaskHeartbeatByIDScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -615,7 +615,7 @@ func (handler *ClusterRedirectionHandlerImpl) RequestCancelWorkflowExecution(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRequestCancelWorkflowExecutionScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -645,7 +645,7 @@ func (handler *ClusterRedirectionHandlerImpl) ResetStickyTaskList(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionResetStickyTaskListScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -675,7 +675,7 @@ func (handler *ClusterRedirectionHandlerImpl) ResetWorkflowExecution(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionResetWorkflowExecutionScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -705,7 +705,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCanceled(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondActivityTaskCanceledScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -740,7 +740,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCanceledByID(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondActivityTaskCanceledByIDScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -770,7 +770,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCompleted(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondActivityTaskCompletedScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -805,7 +805,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCompletedByID(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondActivityTaskCompletedByIDScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -835,7 +835,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskFailed(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondActivityTaskFailedScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -870,7 +870,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskFailedByID(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondActivityTaskFailedByIDScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -900,7 +900,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondDecisionTaskCompleted(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondDecisionTaskCompletedScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -935,7 +935,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondDecisionTaskFailed(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondDecisionTaskFailedScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	token, err := handler.tokenSerializer.Deserialize(request.TaskToken)
@@ -970,7 +970,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondQueryTaskCompleted(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRespondQueryTaskCompletedScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	token, err := handler.tokenSerializer.DeserializeQueryTaskToken(request.TaskToken)
@@ -1005,7 +1005,7 @@ func (handler *ClusterRedirectionHandlerImpl) SignalWithStartWorkflowExecution(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionSignalWithStartWorkflowExecutionScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -1035,7 +1035,7 @@ func (handler *ClusterRedirectionHandlerImpl) SignalWorkflowExecution(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionSignalWorkflowExecutionScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -1064,7 +1064,7 @@ func (handler *ClusterRedirectionHandlerImpl) StartWorkflowExecution(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionStartWorkflowExecutionScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -1094,7 +1094,7 @@ func (handler *ClusterRedirectionHandlerImpl) TerminateWorkflowExecution(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionTerminateWorkflowExecutionScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -1124,7 +1124,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListTaskListPartitions(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionListTaskListPartitionsScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -1154,7 +1154,7 @@ func (handler *ClusterRedirectionHandlerImpl) GetTaskListsByDomain(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionGetTaskListsByDomainScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -1184,7 +1184,7 @@ func (handler *ClusterRedirectionHandlerImpl) RefreshWorkflowTasks(
 
 	scope, startTime := handler.beforeCall(metrics.DCRedirectionRefreshWorkflowTasksScope)
 	defer func() {
-		handler.afterCall(scope, startTime, cluster, &retError)
+		handler.afterCall(recover(), scope, startTime, cluster, &retError)
 	}()
 
 	err = handler.redirectionPolicy.WithDomainNameRedirect(ctx, request.GetDomain(), apiName, func(targetDC string) error {
@@ -1217,13 +1217,14 @@ func (handler *ClusterRedirectionHandlerImpl) beforeCall(
 }
 
 func (handler *ClusterRedirectionHandlerImpl) afterCall(
+	recovered interface{},
 	scope metrics.Scope,
 	startTime time.Time,
 	cluster string,
 	retError *error,
 ) {
 
-	log.CapturePanic(handler.GetLogger(), retError)
+	log.CapturePanic(recovered, handler.GetLogger(), retError)
 
 	scope = scope.Tagged(metrics.TargetClusterTag(cluster))
 	scope.IncCounter(metrics.CadenceDcRedirectionClientRequests)

--- a/service/frontend/clusterRedirectionPolicy.go
+++ b/service/frontend/clusterRedirectionPolicy.go
@@ -242,12 +242,11 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) getTargetClusterAndI
 	if policy.allDomainAPIs {
 		if policy.targetCluster == "" {
 			return currentActiveCluster, true
-		} else {
-			if policy.targetCluster == currentActiveCluster {
-				return currentActiveCluster, true
-			}
-			// fallback to selected APIs if targetCluster is not empty and not the same as currentActiveCluster
 		}
+		if policy.targetCluster == currentActiveCluster {
+			return currentActiveCluster, true
+		}
+		// fallback to selected APIs if targetCluster is not empty and not the same as currentActiveCluster
 	}
 
 	_, ok := policy.selectedAPIs[apiName]

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -265,7 +265,7 @@ func (wh *WorkflowHandler) Health(ctx context.Context) (*types.HealthStatus, err
 // acts as a sandbox and provides isolation for all resources within the domain.  All resources belongs to exactly one
 // domain.
 func (wh *WorkflowHandler) RegisterDomain(ctx context.Context, registerRequest *types.RegisterDomainRequest) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfile(ctx, metrics.FrontendRegisterDomainScope)
 	defer sw.Stop()
@@ -310,7 +310,7 @@ func (wh *WorkflowHandler) ListDomains(
 	ctx context.Context,
 	listRequest *types.ListDomainsRequest,
 ) (response *types.ListDomainsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfile(ctx, metrics.FrontendListDomainsScope)
 	defer sw.Stop()
@@ -339,7 +339,7 @@ func (wh *WorkflowHandler) DescribeDomain(
 	ctx context.Context,
 	describeRequest *types.DescribeDomainRequest,
 ) (response *types.DescribeDomainResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfile(ctx, metrics.FrontendDescribeDomainScope)
 	defer sw.Stop()
@@ -389,7 +389,7 @@ func (wh *WorkflowHandler) UpdateDomain(
 	ctx context.Context,
 	updateRequest *types.UpdateDomainRequest,
 ) (resp *types.UpdateDomainResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfile(ctx, metrics.FrontendUpdateDomainScope)
 	defer sw.Stop()
@@ -476,7 +476,7 @@ func (wh *WorkflowHandler) UpdateDomain(
 // it cannot be used to start new workflow executions.  Existing workflow executions will continue to run on
 // deprecated domains.
 func (wh *WorkflowHandler) DeprecateDomain(ctx context.Context, deprecateRequest *types.DeprecateDomainRequest) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfile(ctx, metrics.FrontendDeprecateDomainScope)
 	defer sw.Stop()
@@ -513,7 +513,7 @@ func (wh *WorkflowHandler) PollForActivityTask(
 	ctx context.Context,
 	pollRequest *types.PollForActivityTaskRequest,
 ) (resp *types.PollForActivityTaskResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	callTime := time.Now()
 
@@ -622,7 +622,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 	ctx context.Context,
 	pollRequest *types.PollForDecisionTaskRequest,
 ) (resp *types.PollForDecisionTaskResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	callTime := time.Now()
 
@@ -788,7 +788,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 	ctx context.Context,
 	heartbeatRequest *types.RecordActivityTaskHeartbeatRequest,
 ) (resp *types.RecordActivityTaskHeartbeatResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendRecordActivityTaskHeartbeatScope)
 
@@ -887,7 +887,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 	ctx context.Context,
 	heartbeatRequest *types.RecordActivityTaskHeartbeatByIDRequest,
 ) (resp *types.RecordActivityTaskHeartbeatResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendRecordActivityTaskHeartbeatByIDScope, heartbeatRequest)
 	defer sw.Stop()
@@ -1002,7 +1002,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 	ctx context.Context,
 	completeRequest *types.RespondActivityTaskCompletedRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendRespondActivityTaskCompletedScope)
 
@@ -1111,7 +1111,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 	ctx context.Context,
 	completeRequest *types.RespondActivityTaskCompletedByIDRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendRespondActivityTaskCompletedByIDScope, completeRequest)
 	defer sw.Stop()
@@ -1236,7 +1236,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 	ctx context.Context,
 	failedRequest *types.RespondActivityTaskFailedRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendRespondActivityTaskFailedScope)
 
@@ -1333,7 +1333,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 	ctx context.Context,
 	failedRequest *types.RespondActivityTaskFailedByIDRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendRespondActivityTaskFailedByIDScope, failedRequest)
 	defer sw.Stop()
@@ -1447,7 +1447,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 	ctx context.Context,
 	cancelRequest *types.RespondActivityTaskCanceledRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendRespondActivityTaskCanceledScope)
 
@@ -1558,7 +1558,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 	ctx context.Context,
 	cancelRequest *types.RespondActivityTaskCanceledByIDRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendRespondActivityTaskCanceledScope, cancelRequest)
 	defer sw.Stop()
@@ -1683,7 +1683,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 	ctx context.Context,
 	completeRequest *types.RespondDecisionTaskCompletedRequest,
 ) (resp *types.RespondDecisionTaskCompletedResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendRespondDecisionTaskCompletedScope)
 
@@ -1793,7 +1793,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 	ctx context.Context,
 	failedRequest *types.RespondDecisionTaskFailedRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendRespondDecisionTaskFailedScope)
 
@@ -1889,7 +1889,7 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 	ctx context.Context,
 	completeRequest *types.RespondQueryTaskCompletedRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendRespondQueryTaskCompletedScope)
 
@@ -1982,7 +1982,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	ctx context.Context,
 	startRequest *types.StartWorkflowExecutionRequest,
 ) (resp *types.StartWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendStartWorkflowExecutionScope, startRequest)
 	defer sw.Stop()
@@ -2166,7 +2166,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 	ctx context.Context,
 	getRequest *types.GetWorkflowExecutionHistoryRequest,
 ) (resp *types.GetWorkflowExecutionHistoryResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendGetWorkflowExecutionHistoryScope, getRequest)
 	defer sw.Stop()
@@ -2438,7 +2438,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(
 	ctx context.Context,
 	signalRequest *types.SignalWorkflowExecutionRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	ctx = wh.withSignalName(ctx, signalRequest.GetDomain(), signalRequest.GetSignalName())
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendSignalWorkflowExecutionScope, signalRequest)
@@ -2554,7 +2554,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 	ctx context.Context,
 	signalWithStartRequest *types.SignalWithStartWorkflowExecutionRequest,
 ) (resp *types.StartWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendSignalWithStartWorkflowExecutionScope, signalWithStartRequest)
 	defer sw.Stop()
@@ -2734,7 +2734,7 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(
 	ctx context.Context,
 	terminateRequest *types.TerminateWorkflowExecutionRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendTerminateWorkflowExecutionScope, terminateRequest)
 	defer sw.Stop()
@@ -2789,7 +2789,7 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(
 	ctx context.Context,
 	resetRequest *types.ResetWorkflowExecutionRequest,
 ) (resp *types.ResetWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendResetWorkflowExecutionScope, resetRequest)
 	defer sw.Stop()
@@ -2843,7 +2843,7 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 	ctx context.Context,
 	cancelRequest *types.RequestCancelWorkflowExecutionRequest,
 ) (retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendRequestCancelWorkflowExecutionScope, cancelRequest)
 	defer sw.Stop()
@@ -2897,7 +2897,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(
 	ctx context.Context,
 	listRequest *types.ListOpenWorkflowExecutionsRequest,
 ) (resp *types.ListOpenWorkflowExecutionsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendListOpenWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
@@ -3014,7 +3014,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(
 	ctx context.Context,
 	listRequest *types.ListArchivedWorkflowExecutionsRequest,
 ) (resp *types.ListArchivedWorkflowExecutionsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendListArchivedWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
@@ -3106,7 +3106,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(
 	ctx context.Context,
 	listRequest *types.ListClosedWorkflowExecutionsRequest,
 ) (resp *types.ListClosedWorkflowExecutionsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendListClosedWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
@@ -3246,7 +3246,7 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(
 	ctx context.Context,
 	listRequest *types.ListWorkflowExecutionsRequest,
 ) (resp *types.ListWorkflowExecutionsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendListWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
@@ -3314,7 +3314,7 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(
 	ctx context.Context,
 	listRequest *types.ListWorkflowExecutionsRequest,
 ) (resp *types.ListWorkflowExecutionsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendScanWorkflowExecutionsScope, listRequest)
 	defer sw.Stop()
@@ -3382,7 +3382,7 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(
 	ctx context.Context,
 	countRequest *types.CountWorkflowExecutionsRequest,
 ) (resp *types.CountWorkflowExecutionsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendCountWorkflowExecutionsScope, countRequest)
 	defer sw.Stop()
@@ -3436,7 +3436,7 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(
 
 // GetSearchAttributes return valid indexed keys
 func (wh *WorkflowHandler) GetSearchAttributes(ctx context.Context) (resp *types.GetSearchAttributesResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfile(ctx, metrics.FrontendGetSearchAttributesScope)
 	defer sw.Stop()
@@ -3461,7 +3461,7 @@ func (wh *WorkflowHandler) ResetStickyTaskList(
 	ctx context.Context,
 	resetRequest *types.ResetStickyTaskListRequest,
 ) (resp *types.ResetStickyTaskListResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendResetStickyTaskListScope, resetRequest)
 	defer sw.Stop()
@@ -3514,7 +3514,7 @@ func (wh *WorkflowHandler) QueryWorkflow(
 	ctx context.Context,
 	queryRequest *types.QueryWorkflowRequest,
 ) (resp *types.QueryWorkflowResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendQueryWorkflowScope, queryRequest)
 	defer sw.Stop()
@@ -3596,7 +3596,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(
 	ctx context.Context,
 	request *types.DescribeWorkflowExecutionRequest,
 ) (resp *types.DescribeWorkflowExecutionResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendDescribeWorkflowExecutionScope, request)
 	defer sw.Stop()
@@ -3653,7 +3653,7 @@ func (wh *WorkflowHandler) DescribeTaskList(
 	ctx context.Context,
 	request *types.DescribeTaskListRequest,
 ) (resp *types.DescribeTaskListResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendDescribeTaskListScope, request)
 	defer sw.Stop()
@@ -3707,7 +3707,7 @@ func (wh *WorkflowHandler) ListTaskListPartitions(
 	ctx context.Context,
 	request *types.ListTaskListPartitionsRequest,
 ) (resp *types.ListTaskListPartitionsResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendListTaskListPartitionsScope, request)
 	defer sw.Stop()
@@ -3744,7 +3744,7 @@ func (wh *WorkflowHandler) GetTaskListsByDomain(
 	ctx context.Context,
 	request *types.GetTaskListsByDomainRequest,
 ) (resp *types.GetTaskListsByDomainResponse, retError error) {
-	defer log.CapturePanic(wh.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &retError)
 
 	scope, sw := wh.startRequestProfileWithDomain(ctx, metrics.FrontendGetTaskListsByDomainScope, request)
 	defer sw.Stop()
@@ -3776,7 +3776,7 @@ func (wh *WorkflowHandler) RefreshWorkflowTasks(
 	ctx context.Context,
 	request *types.RefreshWorkflowTasksRequest,
 ) (err error) {
-	defer log.CapturePanic(wh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &err)
 	scope, sw := wh.startRequestProfile(ctx, metrics.AdminRefreshWorkflowTasksScope)
 	defer sw.Stop()
 
@@ -4272,7 +4272,7 @@ func (wh *WorkflowHandler) checkOngoingFailover(
 		}
 		frontendClient := wh.GetRemoteFrontendClient(clusterName)
 		g.Go(func() (e error) {
-			defer log.CapturePanic(wh.GetLogger(), &e)
+			defer log.CapturePanic(recover(), wh.GetLogger(), &e)
 
 			resp, _ := frontendClient.DescribeDomain(ctx, &types.DescribeDomainRequest{Name: domainName})
 			respChan <- resp
@@ -4401,7 +4401,7 @@ func (wh *WorkflowHandler) allow(isUserEndpoint bool, d domainGetter) bool {
 func (wh *WorkflowHandler) GetClusterInfo(
 	ctx context.Context,
 ) (resp *types.ClusterInfo, err error) {
-	defer log.CapturePanic(wh.GetLogger(), &err)
+	defer log.CapturePanic(recover(), wh.GetLogger(), &err)
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendClientGetClusterInfoScope)
 	if ok := wh.allow(true, nil); !ok {

--- a/service/history/decision/task_handler.go
+++ b/service/history/decision/task_handler.go
@@ -259,7 +259,7 @@ func (handler *taskHandlerImpl) handleDecisionScheduleActivity(
 	}
 
 	event, ai, activityDispatchInfo, dispatched, started, err := handler.mutableState.AddActivityTaskScheduledEvent(
-		handler.decisionTaskCompletedID, attr, ctx, handler.activityCountToDispatch > 0)
+		ctx, handler.decisionTaskCompletedID, attr, handler.activityCountToDispatch > 0)
 	if dispatched {
 		handler.activityCountToDispatch--
 	}

--- a/service/history/execution/history_builder_test.go
+++ b/service/history/execution/history_builder_test.go
@@ -1039,7 +1039,7 @@ func (s *historyBuilderSuite) addActivityTaskScheduledEvent(
 	retryPolicy *types.RetryPolicy,
 	requestLocalDispatch bool,
 ) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo) {
-	event, ai, activityDispatchInfo, _, _, err := s.msBuilder.AddActivityTaskScheduledEvent(decisionCompletedID,
+	event, ai, activityDispatchInfo, _, _, err := s.msBuilder.AddActivityTaskScheduledEvent(nil, decisionCompletedID,
 		&types.ScheduleActivityTaskDecisionAttributes{
 			ActivityID:                    activityID,
 			ActivityType:                  &types.ActivityType{Name: activityType},
@@ -1052,7 +1052,7 @@ func (s *historyBuilderSuite) addActivityTaskScheduledEvent(
 			StartToCloseTimeoutSeconds:    common.Int32Ptr(1),
 			RetryPolicy:                   retryPolicy,
 			RequestLocalDispatch:          requestLocalDispatch,
-		}, nil, false,
+		}, false,
 	)
 	s.Nil(err)
 	if domain == "" {

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -61,7 +61,7 @@ type (
 		AddActivityTaskCanceledEvent(int64, int64, int64, []uint8, string) (*types.HistoryEvent, error)
 		AddActivityTaskCompletedEvent(int64, int64, *types.RespondActivityTaskCompletedRequest) (*types.HistoryEvent, error)
 		AddActivityTaskFailedEvent(int64, int64, *types.RespondActivityTaskFailedRequest) (*types.HistoryEvent, error)
-		AddActivityTaskScheduledEvent(int64, *types.ScheduleActivityTaskDecisionAttributes, context.Context, bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error)
+		AddActivityTaskScheduledEvent(context.Context, int64, *types.ScheduleActivityTaskDecisionAttributes, bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error)
 		AddActivityTaskStartedEvent(*persistence.ActivityInfo, int64, string, string) (*types.HistoryEvent, error)
 		AddActivityTaskTimedOutEvent(int64, int64, types.TimeoutType, []uint8) (*types.HistoryEvent, error)
 		AddCancelTimerFailedEvent(int64, *types.CancelTimerDecisionAttributes, string) (*types.HistoryEvent, error)

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -4421,12 +4421,11 @@ func (e *mutableStateBuilder) updateWithLastFirstEvent(
 func (e *mutableStateBuilder) canReplicateEvents() bool {
 	if e.domainEntry.GetReplicationPolicy() == cache.ReplicationPolicyOneCluster {
 		return false
-	} else {
-		// ReplicationPolicyMultiCluster
-		domainID := e.domainEntry.GetInfo().ID
-		workflowID := e.GetExecutionInfo().WorkflowID
-		return e.shard.GetConfig().EnableReplicationTaskGeneration(domainID, workflowID)
 	}
+	// ReplicationPolicyMultiCluster
+	domainID := e.domainEntry.GetInfo().ID
+	workflowID := e.GetExecutionInfo().WorkflowID
+	return e.shard.GetConfig().EnableReplicationTaskGeneration(domainID, workflowID)
 }
 
 // validateNoEventsAfterWorkflowFinish perform check on history event batch

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -2113,9 +2113,9 @@ func (e *mutableStateBuilder) ReplicateDecisionTaskFailedEvent() error {
 }
 
 func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
+	ctx context.Context,
 	decisionCompletedEventID int64,
 	attributes *types.ScheduleActivityTaskDecisionAttributes,
-	ctx context.Context,
 	dispatch bool,
 ) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
 
@@ -2154,7 +2154,7 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 	}
 	started := false
 	if dispatch {
-		started = e.tryDispatchActivityTask(event, ai, ctx)
+		started = e.tryDispatchActivityTask(ctx, event, ai)
 	}
 	if started {
 		activityStartedScope.IncCounter(metrics.CadenceRequests)
@@ -2171,9 +2171,9 @@ func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
 }
 
 func (e *mutableStateBuilder) tryDispatchActivityTask(
+	ctx context.Context,
 	scheduledEvent *types.HistoryEvent,
 	ai *persistence.ActivityInfo,
-	ctx context.Context,
 ) bool {
 	taggedScope := e.metricsClient.Scope(metrics.HistoryScheduleDecisionTaskScope).Tagged(
 		metrics.DomainTag(e.domainEntry.GetInfo().Name),

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -125,7 +125,7 @@ func (mr *MockMutableStateMockRecorder) AddActivityTaskFailedEvent(arg0, arg1, a
 }
 
 // AddActivityTaskScheduledEvent mocks base method.
-func (m *MockMutableState) AddActivityTaskScheduledEvent(arg0 int64, arg1 *types.ScheduleActivityTaskDecisionAttributes, arg2 context.Context, arg3 bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
+func (m *MockMutableState) AddActivityTaskScheduledEvent(arg0 context.Context, arg1 int64, arg2 *types.ScheduleActivityTaskDecisionAttributes, arg3 bool) (*types.HistoryEvent, *persistence.ActivityInfo, *types.ActivityLocalDispatchInfo, bool, bool, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AddActivityTaskScheduledEvent", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*types.HistoryEvent)

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -298,7 +298,7 @@ func (h *handlerImpl) RecordActivityTaskHeartbeat(
 	wrappedRequest *types.HistoryRecordActivityTaskHeartbeatRequest,
 ) (resp *types.RecordActivityTaskHeartbeatResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRecordActivityTaskHeartbeatScope)
@@ -345,7 +345,7 @@ func (h *handlerImpl) RecordActivityTaskStarted(
 	recordRequest *types.RecordActivityTaskStartedRequest,
 ) (resp *types.RecordActivityTaskStartedResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRecordActivityTaskStartedScope)
@@ -391,7 +391,7 @@ func (h *handlerImpl) RecordDecisionTaskStarted(
 	recordRequest *types.RecordDecisionTaskStartedRequest,
 ) (resp *types.RecordDecisionTaskStartedResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRecordDecisionTaskStartedScope)
@@ -447,7 +447,7 @@ func (h *handlerImpl) RespondActivityTaskCompleted(
 	wrappedRequest *types.HistoryRespondActivityTaskCompletedRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRespondActivityTaskCompletedScope)
@@ -494,7 +494,7 @@ func (h *handlerImpl) RespondActivityTaskFailed(
 	wrappedRequest *types.HistoryRespondActivityTaskFailedRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRespondActivityTaskFailedScope)
@@ -541,7 +541,7 @@ func (h *handlerImpl) RespondActivityTaskCanceled(
 	wrappedRequest *types.HistoryRespondActivityTaskCanceledRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRespondActivityTaskCanceledScope)
@@ -588,7 +588,7 @@ func (h *handlerImpl) RespondDecisionTaskCompleted(
 	wrappedRequest *types.HistoryRespondDecisionTaskCompletedRequest,
 ) (resp *types.HistoryRespondDecisionTaskCompletedResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRespondDecisionTaskCompletedScope)
@@ -644,7 +644,7 @@ func (h *handlerImpl) RespondDecisionTaskFailed(
 	wrappedRequest *types.HistoryRespondDecisionTaskFailedRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRespondDecisionTaskFailedScope)
@@ -710,7 +710,7 @@ func (h *handlerImpl) StartWorkflowExecution(
 	wrappedRequest *types.HistoryStartWorkflowExecutionRequest,
 ) (resp *types.StartWorkflowExecutionResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryStartWorkflowExecutionScope)
@@ -746,7 +746,7 @@ func (h *handlerImpl) DescribeHistoryHost(
 	request *types.DescribeHistoryHostRequest,
 ) (resp *types.DescribeHistoryHostResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	numOfItemsInCacheByID, numOfItemsInCacheByName := h.GetDomainCache().GetCacheSize()
@@ -822,7 +822,7 @@ func (h *handlerImpl) ResetQueue(
 	request *types.ResetQueueRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryResetQueueScope)
@@ -856,7 +856,7 @@ func (h *handlerImpl) DescribeQueue(
 	request *types.DescribeQueueRequest,
 ) (resp *types.DescribeQueueResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryDescribeQueueScope)
@@ -890,7 +890,7 @@ func (h *handlerImpl) DescribeMutableState(
 	request *types.DescribeMutableStateRequest,
 ) (resp *types.DescribeMutableStateResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryDescribeMutabelStateScope)
@@ -921,7 +921,7 @@ func (h *handlerImpl) GetMutableState(
 	getRequest *types.GetMutableStateRequest,
 ) (resp *types.GetMutableStateResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryGetMutableStateScope)
@@ -956,7 +956,7 @@ func (h *handlerImpl) PollMutableState(
 	getRequest *types.PollMutableStateRequest,
 ) (resp *types.PollMutableStateResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryPollMutableStateScope)
@@ -991,7 +991,7 @@ func (h *handlerImpl) DescribeWorkflowExecution(
 	request *types.HistoryDescribeWorkflowExecutionRequest,
 ) (resp *types.DescribeWorkflowExecutionResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryDescribeWorkflowExecutionScope)
@@ -1026,7 +1026,7 @@ func (h *handlerImpl) RequestCancelWorkflowExecution(
 	request *types.HistoryRequestCancelWorkflowExecutionRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRequestCancelWorkflowExecutionScope)
@@ -1073,7 +1073,7 @@ func (h *handlerImpl) SignalWorkflowExecution(
 	wrappedRequest *types.HistorySignalWorkflowExecutionRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistorySignalWorkflowExecutionScope)
@@ -1117,7 +1117,7 @@ func (h *handlerImpl) SignalWithStartWorkflowExecution(
 	wrappedRequest *types.HistorySignalWithStartWorkflowExecutionRequest,
 ) (resp *types.StartWorkflowExecutionResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistorySignalWithStartWorkflowExecutionScope)
@@ -1158,7 +1158,7 @@ func (h *handlerImpl) RemoveSignalMutableState(
 	wrappedRequest *types.RemoveSignalMutableStateRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRemoveSignalMutableStateScope)
@@ -1199,7 +1199,7 @@ func (h *handlerImpl) TerminateWorkflowExecution(
 	wrappedRequest *types.HistoryTerminateWorkflowExecutionRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryTerminateWorkflowExecutionScope)
@@ -1240,7 +1240,7 @@ func (h *handlerImpl) ResetWorkflowExecution(
 	wrappedRequest *types.HistoryResetWorkflowExecutionRequest,
 ) (resp *types.ResetWorkflowExecutionResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryResetWorkflowExecutionScope)
@@ -1279,7 +1279,7 @@ func (h *handlerImpl) QueryWorkflow(
 	ctx context.Context,
 	request *types.HistoryQueryWorkflowRequest,
 ) (resp *types.HistoryQueryWorkflowResponse, retError error) {
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryQueryWorkflowScope)
@@ -1321,7 +1321,7 @@ func (h *handlerImpl) ScheduleDecisionTask(
 	request *types.ScheduleDecisionTaskRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryScheduleDecisionTaskScope)
@@ -1366,7 +1366,7 @@ func (h *handlerImpl) RecordChildExecutionCompleted(
 	request *types.RecordChildExecutionCompletedRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRecordChildExecutionCompletedScope)
@@ -1416,7 +1416,7 @@ func (h *handlerImpl) ResetStickyTaskList(
 	resetRequest *types.HistoryResetStickyTaskListRequest,
 ) (resp *types.HistoryResetStickyTaskListResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryResetStickyTaskListScope)
@@ -1455,7 +1455,7 @@ func (h *handlerImpl) ReplicateEventsV2(
 	replicateRequest *types.ReplicateEventsV2Request,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	if h.isShuttingDown() {
@@ -1495,7 +1495,7 @@ func (h *handlerImpl) SyncShardStatus(
 	syncShardStatusRequest *types.SyncShardStatusRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistorySyncShardStatusScope)
@@ -1537,7 +1537,7 @@ func (h *handlerImpl) SyncActivity(
 	syncActivityRequest *types.SyncActivityRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistorySyncActivityScope)
@@ -1583,7 +1583,7 @@ func (h *handlerImpl) GetReplicationMessages(
 	ctx context.Context,
 	request *types.GetReplicationMessagesRequest,
 ) (resp *types.GetReplicationMessagesResponse, retError error) {
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	h.GetLogger().Debug("Received GetReplicationMessages call.")
@@ -1642,7 +1642,7 @@ func (h *handlerImpl) GetDLQReplicationMessages(
 	ctx context.Context,
 	request *types.GetDLQReplicationMessagesRequest,
 ) (resp *types.GetDLQReplicationMessagesResponse, retError error) {
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	_, sw := h.startRequestProfile(ctx, metrics.HistoryGetDLQReplicationMessagesScope)
@@ -1718,7 +1718,7 @@ func (h *handlerImpl) ReapplyEvents(
 	request *types.HistoryReapplyEventsRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryReapplyEventsScope)
@@ -1760,7 +1760,7 @@ func (h *handlerImpl) CountDLQMessages(
 	ctx context.Context,
 	request *types.CountDLQMessagesRequest,
 ) (resp *types.HistoryCountDLQMessagesResponse, retError error) {
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryCountDLQMessagesScope)
@@ -1776,7 +1776,7 @@ func (h *handlerImpl) CountDLQMessages(
 	for _, shardID := range h.controller.ShardIDs() {
 		shardID := shardID
 		g.Go(func() (e error) {
-			defer log.CapturePanic(h.GetLogger(), &e)
+			defer log.CapturePanic(recover(), h.GetLogger(), &e)
 
 			engine, err := h.controller.GetEngineForShard(int(shardID))
 			if err != nil {
@@ -1808,7 +1808,7 @@ func (h *handlerImpl) ReadDLQMessages(
 	request *types.ReadDLQMessagesRequest,
 ) (resp *types.ReadDLQMessagesResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryReadDLQMessagesScope)
@@ -1832,7 +1832,7 @@ func (h *handlerImpl) PurgeDLQMessages(
 	request *types.PurgeDLQMessagesRequest,
 ) (retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryPurgeDLQMessagesScope)
@@ -1856,7 +1856,7 @@ func (h *handlerImpl) MergeDLQMessages(
 	request *types.MergeDLQMessagesRequest,
 ) (resp *types.MergeDLQMessagesResponse, retError error) {
 
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	if h.isShuttingDown() {
@@ -1932,7 +1932,7 @@ func (h *handlerImpl) GetCrossClusterTasks(
 	ctx context.Context,
 	request *types.GetCrossClusterTasksRequest,
 ) (resp *types.GetCrossClusterTasksResponse, retError error) {
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	_, sw := h.startRequestProfile(ctx, metrics.HistoryGetCrossClusterTasksScope)
@@ -1994,7 +1994,7 @@ func (h *handlerImpl) RespondCrossClusterTasksCompleted(
 	ctx context.Context,
 	request *types.RespondCrossClusterTasksCompletedRequest,
 ) (resp *types.RespondCrossClusterTasksCompletedResponse, retError error) {
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryRespondCrossClusterTasksCompletedScope)
@@ -2031,7 +2031,7 @@ func (h *handlerImpl) GetFailoverInfo(
 	ctx context.Context,
 	request *types.GetFailoverInfoRequest,
 ) (resp *types.GetFailoverInfoResponse, retError error) {
-	defer log.CapturePanic(h.GetLogger(), &retError)
+	defer log.CapturePanic(recover(), h.GetLogger(), &retError)
 	h.startWG.Wait()
 
 	scope, sw := h.startRequestProfile(ctx, metrics.HistoryGetFailoverInfoScope)

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -523,10 +523,9 @@ func newTimerQueueStandbyProcessor(
 					// retry the task if failed to find the domain
 					logger.Warn("Cannot find domain", tag.WorkflowDomainID(timer.DomainID))
 					return false, err
-				} else {
-					logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(timer.DomainID), tag.Value(timer))
-					return false, nil
 				}
+				logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(timer.DomainID), tag.Value(timer))
+				return false, nil
 			}
 		}
 		return taskAllocator.VerifyStandbyTask(clusterName, timer.DomainID, timer)

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -533,10 +533,9 @@ func newTransferQueueStandbyProcessor(
 					// retry the task if failed to find the domain
 					logger.Warn("Cannot find domain", tag.WorkflowDomainID(task.DomainID))
 					return false, err
-				} else {
-					logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(task.DomainID), tag.Value(task))
-					return false, nil
 				}
+				logger.Warn("Cannot find domain, default to not process task.", tag.WorkflowDomainID(task.DomainID), tag.Value(task))
+				return false, nil
 			}
 		}
 		return taskAllocator.VerifyStandbyTask(clusterName, task.DomainID, task)

--- a/service/history/testing/events_util.go
+++ b/service/history/testing/events_util.go
@@ -145,7 +145,7 @@ func AddActivityTaskScheduledEvent(
 ) (*types.HistoryEvent,
 	*persistence.ActivityInfo) {
 
-	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(nil, decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    activityID,
 		ActivityType:                  &types.ActivityType{Name: activityType},
 		TaskList:                      &types.TaskList{Name: taskList},
@@ -154,7 +154,7 @@ func AddActivityTaskScheduledEvent(
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(scheduleToStartTimeout),
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(startToCloseTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
-	}, nil, false,
+	}, false,
 	)
 
 	return event, ai
@@ -175,7 +175,7 @@ func AddActivityTaskScheduledEventWithRetry(
 	retryPolicy *types.RetryPolicy,
 ) (*types.HistoryEvent, *persistence.ActivityInfo) {
 
-	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
+	event, ai, _, _, _, _ := builder.AddActivityTaskScheduledEvent(nil, decisionCompletedID, &types.ScheduleActivityTaskDecisionAttributes{
 		ActivityID:                    activityID,
 		ActivityType:                  &types.ActivityType{Name: activityType},
 		TaskList:                      &types.TaskList{Name: taskList},
@@ -185,7 +185,7 @@ func AddActivityTaskScheduledEventWithRetry(
 		StartToCloseTimeoutSeconds:    common.Int32Ptr(startToCloseTimeout),
 		HeartbeatTimeoutSeconds:       common.Int32Ptr(heartbeatTimeout),
 		RetryPolicy:                   retryPolicy,
-	}, nil, false,
+	}, false,
 	)
 
 	return event, ai

--- a/service/matching/handler.go
+++ b/service/matching/handler.go
@@ -156,7 +156,7 @@ func (h *handlerImpl) AddActivityTask(
 	ctx context.Context,
 	request *types.AddActivityTaskRequest,
 ) (retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	startT := time.Now()
 	domainName := h.domainName(request.GetDomainUUID())
@@ -191,7 +191,7 @@ func (h *handlerImpl) AddDecisionTask(
 	ctx context.Context,
 	request *types.AddDecisionTaskRequest,
 ) (retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	startT := time.Now()
 	domainName := h.domainName(request.GetDomainUUID())
@@ -225,7 +225,7 @@ func (h *handlerImpl) PollForActivityTask(
 	ctx context.Context,
 	request *types.MatchingPollForActivityTaskRequest,
 ) (resp *types.PollForActivityTaskResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	domainName := h.domainName(request.GetDomainUUID())
 	hCtx := h.newHandlerContext(
@@ -262,7 +262,7 @@ func (h *handlerImpl) PollForDecisionTask(
 	ctx context.Context,
 	request *types.MatchingPollForDecisionTaskRequest,
 ) (resp *types.MatchingPollForDecisionTaskResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	domainName := h.domainName(request.GetDomainUUID())
 	hCtx := h.newHandlerContext(
@@ -300,7 +300,7 @@ func (h *handlerImpl) QueryWorkflow(
 	ctx context.Context,
 	request *types.MatchingQueryWorkflowRequest,
 ) (resp *types.QueryWorkflowResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	domainName := h.domainName(request.GetDomainUUID())
 	hCtx := h.newHandlerContext(
@@ -330,7 +330,7 @@ func (h *handlerImpl) RespondQueryTaskCompleted(
 	ctx context.Context,
 	request *types.MatchingRespondQueryTaskCompletedRequest,
 ) (retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	domainName := h.domainName(request.GetDomainUUID())
 	hCtx := h.newHandlerContext(
@@ -353,7 +353,7 @@ func (h *handlerImpl) RespondQueryTaskCompleted(
 // CancelOutstandingPoll is used to cancel outstanding pollers
 func (h *handlerImpl) CancelOutstandingPoll(ctx context.Context,
 	request *types.CancelOutstandingPollRequest) (retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	domainName := h.domainName(request.GetDomainUUID())
 	hCtx := h.newHandlerContext(
@@ -380,7 +380,7 @@ func (h *handlerImpl) DescribeTaskList(
 	ctx context.Context,
 	request *types.MatchingDescribeTaskListRequest,
 ) (resp *types.DescribeTaskListResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	domainName := h.domainName(request.GetDomainUUID())
 	hCtx := h.newHandlerContext(
@@ -406,7 +406,7 @@ func (h *handlerImpl) ListTaskListPartitions(
 	ctx context.Context,
 	request *types.MatchingListTaskListPartitionsRequest,
 ) (resp *types.ListTaskListPartitionsResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	hCtx := newHandlerContext(
 		ctx,
@@ -433,7 +433,7 @@ func (h *handlerImpl) GetTaskListsByDomain(
 	ctx context.Context,
 	request *types.GetTaskListsByDomainRequest,
 ) (resp *types.GetTaskListsByDomainResponse, retError error) {
-	defer log.CapturePanic(h.logger, &retError)
+	defer log.CapturePanic(recover(), h.logger, &retError)
 
 	hCtx := newHandlerContext(
 		ctx,


### PR DESCRIPTION
We decided that our usage of helper functions when using defer/recover was too brittle, since one
too many functions causes recover() not to do the right thing in Go. Switching to this idiom, where
the defer caller also calls recover() ensures that we will get the right result from recover(), but
also lets us continue to use the helper functions to deduplicate the code that runs after recover().
