### PR TITLE
enables CRUD operations for global isolation-groups

### DIFF
--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -677,6 +677,10 @@ func validateKeyDataBlobPair(key dc.Key, blob *types.DataBlob) error {
 		if _, ok := value.(map[string]interface{}); !ok {
 			return err
 		}
+	case dc.ListKey:
+		if _, ok := value.([]interface{}); !ok {
+			return err
+		}
 	default:
 		return fmt.Errorf("unknown key type: %T", key)
 	}

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2527,7 +2527,7 @@ const (
 	// IsolationGroupStateRefreshInterval
 	// KeyName: system.isolationGroupStateRefreshInterval
 	// Value type: Duration
-	// Default value: 2 minutes
+	// Default value: 30 seconds
 	IsolationGroupStateRefreshInterval
 	// IsolationGroupStateFetchTimeout is the dynamic config DB fetch timeout value
 	// KeyName: system.isolationGroupStateFetchTimeout
@@ -2613,6 +2613,12 @@ const (
 	// Default value: N/A
 	// Allowed filters: N/A
 	AllIsolationGroups
+
+	// DefaultIsolationGroupConfigStoreManagerGlobalMapping is the dynamic config value for isolation groups
+	// Note: This is not typically used for normal dynamic config (type 0), but instead
+	// it's used only for IsolationGroup config (type 1).
+	// KeyName: system.defaultIsolationGroupConfigStoreManagerGlobalMapping
+	DefaultIsolationGroupConfigStoreManagerGlobalMapping
 
 	LastListKey
 )
@@ -4480,7 +4486,7 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 	IsolationGroupStateRefreshInterval: DynamicDuration{
 		KeyName:      "system.isolationGroupStateRefreshInterval",
 		Description:  "the frequency by which the IsolationGroupState handler will poll configuration",
-		DefaultValue: time.Minute * 2,
+		DefaultValue: time.Second * 30,
 	},
 	IsolationGroupStateFetchTimeout: DynamicDuration{
 		KeyName:      "system.IsolationGroupStateFetchTimeout",
@@ -4537,6 +4543,15 @@ var MapKeys = map[MapKey]DynamicMap{
 }
 
 var ListKeys = map[ListKey]DynamicList{
+	AllIsolationGroups: {
+		KeyName:     "system.allIsolationGroups",
+		Description: "A list of all the isolation groups in a system",
+	},
+	DefaultIsolationGroupConfigStoreManagerGlobalMapping: {
+		KeyName: "system.defaultIsolationGroupConfigStoreManagerGlobalMapping",
+		Description: "A configuration store for global isolation groups - used in isolation-group config only, not normal dynamic config." +
+			"Not intended for use in normal dynamic config",
+	},
 	HeaderForwardingRules: {
 		KeyName: "admin.HeaderForwardingRules", // make a new scope for global?
 		Description: "Only loaded at startup.  " +

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2606,7 +2606,6 @@ const (
 	// Value type: []rpc.HeaderRule or an []interface{} containing `map[string]interface{}{"Add":bool,"Match":string}` values.
 	// Default value: forward all headers.  (this is a problematic value, and it will be changing as we reduce to a list of known values)
 	HeaderForwardingRules
-
 	// AllIsolationGroups is the list of all possible isolation groups in a service
 	// KeyName: system.allIsolationGroups
 	// Value type: []string
@@ -2614,14 +2613,14 @@ const (
 	// Allowed filters: N/A
 	AllIsolationGroups
 
-	// DefaultIsolationGroupConfigStoreManagerGlobalMapping is the dynamic config value for isolation groups
-	// Note: This is not typically used for normal dynamic config (type 0), but instead
-	// it's used only for IsolationGroup config (type 1).
-	// KeyName: system.defaultIsolationGroupConfigStoreManagerGlobalMapping
-	DefaultIsolationGroupConfigStoreManagerGlobalMapping
-
 	LastListKey
 )
+
+// DefaultIsolationGroupConfigStoreManagerGlobalMapping is the dynamic config value for isolation groups
+// Note: This is not typically used for normal dynamic config (type 0), but instead
+// it's used only for IsolationGroup config (type 1).
+// KeyName: system.defaultIsolationGroupConfigStoreManagerGlobalMapping
+const DefaultIsolationGroupConfigStoreManagerGlobalMapping ListKey = -1 // This is a hack to put it in a different list due to it being a different config type
 
 var IntKeys = map[IntKey]DynamicInt{
 	TestGetIntPropertyKey: DynamicInt{

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1360,6 +1360,13 @@ const (
 	// KeyName: system.largeShardHistoryBlobMetricThreshold
 	// Value type: Int
 	// Default value: 262144 (1/4mb)
+
+	// IsolationGroupStateUpdateRetryAttempts
+	// KeyName: system.isolationGroupStateUpdateRetryAttempts
+	// Value type: int
+	// Default value: 2
+	IsolationGroupStateUpdateRetryAttempts
+
 	LargeShardHistoryBlobMetricThreshold
 	// LastIntKey must be the last one in this const group
 	LastIntKey
@@ -2517,12 +2524,21 @@ const (
 	// Value type: Duration
 	// Default value: 30 minutes
 	ESAnalyzerBufferWaitTime
-
 	// IsolationGroupStateRefreshInterval
 	// KeyName: system.isolationGroupStateRefreshInterval
 	// Value type: Duration
 	// Default value: 2 minutes
 	IsolationGroupStateRefreshInterval
+	// IsolationGroupStateFetchTimeout is the dynamic config DB fetch timeout value
+	// KeyName: system.isolationGroupStateFetchTimeout
+	// Value type: Duration
+	// Default value: 30 seconds
+	IsolationGroupStateFetchTimeout
+	// IsolationGroupStateUpdateTimeout is the dynamic config DB update timeout value
+	// KeyName: system.isolationGroupStateUpdateTimeout
+	// Value type: Duration
+	// Default value: 30 seconds
+	IsolationGroupStateUpdateTimeout
 
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
@@ -3504,6 +3520,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "defines the threshold for what consititutes a large history blob write to alert on, default is 1/4mb",
 		DefaultValue: 262144,
 	},
+	IsolationGroupStateUpdateRetryAttempts: DynamicInt{
+		KeyName:      "system.isolationGroupStateUpdateRetryAttempts",
+		Description:  "The number of attempts to push Isolation group configuration to the config store",
+		DefaultValue: 2,
+	},
 }
 
 var BoolKeys = map[BoolKey]DynamicBool{
@@ -4460,6 +4481,16 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		KeyName:      "system.isolationGroupStateRefreshInterval",
 		Description:  "the frequency by which the IsolationGroupState handler will poll configuration",
 		DefaultValue: time.Minute * 2,
+	},
+	IsolationGroupStateFetchTimeout: DynamicDuration{
+		KeyName:      "system.IsolationGroupStateFetchTimeout",
+		Description:  "IsolationGroupStateFetchTimeout is the dynamic config DB fetch timeout value",
+		DefaultValue: time.Second * 30,
+	},
+	IsolationGroupStateUpdateTimeout: DynamicDuration{
+		KeyName:      "system.IsolationGroupStateUpdateTimeout",
+		Description:  "IsolationGroupStateFetchTimeout is the dynamic config DB update timeout value",
+		DefaultValue: time.Second * 30,
 	},
 	ESAnalyzerBufferWaitTime: DynamicDuration{
 		KeyName:      "worker.ESAnalyzerBufferWaitTime",

--- a/common/isolationgroup/default-isolation-group-state.go
+++ b/common/isolationgroup/default-isolation-group-state.go
@@ -69,7 +69,7 @@ type defaultIsolationGroupStateHandler struct {
 }
 
 const (
-	DefaultIsolationGroupConfigStoreManagerGlobalMapping dynamicconfig.MapKey = iota
+	defaultIsolationGroupConfigStoreManagerGlobalMapping dynamicconfig.ListKey = iota
 )
 
 // NewDefaultIsolationGroupStateWatcher is the default constructor
@@ -188,13 +188,13 @@ func (z *defaultIsolationGroupStateHandler) UpdateGlobalState(ctx context.Contex
 		return err
 	}
 	return z.globalIsolationGroupDrains.UpdateValue(
-		DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+		defaultIsolationGroupConfigStoreManagerGlobalMapping,
 		mappedInput,
 	)
 }
 
 func (z *defaultIsolationGroupStateHandler) GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error) {
-	res, err := z.globalIsolationGroupDrains.ListValue(DefaultIsolationGroupConfigStoreManagerGlobalMapping)
+	res, err := z.globalIsolationGroupDrains.ListValue(defaultIsolationGroupConfigStoreManagerGlobalMapping)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get global isolation groups from datastore: %w", err)
 	}
@@ -225,7 +225,7 @@ func (z *defaultIsolationGroupStateHandler) get(ctx context.Context, domain stri
 		return nil, fmt.Errorf("could not resolve domain in isolationGroup handler: %w", err)
 	}
 	domainState := domainData.GetInfo().IsolationGroupConfig
-	globalCfg, err := z.globalIsolationGroupDrains.ListValue(DefaultIsolationGroupConfigStoreManagerGlobalMapping)
+	globalCfg, err := z.globalIsolationGroupDrains.ListValue(defaultIsolationGroupConfigStoreManagerGlobalMapping)
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve global drains in %w", err)
 	}

--- a/common/isolationgroup/default-isolation-group-state.go
+++ b/common/isolationgroup/default-isolation-group-state.go
@@ -54,17 +54,16 @@ type defaultConfig struct {
 }
 
 type defaultIsolationGroupStateHandler struct {
-	status                          int32
-	done                            chan struct{}
-	log                             log.Logger
-	domainCache                     cache.DomainCache
-	globalIsolationGroupDrains      dynamicconfig.Client
-	globalIsolationGroupDrainClient dynamicconfig.Client
-	config                          defaultConfig
-	subscriptionMu                  sync.Mutex
-	valuesMu                        sync.RWMutex
-	lastSeen                        *isolationGroups
-	updateCB                        func()
+	status                     int32
+	done                       chan struct{}
+	log                        log.Logger
+	domainCache                cache.DomainCache
+	globalIsolationGroupDrains dynamicconfig.Client
+	config                     defaultConfig
+	subscriptionMu             sync.Mutex
+	valuesMu                   sync.RWMutex
+	lastSeen                   *isolationGroups
+	updateCB                   func()
 	// subscriptions is a map of domains->subscription-keys-> subscription channels
 	// for notifying when there's a state change
 	subscriptions map[string]map[string]chan<- ChangeEvent

--- a/common/isolationgroup/default-isolation-group-state.go
+++ b/common/isolationgroup/default-isolation-group-state.go
@@ -328,7 +328,7 @@ func mapAllIsolationGroupsResponse(in []interface{}) ([]string, error) {
 	for k := range in {
 		v, ok := in[k].(string)
 		if !ok {
-			return nil, fmt.Errorf("failed to get all-isolation-groups resonse from dynamic config: got %v (%T)", in[k], in[k])
+			return nil, fmt.Errorf("failed to get all-isolation-groups response from dynamic config: got %v (%T)", in[k], in[k])
 		}
 		allIsolationGroups = append(allIsolationGroups, v)
 	}

--- a/common/isolationgroup/default-isolation-group-state.go
+++ b/common/isolationgroup/default-isolation-group-state.go
@@ -53,17 +53,16 @@ type defaultConfig struct {
 }
 
 type defaultIsolationGroupStateHandler struct {
-	status                          int32
-	done                            chan struct{}
-	log                             log.Logger
-	domainCache                     cache.DomainCache
-	globalIsolationGroupDrains      dynamicconfig.Client
-	globalIsolationGroupDrainClient dynamicconfig.Client
-	config                          defaultConfig
-	subscriptionMu                  sync.Mutex
-	valuesMu                        sync.RWMutex
-	lastSeen                        *isolationGroups
-	updateCB                        func()
+	status                     int32
+	done                       chan struct{}
+	log                        log.Logger
+	domainCache                cache.DomainCache
+	globalIsolationGroupDrains dynamicconfig.Client
+	config                     defaultConfig
+	subscriptionMu             sync.Mutex
+	valuesMu                   sync.RWMutex
+	lastSeen                   *isolationGroups
+	updateCB                   func()
 	// subscriptions is a map of domains->subscription-keys-> subscription channels
 	// for notifying when there's a state change
 	subscriptions map[string]map[string]chan<- ChangeEvent

--- a/common/isolationgroup/default-isolation-group-state.go
+++ b/common/isolationgroup/default-isolation-group-state.go
@@ -24,50 +24,106 @@ package isolationgroup
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"sort"
 	"sync"
 	"sync/atomic"
-	"time"
+
+	"github.com/uber/cadence/common/persistence"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/dynamicconfig/configstore"
+	csc "github.com/uber/cadence/common/dynamicconfig/configstore/config"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
 
+// defaultConfig values for the partitioning library for segmenting portions of workflows into isolation-groups - a resiliency
+// concept meant to help move workflows around and away from failure zones.
+type defaultConfig struct {
+	// IsolationGroupEnabled is a domain-based configuration value for whether this feature is enabled at all
+	IsolationGroupEnabled dynamicconfig.BoolPropertyFnWithDomainFilter
+	// AllIsolationGroups is a static list of all the possible isolation group names
+	AllIsolationGroups []string
+}
+
 type defaultIsolationGroupStateHandler struct {
-	status                     int32
-	done                       chan struct{}
-	log                        log.Logger
-	domainCache                cache.DomainCache
-	globalIsolationGroupDrains persistence.ConfigStoreManager
-	config                     Config
-	subscriptionMu             sync.Mutex
-	valuesMu                   sync.RWMutex
-	lastSeen                   *isolationGroups
-	updateCB                   func()
+	status                          int32
+	done                            chan struct{}
+	log                             log.Logger
+	domainCache                     cache.DomainCache
+	globalIsolationGroupDrains      dynamicconfig.Client
+	globalIsolationGroupDrainClient dynamicconfig.Client
+	config                          defaultConfig
+	subscriptionMu                  sync.Mutex
+	valuesMu                        sync.RWMutex
+	lastSeen                        *isolationGroups
+	updateCB                        func()
 	// subscriptions is a map of domains->subscription-keys-> subscription channels
 	// for notifying when there's a state change
 	subscriptions map[string]map[string]chan<- ChangeEvent
 }
 
+const (
+	DefaultIsolationGroupConfigStoreManagerGlobalMapping dynamicconfig.MapKey = iota
+)
+
+// NewDefaultIsolationGroupStateWatcher is the default constructor
 func NewDefaultIsolationGroupStateWatcher(
 	logger log.Logger,
-	config Config,
+	dc *dynamicconfig.Collection,
+	persistenceCfg *config.Persistence,
 	domainCache cache.DomainCache,
-	manager persistence.ConfigStoreManager,
-) State {
+) (State, error) {
+	stopChan := make(chan struct{})
+	cscConfig := &csc.ClientConfig{
+		PollInterval:        dc.GetDurationProperty(dynamicconfig.IsolationGroupStateRefreshInterval)(),
+		UpdateRetryAttempts: dc.GetIntProperty(dynamicconfig.IsolationGroupStateUpdateRetryAttempts)(),
+		FetchTimeout:        dc.GetDurationProperty(dynamicconfig.IsolationGroupStateFetchTimeout)(),
+		UpdateTimeout:       dc.GetDurationProperty(dynamicconfig.IsolationGroupStateUpdateTimeout)(),
+	}
+	cfgStoreClient, err := configstore.NewConfigStoreClient(cscConfig, persistenceCfg, logger, stopChan, persistence.GlobalIsolationGroupConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failure during setup for the IsolationGroupStateWatcher: %w", err)
+	}
+	return NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(logger, dc, domainCache, cfgStoreClient, stopChan)
+}
+
+// NewDefaultIsolationGroupStateWatcherWithConfigStoreClient Is a constructor which allows passing in the dynamic config client
+func NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
+	logger log.Logger,
+	dc *dynamicconfig.Collection,
+	domainCache cache.DomainCache,
+	cfgStoreClient dynamicconfig.Client,
+	stopChan chan struct{},
+) (State, error) {
+
+	allIGs := dc.GetListProperty(dynamicconfig.AllIsolationGroups)()
+	allIsolationGroups, err := mapAllIsolationGroupsResponse(allIGs)
+	if err != nil {
+		return nil, fmt.Errorf("could not get all isolation groups fron dynamic config: %w", err)
+	}
+
+	config := defaultConfig{
+		IsolationGroupEnabled: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableTasklistIsolation),
+		AllIsolationGroups:    allIsolationGroups,
+	}
+
 	return &defaultIsolationGroupStateHandler{
-		done:                       make(chan struct{}),
+		done:                       stopChan,
 		domainCache:                domainCache,
-		globalIsolationGroupDrains: manager,
+		globalIsolationGroupDrains: cfgStoreClient,
 		status:                     common.DaemonStatusInitialized,
 		log:                        logger,
 		config:                     config,
 		subscriptionMu:             sync.Mutex{},
 		subscriptions:              make(map[string]map[string]chan<- ChangeEvent),
-	}
+	}, nil
 }
 
 func (z *defaultIsolationGroupStateHandler) AvailableIsolationGroupsByDomainID(ctx context.Context, domainID string) (types.IsolationGroupConfiguration, error) {
@@ -103,6 +159,9 @@ func (z *defaultIsolationGroupStateHandler) Start() {
 }
 
 func (z *defaultIsolationGroupStateHandler) Stop() {
+	if z == nil {
+		return
+	}
 	if !atomic.CompareAndSwapInt32(&z.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
 		return
 	}
@@ -122,6 +181,29 @@ func (z *defaultIsolationGroupStateHandler) Unsubscribe(domainID, key string) er
 	defer z.subscriptionMu.Unlock()
 	panic("not implemented")
 	return nil
+}
+
+func (z *defaultIsolationGroupStateHandler) UpdateGlobalState(ctx context.Context, in types.UpdateGlobalIsolationGroupsRequest) error {
+	mappedInput, err := mapUpdateGlobalIsolationGroupsRequest(in.IsolationGroups)
+	if err != nil {
+		return err
+	}
+	return z.globalIsolationGroupDrains.UpdateValue(
+		DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+		mappedInput,
+	)
+}
+
+func (z *defaultIsolationGroupStateHandler) GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error) {
+	res, err := z.globalIsolationGroupDrains.ListValue(DefaultIsolationGroupConfigStoreManagerGlobalMapping)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get global isolation groups from datastore: %w", err)
+	}
+	resp, err := mapDynamicConfigResponse(res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get global isolation groups from datastore: %w", err)
+	}
+	return &types.GetGlobalIsolationGroupsResponse{IsolationGroups: resp}, nil
 }
 
 func (z *defaultIsolationGroupStateHandler) getByDomainID(ctx context.Context, domainID string) (*isolationGroups, error) {
@@ -144,9 +226,12 @@ func (z *defaultIsolationGroupStateHandler) get(ctx context.Context, domain stri
 		return nil, fmt.Errorf("could not resolve domain in isolationGroup handler: %w", err)
 	}
 	domainState := domainData.GetInfo().IsolationGroupConfig
-	globalCfg, err := z.globalIsolationGroupDrains.FetchDynamicConfig(ctx, persistence.GlobalIsolationGroupConfig)
+	globalCfg, err := z.globalIsolationGroupDrains.ListValue(DefaultIsolationGroupConfigStoreManagerGlobalMapping)
+	if err != nil {
+		return nil, fmt.Errorf("could not resolve global drains in %w", err)
+	}
 
-	globalState, err := fromCfgStore(globalCfg)
+	globalState, err := mapDynamicConfigResponse(globalCfg)
 	if err != nil {
 		return nil, fmt.Errorf("could not resolve global drains in isolationGroup handler: %w", err)
 	}
@@ -166,34 +251,6 @@ func (z *defaultIsolationGroupStateHandler) checkIfChanged() {
 	// if any difference, notify subscribers for whom the change is applicable
 	// ie, global changes for all, domain changes for the domain-listeners
 	panic("not implemented")
-}
-
-func (z *defaultIsolationGroupStateHandler) pollForChanges() {
-	ticker := time.NewTicker(z.config.UpdateFrequency())
-	for {
-		select {
-		case <-z.done:
-			return
-		case <-ticker.C:
-			z.checkIfChanged()
-		}
-	}
-}
-
-func isDrained(isolationGroup string, global types.IsolationGroupConfiguration, domain types.IsolationGroupConfiguration) bool {
-	globalCfg, hasGlobalConfig := global[string(isolationGroup)]
-	domainCfg, hasDomainConfig := domain[string(isolationGroup)]
-	if hasGlobalConfig {
-		if globalCfg.State == types.IsolationGroupStateDrained {
-			return true
-		}
-	}
-	if hasDomainConfig {
-		if domainCfg.State == types.IsolationGroupStateDrained {
-			return true
-		}
-	}
-	return false
 }
 
 // A simple explicit deny-based isolation group implementation
@@ -220,6 +277,81 @@ func availableIG(allIsolationGroups []string, global types.IsolationGroupConfigu
 	return out
 }
 
-func fromCfgStore(in *persistence.FetchDynamicConfigResponse) (types.IsolationGroupConfiguration, error) {
-	panic("not implemented")
+func isDrained(isolationGroup string, global types.IsolationGroupConfiguration, domain types.IsolationGroupConfiguration) bool {
+	globalCfg, hasGlobalConfig := global[isolationGroup]
+	domainCfg, hasDomainConfig := domain[isolationGroup]
+	if hasGlobalConfig {
+		if globalCfg.State == types.IsolationGroupStateDrained {
+			return true
+		}
+	}
+	if hasDomainConfig {
+		if domainCfg.State == types.IsolationGroupStateDrained {
+			return true
+		}
+	}
+	return false
+}
+
+// ----- Mappers -----
+// dynamic config library does much of the decoding already, so this is asymmetric
+// to the serialization step. Incoming value should be just
+// map[string]interface{}
+func mapDynamicConfigResponse(in []*types.DynamicConfigEntry) (out types.IsolationGroupConfiguration, err error) {
+	if in == nil {
+		return nil, nil
+	}
+	out = make(types.IsolationGroupConfiguration)
+
+	for _, entry := range in {
+		for _, v := range entry.Values {
+			if v.Value == nil {
+				continue
+			}
+			if v.Value.GetEncodingType() != types.EncodingTypeJSON {
+				return nil, fmt.Errorf("failed to decode values: %v, (%T)", v.Value, v.Value.EncodingType)
+			}
+			var partition types.IsolationGroupPartition
+			err := json.Unmarshal(v.Value.GetData(), &partition)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal entry: %v, got %w", string(v.Value.GetData()), err)
+			}
+			out[partition.Name] = partition
+		}
+	}
+	return out, nil
+}
+
+func mapAllIsolationGroupsResponse(in []interface{}) ([]string, error) {
+	var allIsolationGroups []string
+	for k := range in {
+		v, ok := in[k].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to get all-isolation-groups resonse from dynamic config: got %v (%T)", in[k], in[k])
+		}
+		allIsolationGroups = append(allIsolationGroups, v)
+	}
+	return allIsolationGroups, nil
+}
+
+func mapUpdateGlobalIsolationGroupsRequest(in types.IsolationGroupConfiguration) ([]*types.DynamicConfigValue, error) {
+	var out []*types.DynamicConfigValue
+	for _, v := range in {
+		jsonData, err := json.Marshal(v)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal input for dynamic config: %w", err)
+		}
+		out = append(out, &types.DynamicConfigValue{
+			Value: &types.DataBlob{
+				EncodingType: types.EncodingTypeJSON.Ptr(),
+				Data:         jsonData,
+			},
+			Filters: nil,
+		})
+	}
+	// ensure sort-order
+	sort.Slice(out, func(i, j int) bool {
+		return string(out[i].Value.GetData()) < string(out[j].Value.GetData())
+	})
+	return out, nil
 }

--- a/common/isolationgroup/default-isolation-group-state.go
+++ b/common/isolationgroup/default-isolation-group-state.go
@@ -294,18 +294,13 @@ func isDrained(isolationGroup string, global types.IsolationGroupConfiguration, 
 }
 
 // ----- Mappers -----
-func mapDynamicConfigResponse(in interface{}) (out types.IsolationGroupConfiguration, err error) {
+func mapDynamicConfigResponse(in []interface{}) (out types.IsolationGroupConfiguration, err error) {
 	if in == nil {
 		return nil, nil
 	}
 
-	dcData, ok := in.([]interface{})
-	if !ok {
-		return nil, fmt.Errorf("failed to parse dynamic config data, unexpected format returned: %v, (%T)", in, in)
-	}
-
-	out = make(types.IsolationGroupConfiguration, len(dcData))
-	for _, v := range dcData {
+	out = make(types.IsolationGroupConfiguration, len(in))
+	for _, v := range in {
 		v1, ok := v.(map[string]interface{})
 		if !ok {
 			return nil, fmt.Errorf("failed parse a dynamic config entry, %v, (got %v)", v1, v)

--- a/common/isolationgroup/default-isolation-group-state_test.go
+++ b/common/isolationgroup/default-isolation-group-state_test.go
@@ -23,6 +23,7 @@
 package isolationgroup
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -118,8 +119,8 @@ func TestAvailableIsolationGroups(t *testing.T) {
 
 func TestIsDrained(t *testing.T) {
 
-	igA := string("isolationGroupA")
-	igB := string("isolationGroupB")
+	igA := "isolationGroupA"
+	igB := "isolationGroupB"
 
 	isolationGroupsAllHealthy := types.IsolationGroupConfiguration{
 		igA: {
@@ -182,4 +183,166 @@ func TestIsDrained(t *testing.T) {
 			assert.Equal(t, td.expected, isDrained(td.isolationGroup, td.globalIGCfg, td.domainIGCfg))
 		})
 	}
+}
+
+func TestIsolationGroupStateMapping(t *testing.T) {
+
+	tests := map[string]struct {
+		in          []*types.DynamicConfigEntry
+		expected    types.IsolationGroupConfiguration
+		expectedErr error
+	}{
+		"valid mapping": {
+			in: []*types.DynamicConfigEntry{
+				&types.DynamicConfigEntry{
+					Name: "",
+					Values: []*types.DynamicConfigValue{
+						{
+							Value: &types.DataBlob{
+								EncodingType: types.EncodingTypeJSON.Ptr(),
+								Data:         []byte(`{"Name":"zone-1","State":1}`),
+							},
+						},
+						{
+							Value: &types.DataBlob{
+								EncodingType: types.EncodingTypeJSON.Ptr(),
+								Data:         []byte(`{"Name":"zone-2","State":2}`),
+							},
+						},
+					},
+				},
+			},
+			expected: map[string]types.IsolationGroupPartition{
+				"zone-1": {
+					Name:  "zone-1",
+					State: types.IsolationGroupStateHealthy,
+				},
+				"zone-2": {
+					Name:  "zone-2",
+					State: types.IsolationGroupStateDrained,
+				},
+			},
+		},
+		"invalid values - encoding": {
+			in: []*types.DynamicConfigEntry{
+				&types.DynamicConfigEntry{
+					Name: "",
+					Values: []*types.DynamicConfigValue{
+						{
+							Value: &types.DataBlob{
+								EncodingType: types.EncodingTypeThriftRW.Ptr(), //invalid, not expected to use thrift here
+								Data:         []byte(`{"Name":"zone-1","State":2}`),
+							},
+						},
+					},
+				},
+			},
+			expectedErr: errors.New("failed to decode values: &{ThriftRW [123 34 78 97 109 101 34 58 34 122 111 110 101 45 49 34 44 34 83 116 97 116 101 34 58 50 125]}, (*types.EncodingType)"),
+		},
+		"invalid encoding - incomplete input - 1": {
+			in:       []*types.DynamicConfigEntry{},
+			expected: map[string]types.IsolationGroupPartition{},
+		},
+		"invalid encoding - incomplete input - 2": {
+			in: []*types.DynamicConfigEntry{
+				{
+					Values: nil,
+				},
+			},
+			expected: map[string]types.IsolationGroupPartition{},
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := mapDynamicConfigResponse(td.in)
+			assert.Equal(t, td.expected, res)
+			assert.Equal(t, td.expectedErr, err)
+		})
+	}
+}
+
+func TestMapAllIsolationGroupStates(t *testing.T) {
+
+	tests := map[string]struct {
+		in          []interface{}
+		expected    []string
+		expectedErr error
+	}{
+		"valid mapping": {
+			in:       []interface{}{"zone-1", "zone-2", "zone-3"},
+			expected: []string{"zone-1", "zone-2", "zone-3"},
+		},
+		"invalid mapping": {
+			in:          []interface{}{1, 2, 3},
+			expectedErr: errors.New("failed to get all-isolation-groups resonse from dynamic config: got 1 (int)"),
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := mapAllIsolationGroupsResponse(td.in)
+			assert.Equal(t, td.expected, res)
+			assert.Equal(t, td.expectedErr, err)
+		})
+	}
+}
+
+func TestUpdateRequest(t *testing.T) {
+
+	json := types.EncodingTypeJSON
+
+	tests := map[string]struct {
+		in          types.IsolationGroupConfiguration
+		expected    []*types.DynamicConfigValue
+		expectedErr error
+	}{
+		"valid mapping": {
+			in: types.IsolationGroupConfiguration{
+				"zone-1": {
+					Name:  "zone-1",
+					State: types.IsolationGroupStateHealthy,
+				},
+				"zone-2": {
+					Name:  "zone-2",
+					State: types.IsolationGroupStateDrained,
+				},
+			},
+			expected: []*types.DynamicConfigValue{
+				{
+					Value: &types.DataBlob{
+						EncodingType: &json,
+						Data:         []byte(`{"Name":"zone-1","State":1}`),
+					},
+					Filters: nil,
+				},
+				{
+					Value: &types.DataBlob{
+						EncodingType: &json,
+						Data:         []byte(`{"Name":"zone-2","State":2}`),
+					},
+					Filters: nil,
+				},
+			},
+		},
+		"empty mapping": {
+			in:       types.IsolationGroupConfiguration{},
+			expected: nil,
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := mapUpdateGlobalIsolationGroupsRequest(td.in)
+			assert.Equal(t, td.expected, res)
+			assert.Equal(t, td.expectedErr, err)
+		})
+	}
+}
+
+func TestIsolationGroupShutdown(t *testing.T) {
+	var v defaultIsolationGroupStateHandler
+	assert.NotPanics(t, func() {
+		v.Stop()
+	})
 }

--- a/common/isolationgroup/default-isolation-group-state_test.go
+++ b/common/isolationgroup/default-isolation-group-state_test.go
@@ -420,7 +420,7 @@ func TestIsolationGroupStateMapping(t *testing.T) {
 		},
 		"empty mapping": {
 			in:       nil,
-			expected: types.IsolationGroupConfiguration{},
+			expected: nil,
 		},
 		"invalid mapping 1": {
 			in:          []interface{}{"invalid"},

--- a/common/isolationgroup/default-isolation-group-state_test.go
+++ b/common/isolationgroup/default-isolation-group-state_test.go
@@ -23,8 +23,12 @@
 package isolationgroup
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
+	"github.com/golang/mock/gomock"
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log/loggerimpl"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -114,6 +118,106 @@ func TestAvailableIsolationGroups(t *testing.T) {
 	for name, td := range tests {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, td.expected, availableIG(all, td.globalIGCfg, td.domainIGCfg))
+		})
+	}
+}
+
+func TestUpdateGlobalState(t *testing.T) {
+
+	tests := map[string]struct {
+		in           types.UpdateGlobalIsolationGroupsRequest
+		dcAffordance func(client *dynamicconfig.MockClient)
+		expectedErr  error
+	}{
+		"updating normal value": {
+			in: types.UpdateGlobalIsolationGroupsRequest{IsolationGroups: types.IsolationGroupConfiguration{
+				"zone-1": {Name: "zone-1", State: types.IsolationGroupStateHealthy},
+				"zone-2": {Name: "zone-2", State: types.IsolationGroupStateDrained},
+			}},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().UpdateValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(), // covering the mapping in the mapper unit-test instead
+				)
+			},
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			dcMock := dynamicconfig.NewMockClient(gomock.NewController(t))
+			td.dcAffordance(dcMock)
+			handler := defaultIsolationGroupStateHandler{
+				log:                        loggerimpl.NewNopLogger(),
+				globalIsolationGroupDrains: dcMock,
+			}
+			err := handler.UpdateGlobalState(context.Background(), td.in)
+			assert.Equal(t, td.expectedErr, err)
+		})
+	}
+}
+
+func TestGetGlobalState(t *testing.T) {
+
+	validInput := types.IsolationGroupConfiguration{
+		"zone-1": types.IsolationGroupPartition{
+			Name:  "zone-1",
+			State: types.IsolationGroupStateDrained,
+		},
+		"zone-2": types.IsolationGroupPartition{
+			Name:  "zone-2",
+			State: types.IsolationGroupStateHealthy,
+		},
+	}
+
+	validCfg, _ := mapUpdateGlobalIsolationGroupsRequest(validInput)
+
+	validCfgData := validCfg[0].Value.GetData()
+	dynamicConfigResponse := []interface{}{}
+	json.Unmarshal(validCfgData, &dynamicConfigResponse)
+
+	tests := map[string]struct {
+		in           types.GetGlobalIsolationGroupsRequest
+		dcAffordance func(client *dynamicconfig.MockClient)
+		expected     *types.GetGlobalIsolationGroupsResponse
+		expectedErr  error
+	}{
+		"updating normal value": {
+			in: types.GetGlobalIsolationGroupsRequest{},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(dynamicConfigResponse, nil)
+			},
+			expected: &types.GetGlobalIsolationGroupsResponse{IsolationGroups: validInput},
+		},
+		"an error was returned": {
+			in: types.GetGlobalIsolationGroupsRequest{},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(nil, errors.New("an error"))
+			},
+			expectedErr: errors.New("failed to get global isolation groups from datastore: an error"),
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			dcMock := dynamicconfig.NewMockClient(gomock.NewController(t))
+			td.dcAffordance(dcMock)
+			handler := defaultIsolationGroupStateHandler{
+				log:                        loggerimpl.NewNopLogger(),
+				globalIsolationGroupDrains: dcMock,
+			}
+			res, err := handler.GetGlobalState(context.Background())
+			assert.Equal(t, td.expected, res)
+			if td.expectedErr != nil {
+				// only compare strings because full wrapping makes it fiddly otherwise
+				assert.Equal(t, td.expectedErr.Error(), err.Error())
+			}
 		})
 	}
 }
