### PR TITLE
[code-coverage] Add tests for HandleDecisionTaskStarted

### DIFF
--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -23,7 +23,6 @@ package decision
 import (
 	"context"
 	"errors"
-	"github.com/uber/cadence/service/history/engine"
 	"reflect"
 	"testing"
 

--- a/service/history/decision/handler_test.go
+++ b/service/history/decision/handler_test.go
@@ -23,6 +23,7 @@ package decision
 import (
 	"context"
 	"errors"
+	"github.com/uber/cadence/service/history/engine"
 	"reflect"
 	"testing"
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add tests for HandleDecisionTaskStarted in service/history/decision

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve code coverage

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
n/a
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
