### PR TITLE
Fix multiple lock acquire on membership update

### DIFF
--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/dgryski/go-farm"
 	"github.com/uber/ringpop-go/hashring"
+	"github.com/uber/ringpop-go/membership"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
@@ -239,9 +240,8 @@ func (r *ring) refresh() error {
 	}
 
 	ring := emptyHashring()
-	for _, member := range members {
-		ring.AddMembers(member)
-	}
+	ring.AddMembers(castToMembers(members)...)
+
 	r.members.keys = newMembersMap
 	r.members.refreshed = time.Now()
 	r.value.Store(ring)
@@ -291,4 +291,12 @@ func (r *ring) compareMembers(members []HostInfo) (map[string]HostInfo, bool) {
 		}
 	}
 	return newMembersMap, changed
+}
+
+func castToMembers[T membership.Member](members []T) []membership.Member {
+	result := make([]membership.Member, 0, len(members))
+	for _, h := range members {
+		result = append(result, h)
+	}
+	return result
 }

--- a/common/membership/hashring_test.go
+++ b/common/membership/hashring_test.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 )
@@ -218,7 +217,7 @@ func TestLookupAndRefreshRaceCondition(t *testing.T) {
 	wg.Add(2)
 	go func() {
 		for i := 0; i < 50; i++ {
-			hr.Lookup("a")
+			_, _ = hr.Lookup("a")
 		}
 		wg.Done()
 	}()
@@ -226,7 +225,7 @@ func TestLookupAndRefreshRaceCondition(t *testing.T) {
 		for i := 0; i < 50; i++ {
 			// to bypass internal check
 			hr.members.refreshed = time.Now().AddDate(0, 0, -1)
-			hr.refresh()
+			assert.NoError(t, hr.refresh())
 		}
 		wg.Done()
 	}()

--- a/common/membership/hashring_test.go
+++ b/common/membership/hashring_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Membership ring on refresh need to update the ring members information. This was done one by one, even though it could be done in 1 operation.
I've switched to a single operation that does a single lock acquire on update.
No logical changes.

<!-- Tell your future self why have you made these changes -->
**Why?**
To decrease chances of seeing errors like "Failed to send listener notification, chanel is full".

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
