### PR TITLE
Update run_cass_and_test.sh script to setup cassandra schemas 

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/admin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/admin.go
@@ -124,7 +124,7 @@ func (db *cdb) dropCassandraKeyspace(s gocql.Session, keyspace string) (err erro
 		db.logger.Error(`drop keyspace error`, tag.Error(err))
 		return
 	}
-	db.logger.Debugf("dropped namespace %s with replication factor %d", keyspace)
+	db.logger.Debugf("dropped namespace %s", keyspace)
 	return
 }
 

--- a/scripts/run_cass_and_test.sh
+++ b/scripts/run_cass_and_test.sh
@@ -11,8 +11,20 @@ trap finish EXIT
 # shut down containers
 docker-compose -f docker/docker-compose.yml down;
 
-# run cassandra container
-docker-compose -f docker/docker-compose.yml up -d cassandra;
+# run cassandra & cadence container
+# we need cadence here because it handles db setup
+docker-compose -f docker/docker-compose.yml up -d cassandra cadence;
+
+status=""
+while [[ "$status" != "running" ]]; do
+  echo "waiting for containers to be healthy. status: $health_status"
+  sleep 5
+  status="$(docker inspect docker-cadence-1 -f '{{ .State.Status }}')"
+done;
+
+echo "containers are healthy. sleeping for 10 seconds so cadence container can finish db setup"
+sleep 10
+echo "running tests"
 
 # run the tests with cassandra
 CASSANDRA=1 make test | tee test.log;

--- a/scripts/run_cass_and_test.sh
+++ b/scripts/run_cass_and_test.sh
@@ -17,8 +17,9 @@ docker-compose -f docker/docker-compose.yml up -d cassandra cadence;
 
 status=""
 while [[ "$status" != "running" ]]; do
-  echo "waiting for containers to be healthy. status: $health_status"
+  echo "waiting for containers to be healthy. status: $status"
   sleep 5
+  # checking cadence container is running is sufficient because it depends on health status of cassandra in docker-compose.yml
   status="$(docker inspect docker-cadence-1 -f '{{ .State.Status }}')"
 done;
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`run_cass_and_test.sh` is creating a cassandra container and then running tests with CASSANDRA=1 env var.
This wouldn't work if the cassandra db is not setup properly. e.g. creating keyspaces. 
It was working for me locally because cassandra container was using previously populated data folder. Fresh installations or docker cleanup cause the script to not work.

So updating the script to also run `cadence:master-auto-setup` image which does db prep on startup. 

Note: I looked into using `docker/start.sh` instead of running the cadence container but didn't choose that path. It requires `cqlsh` to be installed on local machine. I have correct version of `cqlsh` but it complains about some python packages missing. Better to just rely on already working setup on cadence:master-auto-setup. 

Follow up note: Some tests invoke `cqlsh` locally so not having a proper local cqlsh setup causes those to fail. Will come back to that issue because it's annoying. Might also ditch this script and fix the [docker-compose based test invocation](https://github.com/uber/cadence/tree/master/docker/buildkite) setup.
