### PR TITLE
Add SecondsSinceEpoch field and update Pinot schema

### DIFF
--- a/schema/Pinot/cadence-visibility-schema.json
+++ b/schema/Pinot/cadence-visibility-schema.json
@@ -1,11 +1,7 @@
 {
   "schemaName": "cadence_visibility_pinot",
-  "primaryKeyColumns": ["DocID"],
+  "primaryKeyColumns": ["RunID"],
   "dimensionFieldSpecs": [
-    {
-      "name": "DocID",
-      "dataType": "STRING"
-    },
     {
       "name": "DomainID",
       "dataType": "STRING"
@@ -29,10 +25,6 @@
     {
       "name": "HistoryLength",
       "dataType": "INT"
-    },
-    {
-      "name": "KafkaKey",
-      "dataType": "STRING"
     },
     {
       "name": "TaskList",
@@ -77,6 +69,11 @@
     "granularity": "1:MILLISECONDS"
   },{
     "name": "ExecutionTime",
+    "dataType": "LONG",
+    "format" : "1:MILLISECONDS:EPOCH",
+    "granularity": "1:MILLISECONDS"
+  },{
+    "name": "SecondsSinceEpoch",
     "dataType": "LONG",
     "format" : "1:MILLISECONDS:EPOCH",
     "granularity": "1:MILLISECONDS"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add SecondsSinceEpoch field for Pinot 
Add same field to schema and remove unused docID and KafkaKey from schema

<!-- Tell your future self why have you made these changes -->
**Why?**
Pinot rolling upsert and deletion need this field

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test and manual test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
