### PR TITLE
Do not make poller crash if isolation group is invalid

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2329,6 +2329,7 @@ const (
 	RemoteToRemoteMatchPerTaskListCounter
 	IsolationTaskMatchPerTaskListCounter
 	PollerPerTaskListCounter
+	PollerInvalidIsolationGroupCounter
 	TaskListManagersGauge
 	TaskLagPerTaskListGauge
 	TaskBacklogPerTaskListGauge
@@ -2930,6 +2931,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		RemoteToRemoteMatchPerTaskListCounter:       {metricName: "remote_to_remote_matches_per_tl", metricRollupName: "remote_to_remote_matches"},
 		IsolationTaskMatchPerTaskListCounter:        {metricName: "isolation_task_matches_per_tl", metricType: Counter},
 		PollerPerTaskListCounter:                    {metricName: "poller_count_per_tl", metricRollupName: "poller_count"},
+		PollerInvalidIsolationGroupCounter:          {metricName: "poller_invalid_isolation_group_per_tl", metricType: Counter},
 		TaskListManagersGauge:                       {metricName: "tasklist_managers", metricType: Gauge},
 		TaskLagPerTaskListGauge:                     {metricName: "task_lag_per_tl", metricType: Gauge},
 		TaskBacklogPerTaskListGauge:                 {metricName: "task_backlog_per_tl", metricType: Gauge},

--- a/service/matching/matcher.go
+++ b/service/matching/matcher.go
@@ -23,7 +23,6 @@ package matching
 import (
 	"context"
 	"errors"
-	"fmt"
 	"time"
 
 	"golang.org/x/time/rate"
@@ -281,7 +280,9 @@ forLoop:
 func (tm *TaskMatcher) Poll(ctx context.Context, isolationGroup string) (*InternalTask, error) {
 	isolatedTaskC, ok := tm.isolatedTaskC[isolationGroup]
 	if !ok && isolationGroup != "" {
-		return nil, &types.BadRequestError{Message: fmt.Sprintf("invalid isolation group: %s", isolationGroup)}
+		// fallback to default isolation group instead of making poller crash if the isolation group is invalid
+		isolatedTaskC = tm.taskC
+		tm.scope.IncCounter(metrics.PollerInvalidIsolationGroupCounter)
 	}
 	// try local match first without blocking until context timeout
 	if task, err := tm.pollNonBlocking(ctx, isolatedTaskC, tm.taskC, tm.queryTaskC); err == nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Do not make poller crash if isolation group is invalid

<!-- Tell your future self why have you made these changes -->
**Why?**
We don't want to break customer pollers when isolation is enabled

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eyeball check

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
