### PR TITLE
Fix copying suite.Suite in integration tests

### DIFF
--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -65,19 +65,19 @@ type (
 
 func TestDomainHandlerGlobalDomainEnabledPrimaryClusterSuite(t *testing.T) {
 	testflags.RequireCassandra(t)
-	s := new(domainHandlerGlobalDomainEnabledPrimaryClusterSuite)
-	suite.Run(t, s)
-}
 
-func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) SetupSuite() {
 	if testing.Verbose() {
 		log.SetOutput(os.Stdout)
 	}
+
+	s := new(domainHandlerGlobalDomainEnabledPrimaryClusterSuite)
 
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true),
 	})
 	s.Setup()
+
+	suite.Run(t, s)
 }
 
 func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TearDownSuite() {

--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -49,8 +49,7 @@ import (
 
 type (
 	domainHandlerGlobalDomainEnabledPrimaryClusterSuite struct {
-		suite.Suite
-		persistencetests.TestBase
+		*persistencetests.TestBase
 
 		minRetentionDays     int
 		maxBadBinaryCount    int
@@ -78,7 +77,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) SetupSuite() {
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true),
 	})
-	s.TestBase.Setup()
+	s.Setup()
 }
 
 func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TearDownSuite() {

--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -75,7 +75,6 @@ func TestDomainHandlerGlobalDomainEnabledPrimaryClusterSuite(t *testing.T) {
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true),
 	})
-	s.Setup()
 
 	suite.Run(t, s)
 }
@@ -85,6 +84,8 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TearDownSuite() {
 }
 
 func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) SetupTest() {
+	s.Setup()
+
 	logger := loggerimpl.NewNopLogger()
 	dcCollection := dc.NewCollection(dc.NewNopClient(), logger)
 	s.minRetentionDays = 1

--- a/common/domain/handler_NotMasterCluster_test.go
+++ b/common/domain/handler_NotMasterCluster_test.go
@@ -49,8 +49,7 @@ import (
 
 type (
 	domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite struct {
-		suite.Suite
-		persistencetests.TestBase
+		*persistencetests.TestBase
 
 		minRetentionDays     int
 		maxBadBinaryCount    int
@@ -78,7 +77,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) SetupSuite() {
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(false),
 	})
-	s.TestBase.Setup()
+	s.Setup()
 }
 
 func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TearDownSuite() {

--- a/common/domain/handler_NotMasterCluster_test.go
+++ b/common/domain/handler_NotMasterCluster_test.go
@@ -75,7 +75,6 @@ func TestDomainHandlerGlobalDomainEnabledNotPrimaryClusterSuite(t *testing.T) {
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(false),
 	})
-	s.Setup()
 
 	suite.Run(t, s)
 }
@@ -85,6 +84,8 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TearDownSuite()
 }
 
 func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) SetupTest() {
+	s.Setup()
+
 	logger := loggerimpl.NewNopLogger()
 	dcCollection := dc.NewCollection(dc.NewNopClient(), logger)
 	s.minRetentionDays = 1

--- a/common/domain/handler_NotMasterCluster_test.go
+++ b/common/domain/handler_NotMasterCluster_test.go
@@ -65,19 +65,19 @@ type (
 
 func TestDomainHandlerGlobalDomainEnabledNotPrimaryClusterSuite(t *testing.T) {
 	testflags.RequireCassandra(t)
-	s := new(domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite)
-	suite.Run(t, s)
-}
 
-func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) SetupSuite() {
 	if testing.Verbose() {
 		log.SetOutput(os.Stdout)
 	}
+
+	s := new(domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite)
 
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(false),
 	})
 	s.Setup()
+
+	suite.Run(t, s)
 }
 
 func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TearDownSuite() {

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -27,16 +27,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber/cadence/testflags"
-
 	"github.com/golang/mock/gomock"
-
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
-
-	"github.com/uber/cadence/common/messaging"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/archiver"
@@ -46,11 +41,13 @@ import (
 	"github.com/uber/cadence/common/config"
 	dc "github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/loggerimpl"
+	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/testflags"
 )
 
 type (
@@ -73,19 +70,19 @@ var nowInt64 = time.Now().UnixNano()
 
 func TestDomainHandlerCommonSuite(t *testing.T) {
 	testflags.RequireCassandra(t)
-	s := new(domainHandlerCommonSuite)
-	suite.Run(t, s)
-}
 
-func (s *domainHandlerCommonSuite) SetupSuite() {
 	if testing.Verbose() {
 		log.SetOutput(os.Stdout)
 	}
+
+	s := new(domainHandlerCommonSuite)
 
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true),
 	})
 	s.Setup()
