### PR TITLE
Add shard id to queue processor related metrics

### DIFF
--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -23,7 +23,6 @@ package queue
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
 	"time"
 
@@ -95,7 +94,7 @@ func newProcessorBase(
 	logger log.Logger,
 	metricsClient metrics.Client,
 ) *processorBase {
-	metricsScope := metricsClient.Scope(options.MetricScope).Tagged(metrics.ShardIDTag(strconv.Itoa(shard.GetShardID())))
+	metricsScope := metricsClient.Scope(options.MetricScope).Tagged(metrics.ShardIDTag(shard.GetShardID()))
 	return &processorBase{
 		shard:         shard,
 		taskProcessor: taskProcessor,

--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -23,6 +23,7 @@ package queue
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -94,7 +95,7 @@ func newProcessorBase(
 	logger log.Logger,
 	metricsClient metrics.Client,
 ) *processorBase {
-	metricsScope := metricsClient.Scope(options.MetricScope)
+	metricsScope := metricsClient.Scope(options.MetricScope).Tagged(metrics.ShardIDTag(strconv.Itoa(shard.GetShardID())))
 	return &processorBase{
 		shard:         shard,
 		taskProcessor: taskProcessor,

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -23,7 +23,6 @@ package queue
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -433,7 +432,7 @@ func (t *timerQueueProcessor) completeTimer() error {
 
 	t.logger.Debugf("Start completing timer task from: %v, to %v", t.ackLevel, newAckLevelTimestamp)
 	t.metricsClient.Scope(metrics.TimerQueueProcessorScope).
-		Tagged(metrics.ShardIDTag(strconv.Itoa(t.shard.GetShardID()))).
+		Tagged(metrics.ShardIDTag(t.shard.GetShardID())).
 		IncCounter(metrics.TaskBatchCompleteCounter)
 
 	for {

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -543,7 +542,7 @@ func (t *timerQueueProcessorBase) notifyNewTimers(timerTasks []persistence.Task)
 
 	isActive := t.options.MetricScope == metrics.TimerActiveQueueProcessorScope
 	minNewTime := timerTasks[0].GetVisibilityTimestamp()
-	shardIDTag := metrics.ShardIDTag(strconv.Itoa(t.shard.GetShardID()))
+	shardIDTag := metrics.ShardIDTag(t.shard.GetShardID())
 	for _, timerTask := range timerTasks {
 		ts := timerTask.GetVisibilityTimestamp()
 		if ts.Before(minNewTime) {

--- a/service/history/queue/timer_queue_processor_base.go
+++ b/service/history/queue/timer_queue_processor_base.go
@@ -25,6 +25,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -542,6 +543,7 @@ func (t *timerQueueProcessorBase) notifyNewTimers(timerTasks []persistence.Task)
 
 	isActive := t.options.MetricScope == metrics.TimerActiveQueueProcessorScope
 	minNewTime := timerTasks[0].GetVisibilityTimestamp()
+	shardIDTag := metrics.ShardIDTag(strconv.Itoa(t.shard.GetShardID()))
 	for _, timerTask := range timerTasks {
 		ts := timerTask.GetVisibilityTimestamp()
 		if ts.Before(minNewTime) {
@@ -552,7 +554,7 @@ func (t *timerQueueProcessorBase) notifyNewTimers(timerTasks []persistence.Task)
 			timerTask.GetType(),
 			isActive,
 		)
-		t.metricsClient.IncCounter(taskScopeIdx, metrics.NewTimerCounter)
+		t.metricsClient.Scope(taskScopeIdx).Tagged(shardIDTag).IncCounter(metrics.NewTimerNotifyCounter)
 	}
 
 	t.notifyNewTimer(minNewTime)

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -25,7 +25,6 @@ import (
 	"errors"
 	"fmt"
 	"math"
-	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -425,7 +424,7 @@ func (t *transferQueueProcessor) completeTransfer() error {
 	}
 
 	t.metricsClient.Scope(metrics.TransferQueueProcessorScope).
-		Tagged(metrics.ShardIDTag(strconv.Itoa(t.shard.GetShardID()))).
+		Tagged(metrics.ShardIDTag(t.shard.GetShardID())).
 		IncCounter(metrics.TaskBatchCompleteCounter)
 
 	for {

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -423,7 +424,9 @@ func (t *transferQueueProcessor) completeTransfer() error {
 		return nil
 	}
 
-	t.metricsClient.IncCounter(metrics.TransferQueueProcessorScope, metrics.TaskBatchCompleteCounter)
+	t.metricsClient.Scope(metrics.TransferQueueProcessorScope).
+		Tagged(metrics.ShardIDTag(strconv.Itoa(t.shard.GetShardID()))).
+		IncCounter(metrics.TaskBatchCompleteCounter)
 
 	for {
 		pageSize := t.config.TransferTaskDeleteBatchSize()

--- a/service/history/queue/transfer_queue_processor_base.go
+++ b/service/history/queue/transfer_queue_processor_base.go
@@ -46,7 +46,6 @@ const (
 
 var (
 	loadQueueTaskThrottleRetryDelay = 5 * time.Second
-
 	persistenceOperationRetryPolicy = common.CreatePersistenceRetryPolicy()
 )
 
@@ -145,7 +144,7 @@ func newTransferQueueProcessorBase(
 			transferQueueProcessorBase,
 			options.ValidationInterval,
 			logger,
-			metricsClient.Scope(options.MetricScope),
+			processorBase.metricsScope,
 		)
 	}
 

--- a/service/history/queue/transfer_queue_validator.go
+++ b/service/history/queue/transfer_queue_validator.go
@@ -71,11 +71,10 @@ func newTransferQueueValidator(
 ) *transferQueueValidator {
 	timeSource := processor.shard.GetTimeSource()
 	return &transferQueueValidator{
-		processor:    processor,
-		timeSource:   timeSource,
-		logger:       logger,
-		metricsScope: metricsScope,
-
+		processor:          processor,
+		timeSource:         timeSource,
+		logger:             logger,
+		metricsScope:       metricsScope,
 		pendingTaskInfos:   make(map[int64]pendingTaskInfo),
 		maxReadLevels:      make(map[int]task.Key),
 		minReadTaskID:      0,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
History's queue processors are created per shard by history engine. Logs had shard-id tag but metrics were missing it. So adding shard id tag to relevant metrics.

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve overall monitoring of queue processor operations.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
1. Build and run
```
./scripts/buildkite/docker-build.sh
docker-compose -f docker/docker-compose.yml up
```
2. Visit prometheus UI: http://localhost:9090/graph
3. Query some queue processor metrics and validate shard_id is there
```
rate(task_batch_complete_counter{operation="TimerQueueProcessor"}[1m])
```

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
We default to 16k shards so cardinality of these queue processor metrics shouldn't be an issue. There's not other high cardinality tags in those metrics.
