### PR TITLE
Adding limit for amount of pending activties in mutable state.

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -302,6 +302,16 @@ const (
 	// Default value: 51200 (50*1024)
 	// Allowed filters: DomainName
 	HistoryCountLimitWarn
+	// PendingActivitiesCountLimitError is the limit of how many pending activities a workflow can have at a point in time
+	// KeyName: limit.pendingActivityCount.error
+	// Value type: Int
+	// Default value: 1024
+	PendingActivitiesCountLimitError
+	// PendingActivitiesCountLimitWarn is the limit of how many activities a workflow can have before a warning is logged
+	// KeyName: limit.pendingActivityCount.warn
+	// Value type: Int
+	// Default value: 512
+	PendingActivitiesCountLimitWarn
 	// DomainNameMaxLength is the length limit for domain name
 	// KeyName: limit.domainNameLength
 	// Value type: Int
@@ -1722,6 +1732,12 @@ const (
 	// Default value: false
 	Lockdown
 
+	// PendingActivityValidationEnabled is feature flag if pending activity count validation is enabled
+	// KeyName: limit.pendingActivityCount.enabled
+	// Value type: bool
+	// Default value: false
+	EnablePendingActivityValidation
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -2522,6 +2538,16 @@ var IntKeys = map[IntKey]DynamicInt{
 		KeyName:      "limit.historyCount.warn",
 		Description:  "HistoryCountLimitWarn is the per workflow execution history event count limit for warning",
 		DefaultValue: 50 * 1024,
+	},
+	PendingActivitiesCountLimitError: DynamicInt{
+		KeyName:      "limit.pendingActivityCount.error",
+		Description:  "PendingActivitiesCountLimitError is the limit of how many pending activities a workflow can have at a point in time",
+		DefaultValue: 1024,
+	},
+	PendingActivitiesCountLimitWarn: DynamicInt{
+		KeyName:      "limit.pendingActivityCount.warn",
+		Description:  "PendingActivitiesCountLimitWarn is the limit of how many activities a workflow can have before a warning is logged",
+		DefaultValue: 512,
 	},
 	DomainNameMaxLength: DynamicInt{
 		KeyName:      "limit.domainNameLength",
@@ -3686,6 +3712,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	Lockdown: DynamicBool{
 		KeyName:      "system.Lockdown",
 		Description:  "Lockdown defines if we want to allow failovers of domains to this cluster",
+		DefaultValue: false,
+	},
+	EnablePendingActivityValidation: DynamicBool{
+		KeyName:      "limit.pendingActivityCount.enabled",
+		Description:  "",
 		DefaultValue: false,
 	},
 }

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3716,7 +3716,7 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	},
 	EnablePendingActivityValidation: DynamicBool{
 		KeyName:      "limit.pendingActivityCount.enabled",
-		Description:  "",
+		Description:  "Enables pending activity count limiting/validation",
 		DefaultValue: false,
 	},
 }

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -232,12 +232,15 @@ type Config struct {
 	AllowArchivingIncompleteHistory  dynamicconfig.BoolPropertyFn
 
 	// Size limit related settings
-	BlobSizeLimitError     dynamicconfig.IntPropertyFnWithDomainFilter
-	BlobSizeLimitWarn      dynamicconfig.IntPropertyFnWithDomainFilter
-	HistorySizeLimitError  dynamicconfig.IntPropertyFnWithDomainFilter
-	HistorySizeLimitWarn   dynamicconfig.IntPropertyFnWithDomainFilter
-	HistoryCountLimitError dynamicconfig.IntPropertyFnWithDomainFilter
-	HistoryCountLimitWarn  dynamicconfig.IntPropertyFnWithDomainFilter
+	BlobSizeLimitError               dynamicconfig.IntPropertyFnWithDomainFilter
+	BlobSizeLimitWarn                dynamicconfig.IntPropertyFnWithDomainFilter
+	HistorySizeLimitError            dynamicconfig.IntPropertyFnWithDomainFilter
+	HistorySizeLimitWarn             dynamicconfig.IntPropertyFnWithDomainFilter
+	HistoryCountLimitError           dynamicconfig.IntPropertyFnWithDomainFilter
+	HistoryCountLimitWarn            dynamicconfig.IntPropertyFnWithDomainFilter
+	PendingActivitiesCountLimitError dynamicconfig.IntPropertyFn
+	PendingActivitiesCountLimitWarn  dynamicconfig.IntPropertyFn
+	PendingActivityValidationEnabled dynamicconfig.BoolPropertyFn
 
 	// ValidSearchAttributes is legal indexed keys that can be used in list APIs
 	ValidSearchAttributes             dynamicconfig.MapPropertyFn
@@ -480,12 +483,15 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, storeType string, isA
 		ArchiveInlineVisibilityGlobalRPS: dc.GetIntProperty(dynamicconfig.ArchiveInlineVisibilityGlobalRPS),
 		AllowArchivingIncompleteHistory:  dc.GetBoolProperty(dynamicconfig.AllowArchivingIncompleteHistory),
 
-		BlobSizeLimitError:     dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError),
-		BlobSizeLimitWarn:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitWarn),
-		HistorySizeLimitError:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitError),
-		HistorySizeLimitWarn:   dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitWarn),
-		HistoryCountLimitError: dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitError),
-		HistoryCountLimitWarn:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitWarn),
+		BlobSizeLimitError:               dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitError),
+		BlobSizeLimitWarn:                dc.GetIntPropertyFilteredByDomain(dynamicconfig.BlobSizeLimitWarn),
+		HistorySizeLimitError:            dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitError),
+		HistorySizeLimitWarn:             dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistorySizeLimitWarn),
+		HistoryCountLimitError:           dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitError),
+		HistoryCountLimitWarn:            dc.GetIntPropertyFilteredByDomain(dynamicconfig.HistoryCountLimitWarn),
+		PendingActivitiesCountLimitError: dc.GetIntProperty(dynamicconfig.PendingActivitiesCountLimitError),
+		PendingActivitiesCountLimitWarn:  dc.GetIntProperty(dynamicconfig.PendingActivitiesCountLimitWarn),
+		PendingActivityValidationEnabled: dc.GetBoolProperty(dynamicconfig.EnablePendingActivityValidation),
 
 		ThrottledLogRPS:   dc.GetIntProperty(dynamicconfig.HistoryThrottledLogRPS),
 		EnableStickyQuery: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableStickyQuery),
