### PR TITLE
added workflow query-types command

### DIFF
--- a/tools/cli/workflow.go
+++ b/tools/cli/workflow.go
@@ -170,6 +170,14 @@ func newWorkflowCommands() []cli.Command {
 			},
 		},
 		{
+			Name:  "query-types",
+			Usage: "list all available query types",
+			Flags: getFlagsForStack(),
+			Action: func(c *cli.Context) {
+				QueryWorkflowUsingQueryTypes(c)
+			},
+		},
+		{
 			Name:  "stack",
 			Usage: "query workflow execution with __stack_trace as query type",
 			Flags: getFlagsForStack(),

--- a/tools/cli/workflowCommands.go
+++ b/tools/cli/workflowCommands.go
@@ -629,6 +629,11 @@ func QueryWorkflowUsingStackTrace(c *cli.Context) {
 	queryWorkflowHelper(c, "__stack_trace")
 }
 
+// QueryWorkflowUsingQueryTypes list all query types of the workflow using __query_types as query type
+func QueryWorkflowUsingQueryTypes(c *cli.Context) {
+	queryWorkflowHelper(c, "__query_types")
+}
+
 func queryWorkflowHelper(c *cli.Context, queryType string) {
 	serviceClient := cFactory.ServerFrontendClient(c)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
A new command `workflow query-types` has been added.


<!-- Tell your future self why have you made these changes -->
**Why?**
The command will allows users to retrieve the list of available query types. https://github.com/uber/cadence/issues/382

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
It has been tested locally. 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No potential risks, the existing functionality hasn't been touched.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
https://github.com/uber/Cadence-Docs/pull/168
