### PR TITLE
Update history to persist partition config

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -519,10 +519,12 @@ func CreateHistoryStartWorkflowRequest(
 	domainID string,
 	startRequest *types.StartWorkflowExecutionRequest,
 	now time.Time,
+	partitionConfig map[string]string,
 ) (*types.HistoryStartWorkflowExecutionRequest, error) {
 	histRequest := &types.HistoryStartWorkflowExecutionRequest{
-		DomainUUID:   domainID,
-		StartRequest: startRequest,
+		DomainUUID:      domainID,
+		StartRequest:    startRequest,
+		PartitionConfig: partitionConfig,
 	}
 
 	delayStartSeconds := startRequest.GetDelayStartSeconds()

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -99,7 +99,7 @@ func TestCreateHistoryStartWorkflowRequest_ExpirationTimeWithCron(t *testing.T) 
 		CronSchedule: "@every 300s",
 	}
 	now := time.Now()
-	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now, nil)
 	require.NoError(t, err)
 	require.NotNil(t, startRequest)
 
@@ -146,7 +146,7 @@ func TestFirstDecisionTaskBackoffDuringStartWorkflow(t *testing.T) {
 			for i := 0; i < caseCount; i++ {
 				// Start at the minute boundary so we know what the backoff should be
 				startTime, _ := time.Parse(time.RFC3339, "2018-12-17T08:00:00+00:00")
-				startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, startTime)
+				startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, startTime, nil)
 				require.NoError(t, err)
 				require.NotNil(t, startRequest)
 
@@ -228,7 +228,7 @@ func testExpirationTime(t *testing.T, delayStartSeconds int, cronSeconds int, ji
 	minDelay := delayStartSeconds + cronSeconds
 	maxDelay := delayStartSeconds + 2*cronSeconds + jitterSeconds
 	now := time.Now()
-	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now, nil)
 	require.NoError(t, err)
 	require.NotNil(t, startRequest)
 
@@ -264,7 +264,7 @@ func TestCreateHistoryStartWorkflowRequest_ExpirationTimeWithoutCron(t *testing.
 		},
 	}
 	now := time.Now()
