### PR TITLE
Stop history queue task processor after shard controller is stopped

### DIFF
--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -187,8 +187,8 @@ func (h *handlerImpl) Stop() {
 	h.prepareToShutDown()
 	h.crossClusterTaskFetchers.Stop()
 	h.replicationTaskFetchers.Stop()
-	h.queueTaskProcessor.Stop()
 	h.controller.Stop()
+	h.queueTaskProcessor.Stop()
 	h.historyEventNotifier.Stop()
 	h.failoverCoordinator.Stop()
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I was checking the errors during deployment time and noticed this wrong shutdown order problem.
Error was `task scheduler has already shutdown` which came from queue processor base.

Who creates who?
- History service creates history handler
- History handler creates queue task processor and shard controller
- Shard controller creates engine
- Engine creates queue processors that uses queue task processor

Current stop order (wrong):
- History service stops history handler
- History handler stops queue task processor and shard controller (in this order)
- Shard controller stops engines
- Engine stops queue processors which try to drain and fail to do so because task processor is already stopped

Fix:
Update History handler to first stop shard controller (which will stop queues) and then stop the task processor once nobody needs them anymore.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve history queue and task processor lifecycle ordering
