### PR TITLE
Submodules step 1/2: convert archivers to a plugin architecture

### DIFF
--- a/common/archiver/provider/init.go
+++ b/common/archiver/provider/init.go
@@ -1,0 +1,91 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package provider
+
+import (
+	"fmt"
+
+	"github.com/uber/cadence/common/archiver"
+	"github.com/uber/cadence/common/archiver/filestore"
+	"github.com/uber/cadence/common/archiver/gcloud"
+	"github.com/uber/cadence/common/archiver/s3store"
+	"github.com/uber/cadence/common/config"
+)
+
+func init() {
+	// TODO: ideally remove this and handle per-instance registration during startup somehow,
+	// as globals and inits have consistently caused issues.
+	//
+	// For now though, it's replacing a hard-coded switch statement, so an init func
+	// is the most straightforward and should-be-identical conversion.
+
+	must := func(err error) {
+		if err != nil {
+			panic(fmt.Errorf("failed to register default provider: %w", err))
+		}
+	}
+
+	must(RegisterHistoryArchiver(filestore.URIScheme, config.FilestoreConfig, func(cfg *config.YamlNode, container *archiver.HistoryBootstrapContainer) (archiver.HistoryArchiver, error) {
+		var out *config.FilestoreArchiver
+		if err := cfg.Decode(&out); err != nil {
+			return nil, fmt.Errorf("bad config: %w", err)
+		}
+		return filestore.NewHistoryArchiver(container, out)
+	}))
+	must(RegisterHistoryArchiver(s3store.URIScheme, config.S3storeConfig, func(cfg *config.YamlNode, container *archiver.HistoryBootstrapContainer) (archiver.HistoryArchiver, error) {
+		var out *config.S3Archiver
+		if err := cfg.Decode(&out); err != nil {
+			return nil, fmt.Errorf("bad config: %w", err)
+		}
+		return s3store.NewHistoryArchiver(container, out)
+	}))
+	must(RegisterHistoryArchiver(gcloud.URIScheme, config.GCloudConfig, func(cfg *config.YamlNode, container *archiver.HistoryBootstrapContainer) (archiver.HistoryArchiver, error) {
+		var out *config.GstorageArchiver
+		if err := cfg.Decode(&out); err != nil {
+			return nil, fmt.Errorf("bad config: %w", err)
+		}
+		return gcloud.NewHistoryArchiver(container, out)
+	}))
+
+	must(RegisterVisibilityArchiver(filestore.URIScheme, config.FilestoreConfig, func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error) {
+		var out *config.FilestoreArchiver
+		if err := cfg.Decode(&out); err != nil {
+			return nil, fmt.Errorf("bad config: %w", err)
+		}
+		return filestore.NewVisibilityArchiver(container, out)
+	}))
+	must(RegisterVisibilityArchiver(s3store.URIScheme, config.S3storeConfig, func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error) {
+		var out *config.S3Archiver
+		if err := cfg.Decode(&out); err != nil {
+			return nil, fmt.Errorf("bad config: %w", err)
+		}
+		return s3store.NewVisibilityArchiver(container, out)
+	}))
+	must(RegisterVisibilityArchiver(gcloud.URIScheme, config.GCloudConfig, func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error) {
+		var out *config.GstorageArchiver
+		if err := cfg.Decode(&out); err != nil {
+			return nil, fmt.Errorf("bad config: %w", err)
+		}
+		return gcloud.NewVisibilityArchiver(container, out)
+	}))
+}

--- a/common/archiver/provider/provider.go
+++ b/common/archiver/provider/provider.go
@@ -213,7 +213,7 @@ func (p *archiverProvider) GetVisibilityArchiver(scheme, serviceName string) (ar
 		return nil, fmt.Errorf("no visibility archiver constructor for scheme %q", scheme)
 	}
 
