### PR TITLE
Adds parameters to Config store client

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -24,6 +24,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/uber/cadence/common/persistence"
+
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/compatibility"
 
@@ -127,6 +129,7 @@ func (s *server) startService() common.Daemon {
 				&s.cfg.Persistence,
 				params.Logger,
 				s.doneC,
+				persistence.DynamicConfig,
 			)
 		case dynamicconfig.FileBasedClient:
 			params.Logger.Info("initialising File Based dynamic config client")

--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -53,6 +53,7 @@ var defaultConfigValues = &csc.ClientConfig{
 }
 
 type configStoreClient struct {
+	configStoreType    persistence.ConfigType
 	values             atomic.Value
 	lastUpdatedTime    time.Time
 	config             *csc.ClientConfig
@@ -68,7 +69,12 @@ type cacheEntry struct {
 }
 
 // NewConfigStoreClient creates a config store client
-func NewConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.Persistence, logger log.Logger, doneCh chan struct{}) (dc.Client, error) {
+func NewConfigStoreClient(clientCfg *csc.ClientConfig,
+	persistenceCfg *config.Persistence,
+	logger log.Logger,
+	doneCh chan struct{},
+	configType persistence.ConfigType,
+) (dc.Client, error) {
 	if persistenceCfg == nil {
 		return nil, errors.New("persistence cfg is nil")
 	}
@@ -87,7 +93,7 @@ func NewConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.Pe
 		clientCfg = defaultConfigValues
 	}
 
-	client, err := newConfigStoreClient(clientCfg, store.NoSQL, logger, doneCh)
+	client, err := newConfigStoreClient(clientCfg, store.NoSQL, logger, doneCh, configType)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +104,13 @@ func NewConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.Pe
 	return client, nil
 }
 
