### PR TITLE
Add helper function to store/retrieve partition config from context

### DIFF
--- a/common/partition/context.go
+++ b/common/partition/context.go
@@ -1,0 +1,59 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package partition
+
+import "context"
+
+type configKey struct{}
+
+type isolationGroupKey struct{}
+
+// ConfigFromContext retrieves infomation about the partition config of the context
+// which is used for tasklist isolation
+func ConfigFromContext(ctx context.Context) map[string]string {
+	val, ok := ctx.Value(configKey{}).(map[string]string)
+	if !ok {
+		return nil
+	}
+	return val
+}
+
+// ContextWithConfig stores the partition config of tasklist isolation into the given context
+func ContextWithConfig(ctx context.Context, partitionConfig map[string]string) context.Context {
+	return context.WithValue(ctx, configKey{}, partitionConfig)
+}
+
+// IsolationGroupFromContext retrieves the isolation group from the given context,
+// which is used to identify which isolation group the poller is from
+func IsolationGroupFromContext(ctx context.Context) string {
+	val, ok := ctx.Value(isolationGroupKey{}).(string)
+	if !ok {
+		return ""
+	}
+	return val
+}
+
+// ContextWithIsolationGroup stores the isolation group into the given context
+func ContextWithIsolationGroup(ctx context.Context, isolationGroup string) context.Context {
+	return context.WithValue(ctx, isolationGroupKey{}, isolationGroup)
+}

--- a/common/partition/context_test.go
+++ b/common/partition/context_test.go
@@ -1,0 +1,38 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package partition
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestContext(t *testing.T) {
+	partitionConfig := map[string]string{"test": "abc"}
+	assert.Equal(t, partitionConfig, ConfigFromContext(ContextWithConfig(context.Background(), partitionConfig)))
+
+	isolationGroup := "zone1"
+	assert.Equal(t, isolationGroup, IsolationGroupFromContext(ContextWithIsolationGroup(context.Background(), isolationGroup)))
+}

--- a/common/partition/default-partitioner.go
+++ b/common/partition/default-partitioner.go
@@ -36,8 +36,8 @@ import (
 )
 
 const (
-	defaultPartitionConfigWorkerIsolationGroup = "worker-isolation-group"
-	defaultPartitionConfigRunID                = "wf-run-id"
+	IsolationGroupKey = "isolation-group"
+	WorkflowRunIDKey  = "wf-run-id"
 )
 
 // DefaultWorkflowPartitionConfig Is the default dataset expected to be passed around in the
