### PR TITLE
Immediate replication task hydration after successful transaction

### DIFF
--- a/common/persistence/workflowExecutionInfo.go
+++ b/common/persistence/workflowExecutionInfo.go
@@ -164,6 +164,23 @@ func (e *WorkflowExecutionInfo) UpdateWorkflowStateCloseStatus(
 
 }
 
+func (e *WorkflowExecutionInfo) IsRunning() bool {
+	switch e.State {
+	case WorkflowStateCreated:
+		return true
+	case WorkflowStateRunning:
+		return true
+	case WorkflowStateCompleted:
+		return false
+	case WorkflowStateZombie:
+		return false
+	case WorkflowStateCorrupted:
+		return false
+	default:
+		panic(fmt.Sprintf("unknown workflow state: %v", e.State))
+	}
+}
+
 // UpdateWorkflowStateCloseStatus update the workflow state
 func (e *WorkflowExecutionInfo) createInvalidStateTransitionErr(
 	currentState int,

--- a/service/history/engine/interface.go
+++ b/service/history/engine/interface.go
@@ -83,5 +83,6 @@ type (
 		NotifyNewTransferTasks(info *hcommon.NotifyTaskInfo)
 		NotifyNewTimerTasks(info *hcommon.NotifyTaskInfo)
 		NotifyNewCrossClusterTasks(info *hcommon.NotifyTaskInfo)
+		NotifyNewReplicationTasks(info *hcommon.NotifyTaskInfo)
 	}
 )

--- a/service/history/engine/interface_mock.go
+++ b/service/history/engine/interface_mock.go
@@ -237,18 +237,6 @@ func (mr *MockEngineMockRecorder) NotifyNewCrossClusterTasks(info interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewCrossClusterTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewCrossClusterTasks), info)
 }
 
-// NotifyNewReplicationTasks mocks base method.
-func (m *MockEngine) NotifyNewReplicationTasks(info *common.NotifyTaskInfo) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "NotifyNewReplicationTasks", info)
-}
-
-// NotifyNewReplicationTasks indicates an expected call of NotifyNewReplicationTasks.
-func (mr *MockEngineMockRecorder) NotifyNewReplicationTasks(info interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewReplicationTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewReplicationTasks), info)
-}
-
 // NotifyNewHistoryEvent mocks base method.
 func (m *MockEngine) NotifyNewHistoryEvent(event *events.Notification) {
 	m.ctrl.T.Helper()
@@ -259,6 +247,18 @@ func (m *MockEngine) NotifyNewHistoryEvent(event *events.Notification) {
 func (mr *MockEngineMockRecorder) NotifyNewHistoryEvent(event interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewHistoryEvent", reflect.TypeOf((*MockEngine)(nil).NotifyNewHistoryEvent), event)
+}
+
+// NotifyNewReplicationTasks mocks base method.
+func (m *MockEngine) NotifyNewReplicationTasks(info *common.NotifyTaskInfo) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyNewReplicationTasks", info)
+}
+
+// NotifyNewReplicationTasks indicates an expected call of NotifyNewReplicationTasks.
+func (mr *MockEngineMockRecorder) NotifyNewReplicationTasks(info interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewReplicationTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewReplicationTasks), info)
 }
 
 // NotifyNewTimerTasks mocks base method.

--- a/service/history/engine/interface_mock.go
+++ b/service/history/engine/interface_mock.go
@@ -237,6 +237,18 @@ func (mr *MockEngineMockRecorder) NotifyNewCrossClusterTasks(info interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewCrossClusterTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewCrossClusterTasks), info)
 }
 
+// NotifyNewReplicationTasks mocks base method.
+func (m *MockEngine) NotifyNewReplicationTasks(info *common.NotifyTaskInfo) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "NotifyNewReplicationTasks", info)
+}
+
+// NotifyNewReplicationTasks indicates an expected call of NotifyNewReplicationTasks.
+func (mr *MockEngineMockRecorder) NotifyNewReplicationTasks(info interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NotifyNewReplicationTasks", reflect.TypeOf((*MockEngine)(nil).NotifyNewReplicationTasks), info)
+}
+
 // NotifyNewHistoryEvent mocks base method.
 func (m *MockEngine) NotifyNewHistoryEvent(event *events.Notification) {
 	m.ctrl.T.Helper()

--- a/service/history/events/blob_test.go
+++ b/service/history/events/blob_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uber/cadence/common/persistence"
 )
 

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -35,6 +35,7 @@ import (
 
 	persistence "github.com/uber/cadence/common/persistence"
 	types "github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/events"
 )
 
 // MockContext is a mock of Context interface.
