### PR TITLE
Admin API

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -799,6 +799,14 @@ const (
 	AdminDeleteWorkflowScope
 	// MaintainCorruptWorkflowScope is the metric scope for admin.MaintainCorruptWorkflow
 	MaintainCorruptWorkflowScope
+	// GetGlobalIsolationGroups is the scope for getting global isolation groups
+	GetGlobalIsolationGroups
+	// UpdateGlobalIsolationGroups is the scope for getting global isolation groups
+	UpdateGlobalIsolationGroups
+	// GetDomainIsolationGroups is the scope for getting domain isolation groups
+	GetDomainIsolationGroups
+	// UpdateDomainIsolationGroups is the scope for getting domain isolation groups
+	UpdateDomainIsolationGroups
 
 	NumAdminScopes
 )
@@ -1581,6 +1589,10 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		AdminListDynamicConfigScope:                 {operation: "AdminListDynamicConfig"},
 		AdminDeleteWorkflowScope:                    {operation: "AdminDeleteWorkflow"},
 		MaintainCorruptWorkflowScope:                {operation: "MaintainCorruptWorkflow"},
+		GetGlobalIsolationGroups:                    {operation: "GetGlobalIsolationGroups"},
+		UpdateGlobalIsolationGroups:                 {operation: "UpdateGlobalIsolationGroups"},
+		GetDomainIsolationGroups:                    {operation: "GetDomainIsolationGroups"},
+		UpdateDomainIsolationGroups:                 {operation: "UpdateDomainIsolationGroups"},
 
 		FrontendRestartWorkflowExecutionScope:           {operation: "RestartWorkflowExecution"},
 		FrontendStartWorkflowExecutionScope:             {operation: "StartWorkflowExecution"},

--- a/service/frontend/adminGrpcHandler.go
+++ b/service/frontend/adminGrpcHandler.go
@@ -182,17 +182,21 @@ func (g adminGRPCHandler) ListDynamicConfig(ctx context.Context, request *adminv
 }
 
 func (g adminGRPCHandler) GetGlobalIsolationGroups(ctx context.Context, request *adminv1.GetGlobalIsolationGroupsRequest) (*adminv1.GetGlobalIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := g.h.GetGlobalIsolationGroups(ctx, proto.ToGetGlobalIsolationGroupsRequest(request))
+	return proto.FromGetGlobalIsolationGroupsResponse(res), proto.FromError(err)
 }
 
 func (g adminGRPCHandler) UpdateGlobalIsolationGroups(ctx context.Context, request *adminv1.UpdateGlobalIsolationGroupsRequest) (*adminv1.UpdateGlobalIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := g.h.UpdateGlobalIsolationGroups(ctx, proto.ToUpdateGlobalIsolationGroupsRequest(request))
+	return proto.FromUpdateGlobalIsolationGroupsResponse(res), proto.FromError(err)
 }
 
 func (g adminGRPCHandler) GetDomainIsolationGroups(ctx context.Context, request *adminv1.GetDomainIsolationGroupsRequest) (*adminv1.GetDomainIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := g.h.GetDomainIsolationGroups(ctx, proto.ToGetDomainIsolationGroupsRequest(request))
+	return proto.FromGetDomainIsolationGroupsResponse(res), proto.FromError(err)
 }
 
 func (g adminGRPCHandler) UpdateDomainIsolationGroups(ctx context.Context, request *adminv1.UpdateDomainIsolationGroupsRequest) (*adminv1.UpdateDomainIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := g.h.UpdateDomainIsolationGroups(ctx, proto.ToUpdateDomainIsolationGroupsRequest(request))
+	return proto.FromUpdateDomainIsolationGroupsResponse(res), proto.FromError(err)
 }

--- a/service/frontend/adminHandler_mock.go
+++ b/service/frontend/adminHandler_mock.go
@@ -221,6 +221,21 @@ func (mr *MockAdminHandlerMockRecorder) GetDLQReplicationMessages(arg0, arg1 int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDLQReplicationMessages", reflect.TypeOf((*MockAdminHandler)(nil).GetDLQReplicationMessages), arg0, arg1)
 }
 
