### PR TITLE
Do not return not exists error in history pagination function

### DIFF
--- a/common/persistence/historyManager.go
+++ b/common/persistence/historyManager.go
@@ -422,6 +422,7 @@ func (m *historyV2ManagerImpl) readRawHistoryBranch(
 	if err != nil {
 		return nil, nil, 0, nil, err
 	}
+	// TODO: consider if it's possible to remove this branch
 	if len(resp.History) == 0 && len(request.NextPageToken) == 0 {
 		return nil, nil, 0, nil, &types.EntityNotExistsError{Message: "Workflow execution history not found."}
 	}

--- a/common/persistence/persistence-utils/historyManagerUtil.go
+++ b/common/persistence/persistence-utils/historyManagerUtil.go
@@ -22,6 +22,7 @@ package persistenceutils
 
 import (
 	"context"
+	"errors"
 
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/persistence"
@@ -125,6 +126,10 @@ func PaginateHistory(
 	if byBatch {
 		response, err := historyV2Mgr.ReadHistoryBranchByBatch(ctx, req)
 		if err != nil {
+			var e *types.EntityNotExistsError
+			if errors.As(err, &e) {
+				return nil, nil, nil, 0, nil
+			}
 			return nil, nil, nil, 0, err
 		}
 
@@ -136,6 +141,10 @@ func PaginateHistory(
 	} else {
 		response, err := historyV2Mgr.ReadHistoryBranch(ctx, req)
 		if err != nil {
+			var e *types.EntityNotExistsError
+			if errors.As(err, &e) {
+				return nil, nil, nil, 0, nil
+			}
 			return nil, nil, nil, 0, err
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Do not return not exists error in history pagination function

<!-- Tell your future self why have you made these changes -->
**Why?**
For a history paginator, if there is no history events, we should not return entity not exists error but stop the iteration.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
