### PR TITLE
Test: Addition of tests for replicationQueue publish and publish to dlq

### DIFF
--- a/common/domain/replication_queue_test.go
+++ b/common/domain/replication_queue_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2023 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package domain
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+)
+
+func TestReplicationQueueImpl_Publish(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockQueue := persistence.NewMockQueueManager(ctrl)
+	rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil) // Mock other dependencies as needed
+
+	tests := []struct {
+		name      string
+		task      *types.ReplicationTask
+		wantErr   bool
+		setupMock func(q *persistence.MockQueueManager)
+	}{
+		{
+			name:    "successful publish",
+			task:    &types.ReplicationTask{},
+			wantErr: false,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().EnqueueMessage(gomock.Any(), gomock.Any()).Return(nil)
+			},
+		},
+		{
+			name:    "publish fails",
+			task:    &types.ReplicationTask{},
+			wantErr: true,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().EnqueueMessage(gomock.Any(), gomock.Any()).Return(errors.New("enqueue error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock(mockQueue)
+			err := rq.Publish(context.Background(), tt.task)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReplicationQueueImpl_PublishToDLQ(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockQueue := persistence.NewMockQueueManager(ctrl)
+	rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil) // Mock other dependencies as needed
+
+	tests := []struct {
+		name      string
+		task      *types.ReplicationTask
+		wantErr   bool
+		setupMock func(q *persistence.MockQueueManager)
+	}{
+		{
+			name:    "successful publish to DLQ",
+			task:    &types.ReplicationTask{},
+			wantErr: false,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().EnqueueMessageToDLQ(gomock.Any(), gomock.Any()).Return(nil)
+			},
+		},
+		{
+			name:    "publish to DLQ fails",
+			task:    &types.ReplicationTask{},
+			wantErr: true,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().EnqueueMessageToDLQ(gomock.Any(), gomock.Any()).Return(errors.New("enqueue to DLQ error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.setupMock(mockQueue)
+			err := rq.PublishToDLQ(context.Background(), tt.task)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/common/domain/replication_queue_test.go
+++ b/common/domain/replication_queue_test.go
@@ -33,12 +33,6 @@ import (
 )
 
 func TestReplicationQueueImpl_Publish(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockQueue := persistence.NewMockQueueManager(ctrl)
-	rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil) // Mock other dependencies as needed
-
 	tests := []struct {
 		name      string
 		task      *types.ReplicationTask
@@ -65,6 +59,9 @@ func TestReplicationQueueImpl_Publish(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockQueue := persistence.NewMockQueueManager(ctrl)
+			rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil)
 			tt.setupMock(mockQueue)
 			err := rq.Publish(context.Background(), tt.task)
 			if tt.wantErr {
@@ -72,17 +69,12 @@ func TestReplicationQueueImpl_Publish(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			ctrl.Finish()
 		})
 	}
 }
 
 func TestReplicationQueueImpl_PublishToDLQ(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-
-	mockQueue := persistence.NewMockQueueManager(ctrl)
-	rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil) // Mock other dependencies as needed
-
 	tests := []struct {
 		name      string
 		task      *types.ReplicationTask
@@ -109,6 +101,9 @@ func TestReplicationQueueImpl_PublishToDLQ(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockQueue := persistence.NewMockQueueManager(ctrl)
+			rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil)
 			tt.setupMock(mockQueue)
 			err := rq.PublishToDLQ(context.Background(), tt.task)
 			if tt.wantErr {
@@ -116,6 +111,7 @@ func TestReplicationQueueImpl_PublishToDLQ(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 			}
+			ctrl.Finish()
 		})
 	}
 }


### PR DESCRIPTION
**What changed?**
Addition of test for replication queue methods for publishing to DLQ. Includes several edge cases.

**Why?**
To make the code more secured, reliable and understandable. As well to increase test code coverage.

**How did you test it?**
unit tests

No potential risks as it contains only test cases.