### PR TITLE
Wrapped errors support on metered persistence wrappers

### DIFF
--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -23,6 +23,7 @@
 package metered
 
 import (
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common/dynamicconfig"
@@ -42,32 +43,32 @@ type base struct {
 }
 
 func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainTag metrics.Scope) {
-	switch err.(type) {
-	case *types.DomainAlreadyExistsError:
+	switch {
+	case errors.As(err, new(*types.DomainAlreadyExistsError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrDomainAlreadyExistsCounterPerDomain)
-	case *types.BadRequestError:
+	case errors.As(err, new(*types.BadRequestError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrBadRequestCounterPerDomain)
-	case *persistence.WorkflowExecutionAlreadyStartedError:
+	case errors.As(err, new(*persistence.WorkflowExecutionAlreadyStartedError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrExecutionAlreadyStartedCounterPerDomain)
-	case *persistence.ConditionFailedError:
+	case errors.As(err, new(*persistence.ConditionFailedError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrConditionFailedCounterPerDomain)
-	case *persistence.CurrentWorkflowConditionFailedError:
+	case errors.As(err, new(*persistence.CurrentWorkflowConditionFailedError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrCurrentWorkflowConditionFailedCounterPerDomain)
-	case *persistence.ShardAlreadyExistError:
+	case errors.As(err, new(*persistence.ShardAlreadyExistError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrShardExistsCounterPerDomain)
-	case *persistence.ShardOwnershipLostError:
+	case errors.As(err, new(*persistence.ShardOwnershipLostError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrShardOwnershipLostCounterPerDomain)
-	case *types.EntityNotExistsError:
+	case errors.As(err, new(*types.EntityNotExistsError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrEntityNotExistsCounterPerDomain)
-	case *persistence.DuplicateRequestError:
+	case errors.As(err, new(*persistence.DuplicateRequestError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrDuplicateRequestCounterPerDomain)
-	case *persistence.TimeoutError:
+	case errors.As(err, new(*persistence.TimeoutError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrTimeoutCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.PersistenceFailuresPerDomain)
-	case *types.ServiceBusyError:
+	case errors.As(err, new(*types.ServiceBusyError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrBusyCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.PersistenceFailuresPerDomain)
-	case *persistence.DBUnavailableError:
+	case errors.As(err, new(*persistence.DBUnavailableError)):
 		scopeWithDomainTag.IncCounter(metrics.PersistenceErrDBUnavailableCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.PersistenceFailuresPerDomain)
 		p.logger.Error("DBUnavailable Error:", tag.Error(err), tag.MetricScope(scope))
@@ -78,32 +79,32 @@ func (p *base) updateErrorMetricPerDomain(scope int, err error, scopeWithDomainT
 }
 
 func (p *base) updateErrorMetric(scope int, err error, metricsScope metrics.Scope) {
-	switch err.(type) {
-	case *types.DomainAlreadyExistsError:
+	switch {
+	case errors.As(err, new(*types.DomainAlreadyExistsError)):
 		metricsScope.IncCounter(metrics.PersistenceErrDomainAlreadyExistsCounter)
-	case *types.BadRequestError:
+	case errors.As(err, new(*types.BadRequestError)):
 		metricsScope.IncCounter(metrics.PersistenceErrBadRequestCounter)
-	case *persistence.WorkflowExecutionAlreadyStartedError:
+	case errors.As(err, new(*persistence.WorkflowExecutionAlreadyStartedError)):
 		metricsScope.IncCounter(metrics.PersistenceErrExecutionAlreadyStartedCounter)
-	case *persistence.ConditionFailedError:
+	case errors.As(err, new(*persistence.ConditionFailedError)):
 		metricsScope.IncCounter(metrics.PersistenceErrConditionFailedCounter)
-	case *persistence.CurrentWorkflowConditionFailedError:
+	case errors.As(err, new(*persistence.CurrentWorkflowConditionFailedError)):
 		metricsScope.IncCounter(metrics.PersistenceErrCurrentWorkflowConditionFailedCounter)
-	case *persistence.ShardAlreadyExistError:
+	case errors.As(err, new(*persistence.ShardAlreadyExistError)):
 		metricsScope.IncCounter(metrics.PersistenceErrShardExistsCounter)
-	case *persistence.ShardOwnershipLostError:
+	case errors.As(err, new(*persistence.ShardOwnershipLostError)):
 		metricsScope.IncCounter(metrics.PersistenceErrShardOwnershipLostCounter)
-	case *types.EntityNotExistsError:
+	case errors.As(err, new(*types.EntityNotExistsError)):
 		metricsScope.IncCounter(metrics.PersistenceErrEntityNotExistsCounter)
-	case *persistence.DuplicateRequestError:
+	case errors.As(err, new(*persistence.DuplicateRequestError)):
 		metricsScope.IncCounter(metrics.PersistenceErrDuplicateRequestCounter)
-	case *persistence.TimeoutError:
+	case errors.As(err, new(*persistence.TimeoutError)):
 		metricsScope.IncCounter(metrics.PersistenceErrTimeoutCounter)
 		metricsScope.IncCounter(metrics.PersistenceFailures)
-	case *types.ServiceBusyError:
+	case errors.As(err, new(*types.ServiceBusyError)):
 		metricsScope.IncCounter(metrics.PersistenceErrBusyCounter)
 		metricsScope.IncCounter(metrics.PersistenceFailures)
-	case *persistence.DBUnavailableError:
+	case errors.As(err, new(*persistence.DBUnavailableError)):
 		metricsScope.IncCounter(metrics.PersistenceErrDBUnavailableCounter)
 		metricsScope.IncCounter(metrics.PersistenceFailures)
 		p.logger.Error("DBUnavailable Error:", tag.Error(err), tag.MetricScope(scope))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added support for wrapped errors on metered wrappers. Once this is landed I'll go through the code and migrate all err.(type) cases to errors.As.

<!-- Tell your future self why have you made these changes -->
**Why?**
To improve error tracing with wrapping in the future.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
