### PR TITLE
Disable isolation for sticky tasklist

### DIFF
--- a/service/matching/matchingEngine_test.go
+++ b/service/matching/matchingEngine_test.go
@@ -1359,6 +1359,7 @@ func (s *matchingEngineSuite) DrainBacklogNoPollersIsolationGroup(taskType int) 
 }
 
 func (s *matchingEngineSuite) TestAddStickyDecisionNoPollerIsolation() {
+	s.T().Skip("skip test until we re-enable isolation for sticky tasklist")
 	taskType := persistence.TaskListTypeDecision
 	s.matchingEngine.config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
 	s.matchingEngine.config.EnableTasklistIsolation = dynamicconfig.GetBoolPropertyFnFilteredByDomainID(true)

--- a/service/matching/taskListManager.go
+++ b/service/matching/taskListManager.go
@@ -571,7 +571,7 @@ func (c *taskListManagerImpl) shouldReload() bool {
 }
 
 func (c *taskListManagerImpl) getIsolationGroupForTask(ctx context.Context, taskInfo *persistence.TaskInfo) (string, error) {
-	if c.enableIsolation && len(taskInfo.PartitionConfig) > 0 {
+	if c.enableIsolation && len(taskInfo.PartitionConfig) > 0 && c.taskListKind != types.TaskListKindSticky {
 		partitionConfig := make(map[string]string)
 		for k, v := range taskInfo.PartitionConfig {
 			partitionConfig[k] = v


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Disable isolation for sticky tasklist

<!-- Tell your future self why have you made these changes -->
**Why?**
Performance is degraded a lot with certain implementation when network leakage is a lot, because we get lots of stickyWorkerUnavailable error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
n/a

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If an isolation group is drained and then undrained, the workflow is still processed by a worker from an isolation group which is different from where the workflow is started.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
