### PR TITLE
Prepares to implement domain updates

### DIFF
--- a/common/isolationgroup/defaultisolationgroup/domain-api-handlers.go
+++ b/common/isolationgroup/defaultisolationgroup/domain-api-handlers.go
@@ -1,0 +1,38 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package defaultisolationgroup
+
+import (
+	"context"
+
+	"github.com/uber/cadence/common/types"
+)
+
+// GetDomainState returns the Isolation Group state as it relates to a domain
+func (z *defaultIsolationGroupStateHandler) GetDomainState(ctx context.Context, req types.GetDomainIsolationGroupsRequest) (*types.GetDomainIsolationGroupsResponse, error) {
+	panic("not implemented")
+}
+
+func (z *defaultIsolationGroupStateHandler) UpdateDomainState(ctx context.Context, state types.UpdateDomainIsolationGroupsRequest) error {
+	panic("not implemented")
+}

--- a/common/isolationgroup/defaultisolationgroup/global-api-handlers.go
+++ b/common/isolationgroup/defaultisolationgroup/global-api-handlers.go
@@ -1,0 +1,117 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package defaultisolationgroup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/types"
+)
+
+func (z *defaultIsolationGroupStateHandler) UpdateGlobalState(ctx context.Context, in types.UpdateGlobalIsolationGroupsRequest) error {
+	mappedInput, err := mapUpdateGlobalIsolationGroupsRequest(in.IsolationGroups)
+	if err != nil {
+		return err
+	}
+	return z.globalIsolationGroupDrains.UpdateValue(
+		dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+		mappedInput,
+	)
+}
+
+func (z *defaultIsolationGroupStateHandler) GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error) {
+	res, err := z.globalIsolationGroupDrains.GetListValue(dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping, nil)
+	if err != nil {
+		var e types.EntityNotExistsError
+		if errors.As(err, &e) {
+			return &types.GetGlobalIsolationGroupsResponse{}, nil
+		}
+		return nil, fmt.Errorf("failed to get global isolation groups from datastore: %w", err)
+	}
+	resp, err := mapDynamicConfigResponse(res)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get global isolation groups from datastore: %w", err)
+	}
+	return &types.GetGlobalIsolationGroupsResponse{IsolationGroups: resp}, nil
+}
+
+func mapDynamicConfigResponse(in []interface{}) (out types.IsolationGroupConfiguration, err error) {
+	if in == nil {
+		return nil, nil
+	}
+
+	out = make(types.IsolationGroupConfiguration, len(in))
+	for _, v := range in {
+		v1, ok := v.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("failed parse a dynamic config entry, %v, (got %v)", v1, v)
+		}
+		n, okName := v1["Name"]
+		s, okState := v1["State"]
+		if !okState || !okName {
+			return nil, fmt.Errorf("failed parse a dynamic config entry, %v, (got %v)", v1, v)
+		}
+		nS, okStr := n.(string)
+		sI, okI := s.(float64)
+		if !okStr || !okI {
+			return nil, fmt.Errorf("failed parse a dynamic config entry, %v, (got %v)", v1, v)
+		}
+		out[nS] = types.IsolationGroupPartition{
+			Name:  nS,
+			State: types.IsolationGroupState(sI),
+		}
+	}
+	return out, nil
+}
+
+func mapAllIsolationGroupsResponse(in []interface{}) ([]string, error) {
+	var allIsolationGroups []string
+	for k := range in {
+		v, ok := in[k].(string)
+		if !ok {
+			return nil, fmt.Errorf("failed to get all-isolation-groups response from dynamic config: got %v (%T)", in[k], in[k])
+		}
+		allIsolationGroups = append(allIsolationGroups, v)
+	}
+	return allIsolationGroups, nil
+}
+
+func mapUpdateGlobalIsolationGroupsRequest(in types.IsolationGroupConfiguration) ([]*types.DynamicConfigValue, error) {
+	jsonData, err := json.Marshal(in.ToPartitionList())
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal input for dynamic config: %w", err)
+	}
+	out := []*types.DynamicConfigValue{
+		&types.DynamicConfigValue{
+			Value: &types.DataBlob{
+				EncodingType: types.EncodingTypeJSON.Ptr(),
+				Data:         jsonData,
+			},
+		},
+	}
+	return out, nil
+}

