### PR TITLE
Add tasklist traffic metrics for non-sticky and non-forwarded tasklists

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1177,6 +1177,8 @@ const (
 	MatchingAddActivityTaskScope
 	// MatchingAddDecisionTaskScope tracks AddDecisionTask API calls received by service
 	MatchingAddDecisionTaskScope
+	// MatchingAddTaskScope tracks both AddActivityTask and AddDevisionTask API calls received by service
+	MatchingAddTaskScope
 	// MatchingTaskListMgrScope is the metrics scope for matching.TaskListManager component
 	MatchingTaskListMgrScope
 	// MatchingQueryWorkflowScope tracks AddDecisionTask API calls received by service
@@ -1766,6 +1768,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MatchingPollForActivityTaskScope:       {operation: "PollForActivityTask"},
 		MatchingAddActivityTaskScope:           {operation: "AddActivityTask"},
 		MatchingAddDecisionTaskScope:           {operation: "AddDecisionTask"},
+		MatchingAddTaskScope:                   {operation: "AddTask"},
 		MatchingTaskListMgrScope:               {operation: "TaskListMgr"},
 		MatchingQueryWorkflowScope:             {operation: "QueryWorkflow"},
 		MatchingRespondQueryTaskCompletedScope: {operation: "RespondQueryTaskCompleted"},
@@ -1876,7 +1879,7 @@ const (
 	CadenceClientFailures
 	CadenceClientLatency
 
-	CadenceDecisionTasklistRequests
+	CadenceTasklistRequests
 
 	CadenceDcRedirectionClientRequests
 	CadenceDcRedirectionClientFailures
@@ -2461,7 +2464,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		CadenceClientRequests:                                        {metricName: "cadence_client_requests", metricType: Counter},
 		CadenceClientFailures:                                        {metricName: "cadence_client_errors", metricType: Counter},
 		CadenceClientLatency:                                         {metricName: "cadence_client_latency", metricType: Timer},
-		CadenceDecisionTasklistRequests:                              {metricName: "cadence_decision_tasklist_request", metricType: Counter},
+		CadenceTasklistRequests:                                      {metricName: "cadence_tasklist_request", metricType: Counter},
 		CadenceDcRedirectionClientRequests:                           {metricName: "cadence_client_requests_redirection", metricType: Counter},
 		CadenceDcRedirectionClientFailures:                           {metricName: "cadence_client_errors_redirection", metricType: Counter},
 		CadenceDcRedirectionClientLatency:                            {metricName: "cadence_client_latency_redirection", metricType: Timer},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1876,6 +1876,8 @@ const (
 	CadenceClientFailures
 	CadenceClientLatency
 
+	CadenceDecisionTasklistRequests
+
 	CadenceDcRedirectionClientRequests
 	CadenceDcRedirectionClientFailures
 	CadenceDcRedirectionClientLatency
@@ -2459,6 +2461,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		CadenceClientRequests:                                        {metricName: "cadence_client_requests", metricType: Counter},
 		CadenceClientFailures:                                        {metricName: "cadence_client_errors", metricType: Counter},
 		CadenceClientLatency:                                         {metricName: "cadence_client_latency", metricType: Timer},
+		CadenceDecisionTasklistRequests:                              {metricName: "cadence_decision_tasklist_request", metricType: Counter},
 		CadenceDcRedirectionClientRequests:                           {metricName: "cadence_client_requests_redirection", metricType: Counter},
 		CadenceDcRedirectionClientFailures:                           {metricName: "cadence_client_errors_redirection", metricType: Counter},
 		CadenceDcRedirectionClientLatency:                            {metricName: "cadence_client_latency_redirection", metricType: Timer},

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -316,8 +316,7 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
 		tag.Dynamic("taskListCombined", taskListID),
 		tag.Dynamic("taskListBaseName", taskList.baseName),
-		tag.Dynamic("forwardedFrom", request.ForwardedFrom),
-		tag.Dynamic("TaskSource", request.Source.String()))
+		tag.Dynamic("forwardedFrom", request.ForwardedFrom))
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)
 	if err != nil {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -324,12 +324,6 @@ func (e *matchingEngineImpl) AddDecisionTask(
 		return false, err
 	}
 
-	e.logger.Info("tlMgr of Cadence Client Request",
-		tag.Dynamic("tlMgr name", tlMgr.TaskListID().qualifiedTaskListName.name),
-		tag.Dynamic("tlMgr basename", tlMgr.TaskListID().qualifiedTaskListName.baseName),
-		tag.Dynamic("tlMgr partition", tlMgr.TaskListID().qualifiedTaskListName.partition),
-		tag.Dynamic("as", tlMgr.String()))
-
 	if taskListKind != nil && *taskListKind == types.TaskListKindSticky {
 		// check if the sticky worker is still available, if not, fail this request early
 		if !tlMgr.HasPollerAfter(time.Now().Add(-_stickyPollerUnavailableWindow)) {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -314,7 +314,7 @@ func (e *matchingEngineImpl) AddDecisionTask(
 
 	// tell if the tasklist is partitioned or sticky
 	if int32(request.GetTaskList().GetKind()) == 0 && request.ForwardedFrom == "" {
-		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceDecisionTasklistRequests)
+		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope).Tagged(metrics.DomainTag(domainName), metrics.TaskListTag(taskListName)).IncCounter(metrics.CadenceDecisionTasklistRequests)
 		e.logger.Info("Emitting tasklist counter", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
 			tag.Dynamic("taskListCombined", taskListID),
 			tag.Dynamic("taskListBaseName", taskList.baseName),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -316,7 +316,8 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
 		tag.Dynamic("taskListCombined", taskListID),
 		tag.Dynamic("taskListBaseName", taskList.baseName),
-		tag.Dynamic("forwardedFrom", request.ForwardedFrom))
+		tag.Dynamic("forwardedFrom", request.ForwardedFrom),
+		tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)
 	if err != nil {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -323,6 +323,12 @@ func (e *matchingEngineImpl) AddDecisionTask(
 		return false, err
 	}
 
+	e.logger.Info("tlMgr of Cadence Client Request",
+		tag.Dynamic("tlMgr name", tlMgr.TaskListID().qualifiedTaskListName.name),
+		tag.Dynamic("tlMgr basename", tlMgr.TaskListID().qualifiedTaskListName.baseName),
+		tag.Dynamic("tlMgr partition", tlMgr.TaskListID().qualifiedTaskListName.partition),
+		tag.Dynamic("as", tlMgr.String()))
+
 	if taskListKind != nil && *taskListKind == types.TaskListKindSticky {
 		// check if the sticky worker is still available, if not, fail this request early
 		if !tlMgr.HasPollerAfter(time.Now().Add(-_stickyPollerUnavailableWindow)) {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -315,6 +315,11 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	// tell if the tasklist is partitioned or sticky
 	if int32(request.GetTaskList().GetKind()) != 1 && &request.ForwardedFrom == nil {
 		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceDecisionTasklistRequests)
+		e.logger.Info("Emitting tasklist counter", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
+			tag.Dynamic("taskListCombined", taskListID),
+			tag.Dynamic("taskListBaseName", taskList.baseName),
+			tag.Dynamic("forwardedFrom", request.ForwardedFrom),
+			tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
 	}
 
 	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -322,6 +322,15 @@ func (e *matchingEngineImpl) AddDecisionTask(
 			tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
 	}
 
+	if int32(request.GetTaskList().GetKind()) == 0 && request.ForwardedFrom != "" {
+		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope).Tagged(metrics.DomainTag(domainName), metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("forwarded")).IncCounter(metrics.CadenceDecisionTasklistRequests)
+		e.logger.Info("Emitting forwarded tasklist", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
+			tag.Dynamic("taskListCombined", taskListID),
+			tag.Dynamic("taskListBaseName", taskList.baseName),
+			tag.Dynamic("forwardedFrom", request.ForwardedFrom),
+			tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
+	}
+
 	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
 		tag.Dynamic("taskListCombined", taskListID),
 		tag.Dynamic("taskListBaseName", taskList.baseName),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -306,9 +306,8 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	if int32(request.GetTaskList().GetKind()) == 0 && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddTaskScope).Tagged(metrics.DomainTag(domainName),
 			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("decision_task")).IncCounter(metrics.CadenceTasklistRequests)
-		e.logger.Info("Emitting tasklist counter", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
+		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", request.TaskList.Name),
 			tag.Dynamic("taskListBaseName", taskList.baseName),
-			tag.Dynamic("forwardedFrom", request.ForwardedFrom),
 			tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
 	}
 
@@ -377,9 +376,8 @@ func (e *matchingEngineImpl) AddActivityTask(
 	if int32(request.GetTaskList().GetKind()) == 0 && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddTaskScope).Tagged(metrics.DomainTag(domainName),
 			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("activity_task")).IncCounter(metrics.CadenceTasklistRequests)
-		e.logger.Info("Emitting tasklist counter", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
+		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", request.TaskList.Name),
 			tag.Dynamic("taskListBaseName", taskList.baseName),
-			tag.Dynamic("forwardedFrom", request.ForwardedFrom),
 			tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
 	}
 

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -303,12 +303,12 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	}
 
 	// Only emit traffic metrics if the tasklist is not sticky and is not forwarded
-	if (taskListKind != nil && *taskListKind != types.TaskListKindSticky) && request.ForwardedFrom == "" {
+	if taskListKind != nil && *taskListKind != types.TaskListKindSticky && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddTaskScope).Tagged(metrics.DomainTag(domainName),
-			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("decision_task")).IncCounter(metrics.CadenceTasklistRequests)
-		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", request.TaskList.Name),
+			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("activity_task")).IncCounter(metrics.CadenceTasklistRequests)
+		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", taskListName),
 			tag.Dynamic("taskListBaseName", taskList.baseName),
-			tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
+			tag.Dynamic("tasklistType", *taskListKind))
 	}
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)
@@ -373,12 +373,12 @@ func (e *matchingEngineImpl) AddActivityTask(
 	}
 
 	// Only emit traffic metrics if the tasklist is not sticky and is not forwarded
