### PR TITLE
[WIP][history] refactor history client with redirect wrapper

### DIFF
--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -21,6 +21,7 @@
 package client
 
 import (
+	"github.com/uber/cadence/common/peerresolver"
 	"time"
 
 	adminv1 "github.com/uber/cadence-idl/go/proto/admin/v1"
@@ -116,7 +117,7 @@ func (cf *rpcClientFactory) NewHistoryClientWithTimeout(timeout time.Duration) (
 		rawClient = thrift.NewHistoryClient(historyserviceclient.New(outboundConfig))
 	}
 
-	peerResolver := history.NewPeerResolver(cf.numberOfHistoryShards, cf.resolver, namedPort)
+	peerResolver := peerresolver.NewPeerResolver(cf.numberOfHistoryShards, cf.resolver, namedPort)
 
 	client := history.NewClient(
 		cf.numberOfHistoryShards,

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -22,6 +22,7 @@ package history
 
 import (
 	"context"
+	"github.com/uber/cadence/common/peerresolver"
 	"math/rand"
 	"sync"
 	"time"
@@ -50,7 +51,7 @@ type (
 		rpcMaxSizeInBytes int // This value currently only used in GetReplicationMessage API
 		tokenSerializer   common.TaskTokenSerializer
 		client            Client
-		peerResolver      PeerResolver
+		peerResolver      peerresolver.PeerResolver
 		logger            log.Logger
 	}
 
@@ -66,7 +67,7 @@ func NewClient(
 	numberOfShards int,
 	rpcMaxSizeInBytes int,
 	client Client,
-	peerResolver PeerResolver,
+	peerResolver peerresolver.PeerResolver,
 	logger log.Logger,
 ) Client {
 	return &clientImpl{
@@ -84,7 +85,7 @@ func (c *clientImpl) StartWorkflowExecution(
 	request *types.HistoryStartWorkflowExecutionRequest,
 	opts ...yarpc.CallOption,
 ) (*types.StartWorkflowExecutionResponse, error) {
-	peer, err := c.peerResolver.FromWorkflowID(request.StartRequest.WorkflowID)
+	peer, err := c.peerResolver.FromRedirectKey(request.ToRedirectKey())
 	if err != nil {
 		return nil, err
 	}

--- a/common/peerresolver/peerResolver.go
+++ b/common/peerresolver/peerResolver.go
@@ -18,12 +18,14 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package history
+package peerresolver
 
 import (
+	"fmt"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/membership"
 	"github.com/uber/cadence/common/service"
+	"github.com/uber/cadence/common/types"
 )
 
 // PeerResolver is used to resolve history peers.
@@ -99,4 +101,21 @@ func (pr PeerResolver) GetAllPeers() ([]string, error) {
 		peers = append(peers, peer)
 	}
 	return peers, nil
+}
+
+// FromRedirectKey resolve the peer from types.RedirectKey by a specific order
+func (pr PeerResolver) FromRedirectKey(key types.RedirectKey) (string, error) {
+	if key.ShardID != nil {
+		return pr.FromShardID(*key.ShardID)
+	}
+	if key.WorkflowID != "" {
+		return pr.FromWorkflowID(key.WorkflowID)
+	}
+	if key.DomainID != "" {
+		return pr.FromDomainID(key.DomainID)
+	}
+	if key.HostAddress != "" {
+		return pr.FromHostAddress(key.HostAddress)
+	}
+	return "", fmt.Errorf("RedirectKey is not valid: %v", key)
 }

--- a/common/peerresolver/peerResolver_test.go
+++ b/common/peerresolver/peerResolver_test.go
@@ -18,7 +18,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package history
+package peerresolver
 
 import (
 	"errors"

--- a/common/types/history.go
+++ b/common/types/history.go
@@ -20,6 +20,10 @@
 
 package types
 
+var (
+	_ RedirectRequest = (*HistoryStartWorkflowExecutionRequest)(nil)
+)
+
 // DescribeMutableStateRequest is an internal type (TBD...)
 type DescribeMutableStateRequest struct {
 	DomainUUID string             `json:"domainUUID,omitempty"`
@@ -948,6 +952,11 @@ func (v *HistoryStartWorkflowExecutionRequest) GetPartitionConfig() (o map[strin
 		return v.PartitionConfig
 	}
 	return
+}
+
+// ToRedirectKey convert request to redirect key
+func (v *HistoryStartWorkflowExecutionRequest) ToRedirectKey() RedirectKey {
+	return RedirectKey{WorkflowID: v.StartRequest.WorkflowID}
 }
 
 // SyncActivityRequest is an internal type (TBD...)

--- a/common/types/redirect.go
+++ b/common/types/redirect.go
@@ -1,0 +1,14 @@
+package types
+
+// RedirectRequest interface for a redirect-able request
+type RedirectRequest interface {
+	ToRedirectKey() RedirectKey
+}
+
+// RedirectKey entity of keys used for redirect
+type RedirectKey struct {
+	ShardID     *int
+	WorkflowID  string
+	DomainID    string
+	HostAddress string
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* moved peerResolver to its own package
* refactor history client to uniformly use peerResolver's `FromRedirectKey` method
* [planned] use codegen to generate redirect wrapper

<!-- Tell your future self why have you made these changes -->
**Why?**

simplify history client to make testing easier

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
