### PR TITLE
Exposing the ability to pull CQL changesets

### DIFF
--- a/service/history/queue/transfer_queue_validator.go
+++ b/service/history/queue/transfer_queue_validator.go
@@ -42,9 +42,9 @@ const (
 
 type (
 	pendingTaskInfo struct {
-		executionInfo    *persistence.WorkflowExecutionInfo
-		task             persistence.Task
-		persistenceError bool
+		executionInfo          *persistence.WorkflowExecutionInfo
+		task                   persistence.Task
+		potentialFalsePositive bool
 	}
 
 	transferQueueValidator struct {
@@ -57,6 +57,7 @@ type (
 
 		pendingTaskInfos   map[int64]pendingTaskInfo
 		maxReadLevels      map[int]task.Key
+		minReadTaskID      int64
 		lastValidateTime   time.Time
 		validationInterval dynamicconfig.DurationPropertyFn
 	}
@@ -77,6 +78,7 @@ func newTransferQueueValidator(
 
 		pendingTaskInfos:   make(map[int64]pendingTaskInfo),
 		maxReadLevels:      make(map[int]task.Key),
+		minReadTaskID:      0,
 		lastValidateTime:   timeSource.Now(),
 		validationInterval: validationInterval,
 	}
@@ -108,10 +110,13 @@ func (v *transferQueueValidator) addTasks(
 	}
 
 	for _, task := range info.Tasks[:numTaskToAdd] {
+		// It is possible that a task is acked before it is added to the validator
+		// In that case, the lost task could be a potential false positive case
+		potentialFalsePositive := info.PersistenceError || task.GetTaskID() <= v.minReadTaskID
 		v.pendingTaskInfos[task.GetTaskID()] = pendingTaskInfo{
-			executionInfo:    info.ExecutionInfo,
-			task:             task,
-			persistenceError: info.PersistenceError,
+			executionInfo:          info.ExecutionInfo,
+			task:                   task,
+			potentialFalsePositive: potentialFalsePositive,
 		}
 	}
 }
@@ -178,10 +183,11 @@ func (v *transferQueueValidator) validatePendingTasks() {
 				tag.WorkflowDomainID(taskInfo.executionInfo.DomainID),
 				tag.WorkflowID(taskInfo.executionInfo.WorkflowID),
 				tag.WorkflowRunID(taskInfo.executionInfo.RunID),
-				tag.Bool(taskInfo.persistenceError),
+				tag.Bool(taskInfo.potentialFalsePositive),
 			)
 			v.metricsScope.IncCounter(metrics.QueueValidatorLostTaskCounter)
 			delete(v.pendingTaskInfos, taskID)
 		}
 	}
+	v.minReadTaskID = minReadTaskID
 }

