### PR TITLE
Add method to list all workflow executions with support for partial match and search params

### DIFF
--- a/common/persistence/dataVisibilityManagerInterfaces.go
+++ b/common/persistence/dataVisibilityManagerInterfaces.go
@@ -142,6 +142,7 @@ type (
 		// Pass in empty slice for first page.
 		NextPageToken []byte
 		Query         string
+		PartialMatch  bool
 	}
 
 	// ListWorkflowExecutionsResponse is the response to ListWorkflowExecutionsRequest

--- a/common/persistence/dataVisibilityManagerInterfaces.go
+++ b/common/persistence/dataVisibilityManagerInterfaces.go
@@ -43,7 +43,7 @@ import (
 // purposes.
 
 // ErrVisibilityOperationNotSupported is an error which indicates that operation is not supported in selected persistence
-var ErrVisibilityOperationNotSupported = &types.BadRequestError{Message: "Operation is not supported. Please use ElasticSearch"}
+var ErrVisibilityOperationNotSupported = &types.BadRequestError{Message: "Operation is not supported"}
 
 type (
 	// RecordWorkflowExecutionStartedRequest is used to add a record of a newly

--- a/common/persistence/dataVisibilityManagerInterfaces.go
+++ b/common/persistence/dataVisibilityManagerInterfaces.go
@@ -142,7 +142,6 @@ type (
 		// Pass in empty slice for first page.
 		NextPageToken []byte
 		Query         string
-		PartialMatch  bool
 	}
 
 	// ListWorkflowExecutionsResponse is the response to ListWorkflowExecutionsRequest

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -710,7 +710,6 @@ type (
 	// InternalListAllWorkflowExecutionsByTypeRequest is used to list all open and closed executions with specific filters in a domain
 	InternalListAllWorkflowExecutionsByTypeRequest struct {
 		InternalListWorkflowExecutionsRequest
-		Status              types.WorkflowExecutionCloseStatus
 		PartialMatch        bool
 		WorkflowSearchValue string // This value will be searched across workflow type, workflow ID and runID
 	}

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -180,6 +180,7 @@ type (
 		GetClosedWorkflowExecution(ctx context.Context, request *InternalGetClosedWorkflowExecutionRequest) (*InternalGetClosedWorkflowExecutionResponse, error)
 		DeleteWorkflowExecution(ctx context.Context, request *VisibilityDeleteWorkflowExecutionRequest) error
 		ListWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsByQueryRequest) (*InternalListWorkflowExecutionsResponse, error)
+		ListAllWorkflowExecutions(ctx context.Context, request *InternalListAllWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error)
 		ScanWorkflowExecutions(ctx context.Context, request *ListWorkflowExecutionsByQueryRequest) (*InternalListWorkflowExecutionsResponse, error)
 		CountWorkflowExecutions(ctx context.Context, request *CountWorkflowExecutionsRequest) (*CountWorkflowExecutionsResponse, error)
 		DeleteUninitializedWorkflowExecution(ctx context.Context, request *VisibilityDeleteWorkflowExecutionRequest) error
@@ -704,6 +705,14 @@ type (
 	InternalListWorkflowExecutionsByTypeRequest struct {
 		InternalListWorkflowExecutionsRequest
 		WorkflowTypeName string
+	}
+
+	// InternalListAllWorkflowExecutionsByTypeRequest is used to list all open and closed executions with specific filters in a domain
+	InternalListAllWorkflowExecutionsByTypeRequest struct {
+		InternalListWorkflowExecutionsRequest
+		Status              types.WorkflowExecutionCloseStatus
+		PartialMatch        bool
+		WorkflowSearchValue string // This value will be searched across workflow type, workflow ID and runID
 	}
 
 	// InternalGetClosedWorkflowExecutionResponse is response from GetWorkflowExecution

--- a/common/persistence/elasticsearch/es_visibility_store.go
+++ b/common/persistence/elasticsearch/es_visibility_store.go
@@ -51,6 +51,8 @@ import (
 
 const (
 	esPersistenceName = "elasticsearch"
+	DomainID          = "DomainID"
+	StartTime         = "StartTime"
 )
 
 type (
@@ -440,6 +442,10 @@ func (v *esVisibilityStore) ListWorkflowExecutions(
 		}
 	}
 	return resp, nil
+}
+
+func (v *esVisibilityStore) ListAllWorkflowExecutions(ctx context.Context, request *p.InternalListAllWorkflowExecutionsByTypeRequest) (*p.InternalListWorkflowExecutionsResponse, error) {
+	return nil, p.ErrVisibilityOperationNotSupported
 }
 
 func (v *esVisibilityStore) ScanWorkflowExecutions(

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -359,6 +359,12 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutionsByType failed"))
 }
 
+func (s *ESVisibilitySuite) TestListAllWorkflowExecutions() {
+	_, err := s.visibilityStore.ListAllWorkflowExecutions(context.Background(), &p.InternalListAllWorkflowExecutionsByTypeRequest{})
+	s.Error(err)
+	s.Equal(p.ErrVisibilityOperationNotSupported, err)
+}
+
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 	s.mockESClient.On("Search", mock.Anything, mock.MatchedBy(func(input *es.SearchRequest) bool {
 		s.False(input.IsOpen)

--- a/common/persistence/nosql/nosql_visibility_store.go
+++ b/common/persistence/nosql/nosql_visibility_store.go
@@ -372,6 +372,13 @@ func (v *nosqlVisibilityStore) ListWorkflowExecutions(
 	return nil, persistence.ErrVisibilityOperationNotSupported
 }
 
+func (v *nosqlVisibilityStore) ListAllWorkflowExecutions(
+	ctx context.Context,
+	request *persistence.InternalListAllWorkflowExecutionsByTypeRequest,
+) (*persistence.InternalListWorkflowExecutionsResponse, error) {
+	return nil, persistence.ErrVisibilityOperationNotSupported
+}
+
 func (v *nosqlVisibilityStore) ScanWorkflowExecutions(
 	_ context.Context,
 	_ *persistence.ListWorkflowExecutionsByQueryRequest) (*persistence.InternalListWorkflowExecutionsResponse, error) {

--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -720,11 +720,10 @@ func (s *PinotQuerySearchField) addEqual(obj string, val interface{}) {
 	s.string += fmt.Sprintf("%s = %s\n", obj, quotedVal)
 }
 
-func (s *PinotQuerySearchField) addLike(obj string, val interface{}) {
+func (s *PinotQuerySearchField) addMatch(obj string, val interface{}) {
 	s.checkFirstSearchField()
 
-	quotedVal := fmt.Sprintf("%%%s%%", val)
-	s.string += fmt.Sprintf("%s LIKE \"%s\"\n", obj, quotedVal)
+	s.string += fmt.Sprintf("text_match(%s, '\"%s\"')\n", obj, val)
 }
 
 func NewPinotQuery(tableName string) PinotQuery {
@@ -1066,9 +1065,9 @@ func getListAllWorkflowExecutionsQuery(tableName string, request *p.InternalList
 
 	if request.WorkflowSearchValue != "" {
 		if request.PartialMatch {
-			query.search.addLike(WorkflowID, request.WorkflowSearchValue)
-			query.search.addLike(WorkflowType, request.WorkflowSearchValue)
-			query.search.addLike(RunID, request.WorkflowSearchValue)
+			query.search.addMatch(WorkflowID, request.WorkflowSearchValue)
+			query.search.addMatch(WorkflowType, request.WorkflowSearchValue)
+			query.search.addMatch(RunID, request.WorkflowSearchValue)
 		} else {
 			query.search.addEqual(WorkflowID, request.WorkflowSearchValue)
 			query.search.addEqual(WorkflowType, request.WorkflowSearchValue)

--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -370,7 +370,7 @@ func (v *pinotVisibilityStore) ListAllWorkflowExecutions(ctx context.Context, re
 
 	query, err := getListAllWorkflowExecutionsQuery(v.pinotClient.GetTableName(), request)
 	if err != nil {
-		v.logger.Error(fmt.Sprintf("failed to build list workflow executions by workflowID query %v", err))
+		v.logger.Error(fmt.Sprintf("failed to build list all workflow executions query %v", err))
 		return nil, err
 	}
 

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -60,7 +60,7 @@ var (
 	testContextTimeout = 5 * time.Second
 
 	validSearchAttr  = definition.GetDefaultIndexedKeys()
-	nextPageTokenErr = fmt.Errorf("next page token: unable to deserialize page token. err: invalid character 'e' looking for beginning of value")
+	errNextPageToken = fmt.Errorf("next page token: unable to deserialize page token. err: invalid character 'e' looking for beginning of value")
 )
 
 func TestRecordWorkflowExecutionStarted(t *testing.T) {
@@ -429,7 +429,7 @@ func TestListOpenWorkflowExecutions(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -488,7 +488,7 @@ func TestListClosedWorkflowExecutions(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -548,7 +548,7 @@ func TestListOpenWorkflowExecutionsByType(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -607,7 +607,7 @@ func TestListClosedWorkflowExecutionsByType(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -665,7 +665,7 @@ func TestListOpenWorkflowExecutionsByWorkflowID(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -723,7 +723,7 @@ func TestListClosedWorkflowExecutionsByWorkflowID(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -781,7 +781,7 @@ func TestListClosedWorkflowExecutionsByStatus(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -901,7 +901,7 @@ func TestListWorkflowExecutions(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,
@@ -994,7 +994,7 @@ func TestListAllWorkflowExecutions(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 	}
 	for name, test := range tests {
@@ -1039,7 +1039,7 @@ func TestScanWorkflowExecutions(t *testing.T) {
 			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
 				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
 			},
-			expectedError: nextPageTokenErr,
+			expectedError: errNextPageToken,
 		},
 		"Case2: normal case with nil response": {
 			request:      request,

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1802,9 +1802,9 @@ FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
-AND ( WorkflowID LIKE "%%123%%"
-OR WorkflowType LIKE "%%123%%"
-OR RunID LIKE "%%123%%"
+AND ( text_match(WorkflowID, '"123"')
+OR text_match(WorkflowType, '"123"')
+OR text_match(RunID, '"123"')
  )
 Order BY StartTime DESC
 LIMIT 0, 10

--- a/common/persistence/sql/sql_visibility_store.go
+++ b/common/persistence/sql/sql_visibility_store.go
@@ -319,6 +319,13 @@ func (s *sqlVisibilityStore) ListWorkflowExecutions(
 	return nil, p.ErrVisibilityOperationNotSupported
 }
 
+func (s *sqlVisibilityStore) ListAllWorkflowExecutions(
+	_ context.Context,
+	_ *p.InternalListAllWorkflowExecutionsByTypeRequest,
+) (*p.InternalListWorkflowExecutionsResponse, error) {
+	return nil, p.ErrVisibilityOperationNotSupported
+}
+
 func (s *sqlVisibilityStore) ScanWorkflowExecutions(
 	_ context.Context,
 	_ *p.ListWorkflowExecutionsByQueryRequest,

--- a/common/persistence/visibility_store_mock.go
+++ b/common/persistence/visibility_store_mock.go
@@ -140,6 +140,21 @@ func (mr *MockVisibilityStoreMockRecorder) GetName() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetName", reflect.TypeOf((*MockVisibilityStore)(nil).GetName))
 }
 
+// ListAllWorkflowExecutions mocks base method.
+func (m *MockVisibilityStore) ListAllWorkflowExecutions(arg0 context.Context, arg1 *InternalListAllWorkflowExecutionsByTypeRequest) (*InternalListWorkflowExecutionsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAllWorkflowExecutions", arg0, arg1)
+	ret0, _ := ret[0].(*InternalListWorkflowExecutionsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAllWorkflowExecutions indicates an expected call of ListAllWorkflowExecutions.
+func (mr *MockVisibilityStoreMockRecorder) ListAllWorkflowExecutions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAllWorkflowExecutions", reflect.TypeOf((*MockVisibilityStore)(nil).ListAllWorkflowExecutions), arg0, arg1)
+}
+
 // ListClosedWorkflowExecutions mocks base method.
 func (m *MockVisibilityStore) ListClosedWorkflowExecutions(arg0 context.Context, arg1 *InternalListWorkflowExecutionsRequest) (*InternalListWorkflowExecutionsResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding support to query all workflow executions with possibility for partial query by leveraging this functionality from pinot

<!-- Tell your future self why have you made these changes -->
**Why?**
cadence web can make a single call to list all workflow executions and user can provide text strings to match for workflow type, workflow ID or runID

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
New unused method

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
