### PR TITLE
Set poll interval for filebased dynamic config if not set

### DIFF
--- a/common/dynamicconfig/file_based_client.go
+++ b/common/dynamicconfig/file_based_client.go
@@ -367,8 +367,10 @@ func validateConfig(config *FileBasedClientConfig) error {
 	if _, err := os.Stat(config.Filepath); err != nil {
 		return fmt.Errorf("error checking dynamic config file at path %s, error: %v", config.Filepath, err)
 	}
+
+	// check if poll interval needs to be adjusted
 	if config.PollInterval < minPollInterval {
-		return fmt.Errorf("poll interval should be at least %v", minPollInterval)
+		config.PollInterval = minPollInterval
 	}
 	return nil
 }

--- a/common/dynamicconfig/file_based_client_test.go
+++ b/common/dynamicconfig/file_based_client_test.go
@@ -226,11 +226,14 @@ func (s *fileBasedClientSuite) TestValidateConfig_FileNotExist() {
 }
 
 func (s *fileBasedClientSuite) TestValidateConfig_ShortPollInterval() {
-	_, err := NewFileBasedClient(&FileBasedClientConfig{
+	cfg := &FileBasedClientConfig{
 		Filepath:     "config/testConfig.yaml",
 		PollInterval: time.Second,
-	}, nil, nil)
-	s.Error(err)
+	}
+	_, err := NewFileBasedClient(cfg, log.NewNoop(), nil)
+	s.NoError(err)
+	s.Equal(minPollInterval, cfg.PollInterval, "fallback to default poll interval")
+
 }
 
 func (s *fileBasedClientSuite) TestMatch() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When poll interval is less than default value, adjust the value instead of returning an error

<!-- Tell your future self why have you made these changes -->
**Why?**
When poll interval config entry is missing, cadence will use `NOOP` dynamic config. Instead of failing back to `NOOP` client, we are adjusting poll interval and have file based dynamic config client in use.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