-func newConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.NoSQL, logger log.Logger, doneCh chan struct{}) (*configStoreClient, error) {
+func newConfigStoreClient(
+	clientCfg *csc.ClientConfig,
+	persistenceCfg *config.NoSQL,
+	logger log.Logger,
+	doneCh chan struct{},
+	configType persistence.ConfigType,
+) (*configStoreClient, error) {
 	store, err := nosql.NewNoSQLConfigStore(*persistenceCfg, logger, nil)
 	if err != nil {
 		return nil, err
@@ -109,6 +121,7 @@ func newConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.No
 		doneCh:             doneCh,
 		configStoreManager: persistence.NewConfigStoreManagerImpl(store, logger),
 		logger:             logger,
+		configStoreType:    configType,
 	}
 
 	return client, nil
@@ -405,7 +418,7 @@ func (csc *configStoreClient) updateValue(name dc.Key, dcValues []*types.Dynamic
 		ctx,
 		&persistence.UpdateDynamicConfigRequest{
 			Snapshot: newSnapshot,
-		}, persistence.DynamicConfig,
+		}, csc.configStoreType,
 	)
 
 	select {
@@ -498,7 +511,7 @@ func (csc *configStoreClient) update() error {
 	ctx, cancel := context.WithTimeout(context.Background(), csc.config.FetchTimeout)
 	defer cancel()
 
-	res, err := csc.configStoreManager.FetchDynamicConfig(ctx, persistence.DynamicConfig)
+	res, err := csc.configStoreManager.FetchDynamicConfig(ctx, csc.configStoreType)
 
 	select {
 	case <-ctx.Done():

--- a/common/dynamicconfig/configstore/config_store_client_test.go
+++ b/common/dynamicconfig/configstore/config_store_client_test.go
@@ -308,7 +308,7 @@ func (s *configStoreClientSuite) SetupTest() {
 		},
 		&config.NoSQL{
 			PluginName: "cassandra",
-		}, log.NewNoop(), s.doneCh)
+		}, log.NewNoop(), s.doneCh, p.DynamicConfig)
 	s.Require().NoError(err)
 
 	s.mockManager = p.NewMockConfigStoreManager(s.mockController)

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1360,13 +1360,6 @@ const (
 	// KeyName: system.largeShardHistoryBlobMetricThreshold
 	// Value type: Int
 	// Default value: 262144 (1/4mb)
-
-	// IsolationGroupStateUpdateRetryAttempts
-	// KeyName: system.isolationGroupStateUpdateRetryAttempts
-	// Value type: int
-	// Default value: 2
-	IsolationGroupStateUpdateRetryAttempts
-
 	LargeShardHistoryBlobMetricThreshold
 	// LastIntKey must be the last one in this const group
 	LastIntKey
@@ -2524,21 +2517,12 @@ const (
 	// Value type: Duration
 	// Default value: 30 minutes
 	ESAnalyzerBufferWaitTime
+
 	// IsolationGroupStateRefreshInterval
 	// KeyName: system.isolationGroupStateRefreshInterval
 	// Value type: Duration
 	// Default value: 2 minutes
 	IsolationGroupStateRefreshInterval
-	// IsolationGroupStateFetchTimeout is the dynamic config DB fetch timeout value
-	// KeyName: system.isolationGroupStateFetchTimeout
-	// Value type: Duration
-	// Default value: 30 seconds
-	IsolationGroupStateFetchTimeout
-	// IsolationGroupStateUpdateTimeout is the dynamic config DB update timeout value
-	// KeyName: system.isolationGroupStateUpdateTimeout
-	// Value type: Duration
-	// Default value: 30 seconds
-	IsolationGroupStateUpdateTimeout
 
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
@@ -3520,11 +3504,6 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "defines the threshold for what consititutes a large history blob write to alert on, default is 1/4mb",
 		DefaultValue: 262144,
 	},
-	IsolationGroupStateUpdateRetryAttempts: DynamicInt{
-		KeyName:      "system.isolationGroupStateUpdateRetryAttempts",
-		Description:  "The number of attempts to push Isolation group configuration to the config store",
-		DefaultValue: 2,
-	},
 }
 
 var BoolKeys = map[BoolKey]DynamicBool{
@@ -4481,16 +4460,6 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		KeyName:      "system.isolationGroupStateRefreshInterval",
 		Description:  "the frequency by which the IsolationGroupState handler will poll configuration",
 		DefaultValue: time.Minute * 2,
-	},
-	IsolationGroupStateFetchTimeout: DynamicDuration{
-		KeyName:      "system.IsolationGroupStateFetchTimeout",
-		Description:  "IsolationGroupStateFetchTimeout is the dynamic config DB fetch timeout value",
-		DefaultValue: time.Second * 30,
-	},
-	IsolationGroupStateUpdateTimeout: DynamicDuration{
-		KeyName:      "system.IsolationGroupStateUpdateTimeout",
-		Description:  "IsolationGroupStateFetchTimeout is the dynamic config DB update timeout value",
-		DefaultValue: time.Second * 30,
 	},
 	ESAnalyzerBufferWaitTime: DynamicDuration{
 		KeyName:      "worker.ESAnalyzerBufferWaitTime",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1360,6 +1360,13 @@ const (
 	// KeyName: system.largeShardHistoryBlobMetricThreshold
 	// Value type: Int
 	// Default value: 262144 (1/4mb)
+
+	// IsolationGroupStateUpdateRetryAttempts
+	// KeyName: system.isolationGroupStateUpdateRetryAttempts
+	// Value type: int
+	// Default value: 2
+	IsolationGroupStateUpdateRetryAttempts
+
 	LargeShardHistoryBlobMetricThreshold
 	// LastIntKey must be the last one in this const group
 	LastIntKey
@@ -2517,12 +2524,21 @@ const (
 	// Value type: Duration
 	// Default value: 30 minutes
 	ESAnalyzerBufferWaitTime
-
 	// IsolationGroupStateRefreshInterval
 	// KeyName: system.isolationGroupStateRefreshInterval
 	// Value type: Duration
 	// Default value: 2 minutes
 	IsolationGroupStateRefreshInterval
+	// IsolationGroupStateFetchTimeout is the dynamic config DB fetch timeout value
+	// KeyName: system.isolationGroupStateFetchTimeout
+	// Value type: Duration
+	// Default value: 30 seconds
+	IsolationGroupStateFetchTimeout
+	// IsolationGroupStateUpdateTimeout is the dynamic config DB update timeout value
+	// KeyName: system.isolationGroupStateUpdateTimeout
+	// Value type: Duration
+	// Default value: 30 seconds
+	IsolationGroupStateUpdateTimeout
 
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
@@ -3504,6 +3520,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "defines the threshold for what consititutes a large history blob write to alert on, default is 1/4mb",
 		DefaultValue: 262144,
 	},
+	IsolationGroupStateUpdateRetryAttempts: DynamicInt{
+		KeyName:      "system.isolationGroupStateUpdateRetryAttempts",
+		Description:  "The number of attempts to push Isolation group configuration to the config store",
+		DefaultValue: 2,
+	},
 }
 
 var BoolKeys = map[BoolKey]DynamicBool{
@@ -4460,6 +4481,16 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		KeyName:      "system.isolationGroupStateRefreshInterval",
 		Description:  "the frequency by which the IsolationGroupState handler will poll configuration",
 		DefaultValue: time.Minute * 2,
+	},
+	IsolationGroupStateFetchTimeout: DynamicDuration{
+		KeyName:      "system.IsolationGroupStateFetchTimeout",
+		Description:  "IsolationGroupStateFetchTimeout is the dynamic config DB fetch timeout value",
+		DefaultValue: time.Second * 30,
+	},
+	IsolationGroupStateUpdateTimeout: DynamicDuration{
+		KeyName:      "system.IsolationGroupStateUpdateTimeout",
+		Description:  "IsolationGroupStateFetchTimeout is the dynamic config DB update timeout value",
+		DefaultValue: time.Second * 30,
 	},
 	ESAnalyzerBufferWaitTime: DynamicDuration{
 		KeyName:      "worker.ESAnalyzerBufferWaitTime",


### PR DESCRIPTION
Background: 

The Isolation-group library was previously using the lower-level `ConfigManager`, however, that was actually not correct and the higher-level config-store Client (a type of DynamicConfig client) provides some caching, as well as the serialization primitives needed, so in preparation for using that, this refactors it to take a type dimension. 

Changes

- Refactors the Dynamic-config client to take a parameter on construction to specify the type of config it is