### PR TITLE
Fix Pinot query validator bug when user pass in not equal query with value missing

### DIFF
--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -241,7 +241,7 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 	}
 	colNameStr := colName.Name.String()
 
-	if comparisonExpr.Operator != sqlparser.EqualStr {
+	if comparisonExpr.Operator != sqlparser.EqualStr && comparisonExpr.Operator != sqlparser.NotEqualStr {
 		if _, ok := timeSystemKeys[colNameStr]; ok {
 			sqlVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal)
 			if !ok {
@@ -280,10 +280,9 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 		} else {
 			newColVal = "-1" // -1 is the default value for all Closed workflows related fields
 		}
-		comparisonExpr.Right = &sqlparser.ColName{
-			Metadata:  colName.Metadata,
-			Name:      sqlparser.NewColIdent(newColVal),
-			Qualifier: colName.Qualifier,
+		comparisonExpr.Right = &sqlparser.SQLVal{
+			Type: sqlparser.IntVal, // or sqlparser.StrVal if you need to assign a string
+			Val:  []byte(newColVal),
 		}
 	} else {
 		if _, ok := timeSystemKeys[colNameStr]; ok {

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -77,9 +77,13 @@ func TestValidateQuery(t *testing.T) {
 			query: "Invalid SQL",
 			err:   "Invalid query.",
 		},
-		"Case8: query with missing val": {
+		"Case8-1: query with missing val": {
 			query:     "CloseTime = missing",
-			validated: "CloseTime = `-1`",
+			validated: "CloseTime = -1",
+		},
+		"Case8-2: query with not missing case": {
+			query:     "CloseTime != missing",
+			validated: "CloseTime != -1",
 		},
 		"Case9: invalid where expression": {
 			query: "InvalidWhereExpr",
@@ -184,6 +188,10 @@ func TestValidateQuery(t *testing.T) {
 		"Case15-15: value in raw string for range statement": {
 			query:     "StartTime between '2024-02-07T15:32:30Z' and '2024-02-07T15:33:30Z'",
 			validated: "StartTime between 1707319950000 and 1707320010000",
+		},
+		"Case15-16: combined time and missing case": {
+			query:     "CloseTime != missing and StartTime >= 1707662555754408145",
+			validated: "CloseTime != -1 and StartTime >= 1707662555754",
 		},
 		"Case16-1: custom int attribute greater than or equal to": {
 			query:     "CustomIntField >= 0",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Pinot can not handle CloseTime != missing case, only handled equal string

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
