### PR TITLE
Getting rid of gomock.Finish

### DIFF
--- a/common/archiver/filestore/historyArchiver_test.go
+++ b/common/archiver/filestore/historyArchiver_test.go
@@ -156,7 +156,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_InvalidRequest() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -179,7 +178,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -202,7 +200,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBatches := []*types.History{
 		{
@@ -242,7 +239,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_NonRetriableErrorOption() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -266,7 +262,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_NonRetriableErrorOption() {
 
 func (s *historyArchiverSuite) TestArchive_Skip() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBlob := &archiver.HistoryBlob{
 		Header: &archiver.HistoryBlobHeader{
@@ -307,7 +302,6 @@ func (s *historyArchiverSuite) TestArchive_Skip() {
 
 func (s *historyArchiverSuite) TestArchive_Success() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBatches := []*types.History{
 		{
@@ -514,7 +508,6 @@ func (s *historyArchiverSuite) TestGet_Success_SmallPageSize() {
 
 func (s *historyArchiverSuite) TestArchiveAndGet() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBlob := &archiver.HistoryBlob{
 		Header: &archiver.HistoryBlobHeader{

--- a/common/archiver/gcloud/historyArchiver_test.go
+++ b/common/archiver/gcloud/historyArchiver_test.go
@@ -134,7 +134,6 @@ func (h *historyArchiverSuite) TestArchive_Fail_InvalidURI() {
 	storageWrapper, _ := connector.NewClientWithParams(mockStorageClient)
 
 	mockCtrl := gomock.NewController(h.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
@@ -161,7 +160,6 @@ func (h *historyArchiverSuite) TestArchive_Fail_InvalidRequest() {
 	storageWrapper.On("Exist", ctx, URI, "").Return(true, nil).Times(1)
 	mockCtrl := gomock.NewController(h.T())
 
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 
 	historyArchiver := newHistoryArchiver(h.container, historyIterator, storageWrapper)
@@ -187,7 +185,6 @@ func (h *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 	storageWrapper.On("Exist", ctx, URI, "").Return(true, nil).Times(1)
 
 	mockCtrl := gomock.NewController(h.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -215,7 +212,6 @@ func (h *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 	storageWrapper := &mocks.Client{}
 	storageWrapper.On("Exist", mock.Anything, mock.Anything, "").Return(true, nil).Times(1)
 
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -244,7 +240,6 @@ func (h *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	storageWrapper := &mocks.Client{}
 	storageWrapper.On("Exist", ctx, URI, "").Return(true, nil).Times(1)
 
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBatches := []*types.History{
 		{
@@ -291,7 +286,6 @@ func (h *historyArchiverSuite) TestArchive_Fail_NonRetriableErrorOption() {
 	storageWrapper := &mocks.Client{}
 	storageWrapper.On("Exist", ctx, URI, "").Return(true, nil).Times(1)
 
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -321,7 +315,6 @@ func (h *historyArchiverSuite) TestArchive_Skip() {
 	storageWrapper.On("Exist", ctx, URI, mock.Anything).Return(true, nil)
 	storageWrapper.On("Upload", ctx, URI, mock.Anything, mock.Anything).Return(nil)
 
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBlob := &archiver.HistoryBlob{
 		Header: &archiver.HistoryBlobHeader{
@@ -369,7 +362,6 @@ func (h *historyArchiverSuite) TestArchive_Success() {
 	storageWrapper.On("Exist", ctx, URI, mock.Anything).Return(false, nil)
 	storageWrapper.On("Upload", ctx, URI, mock.Anything, mock.Anything).Return(nil)
 
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBatches := []*types.History{
 		{

--- a/common/archiver/gcloud/visibilityArchiver_test.go
+++ b/common/archiver/gcloud/visibilityArchiver_test.go
@@ -127,8 +127,6 @@ func (s *visibilityArchiverSuite) TestArchive_Fail_InvalidVisibilityURI() {
 	s.NoError(err)
 	storageWrapper := &mocks.Client{}
 	storageWrapper.On("Exist", mock.Anything, URI, "").Return(true, nil).Times(1)
-	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 
 	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
 	s.NoError(err)
@@ -149,8 +147,6 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidVisibilityURI() {
 	s.NoError(err)
 	storageWrapper := &mocks.Client{}
 	storageWrapper.On("Exist", mock.Anything, URI, "").Return(true, nil).Times(1)
-	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 
 	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
 	s.NoError(err)
@@ -171,8 +167,6 @@ func (s *visibilityArchiverSuite) TestVisibilityArchive() {
 	storageWrapper := &mocks.Client{}
 	storageWrapper.On("Exist", mock.Anything, URI, mock.Anything).Return(false, nil)
 	storageWrapper.On("Upload", mock.Anything, URI, mock.Anything, mock.Anything).Return(nil)
-	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 
 	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
 	s.NoError(err)
@@ -203,7 +197,6 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidQuery() {
 	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
 	s.NoError(err)
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 
 	mockParser := NewMockQueryParser(mockCtrl)
 	mockParser.EXPECT().Parse(gomock.Any()).Return(nil, errors.New("invalid query"))
@@ -225,7 +218,6 @@ func (s *visibilityArchiverSuite) TestQuery_Fail_InvalidToken() {
 	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
 	s.NoError(err)
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 
 	mockParser := NewMockQueryParser(mockCtrl)
 	mockParser.EXPECT().Parse(gomock.Any()).Return(&parsedQuery{
@@ -256,7 +248,6 @@ func (s *visibilityArchiverSuite) TestQuery_Success_NoNextPageToken() {
 	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
 	s.NoError(err)
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 
 	mockParser := NewMockQueryParser(mockCtrl)
 	dayPrecision := string("Day")
@@ -299,7 +290,6 @@ func (s *visibilityArchiverSuite) TestQuery_Success_SmallPageSize() {
 	visibilityArchiver := newVisibilityArchiver(s.container, storageWrapper)
 	s.NoError(err)
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 
 	mockParser := NewMockQueryParser(mockCtrl)
 	dayPrecision := string("Day")

--- a/common/archiver/s3store/historyArchiver_test.go
+++ b/common/archiver/s3store/historyArchiver_test.go
@@ -281,7 +281,7 @@ func (s *historyArchiverSuite) TestArchive_Fail_InvalidRequest() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
+
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -304,7 +304,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_ErrorOnReadHistory() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -327,7 +326,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_TimeoutWhenReadingHistory() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBatches := []*types.History{
 		{
@@ -367,7 +365,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_HistoryMutated() {
 
 func (s *historyArchiverSuite) TestArchive_Fail_NonRetriableErrorOption() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),
@@ -391,7 +388,6 @@ func (s *historyArchiverSuite) TestArchive_Fail_NonRetriableErrorOption() {
 
 func (s *historyArchiverSuite) TestArchive_Skip() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBlob := &archiver.HistoryBlob{
 		Header: &archiver.HistoryBlobHeader{
@@ -437,7 +433,6 @@ func (s *historyArchiverSuite) TestArchive_Skip() {
 
 func (s *historyArchiverSuite) TestArchive_Success() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	historyBatches := []*types.History{
 		{
@@ -626,7 +621,6 @@ func (s *historyArchiverSuite) TestGet_Success_SmallPageSize() {
 
 func (s *historyArchiverSuite) TestArchiveAndGet() {
 	mockCtrl := gomock.NewController(s.T())
-	defer mockCtrl.Finish()
 	historyIterator := archiver.NewMockHistoryIterator(mockCtrl)
 	gomock.InOrder(
 		historyIterator.EXPECT().HasNext().Return(true),

--- a/common/reconciliation/invariant/concreteExecutionExists_test.go
+++ b/common/reconciliation/invariant/concreteExecutionExists_test.go
@@ -155,7 +155,6 @@ func (s *ConcreteExecutionExistsSuite) TestCheck() {
 	}
 	ctrl := gomock.NewController(s.T())
 	mockDomainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		execManager := &mocks.ExecutionManager{}
 		execManager.On("IsWorkflowExecutionExists", mock.Anything, mock.Anything).Return(tc.getConcreteResp, tc.getConcreteErr)

--- a/common/reconciliation/invariant/historyExists_test.go
+++ b/common/reconciliation/invariant/historyExists_test.go
@@ -133,7 +133,6 @@ func (s *HistoryExistsSuite) TestCheck() {
 
 	ctrl := gomock.NewController(s.T())
 	domainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		execManager := &mocks.ExecutionManager{}
 		historyManager := &mocks.HistoryV2Manager{}

--- a/common/reconciliation/invariant/inactiveDomainExists_test.go
+++ b/common/reconciliation/invariant/inactiveDomainExists_test.go
@@ -73,7 +73,6 @@ func (s *InactiveInactiveDomainExistsSuite) TestCheck() {
 
 	ctrl := gomock.NewController(s.T())
 	domainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		execManager := &mocks.ExecutionManager{}
 		execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getExecResp, tc.getExecErr)

--- a/common/reconciliation/invariant/openCurrentExecution_test.go
+++ b/common/reconciliation/invariant/openCurrentExecution_test.go
@@ -173,7 +173,6 @@ func (s *OpenCurrentExecutionSuite) TestCheck() {
 	}
 	ctrl := gomock.NewController(s.T())
 	domainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		execManager := &mocks.ExecutionManager{}
 		execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getConcreteResp, tc.getConcreteErr)

--- a/common/reconciliation/invariant/timerInvalid_test.go
+++ b/common/reconciliation/invariant/timerInvalid_test.go
@@ -140,7 +140,6 @@ func (ts *TimerInvalidTest) TestCheck() {
 	}
 	ctrl := gomock.NewController(ts.T())
 	mockDomainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
 		ts.Run(tc.name, func() {
@@ -268,7 +267,6 @@ func (ts *TimerInvalidTest) TestFix() {
 	}
 	ctrl := gomock.NewController(ts.T())
 	mockDomainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("test-domain-name", nil).AnyTimes()
 		ts.Run(tc.name, func() {

--- a/common/reconciliation/invariant/util_test.go
+++ b/common/reconciliation/invariant/util_test.go
@@ -83,7 +83,6 @@ func (s *UtilSuite) TestDeleteExecution() {
 	}
 	ctrl := gomock.NewController(s.T())
 	mockDomainCache := cache.NewMockDomainCache(ctrl)
-	ctrl.Finish()
 	for _, tc := range testCases {
 		execManager := &mocks.ExecutionManager{}
 		execManager.On("DeleteWorkflowExecution", mock.Anything, mock.Anything, mock.Anything).Return(tc.deleteConcreteErr).Once()
@@ -143,7 +142,6 @@ func (s *UtilSuite) TestExecutionStillOpen() {
 	}
 	ctrl := gomock.NewController(s.T())
 	mockDomainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		execManager := &mocks.ExecutionManager{}
 		execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getExecResp, tc.getExecErr)
@@ -191,7 +189,6 @@ func (s *UtilSuite) TestExecutionStillExists() {
 	}
 	ctrl := gomock.NewController(s.T())
 	mockDomainCache := cache.NewMockDomainCache(ctrl)
-	defer ctrl.Finish()
 	for _, tc := range testCases {
 		execManager := &mocks.ExecutionManager{}
 		execManager.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(tc.getExecResp, tc.getExecErr)

--- a/service/frontend/adminThriftHandler_test.go
+++ b/service/frontend/adminThriftHandler_test.go
@@ -36,7 +36,6 @@ import (
 
 func TestAdminThriftHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	h := NewMockAdminHandler(ctrl)
 	th := NewAdminThriftHandler(h)

--- a/service/frontend/thriftHandler_test.go
+++ b/service/frontend/thriftHandler_test.go
@@ -37,7 +37,6 @@ import (
 
 func TestThriftHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	h := NewMockHandler(ctrl)
 	th := NewThriftHandler(h)

--- a/service/history/thriftHandler_test.go
+++ b/service/history/thriftHandler_test.go
@@ -37,7 +37,6 @@ import (
 
 func TestThriftHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	h := NewMockHandler(ctrl)
 	th := NewThriftHandler(h)

--- a/service/history/workflow/util_test.go
+++ b/service/history/workflow/util_test.go
@@ -92,8 +92,6 @@ func TestUpdateHelper(t *testing.T) {
 			tc.mockSetupFn(mockContext, mockMutableState)
 			err := updateHelper(context.Background(), workflowContext, time.Now(), tc.actionFn)
 			require.NoError(t, err)
-
-			controller.Finish()
 		})
 	}
 
@@ -179,8 +177,6 @@ func TestWorkflowLoad(t *testing.T) {
 			require.Equal(t, constants.TestWorkflowID, workflowContext.GetWorkflowID())
 			require.Equal(t, constants.TestRunID, workflowContext.GetRunID())
 			workflowContext.GetReleaseFn()(nil)
-
-			controller.Finish()
 		})
 	}
 }

--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -44,7 +44,6 @@ import (
 
 func TestDeliverBufferTasks(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	tests := []func(tlm *taskListManagerImpl){
 		func(tlm *taskListManagerImpl) { tlm.taskReader.cancelFunc() },
@@ -73,7 +72,6 @@ func TestDeliverBufferTasks(t *testing.T) {
 
 func TestDeliverBufferTasks_NoPollers(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	tlm := createTestTaskListManager(controller)
 	tlm.taskReader.taskBuffers[defaultTaskBufferIsolationGroup] <- &persistence.TaskInfo{}
@@ -90,7 +88,6 @@ func TestDeliverBufferTasks_NoPollers(t *testing.T) {
 
 func TestReadLevelForAllExpiredTasksInBatch(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	tlm := createTestTaskListManager(controller)
 	tlm.db.rangeID = int64(1)
@@ -165,7 +162,6 @@ func createTestTaskListManagerWithConfig(controller *gomock.Controller, cfg *Con
 
 func TestDescribeTaskList(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	startTaskID := int64(1)
 	taskCount := int64(3)
@@ -233,7 +229,6 @@ func tlMgrStartWithoutNotifyEvent(tlm *taskListManagerImpl) {
 
 func TestCheckIdleTaskList(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	cfg := NewConfig(dynamicconfig.NewNopCollection(), "some random hostname")
 	cfg.IdleTasklistCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
@@ -289,7 +284,6 @@ func TestCheckIdleTaskList(t *testing.T) {
 
 func TestAddTaskStandby(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	cfg := NewConfig(dynamicconfig.NewNopCollection(), "some random hostname")
 	cfg.IdleTasklistCheckInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(10 * time.Millisecond)
@@ -346,7 +340,6 @@ func TestAddTaskStandby(t *testing.T) {
 
 func TestGetPollerIsolationGroup(t *testing.T) {
 	controller := gomock.NewController(t)
-	defer controller.Finish()
 
 	config := defaultTestConfig()
 	config.LongPollExpirationInterval = dynamicconfig.GetDurationPropertyFnFilteredByTaskListInfo(30 * time.Second)

--- a/service/matching/thriftHandler_test.go
+++ b/service/matching/thriftHandler_test.go
@@ -36,7 +36,6 @@ import (
 
 func TestThriftHandler(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
 
 	h := NewMockHandler(ctrl)
 	th := NewThriftHandler(h)

--- a/service/worker/failovermanager/rebalance_workflow_test.go
+++ b/service/worker/failovermanager/rebalance_workflow_test.go
@@ -66,9 +66,7 @@ func (s *rebalanceWorkflowTestSuite) TearDownTest() {
 }
 
 func (s *rebalanceWorkflowTestSuite) TestGetDomainsForRebalanceActivity_ReturnOne() {
-	actEnv, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	actEnv, mockResource := s.prepareTestActivityEnv()
 
 	domains := &types.ListDomainsResponse{
 		Domains: []*types.DescribeDomainResponse{
@@ -153,9 +151,7 @@ func (s *rebalanceWorkflowTestSuite) TestGetDomainsForRebalanceActivity_ReturnOn
 }
 
 func (s *rebalanceWorkflowTestSuite) TestGetDomainsForRebalanceActivity_Error() {
-	actEnv, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	actEnv, mockResource := s.prepareTestActivityEnv()
 
 	mockResource.FrontendClient.EXPECT().ListDomains(gomock.Any(), gomock.Any()).
 		Return(nil, fmt.Errorf("test"))
@@ -291,7 +287,7 @@ func (s *rebalanceWorkflowTestSuite) TestWorkflow_GetRebalanceDomainsActivityErr
 	s.Error(err)
 }
 
-func (s *rebalanceWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestActivityEnvironment, *resource.Test, *gomock.Controller) {
+func (s *rebalanceWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestActivityEnvironment, *resource.Test) {
 	controller := gomock.NewController(s.T())
 	mockResource := resource.NewTest(controller, metrics.Worker)
 
@@ -303,5 +299,10 @@ func (s *rebalanceWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestAc
 	s.activityEnv.SetWorkerOptions(worker.Options{
 		BackgroundActivityContext: context.WithValue(context.Background(), failoverManagerContextKey, ctx),
 	})
-	return s.activityEnv, mockResource, controller
+
+	s.T().Cleanup(func() {
+		mockResource.Finish(s.T())
+	})
+
+	return s.activityEnv, mockResource
 }

--- a/service/worker/failovermanager/workflow_test.go
+++ b/service/worker/failovermanager/workflow_test.go
@@ -327,9 +327,7 @@ func (s *failoverWorkflowTestSuite) TestShouldFailover() {
 }
 
 func (s *failoverWorkflowTestSuite) TestGetDomainsActivity() {
-	env, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := &types.ListDomainsResponse{
 		Domains: []*types.DescribeDomainResponse{
@@ -360,9 +358,7 @@ func (s *failoverWorkflowTestSuite) TestGetDomainsActivity() {
 }
 
 func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_WithTargetDomains() {
-	env, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := &types.ListDomainsResponse{
 		Domains: []*types.DescribeDomainResponse{
@@ -415,9 +411,7 @@ func (s *failoverWorkflowTestSuite) TestGetDomainsActivity_WithTargetDomains() {
 }
 
 func (s *failoverWorkflowTestSuite) TestFailoverActivity_ForceFailover_Success() {
-	env, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := []string{"d1", "d2"}
 	describeTaskListResp := &types.DescribeTaskListResponse{Pollers: []*types.PollerInfo{
@@ -452,9 +446,7 @@ func (s *failoverWorkflowTestSuite) TestFailoverActivity_ForceFailover_Success()
 }
 
 func (s *failoverWorkflowTestSuite) TestFailoverActivity_GracefulFailover_Success() {
-	env, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := []string{"d1", "d2"}
 	describeTaskListResp := &types.DescribeTaskListResponse{Pollers: []*types.PollerInfo{
@@ -500,9 +492,7 @@ func (s *failoverWorkflowTestSuite) TestFailoverActivity_GracefulFailover_Succes
 }
 
 func (s *failoverWorkflowTestSuite) TestFailoverActivity_Error() {
-	env, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := []string{"d1", "d2"}
 	targetCluster := "c2"
@@ -548,9 +538,7 @@ func (s *failoverWorkflowTestSuite) TestFailoverActivity_Error() {
 }
 
 func (s *failoverWorkflowTestSuite) TestFailoverActivity_NoPoller_Error() {
-	env, mockResource, controller := s.prepareTestActivityEnv()
-	defer controller.Finish()
-	defer mockResource.Finish(s.T())
+	env, mockResource := s.prepareTestActivityEnv()
 
 	domains := []string{"d1", "d2"}
 	targetCluster := "c2"
@@ -623,7 +611,7 @@ func (s *failoverWorkflowTestSuite) assertQueryState(env *testsuite.TestWorkflow
 	s.Equal(expectedState, res.State)
 }
 
-func (s *failoverWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestActivityEnvironment, *resource.Test, *gomock.Controller) {
+func (s *failoverWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestActivityEnvironment, *resource.Test) {
 	controller := gomock.NewController(s.T())
 	mockResource := resource.NewTest(controller, metrics.Worker)
 
@@ -635,5 +623,10 @@ func (s *failoverWorkflowTestSuite) prepareTestActivityEnv() (*testsuite.TestAct
 	s.activityEnv.SetWorkerOptions(worker.Options{
 		BackgroundActivityContext: context.WithValue(context.Background(), failoverManagerContextKey, ctx),
 	})
-	return s.activityEnv, mockResource, controller
+
+	s.T().Cleanup(func() {
+		mockResource.Finish(s.T())
+	})
+
+	return s.activityEnv, mockResource
 }

--- a/service/worker/scanner/data_corruption_workflow_test.go
+++ b/service/worker/scanner/data_corruption_workflow_test.go
@@ -94,7 +94,6 @@ func (s *dataCorruptionWorkflowTestSuite) TestWorkflow_TimerFire_Success() {
 func (s *dataCorruptionWorkflowTestSuite) TestExecutionFixerActivity_Success() {
 	env := s.NewTestActivityEnvironment()
 	controller := gomock.NewController(s.T())
-	defer controller.Finish()
 	mockResource := resource.NewTest(controller, metrics.Worker)
 	defer mockResource.Finish(s.T())
 	fixList := []entity.Execution{

--- a/service/worker/scanner/history/scavenger_test.go
+++ b/service/worker/scanner/history/scavenger_test.go
@@ -68,19 +68,18 @@ func (s *ScavengerTestSuite) SetupTest() {
 	s.mockCache = cache.NewMockDomainCache(controller)
 }
 
-func (s *ScavengerTestSuite) createTestScavenger(rps int) (*mocks.HistoryV2Manager, *history.MockClient, *Scavenger, *gomock.Controller) {
+func (s *ScavengerTestSuite) createTestScavenger(rps int) (*mocks.HistoryV2Manager, *history.MockClient, *Scavenger) {
 	db := &mocks.HistoryV2Manager{}
 	controller := gomock.NewController(s.T())
 	workflowClient := history.NewMockClient(controller)
 	maxWorkflowRetentionInDays := dynamicconfig.GetIntPropertyFn(dynamicconfig.MaxRetentionDays.DefaultInt())
 	scvgr := NewScavenger(db, rps, workflowClient, ScavengerHeartbeatDetails{}, s.metric, s.logger, maxWorkflowRetentionInDays, s.mockCache)
 	scvgr.isInTest = true
-	return db, workflowClient, scvgr, controller
+	return db, workflowClient, scvgr
 }
 
 func (s *ScavengerTestSuite) TestAllSkipTasksTwoPages() {
-	db, _, scvgr, controller := s.createTestScavenger(100)
-	defer controller.Finish()
+	db, _, scvgr := s.createTestScavenger(100)
 	db.On("GetAllHistoryTreeBranches", mock.Anything, &p.GetAllHistoryTreeBranchesRequest{
 		PageSize: pageSize,
 	}).Return(&p.GetAllHistoryTreeBranchesResponse{
@@ -131,8 +130,7 @@ func (s *ScavengerTestSuite) TestAllSkipTasksTwoPages() {
 }
 
 func (s *ScavengerTestSuite) TestAllErrorSplittingTasksTwoPages() {
-	db, _, scvgr, controller := s.createTestScavenger(100)
-	defer controller.Finish()
+	db, _, scvgr := s.createTestScavenger(100)
 	db.On("GetAllHistoryTreeBranches", mock.Anything, &p.GetAllHistoryTreeBranchesRequest{
 		PageSize: pageSize,
 	}).Return(&p.GetAllHistoryTreeBranchesResponse{
@@ -183,8 +181,7 @@ func (s *ScavengerTestSuite) TestAllErrorSplittingTasksTwoPages() {
 }
 
 func (s *ScavengerTestSuite) TestNoGarbageTwoPages() {
-	db, client, scvgr, controller := s.createTestScavenger(100)
-	defer controller.Finish()
+	db, client, scvgr := s.createTestScavenger(100)
 	db.On("GetAllHistoryTreeBranches", mock.Anything, &p.GetAllHistoryTreeBranchesRequest{
 		PageSize: pageSize,
 	}).Return(&p.GetAllHistoryTreeBranchesResponse{
@@ -264,8 +261,7 @@ func (s *ScavengerTestSuite) TestNoGarbageTwoPages() {
 }
 
 func (s *ScavengerTestSuite) TestDeletingBranchesTwoPages() {
-	db, client, scvgr, controller := s.createTestScavenger(100)
-	defer controller.Finish()
+	db, client, scvgr := s.createTestScavenger(100)
 	db.On("GetAllHistoryTreeBranches", mock.Anything, &p.GetAllHistoryTreeBranchesRequest{
 		PageSize: pageSize,
 	}).Return(&p.GetAllHistoryTreeBranchesResponse{
@@ -374,8 +370,7 @@ func (s *ScavengerTestSuite) TestDeletingBranchesTwoPages() {
 }
 
 func (s *ScavengerTestSuite) TestMixesTwoPages() {
-	db, client, scvgr, controller := s.createTestScavenger(100)
-	defer controller.Finish()
+	db, client, scvgr := s.createTestScavenger(100)
 	db.On("GetAllHistoryTreeBranches", mock.Anything, &p.GetAllHistoryTreeBranchesRequest{
 		PageSize: pageSize,
 	}).Return(&p.GetAllHistoryTreeBranchesResponse{

--- a/service/worker/scanner/workflow_test.go
+++ b/service/worker/scanner/workflow_test.go
@@ -58,7 +58,6 @@ func (s *scannerWorkflowTestSuite) TestWorkflow() {
 func (s *scannerWorkflowTestSuite) TestScavengerActivity() {
 	env := s.NewTestActivityEnvironment()
 	controller := gomock.NewController(s.T())
-	defer controller.Finish()
 	mockResource := resource.NewTest(controller, metrics.Worker)
 	defer mockResource.Finish(s.T())
 

--- a/tools/cli/adminClusterCommands_test.go
+++ b/tools/cli/adminClusterCommands_test.go
@@ -70,7 +70,6 @@ func TestAdminAddSearchAttribute_isValueTypeValid(t *testing.T) {
 
 func TestAdminFailover(t *testing.T) {
 	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 	serverFrontendClient := frontend.NewMockClient(mockCtrl)
 	domainCLI := &domainCLIImpl{
 		frontendClient: serverFrontendClient,


### PR DESCRIPTION
Since go 1.14 it is not required - gomock registers its finilazer with
t.Cleanup().
At the same time, some of our tests don't call .Finish and some do.
Aligning the experience.

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
Unifying testing experience.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
make test - unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
Only if someone has go <1.14 (unmaintained since Feb 2021)

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
