### PR TITLE
Running each on their own line fixes the issue

### DIFF
--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -2,7 +2,10 @@
 
 set -ex
 
-make go-generate && make fmt && make lint && make copyright
+make go-generate
+make fmt 
+make lint 
+make copyright
 
 # intentionally capture stderr, so status-errors are also PR-failing.
 # in particular this catches "dubious ownership" failures, which otherwise


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Split the different runs into their own lines, so the whole script fails when one of them fails.

Linting is expected to fail as the lint issues fixed in this PR https://github.com/uber/cadence/pull/5613 is not merged yet

<!-- Tell your future self why have you made these changes -->
**Why?**
 Currently the script will not fail even though the lint fails 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
