### PR TITLE
Hotfix for our lack of List*Execution API ratelimiters

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -378,6 +378,12 @@ const (
 	// Default value: UnlimitedRPS
 	// Allowed filters: N/A
 	FrontendWorkerRPS
+	// FrontendVisibilityRPS is the global workflow List*WorkflowExecutions request rate limit per second
+	// KeyName: frontend.visibilityrps
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: N/A
+	FrontendVisibilityRPS
 	// FrontendMaxDomainUserRPSPerInstance is workflow domain rate limit per second
 	// KeyName: frontend.domainrps
 	// Value type: Int
@@ -390,6 +396,12 @@ const (
 	// Default value: UnlimitedRPS
 	// Allowed filters: DomainName
 	FrontendMaxDomainWorkerRPSPerInstance
+	// FrontendMaxDomainVisibilityRPSPerInstance is the per-instance List*WorkflowExecutions request rate limit per second
+	// KeyName: frontend.domainvisibilityrps
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: DomainName
+	FrontendMaxDomainVisibilityRPSPerInstance
 	// FrontendGlobalDomainUserRPS is workflow domain rate limit per second for the whole Cadence cluster
 	// KeyName: frontend.globalDomainrps
 	// Value type: Int
@@ -402,6 +414,12 @@ const (
 	// Default value: UnlimitedRPS
 	// Allowed filters: DomainName
 	FrontendGlobalDomainWorkerRPS
+	// FrontendGlobalDomainVisibilityRPS is the per-domain List*WorkflowExecutions request rate limit per second
+	// KeyName: frontend.globalDomainVisibilityrps
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: DomainName
+	FrontendGlobalDomainVisibilityRPS
 	// FrontendDecisionResultCountLimit is max number of decisions per RespondDecisionTaskCompleted request
 	// KeyName: frontend.decisionResultCountLimit
 	// Value type: Int
@@ -2290,11 +2308,14 @@ var Keys = map[Key]string{
 	FrontendHistoryMaxPageSize:                  "frontend.historyMaxPageSize",
 	FrontendUserRPS:                             "frontend.rps",
 	FrontendWorkerRPS:                           "frontend.workerrps",
+	FrontendVisibilityRPS:                       "frontend.visibilityrps",
 	FrontendMaxDomainUserRPSPerInstance:         "frontend.domainrps",
 	FrontendMaxDomainWorkerRPSPerInstance:       "frontend.domainworkerrps",
+	FrontendMaxDomainVisibilityRPSPerInstance:   "frontend.domainvisibilityrps",
 	FrontendDecisionResultCountLimit:            "frontend.decisionResultCountLimit",
 	FrontendGlobalDomainUserRPS:                 "frontend.globalDomainrps",
 	FrontendGlobalDomainWorkerRPS:               "frontend.globalDomainWorkerrps",
+	FrontendGlobalDomainVisibilityRPS:           "frontend.globalDomainVisibilityrps",
 	FrontendHistoryMgrNumConns:                  "frontend.historyMgrNumConns",
 	FrontendShutdownDrainDuration:               "frontend.shutdownDrainDuration",
 	DisableListVisibilityByFilter:               "frontend.disableListVisibilityByFilter",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -353,6 +353,7 @@ const (
 	// Value type: Int
 	// Default value: 3
 	// Allowed filters: DomainName
+	// deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS
 	FrontendESVisibilityListMaxQPS
 	// FrontendESIndexMaxResultWindow is ElasticSearch index setting max_result_window
 	// KeyName: frontend.esIndexMaxResultWindow
@@ -2297,10 +2298,12 @@ var Keys = map[Key]string{
 	AdminErrorInjectionRate: "admin.errorInjectionRate",
 
 	// frontend settings
-	FrontendPersistenceMaxQPS:                   "frontend.persistenceMaxQPS",
-	FrontendPersistenceGlobalMaxQPS:             "frontend.persistenceGlobalMaxQPS",
-	FrontendVisibilityMaxPageSize:               "frontend.visibilityMaxPageSize",
-	FrontendVisibilityListMaxQPS:                "frontend.visibilityListMaxQPS",
+	FrontendPersistenceMaxQPS:       "frontend.persistenceMaxQPS",
+	FrontendPersistenceGlobalMaxQPS: "frontend.persistenceGlobalMaxQPS",
+	FrontendVisibilityMaxPageSize:   "frontend.visibilityMaxPageSize",
+	// deprecated: never used for ratelimiting, only sampling-based failure injection, and only on database-based visibility
+	FrontendVisibilityListMaxQPS: "frontend.visibilityListMaxQPS",
+	// deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS
 	FrontendESVisibilityListMaxQPS:              "frontend.esVisibilityListMaxQPS",
 	FrontendMaxBadBinaries:                      "frontend.maxBadBinaries",
 	FrontendFailoverCoolDown:                    "frontend.failoverCoolDown",

--- a/common/service/config.go
+++ b/common/service/config.go
@@ -42,8 +42,9 @@ type (
 		DBVisibilityListMaxQPS                      dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 
 		// configs for es visibility
-		ESIndexMaxResultWindow dynamicconfig.IntPropertyFn                 `yaml:"-" json:"-"`
-		ValidSearchAttributes  dynamicconfig.MapPropertyFn                 `yaml:"-" json:"-"`
+		ESIndexMaxResultWindow dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
+		ValidSearchAttributes  dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
+		// deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS
 		ESVisibilityListMaxQPS dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 	}
 )

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -45,20 +45,25 @@ type Config struct {
 	VisibilityMaxPageSize           dynamicconfig.IntPropertyFnWithDomainFilter
 	EnableVisibilitySampling        dynamicconfig.BoolPropertyFn
 	EnableReadFromClosedExecutionV2 dynamicconfig.BoolPropertyFn
-	VisibilityListMaxQPS            dynamicconfig.IntPropertyFnWithDomainFilter
-	EnableReadVisibilityFromES      dynamicconfig.BoolPropertyFnWithDomainFilter
-	ESVisibilityListMaxQPS          dynamicconfig.IntPropertyFnWithDomainFilter
-	ESIndexMaxResultWindow          dynamicconfig.IntPropertyFn
-	HistoryMaxPageSize              dynamicconfig.IntPropertyFnWithDomainFilter
-	UserRPS                         dynamicconfig.IntPropertyFn
-	WorkerRPS                       dynamicconfig.IntPropertyFn
-	MaxDomainUserRPSPerInstance     dynamicconfig.IntPropertyFnWithDomainFilter
-	MaxDomainWorkerRPSPerInstance   dynamicconfig.IntPropertyFnWithDomainFilter
-	GlobalDomainUserRPS             dynamicconfig.IntPropertyFnWithDomainFilter
-	GlobalDomainWorkerRPS           dynamicconfig.IntPropertyFnWithDomainFilter
-	EnableClientVersionCheck        dynamicconfig.BoolPropertyFn
-	DisallowQuery                   dynamicconfig.BoolPropertyFnWithDomainFilter
-	ShutdownDrainDuration           dynamicconfig.DurationPropertyFn
+	// deprecated: never used for ratelimiting, only sampling-based failure injection, and only on database-based visibility
+	VisibilityListMaxQPS       dynamicconfig.IntPropertyFnWithDomainFilter
+	EnableReadVisibilityFromES dynamicconfig.BoolPropertyFnWithDomainFilter
+	// deprecated: never read from
+	ESVisibilityListMaxQPS            dynamicconfig.IntPropertyFnWithDomainFilter
+	ESIndexMaxResultWindow            dynamicconfig.IntPropertyFn
+	HistoryMaxPageSize                dynamicconfig.IntPropertyFnWithDomainFilter
+	UserRPS                           dynamicconfig.IntPropertyFn
+	WorkerRPS                         dynamicconfig.IntPropertyFn
+	VisibilityRPS                     dynamicconfig.IntPropertyFn
+	MaxDomainUserRPSPerInstance       dynamicconfig.IntPropertyFnWithDomainFilter
+	MaxDomainWorkerRPSPerInstance     dynamicconfig.IntPropertyFnWithDomainFilter
+	MaxDomainVisibilityRPSPerInstance dynamicconfig.IntPropertyFnWithDomainFilter
+	GlobalDomainUserRPS               dynamicconfig.IntPropertyFnWithDomainFilter
+	GlobalDomainWorkerRPS             dynamicconfig.IntPropertyFnWithDomainFilter
+	GlobalDomainVisibilityRPS         dynamicconfig.IntPropertyFnWithDomainFilter
+	EnableClientVersionCheck          dynamicconfig.BoolPropertyFn
+	DisallowQuery                     dynamicconfig.BoolPropertyFnWithDomainFilter
+	ShutdownDrainDuration             dynamicconfig.DurationPropertyFn
 
 	// id length limits
 	MaxIDLengthWarnLimit  dynamicconfig.IntPropertyFn
@@ -126,10 +131,13 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, enableReadFro
 		HistoryMaxPageSize:                          dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize, common.GetHistoryMaxPageSize),
 		UserRPS:                                     dc.GetIntProperty(dynamicconfig.FrontendUserRPS, 1200),
 		WorkerRPS:                                   dc.GetIntProperty(dynamicconfig.FrontendWorkerRPS, dynamicconfig.UnlimitedRPS),
+		VisibilityRPS:                               dc.GetIntProperty(dynamicconfig.FrontendVisibilityRPS, dynamicconfig.UnlimitedRPS),
 		MaxDomainUserRPSPerInstance:                 dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainUserRPSPerInstance, 1200),
 		MaxDomainWorkerRPSPerInstance:               dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainWorkerRPSPerInstance, dynamicconfig.UnlimitedRPS),
+		MaxDomainVisibilityRPSPerInstance:           dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainVisibilityRPSPerInstance, dynamicconfig.UnlimitedRPS),
 		GlobalDomainUserRPS:                         dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainUserRPS, 0),
 		GlobalDomainWorkerRPS:                       dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainWorkerRPS, dynamicconfig.UnlimitedRPS),
+		GlobalDomainVisibilityRPS:                   dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainVisibilityRPS, dynamicconfig.UnlimitedRPS),
 		MaxIDLengthWarnLimit:                        dc.GetIntProperty(dynamicconfig.MaxIDLengthWarnLimit, common.DefaultIDLengthWarnLimit),
 		DomainNameMaxLength:                         dc.GetIntPropertyFilteredByDomain(dynamicconfig.DomainNameMaxLength, common.DefaultIDLengthErrorLimit),
 		IdentityMaxLength:                           dc.GetIntPropertyFilteredByDomain(dynamicconfig.IdentityMaxLength, common.DefaultIDLengthErrorLimit),


### PR DESCRIPTION
ElasticSearch is struggling to scale, this is to give us some more breathing room
because our biggest querier will take longer to reduce their rates.

This is very similar to ea4d16525c2210104c58eea8ab57d46821868a5b , but slightly easier because it is only changing the frontend.
A more complete fix of removing or correcting the now-deprecated fields would be good.
