### PR TITLE
fix leaky goroutines in matching

### DIFF
--- a/service/matching/taskListManager_test.go
+++ b/service/matching/taskListManager_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/dynamicconfig"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fixed matching taskReader stop not waiting for stopping underlying dispatchers.

<!-- Tell your future self why have you made these changes -->
**Why?**
With recent logging changes this leaks produces:
```
Log in goroutine after TestIntegrationSuite has completed: 2023-12-19T00:11:34.305Z
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
