### PR TITLE
Ensure scanner scavenger stops in tests

### DIFF
--- a/service/worker/scanner/tasklist/scavenger_test.go
+++ b/service/worker/scanner/tasklist/scavenger_test.go
@@ -192,6 +192,7 @@ func (s *ScavengerTestSuite) TestAllExpiredTasksWithErrors() {
 
 func (s *ScavengerTestSuite) runScavenger() {
 	s.scvgr.Start()
+	defer s.scvgr.Stop()
 	timer := time.NewTimer(scavengerTestTimeout)
 	select {
 	case <-s.scvgr.stopped:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Ensure that scvngr is stopped if the test scenario times out.

<!-- Tell your future self why have you made these changes -->
**Why?**
If the test scenario will somehow take more than 10 seconds the test will fail, but can leak goroutine. So I ensure that the suite does the cleanup.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
