### PR TITLE
Revert "Made the TTLBufferDays configurable"

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1408,13 +1408,6 @@ const (
 	LargeShardHistoryBlobMetricThreshold
 	// LastIntKey must be the last one in this const group
 	LastIntKey
-
-	// TTLBufferDays are the buffer days added into the TTL time for security reasons.
-	// KeyName: system.TTLBufferDays
-	// Value type: Int
-	// Default value: 15
-	// Allowed filters: N/A
-	TTLBufferDays
 )
 
 const (
@@ -3629,11 +3622,6 @@ var IntKeys = map[IntKey]DynamicInt{
 		KeyName:      "system.isolationGroupStateUpdateRetryAttempts",
 		Description:  "The number of attempts to push Isolation group configuration to the config store",
 		DefaultValue: 2,
-	},
-	TTLBufferDays: DynamicInt{
-		KeyName:      "system.TTLBufferDays",
-		Description:  "The number of buffer day in the TTL value",
-		DefaultValue: 15,
 	},
 }
 

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -10,9 +10,6 @@ history.EnableConsistentQueryByDomain:
 system.enableExecutionTTL:
     - value: true
       constraints: {}
-system.TTLBufferDays:
-    - value: 15
-      constraints: {}
 history.enableCrossClusterOperations:
 - value: true
   constraints: {}

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -326,9 +326,6 @@ type Config struct {
 
 	// HostName for machine running the service
 	HostName string
-
-	//TTLBufferdays values for the TTL on workflows.
-	TTLBufferDays dynamicconfig.IntPropertyFn
 }
 
 // New returns new service config with default values
@@ -572,8 +569,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 		LargeShardHistoryEventMetricThreshold: dc.GetIntProperty(dynamicconfig.LargeShardHistoryEventMetricThreshold),
 		LargeShardHistoryBlobMetricThreshold:  dc.GetIntProperty(dynamicconfig.LargeShardHistoryBlobMetricThreshold),
 
-		HostName:      hostname,
-		TTLBufferDays: dc.GetIntProperty(dynamicconfig.TTLBufferDays),
+		HostName: hostname,
 	}
 
 	return cfg

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -45,6 +45,7 @@ import (
 
 const (
 	defaultRemoteCallTimeout = 30 * time.Second
+	ttlBufferDays            = 15
 	dayToSecondMultiplier    = 86400
 )
 

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -4823,7 +4823,7 @@ func (e *mutableStateBuilder) calculateTTL() (int, error) {
 	}
 	config := domainObj.GetConfig()
 	retention := time.Duration(config.Retention)
-	daysInSeconds := int(retention) + e.config.TTLBufferDays()*dayToSecondMultiplier
+	daysInSeconds := int((retention + ttlBufferDays) * dayToSecondMultiplier)
 	//Default state of TTL, means there is no TTL attached.
 	TTLInSeconds := 0
 	startTime := e.executionInfo.StartTimestamp


### PR DESCRIPTION
Reverts uber/cadence#5354

We are reverting this because we have decided not to move forward with the TTL changes.