### PR TITLE
StartWorkflowMetrics

### DIFF
--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -30,7 +30,6 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	"github.com/uber/cadence/service/history/workflowcache"
 	"go.uber.org/yarpc/yarpcerrors"
 	"golang.org/x/sync/errgroup"
 
@@ -54,6 +53,7 @@ import (
 	"github.com/uber/cadence/service/history/resource"
 	"github.com/uber/cadence/service/history/shard"
 	"github.com/uber/cadence/service/history/task"
+	"github.com/uber/cadence/service/history/workflowcache"
 )
 
 const shardOwnershipTransferDelay = 5 * time.Second

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -53,7 +53,6 @@ import (
 	"github.com/uber/cadence/service/history/resource"
 	"github.com/uber/cadence/service/history/shard"
 	"github.com/uber/cadence/service/history/task"
-	"github.com/uber/cadence/service/history/workflowcache"
 )
 
 const shardOwnershipTransferDelay = 5 * time.Second
@@ -74,7 +73,6 @@ type (
 		replicationTaskFetchers  replication.TaskFetchers
 		queueTaskProcessor       task.Processor
 		failoverCoordinator      failover.Coordinator
-		workflowIDCache          workflowcache.WFCache
 	}
 )
 
@@ -104,13 +102,6 @@ func NewHandler(
 		config:          config,
 		tokenSerializer: common.NewJSONTaskTokenSerializer(),
 		rateLimiter:     quotas.NewDynamicRateLimiter(config.RPS.AsFloat64()),
-		workflowIDCache: workflowcache.New(workflowcache.Params{
-			TTL:                    time.Second,
-			MaxCount:               10_000,
-			ExternalLimiterFactory: quotas.NewSimpleDynamicRateLimiterFactory(config.WorkflowIDExternalRPS),
-			InternalLimiterFactory: quotas.NewSimpleDynamicRateLimiterFactory(config.WorkflowIDInternalRPS),
-			Logger:                 resource.GetLogger(),
-		}),
 	}
 
 	// prevent us from trying to serve requests before shard controller is started and ready
@@ -690,11 +681,6 @@ func (h *handlerImpl) StartWorkflowExecution(
 
 	startRequest := wrappedRequest.StartRequest
 	workflowID := startRequest.GetWorkflowID()
-
-	if !h.workflowIDCache.AllowExternal(domainID, workflowID) {
-		// TODO, do the actual rate limiting in a future PR
-	}
-
 	engine, err1 := h.controller.GetEngine(workflowID)
 	if err1 != nil {
 		return nil, h.error(err1, scope, domainID, workflowID, "")

--- a/service/history/handler.go
+++ b/service/history/handler.go
@@ -692,7 +692,7 @@ func (h *handlerImpl) StartWorkflowExecution(
 	workflowID := startRequest.GetWorkflowID()
 
 	if !h.workflowIDCache.AllowExternal(domainID, workflowID) {
-		// TODO, do the actual rate limiting in the future PR
+		// TODO, do the actual rate limiting in a future PR
 	}
 
 	engine, err1 := h.controller.GetEngine(workflowID)

--- a/service/history/workflowcache/cache.go
+++ b/service/history/workflowcache/cache.go
@@ -125,6 +125,7 @@ func (c *wfCache) AllowExternal(domainID string, workflowID string) bool {
 // AllowInternal returns true if the rate limiter for this domain/workflow allows an internal request
 func (c *wfCache) AllowInternal(domainID string, workflowID string) bool {
 	if !c.workflowIdCacheEnabledCheck(domainID) {
+		// If we can't get the cache item, we should allow the request through
 		return true
 	}
 

--- a/service/history/workflowcache/cache.go
+++ b/service/history/workflowcache/cache.go
@@ -33,6 +33,10 @@ import (
 	"github.com/uber/cadence/common/quotas"
 )
 
+var (
+	domainNameError = errors.New("failed to get domain name from domainID")
+)
+
 // WFCache is a per workflow cache used for workflow specific in memory data
 type WFCache interface {
 	AllowExternal(domainID string, workflowID string) bool
@@ -93,6 +97,7 @@ func New(params Params) WFCache {
 func (c *wfCache) workflowIdCacheEnabledCheck(domainID string) bool {
 	domainName, err := c.domainCache.GetDomainName(domainID)
 	if err != nil {
+		c.logError(domainID, "", domainNameError)
 		// The cache is not enabled if the domain does not exist or there is an error getting it (fail open)
 		return false
 	}
@@ -103,6 +108,7 @@ func (c *wfCache) workflowIdCacheEnabledCheck(domainID string) bool {
 // AllowExternal returns true if the rate limiter for this domain/workflow allows an external request
 func (c *wfCache) AllowExternal(domainID string, workflowID string) bool {
 	if !c.workflowIdCacheEnabledCheck(domainID) {
+		// The cache is not enabled if the domain does not exist or there is an error getting it (fail open)
 		return true
 	}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Made the cache aware if the cacheEnabled dynamic config

<!-- Tell your future self why have you made these changes -->
**Why?**
We need this before enabling anything as we need to be able to disable the cache if we start seeing issues

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests and local tests 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
We could see a lot of error logs that cannot be disabled  without changing the code, if we cannot get the domains from the domainCache, I have tested locally and it looks to work

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
