### PR TITLE
Tests for GetDLQAckLevel and UpdateDLQAckLevel

### DIFF
--- a/common/domain/replication_queue_test.go
+++ b/common/domain/replication_queue_test.go
@@ -315,3 +315,85 @@ func TestGetMessagesFromDLQ(t *testing.T) {
 		})
 	}
 }
+
+func TestUpdateDLQAckLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		lastID    int64
+		wantErr   bool
+		setupMock func(q *persistence.MockQueueManager)
+	}{
+		{
+			name:    "successful DLQ ack level update",
+			lastID:  100,
+			wantErr: false,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().UpdateDLQAckLevel(gomock.Any(), gomock.Eq(int64(100)), gomock.Eq("domainReplication")).Return(nil)
+			},
+		},
+		{
+			name:    "DLQ ack level update fails",
+			lastID:  100,
+			wantErr: true,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().UpdateDLQAckLevel(gomock.Any(), gomock.Eq(int64(100)), gomock.Eq("domainReplication")).Return(errors.New("update DLQ ack level error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockQueue := persistence.NewMockQueueManager(ctrl)
+			rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil)
+			tt.setupMock(mockQueue)
+			err := rq.UpdateDLQAckLevel(context.Background(), tt.lastID)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetDLQAckLevel(t *testing.T) {
+	tests := []struct {
+		name      string
+		want      int64
+		wantErr   bool
+		setupMock func(q *persistence.MockQueueManager)
+	}{
+		{
+			name:    "successful DLQ ack level retrieval",
+			want:    100,
+			wantErr: false,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().GetDLQAckLevels(gomock.Any()).Return(map[string]int64{"domainReplication": 100}, nil)
+			},
+		},
+		{
+			name:    "DLQ ack level retrieval fails",
+			wantErr: true,
+			setupMock: func(q *persistence.MockQueueManager) {
+				q.EXPECT().GetDLQAckLevels(gomock.Any()).Return(nil, errors.New("get DLQ ack level error"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			mockQueue := persistence.NewMockQueueManager(ctrl)
+			rq := NewReplicationQueue(mockQueue, "testCluster", nil, nil)
+			tt.setupMock(mockQueue)
+			got, err := rq.GetDLQAckLevel(context.Background())
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Description: 
Unit tests for the `GetDLQAckLevel` and `UpdateDLQAckLevel` methods.

Why?: 
Adequate test coverage for these methods is crucial for ensuring the reliability of our DLQ management.

How did you test it?
unit tests

Potential risks
No risks as it only contains tests.
