### PR TITLE
Fix docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,20 +3,12 @@ ARG TARGET=server
 # Can be used in case a proxy is necessary
 ARG GOPROXY
 
-# Build tcheck binary
-FROM golang:1.17.13-alpine3.15 AS tcheck
-
-WORKDIR /go/src/github.com/uber/tcheck
-
-COPY go.* ./
-RUN go build -mod=readonly -o /go/bin/tcheck github.com/uber/tcheck
-
 # Build Cadence binaries
 FROM golang:1.17.13-alpine3.15 AS builder
 
 ARG RELEASE_VERSION
 
-RUN apk add --update --no-cache ca-certificates make git curl mercurial unzip
+RUN apk add --update --no-cache ca-certificates make git curl mercurial unzip bash
 
 WORKDIR /cadence
 
@@ -68,7 +60,6 @@ FROM alpine AS cadence-server
 ENV CADENCE_HOME /etc/cadence
 RUN mkdir -p /etc/cadence
 
-COPY --from=tcheck /go/bin/tcheck /usr/local/bin
 COPY --from=dockerize /usr/local/bin/dockerize /usr/local/bin
 COPY --from=builder /cadence/cadence-cassandra-tool /usr/local/bin
 COPY --from=builder /cadence/cadence-sql-tool /usr/local/bin
@@ -105,7 +96,6 @@ CMD /start.sh
 # Cadence CLI
 FROM alpine AS cadence-cli
 
-COPY --from=tcheck /go/bin/tcheck /usr/local/bin
 COPY --from=builder /cadence/cadence /usr/local/bin
 
 ENTRYPOINT ["cadence"]

--- a/Makefile
+++ b/Makefile
@@ -280,6 +280,7 @@ $(BUILD)/protoc: $(PROTO_FILES) $(BIN)/$(PROTOC_VERSION_BIN) $(BIN)/protoc-gen-g
 	$(call ensure_idl_submodule)
 	$Q mkdir -p $(PROTO_OUT)
 	$Q echo "protoc..."
+	$Q chmod +x $(BIN)/$(PROTOC_VERSION_BIN)
 	$Q $(foreach PROTO_DIR,$(PROTO_DIRS),$(EMULATE_X86) $(BIN)/$(PROTOC_VERSION_BIN) \
 		--plugin $(BIN)/protoc-gen-gogofast \
 		--plugin $(BIN)/protoc-gen-yarpc-go \
@@ -290,8 +291,11 @@ $(BUILD)/protoc: $(PROTO_FILES) $(BIN)/$(PROTOC_VERSION_BIN) $(BIN)/protoc-gen-g
 		--yarpc-go_out=$(PROTO_OUT) \
 		$$(find $(PROTO_DIR) -name '*.proto');\
 	)
-	$Q cp -R $(PROTO_OUT)/uber/cadence/* $(PROTO_OUT)/
-	$Q rm -r $(PROTO_OUT)/uber
+	$Q # This directory exists for local/buildkite but not for docker builds.
+	$Q if [ -d "$(PROTO_OUT)/uber/cadence" ]; then \
+		cp -R $(PROTO_OUT)/uber/cadence/* $(PROTO_OUT)/; \
+		rm -r $(PROTO_OUT)/uber; \
+	   fi
 	$Q touch $@
 
 # ====================================


### PR DESCRIPTION
Fix docker image build, which has been broken since July 5th.
Tested by building normally & via docker - both locally and in buildkite.
- tcheck wasn't being found, but David and I agree that it seems unnecessary and doesn't seem to be used any more.
- Bash wasn't found in the image, but is needed to run scripts/check-gomod-version.sh, so I added it to the alpine image.
- During docker image build, the protoc binary had 644 permissions but needed to be executed so I added +x
- During docker image build, the PROTO_OUT/uber/cadence directory doesn't exist, so we skip the cp/rm commands that fail otherwise.
