### PR TITLE
Adds some more coverage

### DIFF
--- a/common/isolationgroup/defaultisolationgroupstate/state.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state.go
@@ -81,12 +81,12 @@ func NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(
 	}, nil
 }
 
-func (z *defaultIsolationGroupStateHandler) AvailableIsolationGroupsByDomainID(ctx context.Context, domainID string, availableIsolationGroups []string) (types.IsolationGroupConfiguration, error) {
+func (z *defaultIsolationGroupStateHandler) AvailableIsolationGroupsByDomainID(ctx context.Context, domainID string, availablePollerIsolationGroups []string) (types.IsolationGroupConfiguration, error) {
 	state, err := z.getByDomainID(ctx, domainID)
 	if err != nil {
 		return nil, fmt.Errorf("unable to get isolation group state: %w", err)
 	}
-	availableIsolationGroupsCfg := isolationGroupHealthyListToConfig(availableIsolationGroups)
+	availableIsolationGroupsCfg := isolationGroupHealthyListToConfig(availablePollerIsolationGroups)
 	scope := z.createAvailableisolationGroupMetricsScope(domainID)
 	return availableIG(z.config.AllIsolationGroups, availableIsolationGroupsCfg, state.Global, state.Domain, scope), nil
 }
@@ -140,7 +140,7 @@ func (z *defaultIsolationGroupStateHandler) get(ctx context.Context, domain stri
 	}
 
 	domainData, err := z.domainCache.GetDomain(domain)
-	if err != nil {
+	if err != nil || domainData == nil {
 		return nil, fmt.Errorf("could not resolve domain in isolationGroup handler: %w", err)
 	}
 

--- a/common/isolationgroup/defaultisolationgroupstate/state_test.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state_test.go
@@ -26,6 +26,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/uber/cadence/common/metrics"
@@ -42,6 +43,262 @@ import (
 
 	"github.com/uber/cadence/common/types"
 )
+
+func TestAvailableIsolationGroupsHandler(t *testing.T) {
+
+	validInputNormal := types.IsolationGroupConfiguration{
+		"zone-1": types.IsolationGroupPartition{
+			Name:  "zone-1",
+			State: types.IsolationGroupStateHealthy,
+		},
+		"zone-2": types.IsolationGroupPartition{
+			Name:  "zone-2",
+			State: types.IsolationGroupStateHealthy,
+		},
+	}
+
+	validInputDrains := types.IsolationGroupConfiguration{
+		"zone-1": types.IsolationGroupPartition{
+			Name:  "zone-1",
+			State: types.IsolationGroupStateDrained,
+		},
+	}
+
+	validCfgNormal, _ := isolationgroupapi.MapUpdateGlobalIsolationGroupsRequest(validInputNormal)
+	validCfgDrained, _ := isolationgroupapi.MapUpdateGlobalIsolationGroupsRequest(validInputDrains)
+
+	validCfgDataNormal := validCfgNormal[0].Value.GetData()
+	dynamicConfigResponseNormal := []interface{}{}
+	json.Unmarshal(validCfgDataNormal, &dynamicConfigResponseNormal)
+
+	validCfgDataDrained := validCfgDrained[0].Value.GetData()
+	dynamicConfigResponseDrained := []interface{}{}
+	json.Unmarshal(validCfgDataDrained, &dynamicConfigResponseDrained)
+
+	tests := map[string]struct {
+		availablePollerIsolationGroups []string
+		dcAffordance                   func(client *dynamicconfig.MockClient)
+		domainAffordance               func(mock *cache.MockDomainCache)
+		cfg                            defaultConfig
+		expected                       types.IsolationGroupConfiguration
+		expectedErr                    error
+	}{
+		"normal case - no drains present - no configuration specifying a drain - feature is enabled": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(), // covering the mapping in the mapper unit-test instead
+				).Return(dynamicConfigResponseNormal, nil)
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomainName("domain-id").Return("domain", nil)
+				mock.EXPECT().GetDomain("domain").Return(domainResponse, nil).AnyTimes()
+			},
+			expected: types.IsolationGroupConfiguration{
+				"zone-1": {
+					Name:  "zone-1",
+					State: types.IsolationGroupStateHealthy,
+				},
+				"zone-2": {
+					Name:  "zone-2",
+					State: types.IsolationGroupStateHealthy,
+				},
+			},
+		},
+
+		"normal case - one drain present - no configuration specifying a drain - feature is enabled": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(), // covering the mapping in the mapper unit-test instead
+				).Return(dynamicConfigResponseDrained, nil)
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomainName("domain-id").Return("domain", nil)
+				mock.EXPECT().GetDomain("domain").Return(domainResponse, nil).AnyTimes()
+			},
+			expected: types.IsolationGroupConfiguration{
+				"zone-2": {
+					Name:  "zone-2",
+					State: types.IsolationGroupStateHealthy,
+				},
+			},
+		},
+		"expected case - no global drain data configured": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(nil, nil)
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomainName("domain-id").Return("domain", nil)
+				mock.EXPECT().GetDomain("domain").Return(domainResponse, nil).AnyTimes()
+			},
+			expected: types.IsolationGroupConfiguration{
+				"zone-1": {
+					Name:  "zone-1",
+					State: types.IsolationGroupStateHealthy,
+				},
+				"zone-2": {
+					Name:  "zone-2",
+					State: types.IsolationGroupStateHealthy,
+				},
+			},
+		},
+		"pathological case - problems with global drain data - 1": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(nil, fmt.Errorf("an error"))
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomain("domain").Return(domainResponse, nil).AnyTimes()
+			},
+			expected:    nil,
+			expectedErr: errors.New("unable to get isolation group state: could not resolve global drains in an error"),
+		},
+		"pathological case - problems with domain drain data - cannot resolve domain": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				mock.EXPECT().GetDomainByID("domain-id").Return(nil, errors.New("could not find domain"))
+			},
+			expected:    nil,
+			expectedErr: errors.New("unable to get isolation group state: could not resolve domain in isolationGroup handler: could not find domain"),
+		},
+
+		"pathological case - problems with global drain data - malformed data returned 1": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(nil, fmt.Errorf("an error"))
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomain("domain").Return(domainResponse, nil).AnyTimes()
+			},
+			expected:    nil,
+			expectedErr: errors.New("unable to get isolation group state: could not resolve global drains in an error"),
+		},
+		"pathological case - problems with domain drain data - malformed data returned 1": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomain("domain").Return(nil, errors.New("a failure")).AnyTimes()
+			},
+			expected:    nil,
+			expectedErr: errors.New("unable to get isolation group state: could not resolve domain in isolationGroup handler: a failure"),
+		},
+		"pathological case - problems with domain drain data - malformed data returned 2": {
+			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomain("domain").Return(nil, nil).AnyTimes()
+			},
+			expected:    nil,
+			expectedErr: errors.New("unable to get isolation group state: could not resolve domain in isolationGroup handler: %!w(<nil>)"),
+		},
+		"pathological case - no available pollers": {
+			availablePollerIsolationGroups: nil,
+			cfg: defaultConfig{
+				IsolationGroupEnabled: func(string) bool { return true },
+				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+			},
+			dcAffordance: func(client *dynamicconfig.MockClient) {
+				client.EXPECT().GetListValue(
+					dynamicconfig.DefaultIsolationGroupConfigStoreManagerGlobalMapping,
+					gomock.Any(),
+				).Return(nil, nil)
+			},
+			domainAffordance: func(mock *cache.MockDomainCache) {
+				domainResponse := cache.NewDomainCacheEntryForTest(&persistence.DomainInfo{ID: "domain-id", Name: "domain"}, &persistence.DomainConfig{}, true, nil, 0, nil)
+				mock.EXPECT().GetDomainByID("domain-id").Return(domainResponse, nil)
+				mock.EXPECT().GetDomainName("domain-id").Return("domain", nil)
+				mock.EXPECT().GetDomain("domain").Return(domainResponse, nil).AnyTimes()
+			},
+			expected: types.IsolationGroupConfiguration{},
+		},
+	}
+
+	for name, td := range tests {
+		t.Run(name, func(t *testing.T) {
+			mockCtl := gomock.NewController(t)
+			dcMock := dynamicconfig.NewMockClient(mockCtl)
+			domaincacheMock := cache.NewMockDomainCache(mockCtl)
+			td.dcAffordance(dcMock)
+			td.domainAffordance(domaincacheMock)
+			handler := defaultIsolationGroupStateHandler{
+				log:                        loggerimpl.NewNopLogger(),
+				globalIsolationGroupDrains: dcMock,
+				domainCache:                domaincacheMock,
+				config:                     td.cfg,
+				metricsClient:              metrics.NewNoopMetricsClient(),
+			}
+			res, err := handler.AvailableIsolationGroupsByDomainID(context.TODO(), "domain-id", td.availablePollerIsolationGroups)
+			assert.Equal(t, td.expected, res)
+			if td.expectedErr != nil {
+				assert.Equal(t, td.expectedErr.Error(), err.Error())
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
 
 func TestIsDrainedHandler(t *testing.T) {
 


### PR DESCRIPTION
In the spirit of iteration and feedback the original isolation-group state libraries weren't particularly well test covered. This Adds some necessary test coverage; probably not entirely sufficient, but more than nothing. 