### PR TITLE
Wrap isSecure config in config map for kafka topic

### DIFF
--- a/common/config/kafkaConfig.go
+++ b/common/config/kafkaConfig.go
@@ -45,7 +45,7 @@ type (
 	TopicConfig struct {
 		Cluster string `yaml:"cluster"`
 		// Properties map describes whether the topic properties, such as whether it is secure
-		Properties map[string]interface{} `yaml:"properties,omitempty"`
+		Properties map[string]any `yaml:"properties,omitempty"`
 	}
 
 	// TopicList describes the topic names for each cluster
@@ -103,11 +103,19 @@ func (k *KafkaConfig) GetTopicsForApplication(app string) TopicList {
 }
 
 // GetKafkaPropertiesForTopic gets properties from topic
-func (k *KafkaConfig) GetKafkaPropertiesForTopic(topic string) map[string]interface{} {
+func (k *KafkaConfig) GetKafkaPropertyForTopic(topic string, property string) any {
 	topicConfig, ok := k.Topics[topic]
 	if !ok || topicConfig.Properties == nil {
 		// No properties for the specified topic in the config
 		return nil
 	}
-	return topicConfig.Properties
+
+	// retrieve the property from the topic properties
+	propertyValue, ok := topicConfig.Properties[property]
+	if !ok {
+		// Property not found
+		return nil
+	}
+
+	return propertyValue
 }

--- a/common/config/kafkaConfig.go
+++ b/common/config/kafkaConfig.go
@@ -45,7 +45,7 @@ type (
 	TopicConfig struct {
 		Cluster string `yaml:"cluster"`
 		// Properties map describes whether the topic properties, such as whether it is secure
-		Properties map[string]interface{} `yaml:"Properties,omitempty"`
+		Properties map[string]interface{} `yaml:"properties,omitempty"`
 	}
 
 	// TopicList describes the topic names for each cluster

--- a/common/config/kafkaConfig.go
+++ b/common/config/kafkaConfig.go
@@ -44,9 +44,8 @@ type (
 	// TopicConfig describes the mapping from topic to Kafka cluster
 	TopicConfig struct {
 		Cluster string `yaml:"cluster"`
-		// IsSecure describes whether the topic is secure, by default it is false
-		// If it is set to true, it allows to pass in the token to initialize secure producer for this topic
-		IsSecure bool `yaml:"isSecure,omitempty"`
+		// Properties map describes whether the topic properties, such as whether it is secure
+		Properties map[string]interface{} `yaml:"Properties,omitempty"`
 	}
 
 	// TopicList describes the topic names for each cluster
@@ -103,7 +102,12 @@ func (k *KafkaConfig) GetTopicsForApplication(app string) TopicList {
 	return k.Applications[app]
 }
 
-// GetKafkaClusterSecureConfigForTopic gets isSecure status from topic
-func (k *KafkaConfig) GetKafkaSecureConfigForTopic(topic string) bool {
-	return k.Topics[topic].IsSecure
+// GetKafkaPropertiesForTopic gets properties from topic
+func (k *KafkaConfig) GetKafkaPropertiesForTopic(topic string) map[string]interface{} {
+	topicConfig, ok := k.Topics[topic]
+	if !ok || topicConfig.Properties == nil {
+		// No properties for the specified topic in the config
+		return nil
+	}
+	return topicConfig.Properties
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Unexpose isSecure config, replace with config map

<!-- Tell your future self why have you made these changes -->
**Why?**
IsSecure is internal config for kafka topic, we don't want it to be exposed for public users

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
