### PR TITLE
Fix checksum validation for SQL

### DIFF
--- a/common/persistence/sql/sql_execution_store_test.go
+++ b/common/persistence/sql/sql_execution_store_test.go
@@ -3532,7 +3532,6 @@ func TestGetWorkflowExecution(t *testing.T) {
 				},
 			},
 			mockSetup: func(db *sqlplugin.MockDB, parser *serialization.MockParser) {
-				db.EXPECT().SelectFromExecutions(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromActivityInfoMaps(gomock.Any(), gomock.Any()).Return(nil, errors.New("some random error"))
 				db.EXPECT().SelectFromTimerInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromChildExecutionInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
@@ -3554,7 +3553,6 @@ func TestGetWorkflowExecution(t *testing.T) {
 				},
 			},
 			mockSetup: func(db *sqlplugin.MockDB, parser *serialization.MockParser) {
-				db.EXPECT().SelectFromExecutions(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromActivityInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromTimerInfoMaps(gomock.Any(), gomock.Any()).Return(nil, errors.New("some random error"))
 				db.EXPECT().SelectFromChildExecutionInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
@@ -3576,7 +3574,6 @@ func TestGetWorkflowExecution(t *testing.T) {
 				},
 			},
 			mockSetup: func(db *sqlplugin.MockDB, parser *serialization.MockParser) {
-				db.EXPECT().SelectFromExecutions(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromActivityInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromTimerInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromChildExecutionInfoMaps(gomock.Any(), gomock.Any()).Return(nil, errors.New("some random error"))
@@ -3598,7 +3595,6 @@ func TestGetWorkflowExecution(t *testing.T) {
 				},
 			},
 			mockSetup: func(db *sqlplugin.MockDB, parser *serialization.MockParser) {
-				db.EXPECT().SelectFromExecutions(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromActivityInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromTimerInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromChildExecutionInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
@@ -3620,7 +3616,6 @@ func TestGetWorkflowExecution(t *testing.T) {
 				},
 			},
 			mockSetup: func(db *sqlplugin.MockDB, parser *serialization.MockParser) {
-				db.EXPECT().SelectFromExecutions(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromActivityInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromTimerInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromChildExecutionInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
@@ -3642,7 +3637,6 @@ func TestGetWorkflowExecution(t *testing.T) {
 				},
 			},
 			mockSetup: func(db *sqlplugin.MockDB, parser *serialization.MockParser) {
-				db.EXPECT().SelectFromExecutions(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromActivityInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromTimerInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromChildExecutionInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
@@ -3664,7 +3658,6 @@ func TestGetWorkflowExecution(t *testing.T) {
 				},
 			},
 			mockSetup: func(db *sqlplugin.MockDB, parser *serialization.MockParser) {
-				db.EXPECT().SelectFromExecutions(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromActivityInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromTimerInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)
 				db.EXPECT().SelectFromChildExecutionInfoMaps(gomock.Any(), gomock.Any()).Return(nil, sql.ErrNoRows)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix checksum validation for SQL

<!-- Tell your future self why have you made these changes -->
**Why?**
There is a race condition with delete workflow. What could happen is that a delete workflow transaction can be committed between 2 concurrent read operations and in that case we can get checksum error because data is partially read.
Since checksum is stored in the executions table, we make it the last step of reading. And in this case, either we read full data with checksum or we don't get checksum and return error.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
