### PR TITLE
CLI: print all available dynamic config keys

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -113,6 +113,15 @@ func GetKeyFromKeyName(keyName string) (Key, error) {
 	return keyVal, nil
 }
 
+// GetAllKeys returns a copy of all configuration keys with all details
+func GetAllKeys() map[string]Key {
+	result := make(map[string]Key, len(_keyNames))
+	for k, v := range _keyNames {
+		result[k] = v
+	}
+	return result
+}
+
 func ValidateKeyValuePair(key Key, value interface{}) error {
 	err := fmt.Errorf("key value pair mismatch, key type: %T, value type: %T", key, value)
 	switch key.(type) {

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -1286,12 +1286,12 @@ func newAdminConfigStoreCommands() []cli.Command {
 			},
 		},
 		{
-			Name:    "describe",
-			Aliases: []string{"d"},
-			Usage:   "Describe all available configuration values",
+			Name:    "listall",
+			Aliases: []string{"la"},
+			Usage:   "List all available configuration keys",
 			Flags:   []cli.Flag{getFormatFlag()},
 			Action: func(c *cli.Context) {
-				AdminDescribeDynamicConfig(c)
+				AdminListConfigKeys(c)
 			},
 		},
 	}

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -1285,5 +1285,14 @@ func newAdminConfigStoreCommands() []cli.Command {
 				AdminListDynamicConfig(c)
 			},
 		},
+		{
+			Name:    "describe",
+			Aliases: []string{"d"},
+			Usage:   "Describe all available configuration values",
+			Flags:   []cli.Flag{getFormatFlag()},
+			Action: func(c *cli.Context) {
+				AdminDescribeDynamicConfig(c)
+			},
+		},
 	}
 }

--- a/tools/cli/adminConfigStoreCommands.go
+++ b/tools/cli/adminConfigStoreCommands.go
@@ -212,8 +212,8 @@ func AdminListDynamicConfig(c *cli.Context) {
 	}
 }
 
-// AdminDescribeDynamicConfig lists all available dynamic config keys with description and default value
-func AdminDescribeDynamicConfig(c *cli.Context) {
+// AdminListConfigKeys lists all available dynamic config keys with description and default value
+func AdminListConfigKeys(c *cli.Context) {
 
 	type ConfigRow struct {
 		Name        string      `header:"Name" json:"name"`

--- a/tools/cli/adminConfigStoreCommands.go
+++ b/tools/cli/adminConfigStoreCommands.go
@@ -23,10 +23,13 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 
-	"github.com/urfave/cli"
-
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/types"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/urfave/cli"
 )
 
 type cliEntry struct {
@@ -207,6 +210,37 @@ func AdminListDynamicConfig(c *cli.Context) {
 		}
 		prettyPrintJSONObject(cliEntries)
 	}
+}
+
+// AdminDescribeDynamicConfig lists all available dynamic config keys with description and default value
+func AdminDescribeDynamicConfig(c *cli.Context) {
+
+	type ConfigRow struct {
+		Name        string      `header:"Name" json:"name"`
+		Description string      `header:"Description" json:"description"`
+		Default     interface{} `header:"Default value" json:"default"`
+	}
+
+	var rows []ConfigRow
+
+	for name, k := range dynamicconfig.GetAllKeys() {
+		rows = append(rows, ConfigRow{
+			Name:        name,
+			Description: k.Description(),
+			Default:     k.DefaultValue(),
+		})
+	}
+	// sorting config key names alphabetically
+	sort.SliceStable(rows, func(i, j int) bool {
+		return rows[i].Name < rows[j].Name
+	})
+
+	Render(c, rows, RenderOptions{
+		DefaultTemplate: templateTable,
+		Color:           true,
+		Border:          true,
+		ColumnAlignment: []int{tablewriter.ALIGN_LEFT, tablewriter.ALIGN_LEFT, tablewriter.ALIGN_RIGHT}},
+	)
 }
 
 func convertToInputEntry(dcEntry *types.DynamicConfigEntry) (*cliEntry, error) {

--- a/tools/cli/render.go
+++ b/tools/cli/render.go
@@ -58,6 +58,9 @@ type RenderOptions struct {
 	// Border specified whether to render table border
 	Border bool
 
+	// Custom, per column alignment
+	ColumnAlignment []int
+
 	// Color will use coloring characters while printing table
 	Color bool
 
@@ -166,6 +169,9 @@ func RenderTable(w io.Writer, data interface{}, opts RenderOptions) error {
 	table.SetBorder(opts.Border)
 	table.SetColumnSeparator("|")
 	table.SetHeaderLine(opts.Border)
+	if opts.ColumnAlignment != nil {
+		table.SetColumnAlignment(opts.ColumnAlignment)
+	}
 
 	for r := 0; r < slice.Len(); r++ {
 		var row []string


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding CLI command to print out all available Dynamic Config keys with all details: name, description and default value.
For usability, `--format` flag can be used to print the list in preferred format (json, table, go template)

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, there are 369 configuration keys. 
This command will help to find needed key and also check what is the default value.

Snippet of the output:
```
$ cadence admin config describe
+-----------------------------------------------------------------------+---------------------------------------------------------------+--------------------------------+
|                                 NAME                                  |                          DESCRIPTION                          |         DEFAULT VALUE          |
+-----------------------------------------------------------------------+---------------------------------------------------------------+--------------------------------+
| admin.errorInjectionRate                                              | dminErrorInjectionRate is                                     |                              0 |
|                                                                       | the rate for injecting random                                 |                                |
|                                                                       | error in admin client                                         |                                |
| frontend.decisionResultCountLimit                                     | FrontendDecisionResultCountLimit                              |                              0 |
|                                                                       | is max number of decisions per                                |                                |
|                                                                       | RespondDecisionTaskCompleted                                  |                                |
|                                                                       | request                                                       |                                |
| frontend.disableListVisibilityByFilter                                | DisableListVisibilityByFilter                                 |                          false |
|                                                                       | is config to disable list                                     |                                |
|                                                                       | open/close workflow using                                     |                                |
|                                                                       | filter                                                        |                                |
| frontend.domainFailoverRefreshInterval                                | DomainFailoverRefreshInterval                                 |                            10s |
|                                                                       | is the domain failover refresh                                |                                |
|                                                                       | timer                                                         |                                |
| frontend.domainFailoverRefreshTimerJitterCoefficient                  | DomainFailoverRefreshTimerJitterCoefficient                   |                            0.1 |
|                                                                       | is the jitter for domain failover refresh                     |                                |

```
