### PR TITLE
Stop orphan failover queue processors when its parent stops

### DIFF
--- a/service/history/queue/timer_queue_failover_processor.go
+++ b/service/history/queue/timer_queue_failover_processor.go
@@ -28,7 +28,6 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
-	"github.com/uber/cadence/service/history/engine"
 	"github.com/uber/cadence/service/history/shard"
 	"github.com/uber/cadence/service/history/task"
 )
@@ -36,7 +35,6 @@ import (
 func newTimerQueueFailoverProcessor(
 	standbyClusterName string,
 	shardContext shard.Context,
-	historyEngine engine.Engine,
 	taskProcessor task.Processor,
 	taskAllocator TaskAllocator,
 	taskExecutor task.Executor,

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -310,7 +310,6 @@ func (t *timerQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 	updateClusterAckLevelFn, failoverQueueProcessor := newTimerQueueFailoverProcessor(
 		standbyClusterName,
 		t.shard,
-		t.historyEngine,
 		t.taskProcessor,
 		t.taskAllocator,
 		t.activeTaskExecutor,
@@ -328,8 +327,8 @@ func (t *timerQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 	}
 
 	// Failover queue processors are started on the fly when domains are failed over.
-	// Failover queue processors will be stopped when the timer queue instance is stopped (due to restart or shard movement),
-	// which means the failover queue processor might not finish its job.
+	// Failover queue processors will be stopped when the timer queue instance is stopped (due to restart or shard movement).
+	// This means the failover queue processor might not finish its job.
 	// There is no mechanism to re-start ongoing failover queue processors in the new shard owner.
 	t.failoverQueueProcessors = append(t.failoverQueueProcessors, failoverQueueProcessor)
 	failoverQueueProcessor.Start()

--- a/service/history/queue/timer_queue_processor.go
+++ b/service/history/queue/timer_queue_processor.go
@@ -60,13 +60,14 @@ type timerQueueProcessor struct {
 	shutdownChan chan struct{}
 	shutdownWG   sync.WaitGroup
 
-	ackLevel               time.Time
-	taskAllocator          TaskAllocator
-	activeTaskExecutor     task.Executor
-	activeQueueProcessor   *timerQueueProcessorBase
-	standbyQueueProcessors map[string]*timerQueueProcessorBase
-	standbyTaskExecutors   []task.Executor
-	standbyQueueTimerGates map[string]RemoteTimerGate
+	ackLevel                time.Time
+	taskAllocator           TaskAllocator
+	activeTaskExecutor      task.Executor
+	activeQueueProcessor    *timerQueueProcessorBase
+	standbyQueueProcessors  map[string]*timerQueueProcessorBase
+	standbyTaskExecutors    []task.Executor
+	standbyQueueTimerGates  map[string]RemoteTimerGate
+	failoverQueueProcessors []*timerQueueProcessorBase
 }
 
 // NewTimerQueueProcessor creates a new timer QueueProcessor
@@ -206,7 +207,7 @@ func (t *timerQueueProcessor) Stop() {
 		t.logger.Warn("transferQueueProcessor timed out on shut down", tag.LifeCycleStopTimedout)
 	}
 	t.activeQueueProcessor.Stop()
-	t.activeTaskExecutor.Stop()
+
 	for _, standbyQueueProcessor := range t.standbyQueueProcessors {
 		standbyQueueProcessor.Stop()
 	}
@@ -215,6 +216,15 @@ func (t *timerQueueProcessor) Stop() {
 	for _, standbyTaskExecutor := range t.standbyTaskExecutors {
 		standbyTaskExecutor.Stop()
 	}
+
+	if len(t.failoverQueueProcessors) > 0 {
+		t.logger.Info("Shutting down failover timer queues", tag.Counter(len(t.failoverQueueProcessors)))
+		for _, failoverQueueProcessor := range t.failoverQueueProcessors {
+			failoverQueueProcessor.Stop()
+		}
+	}
+
+	t.activeTaskExecutor.Stop()
 }
 
 func (t *timerQueueProcessor) NotifyNewTask(clusterName string, info *hcommon.NotifyTaskInfo) {
@@ -316,6 +326,12 @@ func (t *timerQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 	if err != nil {
 		t.logger.Error("Error update shard ack level", tag.Error(err))
 	}
+
+	// Failover queue processors are started on the fly when domains are failed over.
+	// Failover queue processors will be stopped when the timer queue instance is stopped (due to restart or shard movement),
+	// which means the failover queue processor might not finish its job.
+	// There is no mechanism to re-start ongoing failover queue processors in the new shard owner.
+	t.failoverQueueProcessors = append(t.failoverQueueProcessors, failoverQueueProcessor)
 	failoverQueueProcessor.Start()
 }
 
@@ -367,7 +383,7 @@ func (t *timerQueueProcessor) UnlockTaskProcessing() {
 func (t *timerQueueProcessor) drain() {
 	if !t.shard.GetConfig().QueueProcessorEnableGracefulSyncShutdown() {
 		if err := t.completeTimer(context.Background()); err != nil {
-			t.logger.Error("Failed to complete timer task during shutdown", tag.Error(err))
+			t.logger.Error("Failed to complete timer task during drain", tag.Error(err))
 		}
 		return
 	}
@@ -376,7 +392,7 @@ func (t *timerQueueProcessor) drain() {
 	ctx, cancel := context.WithTimeout(context.Background(), gracefulShutdownTimeout)
 	defer cancel()
 	if err := t.completeTimer(ctx); err != nil {
-		t.logger.Error("Failed to complete timer task during shutdown", tag.Error(err))
+		t.logger.Error("Failed to complete timer task during drain", tag.Error(err))
 	}
 }
 

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -276,7 +276,6 @@ func (t *transferQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 
 	updateShardAckLevel, failoverQueueProcessor := newTransferQueueFailoverProcessor(
 		t.shard,
-		t.historyEngine,
 		t.taskProcessor,
 		t.taskAllocator,
 		t.activeTaskExecutor,
@@ -295,8 +294,8 @@ func (t *transferQueueProcessor) FailoverDomain(domainIDs map[string]struct{}) {
 	}
 
 	// Failover queue processors are started on the fly when domains are failed over.
-	// Failover queue processors will be stopped when the transfer queue instance is stopped (due to restart or shard movement),
-	// which means the failover queue processor might not finish its job.
+	// Failover queue processors will be stopped when the transfer queue instance is stopped (due to restart or shard movement).
+	// This means the failover queue processor might not finish its job.
 	// There is no mechanism to re-start ongoing failover queue processors in the new shard owner.
 	t.failoverQueueProcessors = append(t.failoverQueueProcessors, failoverQueueProcessor)
 	failoverQueueProcessor.Start()
@@ -604,7 +603,6 @@ func newTransferQueueStandbyProcessor(
 
 func newTransferQueueFailoverProcessor(
 	shardContext shard.Context,
-	historyEngine engine.Engine,
 	taskProcessor task.Processor,
 	taskAllocator TaskAllocator,
 	taskExecutor task.Executor,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Failover queue processors are started on the fly when domains are failed over. They are supposed to process the tasks until domain failover is completed. These failover queue processors are started and never stopped. 
So there's orphaned goroutines for sure.
Another problem is that the failover queue processor might have work to do but the shard ownership might have changed. In that case the task executor etc. is already stopped by the parent and failover queue processor keeps attempting/failing forever. Causing error/alert noise.

With the changes in this PR, failover queue processors will be stopped when its creator is stopped (due to restart or shard movement). No leftover goroutines and forever retryed tasks. Changes are hidden behind existing/relevant `history.replicationTaskFetcherEnableGracefulSyncShutdown` dynamic config. 

Another problem that's not address in this PR: There is no mechanism to re-start ongoing failover queue processors in the new shard owner.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Eliminate source of goroutine leaks
- Reduce alert noise

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Will be tested in staging environments first.
