### PR TITLE
Update frontend to adopt draining isolation groups

### DIFF
--- a/common/resource/resourceTest.go
+++ b/common/resource/resourceTest.go
@@ -96,9 +96,9 @@ type (
 		ExecutionMgr    *mocks.ExecutionManager
 		PersistenceBean *persistenceClient.MockBean
 
-		IsolationGroups     isolationgroup.State
+		IsolationGroups     *isolationgroup.MockState
 		IsolationGroupStore configstore.Client
-		Partitioner         partition.Partitioner
+		Partitioner         *partition.MockPartitioner
 
 		Logger log.Logger
 	}

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -66,6 +66,9 @@ type Config struct {
 	ShutdownDrainDuration             dynamicconfig.DurationPropertyFn
 	Lockdown                          dynamicconfig.BoolPropertyFnWithDomainFilter
 
+	// isolation configuration
+	EnableTasklistIsolation dynamicconfig.BoolPropertyFnWithDomainFilter
+
 	// id length limits
 	MaxIDLengthWarnLimit  dynamicconfig.IntPropertyFn
 	DomainNameMaxLength   dynamicconfig.IntPropertyFnWithDomainFilter
@@ -172,6 +175,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		DecisionResultCountLimit:                    dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendDecisionResultCountLimit),
 		EmitSignalNameMetricsTag:                    dc.GetBoolPropertyFilteredByDomain(dynamicconfig.FrontendEmitSignalNameMetricsTag),
 		Lockdown:                                    dc.GetBoolPropertyFilteredByDomain(dynamicconfig.Lockdown),
+		EnableTasklistIsolation:                     dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableTasklistIsolation),
 		domainConfig: domain.Config{
 			MaxBadBinaryCount:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendMaxBadBinaries),
 			MinRetentionDays:       dc.GetIntProperty(dynamicconfig.MinRetentionDays),

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -602,13 +602,26 @@ func (wh *WorkflowHandler) PollForActivityTask(
 		return nil, wh.error(err, scope, tags...)
 	}
 
+	isolationGroup := wh.getIsolationGroup(ctx, domainName)
+	if !wh.waitUntilIsolationGroupHealthy(ctx, domainName, isolationGroup) {
+		return &types.PollForActivityTaskResponse{}, nil
+	}
+	// it is possible that we wait for a very long time and the remaining time is not long enough for a long poll
+	// in this case, return an empty response
+	if err := common.ValidateLongPollContextTimeout(
+		ctx,
+		"PollForActivityTask",
+		wh.GetThrottledLogger(),
+	); err != nil {
+		return &types.PollForActivityTaskResponse{}, nil
+	}
 	pollerID := uuid.New()
 	op := func() error {
 		resp, err = wh.GetMatchingClient().PollForActivityTask(ctx, &types.MatchingPollForActivityTaskRequest{
 			DomainUUID:     domainID,
 			PollerID:       pollerID,
 			PollRequest:    pollRequest,
-			IsolationGroup: partition.IsolationGroupFromContext(ctx),
+			IsolationGroup: isolationGroup,
 		})
 		return err
 	}
@@ -718,6 +731,20 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 		return nil, wh.error(createServiceBusyError(), scope, tags...)
 	}
 
+	isolationGroup := wh.getIsolationGroup(ctx, domainName)
+	if !wh.waitUntilIsolationGroupHealthy(ctx, domainName, isolationGroup) {
+		return &types.PollForDecisionTaskResponse{}, nil
+	}
+	// it is possible that we wait for a very long time and the remaining time is not long enough for a long poll
+	// in this case, return an empty response
+	if err := common.ValidateLongPollContextTimeout(
+		ctx,
+		"PollForDecisionTask",
+		wh.GetThrottledLogger(),
+	); err != nil {
+		return &types.PollForDecisionTaskResponse{}, nil
+	}
+
 	pollerID := uuid.New()
 	var matchingResp *types.MatchingPollForDecisionTaskResponse
 	op := func() error {
@@ -725,7 +752,7 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 			DomainUUID:     domainID,
 			PollerID:       pollerID,
 			PollRequest:    pollRequest,
-			IsolationGroup: partition.IsolationGroupFromContext(ctx),
+			IsolationGroup: isolationGroup,
 		})
 		return err
 	}
@@ -759,6 +786,57 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 		return nil, wh.error(err, scope, tags...)
 	}
 	return resp, nil
