### PR TITLE
Implement config store for MySQL

### DIFF
--- a/common/persistence/sql/sqlConfigStore.go
+++ b/common/persistence/sql/sqlConfigStore.go
@@ -28,7 +28,6 @@ import (
 
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 	"github.com/uber/cadence/common/persistence/serialization"
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
@@ -68,7 +67,7 @@ func (m *sqlConfigStore) FetchConfig(ctx context.Context, configType persistence
 func (m *sqlConfigStore) UpdateConfig(ctx context.Context, value *persistence.InternalConfigStoreEntry) error {
 	err := m.db.InsertConfig(ctx, value)
 	if err != nil {
-		if _, ok := err.(*nosqlplugin.ConditionFailure); ok {
+		if m.db.IsDupEntryError(err) {
 			return &persistence.ConditionFailedError{Msg: fmt.Sprintf("Version %v already exists. Condition Failed", value.Version)}
 		}
 		return convertCommonErrors(m.db, "UpdateConfig", "", err)

--- a/common/persistence/sql/sqlplugin/interfaces.go
+++ b/common/persistence/sql/sqlplugin/interfaces.go
@@ -569,6 +569,15 @@ type (
 		Data      []byte
 	}
 
+	// ClusterConfigRow represents a row in cluster_config table
+	ClusterConfigRow struct {
+		RowType      int
+		Version      int64
+		Timestamp    time.Time
+		Data         []byte
+		DataEncoding string
+	}
+
 	// tableCRUD defines the API for interacting with the database tables
 	tableCRUD interface {
 		InsertIntoDomain(ctx context.Context, rows *DomainRow) (sql.Result, error)

--- a/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
@@ -92,3 +92,11 @@ func TestMySQLQueuePersistence(t *testing.T) {
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
+
+func TestMySQLConfigPersistence(t *testing.T) {
+	testflags.RequireMySQL(t)
+	s := new(pt.ConfigStorePersistenceSuite)
+	s.TestBase = pt.NewTestBaseWithSQL(GetTestClusterOption())
+	s.TestBase.Setup()
+	suite.Run(t, s)
+}

--- a/schema/mysql/v8/cadence/schema.sql
+++ b/schema/mysql/v8/cadence/schema.sql
@@ -265,3 +265,13 @@ CREATE TABLE queue_metadata (
   data MEDIUMBLOB NOT NULL,
   PRIMARY KEY(queue_type)
 );
+
+CREATE TABLE cluster_config (
+  row_type INT NOT NULL,
+  version BIGINT NOT NULL,
+  --
+  timestamp DATETIME(6) NOT NULL,
+  data           MEDIUMBLOB NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (row_type, version)
+);

--- a/schema/mysql/v8/cadence/versioned/v0.6/cluster_config.sql
+++ b/schema/mysql/v8/cadence/versioned/v0.6/cluster_config.sql
@@ -1,0 +1,9 @@
+CREATE TABLE cluster_config (
+  row_type INT NOT NULL,
+  version BIGINT NOT NULL,
+  --
+  timestamp DATETIME(6) NOT NULL,
+  data           MEDIUMBLOB NOT NULL,
+  data_encoding  VARCHAR(16) NOT NULL,
+  PRIMARY KEY (row_type, version)
+);

--- a/schema/mysql/v8/cadence/versioned/v0.6/manifest.json
+++ b/schema/mysql/v8/cadence/versioned/v0.6/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.6",
+  "MinCompatibleVersion": "0.6",
+  "Description": "create cluster config table",
+  "SchemaUpdateCqlFiles": [
+    "cluster_config.sql"
+  ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -23,7 +23,7 @@ package mysql
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "0.5"
+const Version = "0.6"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "0.7"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -120,7 +120,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.3", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.4", "v0.5"}, ans)
+	s.Equal([]string{"v0.4", "v0.5", "v0.6"}, ans)
 
 	fsys, err = fs.Sub(mysql.SchemaFS, "v8/visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Implement config store my MySQL
- Update config store test to use different row types for different tests so that we don't need to truncate the table in every test

<!-- Tell your future self why have you made these changes -->
**Why?**
- To support config store for MySQL

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
persistence tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
