### PR TITLE
Switch to cassandra 4.1.1 image because 4.1.3 stopped working on some linux distros

### DIFF
--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     environment:
       - "MAX_HEAP_SIZE=256M"
       - "HEAP_NEWSIZE=128M"

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     environment:
       - "MAX_HEAP_SIZE=256M"
       - "HEAP_NEWSIZE=128M"

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     environment:
       - "MAX_HEAP_SIZE=256M"
       - "HEAP_NEWSIZE=128M"

--- a/docker/buildkite/docker-compose-opensearch2.yml
+++ b/docker/buildkite/docker-compose-opensearch2.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     environment:
       - "MAX_HEAP_SIZE=256M"
       - "HEAP_NEWSIZE=128M"

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.5"
 
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     environment:
       - "MAX_HEAP_SIZE=256M"
       - "HEAP_NEWSIZE=128M"

--- a/docker/dev/cassandra-esv7-kafka.yml
+++ b/docker/dev/cassandra-esv7-kafka.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/dev/cassandra-opensearch-kafka.yml
+++ b/docker/dev/cassandra-opensearch-kafka.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/dev/cassandra-pinot-kafka.yml
+++ b/docker/dev/cassandra-pinot-kafka.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/dev/cassandra.yml
+++ b/docker/dev/cassandra.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose-http-api.yml
+++ b/docker/docker-compose-http-api.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose-multiclusters-cass-mysql-es.yaml
+++ b/docker/docker-compose-multiclusters-cass-mysql-es.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose-multiclusters.yml
+++ b/docker/docker-compose-multiclusters.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose-oauth.yml
+++ b/docker/docker-compose-oauth.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
   prometheus:

--- a/docker/docker-compose-statsd.yml
+++ b/docker/docker-compose-statsd.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cassandra:
-    image: cassandra:4.1.3
+    image: cassandra:4.1.1
     ports:
       - "9042:9042"
     environment:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`cassandra:4.1.3` was recently updated and it doesn't work on linux devpods. 
```
% docker run cassandra:4.1.3
Cassandra 4.0 requires either Java 8 (update 151 or newer) or Java 11 (or newer).
```

<!-- Tell your future self why have you made these changes -->
**Why?**
Switching to 4.1.1 to keep the default experience working on all platforms.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`make test` on mac and linux. CI checks.
