### PR TITLE
Revert "Fix error conversion for WorkflowExecutionAlreadyStartedError (#4838)"

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2079,7 +2079,7 @@ func (h *handlerImpl) convertError(err error) error {
 
 		return shard.CreateShardOwnershipLostError(h.GetHostInfo(), info)
 	case *persistence.WorkflowExecutionAlreadyStartedError:
-		return &types.WorkflowExecutionAlreadyStartedError{Message: err.Msg}
+		return &types.InternalServiceError{Message: err.Msg}
 	case *persistence.CurrentWorkflowConditionFailedError:
 		return &types.InternalServiceError{Message: err.Msg}
 	case *persistence.TransactionSizeLimitError:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This reverts commit 48a157e1af87e8302b5d8e492480c15d89a9f277.


<!-- Tell your future self why have you made these changes -->
**Why?**
We have some internal retries checking the old error code.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
