### PR TITLE
Bugfix/improve logging replication message

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -821,7 +821,10 @@ func (c *clientImpl) GetReplicationMessages(
 			requestContext, responseInfo := rpc.ContextWithResponseInfo(requestContext)
 			resp, err := c.client.GetReplicationMessages(requestContext, req, append(opts, yarpc.WithShardKey(peer))...)
 			if err != nil {
-				c.logger.Warn("Failed to get replication tasks from client", tag.Error(err))
+				c.logger.Warn("Failed to get replication tasks from client",
+					tag.Error(err),
+					tag.ShardReplicationToken(req),
+				)
 				// Returns service busy error to notify replication
 				if _, ok := err.(*types.ServiceBusyError); ok {
 					return err

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -454,6 +454,11 @@ func ShardReplicationAck(shardReplicationAck int64) Tag {
 	return newInt64("shard-replication-ack", shardReplicationAck)
 }
 
+// ShardReplicationToken returns information about a particular replication request
+func ShardReplicationToken(token interface{}) Tag {
+	return newObjectTag("shard-replication-token", token)
+}
+
 // PreviousShardRangeID returns tag for PreviousShardRangeID
 func PreviousShardRangeID(id int64) Tag {
 	return newInt64("previous-shard-range-id", id)


### PR DESCRIPTION
Adds a small amount of debug-logs to replication messages during timeouts.

Presently it's difficult for an on-call to know which requests are taking too long and fetching too much data. 
