### PR TITLE
Addressed sync issue in workflow cache

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -947,3 +947,7 @@ func FallbackIsolationGroup(group string) Tag {
 func PollerGroupsConfiguration(pollers types.IsolationGroupConfiguration) Tag {
 	return newObjectTag("poller-isolation-groups", pollers.ToPartitionList())
 }
+
+func WorkflowIDCacheSize(size int) Tag {
+	return newInt("workflow-id-cache-size", size)
+}

--- a/service/history/workflowcache/cache.go
+++ b/service/history/workflowcache/cache.go
@@ -23,9 +23,12 @@
 package workflowcache
 
 import (
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/quotas"
 )
 
@@ -39,6 +42,7 @@ type wfCache struct {
 	lru                    cache.Cache
 	externalLimiterFactory quotas.LimiterFactory
 	internalLimiterFactory quotas.LimiterFactory
+	logger                 log.Logger
 }
 
 type cacheKey struct {
@@ -57,6 +61,7 @@ type Params struct {
 	MaxCount               int
 	ExternalLimiterFactory quotas.LimiterFactory
 	InternalLimiterFactory quotas.LimiterFactory
+	Logger                 log.Logger
 }
 
 // New creates a new WFCache
@@ -64,29 +69,40 @@ func New(params Params) WFCache {
 	return &wfCache{
 		lru: cache.New(&cache.Options{
 			TTL:      params.TTL,
-			Pin:      true,
+			Pin:      false,
 			MaxCount: params.MaxCount,
 		}),
 		externalLimiterFactory: params.ExternalLimiterFactory,
 		internalLimiterFactory: params.InternalLimiterFactory,
+		logger:                 params.Logger,
 	}
 }
 
 // AllowExternal returns true if the rate limiter for this domain/workflow allows an external request
 func (c *wfCache) AllowExternal(domainID string, workflowID string) bool {
 	// Locking is not needed because both getCacheItem and the rate limiter are thread safe
-	value := c.getCacheItem(domainID, workflowID)
+	value, err := c.getCacheItem(domainID, workflowID)
+	if err != nil {
+		c.logError(domainID, workflowID, err)
+		// If we can't get the cache item, we should allow the request through
+		return true
+	}
 	return value.externalRateLimiter.Allow()
 }
 
 // AllowInternal returns true if the rate limiter for this domain/workflow allows an internal request
 func (c *wfCache) AllowInternal(domainID string, workflowID string) bool {
 	// Locking is not needed because both getCacheItem and the rate limiter are thread safe
-	value := c.getCacheItem(domainID, workflowID)
+	value, err := c.getCacheItem(domainID, workflowID)
+	if err != nil {
+		c.logError(domainID, workflowID, err)
+		// If we can't get the cache item, we should allow the request through
+		return true
+	}
 	return value.internalRateLimiter.Allow()
 }
 
-func (c *wfCache) getCacheItem(domainID string, workflowID string) *cacheValue {
+func (c *wfCache) getCacheItem(domainID string, workflowID string) (*cacheValue, error) {
 	// The underlying lru cache is thread safe, so there is no need to lock
 	key := cacheKey{
 		domainID:   domainID,
@@ -95,13 +111,33 @@ func (c *wfCache) getCacheItem(domainID string, workflowID string) *cacheValue {
 
 	value, ok := c.lru.Get(key).(*cacheValue)
 
-	if !ok {
-		value = &cacheValue{
-			externalRateLimiter: c.externalLimiterFactory.GetLimiter(domainID),
-			internalRateLimiter: c.internalLimiterFactory.GetLimiter(domainID),
-		}
-		c.lru.PutIfNotExist(key, value)
+	if ok {
+		return value, nil
 	}
 
-	return value
+	value = &cacheValue{
+		externalRateLimiter: c.externalLimiterFactory.GetLimiter(domainID),
+		internalRateLimiter: c.internalLimiterFactory.GetLimiter(domainID),
+	}
+	// PutIfNotExist is thread safe, and will either return the value that was already in the cache or the value we just created
+	// another thread might have inserted a value between the Get and PutIfNotExist, but that is ok
+	// it should never return an error as we do not use Pin
+	valueInterface, err := c.lru.PutIfNotExist(key, value)
+	value, ok = valueInterface.(*cacheValue)
+
+	// This should never happen, either the value was already in the cache or we just inserted it
+	if !ok {
+		return nil, errors.New("Failed to insert new value into cache")
+	}
+
+	return value, err
+}
+
+func (c *wfCache) logError(domainID string, workflowID string, err error) {
+	c.logger.Error("Unexpected error from workflow cache",
+		tag.Error(err),
+		tag.WorkflowDomainID(domainID),
+		tag.WorkflowID(workflowID),
+		tag.WorkflowIDCacheSize(c.lru.Size()),
+	)
 }

--- a/service/history/workflowcache/cache_test.go
+++ b/service/history/workflowcache/cache_test.go
@@ -28,9 +28,9 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
-
 	"github.com/uber/cadence/common/quotas"
 )
 

--- a/service/history/workflowcache/cache_test.go
+++ b/service/history/workflowcache/cache_test.go
@@ -28,6 +28,8 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 
 	"github.com/uber/cadence/common/quotas"
 )
@@ -63,6 +65,7 @@ func TestWfCache_AllowSingleWorkflow(t *testing.T) {
 		MaxCount:               1_000,
 		ExternalLimiterFactory: externalLimiterFactory,
 		InternalLimiterFactory: internalLimiterFactory,
+		Logger:                 log.NewNoop(),
 	})
 
 	assert.True(t, wfCache.AllowExternal(testDomainID, testWorkflowID))
@@ -103,6 +106,7 @@ func TestWfCache_AllowMultipleWorkflow(t *testing.T) {
 		MaxCount:               1_000,
 		ExternalLimiterFactory: externalLimiterFactory,
 		InternalLimiterFactory: internalLimiterFactory,
+		Logger:                 log.NewNoop(),
 	})
 
 	assert.True(t, wfCache.AllowExternal(testDomainID, testWorkflowID))
@@ -110,4 +114,42 @@ func TestWfCache_AllowMultipleWorkflow(t *testing.T) {
 
 	assert.False(t, wfCache.AllowExternal(testDomainID, testWorkflowID))
 	assert.True(t, wfCache.AllowExternal(testDomainID, testWorkflowID2))
+}
+
+// TestWfCache_AllowInternalError tests that the cache will allow internal requests through if there is an error getting the rate limiter.
+func TestWfCache_AllowError(t *testing.T) {
+	// Setup the mock logger
+	logger := new(log.MockLogger)
+
+	logger.On(
+		"Error",
+		"Unexpected error from workflow cache",
+		[]tag.Tag{
+			tag.Error(assert.AnError),
+			tag.WorkflowDomainID(testDomainID),
+			tag.WorkflowID(testWorkflowID),
+			tag.WorkflowIDCacheSize(0),
+		},
+	).Times(2)
+
+	// Setup the cache, we do not need the factories, as we will mock the getCacheItemFn
+	wfCache := New(Params{
+		TTL:                    time.Minute,
+		MaxCount:               1_000,
+		ExternalLimiterFactory: nil,
+		InternalLimiterFactory: nil,
+		Logger:                 logger,
+	}).(*wfCache)
+
+	// We set getCacheItemFn to a function that will return an error so that we can test the error logic
+	wfCache.getCacheItemFn = func(domainID string, workflowID string) (*cacheValue, error) {
+		return nil, assert.AnError
+	}
+
+	// We fail open
+	assert.True(t, wfCache.AllowExternal(testDomainID, testWorkflowID))
+	assert.True(t, wfCache.AllowInternal(testDomainID, testWorkflowID))
+
+	// We log the error
+	logger.AssertExpectations(t)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now use the value returned from PutIfExists, this is thread safe, either the new value is inserted and returned, or the existing value is returned. 
We also do not need to pin values in the cache, if they get evicted while we use them that is fine. 
Added some more error handling, the error handling should never be triggered though. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The old implementation had a race condition in creating the value and inserting it

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There could still be concurrency issues 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
