### PR TITLE
Changed the error to DomainNotActive for Deprecated domains

### DIFF
--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -195,13 +195,11 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainIDRedirect
 		return err
 	}
 	if domainEntry.IsDeprecatedOrDeleted() {
-		//return fmt.Errorf("domain %v is deprecated or deleted", domainEntry.GetInfo().Name)
-		//return types.NewDomainNotActiveError(domainEntry.GetInfo().Name, domainEntry.GetReplicationConfig().ActiveClusterName)
 		return types.DomainNotActiveError{
 			Message:        "domain is deprecated.",
 			DomainName:     domainEntry.GetInfo().Name,
-			CurrentCluster: "",
-			ActiveCluster:  "",
+			CurrentCluster: policy.currentClusterName,
+			ActiveCluster:  policy.currentClusterName,
 		}
 	}
 	return policy.withRedirect(ctx, domainEntry, apiName, call)
@@ -214,13 +212,11 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainNameRedire
 		return err
 	}
 	if domainEntry.IsDeprecatedOrDeleted() {
-		//return fmt.Errorf("domain %v is deprecated or deleted", domainName)
-
 		return types.DomainNotActiveError{
 			Message:        "domain is deprecated or deleted",
 			DomainName:     domainName,
-			CurrentCluster: "",
-			ActiveCluster:  "",
+			CurrentCluster: policy.currentClusterName,
+			ActiveCluster:  policy.currentClusterName,
 		}
 	}
 	return policy.withRedirect(ctx, domainEntry, apiName, call)

--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -195,7 +195,14 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainIDRedirect
 		return err
 	}
 	if domainEntry.IsDeprecatedOrDeleted() {
-		return fmt.Errorf("domain %v is deprecated or deleted", domainEntry.GetInfo().Name)
+		//return fmt.Errorf("domain %v is deprecated or deleted", domainEntry.GetInfo().Name)
+		//return types.NewDomainNotActiveError(domainEntry.GetInfo().Name, domainEntry.GetReplicationConfig().ActiveClusterName)
+		return types.DomainNotActiveError{
+			Message:        "domain is deprecated.",
+			DomainName:     domainEntry.GetInfo().Name,
+			CurrentCluster: "",
+			ActiveCluster:  "",
+		}
 	}
 	return policy.withRedirect(ctx, domainEntry, apiName, call)
 }
@@ -207,7 +214,14 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainNameRedire
 		return err
 	}
 	if domainEntry.IsDeprecatedOrDeleted() {
-		return fmt.Errorf("domain %v is deprecated or deleted", domainName)
+		//return fmt.Errorf("domain %v is deprecated or deleted", domainName)
+
+		return types.DomainNotActiveError{
+			Message:        "domain is deprecated or deleted",
+			DomainName:     domainName,
+			CurrentCluster: "",
+			ActiveCluster:  "",
+		}
 	}
 	return policy.withRedirect(ctx, domainEntry, apiName, call)
 }

--- a/service/frontend/wrappers/clusterredirection/policy_test.go
+++ b/service/frontend/wrappers/clusterredirection/policy_test.go
@@ -398,11 +398,11 @@ func (s *selectedAPIsForwardingRedirectionPolicySuite) TestGetTargetDataCenter_G
 	for apiName := range selectedAPIsForwardingRedirectionPolicyAPIAllowlist {
 		err := s.policy.WithDomainIDRedirect(context.Background(), s.domainID, apiName, callFn)
 		s.Error(err)
-		s.Equal(fmt.Sprintf("domain %v is deprecated or deleted", s.domainName), err.Error())
+		s.Equal("domain is deprecated.", err.Error())
 
 		err = s.policy.WithDomainNameRedirect(context.Background(), s.domainName, apiName, callFn)
 		s.Error(err)
-		s.Equal(fmt.Sprintf("domain %v is deprecated or deleted", s.domainName), err.Error())
+		s.Equal("domain is deprecated or deleted", err.Error())
 	}
 
 	s.Equal(0, currentClustercallCount)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
As part of oncall fix causing muttley service side error, we think the code is breaking because of misclassified error as it see sprintf error as cadence causing issue, but in real it is not.

I think we have to return errors from below for poll for DecisionTask.

![Pasted Graphic](https://github.com/uber/cadence/assets/17800780/d5016515-5f9a-49f1-a12b-d1431a8436f2)


<!-- Tell your future self why have you made these changes -->
**Why?**
To fix the misclassified error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Uni test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Added change to avoid muttley service SLA mess

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
