### PR TITLE
Persist workflow request ids into Cassandra

### DIFF
--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -240,6 +240,8 @@ type (
 		PreviousLastWriteVersion int64
 
 		NewWorkflowSnapshot InternalWorkflowSnapshot
+
+		WorkflowRequestMode CreateWorkflowRequestMode
 	}
 
 	// InternalGetReplicationTasksResponse is the response to GetReplicationTask
@@ -424,6 +426,8 @@ type (
 		UpdateWorkflowMutation InternalWorkflowMutation
 
 		NewWorkflowSnapshot *InternalWorkflowSnapshot
+
+		WorkflowRequestMode CreateWorkflowRequestMode
 	}
 
 	// InternalConflictResolveWorkflowExecutionRequest is used to reset workflow execution state for Persistence Interface
@@ -440,6 +444,8 @@ type (
 
 		// current workflow
 		CurrentWorkflowMutation *InternalWorkflowMutation
+
+		WorkflowRequestMode CreateWorkflowRequestMode
 	}
 
 	// InternalWorkflowMutation is used as generic workflow execution state mutation for Persistence Interface
@@ -469,6 +475,8 @@ type (
 		TimerTasks        []Task
 		ReplicationTasks  []Task
 
+		WorkflowRequests []*WorkflowRequest
+
 		Condition int64
 
 		Checksum     checksum.Checksum
@@ -493,6 +501,8 @@ type (
 		CrossClusterTasks []Task
 		TimerTasks        []Task
 		ReplicationTasks  []Task
+
+		WorkflowRequests []*WorkflowRequest
 
 		Condition int64
 

--- a/common/persistence/errors.go
+++ b/common/persistence/errors.go
@@ -22,6 +22,8 @@
 
 package persistence
 
+import "fmt"
+
 type (
 	// TimeoutError is returned when a write operation fails due to a timeout
 	TimeoutError struct {
@@ -73,7 +75,15 @@ type (
 		CloseStatus      int
 		LastWriteVersion int64
 	}
+
+	DuplicateRequestError struct {
+		RunID string
+	}
 )
+
+func (e *DuplicateRequestError) Error() string {
+	return fmt.Sprintf("Request has already been applied to runID: %s", e.RunID)
+}
 
 func (e *InvalidPersistenceRequestError) Error() string {
 	return e.Msg

--- a/common/persistence/execution_manager.go
+++ b/common/persistence/execution_manager.go
@@ -346,6 +346,8 @@ func (m *executionManagerImpl) UpdateWorkflowExecution(
 
 		UpdateWorkflowMutation: *serializedWorkflowMutation,
 		NewWorkflowSnapshot:    serializedNewWorkflowSnapshot,
+
+		WorkflowRequestMode: request.WorkflowRequestMode,
 	}
 	msuss := m.statsComputer.computeMutableStateUpdateStats(newRequest)
 	err = m.persistence.UpdateWorkflowExecution(ctx, newRequest)
@@ -563,6 +565,8 @@ func (m *executionManagerImpl) ConflictResolveWorkflowExecution(
 		NewWorkflowSnapshot: serializedNewWorkflowMutation,
 
 		CurrentWorkflowMutation: serializedCurrentWorkflowMutation,
+
+		WorkflowRequestMode: request.WorkflowRequestMode,
 	}
 	msuss := m.statsComputer.computeMutableStateConflictResolveStats(newRequest)
 	err = m.persistence.ConflictResolveWorkflowExecution(ctx, newRequest)
@@ -593,6 +597,8 @@ func (m *executionManagerImpl) CreateWorkflowExecution(
 		PreviousLastWriteVersion: request.PreviousLastWriteVersion,
 
 		NewWorkflowSnapshot: *serializedNewWorkflowSnapshot,
+
+		WorkflowRequestMode: request.WorkflowRequestMode,
 	}
 
 	msuss := m.statsComputer.computeMutableStateCreateStats(newRequest)
@@ -675,6 +681,8 @@ func (m *executionManagerImpl) SerializeWorkflowMutation(
 		ReplicationTasks:  input.ReplicationTasks,
 		TimerTasks:        input.TimerTasks,
 
+		WorkflowRequests: input.WorkflowRequests,
+
 		Condition:    input.Condition,
 		Checksum:     input.Checksum,
 		ChecksumData: checksumData,
@@ -738,6 +746,8 @@ func (m *executionManagerImpl) SerializeWorkflowSnapshot(
 		CrossClusterTasks: input.CrossClusterTasks,
 		ReplicationTasks:  input.ReplicationTasks,
 		TimerTasks:        input.TimerTasks,
+
+		WorkflowRequests: input.WorkflowRequests,
 
 		Condition:    input.Condition,
 		Checksum:     input.Checksum,

--- a/common/persistence/nosql/nosql_execution_store_test.go
+++ b/common/persistence/nosql/nosql_execution_store_test.go
@@ -53,7 +53,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 			name: "success",
 			setupMock: func(mockDB *nosqlplugin.MockDB, shardID int) {
 				mockDB.EXPECT().
-					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 			},
 			expectedResp:  &persistence.CreateWorkflowExecutionResponse{},
@@ -66,7 +66,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 					ShardRangeIDNotMatch: common.Int64Ptr(456),
 				}
 				mockDB.EXPECT().
-					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(err)
 			},
 			expectedResp: nil, // No response expected on error
@@ -89,7 +89,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 					},
 				}
 				mockDB.EXPECT().
-					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(err)
 			},
 			expectedResp: nil, // No response expected on error
@@ -109,7 +109,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 					UnknownConditionFailureDetails: common.StringPtr("Unknown error occurred during operation"),
 				}
 				mockDB.EXPECT().
-					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(err)
 			},
 			expectedResp: nil,
@@ -125,7 +125,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 					CurrentWorkflowConditionFailInfo: common.StringPtr("Current workflow condition failed"),
 				}
 				mockDB.EXPECT().
-					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(err)
 			},
 			expectedResp: nil,
@@ -140,7 +140,7 @@ func TestCreateWorkflowExecution(t *testing.T) {
 				unexpectedErr := errors.New("unexpected error type")
 				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(true).AnyTimes()
 				mockDB.EXPECT().
-					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(unexpectedErr)
 			},
 			expectedResp:  nil,
