### PR TITLE
Physical sharding for NoSQL-based persistence (#5187)

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -198,6 +198,8 @@ type (
 		SQL *SQL `yaml:"sql"`
 		// NoSQL contains the config for a NoSQL based datastore
 		NoSQL *NoSQL `yaml:"nosql"`
+		// ShardedNoSQL contains the config for a collection of NoSQL datastores that are used as a single datastore
+		ShardedNoSQL *ShardedNoSQL `yaml:"shardedNosql"`
 		// ElasticSearch contains the config for a ElasticSearch datastore
 		ElasticSearch *ElasticSearchConfig `yaml:"elasticsearch"`
 	}
@@ -237,6 +239,47 @@ type (
 		// Otherwise please add new fields to the struct for better documentation
 		// If being used in any database, update this comment here to make it clear
 		ConnectAttributes map[string]string `yaml:"connectAttributes"`
+	}
+
+	// ShardedNoSQL contains configuration to connect to a set of NoSQL Database clusters in a sharded manner
+	ShardedNoSQL struct {
+		// DefaultShard is the DB shard where the non-sharded tables (ie. cluster metadata) are stored
+		DefaultShard string `yaml:"defaultShard"`
+		// ShardingPolicy is the configuration for the sharding strategy used
+		ShardingPolicy ShardingPolicy `yaml:"shardingPolicy"`
+		// Connections is the collection of NoSQL DB plugins that are used to connect to the shard
+		Connections map[string]DBShardConnection `yaml:"connections"`
+	}
+
+	// ShardingPolicy contains configuration for physical DB sharding
+	ShardingPolicy struct {
+		// HistoryShardMapping defines the ranges of history shards stored by each DB shard. Ranges listed here *MUST*
+		// be continuous and non-overlapping, such that the first range in the list starts from Shard 0, each following
+		// range starts with <prevRange.End> + 1, and the last range ends with <NumHistoryHosts>-1.
+		HistoryShardMapping []HistoryShardRange `yaml:"historyShardMapping"`
+		// TaskListHashing defines the parameters needed for shard ownership calculation based on hashing
+		TaskListHashing TasklistHashing `yaml:"taskListHashing"`
+	}
+
+	// HistoryShardRange contains configuration for one NoSQL DB Shard
+	HistoryShardRange struct {
+		// Start defines the inclusive lower bound for the history shard range
+		Start int `yaml:"start"`
+		// End defines the exclusive upper bound for the history shard range
+		End int `yaml:"end"`
+		// Shard defines the shard that owns this range
+		Shard string `yaml:"shard"`
+	}
+
+	TasklistHashing struct {
+		// ShardOrder defines the order of shards to be used when hashing tasklists to shards
+		ShardOrder []string `yaml:"shardOrder"`
+	}
+
+	// DBShardConnection contains configuration for one NoSQL DB Shard
+	DBShardConnection struct {
+		// NoSQLPlugin is the NoSQL plugin used for connecting to the DB shard
+		NoSQLPlugin *NoSQL `yaml:"nosqlPlugin"`
 	}
 
 	// SQL is the configuration for connecting to a SQL backed datastore
@@ -516,6 +559,23 @@ type (
 		URI string `yaml:"URI"`
 	}
 )
+
+const (
+	// NonShardedStoreName is the shard name used for singular (non-sharded) stores
+	NonShardedStoreName = "NonShardedStore"
+)
+
+func (n *NoSQL) ConvertToShardedNoSQLConfig() *ShardedNoSQL {
+	connections := make(map[string]DBShardConnection)
+	connections[NonShardedStoreName] = DBShardConnection{
+		NoSQLPlugin: n,
+	}
+
+	return &ShardedNoSQL{
+		DefaultShard: NonShardedStoreName,
+		Connections:  connections,
+	}
+}
 
 // ValidateAndFillDefaults validates this config and fills default values if needed
 func (c *Config) ValidateAndFillDefaults() error {

--- a/common/dynamicconfig/configstore/config_store_client_test.go
+++ b/common/dynamicconfig/configstore/config_store_client_test.go
@@ -298,6 +298,17 @@ func (s *configStoreClientSuite) SetupTest() {
 		},
 	}
 
+	connections := make(map[string]config.DBShardConnection)
+	connections[config.NonShardedStoreName] = config.DBShardConnection{
+		NoSQLPlugin: &config.NoSQL{
+			PluginName: "cassandra",
+		},
+	}
+	dbConfig := config.ShardedNoSQL{
+		DefaultShard: config.NonShardedStoreName,
+		Connections:  connections,
+	}
+
 	var err error
 	s.client, err = newConfigStoreClient(
 		&c.ClientConfig{
@@ -306,9 +317,7 @@ func (s *configStoreClientSuite) SetupTest() {
 			FetchTimeout:        time.Second * 1,
 			UpdateTimeout:       time.Second * 1,
 		},
-		&config.NoSQL{
-			PluginName: "cassandra",
-		}, log.NewNoop(), s.doneCh)
+		&dbConfig, log.NewNoop(), s.doneCh)
 	s.Require().NoError(err)
 
 	s.mockManager = p.NewMockConfigStoreManager(s.mockController)

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -427,6 +427,11 @@ func StoreError(storeErr error) Tag {
 	return newErrorTag("store-error", storeErr)
 }
 
+// StoreShard returns tag for StoreShard
+func StoreShard(storeShard string) Tag {
+	return newPredefinedStringTag("store-shard", storeShard)
+}
+
 // ClientError returns tag for ClientError
 func ClientError(clientErr error) Tag {
 	return newErrorTag("client-error", clientErr)

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -411,7 +411,10 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 	defaultDataStore := Datastore{ratelimit: limiters[f.config.DefaultStore]}
 	switch {
 	case defaultCfg.NoSQL != nil:
-		defaultDataStore.factory = nosql.NewFactory(*defaultCfg.NoSQL, clusterName, f.logger, f.dc)
+		shardedNoSQLConfig := defaultCfg.NoSQL.ConvertToShardedNoSQLConfig()
+		defaultDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, f.dc)
+	case defaultCfg.ShardedNoSQL != nil:
+		defaultDataStore.factory = nosql.NewFactory(*defaultCfg.ShardedNoSQL, clusterName, f.logger, f.dc)
 	case defaultCfg.SQL != nil:
 		if defaultCfg.SQL.EncodingType == "" {
 			defaultCfg.SQL.EncodingType = string(common.EncodingTypeThriftRW)
@@ -454,7 +457,8 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 	visibilityDataStore := Datastore{ratelimit: limiters[f.config.VisibilityStore]}
 	switch {
 	case visibilityCfg.NoSQL != nil:
-		visibilityDataStore.factory = nosql.NewFactory(*visibilityCfg.NoSQL, clusterName, f.logger, f.dc)
+		shardedNoSQLConfig := visibilityCfg.NoSQL.ConvertToShardedNoSQLConfig()
+		visibilityDataStore.factory = nosql.NewFactory(*shardedNoSQLConfig, clusterName, f.logger, f.dc)
 	case visibilityCfg.SQL != nil:
 		var decodingTypes []common.EncodingType
 		for _, dt := range visibilityCfg.SQL.DecodingTypes {

--- a/common/persistence/nosql/nosqlConfigStore.go
+++ b/common/persistence/nosql/nosqlConfigStore.go
@@ -37,20 +37,16 @@ type (
 )
 
 func NewNoSQLConfigStore(
-	cfg config.NoSQL,
+	cfg config.ShardedNoSQL,
 	logger log.Logger,
 	dc *persistence.DynamicConfiguration,
 ) (persistence.ConfigStore, error) {
-	db, err := NewNoSQLDB(&cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
 		return nil, err
 	}
-
 	return &nosqlConfigStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
+		nosqlStore: shardedStore.GetDefaultShard(),
 	}, nil
 }
 

--- a/common/persistence/nosql/nosqlDomainStore.go
+++ b/common/persistence/nosql/nosqlDomainStore.go
@@ -42,21 +42,17 @@ type (
 
 // newNoSQLDomainStore is used to create an instance of DomainStore implementation
 func newNoSQLDomainStore(
-	cfg config.NoSQL,
+	cfg config.ShardedNoSQL,
 	currentClusterName string,
 	logger log.Logger,
 	dc *p.DynamicConfiguration,
 ) (p.DomainStore, error) {
-	db, err := NewNoSQLDB(&cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
 		return nil, err
 	}
-
 	return &nosqlDomainStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
+		nosqlStore:         shardedStore.GetDefaultShard(),
 		currentClusterName: currentClusterName,
 	}, nil
 }

--- a/common/persistence/nosql/nosqlHistoryStore.go
+++ b/common/persistence/nosql/nosqlHistoryStore.go
@@ -22,6 +22,7 @@ package nosql
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -35,40 +36,22 @@ import (
 
 type (
 	nosqlHistoryStore struct {
-		nosqlStore
+		shardedNosqlStore
 	}
 )
 
-// NewNoSQLHistoryStoreFromSession returns new HistoryStore
-func NewNoSQLHistoryStoreFromSession(
-	db nosqlplugin.DB,
-	logger log.Logger,
-) p.HistoryStore {
-
-	return &nosqlHistoryStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
-	}
-}
-
 // newNoSQLHistoryStore is used to create an instance of HistoryStore implementation
 func newNoSQLHistoryStore(
-	cfg config.NoSQL,
+	cfg config.ShardedNoSQL,
 	logger log.Logger,
 	dc *p.DynamicConfiguration,
 ) (p.HistoryStore, error) {
-	db, err := NewNoSQLDB(&cfg, logger, dc)
+	s, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
 		return nil, err
 	}
-
 	return &nosqlHistoryStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
+		shardedNosqlStore: *s,
 	}, nil
 }
 
@@ -88,7 +71,6 @@ func (h *nosqlHistoryStore) AppendHistoryNodes(
 		}
 	}
 
