### PR TITLE
Add attempt-count to task processing logs, and update unit test so that it will cover deadlock

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -591,8 +591,8 @@ func Attempt(attempt int32) Tag {
 }
 
 // AttemptCount returns tag for AttemptCount
-func AttemptCount(attemptCount int64) Tag {
-	return newInt64("attempt-count", attemptCount)
+func AttemptCount(attemptCount int) Tag {
+	return newInt("attempt-count", attemptCount)
 }
 
 // AttemptStart returns tag for AttemptStart

--- a/service/history/task/cross_cluster_task.go
+++ b/service/history/task/cross_cluster_task.go
@@ -359,7 +359,11 @@ func (t *crossClusterSourceTask) HandleErr(
 			if attempt > t.maxRetryCount {
 				t.scope.RecordTimer(metrics.TaskAttemptTimerPerDomain, time.Duration(attempt))
 				t.logger.Error("Critical error processing task, retrying.",
-					tag.Error(err), tag.OperationCritical, tag.TaskType(t.GetTaskType()))
+					tag.Error(err),
+					tag.OperationCritical,
+					tag.TaskType(t.GetTaskType()),
+					tag.AttemptCount(attempt),
+				)
 			}
 		}
 	}()

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -240,6 +240,7 @@ func (t *taskImpl) HandleErr(
 					tag.Error(err),
 					tag.OperationCritical,
 					tag.TaskType(t.GetTaskType()),
+					tag.AttemptCount(t.attempt),
 				)
 			}
 		}

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -82,6 +82,8 @@ func (s *taskSuite) SetupTest() {
 	s.mockTaskInfo.EXPECT().GetDomainID().Return(constants.TestDomainID).AnyTimes()
 	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(constants.TestDomainID).Return(constants.TestDomainName, nil).AnyTimes()
 
+	s.mockTaskInfo.EXPECT().GetTaskType().Return(123)
+
 	s.logger = loggerimpl.NewLoggerForTest(s.Suite)
 	s.maxRetryCount = dynamicconfig.GetIntPropertyFn(10)
 }
@@ -193,6 +195,10 @@ func (s *taskSuite) TestHandleErr_UnknownErr() {
 	taskBase := s.newTestTask(func(task Info) (bool, error) {
 		return true, nil
 	}, nil)
+
+	// make sure it will go into the defer function.
+	// in this case, make it 0 < attempt < stickyTaskMaxRetryCount
+	taskBase.attempt = 10
 
 	err := errors.New("some random error")
 	s.Equal(err, taskBase.HandleErr(err))

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -82,8 +82,6 @@ func (s *taskSuite) SetupTest() {
 	s.mockTaskInfo.EXPECT().GetDomainID().Return(constants.TestDomainID).AnyTimes()
 	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(constants.TestDomainID).Return(constants.TestDomainName, nil).AnyTimes()
 
-	s.mockTaskInfo.EXPECT().GetTaskType().Return(123)
-
 	s.logger = loggerimpl.NewLoggerForTest(s.Suite)
 	s.maxRetryCount = dynamicconfig.GetIntPropertyFn(10)
 }
@@ -195,6 +193,11 @@ func (s *taskSuite) TestHandleErr_UnknownErr() {
 	taskBase := s.newTestTask(func(task Info) (bool, error) {
 		return true, nil
 	}, nil)
+
+	// need to mock a return value for function GetTaskType
+	// if don't do, there'll be an error when code goes into the defer function:
+	// Unexpected call: because: there are no expected calls of the method "GetTaskType" for that receiver
+	s.mockTaskInfo.EXPECT().GetTaskType().Return(123)
 
 	// make sure it will go into the defer function.
 	// in this case, make it 0 < attempt < stickyTaskMaxRetryCount

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -194,9 +194,10 @@ func (s *taskSuite) TestHandleErr_UnknownErr() {
 		return true, nil
 	}, nil)
 
-	// need to mock a return value for function GetTaskType
-	// if don't do, there'll be an error when code goes into the defer function:
+	// Need to mock a return value for function GetTaskType
+	// If don't do, there'll be an error when code goes into the defer function:
 	// Unexpected call: because: there are no expected calls of the method "GetTaskType" for that receiver
+	// But can't put it in the setup function since it may cause other errors
 	s.mockTaskInfo.EXPECT().GetTaskType().Return(123)
 
 	// make sure it will go into the defer function.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add attempt count into task processing logs, without using the function getAttempt().
Update unit test so that it will go into the function that cause the deadlock.

<!-- Tell your future self why have you made these changes -->
**Why?**
Using getAttempt() function caused us a deadlock. Avoid using it will solve this problem.
Unit test never went to the defer function. As a result it didn't detect the deadlock before. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
