### PR TITLE
Adds cli operations for the zonal-isolation drains

### DIFF
--- a/client/admin/client.go
+++ b/client/admin/client.go
@@ -353,6 +353,42 @@ func (c *clientImpl) ListDynamicConfig(
 	return c.client.ListDynamicConfig(ctx, request, opts...)
 }
 
+func (c *clientImpl) GetGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.GetGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+}
+
+func (c *clientImpl) UpdateGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+}
+
+func (c *clientImpl) GetDomainIsolationGroups(
+	ctx context.Context,
+	request *types.GetDomainIsolationGroupsRequest,
+	opts ...yarpc.CallOption) (*types.GetDomainIsolationGroupsResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.GetDomainIsolationGroups(ctx, request, opts...)
+}
+
+func (c *clientImpl) UpdateDomainIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateDomainIsolationGroupsRequest,
+	opts ...yarpc.CallOption) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	ctx, cancel := c.createContext(ctx)
+	defer cancel()
+	return c.client.UpdateDomainIsolationGroups(ctx, request, opts...)
+}
+
 func (c *clientImpl) createContext(parent context.Context) (context.Context, context.CancelFunc) {
 	if parent == nil {
 		return context.WithTimeout(context.Background(), c.timeout)

--- a/client/admin/errorInjectionClient.go
+++ b/client/admin/errorInjectionClient.go
@@ -772,3 +772,107 @@ func (c *errorInjectionClient) ListDynamicConfig(
 	}
 	return resp, clientErr
 }
+
+func (c *errorInjectionClient) GetGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.GetGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.GetGlobalIsolationGroupsResponse, error) {
+	fakeErr := errors.GenerateFakeError(c.errorRate)
+
+	var resp *types.GetGlobalIsolationGroupsResponse
+	var clientErr error
+	var forwardCall bool
+	if forwardCall = errors.ShouldForwardCall(fakeErr); forwardCall {
+		resp, clientErr = c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+	}
+
+	if fakeErr != nil {
+		c.logger.Error(msgInjectedFakeErr,
+			tag.AdminClientOperationGetGlobalIsolationGroups,
+			tag.Error(fakeErr),
+			tag.Bool(forwardCall),
+			tag.ClientError(clientErr),
+		)
+		return nil, fakeErr
+	}
+	return resp, clientErr
+}
+
+func (c *errorInjectionClient) UpdateGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	fakeErr := errors.GenerateFakeError(c.errorRate)
+
+	var resp *types.UpdateGlobalIsolationGroupsResponse
+	var clientErr error
+	var forwardCall bool
+	if forwardCall = errors.ShouldForwardCall(fakeErr); forwardCall {
+		resp, clientErr = c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+	}
+
+	if fakeErr != nil {
+		c.logger.Error(msgInjectedFakeErr,
+			tag.AdminClientOperationUpdateGlobalIsolationGroups,
+			tag.Error(fakeErr),
+			tag.Bool(forwardCall),
+			tag.ClientError(clientErr),
+		)
+		return nil, fakeErr
+	}
+	return resp, clientErr
+}
+
+func (c *errorInjectionClient) GetDomainIsolationGroups(
+	ctx context.Context,
+	request *types.GetDomainIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.GetDomainIsolationGroupsResponse, error) {
+	fakeErr := errors.GenerateFakeError(c.errorRate)
+
+	var resp *types.GetDomainIsolationGroupsResponse
+	var clientErr error
+	var forwardCall bool
+	if forwardCall = errors.ShouldForwardCall(fakeErr); forwardCall {
+		resp, clientErr = c.client.GetDomainIsolationGroups(ctx, request, opts...)
+	}
+
+	if fakeErr != nil {
+		c.logger.Error(msgInjectedFakeErr,
+			tag.AdminClientOperationGetDomainIsolationGroups,
+			tag.Error(fakeErr),
+			tag.Bool(forwardCall),
+			tag.ClientError(clientErr),
+		)
+		return nil, fakeErr
+	}
+	return resp, clientErr
+}
+
+func (c *errorInjectionClient) UpdateDomainIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateDomainIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	fakeErr := errors.GenerateFakeError(c.errorRate)
+
+	var resp *types.UpdateDomainIsolationGroupsResponse
+	var clientErr error
+	var forwardCall bool
+	if forwardCall = errors.ShouldForwardCall(fakeErr); forwardCall {
+		resp, clientErr = c.client.UpdateDomainIsolationGroups(ctx, request, opts...)
+	}
+
+	if fakeErr != nil {
+		c.logger.Error(msgInjectedFakeErr,
+			tag.AdminClientOperationUpdateDomainIsolationGroups,
+			tag.Error(fakeErr),
+			tag.Bool(forwardCall),
+			tag.ClientError(clientErr),
+		)
+		return nil, fakeErr
+	}
+	return resp, clientErr
+}

