### PR TITLE
add a update workflow execution count metric for RI

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2900,6 +2900,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		LargeHistoryBlobCount:                                        {metricName: "large_history_blob_count", metricType: Counter},
 		LargeHistoryEventCount:                                       {metricName: "large_history_event_count", metricType: Counter},
 		LargeHistorySizeCount:                                        {metricName: "large_history_size_count", metricType: Counter},
+		UpdateWorkflowExecutionCount:                                 {metricName: "update_workflow_execution_count", metricType: Counter},
 	},
 	Matching: {
 		PollSuccessPerTaskListCounter:               {metricName: "poll_success_per_tl", metricRollupName: "poll_success"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2293,6 +2293,7 @@ const (
 	LargeHistoryBlobCount
 	LargeHistoryEventCount
 	LargeHistorySizeCount
+	UpdateWorkflowExecutionCount
 
 	NumHistoryMetrics
 )

--- a/service/history/execution/context_util.go
+++ b/service/history/execution/context_util.go
@@ -144,6 +144,7 @@ func emitSessionUpdateStats(
 	countScope.RecordTimer(metrics.TimerTasksCount, time.Duration(stats.TimerTasksCount))
 	countScope.RecordTimer(metrics.CrossClusterTasksCount, time.Duration(stats.CrossClusterTaskCount))
 	countScope.RecordTimer(metrics.ReplicationTasksCount, time.Duration(stats.ReplicationTasksCount))
+	countScope.IncCounter(metrics.UpdateWorkflowExecutionCount)
 }
 
 func emitWorkflowCompletionStats(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adding a new metric to count number of update workflow executions that is happening within a domain.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is needed to integrate with RI. They need a counter metric to ingest. The existing timer one does not work.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This is purely a metric addition for observability. Existing tests all pass.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There are no risks. It is a metric.