@@ -186,7 +186,7 @@ func TestUpdateWorkflowExecution(t *testing.T) {
 			name: "success",
 			setupMock: func(mockDB *nosqlplugin.MockDB, shardID int) {
 				mockDB.EXPECT().
-					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 			},
 			request:       newUpdateWorkflowExecutionRequest,
@@ -196,7 +196,7 @@ func TestUpdateWorkflowExecution(t *testing.T) {
 			name: "Success - UpdateWorkflowModeIgnoreCurrent",
 			setupMock: func(mockDB *nosqlplugin.MockDB, shardID int) {
 				mockDB.EXPECT().
-					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Return(nil)
 			},
 			request: func() *persistence.InternalUpdateWorkflowExecutionRequest {
@@ -210,7 +210,7 @@ func TestUpdateWorkflowExecution(t *testing.T) {
 			name: "UpdateWorkflowModeBypassCurrent - assertNotCurrentExecution failure",
 			setupMock: func(mockDB *nosqlplugin.MockDB, shardID int) {
 				mockDB.EXPECT().
-					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), nil, gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 					Times(0)
 			},
 			request: func() *persistence.InternalUpdateWorkflowExecutionRequest {
@@ -273,6 +273,120 @@ func TestNosqlExecutionStore(t *testing.T) {
 		expectedError error
 	}{
 		{
+			name: "CreateWorkflowExecution success",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil)
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				_, err := store.CreateWorkflowExecution(ctx, newCreateWorkflowExecutionRequest())
+				return err
+			},
+			expectedError: nil,
+		},
+		{
+			name: "CreateWorkflowExecution failure - workflow already exists",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&persistence.WorkflowExecutionAlreadyStartedError{}).Times(1)
+				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsTimeoutError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsThrottlingError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsDBUnavailableError(gomock.Any()).Return(false).AnyTimes()
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				_, err := store.CreateWorkflowExecution(ctx, newCreateWorkflowExecutionRequest())
+				return err
+			},
+			expectedError: &persistence.WorkflowExecutionAlreadyStartedError{},
+		},
+		{
+			name: "CreateWorkflowExecution failure - shard ownership lost",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&persistence.ShardOwnershipLostError{ShardID: shardID, Msg: "shard ownership lost"}).Times(1)
+				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsTimeoutError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsThrottlingError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsDBUnavailableError(gomock.Any()).Return(false).AnyTimes()
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				_, err := store.CreateWorkflowExecution(ctx, newCreateWorkflowExecutionRequest())
+				return err
+			},
+			expectedError: &persistence.ShardOwnershipLostError{},
+		},
+		{
+			name: "CreateWorkflowExecution failure - current workflow condition failed",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&persistence.CurrentWorkflowConditionFailedError{Msg: "current workflow condition failed"}).Times(1)
+				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsTimeoutError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsThrottlingError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsDBUnavailableError(gomock.Any()).Return(false).AnyTimes()
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				_, err := store.CreateWorkflowExecution(ctx, newCreateWorkflowExecutionRequest())
+				return err
+			},
+			expectedError: &persistence.CurrentWorkflowConditionFailedError{},
+		},
+		{
+			name: "CreateWorkflowExecution failure - generic internal service error",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&types.InternalServiceError{Message: "generic internal service error"}).Times(1)
+				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsTimeoutError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsThrottlingError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsDBUnavailableError(gomock.Any()).Return(false).AnyTimes()
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				_, err := store.CreateWorkflowExecution(ctx, newCreateWorkflowExecutionRequest())
+				return err
+			},
+			expectedError: &types.InternalServiceError{},
+		},
+		{
+			name: "CreateWorkflowExecution failure - duplicate request error",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					InsertWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(&nosqlplugin.WorkflowOperationConditionFailure{
+						DuplicateRequest: &nosqlplugin.DuplicateRequest{
+							RunID: "abc",
+						},
+					}).Times(1)
+				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsTimeoutError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsThrottlingError(gomock.Any()).Return(false).AnyTimes()
+				mockDB.EXPECT().IsDBUnavailableError(gomock.Any()).Return(false).AnyTimes()
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				_, err := store.CreateWorkflowExecution(ctx, newCreateWorkflowExecutionRequest())
+				return err
+			},
+			expectedError: &persistence.DuplicateRequestError{},
+		},
+		{
 			name: "GetWorkflowExecution success",
 			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
 				mockDB := nosqlplugin.NewMockDB(ctrl)
@@ -302,6 +416,67 @@ func TestNosqlExecutionStore(t *testing.T) {
 				return err
 			},
 			expectedError: &types.EntityNotExistsError{},
+		},
+		{
+			name: "UpdateWorkflowExecution success",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(nil).Times(1)
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				err := store.UpdateWorkflowExecution(ctx, newUpdateWorkflowExecutionRequest())
+				return err
+			},
+			expectedError: nil,
+		},
+		{
+			name: "UpdateWorkflowExecution failure - invalid update mode",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				// No operation expected on the DB due to invalid mode
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				request := newUpdateWorkflowExecutionRequest()
+				request.Mode = persistence.UpdateWorkflowMode(-1)
+				return store.UpdateWorkflowExecution(ctx, request)
+			},
+			expectedError: &types.InternalServiceError{},
+		},
+		{
+			name: "UpdateWorkflowExecution failure - condition not met",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				conditionFailure := &nosqlplugin.WorkflowOperationConditionFailure{
+					UnknownConditionFailureDetails: common.StringPtr("condition not met"),
+				}
+				mockDB.EXPECT().
+					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(conditionFailure).Times(1)
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				return store.UpdateWorkflowExecution(ctx, newUpdateWorkflowExecutionRequest())
+			},
+			expectedError: &persistence.ConditionFailedError{},
+		},
+		{
+			name: "UpdateWorkflowExecution failure - operational error",
+			setupMock: func(ctrl *gomock.Controller) *nosqlExecutionStore {
+				mockDB := nosqlplugin.NewMockDB(ctrl)
+				mockDB.EXPECT().
+					UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Nil(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+					Return(errors.New("database is unavailable")).Times(1)
+				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(true).AnyTimes()
+				return newTestNosqlExecutionStore(mockDB, log.NewNoop())
+			},
+			testFunc: func(store *nosqlExecutionStore) error {
+				return store.UpdateWorkflowExecution(ctx, newUpdateWorkflowExecutionRequest())
+			},
+			expectedError: &types.InternalServiceError{Message: "database is unavailable"},
 		},
 		{
 			name: "DeleteWorkflowExecution success",
@@ -1419,7 +1594,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 		{
 			name: "DB Error on Reset Execution Insertion",
 			setupMocks: func() {
-				mockDB.EXPECT().UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("DB error")).Times(1)
+				mockDB.EXPECT().UpdateWorkflowExecutionWithTasks(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("DB error")).Times(1)
 				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(false).AnyTimes()
 				mockDB.EXPECT().IsTimeoutError(gomock.Any()).Return(false).AnyTimes()
 				mockDB.EXPECT().IsThrottlingError(gomock.Any()).Return(false).AnyTimes()
@@ -1448,7 +1623,7 @@ func TestConflictResolveWorkflowExecution(t *testing.T) {
 					RangeID: 124, // Example mismatched RangeID to trigger the condition failure
 				}
 				mockDB.EXPECT().UpdateWorkflowExecutionWithTasks(
-					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+					gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
 				).Return(conditionFailure).Times(1)
 				mockDB.EXPECT().IsNotFoundError(gomock.Any()).Return(false).AnyTimes()
 				mockDB.EXPECT().IsTimeoutError(gomock.Any()).Return(false).AnyTimes()
@@ -1512,6 +1687,13 @@ func newUpdateWorkflowExecutionRequest() *persistence.InternalUpdateWorkflowExec
 				State:       persistence.WorkflowStateCreated,
 				CloseStatus: persistence.WorkflowCloseStatusNone,
 			},
+			WorkflowRequests: []*persistence.WorkflowRequest{
+				{
+					RequestID:   constants.TestRequestID,
+					Version:     1,
+					RequestType: persistence.WorkflowRequestTypeStart,
+				},
+			},
 		},
 	}
 }
@@ -1523,6 +1705,13 @@ func getNewWorkflowSnapshot() persistence.InternalWorkflowSnapshot {
 			DomainID:   constants.TestDomainID,
 			WorkflowID: constants.TestWorkflowID,
 			RunID:      constants.TestRunID,
+		},
+		WorkflowRequests: []*persistence.WorkflowRequest{
+			{
+				RequestID:   constants.TestRequestID,
+				Version:     1,
+				RequestType: persistence.WorkflowRequestTypeStart,
+			},
 		},
 	}
 }

--- a/common/persistence/nosql/nosql_execution_store_util.go
+++ b/common/persistence/nosql/nosql_execution_store_util.go
@@ -74,6 +74,25 @@ func (d *nosqlExecutionStore) prepareCreateWorkflowExecutionRequestWithMaps(newW
 	return executionRequest, nil
 }
 
