### PR TITLE
Migrate Buildkite CI from AWS to GKE agent queues

### DIFF
--- a/.buildkite/pipeline-master.yml
+++ b/.buildkite/pipeline-master.yml
@@ -1,13 +1,44 @@
+# `yq 'explode(.)' .buildkite/pipeline-master.yml` to see expanded anchor/aliases
+container:
+  kubernetes: &kubernetes
+    sidecars:
+    - image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-dind:v1
+      volumeMounts:
+        - mountPath: /var/run/
+          name: docker-sock
+      securityContext:
+        privileged: true
+        allowPrivilegeEscalation: true
+    mirrorVolumeMounts: true # CRITICAL: this must be at the same indentation level as sidecars
+    podSpec: &podSpec
+      containers:
+        - &commandContainer
+          image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-command-container:v2
+          command:
+          - |-
+            echo "Command step was not overridden."
+            exit 1
+          volumeMounts:
+            - mountPath: /var/run/
+              name: docker-sock
+          resources:
+            requests:
+              cpu: 7500m
+              memory: 30G
+      volumes:
+      - name: docker-sock
+        emptyDir: {}
+
+agents:
+  queue: buildkite-gcp
+
 steps:
   - label: "fossa analyze"
-    agents:
-      queue: "init"
-      docker: "*"
     command: "./scripts/buildkite/fossa.sh"
+
   - label: ":golang: unit test"
     agents:
       queue: "workers"
-      docker: "*"
     commands:
       - "CASSANDRA_HOST=cassandra make install-schema && make cover_profile" # make install-schema is needed for a server startup test. See main_test.go
       - "./scripts/buildkite/gen_coverage_metadata.sh .build/coverage/metadata.txt"
@@ -23,135 +54,180 @@ steps:
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golangci-lint: validate code is clean"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "./scripts/buildkite/golint.sh"
     artifact_paths: []
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  ./scripts/buildkite/golint.sh
       - docker-compose#v3.0.0:
           run: coverage-report
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with cassandra"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-cassandra
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with cassandra with ElasticSearch V7"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-cassandra
           config: docker/buildkite/docker-compose-es7.yml
 
   - label: ":golang: integration ndc test with cassandra"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make cover_ndc_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make cover_ndc_profile
       - docker-compose#v3.0.0:
           run: integration-test-ndc-cassandra
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with mysql"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-mysql
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration ndc test with mysql"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make cover_ndc_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make cover_ndc_profile
       - docker-compose#v3.0.0:
           run: integration-test-ndc-mysql
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with postgres"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-postgres
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration ndc test with postgres"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "make cover_ndc_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  make cover_ndc_profile
       - docker-compose#v3.0.0:
           run: integration-test-ndc-postgres
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: async wf integration test with kafka"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "go test -timeout 60s -run ^TestAsyncWFIntegrationSuite -tags asyncwfintegration -count 1 -v github.com/uber/cadence/host"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  go test -timeout 60s -run ^TestAsyncWFIntegrationSuite -tags asyncwfintegration -count 1 -v github.com/uber/cadence/host
       - docker-compose#v3.0.0:
           run: integration-test-async-wf
           config: docker/buildkite/docker-compose.yml
@@ -159,27 +235,43 @@ steps:
   - wait
 
   - label: ":golang: code-coverage"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "scripts/buildkite/gocov.sh"
     retry:
       automatic:
         limit: 2
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  scripts/buildkite/gocov.sh
       - docker-compose#v3.0.0:
           run: coverage-report
           config: docker/buildkite/docker-compose.yml
 
   - label: ":docker: build and push master"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "scripts/buildkite/docker-push.sh"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  scripts/buildkite/docker-push.sh
+                env:
+                  - name: DOCKER_LOGIN_PASSWORD
+                    valueFrom:
+                      secretKeyRef:
+                        name: ubercadence-dockerhub
+                        key: password
       - docker-login#v2.0.1:
           username: ubercadence
           password-env: DOCKER_LOGIN_PASSWORD