@@ -570,6 +576,7 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	panicIfErr(inMem.UpdateValue(dynamicconfig.MaxActivityCountDispatchByDomain, 0))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.EnableCrossClusterOperations, true))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.NormalDecisionScheduleToStartMaxAttempts, 3))
+	panicIfErr(inMem.UpdateValue(dynamicconfig.EnablePendingActivityValidation, true))
 	dc := dynamicconfig.NewCollection(inMem, log.NewNoop())
 	config := New(dc, shardNumber, config.StoreTypeCassandra, false)
 	// reduce the duration of long poll to increase test speed
@@ -582,6 +589,7 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	config.MaxActivityCountDispatchByDomain = dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaxActivityCountDispatchByDomain)
 	config.EnableCrossClusterOperations = dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableCrossClusterOperations)
 	config.NormalDecisionScheduleToStartMaxAttempts = dc.GetIntPropertyFilteredByDomain(dynamicconfig.NormalDecisionScheduleToStartMaxAttempts)
+	config.PendingActivityValidationEnabled = dc.GetBoolProperty(dynamicconfig.EnablePendingActivityValidation)
 	return config
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Added limit to how many pending activties mutable state can have.


<!-- Tell your future self why have you made these changes -->
**Why?**

We need to limit mutable state size because otherwise we encounter timeouts when fetching mutable state from database.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Tested locally + unit test.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

If we have some clients that are above the threshold (default value of pending activities is 1024) their workflows would get stuck. In order to avoid this I added warn and error level logging and added feature flag for throwing the error so first we can see how many users will be affected.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
