### PR TITLE
Fix checksum validation for SQL implementation

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -864,6 +864,7 @@ type (
 		DomainID   string
 		Execution  types.WorkflowExecution
 		DomainName string
+		RangeID    int64
 	}
 
 	// GetWorkflowExecutionResponse is the response to GetworkflowExecutionRequest

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -531,6 +531,7 @@ type (
 	InternalGetWorkflowExecutionRequest struct {
 		DomainID  string
 		Execution types.WorkflowExecution
+		RangeID   int64
 	}
 
 	// InternalGetWorkflowExecutionResponse is the response to GetWorkflowExecution for Persistence Interface

--- a/common/persistence/executionManager.go
+++ b/common/persistence/executionManager.go
@@ -73,6 +73,7 @@ func (m *executionManagerImpl) GetWorkflowExecution(
 	internalRequest := &InternalGetWorkflowExecutionRequest{
 		DomainID:  request.DomainID,
 		Execution: request.Execution,
+		RangeID:   request.RangeID,
 	}
 	response, err := m.persistence.GetWorkflowExecution(ctx, internalRequest)
 	if err != nil {
@@ -642,12 +643,9 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 	if err != nil {
 		return nil, err
 	}
-	var checksumData *DataBlob
-	if len(input.Checksum.Value) > 0 {
-		checksumData, err = m.serializer.SerializeChecksum(input.Checksum, common.EncodingTypeJSON)
-		if err != nil {
-			return nil, err
-		}
+	checksumData, err := m.serializer.SerializeChecksum(input.Checksum, common.EncodingTypeJSON)
+	if err != nil {
+		return nil, err
 	}
 
 	return &InternalWorkflowMutation{

--- a/common/persistence/executionManager.go
+++ b/common/persistence/executionManager.go
@@ -642,9 +642,12 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 	if err != nil {
 		return nil, err
 	}
-	checksumData, err := m.serializer.SerializeChecksum(input.Checksum, common.EncodingTypeJSON)
-	if err != nil {
-		return nil, err
+	var checksumData *DataBlob
+	if len(input.Checksum.Value) > 0 {
+		checksumData, err = m.serializer.SerializeChecksum(input.Checksum, common.EncodingTypeJSON)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &InternalWorkflowMutation{

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -476,6 +476,7 @@ func (s *TestBase) GetWorkflowExecutionInfoWithStats(ctx context.Context, domain
 	response, err := s.ExecutionManager.GetWorkflowExecution(ctx, &persistence.GetWorkflowExecutionRequest{
 		DomainID:  domainID,
 		Execution: workflowExecution,
+		RangeID:   s.ShardInfo.RangeID,
 	})
 	if err != nil {
 		return nil, nil, err
@@ -490,6 +491,7 @@ func (s *TestBase) GetWorkflowExecutionInfo(ctx context.Context, domainID string
 	response, err := s.ExecutionManager.GetWorkflowExecution(ctx, &persistence.GetWorkflowExecutionRequest{
 		DomainID:  domainID,
 		Execution: workflowExecution,
+		RangeID:   s.ShardInfo.RangeID,
 	})
 	if err != nil {
 		return nil, err

--- a/common/persistence/serializer.go
+++ b/common/persistence/serializer.go
@@ -304,6 +304,9 @@ func (t *serializerImpl) DeserializeAsyncWorkflowsConfig(data *DataBlob) (*types
 }
 
 func (t *serializerImpl) SerializeChecksum(sum checksum.Checksum, encodingType common.EncodingType) (*DataBlob, error) {
+	if len(sum.Value) == 0 {
+		return nil, nil
+	}
 	return t.serialize(sum, encodingType)
 }
 

--- a/common/persistence/serializer_test.go
+++ b/common/persistence/serializer_test.go
@@ -214,6 +214,7 @@ func TestSerializers(t *testing.T) {
 		{
 			name: "checksum",
 			payloads: map[string]any{
+				"empty":  checksum.Checksum{},
 				"normal": generateChecksum(),
 			},
 			serializeFn: func(payload any, encoding common.EncodingType) (*DataBlob, error) {

--- a/common/persistence/sql/sql_execution_store.go
+++ b/common/persistence/sql/sql_execution_store.go
@@ -379,7 +379,7 @@ func (m *sqlExecutionStore) GetWorkflowExecution(
 	// if we have checksum, we need to make sure the rangeID did not change
 	// if the rangeID changed, it means the shard ownership might have changed
 	// and the workflow might have been updated when we read the data, so the data
-	// we read might not from a consistent view, the checksum validation might fail
+	// we read might not be from a consistent view, the checksum validation might fail
 	// in that case, we need to return an error
 	if state.ChecksumData != nil {
 		row, err := m.db.SelectFromShards(ctx, &sqlplugin.ShardsFilter{ShardID: int64(m.shardID)})

--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -3408,10 +3408,25 @@ func TestGetWorkflowExecution(t *testing.T) {
 					RangeID: 1,
 				}, nil)
 			},
-			wantErr: true,
-			assertErr: func(t *testing.T, err error) {
-				assert.IsType(t, &persistence.ShardOwnershipLostError{}, err)
+			want: &persistence.InternalGetWorkflowExecutionResponse{
+				State: &persistence.InternalWorkflowMutableState{
+					ExecutionInfo: &persistence.InternalWorkflowExecutionInfo{
+						DomainID:               "ff9c8a3f-0e4f-4d3e-a4d2-6f5f8f3f7d9d",
+						WorkflowID:             "test-workflow-id",
+						RunID:                  "ee8d7b6e-876c-4b1e-9b6e-5e3e3c6b6b3f",
+						NextEventID:            101,
+						CompletionEventBatchID: -23,
+					},
+					ActivityInfos:       map[int64]*persistence.InternalActivityInfo{},
+					TimerInfos:          map[string]*persistence.TimerInfo{},
+					ChildExecutionInfos: map[int64]*persistence.InternalChildExecutionInfo{},
+					RequestCancelInfos:  map[int64]*persistence.RequestCancelInfo{},
+					SignalInfos:         map[int64]*persistence.SignalInfo{},
+					SignalRequestedIDs:  map[string]struct{}{},
+					ChecksumData:        nil,
+				},
 			},
+			wantErr: false,
 		},
 		{
 			name: "Error - failed to get shard",

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1209,9 +1209,6 @@ func (c *contextImpl) getWorkflowExecutionWithRetry(
 	case *types.EntityNotExistsError:
 		// it is possible that workflow does not exists
 		return nil, err
-	case *persistence.ShardOwnershipLostError:
-		// shard is stolen, should stop processing the workflow
-		return nil, err
 	default:
 		c.logger.Error(
 			"Persistent fetch operation failure",

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1209,6 +1209,9 @@ func (c *contextImpl) getWorkflowExecutionWithRetry(
 	case *types.EntityNotExistsError:
 		// it is possible that workflow does not exists
 		return nil, err
+	case *persistence.ShardOwnershipLostError:
+		// shard is stolen, should stop processing the workflow
+		return nil, err
 	default:
 		c.logger.Error(
 			"Persistent fetch operation failure",

--- a/service/history/ndc/activity_replicator_test.go
+++ b/service/history/ndc/activity_replicator_test.go
@@ -141,6 +141,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_WorkflowNotFound() {
 			RunID:      runID,
 		},
 		DomainName: domainName,
+		RangeID:    1,
 	}).Return(nil, &types.EntityNotExistsError{})
 	s.mockDomainCache.EXPECT().GetDomainByID(domainID).Return(
 		cache.NewGlobalDomainCacheEntryForTest(

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -443,6 +443,7 @@ func (s *transactionManagerSuite) TestCheckWorkflowExists_DoesNotExists() {
 			RunID:      runID,
 		},
 		DomainName: domainName,
+		RangeID:    1,
 	}).Return(nil, &types.EntityNotExistsError{}).Once()
 
 	exists, err := s.transactionManager.checkWorkflowExists(ctx, domainID, workflowID, runID)
@@ -465,6 +466,7 @@ func (s *transactionManagerSuite) TestCheckWorkflowExists_DoesExists() {
 			RunID:      runID,
 		},
 		DomainName: domainName,
+		RangeID:    1,
 	}).Return(&persistence.GetWorkflowExecutionResponse{}, nil).Once()
 
 	exists, err := s.transactionManager.checkWorkflowExists(ctx, domainID, workflowID, runID)

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -588,6 +588,8 @@ func (s *contextImpl) GetWorkflowExecution(
 	if s.isClosed() {
 		return nil, ErrShardClosed
 	}
+	currentRangeID := s.getRangeID()
+	request.RangeID = currentRangeID
 	return s.executionManager.GetWorkflowExecution(ctx, request)
 }
 

--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -297,6 +297,9 @@ func TestGetWorkflowExecution(t *testing.T) {
 		mockExecutionMgr := &mocks.ExecutionManager{}
 		shardContext := &contextImpl{
 			executionManager: mockExecutionMgr,
+			shardInfo: &persistence.ShardInfo{
+				RangeID: 12,
+			},
 		}
 		if tc.isClosed {
 			shardContext.closed = 1


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a check for the SQL implementation of GetWorkflowExecution operation to exclude false positive checksum validation failure cases.

<!-- Tell your future self why have you made these changes -->
**Why?**
To make sure the checksum validation result is true, the data we read from GetWorkflowExecution operation are from a consistent view. In the NoSQL implementation, the operation is a single read, so the data is from a consistent view. However, in the SQL implementation, the operation is multiple reads from different table. If there is a concurrent update, the data we read isn't from a consistent view and the checksum validation could fail. Normally, we don't have concurrent updates with reads. But when the shard ownership changed, it might not be the case. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
