### PR TITLE
Increased timeout for history archival and visibility records

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -4408,7 +4408,7 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 	TimerProcessorArchivalTimeLimit: DynamicDuration{
 		KeyName:      "history.timerProcessorArchivalTimeLimit",
 		Description:  "TimerProcessorArchivalTimeLimit is the upper time limit for inline history archival",
-		DefaultValue: time.Second * 2,
+		DefaultValue: time.Second * 8,
 	},
 	TimerProcessorMaxTimeShift: DynamicDuration{
 		KeyName:      "history.timerProcessorMaxTimeShift",
@@ -4448,7 +4448,7 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 	TransferProcessorVisibilityArchivalTimeLimit: DynamicDuration{
 		KeyName:      "history.transferProcessorVisibilityArchivalTimeLimit",
 		Description:  "TransferProcessorVisibilityArchivalTimeLimit is the upper time limit for archiving visibility records",
-		DefaultValue: time.Millisecond * 400,
+		DefaultValue: time.Millisecond * 1600,
 	},
 	CrossClusterSourceProcessorMaxPollInterval: DynamicDuration{
 		KeyName:      "history.crossClusterSourceProcessorMaxPollInterval",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Increased timeout values for history and visibility records significantly.


<!-- Tell your future self why have you made these changes -->
**Why?**
This is in response to an issue I filed. See details within: https://github.com/uber/cadence/issues/5408

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Changed values, built it docker image locally, and tested it within our environment.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Extending timeout values seems benign, but may cause a cascade or other timeouts that depend on it. I don't know the code base enough to make a judgement, but would like to hear feedback.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Increased history archival timeout to 8s and visibility records timeout to 1.6s

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
N/A
