### PR TITLE
Added a new dynamic config option MaxWorkflowCacheSize

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1178,7 +1178,7 @@ const (
 	// Allowed filters: ShardID
 	ReplicationTaskProcessorErrorRetryMaxAttempts
 
-	// MaxBufferedReplicationTasks is the max number of workflows for which we store in memory information
+	// MaxWorkflowCacheSize is the max number of workflows for which we store in memory information
 	// Keyname: history.MaxWorkflowCacheSize
 	// Value type: Int
 	// Default value: 1000

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1178,6 +1178,13 @@ const (
 	// Allowed filters: ShardID
 	ReplicationTaskProcessorErrorRetryMaxAttempts
 
+	// MaxBufferedReplicationTasks is the max number of workflows for which we store in memory information
+	// Keyname: history.MaxWorkflowCacheSize
+	// Value type: Int
+	// Default value: 1000
+	// Allowed filters: N/A
+	MaxWorkflowCacheSize
+
 	// key for worker
 
 	// WorkerPersistenceMaxQPS is the max qps worker host can query DB
@@ -3455,6 +3462,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Filters:      []Filter{ShardID},
 		Description:  "ReplicationTaskProcessorErrorRetryMaxAttempts is the max retry attempts for applying replication tasks",
 		DefaultValue: 10,
+	},
+	MaxWorkflowCacheSize: DynamicInt{
+		KeyName:      "history.MaxWorkflowCacheSize",
+		Description:  "is the max number of workflows for which we store in memory information",
+		DefaultValue: 1000,
 	},
 	WorkerPersistenceMaxQPS: DynamicInt{
 		KeyName:      "worker.persistenceMaxQPS",

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1181,7 +1181,7 @@ const (
 	// MaxWorkflowCacheSize is the max number of workflows for which we store in memory information
 	// Keyname: history.MaxWorkflowCacheSize
 	// Value type: Int
-	// Default value: 1000
+	// Default value: 512
 	// Allowed filters: N/A
 	MaxWorkflowCacheSize
 
@@ -3466,7 +3466,7 @@ var IntKeys = map[IntKey]DynamicInt{
 	MaxWorkflowCacheSize: DynamicInt{
 		KeyName:      "history.MaxWorkflowCacheSize",
 		Description:  "is the max number of workflows for which we store in memory information",
-		DefaultValue: 1000,
+		DefaultValue: 512,
 	},
 	WorkerPersistenceMaxQPS: DynamicInt{
 		KeyName:      "worker.persistenceMaxQPS",

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -286,6 +286,9 @@ type Config struct {
 	EnableReplicationTaskGeneration                    dynamicconfig.BoolPropertyFnWithDomainIDAndWorkflowIDFilter
 	EnableRecordWorkflowExecutionUninitialized         dynamicconfig.BoolPropertyFnWithDomainFilter
 
+	// The following are used by the history workflow cache
+	MaxWorkflowCacheSize dynamicconfig.IntPropertyFn
+
 	// The following are used by consistent query
 	EnableConsistentQuery         dynamicconfig.BoolPropertyFn
 	EnableConsistentQueryByDomain dynamicconfig.BoolPropertyFnWithDomainFilter
@@ -540,6 +543,8 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 		ReplicationTaskGenerationQPS:                       dc.GetFloat64Property(dynamicconfig.ReplicationTaskGenerationQPS),
 		EnableReplicationTaskGeneration:                    dc.GetBoolPropertyFilteredByDomainIDAndWorkflowID(dynamicconfig.EnableReplicationTaskGeneration),
 		EnableRecordWorkflowExecutionUninitialized:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableRecordWorkflowExecutionUninitialized),
+
+		MaxWorkflowCacheSize: dc.GetIntProperty(dynamicconfig.MaxWorkflowCacheSize),
 
 		EnableConsistentQuery:                 dc.GetBoolProperty(dynamicconfig.EnableConsistentQuery),
 		EnableConsistentQueryByDomain:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableConsistentQueryByDomain),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added new dynamic config option for controlling the size of the workflow cache.

<!-- Tell your future self why have you made these changes -->
**Why?**
It's important we can change the size of the workflow cache in the running system. So if it is using too much memory we can shrink it, and if its evicting too much we can grow it. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally with the file system client 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
