### PR TITLE
Update Cassandra deletes to use ALL consistency level

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/constants.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/constants.go
@@ -38,11 +38,20 @@ const (
 	// See https://github.com/uber/cadence/issues/4200
 	maxCassandraTTL = int64(157680000)
 
+	// We use local serial consistency level as the default consistency level for conditional updates
+	cassandraDefaultSerialConsLevel = gocql.LocalSerial
+
+	// We use local quorum consistency level as the default consistency level
+	cassandraDefaultConsLevel = gocql.LocalQuorum
+
 	// Although Cadence core data models always require strong consistency, reading visibility is a special case that
 	// eventual consistency is sufficient.
 	// That's because the engine layer writes into visibility with eventual consistency anyway(using transfer tasks)
 	// Do NOT use it in other places, unless you are sure it's the same special cases like reading visibility
 	cassandraLowConslevel = gocql.One
+
+	// We use all consistency level for delete operations to prevent the data resurrection issue
+	cassandraAllConslevel = gocql.All
 )
 
 const (

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain.go
@@ -568,10 +568,10 @@ func (db *cdb) deleteDomain(
 	name, ID string,
 ) error {
 	query := db.session.Query(templateDeleteDomainByNameQueryV2, constDomainPartition, name).WithContext(ctx)
-	if err := query.Exec(); err != nil {
+	if err := db.executeWithConsistencyAll(query); err != nil {
 		return err
 	}
 
 	query = db.session.Query(templateDeleteDomainQuery, ID).WithContext(ctx)
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/events.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/events.go
@@ -130,7 +130,7 @@ func (db *cdb) DeleteFromHistoryTreeAndNode(ctx context.Context, treeFilter *nos
 			nodeFilter.BranchID,
 			nodeFilter.MinNodeID)
 	}
-	return db.session.ExecuteBatch(batch)
+	return db.executeBatchWithConsistencyAll(batch)
 }
 
 // SelectAllHistoryTrees will return all tree branches with pagination

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/batch.go
@@ -63,6 +63,11 @@ func (b *batch) WithTimestamp(timestamp int64) Batch {
 	return b
 }
 
+func (b *batch) Consistency(c Consistency) Batch {
+	b.Batch.SetConsistency(mustConvertConsistency(c))
+	return b
+}
+
 func mustConvertBatchType(batchType BatchType) gocql.BatchType {
 	switch batchType {
 	case LoggedBatch:

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface.go
@@ -41,6 +41,7 @@ type (
 		CreateSession(ClusterConfig) (Session, error)
 
 		nosqlplugin.ClientErrorChecker
+		IsCassandraConsistencyError(error) bool
 	}
 
 	// Session is the interface for interacting with the database.
@@ -73,6 +74,7 @@ type (
 		Query(string, ...interface{})
 		WithContext(context.Context) Batch
 		WithTimestamp(int64) Batch
+		Consistency(Consistency) Batch
 	}
 
 	// Iter is the interface for executing and iterating over all resulting rows.

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface_mock.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/interface_mock.go
@@ -71,6 +71,20 @@ func (mr *MockClientMockRecorder) CreateSession(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSession", reflect.TypeOf((*MockClient)(nil).CreateSession), arg0)
 }
 
+// IsCassandraConsistencyError mocks base method.
+func (m *MockClient) IsCassandraConsistencyError(arg0 error) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsCassandraConsistencyError", arg0)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// IsCassandraConsistencyError indicates an expected call of IsCassandraConsistencyError.
+func (mr *MockClientMockRecorder) IsCassandraConsistencyError(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsCassandraConsistencyError", reflect.TypeOf((*MockClient)(nil).IsCassandraConsistencyError), arg0)
+}
+
 // IsDBUnavailableError mocks base method.
 func (m *MockClient) IsDBUnavailableError(arg0 error) bool {
 	m.ctrl.T.Helper()
@@ -451,6 +465,20 @@ func NewMockBatch(ctrl *gomock.Controller) *MockBatch {
 // EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockBatch) EXPECT() *MockBatchMockRecorder {
 	return m.recorder
+}
+
+// Consistency mocks base method.
+func (m *MockBatch) Consistency(arg0 Consistency) Batch {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Consistency", arg0)
+	ret0, _ := ret[0].(Batch)
+	return ret0
+}
+
+// Consistency indicates an expected call of Consistency.
+func (mr *MockBatchMockRecorder) Consistency(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Consistency", reflect.TypeOf((*MockBatch)(nil).Consistency), arg0)
 }
 
 // Query mocks base method.

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/public/client.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/public/client.go
@@ -84,3 +84,11 @@ func (c client) IsDBUnavailableError(err error) bool {
 	}
 	return false
 }
+
+func (c client) IsCassandraConsistencyError(err error) bool {
+	if req, ok := err.(gogocql.RequestError); ok {
+		// 0x1000 == UNAVAILABLE
+		return req.Code() == 0x1000
+	}
+	return false
+}

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
@@ -95,8 +95,8 @@ func toGoCqlConfig(cfg *config.NoSQL) gocql.ClusterConfig {
 		MaxConns:              cfg.MaxConns,
 		TLS:                   cfg.TLS,
 		ProtoVersion:          cfg.ProtoVersion,
-		Consistency:           gocql.LocalQuorum,
-		SerialConsistency:     gocql.LocalSerial,
+		Consistency:           cassandraDefaultConsLevel,
+		SerialConsistency:     cassandraDefaultSerialConsLevel,
 		Timeout:               defaultSessionTimeout,
 		ConnectTimeout:        defaultConnectTimeout,
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/queue.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/queue.go
@@ -156,7 +156,7 @@ func (db *cdb) DeleteMessagesBefore(
 	exclusiveBeginMessageID int64,
 ) error {
 	query := db.session.Query(templateRangeDeleteMessagesBeforeQuery, queueType, exclusiveBeginMessageID).WithContext(ctx)
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 // Delete all messages in a range between exclusiveBeginMessageID and inclusiveEndMessageID
@@ -167,7 +167,7 @@ func (db *cdb) DeleteMessagesInRange(
 	inclusiveEndMessageID int64,
 ) error {
 	query := db.session.Query(templateRangeDeleteMessagesBetweenQuery, queueType, exclusiveBeginMessageID, inclusiveEndMessageID).WithContext(ctx)
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 // Delete one message
@@ -177,7 +177,7 @@ func (db *cdb) DeleteMessage(
 	messageID int64,
 ) error {
 	query := db.session.Query(templateDeleteMessageQuery, queueType, messageID).WithContext(ctx)
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 // Insert an empty metadata row, starting from a version

--- a/common/persistence/nosql/nosqlplugin/cassandra/visibility.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/visibility.go
@@ -391,7 +391,7 @@ func (db *cdb) DeleteVisibility(ctx context.Context, domainID, workflowID, runID
 			record.StartTime,
 			runID,
 		).WithContext(ctx)
-		return query.Exec()
+		return db.executeWithConsistencyAll(query)
 	}
 	return nil
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow.go
@@ -299,7 +299,7 @@ func (db *cdb) DeleteCurrentWorkflow(ctx context.Context, shardID int, domainID,
 		currentRunIDCondition,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) DeleteWorkflowExecution(ctx context.Context, shardID int, domainID, workflowID, runID string) error {
@@ -313,7 +313,7 @@ func (db *cdb) DeleteWorkflowExecution(ctx context.Context, shardID int, domainI
 		rowTypeExecutionTaskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) SelectAllCurrentWorkflows(ctx context.Context, shardID int, pageToken []byte, pageSize int) ([]*p.CurrentWorkflowExecution, []byte, error) {
@@ -456,7 +456,7 @@ func (db *cdb) DeleteTransferTask(ctx context.Context, shardID int, taskID int64
 		taskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) RangeDeleteTransferTasks(ctx context.Context, shardID int, exclusiveBeginTaskID, inclusiveEndTaskID int64) error {
@@ -471,7 +471,7 @@ func (db *cdb) RangeDeleteTransferTasks(ctx context.Context, shardID int, exclus
 		inclusiveEndTaskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) SelectTimerTasksOrderByVisibilityTime(ctx context.Context, shardID, pageSize int, pageToken []byte, inclusiveMinTime, exclusiveMaxTime time.Time) ([]*nosqlplugin.TimerTask, []byte, error) {
@@ -522,7 +522,7 @@ func (db *cdb) DeleteTimerTask(ctx context.Context, shardID int, taskID int64, v
 		taskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) RangeDeleteTimerTasks(ctx context.Context, shardID int, inclusiveMinTime, exclusiveMaxTime time.Time) error {
@@ -538,7 +538,7 @@ func (db *cdb) RangeDeleteTimerTasks(ctx context.Context, shardID int, inclusive
 		end,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) SelectReplicationTasksOrderByTaskID(ctx context.Context, shardID, pageSize int, pageToken []byte, exclusiveMinTaskID, inclusiveMaxTaskID int64) ([]*nosqlplugin.ReplicationTask, []byte, error) {
@@ -567,7 +567,7 @@ func (db *cdb) DeleteReplicationTask(ctx context.Context, shardID int, taskID in
 		taskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) RangeDeleteReplicationTasks(ctx context.Context, shardID int, inclusiveEndTaskID int64) error {
@@ -581,7 +581,7 @@ func (db *cdb) RangeDeleteReplicationTasks(ctx context.Context, shardID int, inc
 		inclusiveEndTaskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) SelectCrossClusterTasksOrderByTaskID(ctx context.Context, shardID, pageSize int, pageToken []byte, targetCluster string, exclusiveMinTaskID, inclusiveMaxTaskID int64) ([]*nosqlplugin.CrossClusterTask, []byte, error) {
@@ -632,7 +632,7 @@ func (db *cdb) DeleteCrossClusterTask(ctx context.Context, shardID int, targetCl
 		taskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) RangeDeleteCrossClusterTasks(ctx context.Context, shardID int, targetCluster string, exclusiveBeginTaskID, inclusiveEndTaskID int64) error {
@@ -725,7 +725,7 @@ func (db *cdb) DeleteReplicationDLQTask(ctx context.Context, shardID int, source
 		taskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) RangeDeleteReplicationDLQTasks(ctx context.Context, shardID int, sourceCluster string, exclusiveBeginTaskID, inclusiveEndTaskID int64) error {
@@ -740,7 +740,7 @@ func (db *cdb) RangeDeleteReplicationDLQTasks(ctx context.Context, shardID int, 
 		inclusiveEndTaskID,
 	).WithContext(ctx)
 
-	return query.Exec()
+	return db.executeWithConsistencyAll(query)
 }
 
 func (db *cdb) InsertReplicationTask(ctx context.Context, tasks []*nosqlplugin.ReplicationTask, shardCondition nosqlplugin.ShardCondition) error {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update Cassandra deletes to use ALL consistency level

<!-- Tell your future self why have you made these changes -->
**Why?**
- Use ALL consistency level for deletes to prevent data resurrection issue

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test 
staging2 test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If deletes fail with ALL consistency level, we fallback to LOCAL_QUORUM consistency level. There should be no risk


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