+}
+
+func (wh *WorkflowHandler) getIsolationGroup(ctx context.Context, domainName string) string {
+	if wh.config.EnableTasklistIsolation(domainName) {
+		return partition.IsolationGroupFromContext(ctx)
+	}
+	return ""
+}
+
+func (wh *WorkflowHandler) getPartitionConfig(ctx context.Context, domainName string) map[string]string {
+	if wh.config.EnableTasklistIsolation(domainName) {
+		return partition.ConfigFromContext(ctx)
+	}
+	return nil
+}
+
+func (wh *WorkflowHandler) isIsolationGroupHealthy(ctx context.Context, domainName, isolationGroup string) bool {
+	if wh.GetIsolationGroupState() != nil && wh.config.EnableTasklistIsolation(domainName) {
+		isDrained, err := wh.GetIsolationGroupState().IsDrained(ctx, domainName, isolationGroup)
+		if err != nil {
+			wh.GetLogger().Error("Failed to check if an isolation group is drained, assume it's healthy", tag.Error(err))
+			return true
+		}
+		return !isDrained
+	}
+	return true
+}
+
+func (wh *WorkflowHandler) waitUntilIsolationGroupHealthy(ctx context.Context, domainName, isolationGroup string) bool {
+	if wh.GetIsolationGroupState() != nil && wh.config.EnableTasklistIsolation(domainName) {
+		ticker := time.NewTicker(time.Second * 30)
+		defer ticker.Stop()
+		childCtx, cancel := common.CreateChildContext(ctx, 0.05)
+		defer cancel()
+		for {
+			isDrained, err := wh.GetIsolationGroupState().IsDrained(childCtx, domainName, isolationGroup)
+			if err != nil {
+				wh.GetLogger().Error("Failed to check if an isolation group is drained, assume it's healthy", tag.Error(err))
+				return true
+			}
+			if !isDrained {
+				break
+			}
+			select {
+			case <-childCtx.Done():
+				return false
+			case <-ticker.C:
+			}
+		}
+	}
+	return true
 }
 
 func (wh *WorkflowHandler) checkBadBinary(domainEntry *cache.DomainCacheEntry, binaryChecksum string) error {
@@ -2173,9 +2251,14 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 		return nil, wh.error(err, scope, tags...)
 	}
 
+	isolationGroup := wh.getIsolationGroup(ctx, domainName)
+	if !wh.isIsolationGroupHealthy(ctx, domainName, isolationGroup) {
+		return nil, wh.error(&types.BadRequestError{fmt.Sprintf("Domain %s is drained from isolation group %s.", domainName, isolationGroup)}, scope, tags...)
+	}
+
 	wh.GetLogger().Debug("Start workflow execution request domainID", tag.WorkflowDomainID(domainID))
 	historyRequest, err := common.CreateHistoryStartWorkflowRequest(
-		domainID, startRequest, time.Now(), partition.ConfigFromContext(ctx))
+		domainID, startRequest, time.Now(), wh.getPartitionConfig(ctx, domainName))
 	if err != nil {
 		return nil, err
 	}
@@ -2562,6 +2645,11 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(
 		return wh.error(err, scope, tags...)
 	}
 
+	isolationGroup := wh.getIsolationGroup(ctx, domainName)
+	if !wh.isIsolationGroupHealthy(ctx, domainName, isolationGroup) {
+		return wh.error(&types.BadRequestError{fmt.Sprintf("Domain %s is drained from isolation group %s.", domainName, isolationGroup)}, scope, tags...)
+	}
+
 	err = wh.GetHistoryClient().SignalWorkflowExecution(ctx, &types.HistorySignalWorkflowExecutionRequest{
 		DomainUUID:    domainID,
 		SignalRequest: signalRequest,
@@ -2747,10 +2835,15 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 		return nil, wh.error(err, scope, tags...)
 	}
 
+	isolationGroup := wh.getIsolationGroup(ctx, domainName)
+	if !wh.isIsolationGroupHealthy(ctx, domainName, isolationGroup) {
+		return nil, wh.error(&types.BadRequestError{fmt.Sprintf("Domain %s is drained from isolation group %s.", domainName, isolationGroup)}, scope, tags...)
+	}
+
 	resp, err = wh.GetHistoryClient().SignalWithStartWorkflowExecution(ctx, &types.HistorySignalWithStartWorkflowExecutionRequest{
 		DomainUUID:             domainID,
 		SignalWithStartRequest: signalWithStartRequest,
-		PartitionConfig:        partition.ConfigFromContext(ctx),
+		PartitionConfig:        wh.getPartitionConfig(ctx, domainName),
 	})
 	if err != nil {
 		return nil, wh.error(err, scope, tags...)
@@ -3380,6 +3473,11 @@ func (wh *WorkflowHandler) RestartWorkflowExecution(ctx context.Context, request
 		return nil, wh.error(err, scope, tags...)
 	}
 
+	isolationGroup := wh.getIsolationGroup(ctx, domainName)
+	if !wh.isIsolationGroupHealthy(ctx, domainName, isolationGroup) {
+		return nil, wh.error(&types.BadRequestError{fmt.Sprintf("Domain %s is drained from isolation group %s.", domainName, isolationGroup)}, scope, tags...)
+	}
+
 	history, err := wh.GetWorkflowExecutionHistory(ctx, &types.GetWorkflowExecutionHistoryRequest{
 		Domain: domainName,
 		Execution: &types.WorkflowExecution{
@@ -3393,7 +3491,7 @@ func (wh *WorkflowHandler) RestartWorkflowExecution(ctx context.Context, request
 	}
 	startRequest := constructRestartWorkflowRequest(history.History.Events[0].WorkflowExecutionStartedEventAttributes,
 		domainName, request.Identity, wfExecution.WorkflowID)
-	req, err := common.CreateHistoryStartWorkflowRequest(domainID, startRequest, time.Now(), partition.ConfigFromContext(ctx))
+	req, err := common.CreateHistoryStartWorkflowRequest(domainID, startRequest, time.Now(), wh.getPartitionConfig(ctx, domainName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update frontend to reject start/signal/signalwithstart/restart requests from an isolation group that is drained
- Update frontend to block poll requests from an isolation group that is drained until it is undrained

<!-- Tell your future self why have you made these changes -->
**Why?**
To support isolation

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
