### PR TITLE
Fix a bug when set memo in pinot visibility store

### DIFF
--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -611,7 +611,7 @@ func createVisibilityMessage(
 		SearchAttributes[key] = val
 	}
 
-	if memo != nil {
+	if memo != nil && len(memo.Data) > 0 {
 		// add memo into search attr
 		marshalMemo, err := json.Marshal(memo)
 		if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Currently it exists memo not equals to nil but data is empty, pinot will save it to search attribute and cause issue when list workflow executions and deserialize

<!-- Tell your future self why have you made these changes -->
**Why?**
Bug fix

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