-	var err error
 	var treeRow *nosqlplugin.HistoryTreeRow
 	if request.IsNewBranch {
 		var ancestors []*types.HistoryBranchRange
@@ -111,10 +93,16 @@ func (h *nosqlHistoryStore) AppendHistoryNodes(
 		DataEncoding: string(request.Events.Encoding),
 		ShardID:      request.ShardID,
 	}
-	err = h.db.InsertIntoHistoryTreeAndNode(ctx, treeRow, nodeRow)
+
+	storeShard, err := h.GetStoreShardByHistoryShard(request.ShardID)
+	if err != nil {
+		return err
+	}
+
+	err = storeShard.db.InsertIntoHistoryTreeAndNode(ctx, treeRow, nodeRow)
 
 	if err != nil {
-		return convertCommonErrors(h.db, "AppendHistoryNodes", err)
+		return convertCommonErrors(storeShard.db, "AppendHistoryNodes", err)
 	}
 	return nil
 }
@@ -134,9 +122,15 @@ func (h *nosqlHistoryStore) ReadHistoryBranch(
 		NextPageToken: request.NextPageToken,
 		PageSize:      request.PageSize,
 	}
-	rows, pagingToken, err := h.db.SelectFromHistoryNode(ctx, filter)
+
+	storeShard, err := h.GetStoreShardByHistoryShard(request.ShardID)
 	if err != nil {
-		return nil, convertCommonErrors(h.db, "SelectFromHistoryNode", err)
+		return nil, err
+	}
+
+	rows, pagingToken, err := storeShard.db.SelectFromHistoryNode(ctx, filter)
+	if err != nil {
+		return nil, convertCommonErrors(storeShard.db, "SelectFromHistoryNode", err)
 	}
 
 	history := make([]*p.DataBlob, 0, int(request.PageSize))
@@ -297,9 +291,14 @@ func (h *nosqlHistoryStore) ForkHistoryBranch(
 		Info:            request.Info,
 	}
 
-	err := h.db.InsertIntoHistoryTreeAndNode(ctx, treeRow, nil)
+	storeShard, err := h.GetStoreShardByHistoryShard(request.ShardID)
 	if err != nil {
-		return nil, convertCommonErrors(h.db, "ForkHistoryBranch", err)
+		return nil, err
+	}
+
+	err = storeShard.db.InsertIntoHistoryTreeAndNode(ctx, treeRow, nil)
+	if err != nil {
+		return nil, convertCommonErrors(storeShard.db, "ForkHistoryBranch", err)
 	}
 	return resp, nil
 }
@@ -363,9 +362,14 @@ func (h *nosqlHistoryStore) DeleteHistoryBranch(
 		}
 	}
 
-	err = h.db.DeleteFromHistoryTreeAndNode(ctx, treeFilter, nodeFilters)
+	storeShard, err := h.GetStoreShardByHistoryShard(request.ShardID)
 	if err != nil {
-		return convertCommonErrors(h.db, "DeleteHistoryBranch", err)
+		return err
+	}
+
+	err = storeShard.db.DeleteFromHistoryTreeAndNode(ctx, treeFilter, nodeFilters)
+	if err != nil {
+		return convertCommonErrors(storeShard.db, "DeleteHistoryBranch", err)
 	}
 	return nil
 }
