### PR TITLE
Update matching to support tasklist isolation

### DIFF
--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -69,6 +69,10 @@ type (
 		EnableTaskInfoLogByDomainID dynamicconfig.BoolPropertyFnWithDomainIDFilter
 
 		ActivityTaskSyncMatchWaitTime dynamicconfig.DurationPropertyFnWithDomainFilter
+
+		// isolation configuration
+		EnableTasklistIsolation dynamicconfig.BoolPropertyFnWithDomainFilter
+		AllIsolationGroups      []string
 	}
 
 	forwarderConfig struct {
@@ -96,6 +100,8 @@ type (
 		MaxTaskBatchSize                func() int
 		NumWritePartitions              func() int
 		NumReadPartitions               func() int
+		// isolation configuration
+		EnableTasklistIsolation bool
 	}
 )
 
@@ -130,7 +136,20 @@ func NewConfig(dc *dynamicconfig.Collection) *Config {
 		EnableDebugMode:                 dc.GetBoolProperty(dynamicconfig.EnableDebugMode)(),
 		EnableTaskInfoLogByDomainID:     dc.GetBoolPropertyFilteredByDomainID(dynamicconfig.MatchingEnableTaskInfoLogByDomainID),
 		ActivityTaskSyncMatchWaitTime:   dc.GetDurationPropertyFilteredByDomain(dynamicconfig.MatchingActivityTaskSyncMatchWaitTime),
+		EnableTasklistIsolation:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableTasklistIsolation),
+		AllIsolationGroups:              mapIGs(dc.GetListProperty(dynamicconfig.AllIsolationGroups)()),
 	}
