### PR TITLE
Add List*Execution (ElasticSearch) API ratelimiters

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -400,12 +400,14 @@ const (
 	// Value type: Int
 	// Default value: 10
 	// Allowed filters: DomainName
+	// deprecated: never used for ratelimiting, only sampling-based failure injection, and only on database-based visibility
 	FrontendVisibilityListMaxQPS
 	// FrontendESVisibilityListMaxQPS is max qps frontend can list open/close workflows from ElasticSearch
 	// KeyName: frontend.esVisibilityListMaxQPS
 	// Value type: Int
 	// Default value: 30
 	// Allowed filters: DomainName
+	// deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS
 	FrontendESVisibilityListMaxQPS
 	// FrontendESIndexMaxResultWindow is ElasticSearch index setting max_result_window
 	// KeyName: frontend.esIndexMaxResultWindow
@@ -431,6 +433,12 @@ const (
 	// Default value: UnlimitedRPS
 	// Allowed filters: N/A
 	FrontendWorkerRPS
+	// FrontendVisibilityRPS is the global workflow List*WorkflowExecutions request rate limit per second
+	// KeyName: frontend.visibilityrps
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: N/A
+	FrontendVisibilityRPS
 	// FrontendMaxDomainUserRPSPerInstance is workflow domain rate limit per second
 	// KeyName: frontend.domainrps
 	// Value type: Int
@@ -443,6 +451,12 @@ const (
 	// Default value: UnlimitedRPS
 	// Allowed filters: DomainName
 	FrontendMaxDomainWorkerRPSPerInstance
+	// FrontendMaxDomainVisibilityRPSPerInstance is the per-instance List*WorkflowExecutions request rate limit per second
+	// KeyName: frontend.domainvisibilityrps
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: DomainName
+	FrontendMaxDomainVisibilityRPSPerInstance
 	// FrontendGlobalDomainUserRPS is workflow domain rate limit per second for the whole Cadence cluster
 	// KeyName: frontend.globalDomainrps
 	// Value type: Int
@@ -455,6 +469,12 @@ const (
 	// Default value: UnlimitedRPS
 	// Allowed filters: DomainName
 	FrontendGlobalDomainWorkerRPS
+	// FrontendGlobalDomainVisibilityRPS is the per-domain List*WorkflowExecutions request rate limit per second
+	// KeyName: frontend.globalDomainVisibilityrps
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: DomainName
+	FrontendGlobalDomainVisibilityRPS
 	// FrontendDecisionResultCountLimit is max number of decisions per RespondDecisionTaskCompleted request
 	// KeyName: frontend.decisionResultCountLimit
 	// Value type: Int
@@ -2585,13 +2605,15 @@ var IntKeys = map[IntKey]DynamicInt{
 		DefaultValue: 1000,
 	},
 	FrontendVisibilityListMaxQPS: DynamicInt{
-		KeyName:      "frontend.visibilityListMaxQPS",
-		Description:  "FrontendVisibilityListMaxQPS is max qps frontend can list open/close workflows",
+		KeyName: "frontend.visibilityListMaxQPS",
+		Description: "deprecated: never used for ratelimiting, only sampling-based failure injection, and only on database-based visibility.\n" +
+			"FrontendVisibilityListMaxQPS is max qps frontend can list open/close workflows",
 		DefaultValue: 10,
 	},
 	FrontendESVisibilityListMaxQPS: DynamicInt{
-		KeyName:      "frontend.esVisibilityListMaxQPS",
-		Description:  "FrontendESVisibilityListMaxQPS is max qps frontend can list open/close workflows from ElasticSearch",
+		KeyName: "frontend.esVisibilityListMaxQPS",
+		Description: "deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS.\n" +
+			"FrontendESVisibilityListMaxQPS is max qps frontend can list open/close workflows from ElasticSearch",
 		DefaultValue: 30,
 	},
 	FrontendESIndexMaxResultWindow: DynamicInt{
@@ -2614,6 +2636,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "FrontendWorkerRPS is background-processing workflow rate limit per second",
 		DefaultValue: UnlimitedRPS,
 	},
+	FrontendVisibilityRPS: DynamicInt{
+		KeyName:      "frontend.visibilityrps",
+		Description:  "FrontendVisibilityRPS is the global workflow List*WorkflowExecutions request rate limit per second",
+		DefaultValue: UnlimitedRPS,
+	},
 	FrontendMaxDomainUserRPSPerInstance: DynamicInt{
 		KeyName:      "frontend.domainrps",
 		Description:  "FrontendMaxDomainUserRPSPerInstance is workflow domain rate limit per second",
@@ -2624,6 +2651,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "FrontendMaxDomainWorkerRPSPerInstance is background-processing workflow domain rate limit per second",
 		DefaultValue: UnlimitedRPS,
 	},
+	FrontendMaxDomainVisibilityRPSPerInstance: DynamicInt{
+		KeyName:      "frontend.domainvisibilityrps",
+		Description:  "FrontendMaxDomainVisibilityRPSPerInstance is the per-instance List*WorkflowExecutions request rate limit per second",
+		DefaultValue: UnlimitedRPS,
+	},
 	FrontendGlobalDomainUserRPS: DynamicInt{
 		KeyName:      "frontend.globalDomainrps",
 		Description:  "FrontendGlobalDomainUserRPS is workflow domain rate limit per second for the whole Cadence cluster",
@@ -2632,6 +2664,11 @@ var IntKeys = map[IntKey]DynamicInt{
 	FrontendGlobalDomainWorkerRPS: DynamicInt{
 		KeyName:      "frontend.globalDomainWorkerrps",
 		Description:  "FrontendGlobalDomainWorkerRPS is background-processing workflow domain rate limit per second for the whole Cadence cluster",
+		DefaultValue: UnlimitedRPS,
+	},
+	FrontendGlobalDomainVisibilityRPS: DynamicInt{
+		KeyName:      "frontend.globalDomainVisibilityrps",
+		Description:  "FrontendGlobalDomainVisibilityRPS is the per-domain List*WorkflowExecutions request rate limit per second",
 		DefaultValue: UnlimitedRPS,
 	},
 	FrontendDecisionResultCountLimit: DynamicInt{

--- a/common/service/config.go
+++ b/common/service/config.go
@@ -42,8 +42,9 @@ type (
 		DBVisibilityListMaxQPS                      dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 
 		// configs for es visibility
-		ESIndexMaxResultWindow dynamicconfig.IntPropertyFn                 `yaml:"-" json:"-"`
-		ValidSearchAttributes  dynamicconfig.MapPropertyFn                 `yaml:"-" json:"-"`
+		ESIndexMaxResultWindow dynamicconfig.IntPropertyFn `yaml:"-" json:"-"`
+		ValidSearchAttributes  dynamicconfig.MapPropertyFn `yaml:"-" json:"-"`
+		// deprecated: never read from, all ES reads and writes erroneously use PersistenceMaxQPS
 		ESVisibilityListMaxQPS dynamicconfig.IntPropertyFnWithDomainFilter `yaml:"-" json:"-"`
 	}
 )

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -44,21 +44,26 @@ type Config struct {
 	VisibilityMaxPageSize           dynamicconfig.IntPropertyFnWithDomainFilter
 	EnableVisibilitySampling        dynamicconfig.BoolPropertyFn
 	EnableReadFromClosedExecutionV2 dynamicconfig.BoolPropertyFn
-	VisibilityListMaxQPS            dynamicconfig.IntPropertyFnWithDomainFilter
-	EnableReadVisibilityFromES      dynamicconfig.BoolPropertyFnWithDomainFilter
-	ESVisibilityListMaxQPS          dynamicconfig.IntPropertyFnWithDomainFilter
-	ESIndexMaxResultWindow          dynamicconfig.IntPropertyFn
-	HistoryMaxPageSize              dynamicconfig.IntPropertyFnWithDomainFilter
-	UserRPS                         dynamicconfig.IntPropertyFn
-	WorkerRPS                       dynamicconfig.IntPropertyFn
-	MaxDomainUserRPSPerInstance     dynamicconfig.IntPropertyFnWithDomainFilter
-	MaxDomainWorkerRPSPerInstance   dynamicconfig.IntPropertyFnWithDomainFilter
-	GlobalDomainUserRPS             dynamicconfig.IntPropertyFnWithDomainFilter
-	GlobalDomainWorkerRPS           dynamicconfig.IntPropertyFnWithDomainFilter
-	EnableClientVersionCheck        dynamicconfig.BoolPropertyFn
-	DisallowQuery                   dynamicconfig.BoolPropertyFnWithDomainFilter
-	ShutdownDrainDuration           dynamicconfig.DurationPropertyFn
-	Lockdown                        dynamicconfig.BoolPropertyFnWithDomainFilter
+	// deprecated: never used for ratelimiting, only sampling-based failure injection, and only on database-based visibility
+	VisibilityListMaxQPS       dynamicconfig.IntPropertyFnWithDomainFilter
+	EnableReadVisibilityFromES dynamicconfig.BoolPropertyFnWithDomainFilter
+	// deprecated: never read from
+	ESVisibilityListMaxQPS            dynamicconfig.IntPropertyFnWithDomainFilter
+	ESIndexMaxResultWindow            dynamicconfig.IntPropertyFn
+	HistoryMaxPageSize                dynamicconfig.IntPropertyFnWithDomainFilter
+	UserRPS                           dynamicconfig.IntPropertyFn
+	WorkerRPS                         dynamicconfig.IntPropertyFn
+	VisibilityRPS                     dynamicconfig.IntPropertyFn
+	MaxDomainUserRPSPerInstance       dynamicconfig.IntPropertyFnWithDomainFilter
+	MaxDomainWorkerRPSPerInstance     dynamicconfig.IntPropertyFnWithDomainFilter
+	MaxDomainVisibilityRPSPerInstance dynamicconfig.IntPropertyFnWithDomainFilter
+	GlobalDomainUserRPS               dynamicconfig.IntPropertyFnWithDomainFilter
+	GlobalDomainWorkerRPS             dynamicconfig.IntPropertyFnWithDomainFilter
+	GlobalDomainVisibilityRPS         dynamicconfig.IntPropertyFnWithDomainFilter
+	EnableClientVersionCheck          dynamicconfig.BoolPropertyFn
+	DisallowQuery                     dynamicconfig.BoolPropertyFnWithDomainFilter
+	ShutdownDrainDuration             dynamicconfig.DurationPropertyFn
+	Lockdown                          dynamicconfig.BoolPropertyFnWithDomainFilter
 
 	// id length limits
 	MaxIDLengthWarnLimit  dynamicconfig.IntPropertyFn
@@ -127,10 +132,13 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		HistoryMaxPageSize:                          dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendHistoryMaxPageSize),
 		UserRPS:                                     dc.GetIntProperty(dynamicconfig.FrontendUserRPS),
 		WorkerRPS:                                   dc.GetIntProperty(dynamicconfig.FrontendWorkerRPS),
+		VisibilityRPS:                               dc.GetIntProperty(dynamicconfig.FrontendVisibilityRPS),
 		MaxDomainUserRPSPerInstance:                 dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainUserRPSPerInstance),
 		MaxDomainWorkerRPSPerInstance:               dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainWorkerRPSPerInstance),
+		MaxDomainVisibilityRPSPerInstance:           dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxDomainVisibilityRPSPerInstance),
 		GlobalDomainUserRPS:                         dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainUserRPS),
 		GlobalDomainWorkerRPS:                       dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainWorkerRPS),
+		GlobalDomainVisibilityRPS:                   dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendGlobalDomainVisibilityRPS),
 		MaxIDLengthWarnLimit:                        dc.GetIntProperty(dynamicconfig.MaxIDLengthWarnLimit),
 		DomainNameMaxLength:                         dc.GetIntPropertyFilteredByDomain(dynamicconfig.DomainNameMaxLength),
 		IdentityMaxLength:                           dc.GetIntPropertyFilteredByDomain(dynamicconfig.IdentityMaxLength),

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -69,6 +69,15 @@ const (
 
 var _ Handler = (*WorkflowHandler)(nil)
 
+// ratelimitType differentiates between the three categories of ratelimiters
+type ratelimitType int
+
+const (
+	ratelimitTypeUser ratelimitType = iota + 1
+	ratelimitTypeWorker
+	ratelimitTypeVisibility
+)
+
 type (
 	// WorkflowHandler - Thrift handler interface for workflow service
 	WorkflowHandler struct {
@@ -79,6 +88,7 @@ type (
 		tokenSerializer           common.TaskTokenSerializer
 		userRateLimiter           quotas.Policy
 		workerRateLimiter         quotas.Policy
+		visibilityRateLimiter     quotas.Policy
 		config                    *Config
 		versionChecker            client.VersionChecker
 		domainHandler             domain.Handler
@@ -182,6 +192,17 @@ func NewWorkflowHandler(
 					service.Frontend,
 					config.GlobalDomainWorkerRPS.AsFloat64(domain),
 					config.MaxDomainWorkerRPSPerInstance.AsFloat64(domain),
+					resource.GetMembershipResolver(),
+				))
+			}),
+		),
+		visibilityRateLimiter: quotas.NewMultiStageRateLimiter(
+			quotas.NewDynamicRateLimiter(config.VisibilityRPS.AsFloat64()),
+			quotas.NewCollection(func(domain string) quotas.Limiter {
+				return quotas.NewDynamicRateLimiter(quotas.PerMemberDynamic(
+					service.Frontend,
+					config.GlobalDomainVisibilityRPS.AsFloat64(domain),
+					config.MaxDomainVisibilityRPSPerInstance.AsFloat64(domain),
 					resource.GetMembershipResolver(),
 				))
 			}),
@@ -577,7 +598,7 @@ func (wh *WorkflowHandler) PollForActivityTask(
 		return nil, wh.error(errIdentityTooLong, scope, tags...)
 	}
 
-	if ok := wh.allow(false, pollRequest); !ok {
+	if ok := wh.allow(ratelimitTypeWorker, pollRequest); !ok {
 		// pollers exponentially back off up to 10s
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
@@ -697,7 +718,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 		return nil, wh.error(err, scope, tags...)
 	}
 
-	if ok := wh.allow(false, pollRequest); !ok {
+	if ok := wh.allow(ratelimitTypeWorker, pollRequest); !ok {
 		// pollers exponentially back off up to 10s
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
@@ -833,7 +854,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, dw)
+	wh.allow(ratelimitTypeWorker, dw)
 
 	tags := getDomainWfIDRunIDTags(domainName, &types.WorkflowExecution{
 		WorkflowID: taskToken.WorkflowID,
@@ -916,7 +937,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, heartbeatRequest)
+	wh.allow(ratelimitTypeWorker, heartbeatRequest)
 
 	wh.GetLogger().Debug("Received RecordActivityTaskHeartbeatByID")
 	domainID, err := wh.GetDomainCache().GetDomainID(domainName)
@@ -1046,7 +1067,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, dw)
+	wh.allow(ratelimitTypeWorker, dw)
 
 	tags := getDomainWfIDRunIDTags(domainName, &types.WorkflowExecution{
 		WorkflowID: taskToken.WorkflowID,
@@ -1140,7 +1161,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, completeRequest)
+	wh.allow(ratelimitTypeWorker, completeRequest)
 
 	domainID, err := wh.GetDomainCache().GetDomainID(domainName)
 	if err != nil {
@@ -1280,7 +1301,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, dw)
+	wh.allow(ratelimitTypeWorker, dw)
 
 	tags := getDomainWfIDRunIDTags(domainName, &types.WorkflowExecution{
 		WorkflowID: taskToken.WorkflowID,
@@ -1362,7 +1383,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, failedRequest)
+	wh.allow(ratelimitTypeWorker, failedRequest)
 
 	domainID, err := wh.GetDomainCache().GetDomainID(domainName)
 	if err != nil {
@@ -1493,7 +1514,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, dw)
+	wh.allow(ratelimitTypeWorker, dw)
 
 	tags := getDomainWfIDRunIDTags(domainName, &types.WorkflowExecution{
 		WorkflowID: taskToken.WorkflowID,
@@ -1587,7 +1608,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, cancelRequest)
+	wh.allow(ratelimitTypeWorker, cancelRequest)
 
 	domainID, err := wh.GetDomainCache().GetDomainID(domainName)
 	if err != nil {
@@ -1727,7 +1748,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskCompleted(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, dw)
+	wh.allow(ratelimitTypeWorker, dw)
 
 	tags := getDomainWfIDRunIDTags(domainName, &types.WorkflowExecution{
 		WorkflowID: taskToken.WorkflowID,
@@ -1837,7 +1858,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, dw)
+	wh.allow(ratelimitTypeWorker, dw)
 
 	tags := getDomainWfIDRunIDTags(domainName, &types.WorkflowExecution{
 		WorkflowID: taskToken.WorkflowID,
@@ -1933,7 +1954,7 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, dw)
+	wh.allow(ratelimitTypeWorker, dw)
 
 	sizeLimitError := wh.config.BlobSizeLimitError(domainName)
 	sizeLimitWarn := wh.config.BlobSizeLimitWarn(domainName)
@@ -2009,7 +2030,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, startRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, startRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -2191,7 +2212,7 @@ func (wh *WorkflowHandler) GetWorkflowExecutionHistory(
 		return nil, wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, getRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, getRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -2464,7 +2485,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(
 		return wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, signalRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, signalRequest); !ok {
 		return wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -2581,7 +2602,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 		return nil, wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, signalWithStartRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, signalWithStartRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -2759,7 +2780,7 @@ func (wh *WorkflowHandler) TerminateWorkflowExecution(
 		return wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, terminateRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, terminateRequest); !ok {
 		return wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -2814,7 +2835,7 @@ func (wh *WorkflowHandler) ResetWorkflowExecution(
 		return nil, wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, resetRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, resetRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -2868,7 +2889,7 @@ func (wh *WorkflowHandler) RequestCancelWorkflowExecution(
 		return wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, cancelRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, cancelRequest); !ok {
 		return wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -2918,7 +2939,7 @@ func (wh *WorkflowHandler) ListOpenWorkflowExecutions(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, listRequest); !ok {
+	if ok := wh.allow(ratelimitTypeVisibility, listRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3035,7 +3056,7 @@ func (wh *WorkflowHandler) ListArchivedWorkflowExecutions(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, listRequest); !ok {
+	if ok := wh.allow(ratelimitTypeVisibility, listRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3127,7 +3148,7 @@ func (wh *WorkflowHandler) ListClosedWorkflowExecutions(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, listRequest); !ok {
+	if ok := wh.allow(ratelimitTypeVisibility, listRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3267,7 +3288,7 @@ func (wh *WorkflowHandler) ListWorkflowExecutions(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, listRequest); !ok {
+	if ok := wh.allow(ratelimitTypeVisibility, listRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3336,7 +3357,7 @@ func (wh *WorkflowHandler) RestartWorkflowExecution(ctx context.Context, request
 		return nil, wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, request); !ok {
+	if ok := wh.allow(ratelimitTypeUser, request); !ok {
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -3400,7 +3421,7 @@ func (wh *WorkflowHandler) ScanWorkflowExecutions(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, listRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, listRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3468,7 +3489,7 @@ func (wh *WorkflowHandler) CountWorkflowExecutions(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, countRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, countRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3553,7 +3574,7 @@ func (wh *WorkflowHandler) ResetStickyTaskList(
 
 	// Count the request in the host RPS,
 	// but we still accept it even if RPS is exceeded
-	wh.allow(false, resetRequest)
+	wh.allow(ratelimitTypeWorker, resetRequest)
 
 	if err := validateExecution(wfExecution); err != nil {
 		return nil, wh.error(err, scope, tags...)
@@ -3604,7 +3625,7 @@ func (wh *WorkflowHandler) QueryWorkflow(
 		return nil, wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, queryRequest); !ok {
+	if ok := wh.allow(ratelimitTypeUser, queryRequest); !ok {
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -3686,7 +3707,7 @@ func (wh *WorkflowHandler) DescribeWorkflowExecution(
 		return nil, wh.error(errDomainNotSet, scope, tags...)
 	}
 
-	if ok := wh.allow(true, request); !ok {
+	if ok := wh.allow(ratelimitTypeUser, request); !ok {
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
@@ -3739,7 +3760,7 @@ func (wh *WorkflowHandler) DescribeTaskList(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, request); !ok {
+	if ok := wh.allow(ratelimitTypeUser, request); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3789,7 +3810,7 @@ func (wh *WorkflowHandler) ListTaskListPartitions(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, request); !ok {
+	if ok := wh.allow(ratelimitTypeUser, request); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -3826,7 +3847,7 @@ func (wh *WorkflowHandler) GetTaskListsByDomain(
 		return nil, wh.error(errDomainNotSet, scope)
 	}
 
-	if ok := wh.allow(true, request); !ok {
+	if ok := wh.allow(ratelimitTypeUser, request); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 
@@ -4451,15 +4472,22 @@ func (wh *WorkflowHandler) isListRequestPageSizeTooLarge(pageSize int32, domain 
 		pageSize > int32(wh.config.ESIndexMaxResultWindow())
 }
 
-func (wh *WorkflowHandler) allow(isUserEndpoint bool, d domainGetter) bool {
+func (wh *WorkflowHandler) allow(requestType ratelimitType, d domainGetter) bool {
 	domain := ""
 	if d != nil {
 		domain = d.GetDomain()
 	}
-	if isUserEndpoint {
+	switch requestType {
+	case ratelimitTypeUser:
 		return wh.userRateLimiter.Allow(quotas.Info{Domain: domain})
+	case ratelimitTypeWorker:
+		return wh.workerRateLimiter.Allow(quotas.Info{Domain: domain})
+	case ratelimitTypeVisibility:
+		return wh.visibilityRateLimiter.Allow(quotas.Info{Domain: domain})
+	default:
+		wh.GetLogger().Fatal("coding error, unrecognized request ratelimit type value", tag.Value(requestType))
+		panic("unreachable")
 	}
-	return wh.workerRateLimiter.Allow(quotas.Info{Domain: domain})
 }
 
 // GetClusterInfo return information about cadence deployment
@@ -4469,7 +4497,7 @@ func (wh *WorkflowHandler) GetClusterInfo(
 	defer func() { log.CapturePanic(recover(), wh.GetLogger(), &err) }()
 
 	scope := wh.getDefaultScope(ctx, metrics.FrontendClientGetClusterInfoScope)
-	if ok := wh.allow(true, nil); !ok {
+	if ok := wh.allow(ratelimitTypeUser, nil); !ok {
 		return nil, wh.error(createServiceBusyError(), scope)
 	}
 


### PR DESCRIPTION
This is a re-implementation of #4916 that's compatible with the new dynamic config refactor, as
there are enough changes that it wasn't worth trying to merge or cherry-pick.  I've also made
some minor improvements, e.g. added some more descriptions and used private types, but there is
no behavior change from that PR.

---

ES (and in general any kind of "bulk query" API) is a different resource and has quite different
ratelimiting needs than other kinds of requests, so this separates the APIs and adds a new
ratelimiter dynamic config.

Since it kinda looked like we had something for this before, but it wasn't working, I dug around
in the code and discovered that the existing limits are pretty wildly incorrectly used, or were
actually completely unused.
Those variables are now marked as deprecated for visibility, future changes should probably just
remove them entirely (and/or correct them).

