### PR TITLE
Fix visibility mode for admin when use Pinot visibility

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -157,8 +157,8 @@ const (
 	AdvancedVisibilityWritingModeOn = "on"
 	// AdvancedVisibilityWritingModeDual means write to both normal visibility and advanced visibility store
 	AdvancedVisibilityWritingModeDual = "dual"
-	// AdvacnedVisibilityWritingModeTriple means write to both normal visibility and advanced visibility store, includes ES and Pinot
-	AdvacnedVisibilityWritingModeTriple = "triple"
+	// AdvancedVisibilityWritingModeTriple means write to both normal visibility and advanced visibility store, includes ES and Pinot
+	AdvancedVisibilityWritingModeTriple = "triple"
 )
 
 const (

--- a/common/persistence/pinotVisibilityTripleManager.go
+++ b/common/persistence/pinotVisibilityTripleManager.go
@@ -201,6 +201,8 @@ func (v *pinotVisibilityTripleManager) UpsertWorkflowExecution(
 
 func (v *pinotVisibilityTripleManager) chooseVisibilityModeForAdmin() string {
 	switch {
+	case v.dbVisibilityManager != nil && v.esVisibilityManager != nil && v.pinotVisibilityManager != nil:
+		return common.AdvacnedVisibilityWritingModeTriple
 	case v.dbVisibilityManager != nil && v.pinotVisibilityManager != nil:
 		return common.AdvancedVisibilityWritingModeDual
 	case v.pinotVisibilityManager != nil:

--- a/common/persistence/pinotVisibilityTripleManager.go
+++ b/common/persistence/pinotVisibilityTripleManager.go
@@ -202,7 +202,7 @@ func (v *pinotVisibilityTripleManager) UpsertWorkflowExecution(
 func (v *pinotVisibilityTripleManager) chooseVisibilityModeForAdmin() string {
 	switch {
 	case v.dbVisibilityManager != nil && v.esVisibilityManager != nil && v.pinotVisibilityManager != nil:
-		return common.AdvacnedVisibilityWritingModeTriple
+		return common.AdvancedVisibilityWritingModeTriple
 	case v.dbVisibilityManager != nil && v.pinotVisibilityManager != nil:
 		return common.AdvancedVisibilityWritingModeDual
 	case v.pinotVisibilityManager != nil:
@@ -267,7 +267,7 @@ func (v *pinotVisibilityTripleManager) chooseVisibilityManagerForWrite(ctx conte
 		}
 		v.logger.Warn("advanced visibility is not available to write")
 		return dbVisFunc()
-	case common.AdvacnedVisibilityWritingModeTriple:
+	case common.AdvancedVisibilityWritingModeTriple:
 		if v.pinotVisibilityManager != nil && v.esVisibilityManager != nil {
 			if err := pinotVisFunc(); err != nil {
 				return err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix the visibility mode for admin to use both ES/Pinot when run admin commands such as delete
This only affects the admin when use Pinot visibility

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently it can not delete from ES when use Pinot visibility

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Manual test in dev2

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
