### PR TITLE
Add missing exclude-query support to list-workflows on the CLI

### DIFF
--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -697,7 +697,7 @@ func queryWorkflowHelper(c *cli.Context, queryType string) {
 
 // ListWorkflow list workflow executions based on filters
 func ListWorkflow(c *cli.Context) {
-	displayPagedWorkflows(c, listWorkflows(c), !c.Bool(FlagMore))
+	displayPagedWorkflows(c, filterExcludedWorkflows(c, listWorkflows(c)), !c.Bool(FlagMore))
 }
 
 // ListAllWorkflow list all workflow executions based on filters


### PR DESCRIPTION
I'm not really sure why this got missed when they're right next to each other,
But it looks pretty easy to support.

---

Tested with --pagesize, --more, etc and it all seems fine.  Code looks like it's probably pretty straightforwardly supported too.
