### PR TITLE
Corrects the config-store handling for not-found errors

### DIFF
--- a/common/persistence/nosql/nosqlConfigStore.go
+++ b/common/persistence/nosql/nosqlConfigStore.go
@@ -56,6 +56,9 @@ func NewNoSQLConfigStore(
 
 func (m *nosqlConfigStore) FetchConfig(ctx context.Context, configType persistence.ConfigType) (*persistence.InternalConfigStoreEntry, error) {
 	entry, err := m.db.SelectLatestConfig(ctx, int(configType))
+	if m.db.IsNotFoundError(err) {
+		return nil, nil
+	}
 	if err != nil {
 		return nil, convertCommonErrors(m.db, "FetchConfig", err)
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/configStore.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/configStore.go
@@ -56,9 +56,6 @@ func (db *cdb) SelectLatestConfig(ctx context.Context, rowType int) (*persistenc
 
 	query := db.session.Query(templateSelectLatestConfig, rowType).WithContext(ctx)
 	err := query.Scan(&rowType, &version, &timestamp, &data, &encoding)
-	if db.IsNotFoundError(err) {
-		return nil, nil
-	}
 	if err != nil {
 		return nil, err
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/configStore.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/configStore.go
@@ -24,8 +24,6 @@ import (
 	"context"
 	"time"
 
-	"github.com/gocql/gocql"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
@@ -58,7 +56,7 @@ func (db *cdb) SelectLatestConfig(ctx context.Context, rowType int) (*persistenc
 
 	query := db.session.Query(templateSelectLatestConfig, rowType).WithContext(ctx)
 	err := query.Scan(&rowType, &version, &timestamp, &data, &encoding)
-	if err == gocql.ErrNotFound {
+	if db.IsNotFoundError(err) {
 		return nil, nil
 	}
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Swaps the config-store to use the DB plugin checker for not-found entries rather than doing a direct error comparison. This makes it compatible with internal forks of goCQL
<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit-tests, manual-tests. However, given this error it's probably not been tested extensively. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
