### PR TITLE
Add default value for shard_id and update_time in mysql

### DIFF
--- a/schema/mysql/v57/visibility/versioned/v0.6/add_update_time.sql
+++ b/schema/mysql/v57/visibility/versioned/v0.6/add_update_time.sql
@@ -1,1 +1,1 @@
-ALTER TABLE executions_visibility ADD update_time DATETIME(6) NULL;
+ALTER TABLE executions_visibility ADD update_time DATETIME(6) DEFAULT CURRENT_TIMESTAMP(6);

--- a/schema/mysql/v57/visibility/versioned/v0.7/add_shard_id.sql
+++ b/schema/mysql/v57/visibility/versioned/v0.7/add_shard_id.sql
@@ -1,1 +1,1 @@
-ALTER TABLE executions_visibility ADD shard_id INT;
+ALTER TABLE executions_visibility ADD shard_id INT DEFAULT -1;


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add default value for mysql newly added columns, or it will cause backwards compatible issue

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test using mysql

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
