### PR TITLE
Revert gofuzz usage

### DIFF
--- a/common/persistence/serialization/parser_test.go
+++ b/common/persistence/serialization/parser_test.go
@@ -103,7 +103,6 @@ func TestParserRoundTrip(t *testing.T) {
 			CompletionEventBatchID:             common.Int64Ptr(1),
 			CompletionEvent:                    []byte{1, 2, 3},
 			CompletionEventEncoding:            "",
-			IsCron:                             true,
 			TaskList:                           "test_task_list",
 			WorkflowTypeName:                   "test_workflow_type_name",
 			WorkflowTimeout:                    48 * time.Hour,

--- a/common/persistence/serialization/parser_test.go
+++ b/common/persistence/serialization/parser_test.go
@@ -25,13 +25,12 @@ package serialization
 import (
 	"fmt"
 	"reflect"
-	"regexp"
 	"testing"
 	"time"
 
-	fuzz "github.com/google/gofuzz"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/uber/cadence/common/types"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/persistence"
@@ -40,34 +39,228 @@ import (
 func TestParserRoundTrip(t *testing.T) {
 	thriftParser, err := NewParser(common.EncodingTypeThriftRW, common.EncodingTypeThriftRW)
 	assert.NoError(t, err)
-	f := fuzz.New().Funcs(func(e *time.Time, c fuzz.Continue) {
-		*e = time.Unix(c.Int63n(1000000), 0)
-	}, func(e *time.Duration, c fuzz.Continue) {
-		*e = time.Duration(common.DurationToDays(time.Duration(c.Int63n(1000000))))
-	}, func(e *UUID, c fuzz.Continue) {
-		*e = MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-	}).NilChance(0).NumElements(0, 10).
-		// IsCron is dynamic fields that is connected to CronSchedule, so we need to skip it and test separately.
-		SkipFieldsWithPattern(regexp.MustCompile("IsCron|CronSchedule"))
+	now := time.Now().Round(time.Second)
 
 	for _, testCase := range []any{
-		&ShardInfo{},
-		&DomainInfo{},
-		&HistoryTreeInfo{},
-		&WorkflowExecutionInfo{},
-		&ActivityInfo{},
-		&ChildExecutionInfo{},
-		&SignalInfo{},
-		&RequestCancelInfo{},
-		&TimerInfo{},
-		&TaskInfo{},
-		&TaskListInfo{},
-		&TransferTaskInfo{},
-		&TimerTaskInfo{},
-		&ReplicationTaskInfo{},
+		&ShardInfo{
+			StolenSinceRenew:                      1,
+			UpdatedAt:                             now,
+			ReplicationAckLevel:                   1,
+			TransferAckLevel:                      1,
+			TimerAckLevel:                         now,
+			DomainNotificationVersion:             1,
+			ClusterTransferAckLevel:               map[string]int64{"test": 1},
+			ClusterTimerAckLevel:                  map[string]time.Time{"test": now},
+			TransferProcessingQueueStates:         []byte{1, 2, 3},
+			TimerProcessingQueueStates:            []byte{1, 2, 3},
+			Owner:                                 "owner",
+			ClusterReplicationLevel:               map[string]int64{"test": 1},
+			PendingFailoverMarkers:                []byte{2, 3, 4},
+			PendingFailoverMarkersEncoding:        "",
+			TransferProcessingQueueStatesEncoding: "",
+			TimerProcessingQueueStatesEncoding:    "",
+		},
+		&DomainInfo{
+			Name:                        "test",
+			Description:                 "test_desc",
+			Owner:                       "test_owner",
+			Status:                      1,
+			Retention:                   48 * time.Hour,
+			EmitMetric:                  true,
+			ArchivalBucket:              "test_bucket",
+			ArchivalStatus:              1,
+			ConfigVersion:               1,
+			FailoverVersion:             1,
+			NotificationVersion:         1,
+			FailoverNotificationVersion: 1,
+			ActiveClusterName:           "test_active_cluster",
+			Clusters:                    []string{"test_active_cluster", "test_standby_cluster"},
+			Data:                        map[string]string{"test_key": "test_value"},
+			BadBinaries:                 []byte{1, 2, 3},
+			BadBinariesEncoding:         "",
+			HistoryArchivalStatus:       1,
+			HistoryArchivalURI:          "test_history_archival_uri",
+			VisibilityArchivalStatus:    1,
+			VisibilityArchivalURI:       "test_visibility_archival_uri",
+		},
+		&HistoryTreeInfo{
+			CreatedTimestamp: now,
+			Ancestors: []*types.HistoryBranchRange{
+				{
+					BranchID: "test_branch_id1",
+				},
+				{
+					BranchID: "test_branch_id2",
+				},
+			},
+			Info: "test_info",
+		},
+		&WorkflowExecutionInfo{
+			ParentDomainID:                     MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			ParentWorkflowID:                   "test_parent_workflow_id",
+			ParentRunID:                        MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			InitiatedID:                        1,
+			CompletionEventBatchID:             common.Int64Ptr(1),
+			CompletionEvent:                    []byte{1, 2, 3},
+			CompletionEventEncoding:            "",
+			IsCron:                             true,
+			TaskList:                           "test_task_list",
+			WorkflowTypeName:                   "test_workflow_type_name",
+			WorkflowTimeout:                    48 * time.Hour,
+			ExecutionContext:                   []byte{1, 2, 3},
+			State:                              2,
+			CloseStatus:                        1,
+			StartVersion:                       1,
+			LastWriteEventID:                   common.Int64Ptr(2),
+			LastEventTaskID:                    3,
+			LastFirstEventID:                   5,
+			LastProcessedEvent:                 4,
+			StartTimestamp:                     now,
+			LastUpdatedTimestamp:               now,
+			DecisionVersion:                    1,
+			DecisionScheduleID:                 1,
+			DecisionStartedID:                  1,
+			DecisionRequestID:                  "test_decision_request_id",
+			DecisionTimeout:                    48 * time.Hour,
+			DecisionAttempt:                    1,
+			DecisionStartedTimestamp:           now,
+			DecisionScheduledTimestamp:         now,
+			DecisionOriginalScheduledTimestamp: now,
+			CancelRequested:                    true,
+			CancelRequestID:                    "test_cancel_request_id",
+			StickyTaskList:                     "test_sticky_task_list",
+			StickyScheduleToStartTimeout:       48 * time.Hour,
+			ClientLibraryVersion:               "test_client_library_version",
+			ClientFeatureVersion:               "test_client_feature_version",
+			ClientImpl:                         "test_client_impl",
+			SignalCount:                        1,
+			HistorySize:                        100,
+			AutoResetPoints:                    []byte{1, 2, 3},
+			AutoResetPointsEncoding:            "",
+			Memo:                               map[string][]byte{"test_memo_key": {1, 2, 3}},
+			SearchAttributes:                   map[string][]byte{"test_search_attr_key": {1, 2, 3}},
+		},
+		&ActivityInfo{
+			Version:                  1,
+			ScheduledEventBatchID:    2,
+			ScheduledEvent:           []byte{1, 2, 3},
+			ScheduledEventEncoding:   "scheduled_event_encoding",
+			ScheduledTimestamp:       now,
+			StartedID:                1,
+			StartedEvent:             []byte{1, 2, 3},
+			StartedEventEncoding:     "started_event_encoding",
+			StartedTimestamp:         now,
+			ActivityID:               "test_activity_id",
+			RequestID:                "test_request_id",
+			ScheduleToStartTimeout:   48 * time.Hour,
+			ScheduleToCloseTimeout:   48 * time.Hour,
+			StartToCloseTimeout:      48 * time.Hour,
+			HeartbeatTimeout:         48 * time.Hour,
+			CancelRequested:          true,
+			CancelRequestID:          3,
+			TimerTaskStatus:          1,
+			Attempt:                  1,
+			TaskList:                 "test_task_list",
+			StartedIdentity:          "test_started_identity",
+			HasRetryPolicy:           true,
+			RetryInitialInterval:     time.Hour,
+			RetryBackoffCoefficient:  1.1,
+			RetryMaximumInterval:     time.Hour,
+			RetryMaximumAttempts:     1,
+			RetryExpirationTimestamp: now.Add(time.Hour),
+			RetryNonRetryableErrors:  []string{"test_retry_non_retryable_error"},
+			RetryLastWorkerIdentity:  "test_retry_last_worker_identity",
+		},
+		&ChildExecutionInfo{
+			Version:                1,
+			InitiatedEventBatchID:  2,
+			StartedID:              3,
+			InitiatedEvent:         []byte{1, 2, 3},
+			InitiatedEventEncoding: "initiated_event_encoding",
+			StartedWorkflowID:      "test_started_workflow_id",
+			StartedRunID:           MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			StartedEvent:           []byte{1, 2, 3},
+			StartedEventEncoding:   "started_event_encoding",
+			CreateRequestID:        "test_create_request_id",
+			DomainID:               "test_domain_id",
+			WorkflowTypeName:       "test_workflow_type_name",
+			ParentClosePolicy:      1,
+		},
+		&SignalInfo{
+			Version:               1,
+			InitiatedEventBatchID: 2,
+			RequestID:             "test_request_id",
+			Name:                  "test_name",
+			Input:                 []byte{1, 2, 3},
+			Control:               []byte{1, 2, 3},
+		},
+		&RequestCancelInfo{
+			Version:               1,
+			InitiatedEventBatchID: 2,
+			CancelRequestID:       "test_cancel_request_id",
+		},
+		&TimerInfo{
+			Version:         1,
+			StartedID:       2,
+			ExpiryTimestamp: zeroUnix,
+			TaskID:          3,
+		},
+		&TaskInfo{
+			WorkflowID:       "test_workflow_id",
+			RunID:            MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			ScheduleID:       1,
+			ExpiryTimestamp:  now,
+			CreatedTimestamp: now,
+			PartitionConfig:  map[string]string{"test_partition_key": "test_partition_value"},
+		},
+		&TaskListInfo{
+			Kind:            1,
+			AckLevel:        2,
+			ExpiryTimestamp: now,
+			LastUpdated:     now,
+		},
+		&TransferTaskInfo{
+			DomainID:                MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			WorkflowID:              "test_workflow_id",
+			RunID:                   MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			TaskType:                1,
+			TargetDomainID:          MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			TargetDomainIDs:         []UUID{MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"), MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430a8")},
+			TargetWorkflowID:        "test_target_workflow_id",
+			TargetRunID:             MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			TaskList:                "test_task_list",
+			TargetChildWorkflowOnly: true,
+			ScheduleID:              1,
+			Version:                 2,
+			VisibilityTimestamp:     now,
+		},
+		&TimerTaskInfo{
+			DomainID:        MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			WorkflowID:      "test_workflow_id",
+			RunID:           MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			TaskType:        1,
+			TimeoutType:     common.Int16Ptr(1),
+			Version:         2,
+			ScheduleAttempt: 3,
+			EventID:         4,
+		},
+		&ReplicationTaskInfo{
+			DomainID:                MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			WorkflowID:              "test_workflow_id",
+			RunID:                   MustParseUUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8"),
+			TaskType:                1,
+			Version:                 2,
+			FirstEventID:            3,
+			NextEventID:             4,
+			ScheduledID:             5,
+			EventStoreVersion:       6,
+			NewRunEventStoreVersion: 7,
+			BranchToken:             []byte{1, 2, 3},
+			NewRunBranchToken:       []byte{1, 2, 3},
+			CreationTimestamp:       now,
+		},
 	} {
 		t.Run(reflect.TypeOf(testCase).String(), func(t *testing.T) {
-			f.Fuzz(testCase)
 			blob := parse(t, thriftParser, testCase)
 			result := unparse(t, thriftParser, blob, testCase)
 			assert.Equal(t, testCase, result)

--- a/go.mod
+++ b/go.mod
@@ -65,10 +65,7 @@ require (
 	gopkg.in/yaml.v2 v2.3.0
 )
 
-require (
-	github.com/google/go-cmp v0.5.8
-	github.com/google/gofuzz v1.2.0
-)
+require github.com/google/go-cmp v0.5.8
 
 require (
 	cloud.google.com/go v0.102.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -288,8 +288,6 @@ github.com/google/go-cmp v0.5.7/go.mod h1:n+brtR0CgQNWTVd5ZUFpTBC8YFBDLK/h/bpaJ8
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
-github.com/google/gofuzz v1.2.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible h1:/CP5g8u/VJHijgedC/Legn3BAbAaWPgecwXBIDzw5no=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=
 github.com/google/martian/v3 v3.0.0/go.mod h1:y5Zk1BBys9G+gd6Jrk0W3cC1+ELVxBWuIGO+w/tUAp0=


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I've removed gofuzz from serialization parser tests since our logic is more complicated and random data can lead to test failures, since data is changed during parse/unparse roundtrip.
Ive switched to manual data fill that should be easier to extend in case of missing fields.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
