### PR TITLE
Fix docker image builds with an actually-reliable dependency skip

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,13 +20,13 @@ COPY go.* ./
 RUN go mod download
 
 COPY . .
-RUN rm -fr .bin .build
+RUN rm -fr .bin .build idls
 
 ENV CADENCE_RELEASE_VERSION=$RELEASE_VERSION
 
-# bypass codegen, use committed files.  must be run separately, before building things.
-RUN make .fake-codegen
-RUN CGO_ENABLED=0 make copyright cadence-cassandra-tool cadence-sql-tool cadence cadence-server cadence-bench cadence-canary
+# don't do anything fancy, just build.  must be run separately, before building things.
+RUN make .just-build
+RUN CGO_ENABLED=0 make cadence-cassandra-tool cadence-sql-tool cadence cadence-server cadence-bench cadence-canary
 
 
 # Download dockerize

--- a/Makefile
+++ b/Makefile
@@ -320,28 +320,11 @@ $(BUILD)/protoc: $(PROTO_FILES) $(STABLE_BIN)/$(PROTOC_VERSION_BIN) $(BIN)/proto
 # Rule-breaking targets intended ONLY for special cases with no good alternatives.
 # ====================================
 
-.PHONY: .fake-codegen .fake-protoc .fake-thriftrw
-
-# buildkite / release-only target to avoid building / running codegen tools (protoc is unable to be run on alpine).
-# this will ensure that committed code will be used rather than re-generating.
-# must be manually run before (nearly) any other targets.
-.fake-codegen: .fake-protoc .fake-thrift
-	$(warning build-tool binaries have been faked, you will need to delete the $(BIN) folder if you wish to build real ones)
-	$Q # touch a marker-file for a `make clean` warning.  this does not impact behavior.
-	touch $(STABLE_BIN)/fake-codegen
-
-# "build" fake binaries, and touch the book-keeping files, so Make thinks codegen has been run.
-# order matters, as e.g. a $(BIN) newer than a $(BUILD) implies Make should run the $(BIN).
-.fake-protoc: | $(STABLE_BIN) $(BUILD) $(BIN)
-	touch $(STABLE_BIN)/$(PROTOC_VERSION_BIN) $(BIN)/protoc-gen-gogofast $(BIN)/protoc-gen-yarpc-go
-	touch $(BUILD)/protoc
-
-.fake-thrift: | $(BUILD) $(BIN)
-	touch $(BIN)/thriftrw $(BIN)/thriftrw-plugin-yarpc
-	$Q # if the submodule exists, touch thrift_gen markers to fake their generation.
-	$Q # if it does not, do nothing - there are none.
-	$(if $(THRIFT_GEN),touch $(THRIFT_GEN),)
-	touch $(BUILD)/thrift
+# used to bypass checks when building binaries.
+# this is primarily intended for docker image builds, but can be used to skip things locally.
+.PHONY: .just-build
+.just-build: | $(BUILD)
+	touch $(BUILD)/just-build
 
 # ====================================
 # other intermediates
@@ -419,39 +402,48 @@ copyright: $(BIN)/copyright | $(BUILD) ## update copyright headers
 GOOS ?= $(shell go env GOOS)
 GOARCH ?= $(shell go env GOARCH)
 
+# normally, depend on lint, so a full build and check and codegen runs.
+# docker builds though must *not* do this, and need to rely entirely on committed code.
+ifeq (,$(wildcard $(BUILD)/just-build))
+BINS_DEPEND_ON := $(BUILD)/lint
+else
+BINS_DEPEND_ON :=
+$(warning !!!!! lint and codegen disabled, validations skipped !!!!!)
+endif
+
 BINS =
 TOOLS =
 
 BINS  += cadence-cassandra-tool
 TOOLS += cadence-cassandra-tool
-cadence-cassandra-tool: $(BUILD)/lint
+cadence-cassandra-tool: $(BINS_DEPEND_ON)
 	$Q echo "compiling cadence-cassandra-tool with OS: $(GOOS), ARCH: $(GOARCH)"
 	$Q go build -o $@ cmd/tools/cassandra/main.go
 
 BINS  += cadence-sql-tool
 TOOLS += cadence-sql-tool
-cadence-sql-tool: $(BUILD)/lint
+cadence-sql-tool: $(BINS_DEPEND_ON)
 	$Q echo "compiling cadence-sql-tool with OS: $(GOOS), ARCH: $(GOARCH)"
 	$Q go build -o $@ cmd/tools/sql/main.go
 
 BINS  += cadence
 TOOLS += cadence
-cadence: $(BUILD)/lint
+cadence: $(BINS_DEPEND_ON)
 	$Q echo "compiling cadence with OS: $(GOOS), ARCH: $(GOARCH)"
 	$Q go build -ldflags '$(GO_BUILD_LDFLAGS)' -o $@ cmd/tools/cli/main.go
 
 BINS += cadence-server
