### PR TITLE
Hotfix a replication panic causing crashes

### DIFF
--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -123,10 +123,11 @@ func (r *stateRebuilderImpl) Rebuild(
 		return nil, 0, err
 	}
 
-	// need to specially handling the first batch, to initialize mutable state & state builder
+	// Corrupt data handling
 	if !iter.HasNext() {
 		return nil, 0, fmt.Errorf("Attempting to build history state but the iterator has found no history")
 	}
+	// need to specially handling the first batch, to initialize mutable state & state builder
 	batch, err := iter.Next()
 	if err != nil {
 		return nil, 0, err

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -124,6 +124,9 @@ func (r *stateRebuilderImpl) Rebuild(
 	}
 
 	// need to specially handling the first batch, to initialize mutable state & state builder
+	if !iter.HasNext() {
+		return nil, 0, fmt.Errorf("Attempting to build history state but the iterator has found no history")
+	}
 	batch, err := iter.Next()
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
There's an uncaught panic in this codepath which crashes in the presence of probably corrupt data. The issue raises the wider question of uncaught panics not being handled in this processor, but I'll address that in a followup 