### PR TITLE
Add memo in pinot

### DIFF
--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -23,6 +23,7 @@ package persistence
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
@@ -957,6 +958,10 @@ func (d *DataBlob) GetEncodingString() string {
 		return ""
 	}
 	return string(d.Encoding)
+}
+
+func (d *DataBlob) GetVisibilityStoreInfo() ([]byte, error) {
+	return json.Marshal(d)
 }
 
 // GetData is a safe way to get the byte array or nil

--- a/common/pinot/response_utility.go
+++ b/common/pinot/response_utility.go
@@ -83,12 +83,23 @@ func ConvertSearchResultToVisibilityRecord(hit []interface{}, columnNames []stri
 	if err != nil {
 		logger.Error("Unable to Unmarshal searchAttribute map", tag.Error(err))
 	}
+	var memo *p.DataBlob
+	if attributeMap["Memo"] != nil {
+		err = json.Unmarshal([]byte(fmt.Sprintf("%s", attributeMap["Memo"])), &memo)
+		if err != nil {
+			logger.Error("Unable to Unmarshal memo",
+				tag.Error(err),
+			)
+			return nil
+		}
+	}
+	delete(attributeMap, "Memo") // cleanup after we get memo from search attribute
 
 	var source *VisibilityRecord
 	err = json.Unmarshal(jsonSystemKeyMap, &source)
 	if err != nil {
 		logger.Error("Unable to Unmarshal systemKeyMap",
-			tag.Error(err), // tag.ESDocID(fmt.Sprintf(columnNameToValue["DocID"]))
+			tag.Error(err),
 		)
 		return nil
 	}
@@ -106,6 +117,7 @@ func ConvertSearchResultToVisibilityRecord(hit []interface{}, columnNames []stri
 		NumClusters:      source.NumClusters,
 		ShardID:          source.ShardID,
 		SearchAttributes: attributeMap,
+		Memo:             memo,
 	}
 	if source.UpdateTime > 0 {
 		record.UpdateTime = time.UnixMilli(source.UpdateTime)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add memo in pinot:
When write, add memo into search attribute
When read, get memo from search attribute and cleanup that field

NOTE: don't merge it until our customer test it in staging

<!-- Tell your future self why have you made these changes -->
**Why?**
memo was stored in ES but can't be indexed(not in ES schema). We made the pinot schemas according to ES's schema, so we thought that we did't need memo in Pinot, but one customer was complaining about that. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
not risk since Memo is not a functional attribute. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
