### PR TITLE
Add missing mappers for AsyncWorkflowConfiguration

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -1082,6 +1082,7 @@ func FromDescribeDomainResponseDomain(t *types.DescribeDomainResponse) *apiv1.Do
 		domain.HistoryArchivalUri = config.HistoryArchivalURI
 		domain.VisibilityArchivalStatus = FromArchivalStatus(config.VisibilityArchivalStatus)
 		domain.VisibilityArchivalUri = config.VisibilityArchivalURI
+		domain.AsyncWorkflowConfig = FromDomainAsyncWorkflowConfiguraton(config.AsyncWorkflowConfig)
 	}
 	if repl := t.ReplicationConfiguration; repl != nil {
 		domain.ActiveClusterName = repl.ActiveClusterName
@@ -1124,6 +1125,7 @@ func ToDescribeDomainResponseDomain(t *apiv1.Domain) *types.DescribeDomainRespon
 			VisibilityArchivalStatus:               ToArchivalStatus(t.VisibilityArchivalStatus),
 			VisibilityArchivalURI:                  t.VisibilityArchivalUri,
 			IsolationGroups:                        ToIsolationGroupConfig(t.IsolationGroups),
+			AsyncWorkflowConfig:                    ToDomainAsyncWorkflowConfiguraton(t.AsyncWorkflowConfig),
 		},
 		ReplicationConfiguration: &types.DomainReplicationConfiguration{
 			ActiveClusterName: t.ActiveClusterName,
@@ -4303,6 +4305,7 @@ func FromUpdateDomainResponse(t *types.UpdateDomainResponse) *apiv1.UpdateDomain
 		domain.HistoryArchivalUri = config.HistoryArchivalURI
 		domain.VisibilityArchivalStatus = FromArchivalStatus(config.VisibilityArchivalStatus)
 		domain.VisibilityArchivalUri = config.VisibilityArchivalURI
+		domain.AsyncWorkflowConfig = FromDomainAsyncWorkflowConfiguraton(config.AsyncWorkflowConfig)
 	}
 	if repl := t.ReplicationConfiguration; repl != nil {
 		domain.ActiveClusterName = repl.ActiveClusterName
@@ -4334,7 +4337,8 @@ func ToUpdateDomainResponse(t *apiv1.UpdateDomainResponse) *types.UpdateDomainRe
 			HistoryArchivalURI:                     t.Domain.HistoryArchivalUri,
 			VisibilityArchivalStatus:               ToArchivalStatus(t.Domain.VisibilityArchivalStatus),
 			VisibilityArchivalURI:                  t.Domain.VisibilityArchivalUri,
-			IsolationGroups:                        ToIsolationGroupConfig(t.GetDomain().GetIsolationGroups()),
+			IsolationGroups:                        ToIsolationGroupConfig(t.Domain.IsolationGroups),
+			AsyncWorkflowConfig:                    ToDomainAsyncWorkflowConfiguraton(t.Domain.AsyncWorkflowConfig),
 		},
 		ReplicationConfiguration: &types.DomainReplicationConfiguration{
 			ActiveClusterName: t.Domain.ActiveClusterName,

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -1874,6 +1874,7 @@ func FromDomainConfiguration(t *types.DomainConfiguration) *shared.DomainConfigu
 		VisibilityArchivalStatus:               FromArchivalStatus(t.VisibilityArchivalStatus),
 		VisibilityArchivalURI:                  &t.VisibilityArchivalURI,
 		Isolationgroups:                        FromIsolationGroupConfig(t.IsolationGroups),
+		AsyncWorkflowConfiguration:             FromDomainAsyncWorkflowConfiguraton(t.AsyncWorkflowConfig),
 	}
 }
 
@@ -1891,6 +1892,7 @@ func ToDomainConfiguration(t *shared.DomainConfiguration) *types.DomainConfigura
 		VisibilityArchivalStatus:               ToArchivalStatus(t.VisibilityArchivalStatus),
 		VisibilityArchivalURI:                  t.GetVisibilityArchivalURI(),
 		IsolationGroups:                        ToIsolationGroupConfig(t.Isolationgroups),
+		AsyncWorkflowConfig:                    ToDomainAsyncWorkflowConfiguraton(t.AsyncWorkflowConfiguration),
 	}
 }
 

--- a/common/types/testdata/domain.go
+++ b/common/types/testdata/domain.go
@@ -88,6 +88,14 @@ var (
 				State: types.IsolationGroupStateDrained,
 			},
 		},
+		AsyncWorkflowConfig: &types.AsyncWorkflowConfiguration{
+			Enabled:   true,
+			QueueType: "custom",
+			QueueConfig: &types.DataBlob{
+				EncodingType: types.EncodingTypeThriftRW.Ptr(),
+				Data:         []byte("custom queue config"),
+			},
+		},
 	}
 	DomainReplicationConfiguration = types.DomainReplicationConfiguration{
 		ActiveClusterName: ClusterName1,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
There are many places in the codebase that maps one type to another. While adding `AsyncWorkflowConfiguration` field to domain config a few places was missed. Updating them along with corresponding test data.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test