### PR TITLE
Adds isolation-groups base-types

### DIFF
--- a/common/types/admin.go
+++ b/common/types/admin.go
@@ -20,6 +20,8 @@
 
 package types
 
+import "sort"
+
 // AddSearchAttributeRequest is an internal type (TBD...)
 type AddSearchAttributeRequest struct {
 	SearchAttribute map[string]IndexedValueType `json:"searchAttribute,omitempty"`
@@ -363,4 +365,57 @@ func (v *ListDynamicConfigRequest) SerializeForLogging() (string, error) {
 
 type ListDynamicConfigResponse struct {
 	Entries []*DynamicConfigEntry `json:"entries,omitempty"`
+}
+
+type IsolationGroupState int
+
+const (
+	IsolationGroupStateInvalid IsolationGroupState = iota
+	IsolationGroupStateHealthy
+	IsolationGroupStateDrained
+)
+
+type IsolationGroupPartition struct {
+	Name  string
+	State IsolationGroupState
+}
+
+// IsolationGroupConfiguration is an internal representation of a set of
+// isolation-groups as a mapping and may refer to either globally or per-domain (or both) configurations.
+// and their statuses. It's redundantly indexed by IsolationGroup name to simplify lookups.
+//
+// For example: This might be a global configuration persisted
+// in the config store and look like this:
+//
+//	IsolationGroupConfiguration{
+//	  "isolationGroup1234": {Name: "isolationGroup1234", Status: IsolationGroupStatusDrained},
+//	}
+//
+// Indicating that task processing isn't to occur within this isolationGroup anymore, but all others are ok.
+type IsolationGroupConfiguration map[string]IsolationGroupPartition
+
+// ToPartitionList Renders the isolation group to the less complicated and confusing simple list of isolation groups
+func (i IsolationGroupConfiguration) ToPartitionList() []IsolationGroupPartition {
+	out := []IsolationGroupPartition{}
+	for _, v := range i {
+		out = append(out, v)
+	}
+	// ensure determinitism in list ordering for convenience
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Name < out[j].Name
+	})
+	return out
+}
+
+// FromIsolationGroupPartitionList maps a list of isolation to the internal IsolationGroup configuration type
+// whose map keys tend to be used more for set operations
+func FromIsolationGroupPartitionList(in []IsolationGroupPartition) IsolationGroupConfiguration {
+	if len(in) == 0 {
+		return IsolationGroupConfiguration{}
+	}
+	out := IsolationGroupConfiguration{}
+	for _, v := range in {
+		out[v.Name] = v
+	}
+	return out
 }

--- a/common/types/mapper/proto/admin.go
+++ b/common/types/mapper/proto/admin.go
@@ -1162,3 +1162,39 @@ func ToDynamicConfigFilter(t *adminv1.DynamicConfigFilter) *types.DynamicConfigF
 		Value: ToDataBlob(t.Value),
 	}
 }
+
+func FromIsolationGroupConfig(in *types.IsolationGroupConfiguration) *apiv1.IsolationGroupConfiguration {
+	if in == nil {
+		return nil
+	}
+	var out []*apiv1.IsolationGroupPartition
+	for _, v := range *in {
+		out = append(out, &apiv1.IsolationGroupPartition{
+			Name:  v.Name,
+			State: apiv1.IsolationGroupState(v.State),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i] == nil || out[j] == nil {
+			return false
+		}
+		return out[i].Name < out[j].Name
+	})
+	return &apiv1.IsolationGroupConfiguration{
+		IsolationGroups: out,
+	}
+}
+
+func ToIsolationGroupConfig(in *apiv1.IsolationGroupConfiguration) *types.IsolationGroupConfiguration {
+	if in == nil {
+		return nil
+	}
+	out := make(types.IsolationGroupConfiguration)
+	for v := range in.IsolationGroups {
+		out[in.IsolationGroups[v].Name] = types.IsolationGroupPartition{
+			Name:  in.IsolationGroups[v].Name,
+			State: types.IsolationGroupState(in.IsolationGroups[v].State),
+		}
+	}
+	return &out
+}

--- a/common/types/mapper/thrift/admin.go
+++ b/common/types/mapper/thrift/admin.go
@@ -685,3 +685,42 @@ func ToListDynamicConfigResponse(t *admin.ListDynamicConfigResponse) *types.List
 		Entries: ToDynamicConfigEntryArray(t.Entries),
 	}
 }
+
+func FromIsolationGroupConfig(in *types.IsolationGroupConfiguration) *shared.IsolationGroupConfiguration {
+	if in == nil {
+		return nil
+	}
+	var out []*shared.IsolationGroupPartition
+	for _, v := range *in {
+		out = append(out, &shared.IsolationGroupPartition{
+			Name:  strPtr(v.Name),
+			State: igStatePtr(shared.IsolationGroupState(v.State)),
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i] == nil || out[j] == nil {
+			return false
+		}
+		return *out[i].Name < *out[j].Name
+	})
+	return &shared.IsolationGroupConfiguration{
+		IsolationGroups: out,
+	}
+}
+
+func ToIsolationGroupConfig(in *shared.IsolationGroupConfiguration) *types.IsolationGroupConfiguration {
+	if in == nil {
+		return nil
+	}
+	out := make(types.IsolationGroupConfiguration)
+	for v := range in.IsolationGroups {
+		out[in.IsolationGroups[v].GetName()] = types.IsolationGroupPartition{
+			Name:  in.IsolationGroups[v].GetName(),
+			State: types.IsolationGroupState(in.IsolationGroups[v].GetState()),
+		}
+	}
+	return &out
+}
+
+func strPtr(s string) *string                                             { return &s }
+func igStatePtr(s shared.IsolationGroupState) *shared.IsolationGroupState { return &s }

