### PR TITLE
fix scavenger suite

### DIFF
--- a/service/worker/scanner/tasklist/scavenger_test.go
+++ b/service/worker/scanner/tasklist/scavenger_test.go
@@ -193,16 +193,8 @@ func (s *ScavengerTestSuite) TestAllExpiredTasksWithErrors() {
 func (s *ScavengerTestSuite) runScavenger() {
 	s.scvgr.Start()
 	timer := time.NewTimer(scavengerTestTimeout)
-
-	waiter := make(chan struct{})
-
-	go func() {
-		s.scvgr.stopWG.Wait()
-		close(waiter)
-	}()
-
 	select {
-	case <-waiter:
+	case <-s.scvgr.stopped:
 		timer.Stop()
 		return
 	case <-timer.C:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix for scavenger task list test suite that ensures we wait for the ful stop before proceeding to the next test.

<!-- Tell your future self why have you made these changes -->
**Why?**
Recent changes to logging caused panics if we log after the test is finished.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
go test --count=100

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
