### PR TITLE
fix scavenger test suite

### DIFF
--- a/service/worker/scanner/tasklist/scavenger_test.go
+++ b/service/worker/scanner/tasklist/scavenger_test.go
@@ -193,8 +193,16 @@ func (s *ScavengerTestSuite) TestAllExpiredTasksWithErrors() {
 func (s *ScavengerTestSuite) runScavenger() {
 	s.scvgr.Start()
 	timer := time.NewTimer(scavengerTestTimeout)
+
+	waiter := make(chan struct{})
+
+	go func() {
+		s.scvgr.stopWG.Wait()
+		close(waiter)
+	}()
+
 	select {
-	case <-s.scvgr.stopC:
+	case <-waiter:
 		timer.Stop()
 		return
 	case <-timer.C:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed ScavengerTestSuite not waiting for the stop of the running scavenger.

<!-- Tell your future self why have you made these changes -->
**Why?**
The tests were leaking goroutine and logging outside of tests that can lead to panic: Log in goroutine after '' has completed

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests with count=100

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
