### PR TITLE
Added changes to DeleteCurrentWorkflowExecution and GetCurrentExecution

### DIFF
--- a/common/persistence/dataManagerInterfaces.go
+++ b/common/persistence/dataManagerInterfaces.go
@@ -895,6 +895,7 @@ type (
 	GetCurrentExecutionRequest struct {
 		DomainID   string
 		WorkflowID string
+		DomainName string
 	}
 
 	// ListCurrentExecutionsRequest is request to ListCurrentExecutions
@@ -1057,6 +1058,7 @@ type (
 		DomainID   string
 		WorkflowID string
 		RunID      string
+		DomainName string
 	}
 
 	// GetTransferTasksRequest is used to read tasks from the transfer task queue

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -414,7 +414,7 @@ func (p *workflowExecutionPersistenceClient) DeleteCurrentWorkflowExecution(
 	op := func() error {
 		return p.persistence.DeleteCurrentWorkflowExecution(ctx, request)
 	}
-	return p.call(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op)
+	return p.call(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName))
 }
 
 func (p *workflowExecutionPersistenceClient) GetCurrentExecution(
@@ -427,7 +427,7 @@ func (p *workflowExecutionPersistenceClient) GetCurrentExecution(
 		resp, err = p.persistence.GetCurrentExecution(ctx, request)
 		return err
 	}
-	err := p.call(metrics.PersistenceGetCurrentExecutionScope, op)
+	err := p.call(metrics.PersistenceGetCurrentExecutionScope, op, metrics.DomainTag(request.DomainName))
 	if err != nil {
 		return nil, err
 	}

--- a/common/reconciliation/fetcher/current.go
+++ b/common/reconciliation/fetcher/current.go
@@ -48,6 +48,7 @@ func CurrentExecution(
 	req := persistence.GetCurrentExecutionRequest{
 		DomainID:   request.DomainID,
 		WorkflowID: request.WorkflowID,
+		DomainName: request.DomainName,
 	}
 	e, err := retryer.GetCurrentExecution(ctx, &req)
 	if err != nil {

--- a/common/reconciliation/invariant/concreteExecutionExists_test.go
+++ b/common/reconciliation/invariant/concreteExecutionExists_test.go
@@ -160,6 +160,7 @@ func (s *ConcreteExecutionExistsSuite) TestCheck() {
 		execManager := &mocks.ExecutionManager{}
 		execManager.On("IsWorkflowExecutionExists", mock.Anything, mock.Anything).Return(tc.getConcreteResp, tc.getConcreteErr)
 		execManager.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(tc.getCurrentResp, tc.getCurrentErr)
+		mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
 		o := NewConcreteExecutionExists(persistence.NewPersistenceRetryer(execManager, nil, c.CreatePersistenceRetryPolicy()), mockDomainCache)
 		s.Equal(tc.expectedResult, o.Check(context.Background(), tc.execution))
 	}

--- a/common/reconciliation/invariant/openCurrentExecution.go
+++ b/common/reconciliation/invariant/openCurrentExecution.go
@@ -71,9 +71,18 @@ func (o *openCurrentExecution) Check(
 			InvariantName:   o.Name(),
 		}
 	}
+	domainName, err := o.dc.GetDomainName(concreteExecution.DomainID)
+	if err != nil {
+		return CheckResult{
+			CheckResultType: CheckResultTypeFailed,
+			InvariantName:   o.Name(),
+			Info:            "failed to fetch Domain Name",
+		}
+	}
 	currentExecResp, currentExecErr := o.pr.GetCurrentExecution(ctx, &persistence.GetCurrentExecutionRequest{
 		DomainID:   concreteExecution.DomainID,
 		WorkflowID: concreteExecution.WorkflowID,
+		DomainName: domainName,
 	})
 
 	stillOpen, stillOpenErr := ExecutionStillOpen(ctx, &concreteExecution.Execution, o.pr, o.dc)

--- a/common/reconciliation/invariant/util.go
+++ b/common/reconciliation/invariant/util.go
@@ -110,6 +110,7 @@ func DeleteExecution(
 		DomainID:   execution.DomainID,
 		WorkflowID: execution.WorkflowID,
 		RunID:      execution.RunID,
+		DomainName: domainName,
 	}); err != nil {
 		return &FixResult{
 			FixResultType: FixResultTypeFailed,

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -502,6 +502,7 @@ func (adh *adminHandlerImpl) deleteWorkflowFromExecutions(
 		DomainID:   domainID,
 		WorkflowID: workflowID,
 		RunID:      runID,
+		DomainName: domainName,
 	}
 
 	err = exeStore.DeleteCurrentWorkflowExecution(ctx, deleteCurrentReq)

--- a/service/history/events/cache_test.go
+++ b/service/history/events/cache_test.go
@@ -159,7 +159,7 @@ func (s *eventsCacheSuite) TestEventsCacheMissMultiEventsBatchV2Success() {
 		LastFirstEventID: event1.ID,
 	}, nil)
 
-	s.domainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil)
+	s.domainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil).AnyTimes()
 	s.cache.PutEvent(domainID, workflowID, runID, event2.ID, event2)
 	actualEvent, err := s.cache.GetEvent(context.Background(), *shardID, domainID, workflowID, runID, event1.ID, event6.ID, []byte("store_token"))
 	s.Nil(err)
