### PR TITLE
Enable retry on mutable state checksum verification failure

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1973,6 +1973,13 @@ const (
 	// Allowed filters: DomainID
 	EnableTaskVal
 
+	// EnableRetryForChecksumFailure enables retry if mutable state checksum verification fails
+	// KeyName: history.enableMutableStateChecksumFailureRetry
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	EnableRetryForChecksumFailure
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -4228,6 +4235,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "history.workflowIDCacheInternalEnabled",
 		Filters:      []Filter{DomainName},
 		Description:  "WorkflowIDCacheInternalEnabled is the key to enable/disable caching of workflowID specific information for internal requests",
+		DefaultValue: false,
+	},
+	EnableRetryForChecksumFailure: DynamicBool{
+		KeyName:      "history.enableMutableStateChecksumFailureRetry",
+		Filters:      []Filter{DomainName},
+		Description:  "EnableRetryForChecksumFailure enables retry if mutable state checksum verification fails",
 		DefaultValue: false,
 	},
 }

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -306,6 +306,7 @@ type Config struct {
 	MutableStateChecksumGenProbability    dynamicconfig.IntPropertyFnWithDomainFilter
 	MutableStateChecksumVerifyProbability dynamicconfig.IntPropertyFnWithDomainFilter
 	MutableStateChecksumInvalidateBefore  dynamicconfig.FloatPropertyFn
+	EnableRetryForChecksumFailure         dynamicconfig.BoolPropertyFnWithDomainFilter
 
 	// History check for corruptions
 	EnableHistoryCorruptionCheck dynamicconfig.BoolPropertyFnWithDomainFilter
@@ -566,6 +567,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 		MutableStateChecksumGenProbability:    dc.GetIntPropertyFilteredByDomain(dynamicconfig.MutableStateChecksumGenProbability),
 		MutableStateChecksumVerifyProbability: dc.GetIntPropertyFilteredByDomain(dynamicconfig.MutableStateChecksumVerifyProbability),
 		MutableStateChecksumInvalidateBefore:  dc.GetFloat64Property(dynamicconfig.MutableStateChecksumInvalidateBefore),
+		EnableRetryForChecksumFailure:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableRetryForChecksumFailure),
 
 		EnableHistoryCorruptionCheck: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableHistoryCorruptionCheck),
 

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 	"time"
 
@@ -45,6 +46,7 @@ import (
 
 const (
 	defaultRemoteCallTimeout = 30 * time.Second
+	checksumErrorRetryCount  = 3
 )
 
 type conflictError struct {
@@ -252,6 +254,10 @@ func (c *contextImpl) LoadExecutionStats(
 	return c.stats, nil
 }
 
+func isChecksumError(err error) bool {
+	return strings.Contains(err.Error(), "checksum mismatch error")
+}
+
 func (c *contextImpl) LoadWorkflowExecutionWithTaskVersion(
 	ctx context.Context,
 	incomingVersion int64,
@@ -263,22 +269,31 @@ func (c *contextImpl) LoadWorkflowExecutionWithTaskVersion(
 	}
 
 	if c.mutableState == nil {
-		response, err := c.getWorkflowExecutionWithRetry(ctx, &persistence.GetWorkflowExecutionRequest{
-			DomainID:   c.domainID,
-			Execution:  c.workflowExecution,
-			DomainName: domainEntry.GetInfo().Name,
-		})
-		if err != nil {
-			return nil, err
+		var response *persistence.GetWorkflowExecutionResponse
+		for i := 0; i < checksumErrorRetryCount; i++ {
+			response, err = c.getWorkflowExecutionWithRetry(ctx, &persistence.GetWorkflowExecutionRequest{
+				DomainID:   c.domainID,
+				Execution:  c.workflowExecution,
+				DomainName: domainEntry.GetInfo().Name,
+			})
+			if err != nil {
+				return nil, err
+			}
+
+			c.mutableState = NewMutableStateBuilder(
+				c.shard,
+				c.logger,
+				domainEntry,
+			)
+
+			err = c.mutableState.Load(response.State)
+			if err == nil {
+				break
+			} else if !isChecksumError(err) {
+				c.logger.Error("failed to load mutable state", tag.Error(err))
+				break
+			}
 		}
-
-		c.mutableState = NewMutableStateBuilder(
-			c.shard,
-			c.logger,
-			domainEntry,
-		)
-
-		c.mutableState.Load(response.State)
 
 		c.stats = response.State.ExecutionStats
 		c.updateCondition = response.State.ExecutionInfo.NextEventID

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -167,7 +167,7 @@ type (
 		IsWorkflowCompleted() bool
 		IsResourceDuplicated(resourceDedupKey definition.DeduplicationID) bool
 		UpdateDuplicatedResource(resourceDedupKey definition.DeduplicationID)
-		Load(*persistence.WorkflowMutableState)
+		Load(*persistence.WorkflowMutableState) error
 		ReplicateActivityInfo(*types.SyncActivityRequest, bool) error
 		ReplicateActivityTaskCancelRequestedEvent(*types.HistoryEvent) error
 		ReplicateActivityTaskCanceledEvent(*types.HistoryEvent) error

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -1815,9 +1815,11 @@ func (mr *MockMutableStateMockRecorder) IsWorkflowExecutionRunning() *gomock.Cal
 }
 
 // Load mocks base method.
-func (m *MockMutableState) Load(arg0 *persistence.WorkflowMutableState) {
+func (m *MockMutableState) Load(arg0 *persistence.WorkflowMutableState) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Load", arg0)
+	ret := m.ctrl.Call(m, "Load", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Load indicates an expected call of Load.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Enable retry on mutable state checksum failure to reload the mutable state from database
- Improve logging on mutable state checksum failure

<!-- Tell your future self why have you made these changes -->
**Why?**
In the past 3 months, we're bothered by corrupted workflows from our internal sql database. And we suspect that it's because the mutable state we read from database under some edge case is from an inconsistent view of database. We enabled checksum and verified that there is some checksum failures in production, but we don't have the details in the logs and still don't know the root cause.
We add a retry mechanism and hope this will temporarily fix the issue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
this is protected by feature flag, we can disable the feature flag if there is any issue

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
