### PR TITLE
Fix persistence tests setup

### DIFF
--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -214,10 +214,8 @@ func (s *TestBase) Setup() {
 	s.ShardMgr, err = factory.NewShardManager()
 	s.fatalOnError("NewShardManager", err)
 
-	if cfg.DefaultStoreType() == config.StoreTypeCassandra {
-		s.ConfigStoreManager, err = factory.NewConfigStoreManager()
-		s.fatalOnError("NewConfigStoreManager", err)
-	}
+	s.ConfigStoreManager, err = factory.NewConfigStoreManager()
+	s.fatalOnError("NewConfigStoreManager", err)
 
 	s.ExecutionMgrFactory = factory
 	s.ExecutionManager, err = factory.NewExecutionManager(shardID)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix persistence tests setup

<!-- Tell your future self why have you made these changes -->
**Why?**
ConfigStoreManager is only set up for Cassandra in persistence tests, which is unexpected.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
