### PR TITLE
Add limit clause to pinot queries

### DIFF
--- a/common/persistence/Pinot/pinotVisibilityStore.go
+++ b/common/persistence/Pinot/pinotVisibilityStore.go
@@ -493,7 +493,7 @@ func (v *pinotVisibilityStore) checkProducer() {
 }
 
 func createVisibilityMessage(
-// common parameters
+	// common parameters
 	domainID string,
 	wid,
 	rid string,
@@ -506,11 +506,11 @@ func createVisibilityMessage(
 	encoding common.EncodingType,
 	isCron bool,
 	numClusters int16,
-// specific to certain status
-	closeTimeUnixNano int64,                           // close execution
+	// specific to certain status
+	closeTimeUnixNano int64, // close execution
 	closeStatus workflow.WorkflowExecutionCloseStatus, // close execution
-	historyLength int64,                               // close execution
-	updateTimeUnixNano int64,                          // update execution,
+	historyLength int64, // close execution
+	updateTimeUnixNano int64, // update execution,
 	shardID int64,
 	rawSearchAttributes map[string][]byte,
 ) (*indexer.PinotMessage, error) {

--- a/common/persistence/Pinot/pinotVisibilityStore.go
+++ b/common/persistence/Pinot/pinotVisibilityStore.go
@@ -493,7 +493,7 @@ func (v *pinotVisibilityStore) checkProducer() {
 }
 
 func createVisibilityMessage(
-	// common parameters
+// common parameters
 	domainID string,
 	wid,
 	rid string,
@@ -506,11 +506,11 @@ func createVisibilityMessage(
 	encoding common.EncodingType,
 	isCron bool,
 	numClusters int16,
-	// specific to certain status
-	closeTimeUnixNano int64, // close execution
+// specific to certain status
+	closeTimeUnixNano int64,                           // close execution
 	closeStatus workflow.WorkflowExecutionCloseStatus, // close execution
-	historyLength int64, // close execution
-	updateTimeUnixNano int64, // update execution,
+	historyLength int64,                               // close execution
+	updateTimeUnixNano int64,                          // update execution,
 	shardID int64,
 	rawSearchAttributes map[string][]byte,
 ) (*indexer.PinotMessage, error) {
@@ -932,6 +932,16 @@ func getListWorkflowExecutionsByTypeQuery(tableName string, request *p.InternalL
 
 	//query.addPinotSorter(CloseTime, DescendingOrder)
 	//query.addPinotSorter(RunID, DescendingOrder)
+
+	token, err := pnt.GetNextPageToken(request.NextPageToken)
+	if err != nil {
+		panic(fmt.Sprintf("deserialize next page token error: %s", err))
+	}
+
+	from := token.From
+	pageSize := request.PageSize
+	query.addOffsetAndLimits(from, pageSize)
+
 	return query.String()
 }
 
@@ -958,6 +968,16 @@ func getListWorkflowExecutionsByWorkflowIDQuery(tableName string, request *p.Int
 
 	query.addPinotSorter(CloseTime, DescendingOrder)
 	//query.addPinotSorter(RunID, DescendingOrder)
+
+	token, err := pnt.GetNextPageToken(request.NextPageToken)
+	if err != nil {
+		panic(fmt.Sprintf("deserialize next page token error: %s", err))
+	}
+
+	from := token.From
+	pageSize := request.PageSize
+	query.addOffsetAndLimits(from, pageSize)
+
 	return query.String()
 }
 
@@ -991,6 +1011,16 @@ func getListWorkflowExecutionsByStatusQuery(tableName string, request *p.Interna
 
 	query.addPinotSorter(CloseTime, DescendingOrder)
 	//query.addPinotSorter(RunID, DescendingOrder)
+
+	token, err := pnt.GetNextPageToken(request.NextPageToken)
+	if err != nil {
+		panic(fmt.Sprintf("deserialize next page token error: %s", err))
+	}
+
+	from := token.From
+	pageSize := request.PageSize
+	query.addOffsetAndLimits(from, pageSize)
+
 	return query.String()
 }
 

--- a/common/persistence/Pinot/pinotVisibilityStore_test.go
+++ b/common/persistence/Pinot/pinotVisibilityStore_test.go
@@ -386,6 +386,7 @@ AND WorkflowType = 'test-wf-type'
 AND CloseTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus >= 0
 Order BY CloseTime DESC
+LIMIT 0, 10
 `, testTableName)
 	expectOpenResult := fmt.Sprintf(`SELECT *
 FROM %s
@@ -395,6 +396,7 @@ AND StartTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus < 0
 AND CloseTime = -1
 Order BY RunID DESC
+LIMIT 0, 10
 `, testTableName)
 	expectNilResult := ""
 
@@ -426,6 +428,7 @@ AND WorkflowID = 'test-wid'
 AND CloseTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus >= 0
 Order BY CloseTime DESC
+LIMIT 0, 10
 `, testTableName)
 	expectOpenResult := fmt.Sprintf(`SELECT *
 FROM %s
@@ -435,6 +438,7 @@ AND StartTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus < 0
 AND CloseTime = -1
 Order BY CloseTime DESC
+LIMIT 0, 10
 `, testTableName)
 	expectNilResult := ""
 
@@ -464,6 +468,7 @@ WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND CloseStatus = '0'
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY CloseTime DESC
+LIMIT 0, 10
 `, testTableName)
 	expectNilResult := ""
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added limit clause into all queries expect for getCloseWorkflow & countWorkflow APIs

<!-- Tell your future self why have you made these changes -->
**Why?**
Pinot production table was crashed because of lack of limit clause

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test,
Integration test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
