### PR TITLE
added unit test for functions in common/types/mapper/thrift/matching.go

### DIFF
--- a/common/types/mapper/thrift/matching_test.go
+++ b/common/types/mapper/thrift/matching_test.go
@@ -23,6 +23,8 @@ package thrift
 import (
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/cadence/common/types"
@@ -75,7 +77,10 @@ func TestActivityTaskDispatchInfo(t *testing.T) {
 	for _, tc := range testCases {
 		thriftObj := FromActivityTaskDispatchInfo(tc.input)
 		roundTripObj := ToActivityTaskDispatchInfo(thriftObj)
-		assert.Equal(t, tc.input, roundTripObj)
+		opts := cmpopts.IgnoreFields(types.WorkflowExecutionStartedEventAttributes{}, "ParentWorkflowDomainID")
+		if diff := cmp.Diff(tc.input, roundTripObj, opts); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
 	}
 }
 
@@ -229,32 +234,33 @@ func TestMatchingPollForDecisionRequest(t *testing.T) {
 	}
 }
 
-// TODO: fix issue of ParentExecutionWorkflowDomainID not getting populated issue
-// https://uber-cadence.slack.com/archives/CLS1SM941/p1710939637636519
-// func TestMatchingPollForDecisionResponse(t *testing.T) {
-// 	testCases := []struct {
-// 		desc  string
-// 		input *types.MatchingPollForDecisionTaskResponse
-// 	}{
-// 		{
-// 			desc:  "non-nil input test",
-// 			input: &testdata.MatchingPollForDecisionTaskResponse,
-// 		},
-// 		{
-// 			desc:  "empty input test",
-// 			input: &types.MatchingPollForDecisionTaskResponse{},
-// 		},
-// 		{
-// 			desc:  "nil input test",
-// 			input: nil,
-// 		},
-// 	}
-// 	for _, tc := range testCases {
-// 		thriftObj := FromMatchingPollForDecisionTaskResponse(tc.input)
-// 		roundTripObj := ToMatchingPollForDecisionTaskResponse(thriftObj)
-// 		assert.Equal(t, tc.input, roundTripObj)
-// 	}
-// }
+func TestMatchingPollForDecisionResponse(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.MatchingPollForDecisionTaskResponse
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingPollForDecisionTaskResponse,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.MatchingPollForDecisionTaskResponse{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingPollForDecisionTaskResponse(tc.input)
+		roundTripObj := ToMatchingPollForDecisionTaskResponse(thriftObj)
+		opt := cmpopts.IgnoreFields(types.WorkflowExecutionStartedEventAttributes{}, "ParentWorkflowDomainID")
+		if diff := cmp.Diff(tc.input, roundTripObj, opt); diff != "" {
+			t.Fatalf("Mismatch (-want +got):\n%s", diff)
+		}
+	}
+}
 
 func TestMatchingQueryWorkflowRequest(t *testing.T) {
 	testCases := []struct {

--- a/common/types/mapper/thrift/matching_test.go
+++ b/common/types/mapper/thrift/matching_test.go
@@ -1,0 +1,332 @@
+// Copyright (c) 2021 Uber Technologies Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package thrift
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/testdata"
+)
+
+func TestMatchingAddActivityTaskRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.AddActivityTaskRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingAddActivityTaskRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.AddActivityTaskRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingAddActivityTaskRequest(tc.input)
+		roundTripObj := ToMatchingAddActivityTaskRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestActivityTaskDispatchInfo(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.ActivityTaskDispatchInfo
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingActivityTaskDispatchInfo,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.ActivityTaskDispatchInfo{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromActivityTaskDispatchInfo(tc.input)
+		roundTripObj := ToActivityTaskDispatchInfo(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestMatchingAddDecisionTaskRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.AddDecisionTaskRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingAddDecisionTaskRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.AddDecisionTaskRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingAddDecisionTaskRequest(tc.input)
+		roundTripObj := ToMatchingAddDecisionTaskRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestMatchingCancelOutStandingPollRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.CancelOutstandingPollRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingCancelOutstandingPollRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.CancelOutstandingPollRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingCancelOutstandingPollRequest(tc.input)
+		roundTripObj := ToMatchingCancelOutstandingPollRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestMatchingDescribeTaskListRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.MatchingDescribeTaskListRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingDescribeTaskListRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.MatchingDescribeTaskListRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingDescribeTaskListRequest(tc.input)
+		roundTripObj := ToMatchingDescribeTaskListRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestMatchingListTaskListPartitionsRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.MatchingListTaskListPartitionsRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingListTaskListPartitionsRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.MatchingListTaskListPartitionsRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingListTaskListPartitionsRequest(tc.input)
+		roundTripObj := ToMatchingListTaskListPartitionsRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestMatchingPollForActivityRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.MatchingPollForActivityTaskRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingPollForActivityTaskRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.MatchingPollForActivityTaskRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingPollForActivityTaskRequest(tc.input)
+		roundTripObj := ToMatchingPollForActivityTaskRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestMatchingPollForDecisionRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.MatchingPollForDecisionTaskRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingPollForDecisionTaskRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.MatchingPollForDecisionTaskRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingPollForDecisionTaskRequest(tc.input)
+		roundTripObj := ToMatchingPollForDecisionTaskRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+// TODO: fix issue of ParentExecutionWorkflowDomainID not getting populated issue
+// https://uber-cadence.slack.com/archives/CLS1SM941/p1710939637636519
+// func TestMatchingPollForDecisionResponse(t *testing.T) {
+// 	testCases := []struct {
+// 		desc  string
+// 		input *types.MatchingPollForDecisionTaskResponse
+// 	}{
+// 		{
+// 			desc:  "non-nil input test",
+// 			input: &testdata.MatchingPollForDecisionTaskResponse,
+// 		},
+// 		{
+// 			desc:  "empty input test",
+// 			input: &types.MatchingPollForDecisionTaskResponse{},
+// 		},
+// 		{
+// 			desc:  "nil input test",
+// 			input: nil,
+// 		},
+// 	}
+// 	for _, tc := range testCases {
+// 		thriftObj := FromMatchingPollForDecisionTaskResponse(tc.input)
+// 		roundTripObj := ToMatchingPollForDecisionTaskResponse(thriftObj)
+// 		assert.Equal(t, tc.input, roundTripObj)
+// 	}
+// }
+
+func TestMatchingQueryWorkflowRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.MatchingQueryWorkflowRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingQueryWorkflowRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.MatchingQueryWorkflowRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingQueryWorkflowRequest(tc.input)
+		roundTripObj := ToMatchingQueryWorkflowRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestMatchingRespondQueryTaskCompletedRequest(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.MatchingRespondQueryTaskCompletedRequest
+	}{
+		{
+			desc:  "non-nil input test",
+			input: &testdata.MatchingRespondQueryTaskCompletedRequest,
+		},
+		{
+			desc:  "empty input test",
+			input: &types.MatchingRespondQueryTaskCompletedRequest{},
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromMatchingRespondQueryTaskCompletedRequest(tc.input)
+		roundTripObj := ToMatchingRespondQueryTaskCompletedRequest(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}
+
+func TestTaskSource(t *testing.T) {
+	testCases := []struct {
+		desc  string
+		input *types.TaskSource
+	}{
+		{
+			desc:  "non-nil TaskSourceHistory input test",
+			input: types.TaskSourceHistory.Ptr(),
+		},
+		{
+			desc:  "non-nil TaskSourceDBBacklog input test",
+			input: types.TaskSourceDbBacklog.Ptr(),
+		},
+		{
+			desc:  "nil input test",
+			input: nil,
+		},
+	}
+	for _, tc := range testCases {
+		thriftObj := FromTaskSource(tc.input)
+		roundTripObj := ToTaskSource(thriftObj)
+		assert.Equal(t, tc.input, roundTripObj)
+	}
+}

--- a/common/types/testdata/common.go
+++ b/common/types/testdata/common.go
@@ -112,6 +112,8 @@ var (
 	Payload3 = []byte{30, 0}
 )
 
+var Attempt2 = int64(2)
+
 var (
 	ExecutionContext = []byte{110, 0}
 	Control          = []byte{120, 0}
@@ -126,11 +128,9 @@ var (
 	FailureDetails = []byte{190, 0}
 )
 
-var (
-	PartitionConfig = map[string]string{
-		"zone": IsolationGroup,
-	}
-)
+var PartitionConfig = map[string]string{
+	"zone": IsolationGroup,
+}
 
 var (
 	HealthStatus = types.HealthStatus{

--- a/common/types/testdata/service_matching.go
+++ b/common/types/testdata/service_matching.go
@@ -151,4 +151,14 @@ var (
 	}
 
 	DescribeTaskListResponseMap = map[string]*types.DescribeTaskListResponse{DomainName: &MatchingDescribeTaskListResponse}
+
+	MatchingActivityTaskDispatchInfo = types.ActivityTaskDispatchInfo{
+		ScheduledEvent:                  &HistoryEvent_WorkflowExecutionSignaled,
+		StartedTimestamp:                &Timestamp1,
+		Attempt:                         &Attempt2,
+		ScheduledTimestampOfThisAttempt: &Timestamp1,
+		HeartbeatDetails:                Payload2,
+		WorkflowType:                    &WorkflowType,
+		WorkflowDomain:                  DomainName,
+	}
 )

--- a/common/types/testdata/service_matching.go
+++ b/common/types/testdata/service_matching.go
@@ -153,7 +153,7 @@ var (
 	DescribeTaskListResponseMap = map[string]*types.DescribeTaskListResponse{DomainName: &MatchingDescribeTaskListResponse}
 
 	MatchingActivityTaskDispatchInfo = types.ActivityTaskDispatchInfo{
-		ScheduledEvent:                  &HistoryEvent_WorkflowExecutionSignaled,
+		ScheduledEvent:                  &HistoryEvent_WorkflowExecutionStarted,
 		StartedTimestamp:                &Timestamp1,
 		Attempt:                         &Attempt2,
 		ScheduledTimestampOfThisAttempt: &Timestamp1,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added unit tests for function in common/types/mapper/thrift/matching.go

Some call outs:
1. WorkflowExecutionStartedEventAttributes in thrift package doesn't have ParentWorkflowDomainID field. Had to apply a workaround in test payload comparisons to ignore this field.

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve code coverage

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
locally using go test utility.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
NA

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
