### PR TITLE
Added debug information for decision timeout handling

### DIFF
--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -281,6 +281,11 @@ func (t *timerActiveTaskExecutor) executeActivityTimeoutTask(
 		return nil
 	}
 
+	wfType := mutableState.GetWorkflowType()
+	if wfType == nil {
+		return fmt.Errorf("unable to find workflow type, task %s", task)
+	}
+
 	timerSequence := execution.NewTimerSequence(mutableState)
 	referenceTime := t.shard.GetTimeSource().Now()
 	resurrectionCheckMinDelay := t.config.ResurrectionCheckMinDelay(mutableState.GetDomainEntry().GetInfo().Name)
@@ -398,6 +403,7 @@ Loop:
 			mutableState.GetExecutionInfo().DomainID,
 			metrics.TimerActiveTaskActivityTimeoutScope,
 			timerSequenceID.TimerType,
+			metrics.WorkflowTypeTag(wfType.GetName()),
 		)
 		if _, err := mutableState.AddActivityTaskTimedOutEvent(
 			activityInfo.ScheduleID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I've aded a metric dimension for decision type timeout metric.
Also, added a domain name tag to the log message that can allow stakeholders debugging issues.

<!-- Tell your future self why have you made these changes -->
**Why?**
To provide stakeholders runbook to handle schedule_to_start events

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
For huge clusters with a lot of domains and a lot of workflow types, metric dimension can cause increase in cardinality.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Added debug information for decision schedule_to_start.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
