### PR TITLE
Update github action for image publishing to released

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -6,7 +6,7 @@ name: Publish Docker image
 # events but only for the master branch
 on:
   release:
-    types: [ published ]
+    types: [ released ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I updated event that is trigering image publication to subscribe to released event instead of published.
Published is triggered for both prerelease and release and we want to publish images only for releases.
See the docs https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release

<!-- Tell your future self why have you made these changes -->
**Why**
When we've introduced new process for release process with prereleases we've broke image publication and were publishing images manually.

Should resolve https://github.com/uber/cadence/issues/5416 and https://github.com/uber/cadence/issues/5434

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Fixed image publication on release.
