### PR TITLE
Add unit tests for sql task store

### DIFF
--- a/common/persistence/sql/sql_task_store_test.go
+++ b/common/persistence/sql/sql_task_store_test.go
@@ -1,0 +1,1242 @@
+// Copyright (c) 2020 Uber Technologies, Inc.
+// Portions of the Software are attributed to Copyright (c) 2020 Temporal Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"math"
+	"testing"
+	"time"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/persistence/serialization"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
+
+func TestGetTaskListSize(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.GetTaskListSizeRequest
+		mockSetup func(*sqlplugin.MockDB)
+		want      *persistence.GetTaskListSizeResponse
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			req: &persistence.GetTaskListSizeRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskListName: "tl",
+				TaskListType: 0,
+				AckLevel:     10,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().GetTasksCount(gomock.Any(), &sqlplugin.TasksFilter{
+					ShardID:      0,
+					DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					TaskListName: "tl",
+					TaskType:     0,
+					MinTaskID:    common.Int64Ptr(10),
+				}).Return(int64(1), nil)
+			},
+			want: &persistence.GetTaskListSizeResponse{
+				Size: 1,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error case",
+			req: &persistence.GetTaskListSizeRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskListName: "tl",
+				TaskListType: 0,
+				AckLevel:     10,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				err := errors.New("some error")
+				mockDB.EXPECT().GetTasksCount(gomock.Any(), gomock.Any()).Return(int64(0), err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB},
+			}
+
+			tc.mockSetup(mockDB)
+
+			got, err := store.GetTaskListSize(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+				assert.Equal(t, tc.want, got, "Unexpected result for test case")
+			}
+		})
+	}
+}
+
+func TestLeaseTaskList(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.LeaseTaskListRequest
+		mockSetup func(*sqlplugin.MockDB, *sqlplugin.MockTx, *serialization.MockParser)
+		want      *persistence.LeaseTaskListResponse
+		wantErr   bool
+		assertErr func(*testing.T, error)
+	}{
+		{
+			name: "Success case - first lease",
+			req: &persistence.LeaseTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				TaskListKind: persistence.TaskListKindSticky,
+				RangeID:      0,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(nil, sql.ErrNoRows)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				mockDB.EXPECT().InsertIntoTaskListsWithTTL(gomock.Any(), &sqlplugin.TaskListsRowWithTTL{
+					TaskListsRow: sqlplugin.TaskListsRow{
+						ShardID:      0,
+						DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:         "tl",
+						TaskType:     0,
+						Data:         []byte(`tl`),
+						DataEncoding: "tl",
+					},
+					TTL: stickyTasksListsTTL,
+				}).Return(nil, nil)
+				mockParser.EXPECT().TaskListInfoFromBlob([]byte(`tl`), "tl").Return(&serialization.TaskListInfo{
+					AckLevel:        0,
+					Kind:            int16(persistence.TaskListKindSticky),
+					ExpiryTimestamp: time.Unix(0, 0),
+					LastUpdated:     time.Unix(0, 1),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), 0).Return(mockTx, nil)
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(int64(0), nil)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				mockTx.EXPECT().UpdateTaskListsWithTTL(gomock.Any(), &sqlplugin.TaskListsRowWithTTL{
+					TaskListsRow: sqlplugin.TaskListsRow{
+						ShardID:      0,
+						DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:         "tl",
+						TaskType:     0,
+						RangeID:      1,
+						Data:         []byte(`tl`),
+						DataEncoding: "tl",
+					},
+					TTL: stickyTasksListsTTL,
+				}).Return(&sqlResult{rowsAffected: 1}, nil)
+				mockTx.EXPECT().Commit().Return(nil)
+			},
+			want: &persistence.LeaseTaskListResponse{
+				TaskListInfo: &persistence.TaskListInfo{
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+					Name:     "tl",
+					TaskType: 0,
+					RangeID:  1,
+					AckLevel: 0,
+					Kind:     persistence.TaskListKindSticky,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error case - failed to get tasklist",
+			req: &persistence.LeaseTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				TaskListKind: persistence.TaskListKindSticky,
+				RangeID:      0,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				err := errors.New("some error")
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error case - failed to insert tasklist",
+			req: &persistence.LeaseTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				TaskListKind: persistence.TaskListKindSticky,
+				RangeID:      0,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				err := errors.New("some error")
+				mockDB.EXPECT().InsertIntoTaskListsWithTTL(gomock.Any(), gomock.Any()).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error case - condition failed",
+			req: &persistence.LeaseTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				TaskListKind: persistence.TaskListKindSticky,
+				RangeID:      1,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(nil, sql.ErrNoRows)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				mockDB.EXPECT().InsertIntoTaskListsWithTTL(gomock.Any(), &sqlplugin.TaskListsRowWithTTL{
+					TaskListsRow: sqlplugin.TaskListsRow{
+						ShardID:      0,
+						DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:         "tl",
+						TaskType:     0,
+						Data:         []byte(`tl`),
+						DataEncoding: "tl",
+					},
+					TTL: stickyTasksListsTTL,
+				}).Return(nil, nil)
+			},
+			wantErr: true,
+			assertErr: func(t *testing.T, err error) {
+				var expectedErr *persistence.ConditionFailedError
+				assert.True(t, errors.As(err, &expectedErr), "Expected the error to be ConditionFailedError")
+			},
+		},
+		{
+			name: "Error case - failed to lock tasklist",
+			req: &persistence.LeaseTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				TaskListKind: persistence.TaskListKindSticky,
+				RangeID:      0,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(nil, sql.ErrNoRows)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				mockDB.EXPECT().InsertIntoTaskListsWithTTL(gomock.Any(), &sqlplugin.TaskListsRowWithTTL{
+					TaskListsRow: sqlplugin.TaskListsRow{
+						ShardID:      0,
+						DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:         "tl",
+						TaskType:     0,
+						Data:         []byte(`tl`),
+						DataEncoding: "tl",
+					},
+					TTL: stickyTasksListsTTL,
+				}).Return(nil, nil)
+				mockParser.EXPECT().TaskListInfoFromBlob([]byte(`tl`), "tl").Return(&serialization.TaskListInfo{
+					AckLevel:        0,
+					Kind:            int16(persistence.TaskListKindSticky),
+					ExpiryTimestamp: time.Unix(0, 0),
+					LastUpdated:     time.Unix(0, 1),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), 0).Return(mockTx, nil)
+				err := errors.New("some error")
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(int64(0), err)
+				mockTx.EXPECT().IsNotFoundError(err).Return(true)
+				mockTx.EXPECT().Rollback().Return(nil)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error case - failed to update tasklists",
+			req: &persistence.LeaseTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				TaskListKind: persistence.TaskListKindSticky,
+				RangeID:      0,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(nil, sql.ErrNoRows)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				mockDB.EXPECT().InsertIntoTaskListsWithTTL(gomock.Any(), &sqlplugin.TaskListsRowWithTTL{
+					TaskListsRow: sqlplugin.TaskListsRow{
+						ShardID:      0,
+						DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:         "tl",
+						TaskType:     0,
+						Data:         []byte(`tl`),
+						DataEncoding: "tl",
+					},
+					TTL: stickyTasksListsTTL,
+				}).Return(nil, nil)
+				mockParser.EXPECT().TaskListInfoFromBlob([]byte(`tl`), "tl").Return(&serialization.TaskListInfo{
+					AckLevel:        0,
+					Kind:            int16(persistence.TaskListKindSticky),
+					ExpiryTimestamp: time.Unix(0, 0),
+					LastUpdated:     time.Unix(0, 1),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), 0).Return(mockTx, nil)
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(int64(0), nil)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				err := errors.New("some error")
+				mockTx.EXPECT().UpdateTaskListsWithTTL(gomock.Any(), &sqlplugin.TaskListsRowWithTTL{
+					TaskListsRow: sqlplugin.TaskListsRow{
+						ShardID:      0,
+						DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:         "tl",
+						TaskType:     0,
+						RangeID:      1,
+						Data:         []byte(`tl`),
+						DataEncoding: "tl",
+					},
+					TTL: stickyTasksListsTTL,
+				}).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+				mockTx.EXPECT().Rollback().Return(nil)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			mockTx := sqlplugin.NewMockTx(ctrl)
+			mockParser := serialization.NewMockParser(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB, parser: mockParser},
+			}
+
+			tc.mockSetup(mockDB, mockTx, mockParser)
+
+			got, err := store.LeaseTaskList(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+				if tc.assertErr != nil {
+					tc.assertErr(t, err)
+				}
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+				got.TaskListInfo.LastUpdated = tc.want.TaskListInfo.LastUpdated
+				assert.Equal(t, tc.want, got, "Unexpected result for test case")
+			}
+		})
+	}
+}
+
+func TestUpdateTaskList(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.UpdateTaskListRequest
+		mockSetup func(*sqlplugin.MockDB, *sqlplugin.MockTx, *serialization.MockParser)
+		want      *persistence.UpdateTaskListResponse
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			req: &persistence.UpdateTaskListRequest{
+				TaskListInfo: &persistence.TaskListInfo{
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+					Name:     "tl",
+					TaskType: 0,
+					RangeID:  1,
+					AckLevel: 0,
+					Kind:     persistence.TaskListKindSticky,
+				},
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(int64(1), nil)
+				mockDB.EXPECT().SupportsTTL().Return(true)
+				mockTx.EXPECT().UpdateTaskListsWithTTL(gomock.Any(), &sqlplugin.TaskListsRowWithTTL{
+					TaskListsRow: sqlplugin.TaskListsRow{
+						ShardID:      0,
+						DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:         "tl",
+						TaskType:     0,
+						RangeID:      1,
+						Data:         []byte(`tl`),
+						DataEncoding: "tl",
+					},
+					TTL: stickyTasksListsTTL,
+				}).Return(&sqlResult{rowsAffected: 1}, nil)
+				mockTx.EXPECT().Commit().Return(nil)
+			},
+			want:    &persistence.UpdateTaskListResponse{},
+			wantErr: false,
+		},
+		{
+			name: "Error case - failed to lock task list",
+			req: &persistence.UpdateTaskListRequest{
+				TaskListInfo: &persistence.TaskListInfo{
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+					Name:     "tl",
+					TaskType: 0,
+					RangeID:  1,
+					AckLevel: 0,
+					Kind:     persistence.TaskListKindSticky,
+				},
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+				err := errors.New("some error")
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(int64(1), err)
+				mockTx.EXPECT().IsNotFoundError(err).Return(true)
+				mockTx.EXPECT().Rollback().Return(nil)
+			},
+			want:    &persistence.UpdateTaskListResponse{},
+			wantErr: true,
+		},
+		{
+			name: "Error case - failed to update task list",
+			req: &persistence.UpdateTaskListRequest{
+				TaskListInfo: &persistence.TaskListInfo{
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+					Name:     "tl",
+					TaskType: 0,
+					RangeID:  1,
+					AckLevel: 0,
+					Kind:     persistence.TaskListKindSticky,
+				},
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockParser.EXPECT().TaskListInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+				}).Return(int64(1), nil)
+				err := errors.New("some error")
+				mockDB.EXPECT().SupportsTTL().Return(false)
+				mockTx.EXPECT().UpdateTaskLists(gomock.Any(), &sqlplugin.TaskListsRow{
+					ShardID:      0,
+					DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					Name:         "tl",
+					TaskType:     0,
+					RangeID:      1,
+					Data:         []byte(`tl`),
+					DataEncoding: "tl",
+				}).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+				mockTx.EXPECT().Rollback().Return(nil)
+			},
+			want:    &persistence.UpdateTaskListResponse{},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			mockTx := sqlplugin.NewMockTx(ctrl)
+			mockParser := serialization.NewMockParser(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB, parser: mockParser},
+			}
+
+			tc.mockSetup(mockDB, mockTx, mockParser)
+
+			got, err := store.UpdateTaskList(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+				assert.Equal(t, tc.want, got, "Unexpected result for test case")
+			}
+		})
+	}
+}
+
+func TestListTaskList(t *testing.T) {
+	pageSize := 1
+	testCases := []struct {
+		name      string
+		pageToken *taskListPageToken
+		mockSetup func(*sqlplugin.MockDB, *serialization.MockParser)
+		want      *persistence.ListTaskListResponse
+		wantToken *taskListPageToken
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			pageToken: &taskListPageToken{
+				ShardID:  10,
+				DomainID: serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+				Name:     "tl",
+				TaskType: 0,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, filter *sqlplugin.TaskListsFilter) ([]sqlplugin.TaskListsRow, error) {
+					assert.Equal(t, 10, filter.ShardID)
+					assert.Equal(t, serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"), *filter.DomainIDGreaterThan)
+					assert.Equal(t, "tl", *filter.NameGreaterThan)
+					assert.Equal(t, int64(0), *filter.TaskTypeGreaterThan)
+					assert.Equal(t, 1, *filter.PageSize)
+					return []sqlplugin.TaskListsRow{}, nil
+				})
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, filter *sqlplugin.TaskListsFilter) ([]sqlplugin.TaskListsRow, error) {
+					assert.Equal(t, 11, filter.ShardID)
+					assert.Equal(t, serialization.UUID{}, *filter.DomainIDGreaterThan)
+					assert.Equal(t, "", *filter.NameGreaterThan)
+					assert.Equal(t, int64(math.MinInt16), *filter.TaskTypeGreaterThan)
+					assert.Equal(t, 1, *filter.PageSize)
+					return []sqlplugin.TaskListsRow{
+						{
+							ShardID:      11,
+							DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+							Name:         "tl",
+							TaskType:     1,
+							RangeID:      123,
+							Data:         []byte(`tl`),
+							DataEncoding: "tl",
+						},
+					}, nil
+				})
+				mockParser.EXPECT().TaskListInfoFromBlob([]byte(`tl`), "tl").Return(&serialization.TaskListInfo{
+					Kind:            1,
+					AckLevel:        2,
+					ExpiryTimestamp: time.Unix(1, 4),
+					LastUpdated:     time.Unix(10, 0),
+				}, nil)
+			},
+			want: &persistence.ListTaskListResponse{
+				Items: []persistence.TaskListInfo{
+					{
+						DomainID:    "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+						Name:        "tl",
+						TaskType:    1,
+						RangeID:     123,
+						Kind:        1,
+						AckLevel:    2,
+						Expiry:      time.Unix(1, 4),
+						LastUpdated: time.Unix(10, 0),
+					},
+				},
+				NextPageToken: func() []byte {
+					token, err := gobSerialize(&taskListPageToken{
+						ShardID:  11,
+						DomainID: serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+						Name:     "tl",
+						TaskType: 1,
+					})
+					require.NoError(t, err, "failed to serialize page token")
+					return token
+				}(),
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error case",
+			pageToken: &taskListPageToken{
+				ShardID:  10,
+				DomainID: serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+				Name:     "tl",
+				TaskType: 0,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockParser) {
+				err := errors.New("some error")
+				mockDB.EXPECT().SelectFromTaskLists(gomock.Any(), gomock.Any()).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			mockParser := serialization.NewMockParser(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB, parser: mockParser},
+				nShards:  1000,
+			}
+
+			tc.mockSetup(mockDB, mockParser)
+
+			pageToken, err := gobSerialize(tc.pageToken)
+			require.NoError(t, err, "invalid pageToken")
+			req := &persistence.ListTaskListRequest{
+				PageSize:  pageSize,
+				PageToken: pageToken,
+			}
+			got, err := store.ListTaskList(context.Background(), req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+				assert.Equal(t, tc.want, got, "Unexpected result for test case")
+			}
+		})
+	}
+}
+
+func TestDeleteTaskList(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.DeleteTaskListRequest
+		mockSetup func(*sqlplugin.MockDB)
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			req: &persistence.DeleteTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskListName: "tl",
+				TaskListType: 0,
+				RangeID:      10,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().DeleteFromTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(0),
+					RangeID:  common.Int64Ptr(10),
+				}).Return(&sqlResult{rowsAffected: 1}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error case",
+			req: &persistence.DeleteTaskListRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskListName: "tl",
+				TaskListType: 0,
+				RangeID:      10,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				err := errors.New("some error")
+				mockDB.EXPECT().DeleteFromTaskLists(gomock.Any(), gomock.Any()).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB},
+			}
+
+			tc.mockSetup(mockDB)
+
+			err := store.DeleteTaskList(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+			}
+		})
+	}
+}
+
+func TestCreateTasks(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.InternalCreateTasksRequest
+		mockSetup func(*sqlplugin.MockDB, *sqlplugin.MockTx, *serialization.MockParser)
+		want      *persistence.CreateTasksResponse
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			req: &persistence.InternalCreateTasksRequest{
+				TaskListInfo: &persistence.TaskListInfo{
+					Name:     "tl",
+					TaskType: 1,
+					RangeID:  9,
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				},
+				Tasks: []*persistence.InternalCreateTasksInfo{
+					{
+						Data: &persistence.InternalTaskInfo{
+							ScheduleToStartTimeout: time.Second,
+							DomainID:               "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+							TaskID:                 999,
+						},
+						TaskID: 999,
+					},
+				},
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().SupportsTTL().Return(true).Times(4)
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().MaxAllowedTTL().Return(common.DurationPtr(time.Hour), nil)
+				mockParser.EXPECT().TaskInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+				mockTx.EXPECT().InsertIntoTasksWithTTL(gomock.Any(), []sqlplugin.TasksRowWithTTL{
+					{
+						TasksRow: sqlplugin.TasksRow{
+							ShardID:      0,
+							DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+							TaskListName: "tl",
+							TaskType:     1,
+							TaskID:       999,
+							Data:         []byte(`tl`),
+							DataEncoding: "tl",
+						},
+						TTL: common.DurationPtr(time.Second),
+					},
+				}).Return(nil, nil)
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(1),
+				}).Return(int64(9), nil)
+				mockTx.EXPECT().Commit().Return(nil)
+			},
+			want:    &persistence.CreateTasksResponse{},
+			wantErr: false,
+		},
+		{
+			name: "Error case - failed to insert tasks",
+			req: &persistence.InternalCreateTasksRequest{
+				TaskListInfo: &persistence.TaskListInfo{
+					Name:     "tl",
+					TaskType: 1,
+					RangeID:  9,
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				},
+				Tasks: []*persistence.InternalCreateTasksInfo{
+					{
+						Data: &persistence.InternalTaskInfo{
+							ScheduleToStartTimeout: time.Second,
+							DomainID:               "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+							TaskID:                 999,
+						},
+						TaskID: 999,
+					},
+				},
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().SupportsTTL().Return(true).Times(4)
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().MaxAllowedTTL().Return(common.DurationPtr(time.Hour), nil)
+				mockParser.EXPECT().TaskInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+				err := errors.New("some error")
+				mockTx.EXPECT().InsertIntoTasksWithTTL(gomock.Any(), []sqlplugin.TasksRowWithTTL{
+					{
+						TasksRow: sqlplugin.TasksRow{
+							ShardID:      0,
+							DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+							TaskListName: "tl",
+							TaskType:     1,
+							TaskID:       999,
+							Data:         []byte(`tl`),
+							DataEncoding: "tl",
+						},
+						TTL: common.DurationPtr(time.Second),
+					},
+				}).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+				mockTx.EXPECT().Rollback().Return(nil)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Error case - failed to lock tasklist",
+			req: &persistence.InternalCreateTasksRequest{
+				TaskListInfo: &persistence.TaskListInfo{
+					Name:     "tl",
+					TaskType: 1,
+					RangeID:  9,
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				},
+				Tasks: []*persistence.InternalCreateTasksInfo{
+					{
+						Data: &persistence.InternalTaskInfo{
+							ScheduleToStartTimeout: time.Second,
+							DomainID:               "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+							TaskID:                 999,
+						},
+						TaskID: 999,
+					},
+				},
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockTx *sqlplugin.MockTx, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().SupportsTTL().Return(true).Times(4)
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().MaxAllowedTTL().Return(common.DurationPtr(time.Hour), nil)
+				mockParser.EXPECT().TaskInfoToBlob(gomock.Any()).Return(persistence.DataBlob{
+					Data:     []byte(`tl`),
+					Encoding: common.EncodingType("tl"),
+				}, nil)
+				mockDB.EXPECT().BeginTx(gomock.Any(), gomock.Any()).Return(mockTx, nil)
+				mockTx.EXPECT().InsertIntoTasksWithTTL(gomock.Any(), []sqlplugin.TasksRowWithTTL{
+					{
+						TasksRow: sqlplugin.TasksRow{
+							ShardID:      0,
+							DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+							TaskListName: "tl",
+							TaskType:     1,
+							TaskID:       999,
+							Data:         []byte(`tl`),
+							DataEncoding: "tl",
+						},
+						TTL: common.DurationPtr(time.Second),
+					},
+				}).Return(nil, nil)
+				err := errors.New("some error")
+				mockTx.EXPECT().LockTaskLists(gomock.Any(), &sqlplugin.TaskListsFilter{
+					ShardID:  0,
+					DomainID: serialization.UUIDPtr(serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0")),
+					Name:     common.StringPtr("tl"),
+					TaskType: common.Int64Ptr(1),
+				}).Return(int64(0), err)
+				mockTx.EXPECT().IsNotFoundError(err).Return(true)
+				mockTx.EXPECT().Rollback().Return(nil)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			mockTx := sqlplugin.NewMockTx(ctrl)
+			mockParser := serialization.NewMockParser(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB, parser: mockParser},
+			}
+
+			tc.mockSetup(mockDB, mockTx, mockParser)
+
+			got, err := store.CreateTasks(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+				assert.Equal(t, tc.want, got, "Unexpected result for test case")
+			}
+		})
+	}
+}
+
+func TestGetTasks(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.GetTasksRequest
+		mockSetup func(*sqlplugin.MockDB, *serialization.MockParser)
+		want      *persistence.InternalGetTasksResponse
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			req: &persistence.GetTasksRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				ReadLevel:    10,
+				MaxReadLevel: common.Int64Ptr(9999),
+				BatchSize:    1,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().SelectFromTasks(gomock.Any(), &sqlplugin.TasksFilter{
+					ShardID:      0,
+					DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					TaskListName: "tl",
+					TaskType:     0,
+					MinTaskID:    common.Int64Ptr(10),
+					MaxTaskID:    common.Int64Ptr(9999),
+					PageSize:     common.IntPtr(1),
+				}).Return([]sqlplugin.TasksRow{
+					{
+						TaskID:       888,
+						Data:         []byte(`task`),
+						DataEncoding: "task",
+					},
+				}, nil)
+				mockParser.EXPECT().TaskInfoFromBlob([]byte(`task`), "task").Return(&serialization.TaskInfo{
+					WorkflowID:       "test",
+					RunID:            serialization.MustParseUUID("b9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					ScheduleID:       7,
+					ExpiryTimestamp:  time.Unix(9, 0),
+					CreatedTimestamp: time.Unix(8, 7),
+					PartitionConfig:  map[string]string{"a": "b"},
+				}, nil)
+			},
+			want: &persistence.InternalGetTasksResponse{
+				Tasks: []*persistence.InternalTaskInfo{
+					{
+						DomainID:        "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+						WorkflowID:      "test",
+						RunID:           "b9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+						TaskID:          888,
+						ScheduleID:      7,
+						Expiry:          time.Unix(9, 0),
+						CreatedTime:     time.Unix(8, 7),
+						PartitionConfig: map[string]string{"a": "b"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error case",
+			req: &persistence.GetTasksRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskList:     "tl",
+				TaskType:     0,
+				ReadLevel:    10,
+				MaxReadLevel: common.Int64Ptr(9999),
+				BatchSize:    1,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB, mockParser *serialization.MockParser) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				err := errors.New("some error")
+				mockDB.EXPECT().SelectFromTasks(gomock.Any(), &sqlplugin.TasksFilter{
+					ShardID:      0,
+					DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					TaskListName: "tl",
+					TaskType:     0,
+					MinTaskID:    common.Int64Ptr(10),
+					MaxTaskID:    common.Int64Ptr(9999),
+					PageSize:     common.IntPtr(1),
+				}).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			mockParser := serialization.NewMockParser(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB, parser: mockParser},
+			}
+
+			tc.mockSetup(mockDB, mockParser)
+
+			got, err := store.GetTasks(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+				assert.Equal(t, tc.want, got, "Unexpected result for test case")
+			}
+		})
+	}
+}
+
+func TestCompleteTask(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.CompleteTaskRequest
+		mockSetup func(*sqlplugin.MockDB)
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			req: &persistence.CompleteTaskRequest{
+				TaskList: &persistence.TaskListInfo{
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+					Name:     "tl",
+					TaskType: 0,
+				},
+				TaskID: 1001,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().DeleteFromTasks(gomock.Any(), &sqlplugin.TasksFilter{
+					ShardID:      0,
+					DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					TaskListName: "tl",
+					TaskType:     0,
+					TaskID:       common.Int64Ptr(1001),
+				}).Return(&sqlResult{rowsAffected: 1}, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "Error case",
+			req: &persistence.CompleteTaskRequest{
+				TaskList: &persistence.TaskListInfo{
+					DomainID: "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+					Name:     "tl",
+					TaskType: 0,
+				},
+				TaskID: 1001,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				err := errors.New("some error")
+				mockDB.EXPECT().DeleteFromTasks(gomock.Any(), &sqlplugin.TasksFilter{
+					ShardID:      0,
+					DomainID:     serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					TaskListName: "tl",
+					TaskType:     0,
+					TaskID:       common.Int64Ptr(1001),
+				}).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB},
+			}
+
+			tc.mockSetup(mockDB)
+
+			err := store.CompleteTask(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+			}
+		})
+	}
+}
+
+func TestCompleteTaskLessThan(t *testing.T) {
+	testCases := []struct {
+		name      string
+		req       *persistence.CompleteTasksLessThanRequest
+		mockSetup func(*sqlplugin.MockDB)
+		want      *persistence.CompleteTasksLessThanResponse
+		wantErr   bool
+	}{
+		{
+			name: "Success case",
+			req: &persistence.CompleteTasksLessThanRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskListName: "tl",
+				TaskType:     0,
+				TaskID:       1001,
+				Limit:        100,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				mockDB.EXPECT().DeleteFromTasks(gomock.Any(), &sqlplugin.TasksFilter{
+					ShardID:              0,
+					DomainID:             serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					TaskListName:         "tl",
+					TaskType:             0,
+					TaskIDLessThanEquals: common.Int64Ptr(1001),
+					Limit:                common.IntPtr(100),
+				}).Return(&sqlResult{rowsAffected: 100}, nil)
+			},
+			want:    &persistence.CompleteTasksLessThanResponse{TasksCompleted: 100},
+			wantErr: false,
+		},
+		{
+			name: "Error case",
+			req: &persistence.CompleteTasksLessThanRequest{
+				DomainID:     "c9488dc7-20b2-44c3-b2e4-bfea5af62ac0",
+				TaskListName: "tl",
+				TaskType:     0,
+				TaskID:       1001,
+				Limit:        100,
+			},
+			mockSetup: func(mockDB *sqlplugin.MockDB) {
+				mockDB.EXPECT().GetTotalNumDBShards().Return(1)
+				err := errors.New("some error")
+				mockDB.EXPECT().DeleteFromTasks(gomock.Any(), &sqlplugin.TasksFilter{
+					ShardID:              0,
+					DomainID:             serialization.MustParseUUID("c9488dc7-20b2-44c3-b2e4-bfea5af62ac0"),
+					TaskListName:         "tl",
+					TaskType:             0,
+					TaskIDLessThanEquals: common.Int64Ptr(1001),
+					Limit:                common.IntPtr(100),
+				}).Return(nil, err)
+				mockDB.EXPECT().IsNotFoundError(err).Return(true)
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDB := sqlplugin.NewMockDB(ctrl)
+			store := &sqlTaskStore{
+				sqlStore: sqlStore{db: mockDB},
+			}
+
+			tc.mockSetup(mockDB)
+
+			got, err := store.CompleteTasksLessThan(context.Background(), tc.req)
+			if tc.wantErr {
+				assert.Error(t, err, "Expected an error for test case")
+			} else {
+				assert.NoError(t, err, "Did not expect an error for test case")
+				assert.Equal(t, tc.want, got, "Unexpected result for test case")
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add unit tests for sql task store

- Fix a bug in ListTaskLists API: gob encoding does not transmit 0 value, so when deserializing pageToken, we should only pass in an empty token. And also use the correct domainID, when going to the next page. This should fix https://github.com/uber/cadence/issues/3911

<!-- Tell your future self why have you made these changes -->
**Why?**
Add unit tests for sql task store

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
