### PR TITLE
Separate poller token pools for tasklists with isolation

### DIFF
--- a/service/matching/forwarder_test.go
+++ b/service/matching/forwarder_test.go
@@ -42,11 +42,12 @@ import (
 
 type ForwarderTestSuite struct {
 	suite.Suite
-	controller *gomock.Controller
-	client     *matching.MockClient
-	fwdr       *Forwarder
-	cfg        *forwarderConfig
-	taskList   *taskListID
+	controller      *gomock.Controller
+	client          *matching.MockClient
+	fwdr            *Forwarder
+	cfg             *forwarderConfig
+	taskList        *taskListID
+	isolationGroups []string
 }
 
 func TestForwarderSuite(t *testing.T) {
@@ -63,7 +64,8 @@ func (t *ForwarderTestSuite) SetupTest() {
 		ForwarderMaxOutstandingTasks: func() int { return 1 },
 	}
 	t.taskList = newTestTaskListID("fwdr", "tl0", persistence.TaskListTypeDecision)
-	t.fwdr = newForwarder(t.cfg, t.taskList, types.TaskListKindNormal, t.client, nil)
+	t.isolationGroups = []string{"abc", "xyz"}
+	t.fwdr = newForwarder(t.cfg, t.taskList, types.TaskListKindNormal, t.client, t.isolationGroups)
 }
 
 func (t *ForwarderTestSuite) TearDownTest() {
@@ -274,31 +276,44 @@ func (t *ForwarderTestSuite) TestMaxOutstandingConcurrency() {
 			for i := 0; i < concurrency; i++ {
 				wg.Add(1)
 				go func() {
-					select {
-					case token := <-t.fwdr.AddReqTokenC():
-						if !tc.mustLeakToken {
-							token.release()
+					for i := 0; i < len(t.isolationGroups)+1; i++ {
+						select {
+						case token := <-t.fwdr.AddReqTokenC():
+							if !tc.mustLeakToken {
+								token.release("")
+							}
+							atomic.AddInt32(&adds, 1)
+						case <-time.After(time.Millisecond * 100):
+							break
 						}
-						atomic.AddInt32(&adds, 1)
-					case <-time.After(time.Millisecond * 200):
-						break
 					}
 
 					select {
-					case token := <-t.fwdr.PollReqTokenC():
+					case token := <-t.fwdr.PollReqTokenC(""):
 						if !tc.mustLeakToken {
-							token.release()
+							token.release("")
 						}
 						atomic.AddInt32(&polls, 1)
-					case <-time.After(time.Millisecond * 200):
+					case <-time.After(time.Millisecond * 100):
 						break
+					}
+					for _, ig := range t.isolationGroups {
+						select {
+						case token := <-t.fwdr.PollReqTokenC(ig):
+							if !tc.mustLeakToken {
+								token.release(ig)
+							}
+							atomic.AddInt32(&polls, 1)
+						case <-time.After(time.Millisecond * 100):
+							break
+						}
 					}
 					wg.Done()
 				}()
 			}
 			t.True(common.AwaitWaitGroup(&wg, time.Second))
-			t.Equal(tc.output, adds)
-			t.Equal(tc.output, polls)
+			t.Equal(tc.output*int32(len(t.isolationGroups)+1), adds)
+			t.Equal(tc.output*int32(len(t.isolationGroups)+1), polls)
 		})
 	}
 }
@@ -316,9 +331,9 @@ func (t *ForwarderTestSuite) TestMaxOutstandingConfigUpdate() {
 		go func() {
 			<-startC
 			token1 := <-t.fwdr.AddReqTokenC()
-			token1.release()
-			token2 := <-t.fwdr.PollReqTokenC()
-			token2.release()
+			token1.release("")
+			token2 := <-t.fwdr.PollReqTokenC("")
+			token2.release("")
 			doneWG.Done()
 		}()
 	}
@@ -328,7 +343,7 @@ func (t *ForwarderTestSuite) TestMaxOutstandingConfigUpdate() {
 	close(startC)
 	t.True(common.AwaitWaitGroup(&doneWG, time.Second))
 
-	t.Equal(10, cap(t.fwdr.addReqToken.Load().(*ForwarderReqToken).ch))
+	t.Equal(10*(len(t.isolationGroups)+1), cap(t.fwdr.addReqToken.Load().(*ForwarderReqToken).ch))
 	t.Equal(10, cap(t.fwdr.pollReqToken.Load().(*ForwarderReqToken).ch))
 }
 

--- a/service/matching/matcher_test.go
+++ b/service/matching/matcher_test.go
@@ -42,13 +42,14 @@ import (
 
 type MatcherTestSuite struct {
 	suite.Suite
-	controller  *gomock.Controller
-	client      *matching.MockClient
-	fwdr        *Forwarder
-	cfg         *taskListConfig
-	taskList    *taskListID
-	matcher     *TaskMatcher // matcher for child partition
-	rootMatcher *TaskMatcher // matcher for parent partition
+	controller      *gomock.Controller
+	client          *matching.MockClient
+	fwdr            *Forwarder
+	cfg             *taskListConfig
+	taskList        *taskListID
+	matcher         *TaskMatcher // matcher for child partition
+	rootMatcher     *TaskMatcher // matcher for parent partition
+	isolationGroups []string
 }
 
 func TestMatcherSuite(t *testing.T) {
@@ -69,7 +70,8 @@ func (t *MatcherTestSuite) SetupTest() {
 		ForwarderMaxChildrenPerNode:  func() int { return 20 },
 	}
 	t.cfg = tlCfg
-	t.fwdr = newForwarder(&t.cfg.forwarderConfig, t.taskList, types.TaskListKindNormal, t.client, nil)
+	t.isolationGroups = []string{"dca1", "dca2"}
+	t.fwdr = newForwarder(&t.cfg.forwarderConfig, t.taskList, types.TaskListKindNormal, t.client, []string{"dca1", "dca2"})
 	t.matcher = newTaskMatcher(tlCfg, t.fwdr, metrics.NoopScope(metrics.Matching), []string{"dca1", "dca2"})
 
 	rootTaskList := newTestTaskListID(t.taskList.domainID, t.taskList.Parent(20), persistence.TaskListTypeDecision)
@@ -84,8 +86,10 @@ func (t *MatcherTestSuite) TearDownTest() {
 
 func (t *MatcherTestSuite) TestLocalSyncMatch() {
 	// force disable remote forwarding
-	<-t.fwdr.AddReqTokenC()
-	<-t.fwdr.PollReqTokenC()
+	for i := 0; i < len(t.isolationGroups)+1; i++ {
+		<-t.fwdr.AddReqTokenC()
+	}
+	<-t.fwdr.PollReqTokenC("")
 
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
 		task, err := t.matcher.Poll(ctx, "")
@@ -105,8 +109,10 @@ func (t *MatcherTestSuite) TestLocalSyncMatch() {
 
 func (t *MatcherTestSuite) TestIsolationLocalSyncMatch() {
 	// force disable remote forwarding
-	<-t.fwdr.AddReqTokenC()
-	<-t.fwdr.PollReqTokenC()
+	for i := 0; i < len(t.isolationGroups)+1; i++ {
+		<-t.fwdr.AddReqTokenC()
+	}
+	<-t.fwdr.PollReqTokenC("dca1")
 
 	isolationGroup := "dca1"
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
@@ -224,8 +230,10 @@ func (t *MatcherTestSuite) TestSyncMatchFailure() {
 
 func (t *MatcherTestSuite) TestIsolationSyncMatchFailure() {
 	// force disable remote forwarding
-	<-t.fwdr.AddReqTokenC()
-	<-t.fwdr.PollReqTokenC()
+	for i := 0; i < len(t.isolationGroups)+1; i++ {
+		<-t.fwdr.AddReqTokenC()
+	}
+	<-t.fwdr.PollReqTokenC("dca2")
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
 		task, err := t.matcher.Poll(ctx, "dca2")
 		if err == nil {
@@ -243,8 +251,10 @@ func (t *MatcherTestSuite) TestIsolationSyncMatchFailure() {
 
 func (t *MatcherTestSuite) TestQueryLocalSyncMatch() {
 	// force disable remote forwarding
-	<-t.fwdr.AddReqTokenC()
-	<-t.fwdr.PollReqTokenC()
+	for i := 0; i < len(t.isolationGroups)+1; i++ {
+		<-t.fwdr.AddReqTokenC()
+	}
+	<-t.fwdr.PollReqTokenC("")
 
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
 		task, err := t.matcher.PollForQuery(ctx)
@@ -314,7 +324,7 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatch() {
 }
 
 func (t *MatcherTestSuite) TestQueryRemoteSyncMatchError() {
-	<-t.fwdr.PollReqTokenC()
+	<-t.fwdr.PollReqTokenC("")
 
 	matched := false
 	ready, wait := ensureAsyncAfterReady(time.Second, func(ctx context.Context) {
@@ -347,8 +357,10 @@ func (t *MatcherTestSuite) TestQueryRemoteSyncMatchError() {
 
 func (t *MatcherTestSuite) TestMustOfferLocalMatch() {
 	// force disable remote forwarding
-	<-t.fwdr.AddReqTokenC()
-	<-t.fwdr.PollReqTokenC()
+	for i := 0; i < len(t.isolationGroups)+1; i++ {
+		<-t.fwdr.AddReqTokenC()
+	}
+	<-t.fwdr.PollReqTokenC("")
 
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
 		task, err := t.matcher.Poll(ctx, "")
@@ -367,8 +379,10 @@ func (t *MatcherTestSuite) TestMustOfferLocalMatch() {
 
 func (t *MatcherTestSuite) TestIsolationMustOfferLocalMatch() {
 	// force disable remote forwarding
-	<-t.fwdr.AddReqTokenC()
-	<-t.fwdr.PollReqTokenC()
+	for i := 0; i < len(t.isolationGroups)+1; i++ {
+		<-t.fwdr.AddReqTokenC()
+	}
+	<-t.fwdr.PollReqTokenC("dca1")
 
 	wait := ensureAsyncReady(time.Second, func(ctx context.Context) {
 		task, err := t.matcher.Poll(ctx, "dca1")
@@ -502,7 +516,7 @@ func (t *MatcherTestSuite) TestIsolationMustOfferRemoteMatch() {
 }
 
 func (t *MatcherTestSuite) TestRemotePoll() {
-	pollToken := <-t.fwdr.PollReqTokenC()
+	pollToken := <-t.fwdr.PollReqTokenC("")
 
 	var req *types.MatchingPollForDecisionTaskRequest
 	t.client.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -513,7 +527,7 @@ func (t *MatcherTestSuite) TestRemotePoll() {
 	)
 
 	ready, wait := ensureAsyncAfterReady(0, func(_ context.Context) {
-		pollToken.release()
+		pollToken.release("")
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
@@ -528,7 +542,7 @@ func (t *MatcherTestSuite) TestRemotePoll() {
 }
 
 func (t *MatcherTestSuite) TestRemotePollForQuery() {
-	pollToken := <-t.fwdr.PollReqTokenC()
+	pollToken := <-t.fwdr.PollReqTokenC("")
 
 	var req *types.MatchingPollForDecisionTaskRequest
 	t.client.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -539,7 +553,7 @@ func (t *MatcherTestSuite) TestRemotePollForQuery() {
 	)
 
 	ready, wait := ensureAsyncAfterReady(0, func(_ context.Context) {
-		pollToken.release()
+		pollToken.release("")
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Separate poller token pools for tasklists with isolation

<!-- Tell your future self why have you made these changes -->
**Why?**
To allow concurrent forwarding of pollers from different isolation groups. This is to help increase concurrency because pollers from isolation groups are isolated.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
new unit tests and manual test in staging2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
