### PR TITLE
lowering threshold for PRs for a one-time refactor/split

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -19,7 +19,8 @@ coverage:
         if_ci_failed: ignore   # require the CI to pass before setting the status
     patch:
       default:
-        target: 85%            # specify the target coverage for each commit status
+        target: 0% # Todo (David.porter) to immediately revert this after landing a refactor
+                               # specify the target coverage for each commit status
                                #   option: "auto" (compare against parent commit or pull request base)
                                #   option: "X%" a static target percentage to hit
         threshold: 0%          # allow the coverage drop by x% before marking as failure


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This lowers the new diff coverage threshold to 0 for the sake of a refactor/split: https://github.com/uber/cadence/pull/5990. This will be reverted after

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
