### PR TITLE
Improve decode_thrift output

### DIFF
--- a/tools/cli/adminDBCleanCommand.go
+++ b/tools/cli/adminDBCleanCommand.go
@@ -31,6 +31,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/davecgh/go-spew/spew"
 	"github.com/urfave/cli"
 
 	"github.com/uber/cadence/common"
@@ -66,8 +67,14 @@ func AdminDBDataDecodeThrift(c *cli.Context) {
 					ErrorAndExit("cannot encode back to confirm", err)
 				}
 				if bytes.Equal(data, data2) {
-					fmt.Printf("=======Decode into type %v ========\n", typeName)
-					fmt.Println(anyToString(t, true, 0))
+					fmt.Printf("======= Decode into type %v ========\n", typeName)
+					spew.Dump(t)
+					// json-ify it for easier mechanical use
+					js, err := json.Marshal(t)
+					if err == nil {
+						fmt.Println("======= As JSON ========")
+						fmt.Println(string(js))
+					}
 					found = true
 				}
 			}


### PR DESCRIPTION
The current output is not particularly useful for some types:
```
❯ cadence admin db decode_thrift -i '590f000a0c000000010a000a00000000000000560a00141704bf217393afac08001e000000030a002300000000000000010a0024000000000dd674990c004608000a00000000000000'
=======Decode into type shared.History ========
{Events:[len=1]}
```
Now it's much better:
```
❯ cadence admin db decode_thrift -i '590f000a0c000000010a000a00000000000000560a00141708a948a26a263f08001e000000030a002300000000000000010a0024000000000d985dab0c004608000a00000000000000'
======= Decode into type shared.History ========
(*shared.History)(0xc0003fc588)(History{Events: [HistoryEvent{EventId: 86, Timestamp: 1659762592113632831, EventType: WorkflowExecutionTimedOut, Version: 1, TaskId: 228089259, WorkflowExecutionTimedOutEventAttributes: WorkflowExecutionTimedOutEventAttributes{TimeoutType: START_TO_CLOSE}}]})
======= As JSON ========
{"events":[{"eventId":86,"timestamp":1659762592113632831,"eventType":"WorkflowExecutionTimedOut","version":1,"taskId":228089259,"workflowExecutionTimedOutEventAttributes":{"timeoutType":"START_TO_CLOSE"}}]}
```