### PR TITLE
Upgrade Golang base images to remediate CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGET=server
 ARG GOPROXY
 
 # Build tcheck binary
-FROM golang:1.17-alpine3.15 AS tcheck
+FROM golang:1.17.13-alpine3.15 AS tcheck
 
 WORKDIR /go/src/github.com/uber/tcheck
 
@@ -12,7 +12,7 @@ COPY go.* ./
 RUN go build -mod=readonly -o /go/bin/tcheck github.com/uber/tcheck
 
 # Build Cadence binaries
-FROM golang:1.17-alpine3.13 AS builder
+FROM golang:1.17.13-alpine3.15 AS builder
 
 ARG RELEASE_VERSION
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Attempt to fix #4956 by bumping golang base images to `golang:1.17.13-alpine3.15`.


<!-- Tell your future self why have you made these changes -->
**Why?**
To remediate CVEs of Cadence Server. There are many version that can fix this such as `1.18.4` and above, or `1.19.x`. However, I try to use the bare minimum version as possible to not only reach the end goal of fixing the CVEs but also to keep the risk low.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Similar to the steps described in the issue. I did the following to test it:
```sh
# checkout to the latest release tag
git checkout v0.24.0

# cherry-pick (without commit) another fix by #4804 that hasn't been released to narrow the results
git cherry-pick -n 5be511b

# build server image
docker build . -f Dockerfile -t ubercadence/server:master --build-arg TARGET=server && tlis ubercadence/server:master

# scan with any vulnerability scanner
/usr/local/bin/twistcli images scan --details ubercadence/server:master
```

