### PR TITLE
Added a function to evict all elements older than the cache TTL

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -53,10 +53,6 @@ type Cache interface {
 
 	// Size returns the number of entries currently stored in the Cache
 	Size() int
-
-	// EvictItemsPastTimeToLive evicts all items in the cache which are expired
-	// This is not called automatically, but can be called periodically to evict expired items
-	EvictItemsPastTimeToLive()
 }
 
 // Options control the behavior of the cache
@@ -94,7 +90,7 @@ type Options struct {
 	// Should be used when it's important for memory that the expired items are evicted as soon as possible
 	// If not set expired items will be evicted when one of these happens
 	// - when the cache is full
-	// - when EvictItemsPastTimeToLive is called
+	// - when evictItemsPastTimeToLive is called
 	// - when the item is accessed
 	ActivelyEvict bool
 }

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -88,6 +88,15 @@ type Options struct {
 	// to control the max size in bytes of the cache
 	// It is required option if MaxCount is not provided
 	MaxSize uint64
+
+	// ActivelyEvict will evict items that has expired TTL at every operation in the cache
+	// This can be expensive if a lot of items expire at the same time
+	// Should be used when it's important for memory that the expired items are evicted as soon as possible
+	// If not set expired items will be evicted when one of these happens
+	// - when the cache is full
+	// - when EvictItemsPastTimeToLive is called
+	// - when the item is accessed
+	ActivelyEvict bool
 }
 
 // SimpleOptions provides options that can be used to configure SimpleCache

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -53,6 +53,10 @@ type Cache interface {
 
 	// Size returns the number of entries currently stored in the Cache
 	Size() int
+
+	// EvictItemsPastTimeToLive evicts all items in the cache which are expired
+	// This is not called automatically, but can be called periodically to evict expired items
+	EvictItemsPastTimeToLive()
 }
 
 // Options control the behavior of the cache

