### PR TITLE
Improves history handler error metrics and logs

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -2141,7 +2141,7 @@ func (h *handlerImpl) updateErrorMetric(
 
 	var yarpcE *yarpcerrors.Status
 
-	if err == context.DeadlineExceeded || err == context.Canceled {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		scope.IncCounter(metrics.CadenceErrContextTimeoutCounter)
 		return
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Some bad data caused a tasklist to get stuck while trying to update a workflow which was in a bad state. This was more difficult to identify than it should be because the RunID was missing information from the error logs. This change includes this additional information and also protects some of the metrics emission from wrapped errors being misclassified. 

This is not an attempt to do all error handling / wrapping correctly, it's just an incremental change, of which many more are needed. 

<!-- Tell your future self why have you made these changes -->
**Why?**

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
