### PR TITLE
Feature/isolation group library logging improvements

### DIFF
--- a/common/isolationgroup/defaultisolationgroupstate/state.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state.go
@@ -87,7 +87,7 @@ func (z *defaultIsolationGroupStateHandler) AvailableIsolationGroupsByDomainID(c
 		return nil, fmt.Errorf("unable to get isolation group state: %w", err)
 	}
 	availableIsolationGroupsCfg := isolationGroupHealthyListToConfig(availableIsolationGroups)
-	scope := z.createAvailableisolationGroupMetricsScope(domainID, availableIsolationGroups)
+	scope := z.createAvailableisolationGroupMetricsScope(domainID)
 	return availableIG(z.config.AllIsolationGroups, availableIsolationGroupsCfg, state.Global, state.Domain, scope), nil
 }
 
@@ -169,12 +169,9 @@ func (z *defaultIsolationGroupStateHandler) get(ctx context.Context, domain stri
 	return ig, nil
 }
 
-func (z *defaultIsolationGroupStateHandler) createAvailableisolationGroupMetricsScope(domainID string, availableIsolationGroups []string) metrics.Scope {
-	domainName, err := z.domainCache.GetDomainName(domainID)
-	if err != nil {
-		domainName = "unknown-domain"
-	}
-	return z.metricsClient.Scope(metrics.DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope).Tagged(metrics.DomainTag(domainName))
+func (z *defaultIsolationGroupStateHandler) createAvailableisolationGroupMetricsScope(domainID string) metrics.Scope {
+	domainName, _ := z.domainCache.GetDomainName(domainID)
+	return z.metricsClient.Scope(metrics.GetAvailableIsolationGroupsScope).Tagged(metrics.DomainTag(domainName))
 }
 
 // A simple explicit deny-based isolation group implementation

--- a/common/isolationgroup/defaultisolationgroupstate/state.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state.go
@@ -187,11 +187,6 @@ func availableIG(
 		_, hasAvailablePollers := availablePollers[isolationGroup]
 		globalCfg, hasGlobalConfig := global[isolationGroup]
 		domainCfg, hasDomainConfig := domain[isolationGroup]
-		if !hasAvailablePollers {
-			// we don't attempt to dispatch tasks to isolation groups where there are no pollers
-			scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStatePollerUnavailable)
-			continue
-		}
 		if hasGlobalConfig {
 			if globalCfg.State == types.IsolationGroupStateDrained {
 				scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStateDrained)
@@ -203,6 +198,11 @@ func availableIG(
 				scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStateDrained)
 				continue
 			}
+		}
+		if !hasAvailablePollers {
+			// we don't attempt to dispatch tasks to isolation groups where there are no pollers
+			scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStatePollerUnavailable)
+			continue
 		}
 		scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStateHealthy)
 		out[isolationGroup] = types.IsolationGroupPartition{

--- a/common/isolationgroup/defaultisolationgroupstate/state.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state.go
@@ -27,6 +27,8 @@ import (
 	"fmt"
 	"sync/atomic"
 
+	"github.com/uber/cadence/common/metrics"
+
 	"github.com/uber/cadence/common/isolationgroup/isolationgroupapi"
 
 	"github.com/uber/cadence/common"
@@ -44,6 +46,7 @@ type defaultIsolationGroupStateHandler struct {
 	domainCache                cache.DomainCache
 	globalIsolationGroupDrains dynamicconfig.Client
 	config                     defaultConfig
+	metricsClient              metrics.Client
 }
 
 // NewDefaultIsolationGroupStateWatcherWithConfigStoreClient Is a constructor which allows passing in the dynamic config client
@@ -52,6 +55,7 @@ func NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 	dc *dynamicconfig.Collection,
 	domainCache cache.DomainCache,
 	cfgStoreClient dynamicconfig.Client, // can be nil, which means global drain is unsupported
+	metricsClient metrics.Client,
 ) (isolationgroup.State, error) {
 	stopChan := make(chan struct{})
 
@@ -73,6 +77,7 @@ func NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 		status:                     common.DaemonStatusInitialized,
 		log:                        logger,
 		config:                     config,
+		metricsClient:              metricsClient,
 	}, nil
 }
 
