### PR TITLE
Adds global Isolation-group client and admin commands

### DIFF
--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -353,6 +353,20 @@ func (c *clientImpl) ListDynamicConfig(
 	return c.client.ListDynamicConfig(ctx, request, opts...)
 }
 
+func (c *clientImpl) GetGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.GetGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	return c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+}
+
+func (c *clientImpl) UpdateGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	return c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+}
+
 func (c *clientImpl) createContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		return context.WithTimeout(context.Background(), c.timeout)

--- a/client/admin/errorInjectionClient.go
+++ b/client/admin/errorInjectionClient.go
@@ -778,7 +778,24 @@ func (c *errorInjectionClient) GetGlobalIsolationGroups(
 	request *types.GetGlobalIsolationGroupsRequest,
 	opts ...yarpc.CallOption,
 ) (*types.GetGlobalIsolationGroupsResponse, error) {
-	panic("not implemented")
+	fakeErr := errors.GenerateFakeError(c.errorRate)
+	var resp *types.GetGlobalIsolationGroupsResponse
+	var clientErr error
+	var forwardCall bool
+	if forwardCall = errors.ShouldForwardCall(fakeErr); forwardCall {
+		resp, clientErr = c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+	}
+
+	if fakeErr != nil {
+		c.logger.Error(msgInjectedFakeErr,
+			tag.AdminClientOperationGetGlobalIsolationGroups,
+			tag.Error(fakeErr),
+			tag.Bool(forwardCall),
+			tag.ClientError(clientErr),
+		)
+		return nil, fakeErr
+	}
+	return resp, clientErr
 }
 
 func (c *errorInjectionClient) UpdateGlobalIsolationGroups(
@@ -786,5 +803,22 @@ func (c *errorInjectionClient) UpdateGlobalIsolationGroups(
 	request *types.UpdateGlobalIsolationGroupsRequest,
 	opts ...yarpc.CallOption,
 ) (*types.UpdateGlobalIsolationGroupsResponse, error) {
-	panic("not implemented")
+	fakeErr := errors.GenerateFakeError(c.errorRate)
+	var resp *types.UpdateGlobalIsolationGroupsResponse
+	var clientErr error
+	var forwardCall bool
+	if forwardCall = errors.ShouldForwardCall(fakeErr); forwardCall {
+		resp, clientErr = c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+	}
+
+	if fakeErr != nil {
+		c.logger.Error(msgInjectedFakeErr,
+			tag.AdminClientOperationUpdateGlobalIsolationGroups,
+			tag.Error(fakeErr),
+			tag.Bool(forwardCall),
+			tag.ClientError(clientErr),
+		)
+		return nil, fakeErr
+	}
+	return resp, clientErr
 }

--- a/client/admin/errorInjectionClient.go
+++ b/client/admin/errorInjectionClient.go
@@ -772,3 +772,19 @@ func (c *errorInjectionClient) ListDynamicConfig(
 	}
 	return resp, clientErr
 }
+
+func (c *errorInjectionClient) GetGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.GetGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.GetGlobalIsolationGroupsResponse, error) {
+	panic("not implemented")
+}
+
+func (c *errorInjectionClient) UpdateGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	panic("not implemented")
+}

--- a/client/admin/grpcClient.go
+++ b/client/admin/grpcClient.go
@@ -177,3 +177,13 @@ func (g grpcClient) ListDynamicConfig(ctx context.Context, request *types.ListDy
 	response, err := g.c.ListDynamicConfig(ctx, proto.FromListDynamicConfigRequest(request), opts...)
 	return proto.ToListDynamicConfigResponse(response), proto.ToError(err)
 }
+
+func (g grpcClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	response, err := g.c.GetGlobalIsolationGroups(ctx, proto.FromGetGlobalIsolationGroupsRequest(request), opts...)
+	return proto.ToGetGlobalIsolationGroupsResponse(response), proto.ToError(err)
+}
+
+func (g grpcClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	response, err := g.c.UpdateGlobalIsolationGroups(ctx, proto.FromUpdateGlobalIsolationGroupsRequest(request), opts...)
+	return proto.ToUpdateGlobalIsolationGroupsResponse(response), proto.ToError(err)
+}

