### PR TITLE
Fix history corruption check for workflow signaling

### DIFF
--- a/service/history/events/cache.go
+++ b/service/history/events/cache.go
@@ -77,7 +77,7 @@ type (
 )
 
 var (
-	errEventNotFoundInBatch = &types.InternalServiceError{Message: "History event not found within expected batch"}
+	errEventNotFoundInBatch = &types.EntityNotExistsError{Message: "History event not found within expected batch"}
 )
 
 var _ Cache = (*cacheImpl)(nil)

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -965,6 +965,12 @@ func (e *mutableStateBuilder) GetActivityScheduledEvent(
 		// do not return the original error
 		// since original error can be of type entity not exists
 		// which can cause task processing side to fail silently
+		// However, if the error is a persistence transient error,
+		// we return the original error, because we fail to get
+		// the event because of failure from database
+		if persistence.IsTransientError(err) {
+			return nil, err
+		}
 		return nil, ErrMissingActivityScheduledEvent
 	}
 	return scheduledEvent, nil
@@ -1035,6 +1041,12 @@ func (e *mutableStateBuilder) GetChildExecutionInitiatedEvent(
 		// do not return the original error
 		// since original error can be of type entity not exists
 		// which can cause task processing side to fail silently
+		// However, if the error is a persistence transient error,
+		// we return the original error, because we fail to get
+		// the event because of failure from database
+		if persistence.IsTransientError(err) {
+			return nil, err
+		}
 		return nil, ErrMissingChildWorkflowInitiatedEvent
 	}
 	return initiatedEvent, nil
@@ -1142,6 +1154,12 @@ func (e *mutableStateBuilder) GetCompletionEvent(
 		// do not return the original error
 		// since original error can be of type entity not exists
 		// which can cause task processing side to fail silently
+		// However, if the error is a persistence transient error,
+		// we return the original error, because we fail to get
+		// the event because of failure from database
+		if persistence.IsTransientError(err) {
+			return nil, err
+		}
 		return nil, ErrMissingWorkflowCompletionEvent
 	}
 
@@ -1172,6 +1190,12 @@ func (e *mutableStateBuilder) GetStartEvent(
 		// do not return the original error
 		// since original error can be of type entity not exists
 		// which can cause task processing side to fail silently
+		// However, if the error is a persistence transient error,
+		// we return the original error, because we fail to get
+		// the event because of failure from database
+		if persistence.IsTransientError(err) {
+			return nil, err
+		}
 		return nil, ErrMissingWorkflowStartEvent
 	}
 	return startEvent, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not convert persistence transient errors to history corruption errors
- Fix history corruption check for workflow signaling

<!-- Tell your future self why have you made these changes -->
**Why?**
- When the system is overloaded or there is something wrong with the underlying database, we may receive some transient errors and not able to determine if a workflow is resurrected, but we still treat those workflows as resurrected which is wrong.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
