### PR TITLE
Convert pinot query to use unix milliseconds instead of nano

### DIFF
--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -374,8 +374,10 @@ func trimTimeFieldValueFromNanoToMilliSeconds(original *sqlparser.SQLVal) (*sqlp
 	var newVal int64
 	if valInt < 0 { //exclude open workflow which time field will be -1
 		newVal = valInt
+	} else if len(valStr) > 13 { // Assuming nanoseconds if more than 13 digits
+		newVal = valInt / 1000000 // Convert time to milliseconds
 	} else {
-		newVal = valInt / 1000000 // convert time to milliseconds
+		newVal = valInt
 	}
 
 	// Convert the new value back to SQLVal

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -45,6 +45,7 @@ var timeSystemKeys = map[string]bool{
 	"StartTime":     true,
 	"CloseTime":     true,
 	"ExecutionTime": true,
+	"UpdateTime":    true,
 }
 
 // NewPinotQueryValidator create VisibilityQueryValidator

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -240,6 +240,18 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 	colNameStr := colName.Name.String()
 
 	if comparisonExpr.Operator != sqlparser.EqualStr {
+		if _, ok := timeSystemKeys[colNameStr]; ok {
+			sqlVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal)
+			if !ok {
+				return "", fmt.Errorf("error: Failed to convert val")
+			}
+			trimmed, err := trimTimeFieldValueFromNanoToMilliSeconds(sqlVal)
+			if err != nil {
+				return "", err
+			}
+			comparisonExpr.Right = trimmed
+		}
+
 		expr.Format(buf)
 		return buf.String(), nil
 	}

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -137,9 +137,9 @@ func TestValidateQuery(t *testing.T) {
 			query:     "StartTime = 1707319950934000128",
 			validated: "StartTime = 1707319950934",
 		},
-		"Case15-5: unix nano converts to milli seconds for range query": {
-			query:     "StartTime = 1707319950934000128",
-			validated: "StartTime = 1707319950934",
+		"Case15-5: unix nano converts to milli seconds for unequal statements query": {
+			query:     "StartTime > 1707319950934000128",
+			validated: "StartTime > 1707319950934",
 		},
 		"Case15-6: open workflows": {
 			query:     "CloseTime = -1",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -145,29 +145,33 @@ func TestValidateQuery(t *testing.T) {
 			query:     "CloseTime = -1",
 			validated: "CloseTime = -1",
 		},
-		"Case15-6: startTime for range query": {
+		"Case15-7: startTime for range query": {
 			query:     "StartTime BETWEEN 1707319950934000128 AND 1707319950935000128",
 			validated: "StartTime between 1707319950934 and 1707319950935",
 		},
-		"Case15-7: invalid time for trim": {
+		"Case15-8: invalid string for trim": {
 			query:     "CloseTime = abc",
 			validated: "",
 			err:       "error: failed to convert val",
 		},
-		"Case15-8: invalid time for trim": {
+		"Case15-9: invalid value for trim": {
 			query:     "CloseTime = 123.45",
 			validated: "",
 			err:       "error: failed to parse int from SQLVal 123.45",
 		},
-		"Case15-9: invalid from time for range query": {
+		"Case15-10: invalid from time for range query": {
 			query:     "StartTime BETWEEN 17.50 AND 1707319950935000128",
 			validated: "",
 			err:       "error: failed to parse int from SQLVal 17.50",
 		},
-		"Case15-10: invalid to time for range query": {
+		"Case15-11: invalid to time for range query": {
 			query:     "StartTime BETWEEN 1707319950934000128 AND 1707319950935000128.1",
 			validated: "",
 			err:       "error: failed to parse int from SQLVal 1707319950935000128.1",
+		},
+		"Case15-12: value already in milliseconds": {
+			query:     "StartTime = 170731995093",
+			validated: "StartTime = 170731995093",
 		},
 		"Case16-1: custom int attribute greater than or equal to": {
 			query:     "CustomIntField >= 0",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -133,6 +133,22 @@ func TestValidateQuery(t *testing.T) {
 			query:     "StartTime >= 1697754674",
 			validated: "StartTime >= 1697754674",
 		},
+		"Case15-4: unix nano converts to milli seconds for equal statements": {
+			query:     "StartTime = 1707319950934000128",
+			validated: "StartTime = 1707319950934",
+		},
+		"Case15-5: unix nano converts to milli seconds for range query": {
+			query:     "StartTime = 1707319950934000128",
+			validated: "StartTime = 1707319950934",
+		},
+		"Case15-6: open workflows": {
+			query:     "CloseTime = -1",
+			validated: "CloseTime = -1",
+		},
+		"Case15-6: startTime for range query": {
+			query:     "StartTime BETWEEN 1707319950934000128 AND 1707319950935000128",
+			validated: "StartTime between 1707319950934 and 1707319950935",
+		},
 		"Case16-1: custom int attribute greater than or equal to": {
 			query:     "CustomIntField >= 0",
 			validated: "(JSON_MATCH(Attr, '\"$.CustomIntField\" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) >= 0)",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -149,6 +149,26 @@ func TestValidateQuery(t *testing.T) {
 			query:     "StartTime BETWEEN 1707319950934000128 AND 1707319950935000128",
 			validated: "StartTime between 1707319950934 and 1707319950935",
 		},
+		"Case15-7: invalid time for trim": {
+			query:     "CloseTime = abc",
+			validated: "",
+			err:       "error: failed to convert val",
+		},
+		"Case15-8: invalid time for trim": {
+			query:     "CloseTime = 123.45",
+			validated: "",
+			err:       "error: failed to parse int from SQLVal 123.45",
+		},
+		"Case15-9: invalid from time for range query": {
+			query:     "StartTime BETWEEN 17.50 AND 1707319950935000128",
+			validated: "",
+			err:       "error: failed to parse int from SQLVal 17.50",
+		},
+		"Case15-10: invalid to time for range query": {
+			query:     "StartTime BETWEEN 1707319950934000128 AND 1707319950935000128.1",
+			validated: "",
+			err:       "error: failed to parse int from SQLVal 1707319950935000128.1",
+		},
 		"Case16-1: custom int attribute greater than or equal to": {
 			query:     "CustomIntField >= 0",
 			validated: "(JSON_MATCH(Attr, '\"$.CustomIntField\" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) >= 0)",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Convert time units to milliseconds from nanoseconds for pinot query

<!-- Tell your future self why have you made these changes -->
**Why?**
By default it is passing nano seconds from frontend

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
