### PR TITLE
Add a middleware for comparator to use

### DIFF
--- a/common/persistence/pinotVisibilityTripleManager.go
+++ b/common/persistence/pinotVisibilityTripleManager.go
@@ -496,16 +496,13 @@ func (v *pinotVisibilityTripleManager) CountWorkflowExecutions(
 }
 
 func (v *pinotVisibilityTripleManager) chooseVisibilityManagerForRead(ctx context.Context, domain string) VisibilityManager {
-	// temporary code: for Pinot migration usage -->
 	if override := ctx.Value(ContextKey); override == VisibilityOverridePrimary {
-		v.logger.Debug("Pinot Migration log: Primary visibility manager was chosen for read.")
+		v.logger.Info("Pinot Migration log: Primary visibility manager was chosen for read.")
 		return v.esVisibilityManager
 	} else if override == VisibilityOverrideSecondary {
-		v.logger.Debug("Pinot Migration log: Secondary visibility manager was chosen for read.")
+		v.logger.Info("Pinot Migration log: Secondary visibility manager was chosen for read.")
 		return v.pinotVisibilityManager
 	}
-	v.logger.Debug("Pinot Migration log: ContextKey was empty.")
-	// temporary code: ends here <--
 
 	var visibilityMgr VisibilityManager
 	if v.readModeIsFromES(domain) {

--- a/common/persistence/pinotVisibilityTripleManager.go
+++ b/common/persistence/pinotVisibilityTripleManager.go
@@ -46,9 +46,9 @@ type (
 )
 
 const (
-	Primary    = "Primary"
-	Secondary  = "Secondary"
-	ContextKey = ResponseComparatorContextKey("visibility-override")
+	VisibilityOverridePrimary   = "Primary"
+	VisibilityOverrideSecondary = "Secondary"
+	ContextKey                  = ResponseComparatorContextKey("visibility-override")
 )
 
 // ResponseComparatorContextKey is for Pinot/ES response comparator. This struct will be passed into ctx as a key.

--- a/common/persistence/pinotVisibilityTripleManager.go
+++ b/common/persistence/pinotVisibilityTripleManager.go
@@ -497,10 +497,10 @@ func (v *pinotVisibilityTripleManager) CountWorkflowExecutions(
 
 func (v *pinotVisibilityTripleManager) chooseVisibilityManagerForRead(ctx context.Context, domain string) VisibilityManager {
 	// temporary code: for Pinot migration usage -->
-	if override := ctx.Value(ContextKey); override == Primary {
+	if override := ctx.Value(ContextKey); override == VisibilityOverridePrimary {
 		v.logger.Debug("Pinot Migration log: Primary visibility manager was chosen for read.")
 		return v.esVisibilityManager
-	} else if override == Secondary {
+	} else if override == VisibilityOverrideSecondary {
 		v.logger.Debug("Pinot Migration log: Secondary visibility manager was chosen for read.")
 		return v.pinotVisibilityManager
 	}

--- a/common/rpc/middleware.go
+++ b/common/rpc/middleware.go
@@ -116,7 +116,7 @@ func (m *InboundMetricsMiddleware) Handle(ctx context.Context, req *transport.Re
 	return h.Handle(ctx, req, resw)
 }
 
-// YarpcKey is the const for yarpc key
+// ComparatorYarpcKey is the const for yarpc key
 const ComparatorYarpcKey = "cadence-visibility-override"
 
 // PinotComparatorMiddleware checks the header of a grpc request, and then override the context accordingly

--- a/common/rpc/middleware.go
+++ b/common/rpc/middleware.go
@@ -125,9 +125,9 @@ type PinotComparatorMiddleware struct{}
 
 func (m *PinotComparatorMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
 	yarpcKey, _ := req.Headers.Get(ComparatorYarpcKey)
-	if yarpcKey == persistence.Primary {
+	if yarpcKey == persistence.VisibilityOverridePrimary {
 		ctx = contextWithVisibilityOverride(ctx, persistence.VisibilityOverridePrimary)
-	} else if yarpcKey == persistence.Secondary {
+	} else if yarpcKey == persistence.VisibilityOverrideSecondary {
 		ctx = contextWithVisibilityOverride(ctx, persistence.VisibilityOverrideSecondary)
 	}
 	return h.Handle(ctx, req, resw)

--- a/common/rpc/middleware.go
+++ b/common/rpc/middleware.go
@@ -23,7 +23,6 @@ package rpc
 import (
 	"context"
 	"encoding/json"
-	"github.com/uber/cadence/common/persistence"
 	"io"
 
 	"go.uber.org/cadence/worker"
@@ -34,6 +33,7 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/partition"
+	"github.com/uber/cadence/common/persistence"
 )
 
 type authOutboundMiddleware struct {

--- a/common/rpc/middleware.go
+++ b/common/rpc/middleware.go
@@ -126,15 +126,15 @@ type PinotComparatorMiddleware struct{}
 func (m *PinotComparatorMiddleware) Handle(ctx context.Context, req *transport.Request, resw transport.ResponseWriter, h transport.UnaryHandler) error {
 	yarpcKey, _ := req.Headers.Get(ComparatorYarpcKey)
 	if yarpcKey == persistence.Primary {
-		ctx = ContextWithOverride(ctx, persistence.Primary)
+		ctx = contextWithVisibilityOverride(ctx, persistence.VisibilityOverridePrimary)
 	} else if yarpcKey == persistence.Secondary {
-		ctx = ContextWithOverride(ctx, persistence.Secondary)
+		ctx = contextWithVisibilityOverride(ctx, persistence.VisibilityOverrideSecondary)
 	}
 	return h.Handle(ctx, req, resw)
 }
 
 // ContextWithOverride adds a value in ctx
-func ContextWithOverride(ctx context.Context, value string) context.Context {
+func contextWithVisibilityOverride(ctx context.Context, value string) context.Context {
 	return context.WithValue(ctx, persistence.ContextKey, value)
 }
 

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -146,7 +146,7 @@ func NewParams(serviceName string, config *config.Config, dc *dynamicconfig.Coll
 		OutboundTLS: outboundTLS,
 		InboundMiddleware: yarpc.InboundMiddleware{
 			// order matters: ForwardPartitionConfigMiddleware must be applied after ClientPartitionConfigMiddleware
-			Unary: yarpc.UnaryInboundMiddleware(&InboundMetricsMiddleware{}, &ClientPartitionConfigMiddleware{}, &ForwardPartitionConfigMiddleware{}),
+			Unary: yarpc.UnaryInboundMiddleware(&PinotComparatorMiddleware{}, &InboundMetricsMiddleware{}, &ClientPartitionConfigMiddleware{}, &ForwardPartitionConfigMiddleware{}),
 		},
 		OutboundMiddleware: yarpc.OutboundMiddleware{
 			Unary: yarpc.UnaryOutboundMiddleware(&HeaderForwardingMiddleware{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a middleware for comparator to use.

<!-- Tell your future self why have you made these changes -->
**Why?**
We need to receive the yarpc req sent from PinotResponseComparator, and then pass the cadence-visibility-override value into ctx. So that PinotVisibilityTripleManager can use it to switch between pinot and es. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Will do manually testing. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
