### PR TITLE
Set ReplicatorCacheCapacity to 0

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -3225,7 +3225,7 @@ var IntKeys = map[IntKey]DynamicInt{
 	ReplicatorCacheCapacity: DynamicInt{
 		KeyName:      "history.replicatorCacheCapacity",
 		Description:  "ReplicatorCacheCapacity is the capacity of replication cache in number of tasks",
-		DefaultValue: 10000,
+		DefaultValue: 0,
 	},
 	ExecutionMgrNumConns: DynamicInt{
 		KeyName:      "history.executionMgrNumConns",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Change `ReplicatorCacheCapacity` default value from 10000 to 0, meaning that replication cache will be not used

<!-- Tell your future self why have you made these changes -->
**Why?**
With default setting, it takes more than 2Gb of RAM which for low traffic, small instance cluster is unproportionally huge

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
