### PR TITLE
Add unit tests for ConvertGetTaskFailedCauseToErr

### DIFF
--- a/common/util_test.go
+++ b/common/util_test.go
@@ -693,3 +693,17 @@ func TestValidateRetryPolicy_Error(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertGetTaskFailedCauseToErr(t *testing.T) {
+	for cause, wantErr := range map[types.GetTaskFailedCause]error{
+		types.GetTaskFailedCauseServiceBusy:        &types.ServiceBusyError{},
+		types.GetTaskFailedCauseTimeout:            context.DeadlineExceeded,
+		types.GetTaskFailedCauseShardOwnershipLost: &types.ShardOwnershipLostError{},
+		types.GetTaskFailedCauseUncategorized:      &types.InternalServiceError{Message: "uncategorized error"},
+	} {
+		t.Run(cause.String(), func(t *testing.T) {
+			gotErr := ConvertGetTaskFailedCauseToErr(cause)
+			require.Equal(t, wantErr, gotErr)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Unit tests for ConvertGetTaskFailedCauseToErr have been added

<!-- Tell your future self why have you made these changes -->
**Why?**
 ConvertGetTaskFailedCauseToErr was not covered by unit tests 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests are passed


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
