### PR TITLE
Replication cache for sharing hydrated messages

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -941,6 +941,12 @@ const (
 	// Default value: 3
 	// Allowed filters: N/A
 	ReplicatorReadTaskMaxRetryCount
+	// ReplicatorCacheCapacity is the capacity of replication cache in number of tasks
+	// KeyName: history.replicatorCacheCapacity
+	// Value type: Int
+	// Default value: 10000
+	// Allowed filters: N/A
+	ReplicatorCacheCapacity
 
 	// ExecutionMgrNumConns is persistence connections number for ExecutionManager
 	// KeyName: history.executionMgrNumConns
@@ -3039,6 +3045,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		KeyName:      "history.replicatorReadTaskMaxRetryCount",
 		Description:  "ReplicatorReadTaskMaxRetryCount is the number of read replication task retry time",
 		DefaultValue: 3,
+	},
+	ReplicatorCacheCapacity: DynamicInt{
+		KeyName:      "history.replicatorCacheCapacity",
+		Description:  "ReplicatorCacheCapacity is the capacity of replication cache in number of tasks",
+		DefaultValue: 10000,
 	},
 	ExecutionMgrNumConns: DynamicInt{
 		KeyName:      "history.executionMgrNumConns",

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -114,6 +114,7 @@ var (
 	ComponentReplicator                 = component("replicator")
 	ComponentReplicationTaskProcessor   = component("replication-task-processor")
 	ComponentReplicationAckManager      = component("replication-ack-manager")
+	ComponentReplicationCacheManager    = component("replication-cache-manager")
 	ComponentHistoryReplicator          = component("history-replicator")
 	ComponentHistoryResender            = component("history-resender")
 	ComponentIndexer                    = component("indexer")

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1089,6 +1089,8 @@ const (
 	HistoryEventNotificationScope
 	// ReplicatorQueueProcessorScope is the scope used by all metric emitted by replicator queue processor
 	ReplicatorQueueProcessorScope
+	// ReplicatorCacheManagerScope is the scope used by all metric emitted by replicator cache manager
+	ReplicatorCacheManagerScope
 	// ReplicatorTaskHistoryScope is the scope used for history task processing by replicator queue processor
 	ReplicatorTaskHistoryScope
 	// ReplicatorTaskSyncActivityScope is the scope used for sync activity by replicator queue processor
@@ -1705,6 +1707,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		CrossClusterTargetTaskApplyParentClosePolicyScope:               {operation: "CrossClusterTargetTaskTypeApplyParentClosePolicy"},
 		HistoryEventNotificationScope:                                   {operation: "HistoryEventNotification"},
 		ReplicatorQueueProcessorScope:                                   {operation: "ReplicatorQueueProcessor"},
+		ReplicatorCacheManagerScope:                                     {operation: "ReplicatorCacheManager"},
 		ReplicatorTaskHistoryScope:                                      {operation: "ReplicatorTaskHistory"},
 		ReplicatorTaskSyncActivityScope:                                 {operation: "ReplicatorTaskSyncActivity"},
 		ReplicateHistoryEventsScope:                                     {operation: "ReplicateHistoryEvents"},
@@ -2082,10 +2085,13 @@ const (
 	UnbufferReplicationTaskTimer
 	HistoryConflictsCounter
 	CompleteTaskFailedCounter
+	CacheSize
 	CacheRequests
 	CacheFailures
 	CacheLatency
+	CacheHitCounter
 	CacheMissCounter
+	CacheFullCounter
 	AcquireLockFailedCounter
 	WorkflowContextCleared
 	MutableStateSize
@@ -2633,10 +2639,13 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		UnbufferReplicationTaskTimer:                        {metricName: "unbuffer_replication_tasks", metricType: Timer},
 		HistoryConflictsCounter:                             {metricName: "history_conflicts", metricType: Counter},
 		CompleteTaskFailedCounter:                           {metricName: "complete_task_fail_count", metricType: Counter},
+		CacheSize:                                           {metricName: "cache_size", metricType: Gauge},
 		CacheRequests:                                       {metricName: "cache_requests", metricType: Counter},
 		CacheFailures:                                       {metricName: "cache_errors", metricType: Counter},
 		CacheLatency:                                        {metricName: "cache_latency", metricType: Timer},
+		CacheHitCounter:                                     {metricName: "cache_hit", metricType: Counter},
 		CacheMissCounter:                                    {metricName: "cache_miss", metricType: Counter},
+		CacheFullCounter:                                    {metricName: "cache_full", metricType: Counter},
 		AcquireLockFailedCounter:                            {metricName: "acquire_lock_failed", metricType: Counter},
 		WorkflowContextCleared:                              {metricName: "workflow_context_cleared", metricType: Counter},
 		MutableStateSize:                                    {metricName: "mutable_state_size", metricType: Timer},

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -188,6 +188,7 @@ type Config struct {
 	ReplicatorReadTaskMaxRetryCount        dynamicconfig.IntPropertyFn
 	ReplicatorProcessorFetchTasksBatchSize dynamicconfig.IntPropertyFnWithShardIDFilter
 	ReplicatorUpperLatency                 dynamicconfig.DurationPropertyFn
+	ReplicatorCacheCapacity                dynamicconfig.IntPropertyFn
 
 	// Persistence settings
 	ExecutionMgrNumConns dynamicconfig.IntPropertyFn
@@ -453,6 +454,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ReplicatorReadTaskMaxRetryCount:        dc.GetIntProperty(dynamicconfig.ReplicatorReadTaskMaxRetryCount),
 		ReplicatorProcessorFetchTasksBatchSize: dc.GetIntPropertyFilteredByShardID(dynamicconfig.ReplicatorTaskBatchSize),
 		ReplicatorUpperLatency:                 dc.GetDurationProperty(dynamicconfig.ReplicatorUpperLatency),
+		ReplicatorCacheCapacity:                dc.GetIntProperty(dynamicconfig.ReplicatorCacheCapacity),
 
 		ExecutionMgrNumConns:            dc.GetIntProperty(dynamicconfig.ExecutionMgrNumConns),
 		HistoryMgrNumConns:              dc.GetIntProperty(dynamicconfig.HistoryMgrNumConns),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -112,6 +112,7 @@ type (
 		crossClusterTaskProcessors common.Daemon
 		replicationTaskProcessors  []replication.TaskProcessor
 		replicationAckManager      replication.TaskAckManager
+		replicationTaskStore       *replication.TaskStore
 		replicationHydrator        replication.TaskHydrator
 		publicClient               workflowserviceclient.Interface
 		eventsReapplier            ndc.EventsReapplier
@@ -158,6 +159,14 @@ func NewEngineWithShardContext(
 	executionCache := execution.NewCache(shard)
 	failoverMarkerNotifier := failover.NewMarkerNotifier(shard, config, failoverCoordinator)
 	replicationHydrator := replication.NewDeferredTaskHydrator(shard.GetShardID(), historyV2Manager, executionCache, shard.GetDomainCache())
+	replicationTaskStore := replication.NewTaskStore(
+		shard.GetConfig(),
+		shard.GetClusterMetadata(),
+		shard.GetDomainCache(),
+		shard.GetMetricsClient(),
+		shard.GetLogger(),
+		replicationHydrator,
+	)
 	historyEngImpl := &historyEngineImpl{
 		currentClusterName:   currentClusterName,
 		shard:                shard,
@@ -209,13 +218,12 @@ func NewEngineWithShardContext(
 		replicationAckManager: replication.NewTaskAckManager(
 			shard.GetShardID(),
 			shard,
-			shard.GetDomainCache(),
 			shard.GetMetricsClient(),
 			shard.GetLogger(),
-			shard.GetConfig(),
 			replication.NewDynamicTaskReader(shard.GetShardID(), executionManager, shard.GetTimeSource(), config),
-			replicationHydrator,
+			replicationTaskStore,
 		),
+		replicationTaskStore: replicationTaskStore,
 	}
 	historyEngImpl.decisionHandler = decision.NewHandler(
 		shard,

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -160,6 +160,7 @@ func NewEngineWithShardContext(
 	failoverMarkerNotifier := failover.NewMarkerNotifier(shard, config, failoverCoordinator)
 	replicationHydrator := replication.NewDeferredTaskHydrator(shard.GetShardID(), historyV2Manager, executionCache, shard.GetDomainCache())
 	replicationTaskStore := replication.NewTaskStore(
+		shard.GetShardID(),
 		shard.GetConfig(),
 		shard.GetClusterMetadata(),
 		shard.GetDomainCache(),

--- a/service/history/replication/cache.go
+++ b/service/history/replication/cache.go
@@ -1,0 +1,150 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package replication
+
+import (
+	"container/heap"
+	"errors"
+	"sync"
+
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/types"
+)
+
+var (
+	errCacheFull    = errors.New("cache is full")
+	errAlreadyAcked = errors.New("already acked")
+)
+
+// Cache is an in-memory implementation of a cache for storing hydrated replication messages.
+// Messages can come out of order as long as their task ID is higher than last acknowledged message.
+// Out of order is expected as different source clusters will share hydrated replication messages.
+//
+// Cache utilizes heap to keep replication messages in order. This is needed for efficient acknowledgements in O(log N).
+//
+// Cache capacity can be increased dynamically. Decrease will require a restart, as new tasks will not be accepted, but memory will not be reclaimed either.
+//
+// Cache methods are thread safe. It is expected to have writers and readers from different go routines.
+type Cache struct {
+	mu sync.RWMutex
+
+	capacity dynamicconfig.IntPropertyFn
+
+	order int64Heap
+	cache map[int64]*types.ReplicationTask
+
+	lastAck int64
+}
+
+// NewCache create a new instance of replication cache
+func NewCache(capacity dynamicconfig.IntPropertyFn) *Cache {
+	initialCapacity := capacity()
+	return &Cache{
+		capacity: capacity,
+		order:    make(int64Heap, 0, initialCapacity),
+		cache:    make(map[int64]*types.ReplicationTask, initialCapacity),
+	}
+}
+
+// Size returns current size of the cache
+func (c *Cache) Size() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return len(c.order)
+}
+
+// Put stores replication task in the cache.
+// - If cache is full, it will return errCacheFull
+// - If given task has ID lower than previously acknowledged task, it will errOutOfOrder
+func (c *Cache) Put(task *types.ReplicationTask) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Check for full cache
+	if len(c.order) >= c.capacity() {
+		return errCacheFull
+	}
+
+	taskID := task.SourceTaskID
+
+	// Reject task as it was already acknowledged
+	if c.lastAck >= taskID {
+		return errAlreadyAcked
+	}
+
+	// Do not add duplicate tasks
+	if _, exists := c.cache[taskID]; exists {
+		return nil
+	}
+
+	c.cache[taskID] = task
+	heap.Push(&c.order, taskID)
+
+	return nil
+}
+
+// Get will return a stored task having a given taskID.
+// If task is not cache, nil is returned.
+func (c *Cache) Get(taskID int64) *types.ReplicationTask {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.cache[taskID]
+}
+
+// Ack is used to acknowledge replication messages.
+// Meaning they will be removed from the cache.
+func (c *Cache) Ack(level int64) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for c.order.Len() > 0 && c.order.Peek() <= level {
+		taskID := heap.Pop(&c.order).(int64)
+		delete(c.cache, taskID)
+	}
+
+	c.lastAck = level
+}
+
+type int64Heap []int64
+
+func (h int64Heap) Len() int           { return len(h) }
+func (h int64Heap) Less(i, j int) bool { return h[i] < h[j] }
+func (h int64Heap) Swap(i, j int)      { h[i], h[j] = h[j], h[i] }
+
+func (h *int64Heap) Push(x interface{}) {
+	*h = append(*h, x.(int64))
+}
+
+func (h *int64Heap) Pop() interface{} {
+	old := *h
+	n := len(old)
+	x := old[n-1]
+	*h = old[0 : n-1]
+	return x
+}
+
+func (h *int64Heap) Peek() int64 {
+	return (*h)[0]
+}

--- a/service/history/replication/cache_test.go
+++ b/service/history/replication/cache_test.go
@@ -1,0 +1,114 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package replication
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestCache(t *testing.T) {
+	task1 := &types.ReplicationTask{SourceTaskID: 100}
+	task2 := &types.ReplicationTask{SourceTaskID: 200}
+	task3 := &types.ReplicationTask{SourceTaskID: 300}
+	task4 := &types.ReplicationTask{SourceTaskID: 400}
+
+	cache := NewCache(dynamicconfig.GetIntPropertyFn(3))
+
+	assert.Equal(t, 0, cache.Size())
+	require.NoError(t, cache.Put(task2))
+	assert.Equal(t, 1, cache.Size())
+	require.NoError(t, cache.Put(task2))
+	assert.Equal(t, 1, cache.Size())
+	require.NoError(t, cache.Put(task3))
+	assert.Equal(t, 2, cache.Size())
+	require.NoError(t, cache.Put(task1))
+	assert.Equal(t, 3, cache.Size())
+	assert.Equal(t, errCacheFull, cache.Put(task4))
+	assert.Equal(t, 3, cache.Size())
+
+	assert.Nil(t, cache.Get(0))
+	assert.Nil(t, cache.Get(99))
+	assert.Equal(t, task1, cache.Get(100))
+	assert.Nil(t, cache.Get(101))
+	assert.Equal(t, task2, cache.Get(200))
+	assert.Equal(t, task3, cache.Get(300))
+
+	cache.Ack(0)
+	assert.Equal(t, 3, cache.Size())
+	assert.Equal(t, task1, cache.Get(100))
+	assert.Equal(t, task2, cache.Get(200))
+	assert.Equal(t, task3, cache.Get(300))
+
+	cache.Ack(1)
+	assert.Equal(t, 3, cache.Size())
+	assert.Equal(t, task1, cache.Get(100))
+	assert.Equal(t, task2, cache.Get(200))
+	assert.Equal(t, task3, cache.Get(300))
+
+	cache.Ack(99)
+	assert.Equal(t, 3, cache.Size())
+	assert.Equal(t, task1, cache.Get(100))
+	assert.Equal(t, task2, cache.Get(200))
+	assert.Equal(t, task3, cache.Get(300))
+
+	cache.Ack(100)
+	assert.Equal(t, 2, cache.Size())
+	assert.Nil(t, cache.Get(100))
+	assert.Equal(t, task2, cache.Get(200))
+	assert.Equal(t, task3, cache.Get(300))
+
+	assert.Equal(t, errAlreadyAcked, cache.Put(task1))
+
+	cache.Ack(301)
+	assert.Equal(t, 0, cache.Size())
+	assert.Nil(t, cache.Get(100))
+	assert.Nil(t, cache.Get(200))
+	assert.Nil(t, cache.Get(300))
+
+	require.NoError(t, cache.Put(task4))
+	assert.Equal(t, 1, cache.Size())
+	assert.Nil(t, cache.Get(100))
+	assert.Nil(t, cache.Get(200))
+	assert.Nil(t, cache.Get(300))
+	assert.Equal(t, task4, cache.Get(400))
+}
+
+func BenchmarkCache(b *testing.B) {
+	cache := NewCache(dynamicconfig.GetIntPropertyFn(10000))
+	for i := 0; i < 5000; i++ {
+		cache.Put(&types.ReplicationTask{SourceTaskID: int64(i * 100)})
+	}
+
+	for n := 0; n < b.N; n++ {
+		readLevel := int64((n) * 100)
+		cache.Get(readLevel)
+		cache.Put(&types.ReplicationTask{SourceTaskID: int64(n * 100)})
+		cache.Ack(readLevel)
+	}
+}

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -40,7 +40,8 @@ import (
 	"github.com/uber/cadence/service/history/config"
 )
 
-var errUnknownCluster = errors.New("unknown cluster")
+// ErrUnknownCluster is returned when given cluster is not defined in cluster metadata
+var ErrUnknownCluster = errors.New("unknown cluster")
 
 // TaskStore is a component that hydrates and caches replication messages so that they can be reused across several polling source clusters.
 // It also exposes public Put method. This allows pre-store already hydrated messages at the end of successful transaction, saving a DB call to fetch history events.
@@ -110,7 +111,7 @@ func NewTaskStore(
 func (m *TaskStore) Get(ctx context.Context, cluster string, info persistence.ReplicationTaskInfo) (*types.ReplicationTask, error) {
 	cache, ok := m.clusters[cluster]
 	if !ok {
-		return nil, errUnknownCluster
+		return nil, ErrUnknownCluster
 	}
 
 	domain, err := m.domains.GetDomainByID(info.DomainID)
@@ -197,7 +198,7 @@ func (m *TaskStore) Put(task *types.ReplicationTask) {
 func (m *TaskStore) Ack(cluster string, lastTaskID int64) error {
 	cache, ok := m.clusters[cluster]
 	if !ok {
-		return errUnknownCluster
+		return ErrUnknownCluster
 	}
 
 	cache.Ack(lastTaskID)

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -1,0 +1,223 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package replication
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/quotas"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/config"
+)
+
+var errUnknownCluster = errors.New("unknown cluster")
+
+// TaskStore is a component that hydrates and caches replication messages so that they can be reused across several polling source clusters.
+// It also exposes public Put method. This allows pre-store already hydrated messages at the end of successful transaction, saving a DB call to fetch history events.
+//
+// TaskStore uses a separate cache per each source cluster allowing messages to be fetched at different rates.
+// Once a cache becomes full it will not accept further messages for that cluster. Later those messages be fetched from DB and hydrated again.
+// A cache stores only a pointer to the message. It is hydrates once and shared across caches. Cluster acknowledging the message will remove it from that corresponding cache.
+// Once all clusters acknowledge it, no more references will be held, and GC will eventually pick it up.
+type TaskStore struct {
+	clusters      map[string]*Cache
+	domains       domainCache
+	hydrator      taskHydrator
+	rateLimiter   *quotas.DynamicRateLimiter
+	throttleRetry *backoff.ThrottleRetry
+
+	scope  metrics.Scope
+	logger log.Logger
+}
+
+type (
+	domainCache interface {
+		GetDomainByID(id string) (*cache.DomainCacheEntry, error)
+	}
+	taskHydrator interface {
+		Hydrate(ctx context.Context, task persistence.ReplicationTaskInfo) (*types.ReplicationTask, error)
+	}
+)
+
+// NewTaskStore create new instance of TaskStore
+func NewTaskStore(
+	config *config.Config,
+	clusterMetadata cluster.Metadata,
+	domains domainCache,
+	metricsClient metrics.Client,
+	logger log.Logger,
+	hydrator taskHydrator,
+) *TaskStore {
+
+	clusters := map[string]*Cache{}
+	for clusterName := range clusterMetadata.GetRemoteClusterInfo() {
+		clusters[clusterName] = NewCache(config.ReplicatorCacheCapacity)
+	}
+
+	retryPolicy := backoff.NewExponentialRetryPolicy(100 * time.Millisecond)
+	retryPolicy.SetMaximumAttempts(config.ReplicatorReadTaskMaxRetryCount())
+	retryPolicy.SetBackoffCoefficient(1)
+
+	return &TaskStore{
+		clusters: clusters,
+		domains:  domains,
+		hydrator: hydrator,
+		throttleRetry: backoff.NewThrottleRetry(
+			backoff.WithRetryPolicy(retryPolicy),
+			backoff.WithRetryableError(persistence.IsTransientError),
+		),
+		scope:       metricsClient.Scope(metrics.ReplicatorCacheManagerScope),
+		logger:      logger.WithTags(tag.ComponentReplicationCacheManager),
+		rateLimiter: quotas.NewDynamicRateLimiter(config.ReplicationTaskGenerationQPS.AsFloat64()),
+	}
+}
+
+// Get will return a hydrated replication message for a given cluster based on raw task info.
+// It will either return it immediately from cache or hydrate it, store in cache and then return.
+//
+// Returned task may be nil. This may be due domain not existing in a given cluster or replication message is not longer relevant.
+// Either case is valid and such replication message should be ignored and not returned in the response.
+func (m *TaskStore) Get(ctx context.Context, cluster string, info persistence.ReplicationTaskInfo) (*types.ReplicationTask, error) {
+	cache, ok := m.clusters[cluster]
+	if !ok {
+		return nil, errUnknownCluster
+	}
+
+	domain, err := m.domains.GetDomainByID(info.DomainID)
+	if err != nil {
+		return nil, fmt.Errorf("resolving domain: %w", err)
+	}
+
+	// Domain does not exist in this cluster, do not replicate the task
+	if !domain.HasReplicationCluster(cluster) {
+		return nil, nil
+	}
+
+	scope := m.scope.Tagged(metrics.SourceClusterTag(cluster))
+
+	scope.IncCounter(metrics.CacheRequests)
+	sw := scope.StartTimer(metrics.CacheLatency)
+	defer sw.Stop()
+
+	task := cache.Get(info.TaskID)
+	if task != nil {
+		scope.IncCounter(metrics.CacheHitCounter)
+		return task, nil
+	}
+
+	m.scope.IncCounter(metrics.CacheMissCounter)
+
+	// Rate limit to not kill the database
+	m.rateLimiter.Wait(ctx)
+
+	err = m.throttleRetry.Do(ctx, func() error {
+		var err error
+		task, err = m.hydrator.Hydrate(ctx, info)
+		return err
+	})
+
+	if err != nil {
+		m.scope.IncCounter(metrics.CacheFailures)
+		return nil, err
+	}
+
+	m.Put(task)
+
+	return task, nil
+}
+
+// Put will try to store hydrated replication to all cluster caches.
+// Tasks may not be relevant, as domain is not enabled in some clusters. Ignore task for that cluster.
+// Some clusters may be already have full cache. Ignore task, it will be fetched and hydrated again later.
+// Some clusters may already acknowledged such task. Ignore task, it is no longer relevant for such cluster.
+func (m *TaskStore) Put(task *types.ReplicationTask) {
+	// Do not store nil tasks
+	if task == nil {
+		return
+	}
+
+	domain, err := m.getDomain(task)
+	if err != nil {
+		m.logger.Error("failed to resolve domain", tag.Error(err))
+		return
+	}
+
+	for cluster, cache := range m.clusters {
+		if domain != nil && !domain.HasReplicationCluster(cluster) {
+			continue
+		}
+
+		scope := m.scope.Tagged(metrics.SourceClusterTag(cluster))
+
+		err := cache.Put(task)
+		switch err {
+		case errCacheFull:
+			scope.IncCounter(metrics.CacheFullCounter)
+		case errAlreadyAcked:
+			// No action, this is expected.
+			// Some cluster(s) may be already past this, due to different fetch rates.
+		}
+
+		scope.UpdateGauge(metrics.CacheSize, float64(cache.Size()))
+	}
+}
+
+// Ack will acknowledge replication message for a given cluster.
+// This will result in all messages removed from the cache up to a given lastTaskID.
+func (m *TaskStore) Ack(cluster string, lastTaskID int64) error {
+	cache, ok := m.clusters[cluster]
+	if !ok {
+		return errUnknownCluster
+	}
+
+	cache.Ack(lastTaskID)
+
+	scope := m.scope.Tagged(metrics.SourceClusterTag(cluster))
+	scope.UpdateGauge(metrics.CacheSize, float64(cache.Size()))
+
+	return nil
+}
+
+func (m *TaskStore) getDomain(task *types.ReplicationTask) (*cache.DomainCacheEntry, error) {
+	if domainID := task.GetHistoryTaskV2Attributes().GetDomainID(); domainID != "" {
+		return m.domains.GetDomainByID(domainID)
+	}
+	if domainID := task.GetSyncActivityTaskAttributes().GetDomainID(); domainID != "" {
+		return m.domains.GetDomainByID(domainID)
+	}
+	if domainID := task.GetFailoverMarkerAttributes().GetDomainID(); domainID != "" {
+		return m.domains.GetDomainByID(domainID)
+	}
+
+	return nil, nil
+}

--- a/service/history/replication/task_store.go
+++ b/service/history/replication/task_store.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/uber/cadence/common/backoff"
@@ -72,6 +73,7 @@ type (
 
 // NewTaskStore create new instance of TaskStore
 func NewTaskStore(
+	shardID int,
 	config *config.Config,
 	clusterMetadata cluster.Metadata,
 	domains domainCache,
@@ -97,7 +99,10 @@ func NewTaskStore(
 			backoff.WithRetryPolicy(retryPolicy),
 			backoff.WithRetryableError(persistence.IsTransientError),
 		),
-		scope:       metricsClient.Scope(metrics.ReplicatorCacheManagerScope),
+		scope: metricsClient.Scope(
+			metrics.ReplicatorCacheManagerScope,
+			metrics.InstanceTag(strconv.Itoa(shardID)),
+		),
 		logger:      logger.WithTags(tag.ComponentReplicationCacheManager),
 		rateLimiter: quotas.NewDynamicRateLimiter(config.ReplicationTaskGenerationQPS.AsFloat64()),
 	}

--- a/service/history/replication/task_store_test.go
+++ b/service/history/replication/task_store_test.go
@@ -1,0 +1,168 @@
+// The MIT License (MIT)
+//
+// Copyright (c) 2022 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package replication
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/types"
+	hconfig "github.com/uber/cadence/service/history/config"
+)
+
+func TestTaskStore(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("Get error on unknown cluster", func(t *testing.T) {
+		ts := createTestTaskStore(nil, nil)
+		_, err := ts.Get(ctx, "unknown cluster", testTask11)
+		assert.Equal(t, errUnknownCluster, err)
+	})
+
+	t.Run("Get error resolving domain", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{}, nil)
+		_, err := ts.Get(ctx, testClusterA, testTask11)
+		assert.EqualError(t, err, "resolving domain: domain does not exist")
+	})
+
+	t.Run("Get skips task for domains non belonging to polling cluster", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, nil)
+		task, err := ts.Get(ctx, testClusterB, testTask11)
+		assert.NoError(t, err)
+		assert.Nil(t, task)
+	})
+
+	t.Run("Get returns cached replication task", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, nil)
+		ts.Put(&testHydratedTask11)
+		task, err := ts.Get(ctx, testClusterA, testTask11)
+		assert.NoError(t, err)
+		assert.Equal(t, &testHydratedTask11, task)
+	})
+
+	t.Run("Get returns non-cached replication task by hydrating it", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, fakeTaskHydrator{testTask11.TaskID: testHydratedTask11})
+		task, err := ts.Get(ctx, testClusterA, testTask11)
+		assert.NoError(t, err)
+		assert.Equal(t, &testHydratedTask11, task)
+	})
+
+	t.Run("Get fails to hydrate replication task", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, fakeTaskHydrator{testTask11.TaskID: testHydratedTaskErrorNonRecoverable})
+		task, err := ts.Get(ctx, testClusterA, testTask11)
+		assert.EqualError(t, err, "error hydrating task")
+		assert.Nil(t, task)
+	})
+
+	t.Run("Put does not store nil task", func(t *testing.T) {
+		ts := createTestTaskStore(nil, nil)
+		ts.Put(nil)
+		for _, cache := range ts.clusters {
+			assert.Zero(t, cache.Size())
+		}
+	})
+
+	t.Run("Put error resolving domain - does not store task", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{}, nil)
+		ts.Put(&testHydratedTask11)
+		ts.Put(&testHydratedTask12)
+		ts.Put(&testHydratedTask14)
+		for _, cache := range ts.clusters {
+			assert.Zero(t, cache.Size())
+		}
+	})
+
+	t.Run("Put hydrated task into appropriate cache", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, nil)
+		ts.Put(&testHydratedTask11)
+		for _, cluster := range testDomain.GetReplicationConfig().Clusters {
+			assert.Equal(t, 1, ts.clusters[cluster.ClusterName].Size())
+		}
+	})
+
+	t.Run("Put hydrated task without domain info - will put it to all caches", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, nil)
+		ts.Put(&types.ReplicationTask{SourceTaskID: 123})
+		for _, cluster := range testDomain.GetReplicationConfig().Clusters {
+			assert.Equal(t, 1, ts.clusters[cluster.ClusterName].Size())
+		}
+	})
+
+	t.Run("Put full cache error", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, nil)
+		ts.Put(&testHydratedTask11)
+		ts.Put(&testHydratedTask12)
+		ts.Put(&testHydratedTask14)
+		for _, cluster := range testDomain.GetReplicationConfig().Clusters {
+			assert.Equal(t, 2, ts.clusters[cluster.ClusterName].Size())
+		}
+	})
+
+	t.Run("Put will not store acked task", func(t *testing.T) {
+		ts := createTestTaskStore(fakeDomainCache{testDomainID: testDomain}, nil)
+		for _, cluster := range testDomain.GetReplicationConfig().Clusters {
+			ts.Ack(cluster.ClusterName, testHydratedTask11.SourceTaskID)
+			ts.Put(&testHydratedTask11)
+			assert.Equal(t, 0, ts.clusters[cluster.ClusterName].Size())
+		}
+	})
+
+	t.Run("Ack error on unknown cluster", func(t *testing.T) {
+		ts := createTestTaskStore(nil, nil)
+		err := ts.Ack("unknown cluster", 0)
+		assert.Equal(t, errUnknownCluster, err)
+	})
+}
+
+func createTestTaskStore(domains domainCache, hydrator taskHydrator) *TaskStore {
+	cfg := hconfig.Config{
+		ReplicatorCacheCapacity:         dynamicconfig.GetIntPropertyFn(2),
+		ReplicationTaskGenerationQPS:    dynamicconfig.GetFloatPropertyFn(0),
+		ReplicatorReadTaskMaxRetryCount: dynamicconfig.GetIntPropertyFn(1),
+	}
+
+	clusterMetadata := cluster.NewMetadata(0, testClusterC, testClusterC, map[string]config.ClusterInformation{
+		testClusterA: {Enabled: true},
+		testClusterB: {Enabled: true},
+		testClusterC: {Enabled: true},
+	})
+
+	return NewTaskStore(&cfg, clusterMetadata, domains, metrics.NewNoopMetricsClient(), log.NewNoop(), hydrator)
+}
+
+type fakeDomainCache map[string]*cache.DomainCacheEntry
+
+func (cache fakeDomainCache) GetDomainByID(id string) (*cache.DomainCacheEntry, error) {
+	if entry, ok := cache[id]; ok {
+		return entry, nil
+	}
+	return nil, types.EntityNotExistsError{Message: "domain does not exist"}
+}

