### PR TITLE
[history] more cautious in deciding domain state to make decisions on…

### DIFF
--- a/service/history/queue/task_allocator.go
+++ b/service/history/queue/task_allocator.go
@@ -196,10 +196,7 @@ func (t *taskAllocatorImpl) Unlock() {
 func isDomainNotRegistered(shard shard.Context, domainID string) (bool, error) {
 	domainEntry, err := shard.GetDomainCache().GetDomainByID(domainID)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
-			return true, nil
-		}
-		// unexpected error in finding a domain
+		// error in finding a domain
 		return false, err
 	}
 	info := domainEntry.GetInfo()


### PR DESCRIPTION
… dropping queued tasks

<!-- Describe what has changed in this PR -->
**What changed?**

When domain cache returned entity not found error, don't drop queued tasks to be more conservative. 

<!-- Tell your future self why have you made these changes -->
**Why?**

In cases when the cache is dubious, we shouldn't drop the queued tasks.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