@@ -87,17 +88,17 @@ func (mr *MockContextMockRecorder) ConflictResolveWorkflowExecution(ctx, now, co
 }
 
 // CreateWorkflowExecution mocks base method.
-func (m *MockContext) CreateWorkflowExecution(ctx context.Context, newWorkflow *persistence.WorkflowSnapshot, historySize int64, createMode persistence.CreateWorkflowMode, prevRunID string, prevLastWriteVersion int64) error {
+func (m *MockContext) CreateWorkflowExecution(ctx context.Context, newWorkflow *persistence.WorkflowSnapshot, persistedHistory events.PersistedBlob, createMode persistence.CreateWorkflowMode, prevRunID string, prevLastWriteVersion int64) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateWorkflowExecution", ctx, newWorkflow, historySize, createMode, prevRunID, prevLastWriteVersion)
+	ret := m.ctrl.Call(m, "CreateWorkflowExecution", ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateWorkflowExecution indicates an expected call of CreateWorkflowExecution.
-func (mr *MockContextMockRecorder) CreateWorkflowExecution(ctx, newWorkflow, historySize, createMode, prevRunID, prevLastWriteVersion interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) CreateWorkflowExecution(ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockContext)(nil).CreateWorkflowExecution), ctx, newWorkflow, historySize, createMode, prevRunID, prevLastWriteVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockContext)(nil).CreateWorkflowExecution), ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion)
 }
 
 // GetDomainID mocks base method.
@@ -230,10 +231,10 @@ func (mr *MockContextMockRecorder) Lock(ctx interface{}) *gomock.Call {
 }
 
 // PersistNonStartWorkflowBatchEvents mocks base method.
