### PR TITLE
check time type in custom search attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,23 +8,11 @@ You can find a list of previous releases on the [github releases](https://github
 
 ## [Unreleased]
 ### Added
-- Scaffold StartWorkflowExecutionAsync API (#5621)
-- Add Workflow ID cache size metric (#5619)
-- Add retries into Scanner BlobWriter (#5471)
-- Added a unit test for the BlobStoreWriter (#5472)
-- Scaffold async workflow queue provider component (#5627)
-- Add debug logs in PinotTripleVisibilityManager for response comparator testing (#5631)
-- Add a middleware for comparator to use (#5637)
-- Get/Update DomainAsyncWorkflowConfiguraton methods in admin API and CLI (#5616)
-- Added a helper script to run cassandra and execute tests (#5620)
+- Added codecov integration to report unit test coverage numbers
+- Added more unit tests to improve test coverage
 
-### Changed
-- Refactor persistence serializer tests and add more cases (#5625)
-- Replace JWT validation library (#5592)
-- Put a timeout for timer task deletion loop during shutdown (#5626)
-- Set proper max reset points (#5623)
-- Update run_cass_and_test.sh script to setup cassandra schemas (#5628)
-- Catch unit test failures in `make test` (#5635)
+## [1.2.8] - 2024-03-26
+See [Release Note](https://github.com/uber/cadence/releases/tag/v1.2.8) for details
 
 ## [1.2.7] - 2024-02-09
 See [Release Note](https://github.com/uber/cadence/releases/tag/v1.2.7) for details

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -328,14 +328,16 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 	if !ok {
 		return "", fmt.Errorf("invalid search attribute")
 	}
-	// get the value type
-	indexValType := common.ConvertIndexedValueTypeToInternalType(valType, log.NewNoop())
-
+	
 	// get the column value
 	colVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal)
 	if !ok {
 		return "", errors.New("invalid comparison expression, right")
 	}
+
+	// get the value type
+	indexValType := common.ConvertIndexedValueTypeToInternalType(valType, log.NewNoop())
+
 	// if it is dataTime, then check if it is time.Time() type
 	if indexValType == types.IndexedValueTypeDatetime {
 		var err error

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -328,7 +328,7 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 	if !ok {
 		return "", fmt.Errorf("invalid search attribute")
 	}
-	
+
 	// get the column value
 	colVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal)
 	if !ok {

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -337,17 +337,6 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 
 	// get the value type
 	indexValType := common.ConvertIndexedValueTypeToInternalType(valType, log.NewNoop())
-
-	// if it is dataTime, then check if it is time.Time() type
-	if indexValType == types.IndexedValueTypeDatetime {
-		var err error
-		colVal, err = trimTimeFieldValueFromNanoToMilliSeconds(colVal)
-		if err != nil {
-			return "", fmt.Errorf("trim time field %s got error: %w", colNameStr, err)
-		}
-	}
-	colValStr := string(colVal.Val)
-
 	operator := comparisonExpr.Operator
 
 	switch indexValType {
@@ -356,6 +345,12 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 	case types.IndexedValueTypeKeyword:
 		return processCustomKeyword(operator, colNameStr, colValStr), nil
 	case types.IndexedValueTypeDatetime:
+		var err error
+		colVal, err = trimTimeFieldValueFromNanoToMilliSeconds(colVal)
+		if err != nil {
+			return "", fmt.Errorf("trim time field %s got error: %w", colNameStr, err)
+		}
+		colValStr := string(colVal.Val)
 		return processCustomNum(operator, colNameStr, colValStr, "BIGINT"), nil
 	case types.IndexedValueTypeDouble:
 		return processCustomNum(operator, colNameStr, colValStr, "DOUBLE"), nil

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -338,6 +338,7 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 	// get the value type
 	indexValType := common.ConvertIndexedValueTypeToInternalType(valType, log.NewNoop())
 	operator := comparisonExpr.Operator
+	colValStr := string(colVal.Val)
 
 	switch indexValType {
 	case types.IndexedValueTypeString:

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -194,6 +194,14 @@ func TestValidateQuery(t *testing.T) {
 			query:     "CloseTime != missing and StartTime >= 1707662555754408145",
 			validated: "CloseTime != -1 and StartTime >= 1707662555754",
 		},
+		"Case15-17: CustomDatetimeField with big int type case": {
+			query:     "CustomDatetimeField = 1707319950000",
+			validated: "JSON_MATCH(Attr, '\"$.CustomDatetimeField\"=''1707319950000''')",
+		},
+		"Case15-18: CustomDatetimeField with time.Time() type case": {
+			query:     "CustomDatetimeField = '2024-02-07T15:32:30Z'",
+			validated: "JSON_MATCH(Attr, '\"$.CustomDatetimeField\"=''1707319950000''')",
+		},
 		"Case16-1: custom int attribute greater than or equal to": {
 			query:     "CustomIntField >= 0",
 			validated: "(JSON_MATCH(Attr, '\"$.CustomIntField\" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) >= 0)",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -202,6 +202,11 @@ func TestValidateQuery(t *testing.T) {
 			query:     "CustomDatetimeField = '2024-02-07T15:32:30Z'",
 			validated: "JSON_MATCH(Attr, '\"$.CustomDatetimeField\"=''1707319950000''')",
 		},
+		"Case15-19: CustomDatetimeField with error case": {
+			query:     "CustomDatetimeField = 'test'",
+			validated: "",
+			err:       "trim time field CustomDatetimeField got error: error: failed to parse int from SQLVal test",
+		},
 		"Case16-1: custom int attribute greater than or equal to": {
 			query:     "CustomIntField >= 0",
 			validated: "(JSON_MATCH(Attr, '\"$.CustomIntField\" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) >= 0)",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a logic to check time type in custom search attribute.

<!-- Tell your future self why have you made these changes -->
**Why?**
Previously, if there's a time.Time() type passed in, like CustomDateTimeField = '2024-02-07T15:32:30Z', there'll be an error. 
In order to handle this, I converted it before forming the pinot query. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
