### PR TITLE
Fixes classification error for deprecated domains

### DIFF
--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -195,7 +195,7 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainIDRedirect
 		return err
 	}
 	if domainEntry.IsDeprecatedOrDeleted() {
-		return types.DomainNotActiveError{
+		return &types.DomainNotActiveError{
 			Message:        "domain is deprecated.",
 			DomainName:     domainEntry.GetInfo().Name,
 			CurrentCluster: policy.currentClusterName,
@@ -212,7 +212,7 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) WithDomainNameRedire
 		return err
 	}
 	if domainEntry.IsDeprecatedOrDeleted() {
-		return types.DomainNotActiveError{
+		return &types.DomainNotActiveError{
 			Message:        "domain is deprecated or deleted",
 			DomainName:     domainName,
 			CurrentCluster: policy.currentClusterName,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

This fixes errors being classified as server errors (HTTP 5XX errors) when a domain is deprecated and correctly reclassifies them as application/ 4XX errors 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
<img width="1131" alt="Screenshot 2024-05-11 at 9 56 41 PM" src="https://github.com/uber/cadence/assets/2725764/ef2f7a5c-3fbe-4438-acf9-087bfad361fe">


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
