### PR TITLE
Adds a small test to catch issues with deadlocks

### DIFF
--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -22,6 +22,7 @@ package task
 
 import (
 	"errors"
+	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
 
@@ -264,6 +265,18 @@ func (s *taskSuite) TestTaskNack_ResubmitFailed() {
 
 	task.Nack()
 	s.Equal(t.TaskStateNacked, task.State())
+}
+
+func (s *taskSuite) TestHandleErr_ErrMaxAttempts() {
+	taskBase := s.newTestTask(func(task Info) (bool, error) {
+		return true, nil
+	}, nil)
+
+	taskBase.criticalRetryCount = func(i ...dynamicconfig.FilterOption) int { return 0 }
+	s.mockTaskInfo.EXPECT().GetTaskType().Return(0)
+	assert.NotPanics(s.T(), func() {
+		taskBase.HandleErr(errors.New("err"))
+	})
 }
 
 func (s *taskSuite) newTestTask(

--- a/service/history/task/task_test.go
+++ b/service/history/task/task_test.go
@@ -22,9 +22,10 @@ package task
 
 import (
 	"errors"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
It's quite easy to call the getters on tasks in this function and cause a deadlock. Ensuring complete coverage on this branch to prevent this. 