+// GetDomainIsolationGroups mocks base method.
+func (m *MockAdminHandler) GetDomainIsolationGroups(ctx context.Context, request *types.GetDomainIsolationGroupsRequest) (*types.GetDomainIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDomainIsolationGroups", ctx, request)
+	ret0, _ := ret[0].(*types.GetDomainIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDomainIsolationGroups indicates an expected call of GetDomainIsolationGroups.
+func (mr *MockAdminHandlerMockRecorder) GetDomainIsolationGroups(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomainIsolationGroups", reflect.TypeOf((*MockAdminHandler)(nil).GetDomainIsolationGroups), ctx, request)
+}
+
 // GetDomainReplicationMessages mocks base method.
 func (m *MockAdminHandler) GetDomainReplicationMessages(arg0 context.Context, arg1 *types.GetDomainReplicationMessagesRequest) (*types.GetDomainReplicationMessagesResponse, error) {
 	m.ctrl.T.Helper()
@@ -249,6 +264,21 @@ func (m *MockAdminHandler) GetDynamicConfig(arg0 context.Context, arg1 *types.Ge
 func (mr *MockAdminHandlerMockRecorder) GetDynamicConfig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicConfig", reflect.TypeOf((*MockAdminHandler)(nil).GetDynamicConfig), arg0, arg1)
+}
+
+// GetGlobalIsolationGroups mocks base method.
+func (m *MockAdminHandler) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest) (*types.GetGlobalIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetGlobalIsolationGroups", ctx, request)
+	ret0, _ := ret[0].(*types.GetGlobalIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGlobalIsolationGroups indicates an expected call of GetGlobalIsolationGroups.
+func (mr *MockAdminHandlerMockRecorder) GetGlobalIsolationGroups(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGlobalIsolationGroups", reflect.TypeOf((*MockAdminHandler)(nil).GetGlobalIsolationGroups), ctx, request)
 }
 
 // GetReplicationMessages mocks base method.
@@ -478,6 +508,21 @@ func (mr *MockAdminHandlerMockRecorder) Stop() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockAdminHandler)(nil).Stop))
 }
 
