### PR TITLE
Add more debug logs for user timer task execution

### DIFF
--- a/service/history/queue/processor_base.go
+++ b/service/history/queue/processor_base.go
@@ -156,7 +156,7 @@ func (p *processorBase) updateAckLevel() (bool, task.Key, error) {
 	}
 
 	if totalPengingTasks > warnPendingTasks {
-		p.logger.Warn("Too many pending tasks.")
+		p.logger.Warn("Too many pending tasks.", tag.Number(int64(totalPengingTasks)))
 	}
 	// TODO: consider move pendingTasksTime metrics from shardInfoScope to queue processor scope
 	p.metricsClient.RecordTimer(metrics.ShardInfoScope, getPendingTasksMetricIdx(p.options.MetricScope), time.Duration(totalPengingTasks))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add more debug logs for user timer task execution. Some of these will be logged as info log for domains specified in dynamic config `history.enableTimerDebugLogByDomainID`

<!-- Tell your future self why have you made these changes -->
**Why?**
Help identify potential double firing issue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run locally and check logs