@@ -80,8 +80,8 @@ func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, do
 }
 
 func mapPartitionConfigToDefaultPartitionConfig(config PartitionConfig) defaultWorkflowPartitionConfig {
-	isolationGroup, _ := config[defaultPartitionConfigWorkerIsolationGroup]
-	runID, _ := config[defaultPartitionConfigRunID]
+	isolationGroup, _ := config[IsolationGroupKey]
+	runID, _ := config[WorkflowRunIDKey]
 	return defaultWorkflowPartitionConfig{
 		WorkflowStartIsolationGroup: isolationGroup,
 		RunID:                       runID,

--- a/common/rpc.go
+++ b/common/rpc.go
@@ -47,6 +47,17 @@ const (
 	ClientImplHeaderName = "cadence-client-name"
 	// AuthorizationTokenHeaderName refers to the jwt token in the request
 	AuthorizationTokenHeaderName = "cadence-authorization"
+
+	// AutoforwardingClusterHeaderName refers to the name of the header that contains the source cluster of the auto-forwarding request
+	AutoforwardingClusterHeaderName = "cadence-forwarding-cluster"
+
+	// PartitionConfigHeaderName refers to the name of the header that contains the json encoded partition config of the request
+	PartitionConfigHeaderName = "cadence-workflow-partition-config"
+	// IsolationGroupHeaderName refers to the name of the header that contains the isolation group of the client
+	IsolationGroupHeaderName = "cadence-worker-isolation-group"
+
+	// ClientZoneHeaderName refers to the name of the header that contaains the zone which the client request is from
+	ClientZoneHeaderName = "cadence-client-zone"
 )
 
 type (

--- a/common/rpc/middleware.go
+++ b/common/rpc/middleware.go
@@ -22,11 +22,13 @@ package rpc
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/partition"
 
 	"go.uber.org/cadence/worker"
 	"go.uber.org/yarpc"
@@ -176,4 +178,63 @@ func (m *HeaderForwardingMiddleware) Call(ctx context.Context, request *transpor
 	}
 
 	return out.Call(ctx, request)
+}
+
+// ForwardPartitionConfigMiddleware forwards the partition config to remote cluster
+// The middleware should always be applied after any other middleware that inject partition config into the context
+// so that it can overwrites the partition config into the context
+// The purpose of this middleware is to make sure the partition config doesn't change when a request is forwarded from
+// passive cluster to the active cluster
+type ForwardPartitionConfigMiddleware struct{}
+
+func (m *ForwardPartitionConfigMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
+	if _, ok := req.Headers.Get(common.AutoforwardingClusterHeaderName); ok {
+		var partitionConfig map[string]string
+		if blob, ok := req.Headers.Get(common.PartitionConfigHeaderName); ok && len(blob) > 0 {
+			if err := json.Unmarshal([]byte(blob), &partitionConfig); err != nil {
+				return err
+			}
+		}
+		ctx = partition.ContextWithConfig(ctx, partitionConfig)
+		isolationGroup, _ := req.Headers.Get(common.IsolationGroupHeaderName)
+		ctx = partition.ContextWithIsolationGroup(ctx, isolationGroup)
+	}
+	return h.Handle(ctx, req, resw)
+}
+
+func (m *ForwardPartitionConfigMiddleware) Call(ctx context.Context, request *transport.Request, out transport.UnaryOutbound) (*transport.Response, error) {
+	if _, ok := request.Headers.Get(common.AutoforwardingClusterHeaderName); ok {
+		partitionConfig := partition.ConfigFromContext(ctx)
+		if len(partitionConfig) > 0 {
+			blob, err := json.Marshal(partitionConfig)
+			if err != nil {
+				return nil, err
+			}
+			request.Headers = request.Headers.With(common.PartitionConfigHeaderName, string(blob))
+		} else {
+			request.Headers.Del(common.PartitionConfigHeaderName)
+		}
+		isolationGroup := partition.IsolationGroupFromContext(ctx)
+		if isolationGroup != "" {
+			request.Headers = request.Headers.With(common.IsolationGroupHeaderName, isolationGroup)
+		} else {
+			request.Headers.Del(common.IsolationGroupHeaderName)
+		}
+	}
+	return out.Call(ctx, request)
+}
+
+// ZonalPartitionConfigMiddleware stores the partition config and isolation group of the request into the context
+// It reads a header from client request which indicates the zone which the request is from and uses it as the isolation group
+type ZonalPartitionConfigMiddleware struct{}
+
+func (m *ZonalPartitionConfigMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
+	zone, _ := req.Headers.Get(common.ClientZoneHeaderName)
+	if zone != "" {
+		ctx = partition.ContextWithConfig(ctx, map[string]string{
+			partition.IsolationGroupKey: zone,
+		})
+		ctx = partition.ContextWithIsolationGroup(ctx, zone)
+	}
+	return h.Handle(ctx, req, resw)
 }

--- a/common/rpc/middleware_test.go
+++ b/common/rpc/middleware_test.go
@@ -23,18 +23,21 @@ package rpc
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/yarpctest"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/partition"
 )
 
 func TestAuthOubboundMiddleware(t *testing.T) {
@@ -169,6 +172,160 @@ func TestHeaderForwardingMiddleware(t *testing.T) {
 			assert.Equal(t, combinedHeadersWithoutX, r.Headers.Items())
 		}})
 		assert.NoError(t, err)