+func (d *nosqlExecutionStore) prepareWorkflowRequestRows(
+	domainID, workflowID, runID string,
+	requests []*persistence.WorkflowRequest,
+	requestRowsToAppend []*nosqlplugin.WorkflowRequestRow,
+) []*nosqlplugin.WorkflowRequestRow {
+	for _, req := range requests {
+		requestRowsToAppend = append(requestRowsToAppend, &nosqlplugin.WorkflowRequestRow{
+			ShardID:     d.shardID,
+			DomainID:    domainID,
+			WorkflowID:  workflowID,
+			RequestType: req.RequestType,
+			RequestID:   req.RequestID,
+			Version:     req.Version,
+			RunID:       runID,
+		})
+	}
+	return requestRowsToAppend
+}
+
 func (d *nosqlExecutionStore) prepareResetWorkflowExecutionRequestWithMapsAndEventBuffer(resetWorkflow *persistence.InternalWorkflowSnapshot) (*nosqlplugin.WorkflowExecutionRequest, error) {
 	executionInfo := resetWorkflow.ExecutionInfo
 	lastWriteVersion := resetWorkflow.LastWriteVersion
@@ -722,6 +741,10 @@ func (d *nosqlExecutionStore) processUpdateWorkflowResult(err error, rangeID int
 				return &persistence.CurrentWorkflowConditionFailedError{
 					Msg: *conditionFailureErr.CurrentWorkflowConditionFailInfo,
 				}
+			case conditionFailureErr.DuplicateRequest != nil:
+				return &persistence.DuplicateRequestError{
+					RunID: conditionFailureErr.DuplicateRequest.RunID,
+				}
 			default:
 				// If ever runs into this branch, there is bug in the code either in here, or in the implementation of nosql plugin
 				err := fmt.Errorf("unexpected conditionFailureReason error")
@@ -758,4 +781,15 @@ func (d *nosqlExecutionStore) assertNotCurrentExecution(
 	}
 
 	return nil
+}
+
+func getWorkflowRequestWriteMode(mode persistence.CreateWorkflowRequestMode) (nosqlplugin.WorkflowRequestWriteMode, error) {
+	switch mode {
+	case persistence.CreateWorkflowRequestModeNew:
+		return nosqlplugin.WorkflowRequestWriteModeInsert, nil
+	case persistence.CreateWorkflowRequestModeReplicated:
+		return nosqlplugin.WorkflowRequestWriteModeUpsert, nil
+	default:
+		return nosqlplugin.WorkflowRequestWriteMode(-1), fmt.Errorf("unknown create workflow request mode: %v", mode)
+	}
 }

--- a/common/persistence/nosql/nosqlplugin/cassandra/constants.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/constants.go
@@ -63,6 +63,10 @@ const (
 	rowTypeReplicationTask
 	rowTypeDLQ
 	rowTypeCrossClusterTask
+	rowTypeWorkflowRequestStart
+	rowTypeWorkflowRequestSignal
+	rowTypeWorkflowRequestCancel
+	rowTypeWorkflowRequestReset
 )
 
 // Guidelines for creating new special UUID constants
@@ -100,7 +104,9 @@ const (
 	rowTypeDLQDomainID = "10000000-6000-f000-f000-000000000000"
 	rowTypeDLQRunID    = "30000000-6000-f000-f000-000000000000"
 	// Special TaskId constants
-	rowTypeExecutionTaskID = int64(-10)
-	rowTypeShardTaskID     = int64(-11)
-	emptyInitiatedID       = int64(-7)
+	rowTypeExecutionTaskID      = int64(-10)
+	rowTypeShardTaskID          = int64(-11)
+	emptyInitiatedID            = int64(-7)
+	emptyWorkflowRequestVersion = int64(-1000)
+	workflowRequestTTLInSeconds = 10800
 )

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
@@ -237,6 +237,24 @@ const (
 		`and workflow_last_write_version = ? ` +
 		`and workflow_state = ? `
 
+	templateInsertWorkflowRequestQuery = `INSERT INTO executions (` +
+		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
+		`VALUES(?, ?, ?, ?, ?, ?, ?, ?) IF NOT EXISTS USING TTL ?`
+
+	templateUpsertWorkflowRequestQuery = `INSERT INTO executions (` +
+		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
+		`VALUES(?, ?, ?, ?, ?, ?, ?, ?) USING TTL ?`
+
+	templateGetLatestWorkflowRequestQuery = `SELECT current_run_id ` +
+		`FROM executions ` +
+		`WHERE shard_id = ? ` +
+		`and type = ? ` +
+		`and domain_id = ? ` +
+		`and workflow_id = ? ` +
+		`and run_id = ? ` +
+		`and visibility_ts = ? ` +
+		`LIMIT 1`
+
 	templateCreateCurrentWorkflowExecutionQuery = `INSERT INTO executions (` +
 		`shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id, execution, workflow_last_write_version, workflow_state) ` +
 		`VALUES(?, ?, ?, ?, ?, ?, ?, ?, {run_id: ?, create_request_id: ?, state: ?, close_status: ?}, ?, ?) IF NOT EXISTS USING TTL 0 `

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/checksum"
@@ -206,6 +207,67 @@ func (u *fakeUUID) String() string {
 	return u.uuid
 }
 
+var _ (gocql.Query) = &fakeQuery{}
+
+type fakeQuery struct {
+	iter              *fakeIter
+	mapScan           map[string]interface{}
+	err               error
+	scanCASApplied    bool
+	mapScanCASApplied bool
+}
+
+func (q *fakeQuery) Exec() error {
+	return q.err
+}
+
+func (q *fakeQuery) Scan(...interface{}) error {
+	return q.err
+}
+
+func (q *fakeQuery) ScanCAS(...interface{}) (bool, error) {
+	return q.scanCASApplied, q.err
+}
+
+func (q *fakeQuery) MapScan(res map[string]interface{}) error {
+	for k, v := range q.mapScan {
+		res[k] = v
+	}
+	return q.err
+}
+
+func (q *fakeQuery) MapScanCAS(map[string]interface{}) (bool, error) {
+	return q.mapScanCASApplied, q.err
+}
+
+func (q *fakeQuery) Iter() gocql.Iter {
+	return q.iter
+}
+
+func (q *fakeQuery) PageSize(int) gocql.Query {
+	return q
+}
+
+func (q *fakeQuery) PageState([]byte) gocql.Query {
+	return q
+}
+
+func (q *fakeQuery) WithContext(context.Context) gocql.Query {
+	return q
+}
+
+func (q *fakeQuery) WithTimestamp(int64) gocql.Query {
+	return q
+}
+
+func (q *fakeQuery) Consistency(gocql.Consistency) gocql.Query {
+	return q
+}
+
+func (q *fakeQuery) Bind(...interface{}) gocql.Query {
+	return q
+}
+
 func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 	tests := []struct {
 		// fake setup parameters
@@ -259,35 +321,70 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 			},
 		},
 		{
-			desc: "execution already exists",
+			desc: "workflow request already exists",
 			session: &fakeSession{
 				mapExecuteBatchCASApplied: false,
 				iter:                      &fakeIter{},
 				mapExecuteBatchCASPrev: map[string]any{
-					"type":                        rowTypeExecution,
-					"run_id":                      uuid.Parse(permanentRunID),
-					"range_id":                    int64(100),
-					"workflow_last_write_version": int64(3),
-					"execution": map[string]any{
-						"workflow_id": "test-workflow-id",
-						"run_id":      uuid.Parse("bda9cd9c-32fb-4267-b120-346e5351fc46"),
-						"state":       1,
+					"type":   rowTypeWorkflowRequestStart,
+					"run_id": uuid.Parse("4b8045c8-7b45-41e0-bf03-1f0d166b818d"),
+				},
+				query: &fakeQuery{
+					mapScan: map[string]interface{}{
+						"current_run_id": uuid.Parse("6b844fb4-c18a-4979-a2d3-731ebdd1db08"),
 					},
 				},
 			},
 			batch:        &fakeBatch{},
 			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{},
+			execution: &nosqlplugin.WorkflowExecutionRequest{
+				InternalWorkflowExecutionInfo: persistence.InternalWorkflowExecutionInfo{
+					DomainID:   "fd88863f-bb32-4daa-8878-49e08b91545e",
+					WorkflowID: "wfid",
+				},
+			},
 			shardCond: &nosqlplugin.ShardCondition{
+				ShardID: 1,
 				RangeID: 100,
 			},
 			wantErr: &nosqlplugin.WorkflowOperationConditionFailure{
-				CurrentWorkflowConditionFailInfo: common.StringPtr(
-					"Workflow execution already running. WorkflowId: test-workflow-id, " +
-						"RunId: bda9cd9c-32fb-4267-b120-346e5351fc46, rangeID: 100"),
+				DuplicateRequest: &nosqlplugin.DuplicateRequest{
+					RunID: "6b844fb4-c18a-4979-a2d3-731ebdd1db08",
+				},
 			},
 		},
 		{
-			desc: "execution already exists and write mode is CurrentWorkflowWriteModeInsert",
+			desc: "workflow request already exists - but failed to get latest request",
+			session: &fakeSession{
+				mapExecuteBatchCASApplied: false,
+				iter:                      &fakeIter{},
+				mapExecuteBatchCASPrev: map[string]any{
+					"type":   rowTypeWorkflowRequestSignal,
+					"run_id": uuid.Parse("4b8045c8-7b45-41e0-bf03-1f0d166b818d"),
+				},
+				query: &fakeQuery{
+					mapScan: map[string]interface{}{
+						"current_run_id": uuid.Parse("6b844fb4-c18a-4979-a2d3-731ebdd1db08"),
+					},
+					err: fmt.Errorf("failed to get latest request"),
+				},
+			},
+			batch:        &fakeBatch{},
+			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{},
+			execution: &nosqlplugin.WorkflowExecutionRequest{
+				InternalWorkflowExecutionInfo: persistence.InternalWorkflowExecutionInfo{
+					DomainID:   "fd88863f-bb32-4daa-8878-49e08b91545e",
+					WorkflowID: "wfid",
+				},
+			},
+			shardCond: &nosqlplugin.ShardCondition{
+				ShardID: 1,
+				RangeID: 100,
+			},
+			wantErr: fmt.Errorf("failed to get latest request"),
+		},
+		{
+			desc: "current execution already exists and write mode is CurrentWorkflowWriteModeInsert",
 			session: &fakeSession{
 				mapExecuteBatchCASApplied: false,
 				iter:                      &fakeIter{},
@@ -297,15 +394,17 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 					"range_id":                    int64(100),
 					"workflow_last_write_version": int64(3),
 					"execution": map[string]any{
-						"workflow_id": "test-workflow-id",
-						"run_id":      uuid.Parse("bda9cd9c-32fb-4267-b120-346e5351fc46"),
-						"state":       1,
+						"run_id": uuid.Parse("bda9cd9c-32fb-4267-b120-346e5351fc46"),
+						"state":  1,
 					},
 				},
 			},
 			batch: &fakeBatch{},
 			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{
 				WriteMode: nosqlplugin.CurrentWorkflowWriteModeInsert,
+				Row: nosqlplugin.CurrentWorkflowRow{
+					WorkflowID: "test-workflow-id",
+				},
 			},
 			shardCond: &nosqlplugin.ShardCondition{
 				RangeID: 100,
@@ -315,7 +414,7 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 					RunID:            "bda9cd9c-32fb-4267-b120-346e5351fc46",
 					State:            1,
 					LastWriteVersion: 3,
-					OtherInfo:        "Workflow execution already running. WorkflowId: test-workflow-id, RunId: bda9cd9c-32fb-4267-b120-346e5351fc46, rangeID: 100",
+					OtherInfo:        "Workflow execution already running. WorkflowId: test-workflow-id, RunId: bda9cd9c-32fb-4267-b120-346e5351fc46",
 				},
 			},
 		},
