### PR TITLE
Add support of update time for Cassandra, Mysql and Postgres

### DIFF
--- a/common/persistence/dataStoreInterfaces.go
+++ b/common/persistence/dataStoreInterfaces.go
@@ -700,6 +700,7 @@ type (
 		TaskList           string
 		IsCron             bool
 		NumClusters        int16
+		UpdateTimestamp    time.Time
 		SearchAttributes   map[string][]byte
 	}
 

--- a/common/persistence/dataVisibilityManagerInterfaces.go
+++ b/common/persistence/dataVisibilityManagerInterfaces.go
@@ -51,7 +51,7 @@ type (
 		TaskList           string
 		IsCron             bool
 		NumClusters        int16
-		UpdateTimestamp    int64
+		UpdateTimestamp    int64 // unit is unix nano, consistent with start/execution timestamp, same in other requests
 		SearchAttributes   map[string][]byte
 	}
 

--- a/common/persistence/dataVisibilityManagerInterfaces.go
+++ b/common/persistence/dataVisibilityManagerInterfaces.go
@@ -51,6 +51,7 @@ type (
 		TaskList           string
 		IsCron             bool
 		NumClusters        int16
+		UpdateTimestamp    int64
 		SearchAttributes   map[string][]byte
 	}
 

--- a/common/persistence/nosql/nosqlVisibilityStore.go
+++ b/common/persistence/nosql/nosqlVisibilityStore.go
@@ -83,6 +83,7 @@ func (v *nosqlVisibilityStore) RecordWorkflowExecutionStarted(
 			TaskList:      request.TaskList,
 			IsCron:        request.IsCron,
 			NumClusters:   request.NumClusters,
+			UpdateTime:    request.UpdateTimestamp,
 		},
 	})
 	if err != nil {
@@ -119,6 +120,7 @@ func (v *nosqlVisibilityStore) RecordWorkflowExecutionClosed(
 			Status:        &request.Status,
 			CloseTime:     request.CloseTimestamp,
 			HistoryLength: request.HistoryLength,
+			UpdateTime:    request.UpdateTimestamp,
 		},
 	})
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/visibility.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/visibility.go
@@ -39,17 +39,17 @@ const (
 
 const (
 	///////////////// Open Executions /////////////////
-	openExecutionsColumnsForSelect = " workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_list, is_cron, num_clusters "
+	openExecutionsColumnsForSelect = " workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, task_list, is_cron, num_clusters, update_time "
 
 	openExecutionsColumnsForInsert = "(domain_id, domain_partition, " + openExecutionsColumnsForSelect + ")"
 
 	templateCreateWorkflowExecutionStartedWithTTL = `INSERT INTO open_executions ` +
 		openExecutionsColumnsForInsert +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) using TTL ?`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) using TTL ?`
 
 	templateCreateWorkflowExecutionStarted = `INSERT INTO open_executions` +
 		openExecutionsColumnsForInsert +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	templateDeleteWorkflowExecutionStarted = `DELETE FROM open_executions ` +
 		`WHERE domain_id = ? ` +
@@ -96,25 +96,25 @@ const (
 		`and run_id = ? `
 
 	///////////////// Closed Executions /////////////////
-	closedExecutionColumnsForSelect = " workflow_id, run_id, start_time, execution_time, close_time, workflow_type_name, status, history_length, memo, encoding, task_list, is_cron, num_clusters "
+	closedExecutionColumnsForSelect = " workflow_id, run_id, start_time, execution_time, close_time, workflow_type_name, status, history_length, memo, encoding, task_list, is_cron, num_clusters, update_time "
 
 	closedExecutionColumnsForInsert = "(domain_id, domain_partition, " + closedExecutionColumnsForSelect + ")"
 
 	templateCreateWorkflowExecutionClosedWithTTL = `INSERT INTO closed_executions ` +
 		closedExecutionColumnsForInsert +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) using TTL ?`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) using TTL ?`
 
 	templateCreateWorkflowExecutionClosed = `INSERT INTO closed_executions ` +
 		closedExecutionColumnsForInsert +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	templateCreateWorkflowExecutionClosedWithTTLV2 = `INSERT INTO closed_executions_v2 ` +
 		closedExecutionColumnsForInsert +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) using TTL ?`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) using TTL ?`
 
 	templateCreateWorkflowExecutionClosedV2 = `INSERT INTO closed_executions_v2 ` +
 		closedExecutionColumnsForInsert +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	templateGetClosedWorkflowExecutions = `SELECT ` + closedExecutionColumnsForSelect +
 		`FROM closed_executions ` +
