### PR TITLE
Add an "all results" query to scanner/fixer workflows

### DIFF
--- a/service/worker/scanner/shardscanner/aggregators.go
+++ b/service/worker/scanner/shardscanner/aggregators.go
@@ -557,6 +557,14 @@ func (a *ShardScanResultAggregator) adjustAggregation(stats ScanStats, fn func(a
 	}
 }
 
+func (a *ShardScanResultAggregator) GetAllScanResults() (map[int]ScanResult, error) {
+	result := make(map[int]ScanResult, len(a.reports))
+	for k, v := range a.reports {
+		result[k] = v.Result
+	}
+	return result, nil
+}
+
 func getStatusResult(
 	minShardID int,
 	maxShardID int,

--- a/service/worker/scanner/shardscanner/aggregators.go
+++ b/service/worker/scanner/shardscanner/aggregators.go
@@ -330,6 +330,14 @@ func (a *ShardFixResultAggregator) GetReport(shardID int) (*FixReport, error) {
 	return nil, fmt.Errorf("shard %v has not finished yet, check back later for report", shardID)
 }
 
+func (a *ShardFixResultAggregator) GetAllFixResults() (map[int]FixResult, error) {
+	result := make(map[int]FixResult, len(a.reports))
+	for k, v := range a.reports {
+		result[k] = v.Result
+	}
+	return result, nil
+}
+
 func (a *ShardFixResultAggregator) adjustAggregation(stats FixStats, fn func(a, b int64) int64) {
 	a.aggregation.EntitiesCount = fn(a.aggregation.EntitiesCount, stats.EntitiesCount)
 	a.aggregation.SkippedCount = fn(a.aggregation.SkippedCount, stats.SkippedCount)

--- a/service/worker/scanner/shardscanner/fixer_workflow.go
+++ b/service/worker/scanner/shardscanner/fixer_workflow.go
@@ -240,6 +240,12 @@ func setHandlers(aggregator *ShardFixResultAggregator) map[string]interface{} {
 			}
 			return aggregator.GetDomainStatus(req)
 		},
+		AllResultsQuery: func() (map[int]FixResult, error) {
+			if aggregator == nil {
+				return nil, errQueryNotReady
+			}
+			return aggregator.GetAllFixResults()
+		},
 	}
 }
 

--- a/service/worker/scanner/shardscanner/scanner_workflow.go
+++ b/service/worker/scanner/shardscanner/scanner_workflow.go
@@ -47,6 +47,13 @@ const (
 	ShardSizeQuery = "shard_size"
 	// DomainReportQuery is the query name for the query used to get the reports per domains for all finished shards
 	DomainReportQuery = "domain_report"
+	// AllScanResultsQuery returns filenames / paginating data for corruptions and failures in this workflow,
+	// for shards which have finished processing.
+	//
+	// This data is also available for a single shard under ShardReportQuery, but using that requires
+	// re-querying repeatedly if more than that single shard's data is desired, e.g. for manual
+	// troubleshooting purposes.
+	AllScanResultsQuery = "all_scan_results"
 
 	scanShardReportChan = "scanShardReportChan"
 )
@@ -205,6 +212,9 @@ func getScanHandlers(aggregator *ShardScanResultAggregator) map[string]interface
 		},
 		DomainReportQuery: func(req DomainReportQueryRequest) (*DomainScanReportQueryResult, error) {
 			return aggregator.GetDomainStatus(req)
+		},
+		AllScanResultsQuery: func() (map[int]ScanResult, error) {
+			return aggregator.GetAllScanResults()
 		},
 	}
 }

--- a/service/worker/scanner/shardscanner/scanner_workflow.go
+++ b/service/worker/scanner/shardscanner/scanner_workflow.go
@@ -47,13 +47,14 @@ const (
 	ShardSizeQuery = "shard_size"
 	// DomainReportQuery is the query name for the query used to get the reports per domains for all finished shards
 	DomainReportQuery = "domain_report"
-	// AllScanResultsQuery returns filenames / paginating data for corruptions and failures in this workflow,
-	// for shards which have finished processing.
+	// AllResultsQuery returns filenames / paginating data for corruptions and failures in this workflow,
+	// for shards which have finished processing.  This works for both scanner and fixer, and the return structures
+	// are very similar.
 	//
 	// This data is also available for a single shard under ShardReportQuery, but using that requires
 	// re-querying repeatedly if more than that single shard's data is desired, e.g. for manual
 	// troubleshooting purposes.
-	AllScanResultsQuery = "all_scan_results"
+	AllResultsQuery = "all_results"
 
 	scanShardReportChan = "scanShardReportChan"
 )
@@ -213,7 +214,7 @@ func getScanHandlers(aggregator *ShardScanResultAggregator) map[string]interface
 		DomainReportQuery: func(req DomainReportQueryRequest) (*DomainScanReportQueryResult, error) {
 			return aggregator.GetDomainStatus(req)
 		},
-		AllScanResultsQuery: func() (map[int]ScanResult, error) {
+		AllResultsQuery: func() (map[int]ScanResult, error) {
 			return aggregator.GetAllScanResults()
 		},
 	}


### PR DESCRIPTION
Currently, getting all output filenames from these workflows is an exercise in frustration.

You can:
- query `shard_corrupt_keys` to get all shards with corruptions (no data on fails, etc)
- query `shard_report` to get a *single* shard's corruptions, errors, skips, control-flow failures
- browse activity results by hand to discover ^ this in bulk

But unfortunately:
- metrics do not contain per-shard info so finding the relevant activity or shard is hard
- there are essentially no logs in this entire system (!?!)
- there is currently no query to get both failures and corruptions/fixes in bulk
- if one invariant reports "fixed" and then the next returns "fail" because the fix removed data,
  the end result goes into "failures".  this is true for scans too, corrupt + fail == fail.

Many small bits of friction make trying to bulk-analyze this system *incredibly* painful.

While we do need to just rewrite the whole thing to be less... like it is... we can at least expose this bulk info quite easily in a new query.
