### PR TITLE
Pass partition config and isolation group to history/matching even if isolation is disabled

### DIFF
--- a/service/frontend/workflowHandler.go
+++ b/service/frontend/workflowHandler.go
@@ -788,17 +788,11 @@ func (wh *WorkflowHandler) PollForDecisionTask(
 }
 
 func (wh *WorkflowHandler) getIsolationGroup(ctx context.Context, domainName string) string {
-	if wh.config.EnableTasklistIsolation(domainName) {
-		return partition.IsolationGroupFromContext(ctx)
-	}
-	return ""
+	return partition.IsolationGroupFromContext(ctx)
 }
 
 func (wh *WorkflowHandler) getPartitionConfig(ctx context.Context, domainName string) map[string]string {
-	if wh.config.EnableTasklistIsolation(domainName) {
-		return partition.ConfigFromContext(ctx)
-	}
-	return nil
+	return partition.ConfigFromContext(ctx)
 }
 
 func (wh *WorkflowHandler) isIsolationGroupHealthy(ctx context.Context, domainName, isolationGroup string) bool {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Pass partition config and isolation group to history/matching even if isolation is disabled

<!-- Tell your future self why have you made these changes -->
**Why?**
1. This will expose the distribution of tasks among different isolation groups even if isolation is not enabled, and let us know if there is any skewness in the traffic before enabling isolation
2. This will allow history persisting partition config and if isolation can take effect immediately for existing workflows

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
