### PR TITLE
More fixes for golint.sh

### DIFF
--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -143,3 +143,4 @@ func main() {
 	app := buildCLI()
 	app.Run(os.Args)
 }
+

--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -143,4 +143,3 @@ func main() {
 	app := buildCLI()
 	app.Run(os.Args)
 }
-

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -9,7 +9,7 @@ make go-generate && make fmt && make lint && make copyright
 #
 # that's fine, just override it if it looks like we're in buildkite.
 # elsewhere it's probably best to not touch this, and the path is likely wrong.
-if [[ -n $BUILDKITE_AGENT_ID ]]; then
+if [ -n "$BUILDKITE_AGENT_ID" ]; then
   git config --global --add safe.directory /cadence
 fi
 

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -9,12 +9,13 @@ make go-generate && make fmt && make lint && make copyright
 #
 # that's fine, just override it if it looks like we're in buildkite.
 # elsewhere it's probably best to not touch this, and the path is likely wrong.
-if [ -z "$BUILDKITE" ]; then
+if [ -n "$BUILDKITE" ]; then
   git config --global --add safe.directory /cadence
 fi
 
 # intentionally capture stderr, so status-errors are also PR-failing.
-# in particular this catches "dubious ownership" failures.
+# in particular this catches "dubious ownership" failures, which otherwise
+# do not fail this check and the $() hides the exit code.
 if [ -n "$(git status --porcelain  2>&1)" ]; then
   echo "There are changes after make go-generate && make fmt && make lint && make copyright"
   echo "Please rerun the command and commit the changes"

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -9,6 +9,7 @@ make go-generate && make fmt && make lint && make copyright
 #
 # that's fine, just override it if it looks like we're in buildkite.
 # elsewhere it's probably best to not touch this, and the path is likely wrong.
+printenv
 if [ -n "$BUILDKITE_AGENT_ID" ]; then
   git config --global --add safe.directory /cadence
 fi

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -14,7 +14,9 @@ if [ -z "$BUILDKITE" ]; then
 fi
 
 # intentionally capture stderr, so status-errors are also PR-failing
-if [ -n "$( >&1 git status --porcelain)" ]; then
+git status --porcelain
+echo $?
+if [ -n "$(git status --porcelain  >&1)" ]; then
   echo "There are changes after make go-generate && make fmt && make lint && make copyright"
   echo "Please rerun the command and commit the changes"
   git status --porcelain

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -9,14 +9,13 @@ make go-generate && make fmt && make lint && make copyright
 #
 # that's fine, just override it if it looks like we're in buildkite.
 # elsewhere it's probably best to not touch this, and the path is likely wrong.
-if [ -z "$BUILDKITE" ]; then
+if [ -n "$BUILDKITE" ]; then
   git config --global --add safe.directory /cadence
 fi
 
-# intentionally capture stderr, so status-errors are also PR-failing
-git status --porcelain
-echo $?
-if [ -n "$(git status --porcelain  >&1)" ]; then
+# intentionally capture stderr, so status-errors are also PR-failing.
+# in particular this catches "dubious ownership" failures.
+if [ -n "$(git status --porcelain  2>&1)" ]; then
   echo "There are changes after make go-generate && make fmt && make lint && make copyright"
   echo "Please rerun the command and commit the changes"
   git status --porcelain

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -9,12 +9,12 @@ make go-generate && make fmt && make lint && make copyright
 #
 # that's fine, just override it if it looks like we're in buildkite.
 # elsewhere it's probably best to not touch this, and the path is likely wrong.
-if [ -n "$BUILDKITE" ]; then
+if [ -z "$BUILDKITE" ]; then
   git config --global --add safe.directory /cadence
 fi
 
 # intentionally capture stderr, so status-errors are also PR-failing
-if [ -n "$(git status --porcelain >&1)" ]; then
+if [ -n "$( >&1 git status --porcelain)" ]; then
   echo "There are changes after make go-generate && make fmt && make lint && make copyright"
   echo "Please rerun the command and commit the changes"
   git status --porcelain

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -9,7 +9,7 @@ make go-generate && make fmt && make lint && make copyright
 #
 # that's fine, just override it if it looks like we're in buildkite.
 # elsewhere it's probably best to not touch this, and the path is likely wrong.
-if [ -n "$BUILDKITE" ]; then
+if [ -z "$BUILDKITE" ]; then
   git config --global --add safe.directory /cadence
 fi
 

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -9,8 +9,7 @@ make go-generate && make fmt && make lint && make copyright
 #
 # that's fine, just override it if it looks like we're in buildkite.
 # elsewhere it's probably best to not touch this, and the path is likely wrong.
-printenv
-if [ -n "$BUILDKITE_AGENT_ID" ]; then
+if [ -n "$BUILDKITE" ]; then
   git config --global --add safe.directory /cadence
 fi
 


### PR DESCRIPTION
I have no idea why *invalid `sh` syntax* isn't a script failure, but the checkmark is still green:
```
./scripts/buildkite/golint.sh: 12: [[: not found
+ git status --porcelain
fatal: detected dubious ownership in repository at '/cadence'
To add an exception for this directory, call:
	git config --global --add safe.directory /cadence
+ [ -n  ]
```

and apparently [that documented environment variable][1] doesn't actually exist.
`BUILDKITE=true` exists though and it seems reasonable.

and I forgot that `>&1` only captures stdout (and redirects it to stdout), so stderr was still being missed.

this is all so very crazy.

but after throwing enough stuff at the wall and testing with a non-clean git status, this appears to work and makes sense.
this should also catch "dir changed and safe-directory no longer works", unlike before, so we can notice and fix it more quickly.

[1]: https://buildkite.com/docs/pipelines/environment-variables#BUILDKITE_AGENT_ID