-	if (taskListKind != nil && *taskListKind != types.TaskListKindSticky) && request.ForwardedFrom == "" {
+	if taskListKind != nil && *taskListKind != types.TaskListKindSticky && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddTaskScope).Tagged(metrics.DomainTag(domainName),
 			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("activity_task")).IncCounter(metrics.CadenceTasklistRequests)
-		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", request.TaskList.Name),
+		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", taskListName),
 			tag.Dynamic("taskListBaseName", taskList.baseName),
-			tag.Dynamic("tasklistType", int32(request.GetTaskList().GetKind())))
+			tag.Dynamic("tasklistType", *taskListKind))
 	}
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -1051,7 +1051,7 @@ func (e *matchingEngineImpl) emitInfoOrDebugLog(
 	msg string,
 	tags ...tag.Tag,
 ) {
-	if (e.config.EnableDebugMode && e.config.EnableTaskInfoLogByDomainID(domainID)) || (domainID == "89148aa6-cc7f-4208-83e3-8d14555f15e2") {
+	if e.config.EnableDebugMode && e.config.EnableTaskInfoLogByDomainID(domainID) {
 		e.logger.Info(msg, tags...)
 	} else {
 		e.logger.Debug(msg, tags...)

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -306,14 +306,14 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	}
 	sb.WriteString(domainName)
 	sb.WriteString("+")
-	sb.WriteString(taskList.baseName)
+	sb.WriteString(taskList.name)
 	sb.WriteString("+")
-	sb.WriteString(strconv.Itoa(taskList.partition))
+	sb.WriteString(strconv.Itoa(taskList.qualifiedTaskListName.partition))
 
 	taskListID := sb.String()
 
 	e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceClientRequests)
-	e.emitInfoOrDebugLog(domainID, "taskListID of Cadence Client Requests", tag.Dynamic("taskListID", taskListID))
+	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name))
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)
 	if err != nil {
@@ -1040,7 +1040,7 @@ func (e *matchingEngineImpl) emitInfoOrDebugLog(
 	msg string,
 	tags ...tag.Tag,
 ) {
-	if e.config.EnableDebugMode && e.config.EnableTaskInfoLogByDomainID(domainID) {
+	if (e.config.EnableDebugMode && e.config.EnableTaskInfoLogByDomainID(domainID)) || (domainID == "89148aa6-cc7f-4208-83e3-8d14555f15e2") {
 		e.logger.Info(msg, tags...)
 	} else {
 		e.logger.Debug(msg, tags...)

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -313,7 +313,7 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	taskListID := sb.String()
 
 	// tell if the tasklist is partitioned or sticky
-	if int32(request.GetTaskList().GetKind()) != 1 && &request.ForwardedFrom == nil {
+	if int32(request.GetTaskList().GetKind()) == 0 && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceDecisionTasklistRequests)
 		e.logger.Info("Emitting tasklist counter", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
 			tag.Dynamic("taskListCombined", taskListID),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -302,8 +302,8 @@ func (e *matchingEngineImpl) AddDecisionTask(
 		return false, err
 	}
 
-	// tell if the tasklist is partitioned or sticky
-	if int32(request.GetTaskList().GetKind()) == 0 && request.ForwardedFrom == "" {
+	// Only emit traffic metrics if the tasklist is not sticky and is not forwarded
+	if (taskListKind != nil && *taskListKind != types.TaskListKindSticky) && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddTaskScope).Tagged(metrics.DomainTag(domainName),
 			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("decision_task")).IncCounter(metrics.CadenceTasklistRequests)
 		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", request.TaskList.Name),
@@ -372,8 +372,8 @@ func (e *matchingEngineImpl) AddActivityTask(
 		return false, err
 	}
 
-	// tell if the tasklist is partitioned or sticky
-	if int32(request.GetTaskList().GetKind()) == 0 && request.ForwardedFrom == "" {
+	// Only emit traffic metrics if the tasklist is not sticky and is not forwarded
+	if (taskListKind != nil && *taskListKind != types.TaskListKindSticky) && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddTaskScope).Tagged(metrics.DomainTag(domainName),
 			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("activity_task")).IncCounter(metrics.CadenceTasklistRequests)
 		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", request.TaskList.Name),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -312,7 +312,11 @@ func (e *matchingEngineImpl) AddDecisionTask(
 
 	taskListID := sb.String()
 
-	e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceClientRequests)
+	// tell if the tasklist is partitioned or sticky
+	if int32(request.GetTaskList().GetKind()) != 1 && &request.ForwardedFrom == nil {
+		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceClientRequests)
+	}
+
 	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
 		tag.Dynamic("taskListCombined", taskListID),
 		tag.Dynamic("taskListBaseName", taskList.baseName),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -314,7 +314,7 @@ func (e *matchingEngineImpl) AddDecisionTask(
 
 	// tell if the tasklist is partitioned or sticky
 	if int32(request.GetTaskList().GetKind()) != 1 && &request.ForwardedFrom == nil {
-		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceClientRequests)
+		e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceDecisionTasklistRequests)
 	}
 
 	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -313,7 +313,9 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	taskListID := sb.String()
 
 	e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceClientRequests)
-	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name), tag.Dynamic("taskListCombined", taskListID))
+	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
+		tag.Dynamic("taskListCombined", taskListID),
+		tag.Dynamic("taskListBaseName", taskList.baseName))
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)
 	if err != nil {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -305,7 +305,7 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	// Only emit traffic metrics if the tasklist is not sticky and is not forwarded
 	if taskListKind != nil && *taskListKind != types.TaskListKindSticky && request.ForwardedFrom == "" {
 		e.metricsClient.Scope(metrics.MatchingAddTaskScope).Tagged(metrics.DomainTag(domainName),
-			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("activity_task")).IncCounter(metrics.CadenceTasklistRequests)
+			metrics.TaskListTag(taskListName), metrics.TaskListTypeTag("decision_task")).IncCounter(metrics.CadenceTasklistRequests)
 		e.emitInfoOrDebugLog(domainID, "Emitting tasklist counter on decision task", tag.Dynamic("tasklistName", taskListName),
 			tag.Dynamic("taskListBaseName", taskList.baseName),
 			tag.Dynamic("tasklistType", *taskListKind))

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -315,7 +315,9 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceClientRequests)
 	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name),
 		tag.Dynamic("taskListCombined", taskListID),
