### PR TITLE
Validate search-attribute-key so keys are fine in advanced search

### DIFF
--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -23,6 +23,7 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
 
 	"github.com/fatih/color"
 	"github.com/pborman/uuid"
@@ -36,10 +37,15 @@ import (
 
 // An indirection for the prompt function so that it can be mocked in the unit tests
 var promptFn = prompt
+var validSearchAttributeKey = regexp.MustCompile(`^[a-zA-Z][a-zA-Z_0-9]*$`)
 
 // AdminAddSearchAttribute to whitelist search attribute
 func AdminAddSearchAttribute(c *cli.Context) {
 	key := getRequiredOption(c, FlagSearchAttributesKey)
+	if !isValidSearchAttributeKey(key) {
+		ErrorAndExit("Invalid search-attribute key.", nil)
+	}
+
 	valType := getRequiredIntOption(c, FlagSearchAttributesType)
 	if !isValueTypeValid(valType) {
 		ErrorAndExit("Unknown Search Attributes value type.", nil)
@@ -151,6 +157,10 @@ func intValTypeToString(valType int) string {
 	default:
 		return ""
 	}
+}
+
+func isValidSearchAttributeKey(name string) bool {
+	return validSearchAttributeKey.MatchString(name)
 }
 
 func isValueTypeValid(valType int) bool {

--- a/tools/cli/adminClusterCommands.go
+++ b/tools/cli/adminClusterCommands.go
@@ -42,8 +42,8 @@ var validSearchAttributeKey = regexp.MustCompile(`^[a-zA-Z][a-zA-Z_0-9]*$`)
 // AdminAddSearchAttribute to whitelist search attribute
 func AdminAddSearchAttribute(c *cli.Context) {
 	key := getRequiredOption(c, FlagSearchAttributesKey)
-	if !isValidSearchAttributeKey(key) {
-		ErrorAndExit("Invalid search-attribute key.", nil)
+	if err := validateSearchAttributeKey(key); err != nil {
+		ErrorAndExit("Invalid search-attribute key.", err)
 	}
 
 	valType := getRequiredIntOption(c, FlagSearchAttributesType)
@@ -159,8 +159,11 @@ func intValTypeToString(valType int) string {
 	}
 }
 
-func isValidSearchAttributeKey(name string) bool {
-	return validSearchAttributeKey.MatchString(name)
+func validateSearchAttributeKey(name string) error {
+	if !validSearchAttributeKey.MatchString(name) {
+		return fmt.Errorf("has to be contain alphanumeric and start with a letter")
+	}
+	return nil
 }
 
 func isValueTypeValid(valType int) bool {

--- a/tools/cli/adminClusterCommands_test.go
+++ b/tools/cli/adminClusterCommands_test.go
@@ -121,3 +121,14 @@ func TestAdminFailover(t *testing.T) {
 	assert.Equal(t, 0, len(succeed))
 	assert.Equal(t, 0, len(failed))
 }
+
+func TestValidSearchAttributeKey(t *testing.T) {
+	assert.True(t, isValidSearchAttributeKey("city"))
+	assert.True(t, isValidSearchAttributeKey("cityId"))
+	assert.True(t, isValidSearchAttributeKey("paymentProfileUUID"))
+	assert.True(t, isValidSearchAttributeKey("job_type"))
+
+	assert.False(t, isValidSearchAttributeKey("payments-biling-invoices-TransactionUUID"))
+	assert.False(t, isValidSearchAttributeKey("9lives"))
+	assert.False(t, isValidSearchAttributeKey("tax%"))
+}

--- a/tools/cli/adminClusterCommands_test.go
+++ b/tools/cli/adminClusterCommands_test.go
@@ -123,12 +123,12 @@ func TestAdminFailover(t *testing.T) {
 }
 
 func TestValidSearchAttributeKey(t *testing.T) {
-	assert.True(t, isValidSearchAttributeKey("city"))
-	assert.True(t, isValidSearchAttributeKey("cityId"))
-	assert.True(t, isValidSearchAttributeKey("paymentProfileUUID"))
-	assert.True(t, isValidSearchAttributeKey("job_type"))
+	assert.NoError(t, validateSearchAttributeKey("city"))
+	assert.NoError(t, validateSearchAttributeKey("cityId"))
+	assert.NoError(t, validateSearchAttributeKey("paymentProfileUUID"))
+	assert.NoError(t, validateSearchAttributeKey("job_type"))
 
-	assert.False(t, isValidSearchAttributeKey("payments-biling-invoices-TransactionUUID"))
-	assert.False(t, isValidSearchAttributeKey("9lives"))
-	assert.False(t, isValidSearchAttributeKey("tax%"))
+	assert.Error(t, validateSearchAttributeKey("payments-biling-invoices-TransactionUUID"))
+	assert.Error(t, validateSearchAttributeKey("9lives"))
+	assert.Error(t, validateSearchAttributeKey("tax%"))
 }


### PR DESCRIPTION
ElasticSearch engine fails to parse keys with dashes, making those
search-attributes broken for CLI and web.

The reason it is not in the server, is that currently even at Uber we
have keys with dashes, and it will be a problem if we gonna migrate
domains between clusters.

<!-- Describe what has changed in this PR -->
Validate search-attribute before creating on server so it looks like a
valid variable name in most of languages, should be more than expected for
programmers.


<!-- Tell your future self why have you made these changes -->
Stakeholders faced with the issue in the UI.
We spent time investingating why it is not working.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
It is change to CLI, no risks of breaking production.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
Nope

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
optionally - update description of KeyName here: https://cadenceworkflow.io/docs/operation-guide/setup/#dynamic-configuration
