### PR TITLE
Deadlock demo in acquireShards

### DIFF
--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -150,6 +150,7 @@ func (r *ring) Stop() {
 	r.subscribers.keys = make(map[string]chan<- *ChangedEvent)
 	close(r.shutdownCh)
 
+	// TODO: this can deadlock for 1m
 	if success := common.AwaitWaitGroup(&r.shutdownWG, time.Minute); !success {
 		r.logger.Warn("service resolver timed out on shutdown.")
 	}

--- a/service/history/shard/controller.go
+++ b/service/history/shard/controller.go
@@ -384,7 +384,7 @@ func (c *controller) acquireShards() {
 	defer sw.Stop()
 
 	concurrency := common.MaxInt(c.config.AcquireShardConcurrency(), 1)
-	shardActionCh := make(chan int, concurrency)
+	shardActionCh := make(chan int, concurrency) // TODO: wildly wrong, can lead to deadlock
 	var wg sync.WaitGroup
 	wg.Add(concurrency)
 	// Spawn workers that would lookup and add/remove shards concurrently.
@@ -411,6 +411,7 @@ func (c *controller) acquireShards() {
 		}()
 	}
 	// Submit tasks to the channel.
+	// TODO: can deadlock if shutting down
 	for shardID := 0; shardID < c.config.NumberOfShards; shardID++ {
 		shardActionCh <- shardID
 		if c.isShuttingDown() {

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -70,8 +70,7 @@ type (
 )
 
 func TestDeadlock(t *testing.T) {
-
-	useFix := true
+	useFix := false
 	/*
 		`try` is essentially what acquireShards() does:
 

--- a/service/history/shard/controller_test.go
+++ b/service/history/shard/controller_test.go
@@ -209,6 +209,7 @@ func TestDeadlock(t *testing.T) {
 		}
 		if time.Until(dead) < 10*time.Second {
 			t.Log("giving up early")
+			break
 		}
 	}
 }


### PR DESCRIPTION
Demo for #5823, for a flawed construct from the combination of #2888 (concurrently acquire shards) and #3134 (handle shutdown).

It's pretty obviously incorrect:
```
❯ go test -v -test.run TestDeadlock ./service/history/shard
=== RUN   TestDeadlock
    controller_test.go:193: time remaining: 9m59.498006333s, avg runtime: 499.157614ms, longest: 501.214333ms, successes: 100, fails: 0
    controller_test.go:193: time remaining: 9m58.954002708s, avg runtime: 542.559293ms, longest: 543.647833ms, successes: 100, fails: 0
    controller_test.go:193: time remaining: 9m58.434399375s, avg runtime: 518.730977ms, longest: 519.447708ms, successes: 100, fails: 0
    controller_test.go:193: time remaining: 9m57.905938917s, avg runtime: 527.407791ms, longest: 528.353042ms, successes: 100, fails: 0
...
    controller_test.go:193: time remaining: 9m50.650997167s, avg runtime: 498.004745ms, longest: 499.985292ms, successes: 100, fails: 0
    controller_test.go:193: time remaining: 9m50.172357417s, avg runtime: 477.521516ms, longest: 478.509375ms, successes: 100, fails: 0
    controller_test.go:193: time remaining: 9m49.658607167s, avg runtime: 512.926921ms, longest: 513.583542ms, successes: 100, fails: 0
    controller_test.go:193: time remaining: 9m49.151183708s, avg runtime: 504.016801ms, longest: 507.16975ms, successes: 100, fails: 0
    controller_test.go:193: time remaining: 9m48.671873833s, avg runtime: 478.087117ms, longest: 479.052208ms, successes: 100, fails: 0
    controller_test.go:147: took too long
    controller_test.go:193: time remaining: 9m38.669626958s, avg runtime: 542.430156ms, longest: 544.350417ms, successes: 99, fails: 1
                         note 10s have passed ^
         though it's reliably ~0.5s normally.
                CPU is idle during this time.
```

A cause-sequence that leads to this, starting from a full work channel:
- worker thread: worker pulls from chan
- acquire thread: ^ == shard loop pushes to refill the chan, at the same time
- acquire thread: checks shutdown, nope
- acquire thread: push to full chan, blocks
- other thread: shutdown occurs
- worker thread: worker checks shutdown, yes, returns
- and now there are no workers to pull from the full chan, so the push blocks forever

---

The fix is rather easy: buffer correctly, so the acquire thread cannot fail to notice the shutdown.
Then the test runs like:
```
    controller_test.go:205: time remaining: 8m33.72483275s, avg runtime: 12.304837ms, longest: 55.83725ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.683416958s, avg runtime: 17.070645ms, longest: 37.5345ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.634528958s, avg runtime: 15.512894ms, longest: 43.902167ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.565585208s, avg runtime: 18.193592ms, longest: 67.813334ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.50871675s, avg runtime: 10.90086ms, longest: 54.84125ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.452797208s, avg runtime: 9.594426ms, longest: 52.924791ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.394790083s, avg runtime: 15.320305ms, longest: 55.232875ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.33406525s, avg runtime: 20.083535ms, longest: 55.97175ms, successes: 100, fails: 0
    controller_test.go:205: time remaining: 8m33.273468375s, avg runtime: 31.289924ms, longest: 57.83125ms, successes: 100, fails: 0
```
goroutine-swapping and atomics add up a fair bit in these micro-benchmarks - it's >20x faster.  that's inconsequential in the real code though.