### PR TITLE
Ensure testlogger samples all logs

### DIFF
--- a/common/log/loggerimpl/logger.go
+++ b/common/log/loggerimpl/logger.go
@@ -45,6 +45,8 @@ const (
 	defaultMsgForEmpty = "none"
 )
 
+var defaultSampleFn = func(i int) bool { return rand.Intn(i) == 0 }
+
 // NewNopLogger returns a no-op logger
 func NewNopLogger() log.Logger {
 	return NewLogger(zap.NewNop())
@@ -60,19 +62,16 @@ func NewDevelopment() (log.Logger, error) {
 }
 
 // NewLogger returns a new logger
-func NewLogger(zapLogger *zap.Logger) log.Logger {
-	return NewLoggerWithSampleFunc(zapLogger, func(i int) bool {
-		return rand.Intn(i) == 0
-	})
-}
-
-// NewLoggerWithSampleFunc returns a new logger with sample function.
-func NewLoggerWithSampleFunc(zapLogger *zap.Logger, sampleLocalFn func(int) bool) log.Logger {
-	return &loggerImpl{
+func NewLogger(zapLogger *zap.Logger, opts ...Option) log.Logger {
+	impl := &loggerImpl{
 		zapLogger:     zapLogger,
 		skip:          skipForDefaultLogger,
-		sampleLocalFn: sampleLocalFn,
+		sampleLocalFn: defaultSampleFn,
 	}
+	for _, opt := range opts {
+		opt(impl)
+	}
+	return impl
 }
 
 func caller(skip int) string {

--- a/common/log/loggerimpl/logger.go
+++ b/common/log/loggerimpl/logger.go
@@ -47,9 +47,7 @@ const (
 
 // NewNopLogger returns a no-op logger
 func NewNopLogger() log.Logger {
-	return &loggerImpl{
-		zapLogger: zap.NewNop(),
-	}
+	return NewLogger(zap.NewNop())
 }
 
 // NewDevelopment returns a logger at debug level and log into STDERR
@@ -63,13 +61,9 @@ func NewDevelopment() (log.Logger, error) {
 
 // NewLogger returns a new logger
 func NewLogger(zapLogger *zap.Logger) log.Logger {
-	return &loggerImpl{
-		zapLogger: zapLogger,
-		skip:      skipForDefaultLogger,
-		sampleLocalFn: func(i int) bool {
-			return rand.Intn(i) == 0
-		},
-	}
+	return NewLoggerWithSampleFunc(zapLogger, func(i int) bool {
+		return rand.Intn(i) == 0
+	})
 }
 
 // NewLoggerWithSampleFunc returns a new logger with sample function.

--- a/common/log/loggerimpl/logger.go
+++ b/common/log/loggerimpl/logger.go
@@ -161,8 +161,9 @@ func (lg *loggerImpl) WithTags(tags ...tag.Tag) log.Logger {
 	fields := lg.buildFields(tags)
 	zapLogger := lg.zapLogger.With(fields...)
 	return &loggerImpl{
-		zapLogger: zapLogger,
-		skip:      lg.skip,
+		zapLogger:     zapLogger,
+		skip:          lg.skip,
+		sampleLocalFn: lg.sampleLocalFn,
 	}
 }
 

--- a/common/log/loggerimpl/options.go
+++ b/common/log/loggerimpl/options.go
@@ -20,25 +20,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package testlogger
+package loggerimpl
 
-import (
-	"testing"
+// Option is used to set options for the logger.
+type Option func(impl *loggerImpl)
 
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
-
-	"github.com/uber/cadence/common/log"
-	"github.com/uber/cadence/common/log/loggerimpl"
-)
-
-// New is a helper to create new development logger in unit test
-func New(t zaptest.TestingT) log.Logger {
-	if testing.Verbose() {
-		logger, err := loggerimpl.NewDevelopment()
-		require.NoError(t, err)
-		return logger
+// WithSampleFunc sets the sampling function for the logger.
+func WithSampleFunc(fn func(int) bool) Option {
+	return func(impl *loggerImpl) {
+		impl.sampleLocalFn = fn
 	}
-	// test logger samples all logs
-	return loggerimpl.NewLogger(zaptest.NewLogger(t), loggerimpl.WithSampleFunc(func(int) bool { return true }))
 }

--- a/common/log/loggerimpl/replay.go
+++ b/common/log/loggerimpl/replay.go
@@ -45,8 +45,9 @@ func NewReplayLogger(logger log.Logger, ctx workflow.Context, enableLogInReplay 
 	lg, ok := logger.(*loggerImpl)
 	if ok {
 		logger = &loggerImpl{
-			zapLogger: lg.zapLogger,
-			skip:      skipForReplayLogger,
+			zapLogger:     lg.zapLogger,
+			skip:          skipForReplayLogger,
+			sampleLocalFn: lg.sampleLocalFn,
 		}
 	} else {
 		logger.Warn("ReplayLogger may not emit callat tag correctly because the logger passed in is not loggerImpl")

--- a/common/log/loggerimpl/throttle.go
+++ b/common/log/loggerimpl/throttle.go
@@ -50,8 +50,9 @@ func NewThrottledLogger(logger log.Logger, rps dynamicconfig.IntPropertyFn) log.
 	lg, ok := logger.(*loggerImpl)
 	if ok {
 		log = &loggerImpl{
-			zapLogger: lg.zapLogger,
-			skip:      skipForThrottleLogger,
+			zapLogger:     lg.zapLogger,
+			skip:          skipForThrottleLogger,
+			sampleLocalFn: lg.sampleLocalFn,
 		}
 	} else {
 		logger.Warn("ReplayLogger may not emit callat tag correctly because the logger passed in is not loggerImpl")

--- a/common/log/testlogger/testlogger.go
+++ b/common/log/testlogger/testlogger.go
@@ -39,5 +39,6 @@ func New(t zaptest.TestingT) log.Logger {
 		require.NoError(t, err)
 		return logger
 	}
-	return loggerimpl.NewLogger(zaptest.NewLogger(t))
+	// test logger samples all logs
+	return loggerimpl.NewLoggerWithSampleFunc(zaptest.NewLogger(t), func(int) bool { return true })
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated testlogger wrapper to ensure that all log messages are sampled.
To achieve this I've exposed a new consturctor of loggerimpl that passes sampleFn and ensured that default implementation stayed the same.


<!-- Tell your future self why have you made these changes -->
**Why?**
This is required in wrappers changes that use logging.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