@@ -374,9 +378,17 @@ func (h *nosqlHistoryStore) GetAllHistoryTreeBranches(
 	ctx context.Context,
 	request *p.GetAllHistoryTreeBranchesRequest,
 ) (*p.GetAllHistoryTreeBranchesResponse, error) {
-	dbBranches, pagingToken, err := h.db.SelectAllHistoryTrees(ctx, request.NextPageToken, request.PageSize)
+
+	if h.shardingPolicy.hasShardedHistory {
+		return nil, &types.InternalServiceError{
+			Message: fmt.Sprintf("SelectAllHistoryTrees is not supported on sharded nosql db"),
+		}
+	}
+
+	storeShard := h.GetDefaultShard()
+	dbBranches, pagingToken, err := storeShard.db.SelectAllHistoryTrees(ctx, request.NextPageToken, request.PageSize)
 	if err != nil {
-		return nil, convertCommonErrors(h.db, "SelectAllHistoryTrees", err)
+		return nil, convertCommonErrors(storeShard.db, "SelectAllHistoryTrees", err)
 	}
 
 	branchDetails := make([]p.HistoryBranchDetail, 0, int(request.PageSize))
@@ -407,14 +419,17 @@ func (h *nosqlHistoryStore) GetHistoryTree(
 ) (*p.InternalGetHistoryTreeResponse, error) {
 
 	treeID := request.TreeID
-
-	dbBranches, err := h.db.SelectFromHistoryTree(ctx,
+	storeShard, err := h.GetStoreShardByHistoryShard(*request.ShardID)
+	if err != nil {
+		return nil, err
+	}
+	dbBranches, err := storeShard.db.SelectFromHistoryTree(ctx,
 		&nosqlplugin.HistoryTreeFilter{
 			ShardID: *request.ShardID,
 			TreeID:  treeID,
 		})
 	if err != nil {
-		return nil, convertCommonErrors(h.db, "SelectFromHistoryTree", err)
+		return nil, convertCommonErrors(storeShard.db, "SelectFromHistoryTree", err)
 	}
 
 	branches := make([]*types.HistoryBranch, 0)

--- a/common/persistence/nosql/nosqlQueueStore.go
+++ b/common/persistence/nosql/nosqlQueueStore.go
@@ -44,22 +44,18 @@ type (
 )
 
 func newNoSQLQueueStore(
-	cfg config.NoSQL,
+	cfg config.ShardedNoSQL,
 	logger log.Logger,
 	queueType persistence.QueueType,
 	dc *p.DynamicConfiguration,
 ) (persistence.Queue, error) {
-	db, err := NewNoSQLDB(&cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
 		return nil, err
 	}
-
 	queue := &nosqlQueueStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
-		queueType: queueType,
+		nosqlStore: shardedStore.GetDefaultShard(),
+		queueType:  queueType,
 	}
 	if err := queue.createQueueMetadataEntryIfNotExist(); err != nil {
 		return nil, fmt.Errorf("failed to check and create queue metadata entry: %v", err)

--- a/common/persistence/nosql/nosqlShardStore.go
+++ b/common/persistence/nosql/nosqlShardStore.go
@@ -35,7 +35,7 @@ import (
 type (
 	// Implements ShardStore
 	nosqlShardStore struct {
-		nosqlStore
+		shardedNosqlStore
 		currentClusterName string
 	}
 )
@@ -44,47 +44,30 @@ var _ p.ShardStore = (*nosqlShardStore)(nil)
 
 // newNoSQLShardStore is used to create an instance of ShardStore implementation
 func newNoSQLShardStore(
-	cfg config.NoSQL,
+	cfg config.ShardedNoSQL,
 	clusterName string,
 	logger log.Logger,
 	dc *p.DynamicConfiguration,
 ) (p.ShardStore, error) {
-	db, err := NewNoSQLDB(&cfg, logger, dc)
+	s, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
 		return nil, err
 	}
-
 	return &nosqlShardStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
+		shardedNosqlStore:  *s,
 		currentClusterName: clusterName,
 	}, nil
-}
-
-// NewNoSQLShardStoreFromSession is used to create an instance of ShardStore implementation
-// It is being used by some admin toolings
-func NewNoSQLShardStoreFromSession(
-	db nosqlplugin.DB,
-	clusterName string,
-	logger log.Logger,
-) p.ShardStore {
-	return &nosqlShardStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
-		currentClusterName: clusterName,
-	}
 }
 
 func (sh *nosqlShardStore) CreateShard(
 	ctx context.Context,
 	request *p.InternalCreateShardRequest,
 ) error {
-
-	err := sh.db.InsertShard(ctx, request.ShardInfo)
+	storeShard, err := sh.GetStoreShardByHistoryShard(request.ShardInfo.ShardID)
+	if err != nil {
+		return err
+	}
+	err = storeShard.db.InsertShard(ctx, request.ShardInfo)
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
 		if ok {
@@ -93,7 +76,7 @@ func (sh *nosqlShardStore) CreateShard(
 					request.ShardInfo.ShardID, request.ShardInfo.RangeID, conditionFailure.RangeID, conditionFailure.Details),
 			}
 		}
-		return convertCommonErrors(sh.db, "CreateShard", err)
+		return convertCommonErrors(storeShard.db, "CreateShard", err)
 	}
 
 	return nil
@@ -104,16 +87,20 @@ func (sh *nosqlShardStore) GetShard(
 	request *p.InternalGetShardRequest,
 ) (*p.InternalGetShardResponse, error) {
 	shardID := request.ShardID
-	rangeID, shardInfo, err := sh.db.SelectShard(ctx, shardID, sh.currentClusterName)
+	storeShard, err := sh.GetStoreShardByHistoryShard(shardID)
+	if err != nil {
+		return nil, err
+	}
+	rangeID, shardInfo, err := storeShard.db.SelectShard(ctx, shardID, sh.currentClusterName)
 
 	if err != nil {
-		if sh.db.IsNotFoundError(err) {
+		if storeShard.db.IsNotFoundError(err) {
 			return nil, &types.EntityNotExistsError{
 				Message: fmt.Sprintf("Shard not found.  ShardId: %v", shardID),
 			}
 		}
 
-		return nil, convertCommonErrors(sh.db, "GetShard", err)
+		return nil, convertCommonErrors(storeShard.db, "GetShard", err)
 	}
 
 	shardInfoRangeID := shardInfo.RangeID
@@ -150,8 +137,11 @@ func (sh *nosqlShardStore) updateRangeID(
 	rangeID int64,
 	previousRangeID int64,
 ) error {
-
-	err := sh.db.UpdateRangeID(ctx, shardID, rangeID, previousRangeID)
+	storeShard, err := sh.GetStoreShardByHistoryShard(shardID)
+	if err != nil {
+		return err
+	}
+	err = storeShard.db.UpdateRangeID(ctx, shardID, rangeID, previousRangeID)
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
 		if ok {
@@ -161,7 +151,7 @@ func (sh *nosqlShardStore) updateRangeID(
 					previousRangeID, conditionFailure.RangeID, conditionFailure.Details),
 			}
 		}
-		return convertCommonErrors(sh.db, "UpdateRangeID", err)
+		return convertCommonErrors(storeShard.db, "UpdateRangeID", err)
 	}
 
 	return nil
@@ -171,7 +161,11 @@ func (sh *nosqlShardStore) UpdateShard(
 	ctx context.Context,
 	request *p.InternalUpdateShardRequest,
 ) error {
-	err := sh.db.UpdateShard(ctx, request.ShardInfo, request.PreviousRangeID)
+	storeShard, err := sh.GetStoreShardByHistoryShard(request.ShardInfo.ShardID)
+	if err != nil {
+		return err
+	}
+	err = storeShard.db.UpdateShard(ctx, request.ShardInfo, request.PreviousRangeID)
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
 		if ok {
@@ -181,7 +175,7 @@ func (sh *nosqlShardStore) UpdateShard(
 					request.PreviousRangeID, conditionFailure.RangeID, conditionFailure.Details),
 			}
 		}
-		return convertCommonErrors(sh.db, "UpdateShard", err)
+		return convertCommonErrors(storeShard.db, "UpdateShard", err)
 	}
 
 	return nil

--- a/common/persistence/nosql/nosqlTaskStore.go
+++ b/common/persistence/nosql/nosqlTaskStore.go
@@ -37,7 +37,7 @@ import (
 
 type (
 	nosqlTaskStore struct {
-		nosqlStore
+		shardedNosqlStore
 	}
 )
 
@@ -51,20 +51,16 @@ var _ p.TaskStore = (*nosqlTaskStore)(nil)
 
 // newNoSQLTaskStore is used to create an instance of TaskStore implementation
 func newNoSQLTaskStore(
-	cfg config.NoSQL,
+	cfg config.ShardedNoSQL,
 	logger log.Logger,
 	dc *p.DynamicConfiguration,
 ) (p.TaskStore, error) {
-	db, err := NewNoSQLDB(&cfg, logger, dc)
+	s, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
 		return nil, err
 	}
-
 	return &nosqlTaskStore{
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
+		shardedNosqlStore: *s,
 	}, nil
 }
 
@@ -87,14 +83,19 @@ func (t *nosqlTaskStore) LeaseTaskList(
 	now := time.Now()
 	var err, selectErr error
 	var currTL *nosqlplugin.TaskListRow
-	currTL, selectErr = t.db.SelectTaskList(ctx, &nosqlplugin.TaskListFilter{
+	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskList, request.TaskType)
+	if err != nil {
+		return nil, err
+	}
+
+	currTL, selectErr = storeShard.db.SelectTaskList(ctx, &nosqlplugin.TaskListFilter{
 		DomainID:     request.DomainID,
 		TaskListName: request.TaskList,
 		TaskListType: request.TaskType,
 	})
 
 	if selectErr != nil {
-		if t.db.IsNotFoundError(selectErr) { // First time task list is used
+		if storeShard.db.IsNotFoundError(selectErr) { // First time task list is used
 			currTL = &nosqlplugin.TaskListRow{
 				DomainID:        request.DomainID,
 				TaskListName:    request.TaskList,
@@ -104,9 +105,9 @@ func (t *nosqlTaskStore) LeaseTaskList(
 				AckLevel:        initialAckLevel,
 				LastUpdatedTime: now,
 			}
-			err = t.db.InsertTaskList(ctx, currTL)
+			err = storeShard.db.InsertTaskList(ctx, currTL)
 		} else {
-			return nil, convertCommonErrors(t.db, "LeaseTaskList", err)
+			return nil, convertCommonErrors(storeShard.db, "LeaseTaskList", err)
 		}
 	} else {
 		// if request.RangeID is > 0, we are trying to renew an already existing
@@ -122,7 +123,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 		// Update the rangeID as this is an ownership change
 		currTL.RangeID++
 
-		err = t.db.UpdateTaskList(ctx, &nosqlplugin.TaskListRow{
+		err = storeShard.db.UpdateTaskList(ctx, &nosqlplugin.TaskListRow{
 			DomainID:        request.DomainID,
 			TaskListName:    request.TaskList,
 			TaskListType:    request.TaskType,
@@ -140,7 +141,7 @@ func (t *nosqlTaskStore) LeaseTaskList(
 					request.TaskList, request.TaskType, currTL.RangeID, conditionFailure.RangeID),
 			}
 		}
-		return nil, convertCommonErrors(t.db, "LeaseTaskList", err)
+		return nil, convertCommonErrors(storeShard.db, "LeaseTaskList", err)
 	}
 	tli := &p.TaskListInfo{
 		DomainID:    request.DomainID,
@@ -169,11 +170,15 @@ func (t *nosqlTaskStore) UpdateTaskList(
 		AckLevel:        tli.AckLevel,
 		LastUpdatedTime: time.Now(),
 	}
+	storeShard, err := t.GetStoreShardByTaskList(tli.DomainID, tli.Name, tli.TaskType)
+	if err != nil {
+		return nil, err
+	}
 
 	if tli.Kind == p.TaskListKindSticky { // if task_list is sticky, then update with TTL
-		err = t.db.UpdateTaskListWithTTL(ctx, stickyTaskListTTL, taskListToUpdate, tli.RangeID)
+		err = storeShard.db.UpdateTaskListWithTTL(ctx, stickyTaskListTTL, taskListToUpdate, tli.RangeID)
 	} else {
-		err = t.db.UpdateTaskList(ctx, taskListToUpdate, tli.RangeID)
+		err = storeShard.db.UpdateTaskList(ctx, taskListToUpdate, tli.RangeID)
 	}
 
 	if err != nil {
@@ -184,7 +189,7 @@ func (t *nosqlTaskStore) UpdateTaskList(
 					tli.Name, tli.TaskType, tli.RangeID, conditionFailure.Details),
 			}
 		}
-		return nil, convertCommonErrors(t.db, "UpdateTaskList", err)
+		return nil, convertCommonErrors(storeShard.db, "UpdateTaskList", err)
 	}
 
 	return &p.UpdateTaskListResponse{}, nil
@@ -203,7 +208,12 @@ func (t *nosqlTaskStore) DeleteTaskList(
 	ctx context.Context,
 	request *p.DeleteTaskListRequest,
 ) error {
-	err := t.db.DeleteTaskList(ctx, &nosqlplugin.TaskListFilter{
+	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskListName, request.TaskListType)
+	if err != nil {
+		return err
+	}
+
+	err = storeShard.db.DeleteTaskList(ctx, &nosqlplugin.TaskListFilter{
 		DomainID:     request.DomainID,
 		TaskListName: request.TaskListName,
 		TaskListType: request.TaskListType,
@@ -217,7 +227,7 @@ func (t *nosqlTaskStore) DeleteTaskList(
 					request.TaskListName, request.TaskListType, request.RangeID, conditionFailure.Details),
 			}
 		}
-		return convertCommonErrors(t.db, "DeleteTaskList", err)
+		return convertCommonErrors(storeShard.db, "DeleteTaskList", err)
 	}
 
 	return nil
@@ -253,7 +263,14 @@ func (t *nosqlTaskStore) CreateTasks(
 		TaskListType: request.TaskListInfo.TaskType,
 		RangeID:      request.TaskListInfo.RangeID,
 	}
-	err := t.db.InsertTasks(ctx, tasks, tasklistCondition)
+
+	tli := request.TaskListInfo
+	storeShard, err := t.GetStoreShardByTaskList(tli.DomainID, tli.Name, tli.TaskType)
+	if err != nil {
+		return nil, err
+	}
+
+	err = storeShard.db.InsertTasks(ctx, tasks, tasklistCondition)
 
 	if err != nil {
 		conditionFailure, ok := err.(*nosqlplugin.TaskOperationConditionFailure)
@@ -263,7 +280,7 @@ func (t *nosqlTaskStore) CreateTasks(
 					request.TaskListInfo.Name, request.TaskListInfo.TaskType, request.TaskListInfo.RangeID, conditionFailure.Details),
 			}
 		}
-		return nil, convertCommonErrors(t.db, "CreateTasks", err)
+		return nil, convertCommonErrors(storeShard.db, "CreateTasks", err)
 	}
 
 	return &p.CreateTasksResponse{}, nil
@@ -281,7 +298,12 @@ func (t *nosqlTaskStore) GetTasks(
 		return &p.InternalGetTasksResponse{}, nil
 	}
 
-	resp, err := t.db.SelectTasks(ctx, &nosqlplugin.TasksFilter{
+	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskList, request.TaskType)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := storeShard.db.SelectTasks(ctx, &nosqlplugin.TasksFilter{
 		TaskListFilter: nosqlplugin.TaskListFilter{
 			DomainID:     request.DomainID,
 			TaskListName: request.TaskList,
@@ -294,7 +316,7 @@ func (t *nosqlTaskStore) GetTasks(
 	})
 
 	if err != nil {
-		return nil, convertCommonErrors(t.db, "GetTasks", err)
+		return nil, convertCommonErrors(storeShard.db, "GetTasks", err)
 	}
 
 	response := &p.InternalGetTasksResponse{}
@@ -321,7 +343,12 @@ func (t *nosqlTaskStore) CompleteTask(
 	request *p.CompleteTaskRequest,
 ) error {
 	tli := request.TaskList
-	_, err := t.db.RangeDeleteTasks(ctx, &nosqlplugin.TasksFilter{
+	storeShard, err := t.GetStoreShardByTaskList(tli.DomainID, tli.Name, tli.TaskType)
+	if err != nil {
+		return err
+	}
+
+	_, err = storeShard.db.RangeDeleteTasks(ctx, &nosqlplugin.TasksFilter{
 		TaskListFilter: nosqlplugin.TaskListFilter{
 			DomainID:     tli.DomainID,
 			TaskListName: tli.Name,
@@ -334,7 +361,7 @@ func (t *nosqlTaskStore) CompleteTask(
 		BatchSize: 1,
 	})
 	if err != nil {
-		return convertCommonErrors(t.db, "CompleteTask", err)
+		return convertCommonErrors(storeShard.db, "CompleteTask", err)
 	}
 
 	return nil
@@ -347,7 +374,12 @@ func (t *nosqlTaskStore) CompleteTasksLessThan(
 	ctx context.Context,
 	request *p.CompleteTasksLessThanRequest,
 ) (*p.CompleteTasksLessThanResponse, error) {
-	num, err := t.db.RangeDeleteTasks(ctx, &nosqlplugin.TasksFilter{
+	storeShard, err := t.GetStoreShardByTaskList(request.DomainID, request.TaskListName, request.TaskType)
+	if err != nil {
+		return nil, err
+	}
+
+	num, err := storeShard.db.RangeDeleteTasks(ctx, &nosqlplugin.TasksFilter{
 		TaskListFilter: nosqlplugin.TaskListFilter{
 			DomainID:     request.DomainID,
 			TaskListName: request.TaskListName,
@@ -365,7 +397,7 @@ func (t *nosqlTaskStore) CompleteTasksLessThan(
 		BatchSize: request.Limit,
 	})
 	if err != nil {
-		return nil, convertCommonErrors(t.db, "CompleteTasksLessThan", err)
+		return nil, convertCommonErrors(storeShard.db, "CompleteTasksLessThan", err)
 	}
 	return &p.CompleteTasksLessThanResponse{TasksCompleted: num}, nil
 }

--- a/common/persistence/nosql/nosqlVisibilityStore.go
+++ b/common/persistence/nosql/nosqlVisibilityStore.go
@@ -48,21 +48,17 @@ type (
 // newNoSQLVisibilityStore is used to create an instance of VisibilityStore implementation
 func newNoSQLVisibilityStore(
 	listClosedOrderingByCloseTime bool,
-	cfg config.NoSQL,
+	cfg config.ShardedNoSQL,
 	logger log.Logger,
 	dc *p.DynamicConfiguration,
 ) (p.VisibilityStore, error) {
-	db, err := NewNoSQLDB(&cfg, logger, dc)
+	shardedStore, err := newShardedNosqlStore(cfg, logger, dc)
 	if err != nil {
 		return nil, err
 	}
-
 	return &nosqlVisibilityStore{
 		sortByCloseTime: listClosedOrderingByCloseTime,
-		nosqlStore: nosqlStore{
-			db:     db,
-			logger: logger,
-		},
+		nosqlStore:      shardedStore.GetDefaultShard(),
 	}, nil
 }
 

--- a/common/persistence/nosql/shardedNosqlStore.go
+++ b/common/persistence/nosql/shardedNosqlStore.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package nosql
+
+import (
+	"fmt"
+	"sync"
+
+	p "github.com/uber/cadence/common/persistence"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+)
+
+type (
+	// shardedNosqlStore is a store that may have one or more shards
+	shardedNosqlStore struct {
+		sync.RWMutex
+
+		config config.ShardedNoSQL
+		dc     *p.DynamicConfiguration
+		logger log.Logger
+
+		connectedShards map[string]nosqlStore
+		defaultShard    nosqlStore
+		shardingPolicy  shardingPolicy
+	}
+)
+
+func newShardedNosqlStore(cfg config.ShardedNoSQL, logger log.Logger, dc *p.DynamicConfiguration) (*shardedNosqlStore, error) {
+	sn := shardedNosqlStore{
+		config: cfg,
+		dc:     dc,
+		logger: logger,
+	}
+
+	// Connect to the default shard
+	defaultShardName := cfg.DefaultShard
+	store, err := sn.connectToShard(defaultShardName)
+	if err != nil {
+		return nil, err
+	}
+	sn.defaultShard = *store
+	sn.connectedShards = map[string]nosqlStore{
+		defaultShardName: sn.defaultShard,
+	}
+
+	// Parse & validate the sharding policy
+	sn.shardingPolicy, err = newShardingPolicy(logger, cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sn, nil
+}
+
+func (sn *shardedNosqlStore) GetStoreShardByHistoryShard(shardID int) (*nosqlStore, error) {
+	shardName, err := sn.shardingPolicy.getHistoryShardName(shardID)
+	if err != nil {
+		return nil, err
+	}
+	return sn.getShard(shardName)
+}
+
+func (sn *shardedNosqlStore) GetStoreShardByTaskList(domainID string, taskListName string, taskType int) (*nosqlStore, error) {
+	shardName := sn.shardingPolicy.getTaskListShardName(domainID, taskListName, taskType)
+	return sn.getShard(shardName)
+}
+
+func (sn *shardedNosqlStore) GetDefaultShard() nosqlStore {
+	return sn.defaultShard
+}
+
+func (sn *shardedNosqlStore) Close() {
+	for name, shard := range sn.connectedShards {
+		sn.logger.Warn("Closing store shard", tag.StoreShard(name))
+		shard.Close()
+	}
+}
+
+func (sn *shardedNosqlStore) GetName() string {
+	return "shardedNosql"
+}
+
+func (sn *shardedNosqlStore) getShard(shardName string) (*nosqlStore, error) {
+	sn.RLock()
+	shard, found := sn.connectedShards[shardName]
+	sn.RUnlock()
+
+	if found {
+		return &shard, nil
+	}
+
+	_, ok := sn.config.Connections[shardName]
+	if !ok {
+		return nil, &ShardingError{
+			Message: fmt.Sprintf("Unknown db shard name: %v", shardName),
+		}
+	}
+
+	sn.Lock()
+	if shard, ok := sn.connectedShards[shardName]; ok { // read again to double-check
+		sn.Unlock()
+		return &shard, nil
+	}
+
+	s, err := sn.connectToShard(shardName)
+	if err != nil {
+		return nil, err
+	}
+	sn.connectedShards[shardName] = *s
+	sn.logger.Info("Connected to store shard", tag.StoreShard(shardName))
+	sn.Unlock()
+	return s, nil
+}
+
+func (sn *shardedNosqlStore) connectToShard(shardName string) (*nosqlStore, error) {
+	cfg, ok := sn.config.Connections[shardName]
+	if !ok {
+		return nil, &ShardingError{
+			Message: fmt.Sprintf("Unknown db shard name: %v", shardName),
+		}
+	}
+
+	sn.logger.Info("Connecting to store shard", tag.StoreShard(shardName))
+	db, err := NewNoSQLDB(cfg.NoSQLPlugin, sn.logger, sn.dc)
+	if err != nil {
+		sn.logger.Error("Failed to connect to store shard", tag.StoreShard(shardName), tag.Error(err))
+		return nil, err
+	}
+	shard := nosqlStore{
+		db:     db,
+		logger: sn.logger,
+	}
+	return &shard, nil
+}

--- a/common/persistence/nosql/shardedNosqlStore_test.go
+++ b/common/persistence/nosql/shardedNosqlStore_test.go
@@ -1,0 +1,245 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package nosql
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	. "github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
+)
+
+type shardedNosqlStoreTestSuite struct {
+	suite.Suite
+	*require.Assertions
+	mockController *gomock.Controller
+
+	mockPlugin *nosqlplugin.MockPlugin
+}
+
+func (s *shardedNosqlStoreTestSuite) SetupSuite() {
+	s.mockController = gomock.NewController(s.T())
+}
+
+func (s *shardedNosqlStoreTestSuite) TearDownSuite() {
+}
+
+func (s *shardedNosqlStoreTestSuite) SetupTest() {
+	s.Assertions = require.New(s.T())
+
+	mockDB := nosqlplugin.NewMockDB(s.mockController)
+
+	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
+	mockPlugin.EXPECT().
+		CreateDB(gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(mockDB, nil).AnyTimes()
+	delete(supportedPlugins, "cassandra")
+	RegisterPlugin("cassandra", mockPlugin)
+}
+
+func TestShardedNosqlStoreTestSuite(t *testing.T) {
+	s := new(shardedNosqlStoreTestSuite)
+	suite.Run(t, s)
+}
+
+func (s *shardedNosqlStoreTestSuite) TestValidConfiguration() {
+	cfg := getValidShardedNoSQLConfig()
+
+	store, err := newShardedNosqlStore(cfg, log.NewNoop(), nil)
+	s.NoError(err)
+	s.Equal(1, len(store.connectedShards))
+	s.Contains(store.connectedShards, "shard-1")
+	s.Equal(store.GetDefaultShard(), store.defaultShard)
+	s.Equal(store.connectedShards["shard-1"], store.defaultShard)
+	s.Equal("shard-1", store.shardingPolicy.defaultShard)
+	s.True(store.shardingPolicy.hasShardedTasklist)
+	s.True(store.shardingPolicy.hasShardedHistory)
+}
+
+func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForHistoryShard() {
+	mockDB1 := nosqlplugin.NewMockDB(s.mockController)
+	mockDB2 := nosqlplugin.NewMockDB(s.mockController)
+
+	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
+	gomock.InOrder(
+		mockPlugin.EXPECT().
+			CreateDB(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(mockDB1, nil),
+		mockPlugin.EXPECT().
+			CreateDB(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(mockDB2, nil),
+	)
+	delete(supportedPlugins, "cassandra")
+	RegisterPlugin("cassandra", mockPlugin)
+
+	cfg := getValidShardedNoSQLConfig()
+
+	store, err := newShardedNosqlStore(cfg, log.NewNoop(), nil)
+	s.NoError(err)
+	s.Equal(1, len(store.connectedShards))
+	s.True(mockDB1 == store.defaultShard.db)
+
+	// Shard 0 is same default shard in this test, so connectedShards shouldn't change
+	storeShard1, err := store.GetStoreShardByHistoryShard(0)
+	s.NoError(err)
+	s.Equal(1, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+
+	// Getting the same shard again shouldn't create a new connection
+	storeShard1, err = store.GetStoreShardByHistoryShard(0)
+	s.NoError(err)
+	s.Equal(1, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+
+	// Getting a new shard should create a new connection
+	storeShard2, err := store.GetStoreShardByHistoryShard(1)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB2 == storeShard2.db)
+
+	// After the new connection, getting the previous shard should still work as it used to
+	storeShard1, err = store.GetStoreShardByHistoryShard(0)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+
+	// Getting a non-existing shard should result in an error
+	unknownShard, err := store.GetStoreShardByHistoryShard(2)
+	s.ErrorContains(err, "Failed to identify store shard")
+	s.Empty(unknownShard)
+
+	// Ensure the store shard connections created for history shards are available for tasklists, too
+	storeShard1, err = store.GetStoreShardByTaskList("domain1", "tl1", 0)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+	storeShard2, err = store.GetStoreShardByTaskList("domain1", "tl2", 0)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB2 == storeShard2.db)
+}
+
+func (s *shardedNosqlStoreTestSuite) TestStoreSelectionForTasklist() {
+	mockDB1 := nosqlplugin.NewMockDB(s.mockController)
+	mockDB2 := nosqlplugin.NewMockDB(s.mockController)
+
+	mockPlugin := nosqlplugin.NewMockPlugin(s.mockController)
+	gomock.InOrder(
+		mockPlugin.EXPECT().
+			CreateDB(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(mockDB1, nil),
+		mockPlugin.EXPECT().
+			CreateDB(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(mockDB2, nil),
+	)
+	delete(supportedPlugins, "cassandra")
+	RegisterPlugin("cassandra", mockPlugin)
+
+	cfg := getValidShardedNoSQLConfig()
+
+	store, err := newShardedNosqlStore(cfg, log.NewNoop(), nil)
+	s.NoError(err)
+	s.Equal(1, len(store.connectedShards))
+	s.True(mockDB1 == store.defaultShard.db)
+
+	// Shard 0 is same default shard in this test, so connectedShards shouldn't change
+	storeShard1, err := store.GetStoreShardByTaskList("domain1", "tl1", 0)
+	s.NoError(err)
+	s.Equal(1, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+
+	// Getting the same shard again shouldn't create a new connection
+	storeShard1, err = store.GetStoreShardByTaskList("domain1", "tl1", 0)
+	s.NoError(err)
+	s.Equal(1, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+
+	// Getting a new shard should create a new connection
+	storeShard2, err := store.GetStoreShardByTaskList("domain1", "tl2", 0)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB2 == storeShard2.db)
+
+	// After the new connection, getting the previous shard should still work as it used to
+	storeShard1, err = store.GetStoreShardByTaskList("domain1", "tl1", 0)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+
+	// Ensure the store shard connections created for tasklists are available for tasklists, too
+	storeShard1, err = store.GetStoreShardByHistoryShard(0)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB1 == storeShard1.db)
+	storeShard2, err = store.GetStoreShardByHistoryShard(1)
+	s.NoError(err)
+	s.Equal(2, len(store.connectedShards))
+	s.True(mockDB2 == storeShard2.db)
+}
+
+func getValidShardedNoSQLConfig() ShardedNoSQL {
+	return ShardedNoSQL{
+		DefaultShard: "shard-1",
+		ShardingPolicy: ShardingPolicy{
+			HistoryShardMapping: []HistoryShardRange{
+				HistoryShardRange{
+					Start: 0,
+					End:   1,
+					Shard: "shard-1",
+				},
+				HistoryShardRange{
+					Start: 1,
+					End:   2,
+					Shard: "shard-2",
+				},
+			},
+			TaskListHashing: TasklistHashing{
+				ShardOrder: []string{
+					"shard-1",
+					"shard-2",
+				},
+			},
+		},
+		Connections: map[string]DBShardConnection{
+			"shard-1": {
+				NoSQLPlugin: &NoSQL{
+					PluginName: "cassandra",
+					Hosts:      "127.0.0.1",
+					Keyspace:   "unit-test",
+					Port:       1234,
+				},
+			},
+			"shard-2": {
+				NoSQLPlugin: &NoSQL{
+					PluginName: "cassandra",
+					Hosts:      "127.0.0.1",
+					Keyspace:   "unit-test",
+					Port:       5678,
+				},
+			},
+		},
+	}
+}

--- a/common/persistence/nosql/shardingPolicy.go
+++ b/common/persistence/nosql/shardingPolicy.go
@@ -1,0 +1,113 @@
+// Copyright (c) 2022 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package nosql
+
+import (
+	"fmt"
+
+	"github.com/uber/cadence/common/log/tag"
+
+	"github.com/dgryski/go-farm"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+)
+
+type (
+	// shardingPolicy holds the configuration for the sharding logic
+	shardingPolicy struct {
+		logger       log.Logger
+		defaultShard string
+		config       config.ShardedNoSQL
+
+		hasShardedHistory  bool
+		hasShardedTasklist bool
+	}
+)
+
+func newShardingPolicy(logger log.Logger, cfg config.ShardedNoSQL) (shardingPolicy, error) {
+	sp := shardingPolicy{
+		logger:       logger,
+		defaultShard: cfg.DefaultShard,
+		config:       cfg,
+	}
+
+	err := sp.parse()
+	if err != nil {
+		return sp, err
+	}
+
+	return sp, nil
+}
+
+func (sp *shardingPolicy) parse() error {
+	sp.parseHistoryShardMapping()
+	sp.parseTaskListShardingPolicy()
+	return nil
+}
+
+func (sp *shardingPolicy) parseHistoryShardMapping() {
+	historyShardMapping := sp.config.ShardingPolicy.HistoryShardMapping
+	if len(historyShardMapping) == 0 {
+		return
+	}
+	sp.hasShardedHistory = true
+}
+
+func (sp *shardingPolicy) parseTaskListShardingPolicy() {
+	tlShards := sp.config.ShardingPolicy.TaskListHashing.ShardOrder
+	if len(tlShards) == 0 {
+		return
+	}
+	sp.hasShardedTasklist = true
+}
+
+func (sp *shardingPolicy) getHistoryShardName(shardID int) (string, error) {
+	if !sp.hasShardedHistory {
+		sp.logger.Debug("Selected default store shard for history shard", tag.StoreShard(sp.defaultShard), tag.ShardID(shardID))
+		return sp.defaultShard, nil
+	}
+
+	for _, r := range sp.config.ShardingPolicy.HistoryShardMapping {
+		if shardID >= r.Start && shardID < r.End {
+			sp.logger.Debug("Selected store shard history shard", tag.StoreShard(r.Shard), tag.ShardID(shardID))
+			return r.Shard, nil
+		}
+	}
+
+	return "", &ShardingError{
+		Message: fmt.Sprintf("Failed to identify store shard for shardID %v", shardID),
+	}
+}
+
+func (sp *shardingPolicy) getTaskListShardName(domainID string, taskListName string, taskType int) string {
+	if !sp.hasShardedTasklist {
+		sp.logger.Debug("Selected default store shard for tasklist", tag.StoreShard(sp.defaultShard), tag.WorkflowTaskListName(taskListName))
+		return sp.defaultShard
+	}
+	tlShards := sp.config.ShardingPolicy.TaskListHashing.ShardOrder
+	tlShardCount := len(tlShards)
+	hash := farm.Hash32([]byte(domainID+"_"+taskListName)) % uint32(tlShardCount)
+	shardIndex := int(hash) % tlShardCount
+
+	sp.logger.Debug("Selected store shard tasklist", tag.StoreShard(tlShards[shardIndex]), tag.WorkflowTaskListName(taskListName))
+	return tlShards[shardIndex]
+}

--- a/common/persistence/nosql/shardingPolicy_test.go
+++ b/common/persistence/nosql/shardingPolicy_test.go
@@ -1,0 +1,191 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package nosql
+
+import (
+	"testing"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/require"
+
+	. "github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/log"
+)
+
+func TestSimplePolicyWithSharding(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+	require.True(t, sp.hasShardedHistory, "sp.hasShardedHistory must be true")
+	require.True(t, sp.hasShardedTasklist, "sp.hasShardedTasklist must be true")
+}
+
+func TestSimplePolicyWithoutSharding(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	cfg.ShardingPolicy = ShardingPolicy{} // remove the sharding policy
+
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+	require.False(t, sp.hasShardedHistory, "sp.hasShardedHistory must be false")
+	require.False(t, sp.hasShardedTasklist, "sp.hasShardedTasklist must be false")
+}
+
+func TestSimplePolicyWithoutHistorySharding(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	cfg.ShardingPolicy.HistoryShardMapping = []HistoryShardRange{} // remove only the history sharding
+
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+	require.False(t, sp.hasShardedHistory, "sp.hasShardedHistory must be false")
+	require.True(t, sp.hasShardedTasklist, "sp.hasShardedTasklist must be true")
+}
+
+func TestSimplePolicyWithoutTasklistSharding(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	cfg.ShardingPolicy.TaskListHashing = TasklistHashing{} // remove only the tasklist sharding
+
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+	require.True(t, sp.hasShardedHistory, "sp.hasShardedHistory must be false")
+	require.False(t, sp.hasShardedTasklist, "sp.hasShardedTasklist must be true")
+}
+
+func TestHistorySharding(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+
+	shardName0, err1 := sp.getHistoryShardName(0)
+	shardName1, err2 := sp.getHistoryShardName(1)
+
+	require.Nil(t, err1)
+	require.Nil(t, err2)
+	require.Equal(t, "shard-1", shardName0, "shard name must be correct for shard 0")
+	require.Equal(t, "shard-2", shardName1, "shard name must be correct for shard 1")
+}
+
+func TestHistorySharding_UnexpectedGapInHistoryRanges(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	cfg.ShardingPolicy.HistoryShardMapping = []HistoryShardRange{
+		HistoryShardRange{
+			Start: 0,
+			End:   1,
+			Shard: "shard-1",
+		},
+		HistoryShardRange{
+			Start: 2,
+			End:   3,
+			Shard: "shard-2",
+		},
+	}
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+
+	shardName0, err1 := sp.getHistoryShardName(0)
+	shardName2, err2 := sp.getHistoryShardName(2)
+
+	require.Nil(t, err1)
+	require.Nil(t, err2)
+	require.Equal(t, "shard-1", shardName0, "shard name must be correct for shard 0")
+	require.Equal(t, "shard-2", shardName2, "shard name must be correct for shard 2")
+
+	unknownShard, err := sp.getHistoryShardName(1)
+	require.ErrorContains(t, err, "Failed to identify store shard")
+	require.Empty(t, unknownShard)
+}
+
+func TestHistorySharding_OutOfBounds(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+
+	unknownShard, err := sp.getHistoryShardName(-1)
+	require.ErrorContains(t, err, "Failed to identify store shard")
+	require.Empty(t, unknownShard)
+
+	unknownShard, err = sp.getHistoryShardName(2)
+	require.ErrorContains(t, err, "Failed to identify store shard")
+	require.Empty(t, unknownShard)
+}
+
+func TestTaskListSharding_Simple(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+
+	// Note that shardName0 and shardName1 can't really be predicted due to hashing inside the function. The values
+	// below were picked manually to yield the outcome needed. The test is useful to ensure the logic is deterministic.
+	shardName1 := sp.getTaskListShardName("domain1", "tl1", 0)
+	shardName2 := sp.getTaskListShardName("domain1", "tl2", 0)
+
+	require.Equal(t, "shard-1", shardName1, "shard name must be correct for tl1")
+	require.Equal(t, "shard-2", shardName2, "shard name must be correct for tl2")
+}
+
+func TestTaskListSharding_SingleShard(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	cfg.ShardingPolicy.TaskListHashing.ShardOrder = []string{"only-shard"}
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+	require.True(t, sp.hasShardedTasklist, "sp.hasShardedTasklist must be true")
+
+	countExpected := 0
+	countUnexpected := 0
+
+	for i := 0; i < 1000000; i++ {
+		s := sp.getTaskListShardName(uuid.New(), uuid.New(), 0)
+		if s == "only-shard" {
+			countExpected++
+		} else {
+			countUnexpected++
+		}
+	}
+
+	require.Equal(t, 0, countUnexpected, "Unexpected shard names must not be returned")
+	require.Equal(t, 1000000, countExpected, "Expected shard name must be returned always")
+}
+
+func TestTaskListSharding_Probabilistic(t *testing.T) {
+	cfg := getValidShardedNoSQLConfig()
+	sp, err := newShardingPolicy(log.NewNoop(), cfg)
+	require.NoError(t, err)
+
+	countShard1 := 0
+	countShard2 := 0
+	countUnexpected := 0
+
+	for i := 0; i < 1000000; i++ {
+		s := sp.getTaskListShardName(uuid.New(), uuid.New(), 0)
+		if s == "shard-1" {
+			countShard1++
+		} else if s == "shard-2" {
+			countShard2++
+		} else {
+			countUnexpected++
+		}
+	}
+
+	ratio := float32(countShard1) / float32(countShard2)
+
+	require.Equal(t, 0, countUnexpected, "Unexpected shard names must not be returned")
+	require.True(t, ratio > 0.95 && ratio < 1.05, "Shards should have equal chance of being selected")
+}

--- a/common/persistence/nosql/utils.go
+++ b/common/persistence/nosql/utils.go
@@ -28,6 +28,17 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
+type (
+	// ShardingError represents invalid shard
+	ShardingError struct {
+		Message string
+	}
+)
+
+func (e *ShardingError) Error() string {
+	return e.Message
+}
+
 func convertCommonErrors(
 	errChecker nosqlplugin.ClientErrorChecker,
 	operation string,

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -108,7 +108,7 @@ func (s *MatchingPersistenceSuite) TestCreateTask() {
 		s.Equal(workflowExecution.RunID, resp.Tasks[0].RunID)
 		s.Equal(sid, resp.Tasks[0].ScheduleID)
 		s.True(resp.Tasks[0].CreatedTime.UnixNano() > 0)
-		if s.TaskMgr.GetName() != "cassandra" {
+		if s.TaskMgr.GetName() != "cassandra" && s.TaskMgr.GetName() != "shardedNosql" {
 			// cassandra uses TTL and expiry isn't stored as part of task state
 			s.True(time.Now().Before(resp.Tasks[0].Expiry))
 			s.True(resp.Tasks[0].Expiry.Before(time.Now().Add((defaultScheduleToStartTimeout + 1) * time.Second)))
@@ -421,7 +421,7 @@ func (s *MatchingPersistenceSuite) deleteAllTaskList() {
 
 // TestListWithOneTaskList test
 func (s *MatchingPersistenceSuite) TestListWithOneTaskList() {
-	if s.TaskMgr.GetName() == "cassandra" {
+	if s.TaskMgr.GetName() == "cassandra" || s.TaskMgr.GetName() == "shardedNosql" {
 		// ListTaskList API is currently not supported in cassandra
 		return
 	}
@@ -485,7 +485,7 @@ func (s *MatchingPersistenceSuite) TestListWithOneTaskList() {
 
 // TestListWithMultipleTaskList test
 func (s *MatchingPersistenceSuite) TestListWithMultipleTaskList() {
-	if s.TaskMgr.GetName() == "cassandra" {
+	if s.TaskMgr.GetName() == "cassandra" || s.TaskMgr.GetName() == "shardedNosql" {
 		// ListTaskList API is currently not supported in cassandra"
 		return
 	}
@@ -555,7 +555,7 @@ func (s *MatchingPersistenceSuite) TestGetOrphanTasks() {
 	if os.Getenv("SKIP_GET_ORPHAN_TASKS") != "" {
 		s.T().Skipf("GetOrphanTasks not supported in %v", s.TaskMgr.GetName())
 	}
-	if s.TaskMgr.GetName() == "cassandra" {
+	if s.TaskMgr.GetName() == "cassandra" || s.TaskMgr.GetName() == "shardedNosql" {
 		// GetOrphanTasks API is currently not supported in cassandra"
 		return
 	}

--- a/config/development_multiple_cassandra.yaml
+++ b/config/development_multiple_cassandra.yaml
@@ -1,0 +1,155 @@
+persistence:
+  defaultStore: cass-default
+  visibilityStore: cass-visibility
+  numHistoryShards: 4
+  datastores:
+    cass-default:
+      shardedNosql:
+        defaultShard: nosqlDbShard1
+        shardingPolicy:
+          historyShardMapping:
+            - start: 0
+              end: 0
+              shard: nosqlDbShard1
+            - start: 1
+              end: 2
+              shard: nosqlDbShard2
+            - start: 3
+              end: 3
+              shard: nosqlDbShard1
+          taskListHashing:
+            shardOrder:
+              - nosqlDbShard1
+              - nosqlDbShard2
+        connections:
+          nosqlDbShard1:
+            nosqlPlugin:
+              pluginName: "cassandra"
+              hosts: "127.0.0.1"
+              keyspace: "cadence"
+              port: 9042
+          nosqlDbShard2:
+            nosqlPlugin:
+              pluginName: "cassandra"
+              hosts: "127.0.0.1"
+              keyspace: "cadence"
+              port: 9043
+    cass-visibility:
+      nosql:
+        pluginName: "cassandra"
+        hosts: "127.0.0.1"
+        keyspace: "cadence_visibility"
+
+ringpop:
+  name: cadence
+  bootstrapMode: hosts
+  bootstrapHosts: [ "127.0.0.1:7933", "127.0.0.1:7934", "127.0.0.1:7935" ]
+  maxJoinDuration: 30s
+
+services:
+  frontend:
+    rpc:
+      port: 7933
+      grpcPort: 7833
+      bindOnLocalHost: true
+      grpcMaxMsgSize: 33554432
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7936
+
+  matching:
+    rpc:
+      port: 7935
+      grpcPort: 7835
+      bindOnLocalHost: true
+      grpcMaxMsgSize: 33554432
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7938
+
+  history:
+    rpc:
+      port: 7934
+      grpcPort: 7834
+      bindOnLocalHost: true
+      grpcMaxMsgSize: 33554432
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7937
+
+  worker:
+    rpc:
+      port: 7939
+      bindOnLocalHost: true
+    metrics:
+      statsd:
+        hostPort: "127.0.0.1:8125"
+        prefix: "cadence"
+    pprof:
+      port: 7940
+
+clusterGroupMetadata:
+  failoverVersionIncrement: 10
+  primaryClusterName: "cluster0"
+  currentClusterName: "cluster0"
+  clusterGroup:
+    cluster0:
+      enabled: true
+      initialFailoverVersion: 0
+      rpcAddress: "localhost:7833" # this is to let worker service and XDC replicator connected to the frontend service. In cluster setup, localhost will not work
+      rpcTransport: "grpc"
+
+dcRedirectionPolicy:
+  policy: "noop"
+  toDC: ""
+
+archival:
+  history:
+    status: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+      gstorage:
+        credentialsPath: "/tmp/gcloud/keyfile.json"
+  visibility:
+    status: "enabled"
+    enableRead: true
+    provider:
+      filestore:
+        fileMode: "0666"
+        dirMode: "0766"
+
+domainDefaults:
+  archival:
+    history:
+      status: "enabled"
+      URI: "file:///tmp/cadence_archival/development"
+    visibility:
+      status: "enabled"
+      URI: "file:///tmp/cadence_vis_archival/development"
+
+dynamicconfig:
+  client: filebased
+  configstore:
+    pollInterval: "10s"
+    updateRetryAttempts: 2
+    FetchTimeout: "2s"
+    UpdateTimeout: "2s"
+  filebased:
+    filepath: "config/dynamicconfig/development.yaml"
+    pollInterval: "10s"
+
+blobstore:
+  filestore:
+    outputDirectory: "/tmp/blobstore"


### PR DESCRIPTION
What changed?
Added a sharding layer to the NoSQL persistence stack so that Cadence can use multiple Cassandra clusters at once in a physically sharded manner.

Cadence is a heavily storage-bounded system, so the limits for the load per Cadence cluster is strictly limited by the underlying storage system. Given the massive adoption of Cadence at Uber, this scale limitation forces us to create more Cadence clusters than we want to operate. This capability will let us have one or two orders of magnitude larger Cadence clusters than we have today.

Note that this feature only enables bootstrapping a brand-new cluster with multiple databases behind it. Resharding is designed but not implemented yet.

Why?
So that a Cadence cluster can be bootstrapped with multiple Cassandra clusters powering it.

How did you test it?
Added unit tests. Ran samples and tested bench tests in a staging environment.

Potential risks
Since this change significantly changes the low-level persistence logic, it can cause data loss if something goes terribly wrong.

Release notes
The change is backward compatible. Existing Cadence cluster configurations can be updated, if desired, to use the sharded NoSQL config format. However, they must continue having a single shard since Cadence still doesn't have the ability to reshard data.

Documentation Changes
There is a sample config file included in this PR that shows how to make use of the feature in a new cluster.

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
