### PR TITLE
Migrate matching to use tasksV2

### DIFF
--- a/common/persistence/dataManagerInterfaces.go
+++ b/common/persistence/dataManagerInterfaces.go
@@ -446,6 +446,7 @@ type (
 		TaskType    int
 		RangeID     int64
 		AckLevel    int64
+		AckLevels   map[string]int64
 		Kind        int
 		Expiry      time.Time
 		LastUpdated time.Time
@@ -1276,9 +1277,10 @@ type (
 
 	// CreateTaskInfo describes a task to be created in CreateTasksRequest
 	CreateTaskInfo struct {
-		Execution types.WorkflowExecution
-		Data      *TaskInfo
-		TaskID    int64
+		Execution      types.WorkflowExecution
+		Data           *TaskInfo
+		IsolationGroup string
+		TaskID         int64
 	}
 
 	// CreateTasksResponse is the response to CreateTasksRequest
@@ -1287,13 +1289,14 @@ type (
 
 	// GetTasksRequest is used to retrieve tasks of a task list
 	GetTasksRequest struct {
-		DomainID     string
-		TaskList     string
-		TaskType     int
-		ReadLevel    int64  // range exclusive
-		MaxReadLevel *int64 // optional: range inclusive when specified
-		BatchSize    int
-		DomainName   string
+		DomainID       string
+		TaskList       string
+		TaskType       int
+		IsolationGroup string
+		ReadLevel      int64  // range exclusive
+		MaxReadLevel   *int64 // optional: range inclusive when specified
+		BatchSize      int
+		DomainName     string
 	}
 
 	// GetTasksResponse is the response to GetTasksRequests
@@ -1303,19 +1306,21 @@ type (
 
 	// CompleteTaskRequest is used to complete a task
 	CompleteTaskRequest struct {
-		TaskList   *TaskListInfo
-		TaskID     int64
-		DomainName string
+		TaskList       *TaskListInfo
+		IsolationGroup string
+		TaskID         int64
+		DomainName     string
 	}
 
 	// CompleteTasksLessThanRequest contains the request params needed to invoke CompleteTasksLessThan API
 	CompleteTasksLessThanRequest struct {
-		DomainID     string
-		TaskListName string
-		TaskType     int
-		TaskID       int64 // Tasks less than or equal to this ID will be completed
-		Limit        int   // Limit on the max number of tasks that can be completed. Required param
-		DomainName   string
+		DomainID       string
+		TaskListName   string
+		TaskType       int
+		IsolationGroup string
+		TaskID         int64 // Tasks less than or equal to this ID will be completed
+		Limit          int   // Limit on the max number of tasks that can be completed. Required param
+		DomainName     string
 	}
 
 	// CompleteTasksLessThanResponse is the response of CompleteTasksLessThan
@@ -1795,6 +1800,9 @@ type (
 		CompleteTasksLessThan(ctx context.Context, request *CompleteTasksLessThanRequest) (*CompleteTasksLessThanResponse, error)
 		GetOrphanTasks(ctx context.Context, request *GetOrphanTasksRequest) (*GetOrphanTasksResponse, error)
 	}
+
+	// TaskV2Manager is used to manage tasks
+	TaskV2Manager = TaskManager
 
 	// HistoryManager is used to manager workflow history events
 	HistoryManager interface {

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -96,6 +96,11 @@ type (
 		MaxTaskBatchSize                func() int
 		NumWritePartitions              func() int
 		NumReadPartitions               func() int
+		// taskV2 migration
+		EnableTaskV2Migration func() bool
+		// task isolation
+		EnableIsolation func() bool
+		IsolationGroups []string
 	}
 )
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This is a draft PR to update matching to migrate from task v1 to task v2 in order to support isolation at persistence layer for async match.

task v2 has such schema in Cassandra:
```
CREATE TABLE tasks_v2 (
  domain_id        uuid,
  task_list_name   text,
  task_list_type   int, -- enum TaskListType {ActivityTask, DecisionTask}
+ isolation_group  text, -- always empty for tasklist
  type             int, -- enum rowType {Task, TaskList}
  task_id          bigint,  -- unique identifier for tasks, monotonically increasing
  range_id         bigint, -- Used to ensure that only one process can write to the table
  task             frozen<task>,
  task_list        frozen<task_list>,
  PRIMARY KEY ((domain_id, task_list_name, task_list_type), isolation_group, type, task_id)
) WITH COMPACTION = {
    'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
  };
```
task_list type is also updated
```
CREATE TYPE task_list (
  domain_id        uuid,
  name             text,
  type             int, -- enum TaskRowType {ActivityTask, DecisionTask}
  ack_level        bigint, -- task_id of the last acknowledged message
+ ack_levels       map<text, bigint>,
  kind             int, -- enum TaskListKind {Normal, Sticky}
  last_updated     timestamp
);
```

We add a new primary column `isolation_group` to the original table. We also separate the ack levels for each isolation group so that an isolation group will not prevent another isolation group from cleaning tasks from database.

We also introduce a new dynamic config `EnableTaskV2Migration` to control the migration at tasklist level. After this code is merged, matching will read tasks from both task v1 and v2 tables, and it will write to task v1 if the feature flag is disabled and to task v2 if it is enabled. Matching will consume more memory because we need more goroutines reading tasks from both table, but we also gain the ability to migrate task table in both directionn without reloading the tasklist from matching. 
Another thing is that v2 uses more memory than v1, because task reader has multiple goroutines for each isolation group, even if the tasklist does not need isolation, but we also gain the ability to disable or enable isolation without reloading tasklist from matching.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Test is TBD.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