--- a/client/admin/interface.go
+++ b/client/admin/interface.go
@@ -60,4 +60,6 @@ type Client interface {
 	ListDynamicConfig(context.Context, *types.ListDynamicConfigRequest, ...yarpc.CallOption) (*types.ListDynamicConfigResponse, error)
 	DeleteWorkflow(context.Context, *types.AdminDeleteWorkflowRequest, ...yarpc.CallOption) (*types.AdminDeleteWorkflowResponse, error)
 	MaintainCorruptWorkflow(context.Context, *types.AdminMaintainWorkflowRequest, ...yarpc.CallOption) (*types.AdminMaintainWorkflowResponse, error)
+	GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error)
+	UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error)
 }

--- a/client/admin/interface_mock.go
+++ b/client/admin/interface_mock.go
@@ -317,6 +317,26 @@ func (mr *MockClientMockRecorder) GetDynamicConfig(arg0, arg1 interface{}, arg2 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicConfig", reflect.TypeOf((*MockClient)(nil).GetDynamicConfig), varargs...)
 }
 
+// GetGlobalIsolationGroups mocks base method.
+func (m *MockClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetGlobalIsolationGroups", varargs...)
+	ret0, _ := ret[0].(*types.GetGlobalIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGlobalIsolationGroups indicates an expected call of GetGlobalIsolationGroups.
+func (mr *MockClientMockRecorder) GetGlobalIsolationGroups(ctx, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGlobalIsolationGroups", reflect.TypeOf((*MockClient)(nil).GetGlobalIsolationGroups), varargs...)
+}
+
 // GetReplicationMessages mocks base method.
 func (m *MockClient) GetReplicationMessages(arg0 context.Context, arg1 *types.GetReplicationMessagesRequest, arg2 ...yarpc.CallOption) (*types.GetReplicationMessagesResponse, error) {
 	m.ctrl.T.Helper()
@@ -607,4 +627,24 @@ func (mr *MockClientMockRecorder) UpdateDynamicConfig(arg0, arg1 interface{}, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDynamicConfig", reflect.TypeOf((*MockClient)(nil).UpdateDynamicConfig), varargs...)
+}
+
+// UpdateGlobalIsolationGroups mocks base method.
+func (m *MockClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateGlobalIsolationGroups", varargs...)
+	ret0, _ := ret[0].(*types.UpdateGlobalIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateGlobalIsolationGroups indicates an expected call of UpdateGlobalIsolationGroups.
+func (mr *MockClientMockRecorder) UpdateGlobalIsolationGroups(ctx, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGlobalIsolationGroups", reflect.TypeOf((*MockClient)(nil).UpdateGlobalIsolationGroups), varargs...)
 }

--- a/client/admin/metricClient.go
+++ b/client/admin/metricClient.go
@@ -529,3 +529,25 @@ func (c *metricClient) ListDynamicConfig(
 	}
 	return resp, err
 }
+
+func (c *metricClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	c.metricsClient.IncCounter(metrics.AdminClientGetGlobalIsolationGroupsScope, metrics.CadenceClientRequests)
+	sw := c.metricsClient.StartTimer(metrics.AdminClientGetGlobalIsolationGroupsScope, metrics.CadenceClientLatency)
+	resp, err := c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+	sw.Stop()
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.AdminClientGetGlobalIsolationGroupsScope, metrics.CadenceClientFailures)
+	}
+	return resp, err
+}
+
+func (c *metricClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	c.metricsClient.IncCounter(metrics.AdminClientUpdateGlobalIsolationGroupsScope, metrics.CadenceClientRequests)
+	sw := c.metricsClient.StartTimer(metrics.AdminClientUpdateGlobalIsolationGroupsScope, metrics.CadenceClientLatency)
+	resp, err := c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+	sw.Stop()
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.AdminClientUpdateGlobalIsolationGroupsScope, metrics.CadenceClientFailures)
+	}
+	return resp, err
+}

--- a/client/admin/retryableClient.go
+++ b/client/admin/retryableClient.go
@@ -443,3 +443,33 @@ func (c *retryableClient) ListDynamicConfig(
 	err := c.throttleRetry.Do(ctx, op)
 	return resp, err
 }
+
+func (c *retryableClient) GetGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.GetGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.GetGlobalIsolationGroupsResponse, error) {
+	var resp *types.GetGlobalIsolationGroupsResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+		return err
+	}
+	err := c.throttleRetry.Do(ctx, op)
+	return resp, err
+}
+
+func (c *retryableClient) UpdateGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	var resp *types.UpdateGlobalIsolationGroupsResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+		return err
+	}
+	err := c.throttleRetry.Do(ctx, op)
+	return resp, err
+}

