### PR TITLE
Convert client peer resolving errors to service transient errors

### DIFF
--- a/client/history/peerResolver.go
+++ b/client/history/peerResolver.go
@@ -67,9 +67,10 @@ func (pr PeerResolver) FromShardID(shardID int) (string, error) {
 	shardIDString := string(rune(shardID))
 	host, err := pr.resolver.Lookup(service.History, shardIDString)
 	if err != nil {
-		return "", err
+		return "", common.ToServiceTransientError(err)
 	}
-	return host.GetNamedAddress(pr.namedPort)
+	peer, err := host.GetNamedAddress(pr.namedPort)
+	return peer, common.ToServiceTransientError(err)
 }
 
 // FromHostAddress resolves the final history peer responsible for the given host address.
@@ -77,22 +78,23 @@ func (pr PeerResolver) FromShardID(shardID int) (string, error) {
 func (pr PeerResolver) FromHostAddress(hostAddress string) (string, error) {
 	host, err := pr.resolver.LookupByAddress(service.History, hostAddress)
 	if err != nil {
-		return "", err
+		return "", common.ToServiceTransientError(err)
 	}
-	return host.GetNamedAddress(pr.namedPort)
+	peer, err := host.GetNamedAddress(pr.namedPort)
+	return peer, common.ToServiceTransientError(err)
 }
 
 // GetAllPeers returns all history service peers in the cluster ring.
 func (pr PeerResolver) GetAllPeers() ([]string, error) {
 	hosts, err := pr.resolver.Members(service.History)
 	if err != nil {
-		return nil, err
+		return nil, common.ToServiceTransientError(err)
 	}
 	peers := make([]string, 0, len(hosts))
 	for _, host := range hosts {
 		peer, err := host.GetNamedAddress(pr.namedPort)
 		if err != nil {
-			return nil, err
+			return nil, common.ToServiceTransientError(err)
 		}
 		peers = append(peers, peer)
 	}

--- a/common/util.go
+++ b/common/util.go
@@ -263,6 +263,14 @@ func CheckDecisionResultLimit(
 	return nil
 }
 
+// ToServiceTransientError converts an error to ServiceTransientError
+func ToServiceTransientError(err error) error {
+	if err == nil || IsServiceTransientError(err) {
+		return err
+	}
+	return yarpcerrors.Newf(yarpcerrors.CodeUnavailable, err.Error())
+}
+
 // IsServiceTransientError checks if the error is a transient error.
 func IsServiceTransientError(err error) bool {
 	switch err.(type) {

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/yarpcerrors"
 
@@ -340,4 +341,21 @@ func TestConvertErrToGetTaskFailedCause(t *testing.T) {
 	for _, tc := range testCases {
 		require.Equal(t, tc.expectedFailedCause, ConvertErrToGetTaskFailedCause(tc.err))
 	}
+}
+
+func TestToServiceTransientError(t *testing.T) {
+	t.Run("it converts nil", func(t *testing.T) {
+		assert.NoError(t, ToServiceTransientError(nil))
+	})
+
+	t.Run("it keeps transient errors", func(t *testing.T) {
+		err := &types.InternalServiceError{}
+		assert.Equal(t, err, ToServiceTransientError(err))
+		assert.True(t, IsServiceTransientError(ToServiceTransientError(err)))
+	})
+
+	t.Run("it converts errors to transient errors", func(t *testing.T) {
+		err := fmt.Errorf("error")
+		assert.True(t, IsServiceTransientError(ToServiceTransientError(err)))
+	})
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Convert client peer resolving errors to service transient errors

<!-- Tell your future self why have you made these changes -->
**Why?**
When processing signal and cancellation transfer tasks, we check if some errors are transient errors to determine whether we should retry or record a failure event in workflow history.
Peer resolving errors should be treated as transient errors and during deployment and restart we can see these errors.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If we have a bad config file or network issue which causes peer resolving to always fail, those transfer tasks will be stuck. 
But I think that's the behavior we want.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