@@ -334,13 +433,12 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 			},
 			batch: &fakeBatch{},
 			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{
+				WriteMode: nosqlplugin.CurrentWorkflowWriteModeUpdate,
+				Row: nosqlplugin.CurrentWorkflowRow{
+					WorkflowID: "wfid",
+				},
 				Condition: &nosqlplugin.CurrentWorkflowWriteCondition{
 					CurrentRunID: common.StringPtr("fd88863f-bb32-4daa-8878-49e08b91545e"), // not matching current_run_id above on purpose
-				},
-			},
-			execution: &nosqlplugin.WorkflowExecutionRequest{
-				InternalWorkflowExecutionInfo: persistence.InternalWorkflowExecutionInfo{
-					WorkflowID: "wfid",
 				},
 			},
 			shardCond: &nosqlplugin.ShardCondition{
@@ -354,7 +452,7 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 			},
 		},
 		{
-			desc: "creation condition failed",
+			desc: "creation condition failed by mismatch last write version",
 			session: &fakeSession{
 				mapExecuteBatchCASApplied: false,
 				iter:                      &fakeIter{},
@@ -363,15 +461,18 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 					"run_id":                      uuid.Parse(permanentRunID),
 					"range_id":                    int64(100),
 					"workflow_last_write_version": int64(3),
-					"current_run_id":              uuid.Parse("bda9cd9c-32fb-4267-b120-346e5351fc46"),
+					"current_run_id":              uuid.Parse("fd88863f-bb32-4daa-8878-49e08b91545e"),
 				},
 			},
