### PR TITLE
Fixing rendering for isolation-groups in the CLI 

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -1302,7 +1302,12 @@ func newAdminIsolationGroupCommands() []cli.Command {
 		{
 			Name:  "get-global",
 			Usage: "gets the global isolation groups",
-			Flags: []cli.Flag{},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  FlagFormat,
+					Usage: `output format`,
+				},
+			},
 			Action: func(c *cli.Context) {
 				AdminGetGlobalIsolationGroups(c)
 			},
@@ -1339,6 +1344,10 @@ func newAdminIsolationGroupCommands() []cli.Command {
 					Name:     FlagDomain,
 					Usage:    `The domain to operate on`,
 					Required: true,
+				},
+				cli.StringFlag{
+					Name:  FlagFormat,
+					Usage: `output format`,
 				},
 			},
 			Action: func(c *cli.Context) {

--- a/tools/cli/isolation_groups_test.go
+++ b/tools/cli/isolation_groups_test.go
@@ -143,3 +143,49 @@ func TestParseCliInput(t *testing.T) {
 		})
 	}
 }
+
+func TestRenderIsolationGroupNormalOutput(t *testing.T) {
+
+	tests := map[string]struct {
+		input          types.IsolationGroupConfiguration
+		expectedOutput string
+	}{
+		"valid inputs for doing a drain": {
+			input: types.IsolationGroupConfiguration{
+				"zone-1": {
+					Name:  "zone-1",
+					State: types.IsolationGroupStateHealthy,
+				},
+				"zone-2": {
+					Name:  "zone-2",
+					State: types.IsolationGroupStateDrained,
+				},
+				"zone-3-a-very-long-name": {
+					Name:  "zone-3-a-very-long-name",
+					State: types.IsolationGroupStateDrained,
+				},
+				"zone-4": {
+					Name:  "zone-4",
+					State: 5,
+				},
+			},
+			expectedOutput: `Isolation Groups        State
+zone-1                  Healthy
+zone-2                  Drained
+zone-3-a-very-long-name Drained
+zone-4                  Unknown state: 5
+`,
+		},
+		"nothing": {
+			input: types.IsolationGroupConfiguration{},
+			expectedOutput: `-- No groups found --
+`,
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, td.expectedOutput, renderIsolationGroups(td.input))
+		})
+	}
+}


### PR DESCRIPTION
### Changes 
Fixes up output rendering of isolation-groups for the Cli 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
➜ ./cadence admin isolation-groups get-global --format json
[
  {
    "Name": "zone3-231234u123812388123883122",
    "State": 2
  }
]
➜ ./cadence admin isolation-groups get-global
Isolation Groups                State
zone3-231234u123812388123883122 Drained
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
