### PR TITLE
Removed useless metrics tag from the workflowIDcache

### DIFF
--- a/service/history/workflowcache/cache.go
+++ b/service/history/workflowcache/cache.go
@@ -125,7 +125,7 @@ func (c *wfCache) allow(domainID string, workflowID string, rateLimitType rateLi
 	}
 
 	c.metricsClient.
-		Scope(metrics.HistoryClientWfIDCacheScope, metrics.DomainTag(domainName)).
+		Scope(metrics.HistoryClientWfIDCacheScope).
 		UpdateGauge(metrics.WorkflowIDCacheSizeGauge, float64(c.lru.Size()))
 
 	// Locking is not needed because both getCacheItem and the rate limiter are thread safe


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Removed useless metrics tag for the workflowIDcache


<!-- Tell your future self why have you made these changes -->
**Why?**
There is no need to tag the cachesize with a domain as the cache is
host-global, and shared between the domains.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