@@ -81,8 +86,9 @@ func (z *defaultIsolationGroupStateHandler) AvailableIsolationGroupsByDomainID(c
 	if err != nil {
 		return nil, fmt.Errorf("unable to get isolation group state: %w", err)
 	}
-	isolationGroups := common.IntersectionStringSlice(z.config.AllIsolationGroups, availableIsolationGroups)
-	return availableIG(isolationGroups, state.Global, state.Domain), nil
+	availableIsolationGroupsCfg := isolationGroupHealthyListToConfig(availableIsolationGroups)
+	scope := z.createAvailableisolationGroupMetricsScope(domainID, availableIsolationGroups)
+	return availableIG(z.config.AllIsolationGroups, availableIsolationGroupsCfg, state.Global, state.Domain, scope), nil
 }
 
 func (z *defaultIsolationGroupStateHandler) IsDrained(ctx context.Context, domain string, isolationGroup string) (bool, error) {
@@ -163,22 +169,45 @@ func (z *defaultIsolationGroupStateHandler) get(ctx context.Context, domain stri
 	return ig, nil
 }
 
+func (z *defaultIsolationGroupStateHandler) createAvailableisolationGroupMetricsScope(domainID string, availableIsolationGroups []string) metrics.Scope {
+	domainName, err := z.domainCache.GetDomainName(domainID)
+	if err != nil {
+		domainName = "unknown-domain"
+	}
+	return z.metricsClient.Scope(metrics.DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope).Tagged(metrics.DomainTag(domainName))
+}
+
 // A simple explicit deny-based isolation group implementation
-func availableIG(allIsolationGroups []string, global types.IsolationGroupConfiguration, domain types.IsolationGroupConfiguration) types.IsolationGroupConfiguration {
+func availableIG(
+	allIsolationGroups []string,
+	availablePollers types.IsolationGroupConfiguration,
+	global types.IsolationGroupConfiguration,
+	domain types.IsolationGroupConfiguration,
+	scope metrics.Scope,
+) types.IsolationGroupConfiguration {
 	out := types.IsolationGroupConfiguration{}
 	for _, isolationGroup := range allIsolationGroups {
+		_, hasAvailablePollers := availablePollers[isolationGroup]
 		globalCfg, hasGlobalConfig := global[isolationGroup]
 		domainCfg, hasDomainConfig := domain[isolationGroup]
+		if !hasAvailablePollers {
+			// we don't attempt to dispatch tasks to isolation groups where there are no pollers
+			scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStatePollerUnavailable)
+			continue
+		}
 		if hasGlobalConfig {
 			if globalCfg.State == types.IsolationGroupStateDrained {
+				scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStateDrained)
 				continue
 			}
 		}
 		if hasDomainConfig {
 			if domainCfg.State == types.IsolationGroupStateDrained {
+				scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStateDrained)
 				continue
 			}
 		}
+		scope.Tagged(metrics.PollerIsolationGroupTag(isolationGroup)).IncCounter(metrics.IsolationGroupStateHealthy)
 		out[isolationGroup] = types.IsolationGroupPartition{
 			Name:  isolationGroup,
 			State: types.IsolationGroupStateHealthy,
@@ -201,4 +230,15 @@ func isDrained(isolationGroup string, global types.IsolationGroupConfiguration, 
 		}
 	}
 	return false
+}
+
+func isolationGroupHealthyListToConfig(igs []string) types.IsolationGroupConfiguration {
+	out := make(types.IsolationGroupConfiguration, len(igs))
+	for _, ig := range igs {
+		out[ig] = types.IsolationGroupPartition{
+			Name:  ig,
+			State: types.IsolationGroupStateHealthy,
+		}
+	}
+	return out
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -23,6 +23,8 @@ package tag
 import (
 	"fmt"
 	"time"
+
+	"github.com/uber/cadence/common/types"
 )
 
 // All logging tags are defined in this file.
@@ -930,4 +932,8 @@ func PollerGroups(pollers []string) Tag {
 
 func FallbackIsolationGroup(group string) Tag {
 	return newStringTag("fallback-isolation-group", group)
+}
+
+func PollerGroupsConfiguration(pollers types.IsolationGroupConfiguration) Tag {
+	return newObjectTag("poller-isolation-groups", pollers.ToPartitionList())
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -927,3 +927,7 @@ func PartitionConfig(p map[string]string) Tag {
 func PollerGroups(pollers []string) Tag {
 	return newObjectTag("poller-isolation-groups", pollers)
 }
+
+func FallbackIsolationGroup(group string) Tag {
+	return newStringTag("fallback-isolation-group", group)
+}

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1802,7 +1802,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MatchingDescribeTaskListScope:          {operation: "DescribeTaskList"},
 		MatchingListTaskListPartitionsScope:    {operation: "ListTaskListPartitions"},
 		MatchingGetTaskListsByDomainScope:      {operation: "GetTaskListsByDomain"},
-		MatchingPartitionerDefaultPartitioner:  {operation: "Partitioner"},
+		MatchingPartitionerDefaultPartitioner:  {operation: "GetIsolationGroupByDomainID"},
 	},
 	// Worker Scope Names
 	Worker: {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -743,6 +743,8 @@ const (
 	DomainReplicationQueueScope
 	// ClusterMetadataScope is used for the cluster metadata
 	ClusterMetadataScope
+	// DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope is the metric for the default partitioner's getIsolationGroups operation
+	DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope
 
 	NumCommonScopes
 )
@@ -1209,8 +1211,6 @@ const (
 	MatchingListTaskListPartitionsScope
 	// MatchingGetTaskListsByDomainScope tracks GetTaskListsByDomain API calls received by service
 	MatchingGetTaskListsByDomainScope
-	// MatchingPartitionerDefaultPartitioner
-	MatchingPartitionerDefaultPartitioner
 
 	NumMatchingScopes
 )
@@ -1567,6 +1567,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		BlobstoreClientDeleteScope:          {operation: "BlobstoreClientDelete", tags: map[string]string{CadenceRoleTagName: BlobstoreRoleTagValue}},
 		BlobstoreClientDirectoryExistsScope: {operation: "BlobstoreClientDirectoryExists", tags: map[string]string{CadenceRoleTagName: BlobstoreRoleTagValue}},
 
+		DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope: {operation: "DefaultIsolationGroupStateHandlerGetAvailableIsolationGroups"},
+
 		DomainFailoverScope:         {operation: "DomainFailover"},
 		DomainReplicationQueueScope: {operation: "DomainReplicationQueue"},
 		ClusterMetadataScope:        {operation: "ClusterMetadata"},
@@ -1802,7 +1804,6 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MatchingDescribeTaskListScope:          {operation: "DescribeTaskList"},
 		MatchingListTaskListPartitionsScope:    {operation: "ListTaskListPartitions"},
 		MatchingGetTaskListsByDomainScope:      {operation: "GetTaskListsByDomain"},
-		MatchingPartitionerDefaultPartitioner:  {operation: "GetIsolationGroupByDomainID"},
 	},
 	// Worker Scope Names
 	Worker: {
@@ -2018,6 +2019,10 @@ const (
 
 	ParentClosePolicyProcessorSuccess
 	ParentClosePolicyProcessorFailures
+
+	IsolationGroupStatePollerUnavailable
+	IsolationGroupStateDrained
+	IsolationGroupStateHealthy
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -2633,6 +2638,10 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		DomainReplicationQueueSizeErrorCount: {metricName: "domain_replication_queue_failed", metricType: Counter},
 		ParentClosePolicyProcessorSuccess:    {metricName: "parent_close_policy_processor_requests", metricType: Counter},
 		ParentClosePolicyProcessorFailures:   {metricName: "parent_close_policy_processor_errors", metricType: Counter},
+
+		IsolationGroupStatePollerUnavailable: {metricName: "isolation_group_poller_unavailable", metricType: Counter},
+		IsolationGroupStateDrained:           {metricName: "isolation_group_Drained", metricType: Counter},
+		IsolationGroupStateHealthy:           {metricName: "isolation_group_healthy", metricType: Counter},
 	},
 	History: {
 		TaskRequests:             {metricName: "task_requests", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -743,8 +743,8 @@ const (
 	DomainReplicationQueueScope
 	// ClusterMetadataScope is used for the cluster metadata
 	ClusterMetadataScope
-	// DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope is the metric for the default partitioner's getIsolationGroups operation
-	DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope
+	// GetAvailableIsolationGroupsScope is the metric for the default partitioner's getIsolationGroups operation
+	GetAvailableIsolationGroupsScope
 
 	NumCommonScopes
 )
@@ -1567,7 +1567,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		BlobstoreClientDeleteScope:          {operation: "BlobstoreClientDelete", tags: map[string]string{CadenceRoleTagName: BlobstoreRoleTagValue}},
 		BlobstoreClientDirectoryExistsScope: {operation: "BlobstoreClientDirectoryExists", tags: map[string]string{CadenceRoleTagName: BlobstoreRoleTagValue}},
 
-		DefaultIsolationGroupStateHandlerGetAvailableIsolationGroupsScope: {operation: "DefaultIsolationGroupStateHandlerGetAvailableIsolationGroups"},
+		GetAvailableIsolationGroupsScope: {operation: "GetAvailableIsolationGroups"},
 
 		DomainFailoverScope:         {operation: "DomainFailover"},
 		DomainReplicationQueueScope: {operation: "DomainReplicationQueue"},
@@ -2334,8 +2334,6 @@ const (
 	TaskListManagersGauge
 	TaskLagPerTaskListGauge
 	TaskBacklogPerTaskListGauge
-	PartitionerPinnedTask
-	PartitionerUnPinnedTask
 
 	NumMatchingMetrics
 )
@@ -2939,8 +2937,6 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskListManagersGauge:                       {metricName: "tasklist_managers", metricType: Gauge},
 		TaskLagPerTaskListGauge:                     {metricName: "task_lag_per_tl", metricType: Gauge},
 		TaskBacklogPerTaskListGauge:                 {metricName: "task_backlog_per_tl", metricType: Gauge},
-		PartitionerPinnedTask:                       {metricName: "partitioner_pinned_task", metricType: Counter},
-		PartitionerUnPinnedTask:                     {metricName: "partitioner_unpinned_task", metricType: Counter},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -1209,6 +1209,8 @@ const (
 	MatchingListTaskListPartitionsScope
 	// MatchingGetTaskListsByDomainScope tracks GetTaskListsByDomain API calls received by service
 	MatchingGetTaskListsByDomainScope
+	// MatchingPartitionerDefaultPartitioner
+	MatchingPartitionerDefaultPartitioner
 
 	NumMatchingScopes
 )
@@ -1800,6 +1802,7 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		MatchingDescribeTaskListScope:          {operation: "DescribeTaskList"},
 		MatchingListTaskListPartitionsScope:    {operation: "ListTaskListPartitions"},
 		MatchingGetTaskListsByDomainScope:      {operation: "GetTaskListsByDomain"},
+		MatchingPartitionerDefaultPartitioner:  {operation: "Partitioner"},
 	},
 	// Worker Scope Names
 	Worker: {
@@ -2327,6 +2330,8 @@ const (
 	TaskListManagersGauge
 	TaskLagPerTaskListGauge
 	TaskBacklogPerTaskListGauge
+	PartitionerPinnedTask
+	PartitionerUnPinnedTask
 
 	NumMatchingMetrics
 )
@@ -2927,6 +2932,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskListManagersGauge:                       {metricName: "tasklist_managers", metricType: Gauge},
 		TaskLagPerTaskListGauge:                     {metricName: "task_lag_per_tl", metricType: Gauge},
 		TaskBacklogPerTaskListGauge:                 {metricName: "task_backlog_per_tl", metricType: Gauge},
+		PartitionerPinnedTask:                       {metricName: "partitioner_pinned_task", metricType: Counter},
+		PartitionerUnPinnedTask:                     {metricName: "partitioner_pinned_task", metricType: Counter},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2638,7 +2638,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		ParentClosePolicyProcessorFailures:   {metricName: "parent_close_policy_processor_errors", metricType: Counter},
 
 		IsolationGroupStatePollerUnavailable: {metricName: "isolation_group_poller_unavailable", metricType: Counter},
-		IsolationGroupStateDrained:           {metricName: "isolation_group_Drained", metricType: Counter},
+		IsolationGroupStateDrained:           {metricName: "isolation_group_drained", metricType: Counter},
 		IsolationGroupStateHealthy:           {metricName: "isolation_group_healthy", metricType: Counter},
 	},
 	History: {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2933,7 +2933,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskLagPerTaskListGauge:                     {metricName: "task_lag_per_tl", metricType: Gauge},
 		TaskBacklogPerTaskListGauge:                 {metricName: "task_backlog_per_tl", metricType: Gauge},
 		PartitionerPinnedTask:                       {metricName: "partitioner_pinned_task", metricType: Counter},
-		PartitionerUnPinnedTask:                     {metricName: "partitioner_pinned_task", metricType: Counter},
+		PartitionerUnPinnedTask:                     {metricName: "partitioner_unpinned_task", metricType: Counter},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/common/partition/default-partitioner.go
+++ b/common/partition/default-partitioner.go
@@ -129,6 +129,7 @@ func (r *defaultPartitioner) pickIsolationGroup(wfPartition defaultWorkflowParti
 		tag.FallbackIsolationGroup(fallback),
 		tag.IsolationGroup(wfPartition.WorkflowStartIsolationGroup),
 		tag.PollerGroupsConfiguration(available),
+		tag.WorkflowID(wfPartition.WFID),
 	)
 	return fallback
 }

--- a/common/partition/default-partitioner.go
+++ b/common/partition/default-partitioner.go
@@ -26,9 +26,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
+
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
-	"sort"
 
 	"github.com/uber/cadence/common/isolationgroup"
 
@@ -80,7 +81,7 @@ func NewDefaultPartitioner(
 	}
 }
 
-func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, domainID string, wfPartitionData PartitionConfig, availableIsolationGroups []string) (string, error) {
+func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, domainID string, wfPartitionData PartitionConfig, availablePollerIsolationGroups []string) (string, error) {
 	if wfPartitionData == nil {
 		return "", ErrInvalidPartitionConfig
 	}
@@ -89,7 +90,7 @@ func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, do
 		return "", ErrInvalidPartitionConfig
 	}
 
-	available, err := r.isolationGroupState.AvailableIsolationGroupsByDomainID(ctx, domainID, availableIsolationGroups)
+	available, err := r.isolationGroupState.AvailableIsolationGroupsByDomainID(ctx, domainID, availablePollerIsolationGroups)
 	if err != nil {
 		return "", fmt.Errorf("failed to get available isolation groups: %w", err)
 	}
@@ -134,7 +135,7 @@ func (r *defaultPartitioner) pickIsolationGroup(wfPartition defaultWorkflowParti
 	r.log.Debug("isolation group falling back to an available zone:",
 		tag.FallbackIsolationGroup(fallback),
 		tag.IsolationGroup(wfPartition.WorkflowStartIsolationGroup),
-		tag.Dynamic("poller-available-isolation-groups", available),
+		tag.Dynamic("available-isolation-groups", available),
 	)
 	return fallback
 }

--- a/common/partition/default-partitioner.go
+++ b/common/partition/default-partitioner.go
@@ -132,10 +132,10 @@ func (r *defaultPartitioner) pickIsolationGroup(wfPartition defaultWorkflowParti
 	})
 	r.metrics.IncCounter(metrics.PartitionerUnPinnedTask)
 	fallback := pickIsolationGroupFallback(availableList, wfPartition)
-	r.log.Debug("isolation group falling back to an available zone:",
+	r.log.Debug("isolation group falling back to an available zone",
 		tag.FallbackIsolationGroup(fallback),
 		tag.IsolationGroup(wfPartition.WorkflowStartIsolationGroup),
-		tag.Dynamic("available-isolation-groups", available),
+		tag.PollerGroupsConfiguration(available),
 	)
 	return fallback
 }

--- a/common/partition/default-partitioner_test.go
+++ b/common/partition/default-partitioner_test.go
@@ -28,8 +28,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/uber/cadence/common/metrics"
-
 	"github.com/golang/mock/gomock"
 
 	"github.com/uber/cadence/common/isolationgroup"
@@ -100,7 +98,6 @@ func TestPickingAZone(t *testing.T) {
 			partitioner := defaultPartitioner{
 				log:                 loggerimpl.NewNopLogger(),
 				isolationGroupState: nil,
-				metrics:             metrics.NewNoopMetricsClient().Scope(0),
 			}
 			res := partitioner.pickIsolationGroup(td.wfPartitionCfg, td.availablePartitionGroups)
 			assert.Equal(t, td.expected, res)
@@ -215,7 +212,7 @@ func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			ig := isolationgroup.NewMockState(ctrl)
 			td.stateAffordance(ig)
-			partitioner := NewDefaultPartitioner(loggerimpl.NewNopLogger(), ig, metrics.NewNoopMetricsClient())
+			partitioner := NewDefaultPartitioner(loggerimpl.NewNopLogger(), ig)
 			res, err := partitioner.GetIsolationGroupByDomainID(td.incomingContext, domainID, td.partitionKeyPassedIn, isolationGroups)
 
 			assert.Equal(t, td.expectedValue, res)

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -269,7 +269,7 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	partitioner := ensurePartitionerOrDefault(params, dynamicCollection, isolationGroupState)
+	partitioner := ensurePartitionerOrDefault(params, isolationGroupState)
 
 	impl = &Impl{
 		status: common.DaemonStatusInitialized,
@@ -658,9 +658,9 @@ func ensureIsolationGroupStateHandlerOrDefault(
 }
 
 // Use the provided partitioner or the default one
-func ensurePartitionerOrDefault(params *Params, dc *dynamicconfig.Collection, state isolationgroup.State) partition.Partitioner {
+func ensurePartitionerOrDefault(params *Params, state isolationgroup.State) partition.Partitioner {
 	if params.Partitioner != nil {
 		return params.Partitioner
 	}
-	return partition.NewDefaultPartitioner(params.Logger, state)
+	return partition.NewDefaultPartitioner(params.Logger, state, params.MetricsClient)
 }

--- a/common/resource/resourceImpl.go
+++ b/common/resource/resourceImpl.go
@@ -654,6 +654,7 @@ func ensureIsolationGroupStateHandlerOrDefault(
 		dc,
 		domainCache,
 		isolationGroupStore,
+		params.MetricsClient,
 	)
 }
 
@@ -662,5 +663,5 @@ func ensurePartitionerOrDefault(params *Params, state isolationgroup.State) part
 	if params.Partitioner != nil {
 		return params.Partitioner
 	}
-	return partition.NewDefaultPartitioner(params.Logger, state, params.MetricsClient)
+	return partition.NewDefaultPartitioner(params.Logger, state)
 }

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -125,7 +125,7 @@ func (s *matchingEngineSuite) SetupTest() {
 	dcClient.UpdateValue(dynamicconfig.AllIsolationGroups, []interface{}{"datacenterA", "datacenterB"})
 	dc := dynamicconfig.NewCollection(dcClient, s.logger)
 	isolationGroupState, _ := defaultisolationgroupstate.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(s.logger, dc, s.mockDomainCache, s.mockIsolationStore)
-	s.partitioner = partition.NewDefaultPartitioner(s.logger, isolationGroupState)
+	s.partitioner = partition.NewDefaultPartitioner(s.logger, isolationGroupState, metrics.NewNoopMetricsClient())
 	s.handlerContext = newHandlerContext(
 		context.Background(),
 		matchingTestDomainName,

--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -124,8 +124,8 @@ func (s *matchingEngineSuite) SetupTest() {
 	dcClient.UpdateValue(dynamicconfig.EnableTasklistIsolation, true)
 	dcClient.UpdateValue(dynamicconfig.AllIsolationGroups, []interface{}{"datacenterA", "datacenterB"})
 	dc := dynamicconfig.NewCollection(dcClient, s.logger)
-	isolationGroupState, _ := defaultisolationgroupstate.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(s.logger, dc, s.mockDomainCache, s.mockIsolationStore)
-	s.partitioner = partition.NewDefaultPartitioner(s.logger, isolationGroupState, metrics.NewNoopMetricsClient())
+	isolationGroupState, _ := defaultisolationgroupstate.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(s.logger, dc, s.mockDomainCache, s.mockIsolationStore, metrics.NewNoopMetricsClient())
+	s.partitioner = partition.NewDefaultPartitioner(s.logger, isolationGroupState)
 	s.handlerContext = newHandlerContext(
 		context.Background(),
 		matchingTestDomainName,


### PR DESCRIPTION
- Adds debug logs to the partitioner
- Adds metric counters around isolation group selection based on their being either healthy, missing pollers or drained
- includes some minor refactoring in the isolation-group library to make it clearer what was going on with the selection of groups. 

Example metrics query: 

```
fetch  domain:somedomain operation:getavailableisolationgroups name:isolation_group_healthy| sum poller_isolation_group | moving 1m sum ```
