### PR TITLE
Toggling off cross-cluster polling by default

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1646,12 +1646,19 @@ const (
 	// Default value: false
 	// Allowed filters: DomainName
 	EnableConsistentQueryByDomain
-	// EnableCrossClusterOperations indicates if cross cluster operations can be scheduled for a domain
+	// EnableCrossClusterEngine is used as an overall switch for the cross-cluster feature, a feature which, if not enabled
+	// can be quite expensive in terms of resources
+	// KeyName: history.enableCrossClusterEngine
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	EnableCrossClusterEngine
+	// EnableCrossClusterOperationsForDomain indicates if cross cluster operations can be scheduled for a domain
 	// KeyName: history.enableCrossClusterOperations
 	// Value type: Bool
 	// Default value: false
 	// Allowed filters: DomainName
-	EnableCrossClusterOperations
+	EnableCrossClusterOperationsForDomain
 	// EnableHistoryCorruptionCheck enables additional sanity check for corrupted history. This allows early catches of DB corruptions but potiantally increased latency.
 	// KeyName: history.enableHistoryCorruptionCheck
 	// Value type: Bool
@@ -3883,10 +3890,15 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		Description:  "EnableConsistentQueryByDomain indicates if consistent query is enabled for a domain",
 		DefaultValue: false,
 	},
-	EnableCrossClusterOperations: DynamicBool{
+	EnableCrossClusterEngine: DynamicBool{
+		KeyName:      "history.enableCrossClusterEngine",
+		Description:  "an overall toggle for the cross-cluster domain feature",
+		DefaultValue: false,
+	},
+	EnableCrossClusterOperationsForDomain: DynamicBool{
 		KeyName:      "history.enableCrossClusterOperations",
 		Filters:      []Filter{DomainName},
-		Description:  "EnableCrossClusterOperations indicates if cross cluster operations can be scheduled for a domain",
+		Description:  "EnableCrossClusterOperationsForDomain indicates if cross cluster operations can be scheduled for a domain",
 		DefaultValue: false,
 	},
 	EnableHistoryCorruptionCheck: DynamicBool{

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -7,9 +7,6 @@ system.minRetentionDays:
 history.EnableConsistentQueryByDomain:
 - value: true
   constraints: {}
-history.enableCrossClusterOperations:
-- value: true
-  constraints: {}
 history.useNewInitialFailoverVersion:
 - value: true
   constraints: {}

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -293,7 +293,8 @@ type Config struct {
 	EnableConsistentQueryByDomain dynamicconfig.BoolPropertyFnWithDomainFilter
 	MaxBufferedQueryCount         dynamicconfig.IntPropertyFn
 
-	EnableCrossClusterOperations dynamicconfig.BoolPropertyFnWithDomainFilter
+	EnableCrossClusterEngine              dynamicconfig.BoolPropertyFn
+	EnableCrossClusterOperationsForDomain dynamicconfig.BoolPropertyFnWithDomainFilter
 
 	// Data integrity check related config knobs
 	MutableStateChecksumGenProbability    dynamicconfig.IntPropertyFnWithDomainFilter
@@ -547,7 +548,8 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 
 		EnableConsistentQuery:                 dc.GetBoolProperty(dynamicconfig.EnableConsistentQuery),
 		EnableConsistentQueryByDomain:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableConsistentQueryByDomain),
-		EnableCrossClusterOperations:          dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableCrossClusterOperations),
+		EnableCrossClusterEngine:              dc.GetBoolProperty(dynamicconfig.EnableCrossClusterEngine),
+		EnableCrossClusterOperationsForDomain: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableCrossClusterOperationsForDomain),
 		MaxBufferedQueryCount:                 dc.GetIntProperty(dynamicconfig.MaxBufferedQueryCount),
 		MutableStateChecksumGenProbability:    dc.GetIntPropertyFilteredByDomain(dynamicconfig.MutableStateChecksumGenProbability),
 		MutableStateChecksumVerifyProbability: dc.GetIntPropertyFilteredByDomain(dynamicconfig.MutableStateChecksumVerifyProbability),
@@ -599,7 +601,7 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	panicIfErr(inMem.UpdateValue(dynamicconfig.ReplicationTaskProcessorStartWait, time.Nanosecond))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.EnableActivityLocalDispatchByDomain, true))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.MaxActivityCountDispatchByDomain, 0))
-	panicIfErr(inMem.UpdateValue(dynamicconfig.EnableCrossClusterOperations, true))
+	panicIfErr(inMem.UpdateValue(dynamicconfig.EnableCrossClusterOperationsForDomain, true))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.NormalDecisionScheduleToStartMaxAttempts, 3))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.EnablePendingActivityValidation, true))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.QueueProcessorEnableGracefulSyncShutdown, true))
@@ -625,7 +627,7 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	config.ReplicationTaskProcessorStartWait = dc.GetDurationPropertyFilteredByShardID(dynamicconfig.ReplicationTaskProcessorStartWait)
 	config.EnableActivityLocalDispatchByDomain = dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableActivityLocalDispatchByDomain)
 	config.MaxActivityCountDispatchByDomain = dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaxActivityCountDispatchByDomain)
-	config.EnableCrossClusterOperations = dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableCrossClusterOperations)
+	config.EnableCrossClusterOperationsForDomain = dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableCrossClusterOperationsForDomain)
 	config.NormalDecisionScheduleToStartMaxAttempts = dc.GetIntPropertyFilteredByDomain(dynamicconfig.NormalDecisionScheduleToStartMaxAttempts)
 	config.PendingActivityValidationEnabled = dc.GetBoolProperty(dynamicconfig.EnablePendingActivityValidation)
 	config.QueueProcessorEnableGracefulSyncShutdown = dc.GetBoolProperty(dynamicconfig.QueueProcessorEnableGracefulSyncShutdown)

