### PR TITLE
Upgrade domain_config type in cassandra schema to add async wf config

### DIFF
--- a/.gen/go/sqlblobs/sqlblobs.go
+++ b/.gen/go/sqlblobs/sqlblobs.go
@@ -4060,6 +4060,8 @@ type DomainInfo struct {
 	LastUpdatedTime                      *int64            `json:"lastUpdatedTime,omitempty"`
 	IsolationGroupsConfiguration         []byte            `json:"isolationGroupsConfiguration,omitempty"`
 	IsolationGroupsConfigurationEncoding *string           `json:"isolationGroupsConfigurationEncoding,omitempty"`
+	AsyncWorkflowConfiguration           []byte            `json:"asyncWorkflowConfiguration,omitempty"`
+	AsyncWorkflowConfigurationEncoding   *string           `json:"asyncWorkflowConfigurationEncoding,omitempty"`
 }
 
 type _Map_String_String_MapItemList map[string]string
@@ -4114,7 +4116,7 @@ func (_Map_String_String_MapItemList) Close() {}
 //	}
 func (v *DomainInfo) ToWire() (wire.Value, error) {
 	var (
-		fields [26]wire.Field
+		fields [28]wire.Field
 		i      int = 0
 		w      wire.Value
 		err    error
@@ -4326,6 +4328,22 @@ func (v *DomainInfo) ToWire() (wire.Value, error) {
 			return w, err
 		}
 		fields[i] = wire.Field{ID: 58, Value: w}
+		i++
+	}
+	if v.AsyncWorkflowConfiguration != nil {
+		w, err = wire.NewValueBinary(v.AsyncWorkflowConfiguration), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 60, Value: w}
+		i++
+	}
+	if v.AsyncWorkflowConfigurationEncoding != nil {
+		w, err = wire.NewValueString(*(v.AsyncWorkflowConfigurationEncoding)), error(nil)
+		if err != nil {
+			return w, err
+		}
+		fields[i] = wire.Field{ID: 62, Value: w}
 		i++
 	}
 
@@ -4629,6 +4647,24 @@ func (v *DomainInfo) FromWire(w wire.Value) error {
 				var x string
 				x, err = field.Value.GetString(), error(nil)
 				v.IsolationGroupsConfigurationEncoding = &x
+				if err != nil {
+					return err
+				}
+
+			}
+		case 60:
+			if field.Value.Type() == wire.TBinary {
+				v.AsyncWorkflowConfiguration, err = field.Value.GetBinary(), error(nil)
+				if err != nil {
+					return err
+				}
+
+			}
+		case 62:
+			if field.Value.Type() == wire.TBinary {
+				var x string
+				x, err = field.Value.GetString(), error(nil)
+				v.AsyncWorkflowConfigurationEncoding = &x
 				if err != nil {
 					return err
 				}
@@ -4984,6 +5020,30 @@ func (v *DomainInfo) Encode(sw stream.Writer) error {
 		}
 	}
 
+	if v.AsyncWorkflowConfiguration != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 60, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteBinary(v.AsyncWorkflowConfiguration); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
+	if v.AsyncWorkflowConfigurationEncoding != nil {
+		if err := sw.WriteFieldBegin(stream.FieldHeader{ID: 62, Type: wire.TBinary}); err != nil {
+			return err
+		}
+		if err := sw.WriteString(*(v.AsyncWorkflowConfigurationEncoding)); err != nil {
+			return err
+		}
+		if err := sw.WriteFieldEnd(); err != nil {
+			return err
+		}
+	}
+
 	return sw.WriteStructEnd()
 }
 
@@ -5245,6 +5305,20 @@ func (v *DomainInfo) Decode(sr stream.Reader) error {
 				return err
 			}
 