+
+	suite.Run(t, s)
 }
 
 func (s *domainHandlerCommonSuite) TearDownSuite() {

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -55,8 +55,7 @@ import (
 
 type (
 	domainHandlerCommonSuite struct {
-		suite.Suite
-		persistencetests.TestBase
+		*persistencetests.TestBase
 
 		minRetentionDays     int
 		maxBadBinaryCount    int
@@ -86,7 +85,7 @@ func (s *domainHandlerCommonSuite) SetupSuite() {
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true),
 	})
-	s.TestBase.Setup()
+	s.Setup()
 }
 
 func (s *domainHandlerCommonSuite) TearDownSuite() {

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -80,16 +80,17 @@ func TestDomainHandlerCommonSuite(t *testing.T) {
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{
 		ClusterMetadata: cluster.GetTestClusterMetadata(true),
 	})
-	s.Setup()
 
 	suite.Run(t, s)
 }
 
 func (s *domainHandlerCommonSuite) TearDownSuite() {
-	s.TestBase.TearDownWorkflowStore()
+	s.TearDownWorkflowStore()
 }
 
 func (s *domainHandlerCommonSuite) SetupTest() {
+	s.Setup()
+
 	logger := loggerimpl.NewNopLogger()
 	dcCollection := dc.NewCollection(dc.NewNopClient(), logger)
 	s.minRetentionDays = 1

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -40,8 +40,7 @@ import (
 
 type (
 	domainReplicationTaskExecutorSuite struct {
-		suite.Suite
-		persistencetests.TestBase
+		*persistencetests.TestBase
 		domainReplicator *domainReplicationTaskExecutorImpl
 	}
 )
@@ -61,7 +60,7 @@ func (s *domainReplicationTaskExecutorSuite) TearDownSuite() {
 
 func (s *domainReplicationTaskExecutorSuite) SetupTest() {
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	zapLogger, err := zap.NewDevelopment()
 	s.Require().NoError(err)
 	logger := loggerimpl.NewLogger(zapLogger)

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -57,12 +57,13 @@ func TestDomainReplicationTaskExecutorSuite(t *testing.T) {
 	s := new(domainReplicationTaskExecutorSuite)
 
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.Setup()
 
 	suite.Run(t, s)
 }
 
 func (s *domainReplicationTaskExecutorSuite) SetupTest() {
+	s.Setup()
+
 	zapLogger, err := zap.NewDevelopment()
 	s.Require().NoError(err)
 	logger := loggerimpl.NewLogger(zapLogger)

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -22,6 +22,8 @@ package domain
 
 import (
 	"context"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/pborman/uuid"
@@ -47,20 +49,20 @@ type (
 
 func TestDomainReplicationTaskExecutorSuite(t *testing.T) {
 	testflags.RequireCassandra(t)
+
+	if testing.Verbose() {
+		log.SetOutput(os.Stdout)
+	}
+
 	s := new(domainReplicationTaskExecutorSuite)
+
+	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
+	s.Setup()
+
 	suite.Run(t, s)
 }
 
-func (s *domainReplicationTaskExecutorSuite) SetupSuite() {
-}
-
-func (s *domainReplicationTaskExecutorSuite) TearDownSuite() {
-
-}
-
 func (s *domainReplicationTaskExecutorSuite) SetupTest() {
-	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.Setup()
 	zapLogger, err := zap.NewDevelopment()
 	s.Require().NoError(err)
 	logger := loggerimpl.NewLogger(zapLogger)

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/public/testBase.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/public/testBase.go
@@ -27,7 +27,7 @@ import (
 
 // NewTestBaseWithPublicCassandra returns a persistence test base backed by cassandra datastore
 // It is only being used by testing against external/public Cassandra, which require to load the default gocql client
-func NewTestBaseWithPublicCassandra(options *persistencetests.TestBaseOptions) persistencetests.TestBase {
+func NewTestBaseWithPublicCassandra(options *persistencetests.TestBaseOptions) *persistencetests.TestBase {
 	if options.DBPluginName == "" {
 		options.DBPluginName = "cassandra"
 	}

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
@@ -33,7 +33,7 @@ func TestCassandraHistoryPersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.HistoryV2PersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -41,7 +41,7 @@ func TestCassandraMatchingPersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.MatchingPersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -49,7 +49,7 @@ func TestCassandraDomainPersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.MetadataPersistenceSuiteV2)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -57,7 +57,7 @@ func TestCassandraShardPersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.ShardPersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -65,7 +65,7 @@ func TestCassandraVisibilityPersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.DBVisibilityPersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -73,7 +73,7 @@ func TestCassandraExecutionManager(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.ExecutionManagerSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -81,7 +81,7 @@ func TestCassandraExecutionManagerWithEventsV2(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.ExecutionManagerSuiteForEventsV2)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -89,7 +89,7 @@ func TestCassandraQueuePersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.QueuePersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }
 
@@ -97,6 +97,6 @@ func TestCassandraConfigStorePersistence(t *testing.T) {
 	testflags.RequireCassandra(t)
 	s := new(persistencetests.ConfigStorePersistenceSuite)
 	s.TestBase = public.NewTestBaseWithPublicCassandra(&persistencetests.TestBaseOptions{})
-	s.TestBase.Setup()
+	s.Setup()
 	suite.Run(t, s)
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/tests/cassandra_persistence_test.go
@@ -24,7 +24,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/suite"
-
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
 	"github.com/uber/cadence/testflags"

--- a/common/persistence/nosql/nosqlplugin/common.go
+++ b/common/persistence/nosql/nosqlplugin/common.go
@@ -22,18 +22,18 @@
 package nosqlplugin
 
 import (
-	"os"
+	"fmt"
+	"os/exec"
 	"strings"
 )
 
 func getCadencePackageDir() (string, error) {
-	cadencePackageDir, err := os.Getwd()
+	cmdOut, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
 		panic(err)
 	}
-	cadenceIndex := strings.LastIndex(cadencePackageDir, "/cadence/")
-	cadencePackageDir = cadencePackageDir[:cadenceIndex+len("/cadence/")]
-	return cadencePackageDir, err
+
+	return strings.TrimSpace(string(cmdOut)), err
 }
 
 func GetDefaultTestSchemaDir(testSchemaRelativePath string) (string, error) {
@@ -41,5 +41,5 @@ func GetDefaultTestSchemaDir(testSchemaRelativePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return cadencePackageDir + testSchemaRelativePath, nil
+	return fmt.Sprintf("%s/%s", cadencePackageDir, testSchemaRelativePath), nil
 }

--- a/common/persistence/nosql/nosqlplugin/common.go
+++ b/common/persistence/nosql/nosqlplugin/common.go
@@ -22,18 +22,18 @@
 package nosqlplugin
 
 import (
-	"fmt"
-	"os/exec"
+	"os"
 	"strings"
 )
 
 func getCadencePackageDir() (string, error) {
-	cmdOut, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
+	cadencePackageDir, err := os.Getwd()
 	if err != nil {
-		return "", fmt.Errorf("get root directory failed: error %w, output %s", err, cmdOut)
+		panic(err)
 	}
-
-	return strings.TrimSpace(string(cmdOut)), err
+	cadenceIndex := strings.LastIndex(cadencePackageDir, "cadence/")
+	cadencePackageDir = cadencePackageDir[:cadenceIndex+len("cadence/")]
+	return cadencePackageDir, err
 }
 
 func GetDefaultTestSchemaDir(testSchemaRelativePath string) (string, error) {
@@ -41,5 +41,5 @@ func GetDefaultTestSchemaDir(testSchemaRelativePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("%s/%s", cadencePackageDir, testSchemaRelativePath), nil
+	return cadencePackageDir + testSchemaRelativePath, nil
 }

--- a/common/persistence/nosql/nosqlplugin/common.go
+++ b/common/persistence/nosql/nosqlplugin/common.go
@@ -30,7 +30,7 @@ import (
 func getCadencePackageDir() (string, error) {
 	cmdOut, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
 	if err != nil {
-		panic(err)
+		return "", fmt.Errorf("get root directory failed: %w", err)
 	}
 
 	return strings.TrimSpace(string(cmdOut)), err

--- a/common/persistence/nosql/nosqlplugin/common.go
+++ b/common/persistence/nosql/nosqlplugin/common.go
@@ -28,9 +28,9 @@ import (
 )
 
 func getCadencePackageDir() (string, error) {
-	cmdOut, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	cmdOut, err := exec.Command("git", "rev-parse", "--show-toplevel").CombinedOutput()
 	if err != nil {
-		return "", fmt.Errorf("get root directory failed: %w", err)
+		return "", fmt.Errorf("get root directory failed: error %w, output %s", err, cmdOut)
 	}
 
 	return strings.TrimSpace(string(cmdOut)), err

--- a/common/persistence/nosql/nosqlplugin/mongodb/tests/mongodb_persistence_test.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/tests/mongodb_persistence_test.go
@@ -104,7 +104,7 @@ func TestMongoDBConfigStorePersistence(t *testing.T) {
 // 	suite.Run(t, s)
 // }
 
-func NewTestBaseWithMongo() persistencetests.TestBase {
+func NewTestBaseWithMongo() *persistencetests.TestBase {
 	options := &persistencetests.TestBaseOptions{
 		DBPluginName: mongodb.PluginName,
 		DBHost:       getTestConfig().Hosts,

--- a/common/persistence/persistence-tests/configStorePersistenceTest.go
+++ b/common/persistence/persistence-tests/configStorePersistenceTest.go
@@ -39,7 +39,7 @@ import (
 type (
 	// ConfigStorePersistenceSuite contains config store persistence tests
 	ConfigStorePersistenceSuite struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
@@ -43,7 +43,7 @@ type (
 	// DBVisibilityPersistenceSuite tests visibility persistence
 	// It only tests against DB based visibility, AdvancedVisibility test is in ESVisibilitySuite
 	DBVisibilityPersistenceSuite struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -45,7 +45,7 @@ import (
 type (
 	// ExecutionManagerSuite contains matching persistence tests
 	ExecutionManagerSuite struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
+++ b/common/persistence/persistence-tests/executionManagerTestForEventsV2.go
@@ -39,7 +39,7 @@ import (
 type (
 	// ExecutionManagerSuiteForEventsV2 contains matching persistence tests
 	ExecutionManagerSuiteForEventsV2 struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -33,7 +33,6 @@ import (
 
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
 	workflow "github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -47,8 +46,7 @@ import (
 type (
 	// HistoryV2PersistenceSuite contains history persistence tests
 	HistoryV2PersistenceSuite struct {
-		suite.Suite
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -37,7 +37,7 @@ import (
 type (
 	// MatchingPersistenceSuite contains matching persistence tests
 	MatchingPersistenceSuite struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -43,7 +43,7 @@ import (
 type (
 	// MetadataPersistenceSuiteV2 is test of the V2 version of metadata persistence
 	MetadataPersistenceSuiteV2 struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -111,13 +111,13 @@ const (
 )
 
 // NewTestBaseFromParams returns a customized test base from given input
-func NewTestBaseFromParams(params TestBaseParams) TestBase {
+func NewTestBaseFromParams(params TestBaseParams) *TestBase {
 	logger, err := loggerimpl.NewDevelopment()
 	if err != nil {
 		panic(err)
 	}
 
-	return TestBase{
+	return &TestBase{
 		DefaultTestCluster:    params.DefaultTestCluster,
 		VisibilityTestCluster: params.VisibilityTestCluster,
 		ClusterMetadata:       params.ClusterMetadata,
@@ -128,7 +128,7 @@ func NewTestBaseFromParams(params TestBaseParams) TestBase {
 }
 
 // NewTestBaseWithNoSQL returns a persistence test base backed by nosql datastore
-func NewTestBaseWithNoSQL(options *TestBaseOptions) TestBase {
+func NewTestBaseWithNoSQL(options *TestBaseOptions) *TestBase {
 	if options.DBName == "" {
 		options.DBName = "test_" + GenerateRandomDBName(10)
 	}
@@ -153,7 +153,7 @@ func NewTestBaseWithNoSQL(options *TestBaseOptions) TestBase {
 }
 
 // NewTestBaseWithSQL returns a new persistence test base backed by SQL
-func NewTestBaseWithSQL(options *TestBaseOptions) TestBase {
+func NewTestBaseWithSQL(options *TestBaseOptions) *TestBase {
 	if options.DBName == "" {
 		options.DBName = "test_" + GenerateRandomDBName(10)
 	}

--- a/common/persistence/persistence-tests/queuePersistenceTest.go
+++ b/common/persistence/persistence-tests/queuePersistenceTest.go
@@ -33,7 +33,7 @@ import (
 type (
 	// QueuePersistenceSuite contains queue persistence tests
 	QueuePersistenceSuite struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/common/persistence/persistence-tests/shardPersistenceTest.go
+++ b/common/persistence/persistence-tests/shardPersistenceTest.go
@@ -37,7 +37,7 @@ import (
 type (
 	// ShardPersistenceSuite contains shard persistence tests
 	ShardPersistenceSuite struct {
-		TestBase
+		*TestBase
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions

--- a/host/elastic_search_test.go
+++ b/host/elastic_search_test.go
@@ -53,7 +53,7 @@ type ElasticSearchIntegrationSuite struct {
 	// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 	// not merely log an error
 	*require.Assertions
-	IntegrationBase
+	*IntegrationBase
 	esClient esutils.ESClient
 
 	testSearchAttributeKey string

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -71,8 +71,8 @@ type (
 	}
 )
 
-func NewIntegrationBase(params IntegrationBaseParams) IntegrationBase {
-	return IntegrationBase{
+func NewIntegrationBase(params IntegrationBaseParams) *IntegrationBase {
+	return &IntegrationBase{
 		defaultTestCluster:    params.DefaultTestCluster,
 		visibilityTestCluster: params.VisibilityTestCluster,
 		testClusterConfig:     params.TestClusterConfig,

--- a/host/pinot_test.go
+++ b/host/pinot_test.go
@@ -68,7 +68,7 @@ const (
 type PinotIntegrationSuite struct {
 	*require.Assertions
 	logger log.Logger
-	IntegrationBase
+	*IntegrationBase
 	pinotClient pnt.GenericClient
 
 	testSearchAttributeKey string

--- a/host/test_suites.go
+++ b/host/test_suites.go
@@ -36,21 +36,21 @@ type (
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions
-		IntegrationBase
+		*IntegrationBase
 	}
 
 	SizeLimitIntegrationSuite struct {
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions
-		IntegrationBase
+		*IntegrationBase
 	}
 
 	ClientIntegrationSuite struct {
 		// override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test,
 		// not merely log an error
 		*require.Assertions
-		IntegrationBase
+		*IntegrationBase
 		wfService workflowserviceclient.Interface
 		wfClient  client.Client
 		worker    worker.Worker

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -27,10 +27,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/uber/cadence/common/log/loggerimpl"
-
+	"github.com/startreedata/pinot-client-go/pinot"
 	"github.com/uber-go/tally"
-
 	adminClient "github.com/uber/cadence/client/admin"
 	"github.com/uber/cadence/common/archiver"
 	"github.com/uber/cadence/common/archiver/filestore"
@@ -42,6 +40,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/elasticsearch"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/messaging/kafka"
@@ -51,8 +50,6 @@ import (
 	"github.com/uber/cadence/common/persistence/nosql"
 	"github.com/uber/cadence/common/persistence/persistence-tests/testcluster"
 	"github.com/uber/cadence/testflags"
-
-	"github.com/startreedata/pinot-client-go/pinot"
 	// the import is a test dependency
 	_ "github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
 	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
@@ -65,7 +62,7 @@ import (
 type (
 	// TestCluster is a base struct for integration tests
 	TestCluster struct {
-		testBase     persistencetests.TestBase
+		testBase     *persistencetests.TestBase
 		archiverBase *ArchiverBase
 		host         Cadence
 	}
@@ -293,7 +290,7 @@ func NewPersistenceTestCluster(t *testing.T, clusterConfig *TestClusterConfig) t
 	return testCluster
 }
 
-func setupShards(testBase persistencetests.TestBase, numHistoryShards int, logger log.Logger) {
+func setupShards(testBase *persistencetests.TestBase, numHistoryShards int, logger log.Logger) {
 	// shard 0 is always created, we create additional shards if needed
 	for shardID := 1; shardID < numHistoryShards; shardID++ {
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTestPersistenceTimeout)


### PR DESCRIPTION
- Fix integration suite copying suite while passing it around

<!-- Describe what has changed in this PR -->
**What changed?**
Changed TestBase and IntegrationBase to be passed as a pointer to avoid copying suite.Suite internals. That can cause side effects like missing links to test initiated and internal mutex is copied together with the struct.


<!-- Tell your future self why have you made these changes -->
**Why?**
Lint warning, though I see a lot of logs in integration tests that likely are leaking due to this copying.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
run integration tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
