### PR TITLE
Fix slice reuse in cassandra/domain.go

### DIFF
--- a/common/persistence/nosql/nosqlplugin/cassandra/domain.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/domain.go
@@ -410,6 +410,10 @@ func (db *cdb) SelectAllDomains(
 		replicationClusters = []map[string]interface{}{}
 		badBinariesData = []byte("")
 		badBinariesDataEncoding = ""
+		isolationGroups = []byte("")
+		isolationGroupsEncoding = ""
+		asyncWFConfigData = []byte("")
+		asyncWFConfigEncoding = ""
 		failoverEndTime = 0
 		lastUpdateTime = 0
 		retentionDays = 0

--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -1182,8 +1182,14 @@ func (m *MetadataPersistenceSuiteV2) TestListDomains() {
 				VisibilityArchivalStatus: types.ArchivalStatusEnabled,
 				VisibilityArchivalURI:    "test://visibility/uri",
 				BadBinaries:              testBinaries1,
-				IsolationGroups:          types.IsolationGroupConfiguration{},
-				AsyncWorkflowConfig:      types.AsyncWorkflowConfiguration{},
+				IsolationGroups: types.IsolationGroupConfiguration{
+					"name1": types.IsolationGroupPartition{Name: "name1"},
+					"name2": types.IsolationGroupPartition{Name: "name2"},
+				},
+				AsyncWorkflowConfig: types.AsyncWorkflowConfiguration{
+					Enabled:             true,
+					PredefinedQueueName: "queue1",
+				},
 			},
 			ReplicationConfig: &p.DomainReplicationConfig{
 				ActiveClusterName: clusterActive1,
@@ -1211,8 +1217,13 @@ func (m *MetadataPersistenceSuiteV2) TestListDomains() {
 				VisibilityArchivalStatus: types.ArchivalStatusDisabled,
 				VisibilityArchivalURI:    "",
 				BadBinaries:              testBinaries2,
-				IsolationGroups:          types.IsolationGroupConfiguration{},
-				AsyncWorkflowConfig:      types.AsyncWorkflowConfiguration{},
+				IsolationGroups: types.IsolationGroupConfiguration{
+					"name3": types.IsolationGroupPartition{Name: "name3"},
+				},
+				AsyncWorkflowConfig: types.AsyncWorkflowConfiguration{
+					Enabled:             false,
+					PredefinedQueueName: "queue2",
+				},
 			},
 			ReplicationConfig: &p.DomainReplicationConfig{
 				ActiveClusterName: clusterActive2,

--- a/host/integrationbase.go
+++ b/host/integrationbase.go
@@ -58,6 +58,7 @@ type (
 		adminClient              AdminClient
 		Logger                   log.Logger
 		domainName               string
+		secondaryDomainName      string
 		testRawHistoryDomainName string
 		foreignDomainName        string
 		archivalDomainName       string


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Reset the fields for isolationGroups and asyncWFConfigData after each row.

While reading domains from Cassandra the isolationGroups and asncWFConfigData are not properly reset for each row. This can result in the same backing array being reused across multiple rows, resulting in an incorrect or corrupted value being read.


<!-- Tell your future self why have you made these changes -->
**Why?**
Fixes a bug where the domain cache contains the wrong async wf config data and is unable to trigger an async workflow despite it being enabled for that ddomain.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Updated the persistence tests to include isolationGroups and asyncWFConfigData.
- Added a secondary domain to the async wf integration test
- Ran locally and started an async workflow via the java client

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
