### PR TITLE
Fix CLI count&list workflows error message

### DIFF
--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -1263,9 +1263,7 @@ func listWorkflows(c *cli.Context) getWorkflowPageFn {
 			Query:  c.String(FlagListQuery),
 		},
 	)
-	if err != nil {
-		printError("Unable to count workflows. Proceeding with fetching list of workflows...", err)
-	} else {
+	if err == nil {
 		fmt.Printf("Fetching %v workflows...\n", resp.GetCount())
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove display for wf count error message

<!-- Tell your future self why have you made these changes -->
**Why?**
Displaying the error message for wf list command was misleading to users. The error message will still be displayed for the wf count command
More context can be found [here](https://github.com/uber/cadence/pull/5309#issuecomment-1726744101)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