Scan results before:
```
Scan results for: image ubercadence/server:master sha256:6f3a2fb8247667cf9d0a8331fc798da4982fe72692d05ce7be559da0a0dd68df
Vulnerabilities
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
|       CVE        | SEVERITY | CVSS |          PACKAGE          |              VERSION               |                   STATUS                    | PUBLISHED  | DISCOVERED |                    DESCRIPTION                     |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-23806   | critical | 9.10 | go                        | 1.17.3                             | fixed in 1.17.7, 1.16.14                    | > 6 months | < 1 hour   | Curve.IsOnCurve in crypto/elliptic in Go before    |
|                  |          |      |                           |                                    | > 6 months ago                              |            |            | 1.16.14 and 1.17.x before 1.17.7 can incorrectly   |
|                  |          |      |                           |                                    |                                             |            |            | return true in situations with a big.Int value     |
|                  |          |      |                           |                                    |                                             |            |            | that i...                                          |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-30580   | high     | 7.80 | go                        | 1.17.3                             | fixed in 1.18.3, 1.17.11                    | 6 days     | < 1 hour   | Code injection in Cmd.Start in os/exec before      |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | Go 1.17.11 and Go 1.18.3 allows execution of any   |
|                  |          |      |                           |                                    |                                             |            |            | binaries in the working directory named either     |
|                  |          |      |                           |                                    |                                             |            |            | \"..com\...                                        |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-32189   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.5, 1.17.13                    | 6 days     | < 1 hour   | A too-short encoded message can cause a panic in   |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | Float.GobDecode and Rat GobDecode in math/big in   |
|                  |          |      |                           |                                    |                                             |            |            | Go before 1.17.13 and 1.18.5, potentially allowing |
|                  |          |      |                           |                                    |                                             |            |            | a...                                               |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-30635   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Uncontrolled recursion in Decoder.Decode in        |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | encoding/gob before Go 1.17.12 and Go 1.18.4       |
|                  |          |      |                           |                                    |                                             |            |            | allows an attacker to cause a panic due to stack   |
|                  |          |      |                           |                                    |                                             |            |            | exhaustion v...                                    |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-30633   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Uncontrolled recursion in Unmarshal in             |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | encoding/xml before Go 1.17.12 and Go 1.18.4       |
|                  |          |      |                           |                                    |                                             |            |            | allows an attacker to cause a panic due to stack   |
|                  |          |      |                           |                                    |                                             |            |            | exhaustion via un...                               |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-30632   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Uncontrolled recursion in Glob in path/filepath    |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | before Go 1.17.12 and Go 1.18.4 allows an attacker |
|                  |          |      |                           |                                    |                                             |            |            | to cause a panic due to stack exhaustion via a     |
|                  |          |      |                           |                                    |                                             |            |            | path...                                            |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-30631   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Uncontrolled recursion in Reader.Read in           |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | compress/gzip before Go 1.17.12 and Go 1.18.4      |
|                  |          |      |                           |                                    |                                             |            |            | allows an attacker to cause a panic due to stack   |
|                  |          |      |                           |                                    |                                             |            |            | exhaustion via...                                  |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-30630   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Uncontrolled recursion in Glob in io/fs before Go  |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | 1.17.12 and Go 1.18.4 allows an attacker to cause  |
|                  |          |      |                           |                                    |                                             |            |            | a panic due to stack exhaustion via a path which   |
|                  |          |      |                           |                                    |                                             |            |            | c...                                               |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-30629   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.3, 1.17.11                    | 6 days     | < 1 hour   | Non-random values for ticket_age_add in session    |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | tickets in crypto/tls before Go 1.17.11 and Go     |
|                  |          |      |                           |                                    |                                             |            |            | 1.18.3 allow an attacker that can observe TLS      |
|                  |          |      |                           |                                    |                                             |            |            | handshake...                                       |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-28327   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.1, 1.17.9                     | > 3 months | < 1 hour   | The generic P-256 feature in crypto/elliptic in    |
|                  |          |      |                           |                                    | > 3 months ago                              |            |            | Go before 1.17.9 and 1.18.x before 1.18.1 allows a |
|                  |          |      |                           |                                    |                                             |            |            | panic via long scalar input.                       |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-28131   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Uncontrolled recursion in Decoder.Skip in          |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | encoding/xml before Go 1.17.12 and Go 1.18.4       |
|                  |          |      |                           |                                    |                                             |            |            | allows an attacker to cause a panic due to stack   |
|                  |          |      |                           |                                    |                                             |            |            | exhaustion via...                                  |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-24921   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.17.8, 1.16.15                    | > 5 months | < 1 hour   | regexp.Compile in Go before 1.16.15 and 1.17.x     |
|                  |          |      |                           |                                    | > 5 months ago                              |            |            | before 1.17.8 allows stack exhaustion via a deeply |
|                  |          |      |                           |                                    |                                             |            |            | nested expression.                                 |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-24675   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.18.1, 1.17.9                     | > 3 months | < 1 hour   | encoding/pem in Go before 1.17.9 and 1.18.x before |
|                  |          |      |                           |                                    | > 3 months ago                              |            |            | 1.18.1 has a Decode stack overflow via a large     |
|                  |          |      |                           |                                    |                                             |            |            | amount of PEM data.                                |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-23773   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.17.7, 1.16.14                    | > 6 months | < 1 hour   | cmd/go in Go before 1.16.14 and 1.17.x before      |
|                  |          |      |                           |                                    | > 6 months ago                              |            |            | 1.17.7 can misinterpret branch names that falsely  |
|                  |          |      |                           |                                    |                                             |            |            | appear to be version tags. This can lead to        |
|                  |          |      |                           |                                    |                                             |            |            | incorrect ...                                      |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-23772   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.17.7, 1.16.14                    | > 6 months | < 1 hour   | Rat.SetString in math/big in Go before 1.16.14 and |
|                  |          |      |                           |                                    | > 6 months ago                              |            |            | 1.17.x before 1.17.7 has an overflow that can lead |
|                  |          |      |                           |                                    |                                             |            |            | to Uncontrolled Memory Consumption.                |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2021-44716   | high     | 7.50 | go                        | 1.17.3                             | fixed in 1.17.5, 1.16.12                    | > 7 months | < 1 hour   | net/http in Go before 1.16.12 and 1.17.x before    |
|                  |          |      |                           |                                    | > 7 months ago                              |            |            | 1.17.5 allows uncontrolled memory consumption      |
|                  |          |      |                           |                                    |                                             |            |            | in the header canonicalization cache via HTTP/2    |
|                  |          |      |                           |                                    |                                             |            |            | requests...                                        |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2020-29652   | high     | 7.50 | golang.org/x/crypto       | v0.0.0-20200622213623-75b288015ac9 | fixed in v0.0.0-20201216223049-8b5274cf687f | > 1 years  | < 1 hour   | A nil pointer dereference in the                   |
|                  |          |      |                           |                                    | > 7 months ago                              |            |            | golang.org/x/crypto/ssh component through          |
|                  |          |      |                           |                                    |                                             |            |            | v0.0.0-20201203163018-be400aefbc4c for Go allows   |
|                  |          |      |                           |                                    |                                             |            |            | remote attackers to cause ...                      |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-32148   | medium   | 6.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Improper exposure of client IP addresses           |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | in net/http before Go 1.17.12 and Go               |
|                  |          |      |                           |                                    |                                             |            |            | 1.18.4 can be triggered by calling                 |
|                  |          |      |                           |                                    |                                             |            |            | httputil.ReverseProxy.ServeHTTP with ...           |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-1705    | medium   | 6.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Acceptance of some invalid Transfer-Encoding       |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | headers in the HTTP/1 client in net/http before    |
|                  |          |      |                           |                                    |                                             |            |            | Go 1.17.12 and Go 1.18.4 allows HTTP request       |
|                  |          |      |                           |                                    |                                             |            |            | smuggling if...                                    |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2022-1962    | medium   | 5.50 | go                        | 1.17.3                             | fixed in 1.18.4, 1.17.12                    | 6 days     | < 1 hour   | Uncontrolled recursion in the Parse functions in   |
|                  |          |      |                           |                                    | 6 days ago                                  |            |            | go/parser before Go 1.17.12 and Go 1.18.4 allow an |
|                  |          |      |                           |                                    |                                             |            |            | attacker to cause a panic due to stack exhaustion  |
|                  |          |      |                           |                                    |                                             |            |            | ...                                                |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| PRISMA-2022-0164 | medium   | 5.30 | github.com/aws/aws-sdk-go | v1.34.13                           | fixed in v1.40.27                           | > 3 months | < 1 hour   | github.com/aws/aws-sdk-go module prior to v1.40.27 |
|                  |          |      |                           |                                    | > 3 months ago                              |            |            | is vulnerable to Information Exposure. The SDK     |
|                  |          |      |                           |                                    |                                             |            |            | did not automatically suppress sensitive API       |
|                  |          |      |                           |                                    |                                             |            |            | paramet...                                         |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+

Vulnerabilities found for image ubercadence/server:master: total - 21, critical - 1, high - 16, medium - 4, low - 0
Vulnerability threshold check results: PASS

Compliance Issues
+----------+------------------------------------------------------------------------+
| SEVERITY |                              DESCRIPTION                               |
+----------+------------------------------------------------------------------------+
| high     | (CIS_Docker_v1.3.1 - 4.1) Image should be created with a non-root user |
+----------+------------------------------------------------------------------------+
| high     | Private keys stored in image                                           |
+----------+------------------------------------------------------------------------+

Compliance found for image ubercadence/server:master: total - 2, critical - 0, high - 2, medium - 0, low - 0
Compliance threshold check results: PASS
```

