### PR TITLE
Unload taskListManager by instance, not taskListID

### DIFF
--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -1,5 +1,7 @@
-// Copyright (c) 2017-2020 Uber Technologies, Inc.
-//
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
@@ -7,16 +9,16 @@
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
 //
-// The above copyright notice and this permission notice shall be included in
-// all copies or substantial portions of the Software.
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
 //
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 // AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-// THE SOFTWARE.
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
 
 package matching
 
@@ -253,11 +255,14 @@ func (e *matchingEngineImpl) updateTaskList(taskList *taskListID, mgr taskListMa
 	e.taskLists[*taskList] = mgr
 }
 
-func (e *matchingEngineImpl) removeTaskListManager(id *taskListID) {
+func (e *matchingEngineImpl) removeTaskListManager(tlMgr taskListManager) {
+	id := tlMgr.TaskListID()
 	e.taskListsLock.Lock()
-	defer e.taskListsLock.Unlock()
-
-	delete(e.taskLists, *id)
+	currentTlMgr, ok := e.taskLists[*id]
+	if ok && tlMgr == currentTlMgr {
+		delete(e.taskLists, *id)
+	}
+	e.taskListsLock.Unlock()
 	e.metricsClient.Scope(metrics.MatchingTaskListMgrScope).UpdateGauge(
 		metrics.TaskListManagersGauge,
 		float64(len(e.taskLists)),
@@ -836,16 +841,17 @@ func (e *matchingEngineImpl) getTask(
 	return tlMgr.GetTask(ctx, maxDispatchPerSecond)
 }
 
-func (e *matchingEngineImpl) unloadTaskList(id *taskListID) {
+func (e *matchingEngineImpl) unloadTaskList(tlMgr taskListManager) {
+	id := tlMgr.TaskListID()
 	e.taskListsLock.Lock()
-	tlMgr, ok := e.taskLists[*id]
-	if ok {
-		delete(e.taskLists, *id)
+	currentTlMgr, ok := e.taskLists[*id]
+	if !ok || tlMgr != currentTlMgr {
+		e.taskListsLock.Unlock()
+		return
 	}
+	delete(e.taskLists, *id)
 	e.taskListsLock.Unlock()
-	if ok {
-		tlMgr.Stop()
-	}
+	tlMgr.Stop()
 }
 
 // Populate the decision task response based on context and scheduled/started events.

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -83,6 +83,7 @@ type (
 		DescribeTaskList(includeTaskListStatus bool) *types.DescribeTaskListResponse
 		String() string
 		GetTaskListKind() types.TaskListKind
+		TaskListID() *taskListID
 	}
 
 	// Single task list in memory state
@@ -204,7 +205,7 @@ func (c *taskListManagerImpl) Stop() {
 	close(c.shutdownCh)
 	c.taskWriter.Stop()
 	c.taskReader.Stop()
-	c.engine.removeTaskListManager(c.taskListID)
+	c.engine.removeTaskListManager(c)
 	c.logger.Info("Task list manager state changed", tag.LifeCycleStopped)
 }
 
@@ -426,6 +427,10 @@ func (c *taskListManagerImpl) String() string {
 
 func (c *taskListManagerImpl) GetTaskListKind() types.TaskListKind {
 	return c.taskListKind
+}
+
+func (c *taskListManagerImpl) TaskListID() *taskListID {
+	return c.taskListID
 }
 
 // completeTask marks a task as processed. Only tasks created by taskReader (i.e. backlog from db) reach


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
cherry pick https://github.com/temporalio/temporal/pull/1917


<!-- Tell your future self why have you made these changes -->
**Why?**
see https://github.com/temporalio/temporal/pull/1917

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
