### PR TITLE
Fix InsertTasks query for Cassandra

### DIFF
--- a/common/persistence/nosql/nosqlTaskStore.go
+++ b/common/persistence/nosql/nosqlTaskStore.go
@@ -247,7 +247,13 @@ func (t *nosqlTaskStore) CreateTasks(
 		})
 	}
 
-	err := t.db.InsertTasks(ctx, tasks, toTaskListRow(request.TaskListInfo))
+	tasklistCondition := &nosqlplugin.TaskListRow{
+		DomainID:     request.TaskListInfo.DomainID,
+		TaskListName: request.TaskListInfo.Name,
+		TaskListType: request.TaskListInfo.TaskType,
+		RangeID:      request.TaskListInfo.RangeID,
+	}
+	err := t.db.InsertTasks(ctx, tasks, tasklistCondition)
 
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.TaskOperationConditionFailure)
@@ -261,18 +267,6 @@ func (t *nosqlTaskStore) CreateTasks(
 	}
 
 	return &p.CreateTasksResponse{}, nil
-}
-
-func toTaskListRow(info *p.TaskListInfo) *nosqlplugin.TaskListRow {
-	return &nosqlplugin.TaskListRow{
-		DomainID:        info.DomainID,
-		TaskListName:    info.Name,
-		TaskListType:    info.TaskType,
-		TaskListKind:    info.Kind,
-		RangeID:         info.RangeID,
-		AckLevel:        info.AckLevel,
-		LastUpdatedTime: info.LastUpdated,
-	}
 }
 
 func (t *nosqlTaskStore) GetTasks(

--- a/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tasks.go
@@ -136,6 +136,15 @@ const (
 		`and task_id = ? ` +
 		`IF range_id = ?`
 
+	templateUpdateTaskListRangeIDQuery = `UPDATE tasks SET ` +
+		`range_id = ? ` +
+		`WHERE domain_id = ? ` +
+		`and task_list_name = ? ` +
+		`and task_list_type = ? ` +
+		`and type = ? ` +
+		`and task_id = ? ` +
+		`IF range_id = ?`
+
 	templateDeleteTaskListQuery = `DELETE FROM tasks ` +
 		`WHERE domain_id = ? ` +
 		`AND task_list_name = ? ` +
@@ -342,8 +351,6 @@ func (db *cdb) InsertTasks(
 	domainID := tasklistCondition.DomainID
 	taskListName := tasklistCondition.TaskListName
 	taskListType := tasklistCondition.TaskListType
-	taskListKind := tasklistCondition.TaskListKind
-	ackLevel := tasklistCondition.AckLevel
 
 	for _, task := range tasksToInsert {
 		scheduleID := task.ScheduledID
@@ -380,14 +387,8 @@ func (db *cdb) InsertTasks(
 	}
 
 	// The following query is used to ensure that range_id didn't change
-	batch.Query(templateUpdateTaskListQuery,
+	batch.Query(templateUpdateTaskListRangeIDQuery,
 		tasklistCondition.RangeID,
-		domainID,
-		taskListName,
-		taskListType,
-		ackLevel,
-		taskListKind,
-		time.Now(),
 		domainID,
 		taskListName,
 		taskListType,

--- a/service/matching/db.go
+++ b/service/matching/db.go
@@ -39,7 +39,6 @@ type (
 		taskListKind int
 		taskType     int
 		rangeID      int64
-		ackLevel     int64
 		store        persistence.TaskManager
 		logger       log.Logger
 	}
@@ -94,9 +93,8 @@ func (db *taskListDB) RenewLease() (taskListState, error) {
 	if err != nil {
 		return taskListState{}, err
 	}
-	db.ackLevel = resp.TaskListInfo.AckLevel
 	db.rangeID = resp.TaskListInfo.RangeID
-	return taskListState{rangeID: db.rangeID, ackLevel: db.ackLevel}, nil
+	return taskListState{rangeID: db.rangeID, ackLevel: resp.TaskListInfo.AckLevel}, nil
 }
 
 // UpdateState updates the taskList state with the given value
@@ -114,9 +112,6 @@ func (db *taskListDB) UpdateState(ackLevel int64) error {
 		},
 		DomainName: db.domainName,
 	})
-	if err == nil {
-		db.ackLevel = ackLevel
-	}
 	return err
 }
 
@@ -129,9 +124,7 @@ func (db *taskListDB) CreateTasks(tasks []*persistence.CreateTaskInfo) (*persist
 			DomainID: db.domainID,
 			Name:     db.taskListName,
 			TaskType: db.taskType,
-			AckLevel: db.ackLevel,
 			RangeID:  db.rangeID,
-			Kind:     db.taskListKind,
 		},
 		Tasks:      tasks,
 		DomainName: db.domainName,

--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -94,9 +94,8 @@ func TestReadLevelForAllExpiredTasksInBatch(t *testing.T) {
 
 	tlm := createTestTaskListManager(controller)
 	tlm.db.rangeID = int64(1)
-	tlm.db.ackLevel = int64(0)
-	tlm.taskAckManager.SetAckLevel(tlm.db.ackLevel)
-	tlm.taskAckManager.SetReadLevel(tlm.db.ackLevel)
+	tlm.taskAckManager.SetAckLevel(0)
+	tlm.taskAckManager.SetReadLevel(0)
 	require.Equal(t, int64(0), tlm.taskAckManager.GetAckLevel())
 	require.Equal(t, int64(0), tlm.taskAckManager.GetReadLevel())
 
@@ -173,8 +172,7 @@ func TestDescribeTaskList(t *testing.T) {
 	// Create taskList Manager and set taskList state
 	tlm := createTestTaskListManager(controller)
 	tlm.db.rangeID = int64(1)
-	tlm.db.ackLevel = int64(0)
-	tlm.taskAckManager.SetAckLevel(tlm.db.ackLevel)
+	tlm.taskAckManager.SetAckLevel(0)
 
 	for i := int64(0); i < taskCount; i++ {
 		err := tlm.taskAckManager.ReadItem(startTaskID + i)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix the conditional update query of InsertTasks operation for Cassandra
- Code cleanup

<!-- Tell your future self why have you made these changes -->
**Why?**
The conditional update query of InsertTasks should be a no-op. When inserting tasks, we do the conditional update to make sure the rangeID doesn't change and we don't want to update the metadata of tasklists.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing persistence test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There is no risk. The change only affect the LastUpdate metadata of tasklist, which is used for garbage collection. However, we only run the garbage collector of tasklists with database not supporting TTL.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
