### PR TITLE
Warn about bug introduced in 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,20 @@ You can find a list of previous releases on the [github releases](https://github
 ### Fixed
 - Fixed workflow replication for reset workflow (#5412)
 - Fixed visibility mode for admin when use Pinot visibility (#5441)
+- Fix timer-fixer, unfortunately broken in 1.2.5 (#5433)
 
 ## [1.2.5] - 2023-11-01
+
+### Caution:
+
+Prefer 1.2.4 or 1.2.6 if you have enabled the timer fixer.
+These were broken by #5361, and fixed by #5433.
+
+By default this fixer is _disabled_, so the version has not been retracted.
+
+If you have already upgraded to 1.2.5, downgrading or using 1.2.6 should restore the timer fixer.
+Or apply #5433 as a local patch.
+
 ### Added
 - Scanner / Fixer changes (#5361)
   - Stale-workflow detection and cleanup added to shardscanner, disabled by default.


### PR DESCRIPTION
#5361 unfortunately broke timer-fixers, as the shared workflow requires a non-empty "enabled" list and none was provided in that PR.

#5433 restores that functionality.

---

Arguably `v1.2.5` could be retracted, as it introduces a potentially-problematic bug.

Since this fixer is disabled by default, we're going to skip doing that: we would have to publish `v1.2.6` to put the retraction into effect, and anyone updating that rapidly will not have much down-time.  Plus the fixer is not required for correct behavior.