+	})
+}
+
+func TestForwardPartitionConfigMiddleware(t *testing.T) {
+	t.Run("inbound middleware", func(t *testing.T) {
+		partitionConfig := map[string]string{"isolation-group": "xyz"}
+		blob, err := json.Marshal(partitionConfig)
+		require.NoError(t, err)
+		testCases := []struct {
+			message                 string
+			headers                 transport.Headers
+			ctx                     context.Context
+			expectedPartitionConfig map[string]string
+			expectedIsolationGroup  string
+		}{
+			{
+				message: "it injects partition config into context",
+				headers: transport.NewHeaders().
+					With(common.PartitionConfigHeaderName, string(blob)).
+					With(common.IsolationGroupHeaderName, "abc").
+					With(common.AutoforwardingClusterHeaderName, "cluster0"),
+				ctx:                     context.Background(),
+				expectedPartitionConfig: partitionConfig,
+				expectedIsolationGroup:  "abc",
+			},
+			{
+				message: "it overwrites the existing partition config in the context",
+				headers: transport.NewHeaders().
+					With(common.PartitionConfigHeaderName, string(blob)).
+					With(common.IsolationGroupHeaderName, "abc").
+					With(common.AutoforwardingClusterHeaderName, "cluster0"),
+				ctx:                     partition.ContextWithIsolationGroup(partition.ContextWithConfig(context.Background(), map[string]string{"z": "x"}), "fff"),
+				expectedPartitionConfig: partitionConfig,
+				expectedIsolationGroup:  "abc",
+			},
+			{
+				message: "it overwrites the existing partition config in the context with nil config",
+				headers: transport.NewHeaders().
+					With(common.AutoforwardingClusterHeaderName, "cluster0"),
+				ctx:                     partition.ContextWithIsolationGroup(partition.ContextWithConfig(context.Background(), map[string]string{"z": "x"}), "fff"),
+				expectedPartitionConfig: nil,
+				expectedIsolationGroup:  "",
+			},
+			{
+				message: "it injects partition config into context only if the request is an auto-fowarding request",
+				headers: transport.NewHeaders().
+					With(common.PartitionConfigHeaderName, string(blob)).
+					With(common.IsolationGroupHeaderName, "abc"),
+				ctx:                     context.Background(),
+				expectedPartitionConfig: nil,
+				expectedIsolationGroup:  "",
+			},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.message, func(t *testing.T) {
+				m := &ForwardPartitionConfigMiddleware{}
+				h := &fakeHandler{}
+				err := m.Handle(tt.ctx, &transport.Request{Headers: tt.headers}, nil, h)
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedPartitionConfig, partition.ConfigFromContext(h.ctx))
+				assert.Equal(t, tt.expectedIsolationGroup, partition.IsolationGroupFromContext(h.ctx))
+			})
+		}
+	})
+
+	t.Run("outbound middleware", func(t *testing.T) {
+		partitionConfig := map[string]string{"isolation-group": "xyz"}
+		blob, err := json.Marshal(partitionConfig)
+		require.NoError(t, err)
+		testCases := []struct {
+			message                           string
+			headers                           transport.Headers
+			ctx                               context.Context
+			expectedSerializedPartitionConfig string
+			expectedIsolationGroup            string
+		}{
+			{
+				message: "it retrieves partition config from the context and sets it in the request header",
+				headers: transport.NewHeaders().
+					With(common.AutoforwardingClusterHeaderName, "cluster0"),
+				ctx:                               partition.ContextWithIsolationGroup(partition.ContextWithConfig(context.Background(), partitionConfig), "abc"),
+				expectedSerializedPartitionConfig: string(blob),
+				expectedIsolationGroup:            "abc",
+			},
+			{
+				message: "it retrieves partition config from the context and overwrites the existing request header",
+				headers: transport.NewHeaders().
+					With(common.IsolationGroupHeaderName, "lll").
+					With(common.PartitionConfigHeaderName, "asdfasf").
+					With(common.AutoforwardingClusterHeaderName, "cluster0"),
+				ctx:                               partition.ContextWithIsolationGroup(partition.ContextWithConfig(context.Background(), partitionConfig), "abc"),
+				expectedSerializedPartitionConfig: string(blob),
+				expectedIsolationGroup:            "abc",
+			},
+			{
+				message: "it deletes the existing request header if we cannot retrieve partition config from the context",
+				headers: transport.NewHeaders().
+					With(common.IsolationGroupHeaderName, "lll").
+					With(common.PartitionConfigHeaderName, "asdfasf").
+					With(common.AutoforwardingClusterHeaderName, "cluster0"),
+				ctx:                               context.Background(),
+				expectedSerializedPartitionConfig: "",
+				expectedIsolationGroup:            "",
+			},
+			{
+				message: "it retrieves partition config from the context and sets it in the request header only if the request is an auto-forwarding request",
+				headers: transport.NewHeaders().
+					With(common.IsolationGroupHeaderName, "lll").
+					With(common.PartitionConfigHeaderName, "asdfasf"),
+				ctx:                               partition.ContextWithIsolationGroup(partition.ContextWithConfig(context.Background(), partitionConfig), "abc"),
+				expectedSerializedPartitionConfig: "asdfasf",
+				expectedIsolationGroup:            "lll",
+			},
+		}
+
+		for _, tt := range testCases {
+			t.Run(tt.message, func(t *testing.T) {
+				m := &ForwardPartitionConfigMiddleware{}
+				o := &fakeOutbound{
+					verify: func(r *transport.Request) {
+						assert.Equal(t, tt.expectedIsolationGroup, r.Headers.Items()[common.IsolationGroupHeaderName])
+						assert.Equal(t, tt.expectedSerializedPartitionConfig, r.Headers.Items()[common.PartitionConfigHeaderName])
+					},
+				}
+				_, err := m.Call(tt.ctx, &transport.Request{Headers: tt.headers}, o)
+				assert.NoError(t, err)
+			})
+		}
+	})
+}
+
+func TestZonalPartitionConfigMiddleware(t *testing.T) {
+	t.Run("it sets the partition config", func(t *testing.T) {
+		m := &ZonalPartitionConfigMiddleware{}
+		h := &fakeHandler{}
+		headers := transport.NewHeaders().
+			With(common.ClientZoneHeaderName, "dca1")
+		err := m.Handle(context.Background(), &transport.Request{Headers: headers}, nil, h)
+		assert.NoError(t, err)
+		assert.Equal(t, map[string]string{partition.IsolationGroupKey: "dca1"}, partition.ConfigFromContext(h.ctx))
+		assert.Equal(t, "dca1", partition.IsolationGroupFromContext(h.ctx))
+	})
+
+	t.Run("noop when header is empty", func(t *testing.T) {
+		m := &ZonalPartitionConfigMiddleware{}
+		h := &fakeHandler{}
+		headers := transport.NewHeaders()
+		ctx := context.Background()
+		err := m.Handle(ctx, &transport.Request{Headers: headers}, nil, h)
+		assert.NoError(t, err)
+		assert.Nil(t, partition.ConfigFromContext(h.ctx))
+		assert.Equal(t, "", partition.IsolationGroupFromContext(h.ctx))
+		assert.Equal(t, ctx, h.ctx)
 	})
 }
 

