### PR TITLE
Update DSL query to allow filtering by missing start time

### DIFF
--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -516,6 +516,8 @@ var (
 	}
 )
 
+var missingStartTimeRegex = regexp.MustCompile(jsonMissingStartTime)
+
 func getESQueryDSLForScan(request *p.ListWorkflowExecutionsByQueryRequest) (string, error) {
 	sql := getSQLFromListRequest(request)
 	dsl, err := getCustomizedDSLFromSQL(sql, request.DomainUUID)
@@ -632,8 +634,7 @@ func replaceQueryForOpen(dsl *fastjson.Value) *fastjson.Value {
 // ES v6 only accepts "must_not exists" query instead of "missing" query, but elasticsql produces "missing",
 // so use this func to replace.
 func replaceQueryForUninitialized(dsl *fastjson.Value) *fastjson.Value {
-	re := regexp.MustCompile(jsonMissingStartTime)
-	newDslStr := re.ReplaceAllString(dsl.String(), `{"bool":{"must_not":{"exists":{"field":"StartTime"}}}}`)
+	newDslStr := missingStartTimeRegex.ReplaceAllString(dsl.String(), `{"bool":{"must_not":{"exists":{"field":"StartTime"}}}}`)
 	dsl = fastjson.MustParse(newDslStr)
 	return dsl
 }

--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -490,6 +490,7 @@ const (
 	jsonRangeOnExecutionTime = `{"range":{"ExecutionTime":`
 	jsonSortForOpen          = `[{"StartTime":"desc"},{"RunID":"desc"}]`
 	jsonSortWithTieBreaker   = `{"RunID":"desc"}`
+	jsonMissingStartTime     = `{"missing":{"field":"StartTime"}}` //used to identify uninitialized workflow execution records
 
 	dslFieldSort        = "sort"
 	dslFieldSearchAfter = "search_after"
@@ -504,6 +505,7 @@ var (
 		es.StartTime:     true,
 		es.CloseTime:     true,
 		es.ExecutionTime: true,
+		es.UpdateTime:    true,
 	}
 	rangeKeys = map[string]bool{
 		"from":  true,
@@ -601,6 +603,9 @@ func getCustomizedDSLFromSQL(sql string, domainID string) (*fastjson.Value, erro
 		return nil, err
 	}
 	dslStr = dsl.String()
+	if strings.Contains(dslStr, jsonMissingStartTime) { // isUninitialized
+		dsl = replaceQueryForUninitialized(dsl)
+	}
 	if strings.Contains(dslStr, jsonMissingCloseTime) { // isOpen
 		dsl = replaceQueryForOpen(dsl)
 	}
@@ -620,6 +625,15 @@ func getCustomizedDSLFromSQL(sql string, domainID string) (*fastjson.Value, erro
 func replaceQueryForOpen(dsl *fastjson.Value) *fastjson.Value {
 	re := regexp.MustCompile(jsonMissingCloseTime)
 	newDslStr := re.ReplaceAllString(dsl.String(), `{"bool":{"must_not":{"exists":{"field":"CloseTime"}}}}`)
+	dsl = fastjson.MustParse(newDslStr)
+	return dsl
+}
+
+// ES v6 only accepts "must_not exists" query instead of "missing" query, but elasticsql produces "missing",
+// so use this func to replace.
+func replaceQueryForUninitialized(dsl *fastjson.Value) *fastjson.Value {
+	re := regexp.MustCompile(jsonMissingStartTime)
+	newDslStr := re.ReplaceAllString(dsl.String(), `{"bool":{"must_not":{"exists":{"field":"StartTime"}}}}`)
 	dsl = fastjson.MustParse(newDslStr)
 	return dsl
 }

--- a/common/persistence/elasticsearch/esVisibilityStore_test.go
+++ b/common/persistence/elasticsearch/esVisibilityStore_test.go
@@ -745,6 +745,12 @@ func (s *ESVisibilitySuite) TestGetESQueryDSLForCount() {
 	dsl, err = getESQueryDSLForCount(request)
 	s.Nil(err)
 	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"range":{"ExecutionTime":{"gt":"0"}}},{"bool":{"must":[{"range":{"ExecutionTime":{"lt":"1000"}}}]}}]}}]}}}`, dsl)
+
+	request.Query = `StartTime = missing and UpdateTime >= "2022-10-04T16:00:00+07:00"`
+	dsl, err = getESQueryDSLForCount(request)
+	s.Nil(err)
+	s.Equal(`{"query":{"bool":{"must":[{"match_phrase":{"DomainID":{"query":"bfd5c907-f899-4baf-a7b2-2ab85e623ebd"}}},{"bool":{"must":[{"bool":{"must_not":{"exists":{"field":"StartTime"}}}},{"range":{"UpdateTime":{"from":"1664874000000000000"}}}]}}]}}}`, dsl)
+
 }
 
 func (s *ESVisibilitySuite) TestAddDomainToQuery() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update DSL query to allow filtering by missing start time so we can get count of uninitialized workflow executions records. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