--- a/client/admin/grpcClient.go
+++ b/client/admin/grpcClient.go
@@ -177,3 +177,23 @@ func (g grpcClient) ListDynamicConfig(ctx context.Context, request *types.ListDy
 	response, err := g.c.ListDynamicConfig(ctx, proto.FromListDynamicConfigRequest(request), opts...)
 	return proto.ToListDynamicConfigResponse(response), proto.ToError(err)
 }
+
+func (g grpcClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	response, err := g.c.GetGlobalIsolationGroups(ctx, proto.FromGetGlobalIsolationGroupsRequest(request), opts...)
+	return proto.ToGetGlobalIsolationGroupsResponse(response), proto.ToError(err)
+}
+
+func (g grpcClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	response, err := g.c.UpdateGlobalIsolationGroups(ctx, proto.FromUpdateGlobalIsolationGroupsRequest(request), opts...)
+	return proto.ToUpdateGlobalIsolationGroupsResponse(response), proto.ToError(err)
+}
+
+func (g grpcClient) GetDomainIsolationGroups(ctx context.Context, request *types.GetDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetDomainIsolationGroupsResponse, error) {
+	response, err := g.c.GetDomainIsolationGroups(ctx, proto.FromGetDomainIsolationGroupsRequest(request), opts...)
+	return proto.ToGetDomainIsolationGroupsResponse(response), proto.ToError(err)
+}
+
+func (g grpcClient) UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	response, err := g.c.UpdateDomainIsolationGroups(ctx, proto.FromUpdateDomainIsolationGroupsRequest(request), opts...)
+	return proto.ToUpdateDomainIsolationGroupsResponse(response), proto.ToError(err)
+}

--- a/client/admin/interface.go
+++ b/client/admin/interface.go
@@ -60,4 +60,8 @@ type Client interface {
 	ListDynamicConfig(context.Context, *types.ListDynamicConfigRequest, ...yarpc.CallOption) (*types.ListDynamicConfigResponse, error)
 	DeleteWorkflow(context.Context, *types.AdminDeleteWorkflowRequest, ...yarpc.CallOption) (*types.AdminDeleteWorkflowResponse, error)
 	MaintainCorruptWorkflow(context.Context, *types.AdminMaintainWorkflowRequest, ...yarpc.CallOption) (*types.AdminMaintainWorkflowResponse, error)
+	GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error)
+	UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error)
+	GetDomainIsolationGroups(ctx context.Context, request *types.GetDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetDomainIsolationGroupsResponse, error)
+	UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateDomainIsolationGroupsResponse, error)
 }

--- a/client/admin/interface_mock.go
+++ b/client/admin/interface_mock.go
@@ -277,6 +277,26 @@ func (mr *MockClientMockRecorder) GetDLQReplicationMessages(arg0, arg1 interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDLQReplicationMessages", reflect.TypeOf((*MockClient)(nil).GetDLQReplicationMessages), varargs...)
 }
 
