### PR TITLE
Fixing consistency

### DIFF
--- a/tools/cassandra/cqlclient.go
+++ b/tools/cassandra/cqlclient.go
@@ -175,6 +175,10 @@ func (client *CqlClientImpl) CreateSchemaVersionTables() error {
 // ReadSchemaVersion returns the current schema version for the Keyspace
 func (client *CqlClientImpl) ReadSchemaVersion() (string, error) {
 	query := client.session.Query(readSchemaVersionCQL, client.cfg.Keyspace)
+	// Hardcode consistency level to be quorum here to be safe
+	// it seems it was being set as ALL somewhere, which breaks service on start
+	// during node repairs
+	query.Consistency(gocql.LocalQuorum)
 	iter := query.Iter()
 	var version string
 	if !iter.Scan(&version) {


### PR DESCRIPTION
Hotfix for issue where schema checks seem to be breaking on service start due to using consistency-level ALL under some scenarios