### PR TITLE
Hot shard detection

### DIFF
--- a/common/hot-shard/hot-shard.go
+++ b/common/hot-shard/hot-shard.go
@@ -89,7 +89,9 @@ func (d *detector) Check(now time.Time, workflowID string, dim ...string) bool {
 	if ok && existingCount > d.limit {
 		d.log.Warn("hot-shard detected", tag.WorkflowID(workflowID), tag.Dynamic("entries", dim))
 		d.metrics.IncCounter(metrics.HotShardRateLimitTriggered, 1)
-		go d.sampleAndCheck(now, hashedIdentifier, workflowID, dim)
+		// keep adding to counter
+		d.sampleAndCheck(now, hashedIdentifier, workflowID, dim)
+		// but return the result with certainty
 		return true
 	}
 	return d.sampleAndCheck(now, hashedIdentifier, workflowID, dim)

--- a/common/hot-shard/hot-shard.go
+++ b/common/hot-shard/hot-shard.go
@@ -1,0 +1,180 @@
+package hot_shard
+
+import (
+	"github.com/dgryski/go-farm"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/metrics"
+	"math/rand"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Options for Hotshard rate-limiter
+type Options struct {
+	// Main configuration options
+	Limit int // how many events (at the sampled rate) before considering a value to be a hot shard (Default: 10)
+
+	// Additional knobs
+	TotalHashMapSizeLimit int           // how many values to track in its map of hashed values (Default: 1000)
+	WindowSize            time.Duration // The value to sample over, higher values risk greater false-positives if the sample rate is also not commensurately large. (Default:1m)
+	SampleRate            float64       // how frequently to sample input check events as a percentage expressed as a value between 0-1 (Default: 0.001)
+}
+
+// HotShardDetector is a fixed size cache which samples inputs to see if they're being
+// seen frequently, and, if they have been, to flag them.
+type HotShardDetector interface {
+	// Check is a syncronous method which samples the workflows it is given
+	// and checks (at the sample rate) if the workflows are a hot-shard over the window period.
+	// Returns true when the hot-shard is detected.
+	Check(now time.Time, workflowID string, additionalDimensions ...string) bool
+}
+
+const (
+	MetricHotShardDetected   = "hot_shard_detected"
+	_defaultLimit            = 10
+	_defaultSampleRate       = 0.01
+	_defaultWindow           = time.Minute
+	_defaultHashMapSizeLimit = 1000
+)
+
+type detector struct {
+	mu                    sync.RWMutex
+	sb                    strings.Builder
+	windowSize            time.Duration
+	windowCount           map[uint64]int
+	windowStartTime       time.Time
+	limit                 int
+	log                   log.Logger
+	scope                 metrics.Client
+	sampleRate            float64
+	totalHashmapSizeLimit int
+}
+
+func (d *detector) Check(now time.Time, workflowID string, dim ...string) bool {
+	// first, hash the inputs, and see
+	// then if we've seen this value before
+	d.mu.RLock()
+	hashedIdentifier := d.hashInputs(workflowID, dim)
+	existingCount, ok := d.windowCount[hashedIdentifier]
+	d.mu.RUnlock()
+
+	// if the value has been seen before, and we know it's over limit don't sample this, reply immediately that
+	// we've seen this value before
+	if ok && existingCount > d.limit {
+		go d.sampleAndCheck(now, hashedIdentifier, workflowID, dim)
+		return true
+	}
+	return d.sampleAndCheck(now, hashedIdentifier, workflowID, dim)
+}
+
+func (d *detector) sampleAndCheck(now time.Time, hashedIdentifier uint64, workflowID string, dim []string) bool {
+	if !d.shouldSample() {
+		return false
+	}
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	if now.After(d.windowStartTime.Add(d.windowSize)) {
+		// we're rolling over the monitoring window, start afresh
+		d.createNewWindow(now, d.windowStartTime)
+	}
+
+	existingCount, ok := d.windowCount[hashedIdentifier]
+	if !ok {
+		if len(d.windowCount) > d.totalHashmapSizeLimit {
+			// don't keep adding endlessly to the hash map as, for very high
+			// cardinality samples this will just become too large and add no additional
+			// value, but *do* keep adding to existing values > 1 and evict
+			// a not-interesting value
+			for key := range d.windowCount {
+				if d.windowCount[key] == 1 {
+					delete(d.windowCount, key)
+					break
+				}
+			}
+
+			return false
+		}
+		d.windowCount[hashedIdentifier] = 1
+		return false
+	}
+
+	d.windowCount[hashedIdentifier] = existingCount + 1
+	if d.windowCount[hashedIdentifier] > d.limit {
+		d.log.Warn("hot-shard detected", tag.WorkflowID(workflowID), tag.Dynamic("entries", dim))
+		d.scope.IncCounter(metrics.HotShardRateLimitTriggered, 1)
+		return true
+	}
+	return false
+}
+
+// NewDetector creates a hotshard detector with reasonable defaults. The default values should catch
+// (approximately) hot-shard values at a rate greater than 1000 per minute
+func NewDetector(log log.Logger, scope metrics.Client, options Options) HotShardDetector {
+	var sampleRate float64
+	if options.SampleRate != 0.0 {
+		sampleRate = options.SampleRate
+	} else {
+		sampleRate = _defaultSampleRate
+	}
+
+	var limit int
+	if options.Limit != 0 {
+		limit = options.Limit
+	} else {
+		limit = _defaultLimit
+	}
+
+	var window time.Duration
+	if options.WindowSize != 0 {
+		window = options.WindowSize
+	} else {
+		window = _defaultWindow
+	}
+
+	var totalSizeLimit int
+	if options.TotalHashMapSizeLimit != 0 {
+		totalSizeLimit = options.TotalHashMapSizeLimit
+	} else {
+		totalSizeLimit = _defaultHashMapSizeLimit
+	}
+
+	return &detector{
+		mu:                    sync.RWMutex{},
+		limit:                 limit,
+		windowSize:            window,
+		windowCount:           make(map[uint64]int),
+		log:                   log,
+		scope:                 scope,
+		sampleRate:            sampleRate,
+		sb:                    strings.Builder{},
+		totalHashmapSizeLimit: totalSizeLimit,
+	}
+}
+
+func (d *detector) createNewWindow(now time.Time, lastUpdateTime time.Time) {
+	// if we wanted to add any kind of gradual backoff for value greater than the window time
+	// we could add it here
+	d.windowStartTime = now
+	d.windowCount = make(map[uint64]int)
+}
+
+func (d *detector) shouldSample() bool {
+	if rand.Float64() < d.sampleRate {
+		return true
+	}
+	return false
+}
+
+func (d *detector) hashInputs(workflowID string, dim []string) uint64 {
+	d.sb.Reset()
+	d.sb.WriteString(workflowID)
+	for i := range dim {
+		d.sb.WriteString(":")
+		d.sb.WriteString(dim[i])
+	}
+	res := farm.Fingerprint64([]byte(d.sb.String()))
+	return res
+}

--- a/common/hot-shard/hot-shard_test.go
+++ b/common/hot-shard/hot-shard_test.go
@@ -1,15 +1,39 @@
-package hot_shard
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package hotshard
 
 import (
-	"github.com/dgryski/go-farm"
-	"github.com/google/uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/uber/cadence/common/log/loggerimpl"
-	"github.com/uber/cadence/common/metrics"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/dgryski/go-farm"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/metrics"
 )
 
 func TestWindowRollover(t *testing.T) {
@@ -77,7 +101,7 @@ func TestWindowMoving(t *testing.T) {
 		windowStartTime:       time.Time{},
 		limit:                 1000,
 		log:                   loggerimpl.NewNopLogger(),
-		scope:                 metrics.NewNoopMetricsClient(),
+		metrics:               metrics.NewNoopMetricsClient(),
 		sampleRate:            1,
 		totalHashmapSizeLimit: _defaultHashMapSizeLimit,
 	}

--- a/common/hot-shard/hot-shard_test.go
+++ b/common/hot-shard/hot-shard_test.go
@@ -1,0 +1,94 @@
+package hot_shard
+
+import (
+	"github.com/dgryski/go-farm"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/metrics"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestWindowRollover(t *testing.T) {
+
+}
+
+func TestE2ESampleExampleWithSmallSet(t *testing.T) {
+	t1 := time.Now()
+
+	//detector := NewDetector(100, time.Second, 100, loggerimpl.NewNopLogger(), metrics.NewNoopMetricsClient())
+	detector := NewDetector(loggerimpl.NewNopLogger(), metrics.NewNoopMetricsClient(), Options{})
+	for i := 0; i < 100; i++ {
+		assert.False(t, detector.Check(t1, "wf-1", "entry 2"))
+	}
+}
+
+func TestE2ESampleExampleWithModerateSet(t *testing.T) {
+	t1 := time.Now()
+
+	detector := NewDetector(loggerimpl.NewNopLogger(), metrics.NewNoopMetricsClient(), Options{})
+
+	notAHotShard := "wf-1"
+	hotShard := "hs1"
+
+	// everything should be not a hit on the detector initially
+	for i := 0; i < 100; i++ {
+		assert.False(t, detector.Check(t1, notAHotShard))
+		assert.False(t, detector.Check(t1, hotShard))
+		assert.False(t, detector.Check(t1, uuid.New().String()))
+	}
+
+	// some warm data
+	for i := 0; i < 100; i++ {
+		detector.Check(t1, notAHotShard)
+	}
+
+	// add some random guff
+	for i := 0; i < 10000; i++ {
+		detector.Check(t1, uuid.New().String())
+	}
+
+	// trigger the hot shard
+	for i := 0; i < 4000; i++ {
+		detector.Check(t1, hotShard)
+	}
+
+	// by now, the hashtable should contain enough samples of the hot-shard to identify
+	// the problematic shard (wf-2) but not give any false positives
+	for i := 0; i < 10; i++ {
+		assert.False(t, detector.Check(t1, uuid.New().String()))
+		assert.False(t, detector.Check(t1, uuid.New().String()))
+		assert.True(t, detector.Check(t1, hotShard))
+	}
+}
+
+func TestWindowMoving(t *testing.T) {
+	t1 := time.Now()
+	t2 := time.Now().Add(time.Minute + time.Second)
+
+	d := detector{
+		mu:                    sync.RWMutex{},
+		sb:                    strings.Builder{},
+		windowSize:            _defaultWindow,
+		windowCount:           make(map[uint64]int),
+		windowStartTime:       time.Time{},
+		limit:                 1000,
+		log:                   loggerimpl.NewNopLogger(),
+		scope:                 metrics.NewNoopMetricsClient(),
+		sampleRate:            1,
+		totalHashmapSizeLimit: _defaultHashMapSizeLimit,
+	}
+
+	for i := 0; i < 100; i++ {
+		d.Check(t1, "123")
+	}
+
+	hash := farm.Fingerprint64([]byte("123"))
+	assert.Equal(t, 100, d.windowCount[hash])
+
+	d.Check(t2, "123")
+	assert.Equal(t, 1, d.windowCount[hash])
+}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -729,6 +729,8 @@ const (
 	DomainReplicationQueueScope
 	// ClusterMetadataScope is used for the cluster metadata
 	ClusterMetadataScope
+	// HotShardRateLimit scope
+	RateLimterHotShardScope
 
 	NumCommonScopes
 )
@@ -1831,6 +1833,7 @@ const (
 	PersistenceErrDBUnavailableCounter
 	PersistenceSampledCounter
 	PersistenceEmptyResponseCounter
+	HotShardRateLimitTriggered
 
 	PersistenceRequestsPerDomain
 	PersistenceFailuresPerDomain

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -170,6 +170,11 @@ type Config struct {
 	CrossClusterSourceProcessorMaxRedispatchQueueSize             dynamicconfig.IntPropertyFn
 	CrossClusterSourceProcessorMaxPendingTaskSize                 dynamicconfig.IntPropertyFn
 
+	// HotShard rate-limiter detector
+	HotShardDetectionLimit dynamicconfig.IntPropertyFn
+	HotShardWindowDuration dynamicconfig.DurationPropertyFn
+	HotShardSampleRate     dynamicconfig.FloatPropertyFn
+
 	// CrossClusterTargetTaskProcessor settings
 	CrossClusterTargetProcessorMaxPendingTasks            dynamicconfig.IntPropertyFn
 	CrossClusterTargetProcessorMaxRetryCount              dynamicconfig.IntPropertyFn
@@ -454,6 +459,10 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 		CrossClusterFetcherServiceBusyBackoffInterval: dc.GetDurationProperty(dynamicconfig.CrossClusterFetcherServiceBusyBackoffInterval),
 		CrossClusterFetcherErrorBackoffInterval:       dc.GetDurationProperty(dynamicconfig.CrossClusterFetcherErrorBackoffInterval),
 		CrossClusterFetcherJitterCoefficient:          dc.GetFloat64Property(dynamicconfig.CrossClusterFetcherJitterCoefficient),
+
+		HotShardSampleRate:     dc.GetFloat64Property(dynamicconfig.HotShardSampleRate),
+		HotShardWindowDuration: dc.GetDurationProperty(dynamicconfig.HotShardWindowDuration),
+		HotShardDetectionLimit: dc.GetIntProperty(dynamicconfig.HotShardDetectionLimit),
 
 		ReplicatorTaskDeleteBatchSize:          dc.GetIntProperty(dynamicconfig.ReplicatorTaskDeleteBatchSize),
 		ReplicatorReadTaskMaxRetryCount:        dc.GetIntProperty(dynamicconfig.ReplicatorReadTaskMaxRetryCount),


### PR DESCRIPTION
## Hot-shard detection

### Summary

Samples tasks being processed and issues a log and metric if a repeated entry is identified, with the intention of spotting hot-shards.

### Background

Based on a lot of operational experiences, it has been clear for a while that we need a cheap way to identify workflows which are running continue-as-new a lot or have very high task process thrashing on a single shard, such activities can take out a database's availbility. It's also operationally not always quite easy to identify such workflows without more subtle-clues such as looking at timeout correlations and guesswork. 

Initially I was considering a more sophisticated detector - something which would be able to identify if a workflow has ever been seen with some approximate count and considered count-min-sketch implementations for this. However, after fiddling with them for a while I decided against them in favour of a far simpler approach of just sampling. The reason for this is that count-min-sketch and similar probabilistic approximation algorithms overcount, making the risks of false-positives everpresent unless you have a moderate amount of memory allocated for such detection. 

Sampling on the other hand, is, if tuned correctly - by definition - undercounts, making it easier to control, and - I hope - offers a similarly modest memory footprint. 

### Testing 

So far it's only tuned to my laptop, and given it's all configured with absolute values, this is near-certainly wrong. I'll have to tune more once deployed.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Lots, a panic in this could do quite a bit of damage, it'll have to be tested well.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Ready for release, no changes required.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
