### PR TITLE
Improve log for transfer task validator

### DIFF
--- a/service/history/common/type.go
+++ b/service/history/common/type.go
@@ -1,0 +1,36 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package common
+
+import (
+	"github.com/uber/cadence/common/persistence"
+)
+
+type (
+	// NotifyTaskInfo defines the info of task notification
+	NotifyTaskInfo struct {
+		ExecutionInfo    *persistence.WorkflowExecutionInfo
+		Tasks            []persistence.Task
+		PersistenceError bool
+	}
+)

--- a/service/history/engine/interface.go
+++ b/service/history/engine/interface.go
@@ -26,8 +26,8 @@ import (
 	"context"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/events"
 )
 
@@ -80,8 +80,8 @@ type (
 		DescribeCrossClusterQueue(ctx context.Context, clusterName string) (*types.DescribeQueueResponse, error)
 
 		NotifyNewHistoryEvent(event *events.Notification)
-		NotifyNewTransferTasks(executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task)
-		NotifyNewTimerTasks(executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task)
-		NotifyNewCrossClusterTasks(executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task)
+		NotifyNewTransferTasks(info *hcommon.NotifyTaskInfo)
+		NotifyNewTimerTasks(info *hcommon.NotifyTaskInfo)
+		NotifyNewCrossClusterTasks(info *hcommon.NotifyTaskInfo)
 	}
 )

--- a/service/history/engine/interface_mock.go
+++ b/service/history/engine/interface_mock.go
@@ -32,8 +32,8 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 
-	persistence "github.com/uber/cadence/common/persistence"
 	types "github.com/uber/cadence/common/types"
+	common "github.com/uber/cadence/service/history/common"
 	events "github.com/uber/cadence/service/history/events"
 )
 
@@ -226,15 +226,15 @@ func (mr *MockEngineMockRecorder) MergeDLQMessages(ctx, messagesRequest interfac
 }
 
 // NotifyNewCrossClusterTasks mocks base method.
-func (m *MockEngine) NotifyNewCrossClusterTasks(executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task) {
+func (m *MockEngine) NotifyNewCrossClusterTasks(info *common.NotifyTaskInfo) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyNewCrossClusterTasks", executionInfo, tasks)
+	m.ctrl.Call(m, "NotifyNewCrossClusterTasks", info)
 }
 
 // NotifyNewCrossClusterTasks indicates an expected call of NotifyNewCrossClusterTasks.
-func (mr *MockEngineMockRecorder) NotifyNewCrossClusterTasks(executionInfo, tasks interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) NotifyNewCrossClusterTasks(info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewCrossClusterTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewCrossClusterTasks), executionInfo, tasks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewCrossClusterTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewCrossClusterTasks), info)
 }
 
 // NotifyNewHistoryEvent mocks base method.
@@ -250,27 +250,27 @@ func (mr *MockEngineMockRecorder) NotifyNewHistoryEvent(event interface{}) *gomo
 }
 
 // NotifyNewTimerTasks mocks base method.
-func (m *MockEngine) NotifyNewTimerTasks(executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task) {
+func (m *MockEngine) NotifyNewTimerTasks(info *common.NotifyTaskInfo) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyNewTimerTasks", executionInfo, tasks)
+	m.ctrl.Call(m, "NotifyNewTimerTasks", info)
 }
 
 // NotifyNewTimerTasks indicates an expected call of NotifyNewTimerTasks.
-func (mr *MockEngineMockRecorder) NotifyNewTimerTasks(executionInfo, tasks interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) NotifyNewTimerTasks(info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewTimerTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewTimerTasks), executionInfo, tasks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewTimerTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewTimerTasks), info)
 }
 
 // NotifyNewTransferTasks mocks base method.
-func (m *MockEngine) NotifyNewTransferTasks(executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task) {
+func (m *MockEngine) NotifyNewTransferTasks(info *common.NotifyTaskInfo) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyNewTransferTasks", executionInfo, tasks)
+	m.ctrl.Call(m, "NotifyNewTransferTasks", info)
 }
 
 // NotifyNewTransferTasks indicates an expected call of NotifyNewTransferTasks.
-func (mr *MockEngineMockRecorder) NotifyNewTransferTasks(executionInfo, tasks interface{}) *gomock.Call {
+func (mr *MockEngineMockRecorder) NotifyNewTransferTasks(info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewTransferTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewTransferTasks), executionInfo, tasks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewTransferTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewTransferTasks), info)
 }
 
 // PollMutableState mocks base method.

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -38,6 +38,7 @@ import (
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/events"
 	"github.com/uber/cadence/service/history/shard"
 )
