### PR TITLE
Update mutable state to generate workflow requests

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2003,6 +2003,13 @@ const (
 	// Allowed filters: DomainName
 	EnableRetryForChecksumFailure
 
+	// EnableStrongIdempotency enables strong idempotency for APIs
+	// KeyName: history.enableStrongIdempotency
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	EnableStrongIdempotency
+
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
 )
@@ -4308,6 +4315,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "history.enableMutableStateChecksumFailureRetry",
 		Filters:      []Filter{DomainName},
 		Description:  "EnableRetryForChecksumFailure enables retry if mutable state checksum verification fails",
+		DefaultValue: false,
+	},
+	EnableStrongIdempotency: DynamicBool{
+		KeyName:      "history.enableStrongIdempotency",
+		Filters:      []Filter{DomainName},
+		Description:  "EnableStrongIdempotency enables strong idempotency for APIs",
 		DefaultValue: false,
 	},
 }

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -123,6 +123,11 @@ func WorkflowSignalName(signalName string) Tag {
 	return newStringTag("wf-signal-name", signalName)
 }
 
+// WorkflowRequestID returns tag for WorkflowRequestID
+func WorkflowRequestID(requestID string) Tag {
+	return newStringTag("wf-request-id", requestID)
+}
+
 // WorkflowState returns tag for WorkflowState
 func WorkflowState(s int) Tag {
 	return newInt("wf-state", s)

--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -10,6 +10,9 @@ history.EnableConsistentQueryByDomain:
 history.useNewInitialFailoverVersion:
 - value: true
   constraints: {}
+history.enableStrongIdempotency:
+- value: true
+  constraints: {}
 frontend.validSearchAttributes:
 - value:
     BinaryChecksums: 1

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -338,6 +338,8 @@ type Config struct {
 	LargeShardHistoryEventMetricThreshold dynamicconfig.IntPropertyFn
 	LargeShardHistoryBlobMetricThreshold  dynamicconfig.IntPropertyFn
 
+	EnableStrongIdempotency dynamicconfig.BoolPropertyFnWithDomainFilter
+
 	// HostName for machine running the service
 	HostName string
 }
@@ -596,6 +598,8 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 		LargeShardHistoryEventMetricThreshold: dc.GetIntProperty(dynamicconfig.LargeShardHistoryEventMetricThreshold),
 		LargeShardHistoryBlobMetricThreshold:  dc.GetIntProperty(dynamicconfig.LargeShardHistoryBlobMetricThreshold),
 
+		EnableStrongIdempotency: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableStrongIdempotency),
+
 		HostName: hostname,
 	}
 
@@ -637,6 +641,7 @@ func NewForTestByShardNumber(shardNumber int) *Config {
 	}))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.QueueProcessorRandomSplitProbability, 0.5))
 	panicIfErr(inMem.UpdateValue(dynamicconfig.ReplicationTaskFetcherEnableGracefulSyncShutdown, true))
+	panicIfErr(inMem.UpdateValue(dynamicconfig.EnableStrongIdempotency, true))
 
 	dc := dynamicconfig.NewCollection(inMem, log.NewNoop())
 	config := New(dc, shardNumber, 1024*1024, config.StoreTypeCassandra, false, "")

--- a/service/history/engine/engineimpl/historyEngine2_test.go
+++ b/service/history/engine/engineimpl/historyEngine2_test.go
@@ -1122,6 +1122,40 @@ func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_DuplicateRequestError
 	s.Equal("test-run-id", resp.RunID)
 }
 
+func (s *engine2Suite) TestStartWorkflowExecution_BrandNew_DuplicateRequestError_TypeMismatch() {
+	domainID := constants.TestDomainID
+	workflowID := "workflowID"
+	workflowType := "workflowType"
+	taskList := "testTaskList"
+	identity := "testIdentity"
+	partitionConfig := map[string]string{
+		"zone": "phx",
+	}
+
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&p.AppendHistoryNodesResponse{}, nil).Once()
+	s.mockExecutionMgr.On("CreateWorkflowExecution", mock.Anything, mock.MatchedBy(func(request *p.CreateWorkflowExecutionRequest) bool {
+		return !request.NewWorkflowSnapshot.ExecutionInfo.StartTimestamp.IsZero() && reflect.DeepEqual(partitionConfig, request.NewWorkflowSnapshot.ExecutionInfo.PartitionConfig)
+	})).Return(nil, &p.DuplicateRequestError{RequestType: p.WorkflowRequestTypeSignal, RunID: "test-run-id"}).Once()
+
+	requestID := uuid.New()
+	_, err := s.historyEngine.StartWorkflowExecution(context.Background(), &types.HistoryStartWorkflowExecutionRequest{
+		DomainUUID: domainID,
+		StartRequest: &types.StartWorkflowExecutionRequest{
+			Domain:                              domainID,
+			WorkflowID:                          workflowID,
+			WorkflowType:                        &types.WorkflowType{Name: workflowType},
+			TaskList:                            &types.TaskList{Name: taskList},
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1),
+			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(2),
+			Identity:                            identity,
+			RequestID:                           requestID,
+		},
+		PartitionConfig: partitionConfig,
+	})
+	s.Error(err)
+	s.IsType(&p.DuplicateRequestError{}, err)
+}
+
 func (s *engine2Suite) TestStartWorkflowExecution_StillRunning_Dedup() {
 	domainID := constants.TestDomainID
 	workflowID := "workflowID"
@@ -1195,6 +1229,130 @@ func (s *engine2Suite) TestStartWorkflowExecution_StillRunning_NonDeDup() {
 		s.Fail("return err is not *types.WorkflowExecutionAlreadyStartedError")
 	}
 	s.Nil(resp)
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevSuccess_DuplicateRequestError() {
+	domainID := constants.TestDomainID
+	workflowID := "workflowID"
+	runID := "runID"
+	workflowType := "workflowType"
+	taskList := "testTaskList"
+	identity := "testIdentity"
+	lastWriteVersion := common.EmptyVersion
+	partitionConfig := map[string]string{
+		"zone": "phx",
+	}
+
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&p.AppendHistoryNodesResponse{}, nil).Once()
+	s.mockExecutionMgr.On(
+		"CreateWorkflowExecution",
+		mock.Anything,
+		mock.MatchedBy(func(request *p.CreateWorkflowExecutionRequest) bool {
+			return request.Mode == p.CreateWorkflowModeBrandNew &&
+				!request.NewWorkflowSnapshot.ExecutionInfo.StartTimestamp.IsZero() &&
+				reflect.DeepEqual(partitionConfig, request.NewWorkflowSnapshot.ExecutionInfo.PartitionConfig)
+		}),
+	).Return(nil, &p.WorkflowExecutionAlreadyStartedError{
+		Msg:              "random message",
+		StartRequestID:   "oldRequestID",
+		RunID:            runID,
+		State:            p.WorkflowStateCompleted,
+		CloseStatus:      p.WorkflowCloseStatusCompleted,
+		LastWriteVersion: lastWriteVersion,
+	}).Once()
+
+	s.mockExecutionMgr.On(
+		"CreateWorkflowExecution",
+		mock.Anything,
+		mock.MatchedBy(func(request *p.CreateWorkflowExecutionRequest) bool {
+			return request.Mode == p.CreateWorkflowModeWorkflowIDReuse &&
+				request.PreviousRunID == runID &&
+				request.PreviousLastWriteVersion == lastWriteVersion &&
+				!request.NewWorkflowSnapshot.ExecutionInfo.StartTimestamp.IsZero() &&
+				reflect.DeepEqual(partitionConfig, request.NewWorkflowSnapshot.ExecutionInfo.PartitionConfig)
+		}),
+	).Return(nil, &p.DuplicateRequestError{RequestType: p.WorkflowRequestTypeStart, RunID: "test-run-id"}).Once()
+
+	resp, err := s.historyEngine.StartWorkflowExecution(context.Background(), &types.HistoryStartWorkflowExecutionRequest{
+		DomainUUID: domainID,
+		StartRequest: &types.StartWorkflowExecutionRequest{
+			Domain:                              domainID,
+			WorkflowID:                          workflowID,
+			WorkflowType:                        &types.WorkflowType{Name: workflowType},
+			TaskList:                            &types.TaskList{Name: taskList},
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1),
+			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(2),
+			Identity:                            identity,
+			RequestID:                           "newRequestID",
+			WorkflowIDReusePolicy:               types.WorkflowIDReusePolicyAllowDuplicate.Ptr(),
+		},
+		PartitionConfig: partitionConfig,
+	})
+
+	s.Nil(err)
+	s.Equal("test-run-id", resp.RunID)
+}
+
+func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevSuccess_DuplicateRequestError_TypeMismatch() {
+	domainID := constants.TestDomainID
+	workflowID := "workflowID"
+	runID := "runID"
+	workflowType := "workflowType"
+	taskList := "testTaskList"
+	identity := "testIdentity"
+	lastWriteVersion := common.EmptyVersion
+	partitionConfig := map[string]string{
+		"zone": "phx",
+	}
+
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&p.AppendHistoryNodesResponse{}, nil).Once()
+	s.mockExecutionMgr.On(
+		"CreateWorkflowExecution",
+		mock.Anything,
+		mock.MatchedBy(func(request *p.CreateWorkflowExecutionRequest) bool {
+			return request.Mode == p.CreateWorkflowModeBrandNew &&
+				!request.NewWorkflowSnapshot.ExecutionInfo.StartTimestamp.IsZero() &&
+				reflect.DeepEqual(partitionConfig, request.NewWorkflowSnapshot.ExecutionInfo.PartitionConfig)
+		}),
+	).Return(nil, &p.WorkflowExecutionAlreadyStartedError{
+		Msg:              "random message",
+		StartRequestID:   "oldRequestID",
+		RunID:            runID,
+		State:            p.WorkflowStateCompleted,
+		CloseStatus:      p.WorkflowCloseStatusCompleted,
+		LastWriteVersion: lastWriteVersion,
+	}).Once()
+
+	s.mockExecutionMgr.On(
+		"CreateWorkflowExecution",
+		mock.Anything,
+		mock.MatchedBy(func(request *p.CreateWorkflowExecutionRequest) bool {
+			return request.Mode == p.CreateWorkflowModeWorkflowIDReuse &&
+				request.PreviousRunID == runID &&
+				request.PreviousLastWriteVersion == lastWriteVersion &&
+				!request.NewWorkflowSnapshot.ExecutionInfo.StartTimestamp.IsZero() &&
+				reflect.DeepEqual(partitionConfig, request.NewWorkflowSnapshot.ExecutionInfo.PartitionConfig)
+		}),
+	).Return(nil, &p.DuplicateRequestError{RequestType: p.WorkflowRequestTypeSignal, RunID: "test-run-id"}).Once()
+
+	_, err := s.historyEngine.StartWorkflowExecution(context.Background(), &types.HistoryStartWorkflowExecutionRequest{
+		DomainUUID: domainID,
+		StartRequest: &types.StartWorkflowExecutionRequest{
+			Domain:                              domainID,
+			WorkflowID:                          workflowID,
+			WorkflowType:                        &types.WorkflowType{Name: workflowType},
+			TaskList:                            &types.TaskList{Name: taskList},
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1),
+			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(2),
+			Identity:                            identity,
+			RequestID:                           "newRequestID",
+			WorkflowIDReusePolicy:               types.WorkflowIDReusePolicyAllowDuplicate.Ptr(),
+		},
+		PartitionConfig: partitionConfig,
+	})
+
+	s.Error(err)
+	s.IsType(&p.DuplicateRequestError{}, err)
 }
 
 func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevSuccess() {
@@ -1448,11 +1606,53 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_JustSignal_Duplicate
 	s.mockExecutionMgr.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(gceResponse, nil).Once()
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(gwmsResponse, nil).Once()
 	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&p.AppendHistoryNodesResponse{}, nil).Once()