--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -90,7 +90,6 @@ type Options struct {
 	// Should be used when it's important for memory that the expired items are evicted as soon as possible
 	// If not set expired items will be evicted when one of these happens
 	// - when the cache is full
-	// - when evictItemsPastTimeToLive is called
 	// - when the item is accessed
 	ActivelyEvict bool
 }

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -174,9 +174,7 @@ func (c *lru) Get(key interface{}) interface{} {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	if c.activelyEvict {
-		c.evictExpiredItems()
-	}
+	c.evictExpiredItems()
 
 	element := c.byKey[key]
 	if element == nil {
@@ -227,9 +225,7 @@ func (c *lru) Delete(key interface{}) {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	if c.activelyEvict {
-		c.evictExpiredItems()
-	}
+	c.evictExpiredItems()
 
 	element := c.byKey[key]
 	if element != nil {
@@ -255,15 +251,17 @@ func (c *lru) Size() int {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	if c.activelyEvict {
-		c.evictExpiredItems()
-	}
+	c.evictExpiredItems()
 
 	return len(c.byKey)
 }
 
 // evictExpiredItems evicts all items in the cache which are expired
 func (c *lru) evictExpiredItems() {
+	if !c.activelyEvict {
+		return // do nothing if activelyEvict is not set
+	}
+
 	for elt := c.byAccess.Back(); len(c.byKey) > 0 && c.isEntryExpired(elt.Value.(*entryImpl), c.now()); elt = c.byAccess.Back() {
 		c.deleteInternal(elt)
 	}
@@ -276,9 +274,7 @@ func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) 
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
-	if c.activelyEvict {
-		c.evictExpiredItems()
-	}
+	c.evictExpiredItems()
 
 	elt := c.byKey[key]
 	if elt != nil {

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -169,7 +169,7 @@ func New(opts *Options) Cache {
 // Get retrieves the value stored under the given key
 func (c *lru) Get(key interface{}) interface{} {
 	if c.activelyEvict {
-		c.evictItemsPastTimeToLive()
+		c.evictExpiredItems()
 	}
 
 	c.mut.Lock()
@@ -222,7 +222,7 @@ func (c *lru) PutIfNotExist(key interface{}, value interface{}) (interface{}, er
 // Delete deletes a key, value pair associated with a key
 func (c *lru) Delete(key interface{}) {
 	if c.activelyEvict {
-		c.evictItemsPastTimeToLive()
+		c.evictExpiredItems()
 	}
 
 	c.mut.Lock()
@@ -250,7 +250,7 @@ func (c *lru) Release(key interface{}) {
 // Size returns the number of entries currently in the lru, useful if cache is not full
 func (c *lru) Size() int {
 	if c.activelyEvict {
-		c.evictItemsPastTimeToLive()
+		c.evictExpiredItems()
 	}
 
 	c.mut.Lock()
@@ -259,9 +259,9 @@ func (c *lru) Size() int {
 	return len(c.byKey)
 }
 
-// evictItemsPastTimeToLive evicts all items in the cache which are expired
+// evictExpiredItems evicts all items in the cache which are expired
 // This is not called automatically, but can be called periodically to evict expired items
-func (c *lru) evictItemsPastTimeToLive() {
+func (c *lru) evictExpiredItems() {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
@@ -274,7 +274,7 @@ func (c *lru) evictItemsPastTimeToLive() {
 // allowUpdate flag is used to control overwrite behavior if the value exists
 func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) (interface{}, error) {
 	if c.activelyEvict {
-		c.evictItemsPastTimeToLive()
+		c.evictExpiredItems()
 	}
 
 	valueSize := c.sizeFunc(value)

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -262,8 +262,9 @@ func (c *lru) evictExpiredItems() {
 		return // do nothing if activelyEvict is not set
 	}
 
+	now := c.now()
 	for elt := c.byAccess.Back(); elt != nil; elt = c.byAccess.Back() {
-		if !c.isEntryExpired(elt.Value.(*entryImpl), c.now()) {
+		if !c.isEntryExpired(elt.Value.(*entryImpl), now) {
 			// List is sorted by item age, so we can stop as soon as we found first non expired item.
 			break
 		}

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -262,7 +262,7 @@ func (c *lru) evictExpiredItems() {
 		return // do nothing if activelyEvict is not set
 	}
 
-	for elt := c.byAccess.Back(); len(c.byKey) > 0 && c.isEntryExpired(elt.Value.(*entryImpl), c.now()); elt = c.byAccess.Back() {
+	for elt := c.byAccess.Back(); elt != nil && c.isEntryExpired(elt.Value.(*entryImpl), c.now()); elt = c.byAccess.Back() {
 		c.deleteInternal(elt)
 	}
 }

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -169,7 +169,7 @@ func New(opts *Options) Cache {
 // Get retrieves the value stored under the given key
 func (c *lru) Get(key interface{}) interface{} {
 	if c.activelyEvict {
-		c.EvictItemsPastTimeToLive()
+		c.evictItemsPastTimeToLive()
 	}
 
 	c.mut.Lock()
@@ -222,7 +222,7 @@ func (c *lru) PutIfNotExist(key interface{}, value interface{}) (interface{}, er
 // Delete deletes a key, value pair associated with a key
 func (c *lru) Delete(key interface{}) {
 	if c.activelyEvict {
-		c.EvictItemsPastTimeToLive()
+		c.evictItemsPastTimeToLive()
 	}
 
 	c.mut.Lock()
@@ -250,7 +250,7 @@ func (c *lru) Release(key interface{}) {
 // Size returns the number of entries currently in the lru, useful if cache is not full
 func (c *lru) Size() int {
 	if c.activelyEvict {
-		c.EvictItemsPastTimeToLive()
+		c.evictItemsPastTimeToLive()
 	}
 
 	c.mut.Lock()
@@ -259,9 +259,9 @@ func (c *lru) Size() int {
 	return len(c.byKey)
 }
 
-// EvictItemsPastTimeToLive evicts all items in the cache which are expired
+// evictItemsPastTimeToLive evicts all items in the cache which are expired
 // This is not called automatically, but can be called periodically to evict expired items
-func (c *lru) EvictItemsPastTimeToLive() {
+func (c *lru) evictItemsPastTimeToLive() {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
@@ -274,7 +274,7 @@ func (c *lru) EvictItemsPastTimeToLive() {
 // allowUpdate flag is used to control overwrite behavior if the value exists
 func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) (interface{}, error) {
 	if c.activelyEvict {
-		c.EvictItemsPastTimeToLive()
+		c.evictItemsPastTimeToLive()
 	}
 
 	valueSize := c.sizeFunc(value)

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -245,6 +245,17 @@ func (c *lru) Size() int {
 	return len(c.byKey)
 }
 
+// EvictItemsPastTimeToLive evicts all items in the cache which are expired
+// This is not called automatically, but can be called periodically to evict expired items
+func (c *lru) EvictItemsPastTimeToLive() {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	for elt := c.byAccess.Back(); len(c.byKey) > 0 && c.isEntryExpired(elt.Value.(*entryImpl), time.Now()); elt = c.byAccess.Back() {
+		c.deleteInternal(elt)
+	}
+}
+
 // Put puts a new value associated with a given key, returning the existing value (if present)
 // allowUpdate flag is used to control overwrite behavior if the value exists
 func (c *lru) putInternal(key interface{}, value interface{}, allowUpdate bool) (interface{}, error) {

--- a/common/cache/lru.go
+++ b/common/cache/lru.go
@@ -262,7 +262,11 @@ func (c *lru) evictExpiredItems() {
 		return // do nothing if activelyEvict is not set
 	}
 
-	for elt := c.byAccess.Back(); elt != nil && c.isEntryExpired(elt.Value.(*entryImpl), c.now()); elt = c.byAccess.Back() {
+	for elt := c.byAccess.Back(); elt != nil; elt = c.byAccess.Back() {
+		if !c.isEntryExpired(elt.Value.(*entryImpl), c.now()) {
+			// List is sorted by item age, so we can stop as soon as we found first non expired item.
+			break
+		}
 		c.deleteInternal(elt)
 	}
 }

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -427,7 +427,7 @@ func TestEvictItemsPastTimeToLive_SomeExpired(t *testing.T) {
 	assert.Equal(t, 3, cache.Size())
 	time.Sleep(time.Millisecond * 25)
 
-	// Everything is expired but nothing is evicted
+	// Two items are expired but nothing is evicted
 	assert.Equal(t, 3, cache.Size())
 
 	// Evict all expired items

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -434,3 +434,24 @@ func TestEvictItemsPastTimeToLive_SomeExpired(t *testing.T) {
 	cache.EvictItemsPastTimeToLive()
 	assert.Equal(t, 1, cache.Size())
 }
+
+func TestEvictItemsPastTimeToLive_AllExpired_ActivelyEvict(t *testing.T) {
+	cache := New(&Options{
+		MaxCount:      5,
+		TTL:           time.Millisecond * 50,
+		ActivelyEvict: true,
+	})
+
+	_, err := cache.PutIfNotExist("A", t)
+	assert.NoError(t, err)
+	_, err = cache.PutIfNotExist("B", t)
+	assert.NoError(t, err)
+	_, err = cache.PutIfNotExist("C", t)
+	assert.NoError(t, err)
+
+	assert.Equal(t, 3, cache.Size())
+	time.Sleep(time.Millisecond * 100)
+
+	// Calling any action, such as size should evict the expired items
+	assert.Equal(t, 0, cache.Size())
+}

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -388,7 +388,7 @@ func TestPanicOptionsIsNil(t *testing.T) {
 func TestEvictItemsPastTimeToLive_AllExpired_ActivelyEvict(t *testing.T) {
 	cache := New(&Options{
 		MaxCount:      5,
-		TTL:           time.Millisecond * 50,
+		TTL:           time.Millisecond * 75,
 		ActivelyEvict: true,
 	})
 
@@ -404,4 +404,29 @@ func TestEvictItemsPastTimeToLive_AllExpired_ActivelyEvict(t *testing.T) {
 
 	// Calling any action, such as size should evict the expired items
 	assert.Equal(t, 0, cache.Size())
+}
+
+func TestEvictItemsPastTimeToLive_SomeExpired_ActivelyEvict(t *testing.T) {
+	cache := New(&Options{
+		MaxCount:      5,
+		TTL:           time.Millisecond * 75,
+		ActivelyEvict: true,
+	})
+
+	_, err := cache.PutIfNotExist("A", t)
+	assert.NoError(t, err)
+	_, err = cache.PutIfNotExist("B", t)
+	assert.NoError(t, err)
+
+	time.Sleep(time.Millisecond * 50)
+	_, err = cache.PutIfNotExist("C", t)
+	assert.NoError(t, err)
+
+	// Nothing is expired yet
+	assert.Equal(t, 3, cache.Size())
+	time.Sleep(time.Millisecond * 50)
+
+	// Calling any action, such as size should evict the expired items
+	// should only have "C" left
+	assert.Equal(t, 1, cache.Size())
 }

--- a/common/cache/lru_test.go
+++ b/common/cache/lru_test.go
@@ -385,56 +385,6 @@ func TestPanicOptionsIsNil(t *testing.T) {
 	New(nil)
 }
 
-func TestEvictItemsPastTimeToLive_AllExpired(t *testing.T) {
-	cache := New(&Options{
-		MaxCount: 5,
-		TTL:      time.Millisecond * 50,
-	})
-
-	_, err := cache.PutIfNotExist("A", t)
-	assert.NoError(t, err)
-	_, err = cache.PutIfNotExist("B", t)
-	assert.NoError(t, err)
-	_, err = cache.PutIfNotExist("C", t)
-	assert.NoError(t, err)
-
-	assert.Equal(t, 3, cache.Size())
-	time.Sleep(time.Millisecond * 100)
-
-	// Everything is expired but nothing is evicted
-	assert.Equal(t, 3, cache.Size())
-
-	// Evict all expired items
-	cache.EvictItemsPastTimeToLive()
-	assert.Equal(t, 0, cache.Size())
-}
-
-func TestEvictItemsPastTimeToLive_SomeExpired(t *testing.T) {
-	cache := New(&Options{
-		MaxCount: 5,
-		TTL:      time.Millisecond * 50,
-	})
-
-	_, err := cache.PutIfNotExist("A", t)
-	assert.NoError(t, err)
-	_, err = cache.PutIfNotExist("B", t)
-	assert.NoError(t, err)
-
-	time.Sleep(time.Millisecond * 75)
-	_, err = cache.PutIfNotExist("C", t)
-	assert.NoError(t, err)
-
-	assert.Equal(t, 3, cache.Size())
-	time.Sleep(time.Millisecond * 25)
-
-	// Two items are expired but nothing is evicted
-	assert.Equal(t, 3, cache.Size())
-
-	// Evict all expired items
-	cache.EvictItemsPastTimeToLive()
-	assert.Equal(t, 1, cache.Size())
-}
-
 func TestEvictItemsPastTimeToLive_AllExpired_ActivelyEvict(t *testing.T) {
 	cache := New(&Options{
 		MaxCount:      5,

--- a/common/cache/simple.go
+++ b/common/cache/simple.go
@@ -175,6 +175,10 @@ func (c *simple) Iterator() Iterator {
 	return iterator
 }
 
+// EvictItemsPastTimeToLive evicts all items in the cache which are expired
+// the simple cache does not have a concept of TTL so this is a no-op
+func (c *simple) EvictItemsPastTimeToLive() {}
+
 func (c *simple) putInternal(key interface{}, value interface{}, allowUpdate bool) interface{} {
 	elt := c.accessMap[key]
 	if elt != nil {

--- a/common/cache/simple.go
+++ b/common/cache/simple.go
@@ -175,10 +175,6 @@ func (c *simple) Iterator() Iterator {
 	return iterator
 }
 
-// EvictItemsPastTimeToLive evicts all items in the cache which are expired
-// the simple cache does not have a concept of TTL so this is a no-op
-func (c *simple) EvictItemsPastTimeToLive() {}
-
 func (c *simple) putInternal(key interface{}, value interface{}, allowUpdate bool) interface{} {
 	elt := c.accessMap[key]
 	if elt != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added a function to evict all elements in the LRU cache older than the TTL

<!-- Tell your future self why have you made these changes -->
**Why?**
This will enable us to clean out the cache periodically. This is useful for the workflow specific rate limits, as we will only need to keep items which are accessed very frequently. 

We will set the TTL to a low value and periodically clear out the elements that are above this limit to save memory. 

This way there is no need to set and manage a specific cache size 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk, just adding a function 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