@@ -367,12 +368,12 @@ func (c *contextImpl) CreateWorkflowExecution(
 	resp, err := c.createWorkflowExecutionWithRetry(ctx, createRequest)
 	if err != nil {
 		if c.isPersistenceTimeoutError(err) {
-			c.notifyTasksFromWorkflowSnapshot(newWorkflow)
+			c.notifyTasksFromWorkflowSnapshot(newWorkflow, true)
 		}
 		return err
 	}
 
-	c.notifyTasksFromWorkflowSnapshot(newWorkflow)
+	c.notifyTasksFromWorkflowSnapshot(newWorkflow, false)
 
 	// finally emit session stats
 	emitSessionUpdateStats(
@@ -506,9 +507,9 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 	})
 	if err != nil {
 		if c.isPersistenceTimeoutError(err) {
-			c.notifyTasksFromWorkflowSnapshot(resetWorkflow)
-			c.notifyTasksFromWorkflowSnapshot(newWorkflow)
-			c.notifyTasksFromWorkflowMutation(currentWorkflow)
+			c.notifyTasksFromWorkflowSnapshot(resetWorkflow, true)
+			c.notifyTasksFromWorkflowSnapshot(newWorkflow, true)
+			c.notifyTasksFromWorkflowMutation(currentWorkflow, true)
 		}
 		return err
 	}
@@ -531,9 +532,9 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 		workflowCloseState,
 	))
 
-	c.notifyTasksFromWorkflowSnapshot(resetWorkflow)
-	c.notifyTasksFromWorkflowSnapshot(newWorkflow)
-	c.notifyTasksFromWorkflowMutation(currentWorkflow)
+	c.notifyTasksFromWorkflowSnapshot(resetWorkflow, false)
+	c.notifyTasksFromWorkflowSnapshot(newWorkflow, false)
+	c.notifyTasksFromWorkflowMutation(currentWorkflow, false)
 
 	// finally emit session stats
 	domainName := c.GetDomainName()
@@ -670,7 +671,7 @@ func (c *contextImpl) UpdateWorkflowExecutionTasks(
 	})
 	if err != nil {
 		if c.isPersistenceTimeoutError(err) {
-			c.notifyTasksFromWorkflowMutation(currentWorkflow)
+			c.notifyTasksFromWorkflowMutation(currentWorkflow, true)
 		}
 		return err
 	}
@@ -679,7 +680,7 @@ func (c *contextImpl) UpdateWorkflowExecutionTasks(
 	c.updateCondition = currentWorkflow.ExecutionInfo.NextEventID
 
 	// notify current workflow tasks
-	c.notifyTasksFromWorkflowMutation(currentWorkflow)
+	c.notifyTasksFromWorkflowMutation(currentWorkflow, false)
 
 	emitSessionUpdateStats(
 		c.metricsClient,
@@ -797,8 +798,8 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 	})
 	if err != nil {
 		if c.isPersistenceTimeoutError(err) {
-			c.notifyTasksFromWorkflowMutation(currentWorkflow)
-			c.notifyTasksFromWorkflowSnapshot(newWorkflow)
+			c.notifyTasksFromWorkflowMutation(currentWorkflow, true)
+			c.notifyTasksFromWorkflowSnapshot(newWorkflow, true)
 		}
 		return err
 	}
@@ -824,10 +825,10 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 	))
 
 	// notify current workflow tasks
-	c.notifyTasksFromWorkflowMutation(currentWorkflow)
+	c.notifyTasksFromWorkflowMutation(currentWorkflow, false)
 
 	// notify new workflow tasks
-	c.notifyTasksFromWorkflowSnapshot(newWorkflow)
+	c.notifyTasksFromWorkflowSnapshot(newWorkflow, false)
 
 	// finally emit session stats
 	domainName := c.GetDomainName()