+}
+
+func mapIGs(in []interface{}) []string {
+	var allIsolationGroups []string
+	for k := range in {
+		v, ok := in[k].(string)
+		if ok {
+			allIsolationGroups = append(allIsolationGroups, v)
+		}
+	}
+	return allIsolationGroups
 }
 
 func newTaskListConfig(id *taskListID, config *Config, domainCache cache.DomainCache) (*taskListConfig, error) {
@@ -143,6 +162,7 @@ func newTaskListConfig(id *taskListID, config *Config, domainCache cache.DomainC
 	taskType := id.taskType
 	return &taskListConfig{
 		RangeSize:                     config.RangeSize,
+		EnableTasklistIsolation:       config.EnableTasklistIsolation(domainName),
 		ActivityTaskSyncMatchWaitTime: config.ActivityTaskSyncMatchWaitTime,
 		GetTasksBatchSize: func() int {
 			return config.GetTasksBatchSize(domainName, taskListName, taskType)

--- a/service/matching/config.go
+++ b/service/matching/config.go
@@ -101,7 +101,7 @@ type (
 		NumWritePartitions              func() int
 		NumReadPartitions               func() int
 		// isolation configuration
-		EnableTasklistIsolation bool
+		EnableTasklistIsolation func() bool
 	}
 )
 
@@ -161,8 +161,10 @@ func newTaskListConfig(id *taskListID, config *Config, domainCache cache.DomainC
 	taskListName := id.name
 	taskType := id.taskType
 	return &taskListConfig{
-		RangeSize:                     config.RangeSize,
-		EnableTasklistIsolation:       config.EnableTasklistIsolation(domainName),
+		RangeSize: config.RangeSize,
+		EnableTasklistIsolation: func() bool {
+			return config.EnableTasklistIsolation(domainName)
+		},
 		ActivityTaskSyncMatchWaitTime: config.ActivityTaskSyncMatchWaitTime,
 		GetTasksBatchSize: func() int {
 			return config.GetTasksBatchSize(domainName, taskListName, taskType)

--- a/service/matching/forwarder.go
+++ b/service/matching/forwarder.go
@@ -137,6 +137,7 @@ func (fwdr *Forwarder) ForwardTask(ctx context.Context, task *InternalTask) erro
 			ScheduleToStartTimeoutSeconds: &task.event.ScheduleToStartTimeout,
 			Source:                        &task.source,
 			ForwardedFrom:                 fwdr.taskListID.name,
+			PartitionConfig:               task.event.PartitionConfig,
 		})
 	case persistence.TaskListTypeActivity:
 		err = fwdr.client.AddActivityTask(ctx, &types.AddActivityTaskRequest{
@@ -151,6 +152,7 @@ func (fwdr *Forwarder) ForwardTask(ctx context.Context, task *InternalTask) erro
 			ScheduleToStartTimeoutSeconds: &task.event.ScheduleToStartTimeout,
 			Source:                        &task.source,
 			ForwardedFrom:                 fwdr.taskListID.name,
+			PartitionConfig:               task.event.PartitionConfig,
 		})
 	default:
 		return errInvalidTaskListType
@@ -200,6 +202,7 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context) (*InternalTask, error) {
 
 	pollerID, _ := ctx.Value(pollerIDKey).(string)
 	identity, _ := ctx.Value(identityKey).(string)
+	isolationGroup, _ := ctx.Value(_isolationGroupKey).(string)
 
 	switch fwdr.taskListID.taskType {
 	case persistence.TaskListTypeDecision:
@@ -213,7 +216,8 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context) (*InternalTask, error) {
 				},
 				Identity: identity,
 			},
-			ForwardedFrom: fwdr.taskListID.name,
+			ForwardedFrom:  fwdr.taskListID.name,
+			IsolationGroup: isolationGroup,
 		})
 		if err != nil {
 			return nil, fwdr.handleErr(err)
@@ -230,7 +234,8 @@ func (fwdr *Forwarder) ForwardPoll(ctx context.Context) (*InternalTask, error) {
 				},
 				Identity: identity,
 			},
-			ForwardedFrom: fwdr.taskListID.name,
+			ForwardedFrom:  fwdr.taskListID.name,
+			IsolationGroup: isolationGroup,
 		})
 		if err != nil {
 			return nil, fwdr.handleErr(err)

--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -71,7 +71,7 @@ func (t *ForwarderTestSuite) TearDownTest() {
 }
 
 func (t *ForwarderTestSuite) TestForwardTaskError() {
-	task := newInternalTask(&persistence.TaskInfo{}, nil, types.TaskSourceHistory, "", false, nil)
+	task := newInternalTask(&persistence.TaskInfo{}, nil, types.TaskSourceHistory, "", false, nil, "")
 	t.Equal(errNoParent, t.fwdr.ForwardTask(context.Background(), task))
 
 	t.usingTasklistPartition(persistence.TaskListTypeActivity)
@@ -90,7 +90,7 @@ func (t *ForwarderTestSuite) TestForwardDecisionTask() {
 	).Return(nil).Times(1)
 
 	taskInfo := t.newTaskInfo()
-	task := newInternalTask(taskInfo, nil, types.TaskSourceHistory, "", false, nil)
+	task := newInternalTask(taskInfo, nil, types.TaskSourceHistory, "", false, nil, "")
 	t.NoError(t.fwdr.ForwardTask(context.Background(), task))
 	t.NotNil(request)
 	t.Equal(t.taskList.Parent(20), request.TaskList.GetName())
@@ -114,7 +114,7 @@ func (t *ForwarderTestSuite) TestForwardActivityTask() {
 	).Return(nil).Times(1)
 
 	taskInfo := t.newTaskInfo()
-	task := newInternalTask(taskInfo, nil, types.TaskSourceHistory, "", false, nil)
+	task := newInternalTask(taskInfo, nil, types.TaskSourceHistory, "", false, nil, "")
 	t.NoError(t.fwdr.ForwardTask(context.Background(), task))
 	t.NotNil(request)
 	t.Equal(t.taskList.Parent(20), request.TaskList.GetName())
@@ -134,7 +134,7 @@ func (t *ForwarderTestSuite) TestForwardTaskRateExceeded() {
 	rps := 2
 	t.client.EXPECT().AddActivityTask(gomock.Any(), gomock.Any()).Return(nil).Times(rps)
 	taskInfo := t.newTaskInfo()
-	task := newInternalTask(taskInfo, nil, types.TaskSourceHistory, "", false, nil)
+	task := newInternalTask(taskInfo, nil, types.TaskSourceHistory, "", false, nil, "")
 	for i := 0; i < rps; i++ {
 		t.NoError(t.fwdr.ForwardTask(context.Background(), task))
 	}

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -283,7 +283,7 @@ forLoop:
 func (tm *TaskMatcher) Poll(ctx context.Context, isolationGroup string) (*InternalTask, error) {
 	isolatedTaskC, ok := tm.isolatedTaskC[isolationGroup]
 	if !ok && isolationGroup != "" {
-		return nil, fmt.Errorf("invalid isolation group: %s", isolationGroup)
+		return nil, &types.BadRequestError{Message: fmt.Sprintf("invalid isolation group: %s", isolationGroup)}
 	}
 	// try local match first without blocking until context timeout
 	if task, err := tm.pollNonBlocking(ctx, isolatedTaskC, tm.taskC, tm.queryTaskC); err == nil {

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -23,6 +23,7 @@ package matching
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -37,7 +38,8 @@ import (
 // that drains backlog from db. Consumers are the task list pollers
 type TaskMatcher struct {
 	// synchronous task channel to match producer/consumer
-	taskC chan *InternalTask
+	taskC         chan *InternalTask
+	isolatedTaskC map[string]chan *InternalTask
 	// synchronous task channel to match query task - the reason to have
 	// separate channel for this is because there are cases when consumers
 	// are interested in queryTasks but not others. Example is when domain is
@@ -61,14 +63,19 @@ var errTasklistThrottled = errors.New("cannot add to tasklist, limit exceeded")
 // newTaskMatcher returns an task matcher instance. The returned instance can be
 // used by task producers and consumers to find a match. Both sync matches and non-sync
 // matches should use this implementation
-func newTaskMatcher(config *taskListConfig, fwdr *Forwarder, scope metrics.Scope) *TaskMatcher {
+func newTaskMatcher(config *taskListConfig, fwdr *Forwarder, scope metrics.Scope, isolationGroups []string) *TaskMatcher {
 	dPtr := _defaultTaskDispatchRPS
 	limiter := quotas.NewRateLimiter(&dPtr, _defaultTaskDispatchRPSTTL, config.MinTaskThrottlingBurstSize())
+	isolatedTaskC := make(map[string]chan *InternalTask)
+	for _, g := range isolationGroups {
+		isolatedTaskC[g] = make(chan *InternalTask)
+	}
 	return &TaskMatcher{
 		limiter:       limiter,
 		scope:         scope,
 		fwdr:          fwdr,
 		taskC:         make(chan *InternalTask),
+		isolatedTaskC: isolatedTaskC,
 		queryTaskC:    make(chan *InternalTask),
 		numPartitions: config.NumReadPartitions,
 	}
@@ -115,7 +122,7 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *InternalTask) (bool, err
 	}
 
 	select {
-	case tm.taskC <- task: // poller picked up the task
+	case tm.getTaskC(task) <- task: // poller picked up the task
 		if task.responseC != nil {
 			// if there is a response channel, block until resp is received
 			// and return error if the response contains error
@@ -155,7 +162,7 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *InternalTask) (bool, err
 
 func (tm *TaskMatcher) offerOrTimeout(ctx context.Context, task *InternalTask) (bool, error) {
 	select {
-	case tm.taskC <- task: // poller picked up the task
+	case tm.getTaskC(task) <- task: // poller picked up the task
 		if task.responseC != nil {
 			select {
 			case err := <-task.responseC:
@@ -217,18 +224,21 @@ func (tm *TaskMatcher) MustOffer(ctx context.Context, task *InternalTask) error 
 
 	// attempt a match with local poller first. When that
 	// doesn't succeed, try both local match and remote match
+	taskC := tm.getTaskC(task)
 	select {
-	case tm.taskC <- task:
+	case taskC <- task: // poller picked up the task
 		return nil
 	case <-ctx.Done():
 		return ctx.Err()
 	default:
 	}
 
+	// TODO: we need a way to get the notification of the draining events of isolation groups,
+	// otherwise the loop will get stuck forever because the context doesn't have any deadline
 forLoop:
 	for {
 		select {
-		case tm.taskC <- task:
+		case taskC <- task: // poller picked up the task
 			return nil
 		case token := <-tm.fwdrAddReqTokenC():
 			childCtx, cancel := context.WithDeadline(ctx, time.Now().Add(time.Second*2))
@@ -240,7 +250,7 @@ forLoop:
 				// the next forwarded call after this childCtx expires. Till then, we block
 				// hoping for a local poller match
 				select {
-				case tm.taskC <- task:
+				case taskC <- task: // poller picked up the task
 					cancel()
 					return nil
 				case <-childCtx.Done():
@@ -266,28 +276,32 @@ forLoop:
 // Poll blocks until a task is found or context deadline is exceeded
 // On success, the returned task could be a query task or a regular task
 // Returns ErrNoTasks when context deadline is exceeded
-func (tm *TaskMatcher) Poll(ctx context.Context) (*InternalTask, error) {
+func (tm *TaskMatcher) Poll(ctx context.Context, isolationGroup string) (*InternalTask, error) {
+	isolatedTaskC, ok := tm.isolatedTaskC[isolationGroup]
+	if !ok && isolationGroup != "" {
+		return nil, fmt.Errorf("invalid isolation group: %s", isolationGroup)
+	}
 	// try local match first without blocking until context timeout
-	if task, err := tm.pollNonBlocking(ctx, tm.taskC, tm.queryTaskC); err == nil {
+	if task, err := tm.pollNonBlocking(ctx, isolatedTaskC, tm.taskC, tm.queryTaskC); err == nil {
 		return task, nil
 	}
 	// there is no local poller available to pickup this task. Now block waiting
 	// either for a local poller or a forwarding token to be available. When a
 	// forwarding token becomes available, send this poll to a parent partition
-	return tm.pollOrForward(ctx, tm.taskC, tm.queryTaskC)
+	return tm.pollOrForward(ctx, isolatedTaskC, tm.taskC, tm.queryTaskC)
 }
 
 // PollForQuery blocks until a *query* task is found or context deadline is exceeded
 // Returns ErrNoTasks when context deadline is exceeded
 func (tm *TaskMatcher) PollForQuery(ctx context.Context) (*InternalTask, error) {
 	// try local match first without blocking until context timeout
-	if task, err := tm.pollNonBlocking(ctx, nil, tm.queryTaskC); err == nil {
+	if task, err := tm.pollNonBlocking(ctx, nil, nil, tm.queryTaskC); err == nil {
 		return task, nil
 	}
 	// there is no local poller available to pickup this task. Now block waiting
 	// either for a local poller or a forwarding token to be available. When a
 	// forwarding token becomes available, send this poll to a parent partition
-	return tm.pollOrForward(ctx, nil, tm.queryTaskC)
+	return tm.pollOrForward(ctx, nil, nil, tm.queryTaskC)
 }
 
 // UpdateRatelimit updates the task dispatch rate
@@ -311,10 +325,17 @@ func (tm *TaskMatcher) Rate() float64 {
 
 func (tm *TaskMatcher) pollOrForward(
 	ctx context.Context,
+	isolatedTaskC <-chan *InternalTask,
 	taskC <-chan *InternalTask,
 	queryTaskC <-chan *InternalTask,
 ) (*InternalTask, error) {
 	select {
+	case task := <-isolatedTaskC:
+		if task.responseC != nil {
+			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
+		}
+		tm.scope.IncCounter(metrics.PollSuccessPerTaskListCounter)
+		return task, nil
 	case task := <-taskC:
 		if task.responseC != nil {
 			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
@@ -334,16 +355,23 @@ func (tm *TaskMatcher) pollOrForward(
 			return task, nil
 		}
 		token.release()
-		return tm.poll(ctx, taskC, queryTaskC)
+		return tm.poll(ctx, isolatedTaskC, taskC, queryTaskC)
 	}
 }
 
 func (tm *TaskMatcher) poll(
 	ctx context.Context,
+	isolatedTaskC <-chan *InternalTask,
 	taskC <-chan *InternalTask,
 	queryTaskC <-chan *InternalTask,
 ) (*InternalTask, error) {
 	select {
+	case task := <-isolatedTaskC:
+		if task.responseC != nil {
+			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
+		}
+		tm.scope.IncCounter(metrics.PollSuccessPerTaskListCounter)
+		return task, nil
 	case task := <-taskC:
 		if task.responseC != nil {
 			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
@@ -362,10 +390,17 @@ func (tm *TaskMatcher) poll(
 
 func (tm *TaskMatcher) pollNonBlocking(
 	ctx context.Context,
+	isolatedTaskC <-chan *InternalTask,
 	taskC <-chan *InternalTask,
 	queryTaskC <-chan *InternalTask,
 ) (*InternalTask, error) {
 	select {
+	case task := <-isolatedTaskC:
+		if task.responseC != nil {
+			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
+		}
+		tm.scope.IncCounter(metrics.PollSuccessPerTaskListCounter)
+		return task, nil
 	case task := <-taskC:
 		if task.responseC != nil {
 			tm.scope.IncCounter(metrics.PollSuccessWithSyncPerTaskListCounter)
@@ -425,4 +460,12 @@ func (tm *TaskMatcher) ratelimit(ctx context.Context) (*rate.Reservation, error)
 
 func (tm *TaskMatcher) isForwardingAllowed() bool {
 	return tm.fwdr != nil
+}
+
+func (tm *TaskMatcher) getTaskC(task *InternalTask) chan<- *InternalTask {
+	taskC := tm.taskC
+	if isolatedTaskC, ok := tm.isolatedTaskC[task.isolationGroup]; ok && task.isolationGroup != "" {
+		taskC = isolatedTaskC
+	}
+	return taskC
 }

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -37,8 +37,12 @@ import (
 // Producers are usually rpc calls from history or taskReader
 // that drains backlog from db. Consumers are the task list pollers
 type TaskMatcher struct {
-	// synchronous task channel to match producer/consumer
-	taskC         chan *InternalTask
+	// synchronous task channel to match producer/consumer for any isolation group
+	// tasks having no isolation requirement are added to this channel
+	// and pollers from all isolation groups read from this channel
+	taskC chan *InternalTask
+	// synchronos task channels to match producer/consumer for a certain isolation group
+	// the key is the name of the isolation group
 	isolatedTaskC map[string]chan *InternalTask
 	// synchronous task channel to match query task - the reason to have
 	// separate channel for this is because there are cases when consumers

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -70,12 +70,12 @@ func (t *MatcherTestSuite) SetupTest() {
 	}
 	t.cfg = tlCfg
 	t.fwdr = newForwarder(&t.cfg.forwarderConfig, t.taskList, types.TaskListKindNormal, t.client)
-	t.matcher = newTaskMatcher(tlCfg, t.fwdr, metrics.NoopScope(metrics.Matching))
+	t.matcher = newTaskMatcher(tlCfg, t.fwdr, metrics.NoopScope(metrics.Matching), []string{"dca1", "dca2"})
 
 	rootTaskList := newTestTaskListID(t.taskList.domainID, t.taskList.Parent(20), persistence.TaskListTypeDecision)
 	rootTasklistCfg, err := newTaskListConfig(rootTaskList, cfg, t.newDomainCache())
 	t.NoError(err)
-	t.rootMatcher = newTaskMatcher(rootTasklistCfg, nil, metrics.NoopScope(metrics.Matching))
+	t.rootMatcher = newTaskMatcher(rootTasklistCfg, nil, metrics.NoopScope(metrics.Matching), []string{"dca1", "dca2"})
 }
 
 func (t *MatcherTestSuite) TearDownTest() {
@@ -88,13 +88,35 @@ func (t *MatcherTestSuite) TestLocalSyncMatch() {
 	<-t.fwdr.PollReqTokenC()
 
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
-		task, err := t.matcher.Poll(ctx)
+		task, err := t.matcher.Poll(ctx, "")
 		if err == nil {
 			task.finish(nil)
 		}
 	})
 
-	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil)
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil, "")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	syncMatch, err := t.matcher.Offer(ctx, task)
+	cancel()
+	wait()
+	t.NoError(err)
+	t.True(syncMatch)
+}
+
+func (t *MatcherTestSuite) TestIsolationLocalSyncMatch() {
+	// force disable remote forwarding
+	<-t.fwdr.AddReqTokenC()
+	<-t.fwdr.PollReqTokenC()
+
+	isolationGroup := "dca1"
+	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
+		task, err := t.matcher.Poll(ctx, isolationGroup)
+		if err == nil {
+			task.finish(nil)
+		}
+	})
+
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil, "dca1")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	syncMatch, err := t.matcher.Offer(ctx, task)
 	cancel()
@@ -104,14 +126,22 @@ func (t *MatcherTestSuite) TestLocalSyncMatch() {
 }
 
 func (t *MatcherTestSuite) TestRemoteSyncMatch() {
-	t.testRemoteSyncMatch(types.TaskSourceHistory)
+	t.testRemoteSyncMatch(types.TaskSourceHistory, "")
+}
+
+func (t *MatcherTestSuite) TestIsolationRemoteSyncMatch() {
+	t.testRemoteSyncMatch(types.TaskSourceHistory, "dca1")
 }
 
 func (t *MatcherTestSuite) TestRemoteSyncMatchBlocking() {
-	t.testRemoteSyncMatch(types.TaskSourceDbBacklog)
+	t.testRemoteSyncMatch(types.TaskSourceDbBacklog, "")
 }
 
-func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource types.TaskSource) {
+func (t *MatcherTestSuite) TestIsolationRemoteSyncMatchBlocking() {
+	t.testRemoteSyncMatch(types.TaskSourceDbBacklog, "dca1")
+}
+
+func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource types.TaskSource, isolationGroup string) {
 	pollSigC := make(chan struct{})
 
 	bgctx, bgcancel := context.WithTimeout(context.Background(), time.Second)
@@ -122,7 +152,7 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource types.TaskSource) {
 			// so lets delay polling by a bit to verify that
 			time.Sleep(time.Millisecond * 10)
 		}
-		task, err := t.matcher.Poll(bgctx)
+		task, err := t.matcher.Poll(bgctx, isolationGroup)
 		bgcancel()
 		if err == nil && !task.isStarted() {
 			task.finish(nil)
@@ -131,7 +161,7 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource types.TaskSource) {
 
 	t.client.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(arg0 context.Context, arg1 *types.MatchingPollForDecisionTaskRequest, option ...yarpc.CallOption) (*types.MatchingPollForDecisionTaskResponse, error) {
-			task, err := t.rootMatcher.Poll(arg0)
+			task, err := t.rootMatcher.Poll(arg0, isolationGroup)
 			if err != nil {
 				return nil, err
 			}
@@ -143,7 +173,7 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource types.TaskSource) {
 		},
 	).AnyTimes()
 
-	task := newInternalTask(t.newTaskInfo(), nil, taskSource, "", true, nil)
+	task := newInternalTask(t.newTaskInfo(), nil, taskSource, "", true, nil, isolationGroup)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
 	var err error
@@ -155,9 +185,8 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource types.TaskSource) {
 			task.forwardedFrom = req.GetForwardedFrom()
 			close(pollSigC)
 			if taskSource != types.TaskSourceDbBacklog {
-				// when task is not from backlog, wait a bit for poller
-				// to arrive first - when task is from backlog, offer
-				// blocks - so we don't need to do this
+				// when task is not from backlog, wait a bit for poller to arrive first
+				// when task is from backlog, offer blocks, so we don't need to do this
 				time.Sleep(10 * time.Millisecond)
 			}
 			remoteSyncMatch, err = t.rootMatcher.Offer(ctx, task)
@@ -176,7 +205,7 @@ func (t *MatcherTestSuite) testRemoteSyncMatch(taskSource types.TaskSource) {
 }
 
 func (t *MatcherTestSuite) TestSyncMatchFailure() {
-	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil)
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil, "")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 
 	var req *types.AddDecisionTaskRequest
@@ -189,6 +218,25 @@ func (t *MatcherTestSuite) TestSyncMatchFailure() {
 	syncMatch, err := t.matcher.Offer(ctx, task)
 	cancel()
 	t.NotNil(req)
+	t.NoError(err)
+	t.False(syncMatch)
+}
+
+func (t *MatcherTestSuite) TestIsolationSyncMatchFailure() {
+	// force disable remote forwarding
+	<-t.fwdr.AddReqTokenC()
+	<-t.fwdr.PollReqTokenC()
+	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
+		task, err := t.matcher.Poll(ctx, "dca2")
+		if err == nil {
+			task.finish(nil)
+		}
+	})
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", true, nil, "dca1")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	syncMatch, err := t.matcher.Offer(ctx, task)
+	cancel()
+	wait()
 	t.NoError(err)
 	t.False(syncMatch)
 }
@@ -303,13 +351,33 @@ func (t *MatcherTestSuite) TestMustOfferLocalMatch() {
 	<-t.fwdr.PollReqTokenC()
 
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
-		task, err := t.matcher.Poll(ctx)
+		task, err := t.matcher.Poll(ctx, "")
 		if err == nil {
 			task.finish(nil)
 		}
 	})
 
-	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", false, nil)
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", false, nil, "")
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	err := t.matcher.MustOffer(ctx, task)
+	cancel()
+	wait()
+	t.NoError(err)
+}
+
+func (t *MatcherTestSuite) TestIsolationMustOfferLocalMatch() {
+	// force disable remote forwarding
+	<-t.fwdr.AddReqTokenC()
+	<-t.fwdr.PollReqTokenC()
+
+	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
+		task, err := t.matcher.Poll(ctx, "dca1")
+		if err == nil {
+			task.finish(nil)
+		}
+	})
+
+	task := newInternalTask(t.newTaskInfo(), nil, types.TaskSourceHistory, "", false, nil, "dca1")
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	err := t.matcher.MustOffer(ctx, task)
 	cancel()
@@ -324,7 +392,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 		func(arg0 context.Context, arg1 *types.MatchingPollForDecisionTaskRequest, option ...yarpc.CallOption) (*types.MatchingPollForDecisionTaskResponse, error) {
 			<-pollSigC
 			time.Sleep(time.Millisecond * 500) // delay poll to verify that offer blocks on parent
-			task, err := t.rootMatcher.Poll(arg0)
+			task, err := t.rootMatcher.Poll(arg0, "")
 			if err != nil {
 				return nil, err
 			}
@@ -341,7 +409,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 		taskCompleted = true
 	}
 
-	task := newInternalTask(t.newTaskInfo(), completionFunc, types.TaskSourceDbBacklog, "", false, nil)
+	task := newInternalTask(t.newTaskInfo(), completionFunc, types.TaskSourceDbBacklog, "", false, nil, "")
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 
 	var err error
@@ -351,7 +419,7 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 	t.client.EXPECT().AddDecisionTask(gomock.Any(), gomock.Any()).Do(
 		func(arg0 context.Context, arg1 *types.AddDecisionTaskRequest, option ...yarpc.CallOption) {
 			req = arg1
-			task := newInternalTask(task.event.TaskInfo, nil, types.TaskSourceDbBacklog, req.GetForwardedFrom(), true, nil)
+			task := newInternalTask(task.event.TaskInfo, nil, types.TaskSourceDbBacklog, req.GetForwardedFrom(), true, nil, "")
 			close(pollSigC)
 			remoteSyncMatch, err = t.rootMatcher.Offer(ctx, task)
 		},
@@ -359,7 +427,65 @@ func (t *MatcherTestSuite) TestMustOfferRemoteMatch() {
 
 	// Poll needs to happen before MustOffer, or else it goes into the non-blocking path.
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
-		task, err := t.matcher.Poll(ctx)
+		task, err := t.matcher.Poll(ctx, "")
+		t.Nil(err)
+		t.NotNil(task)
+	})
+
+	t.NoError(t.matcher.MustOffer(ctx, task))
+	cancel()
+	wait()
+	t.NotNil(req)
+	t.NoError(err)
+	t.True(remoteSyncMatch)
+	t.True(taskCompleted)
+	t.Equal(t.taskList.name, req.GetForwardedFrom())
+	t.Equal(t.taskList.Parent(20), req.GetTaskList().GetName())
+}
+
+func (t *MatcherTestSuite) TestIsolationMustOfferRemoteMatch() {
+	pollSigC := make(chan struct{})
+
+	t.client.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(arg0 context.Context, arg1 *types.MatchingPollForDecisionTaskRequest, option ...yarpc.CallOption) (*types.MatchingPollForDecisionTaskResponse, error) {
+			<-pollSigC
+			time.Sleep(time.Millisecond * 500) // delay poll to verify that offer blocks on parent
+			task, err := t.rootMatcher.Poll(arg0, "dca1")
+			if err != nil {
+				return nil, err
+			}
+
+			task.finish(nil)
+			return &types.MatchingPollForDecisionTaskResponse{
+				WorkflowExecution: task.workflowExecution(),
+			}, nil
+		},
+	).AnyTimes()
+
+	taskCompleted := false
+	completionFunc := func(*persistence.TaskInfo, error) {
+		taskCompleted = true
+	}
+
+	task := newInternalTask(t.newTaskInfo(), completionFunc, types.TaskSourceDbBacklog, "", false, nil, "dca1")
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
+
+	var err error
+	var remoteSyncMatch bool
+	var req *types.AddDecisionTaskRequest
+	t.client.EXPECT().AddDecisionTask(gomock.Any(), gomock.Any()).Return(errMatchingHostThrottle).Times(1)
+	t.client.EXPECT().AddDecisionTask(gomock.Any(), gomock.Any()).Do(
+		func(arg0 context.Context, arg1 *types.AddDecisionTaskRequest, option ...yarpc.CallOption) {
+			req = arg1
+			task := newInternalTask(task.event.TaskInfo, nil, types.TaskSourceDbBacklog, req.GetForwardedFrom(), true, nil, "dca1")
+			close(pollSigC)
+			remoteSyncMatch, err = t.rootMatcher.Offer(ctx, task)
+		},
+	).Return(nil)
+
+	// Poll needs to happen before MustOffer, or else it goes into the non-blocking path.
+	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
+		task, err := t.matcher.Poll(ctx, "dca1")
 		t.Nil(err)
 		t.NotNil(task)
 	})
@@ -392,7 +518,7 @@ func (t *MatcherTestSuite) TestRemotePoll() {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	ready()
-	task, err := t.matcher.Poll(ctx)
+	task, err := t.matcher.Poll(ctx, "")
 	cancel()
 	wait()
 	t.NoError(err)
@@ -425,6 +551,14 @@ func (t *MatcherTestSuite) TestRemotePollForQuery() {
 	t.NotNil(req)
 	t.NotNil(task)
 	t.True(task.isStarted())
+}
+
+func (t *MatcherTestSuite) TestIsolationPollFailure() {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	task, err := t.matcher.Poll(ctx, "invalid-group")
+	cancel()
+	t.Error(err)
+	t.Nil(task)
 }
 
 func (t *MatcherTestSuite) newDomainCache() cache.DomainCache {

--- a/service/matching/service.go
+++ b/service/matching/service.go
@@ -94,6 +94,7 @@ func (s *Service) Start() {
 		s.GetMetricsClient(),
 		s.GetDomainCache(),
 		s.GetMembershipResolver(),
+		s.GetPartitioner(),
 	)
 
 	s.handler = NewHandler(engine, s.config, s.GetDomainCache(), s.GetMetricsClient(), s.GetLogger(), s.GetThrottledLogger())

--- a/service/matching/task.go
+++ b/service/matching/task.go
@@ -52,6 +52,7 @@ type (
 		domainName               string
 		source                   types.TaskSource
 		forwardedFrom            string     // name of the child partition this task is forwarded from (empty if not forwarded)
+		isolationGroup           string     // isolation group of this task (empty if it can be polled by workers from any isolation group)
 		responseC                chan error // non-nil only where there is a caller waiting for response (sync-match)
 		backlogCountHint         int64
 		activityTaskDispatchInfo *types.ActivityTaskDispatchInfo
@@ -65,6 +66,7 @@ func newInternalTask(
 	forwardedFrom string,
 	forSyncMatch bool,
 	activityTaskDispatchInfo *types.ActivityTaskDispatchInfo,
+	isolationGroup string,
 ) *InternalTask {
 	task := &InternalTask{
 		event: &genericTaskInfo{
@@ -73,6 +75,7 @@ func newInternalTask(
 		},
 		source:                   source,
 		forwardedFrom:            forwardedFrom,
+		isolationGroup:           isolationGroup,
 		activityTaskDispatchInfo: activityTaskDispatchInfo,
 	}
 	if forSyncMatch {

--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/log/tag"
+	"github.com/uber/cadence/common/partition"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
@@ -144,11 +145,13 @@ func createTestTaskListManagerWithConfig(controller *gomock.Controller, cfg *Con
 		panic(err)
 	}
 	tm := newTestTaskManager(logger)
+	mockPartitioner := partition.NewMockPartitioner(controller)
+	mockPartitioner.EXPECT().GetIsolationGroupByDomainID(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	mockDomainCache := cache.NewMockDomainCache(controller)
 	mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry("domainName"), nil).AnyTimes()
 	mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).AnyTimes()
 	me := newMatchingEngine(
-		cfg, tm, nil, logger, mockDomainCache,
+		cfg, tm, nil, logger, mockDomainCache, mockPartitioner,
 	)
 	tl := "tl"
 	dID := "domain"

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -129,7 +129,7 @@ dispatchLoop:
 			if !ok { // Task list getTasks pump is shutdown
 				break dispatchLoop
 			}
-			task := newInternalTask(taskInfo, tr.completeTask, types.TaskSourceDbBacklog, "", false, nil)
+			task := newInternalTask(taskInfo, tr.completeTask, types.TaskSourceDbBacklog, "", false, nil, "")
 			for {
 				err := tr.dispatchTask(tr.cancelCtx, task)
 				if err == nil {

--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -33,6 +33,7 @@ import (
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/partition"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )
@@ -50,20 +51,22 @@ type (
 		taskWriter     *taskWriter
 		taskGC         *taskGC
 		taskAckManager messaging.AckManager
+		partitioner    partition.Partitioner
 		// The cancel objects are to cancel the ratelimiter Wait in dispatchBufferedTasks. The ideal
 		// approach is to use request-scoped contexts and use a unique one for each call to Wait. However
 		// in order to cancel it on shutdown, we need a new goroutine for each call that would wait on
 		// the shutdown channel. To optimize on efficiency, we instead create one and tag it on the struct
 		// so the cancel can be called directly on shutdown.
-		cancelCtx     context.Context
-		cancelFunc    context.CancelFunc
-		stopped       int64 // set to 1 if the reader is stopped or is shutting down
-		logger        log.Logger
-		scope         metrics.Scope
-		throttleRetry *backoff.ThrottleRetry
-		handleErr     func(error) error
-		onFatalErr    func()
-		dispatchTask  func(context.Context, *InternalTask) error
+		cancelCtx          context.Context
+		cancelFunc         context.CancelFunc
+		stopped            int64 // set to 1 if the reader is stopped or is shutting down
+		logger             log.Logger
+		scope              metrics.Scope
+		throttleRetry      *backoff.ThrottleRetry
+		handleErr          func(error) error
+		onFatalErr         func()
+		dispatchTask       func(context.Context, *InternalTask) error
+		isIsolationEnabled func() bool
 	}
 )
 
@@ -77,17 +80,19 @@ func newTaskReader(tlMgr *taskListManagerImpl) *taskReader {
 		taskWriter:     tlMgr.taskWriter,
 		taskGC:         tlMgr.taskGC,
 		taskAckManager: tlMgr.taskAckManager,
+		partitioner:    tlMgr.partitioner,
 		cancelCtx:      ctx,
 		cancelFunc:     cancel,
 		notifyC:        make(chan struct{}, 1),
 		// we always dequeue the head of the buffer and try to dispatch it to a poller
 		// so allocate one less than desired target buffer size
-		taskBuffer:   make(chan *persistence.TaskInfo, tlMgr.config.GetTasksBatchSize()-1),
-		logger:       tlMgr.logger,
-		scope:        tlMgr.scope,
-		handleErr:    tlMgr.handleErr,
-		onFatalErr:   tlMgr.Stop,
-		dispatchTask: tlMgr.DispatchTask,
+		taskBuffer:         make(chan *persistence.TaskInfo, tlMgr.config.GetTasksBatchSize()-1),
+		logger:             tlMgr.logger,
+		scope:              tlMgr.scope,
+		handleErr:          tlMgr.handleErr,
+		onFatalErr:         tlMgr.Stop,
+		dispatchTask:       tlMgr.DispatchTask,
+		isIsolationEnabled: tlMgr.isIsolationEnabled,
 		throttleRetry: backoff.NewThrottleRetry(
 			backoff.WithRetryPolicy(persistenceOperationRetryPolicy),
 			backoff.WithRetryableError(persistence.IsTransientError),
@@ -129,7 +134,18 @@ dispatchLoop:
 			if !ok { // Task list getTasks pump is shutdown
 				break dispatchLoop
 			}
-			task := newInternalTask(taskInfo, tr.completeTask, types.TaskSourceDbBacklog, "", false, nil, "")
+			isolationGroup := ""
+			if tr.isIsolationEnabled() {
+				ctx, cancel := context.WithTimeout(tr.cancelCtx, time.Second)
+				group, err := tr.partitioner.GetIsolationGroupByDomainID(ctx, taskInfo.DomainID, taskInfo.PartitionConfig)
+				if err != nil {
+					tr.logger.Error("Failed to get isolation group for async match task", tag.TaskID(taskInfo.TaskID), tag.Error(err))
+				} else if group != nil {
+					isolationGroup = *group
+				}
+				cancel()
+			}
+			task := newInternalTask(taskInfo, tr.completeTask, types.TaskSourceDbBacklog, "", false, nil, isolationGroup)
 			for {
 				err := tr.dispatchTask(tr.cancelCtx, task)
 				if err == nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update matching to support tasklist isolation
- For domain with tasklist isolation enabled, tasks are only assigned to specific pollers from one isolation group which is calculated from partition config by using a partitioner library

<!-- Tell your future self why have you made these changes -->
**Why?**
To support worker isolation

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
new test cases

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If the feature is enabled, losing pollers from one isolation group can block the task processing of other isolation groups

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