-	cfg, ok := p.historyArchiverConfigs[constructor.configKey]
+	cfg, ok := p.visibilityArchiverConfigs[constructor.configKey]
 	if !ok {
 		return nil, fmt.Errorf("no visibility archiver config for scheme %q, config key %q", scheme, constructor.configKey)
 	}

--- a/common/archiver/provider/provider.go
+++ b/common/archiver/provider/provider.go
@@ -22,12 +22,11 @@ package provider
 
 import (
 	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/uber/cadence/common/archiver"
-	"github.com/uber/cadence/common/archiver/filestore"
-	"github.com/uber/cadence/common/archiver/gcloud"
-	"github.com/uber/cadence/common/archiver/s3store"
+	"github.com/uber/cadence/common/archiver/provider/syncmap"
 	"github.com/uber/cadence/common/config"
 )
 
@@ -60,8 +59,8 @@ type (
 	archiverProvider struct {
 		sync.RWMutex
 
-		historyArchiverConfigs    *config.HistoryArchiverProvider
-		visibilityArchiverConfigs *config.VisibilityArchiverProvider
+		historyArchiverConfigs    config.HistoryArchiverProvider
+		visibilityArchiverConfigs config.VisibilityArchiverProvider
 
 		// Key for the container is just serviceName
 		historyContainers    map[string]*archiver.HistoryBootstrapContainer
@@ -71,12 +70,52 @@ type (
 		historyArchivers    map[string]archiver.HistoryArchiver
 		visibilityArchivers map[string]archiver.VisibilityArchiver
 	}
+
+	historyConstructor struct {
+		fn func(cfg *config.YamlNode, container *archiver.HistoryBootstrapContainer) (archiver.HistoryArchiver, error)
+		// yaml key where this config exists, under archival.history.provider.
+		// This almost certainly should be the same as the scheme, but that'll need more work.
+		configKey string
+	}
+	visibilityConstructor struct {
+		fn func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error)
+		// yaml key where this config exists, under archival.visibility.provider.
+		// This almost certainly should be the same as the scheme, but that'll need more work.
+		configKey string
+	}
 )