-func (m *MockContext) PersistNonStartWorkflowBatchEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (persistence.DataBlob, error) {
+func (m *MockContext) PersistNonStartWorkflowBatchEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (events.PersistedBlob, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PersistNonStartWorkflowBatchEvents", ctx, workflowEvents)
-	ret0, _ := ret[0].(persistence.DataBlob)
+	ret0, _ := ret[0].(events.PersistedBlob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -245,10 +246,10 @@ func (mr *MockContextMockRecorder) PersistNonStartWorkflowBatchEvents(ctx, workf
 }
 
 // PersistStartWorkflowBatchEvents mocks base method.
-func (m *MockContext) PersistStartWorkflowBatchEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (persistence.DataBlob, error) {
+func (m *MockContext) PersistStartWorkflowBatchEvents(ctx context.Context, workflowEvents *persistence.WorkflowEvents) (events.PersistedBlob, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PersistStartWorkflowBatchEvents", ctx, workflowEvents)
-	ret0, _ := ret[0].(persistence.DataBlob)
+	ret0, _ := ret[0].(events.PersistedBlob)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -35,7 +35,7 @@ import (
 
 	persistence "github.com/uber/cadence/common/persistence"
 	types "github.com/uber/cadence/common/types"
-	"github.com/uber/cadence/service/history/events"
+	events "github.com/uber/cadence/service/history/events"
 )
 
 // MockContext is a mock of Context interface.

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1547,20 +1547,7 @@ func (e *mutableStateBuilder) GetPreviousStartedEventID() int64 {
 }
 
 func (e *mutableStateBuilder) IsWorkflowExecutionRunning() bool {
-	switch e.executionInfo.State {
-	case persistence.WorkflowStateCreated:
-		return true
-	case persistence.WorkflowStateRunning:
-		return true
-	case persistence.WorkflowStateCompleted:
-		return false
-	case persistence.WorkflowStateZombie:
-		return false
-	case persistence.WorkflowStateCorrupted:
-		return false
-	default:
-		panic(fmt.Sprintf("unknown workflow state: %v", e.executionInfo.State))
-	}
+	return e.executionInfo.IsRunning()
 }
 
 func (e *mutableStateBuilder) IsWorkflowCompleted() bool {

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2990,6 +2990,7 @@ func hydrateReplicationTask(
 	}
 
 	hydrator := replication.NewImmediateTaskHydrator(
+		exec.IsRunning(),
 		versionHistories,
 		activities,
 		history.Find(info.BranchToken, info.FirstEventID),

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -25,6 +25,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -736,7 +737,7 @@ func (e *historyEngineImpl) startWorkflowHelper(
 	err = wfContext.CreateWorkflowExecution(
 		ctx,
 		newWorkflow,
-		int64(len(historyBlob.Data)),
+		historyBlob,
 		createMode,
 		prevRunID,
 		prevLastWriteVersion,
@@ -802,7 +803,7 @@ func (e *historyEngineImpl) startWorkflowHelper(
 		err = wfContext.CreateWorkflowExecution(
 			ctx,
 			newWorkflow,
-			int64(len(historyBlob.Data)),
+			historyBlob,
 			createMode,
 			prevRunID,
 			t.LastWriteVersion,
@@ -2937,6 +2938,58 @@ func (e *historyEngineImpl) NotifyNewCrossClusterTasks(
 	for targetCluster, tasks := range taskByTargetCluster {
 		e.crossClusterProcessor.NotifyNewTask(targetCluster, &hcommon.NotifyTaskInfo{ExecutionInfo: info.ExecutionInfo, Tasks: tasks, PersistenceError: info.PersistenceError})
 	}
+}
+
+func (e *historyEngineImpl) NotifyNewReplicationTasks(info *hcommon.NotifyTaskInfo) {
+	for _, task := range info.Tasks {
+		hTask, err := hydrateReplicationTask(task, info.ExecutionInfo, info.VersionHistories, info.Activities, info.History)
+		if err != nil {
+			e.logger.Error("failed to preemptively hydrate replication task", tag.Error(err))
+			continue
+		}
+		e.replicationTaskStore.Put(hTask)
+	}
+}
+
+func hydrateReplicationTask(
+	task persistence.Task,
+	exec *persistence.WorkflowExecutionInfo,
+	versionHistories *persistence.VersionHistories,
+	activities map[int64]*persistence.ActivityInfo,
+	history events.PersistedBlobs,
+) (*types.ReplicationTask, error) {
+	info := persistence.ReplicationTaskInfo{
+		DomainID:     exec.DomainID,
+		WorkflowID:   exec.WorkflowID,
+		RunID:        exec.RunID,
+		TaskType:     task.GetType(),
+		CreationTime: task.GetVisibilityTimestamp().UnixNano(),
+		TaskID:       task.GetTaskID(),
+		Version:      task.GetVersion(),
+	}
+
+	switch t := task.(type) {
+	case *persistence.HistoryReplicationTask:
+		info.BranchToken = t.BranchToken
+		info.NewRunBranchToken = t.NewRunBranchToken
+		info.FirstEventID = t.FirstEventID
+		info.NextEventID = t.NextEventID
+	case *persistence.SyncActivityTask:
+		info.ScheduledID = t.ScheduledID
+	case *persistence.FailoverMarkerTask:
+		// No specific fields, but supported
+	default:
+		return nil, errors.New("unknown replication task")
+	}
+
+	hydrator := replication.NewImmediateTaskHydrator(
+		versionHistories,
+		activities,
+		history.Find(info.BranchToken, info.FirstEventID),
+		history.Find(info.NewRunBranchToken, 1),
+	)
+
+	return hydrator.Hydrate(context.Background(), info)
 }
 
 func (e *historyEngineImpl) ResetTransferQueue(

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2994,7 +2994,7 @@ func hydrateReplicationTask(
 		versionHistories,
 		activities,
 		history.Find(info.BranchToken, info.FirstEventID),
-		history.Find(info.NewRunBranchToken, 1),
+		history.Find(info.NewRunBranchToken, common.FirstEventID),
 	)
 
 	return hydrator.Hydrate(context.Background(), info)

--- a/service/history/ndc/new_workflow_transaction_manager.go
+++ b/service/history/ndc/new_workflow_transaction_manager.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/events"
 	"github.com/uber/cadence/service/history/execution"
 )
 
@@ -157,7 +158,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 		return err
 	}
 
-	var targetWorkflowHistoryBlob persistence.DataBlob
+	var targetWorkflowHistoryBlob events.PersistedBlob
 	if len(targetWorkflowEventsSeq[0].Events) > 0 {
 		if targetWorkflowEventsSeq[0].Events[0].GetEventType() == types.EventTypeWorkflowExecutionStarted {
 			targetWorkflowHistoryBlob, err = targetWorkflow.GetContext().PersistStartWorkflowBatchEvents(
@@ -187,7 +188,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 		return targetWorkflow.GetContext().CreateWorkflowExecution(
 			ctx,
 			targetWorkflowSnapshot,
-			int64(len(targetWorkflowHistoryBlob.Data)),
+			targetWorkflowHistoryBlob,
 			createMode,
 			prevRunID,
 			prevLastWriteVersion,
@@ -201,7 +202,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 	return targetWorkflow.GetContext().CreateWorkflowExecution(
 		ctx,
 		targetWorkflowSnapshot,
-		int64(len(targetWorkflowHistoryBlob.Data)),
+		targetWorkflowHistoryBlob,
 		createMode,
 		prevRunID,
 		prevLastWriteVersion,
@@ -235,7 +236,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsZombie(
 		return err
 	}
 
-	var targetWorkflowHistoryBlob persistence.DataBlob
+	var targetWorkflowHistoryBlob events.PersistedBlob
 	if len(targetWorkflowEventsSeq[0].Events) > 0 {
 		if targetWorkflowEventsSeq[0].Events[0].GetEventType() == types.EventTypeWorkflowExecutionStarted {
 			targetWorkflowHistoryBlob, err = targetWorkflow.GetContext().PersistStartWorkflowBatchEvents(
@@ -271,7 +272,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsZombie(
 	err = targetWorkflow.GetContext().CreateWorkflowExecution(
 		ctx,
 		targetWorkflowSnapshot,
-		int64(len(targetWorkflowHistoryBlob.Data)),
+		targetWorkflowHistoryBlob,
 		createMode,
 		prevRunID,
 		prevLastWriteVersion,

--- a/service/history/ndc/new_workflow_transaction_manager_test.go
+++ b/service/history/ndc/new_workflow_transaction_manager_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/events"
 	"github.com/uber/cadence/service/history/execution"
 )
 
@@ -119,7 +120,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Brand
 			},
 		},
 	}
-	workflowHistorySize := int64(12345)
+	workflowHistory := events.PersistedBlob{DataBlob: persistence.DataBlob{Data: make([]byte, 12345)}}
 	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -136,11 +137,11 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Brand
 	context.EXPECT().PersistStartWorkflowBatchEvents(
 		gomock.Any(),
 		workflowEventsSeq[0],
-	).Return(persistence.DataBlob{Data: make([]byte, workflowHistorySize)}, nil).Times(1)
+	).Return(workflowHistory, nil).Times(1)
 	context.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
 		workflowSnapshot,
-		workflowHistorySize,
+		workflowHistory,
 		persistence.CreateWorkflowModeBrandNew,
 		"",
 		int64(0),
@@ -189,7 +190,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 			},
 		},
 	}
-	targetWorkflowHistorySize := int64(12345)
+	targetWorkflowHistory := events.PersistedBlob{DataBlob: persistence.DataBlob{Data: make([]byte, 12345)}}
 	targetMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -214,11 +215,11 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 	targetContext.EXPECT().PersistNonStartWorkflowBatchEvents(
 		gomock.Any(),
 		targetWorkflowEventsSeq[0],
-	).Return(persistence.DataBlob{Data: make([]byte, targetWorkflowHistorySize)}, nil).Times(1)
+	).Return(targetWorkflowHistory, nil).Times(1)
 	targetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
 		targetWorkflowSnapshot,
-		targetWorkflowHistorySize,
+		targetWorkflowHistory,
 		persistence.CreateWorkflowModeWorkflowIDReuse,
 		currentRunID,
 		currentLastWriteVersion,
@@ -270,7 +271,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 			},
 		},
 	}
-	targetWorkflowHistorySize := int64(12345)
+	targetWorkflowHistory := events.PersistedBlob{DataBlob: persistence.DataBlob{Data: make([]byte, 12345)}}
 	targetMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -289,11 +290,11 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 	targetContext.EXPECT().PersistStartWorkflowBatchEvents(
 		gomock.Any(),
 		targetWorkflowEventsSeq[0],
-	).Return(persistence.DataBlob{Data: make([]byte, targetWorkflowHistorySize)}, nil).Times(1)
+	).Return(targetWorkflowHistory, nil).Times(1)
 	targetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
 		targetWorkflowSnapshot,
-		targetWorkflowHistorySize,
+		targetWorkflowHistory,
 		persistence.CreateWorkflowModeZombie,
 		"",
 		int64(0),
@@ -346,7 +347,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 			},
 		},
 	}
-	targetWorkflowHistorySize := int64(12345)
+	targetWorkflowHistory := events.PersistedBlob{DataBlob: persistence.DataBlob{Data: make([]byte, 12345)}}
 	targetMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   domainID,
 		WorkflowID: workflowID,
@@ -365,11 +366,11 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 	targetContext.EXPECT().PersistNonStartWorkflowBatchEvents(
 		gomock.Any(),
 		targetWorkflowEventsSeq[0],
-	).Return(persistence.DataBlob{Data: make([]byte, targetWorkflowHistorySize)}, nil).Times(1)
+	).Return(targetWorkflowHistory, nil).Times(1)
 	targetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
 		targetWorkflowSnapshot,
-		targetWorkflowHistorySize,
+		targetWorkflowHistory,
 		persistence.CreateWorkflowModeZombie,
 		"",
 		int64(0),

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/constants"
+	"github.com/uber/cadence/service/history/events"
 	"github.com/uber/cadence/service/history/execution"
 	"github.com/uber/cadence/service/history/reset"
 	"github.com/uber/cadence/service/history/shard"
@@ -159,7 +160,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Op
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetDomainEntry().Return(s.domainEntry).AnyTimes()
 	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{RunID: runID}).Times(1)
-	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(persistence.DataBlob{}, nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyActive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -233,7 +234,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Cl
 		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil).Once()
 
-	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(persistence.DataBlob{}, nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -266,7 +267,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_O
 	mutableState.EXPECT().IsWorkflowExecutionRunning().Return(true).AnyTimes()
 	mutableState.EXPECT().GetDomainEntry().Return(s.domainEntry).AnyTimes()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(persistence.DataBlob{}, nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -313,7 +314,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_C
 		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: runID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(persistence.DataBlob{}, nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -367,7 +368,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active
 		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(persistence.DataBlob{}, nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)
@@ -419,7 +420,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passiv
 		DomainName: domainName,
 	}).Return(&persistence.GetCurrentExecutionResponse{RunID: currentRunID}, nil).Once()
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
-	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(persistence.DataBlob{}, nil).Times(1)
+	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
 		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
 	).Return(nil).Times(1)

--- a/service/history/replication/task_hydrator.go
+++ b/service/history/replication/task_hydrator.go
@@ -63,7 +63,7 @@ type (
 // NewImmediateTaskHydrator will enrich replication tasks with additional information that is immediately available.
 func NewImmediateTaskHydrator(isRunning bool, vh *persistence.VersionHistories, activities map[int64]*persistence.ActivityInfo, blob, nextBlob *persistence.DataBlob) TaskHydrator {
 	return TaskHydrator{
-		history:    immediateHistoryProvider{blob, nextBlob},
+		history:    immediateHistoryProvider{blob: blob, nextBlob: nextBlob},
 		msProvider: immediateMutableStateProvider{immediateMutableState{isRunning, activities, vh}},
 	}
 }
@@ -289,14 +289,14 @@ type immediateHistoryProvider struct {
 	nextBlob *persistence.DataBlob
 }
 
-func (h immediateHistoryProvider) GetEventBlob(ctx context.Context, task persistence.ReplicationTaskInfo) (*types.DataBlob, error) {
+func (h immediateHistoryProvider) GetEventBlob(_ context.Context, _ persistence.ReplicationTaskInfo) (*types.DataBlob, error) {
 	if h.blob == nil {
 		return nil, errors.New("history blob not set")
 	}
 	return h.blob.ToInternal(), nil
 }
 
-func (h immediateHistoryProvider) GetNextRunEventBlob(ctx context.Context, task persistence.ReplicationTaskInfo) (*types.DataBlob, error) {
+func (h immediateHistoryProvider) GetNextRunEventBlob(_ context.Context, _ persistence.ReplicationTaskInfo) (*types.DataBlob, error) {
 	if h.nextBlob == nil {
 		return nil, nil // Expected and common
 	}
@@ -307,7 +307,7 @@ type immediateMutableStateProvider struct {
 	ms immediateMutableState
 }
 
-func (r immediateMutableStateProvider) GetMutableState(ctx context.Context, domainID, workflowID, runID string) (mutableState, execution.ReleaseFunc, error) {
+func (r immediateMutableStateProvider) GetMutableState(_ context.Context, _, _, _ string) (mutableState, execution.ReleaseFunc, error) {
 	return r.ms, execution.NoopReleaseFn, nil
 }
 

--- a/service/history/replication/task_hydrator.go
+++ b/service/history/replication/task_hydrator.go
@@ -61,10 +61,10 @@ type (
 )
 
 // NewImmediateTaskHydrator will enrich replication tasks with additional information that is immediately available.
-func NewImmediateTaskHydrator(vh *persistence.VersionHistories, activities map[int64]*persistence.ActivityInfo, blob, nextBlob *persistence.DataBlob) TaskHydrator {
+func NewImmediateTaskHydrator(isRunning bool, vh *persistence.VersionHistories, activities map[int64]*persistence.ActivityInfo, blob, nextBlob *persistence.DataBlob) TaskHydrator {
 	return TaskHydrator{
 		history:    immediateHistoryProvider{blob, nextBlob},
-		msProvider: immediateMutableStateProvider{immediateMutableState{activities, vh}},
+		msProvider: immediateMutableStateProvider{immediateMutableState{isRunning, activities, vh}},
 	}
 }
 
@@ -312,13 +312,13 @@ func (r immediateMutableStateProvider) GetMutableState(ctx context.Context, doma
 }
 
 type immediateMutableState struct {
+	isRunning        bool
 	activities       map[int64]*persistence.ActivityInfo
 	versionHistories *persistence.VersionHistories
 }
 
 func (ms immediateMutableState) IsWorkflowExecutionRunning() bool {
-	// Immediate mutable state is always running
-	return true
+	return ms.isRunning
 }
 func (ms immediateMutableState) GetActivityInfo(id int64) (*persistence.ActivityInfo, bool) {
 	info, ok := ms.activities[id]

--- a/service/history/replication/task_hydrator.go
+++ b/service/history/replication/task_hydrator.go
@@ -317,7 +317,7 @@ type immediateMutableState struct {
 }
 
 func (ms immediateMutableState) IsWorkflowExecutionRunning() bool {
-	// Online mutable state is always running
+	// Immediate mutable state is always running
 	return true
 }
 func (ms immediateMutableState) GetActivityInfo(id int64) (*persistence.ActivityInfo, bool) {

--- a/service/history/replication/task_hydrator_test.go
+++ b/service/history/replication/task_hydrator_test.go
@@ -758,7 +758,7 @@ func TestImmediateTaskHydrator(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			h := NewImmediateTaskHydrator(tt.versionHistories, tt.activities, tt.blob, tt.nextRunBlob)
+			h := NewImmediateTaskHydrator(true, tt.versionHistories, tt.activities, tt.blob, tt.nextRunBlob)
 			result, err := h.Hydrate(context.Background(), tt.task)
 
 			if tt.expectErr != "" {

--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -283,7 +283,6 @@ func (r *workflowResetterImpl) persistToDB(
 		return err
 	}
 
-	resetHistorySize := int64(0)
 	if len(resetWorkflowEventsSeq) != 1 {
 		return &types.InternalServiceError{
 			Message: "there should be EXACTLY one batch of events for reset",
@@ -291,16 +290,15 @@ func (r *workflowResetterImpl) persistToDB(
 	}
 
 	// reset workflow with decision task failed or timed out
-	blob, err := resetWorkflow.GetContext().PersistNonStartWorkflowBatchEvents(ctx, resetWorkflowEventsSeq[0])
+	resetWorkflowHistory, err := resetWorkflow.GetContext().PersistNonStartWorkflowBatchEvents(ctx, resetWorkflowEventsSeq[0])
 	if err != nil {
 		return err
 	}
-	resetHistorySize = int64(len(blob.Data))
 
 	return resetWorkflow.GetContext().CreateWorkflowExecution(
 		ctx,
 		resetWorkflowSnapshot,
-		resetHistorySize,
+		resetWorkflowHistory,
 		persistence.CreateWorkflowModeContinueAsNew,
 		currentRunID,
 		currentLastWriteVersion,

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/history/config"
 	"github.com/uber/cadence/service/history/constants"
+	"github.com/uber/cadence/service/history/events"
 	"github.com/uber/cadence/service/history/execution"
 	"github.com/uber/cadence/service/history/shard"
 )
@@ -188,16 +189,16 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 			ID: 123,
 		}},
 	}}
-	resetEventsSize := int64(4321)
+	resetEvents := events.PersistedBlob{DataBlob: persistence.DataBlob{Data: make([]byte, 4321)}}
 	resetMutableState.EXPECT().CloseTransactionAsSnapshot(
 		gomock.Any(),
 		execution.TransactionPolicyActive,
 	).Return(resetSnapshot, resetEventsSeq, nil).Times(1)
-	resetContext.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), resetEventsSeq[0]).Return(persistence.DataBlob{Data: make([]byte, resetEventsSize)}, nil).Times(1)
+	resetContext.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), resetEventsSeq[0]).Return(resetEvents, nil).Times(1)
 	resetContext.EXPECT().CreateWorkflowExecution(
 		gomock.Any(),
 		resetSnapshot,
-		resetEventsSize,
+		resetEvents,
 		persistence.CreateWorkflowModeContinueAsNew,
 		s.currentRunID,
 		currentLastWriteVersion,

--- a/service/history/task/cross_cluster_source_task_executor_test.go
+++ b/service/history/task/cross_cluster_source_task_executor_test.go
@@ -93,6 +93,7 @@ func (s *crossClusterSourceTaskExecutorSuite) SetupTest() {
 	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewReplicationTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 
 	s.mockDomainCache = s.mockShard.Resource.DomainCache

--- a/service/history/task/timer_active_task_executor_test.go
+++ b/service/history/task/timer_active_task_executor_test.go
@@ -122,6 +122,7 @@ func (s *timerActiveTaskExecutorSuite) SetupTest() {
 	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewReplicationTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 
 	s.mockDomainCache = s.mockShard.Resource.DomainCache

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -124,6 +124,7 @@ func (s *timerStandbyTaskExecutorSuite) SetupTest() {
 	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewReplicationTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 	s.mockNDCHistoryResender = ndc.NewMockHistoryResender(s.controller)
 

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -157,6 +157,7 @@ func (s *transferActiveTaskExecutorSuite) SetupTest() {
 	s.mockEngine.EXPECT().NotifyNewTransferTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewTimerTasks(gomock.Any()).AnyTimes()
 	s.mockEngine.EXPECT().NotifyNewCrossClusterTasks(gomock.Any()).AnyTimes()
+	s.mockEngine.EXPECT().NotifyNewReplicationTasks(gomock.Any()).AnyTimes()
 	s.mockShard.SetEngine(s.mockEngine)
 
 	s.mockParentClosePolicyClient = &parentclosepolicy.ClientMock{}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Added `NewImmediateTaskHydrator` with corresponding inner bits for providing readily available data for replication message hydration.
- After successful transactions notify replication tasks with related data to immediately hydrate them and put them into cache.

<!-- Tell your future self why have you made these changes -->
**Why?**
After successful transaction we already have all necessary bits available for replication message hydration. We can take advantage of that - preemptively prepare replication messages and put them into cache, which will later save additional database calls (`readhistorybranch` and `getworkflowexecution`).

This should reduce overall load on database and also reduce replication latency.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests.
- Staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