+		case fh.ID == 60 && fh.Type == wire.TBinary:
+			v.AsyncWorkflowConfiguration, err = sr.ReadBinary()
+			if err != nil {
+				return err
+			}
+
+		case fh.ID == 62 && fh.Type == wire.TBinary:
+			var x string
+			x, err = sr.ReadString()
+			v.AsyncWorkflowConfigurationEncoding = &x
+			if err != nil {
+				return err
+			}
+
 		default:
 			if err := sr.Skip(fh.Type); err != nil {
 				return err
@@ -5274,7 +5348,7 @@ func (v *DomainInfo) String() string {
 		return "<nil>"
 	}
 
-	var fields [26]string
+	var fields [28]string
 	i := 0
 	if v.Name != nil {
 		fields[i] = fmt.Sprintf("Name: %v", *(v.Name))
@@ -5378,6 +5452,14 @@ func (v *DomainInfo) String() string {
 	}
 	if v.IsolationGroupsConfigurationEncoding != nil {
 		fields[i] = fmt.Sprintf("IsolationGroupsConfigurationEncoding: %v", *(v.IsolationGroupsConfigurationEncoding))
+		i++
+	}
+	if v.AsyncWorkflowConfiguration != nil {
+		fields[i] = fmt.Sprintf("AsyncWorkflowConfiguration: %v", v.AsyncWorkflowConfiguration)
+		i++
+	}
+	if v.AsyncWorkflowConfigurationEncoding != nil {
+		fields[i] = fmt.Sprintf("AsyncWorkflowConfigurationEncoding: %v", *(v.AsyncWorkflowConfigurationEncoding))
 		i++
 	}
 
@@ -5499,6 +5581,12 @@ func (v *DomainInfo) Equals(rhs *DomainInfo) bool {
 	if !_String_EqualsPtr(v.IsolationGroupsConfigurationEncoding, rhs.IsolationGroupsConfigurationEncoding) {
 		return false
 	}
+	if !((v.AsyncWorkflowConfiguration == nil && rhs.AsyncWorkflowConfiguration == nil) || (v.AsyncWorkflowConfiguration != nil && rhs.AsyncWorkflowConfiguration != nil && bytes.Equal(v.AsyncWorkflowConfiguration, rhs.AsyncWorkflowConfiguration))) {
+		return false
+	}
+	if !_String_EqualsPtr(v.AsyncWorkflowConfigurationEncoding, rhs.AsyncWorkflowConfigurationEncoding) {
+		return false
+	}
 
 	return true
 }
@@ -5597,6 +5685,12 @@ func (v *DomainInfo) MarshalLogObject(enc zapcore.ObjectEncoder) (err error) {
 	}
 	if v.IsolationGroupsConfigurationEncoding != nil {
 		enc.AddString("isolationGroupsConfigurationEncoding", *v.IsolationGroupsConfigurationEncoding)
+	}
+	if v.AsyncWorkflowConfiguration != nil {
+		enc.AddString("asyncWorkflowConfiguration", base64.StdEncoding.EncodeToString(v.AsyncWorkflowConfiguration))
+	}
+	if v.AsyncWorkflowConfigurationEncoding != nil {
+		enc.AddString("asyncWorkflowConfigurationEncoding", *v.AsyncWorkflowConfigurationEncoding)
 	}
 	return err
 }
@@ -5989,6 +6083,36 @@ func (v *DomainInfo) GetIsolationGroupsConfigurationEncoding() (o string) {
 // IsSetIsolationGroupsConfigurationEncoding returns true if IsolationGroupsConfigurationEncoding is not nil.
 func (v *DomainInfo) IsSetIsolationGroupsConfigurationEncoding() bool {
 	return v != nil && v.IsolationGroupsConfigurationEncoding != nil
+}
+
+// GetAsyncWorkflowConfiguration returns the value of AsyncWorkflowConfiguration if it is set or its
+// zero value if it is unset.
+func (v *DomainInfo) GetAsyncWorkflowConfiguration() (o []byte) {
+	if v != nil && v.AsyncWorkflowConfiguration != nil {
+		return v.AsyncWorkflowConfiguration
+	}
+
+	return
+}
+
+// IsSetAsyncWorkflowConfiguration returns true if AsyncWorkflowConfiguration is not nil.
+func (v *DomainInfo) IsSetAsyncWorkflowConfiguration() bool {
+	return v != nil && v.AsyncWorkflowConfiguration != nil
+}
+
+// GetAsyncWorkflowConfigurationEncoding returns the value of AsyncWorkflowConfigurationEncoding if it is set or its
+// zero value if it is unset.
+func (v *DomainInfo) GetAsyncWorkflowConfigurationEncoding() (o string) {
+	if v != nil && v.AsyncWorkflowConfigurationEncoding != nil {
+		return *v.AsyncWorkflowConfigurationEncoding
+	}
+
+	return
+}
+
+// IsSetAsyncWorkflowConfigurationEncoding returns true if AsyncWorkflowConfigurationEncoding is not nil.
+func (v *DomainInfo) IsSetAsyncWorkflowConfigurationEncoding() bool {
+	return v != nil && v.AsyncWorkflowConfigurationEncoding != nil
 }
 
 type HistoryTreeInfo struct {
@@ -16938,11 +17062,11 @@ var ThriftModule = &thriftreflect.ThriftModule{
 	Name:     "sqlblobs",
 	Package:  "github.com/uber/cadence/.gen/go/sqlblobs",
 	FilePath: "sqlblobs.thrift",
-	SHA1:     "cf56b215a016d7da868d48b487067575b3469a74",
+	SHA1:     "bc1bf1cb91c4540e2cf879ddaf927d501f49e930",
 	Includes: []*thriftreflect.ThriftModule{
 		shared.ThriftModule,
 	},
 	Raw: rawIDL,
 }
 
-const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence.sqlblobs\n\ninclude \"shared.thrift\"\n\nstruct ShardInfo {\n  10: optional i32 stolenSinceRenew\n  12: optional i64 (js.type = \"Long\") updatedAtNanos\n  14: optional i64 (js.type = \"Long\") replicationAckLevel\n  16: optional i64 (js.type = \"Long\") transferAckLevel\n  18: optional i64 (js.type = \"Long\") timerAckLevelNanos\n  24: optional i64 (js.type = \"Long\") domainNotificationVersion\n  34: optional map<string, i64> clusterTransferAckLevel\n  36: optional map<string, i64> clusterTimerAckLevel\n  38: optional string owner\n  40: optional map<string, i64> clusterReplicationLevel\n  42: optional binary pendingFailoverMarkers\n  44: optional string pendingFailoverMarkersEncoding\n  46: optional map<string, i64> replicationDlqAckLevel\n  50: optional binary transferProcessingQueueStates\n  51: optional string transferProcessingQueueStatesEncoding\n  55: optional binary timerProcessingQueueStates\n  56: optional string timerProcessingQueueStatesEncoding\n  60: optional binary crossClusterProcessingQueueStates\n  61: optional string crossClusterProcessingQueueStatesEncoding\n}\n\nstruct DomainInfo {\n  10: optional string name\n  12: optional string description\n  14: optional string owner\n  16: optional i32 status\n  18: optional i16 retentionDays\n  20: optional bool emitMetric\n  22: optional string archivalBucket\n  24: optional i16 archivalStatus\n  26: optional i64 (js.type = \"Long\") configVersion\n  28: optional i64 (js.type = \"Long\") notificationVersion\n  30: optional i64 (js.type = \"Long\") failoverNotificationVersion\n  32: optional i64 (js.type = \"Long\") failoverVersion\n  34: optional string activeClusterName\n  36: optional list<string> clusters\n  38: optional map<string, string> data\n  39: optional binary badBinaries\n  40: optional string badBinariesEncoding\n  42: optional i16 historyArchivalStatus\n  44: optional string historyArchivalURI\n  46: optional i16 visibilityArchivalStatus\n  48: optional string visibilityArchivalURI\n  50: optional i64 (js.type = \"Long\") failoverEndTime\n  52: optional i64 (js.type = \"Long\") previousFailoverVersion\n  54: optional i64 (js.type = \"Long\") lastUpdatedTime\n  56: optional binary isolationGroupsConfiguration\n  58: optional string isolationGroupsConfigurationEncoding\n}\n\nstruct HistoryTreeInfo {\n  10: optional i64 (js.type = \"Long\") createdTimeNanos // For fork operation to prevent race condition of leaking event data when forking branches fail. Also can be used for clean up leaked data\n  12: optional list<shared.HistoryBranchRange> ancestors\n  14: optional string info // For lookup back to workflow during debugging, also background cleanup when fork operation cannot finish self cleanup due to crash.\n}\n\nstruct WorkflowExecutionInfo {\n  10: optional binary parentDomainID\n  12: optional string parentWorkflowID\n  14: optional binary parentRunID\n  16: optional i64 (js.type = \"Long\") initiatedID\n  18: optional i64 (js.type = \"Long\") completionEventBatchID\n  20: optional binary completionEvent\n  22: optional string completionEventEncoding\n  24: optional string taskList\n  26: optional string workflowTypeName\n  28: optional i32 workflowTimeoutSeconds\n  30: optional i32 decisionTaskTimeoutSeconds\n  32: optional binary executionContext\n  34: optional i32 state\n  36: optional i32 closeStatus\n  38: optional i64 (js.type = \"Long\") startVersion\n  44: optional i64 (js.type = \"Long\") lastWriteEventID\n  48: optional i64 (js.type = \"Long\") lastEventTaskID\n  50: optional i64 (js.type = \"Long\") lastFirstEventID\n  52: optional i64 (js.type = \"Long\") lastProcessedEvent\n  54: optional i64 (js.type = \"Long\") startTimeNanos\n  56: optional i64 (js.type = \"Long\") lastUpdatedTimeNanos\n  58: optional i64 (js.type = \"Long\") decisionVersion\n  60: optional i64 (js.type = \"Long\") decisionScheduleID\n  62: optional i64 (js.type = \"Long\") decisionStartedID\n  64: optional i32 decisionTimeout\n  66: optional i64 (js.type = \"Long\") decisionAttempt\n  68: optional i64 (js.type = \"Long\") decisionStartedTimestampNanos\n  69: optional i64 (js.type = \"Long\") decisionScheduledTimestampNanos\n  70: optional bool cancelRequested\n  71: optional i64 (js.type = \"Long\") decisionOriginalScheduledTimestampNanos\n  72: optional string createRequestID\n  74: optional string decisionRequestID\n  76: optional string cancelRequestID\n  78: optional string stickyTaskList\n  80: optional i64 (js.type = \"Long\") stickyScheduleToStartTimeout\n  82: optional i64 (js.type = \"Long\") retryAttempt\n  84: optional i32 retryInitialIntervalSeconds\n  86: optional i32 retryMaximumIntervalSeconds\n  88: optional i32 retryMaximumAttempts\n  90: optional i32 retryExpirationSeconds\n  92: optional double retryBackoffCoefficient\n  94: optional i64 (js.type = \"Long\") retryExpirationTimeNanos\n  96: optional list<string> retryNonRetryableErrors\n  98: optional bool hasRetryPolicy\n  100: optional string cronSchedule\n  102: optional i32 eventStoreVersion\n  104: optional binary eventBranchToken\n  106: optional i64 (js.type = \"Long\") signalCount\n  108: optional i64 (js.type = \"Long\") historySize\n  110: optional string clientLibraryVersion\n  112: optional string clientFeatureVersion\n  114: optional string clientImpl\n  115: optional binary autoResetPoints\n  116: optional string autoResetPointsEncoding\n  118: optional map<string, binary> searchAttributes\n  120: optional map<string, binary> memo\n  122: optional binary versionHistories\n  124: optional string versionHistoriesEncoding\n  126: optional binary firstExecutionRunID\n  128: optional map<string, string> partitionConfig\n}\n\nstruct ActivityInfo {\n  10: optional i64 (js.type = \"Long\") version\n  12: optional i64 (js.type = \"Long\") scheduledEventBatchID\n  14: optional binary scheduledEvent\n  16: optional string scheduledEventEncoding\n  18: optional i64 (js.type = \"Long\") scheduledTimeNanos\n  20: optional i64 (js.type = \"Long\") startedID\n  22: optional binary startedEvent\n  24: optional string startedEventEncoding\n  26: optional i64 (js.type = \"Long\") startedTimeNanos\n  28: optional string activityID\n  30: optional string requestID\n  32: optional i32 scheduleToStartTimeoutSeconds\n  34: optional i32 scheduleToCloseTimeoutSeconds\n  36: optional i32 startToCloseTimeoutSeconds\n  38: optional i32 heartbeatTimeoutSeconds\n  40: optional bool cancelRequested\n  42: optional i64 (js.type = \"Long\") cancelRequestID\n  44: optional i32 timerTaskStatus\n  46: optional i32 attempt\n  48: optional string taskList\n  50: optional string startedIdentity\n  52: optional bool hasRetryPolicy\n  54: optional i32 retryInitialIntervalSeconds\n  56: optional i32 retryMaximumIntervalSeconds\n  58: optional i32 retryMaximumAttempts\n  60: optional i64 (js.type = \"Long\") retryExpirationTimeNanos\n  62: optional double retryBackoffCoefficient\n  64: optional list<string> retryNonRetryableErrors\n  66: optional string retryLastFailureReason\n  68: optional string retryLastWorkerIdentity\n  70: optional binary retryLastFailureDetails\n}\n\nstruct ChildExecutionInfo {\n  10: optional i64 (js.type = \"Long\") version\n  12: optional i64 (js.type = \"Long\") initiatedEventBatchID\n  14: optional i64 (js.type = \"Long\") startedID\n  16: optional binary initiatedEvent\n  18: optional string initiatedEventEncoding\n  20: optional string startedWorkflowID\n  22: optional binary startedRunID\n  24: optional binary startedEvent\n  26: optional string startedEventEncoding\n  28: optional string createRequestID\n  29: optional string domainID\n  30: optional string domainName // deprecated\n  32: optional string workflowTypeName\n  35: optional i32 parentClosePolicy\n}\n\nstruct SignalInfo {\n  10: optional i64 (js.type = \"Long\") version\n  11: optional i64 (js.type = \"Long\") initiatedEventBatchID\n  12: optional string requestID\n  14: optional string name\n  16: optional binary input\n  18: optional binary control\n}\n\nstruct RequestCancelInfo {\n  10: optional i64 (js.type = \"Long\") version\n  11: optional i64 (js.type = \"Long\") initiatedEventBatchID\n  12: optional string cancelRequestID\n}\n\nstruct TimerInfo {\n  10: optional i64 (js.type = \"Long\") version\n  12: optional i64 (js.type = \"Long\") startedID\n  14: optional i64 (js.type = \"Long\") expiryTimeNanos\n  // TaskID is a misleading variable, it actually serves\n  // the purpose of indicating whether a timer task is\n  // generated for this timer info\n  16: optional i64 (js.type = \"Long\") taskID\n}\n\nstruct TaskInfo {\n  10: optional string workflowID\n  12: optional binary runID\n  13: optional i64 (js.type = \"Long\") scheduleID\n  14: optional i64 (js.type = \"Long\") expiryTimeNanos\n  15: optional i64 (js.type = \"Long\") createdTimeNanos\n  17: optional map<string, string> partitionConfig\n}\n\nstruct TaskListInfo {\n  10: optional i16 kind // {Normal, Sticky}\n  12: optional i64 (js.type = \"Long\") ackLevel\n  14: optional i64 (js.type = \"Long\") expiryTimeNanos\n  16: optional i64 (js.type = \"Long\") lastUpdatedNanos\n}\n\nstruct TransferTaskInfo {\n  10: optional binary domainID\n  12: optional string workflowID\n  14: optional binary runID\n  16: optional i16 taskType\n  18: optional binary targetDomainID\n  20: optional string targetWorkflowID\n  22: optional binary targetRunID\n  24: optional string taskList\n  26: optional bool targetChildWorkflowOnly\n  28: optional i64 (js.type = \"Long\") scheduleID\n  30: optional i64 (js.type = \"Long\") version\n  32: optional i64 (js.type = \"Long\") visibilityTimestampNanos\n  34: optional set<binary> targetDomainIDs\n}\n\nstruct TimerTaskInfo {\n  10: optional binary domainID\n  12: optional string workflowID\n  14: optional binary runID\n  16: optional i16 taskType\n  18: optional i16 timeoutType\n  20: optional i64 (js.type = \"Long\") version\n  22: optional i64 (js.type = \"Long\") scheduleAttempt\n  24: optional i64 (js.type = \"Long\") eventID\n}\n\nstruct ReplicationTaskInfo {\n  10: optional binary domainID\n  12: optional string workflowID\n  14: optional binary runID\n  16: optional i16 taskType\n  18: optional i64 (js.type = \"Long\") version\n  20: optional i64 (js.type = \"Long\") firstEventID\n  22: optional i64 (js.type = \"Long\") nextEventID\n  24: optional i64 (js.type = \"Long\") scheduledID\n  26: optional i32 eventStoreVersion\n  28: optional i32 newRunEventStoreVersion\n  30: optional binary branch_token\n  34: optional binary newRunBranchToken\n  38: optional i64 (js.type = \"Long\") creationTime\n}\n\nenum AsyncRequestType {\n  StartWorkflowExecutionAsyncRequest\n}\n\nstruct AsyncRequestMessage {\n  10: optional string partitionKey\n  12: optional AsyncRequestType type\n  14: optional shared.Header header\n  16: optional string encoding\n  18: optional binary payload\n}\n"
+const rawIDL = "// Copyright (c) 2017 Uber Technologies, Inc.\n//\n// Permission is hereby granted, free of charge, to any person obtaining a copy\n// of this software and associated documentation files (the \"Software\"), to deal\n// in the Software without restriction, including without limitation the rights\n// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell\n// copies of the Software, and to permit persons to whom the Software is\n// furnished to do so, subject to the following conditions:\n//\n// The above copyright notice and this permission notice shall be included in\n// all copies or substantial portions of the Software.\n//\n// THE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR\n// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,\n// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE\n// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER\n// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,\n// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN\n// THE SOFTWARE.\n\nnamespace java com.uber.cadence.sqlblobs\n\ninclude \"shared.thrift\"\n\nstruct ShardInfo {\n  10: optional i32 stolenSinceRenew\n  12: optional i64 (js.type = \"Long\") updatedAtNanos\n  14: optional i64 (js.type = \"Long\") replicationAckLevel\n  16: optional i64 (js.type = \"Long\") transferAckLevel\n  18: optional i64 (js.type = \"Long\") timerAckLevelNanos\n  24: optional i64 (js.type = \"Long\") domainNotificationVersion\n  34: optional map<string, i64> clusterTransferAckLevel\n  36: optional map<string, i64> clusterTimerAckLevel\n  38: optional string owner\n  40: optional map<string, i64> clusterReplicationLevel\n  42: optional binary pendingFailoverMarkers\n  44: optional string pendingFailoverMarkersEncoding\n  46: optional map<string, i64> replicationDlqAckLevel\n  50: optional binary transferProcessingQueueStates\n  51: optional string transferProcessingQueueStatesEncoding\n  55: optional binary timerProcessingQueueStates\n  56: optional string timerProcessingQueueStatesEncoding\n  60: optional binary crossClusterProcessingQueueStates\n  61: optional string crossClusterProcessingQueueStatesEncoding\n}\n\nstruct DomainInfo {\n  10: optional string name\n  12: optional string description\n  14: optional string owner\n  16: optional i32 status\n  18: optional i16 retentionDays\n  20: optional bool emitMetric\n  22: optional string archivalBucket\n  24: optional i16 archivalStatus\n  26: optional i64 (js.type = \"Long\") configVersion\n  28: optional i64 (js.type = \"Long\") notificationVersion\n  30: optional i64 (js.type = \"Long\") failoverNotificationVersion\n  32: optional i64 (js.type = \"Long\") failoverVersion\n  34: optional string activeClusterName\n  36: optional list<string> clusters\n  38: optional map<string, string> data\n  39: optional binary badBinaries\n  40: optional string badBinariesEncoding\n  42: optional i16 historyArchivalStatus\n  44: optional string historyArchivalURI\n  46: optional i16 visibilityArchivalStatus\n  48: optional string visibilityArchivalURI\n  50: optional i64 (js.type = \"Long\") failoverEndTime\n  52: optional i64 (js.type = \"Long\") previousFailoverVersion\n  54: optional i64 (js.type = \"Long\") lastUpdatedTime\n  56: optional binary isolationGroupsConfiguration\n  58: optional string isolationGroupsConfigurationEncoding\n  60: optional binary asyncWorkflowConfiguration\n  62: optional string asyncWorkflowConfigurationEncoding\n}\n\nstruct HistoryTreeInfo {\n  10: optional i64 (js.type = \"Long\") createdTimeNanos // For fork operation to prevent race condition of leaking event data when forking branches fail. Also can be used for clean up leaked data\n  12: optional list<shared.HistoryBranchRange> ancestors\n  14: optional string info // For lookup back to workflow during debugging, also background cleanup when fork operation cannot finish self cleanup due to crash.\n}\n\nstruct WorkflowExecutionInfo {\n  10: optional binary parentDomainID\n  12: optional string parentWorkflowID\n  14: optional binary parentRunID\n  16: optional i64 (js.type = \"Long\") initiatedID\n  18: optional i64 (js.type = \"Long\") completionEventBatchID\n  20: optional binary completionEvent\n  22: optional string completionEventEncoding\n  24: optional string taskList\n  26: optional string workflowTypeName\n  28: optional i32 workflowTimeoutSeconds\n  30: optional i32 decisionTaskTimeoutSeconds\n  32: optional binary executionContext\n  34: optional i32 state\n  36: optional i32 closeStatus\n  38: optional i64 (js.type = \"Long\") startVersion\n  44: optional i64 (js.type = \"Long\") lastWriteEventID\n  48: optional i64 (js.type = \"Long\") lastEventTaskID\n  50: optional i64 (js.type = \"Long\") lastFirstEventID\n  52: optional i64 (js.type = \"Long\") lastProcessedEvent\n  54: optional i64 (js.type = \"Long\") startTimeNanos\n  56: optional i64 (js.type = \"Long\") lastUpdatedTimeNanos\n  58: optional i64 (js.type = \"Long\") decisionVersion\n  60: optional i64 (js.type = \"Long\") decisionScheduleID\n  62: optional i64 (js.type = \"Long\") decisionStartedID\n  64: optional i32 decisionTimeout\n  66: optional i64 (js.type = \"Long\") decisionAttempt\n  68: optional i64 (js.type = \"Long\") decisionStartedTimestampNanos\n  69: optional i64 (js.type = \"Long\") decisionScheduledTimestampNanos\n  70: optional bool cancelRequested\n  71: optional i64 (js.type = \"Long\") decisionOriginalScheduledTimestampNanos\n  72: optional string createRequestID\n  74: optional string decisionRequestID\n  76: optional string cancelRequestID\n  78: optional string stickyTaskList\n  80: optional i64 (js.type = \"Long\") stickyScheduleToStartTimeout\n  82: optional i64 (js.type = \"Long\") retryAttempt\n  84: optional i32 retryInitialIntervalSeconds\n  86: optional i32 retryMaximumIntervalSeconds\n  88: optional i32 retryMaximumAttempts\n  90: optional i32 retryExpirationSeconds\n  92: optional double retryBackoffCoefficient\n  94: optional i64 (js.type = \"Long\") retryExpirationTimeNanos\n  96: optional list<string> retryNonRetryableErrors\n  98: optional bool hasRetryPolicy\n  100: optional string cronSchedule\n  102: optional i32 eventStoreVersion\n  104: optional binary eventBranchToken\n  106: optional i64 (js.type = \"Long\") signalCount\n  108: optional i64 (js.type = \"Long\") historySize\n  110: optional string clientLibraryVersion\n  112: optional string clientFeatureVersion\n  114: optional string clientImpl\n  115: optional binary autoResetPoints\n  116: optional string autoResetPointsEncoding\n  118: optional map<string, binary> searchAttributes\n  120: optional map<string, binary> memo\n  122: optional binary versionHistories\n  124: optional string versionHistoriesEncoding\n  126: optional binary firstExecutionRunID\n  128: optional map<string, string> partitionConfig\n}\n\nstruct ActivityInfo {\n  10: optional i64 (js.type = \"Long\") version\n  12: optional i64 (js.type = \"Long\") scheduledEventBatchID\n  14: optional binary scheduledEvent\n  16: optional string scheduledEventEncoding\n  18: optional i64 (js.type = \"Long\") scheduledTimeNanos\n  20: optional i64 (js.type = \"Long\") startedID\n  22: optional binary startedEvent\n  24: optional string startedEventEncoding\n  26: optional i64 (js.type = \"Long\") startedTimeNanos\n  28: optional string activityID\n  30: optional string requestID\n  32: optional i32 scheduleToStartTimeoutSeconds\n  34: optional i32 scheduleToCloseTimeoutSeconds\n  36: optional i32 startToCloseTimeoutSeconds\n  38: optional i32 heartbeatTimeoutSeconds\n  40: optional bool cancelRequested\n  42: optional i64 (js.type = \"Long\") cancelRequestID\n  44: optional i32 timerTaskStatus\n  46: optional i32 attempt\n  48: optional string taskList\n  50: optional string startedIdentity\n  52: optional bool hasRetryPolicy\n  54: optional i32 retryInitialIntervalSeconds\n  56: optional i32 retryMaximumIntervalSeconds\n  58: optional i32 retryMaximumAttempts\n  60: optional i64 (js.type = \"Long\") retryExpirationTimeNanos\n  62: optional double retryBackoffCoefficient\n  64: optional list<string> retryNonRetryableErrors\n  66: optional string retryLastFailureReason\n  68: optional string retryLastWorkerIdentity\n  70: optional binary retryLastFailureDetails\n}\n\nstruct ChildExecutionInfo {\n  10: optional i64 (js.type = \"Long\") version\n  12: optional i64 (js.type = \"Long\") initiatedEventBatchID\n  14: optional i64 (js.type = \"Long\") startedID\n  16: optional binary initiatedEvent\n  18: optional string initiatedEventEncoding\n  20: optional string startedWorkflowID\n  22: optional binary startedRunID\n  24: optional binary startedEvent\n  26: optional string startedEventEncoding\n  28: optional string createRequestID\n  29: optional string domainID\n  30: optional string domainName // deprecated\n  32: optional string workflowTypeName\n  35: optional i32 parentClosePolicy\n}\n\nstruct SignalInfo {\n  10: optional i64 (js.type = \"Long\") version\n  11: optional i64 (js.type = \"Long\") initiatedEventBatchID\n  12: optional string requestID\n  14: optional string name\n  16: optional binary input\n  18: optional binary control\n}\n\nstruct RequestCancelInfo {\n  10: optional i64 (js.type = \"Long\") version\n  11: optional i64 (js.type = \"Long\") initiatedEventBatchID\n  12: optional string cancelRequestID\n}\n\nstruct TimerInfo {\n  10: optional i64 (js.type = \"Long\") version\n  12: optional i64 (js.type = \"Long\") startedID\n  14: optional i64 (js.type = \"Long\") expiryTimeNanos\n  // TaskID is a misleading variable, it actually serves\n  // the purpose of indicating whether a timer task is\n  // generated for this timer info\n  16: optional i64 (js.type = \"Long\") taskID\n}\n\nstruct TaskInfo {\n  10: optional string workflowID\n  12: optional binary runID\n  13: optional i64 (js.type = \"Long\") scheduleID\n  14: optional i64 (js.type = \"Long\") expiryTimeNanos\n  15: optional i64 (js.type = \"Long\") createdTimeNanos\n  17: optional map<string, string> partitionConfig\n}\n\nstruct TaskListInfo {\n  10: optional i16 kind // {Normal, Sticky}\n  12: optional i64 (js.type = \"Long\") ackLevel\n  14: optional i64 (js.type = \"Long\") expiryTimeNanos\n  16: optional i64 (js.type = \"Long\") lastUpdatedNanos\n}\n\nstruct TransferTaskInfo {\n  10: optional binary domainID\n  12: optional string workflowID\n  14: optional binary runID\n  16: optional i16 taskType\n  18: optional binary targetDomainID\n  20: optional string targetWorkflowID\n  22: optional binary targetRunID\n  24: optional string taskList\n  26: optional bool targetChildWorkflowOnly\n  28: optional i64 (js.type = \"Long\") scheduleID\n  30: optional i64 (js.type = \"Long\") version\n  32: optional i64 (js.type = \"Long\") visibilityTimestampNanos\n  34: optional set<binary> targetDomainIDs\n}\n\nstruct TimerTaskInfo {\n  10: optional binary domainID\n  12: optional string workflowID\n  14: optional binary runID\n  16: optional i16 taskType\n  18: optional i16 timeoutType\n  20: optional i64 (js.type = \"Long\") version\n  22: optional i64 (js.type = \"Long\") scheduleAttempt\n  24: optional i64 (js.type = \"Long\") eventID\n}\n\nstruct ReplicationTaskInfo {\n  10: optional binary domainID\n  12: optional string workflowID\n  14: optional binary runID\n  16: optional i16 taskType\n  18: optional i64 (js.type = \"Long\") version\n  20: optional i64 (js.type = \"Long\") firstEventID\n  22: optional i64 (js.type = \"Long\") nextEventID\n  24: optional i64 (js.type = \"Long\") scheduledID\n  26: optional i32 eventStoreVersion\n  28: optional i32 newRunEventStoreVersion\n  30: optional binary branch_token\n  34: optional binary newRunBranchToken\n  38: optional i64 (js.type = \"Long\") creationTime\n}\n\nenum AsyncRequestType {\n  StartWorkflowExecutionAsyncRequest\n}\n\nstruct AsyncRequestMessage {\n  10: optional string partitionKey\n  12: optional AsyncRequestType type\n  14: optional shared.Header header\n  16: optional string encoding\n  18: optional binary payload\n}\n"

--- a/cmd/server/go.mod
+++ b/cmd/server/go.mod
@@ -43,7 +43,7 @@ require (
 	github.com/startreedata/pinot-client-go v0.0.0-20230303070132-3b84c28a9e95 // latest release doesn't support pinot v0.12, so use master branch
 	github.com/stretchr/testify v1.8.3
 	github.com/uber-go/tally v3.3.15+incompatible // indirect
-	github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07
+	github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f
 	github.com/uber/ringpop-go v0.8.5 // indirect
 	github.com/uber/tchannel-go v1.22.2 // indirect
 	github.com/urfave/cli v1.22.4

--- a/cmd/server/go.sum
+++ b/cmd/server/go.sum
@@ -396,6 +396,8 @@ github.com/uber-go/tally v3.3.15+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyu
 github.com/uber/cadence-idl v0.0.0-20211111101836-d6b70b60eb8c/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07 h1:VxvBaCqyXmHIxPHYcQrz3oBsCeiO7diPyFau6E1CgaE=
 github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
+github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f h1:+Z2D/fV23Sl2ZBP4ADMeKH9uXNJO9sJlV9SlR3/QFzw=
+github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR83gdUHXjRJvjoBh1yACsM=
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=

--- a/cmd/server/go.sum
+++ b/cmd/server/go.sum
@@ -394,8 +394,6 @@ github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyu
 github.com/uber-go/tally v3.3.15+incompatible h1:9hLSgNBP28CjIaDmAuRTq9qV+UZY+9PcvAkXO4nNMwg=
 github.com/uber-go/tally v3.3.15+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber/cadence-idl v0.0.0-20211111101836-d6b70b60eb8c/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
-github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07 h1:VxvBaCqyXmHIxPHYcQrz3oBsCeiO7diPyFau6E1CgaE=
-github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f h1:+Z2D/fV23Sl2ZBP4ADMeKH9uXNJO9sJlV9SlR3/QFzw=
 github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR83gdUHXjRJvjoBh1yACsM=

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -812,6 +812,8 @@ func (d *handlerImpl) UpdateAsyncWorkflowConfiguraton(
 		currentDomainConfig.Config.AsyncWorkflowConfig = *updateRequest.Configuration
 	}
 
+	d.logger.Debug("async workflow queue config update", tag.Dynamic("config", currentDomainConfig))
+
 	updateReq := createUpdateRequest(
 		currentDomainConfig.Info,
 		currentDomainConfig.Config,

--- a/common/persistence/nosql/nosql_domain_store.go
+++ b/common/persistence/nosql/nosql_domain_store.go
@@ -281,6 +281,7 @@ func (m *nosqlDomainStore) toNoSQLInternalDomainConfig(
 		VisibilityArchivalURI:    domainConfig.VisibilityArchivalURI,
 		BadBinaries:              domainConfig.BadBinaries,
 		IsolationGroups:          domainConfig.IsolationGroups,
+		AsyncWorkflowsConfig:     domainConfig.AsyncWorkflowsConfig,
 	}, nil
 }
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain.go
@@ -457,7 +457,7 @@ func (db *cdb) DeleteDomain(
 	} else {
 		var ID string
 		query := db.session.Query(templateGetDomainByNameQueryV2, constDomainPartition, *domainName).WithContext(ctx)
-		err := query.Scan(&ID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
+		err := query.Scan(&ID, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil, nil)
 		if err != nil {
 			if db.client.IsNotFoundError(err) {
 				return nil

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain.go
@@ -66,6 +66,7 @@ func (db *cdb) InsertDomain(
 		failoverEndTime = row.FailoverEndTime.UnixNano()
 	}
 	isolationGroupData, isolationGroupEncoding := getIsolationGroupFields(row)
+	asyncWFConfigData, asyncWFConfigEncoding := getAsyncWFConfigFields(row)
 
 	batch.Query(templateCreateDomainByNameQueryWithinBatchV2,
 		constDomainPartition,
@@ -88,6 +89,8 @@ func (db *cdb) InsertDomain(
 		string(row.Config.BadBinaries.Encoding),
 		isolationGroupData,
 		isolationGroupEncoding,
+		asyncWFConfigData,
+		asyncWFConfigEncoding,
 		row.ReplicationConfig.ActiveClusterName,
 		persistence.SerializeClusterConfigs(row.ReplicationConfig.Clusters),
 		row.IsGlobalDomain,
@@ -171,6 +174,7 @@ func (db *cdb) UpdateDomain(
 	}
 
 	isolationGroupData, isolationGroupEncoding := getIsolationGroupFields(row)
+	asyncWFConfigData, asyncWFConfigEncoding := getAsyncWFConfigFields(row)
 
 	batch.Query(templateUpdateDomainByNameQueryWithinBatchV2,
 		row.Info.ID,
@@ -191,6 +195,8 @@ func (db *cdb) UpdateDomain(
 		string(row.Config.BadBinaries.Encoding),
 		isolationGroupData,
 		isolationGroupEncoding,
+		asyncWFConfigData,
+		asyncWFConfigEncoding,
 		row.ReplicationConfig.ActiveClusterName,
 		persistence.SerializeClusterConfigs(row.ReplicationConfig.Clusters),
 		row.ConfigVersion,
@@ -264,6 +270,8 @@ func (db *cdb) SelectDomain(
 	var retentionDays int32
 	var isolationGroupData []byte
 	var isolationGroupEncoding string
+	var asyncWFConfigData []byte
+	var asyncWFConfigEncoding string
 
 	query = db.session.Query(templateGetDomainByNameQueryV2, constDomainPartition, domainName).WithContext(ctx)
 	err = query.Scan(
@@ -287,6 +295,8 @@ func (db *cdb) SelectDomain(
 		&replicationClusters,
 		&isolationGroupData,
 		&isolationGroupEncoding,
+		&asyncWFConfigData,
+		&asyncWFConfigEncoding,
 		&isGlobalDomain,
 		&configVersion,
 		&failoverVersion,
@@ -302,6 +312,7 @@ func (db *cdb) SelectDomain(
 	}
 
 	config.IsolationGroups = persistence.NewDataBlob(isolationGroupData, common.EncodingType(isolationGroupEncoding))
+	config.AsyncWorkflowsConfig = persistence.NewDataBlob(asyncWFConfigData, common.EncodingType(asyncWFConfigEncoding))
 	config.BadBinaries = persistence.NewDataBlob(badBinariesData, common.EncodingType(badBinariesDataEncoding))
 	config.Retention = common.DaysToDuration(retentionDays)
 	replicationConfig.Clusters = persistence.DeserializeClusterConfigs(replicationClusters)
@@ -350,6 +361,8 @@ func (db *cdb) SelectAllDomains(
 	var badBinariesDataEncoding string
 	var isolationGroups []byte
 	var isolationGroupsEncoding string
+	var asyncWFConfigData []byte
+	var asyncWFConfigEncoding string
 	var retentionDays int32
 	var failoverEndTime int64
 	var lastUpdateTime int64
@@ -374,6 +387,8 @@ func (db *cdb) SelectAllDomains(
 		&badBinariesDataEncoding,
 		&isolationGroups,
 		&isolationGroupsEncoding,
+		&asyncWFConfigData,
+		&asyncWFConfigEncoding,
 		&domain.ReplicationConfig.ActiveClusterName,
 		&replicationClusters,
 		&domain.IsGlobalDomain,
@@ -391,6 +406,7 @@ func (db *cdb) SelectAllDomains(
 			domain.ReplicationConfig.Clusters = persistence.DeserializeClusterConfigs(replicationClusters)
 			domain.Config.Retention = common.DaysToDuration(retentionDays)
 			domain.Config.IsolationGroups = persistence.NewDataBlob(isolationGroups, common.EncodingType(isolationGroupsEncoding))
+			domain.Config.AsyncWorkflowsConfig = persistence.NewDataBlob(asyncWFConfigData, common.EncodingType(asyncWFConfigEncoding))
 			domain.LastUpdatedTime = time.Unix(0, lastUpdateTime)
 			if failoverEndTime > emptyFailoverEndTime {
 				domain.FailoverEndTime = common.TimePtr(time.Unix(0, failoverEndTime))
@@ -491,6 +507,16 @@ func getIsolationGroupFields(row *nosqlplugin.DomainRow) ([]byte, string) {
 	if row != nil && row.Config != nil && row.Config.IsolationGroups != nil {
 		d = row.Config.IsolationGroups.GetData()
 		e = row.Config.IsolationGroups.GetEncodingString()
+	}
+	return d, e
+}
+
+func getAsyncWFConfigFields(row *nosqlplugin.DomainRow) ([]byte, string) {
+	var d []byte
+	var e string
+	if row != nil && row.Config != nil && row.Config.AsyncWorkflowsConfig != nil {
+		d = row.Config.AsyncWorkflowsConfig.GetData()
+		e = row.Config.AsyncWorkflowsConfig.GetEncodingString()
 	}
 	return d, e
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/domain_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain_cql.go
@@ -43,7 +43,9 @@ const (
 		`bad_binaries: ?,` +
 		`bad_binaries_encoding: ?,` +
 		`isolation_groups: ?,` +
-		`isolation_groups_encoding: ?` +
+		`isolation_groups_encoding: ?,` +
+		`async_workflow_config: ?,` +
+		`async_workflow_config_encoding: ?` +
 		`}`
 
 	templateDomainReplicationConfigType = `{` +
@@ -75,6 +77,8 @@ const (
 		`replication_config.active_cluster_name, replication_config.clusters, ` +
 		`config.isolation_groups,` +
 		`config.isolation_groups_encoding,` +
+		`config.async_workflow_config,` +
+		`config.async_workflow_config_encoding,` +
 		`is_global_domain, ` +
 		`config_version, ` +
 		`failover_version, ` +
@@ -123,6 +127,7 @@ const (
 		`config.visibility_archival_status, config.visibility_archival_uri, ` +
 		`config.bad_binaries, config.bad_binaries_encoding, ` +
 		`config.isolation_groups, config.isolation_groups_encoding, ` +
+		`config.async_workflow_config, config.async_workflow_config_encoding, ` +
 		`replication_config.active_cluster_name, replication_config.clusters, ` +
 		`is_global_domain, ` +
 		`config_version, ` +

--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -717,16 +717,10 @@ func (m *MetadataPersistenceSuiteV2) TestUpdateDomain() {
 	}
 
 	asyncWFCfg1 := types.AsyncWorkflowConfiguration{
-		QueueType: types.AsyncWorkflowQueueTypeKafka,
-		KafkaConfig: &types.AsyncWorkflowKafkaQueueConfiguration{
-			Topic: "topic1",
-		},
+		PredefinedQueueName: "queue1",
 	}
 	asyncWFCfg2 := types.AsyncWorkflowConfiguration{
-		QueueType: types.AsyncWorkflowQueueTypeKafka,
-		KafkaConfig: &types.AsyncWorkflowKafkaQueueConfiguration{
-			Topic: "topic2",
-		},
+		PredefinedQueueName: "queue2",
 	}
 
 	id := uuid.New()

--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -899,9 +899,7 @@ func (m *MetadataPersistenceSuiteV2) TestUpdateDomain() {
 	m.Equal(&failoverEndTime, resp4.FailoverEndTime)
 	m.Equal(lastUpdateTime, resp4.LastUpdatedTime)
 	m.Equal(isolationGroups2, resp4.Config.IsolationGroups)
-	// TODO(taylan): uncomment when persistent layer schema is updated
-	// m.Equal(asyncWFCfg2, resp4.Config.AsyncWorkflowConfig)
-	m.Equal(types.AsyncWorkflowConfiguration{}, resp4.Config.AsyncWorkflowConfig)
+	m.Equal(asyncWFCfg2, resp4.Config.AsyncWorkflowConfig)
 
 	resp5, err5 := m.GetDomain(ctx, id, "")
 	m.NoError(err5)
@@ -999,10 +997,7 @@ func (m *MetadataPersistenceSuiteV2) TestUpdateDomain() {
 	m.Nil(resp6.FailoverEndTime)
 	m.Equal(lastUpdateTime, resp6.LastUpdatedTime)
 	m.Equal(isolationGroups1, resp6.Config.IsolationGroups)
-
-	// TODO(taylan): uncomment when persistent layer schema is updated
-	// m.Equal(asyncWFCfg1, resp6.Config.AsyncWorkflowConfig)
-	m.Equal(types.AsyncWorkflowConfiguration{}, resp6.Config.AsyncWorkflowConfig)
+	m.Equal(asyncWFCfg1, resp6.Config.AsyncWorkflowConfig)
 }
 
 // TestDeleteDomain test

--- a/common/persistence/serialization/thrift_mapper.go
+++ b/common/persistence/serialization/thrift_mapper.go
@@ -128,6 +128,8 @@ func domainInfoToThrift(info *DomainInfo) *sqlblobs.DomainInfo {
 		LastUpdatedTime:                      timeToUnixNanoPtr(info.LastUpdatedTimestamp),
 		IsolationGroupsConfiguration:         info.IsolationGroups,
 		IsolationGroupsConfigurationEncoding: &info.IsolationGroupsEncoding,
+
+		// TODO(taylan): once idl changes are merged https://github.com/uber/cadence-idl/pull/158, add async workflows config here
 	}
 }
 
@@ -162,6 +164,8 @@ func domainInfoFromThrift(info *sqlblobs.DomainInfo) *DomainInfo {
 		LastUpdatedTimestamp:        timeFromUnixNano(info.GetLastUpdatedTime()),
 		IsolationGroups:             info.GetIsolationGroupsConfiguration(),
 		IsolationGroupsEncoding:     info.GetIsolationGroupsConfigurationEncoding(),
+
+		// TODO(taylan): once idl changes are merged https://github.com/uber/cadence-idl/pull/158, add async workflows config here
 	}
 }
 

--- a/common/persistence/serialization/thrift_mapper.go
+++ b/common/persistence/serialization/thrift_mapper.go
@@ -128,8 +128,8 @@ func domainInfoToThrift(info *DomainInfo) *sqlblobs.DomainInfo {
 		LastUpdatedTime:                      timeToUnixNanoPtr(info.LastUpdatedTimestamp),
 		IsolationGroupsConfiguration:         info.IsolationGroups,
 		IsolationGroupsConfigurationEncoding: &info.IsolationGroupsEncoding,
-
-		// TODO(taylan): once idl changes are merged https://github.com/uber/cadence-idl/pull/158, add async workflows config here
+		AsyncWorkflowConfiguration:           info.AsyncWorkflowConfig,
+		AsyncWorkflowConfigurationEncoding:   &info.AsyncWorkflowConfigEncoding,
 	}
 }
 
@@ -164,8 +164,8 @@ func domainInfoFromThrift(info *sqlblobs.DomainInfo) *DomainInfo {
 		LastUpdatedTimestamp:        timeFromUnixNano(info.GetLastUpdatedTime()),
 		IsolationGroups:             info.GetIsolationGroupsConfiguration(),
 		IsolationGroupsEncoding:     info.GetIsolationGroupsConfigurationEncoding(),
-
-		// TODO(taylan): once idl changes are merged https://github.com/uber/cadence-idl/pull/158, add async workflows config here
+		AsyncWorkflowConfig:         info.AsyncWorkflowConfiguration,
+		AsyncWorkflowConfigEncoding: info.GetAsyncWorkflowConfigurationEncoding(),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/startreedata/pinot-client-go v0.0.0-20230303070132-3b84c28a9e95 // latest release doesn't support pinot v0.12, so use master branch
 	github.com/stretchr/testify v1.8.3
 	github.com/uber-go/tally v3.3.15+incompatible
-	github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07
+	github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f
 	github.com/uber/ringpop-go v0.8.5
 	github.com/uber/tchannel-go v1.22.2
 	github.com/urfave/cli v1.22.4

--- a/go.sum
+++ b/go.sum
@@ -443,6 +443,8 @@ github.com/uber-go/tally v3.3.15+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyu
 github.com/uber/cadence-idl v0.0.0-20211111101836-d6b70b60eb8c/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07 h1:VxvBaCqyXmHIxPHYcQrz3oBsCeiO7diPyFau6E1CgaE=
 github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
+github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f h1:+Z2D/fV23Sl2ZBP4ADMeKH9uXNJO9sJlV9SlR3/QFzw=
+github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR83gdUHXjRJvjoBh1yACsM=
 github.com/uber/jaeger-client-go v2.22.1+incompatible/go.mod h1:WVhlPFC8FDjOFMMWRy2pZqQJSXxYSwNYOkTr/Z6d3Kk=
 github.com/uber/jaeger-lib v2.2.0+incompatible h1:MxZXOiR2JuoANZ3J6DE/U0kSFv/eJ/GfSYVCjK7dyaw=

--- a/go.sum
+++ b/go.sum
@@ -441,8 +441,6 @@ github.com/uber-go/tally v3.3.12+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyu
 github.com/uber-go/tally v3.3.15+incompatible h1:9hLSgNBP28CjIaDmAuRTq9qV+UZY+9PcvAkXO4nNMwg=
 github.com/uber-go/tally v3.3.15+incompatible/go.mod h1:YDTIBxdXyOU/sCWilKB4bgyufu1cEi0jdVnRdxvjnmU=
 github.com/uber/cadence-idl v0.0.0-20211111101836-d6b70b60eb8c/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
-github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07 h1:VxvBaCqyXmHIxPHYcQrz3oBsCeiO7diPyFau6E1CgaE=
-github.com/uber/cadence-idl v0.0.0-20240122233329-e98679fb0e07/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f h1:+Z2D/fV23Sl2ZBP4ADMeKH9uXNJO9sJlV9SlR3/QFzw=
 github.com/uber/cadence-idl v0.0.0-20240127005514-29d89d50745f/go.mod h1:oyUK7GCNCRHCCyWyzifSzXpVrRYVBbAMHAzF5dXiKws=
 github.com/uber/jaeger-client-go v2.22.1+incompatible h1:NHcubEkVbahf9t3p75TOCR83gdUHXjRJvjoBh1yACsM=

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -291,6 +291,8 @@ CREATE TYPE domain_config (
   bad_binaries_encoding blob,
   isolation_groups blob,
   isolation_groups_encoding text,
+  async_workflow_config blob,
+  async_workflow_config_encoding text,
 );
 
 CREATE TYPE cluster_replication_config (

--- a/schema/cassandra/cadence/versioned/v0.37/async_workflow_config.cql
+++ b/schema/cassandra/cadence/versioned/v0.37/async_workflow_config.cql
@@ -1,0 +1,2 @@
+ALTER TYPE domain_config ADD async_workflow_config blob;
+ALTER TYPE domain_config ADD async_workflow_config_encoding text;

--- a/schema/cassandra/cadence/versioned/v0.37/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.37/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.37",
+  "MinCompatibleVersion": "0.37",
+  "Description": "Adding the domain configuration for async workflow config",
+  "SchemaUpdateCqlFiles": [
+    "async_workflow_config.cql"
+  ]
+}

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -23,7 +23,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.36"
+const Version = "0.37"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.9"

--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -4,8 +4,8 @@ set -ex
 
 make tidy
 make go-generate
-make fmt 
-make lint 
+make fmt
+make lint
 make copyright
 
 # intentionally capture stderr, so status-errors are also PR-failing.
@@ -15,5 +15,6 @@ if [ -n "$(git status --porcelain  2>&1)" ]; then
   echo "There are changes after make go-generate && make fmt && make lint && make copyright"
   echo "Please rerun the command and commit the changes"
   git status --porcelain
+  git --no-pager diff
   exit 1
 fi

--- a/service/history/historyEngine.go
+++ b/service/history/historyEngine.go
@@ -503,7 +503,7 @@ func (e *historyEngineImpl) registerDomainFailoverCallback() {
 				previousFailoverVersion := nextDomain.GetPreviousFailoverVersion()
 				previousClusterName, err := e.clusterMetadata.ClusterNameForFailoverVersion(previousFailoverVersion)
 				if err != nil {
-					e.logger.Error("Failed to handle graceful failover", tag.WorkflowDomainID(nextDomain.GetInfo().ID))
+					e.logger.Error("Failed to handle graceful failover", tag.WorkflowDomainID(nextDomain.GetInfo().ID), tag.Error(err))
 					continue
 				}
 

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -108,7 +108,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated `domain_config` type in cassandra schema to include async workflow config blob. This is needed to be able to persist per domain async workflow configs. The layers doing data conversion also needed to be updated.

Past relevant PRs:
- https://github.com/uber/cadence/pull/5608
- https://github.com/uber/cadence/pull/5616
- https://github.com/uber/cadence/pull/5625
- https://github.com/uber/cadence-idl/pull/158

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
1. Create new image locally 
```./scripts/buildkite/docker-build.sh```

2. Run default docker compose 
```docker-compose -f docker-compose.yml up```

3. Test e2e via cli

```
# create a new domain
go run cmd/tools/cli/main.go --domain test-domain domain register --retention 2d

# get Async Queue config of the domain (should be empty)
go run cmd/tools/cli/main.go admin aq get \
  --domain test-domain

# update Async Queue config of the domain
go run cmd/tools/cli/main.go admin aq update \
  --domain test-domain \
  --json "{\"PredefinedQueueName\":\"queue1\"}"

# get Async Queue config of the domain (read what you write)
go run cmd/tools/cli/main.go admin aq get \
  --domain test-domain
```

Also tested other domain APIs such as list/describe.
