### PR TITLE
Adds Dynamic-config type

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -24,6 +24,8 @@ import (
 	"log"
 	"time"
 
+	"github.com/uber/cadence/common/persistence"
+
 	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
 	"go.uber.org/cadence/compatibility"
 
@@ -126,7 +128,7 @@ func (s *server) startService() common.Daemon {
 				&s.cfg.DynamicConfig.ConfigStore,
 				&s.cfg.Persistence,
 				params.Logger,
-				s.doneC,
+				persistence.DynamicConfig,
 			)
 		case dynamicconfig.FileBasedClient:
 			params.Logger.Info("initialising File Based dynamic config client")

--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -369,7 +369,7 @@ func (csc *configStoreClient) Stop() {
 func (csc *configStoreClient) Start() {
 	err := csc.startUpdate()
 	if err != nil {
-		csc.logger.Error("could not start config store", tag.Error(err))
+		csc.logger.Fatal("could not start config store", tag.Error(err))
 		return
 	}
 	if !atomic.CompareAndSwapInt32(&csc.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {

--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -29,6 +29,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/uber/cadence/common"
+
 	"github.com/uber/cadence/common/config"
 	dc "github.com/uber/cadence/common/dynamicconfig"
 	csc "github.com/uber/cadence/common/dynamicconfig/configstore/config"
@@ -40,6 +42,12 @@ import (
 )
 
 var _ dc.Client = (*configStoreClient)(nil)
+
+// Client is a stateful config store
+type Client interface {
+	common.Daemon
+	dc.Client
+}
 
 const (
 	configStoreMinPollInterval = time.Second * 2
@@ -53,6 +61,8 @@ var defaultConfigValues = &csc.ClientConfig{
 }
 
 type configStoreClient struct {
+	status             int32
+	configStoreType    persistence.ConfigType
 	values             atomic.Value
 	lastUpdatedTime    time.Time
 	config             *csc.ClientConfig
@@ -68,7 +78,11 @@ type cacheEntry struct {
 }
 
 // NewConfigStoreClient creates a config store client
-func NewConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.Persistence, logger log.Logger, doneCh chan struct{}) (dc.Client, error) {
+func NewConfigStoreClient(clientCfg *csc.ClientConfig,
+	persistenceCfg *config.Persistence,
+	logger log.Logger,
+	configType persistence.ConfigType,
+) (Client, error) {
 	if persistenceCfg == nil {
 		return nil, errors.New("persistence cfg is nil")
 	}
@@ -95,7 +109,7 @@ func NewConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.Pe
 		dsConfig = ds.NoSQL.ConvertToShardedNoSQLConfig()
 	}
 
-	client, err := newConfigStoreClient(clientCfg, dsConfig, logger, doneCh)
+	client, err := newConfigStoreClient(clientCfg, dsConfig, logger, configType)
 	if err != nil {
 		return nil, err
 	}
@@ -106,17 +120,25 @@ func NewConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.Pe
 	return client, nil
 }
 
-func newConfigStoreClient(clientCfg *csc.ClientConfig, persistenceCfg *config.ShardedNoSQL, logger log.Logger, doneCh chan struct{}) (*configStoreClient, error) {
+func newConfigStoreClient(
+	clientCfg *csc.ClientConfig,
+	persistenceCfg *config.ShardedNoSQL,
+	logger log.Logger,
+	configType persistence.ConfigType,
+) (*configStoreClient, error) {
 	store, err := nosql.NewNoSQLConfigStore(*persistenceCfg, logger, nil)
 	if err != nil {
 		return nil, err
 	}
 
+	doneCh := make(chan struct{})
 	client := &configStoreClient{
+		status:             common.DaemonStatusStarted,
 		config:             clientCfg,
 		doneCh:             doneCh,
 		configStoreManager: persistence.NewConfigStoreManagerImpl(store, logger),
 		logger:             logger,
+		configStoreType:    configType,
 	}
 
 	return client, nil
@@ -337,6 +359,24 @@ func (csc *configStoreClient) ListValue(name dc.Key) ([]*types.DynamicConfigEntr
 	return resList, nil
 }
 
+func (csc *configStoreClient) Stop() {
+	if !atomic.CompareAndSwapInt32(&csc.status, common.DaemonStatusStarted, common.DaemonStatusStopped) {
+		return
+	}
+	close(csc.doneCh)
+}
+
+func (csc *configStoreClient) Start() {
+	err := csc.startUpdate()
+	if err != nil {
+		csc.logger.Error("could not start config store", tag.Error(err))
+		return
+	}
+	if !atomic.CompareAndSwapInt32(&csc.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
+		return
+	}
+}
+
 func (csc *configStoreClient) updateValue(name dc.Key, dcValues []*types.DynamicConfigValue, retryAttempts int) error {
 	//since values are not unique, no way to know if you are trying to update a specific value
 	//or if you want to add another of the same value with different filters.
@@ -413,7 +453,7 @@ func (csc *configStoreClient) updateValue(name dc.Key, dcValues []*types.Dynamic
 		ctx,
 		&persistence.UpdateDynamicConfigRequest{
 			Snapshot: newSnapshot,
-		},
+		}, csc.configStoreType,
 	)
 
 	select {
@@ -506,7 +546,7 @@ func (csc *configStoreClient) update() error {
 	ctx, cancel := context.WithTimeout(context.Background(), csc.config.FetchTimeout)
 	defer cancel()
 
-	res, err := csc.configStoreManager.FetchDynamicConfig(ctx)
+	res, err := csc.configStoreManager.FetchDynamicConfig(ctx, csc.configStoreType)
 
 	select {
 	case <-ctx.Done():
@@ -670,6 +710,10 @@ func validateKeyDataBlobPair(key dc.Key, blob *types.DataBlob) error {
 		}
 	case dc.MapKey:
 		if _, ok := value.(map[string]interface{}); !ok {
+			return err
+		}
+	case dc.ListKey:
+		if _, ok := value.([]interface{}); !ok {
 			return err
 		}
 	default:

--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -370,7 +370,6 @@ func (csc *configStoreClient) Start() {
 	err := csc.startUpdate()
 	if err != nil {
 		csc.logger.Fatal("could not start config store", tag.Error(err))
-		return
 	}
 	if !atomic.CompareAndSwapInt32(&csc.status, common.DaemonStatusInitialized, common.DaemonStatusStarted) {
 		return

--- a/common/dynamicconfig/configstore/config_store_client_test.go
+++ b/common/dynamicconfig/configstore/config_store_client_test.go
@@ -304,10 +304,6 @@ func (s *configStoreClientSuite) SetupTest() {
 			PluginName: "cassandra",
 		},
 	}
-	dbConfig := config.ShardedNoSQL{
-		DefaultShard: config.NonShardedStoreName,
-		Connections:  connections,
-	}
 
 	var err error
 	s.client, err = newConfigStoreClient(
@@ -317,7 +313,11 @@ func (s *configStoreClientSuite) SetupTest() {
 			FetchTimeout:        time.Second * 1,
 			UpdateTimeout:       time.Second * 1,
 		},
-		&dbConfig, log.NewNoop(), s.doneCh)
+
+		&config.ShardedNoSQL{
+			DefaultShard: config.NonShardedStoreName,
+			Connections:  connections,
+		}, log.NewNoop(), p.DynamicConfig)
 	s.Require().NoError(err)
 
 	s.mockManager = p.NewMockConfigStoreManager(s.mockController)
@@ -326,7 +326,7 @@ func (s *configStoreClientSuite) SetupTest() {
 
 func defaultTestSetup(s *configStoreClientSuite) {
 	s.mockManager.EXPECT().
-		FetchDynamicConfig(gomock.Any()).
+		FetchDynamicConfig(gomock.Any(), p.DynamicConfig).
 		Return(&p.FetchDynamicConfigResponse{
 			Snapshot: snapshot1,
 		}, nil).
@@ -693,8 +693,8 @@ func (s *configStoreClientSuite) TestUpdateValue_NilOverwrite() {
 	defaultTestSetup(s)
 
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest) error {
+		UpdateDynamicConfig(gomock.Any(), gomock.Any(), p.DynamicConfig).
+		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest, cfgType p.ConfigType) error {
 			if request.Snapshot.Values.Entries[0].Name != dc.TestGetBoolPropertyKey.String() {
 				return nil
 			}
@@ -709,7 +709,7 @@ func (s *configStoreClientSuite) TestUpdateValue_NoRetrySuccess() {
 	defaultTestSetup(s)
 
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), EqSnapshotVersion(2)).
+		UpdateDynamicConfig(gomock.Any(), EqSnapshotVersion(2), p.DynamicConfig).
 		Return(nil).MaxTimes(1)
 
 	values := []*types.DynamicConfigValue{
@@ -728,7 +728,7 @@ func (s *configStoreClientSuite) TestUpdateValue_NoRetrySuccess() {
 	snapshot2 := snapshot1
 	snapshot2.Values.Entries[0].Values = values
 	s.mockManager.EXPECT().
-		FetchDynamicConfig(gomock.Any()).
+		FetchDynamicConfig(gomock.Any(), p.DynamicConfig).
 		Return(&p.FetchDynamicConfigResponse{
 			Snapshot: snapshot2,
 		}, nil).MaxTimes(1)
@@ -753,7 +753,7 @@ func (s *configStoreClientSuite) TestUpdateValue_SuccessNewKey() {
 	}
 
 	s.mockManager.EXPECT().
-		FetchDynamicConfig(gomock.Any()).
+		FetchDynamicConfig(gomock.Any(), p.DynamicConfig).
 		Return(&p.FetchDynamicConfigResponse{
 			Snapshot: &p.DynamicConfigSnapshot{
 				Version: 1,
@@ -766,8 +766,8 @@ func (s *configStoreClientSuite) TestUpdateValue_SuccessNewKey() {
 		AnyTimes()
 
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest) error {
+		UpdateDynamicConfig(gomock.Any(), gomock.Any(), p.DynamicConfig).
+		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest, cfgType p.ConfigType) error {
 			s.Equal(1, len(request.Snapshot.Values.Entries))
 			s.Equal(request.Snapshot.Values.Entries[0].Values, values)
 			return nil
@@ -780,16 +780,16 @@ func (s *configStoreClientSuite) TestUpdateValue_SuccessNewKey() {
 
 func (s *configStoreClientSuite) TestUpdateValue_RetrySuccess() {
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), EqSnapshotVersion(2)).
+		UpdateDynamicConfig(gomock.Any(), EqSnapshotVersion(2), p.DynamicConfig).
 		Return(&p.ConditionFailedError{}).AnyTimes()
 
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), EqSnapshotVersion(3)).
+		UpdateDynamicConfig(gomock.Any(), EqSnapshotVersion(3), p.DynamicConfig).
 		Return(nil).AnyTimes()
 
 	snapshot1.Version = 2
 	s.mockManager.EXPECT().
-		FetchDynamicConfig(gomock.Any()).
+		FetchDynamicConfig(gomock.Any(), p.DynamicConfig).
 		Return(&p.FetchDynamicConfigResponse{
 			Snapshot: snapshot1,
 		}, nil).AnyTimes()
@@ -804,7 +804,7 @@ func (s *configStoreClientSuite) TestUpdateValue_RetryFailure() {
 	defaultTestSetup(s)
 
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), gomock.Any()).
+		UpdateDynamicConfig(gomock.Any(), gomock.Any(), p.DynamicConfig).
 		Return(&p.ConditionFailedError{}).MaxTimes(retryAttempts + 1)
 
 	err := s.client.UpdateValue(dc.TestGetFloat64PropertyKey, []*types.DynamicConfigValue{})
@@ -814,8 +814,8 @@ func (s *configStoreClientSuite) TestUpdateValue_RetryFailure() {
 func (s *configStoreClientSuite) TestUpdateValue_Timeout() {
 	defaultTestSetup(s)
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ *p.UpdateDynamicConfigRequest) error {
+		UpdateDynamicConfig(gomock.Any(), gomock.Any(), p.DynamicConfig).
+		DoAndReturn(func(_ context.Context, _ *p.UpdateDynamicConfigRequest, cfgType p.ConfigType) error {
 			time.Sleep(2 * time.Second)
 			return nil
 		}).AnyTimes()
@@ -827,8 +827,8 @@ func (s *configStoreClientSuite) TestUpdateValue_Timeout() {
 func (s *configStoreClientSuite) TestRestoreValue_NoFilter() {
 	defaultTestSetup(s)
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest) error {
+		UpdateDynamicConfig(gomock.Any(), gomock.Any(), p.DynamicConfig).
+		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest, cfgType p.ConfigType) error {
 			for _, entry := range request.Snapshot.Values.Entries {
 				if entry.Name == dc.TestGetBoolPropertyKey.String() {
 					for _, value := range entry.Values {
@@ -850,8 +850,8 @@ func (s *configStoreClientSuite) TestRestoreValue_FilterNoMatch() {
 	defaultTestSetup(s)
 
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest) error {
+		UpdateDynamicConfig(gomock.Any(), gomock.Any(), p.DynamicConfig).
+		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest, cfgType p.ConfigType) error {
 			for _, resEntry := range request.Snapshot.Values.Entries {
 				for _, oriEntry := range snapshot1.Values.Entries {
 					if oriEntry.Name == resEntry.Name {
@@ -873,8 +873,8 @@ func (s *configStoreClientSuite) TestRestoreValue_FilterNoMatch() {
 func (s *configStoreClientSuite) TestRestoreValue_FilterMatch() {
 	defaultTestSetup(s)
 	s.mockManager.EXPECT().
-		UpdateDynamicConfig(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest) error {
+		UpdateDynamicConfig(gomock.Any(), gomock.Any(), p.DynamicConfig).
+		DoAndReturn(func(_ context.Context, request *p.UpdateDynamicConfigRequest, cfgType p.ConfigType) error {
 			for _, resEntry := range request.Snapshot.Values.Entries {
 				if resEntry.Name == dc.TestGetBoolPropertyKey.String() {
 					s.Equal(2, len(resEntry.Values))
@@ -906,7 +906,7 @@ func (s *configStoreClientSuite) TestListValues() {
 
 func (s *configStoreClientSuite) TestListValues_EmptyCache() {
 	s.mockManager.EXPECT().
-		FetchDynamicConfig(gomock.Any()).
+		FetchDynamicConfig(gomock.Any(), p.DynamicConfig).
 		Return(&p.FetchDynamicConfigResponse{
 			Snapshot: &p.DynamicConfigSnapshot{
 				Version: 1,

--- a/common/persistence/configStoreManager.go
+++ b/common/persistence/configStoreManager.go
@@ -53,8 +53,8 @@ func (m *configStoreManagerImpl) Close() {
 	m.persistence.Close()
 }
 
-func (m *configStoreManagerImpl) FetchDynamicConfig(ctx context.Context) (*FetchDynamicConfigResponse, error) {
-	values, err := m.persistence.FetchConfig(ctx, DynamicConfig)
+func (m *configStoreManagerImpl) FetchDynamicConfig(ctx context.Context, cfgType ConfigType) (*FetchDynamicConfigResponse, error) {
+	values, err := m.persistence.FetchConfig(ctx, cfgType)
 	if err != nil || values == nil {
 		return nil, err
 	}
@@ -70,14 +70,14 @@ func (m *configStoreManagerImpl) FetchDynamicConfig(ctx context.Context) (*Fetch
 	}}, nil
 }
 
-func (m *configStoreManagerImpl) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest) error {
+func (m *configStoreManagerImpl) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest, cfgType ConfigType) error {
 	blob, err := m.serializer.SerializeDynamicConfigBlob(request.Snapshot.Values, common.EncodingTypeThriftRW)
 	if err != nil {
 		return err
 	}
 
 	entry := &InternalConfigStoreEntry{
-		RowType:   int(DynamicConfig),
+		RowType:   int(cfgType),
 		Version:   request.Snapshot.Version,
 		Timestamp: time.Now(),
 		Values:    blob,

--- a/common/persistence/dataManagerInterfaces.go
+++ b/common/persistence/dataManagerInterfaces.go
@@ -1866,8 +1866,8 @@ type (
 
 	ConfigStoreManager interface {
 		Closeable
-		FetchDynamicConfig(ctx context.Context) (*FetchDynamicConfigResponse, error)
-		UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest) error
+		FetchDynamicConfig(ctx context.Context, cfgType ConfigType) (*FetchDynamicConfigResponse, error)
+		UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest, cfgType ConfigType) error
 		//can add functions for config types other than dynamic config
 	}
 )

--- a/common/persistence/dataManagerInterfaces_mock.go
+++ b/common/persistence/dataManagerInterfaces_mock.go
@@ -1546,30 +1546,30 @@ func (mr *MockConfigStoreManagerMockRecorder) Close() *gomock.Call {
 }
 
 // FetchDynamicConfig mocks base method.
-func (m *MockConfigStoreManager) FetchDynamicConfig(ctx context.Context) (*FetchDynamicConfigResponse, error) {
+func (m *MockConfigStoreManager) FetchDynamicConfig(ctx context.Context, cfgType ConfigType) (*FetchDynamicConfigResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FetchDynamicConfig", ctx)
+	ret := m.ctrl.Call(m, "FetchDynamicConfig", ctx, cfgType)
 	ret0, _ := ret[0].(*FetchDynamicConfigResponse)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FetchDynamicConfig indicates an expected call of FetchDynamicConfig.
-func (mr *MockConfigStoreManagerMockRecorder) FetchDynamicConfig(ctx interface{}) *gomock.Call {
+func (mr *MockConfigStoreManagerMockRecorder) FetchDynamicConfig(ctx, cfgType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchDynamicConfig", reflect.TypeOf((*MockConfigStoreManager)(nil).FetchDynamicConfig), ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FetchDynamicConfig", reflect.TypeOf((*MockConfigStoreManager)(nil).FetchDynamicConfig), ctx, cfgType)
 }
 
 // UpdateDynamicConfig mocks base method.
-func (m *MockConfigStoreManager) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest) error {
+func (m *MockConfigStoreManager) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest, cfgType ConfigType) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateDynamicConfig", ctx, request)
+	ret := m.ctrl.Call(m, "UpdateDynamicConfig", ctx, request, cfgType)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateDynamicConfig indicates an expected call of UpdateDynamicConfig.
-func (mr *MockConfigStoreManagerMockRecorder) UpdateDynamicConfig(ctx, request interface{}) *gomock.Call {
+func (mr *MockConfigStoreManagerMockRecorder) UpdateDynamicConfig(ctx, request, cfgType interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDynamicConfig", reflect.TypeOf((*MockConfigStoreManager)(nil).UpdateDynamicConfig), ctx, request)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDynamicConfig", reflect.TypeOf((*MockConfigStoreManager)(nil).UpdateDynamicConfig), ctx, request, cfgType)
 }

--- a/common/persistence/persistence-tests/configStorePersistenceTest.go
+++ b/common/persistence/persistence-tests/configStorePersistenceTest.go
@@ -212,7 +212,7 @@ func validDatabaseCheck(cfg config.Persistence) bool {
 }
 
 func (s *ConfigStorePersistenceSuite) FetchDynamicConfig(ctx context.Context) (*p.DynamicConfigSnapshot, error) {
-	response, err := s.ConfigStoreManager.FetchDynamicConfig(ctx)
+	response, err := s.ConfigStoreManager.FetchDynamicConfig(ctx, p.DynamicConfig)
 	if err != nil {
 		return nil, err
 	}
@@ -223,5 +223,5 @@ func (s *ConfigStorePersistenceSuite) FetchDynamicConfig(ctx context.Context) (*
 }
 
 func (s *ConfigStorePersistenceSuite) UpdateDynamicConfig(ctx context.Context, snapshot *p.DynamicConfigSnapshot) error {
-	return s.ConfigStoreManager.UpdateDynamicConfig(ctx, &p.UpdateDynamicConfigRequest{Snapshot: snapshot})
+	return s.ConfigStoreManager.UpdateDynamicConfig(ctx, &p.UpdateDynamicConfigRequest{Snapshot: snapshot}, p.DynamicConfig)
 }

--- a/common/persistence/persistenceErrorInjectionClients.go
+++ b/common/persistence/persistenceErrorInjectionClients.go
@@ -2332,14 +2332,14 @@ func (p *queueErrorInjectionPersistenceClient) Close() {
 	p.persistence.Close()
 }
 
-func (p *configStoreErrorInjectionPersistenceClient) FetchDynamicConfig(ctx context.Context) (*FetchDynamicConfigResponse, error) {
+func (p *configStoreErrorInjectionPersistenceClient) FetchDynamicConfig(ctx context.Context, cfgType ConfigType) (*FetchDynamicConfigResponse, error) {
 	fakeErr := generateFakeError(p.errorRate)
 
 	var response *FetchDynamicConfigResponse
 	var persistenceErr error
 	var forwardCall bool
 	if forwardCall = shouldForwardCallToPersistence(fakeErr); forwardCall {
-		response, persistenceErr = p.persistence.FetchDynamicConfig(ctx)
+		response, persistenceErr = p.persistence.FetchDynamicConfig(ctx, cfgType)
 	}
 
 	if fakeErr != nil {
@@ -2354,13 +2354,13 @@ func (p *configStoreErrorInjectionPersistenceClient) FetchDynamicConfig(ctx cont
 	return response, persistenceErr
 }
 
-func (p *configStoreErrorInjectionPersistenceClient) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest) error {
+func (p *configStoreErrorInjectionPersistenceClient) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest, cfgType ConfigType) error {
 	fakeErr := generateFakeError(p.errorRate)
 
 	var persistenceErr error
 	var forwardCall bool
 	if forwardCall = shouldForwardCallToPersistence(fakeErr); forwardCall {
-		persistenceErr = p.persistence.UpdateDynamicConfig(ctx, request)
+		persistenceErr = p.persistence.UpdateDynamicConfig(ctx, request, cfgType)
 	}
 
 	if fakeErr != nil {

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -1731,11 +1731,11 @@ func (p *queuePersistenceClient) Close() {
 	p.persistence.Close()
 }
 
-func (p *configStorePersistenceClient) FetchDynamicConfig(ctx context.Context) (*FetchDynamicConfigResponse, error) {
+func (p *configStorePersistenceClient) FetchDynamicConfig(ctx context.Context, configType ConfigType) (*FetchDynamicConfigResponse, error) {
 	var resp *FetchDynamicConfigResponse
 	op := func() error {
 		var err error
-		resp, err = p.persistence.FetchDynamicConfig(ctx)
+		resp, err = p.persistence.FetchDynamicConfig(ctx, configType)
 		return err
 	}
 	err := p.call(metrics.PersistenceFetchDynamicConfigScope, op)
@@ -1745,9 +1745,9 @@ func (p *configStorePersistenceClient) FetchDynamicConfig(ctx context.Context) (
 	return resp, nil
 }
 
-func (p *configStorePersistenceClient) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest) error {
+func (p *configStorePersistenceClient) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest, configType ConfigType) error {
 	op := func() error {
-		return p.persistence.UpdateDynamicConfig(ctx, request)
+		return p.persistence.UpdateDynamicConfig(ctx, request, configType)
 	}
 	return p.call(metrics.PersistenceUpdateDynamicConfigScope, op)
 }

--- a/common/persistence/persistenceRateLimitedClients.go
+++ b/common/persistence/persistenceRateLimitedClients.go
@@ -1215,19 +1215,19 @@ func (p *queueRateLimitedPersistenceClient) Close() {
 	p.persistence.Close()
 }
 
-func (p *configStoreRateLimitedPersistenceClient) FetchDynamicConfig(ctx context.Context) (*FetchDynamicConfigResponse, error) {
+func (p *configStoreRateLimitedPersistenceClient) FetchDynamicConfig(ctx context.Context, configType ConfigType) (*FetchDynamicConfigResponse, error) {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return nil, ErrPersistenceLimitExceeded
 	}
 
-	return p.persistence.FetchDynamicConfig(ctx)
+	return p.persistence.FetchDynamicConfig(ctx, configType)
 }
 
-func (p *configStoreRateLimitedPersistenceClient) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest) error {
+func (p *configStoreRateLimitedPersistenceClient) UpdateDynamicConfig(ctx context.Context, request *UpdateDynamicConfigRequest, configType ConfigType) error {
 	if ok := p.rateLimiter.Allow(); !ok {
 		return ErrPersistenceLimitExceeded
 	}
-	return p.persistence.UpdateDynamicConfig(ctx, request)
+	return p.persistence.UpdateDynamicConfig(ctx, request, configType)
 }
 
 func (p *configStoreRateLimitedPersistenceClient) Close() {


### PR DESCRIPTION
Changes:

- Refactors the config-store library to include a new dimension called 'configType' which allows for multiple stores. 
- Refactors the config-store slightly to reflect the fact that it is indeed actually a daemon

These changes are tested and part of a larger set of changes of the ['zonal-isolation' feature](https://github.com/uber/cadence-idl/commit/88be1470a45198d4546a484104d54468d6c17dbf)
