### PR TITLE
[cassandra] Expose timeout and consistency level configuration

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -236,6 +236,15 @@ type (
 		TLS *TLS `yaml:"tls"`
 		// ProtoVersion
 		ProtoVersion int `yaml:"protoVersion"`
+		// ConnectTimeout defines duration for initial dial
+		ConnectTimeout time.Duration `yaml:"connectTimeout"`
+		// Timout is a connection timeout
+		Timeout time.Duration `yaml:"timeout"`
+		// Consistency defines default consistency level
+		Consistency string `yaml:"consistency"`
+		// SerialConsistency sets the consistency for the serial part of queries
+		SerialConsistency string `yaml:"serialConsistency"`
+		//Consistency *gocql.Consistency `yaml:"consistency"`
 		// ConnectAttributes is a set of key-value attributes as a supplement/extension to the above common fields
 		// Use it ONLY when a configure is too specific to a particular NoSQL database that should not be in the common struct
 		// Otherwise please add new fields to the struct for better documentation

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -244,7 +244,6 @@ type (
 		Consistency string `yaml:"consistency"`
 		// SerialConsistency sets the consistency for the serial part of queries
 		SerialConsistency string `yaml:"serialConsistency"`
-		//Consistency *gocql.Consistency `yaml:"consistency"`
 		// ConnectAttributes is a set of key-value attributes as a supplement/extension to the above common fields
 		// Use it ONLY when a configure is too specific to a particular NoSQL database that should not be in the common struct
 		// Otherwise please add new fields to the struct for better documentation
@@ -369,7 +368,7 @@ type (
 
 	// Logger contains the config items for logger
 	Logger struct {
-		// Stdout is true then the output needs to goto standard out
+		// Stdout is true then the output`kak needs to goto standard out
 		// By default this is false and output will go to standard error
 		Stdout bool `yaml:"stdout"`
 		// Level is the desired log level

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -368,7 +368,7 @@ type (
 
 	// Logger contains the config items for logger
 	Logger struct {
-		// Stdout is true then the output`kak needs to goto standard out
+		// Stdout is true then the output needs to goto standard out
 		// By default this is false and output will go to standard error
 		Stdout bool `yaml:"stdout"`
 		// Level is the desired log level

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency.go
@@ -138,20 +138,21 @@ func (c Consistency) String() string {
 	}
 }
 
-func ParseConsistency(s string) Consistency {
+func ParseConsistency(s string) (Consistency, error) {
 	var c Consistency
 	if err := c.UnmarshalText([]byte(strings.ToUpper(s))); err != nil {
-		panic(err)
+		return c, fmt.Errorf("parse consistency: %w", err)
 	}
-	return c
+	return c, nil
 }
 
-func ParseSerialConsistency(s string) SerialConsistency {
+func ParseSerialConsistency(s string) (SerialConsistency, error) {
 	var sc SerialConsistency
 	if err := sc.UnmarshalText([]byte(strings.ToUpper(s))); err != nil {
-		panic(err)
+		return sc, fmt.Errorf("parse serial consistency: %w", err)
+
 	}
-	return sc
+	return sc, nil
 }
 
 func (s SerialConsistency) String() string {

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency.go
@@ -22,6 +22,7 @@ package gocql
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/gocql/gocql"
 )
@@ -79,4 +80,104 @@ func mustConvertSerialConsistency(c SerialConsistency) gocql.SerialConsistency {
 	default:
 		panic(fmt.Sprintf("Unknown gocql SerialConsistency level: %v", c))
 	}
+}
+
+func (c Consistency) MarshalText() (text []byte, err error) {
+	return []byte(c.String()), nil
+}
+
+func (c *Consistency) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "ANY":
+		*c = Any
+	case "ONE":
+		*c = One
+	case "TWO":
+		*c = Two
+	case "THREE":
+		*c = Three
+	case "QUORUM":
+		*c = Quorum
+	case "ALL":
+		*c = All
+	case "LOCAL_QUORUM":
+		*c = LocalQuorum
+	case "EACH_QUORUM":
+		*c = EachQuorum
+	case "LOCAL_ONE":
+		*c = LocalOne
+	default:
+		return fmt.Errorf("invalid consistency %q", string(text))
+	}
+
+	return nil
+}
+
+func (c Consistency) String() string {
+	switch c {
+	case Any:
+		return "ANY"
+	case One:
+		return "ONE"
+	case Two:
+		return "TWO"
+	case Three:
+		return "THREE"
+	case Quorum:
+		return "QUORUM"
+	case All:
+		return "ALL"
+	case LocalQuorum:
+		return "LOCAL_QUORUM"
+	case EachQuorum:
+		return "EACH_QUORUM"
+	case LocalOne:
+		return "LOCAL_ONE"
+	default:
+		return fmt.Sprintf("invalid consistency: %d", uint16(c))
+	}
+}
+
+func ParseConsistency(s string) Consistency {
+	var c Consistency
+	if err := c.UnmarshalText([]byte(strings.ToUpper(s))); err != nil {
+		panic(err)
+	}
+	return c
+}
+
+func ParseSerialConsistency(s string) SerialConsistency {
+	var sc SerialConsistency
+	if err := sc.UnmarshalText([]byte(strings.ToUpper(s))); err != nil {
+		panic(err)
+	}
+	return sc
+}
+
+func (s SerialConsistency) String() string {
+	switch s {
+	case Serial:
+		return "SERIAL"
+	case LocalSerial:
+		return "LOCAL_SERIAL"
+	default:
+		return fmt.Sprintf("invalid serial consistency %d", uint16(s))
+	}
+}
+
+func (s SerialConsistency) MarshalText() (text []byte, err error) {
+	return []byte(s.String()), nil
+}
+
+func (s *SerialConsistency) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "SERIAL":
+		*s = Serial
+	case "LOCAL_SERIAL":
+		*s = LocalSerial
+	default:
+		return fmt.Errorf("invalid serial consistency %q", string(text))
+	}
+
+	return nil
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency_test.go
@@ -23,9 +23,10 @@
 package gocql
 
 import (
+	"testing"
+
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
 func TestConsistency_MarshalText(t *testing.T) {

--- a/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/gocql/consistency_test.go
@@ -23,11 +23,176 @@
 package gocql
 
 import (
-	"testing"
-
 	"github.com/gocql/gocql"
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
+
+func TestConsistency_MarshalText(t *testing.T) {
+	tests := []struct {
+		c        Consistency
+		wantText []byte
+		testFn   func(t assert.TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool
+	}{
+		{c: Any, wantText: []byte("ANY"), testFn: assert.Equal},
+		{c: One, wantText: []byte("ONE"), testFn: assert.Equal},
+		{c: Two, wantText: []byte("TWO"), testFn: assert.Equal},
+		{c: Three, wantText: []byte("THREE"), testFn: assert.Equal},
+		{c: Quorum, wantText: []byte("QUORUM"), testFn: assert.Equal},
+		{c: All, wantText: []byte("ALL"), testFn: assert.Equal},
+		{c: LocalQuorum, wantText: []byte("LOCAL_QUORUM"), testFn: assert.Equal},
+		{c: EachQuorum, wantText: []byte("EACH_QUORUM"), testFn: assert.Equal},
+		{c: LocalOne, wantText: []byte("LOCAL_ONE"), testFn: assert.Equal},
+		{c: LocalOne, wantText: []byte("WRONG_VALUE"), testFn: assert.NotEqualValues},
+	}
+	for _, tt := range tests {
+		t.Run(tt.c.String(), func(t *testing.T) {
+			gotText, err := tt.c.MarshalText()
+			assert.NoError(t, err)
+			tt.testFn(t, tt.wantText, gotText)
+		})
+	}
+}
+
+func TestConsistency_String(t *testing.T) {
+	c := Consistency(9)
+	assert.Equal(t, c.String(), "invalid consistency: 9")
+}
+
+func TestConsistency_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		destConsistency Consistency
+		inputText       []byte
+		testFn          func(t assert.TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool
+		wantErr         bool
+	}{
+		{destConsistency: Any, inputText: []byte("ANY"), testFn: assert.Equal},
+		{destConsistency: One, inputText: []byte("ONE"), testFn: assert.Equal},
+		{destConsistency: Two, inputText: []byte("TWO"), testFn: assert.Equal},
+		{destConsistency: Three, inputText: []byte("THREE"), testFn: assert.Equal},
+		{destConsistency: Quorum, inputText: []byte("QUORUM"), testFn: assert.Equal},
+		{destConsistency: All, inputText: []byte("ALL"), testFn: assert.Equal},
+		{destConsistency: LocalQuorum, inputText: []byte("LOCAL_QUORUM"), testFn: assert.Equal},
+		{destConsistency: EachQuorum, inputText: []byte("EACH_QUORUM"), testFn: assert.Equal},
+		{destConsistency: LocalOne, inputText: []byte("LOCAL_ONE"), testFn: assert.Equal},
+		{destConsistency: LocalOne, inputText: []byte("WRONG_VALUE"), testFn: assert.NotEqualValues, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.destConsistency.String(), func(t *testing.T) {
+			var c Consistency
+			err := c.UnmarshalText(tt.inputText)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			tt.testFn(t, tt.destConsistency, c)
+		})
+	}
+}
+
+func TestParseConsistency(t *testing.T) {
+	tests := []struct {
+		destConsistency Consistency
+		inputText       string
+		testFn          func(t assert.TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool
+		wantErr         bool
+	}{
+		{destConsistency: Any, inputText: "any", testFn: assert.Equal},
+		{destConsistency: One, inputText: "ONE", testFn: assert.Equal},
+		{destConsistency: Two, inputText: "TWO", testFn: assert.Equal},
+		{destConsistency: Three, inputText: "THREE", testFn: assert.Equal},
+		{destConsistency: Quorum, inputText: "QUORUM", testFn: assert.Equal},
+		{destConsistency: All, inputText: "all", testFn: assert.Equal},
+		{destConsistency: LocalQuorum, inputText: "LOCAL_QUORUM", testFn: assert.Equal},
+		{destConsistency: EachQuorum, inputText: "EACH_QUORUM", testFn: assert.Equal},
+		{destConsistency: LocalOne, inputText: "LOCAL_ONE", testFn: assert.Equal},
+		{destConsistency: Any, inputText: "WRONG_VALUE_FAILBACK_TO_ANY", testFn: assert.Equal, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.inputText), func(t *testing.T) {
+			got, err := ParseConsistency(tt.inputText)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			tt.testFn(t, tt.destConsistency, got)
+		})
+	}
+}
+
+func TestParseSerialConsistency(t *testing.T) {
+	tests := []struct {
+		destConsistency SerialConsistency
+		inputText       string
+		testFn          func(t assert.TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool
+		wantErr         bool
+	}{
+		{destConsistency: Serial, inputText: "serial", testFn: assert.Equal},
+		{destConsistency: LocalSerial, inputText: "LOCAL_SERIAL", testFn: assert.Equal},
+		{destConsistency: Serial, inputText: "WRONG_VALUE_FAILBACK_TO_ANY", testFn: assert.Equal, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.inputText), func(t *testing.T) {
+			got, err := ParseSerialConsistency(tt.inputText)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			tt.testFn(t, tt.destConsistency, got)
+		})
+	}
+}
+
+func TestSerialConsistency_MarshalText(t *testing.T) {
+	tests := []struct {
+		c        SerialConsistency
+		wantText []byte
+		testFn   func(t assert.TestingT, expected, actual interface{}, msgAndArgs ...interface{}) bool
+	}{
+		{c: Serial, wantText: []byte("SERIAL"), testFn: assert.Equal},
+		{c: LocalSerial, wantText: []byte("LOCAL_SERIAL"), testFn: assert.Equal},
+		{c: LocalSerial, wantText: []byte("WRONG_VALUE"), testFn: assert.NotEqualValues},
+	}
+	for _, tt := range tests {
+		t.Run(tt.c.String(), func(t *testing.T) {
+			gotText, err := tt.c.MarshalText()
+			assert.NoError(t, err)
+			tt.testFn(t, tt.wantText, gotText)
+		})
+	}
+}
+
+func TestSerialConsistency_String(t *testing.T) {
+	c := SerialConsistency(2)
+	assert.Equal(t, c.String(), "invalid serial consistency 2")
+}
+
+func TestSerialConsistency_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		destSerialConsistency SerialConsistency
+		inputText             []byte
+		wantErr               bool
+	}{
+		{destSerialConsistency: Serial, inputText: []byte("SERIAL")},
+		{destSerialConsistency: LocalSerial, inputText: []byte("LOCAL_SERIAL")},
+		{destSerialConsistency: Serial, inputText: []byte("WRONG_VALUE_DEFAULTS_TO_SERIAL"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.destSerialConsistency.String(), func(t *testing.T) {
+			var c SerialConsistency
+			err := c.UnmarshalText(tt.inputText)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.destSerialConsistency, c)
+		})
+	}
+}
 
 func Test_mustConvertConsistency(t *testing.T) {
 	tests := []struct {

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
@@ -95,6 +95,23 @@ func toGoCqlConfig(cfg *config.NoSQL) (gocql.ClusterConfig, error) {
 			return gocql.ClusterConfig{}, err
 		}
 	}
+
+	if cfg.Timeout == 0 {
+		cfg.Timeout = defaultSessionTimeout
+	}
+
+	if cfg.ConnectTimeout == 0 {
+		cfg.ConnectTimeout = defaultConnectTimeout
+	}
+
+	if cfg.Consistency == "" {
+		cfg.Consistency = cassandraDefaultConsLevel.String()
+	}
+
+	if cfg.SerialConsistency == "" {
+		cfg.SerialConsistency = cassandraDefaultSerialConsLevel.String()
+	}
+
 	return gocql.ClusterConfig{
 		Hosts:                 cfg.Hosts,
 		Port:                  cfg.Port,
@@ -107,9 +124,9 @@ func toGoCqlConfig(cfg *config.NoSQL) (gocql.ClusterConfig, error) {
 		MaxConns:              cfg.MaxConns,
 		TLS:                   cfg.TLS,
 		ProtoVersion:          cfg.ProtoVersion,
-		Consistency:           cassandraDefaultConsLevel,
-		SerialConsistency:     cassandraDefaultSerialConsLevel,
-		Timeout:               defaultSessionTimeout,
-		ConnectTimeout:        defaultConnectTimeout,
+		Consistency:           gocql.ParseConsistency(cfg.Consistency),
+		SerialConsistency:     gocql.ParseSerialConsistency(cfg.SerialConsistency),
+		Timeout:               cfg.Timeout,
+		ConnectTimeout:        cfg.ConnectTimeout,
 	}, nil
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin.go
@@ -112,6 +112,16 @@ func toGoCqlConfig(cfg *config.NoSQL) (gocql.ClusterConfig, error) {
 		cfg.SerialConsistency = cassandraDefaultSerialConsLevel.String()
 	}
 
+	consistency, err := gocql.ParseConsistency(cfg.Consistency)
+	if err != nil {
+		return gocql.ClusterConfig{}, err
+	}
+	serialConsistency, err := gocql.ParseSerialConsistency(cfg.SerialConsistency)
+
+	if err != nil {
+		return gocql.ClusterConfig{}, err
+	}
+
 	return gocql.ClusterConfig{
 		Hosts:                 cfg.Hosts,
 		Port:                  cfg.Port,
@@ -124,8 +134,8 @@ func toGoCqlConfig(cfg *config.NoSQL) (gocql.ClusterConfig, error) {
 		MaxConns:              cfg.MaxConns,
 		TLS:                   cfg.TLS,
 		ProtoVersion:          cfg.ProtoVersion,
-		Consistency:           gocql.ParseConsistency(cfg.Consistency),
-		SerialConsistency:     gocql.ParseSerialConsistency(cfg.SerialConsistency),
+		Consistency:           consistency,
+		SerialConsistency:     serialConsistency,
 		Timeout:               cfg.Timeout,
 		ConnectTimeout:        cfg.ConnectTimeout,
 	}, nil

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package cassandra
 
 import (

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
@@ -31,10 +31,11 @@ import (
 
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"github.com/uber/cadence/environment"
 )
 
 func Test_toGoCqlConfig(t *testing.T) {
-
+	t.Setenv(environment.CassandraSeeds, environment.Localhost)
 	tests := []struct {
 		name    string
 		cfg     *config.NoSQL
@@ -45,7 +46,7 @@ func Test_toGoCqlConfig(t *testing.T) {
 			"empty config will be filled with defaults",
 			&config.NoSQL{},
 			gocql.ClusterConfig{
-				Hosts:             "127.0.0.1",
+				Hosts:             environment.Localhost,
 				Port:              9042,
 				ProtoVersion:      4,
 				Timeout:           time.Second * 10,

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
@@ -1,0 +1,44 @@
+package cassandra
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
+	"testing"
+	"time"
+)
+
+func Test_toGoCqlConfig(t *testing.T) {
+
+	tests := []struct {
+		name    string
+		cfg     *config.NoSQL
+		want    gocql.ClusterConfig
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			"empty config will be filled with defaults",
+			&config.NoSQL{},
+			gocql.ClusterConfig{
+				Hosts:             "127.0.0.1",
+				Port:              9042,
+				ProtoVersion:      4,
+				Timeout:           time.Second * 10,
+				Consistency:       gocql.LocalQuorum,
+				SerialConsistency: gocql.LocalSerial,
+				ConnectTimeout:    time.Second * 2,
+			},
+			assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := toGoCqlConfig(tt.cfg)
+			if !tt.wantErr(t, err, fmt.Sprintf("toGoCqlConfig(%v)", tt.cfg)) {
+				return
+			}
+			assert.Equalf(t, tt.want, got, "toGoCqlConfig(%v)", tt.cfg)
+		})
+	}
+}

--- a/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/plugin_test.go
@@ -24,11 +24,13 @@ package cassandra
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/uber/cadence/common/config"
-	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql"
 )
 
 func Test_toGoCqlConfig(t *testing.T) {

--- a/config/development.yaml
+++ b/config/development.yaml
@@ -8,6 +8,10 @@ persistence:
         pluginName: "cassandra"
         hosts: "127.0.0.1"
         keyspace: "cadence"
+        connectTimeout: 2s # defaults to 2s if not defined
+        timeout: 5s # defaults to 10s if not defined
+        consistency: LOCAL_QUORUM # default value
+        serialConsistency: LOCAL_SERIAL # default value
     cass-visibility:
       nosql:
         pluginName: "cassandra"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Allow to change timeout and consistency levels for Cassandra connections.
Default hardcoded values will be applied if no values are provided in configuration

<!-- Tell your future self why have you made these changes -->
**Why?**
There was no way to change hard-coded defaults. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
