### PR TITLE
Reduce metrics cardinality replication.TaskStore

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2641,7 +2641,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		UnbufferReplicationTaskTimer:                        {metricName: "unbuffer_replication_tasks", metricType: Timer},
 		HistoryConflictsCounter:                             {metricName: "history_conflicts", metricType: Counter},
 		CompleteTaskFailedCounter:                           {metricName: "complete_task_fail_count", metricType: Counter},
-		CacheSize:                                           {metricName: "cache_size", metricType: Gauge},
+		CacheSize:                                           {metricName: "cache_size", metricType: Timer},
 		CacheRequests:                                       {metricName: "cache_requests", metricType: Counter},
 		CacheFailures:                                       {metricName: "cache_errors", metricType: Counter},
 		CacheLatency:                                        {metricName: "cache_latency", metricType: Timer},

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -161,7 +161,6 @@ func NewEngineWithShardContext(
 	failoverMarkerNotifier := failover.NewMarkerNotifier(shard, config, failoverCoordinator)
 	replicationHydrator := replication.NewDeferredTaskHydrator(shard.GetShardID(), historyV2Manager, executionCache, shard.GetDomainCache())
 	replicationTaskStore := replication.NewTaskStore(
-		shard.GetShardID(),
 		shard.GetConfig(),
 		shard.GetClusterMetadata(),
 		shard.GetDomainCache(),

--- a/service/history/replication/task_store_test.go
+++ b/service/history/replication/task_store_test.go
@@ -155,7 +155,7 @@ func createTestTaskStore(domains domainCache, hydrator taskHydrator) *TaskStore 
 		testClusterC: {Enabled: true},
 	})
 
-	return NewTaskStore(1, &cfg, clusterMetadata, domains, metrics.NewNoopMetricsClient(), log.NewNoop(), hydrator)
+	return NewTaskStore(&cfg, clusterMetadata, domains, metrics.NewNoopMetricsClient(), log.NewNoop(), hydrator)
 }
 
 type fakeDomainCache map[string]*cache.DomainCacheEntry


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Emit replication cache size as timer, to get a percentile view instead of metric per each shard.

<!-- Tell your future self why have you made these changes -->
**Why?**
Turns out, having metric per shard is very expensive. Dashboard become too sluggish to work with.
Keep higher level metrics only and log warning when cache is full, for debugging specific shards.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