@@ -259,7 +363,7 @@ func TestMapAllIsolationGroupStates(t *testing.T) {
 		},
 		"invalid mapping": {
 			in:          []interface{}{1, 2, 3},
-			expectedErr: errors.New("failed to get all-isolation-groups resonse from dynamic config: got 1 (int)"),
+			expectedErr: errors.New("failed to get all-isolation-groups response from dynamic config: got 1 (int)"),
 		},
 	}
 

--- a/common/isolationgroup/interface.go
+++ b/common/isolationgroup/interface.go
@@ -25,10 +25,7 @@ package isolationgroup
 import (
 	"context"
 
-	"github.com/uber/cadence/common/dynamicconfig"
-
 	"github.com/uber/cadence/common"
-
 	"github.com/uber/cadence/common/types"
 )
 
@@ -50,16 +47,8 @@ type State interface {
 
 	Subscribe(domainID, key string, notifyChannel chan<- ChangeEvent) error
 	Unsubscribe(domainID, key string) error
-}
 
-// Config values for the partitioning library for segmenting portions of workflows into isolation-groups - a resiliency
-// concept meant to help move workflows around and away from failure zones.
-type Config struct {
-	// IsolationGroupEnabled is a domain-based configuration value for whether this feature is enabled at all
-	IsolationGroupEnabled dynamicconfig.BoolPropertyFnWithDomainFilter
-	// AllIsolationGroups is a static list of all the possible isolation group names
-	AllIsolationGroups []string
-	// UpdateFrequency refers to the frequency by which the function
-	// polls the configuration store for changes in isolation group drains
-	UpdateFrequency dynamicconfig.DurationPropertyFn
+	// CRUD operations for state handling
+	GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error)
+	UpdateGlobalState(ctx context.Context, state types.UpdateGlobalIsolationGroupsRequest) error
 }