-	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(nil, &p.DuplicateRequestError{RunID: "test-run-id"}).Once()
+	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(nil, &p.DuplicateRequestError{RequestType: p.WorkflowRequestTypeSignal, RunID: "test-run-id"}).Once()
 
 	resp, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
 	s.Nil(err)
 	s.Equal("test-run-id", resp.GetRunID())
+}
+
+func (s *engine2Suite) TestSignalWithStartWorkflowExecution_JustSignal_DuplicateRequestError_TypeMismatch() {
+	sRequest := &types.HistorySignalWithStartWorkflowExecutionRequest{}
+	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
+	s.Error(err)
+
+	domainID := constants.TestDomainID
+	workflowID := "wId"
+	runID := constants.TestRunID
+	identity := "testIdentity"
+	signalName := "my signal name"
+	input := []byte("test input")
+	sRequest = &types.HistorySignalWithStartWorkflowExecutionRequest{
+		DomainUUID: domainID,
+		SignalWithStartRequest: &types.SignalWithStartWorkflowExecutionRequest{
+			Domain:     domainID,
+			WorkflowID: workflowID,
+			Identity:   identity,
+			SignalName: signalName,
+			Input:      input,
+		},
+	}
+
+	msBuilder := execution.NewMutableStateBuilderWithEventV2(
+		s.historyEngine.shard,
+		testlogger.New(s.Suite.T()),
+		runID,
+		constants.TestLocalDomainEntry,
+	)
+	ms := execution.CreatePersistenceMutableState(msBuilder)
+	gwmsResponse := &p.GetWorkflowExecutionResponse{State: ms}
+	gceResponse := &p.GetCurrentExecutionResponse{RunID: runID}
+
+	s.mockExecutionMgr.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(gceResponse, nil).Once()
+	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(gwmsResponse, nil).Once()
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&p.AppendHistoryNodesResponse{}, nil).Once()
+	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(nil, &p.DuplicateRequestError{RequestType: p.WorkflowRequestTypeStart, RunID: "test-run-id"}).Once()
+
+	_, err = s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
+	s.Error(err)
+	s.IsType(&p.DuplicateRequestError{}, err)
 }
 
 func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist() {
@@ -1548,6 +1748,54 @@ func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist_Dup
 	s.Nil(err)
 	s.Equal("test-run-id", resp.GetRunID())
 }
