### PR TITLE
Improve history queue components shutdowns

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1258,49 +1258,49 @@ const (
 	// Default value: 256
 	// Allowed filters: N/A
 	ScannerMaxTasksProcessedPerTasklistJob
-	// ConcreteExecutionsScannerConcurrency is indicates the concurrency of concrete execution scanner
+	// ConcreteExecutionsScannerConcurrency indicates the concurrency of concrete execution scanner
 	// KeyName: worker.executionsScannerConcurrency
 	// Value type: Int
 	// Default value: 25
 	// Allowed filters: N/A
 	ConcreteExecutionsScannerConcurrency
-	// ConcreteExecutionsScannerBlobstoreFlushThreshold is indicates the flush threshold of blobstore in concrete execution scanner
+	// ConcreteExecutionsScannerBlobstoreFlushThreshold indicates the flush threshold of blobstore in concrete execution scanner
 	// KeyName: worker.executionsScannerBlobstoreFlushThreshold
 	// Value type: Int
 	// Default value: 100
 	// Allowed filters: N/A
 	ConcreteExecutionsScannerBlobstoreFlushThreshold
-	// ConcreteExecutionsScannerActivityBatchSize is indicates the batch size of scanner activities
+	// ConcreteExecutionsScannerActivityBatchSize indicates the batch size of scanner activities
 	// KeyName: worker.executionsScannerActivityBatchSize
 	// Value type: Int
 	// Default value: 25
 	// Allowed filters: N/A
 	ConcreteExecutionsScannerActivityBatchSize
-	// ConcreteExecutionsScannerPersistencePageSize is indicates the page size of execution persistence fetches in concrete execution scanner
+	// ConcreteExecutionsScannerPersistencePageSize indicates the page size of execution persistence fetches in concrete execution scanner
 	// KeyName: worker.executionsScannerPersistencePageSize
 	// Value type: Int
 	// Default value: 1000
 	// Allowed filters: N/A
 	ConcreteExecutionsScannerPersistencePageSize
-	// CurrentExecutionsScannerConcurrency is indicates the concurrency of current executions scanner
+	// CurrentExecutionsScannerConcurrency indicates the concurrency of current executions scanner
 	// KeyName: worker.currentExecutionsConcurrency
 	// Value type: Int
 	// Default value: 25
 	// Allowed filters: N/A
 	CurrentExecutionsScannerConcurrency
-	// CurrentExecutionsScannerBlobstoreFlushThreshold is indicates the flush threshold of blobstore in current executions scanner
+	// CurrentExecutionsScannerBlobstoreFlushThreshold indicates the flush threshold of blobstore in current executions scanner
 	// KeyName: worker.currentExecutionsBlobstoreFlushThreshold
 	// Value type: Int
 	// Default value: 100
 	// Allowed filters: N/A
 	CurrentExecutionsScannerBlobstoreFlushThreshold
-	// CurrentExecutionsScannerActivityBatchSize is indicates the batch size of scanner activities
+	// CurrentExecutionsScannerActivityBatchSize indicates the batch size of scanner activities
 	// KeyName: worker.currentExecutionsActivityBatchSize
 	// Value type: Int
 	// Default value: 25
 	// Allowed filters: N/A
 	CurrentExecutionsScannerActivityBatchSize
-	// CurrentExecutionsScannerPersistencePageSize is indicates the page size of execution persistence fetches in current executions scanner
+	// CurrentExecutionsScannerPersistencePageSize indicates the page size of execution persistence fetches in current executions scanner
 	// KeyName: worker.currentExecutionsPersistencePageSize
 	// Value type: INt
 	// Default value: 1000
@@ -1562,42 +1562,48 @@ const (
 	// Default value: false
 	// Allowed filters: N/A
 	EventsCacheGlobalEnable
-	// QueueProcessorEnableSplit is indicates whether processing queue split policy should be enabled
+	// QueueProcessorEnableSplit indicates whether processing queue split policy should be enabled
 	// KeyName: history.queueProcessorEnableSplit
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: N/A
 	QueueProcessorEnableSplit
-	// QueueProcessorEnableRandomSplitByDomainID is indicates whether random queue split policy should be enabled for a domain
+	// QueueProcessorEnableRandomSplitByDomainID indicates whether random queue split policy should be enabled for a domain
 	// KeyName: history.queueProcessorEnableRandomSplitByDomainID
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: DomainID
 	QueueProcessorEnableRandomSplitByDomainID
-	// QueueProcessorEnablePendingTaskSplitByDomainID is indicates whether pending task split policy should be enabled
+	// QueueProcessorEnablePendingTaskSplitByDomainID indicates whether pending task split policy should be enabled
 	// KeyName: history.queueProcessorEnablePendingTaskSplitByDomainID
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: DomainID
 	QueueProcessorEnablePendingTaskSplitByDomainID
-	// QueueProcessorEnableStuckTaskSplitByDomainID is indicates whether stuck task split policy should be enabled
+	// QueueProcessorEnableStuckTaskSplitByDomainID indicates whether stuck task split policy should be enabled
 	// KeyName: history.queueProcessorEnableStuckTaskSplitByDomainID
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: DomainID
 	QueueProcessorEnableStuckTaskSplitByDomainID
-	// QueueProcessorEnablePersistQueueStates is indicates whether processing queue states should be persisted
+	// QueueProcessorEnablePersistQueueStates indicates whether processing queue states should be persisted
 	// KeyName: history.queueProcessorEnablePersistQueueStates
 	// Value type: Bool
 	// Default value: true
 	// Allowed filters: N/A
 	QueueProcessorEnablePersistQueueStates
-	// QueueProcessorEnableLoadQueueStates is indicates whether processing queue states should be loaded
+	// QueueProcessorEnableLoadQueueStates indicates whether processing queue states should be loaded
 	// KeyName: history.queueProcessorEnableLoadQueueStates
 	// Value type: Bool
 	// Default value: true
 	// Allowed filters: N/A
 	QueueProcessorEnableLoadQueueStates
+	// QueueProcessorEnableGracefulSyncShutdown indicates whether processing queue should be shutdown gracefully & synchronously
+	// KeyName: history.queueProcessorEnableGracefulSyncShutdown
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: ShardID
+	QueueProcessorEnableGracefulSyncShutdown
 	// TransferProcessorEnableValidator is whether validator should be enabled for transferQueueProcessor
 	// KeyName: history.transferProcessorEnableValidator
 	// Value type: Bool
@@ -1690,31 +1696,31 @@ const (
 	// Default value: false
 	// Allowed filters: N/A
 	EnableCleaningOrphanTaskInTasklistScavenger
-	// TaskListScannerEnabled is indicates if task list scanner should be started as part of worker.Scanner
+	// TaskListScannerEnabled indicates if task list scanner should be started as part of worker.Scanner
 	// KeyName: worker.taskListScannerEnabled
 	// Value type: Bool
 	// Default value: true
 	// Allowed filters: N/A
 	TaskListScannerEnabled
-	// HistoryScannerEnabled is indicates if history scanner should be started as part of worker.Scanner
+	// HistoryScannerEnabled indicates if history scanner should be started as part of worker.Scanner
 	// KeyName: worker.historyScannerEnabled
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: N/A
 	HistoryScannerEnabled
-	// ConcreteExecutionsScannerEnabled is indicates if executions scanner should be started as part of worker.Scanner
+	// ConcreteExecutionsScannerEnabled indicates if executions scanner should be started as part of worker.Scanner
 	// KeyName: worker.executionsScannerEnabled
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: N/A
 	ConcreteExecutionsScannerEnabled
-	// ConcreteExecutionsScannerInvariantCollectionMutableState is indicates if mutable state invariant checks should be run
+	// ConcreteExecutionsScannerInvariantCollectionMutableState indicates if mutable state invariant checks should be run
 	// KeyName: worker.executionsScannerInvariantCollectionMutableState
 	// Value type: Bool
 	// Default value: true
 	// Allowed filters: N/A
 	ConcreteExecutionsScannerInvariantCollectionMutableState
-	// ConcreteExecutionsScannerInvariantCollectionHistory is indicates if history invariant checks should be run
+	// ConcreteExecutionsScannerInvariantCollectionHistory indicates if history invariant checks should be run
 	// KeyName: worker.executionsScannerInvariantCollectionHistory
 	// Value type: Bool
 	// Default value: true
@@ -1726,13 +1732,13 @@ const (
 	// Default value: false
 	// Allowed filters: N/A
 	ConcreteExecutionsFixerInvariantCollectionStale
-	// ConcreteExecutionsFixerInvariantCollectionMutableState is indicates if mutable state invariant checks should be run
+	// ConcreteExecutionsFixerInvariantCollectionMutableState indicates if mutable state invariant checks should be run
 	// KeyName: worker.executionsFixerInvariantCollectionMutableState
 	// Value type: Bool
 	// Default value: true
 	// Allowed filters: N/A
 	ConcreteExecutionsFixerInvariantCollectionMutableState
-	// ConcreteExecutionsFixerInvariantCollectionHistory is indicates if history invariant checks should be run
+	// ConcreteExecutionsFixerInvariantCollectionHistory indicates if history invariant checks should be run
 	// KeyName: worker.executionsFixerInvariantCollectionHistory
 	// Value type: Bool
 	// Default value: true
@@ -1744,19 +1750,19 @@ const (
 	// Default value: false
 	// Allowed filters: N/A
 	ConcreteExecutionsScannerInvariantCollectionStale
-	// CurrentExecutionsScannerEnabled is indicates if current executions scanner should be started as part of worker.Scanner
+	// CurrentExecutionsScannerEnabled indicates if current executions scanner should be started as part of worker.Scanner
 	// KeyName: worker.currentExecutionsScannerEnabled
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: N/A
 	CurrentExecutionsScannerEnabled
-	// CurrentExecutionsScannerInvariantCollectionHistory is indicates if history invariant checks should be run
+	// CurrentExecutionsScannerInvariantCollectionHistory indicates if history invariant checks should be run
 	// KeyName: worker.currentExecutionsScannerInvariantCollectionHistory
 	// Value type: Bool
 	// Default value: true
 	// Allowed filters: N/A
 	CurrentExecutionsScannerInvariantCollectionHistory
-	// CurrentExecutionsScannerInvariantCollectionMutableState is indicates if mutable state invariant checks should be run
+	// CurrentExecutionsScannerInvariantCollectionMutableState indicates if mutable state invariant checks should be run
 	// KeyName: worker.currentExecutionsInvariantCollectionMutableState
 	// Value type: Bool
 	// Default value: true
@@ -1781,13 +1787,13 @@ const (
 	// Allowed filters: N/A
 	EnableESAnalyzer
 
-	// EnableStickyQuery is indicates if sticky query should be enabled per domain
+	// EnableStickyQuery indicates if sticky query should be enabled per domain
 	// KeyName: system.enableStickyQuery
 	// Value type: Bool
 	// Default value: true
 	// Allowed filters: DomainName
 	EnableStickyQuery
-	// EnableFailoverManager is indicates if failover manager is enabled
+	// EnableFailoverManager indicates if failover manager is enabled
 	// KeyName: system.enableFailoverManager
 	// Value type: Bool
 	// Default value: true
@@ -3523,42 +3529,42 @@ var IntKeys = map[IntKey]DynamicInt{
 	},
 	ConcreteExecutionsScannerConcurrency: DynamicInt{
 		KeyName:      "worker.executionsScannerConcurrency",
-		Description:  "ConcreteExecutionsScannerConcurrency is indicates the concurrency of concrete execution scanner",
+		Description:  "ConcreteExecutionsScannerConcurrency indicates the concurrency of concrete execution scanner",
 		DefaultValue: 25,
 	},
 	ConcreteExecutionsScannerBlobstoreFlushThreshold: DynamicInt{
 		KeyName:      "worker.executionsScannerBlobstoreFlushThreshold",
-		Description:  "ConcreteExecutionsScannerBlobstoreFlushThreshold is indicates the flush threshold of blobstore in concrete execution scanner",
+		Description:  "ConcreteExecutionsScannerBlobstoreFlushThreshold indicates the flush threshold of blobstore in concrete execution scanner",
 		DefaultValue: 100,
 	},
 	ConcreteExecutionsScannerActivityBatchSize: DynamicInt{
 		KeyName:      "worker.executionsScannerActivityBatchSize",
-		Description:  "ConcreteExecutionsScannerActivityBatchSize is indicates the batch size of scanner activities",
+		Description:  "ConcreteExecutionsScannerActivityBatchSize indicates the batch size of scanner activities",
 		DefaultValue: 25,
 	},
 	ConcreteExecutionsScannerPersistencePageSize: DynamicInt{
 		KeyName:      "worker.executionsScannerPersistencePageSize",
-		Description:  "ConcreteExecutionsScannerPersistencePageSize is indicates the page size of execution persistence fetches in concrete execution scanner",
+		Description:  "ConcreteExecutionsScannerPersistencePageSize indicates the page size of execution persistence fetches in concrete execution scanner",
 		DefaultValue: 1000,
 	},
 	CurrentExecutionsScannerConcurrency: DynamicInt{
 		KeyName:      "worker.currentExecutionsConcurrency",
-		Description:  "CurrentExecutionsScannerConcurrency is indicates the concurrency of current executions scanner",
+		Description:  "CurrentExecutionsScannerConcurrency indicates the concurrency of current executions scanner",
 		DefaultValue: 25,
 	},
 	CurrentExecutionsScannerBlobstoreFlushThreshold: DynamicInt{
 		KeyName:      "worker.currentExecutionsBlobstoreFlushThreshold",
-		Description:  "CurrentExecutionsScannerBlobstoreFlushThreshold is indicates the flush threshold of blobstore in current executions scanner",
+		Description:  "CurrentExecutionsScannerBlobstoreFlushThreshold indicates the flush threshold of blobstore in current executions scanner",
 		DefaultValue: 100,
 	},
 	CurrentExecutionsScannerActivityBatchSize: DynamicInt{
 		KeyName:      "worker.currentExecutionsActivityBatchSize",
-		Description:  "CurrentExecutionsScannerActivityBatchSize is indicates the batch size of scanner activities",
+		Description:  "CurrentExecutionsScannerActivityBatchSize indicates the batch size of scanner activities",
 		DefaultValue: 25,
 	},
 	CurrentExecutionsScannerPersistencePageSize: DynamicInt{
 		KeyName:      "worker.currentExecutionsPersistencePageSize",
-		Description:  "CurrentExecutionsScannerPersistencePageSize is indicates the page size of execution persistence fetches in current executions scanner",
+		Description:  "CurrentExecutionsScannerPersistencePageSize indicates the page size of execution persistence fetches in current executions scanner",
 		DefaultValue: 1000,
 	},
 	TimersScannerConcurrency: DynamicInt{
@@ -3797,36 +3803,41 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	},
 	QueueProcessorEnableSplit: DynamicBool{
 		KeyName:      "history.queueProcessorEnableSplit",
-		Description:  "QueueProcessorEnableSplit is indicates whether processing queue split policy should be enabled",
+		Description:  "QueueProcessorEnableSplit indicates whether processing queue split policy should be enabled",
 		DefaultValue: false,
 	},
 	QueueProcessorEnableRandomSplitByDomainID: DynamicBool{
 		KeyName:      "history.queueProcessorEnableRandomSplitByDomainID",
 		Filters:      []Filter{DomainID},
-		Description:  "QueueProcessorEnableRandomSplitByDomainID is indicates whether random queue split policy should be enabled for a domain",
+		Description:  "QueueProcessorEnableRandomSplitByDomainID indicates whether random queue split policy should be enabled for a domain",
 		DefaultValue: false,
 	},
 	QueueProcessorEnablePendingTaskSplitByDomainID: DynamicBool{
 		KeyName:      "history.queueProcessorEnablePendingTaskSplitByDomainID",
 		Filters:      []Filter{DomainID},
-		Description:  "ueueProcessorEnablePendingTaskSplitByDomainID is indicates whether pending task split policy should be enabled",
+		Description:  "ueueProcessorEnablePendingTaskSplitByDomainID indicates whether pending task split policy should be enabled",
 		DefaultValue: false,
 	},
 	QueueProcessorEnableStuckTaskSplitByDomainID: DynamicBool{
 		KeyName:      "history.queueProcessorEnableStuckTaskSplitByDomainID",
 		Filters:      []Filter{DomainID},
-		Description:  "QueueProcessorEnableStuckTaskSplitByDomainID is indicates whether stuck task split policy should be enabled",
+		Description:  "QueueProcessorEnableStuckTaskSplitByDomainID indicates whether stuck task split policy should be enabled",
 		DefaultValue: false,
 	},
 	QueueProcessorEnablePersistQueueStates: DynamicBool{
 		KeyName:      "history.queueProcessorEnablePersistQueueStates",
-		Description:  "QueueProcessorEnablePersistQueueStates is indicates whether processing queue states should be persisted",
+		Description:  "QueueProcessorEnablePersistQueueStates indicates whether processing queue states should be persisted",
 		DefaultValue: true,
 	},
 	QueueProcessorEnableLoadQueueStates: DynamicBool{
 		KeyName:      "history.queueProcessorEnableLoadQueueStates",
-		Description:  "QueueProcessorEnableLoadQueueStates is indicates whether processing queue states should be loaded",
+		Description:  "QueueProcessorEnableLoadQueueStates indicates whether processing queue states should be loaded",
 		DefaultValue: true,
+	},
+	QueueProcessorEnableGracefulSyncShutdown: DynamicBool{
+		KeyName:      "history.queueProcessorEnableGracefulSyncShutdown",
+		Description:  "QueueProcessorEnableGracefulSyncShutdown indicates whether processing queue should be shutdown gracefully & synchronously",
+		DefaultValue: false,
 	},
 	TransferProcessorEnableValidator: DynamicBool{
 		KeyName:      "history.transferProcessorEnableValidator",
@@ -3908,27 +3919,27 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	},
 	TaskListScannerEnabled: DynamicBool{
 		KeyName:      "worker.taskListScannerEnabled",
-		Description:  "TaskListScannerEnabled is indicates if task list scanner should be started as part of worker.Scanner",
+		Description:  "TaskListScannerEnabled indicates if task list scanner should be started as part of worker.Scanner",
 		DefaultValue: true,
 	},
 	HistoryScannerEnabled: DynamicBool{
 		KeyName:      "worker.historyScannerEnabled",
-		Description:  "HistoryScannerEnabled is indicates if history scanner should be started as part of worker.Scanner",
+		Description:  "HistoryScannerEnabled indicates if history scanner should be started as part of worker.Scanner",
 		DefaultValue: false,
 	},
 	ConcreteExecutionsScannerEnabled: DynamicBool{
 		KeyName:      "worker.executionsScannerEnabled",
-		Description:  "ConcreteExecutionsScannerEnabled is indicates if executions scanner should be started as part of worker.Scanner",
+		Description:  "ConcreteExecutionsScannerEnabled indicates if executions scanner should be started as part of worker.Scanner",
 		DefaultValue: false,
 	},
 	ConcreteExecutionsScannerInvariantCollectionMutableState: DynamicBool{
 		KeyName:      "worker.executionsScannerInvariantCollectionMutableState",
-		Description:  "ConcreteExecutionsScannerInvariantCollectionMutableState is indicates if mutable state invariant checks should be run",
+		Description:  "ConcreteExecutionsScannerInvariantCollectionMutableState indicates if mutable state invariant checks should be run",
 		DefaultValue: true,
 	},
 	ConcreteExecutionsScannerInvariantCollectionHistory: DynamicBool{
 		KeyName:      "worker.executionsScannerInvariantCollectionHistory",
-		Description:  "ConcreteExecutionsScannerInvariantCollectionHistory is indicates if history invariant checks should be run",
+		Description:  "ConcreteExecutionsScannerInvariantCollectionHistory indicates if history invariant checks should be run",
 		DefaultValue: true,
 	},
 	ConcreteExecutionsScannerInvariantCollectionStale: DynamicBool{
@@ -3938,12 +3949,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	},
 	ConcreteExecutionsFixerInvariantCollectionMutableState: DynamicBool{
 		KeyName:      "worker.executionsFixerInvariantCollectionMutableState",
-		Description:  "ConcreteExecutionsFixerInvariantCollectionMutableState is indicates if mutable state invariant checks should be run",
+		Description:  "ConcreteExecutionsFixerInvariantCollectionMutableState indicates if mutable state invariant checks should be run",
 		DefaultValue: true,
 	},
 	ConcreteExecutionsFixerInvariantCollectionHistory: DynamicBool{
 		KeyName:      "worker.executionsFixerInvariantCollectionHistory",
-		Description:  "ConcreteExecutionsFixerInvariantCollectionHistory is indicates if history invariant checks should be run",
+		Description:  "ConcreteExecutionsFixerInvariantCollectionHistory indicates if history invariant checks should be run",
 		DefaultValue: true,
 	},
 	ConcreteExecutionsFixerInvariantCollectionStale: DynamicBool{
@@ -3953,17 +3964,17 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	},
 	CurrentExecutionsScannerEnabled: DynamicBool{
 		KeyName:      "worker.currentExecutionsScannerEnabled",
-		Description:  "CurrentExecutionsScannerEnabled is indicates if current executions scanner should be started as part of worker.Scanner",
+		Description:  "CurrentExecutionsScannerEnabled indicates if current executions scanner should be started as part of worker.Scanner",
 		DefaultValue: false,
 	},
 	CurrentExecutionsScannerInvariantCollectionHistory: DynamicBool{
 		KeyName:      "worker.currentExecutionsScannerInvariantCollectionHistory",
-		Description:  "CurrentExecutionsScannerInvariantCollectionHistory is indicates if history invariant checks should be run",
+		Description:  "CurrentExecutionsScannerInvariantCollectionHistory indicates if history invariant checks should be run",
 		DefaultValue: true,
 	},
 	CurrentExecutionsScannerInvariantCollectionMutableState: DynamicBool{
 		KeyName:      "worker.currentExecutionsInvariantCollectionMutableState",
-		Description:  "CurrentExecutionsScannerInvariantCollectionMutableState is indicates if mutable state invariant checks should be run",
+		Description:  "CurrentExecutionsScannerInvariantCollectionMutableState indicates if mutable state invariant checks should be run",
 		DefaultValue: true,
 	},
 	EnableBatcher: DynamicBool{
@@ -3984,12 +3995,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	EnableStickyQuery: DynamicBool{
 		KeyName:      "system.enableStickyQuery",
 		Filters:      []Filter{DomainName},
-		Description:  "EnableStickyQuery is indicates if sticky query should be enabled per domain",
+		Description:  "EnableStickyQuery indicates if sticky query should be enabled per domain",
 		DefaultValue: true,
 	},
 	EnableFailoverManager: DynamicBool{
 		KeyName:      "system.enableFailoverManager",
-		Description:  "EnableFailoverManager is indicates if failover manager is enabled",
+		Description:  "EnableFailoverManager indicates if failover manager is enabled",
 		DefaultValue: true,
 	},
 	EnableWorkflowShadower: DynamicBool{

--- a/common/util.go
+++ b/common/util.go
@@ -113,7 +113,6 @@ var (
 // Returns true if the Wait() call succeeded before the timeout
 // Returns false if the Wait() did not return before the timeout
 func AwaitWaitGroup(wg *sync.WaitGroup, timeout time.Duration) bool {
-
 	doneC := make(chan struct{})
 
 	go func() {

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -118,6 +118,7 @@ type Config struct {
 	QueueProcessorPollBackoffIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
 	QueueProcessorEnablePersistQueueStates             dynamicconfig.BoolPropertyFn
 	QueueProcessorEnableLoadQueueStates                dynamicconfig.BoolPropertyFn
+	QueueProcessorEnableGracefulSyncShutdown           dynamicconfig.BoolPropertyFn
 
 	// TimerQueueProcessor settings
 	TimerTaskBatchSize                                dynamicconfig.IntPropertyFn
@@ -405,6 +406,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 		QueueProcessorPollBackoffIntervalJitterCoefficient: dc.GetFloat64Property(dynamicconfig.QueueProcessorPollBackoffIntervalJitterCoefficient),
 		QueueProcessorEnablePersistQueueStates:             dc.GetBoolProperty(dynamicconfig.QueueProcessorEnablePersistQueueStates),
 		QueueProcessorEnableLoadQueueStates:                dc.GetBoolProperty(dynamicconfig.QueueProcessorEnableLoadQueueStates),
+		QueueProcessorEnableGracefulSyncShutdown:           dc.GetBoolProperty(dynamicconfig.QueueProcessorEnableGracefulSyncShutdown),
 
 		TimerTaskBatchSize:                                dc.GetIntProperty(dynamicconfig.TimerTaskBatchSize),
 		TimerTaskDeleteBatchSize:                          dc.GetIntProperty(dynamicconfig.TimerTaskDeleteBatchSize),
@@ -598,6 +600,7 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	panicIfErr(inMem.UpdateValue(dynamicconfig.EnableCrossClusterOperations, true))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.NormalDecisionScheduleToStartMaxAttempts, 3))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.EnablePendingActivityValidation, true))
+	panicIfErr(inMem.UpdateValue(dynamicconfig.QueueProcessorEnableGracefulSyncShutdown, true))
 	dc := dynamicconfig.NewCollection(inMem, log.NewNoop())
 	config := New(dc, shardNumber, 1024*1024, config.StoreTypeCassandra, false, "")
 	// reduce the duration of long poll to increase test speed
@@ -611,6 +614,7 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	config.EnableCrossClusterOperations = dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableCrossClusterOperations)
 	config.NormalDecisionScheduleToStartMaxAttempts = dc.GetIntPropertyFilteredByDomain(dynamicconfig.NormalDecisionScheduleToStartMaxAttempts)
 	config.PendingActivityValidationEnabled = dc.GetBoolProperty(dynamicconfig.EnablePendingActivityValidation)
+	config.QueueProcessorEnableGracefulSyncShutdown = dc.GetBoolProperty(dynamicconfig.QueueProcessorEnableGracefulSyncShutdown)
 	return config
 }
 

--- a/service/history/queue/constants.go
+++ b/service/history/queue/constants.go
@@ -20,6 +20,12 @@
 
 package queue
 
+import "time"
+
 const (
 	defaultProcessingQueueLevel = 0
+
+	// gracefulShutdownTimeout is the the hardcoded timeout for queue components to wrap up shutting down.
+	// This is not ideal because we should have a top level deadline for shutdown propagating down to all components.
+	gracefulShutdownTimeout = time.Minute
 )

--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -108,28 +108,19 @@ func newProcessorBase(
 			logger,
 			metricsScope,
 		),
-
 		options:                     options,
 		updateMaxReadLevel:          updateMaxReadLevel,
 		updateClusterAckLevel:       updateClusterAckLevel,
 		updateProcessingQueueStates: updateProcessingQueueStates,
 		queueShutdown:               queueShutdown,
-
-		logger:        logger,
-		metricsClient: metricsClient,
-		metricsScope:  metricsScope,
-
-		rateLimiter: quotas.NewDynamicRateLimiter(options.MaxPollRPS.AsFloat64()),
-
-		status:         common.DaemonStatusInitialized,
-		shutdownCh:     make(chan struct{}),
-		actionNotifyCh: make(chan actionNotification),
-
-		processingQueueCollections: newProcessingQueueCollections(
-			processingQueueStates,
-			logger,
-			metricsClient,
-		),
+		logger:                      logger,
+		metricsClient:               metricsClient,
+		metricsScope:                metricsScope,
+		rateLimiter:                 quotas.NewDynamicRateLimiter(options.MaxPollRPS.AsFloat64()),
+		status:                      common.DaemonStatusInitialized,
+		shutdownCh:                  make(chan struct{}),
+		actionNotifyCh:              make(chan actionNotification),
+		processingQueueCollections:  newProcessingQueueCollections(processingQueueStates, logger, metricsClient),
 	}
 }
 

--- a/service/history/queue/processor_options.go
+++ b/service/history/queue/processor_options.go
@@ -49,6 +49,7 @@ type queueProcessorOptions struct {
 	PollBackoffIntervalJitterCoefficient dynamicconfig.FloatPropertyFn
 	EnablePersistQueueStates             dynamicconfig.BoolPropertyFn
 	EnableLoadQueueStates                dynamicconfig.BoolPropertyFn
+	EnableGracefulSyncShutdown           dynamicconfig.BoolPropertyFn
 	EnableValidator                      dynamicconfig.BoolPropertyFn
 	ValidationInterval                   dynamicconfig.DurationPropertyFn
 	// MaxPendingTaskSize is used in cross cluster queue to limit the pending task count

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -176,13 +176,27 @@ func (t *timerQueueProcessor) Stop() {
 		return
 	}
 
+	if !t.shard.GetConfig().QueueProcessorEnableGracefulSyncShutdown() {
+		t.activeQueueProcessor.Stop()
+		for _, standbyQueueProcessor := range t.standbyQueueProcessors {
+			standbyQueueProcessor.Stop()
+		}
+
+		close(t.shutdownChan)
+		common.AwaitWaitGroup(&t.shutdownWG, time.Minute)
+		return
+	}
+
+	// close the shutdown channel first so processor pumps drains tasks
+	// and then stop the processors
+	close(t.shutdownChan)
+	if !common.AwaitWaitGroup(&t.shutdownWG, gracefulShutdownTimeout) {
+		t.logger.Warn("transferQueueProcessor timed out on shut down", tag.LifeCycleStopTimedout)
+	}
 	t.activeQueueProcessor.Stop()
 	for _, standbyQueueProcessor := range t.standbyQueueProcessors {
 		standbyQueueProcessor.Stop()
 	}
-
-	close(t.shutdownChan)
-	common.AwaitWaitGroup(&t.shutdownWG, time.Minute)
 }
 
 func (t *timerQueueProcessor) NotifyNewTask(clusterName string, info *hcommon.NotifyTaskInfo) {
@@ -225,10 +239,16 @@ func (t *timerQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 		}
 	}
 
+	if standbyClusterName != t.currentClusterName {
+		t.logger.Debugf("Timer queue failover will use minLevel: %v from standbyClusterName: %s", minLevel, standbyClusterName)
+	} else {
+		t.logger.Debugf("Timer queue failover will use minLevel: %v from current cluster: %s", minLevel, t.currentClusterName)
+	}
+
 	maxReadLevel := time.Time{}
 	actionResult, err := t.HandleAction(context.Background(), t.currentClusterName, NewGetStateAction())
 	if err != nil {
-		t.logger.Error("Timer Failover Failed", tag.WorkflowDomainIDs(domainIDs), tag.Error(err))
+		t.logger.Error("Timer failover failed while getting queue states", tag.WorkflowDomainIDs(domainIDs), tag.Error(err))
 		if err == errProcessorShutdown {
 			// processor/shard already shutdown, we don't need to create failover queue processor
 			return
@@ -236,12 +256,20 @@ func (t *timerQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 		// other errors should never be returned for GetStateAction
 		panic(fmt.Sprintf("unknown error for GetStateAction: %v", err))
 	}
+
+	var maxReadLevelQueueLevel int
 	for _, queueState := range actionResult.GetStateActionResult.States {
 		queueReadLevel := queueState.ReadLevel().(timerTaskKey).visibilityTimestamp
 		if maxReadLevel.Before(queueReadLevel) {
 			maxReadLevel = queueReadLevel
+			maxReadLevelQueueLevel = queueState.Level()
 		}
 	}
+
+	if !maxReadLevel.IsZero() {
+		t.logger.Debugf("Timer queue failover will use maxReadLevel: %v from queue at level: %v", maxReadLevel, maxReadLevelQueueLevel)
+	}
+
 	// TODO: Below Add call has no effect, understand the underlying intent and fix it.
 	maxReadLevel.Add(1 * time.Millisecond)
 
@@ -318,6 +346,12 @@ func (t *timerQueueProcessor) UnlockTaskProcessing() {
 	t.taskAllocator.Unlock()
 }
 
+func (t *timerQueueProcessor) drain() {
+	if err := t.completeTimer(); err != nil {
+		t.logger.Error("Failed to complete timer task during shutdown", tag.Error(err))
+	}
+}
+
 func (t *timerQueueProcessor) completeTimerLoop() {
 	defer t.shutdownWG.Done()
 
@@ -327,9 +361,7 @@ func (t *timerQueueProcessor) completeTimerLoop() {
 	for {
 		select {
 		case <-t.shutdownChan:
-			if err := t.completeTimer(); err != nil {
-				t.logger.Error("Error complete timer task", tag.Error(err))
-			}
+			t.drain()
 			return
 		case <-completeTimer.C:
 			for attempt := 0; attempt < t.config.TimerProcessorCompleteTimerFailureRetryCount(); attempt++ {
@@ -338,19 +370,23 @@ func (t *timerQueueProcessor) completeTimerLoop() {
 					break
 				}
 
-				t.logger.Error("Error complete timer task", tag.Error(err))
+				t.logger.Error("Failed to complete timer task", tag.Error(err))
 				if err == shard.ErrShardClosed {
-					go t.Stop()
+					if !t.shard.GetConfig().QueueProcessorEnableGracefulSyncShutdown() {
+						go t.Stop()
+						return
+					}
+
+					t.Stop()
 					return
 				}
-				backoff := time.Duration(attempt * 100)
-				time.Sleep(backoff * time.Millisecond)
 
 				select {
 				case <-t.shutdownChan:
-					// break the retry loop if shutdown chan is closed
-					break
-				default:
+					t.drain()
+					return
+				case <-time.After(time.Duration(attempt*100) * time.Millisecond):
+					// do nothing. retry loop will continue
 				}
 			}
 
@@ -389,7 +425,7 @@ func (t *timerQueueProcessor) completeTimer() error {
 	}
 
 	newAckLevelTimestamp := newAckLevel.(timerTaskKey).visibilityTimestamp
-	t.logger.Debug(fmt.Sprintf("Start completing timer task from: %v, to %v", t.ackLevel, newAckLevelTimestamp))
+	t.logger.Debugf("Start completing timer task from: %v, to %v", t.ackLevel, newAckLevelTimestamp)
 	if !t.ackLevel.Before(newAckLevelTimestamp) {
 		return nil
 	}

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -197,16 +197,14 @@ func (t *transferQueueProcessorBase) Stop() {
 	}
 	t.processingLock.Unlock()
 
-	if success := common.AwaitWaitGroup(&t.shutdownWG, time.Minute); !success {
-		t.logger.Warn("", tag.LifeCycleStopTimedout)
+	if success := common.AwaitWaitGroup(&t.shutdownWG, gracefulShutdownTimeout); !success {
+		t.logger.Warn("transferQueueProcessorBase timed out on shut down", tag.LifeCycleStopTimedout)
 	}
 
 	t.redispatcher.Stop()
 }
 
-func (t *transferQueueProcessorBase) notifyNewTask(
-	info *hcommon.NotifyTaskInfo,
-) {
+func (t *transferQueueProcessorBase) notifyNewTask(info *hcommon.NotifyTaskInfo) {
 	select {
 	case t.notifyCh <- struct{}{}:
 	default:
@@ -295,11 +293,10 @@ func (t *transferQueueProcessorBase) processorPump() {
 	))
 	defer maxPollTimer.Stop()
 
-processorPumpLoop:
 	for {
 		select {
 		case <-t.shutdownCh:
-			break processorPumpLoop
+			return
 		case <-t.notifyCh:
 			// notify all queue collections as they are waiting for the notification when there's
 			// no more task to process. For non-default queue, if we choose to do periodic polling
@@ -313,13 +310,14 @@ processorPumpLoop:
 			))
 		case <-t.processCh:
 			maxRedispatchQueueSize := t.options.MaxRedispatchQueueSize()
-			if t.redispatcher.Size() > maxRedispatchQueueSize {
-				// has too many pending tasks in re-dispatch queue, block loading tasks from persistence
+			if redispathSize := t.redispatcher.Size(); redispathSize > maxRedispatchQueueSize {
+				t.logger.Debugf("Transfer queue has too many pending tasks in re-dispatch queue: %v > maxRedispatchQueueSize: %v, block loading tasks from persistence", redispathSize, maxRedispatchQueueSize)
 				t.redispatcher.Redispatch(maxRedispatchQueueSize)
-				if t.redispatcher.Size() > maxRedispatchQueueSize {
+				if redispathSize := t.redispatcher.Size(); redispathSize > maxRedispatchQueueSize {
 					// if redispatcher still has a large number of tasks
 					// this only happens when system is under very high load
 					// we should backoff here instead of keeping submitting tasks to task processor
+					t.logger.Debugf("Transfer queue still has too many pending tasks in re-dispatch queue: %v > maxRedispatchQueueSize: %v, backing off for %v", redispathSize, maxRedispatchQueueSize, t.options.PollBackoffInterval())
 					time.Sleep(backoff.JitDuration(
 						t.options.PollBackoffInterval(),
 						t.options.PollBackoffIntervalJitterCoefficient(),
@@ -330,15 +328,19 @@ processorPumpLoop:
 				case t.processCh <- struct{}{}:
 				default:
 				}
-				continue processorPumpLoop
+			} else {
+				t.processQueueCollections()
 			}
-
-			t.processQueueCollections()
 		case <-updateAckTimer.C:
 			processFinished, _, err := t.updateAckLevel()
 			if err == shard.ErrShardClosed || (err == nil && processFinished) {
-				go t.Stop()
-				break processorPumpLoop
+				if !t.options.EnableGracefulSyncShutdown() {
+					go t.Stop()
+					return
+				}
+
+				t.Stop()
+				return
 			}
 			updateAckTimer.Reset(backoff.JitDuration(
 				t.options.UpdateAckInterval(),
@@ -576,6 +578,7 @@ func newTransferQueueProcessorOptions(
 		PollBackoffIntervalJitterCoefficient: config.QueueProcessorPollBackoffIntervalJitterCoefficient,
 		EnableValidator:                      config.TransferProcessorEnableValidator,
 		ValidationInterval:                   config.TransferProcessorValidationInterval,
+		EnableGracefulSyncShutdown:           config.QueueProcessorEnableGracefulSyncShutdown,
 	}
 
 	if isFailover {

--- a/service/history/task/redispatcher.go
+++ b/service/history/task/redispatcher.go
@@ -93,18 +93,17 @@ func NewRedispatcher(
 	backoffPolicy.SetExpirationInterval(backoff.NoInterval)
 
 	return &redispatcherImpl{
-		taskProcessor:   taskProcessor,
-		timeSource:      timeSource,
-		options:         options,
-		logger:          logger,
-		metricsScope:    metricsScope,
-		status:          common.DaemonStatusInitialized,
-		shutdownCh:      make(chan struct{}),
-		redispatchCh:    make(chan redispatchNotification, 1),
-		redispatchTimer: nil,
-		backoffPolicy:   backoffPolicy,
-		taskQueues:      make(map[int][]redispatchTask),
-		taskChFull:      make(map[int]bool),
+		taskProcessor: taskProcessor,
+		timeSource:    timeSource,
+		options:       options,
+		logger:        logger,
+		metricsScope:  metricsScope,
+		status:        common.DaemonStatusInitialized,
+		shutdownCh:    make(chan struct{}),
+		redispatchCh:  make(chan redispatchNotification, 1),
+		backoffPolicy: backoffPolicy,
+		taskQueues:    make(map[int][]redispatchTask),
+		taskChFull:    make(map[int]bool),
 	}
 }
 
@@ -140,9 +139,7 @@ func (r *redispatcherImpl) Stop() {
 	r.logger.Info("Task redispatcher stopped.", tag.LifeCycleStopped)
 }
 
-func (r *redispatcherImpl) AddTask(
-	task Task,
-) {
+func (r *redispatcherImpl) AddTask(task Task) {
 	priority := task.Priority()
 	attempt := task.GetAttempt()
 
@@ -160,22 +157,22 @@ func (r *redispatcherImpl) AddTask(
 	r.setupTimerLocked()
 }
 
-func (r *redispatcherImpl) Redispatch(
-	targetSize int,
-) {
+func (r *redispatcherImpl) Redispatch(targetSize int) {
 	doneCh := make(chan struct{})
+	defer close(doneCh)
 
-	select {
-	case r.redispatchCh <- redispatchNotification{
+	ntf := redispatchNotification{
 		targetSize: targetSize,
 		doneCh:     doneCh,
-	}:
-	case <-r.shutdownCh:
-		close(doneCh)
 	}
 
-	// block until the redispatch is done
-	<-doneCh
+	select {
+	case r.redispatchCh <- ntf:
+		// block until the redispatch is done
+		<-doneCh
+	case <-r.shutdownCh:
+		return
+	}
 }
 
 func (r *redispatcherImpl) Size() int {
@@ -198,9 +195,7 @@ func (r *redispatcherImpl) redispatchLoop() {
 	}
 }
 
-func (r *redispatcherImpl) redispatchTasks(
-	notification redispatchNotification,
-) {
+func (r *redispatcherImpl) redispatchTasks(notification redispatchNotification) {
 	r.Lock()
 	defer r.Unlock()
 
@@ -289,27 +284,29 @@ func (r *redispatcherImpl) redispatchTasks(
 }
 
 func (r *redispatcherImpl) setupTimerLocked() {
-	if r.redispatchTimer == nil && !r.isStopped() {
-		r.redispatchTimer = time.AfterFunc(
-			backoff.JitDuration(
-				r.options.TaskRedispatchInterval(),
-				r.options.TaskRedispatchIntervalJitterCoefficient(),
-			),
-			func() {
-				r.Lock()
-				defer r.Unlock()
-				r.redispatchTimer = nil
-
-				select {
-				case r.redispatchCh <- redispatchNotification{
-					targetSize: 0,
-					doneCh:     nil,
-				}:
-				default:
-				}
-			},
-		)
+	if r.redispatchTimer != nil || r.isStopped() {
+		return
 	}
+
+	r.redispatchTimer = time.AfterFunc(
+		backoff.JitDuration(
+			r.options.TaskRedispatchInterval(),
+			r.options.TaskRedispatchIntervalJitterCoefficient(),
+		),
+		func() {
+			r.Lock()
+			defer r.Unlock()
+			r.redispatchTimer = nil
+
+			select {
+			case r.redispatchCh <- redispatchNotification{
+				targetSize: 0,
+				doneCh:     nil,
+			}:
+			default:
+			}
+		},
+	)
 }
 
 func (r *redispatcherImpl) sizeLocked() int {

--- a/service/history/task/redispatcher.go
+++ b/service/history/task/redispatcher.go
@@ -159,8 +159,6 @@ func (r *redispatcherImpl) AddTask(task Task) {
 
 func (r *redispatcherImpl) Redispatch(targetSize int) {
 	doneCh := make(chan struct{})
-	defer close(doneCh)
-
 	ntf := redispatchNotification{
 		targetSize: targetSize,
 		doneCh:     doneCh,
@@ -171,6 +169,7 @@ func (r *redispatcherImpl) Redispatch(targetSize int) {
 		// block until the redispatch is done
 		<-doneCh
 	case <-r.shutdownCh:
+		close(doneCh)
 		return
 	}
 }

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -223,9 +223,7 @@ func (t *taskImpl) Execute() error {
 	return t.taskExecutor.Execute(t, t.shouldProcessTask)
 }
 
-func (t *taskImpl) HandleErr(
-	err error,
-) (retErr error) {
+func (t *taskImpl) HandleErr(err error) (retErr error) {
 	defer func() {
 		if retErr != nil {
 			logEvent(t.eventLogger, "Failed to handle error", retErr)
@@ -333,9 +331,7 @@ func (t *taskImpl) HandleErr(
 	return err
 }
 
-func (t *taskImpl) RetryErr(
-	err error,
-) bool {
+func (t *taskImpl) RetryErr(err error) bool {
 	if err == errWorkflowBusy || isRedispatchErr(err) || err == ErrTaskPendingActive || common.IsContextTimeoutError(err) {
 		return false
 	}
@@ -392,9 +388,7 @@ func (t *taskImpl) Priority() int {
 	return t.priority
 }
 
-func (t *taskImpl) SetPriority(
-	priority int,
-) {
+func (t *taskImpl) SetPriority(priority int) {
 	t.Lock()
 	defer t.Unlock()
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
History's timer and transfer queues are not handling shutdowns properly. This PR will make it slightly better but a proper handling of shutdowns will require bigger refactoring to ensure honoring process level shutdown deadline and ordering of Stop calls. We will most likely achieve that by integration with [Fx](https://github.com/uber-go/fx) at some point.

Changes:
- Introduce `QueueProcessorEnableGracefulSyncShutdown` dynamic config. Default is false. When set to true 
   - Synchronously shut down components (get rid of `go Stop()` calls) 
   - Fix ordering of Stop calls so last attempt to complete tasks may actually work (it's always failing today due to misordered calls)

Misc readability changes:
- Get rid of some named loop breaks. Fix buggy breaks associated with this.
- Get rid of some multiline functions

<!-- Tell your future self why have you made these changes -->
**Why?**
A recent bug shows that there are timer tasks left behind during failover. Handling `Stop()`s properly may prevent that from happening but will dig deeper on potential ack level consistency problems.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Set `QueueProcessorEnableGracefulSyncShutdown: true` in unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Should be minimal but just to be on safe side put the changes behind dynamic config so we can slowly roll this out and rollback if we see issues. 

