### PR TITLE
Change metrics.ShardIDTag to allow int values

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -84,8 +84,8 @@ func metricWithUnknown(key, value string) Tag {
 	return simpleMetric{key: key, value: value}
 }
 
-func ShardIDTag(shardIDStr string) Tag {
-	return metricWithUnknown(shardID, shardIDStr)
+func ShardIDTag(shardIDVal int) Tag {
+	return metricWithUnknown(shardID, strconv.Itoa(shardIDVal))
 }
 
 // DomainTag returns a new domain tag. For timers, this also ensures that we

--- a/common/persistence/persistenceMetricClients.go
+++ b/common/persistence/persistenceMetricClients.go
@@ -22,7 +22,6 @@ package persistence
 
 import (
 	"context"
-	"strconv"
 	"time"
 
 	"github.com/uber/cadence/common/config"
@@ -423,7 +422,7 @@ func (p *workflowExecutionPersistenceClient) CreateWorkflowExecution(
 	var err error
 	if p.enableShardIDMetrics() {
 		err = p.callWithDomainAndShardScope(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	} else {
 		err = p.call(metrics.PersistenceCreateWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName))
 	}
@@ -446,7 +445,7 @@ func (p *workflowExecutionPersistenceClient) GetWorkflowExecution(
 	var err error
 	if p.enableShardIDMetrics() {
 		err = p.callWithDomainAndShardScope(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	} else {
 		err = p.call(metrics.PersistenceGetWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName))
 	}
@@ -471,7 +470,7 @@ func (p *workflowExecutionPersistenceClient) UpdateWorkflowExecution(
 	var err error
 	if p.enableShardIDMetrics() {
 		err = p.callWithDomainAndShardScope(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	} else {
 		err = p.call(metrics.PersistenceUpdateWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName))
 	}
@@ -496,7 +495,7 @@ func (p *workflowExecutionPersistenceClient) ConflictResolveWorkflowExecution(
 	var err error
 	if p.enableShardIDMetrics() {
 		err = p.callWithDomainAndShardScope(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	} else {
 		err = p.call(metrics.PersistenceConflictResolveWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName))
 	}
@@ -517,7 +516,7 @@ func (p *workflowExecutionPersistenceClient) DeleteWorkflowExecution(
 		tag.WorkflowDomainName(request.DomainName), tag.WorkflowID(request.WorkflowID), tag.ShardID(p.GetShardID()))
 	if p.enableShardIDMetrics() {
 		return p.callWithDomainAndShardScope(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	}
 	return p.call(metrics.PersistenceDeleteWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName))
 
@@ -534,7 +533,7 @@ func (p *workflowExecutionPersistenceClient) DeleteCurrentWorkflowExecution(
 		tag.WorkflowDomainName(request.DomainName), tag.WorkflowID(request.WorkflowID), tag.ShardID(p.GetShardID()))
 	if p.enableShardIDMetrics() {
 		return p.callWithDomainAndShardScope(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	}
 	return p.call(metrics.PersistenceDeleteCurrentWorkflowExecutionScope, op, metrics.DomainTag(request.DomainName))
 }
@@ -554,7 +553,7 @@ func (p *workflowExecutionPersistenceClient) GetCurrentExecution(
 	var err error
 	if p.enableShardIDMetrics() {
 		err = p.callWithDomainAndShardScope(metrics.PersistenceGetCurrentExecutionScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	} else {
 		err = p.call(metrics.PersistenceGetCurrentExecutionScope, op, metrics.DomainTag(request.DomainName))
 	}
@@ -599,7 +598,7 @@ func (p *workflowExecutionPersistenceClient) IsWorkflowExecutionExists(
 	var err error
 	if p.enableShardIDMetrics() {
 		err = p.callWithDomainAndShardScope(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.DomainTag(request.DomainName),
-			metrics.ShardIDTag(strconv.Itoa(p.GetShardID())))
+			metrics.ShardIDTag(p.GetShardID()))
 	} else {
 		err = p.call(metrics.PersistenceIsWorkflowExecutionExistsScope, op, metrics.DomainTag(request.DomainName))
 	}

--- a/service/history/execution/context_util.go
+++ b/service/history/execution/context_util.go
@@ -21,7 +21,6 @@
 package execution
 
 import (
-	"strconv"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -34,14 +33,14 @@ import (
 
 func (c *contextImpl) emitLargeWorkflowShardIDStats(blobSize int64, oldHistoryCount int64, oldHistorySize int64, newHistoryCount int64) {
 	if c.shard.GetConfig().EnableShardIDMetrics() {
-		shardIDStr := strconv.Itoa(c.shard.GetShardID())
+		shardID := c.shard.GetShardID()
 
 		blobSizeWarn := common.MinInt64(int64(c.shard.GetConfig().LargeShardHistoryBlobMetricThreshold()), int64(c.shard.GetConfig().BlobSizeLimitWarn(c.GetDomainName())))
 		// check if blob size is larger than threshold in Dynamic config if so alert on it every time
 		if blobSize > blobSizeWarn {
 			c.logger.SampleInfo("Workflow writing a large blob", c.shard.GetConfig().SampleLoggingRate(), tag.WorkflowDomainName(c.GetDomainName()),
 				tag.WorkflowID(c.workflowExecution.GetWorkflowID()), tag.ShardID(c.shard.GetShardID()), tag.WorkflowRunID(c.workflowExecution.GetRunID()))
-			c.metricsClient.Scope(metrics.LargeExecutionBlobShardScope, metrics.ShardIDTag(shardIDStr)).IncCounter(metrics.LargeHistoryBlobCount)
+			c.metricsClient.Scope(metrics.LargeExecutionBlobShardScope, metrics.ShardIDTag(shardID)).IncCounter(metrics.LargeHistoryBlobCount)
 		}
 
 		historyCountWarn := common.MinInt64(int64(c.shard.GetConfig().LargeShardHistoryEventMetricThreshold()), int64(c.shard.GetConfig().HistoryCountLimitWarn(c.GetDomainName())))
@@ -50,7 +49,7 @@ func (c *contextImpl) emitLargeWorkflowShardIDStats(blobSize int64, oldHistoryCo
 		if oldHistoryCount < historyCountWarn && newHistoryCount >= historyCountWarn {
 			c.logger.Warn("Workflow history event count is reaching dangerous levels", tag.WorkflowDomainName(c.GetDomainName()),
 				tag.WorkflowID(c.workflowExecution.GetWorkflowID()), tag.ShardID(c.shard.GetShardID()), tag.WorkflowRunID(c.workflowExecution.GetRunID()))
-			c.metricsClient.Scope(metrics.LargeExecutionCountShardScope, metrics.ShardIDTag(shardIDStr)).IncCounter(metrics.LargeHistoryEventCount)
+			c.metricsClient.Scope(metrics.LargeExecutionCountShardScope, metrics.ShardIDTag(shardID)).IncCounter(metrics.LargeHistoryEventCount)
 		}
 
 		historySizeWarn := common.MinInt64(int64(c.shard.GetConfig().LargeShardHistorySizeMetricThreshold()), int64(c.shard.GetConfig().HistorySizeLimitWarn(c.GetDomainName())))
@@ -58,7 +57,7 @@ func (c *contextImpl) emitLargeWorkflowShardIDStats(blobSize int64, oldHistoryCo
 		if oldHistorySize < historySizeWarn && c.stats.HistorySize >= historySizeWarn {
 			c.logger.Warn("Workflow history event size is reaching dangerous levels", tag.WorkflowDomainName(c.GetDomainName()),
 				tag.WorkflowID(c.workflowExecution.GetWorkflowID()), tag.ShardID(c.shard.GetShardID()), tag.WorkflowRunID(c.workflowExecution.GetRunID()))
-			c.metricsClient.Scope(metrics.LargeExecutionSizeShardScope, metrics.ShardIDTag(shardIDStr)).IncCounter(metrics.LargeHistorySizeCount)
+			c.metricsClient.Scope(metrics.LargeExecutionSizeShardScope, metrics.ShardIDTag(shardID)).IncCounter(metrics.LargeHistorySizeCount)
 		}
 	}
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strconv"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -1171,7 +1170,7 @@ func (e *historyEngineImpl) QueryWorkflow(
 ) (retResp *types.HistoryQueryWorkflowResponse, retErr error) {
 
 	scope := e.metricsClient.Scope(metrics.HistoryQueryWorkflowScope).Tagged(metrics.DomainTag(request.GetRequest().GetDomain()))
-	shardMetricScope := e.metricsClient.Scope(metrics.HistoryQueryWorkflowScope, metrics.ShardIDTag(strconv.Itoa(e.shard.GetShardID())))
+	shardMetricScope := e.metricsClient.Scope(metrics.HistoryQueryWorkflowScope, metrics.ShardIDTag(e.shard.GetShardID()))
 
 	consistentQueryEnabled := e.config.EnableConsistentQuery() && e.config.EnableConsistentQueryByDomain(request.GetRequest().GetDomain())
 	if request.GetRequest().GetQueryConsistencyLevel() == types.QueryConsistencyLevelStrong {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed metrics.ShardIDTag to allow int so consumers can pass shardID and it is converted inside.

<!-- Tell your future self why have you made these changes -->
**Why?**
Simplify calls to metrics.ShardIDTag

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
