### PR TITLE
Simplify history engine task read ID logic

### DIFF
--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -644,8 +644,6 @@ Create_Loop:
 			*types.ServiceBusyError:
 			// No special handling required for these errors
 			// We know write to DB fails if these errors are returned
-			// Updating MaxReadLevel doesn't matter in this case
-			s.updateMaxReadLevelLocked(transferMaxReadLevel)
 			return nil, err
 		case *persistence.ShardOwnershipLostError:
 			{
@@ -680,10 +678,6 @@ Create_Loop:
 					)
 					s.closeShard()
 					break Create_Loop
-				} else {
-					// Shard is re-acquired successfully, and we know write to DB is guaranteed to
-					// complete, it's safe to update MaxReadLevel
-					s.updateMaxReadLevelLocked(transferMaxReadLevel)
 				}
 			}
 		}
@@ -770,8 +764,6 @@ Update_Loop:
 			*types.ServiceBusyError:
 			// No special handling required for these errors
 			// We know write to DB fails if these errors are returned
-			// Updating MaxReadLevel doesn't matter in this case
-			s.updateMaxReadLevelLocked(transferMaxReadLevel)
 			return nil, err
 		case *persistence.ShardOwnershipLostError:
 			{
@@ -806,10 +798,6 @@ Update_Loop:
 					)
 					s.closeShard()
 					break Update_Loop
-				} else {
-					// Shard is re-acquired successfully, and we know write to DB is guaranteed to
-					// complete, it's safe to update MaxReadLevel
-					s.updateMaxReadLevelLocked(transferMaxReadLevel)
 				}
 			}
 		}
@@ -904,8 +892,6 @@ Conflict_Resolve_Loop:
 			*types.ServiceBusyError:
 			// No special handling required for these errors
 			// We know write to DB fails if these errors are returned
-			// Updating MaxReadLevel doesn't matter in this case
-			s.updateMaxReadLevelLocked(transferMaxReadLevel)
 			return nil, err
 		case *persistence.ShardOwnershipLostError:
 			{
@@ -940,10 +926,6 @@ Conflict_Resolve_Loop:
 					)
 					s.closeShard()
 					break Conflict_Resolve_Loop
-				} else {
-					// Shard is re-acquired successfully, and we know write to DB is guaranteed to
-					// complete, it's safe to update MaxReadLevel
-					s.updateMaxReadLevelLocked(transferMaxReadLevel)
 				}
 			}
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Cherry pick https://github.com/temporalio/temporal/pull/2724
- Do not update max readable task ID if transaction to DB is rejected
- Remove redundant logic which try to update max readable task ID after shard range ID increase

<!-- Tell your future self why have you made these changes -->
**Why?**
Simplify logic

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