+
+func (s *engine2Suite) TestSignalWithStartWorkflowExecution_WorkflowNotExist_DuplicateRequestError_TypeMismatch() {
+	sRequest := &types.HistorySignalWithStartWorkflowExecutionRequest{}
+	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
+	s.Error(err)
+
+	domainID := constants.TestDomainID
+	workflowID := "wId"
+	workflowType := "workflowType"
+	taskList := "testTaskList"
+	identity := "testIdentity"
+	signalName := "my signal name"
+	input := []byte("test input")
+	requestID := uuid.New()
+	partitionConfig := map[string]string{
+		"zone": "phx",
+	}
+
+	sRequest = &types.HistorySignalWithStartWorkflowExecutionRequest{
+		DomainUUID: domainID,
+		SignalWithStartRequest: &types.SignalWithStartWorkflowExecutionRequest{
+			Domain:                              domainID,
+			WorkflowID:                          workflowID,
+			WorkflowType:                        &types.WorkflowType{Name: workflowType},
+			TaskList:                            &types.TaskList{Name: taskList},
+			ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(1),
+			TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(2),
+			Identity:                            identity,
+			SignalName:                          signalName,
+			Input:                               input,
+			RequestID:                           requestID,
+		},
+		PartitionConfig: partitionConfig,
+	}
+
+	notExistErr := &types.EntityNotExistsError{Message: "Workflow not exist"}
+
+	s.mockExecutionMgr.On("GetCurrentExecution", mock.Anything, mock.Anything).Return(nil, notExistErr).Once()
+	s.mockHistoryV2Mgr.On("AppendHistoryNodes", mock.Anything, mock.Anything).Return(&p.AppendHistoryNodesResponse{}, nil).Once()
+	s.mockExecutionMgr.On("CreateWorkflowExecution", mock.Anything, mock.MatchedBy(func(request *p.CreateWorkflowExecutionRequest) bool {
+		return !request.NewWorkflowSnapshot.ExecutionInfo.StartTimestamp.IsZero() && reflect.DeepEqual(partitionConfig, request.NewWorkflowSnapshot.ExecutionInfo.PartitionConfig)
+	})).Return(nil, &p.DuplicateRequestError{RequestType: p.WorkflowRequestTypeCancel, RunID: "test-run-id"}).Once()
+
+	_, err = s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)
+	s.Error(err)
+	s.IsType(&p.DuplicateRequestError{}, err)
+}
+
 func (s *engine2Suite) TestSignalWithStartWorkflowExecution_CreateTimeout() {
 	sRequest := &types.HistorySignalWithStartWorkflowExecutionRequest{}
 	_, err := s.historyEngine.SignalWithStartWorkflowExecution(context.Background(), sRequest)

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -115,6 +115,7 @@ type (
 			createMode persistence.CreateWorkflowMode,
 			prevRunID string,
 			prevLastWriteVersion int64,
+			workflowRequestMode persistence.CreateWorkflowRequestMode,
 		) error
 		ConflictResolveWorkflowExecution(
 			ctx context.Context,
@@ -155,6 +156,7 @@ type (
 			newMutableState MutableState,
 			currentWorkflowTransactionPolicy TransactionPolicy,
 			newWorkflowTransactionPolicy *TransactionPolicy,
+			workflowRequestMode persistence.CreateWorkflowRequestMode,
 		) error
 		UpdateWorkflowExecutionTasks(
 			ctx context.Context,
@@ -182,7 +184,7 @@ type (
 		getWorkflowExecutionFn                func(context.Context, *persistence.GetWorkflowExecutionRequest) (*persistence.GetWorkflowExecutionResponse, error)
 		createWorkflowExecutionFn             func(context.Context, *persistence.CreateWorkflowExecutionRequest) (*persistence.CreateWorkflowExecutionResponse, error)
 		updateWorkflowExecutionFn             func(context.Context, *persistence.UpdateWorkflowExecutionRequest) (*persistence.UpdateWorkflowExecutionResponse, error)
-		updateWorkflowExecutionWithNewFn      func(context.Context, time.Time, persistence.UpdateWorkflowMode, Context, MutableState, TransactionPolicy, *TransactionPolicy) error
+		updateWorkflowExecutionWithNewFn      func(context.Context, time.Time, persistence.UpdateWorkflowMode, Context, MutableState, TransactionPolicy, *TransactionPolicy, persistence.CreateWorkflowRequestMode) error
 		notifyTasksFromWorkflowSnapshotFn     func(*persistence.WorkflowSnapshot, events.PersistedBlobs, bool)
 		notifyTasksFromWorkflowMutationFn     func(*persistence.WorkflowMutation, events.PersistedBlobs, bool)
 		emitSessionUpdateStatsFn              func(string, *persistence.MutableStateUpdateSessionStats)
@@ -410,6 +412,7 @@ func (c *contextImpl) CreateWorkflowExecution(
 	createMode persistence.CreateWorkflowMode,
 	prevRunID string,
 	prevLastWriteVersion int64,
+	workflowRequestMode persistence.CreateWorkflowRequestMode,
 ) (retError error) {
 
 	defer func() {
@@ -417,6 +420,10 @@ func (c *contextImpl) CreateWorkflowExecution(
 			c.Clear()
 		}
 	}()
+	err := validateWorkflowRequestsAndMode(newWorkflow.WorkflowRequests, workflowRequestMode)
+	if err != nil {
+		c.logger.Error("workflow requests and mode validation error", tag.Error(err))
+	}
 	domain, errorDomainName := c.shard.GetDomainCache().GetDomainName(c.domainID)
 	if errorDomainName != nil {
 		return errorDomainName
@@ -426,9 +433,9 @@ func (c *contextImpl) CreateWorkflowExecution(
 		Mode:                     createMode,
 		PreviousRunID:            prevRunID,
 		PreviousLastWriteVersion: prevLastWriteVersion,
-
-		NewWorkflowSnapshot: *newWorkflow,
-		DomainName:          domain,
+		NewWorkflowSnapshot:      *newWorkflow,
+		WorkflowRequestMode:      workflowRequestMode,
+		DomainName:               domain,
 	}
 
 	historySize := int64(len(persistedHistory.Data))
@@ -499,10 +506,12 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 				newContext.Clear()
 			}
 		}()
-
 		newWorkflow, newWorkflowEventsSeq, err = newMutableState.CloseTransactionAsSnapshot(now, TransactionPolicyPassive)
 		if err != nil {
 			return err
+		}
+		if len(resetWorkflow.WorkflowRequests) != 0 && len(newWorkflow.WorkflowRequests) != 0 {
+			c.logger.Error("Workflow reqeusts are only expected to be generated from one workflow for ConflictResolveWorkflowExecution")
 		}
 		newWorkflowSizeSize := newContext.GetHistorySize()
 		startEvents := newWorkflowEventsSeq[0]
@@ -526,10 +535,12 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 				currentContext.Clear()
 			}
 		}()
-
 		currentWorkflow, currentWorkflowEventsSeq, err = currentMutableState.CloseTransactionAsMutation(now, *currentTransactionPolicy)
 		if err != nil {
 			return err
+		}
+		if len(currentWorkflow.WorkflowRequests) != 0 {
+			c.logger.Error("workflow requests are not expected from current workflow for ConflictResolveWorkflowExecution")
 		}
 		currentWorkflowSize := currentContext.GetHistorySize()
 		for _, workflowEvents := range currentWorkflowEventsSeq {
@@ -564,6 +575,7 @@ func (c *contextImpl) ConflictResolveWorkflowExecution(
 		ResetWorkflowSnapshot:   *resetWorkflow,
 		NewWorkflowSnapshot:     newWorkflow,
 		CurrentWorkflowMutation: currentWorkflow,
+		WorkflowRequestMode:     persistence.CreateWorkflowRequestModeReplicated,
 		// Encoding, this is set by shard context
 		DomainName: domain,
 	})
@@ -616,7 +628,7 @@ func (c *contextImpl) UpdateWorkflowExecutionAsActive(
 	ctx context.Context,
 	now time.Time,
 ) error {
-	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, TransactionPolicyActive, nil)
+	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, TransactionPolicyActive, nil, persistence.CreateWorkflowRequestModeNew)
 }
 
 func (c *contextImpl) UpdateWorkflowExecutionWithNewAsActive(
@@ -625,14 +637,14 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNewAsActive(
 	newContext Context,
 	newMutableState MutableState,
 ) error {
-	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, newContext, newMutableState, TransactionPolicyActive, TransactionPolicyActive.Ptr())
+	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, newContext, newMutableState, TransactionPolicyActive, TransactionPolicyActive.Ptr(), persistence.CreateWorkflowRequestModeNew)
 }
 
 func (c *contextImpl) UpdateWorkflowExecutionAsPassive(
 	ctx context.Context,
 	now time.Time,
 ) error {
-	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, TransactionPolicyPassive, nil)
+	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, TransactionPolicyPassive, nil, persistence.CreateWorkflowRequestModeReplicated)
 }
 
 func (c *contextImpl) UpdateWorkflowExecutionWithNewAsPassive(
@@ -641,7 +653,7 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNewAsPassive(
 	newContext Context,
 	newMutableState MutableState,
 ) error {
-	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, newContext, newMutableState, TransactionPolicyPassive, TransactionPolicyPassive.Ptr())
+	return c.updateWorkflowExecutionWithNewFn(ctx, now, persistence.UpdateWorkflowModeUpdateCurrent, newContext, newMutableState, TransactionPolicyPassive, TransactionPolicyPassive.Ptr(), persistence.CreateWorkflowRequestModeReplicated)
 }
 
 func (c *contextImpl) UpdateWorkflowExecutionTasks(
@@ -663,6 +675,10 @@ func (c *contextImpl) UpdateWorkflowExecutionTasks(
 		return &types.InternalServiceError{
 			Message: "UpdateWorkflowExecutionTask can only be used for persisting new workflow tasks, but found new history events",
 		}
+	}
+	if len(currentWorkflow.WorkflowRequests) != 0 {
+		// TODO: convert this log to an error once we enable this feature for a long time in production
+		c.logger.Error("UpdateWorkflowExecutionTask can only be used for persisting new workflow tasks, but found new workflow requests")
 	}
 	currentWorkflow.ExecutionStats = &persistence.ExecutionStats{
 		HistorySize: c.GetHistorySize(),
@@ -698,6 +714,7 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 	newMutableState MutableState,
 	currentWorkflowTransactionPolicy TransactionPolicy,
 	newWorkflowTransactionPolicy *TransactionPolicy,
+	workflowRequestMode persistence.CreateWorkflowRequestMode,
 ) (retError error) {
 	defer func() {
 		if retError != nil {
@@ -708,6 +725,10 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 	currentWorkflow, currentWorkflowEventsSeq, err := c.mutableState.CloseTransactionAsMutation(now, currentWorkflowTransactionPolicy)
 	if err != nil {
 		return err
+	}
+	err = validateWorkflowRequestsAndMode(currentWorkflow.WorkflowRequests, workflowRequestMode)
+	if err != nil {
+		c.logger.Error("workflow requests and mode validation error", tag.Error(err))
 	}
 	var persistedBlobs events.PersistedBlobs
 	currentWorkflowSize := c.GetHistorySize()
@@ -736,13 +757,22 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 				newContext.Clear()
 			}
 		}()
-
 		newWorkflow, newWorkflowEventsSeq, err = newMutableState.CloseTransactionAsSnapshot(
 			now,
 			*newWorkflowTransactionPolicy,
 		)
 		if err != nil {
 			return err
+		}
+		if len(newWorkflow.WorkflowRequests) != 0 && len(currentWorkflow.WorkflowRequests) != 0 {
+			// TODO: convert it to an error if we've verified in production
+			c.logger.Error("Workflow reqeusts are only expected to be generated from one workflow for UpdateWorkflowExecution")
+		}
+
+		err := validateWorkflowRequestsAndMode(newWorkflow.WorkflowRequests, workflowRequestMode)
+		if err != nil {
+			// TODO: convert it to an error if we've verified in production
+			c.logger.Error("workflow requests and mode validation error", tag.Error(err))
 		}
 		newWorkflowSizeSize := newContext.GetHistorySize()
 		startEvents := newWorkflowEventsSeq[0]
@@ -785,6 +815,7 @@ func (c *contextImpl) UpdateWorkflowExecutionWithNew(
 		Mode:                   updateMode,
 		UpdateWorkflowMutation: *currentWorkflow,
 		NewWorkflowSnapshot:    newWorkflow,
+		WorkflowRequestMode:    workflowRequestMode,
 		// Encoding, this is set by shard context
 		DomainName: domain,
 	})
@@ -1370,4 +1401,20 @@ func isOperationPossiblySuccessfulError(err error) bool {
 	default:
 		return !IsConflictError(err)
 	}
+}
+
+func validateWorkflowRequestsAndMode(requests []*persistence.WorkflowRequest, mode persistence.CreateWorkflowRequestMode) error {
+	if mode == persistence.CreateWorkflowRequestModeNew {
+		if len(requests) > 2 {
+			return &types.InternalServiceError{Message: "Too many workflow requests for a single API request."}
+		} else if len(requests) == 2 {
+			// SignalWithStartWorkflow API can generate 2 workflow requests
+			if (requests[0].RequestType == persistence.WorkflowRequestTypeStart && requests[1].RequestType == persistence.WorkflowRequestTypeSignal) ||
+				(requests[1].RequestType == persistence.WorkflowRequestTypeStart && requests[0].RequestType == persistence.WorkflowRequestTypeSignal) {
+				return nil
+			}
+			return &types.InternalServiceError{Message: "Too many workflow requests for a single API request."}
+		}
+	}
+	return nil
 }