-	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now)
+	startRequest, err := CreateHistoryStartWorkflowRequest(domainID, request, now, nil)
 	require.NoError(t, err)
 	require.NotNil(t, startRequest)
 

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -2182,7 +2182,7 @@ func (wh *WorkflowHandler) StartWorkflowExecution(
 
 	wh.GetLogger().Debug("Start workflow execution request domainID", tag.WorkflowDomainID(domainID))
 	historyRequest, err := common.CreateHistoryStartWorkflowRequest(
-		domainID, startRequest, time.Now())
+		domainID, startRequest, time.Now(), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -2757,6 +2757,7 @@ func (wh *WorkflowHandler) SignalWithStartWorkflowExecution(
 	resp, err = wh.GetHistoryClient().SignalWithStartWorkflowExecution(ctx, &types.HistorySignalWithStartWorkflowExecutionRequest{
 		DomainUUID:             domainID,
 		SignalWithStartRequest: signalWithStartRequest,
+		PartitionConfig:        nil,
 	})
 	if err != nil {
 		return nil, wh.error(err, scope, tags...)
@@ -3399,7 +3400,7 @@ func (wh *WorkflowHandler) RestartWorkflowExecution(ctx context.Context, request
 	}
 	startRequest := constructRestartWorkflowRequest(history.History.Events[0].WorkflowExecutionStartedEventAttributes,
 		domainName, request.Identity, wfExecution.WorkflowID)
-	req, err := common.CreateHistoryStartWorkflowRequest(domainID, startRequest, time.Now())
+	req, err := common.CreateHistoryStartWorkflowRequest(domainID, startRequest, time.Now(), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/execution/history_builder.go
+++ b/service/history/execution/history_builder.go
@@ -99,6 +99,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionStartedEvent(startRequest *types.Hi
 		Memo:                                request.Memo,
 		SearchAttributes:                    request.SearchAttributes,
 		JitterStartSeconds:                  request.JitterStartSeconds,
+		PartitionConfig:                     startRequest.PartitionConfig,
 	}
 	if parentInfo := startRequest.ParentExecutionInfo; parentInfo != nil {
 		attributes.ParentWorkflowDomainID = &parentInfo.DomainUUID

--- a/service/history/execution/history_builder_test.go
+++ b/service/history/execution/history_builder_test.go
@@ -123,9 +123,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderDynamicSuccess() {
 		WorkflowID: id,
 		RunID:      rid,
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity)
-	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
 	s.Equal(int64(2), s.getNextEventID())
 
 	di := s.addDecisionTaskScheduledEvent()
@@ -432,9 +435,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowStartFailures() {
 		WorkflowID: id,
 		RunID:      rid,
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity)
-	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
 	s.Equal(int64(2), s.getNextEventID())
 
 	di := s.addDecisionTaskScheduledEvent()
@@ -481,9 +487,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionScheduledFailures() {
 		WorkflowID: id,
 		RunID:      rid,
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity)
-	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
 	s.Equal(int64(2), s.getNextEventID())
 
 	di := s.addDecisionTaskScheduledEvent()
@@ -516,9 +525,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionStartedFailures() {
 		WorkflowID: id,
 		RunID:      rid,
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity)
-	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
 	s.Equal(int64(2), s.getNextEventID())
 
 	_, _, err := s.msBuilder.AddDecisionTaskStartedEvent(2, uuid.New(), &types.PollForDecisionTaskRequest{
@@ -572,10 +584,13 @@ func (s *historyBuilderSuite) TestHistoryBuilderFlushBufferedEvents() {
 		WorkflowID: id,
 		RunID:      rid,
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
 	// 1 execution started
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity)
-	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
 	s.Equal(int64(2), s.getNextEventID())
 
 	// 2 decision scheduled
@@ -741,13 +756,13 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationRequested() 
 		WorkflowID: "some random workflow ID",
 		RunID:      uuid.New(),
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(
-		workflowExecution, workflowType, tasklist, input, execTimeout, taskTimeout, identity,
-	)
-	s.validateWorkflowExecutionStartedEvent(
-		workflowStartedEvent, workflowType, tasklist, input, execTimeout, taskTimeout, identity,
-	)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(workflowExecution, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
+
 	s.Equal(int64(2), s.getNextEventID())
 
 	decisionInfo := s.addDecisionTaskScheduledEvent()
@@ -812,13 +827,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationFailed() {
 		WorkflowID: "some random workflow ID",
 		RunID:      uuid.New(),
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(
-		workflowExecution, workflowType, tasklist, input, execTimeout, taskTimeout, identity,
-	)
-	s.validateWorkflowExecutionStartedEvent(
-		workflowStartedEvent, workflowType, tasklist, input, execTimeout, taskTimeout, identity,
-	)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(workflowExecution, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
 	s.Equal(int64(2), s.getNextEventID())
 
 	decisionInfo := s.addDecisionTaskScheduledEvent()
@@ -888,13 +902,12 @@ func (s *historyBuilderSuite) TestHistoryBuilder_DecisionTaskTimedOut() {
 		WorkflowID: "some random workflow ID",
 		RunID:      uuid.New(),
 	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
 
-	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(
-		workflowExecution, workflowType, tasklist, input, execTimeout, taskTimeout, identity,
-	)
-	s.validateWorkflowExecutionStartedEvent(
-		workflowStartedEvent, workflowType, tasklist, input, execTimeout, taskTimeout, identity,
-	)
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(workflowExecution, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
 	s.Equal(int64(2), s.getNextEventID())
 
 	decisionInfo := s.addDecisionTaskScheduledEvent()
@@ -952,7 +965,7 @@ func (s *historyBuilderSuite) getPreviousDecisionStartedEventID() int64 {
 
 func (s *historyBuilderSuite) addWorkflowExecutionStartedEvent(we types.WorkflowExecution, workflowType,
 	taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32,
-	identity string) *types.HistoryEvent {
+	identity string, partitionConfig map[string]string) *types.HistoryEvent {
 
 	request := &types.StartWorkflowExecutionRequest{
 		WorkflowID:                          we.WorkflowID,
@@ -967,8 +980,9 @@ func (s *historyBuilderSuite) addWorkflowExecutionStartedEvent(we types.Workflow
 	event, err := s.msBuilder.AddWorkflowExecutionStartedEvent(
 		we,
 		&types.HistoryStartWorkflowExecutionRequest{
-			DomainUUID:   s.domainID,
-			StartRequest: request,
+			DomainUUID:      s.domainID,
+			StartRequest:    request,
+			PartitionConfig: partitionConfig,
 		},
 	)
 	s.Nil(err)
@@ -1149,7 +1163,7 @@ func (s *historyBuilderSuite) addRequestCancelExternalWorkflowExecutionFailedEve
 }
 
 func (s *historyBuilderSuite) validateWorkflowExecutionStartedEvent(event *types.HistoryEvent, workflowType,
-	taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32, identity string) {
+	taskList string, input []byte, executionStartToCloseTimeout, taskStartToCloseTimeout int32, identity string, partitionConfig map[string]string) {
 	s.NotNil(event)
 	s.Equal(types.EventTypeWorkflowExecutionStarted, *event.EventType)
 	s.Equal(common.FirstEventID, event.ID)
@@ -1161,6 +1175,7 @@ func (s *historyBuilderSuite) validateWorkflowExecutionStartedEvent(event *types
 	s.Equal(executionStartToCloseTimeout, *attributes.ExecutionStartToCloseTimeoutSeconds)
 	s.Equal(taskStartToCloseTimeout, *attributes.TaskStartToCloseTimeoutSeconds)
 	s.Equal(identity, attributes.Identity)
+	s.Equal(partitionConfig, attributes.PartitionConfig)
 	if attributes.CronSchedule == "" {
 		s.Nil(attributes.FirstScheduleTime)
 	} else {

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1678,6 +1678,7 @@ func (e *mutableStateBuilder) addWorkflowExecutionStartedEventForContinueAsNew(
 		ContinuedFailureDetails:         attributes.FailureDetails,
 		ContinueAsNewInitiator:          attributes.Initiator,
 		FirstDecisionTaskBackoffSeconds: attributes.BackoffStartIntervalInSeconds,
+		PartitionConfig:                 previousExecutionInfo.PartitionConfig,
 	}
 
 	// if ContinueAsNew as Cron or decider, recalculate the expiration timestamp and set attempts to 0
@@ -1845,6 +1846,7 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(
 	if event.SearchAttributes != nil {
 		e.executionInfo.SearchAttributes = event.SearchAttributes.GetIndexedFields()
 	}
+	e.executionInfo.PartitionConfig = event.PartitionConfig
 
 	e.writeEventToCache(startEvent)
 

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -2235,6 +2235,7 @@ func (e *mutableStateBuilder) tryDispatchActivityTask(
 			WorkflowDomain:                  e.GetDomainEntry().GetInfo().Name,
 			ScheduledTimestampOfThisAttempt: common.Int64Ptr(ai.ScheduledTime.UnixNano()),
 		},
+		PartitionConfig: e.executionInfo.PartitionConfig,
 	})
 	if err == nil {
 		taggedScope.IncCounter(metrics.DecisionTypeScheduleActivityDispatchSucceedCounter)

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -657,6 +657,9 @@ func (s *mutableStateSuite) prepareTransientDecisionCompletionFirstBatchReplicat
 	workflowTimeoutSecond := int32(222)
 	decisionTimeoutSecond := int32(11)
 	decisionAttempt := int64(0)
+	partitionConfig := map[string]string{
+		"zone": "dca",
+	}
 
 	eventID := int64(1)
 	workflowStartEvent := &types.HistoryEvent{
@@ -670,6 +673,7 @@ func (s *mutableStateSuite) prepareTransientDecisionCompletionFirstBatchReplicat
 			Input:                               nil,
 			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
 			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(decisionTimeoutSecond),
+			PartitionConfig:                     partitionConfig,
 		},
 	}
 	eventID++
@@ -860,6 +864,9 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistence.WorkflowMut
 	}
 	tl := "testTaskList"
 	failoverVersion := int64(300)
+	partitionConfig := map[string]string{
+		"zone": "phx",
+	}
 
 	info := &persistence.WorkflowExecutionInfo{
 		DomainID:                    domainID,
@@ -878,6 +885,7 @@ func (s *mutableStateSuite) buildWorkflowMutableState() *persistence.WorkflowMut
 		DecisionScheduleID:          common.EmptyEventID,
 		DecisionStartedID:           common.EmptyEventID,
 		DecisionTimeout:             100,
+		PartitionConfig:             partitionConfig,
 	}
 
 	activityInfos := map[int64]*persistence.ActivityInfo{

--- a/service/history/execution/mutable_state_util.go
+++ b/service/history/execution/mutable_state_util.go
@@ -365,6 +365,7 @@ func CopyWorkflowExecutionInfo(sourceInfo *persistence.WorkflowExecutionInfo) *p
 		AutoResetPoints:                    sourceInfo.AutoResetPoints,
 		Memo:                               sourceInfo.Memo,
 		SearchAttributes:                   sourceInfo.SearchAttributes,
+		PartitionConfig:                    sourceInfo.PartitionConfig,
 		Attempt:                            sourceInfo.Attempt,
 		HasRetryPolicy:                     sourceInfo.HasRetryPolicy,
 		InitialInterval:                    sourceInfo.InitialInterval,

--- a/service/history/execution/state_rebuilder_test.go
+++ b/service/history/execution/state_rebuilder_test.go
@@ -228,6 +228,9 @@ func (s *stateRebuilderSuite) TestRebuild() {
 	branchToken := []byte("other random branch token")
 	targetBranchToken := []byte("some other random branch token")
 	now := time.Now()
+	partitionConfig := map[string]string{
+		"userid": uuid.New(),
+	}
 
 	targetDomainID := uuid.New()
 	targetDomainName := "other random domain name"
@@ -247,6 +250,7 @@ func (s *stateRebuilderSuite) TestRebuild() {
 			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(123),
 			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(233),
 			Identity:                            "some random identity",
+			PartitionConfig:                     partitionConfig,
 		},
 	}}
 	events2 := []*types.HistoryEvent{{
@@ -325,6 +329,7 @@ func (s *stateRebuilderSuite) TestRebuild() {
 	s.Equal(targetDomainID, rebuildExecutionInfo.DomainID)
 	s.Equal(targetWorkflowID, rebuildExecutionInfo.WorkflowID)
 	s.Equal(targetRunID, rebuildExecutionInfo.RunID)
+	s.Equal(partitionConfig, rebuildExecutionInfo.PartitionConfig)
 	s.Equal(int64(historySize1+historySize2), rebuiltHistorySize)
 	s.Equal(persistence.NewVersionHistories(
 		persistence.NewVersionHistory(

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -894,7 +894,7 @@ UpdateWorkflowLoop:
 		}
 
 		if signalWithStartRequest != nil {
-			startRequest, err = getStartRequest(domainID, signalWithStartRequest.SignalWithStartRequest)
+			startRequest, err = getStartRequest(domainID, signalWithStartRequest.SignalWithStartRequest, signalWithStartRequest.PartitionConfig)
 			if err != nil {
 				return nil, err
 			}
@@ -1635,6 +1635,7 @@ func (e *historyEngineImpl) DescribeWorkflowExecution(
 			IsCron:           len(executionInfo.CronSchedule) > 0,
 			UpdateTime:       common.Int64Ptr(executionInfo.LastUpdatedTimestamp.UnixNano()),
 			SearchAttributes: &types.SearchAttributes{IndexedFields: executionInfo.SearchAttributes},
+			PartitionConfig:  executionInfo.PartitionConfig,
 		},
 	}
 
@@ -2598,7 +2599,7 @@ func (e *historyEngineImpl) SignalWithStartWorkflowExecution(
 	}
 
 	// Start workflow and signal
-	startRequest, err := getStartRequest(domainID, sRequest)
+	startRequest, err := getStartRequest(domainID, sRequest, signalWithStartRequest.PartitionConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -3273,6 +3274,7 @@ func getScheduleID(
 func getStartRequest(
 	domainID string,
 	request *types.SignalWithStartWorkflowExecutionRequest,
+	partitionConfig map[string]string,
 ) (*types.HistoryStartWorkflowExecutionRequest, error) {
 
 	req := &types.StartWorkflowExecutionRequest{
@@ -3295,7 +3297,7 @@ func getStartRequest(
 		JitterStartSeconds:                  request.JitterStartSeconds,
 	}
 
-	return common.CreateHistoryStartWorkflowRequest(domainID, req, time.Now())
+	return common.CreateHistoryStartWorkflowRequest(domainID, req, time.Now(), partitionConfig)
 }
 
 func (e *historyEngineImpl) applyWorkflowIDReusePolicyForSigWithStart(

--- a/service/history/task/cross_cluster_target_task_executor.go
+++ b/service/history/task/cross_cluster_target_task_executor.go
@@ -168,6 +168,7 @@ func (t *crossClusterTargetTaskExecutor) executeStartChildExecutionTask(
 			targetDomainName,
 			attributes.RequestID,
 			attributes.GetInitiatedEventAttributes(),
+			attributes.GetPartitionConfig(),
 		)
 		if err != nil {
 			return nil, err

--- a/service/history/task/cross_cluster_target_task_executor_test.go
+++ b/service/history/task/cross_cluster_target_task_executor_test.go
@@ -136,6 +136,7 @@ func (s *crossClusterTargetTaskExecutorSuite) TestStartChildExecutionTask_StartC
 		task.request.StartChildExecutionAttributes.InitiatedEventAttributes,
 		task.request.StartChildExecutionAttributes.GetRequestID(),
 		s.mockShard.GetTimeSource().Now(),
+		task.request.StartChildExecutionAttributes.GetPartitionConfig(),
 	)
 	require.NoError(s.T(), err)
 	targetRunID := "random target runID"
@@ -162,6 +163,7 @@ func (s *crossClusterTargetTaskExecutorSuite) TestStartChildExecutionTask_StartC
 		task.request.StartChildExecutionAttributes.InitiatedEventAttributes,
 		task.request.StartChildExecutionAttributes.GetRequestID(),
 		s.mockShard.GetTimeSource().Now(),
+		task.request.StartChildExecutionAttributes.GetPartitionConfig(),
 	)
 	require.NoError(s.T(), err)
 	s.mockHistoryClient.EXPECT().StartWorkflowExecution(gomock.Any(), historyReq).

--- a/service/history/task/cross_cluster_task.go
+++ b/service/history/task/cross_cluster_task.go
@@ -638,6 +638,7 @@ func (t *crossClusterSourceTask) getRequestForStartChildExecution(
 		RequestID:                childInfo.CreateRequestID,
 		InitiatedEventID:         initiatedEventID,
 		InitiatedEventAttributes: initiatedEvent.StartChildWorkflowExecutionInitiatedEventAttributes,
+		PartitionConfig:          mutableState.GetExecutionInfo().PartitionConfig,
 	}
 	if childInfo.StartedID != common.EmptyEventID {
 		// childExecution already started, advance to next state

--- a/service/history/task/cross_cluster_task_test.go
+++ b/service/history/task/cross_cluster_task_test.go
@@ -472,6 +472,7 @@ func (s *crossClusterTaskSuite) TestSourceTask_GetStartChildRequest_Invalidated(
 			sourceTask *crossClusterSourceTask,
 			childInfo *persistence.ChildExecutionInfo,
 			initiatedEvent *types.HistoryEvent,
+			partitionConfig map[string]string,
 		) {
 			s.Error(getRequestErr)
 			s.Nil(request)
@@ -507,6 +508,7 @@ func (s *crossClusterTaskSuite) TestSourceTask_GetStartChildRequest_AlreadyStart
 			sourceTask *crossClusterSourceTask,
 			childInfo *persistence.ChildExecutionInfo,
 			initiatedEvent *types.HistoryEvent,
+			partitionConfig map[string]string,
 		) {
 			s.NoError(getRequestErr)
 			s.NotNil(request)
@@ -526,6 +528,7 @@ func (s *crossClusterTaskSuite) TestSourceTask_GetStartChildRequest_AlreadyStart
 				InitiatedEventID:         taskInfo.ScheduleID,
 				InitiatedEventAttributes: initiatedEvent.StartChildWorkflowExecutionInitiatedEventAttributes,
 				TargetRunID:              common.StringPtr(childExecutionRunID),
+				PartitionConfig:          partitionConfig,
 			}, request.StartChildExecutionAttributes)
 			s.Equal(ctask.TaskStatePending, sourceTask.State())
 			s.Equal(processingStateResponseRecorded, sourceTask.ProcessingState())
@@ -562,6 +565,7 @@ func (s *crossClusterTaskSuite) TestSourceTask_GetStartChildRequest_AlreadyStart
 			sourceTask *crossClusterSourceTask,
 			childInfo *persistence.ChildExecutionInfo,
 			initiatedEvent *types.HistoryEvent,
+			partitionConfig map[string]string,
 		) {
 			s.NoError(getRequestErr)
 			s.NotNil(request)
@@ -581,6 +585,7 @@ func (s *crossClusterTaskSuite) TestSourceTask_GetStartChildRequest_AlreadyStart
 				InitiatedEventID:         taskInfo.ScheduleID,
 				InitiatedEventAttributes: initiatedEvent.StartChildWorkflowExecutionInitiatedEventAttributes,
 				TargetRunID:              common.StringPtr(childExecutionRunID),
+				PartitionConfig:          partitionConfig,
 			}, request.StartChildExecutionAttributes)
 			s.Equal(ctask.TaskStatePending, sourceTask.State())
 			s.Equal(processingStateResponseRecorded, sourceTask.ProcessingState())
@@ -617,6 +622,7 @@ func (s *crossClusterTaskSuite) TestSourceTask_GetStartChildRequest_Duplication(
 			sourceTask *crossClusterSourceTask,
 			childInfo *persistence.ChildExecutionInfo,
 			initiatedEvent *types.HistoryEvent,
+			partitionConfig map[string]string,
 		) {
 			s.NoError(getRequestErr)
 			s.Nil(request)
@@ -640,6 +646,7 @@ func (s *crossClusterTaskSuite) testGetStartChildExecutionRequest(
 		sourceTask *crossClusterSourceTask,
 		childInfo *persistence.ChildExecutionInfo,
 		initiatedEvent *types.HistoryEvent,
+		partitionConfig map[string]string,
 	),
 ) {
 	workflowExecution, mutableState, decisionCompletionID, err := test.SetupWorkflowWithCompletedDecision(s.mockShard, sourceDomainID)
@@ -689,7 +696,7 @@ func (s *crossClusterTaskSuite) testGetStartChildExecutionRequest(
 	}
 
 	request, err := sourceTask.GetCrossClusterRequest()
-	validationFn(request, err, sourceTask, childInfo, event)
+	validationFn(request, err, sourceTask, childInfo, event, mutableState.GetExecutionInfo().PartitionConfig)
 }
 
 func (s *crossClusterTaskSuite) TestSourceTask_GetCancelRequest_Duplication() {

--- a/service/history/task/standby_task_util.go
+++ b/service/history/task/standby_task_util.go
@@ -114,31 +114,37 @@ type (
 
 	pushActivityToMatchingInfo struct {
 		activityScheduleToStartTimeout int32
+		partitionConfig                map[string]string
 	}
 
 	pushDecisionToMatchingInfo struct {
 		decisionScheduleToStartTimeout int32
 		tasklist                       types.TaskList
+		partitionConfig                map[string]string
 	}
 )
 
 func newPushActivityToMatchingInfo(
 	activityScheduleToStartTimeout int32,
+	partitionConfig map[string]string,
 ) *pushActivityToMatchingInfo {
 
 	return &pushActivityToMatchingInfo{
 		activityScheduleToStartTimeout: activityScheduleToStartTimeout,
+		partitionConfig:                partitionConfig,
 	}
 }
 
 func newPushDecisionToMatchingInfo(
 	decisionScheduleToStartTimeout int32,
 	tasklist types.TaskList,
+	partitionConfig map[string]string,
 ) *pushDecisionToMatchingInfo {
 
 	return &pushDecisionToMatchingInfo{
 		decisionScheduleToStartTimeout: decisionScheduleToStartTimeout,
 		tasklist:                       tasklist,
+		partitionConfig:                partitionConfig,
 	}
 }
 

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -598,6 +598,7 @@ func (t *timerActiveTaskExecutor) executeActivityRetryTimerTask(
 		TaskList:                      taskList,
 		ScheduleID:                    scheduledID,
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(scheduleToStartTimeout),
+		PartitionConfig:               mutableState.GetExecutionInfo().PartitionConfig,
 	})
 }
 

--- a/service/history/task/timer_active_task_executor_test.go
+++ b/service/history/task/timer_active_task_executor_test.go
@@ -1067,6 +1067,7 @@ func (s *timerActiveTaskExecutorSuite) TestActivityRetryTimer_Fire() {
 			},
 			ScheduleID:                    activityInfo.ScheduleID,
 			ScheduleToStartTimeoutSeconds: common.Int32Ptr(activityInfo.ScheduleToStartTimeout),
+			PartitionConfig:               mutableState.GetExecutionInfo().PartitionConfig,
 		},
 	).Return(nil).Times(1)
 

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -192,7 +192,7 @@ func (t *transferActiveTaskExecutor) processActivityTask(
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
-	return t.pushActivity(ctx, task, timeout)
+	return t.pushActivity(ctx, task, timeout, mutableState.GetExecutionInfo().PartitionConfig)
 }
 
 func (t *transferActiveTaskExecutor) processDecisionTask(
@@ -261,7 +261,7 @@ func (t *transferActiveTaskExecutor) processDecisionTask(
 	// release the context lock since we no longer need mutable state builder and
 	// the rest of logic is making RPC call, which takes time.
 	release(nil)
-	err = t.pushDecision(ctx, task, taskList, decisionTimeout)
+	err = t.pushDecision(ctx, task, taskList, decisionTimeout, mutableState.GetExecutionInfo().PartitionConfig)
 	if _, ok := err.(*types.StickyWorkerUnavailableError); ok {
 		// sticky worker is unavailable, switch to non-sticky task list
 		taskList = &types.TaskList{
@@ -273,7 +273,7 @@ func (t *transferActiveTaskExecutor) processDecisionTask(
 		// There is no need to reset sticky, because if this task is picked by new worker, the new worker will reset
 		// the sticky queue to a new one. However, if worker is completely down, that schedule_to_start timeout task
 		// will re-create a new non-sticky task and reset sticky.
-		err = t.pushDecision(ctx, task, taskList, decisionTimeout)
+		err = t.pushDecision(ctx, task, taskList, decisionTimeout, mutableState.GetExecutionInfo().PartitionConfig)
 	}
 	return err
 }
@@ -877,6 +877,7 @@ func (t *transferActiveTaskExecutor) processStartChildExecution(
 		targetDomainName,
 		childInfo.CreateRequestID,
 		attributes,
+		mutableState.GetExecutionInfo().PartitionConfig,
 	)
 	if err != nil {
 		t.logger.Error("Failed to start child workflow execution",
@@ -1706,6 +1707,7 @@ func startWorkflowWithRetry(
 	targetDomain string,
 	requestID string,
 	attributes *types.StartChildWorkflowExecutionInitiatedEventAttributes,
+	partitionConfig map[string]string,
 ) (string, error) {
 
 	// Get parent domain name
@@ -1738,7 +1740,7 @@ func startWorkflowWithRetry(
 		JitterStartSeconds:    attributes.JitterStartSeconds,
 	}
 
-	historyStartReq, err := common.CreateHistoryStartWorkflowRequest(task.TargetDomainID, frontendStartReq, timeSource.Now())
+	historyStartReq, err := common.CreateHistoryStartWorkflowRequest(task.TargetDomainID, frontendStartReq, timeSource.Now(), partitionConfig)
 	if err != nil {
 		return "", err
 	}

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -139,6 +139,7 @@ func (t *transferStandbyTaskExecutor) processActivityTask(
 		if activityInfo.StartedID == common.EmptyEventID {
 			return newPushActivityToMatchingInfo(
 				activityInfo.ScheduleToStartTimeout,
+				mutableState.GetExecutionInfo().PartitionConfig,
 			), nil
 		}
 
@@ -193,6 +194,7 @@ func (t *transferStandbyTaskExecutor) processDecisionTask(
 			return newPushDecisionToMatchingInfo(
 				decisionTimeout,
 				types.TaskList{Name: executionInfo.TaskList}, // at standby, always use non-sticky tasklist
+				mutableState.GetExecutionInfo().PartitionConfig,
 			), nil
 		}
 
@@ -589,6 +591,7 @@ func (t *transferStandbyTaskExecutor) pushActivity(
 		ctx,
 		task.(*persistence.TransferTaskInfo),
 		timeout,
+		pushActivityInfo.partitionConfig,
 	)
 }
 
@@ -610,6 +613,7 @@ func (t *transferStandbyTaskExecutor) pushDecision(
 		task.(*persistence.TransferTaskInfo),
 		&pushDecisionInfo.tasklist,
 		timeout,
+		pushDecisionInfo.partitionConfig,
 	)
 }
 

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -208,7 +208,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending_PushT
 	workflowExecution, mutableState, decisionCompletionID, err := test.SetupWorkflowWithCompletedDecision(s.mockShard, s.domainID)
 	s.NoError(err)
 
-	event, _ := test.AddActivityTaskScheduledEvent(
+	event, ai := test.AddActivityTaskScheduledEvent(
 		mutableState,
 		decisionCompletionID,
 		"activity-1",
@@ -234,7 +234,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending_PushT
 	persistenceMutableState, err := test.CreatePersistenceMutableState(mutableState, event.ID, event.Version)
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.mockMatchingClient.EXPECT().AddActivityTask(gomock.Any(), createAddActivityTaskRequest(transferTask, ai, mutableState.GetExecutionInfo().PartitionConfig)).Return(nil).Times(1)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)
@@ -332,7 +332,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessDecisionTask_Pending_PushT
 	persistenceMutableState, err := test.CreatePersistenceMutableState(mutableState, di.ScheduleID, di.Version)
 	s.NoError(err)
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.GetWorkflowExecutionResponse{State: persistenceMutableState}, nil)
-	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), gomock.Any()).Return(nil).Times(1)
+	s.mockMatchingClient.EXPECT().AddDecisionTask(gomock.Any(), createAddDecisionTaskRequest(transferTask, mutableState)).Return(nil).Times(1)
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
 	err = s.transferStandbyTaskExecutor.Execute(transferTask, true)

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -89,6 +89,7 @@ func (t *transferTaskExecutorBase) pushActivity(
 	ctx context.Context,
 	task *persistence.TransferTaskInfo,
 	activityScheduleToStartTimeout int32,
+	partitionConfig map[string]string,
 ) error {
 
 	ctx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
@@ -108,6 +109,7 @@ func (t *transferTaskExecutorBase) pushActivity(
 		TaskList:                      &types.TaskList{Name: task.TaskList},
 		ScheduleID:                    task.ScheduleID,
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(activityScheduleToStartTimeout),
+		PartitionConfig:               partitionConfig,
 	})
 }
 
@@ -116,6 +118,7 @@ func (t *transferTaskExecutorBase) pushDecision(
 	task *persistence.TransferTaskInfo,
 	tasklist *types.TaskList,
 	decisionScheduleToStartTimeout int32,
+	partitionConfig map[string]string,
 ) error {
 
 	ctx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
@@ -134,6 +137,7 @@ func (t *transferTaskExecutorBase) pushDecision(
 		TaskList:                      tasklist,
 		ScheduleID:                    task.ScheduleID,
 		ScheduleToStartTimeoutSeconds: common.Int32Ptr(decisionScheduleToStartTimeout),
+		PartitionConfig:               partitionConfig,
 	})
 }
 

--- a/service/history/testing/workflow_util.go
+++ b/service/history/testing/workflow_util.go
@@ -65,6 +65,7 @@ func StartWorkflow(
 				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(2),
 				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 			},
+			PartitionConfig: map[string]string{"userid": uuid.New()},
 		},
 	)
 	if err != nil {

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -846,6 +846,7 @@ type workflowExecutionInfo struct {
 	Memo             *types.Memo
 	SearchAttributes map[string]interface{}
 	AutoResetPoints  *types.ResetPoints
+	PartitionConfig  map[string]string
 }
 
 // pendingActivityInfo has same fields as types.PendingActivityInfo, but different field type for better display
@@ -889,6 +890,7 @@ func convertDescribeWorkflowExecutionResponse(resp *types.DescribeWorkflowExecut
 		Memo:             info.Memo,
 		SearchAttributes: convertSearchAttributesToMapOfInterface(info.SearchAttributes, wfClient, c),
 		AutoResetPoints:  info.AutoResetPoints,
+		PartitionConfig:  info.PartitionConfig,
 	}
 
 	var pendingActs []*pendingActivityInfo


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update history to persist partition config in mutable state and workflow started event and forward it to matching when pushing activity and decision tasks to matching

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