@@ -858,6 +859,7 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 
 func (c *contextImpl) notifyTasksFromWorkflowSnapshot(
 	workflowSnapShot *persistence.WorkflowSnapshot,
+	persistenceError bool,
 ) {
 	if workflowSnapShot == nil {
 		return
@@ -868,11 +870,13 @@ func (c *contextImpl) notifyTasksFromWorkflowSnapshot(
 		workflowSnapShot.TransferTasks,
 		workflowSnapShot.TimerTasks,
 		workflowSnapShot.CrossClusterTasks,
+		persistenceError,
 	)
 }
 
 func (c *contextImpl) notifyTasksFromWorkflowMutation(
 	workflowMutation *persistence.WorkflowMutation,
+	persistenceError bool,
 ) {
 	if workflowMutation == nil {
 		return
@@ -883,6 +887,7 @@ func (c *contextImpl) notifyTasksFromWorkflowMutation(
 		workflowMutation.TransferTasks,
 		workflowMutation.TimerTasks,
 		workflowMutation.CrossClusterTasks,
+		persistenceError,
 	)
 }
 
@@ -891,10 +896,27 @@ func (c *contextImpl) notifyTasks(
 	transferTasks []persistence.Task,
 	timerTasks []persistence.Task,
 	crossClusterTasks []persistence.Task,
+	persistenceError bool,
 ) {
-	c.shard.GetEngine().NotifyNewTransferTasks(executionInfo, transferTasks)
-	c.shard.GetEngine().NotifyNewTimerTasks(executionInfo, timerTasks)
-	c.shard.GetEngine().NotifyNewCrossClusterTasks(executionInfo, crossClusterTasks)
+	transferTaskInfo := &hcommon.NotifyTaskInfo{
+		ExecutionInfo:    executionInfo,
+		Tasks:            transferTasks,
+		PersistenceError: persistenceError,
+	}
+	timerTaskInfo := &hcommon.NotifyTaskInfo{
+		ExecutionInfo:    executionInfo,
+		Tasks:            timerTasks,
+		PersistenceError: persistenceError,
+	}
+	crossClusterTaskInfo := &hcommon.NotifyTaskInfo{
+		ExecutionInfo:    executionInfo,
+		Tasks:            crossClusterTasks,
+		PersistenceError: persistenceError,
+	}
+
+	c.shard.GetEngine().NotifyNewTransferTasks(transferTaskInfo)
+	c.shard.GetEngine().NotifyNewTimerTasks(timerTaskInfo)
+	c.shard.GetEngine().NotifyNewCrossClusterTasks(crossClusterTaskInfo)
 }
 
 func (c *contextImpl) mergeContinueAsNewReplicationTasks(

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -51,6 +51,7 @@ import (
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/decision"
 	"github.com/uber/cadence/service/history/engine"
@@ -468,8 +469,8 @@ func (e *historyEngineImpl) registerDomainFailoverCallback() {
 				// its length > 0 and has correct timestamp, to trigger a db scan
 				fakeDecisionTask := []persistence.Task{&persistence.DecisionTask{}}
 				fakeDecisionTimeoutTask := []persistence.Task{&persistence.DecisionTimeoutTask{VisibilityTimestamp: now}}
-				e.txProcessor.NotifyNewTask(e.currentClusterName, nil, fakeDecisionTask)
-				e.timerProcessor.NotifyNewTask(e.currentClusterName, nil, fakeDecisionTimeoutTask)
+				e.txProcessor.NotifyNewTask(e.currentClusterName, &hcommon.NotifyTaskInfo{Tasks: fakeDecisionTask})
+				e.timerProcessor.NotifyNewTask(e.currentClusterName, &hcommon.NotifyTaskInfo{Tasks: fakeDecisionTimeoutTask})
 			}
 
 			// handle graceful failover on active to passive
@@ -2714,9 +2715,9 @@ func (e *historyEngineImpl) SyncShardStatus(
 	// 3. notify the transfer (essentially a no op, just put it here so it looks symmetric)
 	// 4. notify the cross cluster (essentially a no op, just put it here so it looks symmetric)
 	e.shard.SetCurrentTime(clusterName, now)
-	e.txProcessor.NotifyNewTask(clusterName, nil, []persistence.Task{})
-	e.timerProcessor.NotifyNewTask(clusterName, nil, []persistence.Task{})
-	e.crossClusterProcessor.NotifyNewTask(clusterName, nil, []persistence.Task{})
+	e.txProcessor.NotifyNewTask(clusterName, &hcommon.NotifyTaskInfo{Tasks: []persistence.Task{}})
+	e.timerProcessor.NotifyNewTask(clusterName, &hcommon.NotifyTaskInfo{Tasks: []persistence.Task{}})
+	e.crossClusterProcessor.NotifyNewTask(clusterName, &hcommon.NotifyTaskInfo{Tasks: []persistence.Task{}})
 	return nil
 }
 
@@ -2877,35 +2878,32 @@ func (e *historyEngineImpl) NotifyNewHistoryEvent(
 }
 
 func (e *historyEngineImpl) NotifyNewTransferTasks(
-	executionInfo *persistence.WorkflowExecutionInfo,
-	tasks []persistence.Task,
+	info *hcommon.NotifyTaskInfo,
 ) {
 
-	if len(tasks) > 0 {
-		task := tasks[0]
+	if len(info.Tasks) > 0 {
+		task := info.Tasks[0]
 		clusterName := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
-		e.txProcessor.NotifyNewTask(clusterName, executionInfo, tasks)
+		e.txProcessor.NotifyNewTask(clusterName, info)
 	}
 }
 
 func (e *historyEngineImpl) NotifyNewTimerTasks(
-	executionInfo *persistence.WorkflowExecutionInfo,
-	tasks []persistence.Task,
+	info *hcommon.NotifyTaskInfo,
 ) {
 
-	if len(tasks) > 0 {
-		task := tasks[0]
+	if len(info.Tasks) > 0 {
+		task := info.Tasks[0]
 		clusterName := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
-		e.timerProcessor.NotifyNewTask(clusterName, executionInfo, tasks)
+		e.timerProcessor.NotifyNewTask(clusterName, info)
 	}
 }
 
 func (e *historyEngineImpl) NotifyNewCrossClusterTasks(
-	executionInfo *persistence.WorkflowExecutionInfo,
-	tasks []persistence.Task,
+	info *hcommon.NotifyTaskInfo,
 ) {
 	taskByTargetCluster := make(map[string][]persistence.Task)
-	for _, task := range tasks {
+	for _, task := range info.Tasks {
 		// TODO: consider defining a new interface in persistence package
 		// for cross cluster tasks and add a method for returning the target cluster
 		var targetCluster string
@@ -2927,7 +2925,7 @@ func (e *historyEngineImpl) NotifyNewCrossClusterTasks(
 	}
 
 	for targetCluster, tasks := range taskByTargetCluster {
-		e.crossClusterProcessor.NotifyNewTask(targetCluster, executionInfo, tasks)
+		e.crossClusterProcessor.NotifyNewTask(targetCluster, &hcommon.NotifyTaskInfo{ExecutionInfo: info.ExecutionInfo, Tasks: tasks, PersistenceError: info.PersistenceError})
 	}
 }
 

--- a/service/history/historyEngine2_test.go
+++ b/service/history/historyEngine2_test.go
@@ -98,8 +98,8 @@ func (s *engine2Suite) SetupTest() {
 
 	s.mockTxProcessor = queue.NewMockProcessor(s.controller)
 	s.mockTimerProcessor = queue.NewMockProcessor(s.controller)
-	s.mockTxProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockTimerProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockTxProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockTimerProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any()).AnyTimes()
 
 	s.mockShard = shard.NewTestContext(
 		s.controller,

--- a/service/history/historyEngine3_eventsv2_test.go
+++ b/service/history/historyEngine3_eventsv2_test.go
@@ -90,8 +90,8 @@ func (s *engine3Suite) SetupTest() {
 	s.controller = gomock.NewController(s.T())
 	s.mockTxProcessor = queue.NewMockProcessor(s.controller)
 	s.mockTimerProcessor = queue.NewMockProcessor(s.controller)
-	s.mockTxProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockTimerProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockTxProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockTimerProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any()).AnyTimes()
 
 	s.mockShard = shard.NewTestContext(
 		s.controller,

--- a/service/history/historyEngine_test.go
+++ b/service/history/historyEngine_test.go
@@ -109,8 +109,8 @@ func (s *engineSuite) SetupTest() {
 	s.mockTimerProcessor = queue.NewMockProcessor(s.controller)
 	s.mockEventsReapplier = ndc.NewMockEventsReapplier(s.controller)
 	s.mockWorkflowResetter = reset.NewMockWorkflowResetter(s.controller)
-	s.mockTxProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockTimerProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockTxProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockTimerProcessor.EXPECT().NotifyNewTask(gomock.Any(), gomock.Any()).AnyTimes()
 
 	s.mockShard = shard.NewTestContext(
 		s.controller,

--- a/service/history/ndc/activity_replicator_test.go
+++ b/service/history/ndc/activity_replicator_test.go
@@ -103,9 +103,9 @@ func (s *activityReplicatorSuite) SetupTest() {
 	s.executionCache = execution.NewCache(s.mockShard)
 	s.mockEngine = engine.NewMockEngine(s.controller)
 	s.mockEngine.EXPECT().NotifyNewHistoryEvent(gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 
 	s.activityReplicator = NewActivityReplicator(

--- a/service/history/queue/cross_cluster_queue_processor.go
+++ b/service/history/queue/cross_cluster_queue_processor.go
@@ -29,8 +29,8 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
-	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/engine"
 	"github.com/uber/cadence/service/history/execution"
 	"github.com/uber/cadence/service/history/shard"
@@ -117,10 +117,9 @@ func (c *crossClusterQueueProcessor) Stop() {
 
 func (c *crossClusterQueueProcessor) NotifyNewTask(
 	clusterName string,
-	executionInfo *persistence.WorkflowExecutionInfo,
-	tasks []persistence.Task,
+	info *hcommon.NotifyTaskInfo,
 ) {
-	if len(tasks) == 0 {
+	if len(info.Tasks) == 0 {
 		return
 	}
 

--- a/service/history/queue/interface.go
+++ b/service/history/queue/interface.go
@@ -26,7 +26,7 @@ import (
 	"context"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/persistence"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/task"
 )
 
@@ -89,7 +89,7 @@ type (
 	Processor interface {
 		common.Daemon
 		FailoverDomain(domainIDs map[string]struct{})
-		NotifyNewTask(clusterName string, executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task)
+		NotifyNewTask(clusterName string, info *hcommon.NotifyTaskInfo)
 		HandleAction(ctx context.Context, clusterName string, action *Action) (*ActionResult, error)
 		LockTaskProcessing()
 		UnlockTaskProcessing()

--- a/service/history/queue/interface_mock.go
+++ b/service/history/queue/interface_mock.go
@@ -32,7 +32,7 @@ import (
 
 	gomock "github.com/golang/mock/gomock"
 
-	persistence "github.com/uber/cadence/common/persistence"
+	common "github.com/uber/cadence/service/history/common"
 	task "github.com/uber/cadence/service/history/task"
 )
 
@@ -497,15 +497,15 @@ func (mr *MockProcessorMockRecorder) LockTaskProcessing() *gomock.Call {
 }
 
 // NotifyNewTask mocks base method.
-func (m *MockProcessor) NotifyNewTask(clusterName string, executionInfo *persistence.WorkflowExecutionInfo, tasks []persistence.Task) {
+func (m *MockProcessor) NotifyNewTask(clusterName string, info *common.NotifyTaskInfo) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyNewTask", clusterName, executionInfo, tasks)
+	m.ctrl.Call(m, "NotifyNewTask", clusterName, info)
 }
 
 // NotifyNewTask indicates an expected call of NotifyNewTask.
-func (mr *MockProcessorMockRecorder) NotifyNewTask(clusterName, executionInfo, tasks interface{}) *gomock.Call {
+func (mr *MockProcessorMockRecorder) NotifyNewTask(clusterName, info interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewTask", reflect.TypeOf((*MockProcessor)(nil).NotifyNewTask), clusterName, executionInfo, tasks)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewTask", reflect.TypeOf((*MockProcessor)(nil).NotifyNewTask), clusterName, info)
 }
 
 // Start mocks base method.

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/common/types"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/engine"
 	"github.com/uber/cadence/service/history/execution"
@@ -190,11 +191,10 @@ func (t *timerQueueProcessor) Stop() {
 
 func (t *timerQueueProcessor) NotifyNewTask(
 	clusterName string,
-	_ *persistence.WorkflowExecutionInfo,
-	timerTasks []persistence.Task,
+	info *hcommon.NotifyTaskInfo,
 ) {
 	if clusterName == t.currentClusterName {
-		t.activeQueueProcessor.notifyNewTimers(timerTasks)
+		t.activeQueueProcessor.notifyNewTimers(info.Tasks)
 		return
 	}
 
@@ -209,7 +209,7 @@ func (t *timerQueueProcessor) NotifyNewTask(
 	}
 
 	standbyQueueTimerGate.SetCurrentTime(t.shard.GetCurrentTime(clusterName))
-	standbyQueueProcessor.notifyNewTimers(timerTasks)
+	standbyQueueProcessor.notifyNewTimers(info.Tasks)
 }
 
 func (t *timerQueueProcessor) FailoverDomain(

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -39,6 +39,7 @@ import (
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/common/types"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/engine"
 	"github.com/uber/cadence/service/history/execution"
@@ -200,15 +201,14 @@ func (t *transferQueueProcessor) Stop() {
 
 func (t *transferQueueProcessor) NotifyNewTask(
 	clusterName string,
-	executionInfo *persistence.WorkflowExecutionInfo,
-	transferTasks []persistence.Task,
+	info *hcommon.NotifyTaskInfo,
 ) {
-	if len(transferTasks) == 0 {
+	if len(info.Tasks) == 0 {
 		return
 	}
 
 	if clusterName == t.currentClusterName {
-		t.activeQueueProcessor.notifyNewTask(executionInfo, transferTasks)
+		t.activeQueueProcessor.notifyNewTask(info)
 		return
 	}
 
@@ -216,7 +216,7 @@ func (t *transferQueueProcessor) NotifyNewTask(
 	if !ok {
 		panic(fmt.Sprintf("Cannot find transfer processor for %s.", clusterName))
 	}
-	standbyQueueProcessor.notifyNewTask(executionInfo, transferTasks)
+	standbyQueueProcessor.notifyNewTask(info)
 }
 
 func (t *transferQueueProcessor) FailoverDomain(

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	hcommon "github.com/uber/cadence/service/history/common"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/shard"
 	"github.com/uber/cadence/service/history/task"
@@ -204,17 +205,16 @@ func (t *transferQueueProcessorBase) Stop() {
 }
 
 func (t *transferQueueProcessorBase) notifyNewTask(
-	executionInfo *persistence.WorkflowExecutionInfo,
-	transferTasks []persistence.Task,
+	info *hcommon.NotifyTaskInfo,
 ) {
 	select {
 	case t.notifyCh <- struct{}{}:
 	default:
 	}
 
-	if executionInfo != nil && t.validator != nil {
+	if info.ExecutionInfo != nil && t.validator != nil {
 		// executionInfo will be nil when notifyNewTask is called to trigger a scan, for example during domain failover or sync shard.
-		t.validator.addTasks(executionInfo, transferTasks)
+		t.validator.addTasks(info)
 	}
 }
 

--- a/service/history/task/cross_cluster_source_task_executor_test.go
+++ b/service/history/task/cross_cluster_source_task_executor_test.go
@@ -90,9 +90,9 @@ func (s *crossClusterSourceTaskExecutorSuite) SetupTest() {
 	))
 	s.mockEngine = engine.NewMockEngine(s.controller)
 	s.mockEngine.EXPECT().NotifyNewHistoryEvent(gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 
 	s.mockDomainCache = s.mockShard.Resource.DomainCache

--- a/service/history/task/timer_active_task_executor_test.go
+++ b/service/history/task/timer_active_task_executor_test.go
@@ -119,9 +119,9 @@ func (s *timerActiveTaskExecutorSuite) SetupTest() {
 
 	s.mockEngine = engine.NewMockEngine(s.controller)
 	s.mockEngine.EXPECT().NotifyNewHistoryEvent(gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 
 	s.mockDomainCache = s.mockShard.Resource.DomainCache

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -121,9 +121,9 @@ func (s *timerStandbyTaskExecutorSuite) SetupTest() {
 
 	s.mockEngine = engine.NewMockEngine(s.controller)
 	s.mockEngine.EXPECT().NotifyNewHistoryEvent(gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 	s.mockNDCHistoryResender = ndc.NewMockHistoryResender(s.controller)
 

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -154,9 +154,9 @@ func (s *transferActiveTaskExecutorSuite) SetupTest() {
 
 	s.mockEngine = engine.NewMockEngine(s.controller)
 	s.mockEngine.EXPECT().NotifyNewHistoryEvent(gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any(), gomock.Any()).AnyTimes()
-	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any(), gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 
 	s.mockParentClosePolicyClient = &parentclosepolicy.ClientMock{}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add a tag to the logs of transfer task validator to indicate whether the lost task can be a false positive case

<!-- Tell your future self why have you made these changes -->
**Why?**
- Currently, the transfer task validator logs transfer tasks which can be lost, but when there is a timeout in persistence layer, the transfer tasks may not be persisted in the database, and these can potentially be false positive cases. We want to find these cases from the logs to improve the debugging experience.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
