### PR TITLE
Add domain_type and cluster_groups tags

### DIFF
--- a/common/cache/domainCache.go
+++ b/common/cache/domainCache.go
@@ -464,6 +464,7 @@ UpdateLoop:
 
 		c.scope.Tagged(
 			metrics.DomainTag(nextEntry.info.Name),
+			metrics.DomainTypeTag(nextEntry.isGlobalDomain),
 			metrics.ActiveClusterTag(nextEntry.replicationConfig.ActiveClusterName),
 		).UpdateGauge(metrics.ActiveClusterGauge, 1)
 

--- a/common/cache/domainCache_test.go
+++ b/common/cache/domainCache_test.go
@@ -75,7 +75,7 @@ func (s *domainCacheSuite) SetupTest() {
 	s.logger = loggerimpl.NewLoggerForTest(s.Suite)
 	s.metadataMgr = &mocks.MetadataManager{}
 	metricsClient := metrics.NewClient(tally.NoopScope, metrics.History)
-	s.domainCache = NewDomainCache(s.metadataMgr, metricsClient, s.logger).(*domainCache)
+	s.domainCache = NewDomainCache(s.metadataMgr, cluster.GetTestClusterMetadata(true), metricsClient, s.logger).(*domainCache)
 
 	s.now = time.Now()
 	s.domainCache.timeSource = clock.NewEventTimeSource().Update(s.now)

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -34,6 +34,7 @@ const (
 	instance               = "instance"
 	domain                 = "domain"
 	domainType             = "domain_type"
+	clusterGroup           = "cluster_group"
 	sourceCluster          = "source_cluster"
 	targetCluster          = "target_cluster"
 	activeCluster          = "active_cluster"
@@ -99,6 +100,11 @@ func DomainTypeTag(isGlobal bool) Tag {
 // DomainUnknownTag returns a new domain:unknown tag-value
 func DomainUnknownTag() Tag {
 	return DomainTag("")
+}
+
+// ClusterGroupTag return a new cluster group tag
+func ClusterGroupTag(value string) Tag {
+	return simpleMetric{key: clusterGroup, value: value}
 }
 
 // InstanceTag returns a new instance tag

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -33,6 +33,7 @@ const (
 
 	instance               = "instance"
 	domain                 = "domain"
+	domainType             = "domain_type"
 	sourceCluster          = "source_cluster"
 	targetCluster          = "target_cluster"
 	activeCluster          = "active_cluster"
@@ -81,6 +82,18 @@ func metricWithUnknown(key, value string) Tag {
 // this converts that to an unknown domain.
 func DomainTag(value string) Tag {
 	return metricWithUnknown(domain, value)
+}
+
+// DomainTypeTag returns a tag for domain type.
+// This allows differentiating between global/local domains.
+func DomainTypeTag(isGlobal bool) Tag {
+	var value string
+	if isGlobal {
+		value = "global"
+	} else {
+		value = "local"
+	}
+	return simpleMetric{key: domainType, value: value}
 }
 
 // DomainUnknownTag returns a new domain:unknown tag-value

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -183,6 +183,7 @@ func New(
 
 	domainCache := cache.NewDomainCache(
 		persistenceBean.GetDomainManager(),
+		params.ClusterMetadata,
 		params.MetricsClient,
 		logger,
 	)

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -605,7 +605,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	var replicatorDomainCache cache.DomainCache
 	if c.workerConfig.EnableReplicator {
 		metadataManager := persistence.NewDomainPersistenceMetricsClient(c.domainManager, service.GetMetricsClient(), c.logger, &c.persistenceConfig)
-		replicatorDomainCache = cache.NewDomainCache(metadataManager, service.GetMetricsClient(), service.GetLogger())
+		replicatorDomainCache = cache.NewDomainCache(metadataManager, c.clusterMetadata, service.GetMetricsClient(), service.GetLogger())
 		replicatorDomainCache.Start()
 		c.startWorkerReplicator(service)
 	}
@@ -613,7 +613,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	var clientWorkerDomainCache cache.DomainCache
 	if c.workerConfig.EnableArchiver {
 		metadataProxyManager := persistence.NewDomainPersistenceMetricsClient(c.domainManager, service.GetMetricsClient(), c.logger, &c.persistenceConfig)
-		clientWorkerDomainCache = cache.NewDomainCache(metadataProxyManager, service.GetMetricsClient(), service.GetLogger())
+		clientWorkerDomainCache = cache.NewDomainCache(metadataProxyManager, c.clusterMetadata, service.GetMetricsClient(), service.GetLogger())
 		clientWorkerDomainCache.Start()
 		c.startWorkerClientWorker(params, service, clientWorkerDomainCache)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Added `domain_type` tag to emit whether domain is `global` or `local` when emitting `active_cluster` gauge.
- Added `cluster_group` tag to indicate which cluster group this is. It is a sorted and concatenated string of enabled clusters in the group.

<!-- Tell your future self why have you made these changes -->
**Why?**
With this addition it will be possible to detect whether global domain is active in several clusters and alert on that.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