--- a/client/admin/thriftClient.go
+++ b/client/admin/thriftClient.go
@@ -177,3 +177,13 @@ func (t thriftClient) ListDynamicConfig(ctx context.Context, request *types.List
 	response, err := t.c.ListDynamicConfig(ctx, thrift.FromListDynamicConfigRequest(request), opts...)
 	return thrift.ToListDynamicConfigResponse(response), thrift.ToError(err)
 }
+
+func (t thriftClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	res, err := t.c.GetGlobalIsolationGroups(ctx, thrift.FromGetGlobalIsolationGroupsRequest(request))
+	return thrift.ToGetGlobalIsolationGroupsResponse(res), thrift.ToError(err)
+}
+
+func (t thriftClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	res, err := t.c.UpdateGlobalIsolationGroups(ctx, thrift.FromUpdateGlobalIsolationGroupsRequest(request))
+	return thrift.ToUpdateGlobalIsolationGroupsResponse(res), thrift.ToError(err)
+}

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -301,6 +301,8 @@ var (
 	AdminClientOperationUpdateDynamicConfig               = clientOperation("admin-update-dynamic-config")
 	AdminClientOperationRestoreDynamicConfig              = clientOperation("admin-restore-dynamic-config")
 	AdminClientOperationListDynamicConfig                 = clientOperation("admin-list-dynamic-config")
+	AdminClientOperationGetGlobalIsolationGroups          = clientOperation("admin-get-global-isolation-groups")
+	AdminClientOperationUpdateGlobalIsolationGroups       = clientOperation("admin-update-global-isolation-groups")
 	AdminDeleteWorkflow                                   = clientOperation("admin-delete-workflow")
 	MaintainCorruptWorkflow                               = clientOperation("maintain-corrupt-workflow")
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -545,6 +545,10 @@ const (
 	AdminClientRestoreDynamicConfigScope
 	// AdminClientListDynamicConfigScope tracks RPC calls to admin service
 	AdminClientListDynamicConfigScope
+	// AdminClientGetGlobalIsolationGroupsScope is a request to get all the global isolation-groups
+	AdminClientGetGlobalIsolationGroupsScope
+	// AdminClientUpdateGlobalIsolationGroupsScope is a request to update the global isolation-groups
+	AdminClientUpdateGlobalIsolationGroupsScope
 	// DCRedirectionDeprecateDomainScope tracks RPC calls for dc redirection
 	DCRedirectionDeprecateDomainScope
 	// DCRedirectionDescribeDomainScope tracks RPC calls for dc redirection
@@ -799,6 +803,10 @@ const (
 	AdminDeleteWorkflowScope
 	// MaintainCorruptWorkflowScope is the metric scope for admin.MaintainCorruptWorkflow
 	MaintainCorruptWorkflowScope
+	// GetGlobalIsolationGroups is the scope for getting global isolation groups
+	GetGlobalIsolationGroups
+	// UpdateGlobalIsolationGroups is the scope for getting global isolation groups
+	UpdateGlobalIsolationGroups
 
 	NumAdminScopes
 )
@@ -1459,6 +1467,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		AdminClientUpdateDynamicConfigScope:                   {operation: "AdminClientUpdateDynamicConfigScope", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
 		AdminClientRestoreDynamicConfigScope:                  {operation: "AdminClientRestoreDynamicConfigScope", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
 		AdminClientListDynamicConfigScope:                     {operation: "AdminClientListDynamicConfigScope", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
+		AdminClientGetGlobalIsolationGroupsScope:              {operation: "AdminClientGetGlobalIsolationGroups", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
+		AdminClientUpdateGlobalIsolationGroupsScope:           {operation: "AdminClientUpdateGlobalIsolationGroups", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
 		DCRedirectionDeprecateDomainScope:                     {operation: "DCRedirectionDeprecateDomain", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeDomainScope:                      {operation: "DCRedirectionDescribeDomain", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeTaskListScope:                    {operation: "DCRedirectionDescribeTaskList", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},
@@ -1579,6 +1589,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		AdminListDynamicConfigScope:                 {operation: "AdminListDynamicConfig"},
 		AdminDeleteWorkflowScope:                    {operation: "AdminDeleteWorkflow"},
 		MaintainCorruptWorkflowScope:                {operation: "MaintainCorruptWorkflow"},
+		GetGlobalIsolationGroups:                    {operation: "GetGlobalIsolationGroups"},
+		UpdateGlobalIsolationGroups:                 {operation: "UpdateGlobalIsolationGroups"},
 
 		FrontendRestartWorkflowExecutionScope:           {operation: "RestartWorkflowExecution"},
 		FrontendStartWorkflowExecutionScope:             {operation: "StartWorkflowExecution"},

--- a/common/types/admin.go
+++ b/common/types/admin.go
@@ -392,6 +392,14 @@ type IsolationGroupPartition struct {
 // Indicating that task processing isn't to occur within this isolationGroup anymore, but all others are ok.
 type IsolationGroupConfiguration map[string]IsolationGroupPartition
 
+func (i IsolationGroupConfiguration) ToPartitionList() []IsolationGroupPartition {
+	var out []IsolationGroupPartition
+	for _, v := range i {
+		out = append(out, v)
+	}
+	return out
+}
+
 type GetGlobalIsolationGroupsRequest struct{}
 
 type GetGlobalIsolationGroupsResponse struct {

--- a/common/types/mapper/proto/admin.go
+++ b/common/types/mapper/proto/admin.go
@@ -1173,11 +1173,40 @@ func FromGetGlobalIsolationGroupsResponse(t *types.GetGlobalIsolationGroupsRespo
 	}
 }
 
+func FromGetGlobalIsolationGroupsRequest(t *types.GetGlobalIsolationGroupsRequest) *adminv1.GetGlobalIsolationGroupsRequest {
+	if t == nil {
+		return nil
+	}
+	return &adminv1.GetGlobalIsolationGroupsRequest{}
+}
+
+func FromUpdateGlobalIsolationGroupsRequest(t *types.UpdateGlobalIsolationGroupsRequest) *adminv1.UpdateGlobalIsolationGroupsRequest {
+	if t == nil {
+		return nil
+	}
+	return &adminv1.UpdateGlobalIsolationGroupsRequest{
+		IsolationGroups: isolationGroupConfigToIDL(&t.IsolationGroups),
+	}
+}
+
 func ToGetGlobalIsolationGroupsRequest(t *adminv1.GetGlobalIsolationGroupsRequest) *types.GetGlobalIsolationGroupsRequest {
 	if t == nil {
 		return nil
 	}
 	return &types.GetGlobalIsolationGroupsRequest{}
+}
+
+func ToGetGlobalIsolationGroupsResponse(t *adminv1.GetGlobalIsolationGroupsResponse) *types.GetGlobalIsolationGroupsResponse {
+	if t == nil {
+		return nil
+	}
+	ig := isolationGroupConfigFromIDL(t.IsolationGroups)
+	if ig == nil {
+		return nil
+	}
+	return &types.GetGlobalIsolationGroupsResponse{
+		IsolationGroups: *ig,
+	}
 }
 
 func FromGetDomainIsolationGroupsResponse(t *types.GetDomainIsolationGroupsResponse) *adminv1.GetDomainIsolationGroupsResponse {
@@ -1215,6 +1244,13 @@ func ToUpdateGlobalIsolationGroupsRequest(t *adminv1.UpdateGlobalIsolationGroups
 	return &types.UpdateGlobalIsolationGroupsRequest{
 		IsolationGroups: *cfg,
 	}
+}
+
+func ToUpdateGlobalIsolationGroupsResponse(t *adminv1.UpdateGlobalIsolationGroupsResponse) *types.UpdateGlobalIsolationGroupsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.UpdateGlobalIsolationGroupsResponse{}
 }
 
 func FromUpdateDomainIsolationGroupsResponse(t *types.UpdateDomainIsolationGroupsResponse) *adminv1.UpdateDomainIsolationGroupsResponse {

--- a/common/types/mapper/thrift/admin.go
+++ b/common/types/mapper/thrift/admin.go
@@ -686,6 +686,13 @@ func ToListDynamicConfigResponse(t *admin.ListDynamicConfigResponse) *types.List
 	}
 }
 
+func FromGetGlobalIsolationGroupsRequest(t *types.GetGlobalIsolationGroupsRequest) *admin.GetGlobalIsolationGroupsRequest {
+	if t == nil {
+		return nil
+	}
+	return &admin.GetGlobalIsolationGroupsRequest{}
+}
+
 func FromGetGlobalIsolationGroupsResponse(t *types.GetGlobalIsolationGroupsResponse) *admin.GetGlobalIsolationGroupsResponse {
 	if t == nil {
 		return nil
@@ -693,6 +700,22 @@ func FromGetGlobalIsolationGroupsResponse(t *types.GetGlobalIsolationGroupsRespo
 	cfg := isolationGroupConfigToIDL(&t.IsolationGroups)
 	return &admin.GetGlobalIsolationGroupsResponse{
 		IsolationGroups: cfg,
+	}
+}
+
+func ToGetGlobalIsolationGroupsResponse(t *admin.GetGlobalIsolationGroupsResponse) *types.GetGlobalIsolationGroupsResponse {
+	if t == nil {
+		return nil
+	}
+	if t.IsolationGroups == nil {
+		return &types.GetGlobalIsolationGroupsResponse{}
+	}
+	ig := isolationGroupConfigFromIDL(t.IsolationGroups)
+	if ig == nil {
+		return &types.GetGlobalIsolationGroupsResponse{}
+	}
+	return &types.GetGlobalIsolationGroupsResponse{
+		IsolationGroups: *ig,
 	}
 }
 
@@ -727,6 +750,15 @@ func FromUpdateGlobalIsolationGroupsResponse(t *types.UpdateGlobalIsolationGroup
 	return &admin.UpdateGlobalIsolationGroupsResponse{}
 }
 
+func FromUpdateGlobalIsolationGroupsRequest(t *types.UpdateGlobalIsolationGroupsRequest) *admin.UpdateGlobalIsolationGroupsRequest {
+	if t == nil {
+		return nil
+	}
+	return &admin.UpdateGlobalIsolationGroupsRequest{
+		IsolationGroups: isolationGroupConfigToIDL(&t.IsolationGroups),
+	}
+}
+
 func ToUpdateGlobalIsolationGroupsRequest(t *admin.UpdateGlobalIsolationGroupsRequest) *types.UpdateGlobalIsolationGroupsRequest {
 	if t == nil {
 		return nil
@@ -738,6 +770,13 @@ func ToUpdateGlobalIsolationGroupsRequest(t *admin.UpdateGlobalIsolationGroupsRe
 	return &types.UpdateGlobalIsolationGroupsRequest{
 		IsolationGroups: *cfg,
 	}
+}
+
+func ToUpdateGlobalIsolationGroupsResponse(t *admin.UpdateGlobalIsolationGroupsResponse) *types.UpdateGlobalIsolationGroupsResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.UpdateGlobalIsolationGroupsResponse{}
 }
 
 func FromUpdateDomainIsolationGroupsResponse(t *types.UpdateDomainIsolationGroupsResponse) *admin.UpdateDomainIsolationGroupsResponse {

--- a/common/types/mapper/thrift/admin_test.go
+++ b/common/types/mapper/thrift/admin_test.go
@@ -347,3 +347,50 @@ func TestToUpdateDomainIsolationGroupsRequest(t *testing.T) {
 		})
 	}
 }
+
+func TestToGetGlobalIsolationGroupsResponse(t *testing.T) {
+
+	tests := map[string]struct {
+		in       *admin.GetGlobalIsolationGroupsResponse
+		expected *types.GetGlobalIsolationGroupsResponse
+	}{
+		"valid": {
+			in: &admin.GetGlobalIsolationGroupsResponse{
+				IsolationGroups: &admin.IsolationGroupConfiguration{
+					IsolationGroups: []*admin.IsolationGroupPartition{
+						{
+							Name:  strPtr("zone-1"),
+							State: igStatePtr(admin.IsolationGroupStateDrained),
+						},
+						{
+							Name:  strPtr("zone-2"),
+							State: igStatePtr(admin.IsolationGroupStateHealthy),
+						},
+					},
+				},
+			},
+			expected: &types.GetGlobalIsolationGroupsResponse{
+				IsolationGroups: map[string]types.IsolationGroupPartition{
+					"zone-1": {
+						Name:  "zone-1",
+						State: types.IsolationGroupStateDrained,
+					},
+					"zone-2": {
+						Name:  "zone-2",
+						State: types.IsolationGroupStateHealthy,
+					},
+				},
+			},
+		},
+		"no groups": {
+			in:       &admin.GetGlobalIsolationGroupsResponse{},
+			expected: &types.GetGlobalIsolationGroupsResponse{},
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, td.expected, ToGetGlobalIsolationGroupsResponse(td.in))
+		})
+	}
+}

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -1296,3 +1296,32 @@ func newAdminConfigStoreCommands() []cli.Command {
 		},
 	}
 }
+
+func newAdminIsolationGroupCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:    "get-global",
+			Aliases: []string{"g"},
+			Usage:   "gets the global isolation groups",
+			Flags:   []cli.Flag{},
+			Action: func(c *cli.Context) {
+				AdminGetGlobalIsolationGroups(c)
+			},
+		},
+		{
+			Name:    "update-global",
+			Aliases: []string{"g"},
+			Usage:   "sets the global isolation groups",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     FlagIsolationGroupConfigurations,
+					Usage:    `the configurations to upsert: eg: [{"Name": "zone-1": "State": 2}]. To remove groups, specify an empty configuration`,
+					Required: true,
+				},
+			},
+			Action: func(c *cli.Context) {
+				AdminUpdateGlobalIsolationGroups(c)
+			},
+		},
+	}
+}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -158,6 +158,12 @@ func NewCliApp() *cli.App {
 					Subcommands: newAdminClusterCommands(),
 				},
 				{
+					Name:        "isolation-groups",
+					Aliases:     []string{"ig"},
+					Usage:       "Run admin operation on isolation-groups",
+					Subcommands: newAdminIsolationGroupCommands(),
+				},
+				{
 					Name:        "dlq",
 					Aliases:     []string{"dlq"},
 					Usage:       "Run admin operation on DLQ",

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -294,6 +294,7 @@ const (
 	FlagTransport                         = "transport"
 	FlagTransportWithAlias                = FlagTransport + ", t"
 	FlagFormat                            = "format"
+	FlagIsolationGroupConfigurations      = "config"
 )
 
 var flagsForExecution = []cli.Flag{

--- a/tools/cli/isolation-groups.go
+++ b/tools/cli/isolation-groups.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/uber/cadence/common/types"
+
+	"github.com/urfave/cli"
+)
+
+func AdminGetGlobalIsolationGroups(c *cli.Context) {
+	adminClient := cFactory.ServerAdminClient(c)
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	req := &types.GetGlobalIsolationGroupsRequest{}
+	igs, err := adminClient.GetGlobalIsolationGroups(ctx, req)
+	if err != nil {
+		ErrorAndExit("failed to get isolation-groups:", err)
+	}
+	prettyPrintJSONObject(igs.IsolationGroups.ToPartitionList())
+}
+
+func AdminUpdateGlobalIsolationGroups(c *cli.Context) {
+	adminClient := cFactory.ServerAdminClient(c)
+	cfgString := c.String(FlagIsolationGroupConfigurations)
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	// Not using types.IsolationGroupConfiguration because the duplicate keys
+	// for name is somewhat confusing to work with directly, instead expecting
+	// a more IDL-like input of an array of isolation-groups
+	var input []types.IsolationGroupPartition
+	err := json.Unmarshal([]byte(cfgString), &input)
+	if err != nil {
+		ErrorAndExit(`failed to marshal input. Trying to marshal []types.IsolationGroupPartition
+
+examples: 
+- []                                    # will remove all isolation groups
+- [{"Name": "zone-123", "State": 2}]    # drain zone-123
+`, err)
+	}
+
+	req := types.IsolationGroupConfiguration{}
+	for _, g := range input {
+		req[g.Name] = g
+	}
+
+	_, err = adminClient.UpdateGlobalIsolationGroups(ctx, &types.UpdateGlobalIsolationGroupsRequest{
+		IsolationGroups: req,
+	})
+	if err != nil {
+		ErrorAndExit("failed to update isolation-groups", fmt.Errorf("used %#v, got %v", req, err))
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This adds two commands for updating and getting global isolation groups: 
`admin isolation-groups update-global`
`admin isolation-groups get-global`

This also adds the same commands to the client library: 
- GetGlobalIsolationGroups
- UpdateGlobalIsolationGroups

There remains also the domain-level isolation groups yet to be implemented, though they will be similarly be added in this command. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit-tests
End to end testing manually with the feature fully written with the following: 
```
./cadence admin isolation-groups update-global --config '[{"Name": "zone-1", "State": 2}, {"Name": "zone-2", "State": 1}]'
./cadence admin isolation-groups get-global
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
