### PR TITLE
Added three dynamic config properties

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1178,6 +1178,20 @@ const (
 	// Allowed filters: ShardID
 	ReplicationTaskProcessorErrorRetryMaxAttempts
 
+	// WorkflowIDExternalRPS is the rate limit per workflowID for external calls
+	// KeyName: history.workflowIDExternalRPS
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: DomainName
+	WorkflowIDExternalRPS
+
+	// WorkflowIDInternalRPS is the rate limit per workflowID for internal calls
+	// KeyName: history.workflowIDInternalRPS
+	// Value type: Int
+	// Default value: UnlimitedRPS
+	// Allowed filters: DomainName
+	WorkflowIDInternalRPS
+
 	// key for worker
 
 	// WorkerPersistenceMaxQPS is the max qps worker host can query DB
@@ -1696,6 +1710,12 @@ const (
 	// Default value: true
 	// Allowed filters: DomainName
 	EnableRecordWorkflowExecutionUninitialized
+	// WorkflowIDCacheEnabled is the key to enable/disable caching of workflowID specific information
+	// KeyName: history.workflowIDCacheEnabled
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	WorkflowIDCacheEnabled
 	// AllowArchivingIncompleteHistory will continue on when seeing some error like history mutated(usually caused by database consistency issues)
 	// KeyName: worker.AllowArchivingIncompleteHistory
 	// Value type: Bool
@@ -3478,6 +3498,18 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "ReplicationTaskProcessorErrorRetryMaxAttempts is the max retry attempts for applying replication tasks",
 		DefaultValue: 10,
 	},
+	WorkflowIDExternalRPS: DynamicInt{
+		KeyName:      "history.workflowIDExternalRPS",
+		Filters:      []Filter{DomainName},
+		Description:  "WorkflowIDExternalRPS is the rate limit per workflowID for external calls",
+		DefaultValue: UnlimitedRPS,
+	},
+	WorkflowIDInternalRPS: DynamicInt{
+		KeyName:      "history.workflowIDInternalRPS",
+		Filters:      []Filter{DomainName},
+		Description:  "WorkflowIDInternalRPS is the rate limit per workflowID for internal calls",
+		DefaultValue: UnlimitedRPS,
+	},
 	WorkerPersistenceMaxQPS: DynamicInt{
 		KeyName:      "worker.persistenceMaxQPS",
 		Description:  "WorkerPersistenceMaxQPS is the max qps worker host can query DB",
@@ -4131,6 +4163,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "history.enableTimerDebugLogByDomainID",
 		Filters:      []Filter{DomainID},
 		Description:  "Enable log for debugging timer task issue by domain",
+		DefaultValue: false,
+	},
+	WorkflowIDCacheEnabled: DynamicBool{
+		KeyName:      "history.workflowIDCacheEnabled",
+		Filters:      []Filter{DomainName},
+		Description:  "WorkflowIDCacheEnabled is the key to enable/disable caching of workflowID specific information",
 		DefaultValue: false,
 	},
 }

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -288,6 +288,11 @@ type Config struct {
 	EnableReplicationTaskGeneration                    dynamicconfig.BoolPropertyFnWithDomainIDAndWorkflowIDFilter
 	EnableRecordWorkflowExecutionUninitialized         dynamicconfig.BoolPropertyFnWithDomainFilter
 
+	// The following are used by the history workflowID cache
+	WorkflowIDCacheEnabled dynamicconfig.BoolPropertyFnWithDomainFilter
+	WorkflowIDExternalRPS  dynamicconfig.IntPropertyFnWithDomainFilter
+	WorkflowIDInternalRPS  dynamicconfig.IntPropertyFnWithDomainFilter
+
 	// The following are used by consistent query
 	EnableConsistentQuery         dynamicconfig.BoolPropertyFn
 	EnableConsistentQueryByDomain dynamicconfig.BoolPropertyFnWithDomainFilter
@@ -546,6 +551,10 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 		ReplicationTaskGenerationQPS:                       dc.GetFloat64Property(dynamicconfig.ReplicationTaskGenerationQPS),
 		EnableReplicationTaskGeneration:                    dc.GetBoolPropertyFilteredByDomainIDAndWorkflowID(dynamicconfig.EnableReplicationTaskGeneration),
 		EnableRecordWorkflowExecutionUninitialized:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableRecordWorkflowExecutionUninitialized),
+
+		WorkflowIDCacheEnabled: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.WorkflowIDCacheEnabled),
+		WorkflowIDExternalRPS:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.WorkflowIDExternalRPS),
+		WorkflowIDInternalRPS:  dc.GetIntPropertyFilteredByDomain(dynamicconfig.WorkflowIDInternalRPS),
 
 		EnableConsistentQuery:                 dc.GetBoolProperty(dynamicconfig.EnableConsistentQuery),
 		EnableConsistentQueryByDomain:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableConsistentQueryByDomain),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added three Dynamic config options for the workflow specific IDs project, 

- WorkflowIDCacheEnabled to enable/disable the wf cache, 
- WorkflowIDExternalRPS and WorkflowIDInternalRPS, for controlling the allowed RPS of internal and external calls

I set the default values to their most permissive so we can slowly onboard in the beginning

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a part of ratelimiting too many requests to specific workflow IDs. We need WorkflowIDCacheEnabled as a safety to be able to easily disable the cache in case it causes issues. 
The two RPS values should be configurable so we can slowly onboard the different domains.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally with the file system client

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk just adding the properties 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
