### PR TITLE
Return early when there are no replication tasks

### DIFF
--- a/service/history/replication/task_reader.go
+++ b/service/history/replication/task_reader.go
@@ -64,6 +64,12 @@ func NewDynamicTaskReader(
 // If replication lag is less than config.ReplicatorUpperLatency it will be proportionally smaller.
 // Otherwise default batch size of config.ReplicatorProcessorFetchTasksBatchSize will be used.
 func (r *DynamicTaskReader) Read(ctx context.Context, readLevel int64, maxReadLevel int64) ([]*persistence.ReplicationTaskInfo, bool, error) {
+	// Check if it is even possible to return any results.
+	// If not return early with empty response. Do not hit persistence.
+	if readLevel >= maxReadLevel {
+		return nil, false, nil
+	}
+
 	request := persistence.GetReplicationTasksRequest{
 		ReadLevel:    readLevel,
 		MaxReadLevel: maxReadLevel,

--- a/service/history/replication/task_reader_test.go
+++ b/service/history/replication/task_reader_test.go
@@ -119,7 +119,9 @@ func TestDynamicTaskReader(t *testing.T) {
 			expectResponse: testReplicationTasks,
 		},
 		{
-			name: "ensure last creation time is updated",
+			name:         "ensure last creation time is updated",
+			readLevel:    50,
+			maxReadLevel: 100,
 			prepareExecutions: func(m *persistence.MockExecutionManager) {
 				m.EXPECT().GetReplicationTasks(gomock.Any(), gomock.Any()).Return(&persistence.GetReplicationTasksResponse{Tasks: testReplicationTasks}, nil)
 			},
@@ -127,11 +129,22 @@ func TestDynamicTaskReader(t *testing.T) {
 			expectCreateTime: testTime.Add(-1 * time.Second),
 		},
 		{
-			name: "failed to read replication tasks - return error",
+			name:         "failed to read replication tasks - return error",
+			readLevel:    50,
+			maxReadLevel: 100,
 			prepareExecutions: func(m *persistence.MockExecutionManager) {
 				m.EXPECT().GetReplicationTasks(gomock.Any(), gomock.Any()).Return(nil, errors.New("failed to read replication tasks"))
 			},
 			expectErr: "failed to read replication tasks",
+		},
+		{
+			name:         "do not hit persistence when no task will be returned",
+			readLevel:    50,
+			maxReadLevel: 50,
+			prepareExecutions: func(m *persistence.MockExecutionManager) {
+				m.EXPECT().GetReplicationTasks(gomock.Any(), gomock.Any()).Times(0)
+			},
+			expectResponse: nil,
 		},
 	}
 

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1240,16 +1240,19 @@ func (s *contextImpl) allocateTaskIDsLocked(
 	); err != nil {
 		return err
 	}
-	if err := s.allocateTransferIDsLocked(
-		replicationTasks,
-		transferMaxReadLevel,
-	); err != nil {
-		return err
-	}
-	return s.allocateTimerIDsLocked(
+	if err := s.allocateTimerIDsLocked(
 		domainEntry,
 		workflowID,
 		timerTasks,
+	); err != nil {
+		return err
+	}
+
+	// Ensure that task IDs for replication tasks are generated last.
+	// This allows optimizing replication by checking whether there no potential tasks to read.
+	return s.allocateTransferIDsLocked(
+		replicationTasks,
+		transferMaxReadLevel,
 	)
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Return early when reading replication tasks if it is clear that no task will be returned. Return empty response immediately.
- When generating task IDs, ensure that replication tasks will get generated last. This will mean that we can later quickly compare the last shard task ID (with `GetTransferMaxReadLevel`) with `lastReadTaskID` coming from remote cluster to decide if there are any potential replication tasks to fetch.

<!-- Tell your future self why have you made these changes -->
**Why?**
`GetReplicationTasks` is one of the most intensive DB operations. It is called periodically when remote clusters fetch replication messages (for each shard). It is entirely possible that a shard did not encounter any activity since last call. We can check that and skip DB call.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit test
- Tested on staging2. It significantly reduces db calls. Although traffic is low on there. On production it may not be that significant.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
