### PR TITLE
Improve Cassandra errors for schema check

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
@@ -28,8 +28,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber/cadence/testflags"
-
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
@@ -40,6 +38,7 @@ import (
 	cassandra_db "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra"
 	"github.com/uber/cadence/environment"
 	"github.com/uber/cadence/tools/cassandra"
+	"github.com/uber/cadence/testflags"
 )
 
 type (
@@ -106,7 +105,7 @@ func (s *VersionTestSuite) TestCheckCompatibleVersion() {
 		{"2.0", "1.0", "version mismatch", false},
 		{"1.0", "1.0", "", false},
 		{"1.0", "2.0", "", false},
-		{"1.0", "abc", "unable to read schema version keyspace/database", false},
+		{"1.0", "abc", "reading schema version: unconfigured table schema_version", false},
 	}
 	for _, flag := range flags {
 		s.runCheckCompatibleVersion(flag.expectedVersion, flag.actualVersion, flag.errStr, flag.expectedFail)

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
@@ -37,8 +37,8 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig"
 	cassandra_db "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra"
 	"github.com/uber/cadence/environment"
-	"github.com/uber/cadence/tools/cassandra"
 	"github.com/uber/cadence/testflags"
+	"github.com/uber/cadence/tools/cassandra"
 )
 
 type (

--- a/tools/cassandra/handler.go
+++ b/tools/cassandra/handler.go
@@ -75,7 +75,7 @@ func verifyCompatibleVersion(
 	// However, this file will be refactor to support NoSQL soon. After the refactoring, cycle dependency issue
 	// should be gone and we can use constant at that time
 	if ds.NoSQL.PluginName != "cassandra" {
-		return fmt.Errorf("unknown NoSQL plugin name: %v", ds.NoSQL.PluginName)
+		return fmt.Errorf("unknown NoSQL plugin name: %q", ds.NoSQL.PluginName)
 	}
 
 	return CheckCompatibleVersion(*ds.NoSQL, expectedCassandraVersion)
@@ -100,7 +100,7 @@ func CheckCompatibleVersion(
 		ProtoVersion:          cfg.ProtoVersion,
 	})
 	if err != nil {
-		return fmt.Errorf("unable to create CQL Client: %v", err.Error())
+		return fmt.Errorf("creating CQL client: %w", err)
 	}
 	defer client.Close()
 

--- a/tools/common/schema/handler.go
+++ b/tools/common/schema/handler.go
@@ -35,7 +35,7 @@ func VerifyCompatibleVersion(
 
 	version, err := db.ReadSchemaVersion()
 	if err != nil {
-		return fmt.Errorf("unable to read schema version keyspace/database: %s error: %v", dbName, err.Error())
+		return fmt.Errorf("reading schema version keyspace/database: %q, error: %w", dbName, err)
 	}
 	// In most cases, the versions should match. However if after a schema upgrade there is a code
 	// rollback, the code version (expected version) would fall lower than the actual version in

--- a/tools/sql/clitest/versionTest.go
+++ b/tools/sql/clitest/versionTest.go
@@ -139,7 +139,7 @@ func (s *VersionTestSuite) TestCheckCompatibleVersion() {
 		{"2.0", "1.0", "version mismatch", false},
 		{"1.0", "1.0", "", false},
 		{"1.0", "2.0", "", false},
-		{"1.0", "abc", "unable to read schema version keyspace/database", false},
+		{"1.0", "abc", "schema_version' doesn't exist", false},
 	}
 	for _, flag := range flags {
 		s.runCheckCompatibleVersion(flag.expectedVersion, flag.actualVersion, flag.errStr, flag.expectedFail)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Return original error from `cql` client when doing schema check.


<!-- Tell your future self why have you made these changes -->
**Why?**
Make error self explanatory: from this
```
cassandra schema version compatibility check failed: unable to read schema version keyspace/database: cadence error: failed to get current schema version from cassandra
```
to this

```
cassandra schema version compatibility check failed: reading schema version keyspace/database: "cadence", error: reading schema: unconfigured table schema_version
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