--- a/service/history/replication/task_store_test.go
+++ b/service/history/replication/task_store_test.go
@@ -155,7 +155,7 @@ func createTestTaskStore(domains domainCache, hydrator taskHydrator) *TaskStore 
 		testClusterC: {Enabled: true},
 	})
 
-	return NewTaskStore(&cfg, clusterMetadata, domains, metrics.NewNoopMetricsClient(), log.NewNoop(), hydrator)
+	return NewTaskStore(1, &cfg, clusterMetadata, domains, metrics.NewNoopMetricsClient(), log.NewNoop(), hydrator)
 }
 
 type fakeDomainCache map[string]*cache.DomainCacheEntry

--- a/service/history/replication/task_store_test.go
+++ b/service/history/replication/task_store_test.go
@@ -44,7 +44,7 @@ func TestTaskStore(t *testing.T) {
 	t.Run("Get error on unknown cluster", func(t *testing.T) {
 		ts := createTestTaskStore(nil, nil)
 		_, err := ts.Get(ctx, "unknown cluster", testTask11)
-		assert.Equal(t, errUnknownCluster, err)
+		assert.Equal(t, ErrUnknownCluster, err)
 	})
 
 	t.Run("Get error resolving domain", func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestTaskStore(t *testing.T) {
 	t.Run("Ack error on unknown cluster", func(t *testing.T) {
 		ts := createTestTaskStore(nil, nil)
 		err := ts.Ack("unknown cluster", 0)
-		assert.Equal(t, errUnknownCluster, err)
+		assert.Equal(t, ErrUnknownCluster, err)
 	})
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added replication cache to store hydrated replication messages.

Two components were introduced.
- `replication.Cache` - Data structure only. This is in memory implementation of a cache. Replication tasks always come in order, thus internally heap is utilized to achieve faster `Ack` (range removals from cache). Overall complexity:
  - Get: O(1)
  - Put: O(log N)
  - Ack: O(log N)
where N is the cache size. Cache capacity is configure via new dynamic config property `history.replicatorCacheCapacity`. For now default is 10K. This may be changed later. Increasing capacity can be done dynamically, reducing - requires a restart to reclaim memory.
- `replication.TaskStore` - "manager" component for the cache. It manages separate cache for each cluster. Putting new message will put it to all caches which accept it. Ack/Get work with individual caches. It also deals with filtering out irrelevant task for domains not participating in that cluster. Rate limiting logic and retries were also moved here out from `TaskAckManager`. 

<!-- Tell your future self why have you made these changes -->
**Why?**
This is an optimization attempt to reduce replication caused load on the database.

In particular every time we fetch replication messages, they go through hydration process where raw replication tasks are enriched with history event data (at least for `ReplicationTaskTypeHistoryV2` messages, which are the majority). This results in `readhistorybranch` persistence calls.

When we have multiple polling clusters in nDC setup, each of them result is fetching and hydrating same replication messages. This can be optimized, by introducing this cache. Once one cluster hydrates the message its pointer is put to caches for other clusters, so that they do not have to repeat this process.

We can even take a step further. After a successful transaction for creating/updating workflow, we already have persisted history blobs at that point. Thus on success we could cheaply hydrate the messages and put them into cache immediately. #4953 - preparation step for that. Another PR will follow after, to complete the integration.

On a healthy system this should significantly reduce `readhistorybranch` persistence calls. If replication on one cluster starts lagging, the cache will fill up and we will stop accepting new messages for it. That means that later it will need to read them from the database as it currently done today.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- 100% unit test coverage for new components: `replication.Cache` and `replication.TaskStore`
- Passing existing integration tests
- Deployed branch on staging2, to verify replication still works and cache metrics are emitted.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
