### PR TITLE
Add Debugf and some minor updates to timer queue processor base

### DIFF
--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -8,7 +8,9 @@ steps:
     agents:
       queue: "workers"
       docker: "*"
-    command: "CASSANDRA_HOST=cassandra make install-schema && make cover_profile" # make install-schema is needed for a server startup test. See main_test.go
+    commands:
+      - "sleep 30"
+      - "CASSANDRA_HOST=cassandra make install-schema && make cover_profile" # make install-schema is needed for a server startup test. See main_test.go
     artifact_paths:
       - ".build/coverage/*.out"
     retry:

--- a/common/log/interface.go
+++ b/common/log/interface.go
@@ -41,6 +41,7 @@ import (
 //	 Note: msg should be static, it is not recommended to use fmt.Sprintf() for msg.
 //	       Anything dynamic should be tagged.
 type Logger interface {
+	Debugf(msg string, args ...any)
 	Debug(msg string, tags ...tag.Tag)
 	Info(msg string, tags ...tag.Tag)
 	Warn(msg string, tags ...tag.Tag)
@@ -57,6 +58,7 @@ func NewNoop() Logger {
 	return &noop{}
 }
 
+func (n *noop) Debugf(msg string, args ...any)                         {}
 func (n *noop) Debug(msg string, tags ...tag.Tag)                      {}
 func (n *noop) Info(msg string, tags ...tag.Tag)                       {}
 func (n *noop) Warn(msg string, tags ...tag.Tag)                       {}

--- a/common/log/loggerimpl/logger.go
+++ b/common/log/loggerimpl/logger.go
@@ -113,10 +113,24 @@ func setDefaultMsg(msg string) string {
 	return msg
 }
 
+func (lg *loggerImpl) Debugf(msg string, args ...any) {
+	ce := lg.zapLogger.Check(zap.DebugLevel, setDefaultMsg(fmt.Sprintf(msg, args...)))
+	if ce == nil {
+		return
+	}
+
+	fields := lg.buildFieldsWithCallat(nil)
+	ce.Write(fields...)
+}
+
 func (lg *loggerImpl) Debug(msg string, tags ...tag.Tag) {
-	msg = setDefaultMsg(msg)
+	ce := lg.zapLogger.Check(zap.DebugLevel, setDefaultMsg(msg))
+	if ce == nil {
+		return
+	}
+
 	fields := lg.buildFieldsWithCallat(tags)
-	lg.zapLogger.Debug(msg, fields...)
+	ce.Write(fields...)
 }
 
 func (lg *loggerImpl) Info(msg string, tags ...tag.Tag) {

--- a/common/log/loggerimpl/replay.go
+++ b/common/log/loggerimpl/replay.go
@@ -21,6 +21,7 @@
 package loggerimpl
 
 import (
+	"fmt"
 	"math/rand"
 
 	"go.uber.org/cadence/workflow"
@@ -55,6 +56,14 @@ func NewReplayLogger(logger log.Logger, ctx workflow.Context, enableLogInReplay 
 		ctx:               ctx,
 		enableLogInReplay: enableLogInReplay,
 	}
+}
+
+func (r *replayLogger) Debugf(msg string, args ...any) {
+	if workflow.IsReplaying(r.ctx) && !r.enableLogInReplay {
+		return
+	}
+
+	r.logger.Debugf(fmt.Sprintf(msg, args...))
 }
 
 func (r *replayLogger) Debug(msg string, tags ...tag.Tag) {

--- a/common/log/loggerimpl/throttle.go
+++ b/common/log/loggerimpl/throttle.go
@@ -70,6 +70,12 @@ func NewThrottledLogger(logger log.Logger, rps dynamicconfig.IntPropertyFn) log.
 	return tl
 }
 
+func (tl *throttledLogger) Debugf(msg string, args ...any) {
+	tl.rateLimit(func() {
+		tl.log.Debugf(msg, args...)
+	})
+}
+
 func (tl *throttledLogger) Debug(msg string, tags ...tag.Tag) {
 	tl.rateLimit(func() {
 		tl.log.Debug(msg, tags...)

--- a/common/log/mockLogger.go
+++ b/common/log/mockLogger.go
@@ -31,6 +31,11 @@ type MockLogger struct {
 	mock.Mock
 }
 
+// Debugf provides a mock function with given fields: msg, args
+func (_m *MockLogger) Debugf(msg string, args ...any) {
+	_m.Called(msg, args)
+}
+
 // Debug provides a mock function with given fields: msg, tags
 func (_m *MockLogger) Debug(msg string, tags ...tag.Tag) {
 	_m.Called(msg, tags)

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -2999,42 +2999,35 @@ func (e *historyEngineImpl) ResetWorkflowExecution(
 	}, nil
 }
 
-func (e *historyEngineImpl) NotifyNewHistoryEvent(
-	event *events.Notification,
-) {
-
+func (e *historyEngineImpl) NotifyNewHistoryEvent(event *events.Notification) {
 	e.historyEventNotifier.NotifyNewHistoryEvent(event)
 }
 
-func (e *historyEngineImpl) NotifyNewTransferTasks(
-	info *hcommon.NotifyTaskInfo,
-) {
+func (e *historyEngineImpl) NotifyNewTransferTasks(info *hcommon.NotifyTaskInfo) {
+	if len(info.Tasks) == 0 {
+		return
+	}
 
-	if len(info.Tasks) > 0 {
-		task := info.Tasks[0]
-		clusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
-		if err == nil {
-			e.txProcessor.NotifyNewTask(clusterName, info)
-		}
+	task := info.Tasks[0]
+	clusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
+	if err == nil {
+		e.txProcessor.NotifyNewTask(clusterName, info)
 	}
 }
 
-func (e *historyEngineImpl) NotifyNewTimerTasks(
-	info *hcommon.NotifyTaskInfo,
-) {
+func (e *historyEngineImpl) NotifyNewTimerTasks(info *hcommon.NotifyTaskInfo) {
+	if len(info.Tasks) == 0 {
+		return
+	}
 
-	if len(info.Tasks) > 0 {
-		task := info.Tasks[0]
-		clusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
-		if err == nil {
-			e.timerProcessor.NotifyNewTask(clusterName, info)
-		}
+	task := info.Tasks[0]
+	clusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(task.GetVersion())
+	if err == nil {
+		e.timerProcessor.NotifyNewTask(clusterName, info)
 	}
 }
 
-func (e *historyEngineImpl) NotifyNewCrossClusterTasks(
-	info *hcommon.NotifyTaskInfo,
-) {
+func (e *historyEngineImpl) NotifyNewCrossClusterTasks(info *hcommon.NotifyTaskInfo) {
 	taskByTargetCluster := make(map[string][]persistence.Task)
 	for _, task := range info.Tasks {
 		// TODO: consider defining a new interface in persistence package

--- a/service/history/queue/processing_queue_collection.go
+++ b/service/history/queue/processing_queue_collection.go
@@ -36,10 +36,7 @@ type (
 )
 
 // NewProcessingQueueCollection creates a new collection for non-overlapping queues
-func NewProcessingQueueCollection(
-	level int,
-	queues []ProcessingQueue,
-) ProcessingQueueCollection {
+func NewProcessingQueueCollection(level int, queues []ProcessingQueue) ProcessingQueueCollection {
 	sortProcessingQueue(queues)
 	queueCollection := &processingQueueCollection{
 		level:  level,
@@ -62,10 +59,7 @@ func (c *processingQueueCollection) ActiveQueue() ProcessingQueue {
 	return c.activeQueue
 }
 
-func (c *processingQueueCollection) AddTasks(
-	tasks map[task.Key]task.Task,
-	newReadLevel task.Key,
-) {
+func (c *processingQueueCollection) AddTasks(tasks map[task.Key]task.Task, newReadLevel task.Key) {
 	activeQueue := c.ActiveQueue()
 	activeQueue.AddTasks(tasks, newReadLevel)
 
@@ -215,9 +209,7 @@ func (c *processingQueueCollection) resetActiveQueue() {
 	c.activeQueue = nil
 }
 
-func sortProcessingQueue(
-	queues []ProcessingQueue,
-) {
+func sortProcessingQueue(queues []ProcessingQueue) {
 	sort.Slice(queues, func(i, j int) bool {
 		if queues[i].State().Level() == queues[j].State().Level() {
 			return queues[i].State().AckLevel().Less(queues[j].State().AckLevel())

--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -460,9 +460,7 @@ func (p *processorBase) getProcessingQueueStates() *ActionResult {
 	}
 }
 
-func (p *processorBase) submitTask(
-	task task.Task,
-) (bool, error) {
+func (p *processorBase) submitTask(task task.Task) (bool, error) {
 	submitted, err := p.taskProcessor.TrySubmit(task)
 	if err != nil {
 		select {

--- a/service/history/queue/timer_queue_processor_base_test.go
+++ b/service/history/queue/timer_queue_processor_base_test.go
@@ -140,10 +140,10 @@ func (s *timerQueueProcessorBaseSuite) TestGetTimerTasks_More() {
 	mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything, request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
-	timers, token, err := timerQueueProcessBase.getTimerTasks(readLevel, maxReadLevel, request.NextPageToken, batchSize)
+	got, err := timerQueueProcessBase.getTimerTasks(readLevel, maxReadLevel, request.NextPageToken, batchSize)
 	s.Nil(err)
-	s.Equal(response.Timers, timers)
-	s.Equal(response.NextPageToken, token)
+	s.Equal(response.Timers, got.Timers)
+	s.Equal(response.NextPageToken, got.NextPageToken)
 }
 
 func (s *timerQueueProcessorBaseSuite) TestGetTimerTasks_NoMore() {
@@ -179,10 +179,10 @@ func (s *timerQueueProcessorBaseSuite) TestGetTimerTasks_NoMore() {
 	mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything, request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
-	timers, token, err := timerQueueProcessBase.getTimerTasks(readLevel, maxReadLevel, request.NextPageToken, batchSize)
+	got, err := timerQueueProcessBase.getTimerTasks(readLevel, maxReadLevel, request.NextPageToken, batchSize)
 	s.Nil(err)
-	s.Equal(response.Timers, timers)
-	s.Empty(token)
+	s.Equal(response.Timers, got.Timers)
+	s.Empty(got.NextPageToken)
 }
 
 func (s *timerQueueProcessorBaseSuite) TestReadLookAheadTask() {
@@ -264,11 +264,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_NoNext
 	mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything, lookAheadRequest).Return(&persistence.GetTimerIndexTasksResponse{}, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
+	got, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
-	s.Equal(response.Timers, filteredTasks)
-	s.Nil(lookAheadTask)
-	s.Nil(nextPageToken)
+	s.Equal(response.Timers, got.timerTasks)
+	s.Nil(got.lookAheadTask)
+	s.Nil(got.nextPageToken)
 }
 
 func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_HasNextPage() {
@@ -303,11 +303,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_NoLookAhead_HasNex
 	mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything, request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
+	got, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
-	s.Equal(response.Timers, filteredTasks)
-	s.Nil(lookAheadTask)
-	s.Equal(response.NextPageToken, nextPageToken)
+	s.Equal(response.Timers, got.timerTasks)
+	s.Nil(got.lookAheadTask)
+	s.Equal(response.NextPageToken, got.nextPageToken)
 }
 
 func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_NoNextPage() {
@@ -353,11 +353,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_NoNex
 	mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything, request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
+	got, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
-	s.Equal([]*persistence.TimerTaskInfo{response.Timers[0]}, filteredTasks)
-	s.Equal(response.Timers[1], lookAheadTask)
-	s.Nil(nextPageToken)
+	s.Equal([]*persistence.TimerTaskInfo{response.Timers[0]}, got.timerTasks)
+	s.Equal(response.Timers[1], got.lookAheadTask)
+	s.Nil(got.nextPageToken)
 }
 
 func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_HasNextPage() {
@@ -403,11 +403,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_HasLookAhead_HasNe
 	mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything, request).Return(response, nil).Once()
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
+	got, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
-	s.Equal([]*persistence.TimerTaskInfo{response.Timers[0]}, filteredTasks)
-	s.Equal(response.Timers[1], lookAheadTask)
-	s.Nil(nextPageToken)
+	s.Equal([]*persistence.TimerTaskInfo{response.Timers[0]}, got.timerTasks)
+	s.Equal(response.Timers[1], got.lookAheadTask)
+	s.Nil(got.nextPageToken)
 }
 
 func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_LookAheadFailed_NoNextPage() {
@@ -461,11 +461,11 @@ func (s *timerQueueProcessorBaseSuite) TestReadAndFilterTasks_LookAheadFailed_No
 	mockExecutionMgr.On("GetTimerIndexTasks", mock.Anything, lookAheadRequest).Return(nil, errors.New("some random error")).Times(s.mockShard.GetConfig().TimerProcessorGetFailureRetryCount())
 
 	timerQueueProcessBase := s.newTestTimerQueueProcessorBase(nil, nil, nil, nil, nil)
-	filteredTasks, lookAheadTask, nextPageToken, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
+	got, err := timerQueueProcessBase.readAndFilterTasks(readLevel, maxReadLevel, request.NextPageToken)
 	s.Nil(err)
-	s.Equal(response.Timers, filteredTasks)
-	s.Equal(maxReadLevel.(timerTaskKey).visibilityTimestamp, lookAheadTask.VisibilityTimestamp)
-	s.Nil(nextPageToken)
+	s.Equal(response.Timers, got.timerTasks)
+	s.Equal(maxReadLevel.(timerTaskKey).visibilityTimestamp, got.lookAheadTask.VisibilityTimestamp)
+	s.Nil(got.nextPageToken)
 }
 
 func (s *timerQueueProcessorBaseSuite) TestNotifyNewTimes() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Some non-behavioral changes in timer queue processor: 
   - add debug logs
   - reduce unnecessary multiline formatting
   - wrap too many return parameters in a struct
   - move handling logic to helper functions to make processing loop more lean/readable
- Introduce `Debugf` as a shortcut to `logger.Debug(fmt.Sprintf(..))`. 
- Use zaplogger's `Check()` to avoid processing log tags for Debug logs. Since we plan to add more verbose logs this can help reduce GC overhead in prod.

Misc. change:
- Added 30s sleep before running `unit test` CI job as workaround to failing `make install-schema` due to Cassandra not ready.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve debugging

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`make test`