+// UpdateDomainIsolationGroups mocks base method.
+func (m *MockAdminHandler) UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDomainIsolationGroups", ctx, request)
+	ret0, _ := ret[0].(*types.UpdateDomainIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateDomainIsolationGroups indicates an expected call of UpdateDomainIsolationGroups.
+func (mr *MockAdminHandlerMockRecorder) UpdateDomainIsolationGroups(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomainIsolationGroups", reflect.TypeOf((*MockAdminHandler)(nil).UpdateDomainIsolationGroups), ctx, request)
+}
+
 // UpdateDynamicConfig mocks base method.
 func (m *MockAdminHandler) UpdateDynamicConfig(arg0 context.Context, arg1 *types.UpdateDynamicConfigRequest) error {
 	m.ctrl.T.Helper()
@@ -490,4 +535,19 @@ func (m *MockAdminHandler) UpdateDynamicConfig(arg0 context.Context, arg1 *types
 func (mr *MockAdminHandlerMockRecorder) UpdateDynamicConfig(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDynamicConfig", reflect.TypeOf((*MockAdminHandler)(nil).UpdateDynamicConfig), arg0, arg1)
+}
+
+// UpdateGlobalIsolationGroups mocks base method.
+func (m *MockAdminHandler) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateGlobalIsolationGroups", ctx, request)
+	ret0, _ := ret[0].(*types.UpdateGlobalIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateGlobalIsolationGroups indicates an expected call of UpdateGlobalIsolationGroups.
+func (mr *MockAdminHandlerMockRecorder) UpdateGlobalIsolationGroups(ctx, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGlobalIsolationGroups", reflect.TypeOf((*MockAdminHandler)(nil).UpdateGlobalIsolationGroups), ctx, request)
 }

--- a/service/frontend/adminThriftHandler.go
+++ b/service/frontend/adminThriftHandler.go
@@ -209,17 +209,21 @@ func (t AdminThriftHandler) ListDynamicConfig(ctx context.Context, request *admi
 }
 
 func (t AdminThriftHandler) GetGlobalIsolationGroups(ctx context.Context, request *admin.GetGlobalIsolationGroupsRequest) (*admin.GetGlobalIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := t.h.GetGlobalIsolationGroups(ctx, thrift.ToGetGlobalIsolationGroupsRequest(request))
+	return thrift.FromGetGlobalIsolationGroupsResponse(res), thrift.FromError(err)
 }
 
 func (t AdminThriftHandler) UpdateGlobalIsolationGroups(ctx context.Context, request *admin.UpdateGlobalIsolationGroupsRequest) (*admin.UpdateGlobalIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := t.h.UpdateGlobalIsolationGroups(ctx, thrift.ToUpdateGlobalIsolationGroupsRequest(request))
+	return thrift.FromUpdateGlobalIsolationGroupsResponse(res), thrift.FromError(err)
 }
 
 func (t AdminThriftHandler) GetDomainIsolationGroups(ctx context.Context, request *admin.GetDomainIsolationGroupsRequest) (*admin.GetDomainIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := t.h.GetDomainIsolationGroups(ctx, thrift.ToGetDomainIsolationGroupsRequest(request))
+	return thrift.FromGetDomainIsolationGroupsResponse(res), thrift.FromError(err)
 }
 
 func (t AdminThriftHandler) UpdateDomainIsolationGroups(ctx context.Context, request *admin.UpdateDomainIsolationGroupsRequest) (*admin.UpdateDomainIsolationGroupsResponse, error) {
-	panic("not implemented")
+	res, err := t.h.UpdateDomainIsolationGroups(ctx, thrift.ToUpdateDomainIsolationGroupsRequest(request))
+	return thrift.FromUpdateDomainIsolationGroupsResponse(res), thrift.FromError(err)
 }

--- a/service/frontend/clusterRedirectionHandler_test.go
+++ b/service/frontend/clusterRedirectionHandler_test.go
@@ -24,6 +24,8 @@ import (
 	"context"
 	"testing"
 
+	"github.com/uber/cadence/common/domain"
+
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -104,7 +106,8 @@ func (s *clusterRedirectionHandlerSuite) SetupTest() {
 		false,
 		"hostname",
 	)
-	frontendHandler := NewWorkflowHandler(s.mockResource, s.config, nil, client.NewVersionChecker())
+	dh := domain.NewMockHandler(s.controller)
+	frontendHandler := NewWorkflowHandler(s.mockResource, s.config, client.NewVersionChecker(), dh)
 
 	s.mockFrontendHandler = NewMockHandler(s.controller)
 	s.handler = NewClusterRedirectionHandler(frontendHandler, s.mockResource, s.config, config.ClusterRedirectionPolicy{})

--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -42,7 +42,6 @@ import (
 	"github.com/uber/cadence/common/elasticsearch/validator"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
-	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/partition"
 	"github.com/uber/cadence/common/persistence"
@@ -166,8 +165,8 @@ var (
 func NewWorkflowHandler(
 	resource resource.Resource,
 	config *Config,
-	replicationMessageSink messaging.Producer,
 	versionChecker client.VersionChecker,
+	domainHandler domain.Handler,
 ) *WorkflowHandler {
 	return &WorkflowHandler{
 		Resource:        resource,
@@ -208,16 +207,7 @@ func NewWorkflowHandler(
 			}),
 		),
 		versionChecker: versionChecker,
-		domainHandler: domain.NewHandler(
-			config.domainConfig,
-			resource.GetLogger(),
-			resource.GetDomainManager(),
-			resource.GetClusterMetadata(),
-			domain.NewDomainReplicator(replicationMessageSink, resource.GetLogger()),
-			resource.GetArchivalMetadata(),
-			resource.GetArchiverProvider(),
-			resource.GetTimeSource(),
-		),
+		domainHandler:  domainHandler,
 		visibilityQueryValidator: validator.NewQueryValidator(
 			config.ValidSearchAttributes,
 			config.EnableQueryAttributeValidation,


### PR DESCRIPTION
Background
This is part of the wider ['Zonal-isolation' feature](https://github.com/uber/cadence-idl/commit/88be1470a45198d4546a484104d54468d6c17dbf):

### Changes

- Introduces an admin API for 'global' drains, that is, drains affecting the entire cluster
- Introduces an admin API for 'domain' drains, ie drains that just affect that one domain 

### Testing 
- Unit testing and some manual testing