+// GetDomainIsolationGroups mocks base method.
+func (m *MockClient) GetDomainIsolationGroups(ctx context.Context, request *types.GetDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetDomainIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetDomainIsolationGroups", varargs...)
+	ret0, _ := ret[0].(*types.GetDomainIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDomainIsolationGroups indicates an expected call of GetDomainIsolationGroups.
+func (mr *MockClientMockRecorder) GetDomainIsolationGroups(ctx, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDomainIsolationGroups", reflect.TypeOf((*MockClient)(nil).GetDomainIsolationGroups), varargs...)
+}
+
 // GetDomainReplicationMessages mocks base method.
 func (m *MockClient) GetDomainReplicationMessages(arg0 context.Context, arg1 *types.GetDomainReplicationMessagesRequest, arg2 ...yarpc.CallOption) (*types.GetDomainReplicationMessagesResponse, error) {
 	m.ctrl.T.Helper()
@@ -315,6 +335,26 @@ func (mr *MockClientMockRecorder) GetDynamicConfig(arg0, arg1 interface{}, arg2 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDynamicConfig", reflect.TypeOf((*MockClient)(nil).GetDynamicConfig), varargs...)
+}
+
+// GetGlobalIsolationGroups mocks base method.
+func (m *MockClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetGlobalIsolationGroups", varargs...)
+	ret0, _ := ret[0].(*types.GetGlobalIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetGlobalIsolationGroups indicates an expected call of GetGlobalIsolationGroups.
+func (mr *MockClientMockRecorder) GetGlobalIsolationGroups(ctx, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetGlobalIsolationGroups", reflect.TypeOf((*MockClient)(nil).GetGlobalIsolationGroups), varargs...)
 }
 
 // GetReplicationMessages mocks base method.
@@ -590,6 +630,26 @@ func (mr *MockClientMockRecorder) RestoreDynamicConfig(arg0, arg1 interface{}, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreDynamicConfig", reflect.TypeOf((*MockClient)(nil).RestoreDynamicConfig), varargs...)
 }
 
+// UpdateDomainIsolationGroups mocks base method.
+func (m *MockClient) UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateDomainIsolationGroups", varargs...)
+	ret0, _ := ret[0].(*types.UpdateDomainIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateDomainIsolationGroups indicates an expected call of UpdateDomainIsolationGroups.
+func (mr *MockClientMockRecorder) UpdateDomainIsolationGroups(ctx, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDomainIsolationGroups", reflect.TypeOf((*MockClient)(nil).UpdateDomainIsolationGroups), varargs...)
+}
+
 // UpdateDynamicConfig mocks base method.
 func (m *MockClient) UpdateDynamicConfig(arg0 context.Context, arg1 *types.UpdateDynamicConfigRequest, arg2 ...yarpc.CallOption) error {
 	m.ctrl.T.Helper()
@@ -607,4 +667,24 @@ func (mr *MockClientMockRecorder) UpdateDynamicConfig(arg0, arg1 interface{}, ar
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDynamicConfig", reflect.TypeOf((*MockClient)(nil).UpdateDynamicConfig), varargs...)
+}
+
+// UpdateGlobalIsolationGroups mocks base method.
+func (m *MockClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, request}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateGlobalIsolationGroups", varargs...)
+	ret0, _ := ret[0].(*types.UpdateGlobalIsolationGroupsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateGlobalIsolationGroups indicates an expected call of UpdateGlobalIsolationGroups.
+func (mr *MockClientMockRecorder) UpdateGlobalIsolationGroups(ctx, request interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, request}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateGlobalIsolationGroups", reflect.TypeOf((*MockClient)(nil).UpdateGlobalIsolationGroups), varargs...)
 }

--- a/client/admin/metricClient.go
+++ b/client/admin/metricClient.go
@@ -529,3 +529,47 @@ func (c *metricClient) ListDynamicConfig(
 	}
 	return resp, err
 }
+
+func (c *metricClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	c.metricsClient.IncCounter(metrics.AdminClientGetGlobalIsolationGroupsScope, metrics.CadenceClientRequests)
+	sw := c.metricsClient.StartTimer(metrics.AdminClientGetGlobalIsolationGroupsScope, metrics.CadenceClientLatency)
+	resp, err := c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+	sw.Stop()
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.AdminClientGetGlobalIsolationGroupsScope, metrics.CadenceClientFailures)
+	}
+	return resp, err
+}
+
+func (c *metricClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	c.metricsClient.IncCounter(metrics.AdminClientUpdateGlobalIsolationGroupsScope, metrics.CadenceClientRequests)
+	sw := c.metricsClient.StartTimer(metrics.AdminClientUpdateGlobalIsolationGroupsScope, metrics.CadenceClientLatency)
+	resp, err := c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+	sw.Stop()
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.AdminClientUpdateGlobalIsolationGroupsScope, metrics.CadenceClientFailures)
+	}
+	return resp, err
+}
+
+func (c *metricClient) GetDomainIsolationGroups(ctx context.Context, request *types.GetDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetDomainIsolationGroupsResponse, error) {
+	c.metricsClient.IncCounter(metrics.AdminClientGetDomainIsolationGroupsScope, metrics.CadenceClientRequests)
+	sw := c.metricsClient.StartTimer(metrics.AdminClientGetDomainIsolationGroupsScope, metrics.CadenceClientLatency)
+	resp, err := c.client.GetDomainIsolationGroups(ctx, request, opts...)
+	sw.Stop()
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.AdminClientGetDomainIsolationGroupsScope, metrics.CadenceClientFailures)
+	}
+	return resp, err
+}
+
+func (c *metricClient) UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	c.metricsClient.IncCounter(metrics.AdminClientUpdateDomainIsolationGroupsScope, metrics.CadenceClientRequests)
+	sw := c.metricsClient.StartTimer(metrics.AdminClientUpdateDomainIsolationGroupsScope, metrics.CadenceClientLatency)
+	resp, err := c.client.UpdateDomainIsolationGroups(ctx, request, opts...)
+	sw.Stop()
+	if err != nil {
+		c.metricsClient.IncCounter(metrics.AdminClientUpdateDomainIsolationGroupsScope, metrics.CadenceClientFailures)
+	}
+	return resp, err
+}