--- a/service/history/execution/context_mock.go
+++ b/service/history/execution/context_mock.go
@@ -88,17 +88,17 @@ func (mr *MockContextMockRecorder) ConflictResolveWorkflowExecution(ctx, now, co
 }
 
 // CreateWorkflowExecution mocks base method.
-func (m *MockContext) CreateWorkflowExecution(ctx context.Context, newWorkflow *persistence.WorkflowSnapshot, persistedHistory events.PersistedBlob, createMode persistence.CreateWorkflowMode, prevRunID string, prevLastWriteVersion int64) error {
+func (m *MockContext) CreateWorkflowExecution(ctx context.Context, newWorkflow *persistence.WorkflowSnapshot, persistedHistory events.PersistedBlob, createMode persistence.CreateWorkflowMode, prevRunID string, prevLastWriteVersion int64, workflowRequestMode persistence.CreateWorkflowRequestMode) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateWorkflowExecution", ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion)
+	ret := m.ctrl.Call(m, "CreateWorkflowExecution", ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion, workflowRequestMode)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // CreateWorkflowExecution indicates an expected call of CreateWorkflowExecution.
-func (mr *MockContextMockRecorder) CreateWorkflowExecution(ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) CreateWorkflowExecution(ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion, workflowRequestMode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockContext)(nil).CreateWorkflowExecution), ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkflowExecution", reflect.TypeOf((*MockContext)(nil).CreateWorkflowExecution), ctx, newWorkflow, persistedHistory, createMode, prevRunID, prevLastWriteVersion, workflowRequestMode)
 }
 
 // GetDomainID mocks base method.
@@ -353,17 +353,17 @@ func (mr *MockContextMockRecorder) UpdateWorkflowExecutionTasks(ctx, now interfa
 }
 
 // UpdateWorkflowExecutionWithNew mocks base method.
