### PR TITLE
Adding domain handler changes

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -400,6 +400,24 @@ func (d *handlerImpl) UpdateDomain(
 	visibilityArchivalConfigChanged := false
 	// whether active cluster is changed
 	activeClusterChanged := false
+
+	// Whether isolation-groups are changed. There's semantic API difference between the
+	// domain isolation-group update API which is a flat upsert and this handler API which
+	// relies on modifying specified values only, and leaving the rest as-is.
+	// for callers of the Domain API wishing to update isolation groups,
+	// To distinguish between the operation to remove all drains and
+	// take no action, the UpdateDomain handler uses the presence or nil-ness of the IsolationGroup
+	// field to indicate either drain removal (where the struct is present), and to take no action
+	// where the field is nil.
+	//
+	// ie, for the purposes of this handler:
+	// h.UpdateDomain(ctx, UpdateDomainRequest{
+	//   IsolationGroups: nil,                              // take no action for isolation groups
+	// })
+	// h.UpdateDomain(ctx, UpdateDomainRequest{
+	//   IsolationGroups: IsolationGroupConfiguration{},    // remove all isolation groups for domain
+	// })
+	config, isolationGroupConfigurationChanged, err := d.getIsolationGroupStatus(config, updateRequest)
 	// whether anything other than active cluster is changed
 	configurationChanged := false
 
@@ -484,7 +502,7 @@ func (d *handlerImpl) UpdateDomain(
 		previousFailoverVersion = failoverVersion
 	}
 
-	configurationChanged = historyArchivalConfigChanged || visibilityArchivalConfigChanged || domainInfoChanged || domainConfigChanged || deleteBinaryChanged || replicationConfigChanged
+	configurationChanged = historyArchivalConfigChanged || visibilityArchivalConfigChanged || domainInfoChanged || domainConfigChanged || deleteBinaryChanged || replicationConfigChanged || isolationGroupConfigurationChanged
 
 	if err := d.domainAttrValidator.validateDomainConfig(config); err != nil {
 		return nil, err
@@ -674,6 +692,7 @@ func (d *handlerImpl) createResponse(
 		VisibilityArchivalStatus:               config.VisibilityArchivalStatus.Ptr(),
 		VisibilityArchivalURI:                  config.VisibilityArchivalURI,
 		BadBinaries:                            &config.BadBinaries,
+		IsolationGroups:                        &config.IsolationGroups,
 	}
 
 	clusters := []*types.ClusterReplicationConfiguration{}
@@ -935,6 +954,26 @@ func (d *handlerImpl) updateReplicationConfig(
 		config.ActiveClusterName = *updateRequest.ActiveClusterName
 	}
 	return config, clusterUpdated, activeClusterUpdated, nil
+}
+
+func (d *handlerImpl) getIsolationGroupStatus(
+	incomingCfg *persistence.DomainConfig,
+	updateRequest *types.UpdateDomainRequest,
+) (config *persistence.DomainConfig, isolationGroupsChanged bool, err error) {
+
+	if updateRequest == nil || updateRequest.IsolationGroupConfiguration == nil {
+		return incomingCfg, false, nil
+	}
+
+	if incomingCfg == nil {
+		return &persistence.DomainConfig{
+			IsolationGroups: *updateRequest.IsolationGroupConfiguration,
+		}, true, nil
+	}
+
+	// upsert with whatever is present in the request always
+	incomingCfg.IsolationGroups = *updateRequest.IsolationGroupConfiguration
+	return incomingCfg, true, nil
 }
 
 func getDomainStatus(info *persistence.DomainInfo) *types.DomainStatus {

--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -194,6 +194,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestRegisterGetDom
 		VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 		VisibilityArchivalURI:                  "",
 		BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+		IsolationGroups:                        &types.IsolationGroupConfiguration{},
 	}, resp.Configuration)
 	s.Equal(&types.DomainReplicationConfiguration{
 		ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -261,6 +262,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestRegisterGetDom
 		VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 		VisibilityArchivalURI:                  "",
 		BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+		IsolationGroups:                        &types.IsolationGroupConfiguration{},
 	}, resp.Configuration)
 	s.Equal(&types.DomainReplicationConfiguration{
 		ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -318,6 +320,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateGetDomai
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -394,6 +397,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateGetDomai
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -502,6 +506,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestRegisterGetDom
 		VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 		VisibilityArchivalURI:                  "",
 		BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+		IsolationGroups:                        &types.IsolationGroupConfiguration{},
 	}, resp.Configuration)
 	s.Equal(&types.DomainReplicationConfiguration{
 		ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -570,6 +575,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestRegisterGetDom
 		VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 		VisibilityArchivalURI:                  "",
 		BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+		IsolationGroups:                        &types.IsolationGroupConfiguration{},
 	}, resp.Configuration)
 	s.Equal(&types.DomainReplicationConfiguration{
 		ActiveClusterName: activeClusterName,
@@ -635,6 +641,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateGetDomai
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: activeClusterName,
@@ -722,6 +729,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateGetDomai
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: activeClusterName,
@@ -825,6 +833,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateGetDomai
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: nextActiveClusterName,
@@ -922,6 +931,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateDomain_C
 		VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 		VisibilityArchivalURI:                  "",
 		BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+		IsolationGroups:                        &types.IsolationGroupConfiguration{},
 	}, resp.Configuration)
 	s.Equal(&types.DomainReplicationConfiguration{
 		ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),

--- a/common/domain/handler_NotMasterCluster_test.go
+++ b/common/domain/handler_NotMasterCluster_test.go
@@ -165,6 +165,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TestRegisterGet
 		VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 		VisibilityArchivalURI:                  "",
 		BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+		IsolationGroups:                        &types.IsolationGroupConfiguration{},
 	}, resp.Configuration)
 	s.Equal(&types.DomainReplicationConfiguration{
 		ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -232,6 +233,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TestRegisterGet
 		VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 		VisibilityArchivalURI:                  "",
 		BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+		IsolationGroups:                        &types.IsolationGroupConfiguration{},
 	}, resp.Configuration)
 	s.Equal(&types.DomainReplicationConfiguration{
 		ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -289,6 +291,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TestUpdateGetDo
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -365,6 +368,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TestUpdateGetDo
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: s.ClusterMetadata.GetCurrentClusterName(),
@@ -696,6 +700,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TestUpdateGetDo
 			VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 			VisibilityArchivalURI:                  "",
 			BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+			IsolationGroups:                        &types.IsolationGroupConfiguration{},
 		}, config)
 		s.Equal(&types.DomainReplicationConfiguration{
 			ActiveClusterName: nextActiveClusterName,

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -27,6 +27,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+
+	"github.com/uber/cadence/common/messaging"
+	"github.com/uber/cadence/service/history/constants"
+
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -338,6 +343,8 @@ func (s *domainHandlerCommonSuite) TestListDomain() {
 		}
 	}
 	delete(domains, common.SystemLocalDomainName)
+
+	isolationGroups := types.IsolationGroupConfiguration{}
 	s.Equal(map[string]*types.DescribeDomainResponse{
 		domainName1: {
 			DomainInfo: &types.DomainInfo{
@@ -356,6 +363,7 @@ func (s *domainHandlerCommonSuite) TestListDomain() {
 				VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 				VisibilityArchivalURI:                  "",
 				BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+				IsolationGroups:                        &isolationGroups,
 			},
 			ReplicationConfiguration: &types.DomainReplicationConfiguration{
 				ActiveClusterName: activeClusterName1,
@@ -381,6 +389,7 @@ func (s *domainHandlerCommonSuite) TestListDomain() {
 				VisibilityArchivalStatus:               types.ArchivalStatusDisabled.Ptr(),
 				VisibilityArchivalURI:                  "",
 				BadBinaries:                            &types.BadBinaries{Binaries: map[string]*types.BadBinaryInfo{}},
+				IsolationGroups:                        &isolationGroups,
 			},
 			ReplicationConfiguration: &types.DomainReplicationConfiguration{
 				ActiveClusterName: activeClusterName2,
@@ -618,4 +627,171 @@ func (s *domainHandlerCommonSuite) TestUpdateDomain_ForceFailover_SameActiveClus
 
 func (s *domainHandlerCommonSuite) getRandomDomainName() string {
 	return "domain" + uuid.New()
+}
+
+func TestIsolationGroupUpdating(t *testing.T) {
+
+	t1 := time.Unix(1683086200, 0)
+	info := &persistence.DomainInfo{
+		Name: "domain",
+	}
+	replicationCfg := &persistence.DomainReplicationConfig{
+		ActiveClusterName: "active",
+		Clusters: []*persistence.ClusterReplicationConfig{
+			{
+				ClusterName: "active",
+			},
+		},
+	}
+
+	tests := map[string]struct {
+		in                      *types.UpdateDomainRequest
+		domainManagerAffordance func(m *persistence.MockDomainManager)
+
+		expected    *types.UpdateDomainResponse
+		expectedErr error
+	}{
+		"valid update operation - removing isolation groups": {
+			in: &types.UpdateDomainRequest{
+				Name:                        "domain",
+				IsolationGroupConfiguration: &types.IsolationGroupConfiguration{},
+			},
+			domainManagerAffordance: func(m *persistence.MockDomainManager) {
+
+				m.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{}, nil)
+				m.EXPECT().GetDomain(gomock.Any(), &persistence.GetDomainRequest{
+					Name: "domain",
+				}).Return(&persistence.GetDomainResponse{
+					Info:              info,
+					Config:            &persistence.DomainConfig{},
+					IsGlobalDomain:    true,
+					ReplicationConfig: replicationCfg,
+				}, nil)
+
+				m.EXPECT().UpdateDomain(gomock.Any(), &persistence.UpdateDomainRequest{
+					Info:              info,
+					ReplicationConfig: replicationCfg,
+					LastUpdatedTime:   t1.UnixNano(),
+					ConfigVersion:     1,
+					Config: &persistence.DomainConfig{
+						IsolationGroups: types.IsolationGroupConfiguration{},
+					},
+				}).Return(nil)
+			},
+		},
+		"valid update operation - setting isolation groups": {
+			in: &types.UpdateDomainRequest{
+				Name: "domain",
+				IsolationGroupConfiguration: &types.IsolationGroupConfiguration{
+					"zone-1": {
+						Name:  "zone-1",
+						State: types.IsolationGroupStateHealthy,
+					},
+					"zone-2": {
+						Name:  "zone-2",
+						State: types.IsolationGroupStateDrained,
+					},
+				},
+			},
+			domainManagerAffordance: func(m *persistence.MockDomainManager) {
+
+				m.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{}, nil)
+				m.EXPECT().GetDomain(gomock.Any(), &persistence.GetDomainRequest{
+					Name: "domain",
+				}).Return(&persistence.GetDomainResponse{
+					Info:              info,
+					Config:            &persistence.DomainConfig{},
+					IsGlobalDomain:    true,
+					ReplicationConfig: replicationCfg,
+				}, nil)
+
+				m.EXPECT().UpdateDomain(gomock.Any(), &persistence.UpdateDomainRequest{
+					Info:              info,
+					ReplicationConfig: replicationCfg,
+					LastUpdatedTime:   t1.UnixNano(),
+					ConfigVersion:     1,
+					Config: &persistence.DomainConfig{
+						IsolationGroups: types.IsolationGroupConfiguration{
+							"zone-1": {
+								Name:  "zone-1",
+								State: types.IsolationGroupStateHealthy,
+							},
+							"zone-2": {
+								Name:  "zone-2",
+								State: types.IsolationGroupStateDrained,
+							},
+						},
+					},
+				}).Return(nil)
+			},
+		},
+		"updating something else without an isolation group": {
+			in: &types.UpdateDomainRequest{
+				Name: "domain",
+				Data: map[string]string{"test": "test"},
+			},
+			domainManagerAffordance: func(m *persistence.MockDomainManager) {
+
+				m.EXPECT().GetMetadata(gomock.Any()).Return(&persistence.GetMetadataResponse{}, nil)
+				m.EXPECT().GetDomain(gomock.Any(), &persistence.GetDomainRequest{
+					Name: "domain",
+				}).Return(&persistence.GetDomainResponse{
+					Info:              info,
+					Config:            &persistence.DomainConfig{},
+					IsGlobalDomain:    true,
+					ReplicationConfig: replicationCfg,
+				}, nil)
+
+				m.EXPECT().UpdateDomain(gomock.Any(), &persistence.UpdateDomainRequest{
+					Info: &persistence.DomainInfo{
+						Name: "domain",
+						Data: map[string]string{"test": "test"},
+					},
+					ReplicationConfig: replicationCfg,
+					LastUpdatedTime:   t1.UnixNano(),
+					ConfigVersion:     1,
+					Config:            &persistence.DomainConfig{},
+				}).Return(nil)
+			},
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+
+			ctrl := gomock.NewController(t)
+			logger := loggerimpl.NewNopLogger()
+			domainConfig := Config{
+				MinRetentionDays:  func(opts ...dc.FilterOption) int { return 0 },
+				MaxBadBinaryCount: func(string) int { return 3 },
+				FailoverCoolDown:  func(string) time.Duration { return time.Second },
+			}
+
+			domainMgrMock := persistence.NewMockDomainManager(ctrl)
+			td.domainManagerAffordance(domainMgrMock)
+
+			producer := messaging.NewNoopProducer()
+			replicator := NewDomainReplicator(producer, logger)
+
+			handler := NewHandler(
+				domainConfig,
+				logger,
+				domainMgrMock,
+				constants.TestClusterMetadata,
+				replicator,
+				archiver.NewArchivalMetadata(
+					nil,
+					"",
+					false,
+					"",
+					false,
+					&config.ArchivalDomainDefaults{},
+				),
+				nil,
+				clock.NewEventTimeSource().Update(t1),
+			).(*handlerImpl)
+			_, err := handler.UpdateDomain(context.Background(), td.in)
+			assert.Equal(t, td.expectedErr, err)
+		})
+	}
 }


### PR DESCRIPTION
### Background 

This is part of the wider  ['Zonal-isolation' feature](https://github.com/uber/cadence-idl/commit/88be1470a45198d4546a484104d54468d6c17dbf):

### Changes 

Adds Isolation-group changes to the Domain handler, to update the persistence layer when they're detected and to have them be replicated. 

### Testing 

Unit tests