### PR TITLE
Allow docker compose to work with docker-compose-mysql.yml on M1

### DIFF
--- a/docker/docker-compose-mysql.yml
+++ b/docker/docker-compose-mysql.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   mysql:
+    platform: linux/amd64
     image: mysql:5.7
     ports:
       - "3306:3306"


### PR DESCRIPTION
Trying to run this failed:

  docker-compose -f docker-compose-mysql.yml up
  Pulling mysql (mysql:5.7)...
  5.7: Pulling from library/mysql
  ERROR: no matching manifest for linux/arm64/v8 in the manifest list entries

Solution found here:
https://stackoverflow.com/questions/65456814/docker-apple-silicon-m1-preview-mysql-no-matching-manifest-for-linux-arm64-v8
