### PR TITLE
Revert "CDNC-2088 (#5094) Add attempt-count to task processing logs"

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -591,8 +591,8 @@ func Attempt(attempt int32) Tag {
 }
 
 // AttemptCount returns tag for AttemptCount
-func AttemptCount(attemptCount int) Tag {
-	return newInt("attempt-count", attemptCount)
+func AttemptCount(attemptCount int64) Tag {
+	return newInt64("attempt-count", attemptCount)
 }
 
 // AttemptStart returns tag for AttemptStart

--- a/service/history/task/cross_cluster_task.go
+++ b/service/history/task/cross_cluster_task.go
@@ -359,11 +359,7 @@ func (t *crossClusterSourceTask) HandleErr(
 			if attempt > t.maxRetryCount {
 				t.scope.RecordTimer(metrics.TaskAttemptTimerPerDomain, time.Duration(attempt))
 				t.logger.Error("Critical error processing task, retrying.",
-					tag.Error(err),
-					tag.OperationCritical,
-					tag.TaskType(t.GetTaskType()),
-					tag.AttemptCount(t.GetAttempt()),
-				)
+					tag.Error(err), tag.OperationCritical, tag.TaskType(t.GetTaskType()))
 			}
 		}
 	}()

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -240,7 +240,6 @@ func (t *taskImpl) HandleErr(
 					tag.Error(err),
 					tag.OperationCritical,
 					tag.TaskType(t.GetTaskType()),
-					tag.AttemptCount(t.GetAttempt()),
 				)
 			}
 		}


### PR DESCRIPTION
Removed this commit because there was a deadlock on getAttempt()