--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -1,13 +1,44 @@
+# `yq 'explode(.)' .buildkite/pipeline-pull-request.yml` to see expanded anchor/aliases
+container:
+  kubernetes: &kubernetes
+    sidecars:
+    - image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-dind:v1
+      volumeMounts:
+        - mountPath: /var/run/
+          name: docker-sock
+      securityContext:
+        privileged: true
+        allowPrivilegeEscalation: true
+    mirrorVolumeMounts: true # CRITICAL: this must be at the same indentation level as sidecars
+    podSpec: &podSpec
+      containers:
+        - &commandContainer
+          image: us-west1-docker.pkg.dev/ci-compute/buildkite-images/buildkite-command-container:v2
+          command:
+          - |-
+            echo "Command step was not overridden."
+            exit 1
+          volumeMounts:
+            - mountPath: /var/run/
+              name: docker-sock
+          resources:
+            requests:
+              cpu: 7500m
+              memory: 30G
+      volumes:
+      - name: docker-sock
+        emptyDir: {}
+
+agents:
+  queue: buildkite-gcp
+
 steps:
   - label: "fossa analyze"
-    agents:
-      queue: "init"
-      docker: "*"
     command: "./scripts/buildkite/fossa.sh"
+
   - label: ":golang: unit test"
     agents:
       queue: "workers"
-      docker: "*"
     commands:
       - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
       - "CASSANDRA_HOST=cassandra make install-schema && make cover_profile" # make install-schema is needed for a server startup test. See main_test.go
@@ -24,166 +55,216 @@ steps:
           config: docker/buildkite/docker-compose.yml
 
   - label: ":lint: validate code is clean"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "./scripts/buildkite/golint.sh"
     artifact_paths: []
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  ./scripts/buildkite/golint.sh
       - docker-compose#v3.0.0:
           run: coverage-report
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with cassandra"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-cassandra
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with cassandra with ElasticSearch V7"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-cassandra
           config: docker/buildkite/docker-compose-es7.yml
 
   - label: ":golang: integration test with cassandra with OpenSearch v2"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-cassandra
           config: docker/buildkite/docker-compose-opensearch2.yml
 
   - label: ":golang: integration ndc test with cassandra"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_ndc_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_ndc_profile
       - docker-compose#v3.0.0:
           run: integration-test-ndc-cassandra
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with mysql"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-mysql
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration ndc test with mysql"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_ndc_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_ndc_profile
       - docker-compose#v3.0.0:
           run: integration-test-ndc-mysql
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration test with postgres"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_integration_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_integration_profile
       - docker-compose#v3.0.0:
           run: integration-test-postgres
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: integration ndc test with postgres"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "make cover_ndc_profile"
     artifact_paths:
       - ".build/coverage/*.out"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  make cover_ndc_profile
       - docker-compose#v3.0.0:
           run: integration-test-ndc-postgres
           config: docker/buildkite/docker-compose.yml
 
   - label: ":golang: async wf integration test with kafka"
-    agents:
-      queue: "workers"
-      docker: "*"
-    commands:
-      - "make .just-build" # ensure that we are not rebuilding binaries and not regenerating code
-      - "go test -timeout 60s -run ^TestAsyncWFIntegrationSuite -tags asyncwfintegration -count 1 -v github.com/uber/cadence/host"
     retry:
       automatic:
         limit: 1
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  # ensure that we are not rebuilding binaries and not regenerating code
+                  make .just-build
+                  go test -timeout 60s -run ^TestAsyncWFIntegrationSuite -tags asyncwfintegration -count 1 -v github.com/uber/cadence/host
       - docker-compose#v3.0.0:
           run: integration-test-async-wf
           config: docker/buildkite/docker-compose.yml
