### PR TITLE
Fix SearchAfter usage

### DIFF
--- a/common/elasticsearch/client.go
+++ b/common/elasticsearch/client.go
@@ -340,7 +340,7 @@ func (c *ESClient) getSearchResult(
 	)
 
 	if ShouldSearchAfter(token) {
-		qb.SearchAfter([]interface{}{token.SortValue, token.TieBreaker})
+		qb.SearchAfter(token.SortValue, token.TieBreaker)
 	}
 
 	body, err := qb.String()

--- a/common/elasticsearch/query/builder_test.go
+++ b/common/elasticsearch/query/builder_test.go
@@ -57,7 +57,7 @@ func TestBuilderAgainsESv7(t *testing.T) {
 	qb.Query(NewExistsQuery("user"))
 	qb.Size(10)
 	qb.Sortby(NewFieldSort("runid").Desc())
-	qb.Query(NewBoolQuery().Must(NewMatchQuery("domainID", "uuid"))).SearchAfter([]interface{}{"sortval", "tiebraker"})
+	qb.Query(NewBoolQuery().Must(NewMatchQuery("domainID", "uuid"))).SearchAfter("sortval", "tiebraker")
 	qbs, err := qb.Source()
 	assert.NoError(t, err)
 
@@ -65,7 +65,7 @@ func TestBuilderAgainsESv7(t *testing.T) {
 		Query(elastic.NewExistsQuery("user")).
 		Size(10).
 		SortBy(elastic.NewFieldSort("runid").Desc()).
-		Query(elastic.NewBoolQuery().Must(elastic.NewMatchQuery("domainID", "uuid"))).SearchAfter([]interface{}{"sortval", "tiebraker"})
+		Query(elastic.NewBoolQuery().Must(elastic.NewMatchQuery("domainID", "uuid"))).SearchAfter("sortval", "tiebraker")
 
 	sss, err := searchSource.Source()
 	assert.NoError(t, err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Passing multiple values to `searchAfter` instead of a single slice

<!-- Tell your future self why have you made these changes -->
**Why?**
Previous usage of this function resulted in malformed ElasticSearch query

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Updated unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
