### PR TITLE
ES: single interface for different ES/OpenSearch versions

### DIFF
--- a/common/elasticsearch/client/client.go
+++ b/common/elasticsearch/client/client.go
@@ -1,0 +1,62 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/uber/cadence/common/elasticsearch"
+)
+
+// Client is a generic ES client implementation.
+// This interface allows to use different Elasticsearch and OpenSearch versions
+// without exposing implementation details and structs
+type Client interface {
+	// ClearScroll clears the search context and results for a scrolling search.
+	ClearScroll(ctx context.Context, scrollID string) error
+	// Count returns number of document matches by given query
+	Count(ctx context.Context, index, body string) (int64, error)
+	// CreateIndex creates index with given name
+	CreateIndex(ctx context.Context, index string) error
+	// IsNotFoundError checks if error is a "not found"
+	IsNotFoundError(err error) bool
+	// PutMapping updates Client with new field mapping
+	PutMapping(ctx context.Context, index, body string) error
+	// RunBulkProcessor starts bulk indexing processor
+	// @TODO consider to extract Bulk Processor as a separate entity
+	RunBulkProcessor(ctx context.Context, p *elasticsearch.BulkProcessorParameters) (elasticsearch.GenericBulkProcessor, error)
+	// Scroll retrieves the next batch of results for a scrolling search.
+	Scroll(ctx context.Context, index, body, scrollID string) (*Response, error)
+	// Search returns Elasticsearch hit bytes and additional metadata
+	Search(ctx context.Context, index, body string) (*Response, error)
+}
+
+// Response is used to pass data retrieved from Elasticsearch/OpenSearch to upper layer
+type Response struct {
+	TookInMillis int64
+	TotalHits    int64
+	Hits         [][]byte // response from ES server as bytes, used to unmarshal to internal structs
+	Aggregations map[string]json.RawMessage
+	Sort         []interface{}
+	ScrollID     string
+}

--- a/common/elasticsearch/client/client.go
+++ b/common/elasticsearch/client/client.go
@@ -25,6 +25,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/uber/cadence/common/elasticsearch"
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding interface for versioned ES/OS clients to implement

<!-- Tell your future self why have you made these changes -->
**Why?**
Leaking client structs up makes it impossible to implement business logic in a single place. Adding new ES or OpenSearch client is also very difficult. 

This interface uses `[][]byte` to pass raw data from the server, and client can marshal this data to appropriate struct type.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
