### PR TITLE
Adding panic-handling

### DIFF
--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -194,7 +194,7 @@ func (p *taskProcessorImpl) processReplicationTasks() (stopping bool) {
 	select {
 	case <-p.done:
 		p.logger.Debug("ReplicationTaskProcessor shutting down.")
-		return false
+		return true
 	default:
 	}
 

--- a/service/history/replication/task_processor.go
+++ b/service/history/replication/task_processor.go
@@ -204,7 +204,7 @@ func (p *taskProcessorImpl) processReplicationTasks() (stopping bool) {
 	case response, ok := <-respChan:
 		if !ok {
 			p.logger.Debug("Fetch replication messages chan closed.")
-			return false
+			return true
 		}
 
 		p.logger.Debug("Got fetch replication messages response.",

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -23,10 +23,12 @@ package replication
 import (
 	"context"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/uber/cadence/common/log/loggerimpl"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/log/loggerimpl"
 
 	"go.uber.org/yarpc"
 

--- a/service/history/replication/task_processor_test.go
+++ b/service/history/replication/task_processor_test.go
@@ -23,6 +23,8 @@ package replication
 import (
 	"context"
 	"encoding/json"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/cadence/common/log/loggerimpl"
 	"testing"
 	"time"
 
@@ -317,4 +319,14 @@ func (f fakeTaskFetcher) GetRequestChan() chan<- *request {
 }
 func (f fakeTaskFetcher) GetRateLimiter() *quotas.DynamicRateLimiter {
 	return f.rateLimiter
+}
+
+func TestPanicHandling(t *testing.T) {
+	processor := taskProcessorImpl{
+		logger: loggerimpl.NewNopLogger(),
+	}
+	assert.NotPanics(t, func() {
+		// this will panic with NPEs
+		processor.processReplicationTasks()
+	})
 }


### PR DESCRIPTION
## Context 
As a follow-up to the panic [here](https://github.com/uber/cadence/pull/5074) I'm keen to see that uncaught panics don't cause instability. So with a small refactor, adding a recovery to the replication daemon here. 

## Testing
Unit-testing