--- a/common/isolationgroup/isolation_group_mock.go
+++ b/common/isolationgroup/isolation_group_mock.go
@@ -73,6 +73,21 @@ func (mr *MockStateMockRecorder) AvailableIsolationGroupsByDomainID(ctx, domainI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIsolationGroupsByDomainID", reflect.TypeOf((*MockState)(nil).AvailableIsolationGroupsByDomainID), ctx, domainID)
 }
 
+// GetGlobalState mocks base method.
+func (m *MockState) GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGlobalState", ctx)
+	ret0, _ := ret[0].(*types.GetGlobalIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGlobalState indicates an expected call of GetGlobalState.
+func (mr *MockStateMockRecorder) GetGlobalState(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGlobalState", reflect.TypeOf((*MockState)(nil).GetGlobalState), ctx)
+}
+
 // IsDrained mocks base method.
 func (m *MockState) IsDrained(ctx context.Context, Domain, IsolationGroup string) (bool, error) {
 	m.ctrl.T.Helper()
@@ -153,4 +168,18 @@ func (m *MockState) Unsubscribe(domainID, key string) error {
 func (mr *MockStateMockRecorder) Unsubscribe(domainID, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsubscribe", reflect.TypeOf((*MockState)(nil).Unsubscribe), domainID, key)
+}
+
+// UpdateGlobalState mocks base method.
+func (m *MockState) UpdateGlobalState(ctx context.Context, state types.UpdateGlobalIsolationGroupsRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateGlobalState", ctx, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateGlobalState indicates an expected call of UpdateGlobalState.
+func (mr *MockStateMockRecorder) UpdateGlobalState(ctx, state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGlobalState", reflect.TypeOf((*MockState)(nil).UpdateGlobalState), ctx, state)
 }

--- a/common/resource/resource.go
+++ b/common/resource/resource.go
@@ -23,6 +23,9 @@ package resource
 import (
 	"go.uber.org/yarpc"
 
+	"github.com/uber/cadence/common/isolationgroup"
+	"github.com/uber/cadence/common/partition"
+
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 
 	"github.com/uber/cadence/client"
@@ -38,12 +41,10 @@ import (
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/domain"
-	"github.com/uber/cadence/common/isolationgroup"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/membership"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
-	"github.com/uber/cadence/common/partition"
 	"github.com/uber/cadence/common/persistence"
 	persistenceClient "github.com/uber/cadence/common/persistence/client"
 )

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -247,7 +247,10 @@ func New(
 		return nil, err
 	}
 
-	isolationGroupState := ensureIsolationGroupStateHandlerOrDefault(params, persistenceBean.GetConfigStoreManager(), dynamicCollection, domainCache)
+	isolationGroupState := ensureIsolationGroupStateHandlerOrDefault(
+		params,
+		dynamicCollection,
+		domainCache)
 	partitioner := ensurePartitionerOrDefault(params, dynamicCollection, isolationGroupState)
 
 	impl = &Impl{
@@ -368,7 +371,9 @@ func (h *Impl) Stop() {
 	}
 	h.runtimeMetricsReporter.Stop()
 	h.persistenceBean.Close()
-	h.isolationGroups.Stop()
+	if h.isolationGroups != nil {
+		h.isolationGroups.Stop()
+	}
 }
 
 // GetServiceName return service name
@@ -568,38 +573,23 @@ func (h *Impl) GetPartitioner() partition.Partitioner {
 	return h.partitioner
 }
 
-func mapIGs(log log.Logger, in []interface{}) []string {
-	var allIsolationGroups []string
-	for k := range in {
-		v, ok := in[k].(string)
-		if ok {
-			allIsolationGroups = append(allIsolationGroups, v)
-		} else {
-			log.Error("Invalid isolation-group: ", tag.Dynamic("isolation-group", v))
-		}
-	}
-	return allIsolationGroups
-}
-
 // Use the provided IsolationGroupStateHandler or the default one
-func ensureIsolationGroupStateHandlerOrDefault(params *Params,
-	cfgStoreMgr persistence.ConfigStoreManager,
+func ensureIsolationGroupStateHandlerOrDefault(
+	params *Params,
 	dc *dynamicconfig.Collection,
 	domainCache cache.DomainCache,
 ) isolationgroup.State {
 
-	allIGs := dc.GetListProperty(dynamicconfig.AllIsolationGroups)()
-	allIsolationGroups := mapIGs(params.Logger, allIGs)
-
 	if params.IsolationGroupState != nil {
 		return params.IsolationGroupState
 	}
-	cfg := isolationgroup.Config{
-		IsolationGroupEnabled: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableTasklistIsolation),
-		UpdateFrequency:       dc.GetDurationProperty(dynamicconfig.IsolationGroupStateRefreshInterval),
-		AllIsolationGroups:    allIsolationGroups,
+
+	ig, err := isolationgroup.NewDefaultIsolationGroupStateWatcher(params.Logger, dc, &params.PersistenceConfig, domainCache)
+	if err != nil {
+		params.Logger.Error("failed to load up isolation-group", tag.Error(err))
+		return nil
 	}
-	return isolationgroup.NewDefaultIsolationGroupStateWatcher(params.Logger, cfg, domainCache, cfgStoreMgr)
+	return ig
 }
 
 // Use the provided partitioner or the default one

--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -26,7 +26,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	publicservicetest "go.uber.org/cadence/.gen/go/cadence/workflowservicetest"
-
 	"go.uber.org/yarpc"
 	"go.uber.org/zap"
 
@@ -202,7 +201,6 @@ func NewTest(
 		HistoryMgr:      historyMgr,
 		ExecutionMgr:    executionMgr,
 		PersistenceBean: persistenceBean,
-
 		IsolationGroups: isolationGroupMock,
 		Partitioner:     partitionMock,
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Adds CRUD operations to isolation-group library
- Moves isolation-group-library to use the dynamic config client in line with other config-store providers
- Unexports some configuration no longer making sense to export for the IsolationGroup library

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
select * from cluster_config;

@ Row 1
-----------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 row_type  | 1
 version   | 1
 encoding  | thriftrw
 timestamp | 2023-04-07 02:14:47.117000+0000
 values    | 0x590a000a00000000000000000f00140c000000010b000a0000003b73797374656d2e64656661756c7449736f6c6174696f6e47726f7570436f6e66696753746f72654d616e61676572476c6f62616c4d617070696e670f00140c000000010c000a08000a000000010b0014000000395b7b224e616d65223a227a6f6e652d31222c225374617465223a327d2c7b224e616d65223a227a6f6e652d32222c225374617465223a317d5d00000000

(1 rows)
```
```
cadence admin db decode_thrift -i '590a000a00000000000000000f00140c000000010b000a0000003b73797374656d2e64656661756c7449736f6c6174696f6e47726f7570436f6e66696753746f72654d616e61676572476c6f62616c4d617070696e670f00140c000000010c000a08000a000000010b0014000000395b7b224e616d65223a227a6f6e652d31222c225374617465223a327d2c7b224e616d65223a227a6f6e652d32222c225374617465223a317d5d00000000'
======= Decode into type config.DynamicConfigBlob ========
(*config.DynamicConfigBlob)(0x140001442e0)(DynamicConfigBlob{SchemaVersion: 0, Entries: [DynamicConfigEntry{Name: system.defaultIsolationGroupConfigStoreManagerGlobalMapping, Values: [DynamicConfigValue{Value: DataBlob{EncodingType: JSON, Data: [91 123 34 78 97 109 101 34 58 34 122 111 110 101 45 49 34 44 34 83 116 97 116 101 34 58 50 125 44 123 34 78 97 109 101 34 58 34 122 111 110 101 45 50 34 44 34 83 116 97 116 101 34 58 49 125 93]}}]}]})
======= As JSON ========
{"schemaVersion":0,"entries":[{"name":"system.defaultIsolationGroupConfigStoreManagerGlobalMapping","values":[{"value":{"EncodingType":"JSON","Data":"W3siTmFtZSI6InpvbmUtMSIsIlN0YXRlIjoyfSx7Ik5hbWUiOiJ6b25lLTIiLCJTdGF0ZSI6MX1d"}}]}]}
➜  cadence git:(feature/ig-lib-refactor) pbpaste | jq .
{
  "schemaVersion": 0,
  "entries": [
    {
      "name": "system.defaultIsolationGroupConfigStoreManagerGlobalMapping",
      "values": [
        {
          "value": {
            "EncodingType": "JSON",
            "Data": "W3siTmFtZSI6InpvbmUtMSIsIlN0YXRlIjoyfSx7Ik5hbWUiOiJ6b25lLTIiLCJTdGF0ZSI6MX1d"
          }
        }
      ]
    }
  ]
}
```
```
echo W3siTmFtZSI6InpvbmUtMSIsIlN0YXRlIjoyfSx7Ik5hbWUiOiJ6b25lLTIiLCJTdGF0ZSI6MX1d | base64 -D
[{"Name":"zone-1","State":2},{"Name":"zone-2","State":1}]
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
