### PR TITLE
Addition of tests for HandleDomainCreationReplicationTask in replicationTaskExecutor

### DIFF
--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -22,7 +22,6 @@ package domain
 
 import (
 	"context"
-	"github.com/uber/cadence/common/log/testlogger"
 	"testing"
 	"time"
 
@@ -33,6 +32,7 @@ import (
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/testlogger"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
 )

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -21,7 +21,10 @@
 package domain
 
 import (
+	"context"
+	"github.com/uber/cadence/common/log/testlogger"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
@@ -242,6 +245,161 @@ func TestDomainReplicationTaskExecutor_Execute(t *testing.T) {
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.IsType(t, tt.errType, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func domainCreationTask() *types.DomainTaskAttributes {
+	return &types.DomainTaskAttributes{
+		DomainOperation: types.DomainOperationCreate.Ptr(),
+		ID:              "testDomainID",
+		Info: &types.DomainInfo{
+			Name:        "testDomain",
+			Status:      types.DomainStatusRegistered.Ptr(),
+			Description: "This is a test domain",
+			OwnerEmail:  "owner@test.com",
+			Data:        map[string]string{"key1": "value1"}, // Arbitrary domain metadata
+		},
+		Config: &types.DomainConfiguration{
+			WorkflowExecutionRetentionPeriodInDays: 10,
+			EmitMetric:                             true,
+			HistoryArchivalStatus:                  types.ArchivalStatusEnabled.Ptr(),
+			HistoryArchivalURI:                     "test://history/archival",
+			VisibilityArchivalStatus:               types.ArchivalStatusEnabled.Ptr(),
+			VisibilityArchivalURI:                  "test://visibility/archival",
+		},
+		ReplicationConfig: &types.DomainReplicationConfiguration{
+			ActiveClusterName: "activeClusterName",
+			Clusters: []*types.ClusterReplicationConfiguration{
+				{
+					ClusterName: "activeClusterName",
+				},
+				{
+					ClusterName: "standbyClusterName",
+				},
+			},
+		},
+		ConfigVersion:           1,
+		FailoverVersion:         1,
+		PreviousFailoverVersion: 0,
+	}
+}
+
+func TestHandleDomainCreationReplicationTask(t *testing.T) {
+	tests := []struct {
+		name      string
+		task      *types.DomainTaskAttributes
+		setup     func(mockDomainManager *persistence.MockDomainManager)
+		wantError bool
+	}{
+		{
+			name: "Successful Domain Creation",
+			task: domainCreationTask(),
+			setup: func(mockDomainManager *persistence.MockDomainManager) {
+				mockDomainManager.EXPECT().
+					CreateDomain(gomock.Any(), gomock.Any()).
+					Return(&persistence.CreateDomainResponse{ID: "testDomainID"}, nil)
+			},
+			wantError: false,
+		},
+		{
+			name: "Generic Error During Domain Creation",
+			task: domainCreationTask(),
+			setup: func(mockDomainManager *persistence.MockDomainManager) {
+				mockDomainManager.EXPECT().
+					CreateDomain(gomock.Any(), gomock.Any()).
+					Return(nil, types.InternalServiceError{Message: "an internal error"}).
+					Times(1)
+
+				// Since CreateDomain failed, handleDomainCreationReplicationTask check for domain existence by name and ID
+				mockDomainManager.EXPECT().
+					GetDomain(gomock.Any(), gomock.Any()).
+					Return(nil, &types.EntityNotExistsError{}). // Simulate that no domain exists with the given name/ID
+					AnyTimes()
+			},
+			wantError: true,
+		},
+		{
+			name: "Handle Name/UUID Collision - EntityNotExistsError",
+			task: domainCreationTask(),
+			setup: func(mockDomainManager *persistence.MockDomainManager) {
+				mockDomainManager.EXPECT().
+					CreateDomain(gomock.Any(), gomock.Any()).
+					Return(nil, ErrNameUUIDCollision).Times(1)
+
+				mockDomainManager.EXPECT().
+					GetDomain(gomock.Any(), gomock.Any()).Return(nil, &types.EntityNotExistsError{}).AnyTimes()
+			},
+			wantError: true,
+		},
+		{
+			name: "Immediate Error Return from CreateDomain",
+			setup: func(mockDomainManager *persistence.MockDomainManager) {
+				mockDomainManager.EXPECT().
+					CreateDomain(gomock.Any(), gomock.Any()).
+					Return(nil, types.InternalServiceError{Message: "internal error"}).
+					Times(1)
+				mockDomainManager.EXPECT().
+					GetDomain(gomock.Any(), gomock.Any()).
+					Return(nil, ErrInvalidDomainStatus).
+					AnyTimes()
+			},
+			task:      domainCreationTask(),
+			wantError: true,
+		},
+		{
+			name: "Domain Creation with Nil Status",
+			task: &types.DomainTaskAttributes{
+				DomainOperation: types.DomainOperationCreate.Ptr(),
+				ID:              "testDomainID",
+				Info: &types.DomainInfo{
+					Name: "testDomain",
+					// Status is intentionally left as nil to trigger the error
+				},
+			},
+			setup: func(mockDomainManager *persistence.MockDomainManager) {
+				// No need to set up a mock for CreateDomain as the call should not reach this point
+			},
+			wantError: true,
+		},
+		{
+			name: "Domain Creation with Unrecognized Status",
+			task: &types.DomainTaskAttributes{
+				DomainOperation: types.DomainOperationCreate.Ptr(),
+				ID:              "testDomainID",
+				Info: &types.DomainInfo{
+					Name:   "testDomain",
+					Status: types.DomainStatus(999).Ptr(), // Assuming 999 is an unrecognized status
+				},
+			},
+			setup: func(mockDomainManager *persistence.MockDomainManager) {
+				// As before, no need for mock setup for CreateDomain
+			},
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+
+			mockDomainManager := persistence.NewMockDomainManager(ctrl)
+			mockLogger := testlogger.New(t)
+			mockTimeSource := clock.NewMockedTimeSourceAt(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)) // Fixed time
+
+			executor := &domainReplicationTaskExecutorImpl{
+				domainManager: mockDomainManager,
+				logger:        mockLogger,
+				timeSource:    mockTimeSource,
+			}
+
+			tt.setup(mockDomainManager)
+			err := executor.handleDomainCreationReplicationTask(context.Background(), tt.task)
+			if tt.wantError {
+				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
What changed?
Added tests in common/domain folder for HandleDomainCreationReplicationTask in replicationTaskExecutor go file

Why?
to increase code coverage

How did you test it?
Unit Tests

Potential risks
No risks, as it only involves tests with mocking behaviors.