### PR TITLE
Fix race between startup and shutdown in task reader

### DIFF
--- a/service/matching/taskReader.go
+++ b/service/matching/taskReader.go
@@ -127,9 +127,17 @@ func newTaskReader(tlMgr *taskListManagerImpl, isolationGroups []string) *taskRe
 func (tr *taskReader) Start() {
 	tr.Signal()
 	for g := range tr.taskBuffers {
-		go tr.dispatchBufferedTasks(g)
+		tr.stopWg.Add(1)
+		go func() {
+			defer tr.stopWg.Done()
+			tr.dispatchBufferedTasks(g)
+		}()
 	}
-	go tr.getTasksPump()
+	tr.stopWg.Add(1)
+	go func() {
+		defer tr.stopWg.Done()
+		tr.getTasksPump()
+	}()
 }
 
 func (tr *taskReader) Stop() {
@@ -154,8 +162,6 @@ func (tr *taskReader) Signal() {
 }
 
 func (tr *taskReader) dispatchBufferedTasks(isolationGroup string) {
-	tr.stopWg.Add(1)
-	defer tr.stopWg.Done()
 dispatchLoop:
 	for {
 		select {
@@ -175,9 +181,6 @@ dispatchLoop:
 }
 
 func (tr *taskReader) getTasksPump() {
-	tr.stopWg.Add(1)
-	defer tr.stopWg.Done()
-
 	updateAckTimer := time.NewTimer(tr.config.UpdateAckInterval())
 	defer updateAckTimer.Stop()
 getTasksPumpLoop:


### PR DESCRIPTION
Nothing ensures all goroutines are started before shutdown, and in tests that's somewhat likely to occur.
Risk to production is probably very low, but definitely best to fix there too.

As a general statement for any readers:
```go
func (s *self) thing() {
  s.wg.Add(1)
  defer s.wg.Done()
  ...
}

// elsewhere
go s.thing()
```
^ this pattern is *almost always* unsafe, at least on a technical level.

All adds need to occur before any Wait() can possibly finish, so they should **always** be added in the "parent" thread, never in the goroutine that things will wait on.
