### PR TITLE
Set 12.4 version for postgres image

### DIFF
--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -25,7 +25,7 @@ services:
           - mysql
 
   postgres:
-    image: postgres:12
+    image: postgres:12.4
     environment:
       POSTGRES_PASSWORD: cadence
       POSTGRES_USER: cadence

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -18,7 +18,7 @@ services:
           - mysql
 
   postgres:
-    image: postgres:12
+    image: postgres:12.4
     environment:
       POSTGRES_PASSWORD: cadence
     ports:

--- a/docker/dev/postgres.yml
+++ b/docker/dev/postgres.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:12
+    image: postgres:12.4
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: cadence

--- a/docker/docker-compose-postgres.yml
+++ b/docker/docker-compose-postgres.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   postgres:
-    image: postgres:12
+    image: postgres:12.4
     environment:
       POSTGRES_USER: cadence
       POSTGRES_PASSWORD: cadence


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Set postgres image version to "12.4"

<!-- Tell your future self why have you made these changes -->
**Why?**
Version 12 started to fail with error.
```
2023-06-16T10:42:35.005245719Z Check your installation.
2023-06-16T10:42:38.915855610Z popen failure: Cannot allocate memory
2023-06-16T10:42:38.915879779Z initdb: error: The program "postgres" is needed by initdb but was not found in the
2023-06-16T10:42:38.915884922Z same directory as "/usr/lib/postgresql/12/bin/initdb".
2023-06-16T10:42:38.915888378Z Check your installation.
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
