### PR TITLE
Reduce flakiness on workflow-ID-specific ratelimit test

### DIFF
--- a/host/workflowidratelimit_test.go
+++ b/host/workflowidratelimit_test.go
@@ -145,9 +145,9 @@ func (s *WorkflowIDRateLimitIntegrationSuite) TestWorkflowIDSpecificRateLimits()
 			}
 		}
 	}
-	// 5 fairly regularly fails, 4 seems probably-likely to be reliable with minor time skew,
-	// but be a bit more permissive as buildkite hosts vary a lot
-	assert.GreaterOrEqual(s.T(), limited, 3, "should have encountered some rate-limit errors after the burst was exhausted")
+	// 5 fails occasionally, trying 4.  If needed, reduce to 3 or find a way to
+	// make this test less sensitive to latency, as test-runner hosts vary a lot.
+	assert.GreaterOrEqual(s.T(), limited, 4, "should have encountered some rate-limit errors after the burst was exhausted")
 
 	// After 1 second we should be able to start another workflow without being limited
 	time.Sleep(1 * time.Second)

--- a/host/workflowidratelimit_test.go
+++ b/host/workflowidratelimit_test.go
@@ -149,7 +149,7 @@ func (s *WorkflowIDRateLimitIntegrationSuite) TestWorkflowIDSpecificRateLimits()
 	// make this test less sensitive to latency, as test-runner hosts vary a lot.
 	assert.GreaterOrEqual(s.T(), limited, 4, "should have encountered some rate-limit errors after the burst was exhausted")
 
-	// After 1 second we should be able to start another workflow without being limited
+	// After 1 second (200ms at a minimum) we should be able to start more workflows without being limited
 	time.Sleep(1 * time.Second)
 	_, err := s.engine.StartWorkflowExecution(ctx, request)
 	assert.NoError(s.T(), err)


### PR DESCRIPTION
This test had three issues:
1. it's *very* time-sensitive, spending >=200ms across all StartWorkflowExecution calls will allow one (or more) of the "should be limited" calls to succeed.  This is now more permissive.
2. it seems to misunderstand / be misleading about how ratelimits work.  The reason the first 5 calls can be done "immediately" is due to the burst value, not the RPS itself.  We just init the burst with that value.
3. if `assert.ErrorAs` failed, the next line would panic because the error value was nil.  `require` would work too, but switching to `if assert.ErrorAs(...) {...}` lets the rest of the checks continue, and it's relatively simple.

These are now fixed.
