### PR TITLE
Restore cadence-server builds, previously building the CLI twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -437,7 +437,7 @@ cadence: $(BINS_DEPEND_ON)
 BINS += cadence-server
 cadence-server: $(BINS_DEPEND_ON)
 	$Q echo "compiling cadence-server with OS: $(GOOS), ARCH: $(GOARCH)"
-	$Q ./scripts/build-with-ldflags.sh -o $@ cmd/tools/cli/main.go
+	$Q ./scripts/build-with-ldflags.sh -o $@ cmd/server/main.go
 
 BINS += cadence-canary
 cadence-canary: $(BINS_DEPEND_ON)


### PR DESCRIPTION
#5539 / commit a8921b2 unfortunately has a bad bit of copypasta that changed the `cadence-server` build to make the CLI.
This restores that makefile target to what it should be.

tbh I'm not quite sure how this got past CI.  Maybe we don't actually run the binary anywhere as part of an E2E test?
It is fairly quick to notice at least though, since it causes problems quickly.
