### PR TITLE
Make isolation group store client optional

### DIFF
--- a/common/isolationgroup/isolationgroupapi/global-api-handlers.go
+++ b/common/isolationgroup/isolationgroupapi/global-api-handlers.go
@@ -32,6 +32,9 @@ import (
 )
 
 func (z *handlerImpl) UpdateGlobalState(ctx context.Context, in types.UpdateGlobalIsolationGroupsRequest) error {
+	if z.globalIsolationGroupDrains == nil {
+		return &types.BadRequestError{"global isolation group drain is not supported in this cluster"}
+	}
 	mappedInput, err := MapUpdateGlobalIsolationGroupsRequest(in.IsolationGroups)
 	if err != nil {
 		return err
@@ -43,6 +46,9 @@ func (z *handlerImpl) UpdateGlobalState(ctx context.Context, in types.UpdateGlob
 }
 
 func (z *handlerImpl) GetGlobalState(ctx context.Context) (*types.GetGlobalIsolationGroupsResponse, error) {
+	if z.globalIsolationGroupDrains == nil {
+		return nil, &types.BadRequestError{"global isolation group drain is not supported in this cluster"}
+	}
 	res, err := z.globalIsolationGroupDrains.GetListValue(dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping, nil)
 	if err != nil {
 		var e types.EntityNotExistsError

--- a/service/frontend/adminHandler.go
+++ b/service/frontend/adminHandler.go
@@ -1743,11 +1743,12 @@ func (adh *adminHandlerImpl) GetGlobalIsolationGroups(ctx context.Context, reque
 	if request == nil {
 		return nil, adh.error(errRequestNotSet, scope)
 	}
-	if adh.isolationGroups == nil {
-		return nil, adh.error(types.BadRequestError{Message: "isolation groups are not enabled in this cluster"}, scope)
-	}
 
-	return adh.isolationGroups.GetGlobalState(ctx)
+	resp, err := adh.isolationGroups.GetGlobalState(ctx)
+	if err != nil {
+		return nil, adh.error(err, scope)
+	}
+	return resp, nil
 }
 
 func (adh *adminHandlerImpl) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest) (_ *types.UpdateGlobalIsolationGroupsResponse, retError error) {
@@ -1757,12 +1758,9 @@ func (adh *adminHandlerImpl) UpdateGlobalIsolationGroups(ctx context.Context, re
 	if request == nil {
 		return nil, adh.error(errRequestNotSet, scope)
 	}
-	if adh.isolationGroups == nil {
-		return nil, adh.error(types.BadRequestError{Message: "isolation groups are not enabled in this cluster"}, scope)
-	}
 	err := adh.isolationGroups.UpdateGlobalState(ctx, *request)
 	if err != nil {
-		return nil, err
+		return nil, adh.error(err, scope)
 	}
 	return &types.UpdateGlobalIsolationGroupsResponse{}, nil
 }
@@ -1775,11 +1773,12 @@ func (adh *adminHandlerImpl) GetDomainIsolationGroups(ctx context.Context, reque
 	if request == nil {
 		return nil, adh.error(errRequestNotSet, scope)
 	}
-	if adh.isolationGroups == nil {
-		return nil, adh.error(types.BadRequestError{Message: "isolation groups are not enabled in this cluster"}, scope)
-	}
 
-	return adh.isolationGroups.GetDomainState(ctx, types.GetDomainIsolationGroupsRequest{Domain: request.Domain})
+	resp, err := adh.isolationGroups.GetDomainState(ctx, types.GetDomainIsolationGroupsRequest{Domain: request.Domain})
+	if err != nil {
+		return nil, adh.error(err, scope)
+	}
+	return resp, nil
 }
 
 func (adh *adminHandlerImpl) UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest) (_ *types.UpdateDomainIsolationGroupsResponse, retError error) {
@@ -1789,12 +1788,9 @@ func (adh *adminHandlerImpl) UpdateDomainIsolationGroups(ctx context.Context, re
 	if request == nil {
 		return nil, adh.error(errRequestNotSet, scope)
 	}
-	if adh.isolationGroups == nil {
-		return nil, adh.error(types.BadRequestError{Message: "isolation groups are not enabled in this cluster"}, scope)
-	}
 	err := adh.isolationGroups.UpdateDomainState(ctx, *request)
 	if err != nil {
-		return nil, err
+		return nil, adh.error(err, scope)
 	}
 	return &types.UpdateDomainIsolationGroupsResponse{}, nil
 }

--- a/service/frontend/adminHandler_test.go
+++ b/service/frontend/adminHandler_test.go
@@ -807,7 +807,7 @@ func Test_GetGlobalIsolationGroups(t *testing.T) {
 			ighandlerAffordance: func(mock *isolationgroupapi.MockHandler) {
 				mock.EXPECT().GetGlobalState(gomock.Any()).Return(nil, assert.AnError)
 			},
-			expectedErr: assert.AnError,
+			expectedErr: &types.InternalServiceError{Message: assert.AnError.Error()},
 		},
 	}
 
@@ -871,7 +871,7 @@ func Test_UpdateGlobalIsolationGroups(t *testing.T) {
 			ighandlerAffordance: func(mock *isolationgroupapi.MockHandler) {
 				mock.EXPECT().UpdateGlobalState(gomock.Any(), validConfig).Return(assert.AnError)
 			},
-			expectedErr: assert.AnError,
+			expectedErr: &types.InternalServiceError{Message: assert.AnError.Error()},
 		},
 	}
 
@@ -950,7 +950,7 @@ func Test_GetDomainIsolationGroups(t *testing.T) {
 					Domain: "domain",
 				}).Return(nil, assert.AnError)
 			},
-			expectedErr: assert.AnError,
+			expectedErr: &types.InternalServiceError{Message: assert.AnError.Error()},
 		},
 	}
 
@@ -1017,7 +1017,7 @@ func Test_UpdateDomainIsolationGroups(t *testing.T) {
 			ighandlerAffordance: func(mock *isolationgroupapi.MockHandler) {
 				mock.EXPECT().UpdateDomainState(gomock.Any(), validConfig).Return(assert.AnError)
 			},
-			expectedErr: assert.AnError,
+			expectedErr: &types.InternalServiceError{Message: assert.AnError.Error()},
 		},
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make isolation group store client optional for default isolation group state

<!-- Tell your future self why have you made these changes -->
**Why?**
To support domain drain for SQL database

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**


<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