--- a/service/frontend/clusterRedirectionHandler.go
+++ b/service/frontend/clusterRedirectionHandler.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"time"
 
+	"go.uber.org/yarpc"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/log"
@@ -43,6 +45,7 @@ type (
 		redirectionPolicy  ClusterRedirectionPolicy
 		tokenSerializer    common.TaskTokenSerializer
 		frontendHandler    Handler
+		callOptions        []yarpc.CallOption
 	}
 )
 
@@ -66,6 +69,7 @@ func NewClusterRedirectionHandler(
 		redirectionPolicy:  dcRedirectionPolicy,
 		tokenSerializer:    common.NewJSONTaskTokenSerializer(),
 		frontendHandler:    wfHandler,
+		callOptions:        []yarpc.CallOption{yarpc.WithHeader(common.AutoforwardingClusterHeaderName, resource.GetClusterMetadata().GetCurrentClusterName())},
 	}
 }
 
@@ -180,7 +184,7 @@ func (handler *ClusterRedirectionHandlerImpl) DescribeTaskList(
 			resp, err = handler.frontendHandler.DescribeTaskList(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.DescribeTaskList(ctx, request)
+			resp, err = remoteClient.DescribeTaskList(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -210,7 +214,7 @@ func (handler *ClusterRedirectionHandlerImpl) DescribeWorkflowExecution(
 			resp, err = handler.frontendHandler.DescribeWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.DescribeWorkflowExecution(ctx, request)
+			resp, err = remoteClient.DescribeWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -240,7 +244,7 @@ func (handler *ClusterRedirectionHandlerImpl) GetWorkflowExecutionHistory(
 			resp, err = handler.frontendHandler.GetWorkflowExecutionHistory(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.GetWorkflowExecutionHistory(ctx, request)
+			resp, err = remoteClient.GetWorkflowExecutionHistory(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -270,7 +274,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListArchivedWorkflowExecutions(
 			resp, err = handler.frontendHandler.ListArchivedWorkflowExecutions(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ListArchivedWorkflowExecutions(ctx, request)
+			resp, err = remoteClient.ListArchivedWorkflowExecutions(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -300,7 +304,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListClosedWorkflowExecutions(
 			resp, err = handler.frontendHandler.ListClosedWorkflowExecutions(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ListClosedWorkflowExecutions(ctx, request)
+			resp, err = remoteClient.ListClosedWorkflowExecutions(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -330,7 +334,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListOpenWorkflowExecutions(
 			resp, err = handler.frontendHandler.ListOpenWorkflowExecutions(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ListOpenWorkflowExecutions(ctx, request)
+			resp, err = remoteClient.ListOpenWorkflowExecutions(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -360,7 +364,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListWorkflowExecutions(
 			resp, err = handler.frontendHandler.ListWorkflowExecutions(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ListWorkflowExecutions(ctx, request)
+			resp, err = remoteClient.ListWorkflowExecutions(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -389,7 +393,7 @@ func (handler *ClusterRedirectionHandlerImpl) ScanWorkflowExecutions(
 			resp, err = handler.frontendHandler.ScanWorkflowExecutions(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ScanWorkflowExecutions(ctx, request)
+			resp, err = remoteClient.ScanWorkflowExecutions(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -419,7 +423,7 @@ func (handler *ClusterRedirectionHandlerImpl) CountWorkflowExecutions(
 			resp, err = handler.frontendHandler.CountWorkflowExecutions(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.CountWorkflowExecutions(ctx, request)
+			resp, err = remoteClient.CountWorkflowExecutions(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -464,7 +468,7 @@ func (handler *ClusterRedirectionHandlerImpl) PollForActivityTask(
 			resp, err = handler.frontendHandler.PollForActivityTask(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.PollForActivityTask(ctx, request)
+			resp, err = remoteClient.PollForActivityTask(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -494,7 +498,7 @@ func (handler *ClusterRedirectionHandlerImpl) PollForDecisionTask(
 			resp, err = handler.frontendHandler.PollForDecisionTask(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.PollForDecisionTask(ctx, request)
+			resp, err = remoteClient.PollForDecisionTask(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -530,7 +534,7 @@ func (handler *ClusterRedirectionHandlerImpl) QueryWorkflow(
 			resp, err = handler.frontendHandler.QueryWorkflow(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.QueryWorkflow(ctx, request)
+			resp, err = remoteClient.QueryWorkflow(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -565,7 +569,7 @@ func (handler *ClusterRedirectionHandlerImpl) RecordActivityTaskHeartbeat(
 			resp, err = handler.frontendHandler.RecordActivityTaskHeartbeat(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.RecordActivityTaskHeartbeat(ctx, request)
+			resp, err = remoteClient.RecordActivityTaskHeartbeat(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -595,7 +599,7 @@ func (handler *ClusterRedirectionHandlerImpl) RecordActivityTaskHeartbeatByID(
 			resp, err = handler.frontendHandler.RecordActivityTaskHeartbeatByID(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.RecordActivityTaskHeartbeatByID(ctx, request)
+			resp, err = remoteClient.RecordActivityTaskHeartbeatByID(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -625,7 +629,7 @@ func (handler *ClusterRedirectionHandlerImpl) RequestCancelWorkflowExecution(
 			err = handler.frontendHandler.RequestCancelWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RequestCancelWorkflowExecution(ctx, request)
+			err = remoteClient.RequestCancelWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -655,7 +659,7 @@ func (handler *ClusterRedirectionHandlerImpl) ResetStickyTaskList(
 			resp, err = handler.frontendHandler.ResetStickyTaskList(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ResetStickyTaskList(ctx, request)
+			resp, err = remoteClient.ResetStickyTaskList(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -685,7 +689,7 @@ func (handler *ClusterRedirectionHandlerImpl) ResetWorkflowExecution(
 			resp, err = handler.frontendHandler.ResetWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ResetWorkflowExecution(ctx, request)
+			resp, err = remoteClient.ResetWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -720,7 +724,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCanceled(
 			err = handler.frontendHandler.RespondActivityTaskCanceled(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondActivityTaskCanceled(ctx, request)
+			err = remoteClient.RespondActivityTaskCanceled(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -750,7 +754,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCanceledByID(
 			err = handler.frontendHandler.RespondActivityTaskCanceledByID(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondActivityTaskCanceledByID(ctx, request)
+			err = remoteClient.RespondActivityTaskCanceledByID(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -785,7 +789,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCompleted(
 			err = handler.frontendHandler.RespondActivityTaskCompleted(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondActivityTaskCompleted(ctx, request)
+			err = remoteClient.RespondActivityTaskCompleted(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -815,7 +819,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskCompletedByID(
 			err = handler.frontendHandler.RespondActivityTaskCompletedByID(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondActivityTaskCompletedByID(ctx, request)
+			err = remoteClient.RespondActivityTaskCompletedByID(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -850,7 +854,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskFailed(
 			err = handler.frontendHandler.RespondActivityTaskFailed(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondActivityTaskFailed(ctx, request)
+			err = remoteClient.RespondActivityTaskFailed(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -880,7 +884,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondActivityTaskFailedByID(
 			err = handler.frontendHandler.RespondActivityTaskFailedByID(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondActivityTaskFailedByID(ctx, request)
+			err = remoteClient.RespondActivityTaskFailedByID(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -915,7 +919,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondDecisionTaskCompleted(
 			resp, err = handler.frontendHandler.RespondDecisionTaskCompleted(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.RespondDecisionTaskCompleted(ctx, request)
+			resp, err = remoteClient.RespondDecisionTaskCompleted(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -950,7 +954,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondDecisionTaskFailed(
 			err = handler.frontendHandler.RespondDecisionTaskFailed(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondDecisionTaskFailed(ctx, request)
+			err = remoteClient.RespondDecisionTaskFailed(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -985,7 +989,7 @@ func (handler *ClusterRedirectionHandlerImpl) RespondQueryTaskCompleted(
 			err = handler.frontendHandler.RespondQueryTaskCompleted(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RespondQueryTaskCompleted(ctx, request)
+			err = remoteClient.RespondQueryTaskCompleted(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1010,7 +1014,7 @@ func (handler *ClusterRedirectionHandlerImpl) RestartWorkflowExecution(ctx conte
 			resp, err = handler.frontendHandler.RestartWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.RestartWorkflowExecution(ctx, request)
+			resp, err = remoteClient.RestartWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1040,7 +1044,7 @@ func (handler *ClusterRedirectionHandlerImpl) SignalWithStartWorkflowExecution(
 			resp, err = handler.frontendHandler.SignalWithStartWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.SignalWithStartWorkflowExecution(ctx, request)
+			resp, err = remoteClient.SignalWithStartWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1070,7 +1074,7 @@ func (handler *ClusterRedirectionHandlerImpl) SignalWorkflowExecution(
 			err = handler.frontendHandler.SignalWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.SignalWorkflowExecution(ctx, request)
+			err = remoteClient.SignalWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1099,7 +1103,7 @@ func (handler *ClusterRedirectionHandlerImpl) StartWorkflowExecution(
 			resp, err = handler.frontendHandler.StartWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.StartWorkflowExecution(ctx, request)
+			resp, err = remoteClient.StartWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1129,7 +1133,7 @@ func (handler *ClusterRedirectionHandlerImpl) TerminateWorkflowExecution(
 			err = handler.frontendHandler.TerminateWorkflowExecution(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.TerminateWorkflowExecution(ctx, request)
+			err = remoteClient.TerminateWorkflowExecution(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1159,7 +1163,7 @@ func (handler *ClusterRedirectionHandlerImpl) ListTaskListPartitions(
 			resp, err = handler.frontendHandler.ListTaskListPartitions(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.ListTaskListPartitions(ctx, request)
+			resp, err = remoteClient.ListTaskListPartitions(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1189,7 +1193,7 @@ func (handler *ClusterRedirectionHandlerImpl) GetTaskListsByDomain(
 			resp, err = handler.frontendHandler.GetTaskListsByDomain(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			resp, err = remoteClient.GetTaskListsByDomain(ctx, request)
+			resp, err = remoteClient.GetTaskListsByDomain(ctx, request, handler.callOptions...)
 		}
 		return err
 	})
@@ -1219,7 +1223,7 @@ func (handler *ClusterRedirectionHandlerImpl) RefreshWorkflowTasks(
 			err = handler.frontendHandler.RefreshWorkflowTasks(ctx, request)
 		default:
 			remoteClient := handler.GetRemoteFrontendClient(targetDC)
-			err = remoteClient.RefreshWorkflowTasks(ctx, request)
+			err = remoteClient.RefreshWorkflowTasks(ctx, request, handler.callOptions...)
 		}
 		return err
 	})

--- a/service/frontend/clusterRedirectionHandler_test.go
+++ b/service/frontend/clusterRedirectionHandler_test.go
@@ -135,7 +135,7 @@ func (s *clusterRedirectionHandlerSuite) TestDescribeTaskList() {
 	s.mockFrontendHandler.EXPECT().DescribeTaskList(gomock.Any(), req).Return(&types.DescribeTaskListResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), req).Return(&types.DescribeTaskListResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().DescribeTaskList(gomock.Any(), req, s.handler.callOptions).Return(&types.DescribeTaskListResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -158,7 +158,7 @@ func (s *clusterRedirectionHandlerSuite) TestDescribeWorkflowExecution() {
 	s.mockFrontendHandler.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(&types.DescribeWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), req).Return(&types.DescribeWorkflowExecutionResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().DescribeWorkflowExecution(gomock.Any(), req, s.handler.callOptions).Return(&types.DescribeWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -181,7 +181,7 @@ func (s *clusterRedirectionHandlerSuite) TestGetWorkflowExecutionHistory() {
 	s.mockFrontendHandler.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), req).Return(&types.GetWorkflowExecutionHistoryResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), req).Return(&types.GetWorkflowExecutionHistoryResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().GetWorkflowExecutionHistory(gomock.Any(), req, s.handler.callOptions).Return(&types.GetWorkflowExecutionHistoryResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -204,7 +204,7 @@ func (s *clusterRedirectionHandlerSuite) TestListArchivedWorkflowExecutions() {
 	s.mockFrontendHandler.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(), req).Return(&types.ListArchivedWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(), req).Return(&types.ListArchivedWorkflowExecutionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ListArchivedWorkflowExecutions(gomock.Any(), req, s.handler.callOptions).Return(&types.ListArchivedWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -227,7 +227,7 @@ func (s *clusterRedirectionHandlerSuite) TestListClosedWorkflowExecutions() {
 	s.mockFrontendHandler.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), req).Return(&types.ListClosedWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), req).Return(&types.ListClosedWorkflowExecutionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ListClosedWorkflowExecutions(gomock.Any(), req, s.handler.callOptions).Return(&types.ListClosedWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -250,7 +250,7 @@ func (s *clusterRedirectionHandlerSuite) TestListOpenWorkflowExecutions() {
 	s.mockFrontendHandler.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), req).Return(&types.ListOpenWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), req).Return(&types.ListOpenWorkflowExecutionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ListOpenWorkflowExecutions(gomock.Any(), req, s.handler.callOptions).Return(&types.ListOpenWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -273,7 +273,7 @@ func (s *clusterRedirectionHandlerSuite) TestListWorkflowExecutions() {
 	s.mockFrontendHandler.EXPECT().ListWorkflowExecutions(gomock.Any(), req).Return(&types.ListWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ListWorkflowExecutions(gomock.Any(), req).Return(&types.ListWorkflowExecutionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ListWorkflowExecutions(gomock.Any(), req, s.handler.callOptions).Return(&types.ListWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -296,7 +296,7 @@ func (s *clusterRedirectionHandlerSuite) TestScanWorkflowExecutions() {
 	s.mockFrontendHandler.EXPECT().ScanWorkflowExecutions(gomock.Any(), req).Return(&types.ListWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ScanWorkflowExecutions(gomock.Any(), req).Return(&types.ListWorkflowExecutionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ScanWorkflowExecutions(gomock.Any(), req, s.handler.callOptions).Return(&types.ListWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -319,7 +319,7 @@ func (s *clusterRedirectionHandlerSuite) TestCountWorkflowExecutions() {
 	s.mockFrontendHandler.EXPECT().CountWorkflowExecutions(gomock.Any(), req).Return(&types.CountWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().CountWorkflowExecutions(gomock.Any(), req).Return(&types.CountWorkflowExecutionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().CountWorkflowExecutions(gomock.Any(), req, s.handler.callOptions).Return(&types.CountWorkflowExecutionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -342,7 +342,7 @@ func (s *clusterRedirectionHandlerSuite) TestPollForActivityTask() {
 	s.mockFrontendHandler.EXPECT().PollForActivityTask(gomock.Any(), req).Return(&types.PollForActivityTaskResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().PollForActivityTask(gomock.Any(), req).Return(&types.PollForActivityTaskResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().PollForActivityTask(gomock.Any(), req, s.handler.callOptions).Return(&types.PollForActivityTaskResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -365,7 +365,7 @@ func (s *clusterRedirectionHandlerSuite) TestPollForDecisionTask() {
 	s.mockFrontendHandler.EXPECT().PollForDecisionTask(gomock.Any(), req).Return(&types.PollForDecisionTaskResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().PollForDecisionTask(gomock.Any(), req).Return(&types.PollForDecisionTaskResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().PollForDecisionTask(gomock.Any(), req, s.handler.callOptions).Return(&types.PollForDecisionTaskResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -388,7 +388,7 @@ func (s *clusterRedirectionHandlerSuite) TestQueryWorkflow() {
 	s.mockFrontendHandler.EXPECT().QueryWorkflow(gomock.Any(), req).Return(&types.QueryWorkflowResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().QueryWorkflow(gomock.Any(), req).Return(&types.QueryWorkflowResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().QueryWorkflow(gomock.Any(), req, s.handler.callOptions).Return(&types.QueryWorkflowResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -412,7 +412,7 @@ func (s *clusterRedirectionHandlerSuite) TestQueryWorkflowStrongConsistency() {
 	s.mockFrontendHandler.EXPECT().QueryWorkflow(gomock.Any(), req).Return(&types.QueryWorkflowResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().QueryWorkflow(gomock.Any(), req).Return(&types.QueryWorkflowResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().QueryWorkflow(gomock.Any(), req, s.handler.callOptions).Return(&types.QueryWorkflowResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -439,7 +439,7 @@ func (s *clusterRedirectionHandlerSuite) TestRecordActivityTaskHeartbeat() {
 	s.mockFrontendHandler.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), req).Return(&types.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), req).Return(&types.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RecordActivityTaskHeartbeat(gomock.Any(), req, s.handler.callOptions).Return(&types.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -462,7 +462,7 @@ func (s *clusterRedirectionHandlerSuite) TestRecordActivityTaskHeartbeatByID() {
 	s.mockFrontendHandler.EXPECT().RecordActivityTaskHeartbeatByID(gomock.Any(), req).Return(&types.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RecordActivityTaskHeartbeatByID(gomock.Any(), req).Return(&types.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RecordActivityTaskHeartbeatByID(gomock.Any(), req, s.handler.callOptions).Return(&types.RecordActivityTaskHeartbeatResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -483,7 +483,7 @@ func (s *clusterRedirectionHandlerSuite) TestRequestCancelWorkflowExecution() {
 	s.mockFrontendHandler.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RequestCancelWorkflowExecution(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -506,7 +506,7 @@ func (s *clusterRedirectionHandlerSuite) TestResetStickyTaskList() {
 	s.mockFrontendHandler.EXPECT().ResetStickyTaskList(gomock.Any(), req).Return(&types.ResetStickyTaskListResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ResetStickyTaskList(gomock.Any(), req).Return(&types.ResetStickyTaskListResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ResetStickyTaskList(gomock.Any(), req, s.handler.callOptions).Return(&types.ResetStickyTaskListResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -529,7 +529,7 @@ func (s *clusterRedirectionHandlerSuite) TestResetWorkflowExecution() {
 	s.mockFrontendHandler.EXPECT().ResetWorkflowExecution(gomock.Any(), req).Return(&types.ResetWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ResetWorkflowExecution(gomock.Any(), req).Return(&types.ResetWorkflowExecutionResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ResetWorkflowExecution(gomock.Any(), req, s.handler.callOptions).Return(&types.ResetWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -554,7 +554,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondActivityTaskCanceled() {
 	s.mockFrontendHandler.EXPECT().RespondActivityTaskCanceled(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCanceled(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCanceled(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -575,7 +575,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondActivityTaskCanceledByID() {
 	s.mockFrontendHandler.EXPECT().RespondActivityTaskCanceledByID(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCanceledByID(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCanceledByID(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -600,7 +600,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondActivityTaskCompleted() {
 	s.mockFrontendHandler.EXPECT().RespondActivityTaskCompleted(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCompleted(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCompleted(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -621,7 +621,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondActivityTaskCompletedByID() 
 	s.mockFrontendHandler.EXPECT().RespondActivityTaskCompletedByID(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCompletedByID(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskCompletedByID(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -646,7 +646,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondActivityTaskFailed() {
 	s.mockFrontendHandler.EXPECT().RespondActivityTaskFailed(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskFailed(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskFailed(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -667,7 +667,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondActivityTaskFailedByID() {
 	s.mockFrontendHandler.EXPECT().RespondActivityTaskFailedByID(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskFailedByID(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondActivityTaskFailedByID(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -694,7 +694,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondDecisionTaskCompleted() {
 	s.mockFrontendHandler.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), req).Return(&types.RespondDecisionTaskCompletedResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), req).Return(&types.RespondDecisionTaskCompletedResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondDecisionTaskCompleted(gomock.Any(), req, s.handler.callOptions).Return(&types.RespondDecisionTaskCompletedResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -719,7 +719,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondDecisionTaskFailed() {
 	s.mockFrontendHandler.EXPECT().RespondDecisionTaskFailed(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondDecisionTaskFailed(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondDecisionTaskFailed(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -744,7 +744,7 @@ func (s *clusterRedirectionHandlerSuite) TestRespondQueryTaskCompleted() {
 	s.mockFrontendHandler.EXPECT().RespondQueryTaskCompleted(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().RespondQueryTaskCompleted(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().RespondQueryTaskCompleted(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -767,7 +767,7 @@ func (s *clusterRedirectionHandlerSuite) TestSignalWithStartWorkflowExecution() 
 	s.mockFrontendHandler.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), req).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), req).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().SignalWithStartWorkflowExecution(gomock.Any(), req, s.handler.callOptions).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -788,7 +788,7 @@ func (s *clusterRedirectionHandlerSuite) TestSignalWorkflowExecution() {
 	s.mockFrontendHandler.EXPECT().SignalWorkflowExecution(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().SignalWorkflowExecution(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().SignalWorkflowExecution(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -811,7 +811,7 @@ func (s *clusterRedirectionHandlerSuite) TestStartWorkflowExecution() {
 	s.mockFrontendHandler.EXPECT().StartWorkflowExecution(gomock.Any(), req).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), req).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().StartWorkflowExecution(gomock.Any(), req, s.handler.callOptions).Return(&types.StartWorkflowExecutionResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -832,7 +832,7 @@ func (s *clusterRedirectionHandlerSuite) TestTerminateWorkflowExecution() {
 	s.mockFrontendHandler.EXPECT().TerminateWorkflowExecution(gomock.Any(), req).Return(nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), req).Return(nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().TerminateWorkflowExecution(gomock.Any(), req, s.handler.callOptions).Return(nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -859,7 +859,7 @@ func (s *clusterRedirectionHandlerSuite) TestListTaskListPartitions() {
 	s.mockFrontendHandler.EXPECT().ListTaskListPartitions(gomock.Any(), req).Return(&types.ListTaskListPartitionsResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().ListTaskListPartitions(gomock.Any(), req).Return(&types.ListTaskListPartitionsResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().ListTaskListPartitions(gomock.Any(), req, s.handler.callOptions).Return(&types.ListTaskListPartitionsResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }
@@ -882,7 +882,7 @@ func (s *clusterRedirectionHandlerSuite) TestGetTaskListsByDomain() {
 	s.mockFrontendHandler.EXPECT().GetTaskListsByDomain(gomock.Any(), req).Return(&types.GetTaskListsByDomainResponse{}, nil).Times(1)
 	err = callFn(s.currentClusterName)
 	s.Nil(err)
-	s.mockRemoteFrontendClient.EXPECT().GetTaskListsByDomain(gomock.Any(), req).Return(&types.GetTaskListsByDomainResponse{}, nil).Times(1)
+	s.mockRemoteFrontendClient.EXPECT().GetTaskListsByDomain(gomock.Any(), req, s.handler.callOptions).Return(&types.GetTaskListsByDomainResponse{}, nil).Times(1)
 	err = callFn(s.alternativeClusterName)
 	s.Nil(err)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add helper function to store/retrieve partition config into/from context
- Update frontend workflowHandler to retrieve partition config from context and set it to the requests to history
- Add a middleware (`ZonalPartitionConfigMiddleware`) as an example to demonstrate how to store partition config into context
- Update clusterRedirectionHandler to set a header to indicate which cluster the requests are from for all auto-forwarding requests
- Add a middleware (`ForwardPartitionConfigMiddleware`) which forwards partition config to remote cluster

`ForwardPartitionConfigMiddleware` must be used if we want to enable tasklist isolation feature. `ZonalPartitionConfigMiddleware` can be replaced with a different implementation. For example, if zonal isolation is enabled at network layer, we can create a middleware which derives the zone which the requests are from on the server side, which is more reliable than letting client set a header indicating which zone the requests are from.

<!-- Tell your future self why have you made these changes -->
**Why?**
To provide a way to set isolation groups for frontend requests

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
