### PR TITLE
Fix GetListWorkflowExecutionsByStatusQuery to set status as int

### DIFF
--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -1058,20 +1058,20 @@ func getListWorkflowExecutionsByStatusQuery(tableName string, request *p.Interna
 	query.filters.addEqual(DomainID, request.DomainUUID)
 	query.filters.addEqual(IsDeleted, false)
 
-	status := "0"
+	status := 0
 	switch request.Status.String() {
 	case "COMPLETED":
-		status = "0"
+		status = 0
 	case "FAILED":
-		status = "1"
+		status = 1
 	case "CANCELED":
-		status = "2"
+		status = 2
 	case "TERMINATED":
-		status = "3"
+		status = 3
 	case "CONTINUED_AS_NEW":
-		status = "4"
+		status = 4
 	case "TIMED_OUT":
-		status = "5"
+		status = 5
 	}
 
 	query.filters.addEqual(CloseStatus, status)

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1535,7 +1535,7 @@ func TestGetListWorkflowExecutionsByStatusQuery(t *testing.T) {
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
-AND CloseStatus = '0'
+AND CloseStatus = 0
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1558,7 +1558,7 @@ LIMIT 0, 10
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
-AND CloseStatus = '1'
+AND CloseStatus = 1
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1581,7 +1581,7 @@ LIMIT 0, 10
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
-AND CloseStatus = '2'
+AND CloseStatus = 2
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1604,7 +1604,7 @@ LIMIT 0, 10
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
-AND CloseStatus = '3'
+AND CloseStatus = 3
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1627,7 +1627,7 @@ LIMIT 0, 10
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
-AND CloseStatus = '4'
+AND CloseStatus = 4
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1650,7 +1650,7 @@ LIMIT 0, 10
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
-AND CloseStatus = '5'
+AND CloseStatus = 5
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
 LIMIT 0, 10


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Currently when it builds the query, it sets CloseStatus as string which is not matched with Pinot schema and can cause query failure.

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