--- a/client/admin/retryableClient.go
+++ b/client/admin/retryableClient.go
@@ -443,3 +443,63 @@ func (c *retryableClient) ListDynamicConfig(
 	err := c.throttleRetry.Do(ctx, op)
 	return resp, err
 }
+
+func (c *retryableClient) GetGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.GetGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.GetGlobalIsolationGroupsResponse, error) {
+	var resp *types.GetGlobalIsolationGroupsResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.GetGlobalIsolationGroups(ctx, request, opts...)
+		return err
+	}
+	err := c.throttleRetry.Do(ctx, op)
+	return resp, err
+}
+
+func (c *retryableClient) UpdateGlobalIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateGlobalIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	var resp *types.UpdateGlobalIsolationGroupsResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.UpdateGlobalIsolationGroups(ctx, request, opts...)
+		return err
+	}
+	err := c.throttleRetry.Do(ctx, op)
+	return resp, err
+}
+
+func (c *retryableClient) GetDomainIsolationGroups(
+	ctx context.Context,
+	request *types.GetDomainIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.GetDomainIsolationGroupsResponse, error) {
+	var resp *types.GetDomainIsolationGroupsResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.GetDomainIsolationGroups(ctx, request, opts...)
+		return err
+	}
+	err := c.throttleRetry.Do(ctx, op)
+	return resp, err
+}
+
+func (c *retryableClient) UpdateDomainIsolationGroups(
+	ctx context.Context,
+	request *types.UpdateDomainIsolationGroupsRequest,
+	opts ...yarpc.CallOption,
+) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	var resp *types.UpdateDomainIsolationGroupsResponse
+	op := func() error {
+		var err error
+		resp, err = c.client.UpdateDomainIsolationGroups(ctx, request, opts...)
+		return err
+	}
+	err := c.throttleRetry.Do(ctx, op)
+	return resp, err
+}

--- a/client/admin/thriftClient.go
+++ b/client/admin/thriftClient.go
@@ -177,3 +177,23 @@ func (t thriftClient) ListDynamicConfig(ctx context.Context, request *types.List
 	response, err := t.c.ListDynamicConfig(ctx, thrift.FromListDynamicConfigRequest(request), opts...)
 	return thrift.ToListDynamicConfigResponse(response), thrift.ToError(err)
 }
