### PR TITLE
Revert codecov patch threshold to 85%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,7 @@ coverage:
         if_ci_failed: ignore   # require the CI to pass before setting the status
     patch:
       default:
-        target: 0%            # specify the target coverage for each commit status
+        target: 85%            # specify the target coverage for each commit status
                                #   option: "auto" (compare against parent commit or pull request base)
                                #   option: "X%" a static target percentage to hit
         threshold: 0%          # allow the coverage drop by x% before marking as failure


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I had to bypass 85% patch coverage threshold to split the history engine into multiple files in #5972.
It's merged so bringing the threshold back.