### PR TITLE
Upgrade cassandra image to 4.1.3 in docker compose files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ You can find a list of previous releases on the [github releases](https://github
 ### Added
 - Improves history handler error metrics and logs (#5438)
 - Added range query support for Pinot json index (#5426)
+- Cassandra version is changed from 3.11 to 4.1.3 (#5461)
+  - If your machine already has ubercadence/server:master-auto-setup image then you need to repull so it works with latest docker-compose*.yml files
 
 ### Fixed
 - Fixed workflow replication for reset workflow (#5412)

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_updateTask_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_updateTask_test.go
@@ -83,7 +83,7 @@ func (s *UpdateSchemaTestSuite) TestShortcut() {
 	defer client.Close()
 	dir := rootRelativePath + "schema/cassandra/cadence/versioned"
 
-	cqlshArgs := []string{"--cqlversion=3.4.4", "-e", "DESC KEYSPACE %s;"}
+	cqlshArgs := []string{"--cqlversion=3.4.6", "-e", "DESC KEYSPACE %s;"}
 	if cassandraHost := os.Getenv("CASSANDRA_HOST"); cassandraHost != "" {
 		cqlshArgs = append(cqlshArgs, cassandraHost)
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_tool_version_test.go
@@ -107,7 +107,7 @@ func (s *VersionTestSuite) TestCheckCompatibleVersion() {
 		{"2.0", "1.0", "version mismatch", false},
 		{"1.0", "1.0", "", false},
 		{"1.0", "2.0", "", false},
-		{"1.0", "abc", "reading schema version: unconfigured table schema_version", false},
+		{"1.0", "abc", "reading schema version: table schema_version does not exist", false},
 	}
 	for _, flag := range flags {
 		s.runCheckCompatibleVersion(flag.expectedVersion, flag.actualVersion, flag.errStr, flag.expectedFail)

--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     networks:
       services-network:
         aliases:

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
     networks:

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     expose:
       - "9042"
     networks:

--- a/docker/buildkite/docker-compose-opensearch2.yml
+++ b/docker/buildkite/docker-compose-opensearch2.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     networks:
       services-network:
         aliases:

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     networks:
       services-network:
         aliases:

--- a/docker/dev/cassandra-esv7-kafka.yml
+++ b/docker/dev/cassandra-esv7-kafka.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   elasticsearch:

--- a/docker/dev/cassandra-opensearch-kafka.yml
+++ b/docker/dev/cassandra-opensearch-kafka.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   elasticsearch:

--- a/docker/dev/cassandra-pinot-kafka.yml
+++ b/docker/dev/cassandra-pinot-kafka.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   zookeeper:

--- a/docker/dev/cassandra.yml
+++ b/docker/dev/cassandra.yml
@@ -1,6 +1,6 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/docker-compose-http-api.yml
+++ b/docker/docker-compose-http-api.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/docker-compose-multiclusters-cass-mysql-es.yaml
+++ b/docker/docker-compose-multiclusters-cass-mysql-es.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   mysql:
@@ -78,10 +78,10 @@ services:
   cadence-secondary:
     image: ubercadence/server:master-auto-setup
     ports:
-      - "9000:9000"
       - "9001:9001"
       - "9002:9002"
       - "9003:9003"
+      - "9004:9004"
       - "7943:7933"
       - "7944:7934"
       - "7945:7935"
@@ -92,10 +92,10 @@ services:
       - "MYSQL_USER=root"
       - "MYSQL_PWD=root"
       - "MYSQL_SEEDS=mysql"
-      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:9000"
-      - "PROMETHEUS_ENDPOINT_1=0.0.0.0:9001"
-      - "PROMETHEUS_ENDPOINT_2=0.0.0.0:9002"
-      - "PROMETHEUS_ENDPOINT_3=0.0.0.0:9003"
+      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:9001"
+      - "PROMETHEUS_ENDPOINT_1=0.0.0.0:9002"
+      - "PROMETHEUS_ENDPOINT_2=0.0.0.0:9003"
+      - "PROMETHEUS_ENDPOINT_3=0.0.0.0:9004"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
       - "IS_NOT_PRIMARY=true"
       - "ENABLE_GLOBAL_DOMAIN=true"

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:
@@ -72,10 +72,10 @@ services:
   cadence-secondary:
     image: ubercadence/server:master-auto-setup
     ports:
-      - "9000:9000"
       - "9001:9001"
       - "9002:9002"
       - "9003:9003"
+      - "9004:9004"
       - "7943:7933"
       - "7944:7934"
       - "7945:7935"
@@ -83,10 +83,10 @@ services:
       - "7843:7833"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
-      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:9000"
-      - "PROMETHEUS_ENDPOINT_1=0.0.0.0:9001"
-      - "PROMETHEUS_ENDPOINT_2=0.0.0.0:9002"
-      - "PROMETHEUS_ENDPOINT_3=0.0.0.0:9003"
+      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:9001"
+      - "PROMETHEUS_ENDPOINT_1=0.0.0.0:9002"
+      - "PROMETHEUS_ENDPOINT_2=0.0.0.0:9003"
+      - "PROMETHEUS_ENDPOINT_3=0.0.0.0:9004"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development_es.yaml"
       - "IS_NOT_PRIMARY=true"
       - "ENABLE_GLOBAL_DOMAIN=true"

--- a/docker/docker-compose-multiclusters.yml
+++ b/docker/docker-compose-multiclusters.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:
@@ -44,10 +44,10 @@ services:
   cadence-secondary:
     image: ubercadence/server:master-auto-setup
     ports:
-      - "9000:9000"
       - "9001:9001"
       - "9002:9002"
       - "9003:9003"
+      - "9004:9004"
       - "7943:7933"
       - "7944:7934"
       - "7945:7935"
@@ -55,10 +55,10 @@ services:
       - "7843:7833"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
-      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:9000"
-      - "PROMETHEUS_ENDPOINT_1=0.0.0.0:9001"
-      - "PROMETHEUS_ENDPOINT_2=0.0.0.0:9002"
-      - "PROMETHEUS_ENDPOINT_3=0.0.0.0:9003"
+      - "PROMETHEUS_ENDPOINT_0=0.0.0.0:9001"
+      - "PROMETHEUS_ENDPOINT_1=0.0.0.0:9002"
+      - "PROMETHEUS_ENDPOINT_2=0.0.0.0:9003"
+      - "PROMETHEUS_ENDPOINT_3=0.0.0.0:9004"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
       - "IS_NOT_PRIMARY=true"
       - "ENABLE_GLOBAL_DOMAIN=true"

--- a/docker/docker-compose-oauth.yml
+++ b/docker/docker-compose-oauth.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/docker-compose-statsd.yml
+++ b/docker/docker-compose-statsd.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   statsd:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:3.11
+    image: cassandra:4.1.3
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -88,7 +88,7 @@ setup_schema() {
 
 wait_for_cassandra() {
     server=`echo $CASSANDRA_SEEDS | awk -F ',' '{print $1}'`
-    until cqlsh -u $CASSANDRA_USER -p $CASSANDRA_PASSWORD --cqlversion=3.4.4 --protocol-version=$CASSANDRA_PROTO_VERSION $server < /dev/null; do
+    until cqlsh -u $CASSANDRA_USER -p $CASSANDRA_PASSWORD --cqlversion=3.4.6 --protocol-version=$CASSANDRA_PROTO_VERSION $server < /dev/null; do
         echo 'waiting for cassandra to start up'
         sleep 1
     done

--- a/docs/howtos/cassandra-fql.md
+++ b/docs/howtos/cassandra-fql.md
@@ -1,0 +1,23 @@
+# View Cassandra full query logs
+
+1. Run cadence components via docker compose
+```
+docker-compose docker/docker-compose.yml up
+```
+
+2. First enable fql via nodetool ([ref](https://cassandra.apache.org/doc/stable/cassandra/operating/fqllogging.html#enabling-fql))
+```
+docker exec $(docker inspect --format="{{.Id}}" docker-cassandra-1) nodetool enablefullquerylog --path /tmp/cassandra_fql
+```
+
+3. Check `/tmp/cassandra_fql` folder exists
+```
+docker exec $(docker inspect --format="{{.Id}}" docker-cassandra-1) ls /tmp/cassandra_fql
+```
+
+4. Run some workflows to generate queries (optional)
+
+5. Inspect the full query log dump via fqltool (it's under tools/bin in default apache cassandra installation)
+```
+docker cp $(docker inspect --format="{{.Id}}" docker-cassandra-1):/tmp/cassandra_fql/ /tmp/cassandra_fql/ && fqltool dump /tmp/cassandra_fql | less
+```


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Docker compose files were referring to an older version (3.11) of Cassandra. Updated them with current GA version 4.1.3.

ubercadence/server:master-auto-setup container's initialization script waits on Cassandra to be up and corresponding wait command is updated to use `--cqlversion=3.4.6` (previously 3.4.4). 

Misc change: I was also interested in to see Cassandra's [full query logs](https://cassandra.apache.org/doc/stable/cassandra/operating/fqllogging.html). Added `docs/howtos/cassandra-fql.md` to explain the steps on how to check FQL.

<!-- Tell your future self why have you made these changes -->
**Why?**
To keep things up to date. Assuming Cassandra 4+ is more widely used.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Locally run `make test` and bench tests
- Tried a few of the docker-compose-*.yml files

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Users who depends on `ubercadence/server:master-auto-setup` should pull new image before running docker-compose. Hopefully this is only used for development/discovery use cases. Left a note in changelog for this.

