### PR TITLE
Refactor/zonal isolation milezone i cleanup

### DIFF
--- a/common/isolationgroup/defaultisolationgroupstate/state.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state.go
@@ -129,21 +129,6 @@ func (z *defaultIsolationGroupStateHandler) Stop() {
 	close(z.done)
 }
 
-func (z *defaultIsolationGroupStateHandler) Subscribe(domainID, key string, notifyChannel chan<- isolationgroup.ChangeEvent) error {
-	z.subscriptionMu.Lock()
-	defer z.subscriptionMu.Unlock()
-
-	panic("not implemented")
-	return nil
-}
-
-func (z *defaultIsolationGroupStateHandler) Unsubscribe(domainID, key string) error {
-	z.subscriptionMu.Lock()
-	defer z.subscriptionMu.Unlock()
-	panic("not implemented")
-	return nil
-}
-
 func (z *defaultIsolationGroupStateHandler) getByDomainID(ctx context.Context, domainID string) (*isolationGroups, error) {
 	domain, err := z.domainCache.GetDomainByID(domainID)
 	if err != nil {
@@ -186,15 +171,6 @@ func (z *defaultIsolationGroupStateHandler) get(ctx context.Context, domain stri
 	}
 
 	return ig, nil
-}
-
-func (z *defaultIsolationGroupStateHandler) checkIfChanged() {
-	// todo (david.porter)
-	// check new values against existing cached ones
-	// get the difference
-	// if any difference, notify subscribers for whom the change is applicable
-	// ie, global changes for all, domain changes for the domain-listeners
-	panic("not implemented")
 }
 
 // A simple explicit deny-based isolation group implementation

--- a/common/isolationgroup/defaultisolationgroupstate/state.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state.go
@@ -25,7 +25,6 @@ package defaultisolationgroupstate
 import (
 	"context"
 	"fmt"
-	"sync"
 	"sync/atomic"
 
 	"github.com/uber/cadence/common/isolationgroup/isolationgroupapi"
@@ -45,8 +44,6 @@ type defaultIsolationGroupStateHandler struct {
 	domainCache                cache.DomainCache
 	globalIsolationGroupDrains dynamicconfig.Client
 	config                     defaultConfig
-	subscriptionMu             sync.Mutex
-	valuesMu                   sync.RWMutex
 	lastSeen                   *isolationGroups
 	updateCB                   func()
 	// subscriptions is a map of domains->subscription-keys-> subscription channels
@@ -81,8 +78,6 @@ func NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 		status:                     common.DaemonStatusInitialized,
 		log:                        logger,
 		config:                     config,
-		subscriptionMu:             sync.Mutex{},
-		subscriptions:              make(map[string]map[string]chan<- isolationgroup.ChangeEvent),
 	}, nil
 }
 

--- a/common/isolationgroup/interface.go
+++ b/common/isolationgroup/interface.go
@@ -44,7 +44,4 @@ type State interface {
 	// AvailableIsolationGroupsByDomainID returns the available isolation zones for a domain.
 	// Takes into account global and domain zones
 	AvailableIsolationGroupsByDomainID(ctx context.Context, domainID string, availableIsolationGroups []string) (types.IsolationGroupConfiguration, error)
-
-	Subscribe(domainID, key string, notifyChannel chan<- ChangeEvent) error
-	Unsubscribe(domainID, key string) error
 }

--- a/common/isolationgroup/isolation_group_mock.go
+++ b/common/isolationgroup/isolation_group_mock.go
@@ -126,31 +126,3 @@ func (mr *MockStateMockRecorder) Stop() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockState)(nil).Stop))
 }
-
-// Subscribe mocks base method.
-func (m *MockState) Subscribe(domainID, key string, notifyChannel chan<- ChangeEvent) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subscribe", domainID, key, notifyChannel)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Subscribe indicates an expected call of Subscribe.
-func (mr *MockStateMockRecorder) Subscribe(domainID, key, notifyChannel interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockState)(nil).Subscribe), domainID, key, notifyChannel)
-}
-
-// Unsubscribe mocks base method.
-func (m *MockState) Unsubscribe(domainID, key string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Unsubscribe", domainID, key)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Unsubscribe indicates an expected call of Unsubscribe.
-func (mr *MockStateMockRecorder) Unsubscribe(domainID, key interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unsubscribe", reflect.TypeOf((*MockState)(nil).Unsubscribe), domainID, key)
-}


### PR DESCRIPTION
Removes interfaces not used in Milestone 1 of this feature: