### PR TITLE
Replace wurstmeister kafka/zookeeper images with bitnami kafka image

### DIFF
--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -16,25 +16,29 @@ services:
       timeout: 30s
       retries: 10
 
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    networks:
-      services-network:
-        aliases:
-          - zookeeper
-
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
     networks:
       services-network:
         aliases:
           - kafka
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3

--- a/docker/buildkite/docker-compose-es7.yml
+++ b/docker/buildkite/docker-compose-es7.yml
@@ -17,14 +17,14 @@ services:
       retries: 10
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     networks:
       services-network:
         aliases:
           - zookeeper
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     networks:

--- a/docker/buildkite/docker-compose-local-async-wf.yml
+++ b/docker/buildkite/docker-compose-local-async-wf.yml
@@ -40,7 +40,7 @@ services:
     networks:
       services-network:
         aliases:
-          - integration-test
+          - kafka
 
   integration-test-async-wf:
     build:

--- a/docker/buildkite/docker-compose-local-async-wf.yml
+++ b/docker/buildkite/docker-compose-local-async-wf.yml
@@ -1,4 +1,4 @@
-# version: "3.5"
+version: "3.5"
 
 services:
   cassandra:

--- a/docker/buildkite/docker-compose-local-async-wf.yml
+++ b/docker/buildkite/docker-compose-local-async-wf.yml
@@ -19,7 +19,7 @@ services:
       retries: 10
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"
     networks:
@@ -28,7 +28,7 @@ services:
           - zookeeper
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/buildkite/docker-compose-local-async-wf.yml
+++ b/docker/buildkite/docker-compose-local-async-wf.yml
@@ -1,4 +1,4 @@
-version: "3.5"
+# version: "3.5"
 
 services:
   cassandra:
@@ -18,32 +18,29 @@ services:
       timeout: 30s
       retries: 10
 
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
-    networks:
-      services-network:
-        aliases:
-          - zookeeper
-
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
+    environment:
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
     networks:
       services-network:
         aliases:
-          - kafka
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      # create a topic with 10 partitions and 1 replica
-      # topic name must match ASYNC_WF_KAFKA_QUEUE_TOPIC specified in cadence container above
-      KAFKA_CREATE_TOPICS: "async-wf-topic1:10:1"
+          - integration-test
 
   integration-test-async-wf:
     build:

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -18,29 +18,29 @@ services:
       timeout: 30s
       retries: 10
 
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
-    networks:
-      services-network:
-        aliases:
-          - zookeeper
-
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
+    environment:
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
     networks:
       services-network:
         aliases:
           - kafka
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3

--- a/docker/buildkite/docker-compose-local-es7.yml
+++ b/docker/buildkite/docker-compose-local-es7.yml
@@ -19,7 +19,7 @@ services:
       retries: 10
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"
     networks:
@@ -28,7 +28,7 @@ services:
           - zookeeper
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -44,29 +44,29 @@ services:
         aliases:
           - postgres
 
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    expose:
-      - "2181"
-    networks:
-      services-network:
-        aliases:
-          - zookeeper
-
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
-    expose:
-      - "9092"
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
     networks:
       services-network:
         aliases:
           - kafka
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22

--- a/docker/buildkite/docker-compose-local.yml
+++ b/docker/buildkite/docker-compose-local.yml
@@ -45,7 +45,7 @@ services:
           - postgres
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     expose:
       - "2181"
     networks:
@@ -54,7 +54,7 @@ services:
           - zookeeper
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     expose:

--- a/docker/buildkite/docker-compose-opensearch2.yml
+++ b/docker/buildkite/docker-compose-opensearch2.yml
@@ -16,25 +16,29 @@ services:
       timeout: 30s
       retries: 10
 
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    networks:
-      services-network:
-        aliases:
-          - zookeeper
-
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
     networks:
       services-network:
         aliases:
           - kafka
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
 
   elasticsearch:
     image: opensearchproject/opensearch:2.5.0

--- a/docker/buildkite/docker-compose-opensearch2.yml
+++ b/docker/buildkite/docker-compose-opensearch2.yml
@@ -17,14 +17,14 @@ services:
       retries: 10
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     networks:
       services-network:
         aliases:
           - zookeeper
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     networks:

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -36,28 +36,29 @@ services:
         aliases:
           - postgres
 
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    networks:
-      services-network:
-        aliases:
-          - zookeeper
-
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
+    ports:
+      - "9092:9092"
+    environment:
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
     networks:
       services-network:
         aliases:
           - kafka
-    environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      # for async wf tests, create a topic with 10 partitions and 1 replica
-      # topic name must match ASYNC_WF_KAFKA_QUEUE_TOPIC
-      KAFKA_CREATE_TOPICS: "async-wf-topic1:10:1"
 
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22

--- a/docker/buildkite/docker-compose.yml
+++ b/docker/buildkite/docker-compose.yml
@@ -37,14 +37,14 @@ services:
           - postgres
 
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     networks:
       services-network:
         aliases:
           - zookeeper
 
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     networks:

--- a/docker/dev/cassandra-esv7-kafka.yml
+++ b/docker/dev/cassandra-esv7-kafka.yml
@@ -14,16 +14,21 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"

--- a/docker/dev/cassandra-esv7-kafka.yml
+++ b/docker/dev/cassandra-esv7-kafka.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:
@@ -24,6 +24,6 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"

--- a/docker/dev/cassandra-opensearch-kafka.yml
+++ b/docker/dev/cassandra-opensearch-kafka.yml
@@ -15,7 +15,7 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:
@@ -25,6 +25,6 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"

--- a/docker/dev/cassandra-opensearch-kafka.yml
+++ b/docker/dev/cassandra-opensearch-kafka.yml
@@ -15,16 +15,21 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"

--- a/docker/dev/cassandra-pinot-kafka.yml
+++ b/docker/dev/cassandra-pinot-kafka.yml
@@ -48,21 +48,25 @@ services:
       JAVA_OPTS: "-Dplugins.dir=/opt/pinot/plugins -Xms4G -Xmx16G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xloggc:gc-pinot-server.log"
     depends_on:
       - pinot-broker
-  kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+   kafka:
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
-    expose:
-      - "9093"
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181/kafka
-      KAFKA_BROKER_ID: 0
-      KAFKA_ADVERTISED_HOST_NAME: kafka
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9093,OUTSIDE://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3
     ports:

--- a/docker/dev/cassandra-pinot-kafka.yml
+++ b/docker/dev/cassandra-pinot-kafka.yml
@@ -49,7 +49,7 @@ services:
     depends_on:
       - pinot-broker
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/dev/mongo-esv7-kafka.yml
+++ b/docker/dev/mongo-esv7-kafka.yml
@@ -25,16 +25,21 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"

--- a/docker/dev/mongo-esv7-kafka.yml
+++ b/docker/dev/mongo-esv7-kafka.yml
@@ -25,7 +25,7 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:
@@ -35,6 +35,6 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"

--- a/docker/dev/mysql-esv7-kafka.yml
+++ b/docker/dev/mysql-esv7-kafka.yml
@@ -13,7 +13,7 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:
@@ -23,6 +23,6 @@ services:
       KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"

--- a/docker/dev/mysql-esv7-kafka.yml
+++ b/docker/dev/mysql-esv7-kafka.yml
@@ -13,16 +13,21 @@ services:
     environment:
       - discovery.type=single-node
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"

