### PR TITLE
Make test should pass locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -519,16 +519,16 @@ test: bins ## Build and run all tests. This target is for local development. The
 	$Q rm -f test
 	$Q rm -f test.log
 	$Q echo Running special test cases without race detector:
-	$Q go test -v ./cmd/server/cadence/ $(TEST_FLAGS)
+	$Q go test -v ./cmd/server/cadence/
 	$Q for dir in $(PKG_TEST_DIRS); do \
-		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) $(TEST_FLAGS) | tee -a test.log; \
+		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) | tee -a test.log; \
 	done;
 
 test_e2e: bins
 	$Q rm -f test
 	$Q rm -f test.log
 	$Q for dir in $(INTEG_TEST_ROOT); do \
-		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) $(TEST_FLAGS) | tee -a test.log; \
+		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) | tee -a test.log; \
 	done;
 
 # need to run end-to-end xdc tests with race detector off because of ringpop bug causing data race issue
@@ -536,7 +536,7 @@ test_e2e_xdc: bins
 	$Q rm -f test
 	$Q rm -f test.log
 	$Q for dir in $(INTEG_TEST_XDC_ROOT); do \
-		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) $(TEST_FLAGS)  | tee -a test.log; \
+		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) | tee -a test.log; \
 	done;
 
 cover_profile: bins
@@ -545,11 +545,11 @@ cover_profile: bins
 	$Q echo "mode: atomic" > $(UNIT_COVER_FILE)
 
 	$Q echo Running special test cases without race detector:
-	$Q go test -v ./cmd/server/cadence/ $(TEST_FLAGS)
+	$Q go test -v ./cmd/server/cadence/
 	$Q echo Running package tests:
 	$Q for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
-		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out $(TEST_FLAGS) || exit 1; \
+		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
 		cat $(BUILD)/"$$dir"/coverage.out | grep -v "^mode: \w\+" >> $(UNIT_COVER_FILE); \
 	done;
 
@@ -560,7 +560,7 @@ cover_integration_profile: bins
 
 	$Q echo Running integration test with $(PERSISTENCE_TYPE) $(PERSISTENCE_PLUGIN)
 	$Q mkdir -p $(BUILD)/$(INTEG_TEST_DIR)
-	$Q time go test $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) $(TEST_FLAGS) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
+	$Q time go test $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
 	$Q cat $(BUILD)/$(INTEG_TEST_DIR)/coverage.out | grep -v "^mode: \w\+" >> $(INTEG_COVER_FILE)
 
 cover_ndc_profile: bins
@@ -570,7 +570,7 @@ cover_ndc_profile: bins
 
 	$Q echo Running integration test for 3+ dc with $(PERSISTENCE_TYPE) $(PERSISTENCE_PLUGIN)
 	$Q mkdir -p $(BUILD)/$(INTEG_TEST_NDC_DIR)
-	$Q time go test -v -timeout $(TEST_TIMEOUT) $(INTEG_TEST_NDC_ROOT) $(TEST_TAG) $(TEST_FLAGS) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_NDC_DIR)/coverage.out -count=$(TEST_RUN_COUNT) || exit 1;
+	$Q time go test -v -timeout $(TEST_TIMEOUT) $(INTEG_TEST_NDC_ROOT) $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_NDC_DIR)/coverage.out -count=$(TEST_RUN_COUNT) || exit 1;
 	$Q cat $(BUILD)/$(INTEG_TEST_NDC_DIR)/coverage.out | grep -v "^mode: \w\+" | grep -v "mode: set" >> $(INTEG_NDC_COVER_FILE)
 
 $(COVER_ROOT)/cover.out: $(UNIT_COVER_FILE) $(INTEG_COVER_FILE_CASS) $(INTEG_COVER_FILE_MYSQL) $(INTEG_COVER_FILE_POSTGRES) $(INTEG_NDC_COVER_FILE_CASS) $(INTEG_NDC_COVER_FILE_MYSQL) $(INTEG_NDC_COVER_FILE_POSTGRES)

--- a/Makefile
+++ b/Makefile
@@ -472,7 +472,7 @@ INTEG_TEST_XDC_ROOT=./host/xdc
 INTEG_TEST_XDC_DIR=hostxdc
 INTEG_TEST_NDC_ROOT=./host/ndc
 INTEG_TEST_NDC_DIR=hostndc
-OPT_OUT_TEST=./bench/% ./canary/%
+OPT_OUT_TEST=
 
 TEST_TIMEOUT ?= 20m
 TEST_ARG ?= -race $(if $(verbose),-v) -timeout $(TEST_TIMEOUT)

--- a/Makefile
+++ b/Makefile
@@ -519,16 +519,16 @@ test: bins ## Build and run all tests. This target is for local development. The
 	$Q rm -f test
 	$Q rm -f test.log
 	$Q echo Running special test cases without race detector:
-	$Q go test -v ./cmd/server/cadence/
+	$Q go test -v ./cmd/server/cadence/ $(TEST_FLAGS)
 	$Q for dir in $(PKG_TEST_DIRS); do \
-		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) | tee -a test.log; \
+		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) $(TEST_FLAGS) | tee -a test.log; \
 	done;
 
 test_e2e: bins
 	$Q rm -f test
 	$Q rm -f test.log
 	$Q for dir in $(INTEG_TEST_ROOT); do \
-		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) | tee -a test.log; \
+		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) $(TEST_FLAGS) | tee -a test.log; \
 	done;
 
 # need to run end-to-end xdc tests with race detector off because of ringpop bug causing data race issue
