### PR TITLE
Fix panic while parsing workflows with timeouts

### DIFF
--- a/tools/cli/utils.go
+++ b/tools/cli/utils.go
@@ -39,18 +39,16 @@ import (
 	"strings"
 	"time"
 
-	"github.com/uber/cadence/common/pagination"
-
-	"github.com/uber/cadence/client/frontend"
-	"github.com/uber/cadence/common/types"
-
 	"github.com/cristalhq/jwt/v3"
 	"github.com/fatih/color"
 	"github.com/urfave/cli"
 	"github.com/valyala/fastjson"
 
+	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/authorization"
+	"github.com/uber/cadence/common/pagination"
+	"github.com/uber/cadence/common/types"
 )
 
 // JSONHistorySerializer is used to encode history event in JSON
@@ -157,6 +155,13 @@ func HistoryEventToString(e *types.HistoryEvent, printFully bool, maxFieldLength
 }
 
 func anyToString(d interface{}, printFully bool, maxFieldLength int) string {
+	// fields related to schedule are of time.Time type, and we shouldn't dive
+	// into it with reflection - it's fields are private.
+	tm, ok := d.(time.Time)
+	if ok {
+		return trimText(tm.String(), maxFieldLength)
+	}
+
 	v := reflect.ValueOf(d)
 	switch v.Kind() {
 	case reflect.Ptr:

--- a/tools/cli/utils_test.go
+++ b/tools/cli/utils_test.go
@@ -22,6 +22,7 @@ package cli
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -91,4 +92,35 @@ func Test_ParseIntMultiRange(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_anyToStringWorksWithTime(t *testing.T) {
+	tm := time.Date(2020, 1, 15, 14, 30, 45, 0, time.UTC)
+
+	assert.Equal(
+		t,
+		"2020-01-15 14:30:45 +0000 UTC",
+		anyToString(tm, false, 100),
+	)
+	assert.Equal(
+		t,
+		"2020-01-15 ...  +0000 UTC",
+		anyToString(tm, false, 20),
+		"trimming should work for time.Time as well",
+	)
+}
+
+func Test_anyToString(t *testing.T) {
+	info := struct {
+		Name   string
+		Number int
+		Time   time.Time
+	}{
+		"Joel",
+		1234,
+		time.Date(2019, 1, 15, 14, 30, 45, 0, time.UTC),
+	}
+
+	res := anyToString(info, false, 100)
+	assert.Equal(t, "{Name:Joel, Number:1234, Time:2019-01-15 14:30:45 +0000 UTC}", res)
 }


### PR DESCRIPTION
When cadence-cli parses workflows with timeouts it panic since these for this workflows Cadence is using time.Time and tries to dig into it's private fields with reflection.
The fix is to detect this edge-case and to print time.Time as fmt would do.

+Rename util.go -> utils.go so that utils_test.go are now contribute to coverage%

<!-- Describe what has changed in this PR -->
**What changed?**
Instead of calling reflection on time.Time and its private fields, we're now print it just like `fmt.Sprint` would


<!-- Tell your future self why have you made these changes -->
**Why?**
An attempt to call `workflow show` for cadence.canary.cron workflows is making CLI panic
That's because of FirstScheduleTime having time.Time type and CLI was diving into it with reflection.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit-test + testing with cadence-cli


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
I don't see any. This is CLI + it's been panicing before, and shouldn't panic now

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