-cadence-server: $(BUILD)/lint
+cadence-server: $(BINS_DEPEND_ON)
 	$Q echo "compiling cadence-server with OS: $(GOOS), ARCH: $(GOARCH)"
 	$Q go build -ldflags '$(GO_BUILD_LDFLAGS)' -o $@ cmd/server/main.go
 
 BINS += cadence-canary
-cadence-canary: $(BUILD)/lint
+cadence-canary: $(BINS_DEPEND_ON)
 	$Q echo "compiling cadence-canary with OS: $(GOOS), ARCH: $(GOARCH)"
 	$Q go build -o $@ cmd/canary/main.go
 
 BINS += cadence-bench
-cadence-bench: $(BUILD)/lint
+cadence-bench: $(BINS_DEPEND_ON)
 	$Q echo "compiling cadence-bench with OS: $(GOOS), ARCH: $(GOARCH)"
 	$Q go build -o $@ cmd/bench/main.go
 

--- a/Makefile
+++ b/Makefile
@@ -468,8 +468,8 @@ clean: ## Clean build products
 	rm -f $(BINS)
 	rm -Rf $(BUILD)
 	$(if \
-		$(filter $(BIN)/fake-codegen, $(wildcard $(BIN)/*)), \
-		$(warning fake build tools may exist, delete the $(BIN) folder to get real ones if desired),)
+		$(wildcard $(STABLE_BIN)/*), \
+		$(warning usually-stable build tools still exist, delete the $(STABLE_BIN) folder to rebuild them),)
 
 # v----- not yet cleaned up -----v
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -109,6 +109,31 @@ docker-compose down
 docker-compose up
 ```
 
+DIY: Troubleshooting docker builds
+----------------------------------
+
+Note that Docker has been making changes to its build system, and the new system is currently missing some capabilities
+that the old one had, and makes major changes to how you control it.
+When searching for workarounds, make sure you are looking at modern answers, and consider specifically searching for
+"buildkit" solutions.  
+You can also disable buildkit explicitly with `DOCKER_BUILDKIT=0 docker build ...`.
+
+For output limiting (e.g. `[output clipped ...]` messages), or for anything that requires changing buildkit environment
+variables or other options, start a new builder and use it to build with:
+```
+# create a new builder with your options
+docker buildx create ...
+# which will print out a name, use it in the build step.
+
+# now use the exact same command as normal, but it prepends `buildx` and adds a builder flag.
+docker buildx build . -t ubercadence/<imageName>:YOUR_TAG --builder <that_builder_name>
+```
+
+For output limiting (e.g. `[output clipped ...]` messages), you can fix this with some buildkit env variables:
+```
+docker buildx create --driver-opt env.BUILDKIT_STEP_LOG_MAX_SIZE=-1 --driver-opt env.BUILDKIT_STEP_LOG_MAX_SPEED=-1
+```
+
 DIY: Running a custom cadence server locally alongside cadence requirements
 ---------------------------------------------------------------------------
 If you want to test out a custom-built cadence server, while running all the normal cadence dependencies, there's a simple workflow to do that:


### PR DESCRIPTION
Honestly this is so obvious in retrospect that I don't know why I tried to do the fake-codegen thing.
The easiest way to skip dependencies is... to not declare that dependency in the first place.

---

Our github actions to release a new docker image are failing with errors like
```
Step 14/58 : RUN CGO_ENABLED=0 make copyright cadence-cassandra-tool cadence-sql-tool cadence cadence-server cadence-bench cadence-canary
 ---> Running in 689359fdaa6b
.bin/copyright
building revive from internal/tools/go.mod...
go: downloading github.com/mgechev/revive v1.2.2-0.20220724073416-db56db0b6a11
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: downloading github.com/BurntSushi/toml v1.2.0
go: downloading github.com/mattn/go-colorable v0.1.12
go: downloading github.com/mgechev/dots v0.0.0-20210922191527-e955255bf517
go: downloading github.com/chavacava/garif v0.0.0-20220630083739-93517212f375
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading golang.org/x/sys v0.0.0-2022061022[130](https://github.com/uber/cadence/actions/runs/4059406201/jobs/6987848251#step:4:131)4-9f5ed59c137d
go: downloading github.com/mattn/go-runewidth v0.0.9
building goimports from internal/tools/go.mod...
Makefile:252: *** idls/ submodule must exist, or build will fail.  Run `git submodule update --init` and try again.  Stop.
The command '/bin/sh -c CGO_ENABLED=0 make copyright cadence-cassandra-tool cadence-sql-tool cadence cadence-server cadence-bench cadence-canary' returned a non-zero code: 2
```
which comes from at least two things:

1. `make copyright [stuff that depends on copyright]` doesn't make sense with Make.  Order isn't guaranteed like that, and the newly-invalidated tree of dependencies may not be noticed.  So that's bad.
2. `make .fake-codegen` didn't work anyway, because Make noticed other dependencies of lint/codegen/etc were still missing, and it started building them.

The fix is pretty obvious - don't bother trying to `touch` all the dependencies, just _remove_ the dependency.
This way it trivially does what we want: just calls `go build` a bunch, without making any changes to files.

---

When merged, I'll cherry-pick this over to the 0.25.x branch so we can do a release there.