@@ -536,7 +536,7 @@ test_e2e_xdc: bins
 	$Q rm -f test
 	$Q rm -f test.log
 	$Q for dir in $(INTEG_TEST_XDC_ROOT); do \
-		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) | tee -a test.log; \
+		go test $(TEST_ARG) -coverprofile=$@ "$$dir" $(TEST_TAG) $(TEST_FLAGS)  | tee -a test.log; \
 	done;
 
 cover_profile: bins
@@ -545,11 +545,11 @@ cover_profile: bins
 	$Q echo "mode: atomic" > $(UNIT_COVER_FILE)
 
 	$Q echo Running special test cases without race detector:
-	$Q go test -v ./cmd/server/cadence/
+	$Q go test -v ./cmd/server/cadence/ $(TEST_FLAGS)
 	$Q echo Running package tests:
 	$Q for dir in $(PKG_TEST_DIRS); do \
 		mkdir -p $(BUILD)/"$$dir"; \
-		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out || exit 1; \
+		go test "$$dir" $(TEST_ARG) -coverprofile=$(BUILD)/"$$dir"/coverage.out $(TEST_FLAGS) || exit 1; \
 		cat $(BUILD)/"$$dir"/coverage.out | grep -v "^mode: \w\+" >> $(UNIT_COVER_FILE); \
 	done;
 
@@ -560,7 +560,7 @@ cover_integration_profile: bins
 
 	$Q echo Running integration test with $(PERSISTENCE_TYPE) $(PERSISTENCE_PLUGIN)
 	$Q mkdir -p $(BUILD)/$(INTEG_TEST_DIR)
-	$Q time go test $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
+	$Q time go test $(INTEG_TEST_ROOT) $(TEST_ARG) $(TEST_TAG) $(TEST_FLAGS) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_DIR)/coverage.out || exit 1;
 	$Q cat $(BUILD)/$(INTEG_TEST_DIR)/coverage.out | grep -v "^mode: \w\+" >> $(INTEG_COVER_FILE)
 
 cover_ndc_profile: bins
@@ -570,7 +570,7 @@ cover_ndc_profile: bins
 
 	$Q echo Running integration test for 3+ dc with $(PERSISTENCE_TYPE) $(PERSISTENCE_PLUGIN)
 	$Q mkdir -p $(BUILD)/$(INTEG_TEST_NDC_DIR)
-	$Q time go test -v -timeout $(TEST_TIMEOUT) $(INTEG_TEST_NDC_ROOT) $(TEST_TAG) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_NDC_DIR)/coverage.out -count=$(TEST_RUN_COUNT) || exit 1;
+	$Q time go test -v -timeout $(TEST_TIMEOUT) $(INTEG_TEST_NDC_ROOT) $(TEST_TAG) $(TEST_FLAGS) -persistenceType=$(PERSISTENCE_TYPE) -sqlPluginName=$(PERSISTENCE_PLUGIN) $(GOCOVERPKG_ARG) -coverprofile=$(BUILD)/$(INTEG_TEST_NDC_DIR)/coverage.out -count=$(TEST_RUN_COUNT) || exit 1;
 	$Q cat $(BUILD)/$(INTEG_TEST_NDC_DIR)/coverage.out | grep -v "^mode: \w\+" | grep -v "mode: set" >> $(INTEG_NDC_COVER_FILE)
 
 $(COVER_ROOT)/cover.out: $(UNIT_COVER_FILE) $(INTEG_COVER_FILE_CASS) $(INTEG_COVER_FILE_MYSQL) $(INTEG_COVER_FILE_POSTGRES) $(INTEG_NDC_COVER_FILE_CASS) $(INTEG_NDC_COVER_FILE_MYSQL) $(INTEG_NDC_COVER_FILE_POSTGRES)

--- a/canary/workflow_test.go
+++ b/canary/workflow_test.go
@@ -132,7 +132,7 @@ func (s *workflowTestSuite) TestSanityWorkflow() {
 
 func (s *workflowTestSuite) TestLocalActivityWorkflow() {
 	s.env.OnActivity(getConditionData).Return(int32(20), nil).Once()
-	s.env.ExecuteWorkflow(localActivityWorkfow)
+	s.env.ExecuteWorkflow(localActivityWorkfow, time.Now().UnixNano())
 	s.True(s.env.IsWorkflowCompleted())
 	s.NoError(s.env.GetWorkflowError())
 

--- a/cmd/server/cadence/server_test.go
+++ b/cmd/server/cadence/server_test.go
@@ -29,6 +29,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/cadence/testflags"
+
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -46,6 +48,7 @@ type ServerSuite struct {
 }
 
 func TestServerSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	suite.Run(t, new(ServerSuite))
 }
 

--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/testflags"
 )
 
 type (
@@ -64,6 +65,7 @@ type (
 )
 
 func TestDomainHandlerGlobalDomainEnabledPrimaryClusterSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(domainHandlerGlobalDomainEnabledPrimaryClusterSuite)
 	suite.Run(t, s)
 }