--- a/tools/common/schema/updatetask.go
+++ b/tools/common/schema/updatetask.go
@@ -59,7 +59,7 @@ type (
 	// corresponding to a single schema version
 	ChangeSet struct {
 		Version  string
-		Manifest *manifest
+		manifest *manifest
 		CqlStmts []string
 	}
 
@@ -115,7 +115,7 @@ func (task *UpdateTask) Run() error {
 			log.Println("Found zero updates to run")
 		}
 		for _, upd := range updates {
-			log.Printf("DryRun of updating to version: %s, manifest: %s \n", upd.Version, upd.Manifest)
+			log.Printf("DryRun of updating to version: %s, manifest: %s \n", upd.Version, upd.manifest)
 			for _, stmt := range upd.CqlStmts {
 				log.Printf("DryRun query:%s \n", stmt)
 			}
@@ -174,12 +174,12 @@ func (task *UpdateTask) execCQLStmts(ver string, stmts []string) error {
 
 func (task *UpdateTask) updateSchemaVersion(oldVer string, cs *ChangeSet) error {
 
-	err := task.db.UpdateSchemaVersion(cs.Version, cs.Manifest.MinCompatibleVersion)
+	err := task.db.UpdateSchemaVersion(cs.Version, cs.manifest.MinCompatibleVersion)
 	if err != nil {
 		return fmt.Errorf("failed to update schema_version table, err=%v", err.Error())
 	}
 
-	err = task.db.WriteSchemaUpdateLog(oldVer, cs.Manifest.CurrVersion, cs.Manifest.md5, cs.Manifest.Description)
+	err = task.db.WriteSchemaUpdateLog(oldVer, cs.manifest.CurrVersion, cs.manifest.md5, cs.manifest.Description)
 	if err != nil {
 		return fmt.Errorf("failed to add entry to schema_update_history, err=%v", err.Error())
 	}
@@ -227,7 +227,7 @@ func (task *UpdateTask) BuildChangeSet(currVer string) ([]ChangeSet, error) {
 		}
 
 		cs := ChangeSet{}
-		cs.Manifest = m
+		cs.manifest = m
 		cs.CqlStmts = stmts
 		cs.Version = m.CurrVersion
 		result = append(result, cs)

--- a/tools/common/schema/updatetask.go
+++ b/tools/common/schema/updatetask.go
@@ -55,12 +55,12 @@ type (
 		md5                  string
 	}
 
-	// changeSet represents all the changes
+	// ChangeSet represents all the changes
 	// corresponding to a single schema version
-	changeSet struct {
-		version  string
-		manifest *manifest
-		cqlStmts []string
+	ChangeSet struct {
+		Version  string
+		Manifest *manifest
+		CqlStmts []string
 	}
 
 	// byVersion is a comparator type
@@ -104,7 +104,7 @@ func (task *UpdateTask) Run() error {
 		return fmt.Errorf("error reading current schema version:%v", err.Error())
 	}
 
-	updates, err := task.buildChangeSet(currVer)
+	updates, err := task.BuildChangeSet(currVer)
 	if err != nil {
 		return err
 	}
@@ -115,8 +115,8 @@ func (task *UpdateTask) Run() error {
 			log.Println("Found zero updates to run")
 		}
 		for _, upd := range updates {
-			log.Printf("DryRun of updating to version: %s, manifest: %s \n", upd.version, upd.manifest)
-			for _, stmt := range upd.cqlStmts {
+			log.Printf("DryRun of updating to version: %s, manifest: %s \n", upd.Version, upd.Manifest)
+			for _, stmt := range upd.CqlStmts {
 				log.Printf("DryRun query:%s \n", stmt)
 			}
 		}
@@ -131,7 +131,7 @@ func (task *UpdateTask) Run() error {
 	return nil
 }
 
-func (task *UpdateTask) executeUpdates(currVer string, updates []changeSet) error {
+func (task *UpdateTask) executeUpdates(currVer string, updates []ChangeSet) error {
 
 	if len(updates) == 0 {
 		log.Printf("found zero updates from current version %v", currVer)
@@ -141,7 +141,7 @@ func (task *UpdateTask) executeUpdates(currVer string, updates []changeSet) erro
 	for _, cs := range updates {
 		csStart := time.Now()
 
-		err := task.execCQLStmts(cs.version, cs.cqlStmts)
+		err := task.execCQLStmts(cs.Version, cs.CqlStmts)
 		if err != nil {
 			return err
 		}
@@ -150,8 +150,8 @@ func (task *UpdateTask) executeUpdates(currVer string, updates []changeSet) erro
 			return err
 		}
 
-		log.Printf("Schema updated from %v to %v, elapsed %v\n", currVer, cs.version, time.Since(csStart))
-		currVer = cs.version
+		log.Printf("Schema updated from %v to %v, elapsed %v\n", currVer, cs.Version, time.Since(csStart))
+		currVer = cs.Version
 	}
 
 	log.Printf("All schema changes completed in %v\n", time.Since(updStart))
@@ -172,14 +172,14 @@ func (task *UpdateTask) execCQLStmts(ver string, stmts []string) error {
 	return nil
 }
 
-func (task *UpdateTask) updateSchemaVersion(oldVer string, cs *changeSet) error {
+func (task *UpdateTask) updateSchemaVersion(oldVer string, cs *ChangeSet) error {
 
-	err := task.db.UpdateSchemaVersion(cs.version, cs.manifest.MinCompatibleVersion)
+	err := task.db.UpdateSchemaVersion(cs.Version, cs.Manifest.MinCompatibleVersion)
 	if err != nil {
 		return fmt.Errorf("failed to update schema_version table, err=%v", err.Error())
 	}
 
-	err = task.db.WriteSchemaUpdateLog(oldVer, cs.manifest.CurrVersion, cs.manifest.md5, cs.manifest.Description)
+	err = task.db.WriteSchemaUpdateLog(oldVer, cs.Manifest.CurrVersion, cs.Manifest.md5, cs.Manifest.Description)
 	if err != nil {
 		return fmt.Errorf("failed to add entry to schema_update_history, err=%v", err.Error())
 	}
@@ -187,7 +187,7 @@ func (task *UpdateTask) updateSchemaVersion(oldVer string, cs *changeSet) error 
 	return nil
 }
 
-func (task *UpdateTask) buildChangeSet(currVer string) ([]changeSet, error) {
+func (task *UpdateTask) BuildChangeSet(currVer string) ([]ChangeSet, error) {
 
 	config := task.config
 
@@ -196,7 +196,7 @@ func (task *UpdateTask) buildChangeSet(currVer string) ([]changeSet, error) {
 		return nil, fmt.Errorf("error listing schema dir:%v", err.Error())
 	}
 
-	var result []changeSet
+	var result []ChangeSet
 
 	for _, vd := range verDirs {
 
@@ -226,10 +226,10 @@ func (task *UpdateTask) buildChangeSet(currVer string) ([]changeSet, error) {
 			return nil, fmt.Errorf("error processing version %v:%v", vd, e.Error())
 		}
 
-		cs := changeSet{}
-		cs.manifest = m
-		cs.cqlStmts = stmts
-		cs.version = m.CurrVersion
+		cs := ChangeSet{}
+		cs.Manifest = m
+		cs.CqlStmts = stmts
+		cs.Version = m.CurrVersion
 		result = append(result, cs)
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Exposing SQL statements during update operations

<!-- Tell your future self why have you made these changes -->
**Why?**
Access to the actual SQL statements is helpful for building some tooling regarding schema automation upgrading. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
