### PR TITLE
Fix workflow started metric

### DIFF
--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -952,8 +952,7 @@ func (t *transferActiveTaskExecutor) processRecordWorkflowStartedOrUpsertHelper(
 	recordStart bool,
 ) (retError error) {
 
-	workflowStartedScope := t.metricsClient.Scope(metrics.TransferActiveTaskRecordWorkflowStartedScope,
-		metrics.DomainTag(task.DomainID))
+	workflowStartedScope := getOrCreateDomainTaggedScope(t.shard, metrics.TransferActiveTaskRecordWorkflowStartedScope, task.DomainID, t.logger)
 
 	wfContext, release, err := t.executionCache.GetOrCreateWorkflowExecutionWithTimeout(
 		task.DomainID,

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -455,8 +455,7 @@ func (t *transferStandbyTaskExecutor) processRecordWorkflowStartedOrUpsertHelper
 	isRecordStart bool,
 ) error {
 
-	workflowStartedScope := t.metricsClient.Scope(metrics.TransferStandbyTaskRecordWorkflowStartedScope,
-		metrics.DomainTag(transferTask.DomainID))
+	workflowStartedScope := getOrCreateDomainTaggedScope(t.shard, metrics.TransferStandbyTaskRecordWorkflowStartedScope, transferTask.DomainID, t.logger)
 
 	// verify task version for RecordWorkflowStarted.
 	// upsert doesn't require verifyTask, because it is just a sync of mutableState.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed metric tag from domainID to domainName

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently the metric is tagged with domainID and is being disregarded by M3 due to cardinality

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Deployed the change in dev environment

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Metric break/inaccuracy

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
