### PR TITLE
Address data race in task processor test

### DIFF
--- a/service/history/task/processor_test.go
+++ b/service/history/task/processor_test.go
@@ -104,9 +104,11 @@ func (s *queueTaskProcessorSuite) TestGetOrCreateShardTaskScheduler_ProcessorNot
 
 func (s *queueTaskProcessorSuite) TestGetOrCreateShardTaskScheduler_ShardProcessorAlreadyExists() {
 	mockScheduler := task.NewMockScheduler(s.controller)
+	mockScheduler.EXPECT().Stop().Times(1)
 	s.processor.shardSchedulers[s.mockShard] = mockScheduler
 
 	s.processor.Start()
+	defer s.processor.Stop()
 	scheduler, err := s.processor.getOrCreateShardTaskScheduler(s.mockShard)
 	s.NoError(err)
 	s.Equal(mockScheduler, scheduler)
@@ -116,6 +118,7 @@ func (s *queueTaskProcessorSuite) TestGetOrCreateShardTaskScheduler_ShardProcess
 	s.Empty(s.processor.shardSchedulers)
 
 	s.processor.Start()
+	defer s.processor.Stop()
 	scheduler, err := s.processor.getOrCreateShardTaskScheduler(s.mockShard)
 	s.NoError(err)
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
History task processor failed in CI with a data race issue (see below). Addressing it by stopping the processor instances.

```
WARNING: DATA RACE
Read at 0x00c000e91563 by goroutine 380:
  ...
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/core.go:90 +0x192
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.13.0/zapcore/entry.go:216 +0x20f
  github.com/uber/cadence/common/log/loggerimpl.(*loggerImpl).Debug()
      /home/runner/work/cadence/cadence/common/log/loggerimpl/logger.go:132 +0xc4
  github.com/uber/cadence/common/task.(*weightedRoundRobinTaskSchedulerImpl).dispatcher()
      /home/runner/work/cadence/cadence/common/task/weighted_round_robin_task_scheduler.go:202 +0x19a
  github.com/uber/cadence/common/task.(*weightedRoundRobinTaskSchedulerImpl).Start.gowrap1()
      /home/runner/work/cadence/cadence/common/task/weighted_round_robin_task_scheduler.go:109 +0x33

Previous write at 0x00c000e91563 by goroutine 178:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.22.1/x64/src/testing/testing.go:1676 +0x8fa
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.22.1/x64/src/runtime/panic.go:602 +0x5d
  github.com/stretchr/testify/suite.Run.func1()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.3/suite/suite.go:187 +0x30f
  testing.tRunner()
      /opt/hostedtoolcache/go/1.22.1/x64/src/testing/testing.go:1689 +0x21e
  testing.(*T).Run.gowrap1()
      /opt/hostedtoolcache/go/1.22.1/x64/src/testing/testing.go:1742 +0x44
```

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
`go test -timeout 60s -run ^TestQueueTaskProcessorSuite$ github.com/uber/cadence/service/history/task -race -count=10 -v `