### PR TITLE
Resolve an infinite loop around impossible cron schedules

### DIFF
--- a/common/backoff/cron_test.go
+++ b/common/backoff/cron_test.go
@@ -32,28 +32,27 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var crontests = []struct {
-	cron      string
-	startTime string
-	endTime   string
-	result    time.Duration
-}{
-	{"0 10 * * *", "2018-12-17T08:00:00-08:00", "", time.Hour * 18},
-	{"0 10 * * *", "2018-12-18T02:00:00-08:00", "", time.Hour * 24},
-	{"0 * * * *", "2018-12-17T08:08:00+00:00", "", time.Minute * 52},
-	{"0 * * * *", "2018-12-17T09:00:00+00:00", "", time.Hour},
-	{"* * * * *", "2018-12-17T08:08:18+00:00", "", time.Second * 42},
-	{"0 * * * *", "2018-12-17T09:00:00+00:00", "", time.Minute * 60},
-	{"0 10 * * *", "2018-12-17T08:00:00+00:00", "2018-12-20T00:00:00+00:00", time.Hour * 10},
-	{"0 10 * * *", "2018-12-17T08:00:00+00:00", "2018-12-17T09:00:00+00:00", time.Hour},
-	{"*/10 * * * *", "2018-12-17T00:04:00+00:00", "2018-12-17T01:02:00+00:00", time.Minute * 8},
-	{"invalid-cron-spec", "2018-12-17T00:04:00+00:00", "2018-12-17T01:02:00+00:00", NoBackoff},
-	{"@every 5h", "2018-12-17T08:00:00+00:00", "2018-12-17T09:00:00+00:00", time.Hour * 4},
-	{"@every 5h", "2018-12-17T08:00:00+00:00", "2018-12-18T00:00:00+00:00", time.Hour * 4},
-	{"0 3 * * 0-6", "2018-12-17T08:00:00-08:00", "", time.Hour * 11},
-}
-
 func TestCron(t *testing.T) {
+	var crontests = []struct {
+		cron      string
+		startTime string
+		endTime   string
+		result    time.Duration
+	}{
+		{"0 10 * * *", "2018-12-17T08:00:00-08:00", "", time.Hour * 18},
+		{"0 10 * * *", "2018-12-18T02:00:00-08:00", "", time.Hour * 24},
+		{"0 * * * *", "2018-12-17T08:08:00+00:00", "", time.Minute * 52},
+		{"0 * * * *", "2018-12-17T09:00:00+00:00", "", time.Hour},
+		{"* * * * *", "2018-12-17T08:08:18+00:00", "", time.Second * 42},
+		{"0 * * * *", "2018-12-17T09:00:00+00:00", "", time.Minute * 60},
+		{"0 10 * * *", "2018-12-17T08:00:00+00:00", "2018-12-20T00:00:00+00:00", time.Hour * 10},
+		{"0 10 * * *", "2018-12-17T08:00:00+00:00", "2018-12-17T09:00:00+00:00", time.Hour},
+		{"*/10 * * * *", "2018-12-17T00:04:00+00:00", "2018-12-17T01:02:00+00:00", time.Minute * 8},
+		{"invalid-cron-spec", "2018-12-17T00:04:00+00:00", "2018-12-17T01:02:00+00:00", NoBackoff},
+		{"@every 5h", "2018-12-17T08:00:00+00:00", "2018-12-17T09:00:00+00:00", time.Hour * 4},
+		{"@every 5h", "2018-12-17T08:00:00+00:00", "2018-12-18T00:00:00+00:00", time.Hour * 4},
+		{"0 3 * * 0-6", "2018-12-17T08:00:00-08:00", "", time.Hour * 11},
+	}
 	for idx, tt := range crontests {
 		t.Run(strconv.Itoa(idx), func(t *testing.T) {
 			start, _ := time.Parse(time.RFC3339, tt.startTime)
@@ -62,12 +61,15 @@ func TestCron(t *testing.T) {
 				end, _ = time.Parse(time.RFC3339, tt.endTime)
 			}
 			sched, err := ValidateSchedule(tt.cron)
-			if tt.result != NoBackoff {
-				assert.NoError(t, err)
+			if tt.result == NoBackoff {
+				// no backoff == error, simplifies the test-struct a bit
+				require.ErrorContains(t, err, "Invalid CronSchedule")
+			} else {
+				require.NoError(t, err)
+				backoff, err := GetBackoffForNextSchedule(sched, start, end, 0)
+				require.NoError(t, err)
+				assert.Equal(t, tt.result, backoff, "The cron spec is %s and the expected result is %s", tt.cron, tt.result)
 			}
-			backoff, err := GetBackoffForNextSchedule(sched, start, end, 0)
-			require.NoError(t, err)
-			assert.Equal(t, tt.result, backoff, "The cron spec is %s and the expected result is %s", tt.cron, tt.result)
 		})
 	}
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -163,6 +163,11 @@ func BlobSizeViolationOperation(operation string) Tag {
 	return newStringTag("blob-size-violation-operation", operation)
 }
 
+// WorkflowCronSchedule returns a tag to report a workflow's cron schedule
+func WorkflowCronSchedule(schedule string) Tag {
+	return newStringTag("wf-cron-schedule", schedule)
+}
+
 // domain related
 
 // WorkflowDomainID returns tag for WorkflowDomainID

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -99,7 +99,8 @@ func TestCreateHistoryStartWorkflowRequest_ExpirationTimeWithCron(t *testing.T) 
 		CronSchedule: "@every 300s",
 	}
 	now := time.Now()
-	startRequest := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	require.NoError(t, err)
 	require.NotNil(t, startRequest)
 
 	expirationTime := startRequest.GetExpirationTimestamp()
@@ -145,7 +146,8 @@ func TestFirstDecisionTaskBackoffDuringStartWorkflow(t *testing.T) {
 			for i := 0; i < caseCount; i++ {
 				// Start at the minute boundary so we know what the backoff should be
 				startTime, _ := time.Parse(time.RFC3339, "2018-12-17T08:00:00+00:00")
-				startRequest := CreateHistoryStartWorkflowRequest(domainID, request, startTime)
+				startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, startTime)
+				require.NoError(t, err)
 				require.NotNil(t, startRequest)
 
 				backoff := startRequest.GetFirstDecisionTaskBackoffSeconds()
@@ -226,7 +228,8 @@ func testExpirationTime(t *testing.T, delayStartSeconds int, cronSeconds int, ji
 	minDelay := delayStartSeconds + cronSeconds
 	maxDelay := delayStartSeconds + 2*cronSeconds + jitterSeconds
 	now := time.Now()
-	startRequest := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	require.NoError(t, err)
 	require.NotNil(t, startRequest)
 
 	expirationTime := startRequest.GetExpirationTimestamp()
@@ -261,7 +264,8 @@ func TestCreateHistoryStartWorkflowRequest_ExpirationTimeWithoutCron(t *testing.
 		},
 	}
 	now := time.Now()
-	startRequest := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	require.NoError(t, err)
 	require.NotNil(t, startRequest)
 
 	expirationTime := startRequest.GetExpirationTimestamp()

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2070,8 +2070,10 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(err, scope, tags...)
 	}
 
-	if _, err := backoff.ValidateSchedule(startRequest.GetCronSchedule()); err != nil {
-		return nil, wh.error(err, scope, tags...)
+	if startRequest.GetCronSchedule() != "" {
+		if _, err := backoff.ValidateSchedule(startRequest.GetCronSchedule()); err != nil {
+			return nil, wh.error(err, scope, tags...)
+		}
 	}
 
 	wh.GetLogger().Debug(
@@ -2707,8 +2709,10 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 		return nil, wh.error(err, scope, tags...)
 	}
 
-	if _, err := backoff.ValidateSchedule(signalWithStartRequest.GetCronSchedule()); err != nil {
-		return nil, wh.error(err, scope, tags...)
+	if signalWithStartRequest.GetCronSchedule() != "" {
+		if _, err := backoff.ValidateSchedule(signalWithStartRequest.GetCronSchedule()); err != nil {
+			return nil, wh.error(err, scope, tags...)
+		}
 	}
 
 	if err := wh.searchAttributesValidator.ValidateSearchAttributes(signalWithStartRequest.SearchAttributes, domainName); err != nil {

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2070,7 +2070,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(err, scope, tags...)
 	}
 
-	if err := backoff.ValidateSchedule(startRequest.GetCronSchedule()); err != nil {
+	if _, err := backoff.ValidateSchedule(startRequest.GetCronSchedule()); err != nil {
 		return nil, wh.error(err, scope, tags...)
 	}
 
@@ -2122,7 +2122,11 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 
 		// Request using start/end time zero value, which will get us an exact answer (i.e. its not in the
 		// middle of a minute)
-		backoffSeconds := backoff.GetBackoffForNextScheduleInSeconds(cron, time.Time{}, time.Time{}, jitter)
+		backoffSeconds, err := backoff.GetBackoffForNextScheduleInSeconds(cron, time.Time{}, time.Time{}, jitter)
+		if err != nil {
+			tags = append(tags, tag.WorkflowCronSchedule(cron))
+			return nil, wh.error(err, scope, tags...)
+		}
 		if jitter > backoffSeconds {
 			return nil, wh.error(errInvalidJitterStartSeconds2, scope, tags...)
 		}
@@ -2175,8 +2179,11 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 	}
 
 	wh.GetLogger().Debug("Start workflow execution request domainID", tag.WorkflowDomainID(domainID))
-	historyRequest := common.CreateHistoryStartWorkflowRequest(
+	historyRequest, err := common.CreateHistoryStartWorkflowRequest(
 		domainID, startRequest, time.Now())
+	if err != nil {
+		return nil, err
+	}
 
 	resp, err = wh.GetHistoryClient().StartWorkflowExecution(ctx, historyRequest)
 	if err != nil {
@@ -2700,7 +2707,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 		return nil, wh.error(err, scope, tags...)
 	}
 
-	if err := backoff.ValidateSchedule(signalWithStartRequest.GetCronSchedule()); err != nil {
+	if _, err := backoff.ValidateSchedule(signalWithStartRequest.GetCronSchedule()); err != nil {
 		return nil, wh.error(err, scope, tags...)
 	}
 
@@ -3388,13 +3395,16 @@ func (wh *WorkflowHandler) RestartWorkflowExecution(ctx context.Context, request
 	}
 	startRequest := constructRestartWorkflowRequest(history.History.Events[0].WorkflowExecutionStartedEventAttributes,
 		domainName, request.Identity, wfExecution.WorkflowID)
-	startResp, err := wh.GetHistoryClient().StartWorkflowExecution(ctx, common.CreateHistoryStartWorkflowRequest(
-		domainID, startRequest, time.Now()))
-	resp = &types.RestartWorkflowExecutionResponse{
-		RunID: startResp.RunID,
+	req, err := common.CreateHistoryStartWorkflowRequest(domainID, startRequest, time.Now())
+	if err != nil {
+		return nil, err
 	}
+	startResp, err := wh.GetHistoryClient().StartWorkflowExecution(ctx, req)
 	if err != nil {
 		return nil, wh.normalizeVersionedErrors(ctx, wh.error(err, scope, tags...))
+	}
+	resp = &types.RestartWorkflowExecutionResponse{
+		RunID: startResp.RunID,
 	}
 
 	return resp, nil

--- a/service/history/decision/checker.go
+++ b/service/history/decision/checker.go
@@ -755,8 +755,10 @@ func (v *attrValidator) validateStartChildExecutionAttributes(
 		return err
 	}
 
-	if _, err := backoff.ValidateSchedule(attributes.GetCronSchedule()); err != nil {
-		return err
+	if attributes.GetCronSchedule() != "" {
+		if _, err := backoff.ValidateSchedule(attributes.GetCronSchedule()); err != nil {
+			return err
+		}
 	}
 
 	// Inherit tasklist from parent workflow execution if not provided on decision

--- a/service/history/decision/checker.go
+++ b/service/history/decision/checker.go
@@ -755,7 +755,7 @@ func (v *attrValidator) validateStartChildExecutionAttributes(
 		return err
 	}
 
-	if err := backoff.ValidateSchedule(attributes.GetCronSchedule()); err != nil {
+	if _, err := backoff.ValidateSchedule(attributes.GetCronSchedule()); err != nil {
 		return err
 	}
 

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1090,6 +1090,10 @@ func (e *mutableStateBuilder) GetCronBackoffDuration(
 	if len(info.CronSchedule) == 0 {
 		return backoff.NoBackoff, nil
 	}
+	sched, err := backoff.ValidateSchedule(info.CronSchedule)
+	if err != nil {
+		return backoff.NoBackoff, err
+	}
 	// TODO: decide if we can add execution time in execution info.
 	executionTime := e.executionInfo.StartTimestamp
 	// This only call when doing ContinueAsNew. At this point, the workflow should have a start event
@@ -1102,7 +1106,7 @@ func (e *mutableStateBuilder) GetCronBackoffDuration(
 		time.Duration(workflowStartEvent.GetWorkflowExecutionStartedEventAttributes().GetFirstDecisionTaskBackoffSeconds()) * time.Second
 	executionTime = executionTime.Add(firstDecisionTaskBackoff)
 	jitterStartSeconds := workflowStartEvent.GetWorkflowExecutionStartedEventAttributes().GetJitterStartSeconds()
-	return backoff.GetBackoffForNextSchedule(info.CronSchedule, executionTime, e.timeSource.Now(), jitterStartSeconds), nil
+	return backoff.GetBackoffForNextSchedule(sched, executionTime, e.timeSource.Now(), jitterStartSeconds)
 }
 
 // GetSignalInfo get details about a signal request that is currently in progress.

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -3288,9 +3288,7 @@ func getStartRequest(
 		JitterStartSeconds:                  request.JitterStartSeconds,
 	}
 
-	startRequest := common.CreateHistoryStartWorkflowRequest(domainID, req, time.Now())
-
-	return startRequest, nil
+	return common.CreateHistoryStartWorkflowRequest(domainID, req, time.Now())
 }
 
 func (e *historyEngineImpl) applyWorkflowIDReusePolicyForSigWithStart(

--- a/service/history/task/cross_cluster_target_task_executor_test.go
+++ b/service/history/task/cross_cluster_target_task_executor_test.go
@@ -129,7 +129,7 @@ func (s *crossClusterTargetTaskExecutorSuite) TestExecute_InvalidTargetDomain() 
 func (s *crossClusterTargetTaskExecutorSuite) TestStartChildExecutionTask_StartChildSuccess() {
 	task := s.getTestStartChildExecutionTask(processingStateInitialized, nil)
 
-	historyReq := createTestChildWorkflowExecutionRequest(
+	historyReq, err := createTestChildWorkflowExecutionRequest(
 		constants.TestDomainName,
 		constants.TestTargetDomainName,
 		task.GetInfo().(*persistence.CrossClusterTaskInfo),
@@ -137,11 +137,12 @@ func (s *crossClusterTargetTaskExecutorSuite) TestStartChildExecutionTask_StartC
 		task.request.StartChildExecutionAttributes.GetRequestID(),
 		s.mockShard.GetTimeSource().Now(),
 	)
+	require.NoError(s.T(), err)
 	targetRunID := "random target runID"
 	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), historyReq).
 		Return(&types.StartWorkflowExecutionResponse{RunID: targetRunID}, nil).Times(1)
 
-	err := s.executor.Execute(task, true)
+	err = s.executor.Execute(task, true)
 	s.NoError(err)
 
 	s.Equal(task.GetTaskID(), task.response.GetTaskID())
@@ -154,7 +155,7 @@ func (s *crossClusterTargetTaskExecutorSuite) TestStartChildExecutionTask_StartC
 func (s *crossClusterTargetTaskExecutorSuite) TestStartChildExecutionTask_StartChildFailed() {
 	task := s.getTestStartChildExecutionTask(processingStateInitialized, nil)
 
-	historyReq := createTestChildWorkflowExecutionRequest(
+	historyReq, err := createTestChildWorkflowExecutionRequest(
 		constants.TestDomainName,
 		constants.TestTargetDomainName,
 		task.GetInfo().(*persistence.CrossClusterTaskInfo),
@@ -162,10 +163,11 @@ func (s *crossClusterTargetTaskExecutorSuite) TestStartChildExecutionTask_StartC
 		task.request.StartChildExecutionAttributes.GetRequestID(),
 		s.mockShard.GetTimeSource().Now(),
 	)
+	require.NoError(s.T(), err)
 	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), historyReq).
 		Return(nil, &types.WorkflowExecutionAlreadyStartedError{}).Times(1)
 
-	err := s.executor.Execute(task, true)
+	err = s.executor.Execute(task, true)
 	s.NoError(err)
 
 	s.Equal(task.GetTaskID(), task.response.GetTaskID())

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1738,7 +1738,10 @@ func startWorkflowWithRetry(
 		JitterStartSeconds:    attributes.JitterStartSeconds,
 	}
 
-	historyStartReq := common.CreateHistoryStartWorkflowRequest(task.TargetDomainID, frontendStartReq, timeSource.Now())
+	historyStartReq, err := common.CreateHistoryStartWorkflowRequest(task.TargetDomainID, frontendStartReq, timeSource.Now())
+	if err != nil {
+		return "", err
+	}
 	historyStartReq.ParentExecutionInfo = &types.ParentExecutionInfo{
 		DomainUUID: task.DomainID,
 		Domain:     domainName,

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1202,7 +1202,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessStartChildExecution_Success
 			taskInfo := transferTask.GetInfo().(*persistence.TransferTaskInfo)
 			event, err = mutableState.GetChildExecutionInitiatedEvent(context.Background(), taskInfo.ScheduleID)
 			s.NoError(err)
-			historyReq := createTestChildWorkflowExecutionRequest(
+			historyReq, err := createTestChildWorkflowExecutionRequest(
 				s.domainName,
 				s.childDomainName,
 				taskInfo,
@@ -1210,6 +1210,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessStartChildExecution_Success
 				childInfo.CreateRequestID,
 				s.mockShard.GetTimeSource().Now(),
 			)
+			require.NoError(s.T(), err)
 			s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), historyReq).Return(&types.StartWorkflowExecutionResponse{RunID: childExecution.RunID}, nil).Times(1)
 			s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 			s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
@@ -1241,7 +1242,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessStartChildExecution_Failure
 			taskInfo := transferTask.GetInfo().(*persistence.TransferTaskInfo)
 			event, err = mutableState.GetChildExecutionInitiatedEvent(context.Background(), taskInfo.ScheduleID)
 			s.NoError(err)
-			historyReq := createTestChildWorkflowExecutionRequest(
+			historyReq, err := createTestChildWorkflowExecutionRequest(
 				s.domainName,
 				s.childDomainName,
 				taskInfo,
@@ -1249,6 +1250,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessStartChildExecution_Failure
 				childInfo.CreateRequestID,
 				s.mockShard.GetTimeSource().Now(),
 			)
+			require.NoError(s.T(), err)
 			s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), historyReq).Return(nil, &types.WorkflowExecutionAlreadyStartedError{}).Times(1)
 			s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&persistence.AppendHistoryNodesResponse{}, nil).Once()
 			s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
@@ -1760,7 +1762,7 @@ func createTestChildWorkflowExecutionRequest(
 	attributes *types.StartChildWorkflowExecutionInitiatedEventAttributes,
 	requestID string,
 	now time.Time,
-) *types.HistoryStartWorkflowExecutionRequest {
+) (*types.HistoryStartWorkflowExecutionRequest, error) {
 
 	workflowExecution := types.WorkflowExecution{
 		WorkflowID: taskInfo.WorkflowID,
@@ -1787,11 +1789,14 @@ func createTestChildWorkflowExecutionRequest(
 		InitiatedID: taskInfo.ScheduleID,
 	}
 
-	historyStartReq := common.CreateHistoryStartWorkflowRequest(
+	historyStartReq, err := common.CreateHistoryStartWorkflowRequest(
 		taskInfo.TargetDomainID, frontendStartReq, now)
+	if err != nil {
+		return nil, err
+	}
 
 	historyStartReq.ParentExecutionInfo = parentInfo
-	return historyStartReq
+	return historyStartReq, nil
 }
 
 func createUpsertWorkflowSearchAttributesRequest(


### PR DESCRIPTION
We got some infinite (or near enough to infinite) hot loops in cron-schedule-Next-ing code today.
While we don't yet have any concrete examples to investigate, I'm going to claim it's due to being 2 weeks away from the end of February, and February is weird.  People are probably accidentally scheduling things for Feb 30 or 31.

There does seem to be some invalid cron schedule parsing happening in robfig/cron, e.g. for `0 0 0 , 0`, but the bulk of the blame for this rests on our code: `.Next` returns a zero-valued time if there is no next time, and that's `.Before` other dates... by a very large margin.
There's a decent chance the next `.Next` will return another zero value too, leading to a truly infinite loop.

Since a lot of this code was kinda ridiculous about not returning errors, I've just changed that and all callers.
In most cases there was a simple place "nearby" that already returned errors, so it just now returns another kind of error.

---

Because these invalid schedules are likely *always* invalid (robfig/cron checks 5 years of values, e.g. to work around leap years), and this would *always* infinite loop on those values, I believe it's safe to assume that these invalid cron schedules have never been written to databases.
