### PR TITLE
Do not get workflow execution from database when shard is closed

### DIFF
--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1193,7 +1193,7 @@ func (c *contextImpl) getWorkflowExecutionWithRetry(
 	var resp *persistence.GetWorkflowExecutionResponse
 	op := func() error {
 		var err error
-		resp, err = c.executionManager.GetWorkflowExecution(ctx, request)
+		resp, err = c.shard.GetWorkflowExecution(ctx, request)
 
 		return err
 	}

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -389,7 +389,7 @@ func (r *transactionManagerImpl) checkWorkflowExists(
 	if errorDomainName != nil {
 		return false, errorDomainName
 	}
-	_, err := r.shard.GetExecutionManager().GetWorkflowExecution(
+	_, err := r.shard.GetWorkflowExecution(
 		ctx,
 		&persistence.GetWorkflowExecutionRequest{
 			DomainID: domainID,

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -107,6 +107,7 @@ type (
 		GetDomainNotificationVersion() int64
 		UpdateDomainNotificationVersion(domainNotificationVersion int64) error
 
+		GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error)
 		CreateWorkflowExecution(ctx context.Context, request *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error)
 		UpdateWorkflowExecution(ctx context.Context, request *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error)
 		ConflictResolveWorkflowExecution(ctx context.Context, request *persistence.ConflictResolveWorkflowExecutionRequest) (*persistence.ConflictResolveWorkflowExecutionResponse, error)
@@ -576,6 +577,16 @@ func (s *contextImpl) UpdateTimerMaxReadLevel(cluster string) time.Time {
 
 	s.timerMaxReadLevelMap[cluster] = currentTime.Add(s.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)
 	return s.timerMaxReadLevelMap[cluster]
+}
+
+func (s *contextImpl) GetWorkflowExecution(
+	ctx context.Context,
+	request *persistence.GetWorkflowExecutionRequest,
+) (*persistence.GetWorkflowExecutionResponse, error) {
+	if s.isClosed() {
+		return nil, ErrShardClosed
+	}
+	return s.executionManager.GetWorkflowExecution(ctx, request)
 }
 
 func (s *contextImpl) CreateWorkflowExecution(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Do not get workflow execution from database when shard is closed

<!-- Tell your future self why have you made these changes -->
**Why?**
When a shard is closed, we should stop all the operations to the database from that shard. Read operation was allowed because it is safe. But since we do a checksum validation after GetWorkflowExecution from database, a false negative result might be returned from the validation if we allow reading data after a shard is closed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
