### PR TITLE
Added Executor Interface and TimerTaskExecutorBase with stop() Method and improve context management in TimerQueueProcessor

### DIFF
--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -196,7 +196,7 @@ func (t *timerQueueProcessor) Stop() {
 		t.logger.Warn("transferQueueProcessor timed out on shut down", tag.LifeCycleStopTimedout)
 	}
 	t.activeQueueProcessor.Stop()
-	t.activeQueueProcessor.Stop()
+	t.activeTaskExecutor.Stop()
 	for _, standbyQueueProcessor := range t.standbyQueueProcessors {
 		standbyQueueProcessor.Stop()
 	}

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -178,6 +178,8 @@ func (t *timerQueueProcessor) Stop() {
 
 	if !t.shard.GetConfig().QueueProcessorEnableGracefulSyncShutdown() {
 		t.activeQueueProcessor.Stop()
+		// stop active executor after queue processor
+		t.activeTaskExecutor.Stop()
 		for _, standbyQueueProcessor := range t.standbyQueueProcessors {
 			standbyQueueProcessor.Stop()
 		}
@@ -193,6 +195,7 @@ func (t *timerQueueProcessor) Stop() {
 	if !common.AwaitWaitGroup(&t.shutdownWG, gracefulShutdownTimeout) {
 		t.logger.Warn("transferQueueProcessor timed out on shut down", tag.LifeCycleStopTimedout)
 	}
+	t.activeQueueProcessor.Stop()
 	t.activeQueueProcessor.Stop()
 	for _, standbyQueueProcessor := range t.standbyQueueProcessors {
 		standbyQueueProcessor.Stop()

--- a/service/history/task/cross_cluster_source_task_executor.go
+++ b/service/history/task/cross_cluster_source_task_executor.go
@@ -110,6 +110,9 @@ func (t *crossClusterSourceTaskExecutor) Execute(
 	return err
 }
 
+// Empty func for now
+func (t *crossClusterSourceTaskExecutor) Stop() {}
+
 func (t *crossClusterSourceTaskExecutor) executeStartChildExecutionTask(
 	ctx context.Context,
 	task *crossClusterSourceTask,

--- a/service/history/task/cross_cluster_source_task_executor_test.go
+++ b/service/history/task/cross_cluster_source_task_executor_test.go
@@ -123,6 +123,7 @@ func (s *crossClusterSourceTaskExecutorSuite) SetupTest() {
 }
 
 func (s *crossClusterSourceTaskExecutorSuite) TearDownTest() {
+	defer s.executor.Stop()
 	s.controller.Finish()
 	s.mockShard.Finish(s.T())
 }

--- a/service/history/task/cross_cluster_target_task_executor.go
+++ b/service/history/task/cross_cluster_target_task_executor.go
@@ -143,6 +143,9 @@ func (t *crossClusterTargetTaskExecutor) Execute(
 	return nil
 }
 
+// Empty func for now
+func (t *crossClusterTargetTaskExecutor) Stop() {}
+
 func (t *crossClusterTargetTaskExecutor) executeStartChildExecutionTask(
 	ctx context.Context,
 	task *crossClusterTargetTask,

--- a/service/history/task/cross_cluster_target_task_executor_test.go
+++ b/service/history/task/cross_cluster_target_task_executor_test.go
@@ -85,6 +85,7 @@ func (s *crossClusterTargetTaskExecutorSuite) SetupTest() {
 }
 
 func (s *crossClusterTargetTaskExecutorSuite) TearDownTest() {
+	defer s.executor.Stop()
 	s.controller.Finish()
 	s.mockShard.Finish(s.T())
 }

--- a/service/history/task/interface.go
+++ b/service/history/task/interface.go
@@ -72,6 +72,7 @@ type (
 	// Executor contains the execution logic for Task
 	Executor interface {
 		Execute(task Task, shouldProcessTask bool) error
+		Stop()
 	}
 
 	// Filter filters Task

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -856,6 +856,18 @@ func (mr *MockExecutorMockRecorder) Execute(task, shouldProcessTask interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Execute", reflect.TypeOf((*MockExecutor)(nil).Execute), task, shouldProcessTask)
 }
 
+// Stop mocks base method.
+func (m *MockExecutor) Stop() {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Stop")
+}
+
+// Stop indicates an expected call of Stop.
+func (mr *MockExecutorMockRecorder) Stop() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Stop", reflect.TypeOf((*MockExecutor)(nil).Stop))
+}
+
 // MockPriorityAssigner is a mock of PriorityAssigner interface.
 type MockPriorityAssigner struct {
 	ctrl     *gomock.Controller

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -87,7 +87,7 @@ func (t *timerActiveTaskExecutor) Execute(
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
+	ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 	defer cancel()
 
 	switch timerTask.TaskType {
@@ -105,7 +105,7 @@ func (t *timerActiveTaskExecutor) Execute(
 		return t.executeWorkflowBackoffTimerTask(ctx, timerTask)
 	case persistence.TaskTypeDeleteHistoryEvent:
 		// special timeout for delete history event
-		deleteHistoryEventContext, deleteHistoryEventCancel := context.WithTimeout(context.Background(), time.Duration(t.config.DeleteHistoryEventContextTimeout())*time.Second)
+		deleteHistoryEventContext, deleteHistoryEventCancel := context.WithTimeout(t.ctx, time.Duration(t.config.DeleteHistoryEventContextTimeout())*time.Second)
 		defer deleteHistoryEventCancel()
 		return t.executeDeleteHistoryEventTask(deleteHistoryEventContext, timerTask)
 	default:
@@ -157,7 +157,7 @@ func (t *timerActiveTaskExecutor) executeUserTimerTimeoutTask(
 	// is encountered, so that we don't need to scan history multiple times
 	// where there're multiple timers with high delay
 	var resurrectedTimer map[string]struct{}
-	scanWorkflowCtx, cancel := context.WithTimeout(context.Background(), scanWorkflowTimeout)
+	scanWorkflowCtx, cancel := context.WithTimeout(t.ctx, scanWorkflowTimeout)
 	defer cancel()
 
 	sortedUserTimers := timerSequence.LoadAndSortUserTimers()
@@ -304,7 +304,7 @@ func (t *timerActiveTaskExecutor) executeActivityTimeoutTask(
 	// is encountered, so that we don't need to scan history multiple times
 	// where there're multiple timers with high delay
 	var resurrectedActivity map[int64]struct{}
-	scanWorkflowCtx, cancel := context.WithTimeout(context.Background(), scanWorkflowTimeout)
+	scanWorkflowCtx, cancel := context.WithTimeout(t.ctx, scanWorkflowTimeout)
 	defer cancel()
 
 	// need to clear activity heartbeat timer task mask for new activity timer task creation

--- a/service/history/task/timer_active_task_executor.go
+++ b/service/history/task/timer_active_task_executor.go
@@ -87,21 +87,30 @@ func (t *timerActiveTaskExecutor) Execute(
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
-	defer cancel()
-
 	switch timerTask.TaskType {
 	case persistence.TaskTypeUserTimer:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeUserTimerTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeActivityTimeout:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeActivityTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeDecisionTimeout:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeDecisionTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeWorkflowTimeout:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeWorkflowTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeActivityRetryTimer:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeActivityRetryTimerTask(ctx, timerTask)
 	case persistence.TaskTypeWorkflowBackoffTimer:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeWorkflowBackoffTimerTask(ctx, timerTask)
 	case persistence.TaskTypeDeleteHistoryEvent:
 		// special timeout for delete history event

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -91,7 +91,7 @@ func (t *timerStandbyTaskExecutor) Execute(
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), taskDefaultTimeout)
+	ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
 	defer cancel()
 
 	switch timerTask.TaskType {
@@ -111,7 +111,7 @@ func (t *timerStandbyTaskExecutor) Execute(
 		return t.executeWorkflowBackoffTimerTask(ctx, timerTask)
 	case persistence.TaskTypeDeleteHistoryEvent:
 		// special timeout for delete history event
-		deleteHistoryEventContext, deleteHistoryEventCancel := context.WithTimeout(context.Background(), time.Duration(t.config.DeleteHistoryEventContextTimeout())*time.Second)
+		deleteHistoryEventContext, deleteHistoryEventCancel := context.WithTimeout(t.ctx, time.Duration(t.config.DeleteHistoryEventContextTimeout())*time.Second)
 		defer deleteHistoryEventCancel()
 		return t.executeDeleteHistoryEventTask(deleteHistoryEventContext, timerTask)
 	default:

--- a/service/history/task/timer_standby_task_executor.go
+++ b/service/history/task/timer_standby_task_executor.go
@@ -91,23 +91,30 @@ func (t *timerStandbyTaskExecutor) Execute(
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
-	defer cancel()
-
 	switch timerTask.TaskType {
 	case persistence.TaskTypeUserTimer:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeUserTimerTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeActivityTimeout:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeActivityTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeDecisionTimeout:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeDecisionTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeWorkflowTimeout:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeWorkflowTimeoutTask(ctx, timerTask)
 	case persistence.TaskTypeActivityRetryTimer:
 		// retry backoff timer should not get created on passive cluster
 		// TODO: add error logs
 		return nil
 	case persistence.TaskTypeWorkflowBackoffTimer:
+		ctx, cancel := context.WithTimeout(t.ctx, taskDefaultTimeout)
+		defer cancel()
 		return t.executeWorkflowBackoffTimerTask(ctx, timerTask)
 	case persistence.TaskTypeDeleteHistoryEvent:
 		// special timeout for delete history event

--- a/service/history/task/timer_task_executor_base_test.go
+++ b/service/history/task/timer_task_executor_base_test.go
@@ -115,6 +115,7 @@ func (s *timerQueueTaskExecutorBaseSuite) TearDownTest() {
 	s.controller.Finish()
 	s.mockShard.Finish(s.T())
 	s.mockArchivalClient.AssertExpectations(s.T())
+	s.timerQueueTaskExecutorBase.Stop()
 }
 
 func (s *timerQueueTaskExecutorBaseSuite) TestDeleteWorkflow_NoErr() {

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -161,6 +161,9 @@ func (t *transferActiveTaskExecutor) Execute(
 	}
 }
 
+// Empty func for now
+func (t *transferActiveTaskExecutor) Stop() {}
+
 func (t *transferActiveTaskExecutor) processActivityTask(
 	ctx context.Context,
 	task *persistence.TransferTaskInfo,

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -215,6 +215,7 @@ func (s *transferActiveTaskExecutorSuite) SetupTest() {
 }
 
 func (s *transferActiveTaskExecutorSuite) TearDownTest() {
+	s.transferActiveTaskExecutor.Stop()
 	s.controller.Finish()
 	s.mockShard.Finish(s.T())
 	s.mockArchivalClient.AssertExpectations(s.T())

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -118,6 +118,9 @@ func (t *transferStandbyTaskExecutor) Execute(
 	}
 }
 
+// Empty func for now
+func (t *transferStandbyTaskExecutor) Stop() {}
+
 func (t *transferStandbyTaskExecutor) processActivityTask(
 	ctx context.Context,
 	transferTask *persistence.TransferTaskInfo,

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -166,6 +166,7 @@ func (s *transferStandbyTaskExecutorSuite) TearDownTest() {
 	s.controller.Finish()
 	s.mockShard.Finish(s.T())
 	s.mockArchivalClient.AssertExpectations(s.T())
+	s.transferStandbyTaskExecutor.Stop()
 }
 
 func (s *transferStandbyTaskExecutorSuite) TestProcessActivityTask_Pending() {


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Added stop() to the Executor interface and created an empty stop() function for future implementations in Executors.
Implemented stop() in TimerTaskExecutorBase.
Added context and cancelFn in TimerTaskExecutorBase struct and replaced context.Background() with internal context to prevent memory leaks.
Called executor.stop() in TimerQueueProcessor to prevent context leaks.

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently we are creating new context and pass that to downstream without proper stop signal propagation

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
We are calling the stop method at the end of the lifecycle so there won't be any added risks.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
