### PR TITLE
Use internal IndexedValueType

### DIFF
--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -20,7 +20,7 @@
 
 package definition
 
-import "github.com/uber/cadence/.gen/go/shared"
+import "github.com/uber/cadence/common/types"
 
 // valid indexed fields on ES
 const (
@@ -65,16 +65,16 @@ var defaultIndexedKeys = createDefaultIndexedKeys()
 
 func createDefaultIndexedKeys() map[string]interface{} {
 	defaultIndexedKeys := map[string]interface{}{
-		CustomStringField:    shared.IndexedValueTypeString,
-		CustomKeywordField:   shared.IndexedValueTypeKeyword,
-		CustomIntField:       shared.IndexedValueTypeInt,
-		CustomBoolField:      shared.IndexedValueTypeBool,
-		CustomDoubleField:    shared.IndexedValueTypeDouble,
-		CustomDatetimeField:  shared.IndexedValueTypeDatetime,
-		CadenceChangeVersion: shared.IndexedValueTypeKeyword,
-		BinaryChecksums:      shared.IndexedValueTypeKeyword,
-		CustomDomain:         shared.IndexedValueTypeString,
-		Operator:             shared.IndexedValueTypeString,
+		CustomStringField:    types.IndexedValueTypeString,
+		CustomKeywordField:   types.IndexedValueTypeKeyword,
+		CustomIntField:       types.IndexedValueTypeInt,
+		CustomBoolField:      types.IndexedValueTypeBool,
+		CustomDoubleField:    types.IndexedValueTypeDouble,
+		CustomDatetimeField:  types.IndexedValueTypeDatetime,
+		CadenceChangeVersion: types.IndexedValueTypeKeyword,
+		BinaryChecksums:      types.IndexedValueTypeKeyword,
+		CustomDomain:         types.IndexedValueTypeString,
+		Operator:             types.IndexedValueTypeString,
 	}
 	for k, v := range systemIndexedKeys {
 		defaultIndexedKeys[k] = v
@@ -89,19 +89,19 @@ func GetDefaultIndexedKeys() map[string]interface{} {
 
 // systemIndexedKeys is Cadence created visibility keys
 var systemIndexedKeys = map[string]interface{}{
-	DomainID:      shared.IndexedValueTypeKeyword,
-	WorkflowID:    shared.IndexedValueTypeKeyword,
-	RunID:         shared.IndexedValueTypeKeyword,
-	WorkflowType:  shared.IndexedValueTypeKeyword,
-	StartTime:     shared.IndexedValueTypeInt,
-	ExecutionTime: shared.IndexedValueTypeInt,
-	CloseTime:     shared.IndexedValueTypeInt,
-	CloseStatus:   shared.IndexedValueTypeInt,
-	HistoryLength: shared.IndexedValueTypeInt,
-	TaskList:      shared.IndexedValueTypeKeyword,
-	IsCron:        shared.IndexedValueTypeBool,
-	NumClusters:   shared.IndexedValueTypeInt,
-	UpdateTime:    shared.IndexedValueTypeInt,
+	DomainID:      types.IndexedValueTypeKeyword,
+	WorkflowID:    types.IndexedValueTypeKeyword,
+	RunID:         types.IndexedValueTypeKeyword,
+	WorkflowType:  types.IndexedValueTypeKeyword,
+	StartTime:     types.IndexedValueTypeInt,
+	ExecutionTime: types.IndexedValueTypeInt,
+	CloseTime:     types.IndexedValueTypeInt,
+	CloseStatus:   types.IndexedValueTypeInt,
+	HistoryLength: types.IndexedValueTypeInt,
+	TaskList:      types.IndexedValueTypeKeyword,
+	IsCron:        types.IndexedValueTypeBool,
+	NumClusters:   types.IndexedValueTypeInt,
+	UpdateTime:    types.IndexedValueTypeInt,
 }
 
 // IsSystemIndexedKey return true is key is system added

--- a/common/elasticsearch/validator/searchAttrValidator.go
+++ b/common/elasticsearch/validator/searchAttrValidator.go
@@ -128,7 +128,7 @@ func (sv *SearchAttributesValidator) isValidSearchAttributesValue(
 	key string,
 	value []byte,
 ) bool {
-	valueType := common.ConvertIndexedValueTypeToThriftType(validAttr[key], sv.logger)
+	valueType := common.ConvertIndexedValueTypeToInternalType(validAttr[key], sv.logger)
 	_, err := common.DeserializeSearchAttributeValue(value, valueType)
 	return err == nil
 }

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/yarpcerrors"
 
-	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -272,11 +271,16 @@ func TestCreateHistoryStartWorkflowRequest_ExpirationTimeWithoutCron(t *testing.
 	require.True(t, delta < 62*time.Second)
 }
 
-func TestConvertIndexedValueTypeToThriftType(t *testing.T) {
-	expected := workflow.IndexedValueType_Values()
-	for i := 0; i < len(expected); i++ {
-		require.Equal(t, expected[i], ConvertIndexedValueTypeToThriftType(i, nil))
-		require.Equal(t, expected[i], ConvertIndexedValueTypeToThriftType(float64(i), nil))
+func TestConvertIndexedValueTypeToInternalType(t *testing.T) {
+	values := []types.IndexedValueType{types.IndexedValueTypeString, types.IndexedValueTypeKeyword, types.IndexedValueTypeInt, types.IndexedValueTypeDouble, types.IndexedValueTypeBool, types.IndexedValueTypeDatetime}
+	for _, expected := range values {
+		require.Equal(t, expected, ConvertIndexedValueTypeToInternalType(int(expected), nil))
+		require.Equal(t, expected, ConvertIndexedValueTypeToInternalType(float64(expected), nil))
+
+		buffer, err := expected.MarshalText()
+		require.NoError(t, err)
+		require.Equal(t, expected, ConvertIndexedValueTypeToInternalType(buffer, nil))
+		require.Equal(t, expected, ConvertIndexedValueTypeToInternalType(string(buffer), nil))
 	}
 }
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -50,7 +50,6 @@ import (
 	"github.com/uber/cadence/common/resource"
 	"github.com/uber/cadence/common/service"
 	"github.com/uber/cadence/common/types"
-	"github.com/uber/cadence/common/types/mapper/thrift"
 )
 
 const (
@@ -4466,7 +4465,7 @@ func (wh *WorkflowHandler) getArchivedHistory(
 func (wh *WorkflowHandler) convertIndexedKeyToThrift(keys map[string]interface{}) map[string]types.IndexedValueType {
 	converted := make(map[string]types.IndexedValueType)
 	for k, v := range keys {
-		converted[k] = thrift.ToIndexedValueType(common.ConvertIndexedValueTypeToThriftType(v, wh.GetLogger()))
+		converted[k] = common.ConvertIndexedValueTypeToInternalType(v, wh.GetLogger())
 	}
 	return converted
 }

--- a/service/frontend/workflowHandler_test.go
+++ b/service/frontend/workflowHandler_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
@@ -1410,12 +1409,18 @@ func (s *workflowHandlerSuite) TestConvertIndexedKeyToThrift() {
 		"key4i": 3,
 		"key5i": 4,
 		"key6i": 5,
-		"key1t": shared.IndexedValueTypeString,
-		"key2t": shared.IndexedValueTypeKeyword,
-		"key3t": shared.IndexedValueTypeInt,
-		"key4t": shared.IndexedValueTypeDouble,
-		"key5t": shared.IndexedValueTypeBool,
-		"key6t": shared.IndexedValueTypeDatetime,
+		"key1t": types.IndexedValueTypeString,
+		"key2t": types.IndexedValueTypeKeyword,
+		"key3t": types.IndexedValueTypeInt,
+		"key4t": types.IndexedValueTypeDouble,
+		"key5t": types.IndexedValueTypeBool,
+		"key6t": types.IndexedValueTypeDatetime,
+		"key1s": "STRING",
+		"key2s": "KEYWORD",
+		"key3s": "INT",
+		"key4s": "DOUBLE",
+		"key5s": "BOOL",
+		"key6s": "DATETIME",
 	}
 	result := wh.convertIndexedKeyToThrift(m)
 	s.Equal(types.IndexedValueTypeString, result["key1"])
@@ -1436,6 +1441,12 @@ func (s *workflowHandlerSuite) TestConvertIndexedKeyToThrift() {
 	s.Equal(types.IndexedValueTypeDouble, result["key4t"])
 	s.Equal(types.IndexedValueTypeBool, result["key5t"])
 	s.Equal(types.IndexedValueTypeDatetime, result["key6t"])
+	s.Equal(types.IndexedValueTypeString, result["key1s"])
+	s.Equal(types.IndexedValueTypeKeyword, result["key2s"])
+	s.Equal(types.IndexedValueTypeInt, result["key3s"])
+	s.Equal(types.IndexedValueTypeDouble, result["key4s"])
+	s.Equal(types.IndexedValueTypeBool, result["key5s"])
+	s.Equal(types.IndexedValueTypeDatetime, result["key6s"])
 	s.Panics(func() {
 		wh.convertIndexedKeyToThrift(map[string]interface{}{
 			"invalidType": "unknown",

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -45,7 +45,6 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/types"
-	"github.com/uber/cadence/common/types/mapper/thrift"
 	"github.com/uber/cadence/service/history/execution"
 )
 
@@ -965,7 +964,7 @@ func convertSearchAttributesToMapOfInterface(searchAttributes *types.SearchAttri
 	indexedFields := searchAttributes.GetIndexedFields()
 	for k, v := range indexedFields {
 		valueType := validKeys[k]
-		deserializedValue, err := common.DeserializeSearchAttributeValue(v, thrift.FromIndexedValueType(valueType))
+		deserializedValue, err := common.DeserializeSearchAttributeValue(v, valueType)
 		if err != nil {
 			ErrorAndExit("Error deserializing search attribute value", err)
 		}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

> Use internal IndexedValueType instead of thrift type

> Support string type conversion 

<!-- Tell your future self why have you made these changes -->
**Why?**

> We should use internal type

> We need to support string type conversion, because when we do json encoding, those values will be converted to strings.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