@@ -191,23 +272,34 @@ steps:
   - wait
 
   - label: ":golang: code-coverage"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "scripts/buildkite/gocov.sh"
     retry:
       automatic:
         limit: 2
     plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  scripts/buildkite/gocov.sh
       - docker-compose#v3.0.0:
           run: coverage-report
           config: docker/buildkite/docker-compose.yml
 
   - label: ":docker: build (no push)"
-    agents:
-      queue: "workers"
-      docker: "*"
-    command: "scripts/buildkite/docker-build.sh"
     retry:
       automatic:
         limit: 1
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                - |-
+                  scripts/buildkite/docker-build.sh

--- a/common/persistence/persistence-tests/historyV2PersistenceTest.go
+++ b/common/persistence/persistence-tests/historyV2PersistenceTest.go
@@ -125,7 +125,7 @@ func (s *HistoryV2PersistenceSuite) TestScanAllTrees() {
 	if os.Getenv("SKIP_SCAN_HISTORY") != "" {
 		s.T().Skipf("GetAllHistoryTreeBranches not supported in %v", s.TaskMgr.GetName())
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), testContextTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), largeTestContextTimeout)
 	defer cancel()
 
 	resp, err := s.HistoryV2Mgr.GetAllHistoryTreeBranches(ctx, &p.GetAllHistoryTreeBranchesRequest{

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -18,6 +18,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 RUN pip install cqlsh
 
+# Install buildkite-agent
+# https://buildkite.com/docs/agent/v3/ubuntu
+RUN apt-get install -y apt-transport-https dirmngr
+RUN curl -fsSL https://keys.openpgp.org/vks/v1/by-fingerprint/32A37959C2FA5C3C99EFBC32A79206696452D198 | \
+  gpg --dearmor -o /usr/share/keyrings/buildkite-agent-archive-keyring.gpg
+RUN echo \
+  "deb [signed-by=/usr/share/keyrings/buildkite-agent-archive-keyring.gpg] https://apt.buildkite.com/buildkite-agent stable main" | \
+  tee /etc/apt/sources.list.d/buildkite-agent.list
+RUN apt-get update && apt-get install -yy --no-install-recommends buildkite-agent
+
 # verbose test output from `make`, can be disabled with V=0
 ENV V=0
 

--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -69,7 +69,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:

--- a/docker/buildkite/docker-compose-opensearch2.yml
+++ b/docker/buildkite/docker-compose-opensearch2.yml
@@ -70,7 +70,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -108,7 +108,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -137,7 +136,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -165,7 +163,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -193,7 +190,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -222,7 +218,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -250,7 +245,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -278,7 +272,6 @@ services:
       - kafka
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -306,7 +299,6 @@ services:
         condition: service_started
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
     networks:
       services-network:
         aliases:
@@ -337,7 +329,6 @@ services:
       - COVERALLS_TOKEN
     volumes:
       - ../../:/cadence
-      - /usr/bin/buildkite-agent:/usr/bin/buildkite-agent
 
 networks:
   services-network:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update Buildkite pipeline yaml to work with the newly provisioned queues in Google Kubernetes Engine
- Use [agent-stack-k8s v0.8.0 helm chart](https://github.com/buildkite/agent-stack-k8s/tree/v0.8.0?tab=readme-ov-file#cloning-repos-via-ssh) which has its own expected pipeline yaml syntax in order to successfully onboard. 
- Install buildkite-agent in Dockerfile for use in the code coverage step
  - The mount that previously worked in AWS's VM based infra doesn't work in Kubernete's container based set up. Install the cli directly for simplicity. 
- Increase timeout for a test that was flakier on GKE
- Leave the unit-test step on AWS while debugging timeout issues. 

<!-- Tell your future self why have you made these changes -->
**Why?**
- Migrate from AWS > Google Cloud. Buildkite Enterprise recommends GKE (as opposed to GCP) as the way to have a queue with autoscaling compute. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- https://buildkite.com/uberopensource/cadence-server/builds/18881

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- CI builds will be broken or flaky
- Can be mitigated by a git revert

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
n/a

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
n/a