-func (m *MockContext) UpdateWorkflowExecutionWithNew(ctx context.Context, now time.Time, updateMode persistence.UpdateWorkflowMode, newContext Context, newMutableState MutableState, currentWorkflowTransactionPolicy TransactionPolicy, newWorkflowTransactionPolicy *TransactionPolicy) error {
+func (m *MockContext) UpdateWorkflowExecutionWithNew(ctx context.Context, now time.Time, updateMode persistence.UpdateWorkflowMode, newContext Context, newMutableState MutableState, currentWorkflowTransactionPolicy TransactionPolicy, newWorkflowTransactionPolicy *TransactionPolicy, workflowRequestMode persistence.CreateWorkflowRequestMode) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithNew", ctx, now, updateMode, newContext, newMutableState, currentWorkflowTransactionPolicy, newWorkflowTransactionPolicy)
+	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithNew", ctx, now, updateMode, newContext, newMutableState, currentWorkflowTransactionPolicy, newWorkflowTransactionPolicy, workflowRequestMode)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateWorkflowExecutionWithNew indicates an expected call of UpdateWorkflowExecutionWithNew.
-func (mr *MockContextMockRecorder) UpdateWorkflowExecutionWithNew(ctx, now, updateMode, newContext, newMutableState, currentWorkflowTransactionPolicy, newWorkflowTransactionPolicy interface{}) *gomock.Call {
+func (mr *MockContextMockRecorder) UpdateWorkflowExecutionWithNew(ctx, now, updateMode, newContext, newMutableState, currentWorkflowTransactionPolicy, newWorkflowTransactionPolicy, workflowRequestMode interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithNew", reflect.TypeOf((*MockContext)(nil).UpdateWorkflowExecutionWithNew), ctx, now, updateMode, newContext, newMutableState, currentWorkflowTransactionPolicy, newWorkflowTransactionPolicy)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithNew", reflect.TypeOf((*MockContext)(nil).UpdateWorkflowExecutionWithNew), ctx, now, updateMode, newContext, newMutableState, currentWorkflowTransactionPolicy, newWorkflowTransactionPolicy, workflowRequestMode)
 }
 
 // UpdateWorkflowExecutionWithNewAsActive mocks base method.

--- a/service/history/execution/history_builder_test.go
+++ b/service/history/execution/history_builder_test.go
@@ -1066,6 +1066,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowExternalCancellationRequ
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateWorkflowExecutionCancelRequestedEvent(cancellationEvent, 5, "cancel workflow", "identity", nil, types.WorkflowExecution{}, "b071cbe8-3a95-4223-a8ac-f308a42db383")
 	s.Equal(int64(6), s.getNextEventID())
+	_, exists := s.msBuilder.(*mutableStateBuilder).workflowRequests[persistence.WorkflowRequest{
+		RequestID:   "b071cbe8-3a95-4223-a8ac-f308a42db383",
+		RequestType: persistence.WorkflowRequestTypeCancel,
+		Version:     s.msBuilder.GetCurrentVersion(),
+	}]
+	s.True(exists)
 }
 
 func (s *historyBuilderSuite) TestHistoryBuilderWorkflowExternalSignaled() {
@@ -1126,6 +1132,12 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowExternalSignaled() {
 	s.Nil(s.msBuilder.FlushBufferedEvents())
 	s.validateWorkflowExecutionSignaledEvent(signalEvent, 5, "test-signal", []byte("input"), "id", "3b8d0ec2-e1ff-4f61-915b-1ffca831361e")
 	s.Equal(int64(6), s.getNextEventID())
+	_, exists := s.msBuilder.(*mutableStateBuilder).workflowRequests[persistence.WorkflowRequest{
+		RequestID:   "3b8d0ec2-e1ff-4f61-915b-1ffca831361e",
+		RequestType: persistence.WorkflowRequestTypeSignal,
+		Version:     s.msBuilder.GetCurrentVersion(),
+	}]
+	s.True(exists)
 }
 func (s *historyBuilderSuite) getNextEventID() int64 {
 	return s.msBuilder.GetExecutionInfo().NextEventID

--- a/service/history/execution/history_builder_test.go
+++ b/service/history/execution/history_builder_test.go
@@ -560,6 +560,67 @@ func (s *historyBuilderSuite) TestHistoryBuilderDecisionScheduledTimedout() {
 	s.Equal(int64(4), s.getNextEventID())
 }
 
+func (s *historyBuilderSuite) TestHistoryBuilderDecisionStartedTimedout() {
+	id := "historybuilder-decisionscheduled-failures-test-workflow-id"
+	rid := "historybuilder-decisionscheduled-failures-test-run-id"
+	wt := "historybuilder-decisionscheduled-failures-type"
+	tl := "historybuilder-decisionscheduled-failures-tasklist"
+	identity := "historybuilder-decisionscheduled-failures-worker"
+	input := []byte("historybuilder-decisionscheduled-failures-input")
+	execTimeout := int32(60)
+	taskTimeout := int32(10)
+	we := types.WorkflowExecution{
+		WorkflowID: id,
+		RunID:      rid,
+	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
+
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(we, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, wt, tl, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.Equal(int64(2), s.getNextEventID())
+
+	di := s.addDecisionTaskScheduledEvent()
+	s.validateDecisionTaskScheduledEvent(di, 2, tl, taskTimeout)
+	s.Equal(int64(3), s.getNextEventID())
+	di0, decisionRunning0 := s.msBuilder.GetDecisionInfo(2)
+	s.True(decisionRunning0)
+	s.Equal(common.EmptyEventID, di0.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
+
+	decisionStartedEvent := s.addDecisionTaskStartedEvent(2, tl, identity)
+	s.validateDecisionTaskStartedEvent(decisionStartedEvent, 3, 2, identity)
+	s.Equal(int64(4), s.getNextEventID())
+	decisionInfo, decisionRunning := s.msBuilder.GetDecisionInfo(2)
+	s.True(decisionRunning)
+	s.NotNil(decisionInfo)
+	s.Equal(int64(2), decisionInfo.ScheduleID)
+	s.Equal(int64(3), decisionInfo.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
+
+	decisionTimeoutEvent := s.addDecisionTaskStartedTimedOutEvent(2, 3)
+	s.NotNil(decisionTimeoutEvent)
+	s.validateDecisionTaskTimedoutEvent(decisionTimeoutEvent, 4, 2, 3, types.TimeoutTypeStartToClose, "", "", common.EmptyVersion, "", types.DecisionTaskTimedOutCauseTimeout)
+	s.Equal(int64(5), s.getNextEventID())
+
+	di2 := s.addDecisionTaskScheduledEvent()
+	s.validateDecisionTaskScheduledEvent(di2, 5, tl, taskTimeout)
+	s.Equal(int64(5), s.getNextEventID())
+	di1, decisionRunning1 := s.msBuilder.GetDecisionInfo(5)
+	s.True(decisionRunning1)
+	s.Equal(int64(1), di1.Attempt)
+	s.Equal(common.EmptyEventID, di1.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
+
+	decisionStartedEvent = s.addDecisionTaskStartedEvent(5, tl, identity)
+	s.Nil(decisionStartedEvent)
+	s.Equal(int64(5), s.getNextEventID())
+
+	decisionTimeoutEvent = s.addDecisionTaskStartedTimedOutEvent(5, 6)
+	s.Equal(int64(5), s.getNextEventID())
+}
+
 func (s *historyBuilderSuite) TestHistoryBuilderDecisionStartedFailures() {
 	id := "historybuilder-decisionstarted-failures-test-workflow-id"
 	rid := "historybuilder-decisionstarted-failures-test-run-id"
@@ -939,7 +1000,83 @@ func (s *historyBuilderSuite) TestHistoryBuilderWorkflowCancellationFailed() {
 	s.Equal(int64(7), s.getNextEventID())
 }
 
-func (s *historyBuilderSuite) TestHistoryBuilder_DecisionTaskTimedOut() {
+func (s *historyBuilderSuite) TestHistoryBuilder_DecisionTaskResetTimedOut() {
+	workflowType := "some random workflow type"
+	tasklist := "some random tasklist"
+	identity := "some random identity"
+	input := []byte("some random workflow input")
+	execTimeout := int32(60)
+	taskTimeout := int32(10)
+	workflowExecution := types.WorkflowExecution{
+		WorkflowID: "some random workflow ID",
+		RunID:      uuid.New(),
+	}
+	partitionConfig := map[string]string{
+		"zone": "dca1",
+	}
+
+	workflowStartedEvent := s.addWorkflowExecutionStartedEvent(workflowExecution, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.validateWorkflowExecutionStartedEvent(workflowStartedEvent, workflowType, tasklist, input, execTimeout, taskTimeout, identity, partitionConfig)
+	s.Equal(int64(2), s.getNextEventID())
+
+	decisionInfo := s.addDecisionTaskScheduledEvent()
+	s.validateDecisionTaskScheduledEvent(decisionInfo, 2, tasklist, taskTimeout)
+	s.Equal(int64(3), s.getNextEventID())
+	decisionInfo, decisionRunning := s.msBuilder.GetDecisionInfo(2)
+	s.True(decisionRunning)
+	s.NotNil(decisionInfo)
+	s.Equal(int64(2), decisionInfo.ScheduleID)
+	s.Equal(common.EmptyEventID, decisionInfo.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
+
+	decisionStartedEvent := s.addDecisionTaskStartedEvent(2, tasklist, identity)
+	s.validateDecisionTaskStartedEvent(decisionStartedEvent, 3, 2, identity)
+	s.Equal(int64(4), s.getNextEventID())
+	decisionInfo, decisionRunning = s.msBuilder.GetDecisionInfo(2)
+	s.True(decisionRunning)
+	s.NotNil(decisionInfo)
+	s.Equal(int64(2), decisionInfo.ScheduleID)
+	s.Equal(int64(3), decisionInfo.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
+
+	baseRunID := uuid.New()
+	newRunID := uuid.New()
+	forkVersion := int64(10)
+	resetRequestID := uuid.New()
+	decisionFailedEvent, err := s.msBuilder.AddDecisionTaskFailedEvent(2, 3, types.DecisionTaskFailedCauseResetWorkflow, nil, identity, "", "", baseRunID, newRunID, forkVersion, resetRequestID)
+	s.NoError(err)
+	s.NotNil(decisionFailedEvent.GetDecisionTaskFailedEventAttributes())
+	s.Equal(baseRunID, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetBaseRunID())
+	s.Equal(newRunID, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetNewRunID())
+	s.Equal(forkVersion, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetForkEventVersion())
+	s.Equal(resetRequestID, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetRequestID())
+	s.Equal(int64(5), s.getNextEventID())
+
+	decisionInfo = s.addDecisionTaskScheduledEvent()
+	s.validateDecisionTaskScheduledEvent(decisionInfo, 5, tasklist, taskTimeout)
+	s.Equal(int64(6), s.getNextEventID())
+
+	decisionStartedEvent = s.addDecisionTaskStartedEvent(5, tasklist, identity)
+	s.validateDecisionTaskStartedEvent(decisionStartedEvent, 6, 5, identity)
+	s.Equal(int64(7), s.getNextEventID())
+	decisionInfo, decisionRunning = s.msBuilder.GetDecisionInfo(5)
+	s.True(decisionRunning)
+	s.NotNil(decisionInfo)
+	s.Equal(int64(5), decisionInfo.ScheduleID)
+	s.Equal(int64(6), decisionInfo.StartedID)
+	s.Equal(common.EmptyEventID, s.getPreviousDecisionStartedEventID())
+
+	decisionFailedEvent, err = s.msBuilder.AddDecisionTaskFailedEvent(5, 6, types.DecisionTaskFailedCauseResetWorkflow, nil, identity, "", "", baseRunID, newRunID, forkVersion, resetRequestID)
+	s.NoError(err)
+	s.NotNil(decisionFailedEvent.GetDecisionTaskFailedEventAttributes())
+	s.Equal(baseRunID, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetBaseRunID())
+	s.Equal(newRunID, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetNewRunID())
+	s.Equal(forkVersion, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetForkEventVersion())
+	s.Equal(resetRequestID, decisionFailedEvent.GetDecisionTaskFailedEventAttributes().GetRequestID())
+	s.Equal(int64(8), s.getNextEventID())
+}
+
+func (s *historyBuilderSuite) TestHistoryBuilder_DecisionTaskResetFailed() {
 	workflowType := "some random workflow type"
 	tasklist := "some random tasklist"
 	identity := "some random identity"
@@ -1215,6 +1352,15 @@ func (s *historyBuilderSuite) addDecisionTaskTimedOutEvent(
 	scheduleID int64,
 ) *types.HistoryEvent {
 	event, err := s.msBuilder.AddDecisionTaskScheduleToStartTimeoutEvent(scheduleID)
+	s.Nil(err)
+	return event
+}
+
+func (s *historyBuilderSuite) addDecisionTaskStartedTimedOutEvent(
+	scheduleID int64,
+	startID int64,
+) *types.HistoryEvent {
+	event, err := s.msBuilder.AddDecisionTaskTimedOutEvent(scheduleID, startID)
 	s.Nil(err)
 	return event
 }

--- a/service/history/execution/mutable_state.go
+++ b/service/history/execution/mutable_state.go
@@ -183,10 +183,10 @@ type (
 		ReplicateChildWorkflowExecutionTerminatedEvent(*types.HistoryEvent) error
 		ReplicateChildWorkflowExecutionTimedOutEvent(*types.HistoryEvent) error
 		ReplicateDecisionTaskCompletedEvent(*types.HistoryEvent) error
-		ReplicateDecisionTaskFailedEvent() error
+		ReplicateDecisionTaskFailedEvent(*types.HistoryEvent) error
 		ReplicateDecisionTaskScheduledEvent(int64, int64, string, int32, int64, int64, int64, bool) (*DecisionInfo, error)
 		ReplicateDecisionTaskStartedEvent(*DecisionInfo, int64, int64, int64, string, int64) (*DecisionInfo, error)
-		ReplicateDecisionTaskTimedOutEvent(types.TimeoutType) error
+		ReplicateDecisionTaskTimedOutEvent(*types.HistoryEvent) error
 		ReplicateExternalWorkflowExecutionCancelRequested(*types.HistoryEvent) error
 		ReplicateExternalWorkflowExecutionSignaled(*types.HistoryEvent) error
 		ReplicateRequestCancelExternalWorkflowExecutionFailedEvent(*types.HistoryEvent) error

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -149,6 +149,8 @@ type (
 		insertReplicationTasks  []persistence.Task
 		insertTimerTasks        []persistence.Task
 
+		workflowRequests map[persistence.WorkflowRequest]struct{}
+
 		// do not rely on this, this is only updated on
 		// Load() and closeTransactionXXX methods. So when
 		// a transaction is in progress, this value will be
@@ -232,6 +234,8 @@ func newMutableStateBuilder(
 		timeSource:      shard.GetTimeSource(),
 		logger:          logger,
 		metricsClient:   shard.GetMetricsClient(),
+
+		workflowRequests: make(map[persistence.WorkflowRequest]struct{}),
 	}
 	s.executionInfo = &persistence.WorkflowExecutionInfo{
 		DecisionVersion:    common.EmptyVersion,
@@ -1800,7 +1804,15 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(
 ) error {
 
 	event := startEvent.WorkflowExecutionStartedEventAttributes
+	if event.GetRequestID() != "" {
+		requestID = event.GetRequestID()
+	}
 	e.executionInfo.CreateRequestID = requestID
+	e.insertWorkflowRequest(persistence.WorkflowRequest{
+		RequestID:   requestID,
+		Version:     startEvent.Version,
+		RequestType: persistence.WorkflowRequestTypeStart,
+	})
 	e.executionInfo.DomainID = e.domainEntry.GetInfo().ID
 	e.executionInfo.WorkflowID = execution.GetWorkflowID()
 	e.executionInfo.RunID = execution.GetRunID()
@@ -2083,9 +2095,9 @@ func (e *mutableStateBuilder) AddDecisionTaskTimedOutEvent(
 }
 
 func (e *mutableStateBuilder) ReplicateDecisionTaskTimedOutEvent(
-	timeoutType types.TimeoutType,
+	event *types.HistoryEvent,
 ) error {
-	return e.decisionTaskManager.ReplicateDecisionTaskTimedOutEvent(timeoutType)
+	return e.decisionTaskManager.ReplicateDecisionTaskTimedOutEvent(event)
 }
 
 func (e *mutableStateBuilder) AddDecisionTaskScheduleToStartTimeoutEvent(
@@ -2152,8 +2164,8 @@ func (e *mutableStateBuilder) AddDecisionTaskFailedEvent(
 	)
 }
 
-func (e *mutableStateBuilder) ReplicateDecisionTaskFailedEvent() error {
-	return e.decisionTaskManager.ReplicateDecisionTaskFailedEvent()
+func (e *mutableStateBuilder) ReplicateDecisionTaskFailedEvent(event *types.HistoryEvent) error {
+	return e.decisionTaskManager.ReplicateDecisionTaskFailedEvent(event)
 }
 
 func (e *mutableStateBuilder) AddActivityTaskScheduledEvent(
@@ -2800,9 +2812,6 @@ func (e *mutableStateBuilder) AddWorkflowExecutionCancelRequestedEvent(
 	if err := e.ReplicateWorkflowExecutionCancelRequestedEvent(event); err != nil {
 		return nil, err
 	}
-
-	// Set the CancelRequestID on the active cluster.  This information is not part of the history event.
-	e.executionInfo.CancelRequestID = request.CancelRequest.GetRequestID()
 	return event, nil
 }
 
@@ -2811,6 +2820,13 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionCancelRequestedEvent(
 ) error {
 
 	e.executionInfo.CancelRequested = true
+	requestID := event.WorkflowExecutionCancelRequestedEventAttributes.RequestID
+	e.executionInfo.CancelRequestID = requestID
+	e.insertWorkflowRequest(persistence.WorkflowRequest{
+		RequestID:   requestID,
+		Version:     event.Version,
+		RequestType: persistence.WorkflowRequestTypeCancel,
+	})
 	return nil
 }
 
@@ -3364,6 +3380,11 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionSignaled(
 
 	// Increment signal count in mutable state for this workflow execution
 	e.executionInfo.SignalCount++
+	e.insertWorkflowRequest(persistence.WorkflowRequest{
+		RequestID:   event.WorkflowExecutionSignaledEventAttributes.RequestID,
+		Version:     event.Version,
+		RequestType: persistence.WorkflowRequestTypeSignal,
+	})
 	return nil
 }
 
@@ -4117,6 +4138,8 @@ func (e *mutableStateBuilder) CloseTransactionAsMutation(
 		ReplicationTasks:  e.insertReplicationTasks,
 		TimerTasks:        e.insertTimerTasks,
 
+		WorkflowRequests: convertWorkflowRequests(e.workflowRequests),
+
 		Condition: e.nextEventIDInDB,
 		Checksum:  checksum,
 	}
@@ -4194,6 +4217,8 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 		CrossClusterTasks: e.insertCrossClusterTasks,
 		ReplicationTasks:  e.insertReplicationTasks,
 		TimerTasks:        e.insertTimerTasks,
+
+		WorkflowRequests: convertWorkflowRequests(e.workflowRequests),
 
 		Condition: e.nextEventIDInDB,
 		Checksum:  checksum,
@@ -4304,6 +4329,7 @@ func (e *mutableStateBuilder) cleanupTransaction() error {
 	e.insertReplicationTasks = nil
 	e.insertTimerTasks = nil
 
+	e.workflowRequests = make(map[persistence.WorkflowRequest]struct{})
 	return nil
 }
 
@@ -4751,6 +4777,15 @@ func (e *mutableStateBuilder) checkMutability(
 		return ErrWorkflowFinished
 	}
 	return nil
+}
+
+func (e *mutableStateBuilder) insertWorkflowRequest(request persistence.WorkflowRequest) {
+	if e.domainEntry != nil && e.config.EnableStrongIdempotency(e.domainEntry.GetInfo().Name) && request.RequestID != "" {
+		if _, ok := e.workflowRequests[request]; ok {
+			e.logWarn("error encountering duplicate request", tag.WorkflowRequestID(request.RequestID))
+		}
+		e.workflowRequests[request] = struct{}{}
+	}
 }
 
 func (e *mutableStateBuilder) generateChecksum() checksum.Checksum {

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1805,6 +1805,8 @@ func (e *mutableStateBuilder) ReplicateWorkflowExecutionStartedEvent(
 
 	event := startEvent.WorkflowExecutionStartedEventAttributes
 	if event.GetRequestID() != "" {
+		// prefer requestID from history event, ideally we should remove the requestID parameter
+		// removing it may or may not be backward compatible, so keep it now
 		requestID = event.GetRequestID()
 	}
 	e.executionInfo.CreateRequestID = requestID

--- a/service/history/execution/mutable_state_decision_task_manager_mock.go
+++ b/service/history/execution/mutable_state_decision_task_manager_mock.go
@@ -348,17 +348,17 @@ func (mr *MockmutableStateDecisionTaskManagerMockRecorder) ReplicateDecisionTask
 }
 
 // ReplicateDecisionTaskFailedEvent mocks base method.
-func (m *MockmutableStateDecisionTaskManager) ReplicateDecisionTaskFailedEvent() error {
+func (m *MockmutableStateDecisionTaskManager) ReplicateDecisionTaskFailedEvent(arg0 *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateDecisionTaskFailedEvent")
+	ret := m.ctrl.Call(m, "ReplicateDecisionTaskFailedEvent", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReplicateDecisionTaskFailedEvent indicates an expected call of ReplicateDecisionTaskFailedEvent.
-func (mr *MockmutableStateDecisionTaskManagerMockRecorder) ReplicateDecisionTaskFailedEvent() *gomock.Call {
+func (mr *MockmutableStateDecisionTaskManagerMockRecorder) ReplicateDecisionTaskFailedEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateDecisionTaskFailedEvent", reflect.TypeOf((*MockmutableStateDecisionTaskManager)(nil).ReplicateDecisionTaskFailedEvent))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateDecisionTaskFailedEvent", reflect.TypeOf((*MockmutableStateDecisionTaskManager)(nil).ReplicateDecisionTaskFailedEvent), arg0)
 }
 
 // ReplicateDecisionTaskScheduledEvent mocks base method.
@@ -392,17 +392,17 @@ func (mr *MockmutableStateDecisionTaskManagerMockRecorder) ReplicateDecisionTask
 }
 
 // ReplicateDecisionTaskTimedOutEvent mocks base method.
-func (m *MockmutableStateDecisionTaskManager) ReplicateDecisionTaskTimedOutEvent(timeoutType types.TimeoutType) error {
+func (m *MockmutableStateDecisionTaskManager) ReplicateDecisionTaskTimedOutEvent(arg0 *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateDecisionTaskTimedOutEvent", timeoutType)
+	ret := m.ctrl.Call(m, "ReplicateDecisionTaskTimedOutEvent", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReplicateDecisionTaskTimedOutEvent indicates an expected call of ReplicateDecisionTaskTimedOutEvent.
-func (mr *MockmutableStateDecisionTaskManagerMockRecorder) ReplicateDecisionTaskTimedOutEvent(timeoutType interface{}) *gomock.Call {
+func (mr *MockmutableStateDecisionTaskManagerMockRecorder) ReplicateDecisionTaskTimedOutEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateDecisionTaskTimedOutEvent", reflect.TypeOf((*MockmutableStateDecisionTaskManager)(nil).ReplicateDecisionTaskTimedOutEvent), timeoutType)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateDecisionTaskTimedOutEvent", reflect.TypeOf((*MockmutableStateDecisionTaskManager)(nil).ReplicateDecisionTaskTimedOutEvent), arg0)
 }
 
 // ReplicateTransientDecisionTaskScheduled mocks base method.

--- a/service/history/execution/mutable_state_mock.go
+++ b/service/history/execution/mutable_state_mock.go
@@ -2040,17 +2040,17 @@ func (mr *MockMutableStateMockRecorder) ReplicateDecisionTaskCompletedEvent(arg0
 }
 
 // ReplicateDecisionTaskFailedEvent mocks base method.
-func (m *MockMutableState) ReplicateDecisionTaskFailedEvent() error {
+func (m *MockMutableState) ReplicateDecisionTaskFailedEvent(arg0 *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReplicateDecisionTaskFailedEvent")
+	ret := m.ctrl.Call(m, "ReplicateDecisionTaskFailedEvent", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // ReplicateDecisionTaskFailedEvent indicates an expected call of ReplicateDecisionTaskFailedEvent.
-func (mr *MockMutableStateMockRecorder) ReplicateDecisionTaskFailedEvent() *gomock.Call {
+func (mr *MockMutableStateMockRecorder) ReplicateDecisionTaskFailedEvent(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateDecisionTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateDecisionTaskFailedEvent))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReplicateDecisionTaskFailedEvent", reflect.TypeOf((*MockMutableState)(nil).ReplicateDecisionTaskFailedEvent), arg0)
 }
 
 // ReplicateDecisionTaskScheduledEvent mocks base method.
@@ -2084,7 +2084,7 @@ func (mr *MockMutableStateMockRecorder) ReplicateDecisionTaskStartedEvent(arg0, 
 }
 
 // ReplicateDecisionTaskTimedOutEvent mocks base method.
-func (m *MockMutableState) ReplicateDecisionTaskTimedOutEvent(arg0 types.TimeoutType) error {
+func (m *MockMutableState) ReplicateDecisionTaskTimedOutEvent(arg0 *types.HistoryEvent) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReplicateDecisionTaskTimedOutEvent", arg0)
 	ret0, _ := ret[0].(error)

--- a/service/history/execution/mutable_state_util.go
+++ b/service/history/execution/mutable_state_util.go
@@ -205,6 +205,15 @@ func convertUpdateSignalInfos(
 	return outputs
 }
 
+func convertWorkflowRequests(inputs map[persistence.WorkflowRequest]struct{}) []*persistence.WorkflowRequest {
+	outputs := make([]*persistence.WorkflowRequest, 0, len(inputs))
+	for key := range inputs {
+		key := key // TODO: remove this trick once we upgrade go to 1.22
+		outputs = append(outputs, &key)
+	}
+	return outputs
+}
+
 // FailDecision fails the current decision task
 func FailDecision(
 	mutableState MutableState,

--- a/service/history/execution/mutable_state_util_test.go
+++ b/service/history/execution/mutable_state_util_test.go
@@ -295,3 +295,24 @@ func TestTrimBinaryChecksums(t *testing.T) {
 	assert.Equal(t, recentBinaryChecksums, trimedBinaryChecksums)
 	assert.Equal(t, currResetPoints, trimedResetPoints)
 }
+
+func TestConvertWorkflowRequests(t *testing.T) {
+	inputs := map[persistence.WorkflowRequest]struct{}{}
+	inputs[persistence.WorkflowRequest{RequestID: "aaa", Version: 1, RequestType: persistence.WorkflowRequestTypeStart}] = struct{}{}
+	inputs[persistence.WorkflowRequest{RequestID: "aaa", Version: 1, RequestType: persistence.WorkflowRequestTypeSignal}] = struct{}{}
+
+	expectedOutputs := []*persistence.WorkflowRequest{
+		{
+			RequestID:   "aaa",
+			Version:     1,
+			RequestType: persistence.WorkflowRequestTypeStart,
+		},
+		{
+			RequestID:   "aaa",
+			Version:     1,
+			RequestType: persistence.WorkflowRequestTypeSignal,
+		},
+	}
+
+	assert.ElementsMatch(t, expectedOutputs, convertWorkflowRequests(inputs))
+}

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -195,7 +195,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 		case types.EventTypeDecisionTaskTimedOut:
 			if err := b.mutableState.ReplicateDecisionTaskTimedOutEvent(
-				event.DecisionTaskTimedOutEventAttributes.GetTimeoutType(),
+				event,
 			); err != nil {
 				return nil, err
 			}
@@ -207,7 +207,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 			}
 
 		case types.EventTypeDecisionTaskFailed:
-			if err := b.mutableState.ReplicateDecisionTaskFailedEvent(); err != nil {
+			if err := b.mutableState.ReplicateDecisionTaskFailedEvent(event); err != nil {
 				return nil, err
 			}
 

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -706,7 +706,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeDecisionTaskTimedOut() {
 			TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
 		},
 	}
-	s.mockMutableState.EXPECT().ReplicateDecisionTaskTimedOutEvent(types.TimeoutTypeStartToClose).Return(nil).Times(1)
+	s.mockMutableState.EXPECT().ReplicateDecisionTaskTimedOutEvent(event).Return(nil).Times(1)
 	tasklist := "some random tasklist"
 	executionInfo := &persistence.WorkflowExecutionInfo{
 		TaskList: tasklist,
@@ -743,7 +743,7 @@ func (s *stateBuilderSuite) TestApplyEvents_EventTypeDecisionTaskFailed() {
 			StartedEventID:   startedID,
 		},
 	}
-	s.mockMutableState.EXPECT().ReplicateDecisionTaskFailedEvent().Return(nil).Times(1)
+	s.mockMutableState.EXPECT().ReplicateDecisionTaskFailedEvent(event).Return(nil).Times(1)
 	tasklist := "some random tasklist"
 	executionInfo := &persistence.WorkflowExecutionInfo{
 		TaskList: tasklist,

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -180,7 +180,7 @@ func (r *stateRebuilderImpl) Rebuild(
 		}
 	}
 
-	// close rebuilt mutable state transaction clearing all generated tasks, etc.
+	// close rebuilt mutable state transaction clearing all generated tasks, workflow requests, etc.
 	_, _, err = rebuiltMutableState.CloseTransactionAsSnapshot(now, TransactionPolicyPassive)
 	if err != nil {
 		return nil, 0, err

--- a/service/history/ndc/activity_replicator.go
+++ b/service/history/ndc/activity_replicator.go
@@ -204,6 +204,7 @@ func (r *activityReplicatorImpl) SyncActivity(
 		nil, // no new workflow
 		execution.TransactionPolicyPassive,
 		nil,
+		persistence.CreateWorkflowRequestModeReplicated,
 	)
 }
 

--- a/service/history/ndc/activity_replicator_test.go
+++ b/service/history/ndc/activity_replicator_test.go
@@ -1143,6 +1143,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning() {
 		nil,
 		execution.TransactionPolicyPassive,
 		nil,
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 	err = s.activityReplicator.SyncActivity(ctx.Background(), request)
 	s.NoError(err)
@@ -1230,6 +1231,7 @@ func (s *activityReplicatorSuite) TestSyncActivity_ActivityRunning_ZombieWorkflo
 		nil,
 		execution.TransactionPolicyPassive,
 		nil,
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 	err = s.activityReplicator.SyncActivity(ctx.Background(), request)
 	s.NoError(err)

--- a/service/history/ndc/events_reapplier.go
+++ b/service/history/ndc/events_reapplier.go
@@ -100,7 +100,7 @@ func (r *eventsReapplierImpl) ReapplyEvents(
 			signal.GetSignalName(),
 			signal.GetInput(),
 			signal.GetIdentity(),
-			signal.GetRequestID(),
+			"", // Do not set requestID for requests reapplied, because they have already been applied previously
 		); err != nil {
 			return nil, err
 		}

--- a/service/history/ndc/events_reapplier_test.go
+++ b/service/history/ndc/events_reapplier_test.go
@@ -97,7 +97,7 @@ func (s *eventReapplicationSuite) TestReapplyEvents_AppliedEvent() {
 		attr.GetSignalName(),
 		attr.GetInput(),
 		attr.GetIdentity(),
-		attr.GetRequestID(),
+		"",
 	).Return(event, nil).Times(1)
 	dedupResource := definition.NewEventReappliedID(runID, event.ID, event.Version)
 	msBuilderCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(false).Times(1)
@@ -170,7 +170,7 @@ func (s *eventReapplicationSuite) TestReapplyEvents_PartialAppliedEvent() {
 		attr1.GetSignalName(),
 		attr1.GetInput(),
 		attr1.GetIdentity(),
-		attr1.GetRequestID(),
+		"",
 	).Return(event1, nil).Times(1)
 	dedupResource1 := definition.NewEventReappliedID(runID, event1.ID, event1.Version)
 	msBuilderCurrent.EXPECT().IsResourceDuplicated(dedupResource1).Return(false).Times(1)
@@ -212,7 +212,7 @@ func (s *eventReapplicationSuite) TestReapplyEvents_Error() {
 		attr.GetSignalName(),
 		attr.GetInput(),
 		attr.GetIdentity(),
-		attr.GetRequestID(),
+		"",
 	).Return(nil, fmt.Errorf("test")).Times(1)
 	dedupResource := definition.NewEventReappliedID(runID, event.ID, event.Version)
 	msBuilderCurrent.EXPECT().IsResourceDuplicated(dedupResource).Return(false).Times(1)

--- a/service/history/ndc/existing_workflow_transaction_manager.go
+++ b/service/history/ndc/existing_workflow_transaction_manager.go
@@ -316,6 +316,7 @@ func (r *transactionManagerForExistingWorkflowImpl) updateAsZombie(
 		newMutableState,
 		execution.TransactionPolicyPassive,
 		newTransactionPolicy,
+		persistence.CreateWorkflowRequestModeReplicated,
 	)
 }
 

--- a/service/history/ndc/existing_workflow_transaction_manager_test.go
+++ b/service/history/ndc/existing_workflow_transaction_manager_test.go
@@ -344,6 +344,7 @@ func (s *transactionManagerForExistingWorkflowSuite) TestDispatchForExistingWork
 		newMutableState,
 		execution.TransactionPolicyPassive,
 		execution.TransactionPolicyPassive.Ptr(),
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 
 	err := s.updateMgr.dispatchForExistingWorkflow(ctx, now, isWorkflowRebuilt, targetWorkflow, newWorkflow)
@@ -416,6 +417,7 @@ func (s *transactionManagerForExistingWorkflowSuite) TestDispatchForExistingWork
 		(execution.MutableState)(nil),
 		execution.TransactionPolicyPassive,
 		(*execution.TransactionPolicy)(nil),
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 
 	err := s.updateMgr.dispatchForExistingWorkflow(ctx, now, isWorkflowRebuilt, targetWorkflow, newWorkflow)

--- a/service/history/ndc/new_workflow_transaction_manager.go
+++ b/service/history/ndc/new_workflow_transaction_manager.go
@@ -192,6 +192,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 			createMode,
 			prevRunID,
 			prevLastWriteVersion,
+			persistence.CreateWorkflowRequestModeReplicated,
 		)
 	}
 
@@ -206,6 +207,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsCurrent(
 		createMode,
 		prevRunID,
 		prevLastWriteVersion,
+		persistence.CreateWorkflowRequestModeReplicated,
 	)
 }
 
@@ -276,6 +278,7 @@ func (r *transactionManagerForNewWorkflowImpl) createAsZombie(
 		createMode,
 		prevRunID,
 		prevLastWriteVersion,
+		persistence.CreateWorkflowRequestModeReplicated,
 	)
 	switch err.(type) {
 	case nil:
@@ -313,6 +316,7 @@ func (r *transactionManagerForNewWorkflowImpl) suppressCurrentAndCreateAsCurrent
 		targetWorkflow.GetMutableState(),
 		currentWorkflowPolicy,
 		execution.TransactionPolicyPassive.Ptr(),
+		persistence.CreateWorkflowRequestModeReplicated,
 	)
 }
 

--- a/service/history/ndc/new_workflow_transaction_manager_test.go
+++ b/service/history/ndc/new_workflow_transaction_manager_test.go
@@ -145,6 +145,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Brand
 		persistence.CreateWorkflowModeBrandNew,
 		"",
 		int64(0),
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 
 	err := s.createManager.dispatchForNewWorkflow(ctx, now, workflow)
@@ -223,6 +224,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 		persistence.CreateWorkflowModeWorkflowIDReuse,
 		currentRunID,
 		currentLastWriteVersion,
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 
 	err := s.createManager.dispatchForNewWorkflow(ctx, now, targetWorkflow)
@@ -298,6 +300,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 		persistence.CreateWorkflowModeZombie,
 		"",
 		int64(0),
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 	targetContext.EXPECT().ReapplyEvents(targetWorkflowEventsSeq).Return(nil).Times(1)
 
@@ -374,6 +377,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Creat
 		persistence.CreateWorkflowModeZombie,
 		"",
 		int64(0),
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(&persistence.WorkflowExecutionAlreadyStartedError{}).Times(1)
 	targetContext.EXPECT().ReapplyEvents(targetWorkflowEventsSeq).Return(nil).Times(1)
 
@@ -434,6 +438,7 @@ func (s *transactionManagerForNewWorkflowSuite) TestDispatchForNewWorkflow_Suppr
 		targetMutableState,
 		currentWorkflowPolicy,
 		execution.TransactionPolicyPassive.Ptr(),
+		persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 
 	err := s.createManager.dispatchForNewWorkflow(ctx, now, targetWorkflow)

--- a/service/history/ndc/transaction_manager.go
+++ b/service/history/ndc/transaction_manager.go
@@ -261,6 +261,7 @@ func (r *transactionManagerImpl) backfillWorkflow(
 		nil,
 		transactionPolicy,
 		nil,
+		persistence.CreateWorkflowRequestModeReplicated,
 	)
 }
 

--- a/service/history/ndc/transaction_manager_test.go
+++ b/service/history/ndc/transaction_manager_test.go
@@ -162,7 +162,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Op
 	mutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{RunID: runID}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyActive, (*execution.TransactionPolicy)(nil),
+		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyActive, (*execution.TransactionPolicy)(nil), persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 	err := s.transactionManager.backfillWorkflow(ctx, now, workflow, workflowEvents)
 	s.NoError(err)
@@ -236,7 +236,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Active_Cl
 
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
+		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil), persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 
 	err := s.transactionManager.backfillWorkflow(ctx, now, workflow, workflowEvents)
@@ -269,7 +269,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_O
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
+		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil), persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 	err := s.transactionManager.backfillWorkflow(ctx, now, workflow, workflowEvents)
 	s.NoError(err)
@@ -316,7 +316,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_CurrentWorkflow_Passive_C
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
+		gomock.Any(), now, persistence.UpdateWorkflowModeUpdateCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil), persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 
 	err := s.transactionManager.backfillWorkflow(ctx, now, workflow, workflowEvents)
@@ -370,7 +370,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Active
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
+		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil), persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 	err := s.transactionManager.backfillWorkflow(ctx, now, workflow, workflowEvents)
 	s.NoError(err)
@@ -422,7 +422,7 @@ func (s *transactionManagerSuite) TestBackfillWorkflow_NotCurrentWorkflow_Passiv
 	context.EXPECT().ReapplyEvents([]*persistence.WorkflowEvents{workflowEvents}).Times(1)
 	context.EXPECT().PersistNonStartWorkflowBatchEvents(gomock.Any(), workflowEvents).Return(events.PersistedBlob{}, nil).Times(1)
 	context.EXPECT().UpdateWorkflowExecutionWithNew(
-		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil),
+		gomock.Any(), now, persistence.UpdateWorkflowModeBypassCurrent, nil, nil, execution.TransactionPolicyPassive, (*execution.TransactionPolicy)(nil), persistence.CreateWorkflowRequestModeReplicated,
 	).Return(nil).Times(1)
 	err := s.transactionManager.backfillWorkflow(ctx, now, workflow, workflowEvents)
 	s.NoError(err)

--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -303,6 +303,7 @@ func (r *workflowResetterImpl) persistToDB(
 		persistence.CreateWorkflowModeContinueAsNew,
 		currentRunID,
 		currentLastWriteVersion,
+		persistence.CreateWorkflowRequestModeNew,
 	)
 }
 

--- a/service/history/reset/resetter.go
+++ b/service/history/reset/resetter.go
@@ -587,7 +587,7 @@ func (r *workflowResetterImpl) reapplyEvents(
 				attr.GetSignalName(),
 				attr.GetInput(),
 				attr.GetIdentity(),
-				attr.GetRequestID(),
+				"", // Do not set requestID for requests reapplied, because they have already been applied previously
 			); err != nil {
 				return err
 			}

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -203,6 +203,7 @@ func (s *workflowResetterSuite) TestPersistToDB_CurrentNotTerminated() {
 		persistence.CreateWorkflowModeContinueAsNew,
 		s.currentRunID,
 		currentLastWriteVersion,
+		persistence.CreateWorkflowRequestModeNew,
 	).Return(nil).Times(1)
 
 	err := s.workflowResetter.persistToDB(context.Background(), currentWorkflowTerminated, currentWorkflow, resetWorkflow)

--- a/service/history/reset/resetter_test.go
+++ b/service/history/reset/resetter_test.go
@@ -642,7 +642,7 @@ func (s *workflowResetterSuite) TestReapplyEvents() {
 				attr.GetSignalName(),
 				attr.GetInput(),
 				attr.GetIdentity(),
-				attr.GetRequestID(),
+				"",
 			).Return(&types.HistoryEvent{}, nil).Times(1)
 		}
 	}

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -648,6 +648,7 @@ func (s *contextImpl) CreateWorkflowExecution(
 	case *types.WorkflowExecutionAlreadyStartedError,
 		*persistence.WorkflowExecutionAlreadyStartedError,
 		*persistence.CurrentWorkflowConditionFailedError,
+		*persistence.DuplicateRequestError,
 		*types.ServiceBusyError:
 		// No special handling required for these errors
 		// We know write to DB fails if these errors are returned
@@ -755,6 +756,7 @@ func (s *contextImpl) UpdateWorkflowExecution(
 		s.updateMaxReadLevelLocked(transferMaxReadLevel)
 		return resp, nil
 	case *persistence.ConditionFailedError,
+		*persistence.DuplicateRequestError,
 		*types.ServiceBusyError:
 		// No special handling required for these errors
 		// We know write to DB fails if these errors are returned

--- a/service/history/task/timer_standby_task_executor_test.go
+++ b/service/history/task/timer_standby_task_executor_test.go
@@ -530,8 +530,10 @@ func (s *timerStandbyTaskExecutorSuite) TestProcessActivityTimeout_Multiple_CanU
 				NewBufferedEvents:         nil,
 				ClearBufferedEvents:       false,
 				VersionHistories:          mutableState.GetVersionHistories(),
+				WorkflowRequests:          []*persistence.WorkflowRequest{},
 			},
 			NewWorkflowSnapshot: nil,
+			WorkflowRequestMode: persistence.CreateWorkflowRequestModeReplicated,
 			Encoding:            common.EncodingType(s.mockShard.GetConfig().EventEncodingType(s.domainID)),
 			DomainName:          constants.TestDomainName,
 		}, input)

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -261,6 +261,9 @@ UpdateHistoryLoop:
 		}
 
 		err = workflowContext.GetContext().UpdateWorkflowExecutionAsActive(ctx, now)
+		if _, ok := err.(*persistence.DuplicateRequestError); ok {
+			return nil
+		}
 		if execution.IsConflictError(err) {
 			if attempt != ConditionalRetryCount-1 {
 				_, err = workflowContext.ReloadMutableState(ctx)

--- a/service/history/workflow/util_test.go
+++ b/service/history/workflow/util_test.go
@@ -79,6 +79,15 @@ func TestUpdateHelper(t *testing.T) {
 				return UpdateWithoutDecision, nil
 			},
 		},
+		{
+			msg: "duplicate request",
+			mockSetupFn: func(mockContext *execution.MockContext, mockMutableState *execution.MockMutableState) {
+				mockContext.EXPECT().UpdateWorkflowExecutionAsActive(gomock.Any(), gomock.Any()).Return(&persistence.DuplicateRequestError{})
+			},
+			actionFn: func(context execution.Context, mutableState execution.MutableState) (*UpdateAction, error) {
+				return UpdateWithoutDecision, nil
+			},
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR is built on top of https://github.com/uber/cadence/pull/5826.
In this PR, we generate workflow requests from external API requests and replication events and store them in database to detect duplicated requests. If a duplicated requests is detected, a DuplicateRequestError is returned by persistence layer with the run_id telling upper layer which run the request has been applied to. And when this error is returned, the API does no-op and return the run_id to the caller.

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve idempotency of Cadence APIs

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
We have a feature flag to turn on/off this feature. And we'll rollout this feature at domain level.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
