### PR TITLE
Update the build-changed message failure

### DIFF
--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -4,16 +4,17 @@ set -ex
 
 make tidy
 make go-generate
+make copyright
 make fmt
 make lint
-make copyright
 
 # intentionally capture stderr, so status-errors are also PR-failing.
 # in particular this catches "dubious ownership" failures, which otherwise
 # do not fail this check and the $() hides the exit code.
 if [ -n "$(git status --porcelain  2>&1)" ]; then
-  echo "There are changes after make go-generate && make fmt && make lint && make copyright"
-  echo "Please rerun the command and commit the changes"
+  echo "There file changes after applying your diff and performing a build."
+  echo "Please run this command and commit the changes:"
+  echo "\tmake tidy && make copyright && make go-generate && make fmt && make lint"
   git status --porcelain
   git --no-pager diff
   exit 1


### PR DESCRIPTION
`make tidy` isn't mentioned, and the command/checks weren't even in the right order anyway.

We should probably streamline pre-test PR checks anyway, but fixing the message is a clear improvement.