--- a/service/history/decision/checker.go
+++ b/service/history/decision/checker.go
@@ -862,7 +862,7 @@ func (v *attrValidator) validateCrossDomainCall(
 	// both global domain with > 1 replication cluster
 	// when code reaches here, at least one domain has more than one cluster
 	if len(sourceClusters) == len(targetClusters) &&
-		v.config.EnableCrossClusterOperations(sourceDomainEntry.GetInfo().Name) {
+		v.config.EnableCrossClusterOperationsForDomain(sourceDomainEntry.GetInfo().Name) {
 		// check if the source domain cluster matches those for the target domain
 		for _, sourceCluster := range sourceClusters {
 			found := false

--- a/service/history/decision/checker_test.go
+++ b/service/history/decision/checker_test.go
@@ -98,7 +98,7 @@ func (s *attrValidatorSuite) SetupTest() {
 		ActivityMaxScheduleToStartTimeoutForRetry: dynamicconfig.GetDurationPropertyFnFilteredByDomain(
 			time.Duration(s.testActivityMaxScheduleToStartTimeoutForRetryInSeconds) * time.Second,
 		),
-		EnableCrossClusterOperations: dynamicconfig.GetBoolPropertyFnFilteredByDomain(false),
+		EnableCrossClusterOperationsForDomain: dynamicconfig.GetBoolPropertyFnFilteredByDomain(false),
 	}
 	s.validator = newAttrValidator(
 		s.mockDomainCache,
@@ -495,7 +495,7 @@ func (s *attrValidatorSuite) TestValidateCrossDomainCall_GlobalToGlobal_DiffDoma
 	err := s.validator.validateCrossDomainCall(s.testDomainID, s.testTargetDomainID)
 	s.IsType(&types.BadRequestError{}, err)
 
-	s.validator.config.EnableCrossClusterOperations = dynamicconfig.GetBoolPropertyFnFilteredByDomain(true)
+	s.validator.config.EnableCrossClusterOperationsForDomain = dynamicconfig.GetBoolPropertyFnFilteredByDomain(true)
 	err = s.validator.validateCrossDomainCall(s.testDomainID, s.testTargetDomainID)
 	s.Nil(err)
 }

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -294,6 +294,7 @@ func NewEngineWithShardContext(
 		queueTaskProcessor,
 		crossClusterTaskFetchers,
 		&task.CrossClusterTaskProcessorOptions{
+			Enabled:                    config.EnableCrossClusterEngine,
 			MaxPendingTasks:            config.CrossClusterTargetProcessorMaxPendingTasks,
 			TaskMaxRetryCount:          config.CrossClusterTargetProcessorMaxRetryCount,
 			TaskRedispatchInterval:     config.ActiveTaskRedispatchInterval,

--- a/service/history/task/cross_cluster_task_processor.go
+++ b/service/history/task/cross_cluster_task_processor.go
@@ -45,6 +45,7 @@ const (
 type (
 	// CrossClusterTaskProcessorOptions configures crossClusterTaskProcessor
 	CrossClusterTaskProcessorOptions struct {
+		Enabled                    dynamicconfig.BoolPropertyFn
 		MaxPendingTasks            dynamicconfig.IntPropertyFn
 		TaskMaxRetryCount          dynamicconfig.IntPropertyFn
 		TaskRedispatchInterval     dynamicconfig.DurationPropertyFn
@@ -89,15 +90,19 @@ func NewCrossClusterTaskProcessors(
 	options *CrossClusterTaskProcessorOptions,
 ) common.Daemon {
 	processors := make(crossClusterTaskProcessors, 0, len(taskFetchers))
-	for _, fetcher := range taskFetchers {
-		processor := newCrossClusterTaskProcessor(
-			shard,
-			taskProcessor,
-			fetcher,
-			options,
-		)
-		processors = append(processors, processor)
+
+	if options.Enabled() {
+		for _, fetcher := range taskFetchers {
+			processor := newCrossClusterTaskProcessor(
+				shard,
+				taskProcessor,
+				fetcher,
+				options,
+			)
+			processors = append(processors, processor)
+		}
 	}
+
 	return processors
 }
 

--- a/service/history/task/cross_cluster_task_processor_test.go
+++ b/service/history/task/cross_cluster_task_processor_test.go
@@ -80,6 +80,7 @@ func (s *crossClusterTaskProcessorSuite) SetupTest() {
 	s.mockShard.Resource.DomainCache.EXPECT().GetDomainName(constants.TestDomainID).Return(constants.TestDomainName, nil).AnyTimes()
 
 	s.processorOptions = &CrossClusterTaskProcessorOptions{
+		Enabled:                    dynamicconfig.GetBoolPropertyFn(true),
 		MaxPendingTasks:            dynamicconfig.GetIntPropertyFn(100),
 		TaskMaxRetryCount:          dynamicconfig.GetIntPropertyFn(100),
 		TaskRedispatchInterval:     dynamicconfig.GetDurationPropertyFn(time.Hour),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This toggles off the cross-cluster background daemons which do a fair amount of IO to the database on startup and sometimes interfere badly with persistence layer rate-limiting during high load and outages. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Tested locally with docker

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

For any users who're using the cross-cluster feature (I'm not aware of any), they will also need to include the following dynamic config to enable this feature now. 

`history.enableCrossClusterEngine` to be true

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