--- a/common/types/mapper/thrift/thrift-tests/shared_test.go
+++ b/common/types/mapper/thrift/thrift-tests/shared_test.go
@@ -23,6 +23,8 @@ package thrifttests
 import (
 	"testing"
 
+	"github.com/uber/cadence/.gen/go/shared"
+
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/cadence/common/types"

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -1785,13 +1785,14 @@ type DomainCacheInfo struct {
 
 // DomainConfiguration is an internal type (TBD...)
 type DomainConfiguration struct {
-	WorkflowExecutionRetentionPeriodInDays int32           `json:"workflowExecutionRetentionPeriodInDays,omitempty"`
-	EmitMetric                             bool            `json:"emitMetric,omitempty"`
-	BadBinaries                            *BadBinaries    `json:"badBinaries,omitempty"`
-	HistoryArchivalStatus                  *ArchivalStatus `json:"historyArchivalStatus,omitempty"`
-	HistoryArchivalURI                     string          `json:"historyArchivalURI,omitempty"`
-	VisibilityArchivalStatus               *ArchivalStatus `json:"visibilityArchivalStatus,omitempty"`
-	VisibilityArchivalURI                  string          `json:"visibilityArchivalURI,omitempty"`
+	WorkflowExecutionRetentionPeriodInDays int32                        `json:"workflowExecutionRetentionPeriodInDays,omitempty"`
+	EmitMetric                             bool                         `json:"emitMetric,omitempty"`
+	BadBinaries                            *BadBinaries                 `json:"badBinaries,omitempty"`
+	HistoryArchivalStatus                  *ArchivalStatus              `json:"historyArchivalStatus,omitempty"`
+	HistoryArchivalURI                     string                       `json:"historyArchivalURI,omitempty"`
+	VisibilityArchivalStatus               *ArchivalStatus              `json:"visibilityArchivalStatus,omitempty"`
+	VisibilityArchivalURI                  string                       `json:"visibilityArchivalURI,omitempty"`
+	IsolationGroups                        *IsolationGroupConfiguration `json:"isolationGroupConfiguration,omitempty"`
 }
 
 // GetWorkflowExecutionRetentionPeriodInDays is an internal getter (TBD...)
@@ -6749,6 +6750,7 @@ type UpdateDomainRequest struct {
 	SecurityToken                          string                             `json:"securityToken,omitempty"`
 	DeleteBadBinary                        *string                            `json:"deleteBadBinary,omitempty"`
 	FailoverTimeoutInSeconds               *int32                             `json:"failoverTimeoutInSeconds,omitempty"`
+	IsolationGroupConfiguration            *IsolationGroupConfiguration       `json:"isolationGroupConfiguration,omitempty"`
 }
 
 func (v *UpdateDomainRequest) SerializeForLogging() (string, error) {
@@ -7896,6 +7898,14 @@ func (v *CrossClusterStartChildExecutionRequestAttributes) GetTargetRunID() (o s
 	return
 }
 
+// GetTargetRunID is an internal getter (TBD...)
+func (v *CrossClusterStartChildExecutionRequestAttributes) GetPartitionConfig() (o map[string]string) {
+	if v != nil && v.PartitionConfig != nil {
+		return v.PartitionConfig
+	}
+	return
+}
+
 // CrossClusterStartChildExecutionResponseAttributes is an internal type (TBD...)
 type CrossClusterStartChildExecutionResponseAttributes struct {
 	RunID string `json:"runID,omitempty"`
@@ -7905,14 +7915,6 @@ type CrossClusterStartChildExecutionResponseAttributes struct {
 func (v *CrossClusterStartChildExecutionResponseAttributes) GetRunID() (o string) {
 	if v != nil {
 		return v.RunID
-	}
-	return
-}
-
-// GetTargetRunID is an internal getter (TBD...)
-func (v *CrossClusterStartChildExecutionRequestAttributes) GetPartitionConfig() (o map[string]string) {
-	if v != nil && v.PartitionConfig != nil {
-		return v.PartitionConfig
 	}
 	return
 }

--- a/common/types/testdata/domain.go
+++ b/common/types/testdata/domain.go
@@ -78,6 +78,16 @@ var (
 		HistoryArchivalURI:                     HistoryArchivalURI,
 		VisibilityArchivalStatus:               &ArchivalStatus,
 		VisibilityArchivalURI:                  VisibilityArchivalURI,
+		IsolationGroups: &types.IsolationGroupConfiguration{
+			"zone-1": {
+				Name:  "zone-1",
+				State: types.IsolationGroupStateHealthy,
+			},
+			"zone-2": {
+				Name:  "zone-2",
+				State: types.IsolationGroupStateDrained,
+			},
+		},
 	}
 	DomainReplicationConfiguration = types.DomainReplicationConfiguration{
 		ActiveClusterName: ClusterName1,


### PR DESCRIPTION
This adds the following base types, formed on their equivalent IDL types: 

#### Isolation-group-status:
A bool flag indicating whether an isolation-group is drained or not. For the sake of the initial open-source implementation, only the _drained_ status is important, as anything not specified is expected to be healthy, however, the IDL offers the base for alternative implementations. 

#### Isolation-group-partition:
A single isolation group, with it's name, it's status and potentially any future group-specific information.

#### isolation-group configuration
An entire set of isolation-groups. This is presented externally as an unsorted list of isolation-group partitions, however represented internally here as a map due to it being better suited for set-membership operations which are mostly what the isolation-groups are used for. 