### PR TITLE
Scanner to purge deprecated domain workflows

### DIFF
--- a/common/reconciliation/constants.go
+++ b/common/reconciliation/constants.go
@@ -29,4 +29,5 @@ const (
 	CheckDataCorruptionWorkflowID                   = "check-data-corruption-workflow-id"
 	CheckDataCorruptionWorkflowTimeoutInSeconds     = 24 * 60 * 60
 	CheckDataCorruptionWorkflowTaskTimeoutInSeconds = 60
+	deprecatedDomainStatus                          = 1
 )

--- a/common/reconciliation/invariant/concreteExecutionExists.go
+++ b/common/reconciliation/invariant/concreteExecutionExists.go
@@ -76,7 +76,6 @@ func (c *concreteExecutionExists) Check(
 	}
 	domainID := currentExecution.GetDomainID()
 	domain, errorDomainName := c.cache.GetDomainByID(domainID)
-	domainName := domain.GetInfo().Name
 	if errorDomainName != nil {
 		return CheckResult{
 			CheckResultType: CheckResultTypeFailed,
@@ -85,7 +84,8 @@ func (c *concreteExecutionExists) Check(
 			InfoDetails:     errorDomainName.Error(),
 		}
 	}
-	if domain.GetInfo().Status == 1 {
+	domainName := domain.GetInfo().Name
+	if domain.GetInfo().Status == deprecatedDomainStatus {
 		return CheckResult{
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   c.Name(),

--- a/common/reconciliation/invariant/concreteExecutionExists.go
+++ b/common/reconciliation/invariant/concreteExecutionExists.go
@@ -89,7 +89,7 @@ func (c *concreteExecutionExists) Check(
 		return CheckResult{
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   c.Name(),
-			Info:            "failed to check: domain is deprecated",
+			Info:            "domain is deprecated",
 			InfoDetails: fmt.Sprintf("domain has been deprecated. DomainID: %v, DomainName: %v",
 				domainName, domainID),
 		}

--- a/common/reconciliation/invariant/concreteExecutionExists_test.go
+++ b/common/reconciliation/invariant/concreteExecutionExists_test.go
@@ -28,6 +28,8 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/uber/cadence/service/history/constants"
+
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/mock"
@@ -161,6 +163,7 @@ func (s *ConcreteExecutionExistsSuite) TestCheck() {
 		execManager.On("IsWorkflowExecutionExists", mock.Anything, mock.Anything).Return(tc.getConcreteResp, tc.getConcreteErr)
 		execManager.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(tc.getCurrentResp, tc.getCurrentErr)
 		mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
+		mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(constants.TestGlobalDomainEntry, nil).AnyTimes()
 		o := NewConcreteExecutionExists(persistence.NewPersistenceRetryer(execManager, nil, c.CreatePersistenceRetryPolicy()), mockDomainCache)
 		s.Equal(tc.expectedResult, o.Check(context.Background(), tc.execution))
 	}

--- a/common/reconciliation/invariant/historyExists.go
+++ b/common/reconciliation/invariant/historyExists.go
@@ -85,7 +85,7 @@ func (h *historyExists) Check(
 		return CheckResult{
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   h.Name(),
-			Info:            "failed to check: domain is deprecated",
+			Info:            "domain is deprecated",
 			InfoDetails: fmt.Sprintf("domain has been deprecated. DomainID: %v, DomainName: %v",
 				domainName, domainID),
 		}

--- a/common/reconciliation/invariant/historyExists.go
+++ b/common/reconciliation/invariant/historyExists.go
@@ -35,6 +35,7 @@ import (
 
 const (
 	historyPageSize = 1
+	deprecatedDomainStatus
 )
 
 type (
@@ -71,7 +72,6 @@ func (h *historyExists) Check(
 	}
 	domainID := concreteExecution.GetDomainID()
 	domain, errorDomainName := h.dc.GetDomainByID(domainID)
-	domainName := domain.GetInfo().Name
 	if errorDomainName != nil {
 		return CheckResult{
 			CheckResultType: CheckResultTypeFailed,
@@ -80,7 +80,8 @@ func (h *historyExists) Check(
 			InfoDetails:     errorDomainName.Error(),
 		}
 	}
-	if domain.GetInfo().Status == 1 {
+	domainName := domain.GetInfo().Name
+	if domain.GetInfo().Status == deprecatedDomainStatus {
 		return CheckResult{
 			CheckResultType: CheckResultTypeCorrupted,
 			InvariantName:   h.Name(),

--- a/common/reconciliation/invariant/historyExists_test.go
+++ b/common/reconciliation/invariant/historyExists_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/history/constants"
 )
 
 type HistoryExistsSuite struct {
@@ -140,6 +141,7 @@ func (s *HistoryExistsSuite) TestCheck() {
 		execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getExecResp, tc.getExecErr)
 		historyManager.On("ReadHistoryBranch", mock.Anything, mock.Anything).Return(tc.getHistoryResp, tc.getHistoryErr)
 		domainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
+		domainCache.EXPECT().GetDomainByID(gomock.Any()).Return(constants.TestGlobalDomainEntry, nil).AnyTimes()
 		i := NewHistoryExists(persistence.NewPersistenceRetryer(execManager, historyManager, c2.CreatePersistenceRetryPolicy()), domainCache)
 		result := i.Check(context.Background(), getOpenConcreteExecution())
 		s.Equal(tc.expectedResult, result)

--- a/common/reconciliation/invariant/openCurrentExecution_test.go
+++ b/common/reconciliation/invariant/openCurrentExecution_test.go
@@ -25,6 +25,7 @@ package invariant
 import (
 	"context"
 	"errors"
+	"github.com/uber/cadence/service/history/constants"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -179,6 +180,7 @@ func (s *OpenCurrentExecutionSuite) TestCheck() {
 		execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getConcreteResp, tc.getConcreteErr)
 		execManager.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(tc.getCurrentResp, tc.getCurrentErr)
 		domainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
+		domainCache.EXPECT().GetDomainByID(gomock.Any()).Return(constants.TestGlobalDomainEntry, nil).AnyTimes()
 		o := NewOpenCurrentExecution(persistence.NewPersistenceRetryer(execManager, nil, c2.CreatePersistenceRetryPolicy()), domainCache)
 		s.Equal(tc.expectedResult, o.Check(context.Background(), tc.execution))
 	}

--- a/service/worker/scanner/data_corruption_workflow_test.go
+++ b/service/worker/scanner/data_corruption_workflow_test.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/uber/cadence/service/history/constants"
+
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/mock"
@@ -135,6 +137,7 @@ func (s *dataCorruptionWorkflowTestSuite) TestExecutionFixerActivity_Success() {
 	})
 	tlScavengerHBInterval = time.Millisecond * 10
 	mockResource.DomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
+	mockResource.DomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(constants.TestGlobalDomainEntry, nil).AnyTimes()
 	_, err := env.ExecuteActivity(ExecutionFixerActivity, fixList)
 	s.NoError(err)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added domain Status check for the deprecated domains in the invariants.


<!-- Tell your future self why have you made these changes -->
**Why?**
The changes were made to enable identification of the workflows that are associated with the deprecated domains and need deletion.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated existing unit tests and tested locally.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The change is not a breaking change. worse case scenario is that some workflows might be missed from deletion. the risk of active workflows getting removed is minimal due to the existence of a hard condition on domain status.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
NA
<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
NA
