### PR TITLE
Unify cassandra setup in docker-compose

### DIFF
--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -3,10 +3,18 @@ version: "3.5"
 services:
   cassandra:
     image: cassandra:4.1.3
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
     networks:
       services-network:
         aliases:
           - cassandra
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
 
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
@@ -53,9 +61,12 @@ services:
       - BUILDKITE_BUILD_ID
       - BUILDKITE_BUILD_NUMBER
     depends_on:
-      - cassandra
-      - elasticsearch
-      - kafka
+      cassandra:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      kafka:
+        condition: service_started
     volumes:
       - ../../:/cadence
       - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -3,12 +3,20 @@ version: "3.5"
 services:
   cassandra:
     image: cassandra:4.1.3
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
     ports:
       - "9042:9042"
     networks:
       services-network:
         aliases:
           - cassandra
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
 
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
@@ -68,9 +76,12 @@ services:
       - "TEST_TAG=esintegration"
       - "ES_VERSION=v7"
     depends_on:
-      - cassandra
-      - elasticsearch
-      - kafka
+      cassandra:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      kafka:
+        condition: service_started
     volumes:
       - ../../:/cadence
     networks:

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -3,6 +3,9 @@ version: "3.5"
 services:
   cassandra:
     image: cassandra:4.1.3
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
     expose:
       - "9042"
     networks:

--- a/docker/buildkite/docker-compose-opensearch2.yml
+++ b/docker/buildkite/docker-compose-opensearch2.yml
@@ -3,10 +3,18 @@ version: "3.5"
 services:
   cassandra:
     image: cassandra:4.1.3
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
     networks:
       services-network:
         aliases:
           - cassandra
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
 
   zookeeper:
     image: wurstmeister/zookeeper:3.4.6
@@ -54,9 +62,12 @@ services:
       - BUILDKITE_BUILD_ID
       - BUILDKITE_BUILD_NUMBER
     depends_on:
-      - cassandra
-      - elasticsearch
-      - kafka
+      cassandra:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_started
+      kafka:
+        condition: service_started
     volumes:
       - ../../:/cadence
       - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -3,6 +3,9 @@ version: "3.5"
 services:
   cassandra:
     image: cassandra:4.1.3
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
     networks:
       services-network:
         aliases:

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -56,10 +64,14 @@ services:
       - "ES_VERSION=v7"
       - "KAFKA_SEEDS=kafka"
     depends_on:
-      - cassandra
-      - prometheus
-      - kafka
-      - elasticsearch
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
+      kafka:
+        condition: service_started
+      elasticsearch:
+        condition: service_started
   cadence-web:
     image: ubercadence/web:latest
     environment:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -55,10 +63,14 @@ services:
       - "ES_SEEDS=elasticsearch"
       - "KAFKA_SEEDS=kafka"
     depends_on:
-      - cassandra
-      - prometheus
-      - kafka
-      - elasticsearch
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
+      kafka:
+        condition: service_started
+      elasticsearch:
+        condition: service_started
   cadence-web:
     image: ubercadence/web:latest
     environment:

--- a/docker/docker-compose-http-api.yml
+++ b/docker/docker-compose-http-api.yml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -39,8 +47,10 @@ services:
       - "FRONTEND_HTTP_PORT=8800"
       - "FRONTEND_HTTP_PROCEDURES=uber.cadence.api.v1.WorkflowAPI::StartWorkflowExecution,uber.cadence.api.v1.WorkflowAPI::SignalWorkflowExecution,uber.cadence.api.v1.WorkflowAPI::QueryWorkflow,uber.cadence.api.v1.WorkflowAPI::DescribeWorkflowExecution,uber.cadence.api.v1.VisibilityAPI::ListWorkflowExecutions"
     depends_on:
-      - cassandra
-      - prometheus
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
   cadence-web:
     image: ubercadence/web:latest
     environment:

--- a/docker/docker-compose-multiclusters-cass-mysql-es.yaml
+++ b/docker/docker-compose-multiclusters-cass-mysql-es.yaml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   mysql:
     image: mysql:8.0
     ports:
@@ -71,10 +79,14 @@ services:
       - "VISIBILITY_NAME=cadence-visibility-primary"
       - "FRONTEND_SERVICE=cadence"
     depends_on:
-      - cassandra
-      - prometheus
-      - kafka
-      - elasticsearch
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
+      kafka:
+        condition: service_started
+      elasticsearch:
+        condition: service_started
   cadence-secondary:
     image: ubercadence/server:master-auto-setup
     ports:

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -65,10 +73,14 @@ services:
       - "VISIBILITY_NAME=cadence-visibility-primary"
       - "FRONTEND_SERVICE=cadence"
     depends_on:
-      - cassandra
-      - prometheus
-      - kafka
-      - elasticsearch
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
+      kafka:
+        condition: service_started
+      elasticsearch:
+        condition: service_started
   cadence-secondary:
     image: ubercadence/server:master-auto-setup
     ports:
@@ -103,10 +115,14 @@ services:
       - "VISIBILITY_NAME=cadence-visibility-secondary"
       - "FRONTEND_SERVICE=cadence-secondary"
     depends_on:
-      - cassandra
-      - prometheus
-      - kafka
-      - elasticsearch
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
+      kafka:
+        condition: service_started
+      elasticsearch:
+        condition: service_started
   cadence-web:
     image: ubercadence/web:latest
     environment:

--- a/docker/docker-compose-multiclusters.yml
+++ b/docker/docker-compose-multiclusters.yml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -39,8 +47,10 @@ services:
       - "STATSD_HISTORY_PREFIX=cadence-history-primary"
       - "STATSD_WORKER_PREFIX=cadence-worker-primary"
     depends_on:
-      - cassandra
-      - prometheus
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
   cadence-secondary:
     image: ubercadence/server:master-auto-setup
     ports:
@@ -69,8 +79,10 @@ services:
       - "STATSD_HISTORY_PREFIX=cadence-history-secondary"
       - "STATSD_WORKER_PREFIX=cadence-worker-secondary"
     depends_on:
-      - cassandra
-      - prometheus
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
   cadence-web:
     image: ubercadence/web:latest
     environment:

--- a/docker/docker-compose-statsd.yml
+++ b/docker/docker-compose-statsd.yml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   statsd:
     image: graphiteapp/graphite-statsd
     ports:
@@ -24,8 +32,10 @@ services:
       - "STATSD_ENDPOINT=statsd:8125"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
-      - cassandra
-      - statsd
+      cassandra:
+        condition: service_healthy
+      statsd:
+        condition: service_started
   cadence-web:
     image: ubercadence/web:latest
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,6 +4,14 @@ services:
     image: cassandra:4.1.3
     ports:
       - "9042:9042"
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
   prometheus:
     image: prom/prometheus:latest
     volumes:
@@ -36,8 +44,10 @@ services:
       - "PROMETHEUS_ENDPOINT_3=0.0.0.0:8003"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
     depends_on:
-      - cassandra
-      - prometheus
+      cassandra:
+        condition: service_healthy
+      prometheus:
+        condition: service_started
   cadence-web:
     image: ubercadence/web:latest
     environment:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I've set limits for java heap size to shrink cassandra memmory allocation.
Also, unified all cassandra images in docker-compose files with the same values for heap, healthchecks and depends_on


<!-- Tell your future self why have you made these changes -->
**Why?**
To have a sane and unified way to run minimal local/ci cassandra setup.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local docker-compose up and local docker/buildkite run


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