-		tag.Dynamic("taskListBaseName", taskList.baseName))
+		tag.Dynamic("taskListBaseName", taskList.baseName),
+		tag.Dynamic("forwardedFrom", request.ForwardedFrom),
+		tag.Dynamic("TaskSource", request.Source.String()))
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)
 	if err != nil {

--- a/service/matching/matchingEngine.go
+++ b/service/matching/matchingEngine.go
@@ -313,7 +313,7 @@ func (e *matchingEngineImpl) AddDecisionTask(
 	taskListID := sb.String()
 
 	e.metricsClient.Scope(metrics.MatchingAddDecisionTaskScope, metrics.TaskListTag(taskListID)).IncCounter(metrics.CadenceClientRequests)
-	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name))
+	e.logger.Info("taskListID of Cadence Client Requests", tag.Dynamic("Domain", domainName), tag.Dynamic("tasklistName", request.TaskList.Name), tag.Dynamic("taskListCombined", taskListID))
 
 	tlMgr, err := e.getTaskListManager(taskList, taskListKind)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a new emit metrics to track the rate of task being added into non-sticky and non-forwarded tasklists.

<!-- Tell your future self why have you made these changes -->
**Why?**
This metric allow us to better monitor tasklist and determine whether we need to partition tasklist if the tasklist becomes too long.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Test both on existing local unit tests and on staging env.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Got blocked due to reaching series limit on emitted data.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
