### PR TITLE
Add default value for shard_id and update_time in postgres

### DIFF
--- a/schema/postgres/visibility/versioned/v0.6/add_update_time.sql
+++ b/schema/postgres/visibility/versioned/v0.6/add_update_time.sql
@@ -1,1 +1,1 @@
-ALTER TABLE executions_visibility ADD update_time TIMESTAMP NULL;
+ALTER TABLE executions_visibility ADD update_time TIMESTAMP NULL DEFAULT CURRENT_TIMESTAMP;

--- a/schema/postgres/visibility/versioned/v0.7/add_shard_id.sql
+++ b/schema/postgres/visibility/versioned/v0.7/add_shard_id.sql
@@ -1,1 +1,1 @@
-ALTER TABLE executions_visibility ADD shard_id INTEGER NULL;
+ALTER TABLE executions_visibility ADD shard_id INTEGER NULL DEFAULT -1;


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added default value for shard_id and update_time to make it backwards compatible

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test using local postgres

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
