### PR TITLE
Re-enable kafka consumer test

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -33,6 +33,7 @@ ignore:
   - "**/main.go"
   - "**/mocks/**"
   - "**/testing/**"
+  - "**/testdata/**"
   - "bench/**"
   - "canary/**"
   - "common/persistence/persistence-tests/**"
@@ -42,7 +43,6 @@ ignore:
   - "common/persistence/nosql/nosqlplugin/dynamodb/**"
   - "common/persistence/nosql/nosqlplugin/mongodb/**"
   - "common/types/shared.go" # 8k lines of getters. Not worth testing manually but consider switching to generated code.
-  - "common/types/testdata/**"
   - "idls/**"
   - "host/**"
   - "testflags/**"

--- a/common/messaging/kafka/consumer_impl_test.go
+++ b/common/messaging/kafka/consumer_impl_test.go
@@ -38,9 +38,6 @@ import (
 )
 
 func TestNewConsumer(t *testing.T) {
-	// TODO: remove skip after PR #5712 is merged
-	t.Skip()
-
 	mockProducer := mocks.NewSyncProducer(t, nil)
 	group := "tests"
 	mockBroker := initMockBroker(t, group)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`TestNewConsumer` was flaky so it was disabled recently. Underlying issues are addressed in #5712 so re-enabling it.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`go test -timeout 60s -run ^TestNewConsumer$ github.com/uber/cadence/common/messaging/kafka -v -count=100`