-			batch:        &fakeBatch{},
-			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{},
-			execution: &nosqlplugin.WorkflowExecutionRequest{
-				InternalWorkflowExecutionInfo: persistence.InternalWorkflowExecutionInfo{
+			batch: &fakeBatch{},
+			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{
+				WriteMode: nosqlplugin.CurrentWorkflowWriteModeUpdate,
+				Row: nosqlplugin.CurrentWorkflowRow{
 					WorkflowID: "wfid",
-					RunID:      "bda9cd9c-32fb-4267-b120-346e5351fc46",
+				},
+				Condition: &nosqlplugin.CurrentWorkflowWriteCondition{
+					CurrentRunID:     common.StringPtr("fd88863f-bb32-4daa-8878-49e08b91545e"), // not matching current_run_id above on purpose
+					LastWriteVersion: common.Int64Ptr(1),
 				},
 			},
 			shardCond: &nosqlplugin.ShardCondition{
@@ -379,12 +480,47 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 			},
 			wantErr: &nosqlplugin.WorkflowOperationConditionFailure{
 				CurrentWorkflowConditionFailInfo: common.StringPtr(
-					"Workflow execution creation condition failed. WorkflowId: wfid, " +
-						"CurrentRunID: bda9cd9c-32fb-4267-b120-346e5351fc46"),
+					"Workflow execution creation condition failed. " +
+						"WorkflowId: wfid, Expected Version: 1, Actual Version: 3"),
 			},
 		},
 		{
-			desc: "execution already running",
+			desc: "creation condition failed by mismatch state",
+			session: &fakeSession{
+				mapExecuteBatchCASApplied: false,
+				iter:                      &fakeIter{},
+				mapExecuteBatchCASPrev: map[string]any{
+					"type":                        rowTypeExecution,
+					"run_id":                      uuid.Parse(permanentRunID),
+					"range_id":                    int64(100),
+					"workflow_last_write_version": int64(3),
+					"current_run_id":              uuid.Parse("fd88863f-bb32-4daa-8878-49e08b91545e"),
+					"workflow_state":              2,
+				},
+			},
+			batch: &fakeBatch{},
+			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{
+				WriteMode: nosqlplugin.CurrentWorkflowWriteModeUpdate,
+				Row: nosqlplugin.CurrentWorkflowRow{
+					WorkflowID: "wfid",
+				},
+				Condition: &nosqlplugin.CurrentWorkflowWriteCondition{
+					CurrentRunID:     common.StringPtr("fd88863f-bb32-4daa-8878-49e08b91545e"), // not matching current_run_id above on purpose
+					LastWriteVersion: common.Ptr(int64(3)),
+					State:            common.Ptr(int(10)),
+				},
+			},
+			shardCond: &nosqlplugin.ShardCondition{
+				RangeID: 100,
+			},
+			wantErr: &nosqlplugin.WorkflowOperationConditionFailure{
+				CurrentWorkflowConditionFailInfo: common.StringPtr(
+					"Workflow execution creation condition failed. " +
+						"WorkflowId: wfid, Expected State: 10, Actual State: 2"),
+			},
+		},
+		{
+			desc: "concrete execution already exists",
 			session: &fakeSession{
 				mapExecuteBatchCASApplied: false,
 				iter:                      &fakeIter{},
@@ -411,7 +547,7 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 			wantErr: &nosqlplugin.WorkflowOperationConditionFailure{
 				WorkflowExecutionAlreadyExists: &nosqlplugin.WorkflowExecutionAlreadyExists{
 					OtherInfo: "Workflow execution already running. WorkflowId: wfid, " +
-						"RunId: bda9cd9c-32fb-4267-b120-346e5351fc46, rangeID: 100",
+						"RunId: bda9cd9c-32fb-4267-b120-346e5351fc46",
 					CreateRequestID:  "reqid_123",
 					RunID:            "bda9cd9c-32fb-4267-b120-346e5351fc46",
 					State:            2,
@@ -449,7 +585,7 @@ func TestExecuteCreateWorkflowBatchTransaction(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := executeCreateWorkflowBatchTransaction(tc.session, tc.batch, tc.currentWFReq, tc.execution, tc.shardCond)
+			err := executeCreateWorkflowBatchTransaction(context.Background(), tc.session, tc.batch, tc.currentWFReq, tc.execution, tc.shardCond)
 			if diff := errDiff(tc.wantErr, err); diff != "" {
 				t.Fatalf("Error mismatch (-want +got):\n%s", diff)
 			}
@@ -511,6 +647,57 @@ func TestExecuteUpdateWorkflowBatchTransaction(t *testing.T) {
 			wantErr: &nosqlplugin.WorkflowOperationConditionFailure{
 				ShardRangeIDNotMatch: common.Int64Ptr(200),
 			},
+		},
+		{
+			desc: "workflow request already exists",
+			session: &fakeSession{
+				mapExecuteBatchCASApplied: false,
+				iter:                      &fakeIter{},
+				mapExecuteBatchCASPrev: map[string]any{
+					"type":   rowTypeWorkflowRequestSignal,
+					"run_id": uuid.Parse("4b8045c8-7b45-41e0-bf03-1f0d166b818d"),
+				},
+				query: &fakeQuery{
+					mapScan: map[string]interface{}{
+						"current_run_id": uuid.Parse("6b844fb4-c18a-4979-a2d3-731ebdd1db08"),
+					},
+				},
+			},
+			batch:        &fakeBatch{},
+			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{},
+			shardCond: &nosqlplugin.ShardCondition{
+				ShardID: 1,
+				RangeID: 100,
+			},
+			wantErr: &nosqlplugin.WorkflowOperationConditionFailure{
+				DuplicateRequest: &nosqlplugin.DuplicateRequest{
+					RunID: "6b844fb4-c18a-4979-a2d3-731ebdd1db08",
+				},
+			},
+		},
+		{
+			desc: "workflow request already exists - but failed to get latest request",
+			session: &fakeSession{
+				mapExecuteBatchCASApplied: false,
+				iter:                      &fakeIter{},
+				mapExecuteBatchCASPrev: map[string]any{
+					"type":   rowTypeWorkflowRequestCancel,
+					"run_id": uuid.Parse("4b8045c8-7b45-41e0-bf03-1f0d166b818d"),
+				},
+				query: &fakeQuery{
+					mapScan: map[string]interface{}{
+						"current_run_id": uuid.Parse("6b844fb4-c18a-4979-a2d3-731ebdd1db08"),
+					},
+					err: fmt.Errorf("failed to get latest request"),
+				},
+			},
+			batch:        &fakeBatch{},
+			currentWFReq: &nosqlplugin.CurrentWorkflowWriteRequest{},
+			shardCond: &nosqlplugin.ShardCondition{
+				ShardID: 1,
+				RangeID: 100,
+			},
+			wantErr: fmt.Errorf("failed to get latest request"),
 		},
 		{
 			desc: "nextEventID mismatch for execution row",
@@ -594,12 +781,164 @@ func TestExecuteUpdateWorkflowBatchTransaction(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.desc, func(t *testing.T) {
-			err := executeUpdateWorkflowBatchTransaction(tc.session, tc.batch, tc.currentWFReq, tc.prevNextEventIDCond, tc.shardCond)
+			err := executeUpdateWorkflowBatchTransaction(context.Background(), tc.session, tc.batch, tc.currentWFReq, tc.prevNextEventIDCond, tc.shardCond)
 			if diff := errDiff(tc.wantErr, err); diff != "" {
 				t.Fatalf("Error mismatch (-want +got):\n%s", diff)
 			}
 			if !tc.session.iter.closed {
 				t.Error("iterator not closed")
+			}
+		})
+	}
+}
+
+func TestGetRequestRowType(t *testing.T) {
+	testCases := []struct {
+		name        string
+		requestType persistence.WorkflowRequestType
+		wantErr     bool
+		want        int
+	}{
+		{
+			name:        "StartWorkflow request",
+			requestType: persistence.WorkflowRequestTypeStart,
+			wantErr:     false,
+			want:        rowTypeWorkflowRequestStart,
+		},
+		{
+			name:        "SignalWithWorkflow request",
+			requestType: persistence.WorkflowRequestTypeSignal,
+			wantErr:     false,
+			want:        rowTypeWorkflowRequestSignal,
+		},
+		{
+			name:        "SignalWorkflow request",
+			requestType: persistence.WorkflowRequestTypeSignal,
+			wantErr:     false,
+			want:        rowTypeWorkflowRequestSignal,
+		},
+		{
+			name:        "CancelWorkflow request",
+			requestType: persistence.WorkflowRequestTypeCancel,
+			wantErr:     false,
+			want:        rowTypeWorkflowRequestCancel,
+		},
+		{
+			name:        "ResetWorkflow request",
+			requestType: persistence.WorkflowRequestTypeReset,
+			wantErr:     false,
+			want:        rowTypeWorkflowRequestReset,
+		},
+		{
+			name:        "unknown request",
+			requestType: persistence.WorkflowRequestType(-999),
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			want, err := getRequestRowType(tc.requestType)
+			gotErr := (err != nil)
+			if gotErr != tc.wantErr {
+				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)
+			}
+			if gotErr {
+				return
+			}
+
+			if diff := cmp.Diff(tc.want, want); diff != "" {
+				t.Fatalf("request type mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestInsertOrUpsertWorkflowRequestRow(t *testing.T) {
+	testCases := []struct {
+		name        string
+		request     *nosqlplugin.WorkflowRequestsWriteRequest
+		wantErr     bool
+		wantQueries []string
+	}{
+		{
+			name: "WorkflowRequestWriteModeInsert",
+			request: &nosqlplugin.WorkflowRequestsWriteRequest{
+				Rows: []*nosqlplugin.WorkflowRequestRow{
+					{
+						ShardID:    1,
+						DomainID:   "c09537fd-67ce-4b08-a817-eb8f12ad3a91",
+						WorkflowID: "test",
+						RunID:      "25bd1013-0e79-4c45-8e55-08bb45886896",
+						RequestID:  "9ab1d25d-8620-440a-b3f1-d3167e08c769",
+						Version:    100,
+					},
+				},
+				WriteMode: nosqlplugin.WorkflowRequestWriteModeInsert,
+			},
+			wantErr: false,
+			wantQueries: []string{
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, 1000, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+					`IF NOT EXISTS USING TTL 10800`,
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, -100, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+					`IF NOT EXISTS USING TTL 10800`,
+			},
+		},
+		{
+			name: "WorkflowRequestWriteModeUpsert",
+			request: &nosqlplugin.WorkflowRequestsWriteRequest{
+				Rows: []*nosqlplugin.WorkflowRequestRow{
+					{
+						ShardID:    1,
+						DomainID:   "c09537fd-67ce-4b08-a817-eb8f12ad3a91",
+						WorkflowID: "test",
+						RunID:      "25bd1013-0e79-4c45-8e55-08bb45886896",
+						RequestID:  "9ab1d25d-8620-440a-b3f1-d3167e08c769",
+						Version:    100,
+					},
+				},
+				WriteMode: nosqlplugin.WorkflowRequestWriteModeUpsert,
+			},
+			wantErr: false,
+			wantQueries: []string{
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, 1000, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+					`USING TTL 10800`,
+				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, visibility_ts, task_id, current_run_id) ` +
+					`VALUES(1, 7, c09537fd-67ce-4b08-a817-eb8f12ad3a91, test, 9ab1d25d-8620-440a-b3f1-d3167e08c769, 946684800000, -100, 25bd1013-0e79-4c45-8e55-08bb45886896) ` +
+					`USING TTL 10800`,
+			},
+		},
+		{
+			name: "unknown mode",
+			request: &nosqlplugin.WorkflowRequestsWriteRequest{
+				Rows: []*nosqlplugin.WorkflowRequestRow{
+					{
+						RequestType: persistence.WorkflowRequestTypeStart,
+					},
+				},
+				WriteMode: nosqlplugin.WorkflowRequestWriteMode(-100),
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			batch := &fakeBatch{}
+			err := insertOrUpsertWorkflowRequestRow(batch, tc.request)
+			gotErr := (err != nil)
+			if gotErr != tc.wantErr {
+				t.Fatalf("Got error: %v, want?: %v", err, tc.wantErr)
+			}
+			if gotErr {
+				return
+			}
+
+			if diff := cmp.Diff(tc.wantQueries, batch.queries); diff != "" {
+				t.Fatalf("Query mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}
@@ -2536,6 +2875,13 @@ func TestMustConvertToSlice(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestIsRequestRowType(t *testing.T) {
+	assert.True(t, isRequestRowType(rowTypeWorkflowRequestStart))
+	assert.True(t, isRequestRowType(rowTypeWorkflowRequestSignal))
+	assert.True(t, isRequestRowType(rowTypeWorkflowRequestCancel))
+	assert.True(t, isRequestRowType(rowTypeWorkflowRequestReset))
 }
 
 func errDiff(want, got error) string {

--- a/common/persistence/nosql/nosqlplugin/dynamodb/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/workflow.go
@@ -33,6 +33,7 @@ var _ nosqlplugin.WorkflowCRUD = (*ddb)(nil)
 
 func (db *ddb) InsertWorkflowExecutionWithTasks(
 	ctx context.Context,
+	requests *nosqlplugin.WorkflowRequestsWriteRequest,
 	currentWorkflowRequest *nosqlplugin.CurrentWorkflowWriteRequest,
 	execution *nosqlplugin.WorkflowExecutionRequest,
 	transferTasks []*nosqlplugin.TransferTask,
@@ -46,6 +47,7 @@ func (db *ddb) InsertWorkflowExecutionWithTasks(
 
 func (db *ddb) UpdateWorkflowExecutionWithTasks(
 	ctx context.Context,
+	requests *nosqlplugin.WorkflowRequestsWriteRequest,
 	currentWorkflowRequest *nosqlplugin.CurrentWorkflowWriteRequest,
 	mutatedExecution *nosqlplugin.WorkflowExecutionRequest,
 	insertedExecution *nosqlplugin.WorkflowExecutionRequest,

--- a/common/persistence/nosql/nosqlplugin/errors.go
+++ b/common/persistence/nosql/nosqlplugin/errors.go
@@ -30,6 +30,11 @@ type (
 		ShardRangeIDNotMatch             *int64  // return the previous shardRangeID
 		WorkflowExecutionAlreadyExists   *WorkflowExecutionAlreadyExists
 		CurrentWorkflowConditionFailInfo *string // return the logging info if fail on condition of CurrentWorkflow
+		DuplicateRequest                 *DuplicateRequest
+	}
+
+	DuplicateRequest struct {
+		RunID string
 	}
 
 	WorkflowExecutionAlreadyExists struct {

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -413,6 +413,7 @@ type (
 		// The API returns error if there is any. If any of the condition is not met, returns WorkflowOperationConditionFailure
 		InsertWorkflowExecutionWithTasks(
 			ctx context.Context,
+			requests *WorkflowRequestsWriteRequest,
 			currentWorkflowRequest *CurrentWorkflowWriteRequest,
 			execution *WorkflowExecutionRequest,
 			transferTasks []*TransferTask,
@@ -440,6 +441,7 @@ type (
 		// The API returns error if there is any. If any of the condition is not met, returns WorkflowOperationConditionFailure
 		UpdateWorkflowExecutionWithTasks(
 			ctx context.Context,
+			requests *WorkflowRequestsWriteRequest,
 			currentWorkflowRequest *CurrentWorkflowWriteRequest,
 			mutatedExecution *WorkflowExecutionRequest,
 			insertedExecution *WorkflowExecutionRequest,

--- a/common/persistence/nosql/nosqlplugin/interfaces_mock.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces_mock.go
@@ -558,17 +558,17 @@ func (mr *MockDBMockRecorder) InsertVisibility(ctx, ttlSeconds, row interface{})
 }
 
 // InsertWorkflowExecutionWithTasks mocks base method.
-func (m *MockDB) InsertWorkflowExecutionWithTasks(ctx context.Context, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockDB) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertWorkflowExecutionWithTasks indicates an expected call of InsertWorkflowExecutionWithTasks.
-func (mr *MockDBMockRecorder) InsertWorkflowExecutionWithTasks(ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
+func (mr *MockDBMockRecorder) InsertWorkflowExecutionWithTasks(ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertWorkflowExecutionWithTasks", reflect.TypeOf((*MockDB)(nil).InsertWorkflowExecutionWithTasks), ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertWorkflowExecutionWithTasks", reflect.TypeOf((*MockDB)(nil).InsertWorkflowExecutionWithTasks), ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 }
 
 // IsDBUnavailableError mocks base method.
@@ -1256,17 +1256,17 @@ func (mr *MockDBMockRecorder) UpdateVisibility(ctx, ttlSeconds, row interface{})
 }
 
 // UpdateWorkflowExecutionWithTasks mocks base method.
-func (m *MockDB) UpdateWorkflowExecutionWithTasks(ctx context.Context, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockDB) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateWorkflowExecutionWithTasks indicates an expected call of UpdateWorkflowExecutionWithTasks.
-func (mr *MockDBMockRecorder) UpdateWorkflowExecutionWithTasks(ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
+func (mr *MockDBMockRecorder) UpdateWorkflowExecutionWithTasks(ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithTasks", reflect.TypeOf((*MockDB)(nil).UpdateWorkflowExecutionWithTasks), ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithTasks", reflect.TypeOf((*MockDB)(nil).UpdateWorkflowExecutionWithTasks), ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 }
 
 // MocktableCRUD is a mock of tableCRUD interface.
@@ -1673,17 +1673,17 @@ func (mr *MocktableCRUDMockRecorder) InsertVisibility(ctx, ttlSeconds, row inter
 }
 
 // InsertWorkflowExecutionWithTasks mocks base method.
-func (m *MocktableCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MocktableCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertWorkflowExecutionWithTasks indicates an expected call of InsertWorkflowExecutionWithTasks.
-func (mr *MocktableCRUDMockRecorder) InsertWorkflowExecutionWithTasks(ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
+func (mr *MocktableCRUDMockRecorder) InsertWorkflowExecutionWithTasks(ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertWorkflowExecutionWithTasks", reflect.TypeOf((*MocktableCRUD)(nil).InsertWorkflowExecutionWithTasks), ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertWorkflowExecutionWithTasks", reflect.TypeOf((*MocktableCRUD)(nil).InsertWorkflowExecutionWithTasks), ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 }
 
 // IsWorkflowExecutionExists mocks base method.
@@ -2301,17 +2301,17 @@ func (mr *MocktableCRUDMockRecorder) UpdateVisibility(ctx, ttlSeconds, row inter
 }
 
 // UpdateWorkflowExecutionWithTasks mocks base method.
-func (m *MocktableCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MocktableCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateWorkflowExecutionWithTasks indicates an expected call of UpdateWorkflowExecutionWithTasks.
-func (mr *MocktableCRUDMockRecorder) UpdateWorkflowExecutionWithTasks(ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
+func (mr *MocktableCRUDMockRecorder) UpdateWorkflowExecutionWithTasks(ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithTasks", reflect.TypeOf((*MocktableCRUD)(nil).UpdateWorkflowExecutionWithTasks), ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithTasks", reflect.TypeOf((*MocktableCRUD)(nil).UpdateWorkflowExecutionWithTasks), ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 }
 
 // MockClientErrorChecker is a mock of ClientErrorChecker interface.
@@ -3278,17 +3278,17 @@ func (mr *MockWorkflowCRUDMockRecorder) InsertReplicationTask(ctx, tasks, condit
 }
 
 // InsertWorkflowExecutionWithTasks mocks base method.
-func (m *MockWorkflowCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockWorkflowCRUD) InsertWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, execution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	ret := m.ctrl.Call(m, "InsertWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertWorkflowExecutionWithTasks indicates an expected call of InsertWorkflowExecutionWithTasks.
-func (mr *MockWorkflowCRUDMockRecorder) InsertWorkflowExecutionWithTasks(ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
+func (mr *MockWorkflowCRUDMockRecorder) InsertWorkflowExecutionWithTasks(ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertWorkflowExecutionWithTasks", reflect.TypeOf((*MockWorkflowCRUD)(nil).InsertWorkflowExecutionWithTasks), ctx, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertWorkflowExecutionWithTasks", reflect.TypeOf((*MockWorkflowCRUD)(nil).InsertWorkflowExecutionWithTasks), ctx, requests, currentWorkflowRequest, execution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 }
 
 // IsWorkflowExecutionExists mocks base method.
@@ -3534,17 +3534,17 @@ func (mr *MockWorkflowCRUDMockRecorder) SelectWorkflowExecution(ctx, shardID, do
 }
 
 // UpdateWorkflowExecutionWithTasks mocks base method.
-func (m *MockWorkflowCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
+func (m *MockWorkflowCRUD) UpdateWorkflowExecutionWithTasks(ctx context.Context, requests *WorkflowRequestsWriteRequest, currentWorkflowRequest *CurrentWorkflowWriteRequest, mutatedExecution, insertedExecution, resetExecution *WorkflowExecutionRequest, transferTasks []*TransferTask, crossClusterTasks []*CrossClusterTask, replicationTasks []*ReplicationTask, timerTasks []*TimerTask, shardCondition *ShardCondition) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	ret := m.ctrl.Call(m, "UpdateWorkflowExecutionWithTasks", ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // UpdateWorkflowExecutionWithTasks indicates an expected call of UpdateWorkflowExecutionWithTasks.
-func (mr *MockWorkflowCRUDMockRecorder) UpdateWorkflowExecutionWithTasks(ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
+func (mr *MockWorkflowCRUDMockRecorder) UpdateWorkflowExecutionWithTasks(ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithTasks", reflect.TypeOf((*MockWorkflowCRUD)(nil).UpdateWorkflowExecutionWithTasks), ctx, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateWorkflowExecutionWithTasks", reflect.TypeOf((*MockWorkflowCRUD)(nil).UpdateWorkflowExecutionWithTasks), ctx, requests, currentWorkflowRequest, mutatedExecution, insertedExecution, resetExecution, transferTasks, crossClusterTasks, replicationTasks, timerTasks, shardCondition)
 }
 
 // MockConfigStoreCRUD is a mock of ConfigStoreCRUD interface.

--- a/common/persistence/nosql/nosqlplugin/mongodb/workflow.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/workflow.go
@@ -33,6 +33,7 @@ var _ nosqlplugin.WorkflowCRUD = (*mdb)(nil)
 
 func (db *mdb) InsertWorkflowExecutionWithTasks(
 	ctx context.Context,
+	requests *nosqlplugin.WorkflowRequestsWriteRequest,
 	currentWorkflowRequest *nosqlplugin.CurrentWorkflowWriteRequest,
 	execution *nosqlplugin.WorkflowExecutionRequest,
 	transferTasks []*nosqlplugin.TransferTask,
@@ -46,6 +47,7 @@ func (db *mdb) InsertWorkflowExecutionWithTasks(
 
 func (db *mdb) UpdateWorkflowExecutionWithTasks(
 	ctx context.Context,
+	requests *nosqlplugin.WorkflowRequestsWriteRequest,
 	currentWorkflowRequest *nosqlplugin.CurrentWorkflowWriteRequest,
 	mutatedExecution *nosqlplugin.WorkflowExecutionRequest,
 	insertedExecution *nosqlplugin.WorkflowExecutionRequest,

--- a/common/persistence/nosql/nosqlplugin/types.go
+++ b/common/persistence/nosql/nosqlplugin/types.go
@@ -123,6 +123,24 @@ type (
 		LastWriteVersion int64
 	}
 
+	// WorkflowRequestRow is the request which has been applied to a workflow
+	WorkflowRequestRow struct {
+		ShardID     int
+		DomainID    string
+		WorkflowID  string
+		RequestType persistence.WorkflowRequestType
+		RequestID   string
+		Version     int64
+		RunID       string
+	}
+
+	WorkflowRequestWriteMode int
+
+	WorkflowRequestsWriteRequest struct {
+		Rows      []*WorkflowRequestRow
+		WriteMode WorkflowRequestWriteMode
+	}
+
 	// TasksFilter is for filtering tasks
 	TasksFilter struct {
 		TaskListFilter
@@ -336,6 +354,11 @@ const (
 	EventBufferWriteModeAppend
 	// EventBufferWriteModeClear will clear(delete all event from) the event buffer
 	EventBufferWriteModeClear
+)
+
+const (
+	WorkflowRequestWriteModeInsert WorkflowRequestWriteMode = iota
+	WorkflowRequestWriteModeUpsert
 )
 
 // GetCurrentRunID returns the current runID

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -179,6 +179,76 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionDeDup() {
 	s.IsType(&p.WorkflowExecutionAlreadyStartedError{}, err)
 }
 
+func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionWithWorkflowRequestsDedup() {
+	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	defer cancel()
+
+	domainID := uuid.New()
+	domainName := uuid.New()
+	workflowID := "create-workflow-test-dedup"
+	runID := uuid.New()
+	requestID := uuid.New()
+	tasklist := "some random tasklist"
+	workflowType := "some random workflow type"
+	workflowTimeout := int32(10)
+	decisionTimeout := int32(14)
+	lastProcessedEventID := int64(0)
+	nextEventID := int64(3)
+	csum := s.newRandomChecksum()
+	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
+		{
+			EventID: nextEventID,
+			Version: common.EmptyVersion,
+		},
+	})
+	versionHistories := p.NewVersionHistories(versionHistory)
+
+	req := &p.CreateWorkflowExecutionRequest{
+		NewWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo: &p.WorkflowExecutionInfo{
+				CreateRequestID:             requestID,
+				DomainID:                    domainID,
+				WorkflowID:                  workflowID,
+				RunID:                       runID,
+				FirstExecutionRunID:         runID,
+				TaskList:                    tasklist,
+				WorkflowTypeName:            workflowType,
+				WorkflowTimeout:             workflowTimeout,
+				DecisionStartToCloseTimeout: decisionTimeout,
+				LastFirstEventID:            common.FirstEventID,
+				NextEventID:                 nextEventID,
+				LastProcessedEvent:          lastProcessedEventID,
+				State:                       p.WorkflowStateCreated,
+				CloseStatus:                 p.WorkflowCloseStatusNone,
+			},
+			ExecutionStats:   &p.ExecutionStats{},
+			Checksum:         csum,
+			VersionHistories: versionHistories,
+			WorkflowRequests: []*p.WorkflowRequest{
+				{
+					RequestID:   requestID,
+					Version:     1,
+					RequestType: p.WorkflowRequestTypeStart,
+				},
+			},
+		},
+		RangeID:             s.ShardInfo.RangeID,
+		Mode:                p.CreateWorkflowModeBrandNew,
+		WorkflowRequestMode: p.CreateWorkflowRequestModeReplicated,
+		DomainName:          domainName,
+	}
+	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, req)
+	s.Nil(err)
+	req.WorkflowRequestMode = p.CreateWorkflowRequestModeNew
+	_, err = s.ExecutionManager.CreateWorkflowExecution(ctx, req)
+	s.Error(err)
+	s.IsType(&p.DuplicateRequestError{}, err)
+	req.WorkflowRequestMode = p.CreateWorkflowRequestModeReplicated
+	_, err = s.ExecutionManager.CreateWorkflowExecution(ctx, req)
+	s.Error(err)
+	s.IsType(&p.WorkflowExecutionAlreadyStartedError{}, err)
+}
+
 // TestCreateWorkflowExecutionStateCloseStatus test
 func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionStateCloseStatus() {
 	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
@@ -406,6 +476,109 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionWithZombieState() {
 	s.Equal(p.WorkflowStateZombie, info.ExecutionInfo.State)
 	s.Equal(p.WorkflowCloseStatusNone, info.ExecutionInfo.CloseStatus)
 	s.assertChecksumsEqual(csum, info.Checksum)
+}
+
+func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithWorkflowRequestsDedup() {
+	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	defer cancel()
+
+	domainID := uuid.New()
+	domainName := uuid.New()
+	workflowID := "create-workflow-test-dedup"
+	runID := uuid.New()
+	requestID := uuid.New()
+	tasklist := "some random tasklist"
+	workflowType := "some random workflow type"
+	workflowTimeout := int32(10)
+	decisionTimeout := int32(14)
+	lastProcessedEventID := int64(0)
+	nextEventID := int64(3)
+	csum := s.newRandomChecksum()
+	versionHistory := p.NewVersionHistory([]byte{}, []*p.VersionHistoryItem{
+		{
+			EventID: nextEventID,
+			Version: common.EmptyVersion,
+		},
+	})
+	versionHistories := p.NewVersionHistories(versionHistory)
+
+	req := &p.CreateWorkflowExecutionRequest{
+		NewWorkflowSnapshot: p.WorkflowSnapshot{
+			ExecutionInfo: &p.WorkflowExecutionInfo{
+				CreateRequestID:             requestID,
+				DomainID:                    domainID,
+				WorkflowID:                  workflowID,
+				RunID:                       runID,
+				FirstExecutionRunID:         runID,
+				TaskList:                    tasklist,
+				WorkflowTypeName:            workflowType,
+				WorkflowTimeout:             workflowTimeout,
+				DecisionStartToCloseTimeout: decisionTimeout,
+				LastFirstEventID:            common.FirstEventID,
+				NextEventID:                 nextEventID,
+				LastProcessedEvent:          lastProcessedEventID,
+				State:                       p.WorkflowStateCreated,
+				CloseStatus:                 p.WorkflowCloseStatusNone,
+			},
+			ExecutionStats:   &p.ExecutionStats{},
+			Checksum:         csum,
+			VersionHistories: versionHistories,
+			WorkflowRequests: []*p.WorkflowRequest{
+				{
+					RequestID:   requestID,
+					Version:     1,
+					RequestType: p.WorkflowRequestTypeStart,
+				},
+				{
+					RequestID:   requestID,
+					Version:     1,
+					RequestType: p.WorkflowRequestTypeSignal,
+				},
+			},
+		},
+		RangeID:             s.ShardInfo.RangeID,
+		Mode:                p.CreateWorkflowModeBrandNew,
+		WorkflowRequestMode: p.CreateWorkflowRequestModeNew,
+		DomainName:          domainName,
+	}
+	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, req)
+	s.Nil(err)
+	info, err := s.GetWorkflowExecutionInfo(ctx, domainID, types.WorkflowExecution{WorkflowID: workflowID, RunID: runID})
+	s.Nil(err)
+	csum = s.newRandomChecksum() // update the checksum to new value
+	updatedInfo := copyWorkflowExecutionInfo(info.ExecutionInfo)
+	updatedStats := copyExecutionStats(info.ExecutionStats)
+	updatedInfo.State = p.WorkflowStateRunning
+	updatedInfo.CloseStatus = p.WorkflowCloseStatusNone
+	updateReq := &p.UpdateWorkflowExecutionRequest{
+		UpdateWorkflowMutation: p.WorkflowMutation{
+			ExecutionInfo:    updatedInfo,
+			ExecutionStats:   updatedStats,
+			Condition:        nextEventID,
+			Checksum:         csum,
+			VersionHistories: versionHistories,
+			WorkflowRequests: []*p.WorkflowRequest{
+				{
+					RequestID:   requestID,
+					Version:     1,
+					RequestType: p.WorkflowRequestTypeSignal,
+				},
+			},
+		},
+		RangeID:             s.ShardInfo.RangeID,
+		Mode:                p.UpdateWorkflowModeUpdateCurrent,
+		WorkflowRequestMode: p.CreateWorkflowRequestModeNew,
+	}
+	_, err = s.ExecutionManager.UpdateWorkflowExecution(ctx, updateReq)
+	s.Error(err)
+	s.IsType(&p.DuplicateRequestError{}, err)
+	updateReq.WorkflowRequestMode = p.CreateWorkflowRequestModeReplicated
+	_, err = s.ExecutionManager.UpdateWorkflowExecution(ctx, updateReq)
+	s.Nil(err)
+	updateReq.UpdateWorkflowMutation.WorkflowRequests[0].RequestID = uuid.New()
+	updateReq.WorkflowRequestMode = p.CreateWorkflowRequestModeNew
+	_, err = s.ExecutionManager.UpdateWorkflowExecution(ctx, updateReq)
+	s.Nil(err)
 }
 
 // TestUpdateWorkflowExecutionStateCloseStatus test

--- a/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/mysql_persistence_test.go
@@ -70,9 +70,21 @@ func TestMySQLShardPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+type ExecutionManagerSuite struct {
+	pt.ExecutionManagerSuite
+}
+
+func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionWithWorkflowRequestsDedup() {
+	s.T().Skip("skip the test until we store workflow_request in mysql")
+}
+
+func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithWorkflowRequestsDedup() {
+	s.T().Skip("skip the test until we store workflow_request in mysql")
+}
+
 func TestMySQLExecutionManagerSuite(t *testing.T) {
 	testflags.RequireMySQL(t)
-	s := new(pt.ExecutionManagerSuite)
+	s := new(ExecutionManagerSuite)
 	option, err := GetTestClusterOption()
 	assert.NoError(t, err)
 	s.TestBase = pt.NewTestBaseWithSQL(t, option)

--- a/common/persistence/sql/sqlplugin/postgres/postgres_persistence_test.go
+++ b/common/persistence/sql/sqlplugin/postgres/postgres_persistence_test.go
@@ -70,9 +70,21 @@ func TestPostgresSQLShardPersistenceSuite(t *testing.T) {
 	suite.Run(t, s)
 }
 
+type ExecutionManagerSuite struct {
+	pt.ExecutionManagerSuite
+}
+
+func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionWithWorkflowRequestsDedup() {
+	s.T().Skip("skip the test until we store workflow_request in postgres sql")
+}
+
+func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithWorkflowRequestsDedup() {
+	s.T().Skip("skip the test until we store workflow_request in postgres sql")
+}
+
 func TestPostgresSQLExecutionManagerSuite(t *testing.T) {
 	testflags.RequirePostgres(t)
-	s := new(pt.ExecutionManagerSuite)
+	s := new(ExecutionManagerSuite)
 	options, err := GetTestClusterOption()
 	assert.NoError(t, err)
 	s.TestBase = pt.NewTestBaseWithSQL(t, options)

--- a/service/history/constants/test_constants.go
+++ b/service/history/constants/test_constants.go
@@ -60,6 +60,8 @@ var (
 	TestWorkflowID = "random-workflow-id"
 	// TestRunID is the workflow runID for test
 	TestRunID = "0d00698f-08e1-4d36-a3e2-3bf109f5d2d6"
+	// TestRequestID is the request ID for test
+	TestRequestID = "143b22cd-dfac-4d59-9398-893f89d89df6"
 
 	// TestClusterMetadata is the cluster metadata for test
 	TestClusterMetadata = cluster.GetTestClusterMetadata(true)


### PR DESCRIPTION
# WorkflowRequest:
WorkflowRequest is a new type of data introduced in this PR which will be stored in database to allow detecting duplicate requests. By detecting duplicate requests, we can guarantee idempotency of the following APIs: 
- StartWorkflowExecution
- SignalWorkflowExecution
- CancelWorkflowExecution
- ResetWorkflowExecution
- SignalWithStartWorkflowExecution

A workflow request is identified by (`shard_id`, `domain_id`, `workflow_id`, `request_id`, `request_type`, `version`), and `run_id` is associated indicating which workflow the request has been applied to. Among them, `shard_id` is derived from `workflow_id`, and `version` is the failover version of the domain when the request is applied. `request_id` is a UUID set in Cadence API requests.

## request_type:
Normally, `request_id` is not reused by clients because it's a UUID, but it may be reused incorrectly by different APIs. For example, a SignalWorkflow request with `request_id: 7cfc8e22-b252-447d-ab03-9e5eda68dc35` has been applied to workflow `test-wf` and later a CancelWorkflow request with the same request_id is sent to the same workflow. In such case, we need to handle the CancelWorkflow request properly. There are 3 options to handle the second request:
1. Make it a no-op
2. Apply the request
3. Return an error telling the customer that the request_id shouldn't be reused

Our implementation chooses the 2nd option, because it's more reasonable compared to option 1 and requires no change from client side compared to option 3. `request_type` is used for implementation of 2nd option, and without `request_type` we can only go with option 1, because we cannot differentiate different API requests.

We currently support 4 request types:
- WorkflowRequestTypeStart
- WorkflowRequestTypeSignal
- WorkflowRequestTypeCancel
- WorkflowRequestTypeReset

And they are mapped to the APIs mentioned above. However, `SignalWithStartWorkflowExecution` is treated differently. This single API request is mapped to 2 workflow requests stored in database, 1 with type `WorkflowRequestTypeStart` and 1 with type `WorkflowRequestTypeSignal`. And if a workflow is signaled and started by this API with `request_id: 7cfc8e22-b252-447d-ab03-9e5eda68dc35`. Not only SignalWithStartWorkflowExecution with the same `request_id` will be no-op, but also `StartWorkflowExecution` and `SignalWorkflowExecution` with the same `request_id` will also be no-op. This is to simplify the implementation and keeps the behavior the same with the current idempotency implementation.

# Replication of WorkflowRequest:
WorkflowRequests need to be replicated to guarantee idempotency of APIs for global domains after a domain failover. But replication is done asynchronously, and by the time a workflow request is replicated, there might be already an existing request with the same `request_id` in the database, because the request is retried and applied after failover before getting replicated from the old cluster. `version` is used for such conflict resolution. And we also introduce `CreateWorkflowRequestMode` when writing workflow_requests to database.
- `CreateWorkflowRequestModeNew` is used for workflow_requests generated from Cadence API requests. And we should not apply the request if there is already a workflow_request with the same `request_id` in the database, even if the `version` is different.
- `CreateWorkflowRequestModeReplicated` is used for workflow_requests generated from replication. And we should always apply the request to achieve eventual consistency.

# Cassandra Implementation:
Because Cassandra doesn't support cross-table LWT, the workflow_request has to be stored in the existing `execution` table so that the data can be inserted as a part of the transaction which stores the change of mutable state. We uses the following columns of execution table to store workflow_request data:
- shard_id -> shard_id
- type -> request_type
- domain_id -> domain_id
- workflow_id -> workflow_id
- run_id -> request_id
- task_id -> version * -1 (this is because we want to fetch the data in descending order)
- current_run_id -> run_id

# Risk:
This PR has no risk, because it only defines the struct and interface needed for storing workflow_requests. A following PR will use the change and stores data in database.