### PR TITLE
[CLI] add domain migration command with domain metadata checker

### DIFF
--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -22,6 +22,7 @@ package cli
 
 import (
 	"fmt"
+
 	"github.com/urfave/cli"
 )
 

--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -86,7 +86,7 @@ func newDomainCommands() []cli.Command {
 		{
 			Name:    "migration",
 			Aliases: []string{"mi"},
-			Usage:   "Migrate existing workflow domain",
+			Usage:   "Migrate existing domain to new domain. This command only validates the settings. It does not perform actual data migration",
 			Flags:   migrateDomainFlags,
 			Action: func(c *cli.Context) {
 				newDomainCLI(c, false).MigrateDomain(c)

--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -22,7 +22,6 @@ package cli
 
 import (
 	"fmt"
-
 	"github.com/urfave/cli"
 )
 
@@ -81,6 +80,16 @@ func newDomainCommands() []cli.Command {
 			Flags:   describeDomainFlags,
 			Action: func(c *cli.Context) {
 				newDomainCLI(c, false).DescribeDomain(c)
+			},
+		},
+
+		{
+			Name:    "migration",
+			Aliases: []string{"mi"},
+			Usage:   "Migrate existing workflow domain",
+			Flags:   migrateDomainFlags,
+			Action: func(c *cli.Context) {
+				newDomainCLI(c, false).MigrateDomain(c)
 			},
 		},
 	}

--- a/tools/cli/domainUtils.go
+++ b/tools/cli/domainUtils.go
@@ -201,6 +201,20 @@ var (
 		getFormatFlag(),
 	}
 
+	migrateDomainFlags = []cli.Flag{
+
+		cli.StringFlag{
+			Name:  FlagDestinationAddress,
+			Usage: "t",
+		},
+		cli.StringFlag{
+			Name:  FlagDestinationDomain,
+			Usage: "t",
+		},
+
+		getFormatFlag(),
+	}
+
 	adminDomainCommonFlags = getDBFlags()
 
 	adminRegisterDomainFlags = append(

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -76,20 +76,28 @@ type ClientFactory interface {
 }
 
 type clientFactory struct {
-	hostPort   string
-	dispatcher *yarpc.Dispatcher
-	logger     *zap.Logger
+	addressFlagFunc func(c *cli.Context) string
+	hostPort        string
+	dispatcher      *yarpc.Dispatcher
+	logger          *zap.Logger
 }
 
+// DEPRECATED don't use, only reserved for backward compatibility purposes
 // NewClientFactory creates a new ClientFactory
 func NewClientFactory() ClientFactory {
+	return newClientFactory(func(c *cli.Context) string {
+		return c.GlobalString(FlagAddress)
+	})
+}
+
+func newClientFactory(f func(c *cli.Context) string) ClientFactory {
 	logger, err := zap.NewDevelopment()
 	if err != nil {
 		panic(err)
 	}
-
 	return &clientFactory{
-		logger: logger,
+		addressFlagFunc: f,
+		logger:          logger,
 	}
 }
 
@@ -156,9 +164,10 @@ func (b *clientFactory) ensureDispatcher(c *cli.Context) {
 	if shouldUseGrpc {
 		b.hostPort = grpcPort
 	}
-	if addr := c.GlobalString(FlagAddress); addr != "" {
+	if addr := b.addressFlagFunc(c); addr != "" {
 		b.hostPort = addr
 	}
+
 	var outbounds transport.Outbounds
 	if shouldUseGrpc {
 		grpcTransport := grpc.NewTransport()

--- a/tools/cli/flags.go
+++ b/tools/cli/flags.go
@@ -32,6 +32,7 @@ const (
 	FlagDecodingTypes                     = "decoding_types"
 	FlagAddress                           = "address"
 	FlagAddressWithAlias                  = FlagAddress + ", ad"
+	FlagDestinationAddress                = "destination_address"
 	FlagHistoryAddress                    = "history_address"
 	FlagDBType                            = "db_type"
 	FlagDBAddress                         = "db_address"
@@ -42,6 +43,7 @@ const (
 	FlagProtoVersion                      = "protocol_version"
 	FlagDomainID                          = "domain_id"
 	FlagDomain                            = "domain"
+	FlagDestinationDomain                 = "destination_domain" // added  this
 	FlagDomainWithAlias                   = FlagDomain + ", do"
 	FlagShardID                           = "shard_id"
 	FlagShardIDWithAlias                  = FlagShardID + ", sid"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
Added a domain migration command. Currently, it checks the domain metadata and long running workflows. 

<!-- Tell your future self why have you made these changes -->
To ensure both domains exist before domain migration happens.
To ensure domain doesn't have long running workflows that migration cannot handle.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
tested locally with docker compose

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