+
+func (t thriftClient) GetGlobalIsolationGroups(ctx context.Context, request *types.GetGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetGlobalIsolationGroupsResponse, error) {
+	res, err := t.c.GetGlobalIsolationGroups(ctx, thrift.FromGetGlobalIsolationGroupsRequest(request), opts...)
+	return thrift.ToGetGlobalIsolationGroupsResponse(res), thrift.ToError(err)
+}
+
+func (t thriftClient) UpdateGlobalIsolationGroups(ctx context.Context, request *types.UpdateGlobalIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateGlobalIsolationGroupsResponse, error) {
+	res, err := t.c.UpdateGlobalIsolationGroups(ctx, thrift.FromUpdateGlobalIsolationGroupsRequest(request), opts...)
+	return thrift.ToUpdateGlobalIsolationGroupsResponse(res), thrift.ToError(err)
+}
+
+func (t thriftClient) GetDomainIsolationGroups(ctx context.Context, request *types.GetDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.GetDomainIsolationGroupsResponse, error) {
+	res, err := t.c.GetDomainIsolationGroups(ctx, thrift.FromGetDomainIsolationGroupsRequest(request), opts...)
+	return thrift.ToGetDomainIsolationGroupsResponse(res), thrift.ToError(err)
+}
+
+func (t thriftClient) UpdateDomainIsolationGroups(ctx context.Context, request *types.UpdateDomainIsolationGroupsRequest, opts ...yarpc.CallOption) (*types.UpdateDomainIsolationGroupsResponse, error) {
+	res, err := t.c.UpdateDomainIsolationGroups(ctx, thrift.FromUpdateDomainIsolationGroupsRequest(request), opts...)
+	return thrift.ToUpdateDomainIsolationGroupsResponse(res), thrift.ToError(err)
+}

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -301,6 +301,10 @@ var (
 	AdminClientOperationUpdateDynamicConfig               = clientOperation("admin-update-dynamic-config")
 	AdminClientOperationRestoreDynamicConfig              = clientOperation("admin-restore-dynamic-config")
 	AdminClientOperationListDynamicConfig                 = clientOperation("admin-list-dynamic-config")
+	AdminClientOperationUpdateGlobalIsolationGroups       = clientOperation("admin-update-global-isolation-groups")
+	AdminClientOperationGetGlobalIsolationGroups          = clientOperation("admin-get-global-isolation-groups")
+	AdminClientOperationUpdateDomainIsolationGroups       = clientOperation("admin-update-domain-isolation-groups")
+	AdminClientOperationGetDomainIsolationGroups          = clientOperation("admin-get-domain-isolation-groups")
 	AdminDeleteWorkflow                                   = clientOperation("admin-delete-workflow")
 	MaintainCorruptWorkflow                               = clientOperation("maintain-corrupt-workflow")
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -545,6 +545,14 @@ const (
 	AdminClientRestoreDynamicConfigScope
 	// AdminClientListDynamicConfigScope tracks RPC calls to admin service
 	AdminClientListDynamicConfigScope
+	// AdminClientGetGlobalIsolationGroupsScope is a request to get all the global isolation-groups
+	AdminClientGetGlobalIsolationGroupsScope
+	// AdminClientUpdateGlobalIsolationGroupsScope is a request to update the global isolation-groups
+	AdminClientUpdateGlobalIsolationGroupsScope
+	// AdminClientGetDomainIsolationGroupsScope is a request to get the domains' isolation groups
+	AdminClientGetDomainIsolationGroupsScope
+	// AdminClientUpdateDomainIsolationGroupsScope is a request to update the domains isolation-groups
+	AdminClientUpdateDomainIsolationGroupsScope
 	// DCRedirectionDeprecateDomainScope tracks RPC calls for dc redirection
 	DCRedirectionDeprecateDomainScope
 	// DCRedirectionDescribeDomainScope tracks RPC calls for dc redirection
@@ -1461,6 +1469,10 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		AdminClientUpdateDynamicConfigScope:                   {operation: "AdminClientUpdateDynamicConfigScope", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
 		AdminClientRestoreDynamicConfigScope:                  {operation: "AdminClientRestoreDynamicConfigScope", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
 		AdminClientListDynamicConfigScope:                     {operation: "AdminClientListDynamicConfigScope", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
+		AdminClientGetGlobalIsolationGroupsScope:              {operation: "AdminClientGetGlobalIsolationGroups", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
+		AdminClientUpdateGlobalIsolationGroupsScope:           {operation: "AdminClientUpdateGlobalIsolationGroups", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
+		AdminClientGetDomainIsolationGroupsScope:              {operation: "AdminClientGetDomainIsolationGroups", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
+		AdminClientUpdateDomainIsolationGroupsScope:           {operation: "AdminClientUpdateDomainIsolationGroups", tags: map[string]string{CadenceRoleTagName: AdminClientRoleTagValue}},
 		DCRedirectionDeprecateDomainScope:                     {operation: "DCRedirectionDeprecateDomain", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeDomainScope:                      {operation: "DCRedirectionDescribeDomain", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},
 		DCRedirectionDescribeTaskListScope:                    {operation: "DCRedirectionDescribeTaskList", tags: map[string]string{CadenceRoleTagName: DCRedirectionRoleTagValue}},

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -1296,3 +1296,83 @@ func newAdminConfigStoreCommands() []cli.Command {
 		},
 	}
 }
+
+func newAdminIsolationGroupCommands() []cli.Command {
+	return []cli.Command{
+		{
+			Name:  "get-global",
+			Usage: "gets the global isolation groups",
+			Flags: []cli.Flag{},
+			Action: func(c *cli.Context) {
+				AdminGetGlobalIsolationGroups(c)
+			},
+		},
+		{
+			Name:  "update-global",
+			Usage: "sets the global isolation groups",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     FlagIsolationGroupJSONConfigurations,
+					Usage:    `the configurations to upsert: eg: [{"Name": "zone-1": "State": 2}]. To remove groups, specify an empty configuration`,
+					Required: false,
+				},
+				cli.StringSliceFlag{
+					Name:     FlagIsolationGroupSetDrains,
+					Usage:    "Use to upsert the configuration for all drains. Note that this is an upsert operation and will overwrite all existing configuration",
+					Required: false,
+				},
+				cli.BoolFlag{
+					Name:     FlagIsolationGroupsRemoveAllDrains,
+					Usage:    "Removes all drains",
+					Required: false,
+				},
+			},
+			Action: func(c *cli.Context) {
+				AdminUpdateGlobalIsolationGroups(c)
+			},
+		},
+		{
+			Name:  "get-domain",
+			Usage: "gets the domain isolation groups",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     FlagDomain,
+					Usage:    `The domain to operate on`,
+					Required: true,
+				},
+			},
+			Action: func(c *cli.Context) {
+				AdminGetDomainIsolationGroups(c)
+			},
+		},
+		{
+			Name:  "update-domain",
+			Usage: "sets the domain isolation groups",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:     FlagDomain,
+					Usage:    `The domain to operate on`,
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:     FlagIsolationGroupJSONConfigurations,
+					Usage:    `the configurations to upsert: eg: [{"Name": "zone-1": "State": 2}]. To remove groups, specify an empty configuration`,
+					Required: false,
+				},
+				cli.StringSliceFlag{
+					Name:     FlagIsolationGroupSetDrains,
+					Usage:    "Use to upsert the configuration for all drains. Note that this is an upsert operation and will overwrite all existing configuration",
+					Required: false,
+				},
+				cli.BoolFlag{
+					Name:     FlagIsolationGroupsRemoveAllDrains,
+					Usage:    "Removes all drains",
+					Required: false,
+				},
+			},
+			Action: func(c *cli.Context) {
+				AdminUpdateDomainIsolationGroups(c)
+			},
+		},
+	}
+}

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -158,6 +158,12 @@ func NewCliApp() *cli.App {
 					Subcommands: newAdminClusterCommands(),
 				},
 				{
+					Name:        "isolation-groups",
+					Aliases:     []string{"ig"},
+					Usage:       "Run admin operation on isolation-groups",
+					Subcommands: newAdminIsolationGroupCommands(),
+				},
+				{
 					Name:        "dlq",
 					Aliases:     []string{"dlq"},
 					Usage:       "Run admin operation on DLQ",

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -294,6 +294,9 @@ const (
 	FlagTransport                         = "transport"
 	FlagTransportWithAlias                = FlagTransport + ", t"
 	FlagFormat                            = "format"
+	FlagIsolationGroupSetDrains           = "set-drains"
+	FlagIsolationGroupJSONConfigurations  = "json"
+	FlagIsolationGroupsRemoveAllDrains    = "remove-all-drains"
 )
 
 var flagsForExecution = []cli.Flag{

--- a/tools/cli/isolation-groups.go
+++ b/tools/cli/isolation-groups.go
@@ -1,0 +1,206 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/uber/cadence/common/types"
+
+	"github.com/urfave/cli"
+)
+
+func AdminGetGlobalIsolationGroups(c *cli.Context) {
+	adminClient := cFactory.ServerAdminClient(c)
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	req := &types.GetGlobalIsolationGroupsRequest{}
+	igs, err := adminClient.GetGlobalIsolationGroups(ctx, req)
+	if err != nil {
+		ErrorAndExit("failed to get isolation-groups:", err)
+	}
+	prettyPrintJSONObject(igs.IsolationGroups.ToPartitionList())
+}
+
+func AdminUpdateGlobalIsolationGroups(c *cli.Context) {
+	adminClient := cFactory.ServerAdminClient(c)
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	err := validateIsolationGroupUpdateArgs(
+		c.String(FlagDomain),
+		c.GlobalString(FlagDomain),
+		c.StringSlice(FlagIsolationGroupSetDrains),
+		c.String(FlagIsolationGroupJSONConfigurations),
+		c.Bool(FlagIsolationGroupsRemoveAllDrains),
+		false,
+	)
+	if err != nil {
+		ErrorAndExit("invalid args:", err)
+	}
+
+	cfg, err := parseIsolationGroupCliInputCfg(
+		c.StringSlice(FlagIsolationGroupSetDrains),
+		c.String(FlagIsolationGroupJSONConfigurations),
+		c.Bool(FlagIsolationGroupsRemoveAllDrains),
+	)
+	if err != nil {
+		ErrorAndExit("failed to parse input:", err)
+	}
+
+	_, err = adminClient.UpdateGlobalIsolationGroups(ctx, &types.UpdateGlobalIsolationGroupsRequest{
+		IsolationGroups: *cfg,
+	})
+	if err != nil {
+		ErrorAndExit("failed to update isolation-groups", fmt.Errorf("used %#v, got %v", cfg, err))
+	}
+}
+
+func AdminGetDomainIsolationGroups(c *cli.Context) {
+	adminClient := cFactory.ServerAdminClient(c)
+	domain := c.String(FlagDomain)
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	req := &types.GetDomainIsolationGroupsRequest{
+		Domain: domain,
+	}
+	igs, err := adminClient.GetDomainIsolationGroups(ctx, req)
+	if err != nil {
+		ErrorAndExit("failed to get isolation-groups:", err)
+	}
+	prettyPrintJSONObject(igs.IsolationGroups.ToPartitionList())
+}
+
+func AdminUpdateDomainIsolationGroups(c *cli.Context) {
+	adminClient := cFactory.ServerAdminClient(c)
+	domain := c.String(FlagDomain)
+
+	err := validateIsolationGroupUpdateArgs(
+		c.String(FlagDomain),
+		c.GlobalString(FlagDomain),
+		c.StringSlice(FlagIsolationGroupSetDrains),
+		c.String(FlagIsolationGroupJSONConfigurations),
+		c.Bool(FlagIsolationGroupsRemoveAllDrains),
+		true,
+	)
+	if err != nil {
+		ErrorAndExit("invalid args:", err)
+	}
+
+	ctx, cancel := newContext(c)
+	defer cancel()
+
+	cfg, err := parseIsolationGroupCliInputCfg(
+		c.StringSlice(FlagIsolationGroupSetDrains),
+		c.String(FlagIsolationGroupJSONConfigurations),
+		c.Bool(FlagIsolationGroupsRemoveAllDrains),
+	)
+	if err != nil {
+		ErrorAndExit("failed to parse input:", err)
+	}
+
+	req := &types.UpdateDomainIsolationGroupsRequest{
+		Domain:          domain,
+		IsolationGroups: *cfg,
+	}
+	_, err = adminClient.UpdateDomainIsolationGroups(ctx, req)
+
+	if err != nil {
+		ErrorAndExit("failed to update isolation-groups", fmt.Errorf("used %#v, got %v", req, err))
+	}
+}
+
+func validateIsolationGroupUpdateArgs(
+	domainArgs string,
+	globalDomainArg string,
+	setDrainsArgs []string,
+	jsonCfgArgs string,
+	removeAllDrainsArgs bool,
+	requiresDomain bool,
+) error {
+	if requiresDomain {
+		if globalDomainArg != "" {
+			return fmt.Errorf("the flag '--domain' has to go at the end")
+		}
+		if domainArgs == "" {
+			return fmt.Errorf("the --domain flag is required")
+		}
+	}
+
+	if len(setDrainsArgs) == 0 &&
+		jsonCfgArgs == "" &&
+		!removeAllDrainsArgs {
+		return fmt.Errorf("need to specify either %q, %q or %q flags",
+			FlagIsolationGroupSetDrains,
+			FlagIsolationGroupJSONConfigurations,
+			FlagIsolationGroupsRemoveAllDrains,
+		)
+	}
+
+	if removeAllDrainsArgs && (len(setDrainsArgs) != 0 || jsonCfgArgs != "") {
+		return fmt.Errorf("specify either remove or set-drains, not both")
+	}
+
+	return nil
+}
+
+func parseIsolationGroupCliInputCfg(drains []string, jsonInput string, removeAllDrains bool) (*types.IsolationGroupConfiguration, error) {
+
+	req := types.IsolationGroupConfiguration{}
+	if removeAllDrains {
+		return &req, nil
+	}
+
+	if len(drains) != 0 {
+		req := types.IsolationGroupConfiguration{}
+		for _, drain := range drains {
+			req[drain] = types.IsolationGroupPartition{
+				Name:  drain,
+				State: types.IsolationGroupStateDrained,
+			}
+		}
+		return &req, nil
+	}
+
+	var input []types.IsolationGroupPartition
+	err := json.Unmarshal([]byte(jsonInput), &input)
+
+	if err != nil {
+		return nil, fmt.Errorf(`failed to marshal input. Trying to marshal []types.IsolationGroupPartition
+
+examples: 
+- []                                    # will remove all isolation groups
+- [{"Name": "zone-123", "State": 2}]    # drain zone-123
+
+%v`, err)
+	}
+	for _, g := range input {
+		req[g.Name] = g
+	}
+
+	return &req, nil
+}

--- a/tools/cli/isolation_groups_test.go
+++ b/tools/cli/isolation_groups_test.go
@@ -1,0 +1,145 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/types"
+)
+
+func TestValidateIsolationGroupArgs(t *testing.T) {
+
+	tests := map[string]struct {
+		domainArgs          string
+		globalDomainArg     string
+		setDrainsArgs       []string
+		jsonConfigArgs      string
+		removeAllDrainsArgs bool
+
+		requiresDomain bool
+		expectedErr    error
+	}{
+		"valid inputs for doing a drain": {
+			domainArgs:      "some-domain",
+			globalDomainArg: "",
+			setDrainsArgs:   []string{"zone-1", "zone-2"},
+			jsonConfigArgs:  "",
+
+			expectedErr: nil,
+		},
+		"valid json input": {
+			domainArgs:      "some-domain",
+			globalDomainArg: "",
+			setDrainsArgs:   nil,
+			jsonConfigArgs:  "{}",
+
+			expectedErr: nil,
+		},
+		"invalid - no domain": {
+			domainArgs:      "",
+			globalDomainArg: "",
+			setDrainsArgs:   nil,
+			jsonConfigArgs:  "{}",
+			requiresDomain:  true,
+
+			expectedErr: errors.New("the --domain flag is required"),
+		},
+		"invalid - global domain": {
+			domainArgs:      "",
+			globalDomainArg: "second domain",
+			setDrainsArgs:   nil,
+			jsonConfigArgs:  "{}",
+			requiresDomain:  true,
+
+			expectedErr: errors.New("the flag '--domain' has to go at the end"),
+		},
+		"invalid - no config domain": {
+			domainArgs:      "domain",
+			globalDomainArg: "",
+			setDrainsArgs:   nil,
+			jsonConfigArgs:  "",
+			requiresDomain:  true,
+
+			expectedErr: errors.New("need to specify either \"set-drains\", \"json\" or \"remove-all-drains\" flags"),
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, td.expectedErr, validateIsolationGroupUpdateArgs(
+				td.domainArgs,
+				td.globalDomainArg,
+				td.setDrainsArgs,
+				td.jsonConfigArgs,
+				td.removeAllDrainsArgs,
+				td.requiresDomain))
+		})
+	}
+}
+
+func TestParseCliInput(t *testing.T) {
+
+	tests := map[string]struct {
+		setDrainsArgs  []string
+		jsonConfigArgs string
+
+		expected    *types.IsolationGroupConfiguration
+		expectedErr error
+	}{
+		"valid inputs for doing a drain": {
+			setDrainsArgs:  []string{"zone-1", "zone-2"},
+			jsonConfigArgs: "",
+
+			expected: &types.IsolationGroupConfiguration{
+				"zone-1": {Name: "zone-1", State: types.IsolationGroupStateDrained},
+				"zone-2": {Name: "zone-2", State: types.IsolationGroupStateDrained},
+			},
+		},
+		"valid json input": {
+			setDrainsArgs:  nil,
+			jsonConfigArgs: "[{\"Name\": \"zone-1\", \"State\": 2}, {\"Name\": \"zone-2\", \"State\": 1}]",
+			expected: &types.IsolationGroupConfiguration{
+				"zone-1": {Name: "zone-1", State: types.IsolationGroupStateDrained},
+				"zone-2": {Name: "zone-2", State: types.IsolationGroupStateHealthy},
+			},
+
+			expectedErr: nil,
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			res, err := parseIsolationGroupCliInputCfg(
+				td.setDrainsArgs,
+				td.jsonConfigArgs,
+				false,
+			)
+			assert.Equal(t, td.expected, res)
+			assert.Equal(t, td.expectedErr, err)
+		})
+	}
+}


### PR DESCRIPTION
Background
This is part of the wider ['Zonal-isolation' feature](https://github.com/uber/cadence-idl/commit/88be1470a45198d4546a484104d54468d6c17dbf):

Changes

Introduces commands for updating and getting the current state of isolation groups: 
```bash
# to read for a domain 
cadence admin isolation-groups get-domain --domain cadence-system

# to read 'globally', ie for all domains
cadence admin isolation-groups get-global

# To add a drain to zones 1 and zone-2:
$ cadence admin isolation-groups update-global --set-drains zone-1 zone-2  

# Note that this is Upsert semantics, so by doing this subsequently.. 
$ cadence admin isolation-groups update-global --set-drains zone-3
# ... now only zone-3 is drained, zone-1 and zone-2 drains are removed

# to drain just for some domain 
$ cadence admin isolation-groups update-domain --set-drains zone-3 --domain some-domain

# to remove
$ cadence admin isolation-groups update-domain --remove-all-drains
```

Testing
Unit tests