--- a/docker/docker-compose-async-wf-kafka.yml
+++ b/docker/docker-compose-async-wf-kafka.yml
@@ -75,11 +75,11 @@ services:
     ports:
       - '3000:3000'
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/docker-compose-async-wf-kafka.yml
+++ b/docker/docker-compose-async-wf-kafka.yml
@@ -74,20 +74,22 @@ services:
       - prometheus
     ports:
       - '3000:3000'
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      # create a topic with 10 partitions and 1 replica
-      # topic name must match ASYNC_WF_KAFKA_QUEUE_TOPIC specified in cadence container above
-      KAFKA_CREATE_TOPICS: "async-wf-topic1:10:1"
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -21,11 +21,11 @@ services:
     ports:
       - '9090:9090'
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/docker-compose-es-v7.yml
+++ b/docker/docker-compose-es-v7.yml
@@ -20,20 +20,25 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
       - '9090:9090'
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:7.9.3
     ports:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -21,11 +21,11 @@ services:
     ports:
       - '9090:9090'
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/docker-compose-es.yml
+++ b/docker/docker-compose-es.yml
@@ -20,20 +20,25 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
       - '9090:9090'
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22
     ports:

--- a/docker/docker-compose-multiclusters-cass-mysql-es.yaml
+++ b/docker/docker-compose-multiclusters-cass-mysql-es.yaml
@@ -27,11 +27,11 @@ services:
     ports:
       - '9090:9090'
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/docker-compose-multiclusters-cass-mysql-es.yaml
+++ b/docker/docker-compose-multiclusters-cass-mysql-es.yaml
@@ -26,20 +26,25 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
       - '9090:9090'
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22
     ports:

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -21,11 +21,11 @@ services:
     ports:
       - '9090:9090'
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: ubercadence/wurstmeister-zookeeper:3.4.6
     ports:
       - "2181:2181"
   kafka:
-    image: wurstmeister/kafka:2.12-2.1.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/docker-compose-multiclusters-es.yml
+++ b/docker/docker-compose-multiclusters-es.yml
@@ -20,20 +20,25 @@ services:
       - '--config.file=/etc/prometheus/prometheus.yml'
     ports:
       - '9090:9090'
-  zookeeper:
-    image: ubercadence/wurstmeister-zookeeper:3.4.6
-    ports:
-      - "2181:2181"
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
     environment:
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.22
     ports:

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -13,7 +13,7 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
     depends_on:
       - zookeeper
     ports:

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -13,20 +13,24 @@ services:
     ports:
       - '9090:9090'
   kafka:
-    image: ubercadence/wurstmeister-kafka:2.12-2.1.1
-    depends_on:
-      - zookeeper
+    image: docker.io/bitnami/kafka:3.7
+    hostname: kafka
+    container_name: kafka
     ports:
       - "9092:9092"
-    expose:
-      - "9093"
     environment:
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181/kafka
-      KAFKA_BROKER_ID: 0
-      KAFKA_ADVERTISED_HOST_NAME: kafka
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9093,OUTSIDE://localhost:9092
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9093,OUTSIDE://0.0.0.0:9092
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,OUTSIDE:PLAINTEXT
+      # KRaft settings
+      - "KAFKA_CFG_NODE_ID=0"
+      - "KAFKA_CFG_PROCESS_ROLES=controller,broker"
+      - "KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093"
+      # Listeners
+      - "KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093"
+      - "KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092"
+      - "KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT"
+      - "KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER"
+      - "KAFKA_CFG_INTER_BROKER_LISTENER_NAME=PLAINTEXT"
+      # Topic settings
+      - "KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true"
   zookeeper:
     image: zookeeper:3.5.8
     container_name: zookeeper


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Integration tests depend on following images that seems to be [gone](https://github.com/wurstmeister/zookeeper-docker/issues/31). 
- `wurstmeister/kafka:2.12-2.1.1`
- `wurstmeister/zookeeper:3.4.6`

These kafka/zookeeper images are 3rd party built and that project doesn't seem to be actively maintained. Not having these images is blocking [CI checks](https://buildkite.com/uberopensource/cadence-server/builds/19209#_) for all active PRs at the moment. 

To fix this issue I am switching to `bitnami/kafka:3.7` image which is newer version of kafka and doesn't have zookeeper dependency anymore. Updated all the docker compose files but didn't test the ones that are not covered by CI. There might be some follow up fixes.

<!-- Tell your future self why have you made these changes -->
**Why?**
Unblock CI.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
CI checks in this PR.

