### PR TITLE
MigrationChecker interface to expose migration CLI

### DIFF
--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -89,7 +89,7 @@ func newDomainCommands() []cli.Command {
 			Usage:   "Migrate existing domain to new domain. This command only validates the settings. It does not perform actual data migration",
 			Flags:   migrateDomainFlags,
 			Action: func(c *cli.Context) {
-				NewDomainMigrationChecker(c).Validation(c)
+				NewDomainMigrationCommand(c).Validation(c)
 			},
 		},
 	}

--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -89,7 +89,7 @@ func newDomainCommands() []cli.Command {
 			Usage:   "Migrate existing domain to new domain. This command only validates the settings. It does not perform actual data migration",
 			Flags:   migrateDomainFlags,
 			Action: func(c *cli.Context) {
-				newDomainMigrationCLIImpl(c).Validation(c)
+				NewDomainMigrationChecker(c).Validation(c)
 			},
 		},
 	}

--- a/tools/cli/domainMigrationCommand.go
+++ b/tools/cli/domainMigrationCommand.go
@@ -110,13 +110,11 @@ var (
 )
 
 type DomainMigrationChecker interface {
-	NewDomainMigrationCLIImpl(c *cli.Context) *domainMigrationCLIImpl
 	Validation(c *cli.Context)
-	domainMetaDataCheck(c *cli.Context) DomainMigrationRow
-	domainWorkFlowCheck(c *cli.Context) DomainMigrationRow
-	countLongRunningWorkflow(c *cli.Context) int
-	searchAttributesChecker(c *cli.Context) DomainMigrationRow
-	dynamicConfigCheck(c *cli.Context) DomainMigrationRow
+	DomainMetaDataCheck(c *cli.Context) DomainMigrationRow
+	DomainWorkFlowCheck(c *cli.Context) DomainMigrationRow
+	SearchAttributesChecker(c *cli.Context) DomainMigrationRow
+	DynamicConfigCheck(c *cli.Context) DomainMigrationRow
 }
 
 func (d *domainMigrationCLIImpl) NewDomainMigrationCLIImpl(c *cli.Context) *domainMigrationCLIImpl {
@@ -140,10 +138,10 @@ type domainMigrationCLIImpl struct {
 
 func (d *domainMigrationCLIImpl) Validation(c *cli.Context) {
 	checkers := []func(*cli.Context) DomainMigrationRow{
-		d.domainMetaDataCheck,
-		d.domainWorkFlowCheck,
-		d.dynamicConfigCheck,
-		d.searchAttributesChecker,
+		d.DomainMetaDataCheck,
+		d.DomainWorkFlowCheck,
+		d.DynamicConfigCheck,
+		d.SearchAttributesChecker,
 	}
 	wg := &sync.WaitGroup{}
 	results := make([]DomainMigrationRow, len(checkers))
@@ -168,7 +166,7 @@ func (d *domainMigrationCLIImpl) Validation(c *cli.Context) {
 	}
 }
 
-func (d *domainMigrationCLIImpl) domainMetaDataCheck(c *cli.Context) DomainMigrationRow {
+func (d *domainMigrationCLIImpl) DomainMetaDataCheck(c *cli.Context) DomainMigrationRow {
 	domain := c.GlobalString(FlagDomain)
 	newDomain := c.String(FlagDestinationDomain)
 	ctx, cancel := newContext(c)
@@ -209,7 +207,7 @@ func metaDataValidation(currResp *types.DescribeDomainResponse, newResp *types.D
 	return true, ""
 }
 
-func (d *domainMigrationCLIImpl) domainWorkFlowCheck(c *cli.Context) DomainMigrationRow {
+func (d *domainMigrationCLIImpl) DomainWorkFlowCheck(c *cli.Context) DomainMigrationRow {
 	countWorkFlows := d.countLongRunningWorkflow(c)
 	check := countWorkFlows == 0
 	return DomainMigrationRow{
@@ -237,7 +235,7 @@ func (d *domainMigrationCLIImpl) countLongRunningWorkflow(c *cli.Context) int {
 	return int(response.GetCount())
 }
 
-func (d *domainMigrationCLIImpl) searchAttributesChecker(c *cli.Context) DomainMigrationRow {
+func (d *domainMigrationCLIImpl) SearchAttributesChecker(c *cli.Context) DomainMigrationRow {
 	ctx, cancel := newContext(c)
 	defer cancel()
 
@@ -322,7 +320,7 @@ func findMissingAttributes(requiredAttributes map[string]types.IndexedValueType,
 	return missingAttributes
 }
 
-func (d *domainMigrationCLIImpl) dynamicConfigCheck(c *cli.Context) DomainMigrationRow {
+func (d *domainMigrationCLIImpl) DynamicConfigCheck(c *cli.Context) DomainMigrationRow {
 	var mismatchedConfigs []MismatchedDynamicConfig
 	check := true
 

--- a/tools/cli/domainMigrationCommand.go
+++ b/tools/cli/domainMigrationCommand.go
@@ -109,7 +109,7 @@ var (
 	}
 )
 
-type DomainMigrationChecker interface {
+type DomainMigrationCommand interface {
 	Validation(c *cli.Context)
 	DomainMetaDataCheck(c *cli.Context) DomainMigrationRow
 	DomainWorkFlowCheck(c *cli.Context) DomainMigrationRow
@@ -127,7 +127,7 @@ func (d *domainMigrationCLIImpl) NewDomainMigrationCLIImpl(c *cli.Context) *doma
 }
 
 // Export a function to create an instance of the domainMigrationCLIImpl.
-func NewDomainMigrationChecker(c *cli.Context) DomainMigrationChecker {
+func NewDomainMigrationCommand(c *cli.Context) DomainMigrationCommand {
 	return &domainMigrationCLIImpl{}
 }
 


### PR DESCRIPTION
In this PR, we've made several changes to the code:

- Added `DomainMigrationChecker` interface to expose the validation methods outside for Prodfix check/fix.
- Updated the `domainMigrationCLIImpl` struct to include client dependencies.
- Added validation checks for domain metadata, workflow status, search attributes, and dynamic configurations.

