### PR TITLE
Making a schema tooling concrete -> interface

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_cqlclient_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_cqlclient_test.go
@@ -40,7 +40,7 @@ type (
 	}
 )
 
-var _ test.DB = (*cassandra.CqlClient)(nil)
+var _ test.DB = (cassandra.CqlClient)(nil)
 
 func TestCQLClientTestSuite(t *testing.T) {
 	testflags.RequireCassandra(t)

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_setupTask_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_setupTask_test.go
@@ -37,7 +37,7 @@ import (
 type (
 	SetupSchemaTestSuite struct {
 		test.SetupSchemaTestBase
-		client *cassandra.CqlClient
+		client cassandra.CqlClient
 	}
 )
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/utils.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/utils.go
@@ -28,7 +28,7 @@ import (
 // NOTE: change this when moving the test files around during refactoring
 const rootRelativePath = "../../../../../../"
 
-func NewTestCQLClient(keyspace string) (*cassandra.CqlClient, error) {
+func NewTestCQLClient(keyspace string) (cassandra.CqlClient, error) {
 	return cassandra.NewCQLClient(&cassandra.CQLClientConfig{
 		Hosts:                 environment.GetCassandraAddress(),
 		Port:                  cassandra.DefaultCassandraPort,

--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -145,7 +145,7 @@ func (client *CqlClientImpl) DropDatabase(name string) error {
 	return client.DropKeyspace(name)
 }
 
-// createNTSKeyspace creates a cassandra Keyspace if it doesn't exist using network topology strategy
+// CreateNTSKeyspace creates a cassandra Keyspace if it doesn't exist using network topology strategy
 func (client *CqlClientImpl) CreateKeyspace(name string) error {
 	return client.ExecDDLQuery(fmt.Sprintf(createKeyspaceCQL, name, client.nReplicas))
 }
@@ -187,7 +187,7 @@ func (client *CqlClientImpl) ReadSchemaVersion() (string, error) {
 	return version, nil
 }
 
-// UpdateShemaVersion updates the schema version for the Keyspace
+// UpdateSchemaVersion updates the schema version for the Keyspace
 func (client *CqlClientImpl) UpdateSchemaVersion(newVersion string, minCompatibleVersion string) error {
 	query := client.session.Query(writeSchemaVersionCQL, client.cfg.Keyspace, time.Now(), newVersion, minCompatibleVersion)
 	return query.Exec()


### PR DESCRIPTION
Moves the CqlClient tool struct to be an interface. The intent being to enable better testing for schema tooling.

Testing: Unit tests