Scan results after builder bump to `golang:1.17.13-alpine3.15`:
```md
Scan results for: image ubercadence/server:master sha256:c6135c848d0a9581b3034df1f9e7fb57f8d7b22c062c25b0e6ae93e96e24cdb0
Vulnerabilities
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
|       CVE        | SEVERITY | CVSS |          PACKAGE          |              VERSION               |                   STATUS                    | PUBLISHED  | DISCOVERED |                    DESCRIPTION                     |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| CVE-2020-29652   | high     | 7.50 | golang.org/x/crypto       | v0.0.0-20200622213623-75b288015ac9 | fixed in v0.0.0-20201216223049-8b5274cf687f | > 1 years  | < 1 hour   | A nil pointer dereference in the                   |
|                  |          |      |                           |                                    | > 7 months ago                              |            |            | golang.org/x/crypto/ssh component through          |
|                  |          |      |                           |                                    |                                             |            |            | v0.0.0-20201203163018-be400aefbc4c for Go allows   |
|                  |          |      |                           |                                    |                                             |            |            | remote attackers to cause ...                      |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+
| PRISMA-2022-0164 | medium   | 5.30 | github.com/aws/aws-sdk-go | v1.34.13                           | fixed in v1.40.27                           | > 3 months | < 1 hour   | github.com/aws/aws-sdk-go module prior to v1.40.27 |
|                  |          |      |                           |                                    | > 3 months ago                              |            |            | is vulnerable to Information Exposure. The SDK     |
|                  |          |      |                           |                                    |                                             |            |            | did not automatically suppress sensitive API       |
|                  |          |      |                           |                                    |                                             |            |            | paramet...                                         |
+------------------+----------+------+---------------------------+------------------------------------+---------------------------------------------+------------+------------+----------------------------------------------------+

Vulnerabilities found for image ubercadence/server:master: total - 2, critical - 0, high - 1, medium - 1, low - 0
Vulnerability threshold check results: PASS

Compliance Issues
+----------+------------------------------------------------------------------------+
| SEVERITY |                              DESCRIPTION                               |
+----------+------------------------------------------------------------------------+
| high     | (CIS_Docker_v1.3.1 - 4.1) Image should be created with a non-root user |
+----------+------------------------------------------------------------------------+
| high     | Private keys stored in image                                           |
+----------+------------------------------------------------------------------------+

Compliance found for image ubercadence/server:master: total - 2, critical - 0, high - 2, medium - 0, low - 0
Compliance threshold check results: PASS
```
Note that:
- Vulnerability CVE-2020-29652 of `golang.org/x/crypto` has been reported by #4729
- Compliance Issue `Image should be created with a non-root user` has been reported by #4790

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
I believe it's low risk because there's only patch version upgrade for golang and minor version upgrade for alpine.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