+
+var (
+	historyConstructors    = syncmap.New[string, historyConstructor]()
+	visibilityConstructors = syncmap.New[string, visibilityConstructor]()
+)
+
+func RegisterHistoryArchiver(scheme, configKey string, constructor func(cfg *config.YamlNode, container *archiver.HistoryBootstrapContainer) (archiver.HistoryArchiver, error)) error {
+	inserted := historyConstructors.Put(scheme, historyConstructor{
+		fn:        constructor,
+		configKey: configKey,
+	})
+	if !inserted {
+		return fmt.Errorf("history archiver already registered for scheme %q", scheme)
+	}
+	return nil
+}
+
+func RegisterVisibilityArchiver(scheme, configKey string, constructor func(cfg *config.YamlNode, container *archiver.VisibilityBootstrapContainer) (archiver.VisibilityArchiver, error)) error {
+	inserted := visibilityConstructors.Put(scheme, visibilityConstructor{
+		fn:        constructor,
+		configKey: configKey,
+	})
+	if !inserted {
+		return fmt.Errorf("visibility archiver already registered for scheme %q", scheme)
+	}
+	return nil
+}
 
 // NewArchiverProvider returns a new Archiver provider
 func NewArchiverProvider(
-	historyArchiverConfigs *config.HistoryArchiverProvider,
-	visibilityArchiverConfigs *config.VisibilityArchiverProvider,
+	historyArchiverConfigs config.HistoryArchiverProvider,
+	visibilityArchiverConfigs config.VisibilityArchiverProvider,
 ) ArchiverProvider {
 	return &archiverProvider{
 		historyArchiverConfigs:    historyArchiverConfigs,
@@ -131,31 +170,19 @@ func (p *archiverProvider) GetHistoryArchiver(scheme, serviceName string) (histo
 		return nil, ErrBootstrapContainerNotFound
 	}
 
-	switch scheme {
-	case filestore.URIScheme:
-		if p.historyArchiverConfigs.Filestore == nil {
-			return nil, ErrArchiverConfigNotFound
-		}
-		historyArchiver, err = filestore.NewHistoryArchiver(container, p.historyArchiverConfigs.Filestore)
-
-	case gcloud.URIScheme:
-		if p.historyArchiverConfigs.Gstorage == nil {
-			return nil, ErrArchiverConfigNotFound
-		}
-
-		historyArchiver, err = gcloud.NewHistoryArchiver(container, p.historyArchiverConfigs.Gstorage)
-
-	case s3store.URIScheme:
-		if p.historyArchiverConfigs.S3store == nil {
-			return nil, ErrArchiverConfigNotFound
-		}
-		historyArchiver, err = s3store.NewHistoryArchiver(container, p.historyArchiverConfigs.S3store)
-	default:
-		return nil, ErrUnknownScheme
+	constructor, ok := historyConstructors.Get(scheme)
+	if !ok {
+		return nil, fmt.Errorf("no history archiver constructor for scheme %q", scheme)
 	}
 
+	cfg, ok := p.historyArchiverConfigs[constructor.configKey]
+	if !ok {
+		return nil, fmt.Errorf("no history archiver config for scheme %q, config key %q", scheme, constructor.configKey)
+	}
+
+	historyArchiver, err = constructor.fn(cfg, container)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("history archiver constructor failed for scheme %q, config key %q: err: %w", scheme, constructor.configKey, err)
 	}
 
 	p.Lock()
@@ -181,31 +208,19 @@ func (p *archiverProvider) GetVisibilityArchiver(scheme, serviceName string) (ar
 		return nil, ErrBootstrapContainerNotFound
 	}
 
-	var visibilityArchiver archiver.VisibilityArchiver
-	var err error
-
-	switch scheme {
-	case filestore.URIScheme:
-		if p.visibilityArchiverConfigs.Filestore == nil {
-			return nil, ErrArchiverConfigNotFound
-		}
-		visibilityArchiver, err = filestore.NewVisibilityArchiver(container, p.visibilityArchiverConfigs.Filestore)
-	case s3store.URIScheme:
-		if p.visibilityArchiverConfigs.S3store == nil {
-			return nil, ErrArchiverConfigNotFound
-		}
-		visibilityArchiver, err = s3store.NewVisibilityArchiver(container, p.visibilityArchiverConfigs.S3store)
-	case gcloud.URIScheme:
-		if p.visibilityArchiverConfigs.Gstorage == nil {
-			return nil, ErrArchiverConfigNotFound
-		}
-		visibilityArchiver, err = gcloud.NewVisibilityArchiver(container, p.visibilityArchiverConfigs.Gstorage)
-
-	default:
-		return nil, ErrUnknownScheme
+	constructor, ok := visibilityConstructors.Get(scheme)
+	if !ok {
+		return nil, fmt.Errorf("no visibility archiver constructor for scheme %q", scheme)
 	}
+
+	cfg, ok := p.historyArchiverConfigs[constructor.configKey]
+	if !ok {
+		return nil, fmt.Errorf("no visibility archiver config for scheme %q, config key %q", scheme, constructor.configKey)
+	}
+
+	visibilityArchiver, err := constructor.fn(cfg, container)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("visibility archiver constructor failed for scheme %q, config key %q: err: %w", scheme, constructor.configKey, err)
 	}
 
 	p.Lock()

--- a/common/archiver/provider/syncmap/syncmap.go
+++ b/common/archiver/provider/syncmap/syncmap.go
@@ -1,0 +1,61 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package syncmap
+
+import "sync"
+
+// syncmap is a very simple type-safe locked map, with semantics similar to sync.Map,
+// but only supports inserting once and getting.
+type (
+	syncmap[K comparable, V any] struct {
+		mut  sync.Mutex
+		data map[K]V
+	}
+	SyncMap[K comparable, V any] interface {
+		Get(key K) (value V, ok bool)
+		Put(key K, value V) (inserted bool)
+	}
+)
+
+func New[K comparable, V any]() SyncMap[K, V] {
+	return &syncmap[K, V]{
+		data: make(map[K]V),
+	}
+}
+
+func (m *syncmap[K, V]) Get(key K) (value V, ok bool) {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+	value, ok = m.data[key]
+	return value, ok
+}
+
+func (m *syncmap[K, V]) Put(key K, value V) (inserted bool) {
+	m.mut.Lock()
+	defer m.mut.Unlock()
+	if _, ok := m.data[key]; ok {
+		return false
+	}
+	m.data[key] = value
+	return true
+}

--- a/common/config/archival_test.go
+++ b/common/config/archival_test.go
@@ -28,16 +28,22 @@ import (
 	"github.com/uber/cadence/common"
 )
 
+func defaultFilestoreConfig(t *testing.T) *YamlNode {
+	node, err := ToYamlNode(&FilestoreArchiver{
+		FileMode: "044",
+	})
+	require.NoError(t, err)
+	return node
+}
+
 // History archival
 
 func TestValidEnabledHistoryArchivalConfig(t *testing.T) {
 	archival := Archival{
 		History: HistoryArchival{
 			Status: common.ArchivalEnabled,
-			Provider: &HistoryArchiverProvider{
-				Filestore: &FilestoreArchiver{
-					FileMode: "044",
-				},
+			Provider: HistoryArchiverProvider{
+				FilestoreConfig: defaultFilestoreConfig(t),
 			},
 		},
 	}
@@ -62,10 +68,8 @@ func TestInvalidHEnabledHistoryArchivalConfig(t *testing.T) {
 func TestValidDisabledHistoryArchivalConfig(t *testing.T) {
 	archival := Archival{
 		History: HistoryArchival{
-			Provider: &HistoryArchiverProvider{
-				Filestore: &FilestoreArchiver{
-					FileMode: "044",
-				},
+			Provider: HistoryArchiverProvider{
+				FilestoreConfig: defaultFilestoreConfig(t),
 			},
 		},
 	}
@@ -97,10 +101,8 @@ func TestValidEnabledVisibilityArchivalConfig(t *testing.T) {
 	archival := Archival{
 		Visibility: VisibilityArchival{
 			Status: common.ArchivalEnabled,
-			Provider: &VisibilityArchiverProvider{
-				Filestore: &FilestoreArchiver{
-					FileMode: "044",
-				},
+			Provider: VisibilityArchiverProvider{
+				FilestoreConfig: defaultFilestoreConfig(t),
 			},
 		},
 	}
@@ -125,10 +127,8 @@ func TestInvalidHEnabledVisibilityArchivalConfig(t *testing.T) {
 func TestValidDisabledVisibilityArchivalConfig(t *testing.T) {
 	archival := Archival{
 		Visibility: VisibilityArchival{
-			Provider: &VisibilityArchiverProvider{
-				Filestore: &FilestoreArchiver{
-					FileMode: "044",
-				},
+			Provider: VisibilityArchiverProvider{
+				FilestoreConfig: defaultFilestoreConfig(t),
 			},
 		},
 	}

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -30,6 +30,7 @@ import (
 	"github.com/uber-go/tally/m3"
 	"github.com/uber-go/tally/prometheus"
 	yarpctls "go.uber.org/yarpc/api/transport/tls"
+	"gopkg.in/yaml.v2" // CAUTION: go.uber.org/config does not support yaml.v3
 
 	"github.com/uber/cadence/common/dynamicconfig"
 	c "github.com/uber/cadence/common/dynamicconfig/configstore/config"
@@ -488,15 +489,22 @@ type (
 		// EnableRead whether history can be read from archival
 		EnableRead bool `yaml:"enableRead"`
 		// Provider contains the config for all history archivers
-		Provider *HistoryArchiverProvider `yaml:"provider"`
+		Provider HistoryArchiverProvider `yaml:"provider"`
 	}
 
-	// HistoryArchiverProvider contains the config for all history archivers
-	HistoryArchiverProvider struct {
-		Filestore *FilestoreArchiver `yaml:"filestore"`
-		Gstorage  *GstorageArchiver  `yaml:"gstorage"`
-		S3store   *S3Archiver        `yaml:"s3store"`
-	}
+	// HistoryArchiverProvider contains the config for all history archivers.
+	//
+	// Because archivers support external plugins, so there is no fundamental structure expected,
+	// but a top-level key per named store plugin is required, and will be used to select the
+	// config for a plugin as it is initialized.
+	//
+	// Config keys and structures expected in the main default binary include:
+	//  - FilestoreConfig: [*FilestoreArchiver], used with provider scheme [github.com/uber/cadence/common/archiver/filestore.URIScheme]
+	//  - S3storeConfig: [*S3Archiver], used with provider scheme [github.com/uber/cadence/common/archiver/s3store.URIScheme]
+	//  - GCloudConfig: [*GstorageArchiver], used with provider scheme [github.com/uber/cadence/common/archiver/gcloud.URIScheme]
+	//
+	// For handling hardcoded config, see ToYamlNode.
+	HistoryArchiverProvider map[string]*YamlNode
 
 	// VisibilityArchival contains the config for visibility archival
 	VisibilityArchival struct {
@@ -505,15 +513,22 @@ type (
 		// EnableRead whether visibility can be read from archival
 		EnableRead bool `yaml:"enableRead"`
 		// Provider contains the config for all visibility archivers
-		Provider *VisibilityArchiverProvider `yaml:"provider"`
+		Provider VisibilityArchiverProvider `yaml:"provider"`
 	}
 
-	// VisibilityArchiverProvider contains the config for all visibility archivers
-	VisibilityArchiverProvider struct {
-		Filestore *FilestoreArchiver `yaml:"filestore"`
-		S3store   *S3Archiver        `yaml:"s3store"`
-		Gstorage  *GstorageArchiver  `yaml:"gstorage"`
-	}
+	// VisibilityArchiverProvider contains the config for all visibility archivers.
+	//
+	// Because archivers support external plugins, so there is no fundamental structure expected,
+	// but a top-level key per named store plugin is required, and will be used to select the
+	// config for a plugin as it is initialized.
+	//
+	// Config keys and structures expected in the main default binary include:
+	//  - FilestoreConfig: [*FilestoreArchiver], used with provider scheme [github.com/uber/cadence/common/archiver/filestore.URIScheme]
+	//  - S3storeConfig: [*S3Archiver], used with provider scheme [github.com/uber/cadence/common/archiver/s3store.URIScheme]
+	//  - GCloudConfig: [*GstorageArchiver], used with provider scheme [github.com/uber/cadence/common/archiver/gcloud.URIScheme]
+	//
+	// For handling hardcoded config, see ToYamlNode.
+	VisibilityArchiverProvider map[string]*YamlNode
 
 	// FilestoreArchiver contain the config for filestore archiver
 	FilestoreArchiver struct {
@@ -576,12 +591,50 @@ type (
 		// URI is the domain default URI for visibility archiver
 		URI string `yaml:"URI"`
 	}
+
+	// YamlNode is a lazy-unmarshaler, because *yaml.Node only exists in gopkg.in/yaml.v3, not v2,
+	// and go.uber.org/config currently uses only v2.
+	YamlNode struct {
+		unmarshal func(out any) error
+	}
 )
 
 const (
 	// NonShardedStoreName is the shard name used for singular (non-sharded) stores
 	NonShardedStoreName = "NonShardedStore"
+
+	FilestoreConfig = "filestore"
+	S3storeConfig   = "s3store"
+	GCloudConfig    = "gstorage"
 )
+
+var _ yaml.Unmarshaler = (*YamlNode)(nil)
+
+func (y *YamlNode) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	y.unmarshal = unmarshal
+	return nil
+}
+
+func (y *YamlNode) Decode(out any) error {
+	return y.unmarshal(out)
+}
+
+// ToYamlNode is a bit of a hack to get a *yaml.Node for config-parsing compatibility purposes.
+// There is probably a better way to achieve this with yaml-loading compatibility, but this is at least fairly simple.
+func ToYamlNode(input any) (*YamlNode, error) {
+	data, err := yaml.Marshal(input)
+	if err != nil {
+		// should be extremely unlikely, unless yaml marshaling is customized
+		return nil, fmt.Errorf("could not serialize data to yaml: %w", err)
+	}
+	var out *YamlNode
+	err = yaml.Unmarshal(data, &out)
+	if err != nil {
+		// should not be possible
+		return nil, fmt.Errorf("could not deserialize to yaml node: %w", err)
+	}
+	return out, nil
+}
 
 func (n *NoSQL) ConvertToShardedNoSQLConfig() *ShardedNoSQL {
 	connections := make(map[string]DBShardConnection)

--- a/common/config/loader.go
+++ b/common/config/loader.go
@@ -73,7 +73,7 @@ func Load(env string, configDir string, zone string, config interface{}) error {
 
 	files, err := getConfigFiles(env, configDir, zone)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to get config files: %w", err)
 	}
 
 	log.Printf("Loading configFiles=%v\n", files)
@@ -88,15 +88,19 @@ func Load(env string, configDir string, zone string, config interface{}) error {
 
 	yaml, err := uconfig.NewYAML(options...)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to create yaml parser: %w", err)
 	}
 
 	err = yaml.Get(uconfig.Root).Populate(config)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to populate config: %w", err)
 	}
 
-	return validator.Validate(config)
+	err = validator.Validate(config)
+	if err != nil {
+		return fmt.Errorf("failed to validate config: %w", err)
+	}
+	return nil
 }
 
 // getConfigFiles returns the list of config files to

--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -335,13 +335,14 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 		FileMode: "0666",
 		DirMode:  "0766",
 	}
-	provider := provider.NewArchiverProvider(
-		&config.HistoryArchiverProvider{
-			Filestore: cfg,
-		},
-		&config.VisibilityArchiverProvider{
-			Filestore: cfg,
-		},
+	node, err := config.ToYamlNode(cfg)
+	if err != nil {
+		logger.Fatal("Should be impossible: failed to convert filestore archiver config to a yaml node")
+	}
+
+	archiverProvider := provider.NewArchiverProvider(
+		config.HistoryArchiverProvider{config.FilestoreConfig: node},
+		config.VisibilityArchiverProvider{config.FilestoreConfig: node},
 	)
 	return &ArchiverBase{
 		metadata: archiver.NewArchivalMetadata(dcCollection, "enabled", true, "enabled", true, &config.ArchivalDomainDefaults{
@@ -354,7 +355,7 @@ func newArchiverBase(enabled bool, logger log.Logger) *ArchiverBase {
 				URI:    "testScheme://test/visibility/archive/path",
 			},
 		}),
-		provider:                 provider,
+		provider:                 archiverProvider,
 		historyStoreDirectory:    historyStoreDirectory,
 		visibilityStoreDirectory: visibilityStoreDirectory,
 		historyURI:               filestore.URIScheme + "://" + historyStoreDirectory,


### PR DESCRIPTION
Breaking the gcloud plugin into a separate submodule (so the main module can remove these optional libraries) requires that the main module does not import it.

Since this was a hard-coded switch statement, that wasn't really possible.  So I've converted it to an at-`init`-time registration system, and I'll invert that import-flow in a later PR.  This one is intentionally trying to be a (relatively) straightforward refactor.

This is almost certainly better not using `init`, and the scheme/key separation seems strange... but that's a less-obviously-identical-behavior change, and we kinda need to split this apart ASAP.
Step 2 will introduce two submodules (gcloud plugin, and cmd/server which will import both the plugin and the "main" module), along with some makefile/automation changes to make things continue working like before.