--- a/common/domain/handler_NotMasterCluster_test.go
+++ b/common/domain/handler_NotMasterCluster_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/testflags"
 )
 
 type (
@@ -64,6 +65,7 @@ type (
 )
 
 func TestDomainHandlerGlobalDomainEnabledNotPrimaryClusterSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite)
 	suite.Run(t, s)
 }

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/testflags"
 )
 
 type (
@@ -67,6 +68,7 @@ type (
 var nowInt64 = time.Now().UnixNano()
 
 func TestDomainHandlerCommonSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(domainHandlerCommonSuite)
 	suite.Run(t, s)
 }

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/testflags"
 )
 
 type (
@@ -46,6 +47,7 @@ type (
 )
 
 func TestDomainReplicationTaskExecutorSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(domainReplicationTaskExecutorSuite)
 	suite.Run(t, s)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
@@ -27,9 +27,11 @@ import (
 
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/testflags"
 )
 
 func TestCassandraHistoryPersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -37,6 +39,7 @@ func TestCassandraHistoryPersistence(t *testing.T) {
 }
 
 func TestCassandraMatchingPersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.MatchingPersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -44,6 +47,7 @@ func TestCassandraMatchingPersistence(t *testing.T) {
 }
 
 func TestCassandraDomainPersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -51,6 +55,7 @@ func TestCassandraDomainPersistence(t *testing.T) {
 }
 
 func TestCassandraShardPersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.ShardPersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -58,6 +63,7 @@ func TestCassandraShardPersistence(t *testing.T) {
 }
 
 func TestCassandraVisibilityPersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.DBVisibilityPersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -65,6 +71,7 @@ func TestCassandraVisibilityPersistence(t *testing.T) {
 }
 
 func TestCassandraExecutionManager(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.ExecutionManagerSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -72,6 +79,7 @@ func TestCassandraExecutionManager(t *testing.T) {
 }
 
 func TestCassandraExecutionManagerWithEventsV2(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.ExecutionManagerSuiteForEventsV2)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -79,6 +87,7 @@ func TestCassandraExecutionManagerWithEventsV2(t *testing.T) {
 }
 
 func TestQueuePersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()
@@ -86,6 +95,7 @@ func TestQueuePersistence(t *testing.T) {
 }
 
 func TestConfigStorePersistence(t *testing.T) {
+	testflags.RequireCassandra(t)
 	s := new(persistencetests.ConfigStorePersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
 	s.TestBase.Setup()

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
@@ -86,7 +86,7 @@ func TestCassandraExecutionManagerWithEventsV2(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestQueuePersistence(t *testing.T) {
+func TestCassandraQueuePersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
@@ -94,7 +94,7 @@ func TestQueuePersistence(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestConfigStorePersistence(t *testing.T) {
+func TestCassandraConfigStorePersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.ConfigStorePersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_cqlclient_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_cqlclient_test.go
@@ -23,6 +23,8 @@ package tests
 import (
 	"testing"
 
+	"github.com/uber/cadence/testflags"
+
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
@@ -41,6 +43,7 @@ type (
 var _ test.DB = (*cassandra.CqlClient)(nil)
 
 func TestCQLClientTestSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	suite.Run(t, new(CQLClientTestSuite))
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_setupTask_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_setupTask_test.go
@@ -24,6 +24,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/uber/cadence/testflags"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
 
@@ -40,6 +42,7 @@ type (
 )
 
 func TestSetupSchemaTestSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	suite.Run(t, new(SetupSchemaTestSuite))
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_updateTask_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_updateTask_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/schema/cassandra"
+	"github.com/uber/cadence/testflags"
 	cassandra2 "github.com/uber/cadence/tools/cassandra"
 	"github.com/uber/cadence/tools/common/schema/test"
 )
@@ -37,6 +38,7 @@ type UpdateSchemaTestSuite struct {
 }
 
 func TestUpdateSchemaTestSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	suite.Run(t, new(UpdateSchemaTestSuite))
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
@@ -28,6 +28,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/cadence/testflags"
+
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -48,6 +50,7 @@ type (
 )
 
 func TestVersionTestSuite(t *testing.T) {
+	testflags.RequireCassandra(t)
 	suite.Run(t, new(VersionTestSuite))
 }
 

--- a/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/tests/dynamodb_persistence_test.go
@@ -29,7 +29,7 @@ import (
 
 // This is to make sure adding new noop method when adding new nosql interfaces
 // Remove it when any other tests are implemented.
-func TestNoopStruct(t *testing.T) {
+func TestDynamoDBNoopStruct(t *testing.T) {
 	_, _ = dynamodb.NewDynamoDB(config.NoSQL{}, nil)
 }
 
@@ -54,7 +54,7 @@ func TestDynamoDBDomainPersistence(t *testing.T) {
 	//suite.Run(t, s)
 }
 
-func TestQueuePersistence(t *testing.T) {
+func TestDynamoDBQueuePersistence(t *testing.T) {
 	//s := new(persistencetests.QueuePersistenceSuite)
 	//s.TestBase = public.NewTestBaseWithDynamoDB(&persistencetests.TestBaseOptions{})
 	//s.TestBase.Setup()

--- a/common/persistence/nosql/nosqlplugin/mongodb/tests/mongodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/tests/mongodb_persistence_test.go
@@ -29,9 +29,11 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/mongodb"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/environment"
+	"github.com/uber/cadence/testflags"
 )
 
 func TestConfigStorePersistence(t *testing.T) {
+	testflags.RequireMongoDB(t)
 	s := new(persistencetests.ConfigStorePersistenceSuite)
 	s.TestBase = NewTestBaseWithMongo()
 	s.TestBase.Setup()

--- a/common/persistence/nosql/nosqlplugin/mongodb/tests/mongodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/tests/mongodb_persistence_test.go
@@ -32,7 +32,7 @@ import (
 	"github.com/uber/cadence/testflags"
 )
 
-func TestConfigStorePersistence(t *testing.T) {
+func TestMongoDBConfigStorePersistence(t *testing.T) {
 	testflags.RequireMongoDB(t)
 	s := new(persistencetests.ConfigStorePersistenceSuite)
 	s.TestBase = NewTestBaseWithMongo()
@@ -65,7 +65,7 @@ func TestConfigStorePersistence(t *testing.T) {
 // }
 
 // TODO uncomment the test once MessageQueueCRUD is implemented
-// func TestQueuePersistence(t *testing.T) {
+// func TestMongoDBQueuePersistence(t *testing.T) {
 // 	s := new(persistencetests.QueuePersistenceSuite)
 // 	s.TestBase = NewTestBaseWithMongo()
 // 	s.TestBase.Setup()
@@ -73,7 +73,7 @@ func TestConfigStorePersistence(t *testing.T) {
 // }
 
 // TODO uncomment the test once ShardCRUD is implemented
-// func TestCassandraShardPersistence(t *testing.T) {
+// func TestMongoDBShardPersistence(t *testing.T) {
 // 	s := new(persistencetests.ShardPersistenceSuite)
 // 	s.TestBase = NewTestBaseWithMongo()
 // 	s.TestBase.Setup()
@@ -81,7 +81,7 @@ func TestConfigStorePersistence(t *testing.T) {
 // }
 
 // TODO uncomment the test once VisibilityCRUD is implemented
-// func TestCassandraVisibilityPersistence(t *testing.T) {
+// func TestMongoDBVisibilityPersistence(t *testing.T) {
 // 	s := new(persistencetests.DBVisibilityPersistenceSuite)
 // 	s.TestBase = NewTestBaseWithMongo()
 // 	s.TestBase.Setup()
@@ -89,7 +89,7 @@ func TestConfigStorePersistence(t *testing.T) {
 // }
 
 // TODO uncomment the test once WorkflowCRUD is implemented
-// func TestCassandraExecutionManager(t *testing.T) {
+// func TestMongoDBExecutionManager(t *testing.T) {
 // 	s := new(persistencetests.ExecutionManagerSuite)
 // 	s.TestBase = NewTestBaseWithMongo()
 // 	s.TestBase.Setup()
@@ -97,7 +97,7 @@ func TestConfigStorePersistence(t *testing.T) {
 // }
 
 // TODO uncomment the test once WorkflowCRUD is implemented
-// func TestCassandraExecutionManagerWithEventsV2(t *testing.T) {
+// func TestMongoDBExecutionManagerWithEventsV2(t *testing.T) {
 // 	s := new(persistencetests.ExecutionManagerSuiteForEventsV2)
 // 	s.TestBase = NewTestBaseWithMongo()
 // 	s.TestBase.Setup()

--- a/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
@@ -26,9 +26,11 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/testflags"
 )
 
 func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.HistoryV2PersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -36,6 +38,7 @@ func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
 }
 
 func TestSQLMatchingPersistenceSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.MatchingPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -43,6 +46,7 @@ func TestSQLMatchingPersistenceSuite(t *testing.T) {
 }
 
 func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.MetadataPersistenceSuiteV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -50,6 +54,7 @@ func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
 }
 
 func TestSQLShardPersistenceSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.ShardPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -57,6 +62,7 @@ func TestSQLShardPersistenceSuite(t *testing.T) {
 }
 
 func TestSQLExecutionManagerSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.ExecutionManagerSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -64,6 +70,7 @@ func TestSQLExecutionManagerSuite(t *testing.T) {
 }
 
 func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.ExecutionManagerSuiteForEventsV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -71,6 +78,7 @@ func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
 }
 
 func TestSQLVisibilityPersistenceSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.DBVisibilityPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -78,6 +86,7 @@ func TestSQLVisibilityPersistenceSuite(t *testing.T) {
 }
 
 func TestSQLQueuePersistence(t *testing.T) {
+	testflags.RequireMySQL(t)
 	s := new(pt.QueuePersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()

--- a/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/uber/cadence/testflags"
 )
 
-func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
+func TestMySQLHistoryV2PersistenceSuite(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.HistoryV2PersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -37,7 +37,7 @@ func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLMatchingPersistenceSuite(t *testing.T) {
+func TestMySQLMatchingPersistenceSuite(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.MatchingPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -45,7 +45,7 @@ func TestSQLMatchingPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
+func TestMySQLMetadataPersistenceSuiteV2(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.MetadataPersistenceSuiteV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -53,7 +53,7 @@ func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLShardPersistenceSuite(t *testing.T) {
+func TestMySQLShardPersistenceSuite(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.ShardPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -61,7 +61,7 @@ func TestSQLShardPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLExecutionManagerSuite(t *testing.T) {
+func TestMySQLExecutionManagerSuite(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.ExecutionManagerSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -69,7 +69,7 @@ func TestSQLExecutionManagerSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
+func TestMySQLExecutionManagerWithEventsV2(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.ExecutionManagerSuiteForEventsV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -77,7 +77,7 @@ func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLVisibilityPersistenceSuite(t *testing.T) {
+func TestMySQLVisibilityPersistenceSuite(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.DBVisibilityPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -85,7 +85,7 @@ func TestSQLVisibilityPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLQueuePersistence(t *testing.T) {
+func TestMySQLQueuePersistence(t *testing.T) {
 	testflags.RequireMySQL(t)
 	s := new(pt.QueuePersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())

--- a/common/persistence/sql/sqlplugin/postgres/postgres_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/postgres_persistence_test.go
@@ -26,9 +26,11 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	pt "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/testflags"
 )
 
 func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
+	testflags.RequirePostgres(t)
 	s := new(pt.HistoryV2PersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -36,6 +38,7 @@ func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
 }
 
 func TestSQLMatchingPersistenceSuite(t *testing.T) {
+	testflags.RequirePostgres(t)
 	s := new(pt.MatchingPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -43,6 +46,7 @@ func TestSQLMatchingPersistenceSuite(t *testing.T) {
 }
 
 func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
+	testflags.RequirePostgres(t)
 	s := new(pt.MetadataPersistenceSuiteV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -50,6 +54,7 @@ func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
 }
 
 func TestSQLShardPersistenceSuite(t *testing.T) {
+	testflags.RequirePostgres(t)
 	s := new(pt.ShardPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -57,6 +62,7 @@ func TestSQLShardPersistenceSuite(t *testing.T) {
 }
 
 func TestSQLExecutionManagerSuite(t *testing.T) {
+	testflags.RequirePostgres(t)
 	s := new(pt.ExecutionManagerSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -64,6 +70,7 @@ func TestSQLExecutionManagerSuite(t *testing.T) {
 }
 
 func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
+	testflags.RequirePostgres(t)
 	s := new(pt.ExecutionManagerSuiteForEventsV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()
@@ -71,6 +78,7 @@ func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
 }
 
 func TestSQLVisibilityPersistenceSuite(t *testing.T) {
+	testflags.RequirePostgres(t)
 	s := new(pt.DBVisibilityPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 	s.TestBase.Setup()

--- a/common/persistence/sql/sqlplugin/postgres/postgres_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/postgres_persistence_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/uber/cadence/testflags"
 )
 
-func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
+func TestPostgresSQLHistoryV2PersistenceSuite(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(pt.HistoryV2PersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -37,7 +37,7 @@ func TestSQLHistoryV2PersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLMatchingPersistenceSuite(t *testing.T) {
+func TestPostgresSQLMatchingPersistenceSuite(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(pt.MatchingPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -45,7 +45,7 @@ func TestSQLMatchingPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
+func TestPostgresSQLMetadataPersistenceSuiteV2(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(pt.MetadataPersistenceSuiteV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -53,7 +53,7 @@ func TestSQLMetadataPersistenceSuiteV2(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLShardPersistenceSuite(t *testing.T) {
+func TestPostgresSQLShardPersistenceSuite(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(pt.ShardPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -61,7 +61,7 @@ func TestSQLShardPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLExecutionManagerSuite(t *testing.T) {
+func TestPostgresSQLExecutionManagerSuite(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(pt.ExecutionManagerSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -69,7 +69,7 @@ func TestSQLExecutionManagerSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
+func TestPostgresSQLExecutionManagerWithEventsV2(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(pt.ExecutionManagerSuiteForEventsV2)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -77,7 +77,7 @@ func TestSQLExecutionManagerWithEventsV2(t *testing.T) {
 	suite.Run(t, s)
 }
 
-func TestSQLVisibilityPersistenceSuite(t *testing.T) {
+func TestPostgresSQLVisibilityPersistenceSuite(t *testing.T) {
 	testflags.RequirePostgres(t)
 	s := new(pt.DBVisibilityPersistenceSuite)
 	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
@@ -88,15 +88,15 @@ func TestSQLVisibilityPersistenceSuite(t *testing.T) {
 // TODO flaky test in buildkite
 // https://github.com/uber/cadence/issues/2877
 /*
-FAIL: TestSQLQueuePersistence/TestDomainReplicationQueue (0.26s)
+FAIL: TestPostgresSQLQueuePersistence/TestDomainReplicationQueue (0.26s)
         queuePersistenceTest.go:102:
             	Error Trace:	queuePersistenceTest.go:102
             	Error:      	Not equal:
             	            	expected: 99
             	            	actual  : 98
-            	Test:       	TestSQLQueuePersistence/TestDomainReplicationQueue
+            	Test:       	TestPostgresSQLQueuePersistence/TestDomainReplicationQueue
 */
-//func TestSQLQueuePersistence(t *testing.T) {
+//func TestPostgresSQLQueuePersistence(t *testing.T) {
 //	s := new(pt.QueuePersistenceSuite)
 //	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
 //	s.TestBase.Setup()

--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -42,7 +42,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-cassandra"
+      - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -42,6 +42,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-cassandra"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -61,7 +61,7 @@ services:
       - "7935:7935"
       - "7939:7939"
     environment:
-      - "TEST_FLAGS=-cassandra"
+      - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -61,6 +61,7 @@ services:
       - "7935:7935"
       - "7939:7939"
     environment:
+      - "TEST_FLAGS=-cassandra"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -88,7 +88,10 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_profile
     environment:
-      - "TEST_FLAGS=-cassandra -mysql -postgres -mongodb"
+      - "CASSANDRA=1"
+      - "MYSQL=1"
+      - "POSTGRES=1"
+      - "MONGODB=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "MYSQL_SEEDS=mysql"
       - "POSTGRES_SEEDS=postgres"
@@ -112,7 +115,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile
     environment:
-      - "TEST_FLAGS=-cassandra"
+      - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -134,7 +137,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile
     environment:
-      - "TEST_FLAGS=-mysql"
+      - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -157,7 +160,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile
     environment:
-      - "TEST_FLAGS=-postgres"
+      - "POSTGRES=1"
       - "POSTGRES_SEEDS=postgres"
       - "PERSISTENCE_PLUGIN=postgres"
       - "ES_SEEDS=elasticsearch"
@@ -181,7 +184,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile EVENTSV2=true
     environment:
-      - "TEST_FLAGS=-cassandra"
+      - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -203,7 +206,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_ndc_profile
     environment:
-      - "TEST_FLAGS=-cassandra"
+      - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -225,7 +228,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_ndc_profile
     environment:
-      - "TEST_FLAGS=-mysql"
+      - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -88,6 +88,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_profile
     environment:
+      - "TEST_FLAGS=-cassandra -mysql -postgres -mongodb"
       - "CASSANDRA_SEEDS=cassandra"
       - "MYSQL_SEEDS=mysql"
       - "POSTGRES_SEEDS=postgres"
@@ -111,6 +112,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile
     environment:
+      - "TEST_FLAGS=-cassandra"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -132,6 +134,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile
     environment:
+      - "TEST_FLAGS=-mysql"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -154,6 +157,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile
     environment:
+      - "TEST_FLAGS=-postgres"
       - "POSTGRES_SEEDS=postgres"
       - "PERSISTENCE_PLUGIN=postgres"
       - "ES_SEEDS=elasticsearch"
@@ -177,6 +181,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_integration_profile EVENTSV2=true
     environment:
+      - "TEST_FLAGS=-cassandra"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -198,6 +203,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_ndc_profile
     environment:
+      - "TEST_FLAGS=-cassandra"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -219,6 +225,7 @@ services:
       dockerfile: ./docker/buildkite/Dockerfile
     command: make cover_ndc_profile
     environment:
+      - "TEST_FLAGS=-mysql"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-cassandra -mysql -postgres -mongodb"
       - "CASSANDRA_SEEDS=cassandra"
       - "MYSQL_SEEDS=mysql"
       - "POSTGRES_SEEDS=postgres"
@@ -99,6 +100,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-cassandra"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -124,6 +126,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-mysql"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -151,6 +154,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-postgres"
       - "POSTGRES_SEEDS=postgres"
       - "PERSISTENCE_PLUGIN=postgres"
       - "ES_SEEDS=elasticsearch"
@@ -178,6 +182,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-cassandra"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -203,6 +208,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-mysql"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -230,6 +236,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
+      - "TEST_FLAGS=-postgres"
       - "POSTGRES_SEEDS=postgres"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -73,7 +73,10 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-cassandra -mysql -postgres -mongodb"
+      - "CASSANDRA=1"
+      - "MYSQL=1"
+      - "POSTGRES=1"
+      - "MONGODB=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "MYSQL_SEEDS=mysql"
       - "POSTGRES_SEEDS=postgres"
@@ -100,7 +103,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-cassandra"
+      - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -126,7 +129,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-mysql"
+      - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -154,7 +157,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-postgres"
+      - "POSTGRES=1"
       - "POSTGRES_SEEDS=postgres"
       - "PERSISTENCE_PLUGIN=postgres"
       - "ES_SEEDS=elasticsearch"
@@ -182,7 +185,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-cassandra"
+      - "CASSANDRA=1"
       - "CASSANDRA_SEEDS=cassandra"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -208,7 +211,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-mysql"
+      - "MYSQL=1"
       - "MYSQL_SEEDS=mysql"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
@@ -236,7 +239,7 @@ services:
       context: ../../
       dockerfile: ./docker/buildkite/Dockerfile
     environment:
-      - "TEST_FLAGS=-postgres"
+      - "POSTGRES=1"
       - "POSTGRES_SEEDS=postgres"
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"

--- a/host/client_integration_test.go
+++ b/host/client_integration_test.go
@@ -61,13 +61,14 @@ func init() {
 }
 
 func TestClientIntegrationSuite(t *testing.T) {
+
 	flag.Parse()
 
 	clusterConfig, err := GetTestClusterConfig("testdata/clientintegrationtestcluster.yaml")
 	if err != nil {
 		panic(err)
 	}
-	testCluster := NewPersistenceTestCluster(clusterConfig)
+	testCluster := NewPersistenceTestCluster(t, clusterConfig)
 
 	s := new(ClientIntegrationSuite)
 	params := IntegrationBaseParams{

--- a/host/elastic_search_test.go
+++ b/host/elastic_search_test.go
@@ -70,7 +70,7 @@ func TestElasticsearchIntegrationSuite(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	testCluster := NewPersistenceTestCluster(clusterConfig)
+	testCluster := NewPersistenceTestCluster(t, clusterConfig)
 
 	s := new(ElasticSearchIntegrationSuite)
 	params := IntegrationBaseParams{

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -53,7 +53,7 @@ func TestIntegrationSuite(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	testCluster := NewPersistenceTestCluster(clusterConfig)
+	testCluster := NewPersistenceTestCluster(t, clusterConfig)
 
 	s := new(IntegrationSuite)
 	params := IntegrationBaseParams{

--- a/host/ndc/integration_test.go
+++ b/host/ndc/integration_test.go
@@ -66,7 +66,7 @@ func TestNDCIntegrationTestSuite(t *testing.T) {
 	}
 	clusterConfigs[0].WorkerConfig = &host.WorkerConfig{}
 	clusterConfigs[1].WorkerConfig = &host.WorkerConfig{}
-	testCluster := host.NewPersistenceTestCluster(clusterConfigs[0])
+	testCluster := host.NewPersistenceTestCluster(t, clusterConfigs[0])
 	params := NDCIntegrationTestSuiteParams{
 		ClusterConfigs:        clusterConfigs,
 		DefaultTestCluster:    testCluster,

--- a/host/size_limit_test.go
+++ b/host/size_limit_test.go
@@ -44,7 +44,7 @@ func TestSizeLimitIntegrationSuite(t *testing.T) {
 	if err != nil {
 		panic(err)
 	}
-	testCluster := NewPersistenceTestCluster(clusterConfig)
+	testCluster := NewPersistenceTestCluster(t, clusterConfig)
 
 	s := new(SizeLimitIntegrationSuite)
 	params := IntegrationBaseParams{

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -201,8 +201,8 @@ func NewPersistenceTestCluster(t *testing.T, clusterConfig *TestClusterConfig) t
 		// TODO refactor to support other NoSQL
 		ops := clusterConfig.Persistence
 		ops.DBPluginName = "cassandra"
-		testCluster = nosql.NewTestCluster(ops.DBPluginName, ops.DBName, ops.DBUsername, ops.DBPassword, ops.DBHost, ops.DBPort, ops.ProtoVersion, "")
 		testflags.RequireCassandra(t)
+		testCluster = nosql.NewTestCluster(ops.DBPluginName, ops.DBName, ops.DBUsername, ops.DBPassword, ops.DBHost, ops.DBPort, ops.ProtoVersion, "")
 	} else if TestFlags.PersistenceType == config.StoreTypeSQL {
 		var ops *persistencetests.TestBaseOptions
 		if TestFlags.SQLPluginName == mysql.PluginName {

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"testing"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -47,6 +48,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql"
 	"github.com/uber/cadence/common/persistence/persistence-tests/testcluster"
+	"github.com/uber/cadence/testflags"
 
 	// the import is a test dependency
 	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
@@ -189,7 +191,7 @@ func NewClusterMetadata(options *TestClusterConfig) cluster.Metadata {
 	return clusterMetadata
 }
 
-func NewPersistenceTestCluster(clusterConfig *TestClusterConfig) testcluster.PersistenceTestCluster {
+func NewPersistenceTestCluster(t *testing.T, clusterConfig *TestClusterConfig) testcluster.PersistenceTestCluster {
 	// NOTE: Override here to keep consistent. clusterConfig will be used in the test for some purposes.
 	clusterConfig.Persistence.StoreType = TestFlags.PersistenceType
 	clusterConfig.Persistence.DBPluginName = TestFlags.SQLPluginName
@@ -200,11 +202,14 @@ func NewPersistenceTestCluster(clusterConfig *TestClusterConfig) testcluster.Per
 		ops := clusterConfig.Persistence
 		ops.DBPluginName = "cassandra"
 		testCluster = nosql.NewTestCluster(ops.DBPluginName, ops.DBName, ops.DBUsername, ops.DBPassword, ops.DBHost, ops.DBPort, ops.ProtoVersion, "")
+		testflags.RequireCassandra(t)
 	} else if TestFlags.PersistenceType == config.StoreTypeSQL {
 		var ops *persistencetests.TestBaseOptions
 		if TestFlags.SQLPluginName == mysql.PluginName {
+			testflags.RequireMySQL(t)
 			ops = mysql.GetTestClusterOption()
 		} else if TestFlags.SQLPluginName == postgres.PluginName {
+			testflags.RequirePostgres(t)
 			ops = postgres.GetTestClusterOption()
 		} else {
 			panic("not supported plugin " + TestFlags.SQLPluginName)

--- a/testflags/testflags.go
+++ b/testflags/testflags.go
@@ -1,0 +1,69 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package testflags
+
+import (
+	"flag"
+	"testing"
+)
+
+var TestFlags struct {
+	mysql     bool
+	postgres  bool
+	mongodb   bool
+	cassandra bool
+}
+
+func init() {
+	flag.BoolVar(&TestFlags.mysql, "mysql", false, "MySQL external dependency")
+	flag.BoolVar(&TestFlags.postgres, "postgres", false, "PostGreSQL external dependency")
+	flag.BoolVar(&TestFlags.mongodb, "mongodb", false, "MongoDB external dependency")
+	flag.BoolVar(&TestFlags.cassandra, "cassandra", false, "Cassandra external dependency")
+}
+
+// TODO: Better instructions:
+// 1) How to start external dependencies - maybe link to docs so we can change it easily?
+// 2) How to run the tests
+func RequireMySQL(t *testing.T) {
+	if !TestFlags.mysql {
+		t.Skip("Skipping test that requires 'mysql' to run - start XXX and append '-mysql' to run this test.")
+	}
+}
+
+func RequirePostgres(t *testing.T) {
+	if !TestFlags.postgres {
+		t.Skip("Skipping test that requires 'postgres' to run - start XXX and append '-postgres' to run this test.")
+	}
+}
+
+func RequireMongoDB(t *testing.T) {
+	if !TestFlags.mongodb {
+		t.Skip("Skipping test that requires 'mongodb' to run - start XXX and append '-mongodb' to run this test.")
+	}
+}
+
+func RequireCassandra(t *testing.T) {
+	if !TestFlags.cassandra {
+		t.Skip("Skipping test that requires 'cassandra' to run - start XXX and append '-cassandra' to run this test.")
+	}
+}

--- a/testflags/testflags.go
+++ b/testflags/testflags.go
@@ -41,29 +41,28 @@ func init() {
 	flag.BoolVar(&TestFlags.cassandra, "cassandra", false, "Cassandra external dependency")
 }
 
-// TODO: Better instructions:
-// 1) How to start external dependencies - maybe link to docs so we can change it easily?
-// 2) How to run the tests
+// In order to start external dependencies, see documentation at https://github.com/uber/cadence
+
 func RequireMySQL(t *testing.T) {
 	if !TestFlags.mysql {
-		t.Skip("Skipping test that requires 'mysql' to run - start XXX and append '-mysql' to run this test.")
+		t.Skip("Skipping test that requires 'mysql' to run - start mysql and append '-mysql' to run this test.")
 	}
 }
 
 func RequirePostgres(t *testing.T) {
 	if !TestFlags.postgres {
-		t.Skip("Skipping test that requires 'postgres' to run - start XXX and append '-postgres' to run this test.")
+		t.Skip("Skipping test that requires 'postgres' to run - start postgres and append '-postgres' to run this test.")
 	}
 }
 
 func RequireMongoDB(t *testing.T) {
 	if !TestFlags.mongodb {
-		t.Skip("Skipping test that requires 'mongodb' to run - start XXX and append '-mongodb' to run this test.")
+		t.Skip("Skipping test that requires 'mongodb' to run - start mongodb and append '-mongodb' to run this test.")
 	}
 }
 
 func RequireCassandra(t *testing.T) {
 	if !TestFlags.cassandra {
-		t.Skip("Skipping test that requires 'cassandra' to run - start XXX and append '-cassandra' to run this test.")
+		t.Skip("Skipping test that requires 'cassandra' to run - start cassandra and append '-cassandra' to run this test.")
 	}
 }

--- a/testflags/testflags.go
+++ b/testflags/testflags.go
@@ -23,46 +23,52 @@
 package testflags
 
 import (
-	"flag"
+	"fmt"
+	"os"
 	"testing"
 )
 
-var TestFlags struct {
-	mysql     bool
-	postgres  bool
-	mongodb   bool
-	cassandra bool
-}
-
-func init() {
-	flag.BoolVar(&TestFlags.mysql, "mysql", false, "MySQL external dependency")
-	flag.BoolVar(&TestFlags.postgres, "postgres", false, "PostGreSQL external dependency")
-	flag.BoolVar(&TestFlags.mongodb, "mongodb", false, "MongoDB external dependency")
-	flag.BoolVar(&TestFlags.cassandra, "cassandra", false, "Cassandra external dependency")
-}
-
+// Pass these testflags in as environment variables in order to run tests marked as needing an
+// external dependency.
+// Tests can be marked as having an external dependency by calling the Require* functions below.
 // In order to start external dependencies, see documentation at https://github.com/uber/cadence
 
+var (
+	cassandra = "CASSANDRA"
+	mongodb   = "MONGODB"
+	mysql     = "MYSQL"
+	postgres  = "POSTGRES"
+)
+
+// NOTE: We are using environment variables instead of go testflags or go build directives, because we:
+// 1) Want tests to be built all the time (go build directives don't give us that)
+// 2) Want tests to be marked as skipped (go build directives don't give us that)
+// 3) Want to be able to run individual tests (go testflags errors if the test doesn't import
+// something that defines the testflags.)
+
 func RequireMySQL(t *testing.T) {
-	if !TestFlags.mysql {
-		t.Skip("Skipping test that requires 'mysql' to run - start mysql and append '-mysql' to run this test.")
-	}
+	require(t, mysql)
 }
 
 func RequirePostgres(t *testing.T) {
-	if !TestFlags.postgres {
-		t.Skip("Skipping test that requires 'postgres' to run - start postgres and append '-postgres' to run this test.")
-	}
+	require(t, postgres)
 }
 
 func RequireMongoDB(t *testing.T) {
-	if !TestFlags.mongodb {
-		t.Skip("Skipping test that requires 'mongodb' to run - start mongodb and append '-mongodb' to run this test.")
-	}
+	require(t, mongodb)
 }
 
 func RequireCassandra(t *testing.T) {
-	if !TestFlags.cassandra {
-		t.Skip("Skipping test that requires 'cassandra' to run - start cassandra and append '-cassandra' to run this test.")
+	require(t, cassandra)
+}
+
+func require(t *testing.T, name string) {
+	if !checkEnv(name) {
+		t.Skip(fmt.Sprintf("Skipping test that requires %s to run - start %s and set '%s=1' environment variable to run this test.",
+			name, name, name))
 	}
+}
+
+func checkEnv(name string) bool {
+	return os.Getenv(name) != ""
 }

--- a/tools/sql/clitest/cli_test.go
+++ b/tools/sql/clitest/cli_test.go
@@ -26,26 +26,32 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin/mysql"
+	"github.com/uber/cadence/testflags"
 )
 
 // TODO: Setup postgres test in build-kite
 
 func TestMySQLConnTestSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	suite.Run(t, NewSQLConnTestSuite(mysql.PluginName))
 }
 
 func TestMySQLHandlerTestSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	suite.Run(t, NewHandlerTestSuite(mysql.PluginName))
 }
 
 func TestMySQLSetupSchemaTestSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	suite.Run(t, NewSetupSchemaTestSuite(mysql.PluginName))
 }
 
 func TestMySQLUpdateSchemaTestSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	suite.Run(t, NewUpdateSchemaTestSuite(mysql.PluginName))
 }
 
 func TestMySQLVersionTestSuite(t *testing.T) {
+	testflags.RequireMySQL(t)
 	suite.Run(t, NewVersionTestSuite(mysql.PluginName))
 }


### PR DESCRIPTION
- Fix render_test when running locally - tests can't depend on dev's local timezone.
- Add test flags that are used to skip tests that have external dependencies. 
-- Plumb the RequiresX() functions into tests that depend on them.

Make test now runs failure-free locally.
