### PR TITLE
Enhance workflowDeletionTaskJitterRange to handle deletes piling up when many workflows have finished at the same time.

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3357,7 +3357,7 @@ var IntKeys = map[IntKey]DynamicInt{
 	WorkflowDeletionJitterRange: DynamicInt{
 		KeyName:      "system.workflowDeletionJitterRange",
 		Description:  "WorkflowDeletionJitterRange defines the duration in minutes for workflow close tasks jittering",
-		DefaultValue: 1,
+		DefaultValue: 60,
 	},
 }
 

--- a/host/dynamicconfig.go
+++ b/host/dynamicconfig.go
@@ -46,6 +46,7 @@ var (
 		dynamicconfig.ReplicationTaskProcessorErrorRetryWait:        time.Millisecond,
 		dynamicconfig.EnableConsistentQueryByDomain:                 true,
 		dynamicconfig.MinRetentionDays:                              0,
+		dynamicconfig.WorkflowDeletionJitterRange:                   1,
 	}
 )
 

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -245,7 +245,11 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowCloseTasks(
 	}
 
 	closeTimestamp := time.Unix(0, closeEvent.GetTimestamp())
-	retentionDuration := (time.Duration(retentionInDays) * time.Hour * 24) + (time.Duration(rand.Intn(workflowDeletionTaskJitterRange)) * time.Minute)
+	retentionDuration := (time.Duration(retentionInDays) * time.Hour * 24)
+	if workflowDeletionTaskJitterRange > 1 {
+		retentionDuration += time.Duration(rand.Intn(workflowDeletionTaskJitterRange*60)) * time.Second
+	}
+
 	r.mutableState.AddTimerTasks(&persistence.DeleteHistoryEventTask{
 		// TaskID is set by shard
 		VisibilityTimestamp: closeTimestamp.Add(retentionDuration),


### PR DESCRIPTION
* Fix panics when values < 1 are provided
* Randomize the timestamp on a second granularity so that deletes are
  more spread out than before.
* Default to 60 minutes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Tested with current unit tests which change the value
