### PR TITLE
Change time procces func to admit sec,milli,micro and nano in command queries 

### DIFF
--- a/common/persistence/elasticsearch/esVisibilityStore.go
+++ b/common/persistence/elasticsearch/esVisibilityStore.go
@@ -947,6 +947,12 @@ func timeProcessFunc(obj *fastjson.Object, key string, value *fastjson.Value) er
 
 		// first check if already in int64 format
 		if _, err := strconv.ParseInt(timeStr, 10, 64); err == nil {
+			// In case of seconds, milliseconds, microseconds it is padded with zeros. Otherwise, you would only get a response in the case of strict nano format
+			if len(timeStr) > 9 && len(timeStr) < 19 {
+				padding := strings.Repeat("0", 19-len(timeStr))
+				timeStr = timeStr + padding
+				obj.Set(key, fastjson.MustParse(fmt.Sprintf(`"%v"`, timeStr)))
+			}
 			return nil
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The time processor is modified to allow queries in which search queries are entered with precision of seconds, milliseconds, microseconds and nanoseconds.

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently, the queries made to obtain a list of flows forced to introduce the complete format of the date in nano type, for example: cadence --domain samples-domain wf list --query "CloseTime >1683388191918908000"  If queries were made with less precision, for example micro (1683388191918908), milli (1683388191918) or sec (1683388191) the query did not return information when comparing with a different type. To avoid this problem, padding is performed by completing the searched dates with zero until the types are equal and all formats can be consulted.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Running various tests via command with different operators (><=) and different date formats
cadence --domain samples-domain wf list --query "CloseTime >1683388191918908000"

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