--- a/common/isolationgroup/defaultisolationgroup/global-api-handlers_test.go
+++ b/common/isolationgroup/defaultisolationgroup/global-api-handlers_test.go
@@ -1,0 +1,137 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package defaultisolationgroup
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestUpdateGlobalState(t *testing.T) {
+
+	tests := map[string]struct {
+		in           types.UpdateGlobalIsolationGroupsRequest
+		dcAffordance func(client *dynamicconfig.MockClient)
+		expectedErr  error
+	}{
+		"updating normal value": {
+			in: types.UpdateGlobalIsolationGroupsRequest{IsolationGroups: types.IsolationGroupConfiguration{
+				"zone-1": {Name: "zone-1", State: types.IsolationGroupStateHealthy},
+				"zone-2": {Name: "zone-2", State: types.IsolationGroupStateDrained},
+			}},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().UpdateValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(), // covering the mapping in the mapper unit-test instead
+				)
+			},
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			dcMock := dynamicconfig.NewMockClient(gomock.NewController(t))
+			td.dcAffordance(dcMock)
+			handler := defaultIsolationGroupStateHandler{
+				log:                        loggerimpl.NewNopLogger(),
+				globalIsolationGroupDrains: dcMock,
+			}
+			err := handler.UpdateGlobalState(context.Background(), td.in)
+			assert.Equal(t, td.expectedErr, err)
+		})
+	}
+}
+
+func TestGetGlobalState(t *testing.T) {
+
+	validInput := types.IsolationGroupConfiguration{
+		"zone-1": types.IsolationGroupPartition{
+			Name:  "zone-1",
+			State: types.IsolationGroupStateDrained,
+		},
+		"zone-2": types.IsolationGroupPartition{
+			Name:  "zone-2",
+			State: types.IsolationGroupStateHealthy,
+		},
+	}
+
+	validCfg, _ := mapUpdateGlobalIsolationGroupsRequest(validInput)
+
+	validCfgData := validCfg[0].Value.GetData()
+	dynamicConfigResponse := []interface{}{}
+	json.Unmarshal(validCfgData, &dynamicConfigResponse)
+
+	tests := map[string]struct {
+		in           types.GetGlobalIsolationGroupsRequest
+		dcAffordance func(client *dynamicconfig.MockClient)
+		expected     *types.GetGlobalIsolationGroupsResponse
+		expectedErr  error
+	}{
+		"updating normal value": {
+			in: types.GetGlobalIsolationGroupsRequest{},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(dynamicConfigResponse, nil)
+			},
+			expected: &types.GetGlobalIsolationGroupsResponse{IsolationGroups: validInput},
+		},
+		"an error was returned": {
+			in: types.GetGlobalIsolationGroupsRequest{},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(nil, errors.New("an error"))
+			},
+			expectedErr: errors.New("failed to get global isolation groups from datastore: an error"),
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			dcMock := dynamicconfig.NewMockClient(gomock.NewController(t))
+			td.dcAffordance(dcMock)
+			handler := defaultIsolationGroupStateHandler{
+				log:                        loggerimpl.NewNopLogger(),
+				globalIsolationGroupDrains: dcMock,
+			}
+			res, err := handler.GetGlobalState(context.Background())
+			assert.Equal(t, td.expected, res)
+			if td.expectedErr != nil {
+				// only compare strings because full wrapping makes it fiddly otherwise
+				assert.Equal(t, td.expectedErr.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/common/isolationgroup/defaultisolationgroup/state.go
+++ b/common/isolationgroup/defaultisolationgroup/state.go
@@ -20,12 +20,10 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package isolationgroup
+package defaultisolationgroup
 
 import (
 	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -39,18 +37,10 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/isolationgroup"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/types"
 )
-
-// defaultConfig values for the partitioning library for segmenting portions of workflows into isolation-groups - a resiliency
-// concept meant to help move workflows around and away from failure zones.
-type defaultConfig struct {
-	// IsolationGroupEnabled is a domain-based configuration value for whether this feature is enabled at all
-	IsolationGroupEnabled dynamicconfig.BoolPropertyFnWithDomainFilter
-	// AllIsolationGroups is a static list of all the possible isolation group names
-	AllIsolationGroups []string
-}
 
 type defaultIsolationGroupStateHandler struct {
 	status                     int32
@@ -58,6 +48,7 @@ type defaultIsolationGroupStateHandler struct {
 	log                        log.Logger
 	domainCache                cache.DomainCache
 	globalIsolationGroupDrains dynamicconfig.Client
+	domainManager              persistence.DomainManager
 	config                     defaultConfig
 	subscriptionMu             sync.Mutex
 	valuesMu                   sync.RWMutex
@@ -65,7 +56,7 @@ type defaultIsolationGroupStateHandler struct {
 	updateCB                   func()
 	// subscriptions is a map of domains->subscription-keys-> subscription channels
 	// for notifying when there's a state change
-	subscriptions map[string]map[string]chan<- ChangeEvent
+	subscriptions map[string]map[string]chan<- isolationgroup.ChangeEvent
 }
 
 // NewDefaultIsolationGroupStateWatcher is the default constructor
@@ -74,7 +65,8 @@ func NewDefaultIsolationGroupStateWatcher(
 	dc *dynamicconfig.Collection,
 	persistenceCfg *config.Persistence,
 	domainCache cache.DomainCache,
-) (State, error) {
+	domainManager persistence.DomainManager,
+) (isolationgroup.State, error) {
 	stopChan := make(chan struct{})
 	cscConfig := &csc.ClientConfig{
 		PollInterval:        dc.GetDurationProperty(dynamicconfig.IsolationGroupStateRefreshInterval)(),
@@ -86,7 +78,7 @@ func NewDefaultIsolationGroupStateWatcher(
 	if err != nil {
 		return nil, fmt.Errorf("failure during setup for the IsolationGroupStateWatcher: %w", err)
 	}
-	return NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(logger, dc, domainCache, cfgStoreClient, stopChan)
+	return NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(logger, dc, domainCache, domainManager, cfgStoreClient, stopChan)
 }
 
 // NewDefaultIsolationGroupStateWatcherWithConfigStoreClient Is a constructor which allows passing in the dynamic config client
@@ -94,9 +86,10 @@ func NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 	logger log.Logger,
 	dc *dynamicconfig.Collection,
 	domainCache cache.DomainCache,
+	domainManager persistence.DomainManager,
 	cfgStoreClient dynamicconfig.Client,
 	stopChan chan struct{},
-) (State, error) {
+) (isolationgroup.State, error) {
 
 	allIGs := dc.GetListProperty(dynamicconfig.AllIsolationGroups)()
 	allIsolationGroups, err := mapAllIsolationGroupsResponse(allIGs)
@@ -114,10 +107,11 @@ func NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 		domainCache:                domainCache,
 		globalIsolationGroupDrains: cfgStoreClient,
 		status:                     common.DaemonStatusInitialized,
+		domainManager:              domainManager,
 		log:                        logger,
 		config:                     config,
 		subscriptionMu:             sync.Mutex{},
-		subscriptions:              make(map[string]map[string]chan<- ChangeEvent),
+		subscriptions:              make(map[string]map[string]chan<- isolationgroup.ChangeEvent),
 	}, nil
 }
 
@@ -163,7 +157,7 @@ func (z *defaultIsolationGroupStateHandler) Stop() {
 	close(z.done)
 }
 
-func (z *defaultIsolationGroupStateHandler) Subscribe(domainID, key string, notifyChannel chan<- ChangeEvent) error {
+func (z *defaultIsolationGroupStateHandler) Subscribe(domainID, key string, notifyChannel chan<- isolationgroup.ChangeEvent) error {
 	z.subscriptionMu.Lock()
 	defer z.subscriptionMu.Unlock()
 
@@ -176,33 +170,6 @@ func (z *defaultIsolationGroupStateHandler) Unsubscribe(domainID, key string) er
 	defer z.subscriptionMu.Unlock()
 	panic("not implemented")
 	return nil
-}
-
-func (z *defaultIsolationGroupStateHandler) UpdateGlobalState(ctx context.Context, in types.UpdateGlobalIsolationGroupsRequest) error {
-	mappedInput, err := mapUpdateGlobalIsolationGroupsRequest(in.IsolationGroups)
-	if err != nil {
-		return err
-	}
-	return z.globalIsolationGroupDrains.UpdateValue(
-		dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
-		mappedInput,
-	)
-}
-
-func (z *defaultIsolationGroupStateHandler) GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error) {
-	res, err := z.globalIsolationGroupDrains.GetListValue(dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping, nil)
-	if err != nil {
-		var e types.EntityNotExistsError
-		if errors.As(err, &e) {
-			return &types.GetGlobalIsolationGroupsResponse{}, nil
-		}
-		return nil, fmt.Errorf("failed to get global isolation groups from datastore: %w", err)
-	}
-	resp, err := mapDynamicConfigResponse(res)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get global isolation groups from datastore: %w", err)
-	}
-	return &types.GetGlobalIsolationGroupsResponse{IsolationGroups: resp}, nil
 }
 
 func (z *defaultIsolationGroupStateHandler) getByDomainID(ctx context.Context, domainID string) (*isolationGroups, error) {
@@ -290,62 +257,4 @@ func isDrained(isolationGroup string, global types.IsolationGroupConfiguration, 
 		}
 	}
 	return false
-}
-
-// ----- Mappers -----
-func mapDynamicConfigResponse(in []interface{}) (out types.IsolationGroupConfiguration, err error) {
-	if in == nil {
-		return nil, nil
-	}
-
-	out = make(types.IsolationGroupConfiguration, len(in))
-	for _, v := range in {
-		v1, ok := v.(map[string]interface{})
-		if !ok {
-			return nil, fmt.Errorf("failed parse a dynamic config entry, %v, (got %v)", v1, v)
-		}
-		n, okName := v1["Name"]
-		s, okState := v1["State"]
-		if !okState || !okName {
-			return nil, fmt.Errorf("failed parse a dynamic config entry, %v, (got %v)", v1, v)
-		}
-		nS, okStr := n.(string)
-		sI, okI := s.(float64)
-		if !okStr || !okI {
-			return nil, fmt.Errorf("failed parse a dynamic config entry, %v, (got %v)", v1, v)
-		}
-		out[nS] = types.IsolationGroupPartition{
-			Name:  nS,
-			State: types.IsolationGroupState(sI),
-		}
-	}
-	return out, nil
-}
-
-func mapAllIsolationGroupsResponse(in []interface{}) ([]string, error) {
-	var allIsolationGroups []string
-	for k := range in {
-		v, ok := in[k].(string)
-		if !ok {
-			return nil, fmt.Errorf("failed to get all-isolation-groups response from dynamic config: got %v (%T)", in[k], in[k])
-		}
-		allIsolationGroups = append(allIsolationGroups, v)
-	}
-	return allIsolationGroups, nil
-}
-
-func mapUpdateGlobalIsolationGroupsRequest(in types.IsolationGroupConfiguration) ([]*types.DynamicConfigValue, error) {
-	jsonData, err := json.Marshal(in.ToPartitionList())
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal input for dynamic config: %w", err)
-	}
-	out := []*types.DynamicConfigValue{
-		&types.DynamicConfigValue{
-			Value: &types.DataBlob{
-				EncodingType: types.EncodingTypeJSON.Ptr(),
-				Data:         jsonData,
-			},
-		},
-	}
-	return out, nil
 }

--- a/common/isolationgroup/defaultisolationgroup/types.go
+++ b/common/isolationgroup/defaultisolationgroup/types.go
@@ -1,0 +1,43 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package defaultisolationgroup
+
+import (
+	"github.com/uber/cadence/common/dynamicconfig"
+	"github.com/uber/cadence/common/types"
+)
+
+// IsolationGroups is an internal convenience return type of a collection of IsolationGroup configurations
+type isolationGroups struct {
+	Global types.IsolationGroupConfiguration
+	Domain types.IsolationGroupConfiguration
+}
+
+// defaultConfig values for the partitioning library for segmenting portions of workflows into isolation-groups - a resiliency
+// concept meant to help move workflows around and away from failure zones.
+type defaultConfig struct {
+	// IsolationGroupEnabled is a domain-based configuration value for whether this feature is enabled at all
+	IsolationGroupEnabled dynamicconfig.BoolPropertyFnWithDomainFilter
+	// AllIsolationGroups is a static list of all the possible isolation group names
+	AllIsolationGroups []string
+}

--- a/common/isolationgroup/interface.go
+++ b/common/isolationgroup/interface.go
@@ -48,7 +48,12 @@ type State interface {
 	Subscribe(domainID, key string, notifyChannel chan<- ChangeEvent) error
 	Unsubscribe(domainID, key string) error
 
-	// CRUD operations for state handling
+	// GetGlobalState returns the current configuration of isolation-groups which apply to all domains
 	GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error)
+	// UpdateGlobalState updates isolation-groups which apply to all domains
 	UpdateGlobalState(ctx context.Context, state types.UpdateGlobalIsolationGroupsRequest) error
+	// GetDomainState is the read operation for getting the current state of a domain's isolation-groups
+	GetDomainState(ctx context.Context, request types.GetDomainIsolationGroupsRequest) (*types.GetDomainIsolationGroupsResponse, error)
+	// UpdateDomainState is the read operation for updating a domain's isolation-groups
+	UpdateDomainState(ctx context.Context, state types.UpdateDomainIsolationGroupsRequest) error
 }

--- a/common/isolationgroup/isolation_group_mock.go
+++ b/common/isolationgroup/isolation_group_mock.go
@@ -73,6 +73,21 @@ func (mr *MockStateMockRecorder) AvailableIsolationGroupsByDomainID(ctx, domainI
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIsolationGroupsByDomainID", reflect.TypeOf((*MockState)(nil).AvailableIsolationGroupsByDomainID), ctx, domainID)
 }
 
+// GetDomainState mocks base method.
+func (m *MockState) GetDomainState(ctx context.Context, request types.GetDomainIsolationGroupsRequest) (*types.GetDomainIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomainState", ctx, request)
+	ret0, _ := ret[0].(*types.GetDomainIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDomainState indicates an expected call of GetDomainState.
+func (mr *MockStateMockRecorder) GetDomainState(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomainState", reflect.TypeOf((*MockState)(nil).GetDomainState), ctx, request)
+}
+
 // GetGlobalState mocks base method.
 func (m *MockState) GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error) {
 	m.ctrl.T.Helper()
@@ -168,6 +183,20 @@ func (m *MockState) Unsubscribe(domainID, key string) error {
 func (mr *MockStateMockRecorder) Unsubscribe(domainID, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsubscribe", reflect.TypeOf((*MockState)(nil).Unsubscribe), domainID, key)
+}
+
+// UpdateDomainState mocks base method.
+func (m *MockState) UpdateDomainState(ctx context.Context, state types.UpdateDomainIsolationGroupsRequest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDomainState", ctx, state)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateDomainState indicates an expected call of UpdateDomainState.
+func (mr *MockStateMockRecorder) UpdateDomainState(ctx, state interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomainState", reflect.TypeOf((*MockState)(nil).UpdateDomainState), ctx, state)
 }
 
 // UpdateGlobalState mocks base method.

--- a/common/isolationgroup/types.go
+++ b/common/isolationgroup/types.go
@@ -29,9 +29,3 @@ import (
 type ChangeEvent struct {
 	Changed types.IsolationGroupConfiguration
 }
-
-// IsolationGroups is an internal convenience return type of a collection of IsolationGroup configurations
-type isolationGroups struct {
-	Global types.IsolationGroupConfiguration
-	Domain types.IsolationGroupConfiguration
-}

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -27,11 +27,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/uber/cadence/common/isolationgroup/defaultisolationgroup"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/uber-go/tally"
 
 	"github.com/uber/cadence/common/cluster"
-	"github.com/uber/cadence/common/isolationgroup"
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/service"
 
@@ -852,12 +853,14 @@ func Test_GetGlobalIsolationGroups(t *testing.T) {
 			td.configStoreDCAffordance(configStoreManagerClientMock)
 			td.dynamicConfigAffordance(dcClientMock)
 
-			ig, err := isolationgroup.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
+			ig, err := defaultisolationgroup.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 				loggerimpl.NewNopLogger(),
 				dc,
 				domainCache,
+				domainManager,
 				configStoreManagerClientMock,
-				make(chan struct{}))
+				make(chan struct{}),
+			)
 
 			assert.NoError(t, err)
 
@@ -947,10 +950,11 @@ func Test_UpdateGlobalIsolationGroups(t *testing.T) {
 			td.configStoreDCAffordance(configStoreManagerClientMock)
 			td.dynamicConfigAffordance(dcClientMock)
 
-			ig, err := isolationgroup.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
+			ig, err := defaultisolationgroup.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 				loggerimpl.NewNopLogger(),
 				dc,
 				domainCache,
+				domainManager,
 				configStoreManagerClientMock,
 				make(chan struct{}))
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

- Refactors the default implementation of IsolationGroupState by pulling it into a subfolder and splitting it apart
- Adds the DomainManager as a dependency in preparation for the implementation for domain-based drains. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
