### PR TITLE
Fix CreateWorkflowModeContinueAsNew for SQL

### DIFF
--- a/common/persistence/sql/sqlExecutionStore.go
+++ b/common/persistence/sql/sqlExecutionStore.go
@@ -185,9 +185,13 @@ func (m *sqlExecutionStore) createWorkflowExecutionTx(
 			}
 
 		case p.CreateWorkflowModeContinueAsNew:
-			// continueAsNew mode expects a current run exists
-			if err := assertRunIDMismatch(serialization.MustParseUUID(executionInfo.RunID), row.RunID); err != nil {
-				return nil, err
+			runIDStr := row.RunID.String()
+			if runIDStr != request.PreviousRunID {
+				return nil, &p.CurrentWorkflowConditionFailedError{
+					Msg: fmt.Sprintf("Workflow execution creation condition failed. WorkflowId: %v, "+
+						"RunID: %v, PreviousRunID: %v",
+						workflowID, runIDStr, request.PreviousRunID),
+				}
 			}
 
 		default:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update CreateWorkflowModeContinueAsNew of SQL to check if the run ID from the request matches the current run ID.
And also makes the behavior the same as NoSQL implementation, see https://github.com/uber/cadence/blob/v1.2.4/common/persistence/nosql/nosqlExecutionStoreUtil.go#L715

<!-- Tell your future self why have you made these changes -->
**Why?**
This is to make sure the behavior is the same as NoSQL implementation. And without this check, concurrent workflow resets could result in multiple open workflows with the same workflow id, and one of them will get stuck forever.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
eyeball check, 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
