### PR TITLE
Update consistency level for cassandra visibility

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/constants.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/constants.go
@@ -48,7 +48,7 @@ const (
 	// eventual consistency is sufficient.
 	// That's because the engine layer writes into visibility with eventual consistency anyway(using transfer tasks)
 	// Do NOT use it in other places, unless you are sure it's the same special cases like reading visibility
-	cassandraLowConslevel = gocql.One
+	cassandraLowConslevel = gocql.LocalOne
 
 	// We use all consistency level for delete operations to prevent the data resurrection issue
 	cassandraAllConslevel = gocql.All


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use local_one consistency instead of one

<!-- Tell your future self why have you made these changes -->
**Why?**
In a multiple datacenter clusters, a consistency level of ONE is often desirable, but cross-DC traffic is not. LOCAL_ONE accomplishes this.
<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