@@ -183,7 +183,7 @@ func (s *eventsCacheSuite) TestEventsCacheMissV2Failure() {
 		DomainName:    domainName,
 	}).Return(nil, expectedErr)
 
-	s.domainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil)
+	s.domainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil).AnyTimes()
 	actualEvent, err := s.cache.GetEvent(context.Background(), *shardID, domainID, workflowID, runID, int64(11), int64(14), []byte("store_token"))
 	s.Nil(actualEvent)
 	s.Equal(expectedErr, err)
@@ -220,7 +220,7 @@ func (s *eventsCacheSuite) TestEventsCacheDisableSuccess() {
 		LastFirstEventID: event2.ID,
 	}, nil)
 
-	s.domainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil)
+	s.domainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil).AnyTimes()
 	s.cache.PutEvent(domainID, workflowID, runID, event1.ID, event1)
 	s.cache.PutEvent(domainID, workflowID, runID, event2.ID, event2)
 	s.cache.disabled = true

--- a/service/history/execution/cache.go
+++ b/service/history/execution/cache.go
@@ -254,12 +254,16 @@ func (c *Cache) validateWorkflowExecutionInfo(
 	if execution.GetWorkflowID() == "" {
 		return &types.BadRequestError{Message: "Can't load workflow execution.  WorkflowId not set."}
 	}
-
+	domainName, err := c.shard.GetDomainCache().GetDomainName(domainID)
+	if err != nil {
+		return err
+	}
 	// RunID is not provided, lets try to retrieve the RunID for current active execution
 	if execution.GetRunID() == "" {
 		response, err := c.getCurrentExecutionWithRetry(ctx, &persistence.GetCurrentExecutionRequest{
 			DomainID:   domainID,
 			WorkflowID: execution.GetWorkflowID(),
+			DomainName: domainName,
 		})
 
 		if err != nil {

--- a/service/history/execution/cache_test.go
+++ b/service/history/execution/cache_test.go
@@ -85,10 +85,12 @@ func (s *historyCacheSuite) TestHistoryCacheBasic() {
 	s.cache = NewCache(s.mockShard)
 
 	domainID := "test_domain_id"
+	domainName := "test_domain_name"
 	execution1 := types.WorkflowExecution{
 		WorkflowID: "some random workflow ID",
 		RunID:      uuid.New(),
 	}
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil).AnyTimes()
 	mockMS1 := NewMockMutableState(s.controller)
 	context, release, err := s.cache.GetOrCreateWorkflowExecutionForBackground(domainID, execution1)
 	s.Nil(err)
@@ -117,7 +119,7 @@ func (s *historyCacheSuite) TestHistoryCachePinning() {
 		WorkflowID: "wf-cache-test-pinning",
 		RunID:      uuid.New(),
 	}
-
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test_domain_name", nil).AnyTimes()
 	context, release, err := s.cache.GetOrCreateWorkflowExecutionForBackground(domainID, we)
 	s.Nil(err)
 
@@ -152,7 +154,7 @@ func (s *historyCacheSuite) TestHistoryCacheClear() {
 		WorkflowID: "wf-cache-test-clear",
 		RunID:      uuid.New(),
 	}
-
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test_domain_name", nil).AnyTimes()
 	context, release, err := s.cache.GetOrCreateWorkflowExecutionForBackground(domainID, we)
 	s.Nil(err)
 	// since we are just testing whether the release function will clear the cache
@@ -199,7 +201,7 @@ func (s *historyCacheSuite) TestHistoryCacheConcurrentAccess() {
 		release(errors.New("some random error message"))
 		waitGroup.Done()
 	}
-
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
 	for i := 0; i < coroutineCount; i++ {
 		waitGroup.Add(1)
 		go testFn()

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2265,7 +2265,7 @@ func (e *historyEngineImpl) RequestCancelWorkflowExecution(
 		RunID:      request.WorkflowExecution.RunID,
 	}
 
-	return workflow.UpdateCurrentWithActionFunc(ctx, e.executionCache, e.executionManager, domainID, workflowExecution, e.timeSource.Now(),
+	return workflow.UpdateCurrentWithActionFunc(ctx, e.executionCache, e.executionManager, domainID, e.shard.GetDomainCache(), workflowExecution, e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) (*workflow.UpdateAction, error) {
 			if !mutableState.IsWorkflowExecutionRunning() {
 				return nil, workflow.ErrAlreadyCompleted
@@ -2313,7 +2313,6 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 		return errDomainDeprecated
 	}
 	domainID := domainEntry.GetInfo().ID
-
 	request := signalRequest.SignalRequest
 	parentExecution := signalRequest.ExternalWorkflowExecution
 	childWorkflowOnly := signalRequest.GetChildWorkflowOnly()
@@ -2327,6 +2326,7 @@ func (e *historyEngineImpl) SignalWorkflowExecution(
 		e.executionCache,
 		e.executionManager,
 		domainID,
+		e.shard.GetDomainCache(),
 		workflowExecution,
 		e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) (*workflow.UpdateAction, error) {
@@ -2605,6 +2605,7 @@ func (e *historyEngineImpl) TerminateWorkflowExecution(
 		e.executionCache,
 		e.executionManager,
 		domainID,
+		e.shard.GetDomainCache(),
 		workflowExecution,
 		e.timeSource.Now(),
 		func(wfContext execution.Context, mutableState execution.MutableState) (*workflow.UpdateAction, error) {
@@ -2765,11 +2766,15 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 			Message: "Decision finish ID must be > 1 && <= workflow next event ID.",
 		}
 	}
-
+	domainName, err := e.shard.GetDomainCache().GetDomainName(domainID)
+	if err != nil {
+		return nil, err
+	}
 	// also load the current run of the workflow, it can be different from the base runID
 	resp, err := e.executionManager.GetCurrentExecution(ctx, &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
 		WorkflowID: request.WorkflowExecution.GetWorkflowID(),
+		DomainName: domainName,
 	})
 	if err != nil {
 		return nil, err

--- a/service/history/ndc/activity_replicator_test.go
+++ b/service/history/ndc/activity_replicator_test.go
@@ -175,6 +175,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_WorkflowClosed() {
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -234,6 +235,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_IncomingScheduleIDLarger_Inco
 		versionHistoryItem0,
 		versionHistoryItem2,
 	})
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -283,7 +285,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_IncomingScheduleIDLarger_Inco
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:    domainID,
 		WorkflowID:  workflowID,
@@ -344,7 +346,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_VersionHistories_IncomingVers
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -422,7 +424,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_DifferentVersionHistories_Inc
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -511,7 +513,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_VersionHistories_IncomingSche
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -596,7 +598,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_VersionHistories_SameSchedule
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -668,7 +670,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_VersionHistories_LocalVersion
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -741,7 +743,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityCompleted() {
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -797,7 +799,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_LocalActivity
 	context.EXPECT().Clear().AnyTimes()
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:       domainID,
 		WorkflowID:     workflowID,
@@ -860,7 +862,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_Update_SameVe
 	context.EXPECT().Clear().Times(1)
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:          domainID,
 		WorkflowID:        workflowID,
@@ -935,7 +937,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_Update_SameVe
 	context.EXPECT().Clear().Times(1)
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:          domainID,
 		WorkflowID:        workflowID,
@@ -1010,7 +1012,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_Update_Larger
 	context.EXPECT().Clear().Times(1)
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:          domainID,
 		WorkflowID:        workflowID,
@@ -1084,7 +1086,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning() {
 	context.EXPECT().Unlock().Times(1)
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:          domainID,
 		WorkflowID:        workflowID,
@@ -1171,7 +1173,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_ZombieWorkflo
 	context.EXPECT().Unlock().Times(1)
 	_, err := s.executionCache.PutIfNotExist(key, context)
 	s.NoError(err)
-
+	s.mockDomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	request := &types.SyncActivityRequest{
 		DomainID:          domainID,
 		WorkflowID:        workflowID,

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -413,12 +413,16 @@ func (r *transactionManagerImpl) getCurrentWorkflowRunID(
 	domainID string,
 	workflowID string,
 ) (string, error) {
-
+	domainName, err := r.shard.GetDomainCache().GetDomainName(domainID)
+	if err != nil {
+		return "", err
+	}
 	resp, err := r.shard.GetExecutionManager().GetCurrentExecution(
 		ctx,
 		&persistence.GetCurrentExecutionRequest{
 			DomainID:   domainID,
 			WorkflowID: workflowID,
+			DomainName: domainName,
 		},
 	)
 

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -413,9 +413,10 @@ func (r *transactionManagerImpl) getCurrentWorkflowRunID(
 	domainID string,
 	workflowID string,
 ) (string, error) {
-	domainName, err := r.shard.GetDomainCache().GetDomainName(domainID)
-	if err != nil {
-		return "", err
+
+	domainName, errorDomainName := r.shard.GetDomainCache().GetDomainName(domainID)
+	if errorDomainName != nil {
+		return "", errorDomainName
 	}
 	resp, err := r.shard.GetExecutionManager().GetCurrentExecution(
 		ctx,

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -175,6 +175,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Cl
 	domainID := "some random domain ID"
 	workflowID := "some random workflow ID"
 	runID := "some random run ID"
+	domainName := "some random domainName"
 	lastDecisionTaskStartedEventID := int64(9999)
 	nextEventID := lastDecisionTaskStartedEventID * 2
 	lastDecisionTaskStartedVersion := s.domainEntry.GetFailoverVersion()
@@ -225,9 +226,11 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Cl
 		false,
 	).Return(nil).Times(1)
 
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	s.mockExecutionManager.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
+		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil).Once()
 
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
@@ -328,6 +331,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active
 	workflowID := "some random workflow ID"
 	runID := "some random run ID"
 	currentRunID := "other random run ID"
+	domainName := "some random domainName"
 
 	releaseCalled := false
 
@@ -356,10 +360,11 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}).AnyTimes()
-
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	s.mockExecutionManager.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
+		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
@@ -379,7 +384,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passiv
 	workflowID := "some random workflow ID"
 	runID := "some random run ID"
 	currentRunID := "other random run ID"
-
+	domainName := "some random domainName"
 	releaseCalled := false
 
 	workflow := execution.NewMockWorkflow(s.controller)
@@ -407,10 +412,11 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passiv
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}).AnyTimes()
-
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	s.mockExecutionManager.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
+		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)
@@ -469,10 +475,12 @@ func (s *transactionManagerSuite) TestGetWorkflowCurrentRunID_Missing() {
 	ctx := ctx.Background()
 	domainID := "some random domain ID"
 	workflowID := "some random workflow ID"
-
+	domainName := "some random domainName"
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	s.mockExecutionManager.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
+		DomainName: domainName,
 	}).Return(nil, &types.EntityNotExistsError{}).Once()
 
 	currentRunID, err := s.transactionManager.getCurrentWorkflowRunID(ctx, domainID, workflowID)
@@ -485,10 +493,12 @@ func (s *transactionManagerSuite) TestGetWorkflowCurrentRunID_Exists() {
 	domainID := "some random domain ID"
 	workflowID := "some random workflow ID"
 	runID := "some random run ID"
-
+	domainName := "some random domainName"
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(domainID).Return(domainName, nil).AnyTimes()
 	s.mockExecutionManager.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
+		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil).Once()
 
 	currentRunID, err := s.transactionManager.getCurrentWorkflowRunID(ctx, domainID, workflowID)

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -279,6 +279,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_C
 	domainID := "some random domain ID"
 	workflowID := "some random workflow ID"
 	runID := "some random run ID"
+	domainName := "some random domainName"
 
 	releaseCalled := false
 
@@ -302,10 +303,11 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_C
 		WorkflowID: workflowID,
 		RunID:      runID,
 	}).AnyTimes()
-
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return(domainName, nil).AnyTimes()
 	s.mockExecutionManager.On("GetCurrentExecution", mock.Anything, &persistence.GetCurrentExecutionRequest{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
+		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(int64(0), nil).Times(1)

--- a/service/history/replication/task_hydrator_test.go
+++ b/service/history/replication/task_hydrator_test.go
@@ -571,9 +571,9 @@ func TestMutableStateLoader_GetMutableState(t *testing.T) {
 	expectedMS := execution.NewMockMutableState(controller)
 	msLoader := mutableStateLoader{executionCache}
 
+	domainCache.EXPECT().GetDomainName(gomock.Any()).Return(testDomainName, nil).AnyTimes()
 	exec, release, err := executionCache.GetOrCreateWorkflowExecution(ctx, testDomainID, types.WorkflowExecution{WorkflowID: testWorkflowID, RunID: testRunID})
 	require.NoError(t, err)
-
 	// Try getting mutable state while it is still locked, will result in an error
 	contextWithTimeout, cancel := context.WithTimeout(ctx, time.Millisecond)
 	defer cancel()

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -447,7 +447,7 @@ func (s *workflowResetterSuite) TestReapplyContinueAsNewWorkflowEvents() {
 		History:       []*types.History{{Events: newEvents}},
 		NextPageToken: nil,
 	}, nil).Once()
-
+	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain", nil).AnyTimes()
 	resetContext := execution.NewMockContext(s.controller)
 	resetContext.EXPECT().Lock(gomock.Any()).Return(nil).Times(1)
 	resetContext.EXPECT().Unlock().Times(1)

--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -244,12 +244,16 @@ func (t *timerTaskExecutorBase) deleteCurrentWorkflowExecution(
 	ctx context.Context,
 	task *persistence.TimerTaskInfo,
 ) error {
-
+	domainName, err := t.shard.GetDomainCache().GetDomainName(task.DomainID)
+	if err != nil {
+		return err
+	}
 	op := func() error {
 		return t.shard.GetExecutionManager().DeleteCurrentWorkflowExecution(ctx, &persistence.DeleteCurrentWorkflowExecutionRequest{
 			DomainID:   task.DomainID,
 			WorkflowID: task.WorkflowID,
 			RunID:      task.RunID,
+			DomainName: domainName,
 		})
 	}
 	return t.throttleRetry.Do(ctx, op)

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1044,13 +1044,17 @@ func (t *transferActiveTaskExecutor) processResetWorkflow(
 		tag.WorkflowID(task.WorkflowID),
 		tag.WorkflowRunID(task.RunID),
 	)
-
+	domainName, err := t.shard.GetDomainCache().GetDomainName(task.DomainID)
+	if err != nil {
+		return err
+	}
 	if !currentMutableState.IsWorkflowExecutionRunning() {
 		// it means this this might not be current anymore, we need to check
 		var resp *persistence.GetCurrentExecutionResponse
 		resp, err = t.shard.GetExecutionManager().GetCurrentExecution(ctx, &persistence.GetCurrentExecutionRequest{
 			DomainID:   task.DomainID,
 			WorkflowID: task.WorkflowID,
+			DomainName: domainName,
 		})
 		if err != nil {
 			return err

--- a/service/history/workflow/util_test.go
+++ b/service/history/workflow/util_test.go
@@ -162,7 +162,7 @@ func TestWorkflowLoad(t *testing.T) {
 
 			mockDomainCache := mockShard.Resource.DomainCache
 			mockDomainCache.EXPECT().GetDomainByID(constants.TestLocalDomainEntry.GetInfo().ID).Return(constants.TestLocalDomainEntry, nil)
-			mockDomainCache.EXPECT().GetDomainName(constants.TestLocalDomainEntry.GetInfo().ID).Return(constants.TestLocalDomainEntry.GetInfo().Name, nil)
+			mockDomainCache.EXPECT().GetDomainName(constants.TestLocalDomainEntry.GetInfo().ID).Return(constants.TestLocalDomainEntry.GetInfo().Name, nil).AnyTimes()
 
 			tc.mockSetupFn(mockShard)
 
@@ -171,6 +171,7 @@ func TestWorkflowLoad(t *testing.T) {
 				execution.NewCache(mockShard),
 				mockShard.Resource.ExecutionMgr,
 				constants.TestDomainID,
+				constants.TestDomainName,
 				constants.TestWorkflowID,
 				tc.runID,
 			)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added changes to DeleteCurrentWorkflowExecution and GetCurrentExecution

<!-- Tell your future self why have you made these changes -->
**Why?**
To create metrics using DomainTag for domain Cost Attribution

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested Locally. Added mock tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No potential risks.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
N/A