@@ -262,6 +262,7 @@ func (db *cdb) UpdateVisibility(ctx context.Context, ttlSeconds int64, row *nosq
 			row.TaskList,
 			row.IsCron,
 			row.NumClusters,
+			row.UpdateTime,
 		)
 		// duplicate write to v2 to order by close time
 		batch.Query(templateCreateWorkflowExecutionClosedV2,
@@ -280,6 +281,7 @@ func (db *cdb) UpdateVisibility(ctx context.Context, ttlSeconds int64, row *nosq
 			row.TaskList,
 			row.IsCron,
 			row.NumClusters,
+			row.UpdateTime,
 		)
 	} else {
 		batch.Query(templateCreateWorkflowExecutionClosedWithTTL,
@@ -298,6 +300,7 @@ func (db *cdb) UpdateVisibility(ctx context.Context, ttlSeconds int64, row *nosq
 			row.TaskList,
 			row.IsCron,
 			row.NumClusters,
+			row.UpdateTime,
 			ttlSeconds,
 		)
 		// duplicate write to v2 to order by close time
@@ -317,6 +320,7 @@ func (db *cdb) UpdateVisibility(ctx context.Context, ttlSeconds int64, row *nosq
 			row.TaskList,
 			row.IsCron,
 			row.NumClusters,
+			row.UpdateTime,
 			ttlSeconds,
 		)
 	}
@@ -683,7 +687,8 @@ func readOpenWorkflowExecutionRecord(
 	var taskList string
 	var isCron bool
 	var numClusters int16
-	if iter.Scan(&workflowID, &runID, &startTime, &executionTime, &typeName, &memo, &encoding, &taskList, &isCron, &numClusters) {
+	var updateTime time.Time
+	if iter.Scan(&workflowID, &runID, &startTime, &executionTime, &typeName, &memo, &encoding, &taskList, &isCron, &numClusters, &updateTime) {
 		record := &persistence.InternalVisibilityWorkflowExecutionInfo{
 			WorkflowID:    workflowID,
 			RunID:         runID,
@@ -694,6 +699,7 @@ func readOpenWorkflowExecutionRecord(
 			TaskList:      taskList,
 			IsCron:        isCron,
 			NumClusters:   numClusters,
+			UpdateTime:    updateTime,
 		}
 		return record, true
 	}
@@ -716,7 +722,8 @@ func readClosedWorkflowExecutionRecord(
 	var taskList string
 	var isCron bool
 	var numClusters int16
-	if iter.Scan(&workflowID, &runID, &startTime, &executionTime, &closeTime, &typeName, &status, &historyLength, &memo, &encoding, &taskList, &isCron, &numClusters) {
+	var updateTime time.Time
+	if iter.Scan(&workflowID, &runID, &startTime, &executionTime, &closeTime, &typeName, &status, &historyLength, &memo, &encoding, &taskList, &isCron, &numClusters, &updateTime) {
 		record := &persistence.InternalVisibilityWorkflowExecutionInfo{
 			WorkflowID:    workflowID,
 			RunID:         runID,
@@ -730,6 +737,7 @@ func readClosedWorkflowExecutionRecord(
 			TaskList:      taskList,
 			IsCron:        isCron,
 			NumClusters:   numClusters,
+			UpdateTime:    updateTime,
 		}
 		return record, true
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/visibility.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/visibility.go
@@ -204,6 +204,7 @@ func (db *cdb) InsertVisibility(ctx context.Context, ttlSeconds int64, row *nosq
 			row.TaskList,
 			row.IsCron,
 			row.NumClusters,
+			row.UpdateTime,
 		).WithContext(ctx)
 	} else {
 		query = db.session.Query(templateCreateWorkflowExecutionStartedWithTTL,
@@ -219,6 +220,7 @@ func (db *cdb) InsertVisibility(ctx context.Context, ttlSeconds int64, row *nosq
 			row.TaskList,
 			row.IsCron,
 			row.NumClusters,
+			row.UpdateTime,
 			ttlSeconds,
 		).WithContext(ctx)
 	}

--- a/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
@@ -119,6 +119,7 @@ func (s *DBVisibilityPersistenceSuite) TestBasicVisibility() {
 		Execution:        workflowExecution,
 		WorkflowTypeName: "visibility-workflow",
 		StartTimestamp:   startTime,
+		UpdateTimestamp:  0,
 	}
 	err0 := s.VisibilityMgr.RecordWorkflowExecutionStarted(ctx, startReq)
 	s.Nil(err0)
@@ -139,6 +140,7 @@ func (s *DBVisibilityPersistenceSuite) TestBasicVisibility() {
 		WorkflowTypeName: "visibility-workflow",
 		StartTimestamp:   startTime,
 		CloseTimestamp:   time.Now().UnixNano(),
+		UpdateTimestamp:  time.Now().UnixNano(),
 		HistoryLength:    5,
 	}
 	err2 := s.VisibilityMgr.RecordWorkflowExecutionClosed(ctx, closeReq)

--- a/common/persistence/sql/sqlVisibilityStore.go
+++ b/common/persistence/sql/sqlVisibilityStore.go
@@ -77,6 +77,7 @@ func (s *sqlVisibilityStore) RecordWorkflowExecutionStarted(
 		Encoding:         string(request.Memo.GetEncoding()),
 		IsCron:           request.IsCron,
 		NumClusters:      request.NumClusters,
+		UpdateTime:       request.UpdateTimestamp,
 	})
 
 	if err != nil {
@@ -104,6 +105,7 @@ func (s *sqlVisibilityStore) RecordWorkflowExecutionClosed(
 		Encoding:         string(request.Memo.GetEncoding()),
 		IsCron:           request.IsCron,
 		NumClusters:      request.NumClusters,
+		UpdateTime:       request.UpdateTimestamp,
 	})
 	if err != nil {
 		return convertCommonErrors(s.db, "RecordWorkflowExecutionClosed", "", err)
@@ -334,6 +336,7 @@ func (s *sqlVisibilityStore) rowToInfo(row *sqlplugin.VisibilityRow) *p.Internal
 		IsCron:        row.IsCron,
 		NumClusters:   row.NumClusters,
 		Memo:          p.NewDataBlob(row.Memo, common.EncodingType(row.Encoding)),
+		UpdateTime:    row.UpdateTime,
 	}
 	if row.CloseStatus != nil {
 		status := workflow.WorkflowExecutionCloseStatus(*row.CloseStatus)

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -538,6 +538,7 @@ type (
 		Encoding         string
 		IsCron           bool
 		NumClusters      int16
+		UpdateTime       time.Time
 	}
 
 	// VisibilityFilter contains the column names within executions_visibility table that

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -35,7 +35,7 @@ const (
 		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	templateCreateWorkflowExecutionClosed = `REPLACE INTO executions_visibility (` +
-		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, close_status, history_length, memo, encoding, is_cron, num_clusters. update_time) ` +
+		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, close_status, history_length, memo, encoding, is_cron, num_clusters, update_time) ` +
 		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	// RunID condition is needed for correct pagination

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -46,7 +46,7 @@ const (
          ORDER BY start_time DESC, run_id
          LIMIT ?`
 
-	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, update_time)`
+	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, update_time`
 	templateOpenSelect     = `SELECT ` + templateOpenFieldNames + ` FROM executions_visibility WHERE close_status IS NULL `
 
 	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, close_status, history_length

--- a/common/persistence/sql/sqlplugin/mysql/visibility.go
+++ b/common/persistence/sql/sqlplugin/mysql/visibility.go
@@ -31,12 +31,12 @@ import (
 
 const (
 	templateCreateWorkflowExecutionStarted = `INSERT IGNORE INTO executions_visibility (` +
-		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, num_clusters) ` +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, num_clusters, update_time) ` +
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	templateCreateWorkflowExecutionClosed = `REPLACE INTO executions_visibility (` +
-		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, close_status, history_length, memo, encoding, is_cron, num_clusters) ` +
-		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, close_status, history_length, memo, encoding, is_cron, num_clusters. update_time) ` +
+		`VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	// RunID condition is needed for correct pagination
 	templateConditions = ` AND domain_id = ?
@@ -46,7 +46,7 @@ const (
          ORDER BY start_time DESC, run_id
          LIMIT ?`
 
-	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron`
+	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, update_time)`
 	templateOpenSelect     = `SELECT ` + templateOpenFieldNames + ` FROM executions_visibility WHERE close_status IS NULL `
 
 	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, close_status, history_length
@@ -66,7 +66,7 @@ const (
 
 	templateGetClosedWorkflowExecutionsByStatus = templateClosedSelect + `AND close_status = ?` + templateConditions
 
-	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, close_status, history_length, is_cron
+	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, close_status, history_length, is_cron, update_time
 		 FROM executions_visibility
 		 WHERE domain_id = ? AND close_status IS NOT NULL
 		 AND run_id = ?`
@@ -93,7 +93,8 @@ func (mdb *db) InsertIntoVisibility(ctx context.Context, row *sqlplugin.Visibili
 		row.Memo,
 		row.Encoding,
 		row.IsCron,
-		row.NumClusters)
+		row.NumClusters,
+		row.UpdateTime)
 }
 
 // ReplaceIntoVisibility replaces an existing row if it exist or creates a new row in visibility table
@@ -118,7 +119,8 @@ func (mdb *db) ReplaceIntoVisibility(ctx context.Context, row *sqlplugin.Visibil
 			row.Memo,
 			row.Encoding,
 			row.IsCron,
-			row.NumClusters)
+			row.NumClusters,
+			row.UpdateTime)
 	default:
 		return nil, errCloseParams
 	}

--- a/common/persistence/sql/sqlplugin/postgres/visibility.go
+++ b/common/persistence/sql/sqlplugin/postgres/visibility.go
@@ -32,13 +32,13 @@ import (
 
 const (
 	templateCreateWorkflowExecutionStarted = `INSERT INTO executions_visibility (` +
-		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, num_clusters) ` +
-		`VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, num_clusters, update_time) ` +
+		`VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
          ON CONFLICT (domain_id, run_id) DO NOTHING`
 
 	templateCreateWorkflowExecutionClosed = `INSERT INTO executions_visibility (` +
-		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, close_status, history_length, memo, encoding, is_cron, num_clusters) ` +
-		`VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+		`domain_id, workflow_id, run_id, start_time, execution_time, workflow_type_name, close_time, close_status, history_length, memo, encoding, is_cron, num_clusters, update_time) ` +
+		`VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
 		ON CONFLICT (domain_id, run_id) DO UPDATE
 		  SET workflow_id = excluded.workflow_id,
 		      start_time = excluded.start_time,
@@ -50,7 +50,8 @@ const (
 			  memo = excluded.memo,
 			  encoding = excluded.encoding,
 				is_cron = excluded.is_cron,
-				num_clusters = excluded.num_clusters`
+				num_clusters = excluded.num_clusters,
+				update_time = excluded.update_time`
 
 	// RunID condition is needed for correct pagination
 	templateConditions1 = ` AND domain_id = $1
@@ -67,7 +68,7 @@ const (
          ORDER BY start_time DESC, run_id
          LIMIT $7`
 
-	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron`
+	templateOpenFieldNames = `workflow_id, run_id, start_time, execution_time, workflow_type_name, memo, encoding, is_cron, update_time`
 	templateOpenSelect     = `SELECT ` + templateOpenFieldNames + ` FROM executions_visibility WHERE close_status IS NULL `
 
 	templateClosedSelect = `SELECT ` + templateOpenFieldNames + `, close_time, close_status, history_length
@@ -87,7 +88,7 @@ const (
 
 	templateGetClosedWorkflowExecutionsByStatus = templateClosedSelect + `AND close_status = $1` + templateConditions2
 
-	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, close_status, history_length, is_cron
+	templateGetClosedWorkflowExecution = `SELECT workflow_id, run_id, start_time, execution_time, memo, encoding, close_time, workflow_type_name, close_status, history_length, is_cron, update_time
 		 FROM executions_visibility
 		 WHERE domain_id = $1 AND close_status IS NOT NULL
 		 AND run_id = $2`
@@ -112,7 +113,8 @@ func (pdb *db) InsertIntoVisibility(ctx context.Context, row *sqlplugin.Visibili
 		row.Memo,
 		row.Encoding,
 		row.IsCron,
-		row.NumClusters)
+		row.NumClusters,
+		row.UpdateTime)
 }
 
 // ReplaceIntoVisibility replaces an existing row if it exist or creates a new row in visibility table
@@ -135,7 +137,8 @@ func (pdb *db) ReplaceIntoVisibility(ctx context.Context, row *sqlplugin.Visibil
 			row.Memo,
 			row.Encoding,
 			row.IsCron,
-			row.NumClusters)
+			row.NumClusters,
+			row.UpdateTime)
 	default:
 		return nil, errCloseParams
 	}

--- a/common/persistence/visibilitySingleManager.go
+++ b/common/persistence/visibilitySingleManager.go
@@ -78,6 +78,7 @@ func (v *visibilityManagerImpl) RecordWorkflowExecutionStarted(
 		IsCron:             request.IsCron,
 		NumClusters:        request.NumClusters,
 		Memo:               v.serializeMemo(request.Memo, request.DomainUUID, request.Execution.GetWorkflowID(), request.Execution.GetRunID()),
+		UpdateTimestamp:    time.Unix(0, request.UpdateTimestamp),
 		SearchAttributes:   request.SearchAttributes,
 	}
 	return v.persistence.RecordWorkflowExecutionStarted(ctx, req)

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -26,4 +26,4 @@ package cassandra
 const Version = "0.33"
 
 // VisibilityVersion is the Cassandra visibility database release version
-const VisibilityVersion = "0.7"
+const VisibilityVersion = "0.8"

--- a/schema/cassandra/visibility/schema.cql
+++ b/schema/cassandra/visibility/schema.cql
@@ -11,6 +11,7 @@ CREATE TABLE open_executions (
   task_list            text,
   is_cron              boolean,
   num_clusters         int,
+  update_time          timestamp,
   PRIMARY KEY  ((domain_id, domain_partition), start_time, run_id)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
   AND COMPACTION = {
@@ -39,6 +40,7 @@ CREATE TABLE closed_executions (
   task_list            text,
   is_cron              boolean,
   num_clusters         int,
+  update_time          timestamp,
   PRIMARY KEY  ((domain_id, domain_partition), start_time, run_id)
 ) WITH CLUSTERING ORDER BY (start_time DESC)
   AND COMPACTION = {
@@ -68,6 +70,7 @@ CREATE TABLE closed_executions_v2 (
   task_list            text,
   is_cron              boolean,
   num_clusters         int,
+  update_time          timestamp,
   PRIMARY KEY  ((domain_id, domain_partition), close_time, run_id)
 ) WITH CLUSTERING ORDER BY (close_time DESC)
   AND COMPACTION = {

--- a/schema/cassandra/visibility/versioned/v0.8/add_update_time.cql
+++ b/schema/cassandra/visibility/versioned/v0.8/add_update_time.cql
@@ -1,0 +1,3 @@
+ALTER TABLE open_executions ADD update_time timestamp;
+ALTER TABLE closed_executions ADD update_time timestamp;
+ALTER TABLE closed_executions_v2 ADD update_time timestamp;

--- a/schema/cassandra/visibility/versioned/v0.8/manifest.json
+++ b/schema/cassandra/visibility/versioned/v0.8/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.8",
+  "MinCompatibleVersion": "0.8",
+  "Description": "add update_time field to visibility",
+  "SchemaUpdateCqlFiles": [
+    "add_update_time.cql"
+  ]
+}

--- a/schema/mysql/v57/visibility/schema.sql
+++ b/schema/mysql/v57/visibility/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE executions_visibility (
   task_list            VARCHAR(255) DEFAULT '' NOT NULL,
   is_cron              BOOLEAN DEFAULT false NOT NULL,
   num_clusters         INT NULL,
+  update_time          DATETIME(6) NULL,
 
   PRIMARY KEY  (domain_id, run_id)
 );

--- a/schema/mysql/v57/visibility/versioned/v0.6/add_update_time.sql
+++ b/schema/mysql/v57/visibility/versioned/v0.6/add_update_time.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions_visibility ADD update_time DATETIME(6) NULL;

--- a/schema/mysql/v57/visibility/versioned/v0.6/manifest.json
+++ b/schema/mysql/v57/visibility/versioned/v0.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.6",
+  "MinCompatibleVersion": "0.6",
+  "Description": "add update_time field to visibility",
+  "SchemaUpdateCqlFiles": [
+    "add_update_time.sql"
+  ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -26,4 +26,4 @@ package mysql
 const Version = "0.5"
 
 // VisibilityVersion is the MySQL visibility database release version
-const VisibilityVersion = "0.5"
+const VisibilityVersion = "0.6"

--- a/schema/postgres/version.go
+++ b/schema/postgres/version.go
@@ -28,4 +28,4 @@ const Version = "0.4"
 
 // VisibilityVersion is the Postgres visibility database release version
 // Cadence supports both MySQL and Postgres officially, so upgrade should be perform for both MySQL and Postgres
-const VisibilityVersion = "0.5"
+const VisibilityVersion = "0.6"

--- a/schema/postgres/visibility/schema.sql
+++ b/schema/postgres/visibility/schema.sql
@@ -13,6 +13,7 @@ CREATE TABLE executions_visibility (
   task_list            VARCHAR(255) DEFAULT '' NOT NULL,
   is_cron              BOOLEAN DEFAULT false NOT NULL,
   num_clusters         INTEGER NULL,
+  update_time          TIMESTAMP NULL,
 
   PRIMARY KEY  (domain_id, run_id)
 );

--- a/schema/postgres/visibility/versioned/v0.6/add_update_time.sql
+++ b/schema/postgres/visibility/versioned/v0.6/add_update_time.sql
@@ -1,0 +1,1 @@
+ALTER TABLE executions_visibility ADD update_time TIMESTAMP NULL;

--- a/schema/postgres/visibility/versioned/v0.6/manifest.json
+++ b/schema/postgres/visibility/versioned/v0.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.6",
+  "MinCompatibleVersion": "0.6",
+  "Description": "add update_time field to visibility",
+  "SchemaUpdateCqlFiles": [
+    "add_update_time.sql"
+  ]
+}

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1024,6 +1024,7 @@ func (t *transferActiveTaskExecutor) processRecordWorkflowStartedOrUpsertHelper(
 			isCron,
 			numClusters,
 			visibilityMemo,
+			updateTimestamp.UnixNano(),
 			searchAttr,
 		)
 	}

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1687,6 +1687,7 @@ func createRecordWorkflowExecutionStartedRequest(
 		TaskList:           taskInfo.TaskList,
 		IsCron:             len(executionInfo.CronSchedule) > 0,
 		NumClusters:        numClusters,
+		UpdateTimestamp:    executionInfo.LastUpdatedTimestamp.UnixNano(),
 	}
 }
 

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -501,6 +501,7 @@ func (t *transferStandbyTaskExecutor) processRecordWorkflowStartedOrUpsertHelper
 			isCron,
 			numClusters,
 			visibilityMemo,
+			updateTimestamp.UnixNano(),
 			searchAttr,
 		)
 	}

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -151,6 +151,7 @@ func (t *transferTaskExecutorBase) recordWorkflowStarted(
 	isCron bool,
 	numClusters int16,
 	visibilityMemo *types.Memo,
+	updateTimeUnixNano int64,
 	searchAttributes map[string][]byte,
 ) error {
 
@@ -185,6 +186,7 @@ func (t *transferTaskExecutorBase) recordWorkflowStarted(
 		TaskList:           taskList,
 		IsCron:             isCron,
 		NumClusters:        numClusters,
+		UpdateTimestamp:    updateTimeUnixNano,
 		SearchAttributes:   searchAttributes,
 	}
 
@@ -380,7 +382,12 @@ func getWorkflowExecutionTimestamp(
 func getWorkflowLastUpdatedTimestamp(
 	msBuilder execution.MutableState,
 ) time.Time {
-	return msBuilder.GetExecutionInfo().LastUpdatedTimestamp
+
+	executionInfo := msBuilder.GetExecutionInfo()
+	if executionInfo != nil {
+		return executionInfo.LastUpdatedTimestamp
+	}
+	return time.Unix(0, 0)
 }
 
 func getWorkflowMemo(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add support of update time field for Cassandra, MySQL and Postgres.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Test the changes locally.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
