### PR TITLE
Generate a metadata file artifact in unit test buildkite job

### DIFF
--- a/.buildkite/pipeline-master.yml
+++ b/.buildkite/pipeline-master.yml
@@ -8,9 +8,12 @@ steps:
     agents:
       queue: "workers"
       docker: "*"
-    command: "CASSANDRA_HOST=cassandra make install-schema && make cover_profile" # make install-schema is needed for a server startup test. See main_test.go
+    commands:
+      - "CASSANDRA_HOST=cassandra make install-schema && make cover_profile" # make install-schema is needed for a server startup test. See main_test.go
+      - "./scripts/buildkite/gen_coverage_metadata.sh .build/coverage/metadata.txt"
     artifact_paths:
       - ".build/coverage/*.out"
+      - ".build/coverage/metadata.txt"
     retry:
       automatic:
         limit: 1

--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -11,8 +11,10 @@ steps:
     commands:
       - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
       - "CASSANDRA_HOST=cassandra make install-schema && make cover_profile" # make install-schema is needed for a server startup test. See main_test.go
+      - "./scripts/buildkite/gen_coverage_metadata.sh .build/coverage/metadata.txt"
     artifact_paths:
       - ".build/coverage/*.out"
+      - ".build/coverage/metadata.txt"
     retry:
       automatic:
         limit: 1

--- a/scripts/buildkite/gen_coverage_metadata.sh
+++ b/scripts/buildkite/gen_coverage_metadata.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -ex
+
+# This script generates coverage metadata for the coverage report.
+# Output is used by SonarQube integration in Uber and not used by OS repo coverage tool itself.
+
+# Example output:
+#   commit-sha: 6953daa563e8e44512bc349c9608484cfd4ec4ff
+#   timestamp: 2024-03-04T19:29:16Z
+
+output_path="$1"
+
+echo "commit-sha: $(git rev-parse HEAD)" > "$output_path"
+echo "timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$output_path"
+
+echo "Coverage metadata written to $output_path"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`unit test` job in buildkite pipelines will generate a new file as an artifact. 


<!-- Tell your future self why have you made these changes -->
**Why?**
This is needed to integrate with SonarQube.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run `./scripts/buildkite/gen_coverage_metadata.sh .build/coverage/metadata.txt` and check the content of metadata.txt.
```
commit-sha: 089095d18943cfc58bde19a1436876d97ec5559f
timestamp: 2024-03-04T19:35:21Z

```

Also checked the [buildkite job](https://buildkite.com/uberopensource/cadence-server/builds/17831#_) that runs as part of the PR:
<img width="1194" alt="Screenshot 2024-03-04 at 12 19 44 PM" src="https://github.com/uber/cadence/assets/1688634/d8ee2868-984f-4caf-a500-fb05e44dc583">
