### PR TITLE
Introduce support for wrapped errors in the codebase

### DIFF
--- a/bench/lib/client.go
+++ b/bench/lib/client.go
@@ -22,6 +22,7 @@ package lib
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -64,7 +65,7 @@ func (client CadenceClient) CreateDomain(name string, desc string, owner string)
 	defer cancel()
 	err := client.Register(ctx, req)
 	if err != nil {
-		if _, ok := err.(*shared.DomainAlreadyExistsError); !ok {
+		if errors.As(err, new(*shared.DomainAlreadyExistsError)) {
 			return err
 		}
 	}

--- a/bench/lib/client.go
+++ b/bench/lib/client.go
@@ -65,7 +65,7 @@ func (client CadenceClient) CreateDomain(name string, desc string, owner string)
 	defer cancel()
 	err := client.Register(ctx, req)
 	if err != nil {
-		if errors.As(err, new(*shared.DomainAlreadyExistsError)) {
+		if !errors.As(err, new(*shared.DomainAlreadyExistsError)) {
 			return err
 		}
 	}

--- a/bench/lib/metrics.go
+++ b/bench/lib/metrics.go
@@ -21,6 +21,7 @@
 package lib
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -147,7 +148,7 @@ func recordWorkflowEnd(
 		return err
 	}
 	scope.Counter(FailedCount).Inc(1)
-	if _, ok := err.(*workflow.TimeoutError); ok {
+	if errors.As(err, new(*workflow.TimeoutError)) {
 		scope.Counter(errTimeoutCount).Inc(1)
 	}
 	return err

--- a/bench/load/common/helpers.go
+++ b/bench/load/common/helpers.go
@@ -22,6 +22,7 @@ package common
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -51,25 +52,22 @@ func GetActivityServiceConfig(ctx context.Context) *lib.RuntimeContext {
 
 // IsServiceBusyError returns if the err is a ServiceBusyError
 func IsServiceBusyError(err error) bool {
-	_, ok := err.(*shared.ServiceBusyError)
-	return ok
+	return errors.As(err, new(*shared.ServiceBusyError))
 }
 
 // IsCancellationAlreadyRequestedError returns if the err is a CancellationAlreadyRequestedError
 func IsCancellationAlreadyRequestedError(err error) bool {
-	_, ok := err.(*shared.CancellationAlreadyRequestedError)
-	return ok
+	return errors.As(err, new(*shared.CancellationAlreadyRequestedError))
 }
 
 // IsEntityNotExistsError returns if the err is a EntityNotExistsError
 func IsEntityNotExistsError(err error) bool {
-	_, ok := err.(*shared.EntityNotExistsError)
-	return ok
+	return errors.As(err, new(*shared.EntityNotExistsError))
 }
 
 // IsNonRetryableError return true if the err is considered non-retryable
 func IsNonRetryableError(err error) bool {
-	if err == context.DeadlineExceeded || err == context.Canceled {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 		return true
 	}
 

--- a/bench/load/cron/workflow.go
+++ b/bench/load/cron/workflow.go
@@ -22,6 +22,7 @@ package cron
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"strconv"
@@ -286,7 +287,8 @@ func launcherWorkflow(
 		} else if err := childFuture.Get(childCtx, nil); err != nil {
 			result.TestStatus = testStatusFailed
 			result.Details = err.Error()
-			if customErr, ok := err.(*cadence.CustomError); ok {
+			var customErr *cadence.CustomError
+			if errors.As(err, &customErr) {
 				var detailStr string
 				if err := customErr.Details(&detailStr); err == nil {
 					result.Details += ": " + detailStr

--- a/canary/canary.go
+++ b/canary/canary.go
@@ -22,6 +22,7 @@ package canary
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/opentracing/opentracing-go"
@@ -158,7 +159,7 @@ func (c *canaryImpl) startCronWorkflow() {
 	if err != nil {
 		// TODO: improvement: compare the cron schedule to decide whether or not terminating the current one
 		// https://github.com/uber/cadence/issues/4469
-		if _, ok := err.(*shared.WorkflowExecutionAlreadyStartedError); !ok {
+		if errors.As(err, new(*shared.WorkflowExecutionAlreadyStartedError)) {
 			c.runtime.logger.Error("error starting cron workflow", zap.Error(err))
 		} else {
 			c.runtime.logger.Info("cron workflow already started, you may need to terminate and restart if cron schedule is changed...")

--- a/canary/canary.go
+++ b/canary/canary.go
@@ -159,7 +159,7 @@ func (c *canaryImpl) startCronWorkflow() {
 	if err != nil {
 		// TODO: improvement: compare the cron schedule to decide whether or not terminating the current one
 		// https://github.com/uber/cadence/issues/4469
-		if errors.As(err, new(*shared.WorkflowExecutionAlreadyStartedError)) {
+		if !errors.As(err, new(*shared.WorkflowExecutionAlreadyStartedError)) {
 			c.runtime.logger.Error("error starting cron workflow", zap.Error(err))
 		} else {
 			c.runtime.logger.Info("cron workflow already started, you may need to terminate and restart if cron schedule is changed...")

--- a/canary/cancellation.go
+++ b/canary/cancellation.go
@@ -77,7 +77,7 @@ func cancellationWorkflow(ctx workflow.Context, inputScheduledTimeNanos int64) e
 		workflow.GetLogger(ctx).Info(msg)
 		return profile.end(errors.New(msg))
 	}
-	if _, ok := err.(*cadence.CanceledError); !ok {
+	if !errors.As(err, new(*cadence.CanceledError)) {
 		workflow.GetLogger(ctx).Info("cancellationWorkflow failed: child workflow return non CanceledError", zap.Error(err))
 		return profile.end(err)
 	}
@@ -108,7 +108,7 @@ func cancellationWorkflow(ctx workflow.Context, inputScheduledTimeNanos int64) e
 			workflow.GetLogger(ctx).Info(msg)
 			return errors.New(msg)
 		}
-		if _, ok := err.(*cadence.CanceledError); !ok {
+		if !errors.As(err, new(*cadence.CanceledError)) {
 			workflow.GetLogger(ctx).Info("cancellationWorkflow failed: child workflow return non CanceledError", zap.Error(err))
 			return err
 		}
@@ -151,7 +151,7 @@ func cancellationWorkflow(ctx workflow.Context, inputScheduledTimeNanos int64) e
 			workflow.GetLogger(ctx).Info(msg)
 			return errors.New(msg)
 		}
-		if _, ok := err.(*cadence.CanceledError); !ok {
+		if !errors.As(err, new(*cadence.CanceledError)) {
 			workflow.GetLogger(ctx).Info("cancellationWorkflow failed: child workflow return non CanceledError", zap.Error(err))
 			return err
 		}
@@ -192,7 +192,7 @@ func cancellationActivity(ctx context.Context, scheduledTimeNanos int64) error {
 		if err == nil {
 			return errors.New("cancellationWorkflow failed: non child workflow not cancelled")
 		}
-		if _, ok := err.(*cadence.CanceledError); !ok {
+		if !errors.As(err, new(*cadence.CanceledError)) {
 			return err
 		}
 		return nil

--- a/canary/client.go
+++ b/canary/client.go
@@ -22,6 +22,7 @@ package canary
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/opentracing/opentracing-go"
@@ -74,7 +75,7 @@ func (client *cadenceClient) createDomain(name string, desc string, owner string
 	}
 	err := client.Register(context.Background(), req)
 	if err != nil {
-		if _, ok := err.(*shared.DomainAlreadyExistsError); !ok {
+		if errors.As(err, new(*shared.DomainAlreadyExistsError)) {
 			return err
 		}
 	}

--- a/canary/client.go
+++ b/canary/client.go
@@ -75,7 +75,7 @@ func (client *cadenceClient) createDomain(name string, desc string, owner string
 	}
 	err := client.Register(context.Background(), req)
 	if err != nil {
-		if errors.As(err, new(*shared.DomainAlreadyExistsError)) {
+		if !errors.As(err, new(*shared.DomainAlreadyExistsError)) {
 			return err
 		}
 	}

--- a/canary/metrics.go
+++ b/canary/metrics.go
@@ -21,6 +21,7 @@
 package canary
 
 import (
+	"errors"
 	"time"
 
 	"github.com/uber-go/tally"
@@ -99,7 +100,7 @@ func recordWorkflowEnd(scope tally.Scope, elapsed time.Duration, err error) erro
 		return err
 	}
 	scope.Counter(failedCount).Inc(1)
-	if _, ok := err.(*workflow.TimeoutError); ok {
+	if errors.As(err, new(*workflow.TimeoutError)) {
 		scope.Counter(errTimeoutCount).Inc(1)
 	}
 	return err

--- a/canary/timeout.go
+++ b/canary/timeout.go
@@ -62,7 +62,7 @@ func timeoutWorkflow(ctx workflow.Context, inputScheduledTimeNanos int64) error 
 
 	activityErr := activityFuture.Get(ctx, nil)
 	if activityErr != nil {
-		if errors.As(err, new(*workflow.TimeoutError)) {
+		if !errors.As(err, new(*workflow.TimeoutError)) {
 			workflow.GetLogger(ctx).Info("activity timeout failed", zap.Error(activityErr))
 		} else {
 			activityErr = nil

--- a/canary/timeout.go
+++ b/canary/timeout.go
@@ -22,6 +22,7 @@ package canary
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -61,7 +62,7 @@ func timeoutWorkflow(ctx workflow.Context, inputScheduledTimeNanos int64) error 
 
 	activityErr := activityFuture.Get(ctx, nil)
 	if activityErr != nil {
-		if _, ok := activityErr.(*workflow.TimeoutError); !ok {
+		if errors.As(err, new(*workflow.TimeoutError)) {
 			workflow.GetLogger(ctx).Info("activity timeout failed", zap.Error(activityErr))
 		} else {
 			activityErr = nil

--- a/canary/timeout.go
+++ b/canary/timeout.go
@@ -62,7 +62,7 @@ func timeoutWorkflow(ctx workflow.Context, inputScheduledTimeNanos int64) error 
 
 	activityErr := activityFuture.Get(ctx, nil)
 	if activityErr != nil {
-		if !errors.As(err, new(*workflow.TimeoutError)) {
+		if !errors.As(activityErr, new(*workflow.TimeoutError)) {
 			workflow.GetLogger(ctx).Info("activity timeout failed", zap.Error(activityErr))
 		} else {
 			activityErr = nil

--- a/canary/visibilityArchival.go
+++ b/canary/visibilityArchival.go
@@ -239,6 +239,5 @@ func getURIScheme(URI string) string {
 func isBadRequestError(
 	err error,
 ) bool {
-	_, ok := err.(*shared.BadRequestError)
-	return ok
+	return errors.As(err, new(*shared.BadRequestError))
 }

--- a/common/archiver/historyIterator.go
+++ b/common/archiver/historyIterator.go
@@ -188,7 +188,7 @@ func (i *historyIterator) readHistoryBatches(ctx context.Context, firstEventID i
 	newIterState := historyIteratorState{}
 	for size < targetSize {
 		currHistoryBatches, err := i.readHistory(ctx, firstEventID)
-		if _, ok := err.(*types.EntityNotExistsError); ok && firstEventID != common.FirstEventID {
+		if errors.As(err, new(*types.EntityNotExistsError)) && firstEventID != common.FirstEventID {
 			newIterState.FinishedIteration = true
 			return historyBatches, newIterState, nil
 		}
@@ -217,7 +217,7 @@ func (i *historyIterator) readHistoryBatches(ctx context.Context, firstEventID i
 	// If you are here, it means the target size is met after adding the last batch of read history.
 	// We need to check if there's more history batches.
 	_, err := i.readHistory(ctx, firstEventID)
-	if _, ok := err.(*types.EntityNotExistsError); ok && firstEventID != common.FirstEventID {
+	if errors.As(err, new(*types.EntityNotExistsError)) && firstEventID != common.FirstEventID {
 		newIterState.FinishedIteration = true
 		return historyBatches, newIterState, nil
 	}

--- a/common/archiver/s3store/util.go
+++ b/common/archiver/s3store/util.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"strings"
@@ -127,8 +128,8 @@ func keyExists(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key s
 }
 
 func isNotFoundError(err error) bool {
-	aerr, ok := err.(awserr.Error)
-	return ok && (aerr.Code() == "NotFound")
+	var aerr awserr.Error
+	return errors.As(err, &aerr) && (aerr.Code() == "NotFound")
 }
 
 // Key construction
@@ -191,7 +192,8 @@ func upload(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key stri
 		Body:   bytes.NewReader(data),
 	})
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
+		var aerr awserr.Error
+		if errors.As(err, &aerr) {
 			if aerr.Code() == s3.ErrCodeNoSuchBucket {
 				return &types.BadRequestError{Message: errBucketNotExists.Error()}
 			}
@@ -210,7 +212,8 @@ func download(ctx context.Context, s3cli s3iface.S3API, URI archiver.URI, key st
 	})
 
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
+		var aerr awserr.Error
+		if errors.As(err, &aerr) {
 			if aerr.Code() == s3.ErrCodeNoSuchBucket {
 				return nil, &types.BadRequestError{Message: errBucketNotExists.Error()}
 			}

--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -22,6 +22,7 @@ package backoff
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -117,8 +118,7 @@ func NewThrottleRetry(opts ...ThrottleRetryOption) *ThrottleRetry {
 		},
 		throttlePolicy: throttlePolicy,
 		isThrottle: func(err error) bool {
-			_, ok := err.(*types.ServiceBusyError)
-			return ok
+			return errors.As(err, new(*types.ServiceBusyError))
 		},
 		clock: SystemClock,
 	}

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -22,6 +22,7 @@ package backoff
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -144,7 +145,7 @@ func (s *RetrySuite) TestIsRetryableSuccess() {
 	}
 
 	isRetryable := func(err error) bool {
-		if _, ok := err.(*someError); ok {
+		if errors.As(err, new(*someError)) {
 			return true
 		}
 

--- a/common/domain/replicationTaskExecutor.go
+++ b/common/domain/replicationTaskExecutor.go
@@ -24,6 +24,7 @@ package domain
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common/clock"
@@ -210,7 +211,7 @@ func (h *domainReplicationTaskExecutorImpl) handleDomainUpdateReplicationTask(ct
 		Name: task.Info.GetName(),
 	})
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			// this can happen if the create domain replication task is to processed.
 			// e.g. new cluster which does not have anything
 			return h.handleDomainCreationReplicationTask(ctx, task)

--- a/common/dynamicconfig/config.go
+++ b/common/dynamicconfig/config.go
@@ -21,6 +21,7 @@
 package dynamicconfig
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -73,7 +74,7 @@ func (c *Collection) logError(
 	if errCount%errCountLogThreshold == 0 {
 		// log only every 'x' errors to reduce mem allocs and to avoid log noise
 		filteredKey := getFilteredKeyAsString(key, filters)
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			c.logger.Debug("dynamic config not set, use default value", tag.Key(filteredKey))
 		} else {
 			c.logger.Warn("Failed to fetch key from dynamic config", tag.Key(filteredKey), tag.Error(err))

--- a/common/dynamicconfig/configstore/config_store_client.go
+++ b/common/dynamicconfig/configstore/config_store_client.go
@@ -469,7 +469,7 @@ func (csc *configStoreClient) updateValue(name dc.Key, dcValues []*types.Dynamic
 		return errors.New("timeout error on update")
 	default:
 		if err != nil {
-			if _, ok := err.(*persistence.ConditionFailedError); ok && retryAttempts > 0 {
+			if errors.As(err, new(*persistence.ConditionFailedError)) && retryAttempts > 0 {
 				// fetch new config and retry
 				err := csc.update()
 				if err != nil {

--- a/common/elasticsearch/client/os2/client_test.go
+++ b/common/elasticsearch/client/os2/client_test.go
@@ -27,6 +27,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -230,7 +231,8 @@ func TestParseError(t *testing.T) {
 			err := os2Client.parseError(&response)
 
 			if !tt.expectError {
-				if parsedErr, ok := err.(*osError); ok && parsedErr.Details != nil {
+				var parsedErr *osError
+				if errors.As(err, &parsedErr) && parsedErr.Details != nil {
 					assert.Equal(t, tt.expectedErrMsg, parsedErr.Details.Reason, "Error message mismatch for case: %s", tt.name)
 				} else {
 					t.Errorf("Failed to assert error reason for case: %s", tt.name)

--- a/common/elasticsearch/client/v6/client_bulk.go
+++ b/common/elasticsearch/client/v6/client_bulk.go
@@ -24,6 +24,7 @@ package v6
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/olivere/elastic"
@@ -146,9 +147,9 @@ func convertV6ErrorToGenericError(err error) *bulk.GenericError {
 		return nil
 	}
 	status := bulk.UnknownStatusCode
-	switch e := err.(type) {
-	case *elastic.Error:
-		status = e.Status
+	var elasticError *elastic.Error
+	if errors.As(err, &elasticError) {
+		status = elasticError.Status
 	}
 	return &bulk.GenericError{
 		Status:  status,

--- a/common/elasticsearch/client/v7/client_bulk.go
+++ b/common/elasticsearch/client/v7/client_bulk.go
@@ -24,6 +24,7 @@ package v7
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/olivere/elastic/v7"
@@ -189,9 +190,9 @@ func convertV7ErrorToGenericError(err error) *bulk.GenericError {
 		return nil
 	}
 	status := bulk.UnknownStatusCode
-	switch e := err.(type) {
-	case *elastic.Error:
-		status = e.Status
+	var elasticError *elastic.Error
+	if errors.As(err, &elasticError) {
+		status = elasticError.Status
 	}
 	return &bulk.GenericError{
 		Status:  status,

--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -53,6 +53,7 @@ package persistence
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -1665,8 +1666,7 @@ type (
 
 // IsTimeoutError check whether error is TimeoutError
 func IsTimeoutError(err error) bool {
-	_, ok := err.(*TimeoutError)
-	return ok
+	return errors.As(err, new(*TimeoutError))
 }
 
 // GetTaskID returns the task ID for transfer task
@@ -1970,8 +1970,8 @@ func NewGetReplicationTasksFromDLQRequest(
 
 // IsTransientError checks if the error is a transient persistence error
 func IsTransientError(err error) bool {
-	switch err.(type) {
-	case *types.InternalServiceError, *types.ServiceBusyError, *TimeoutError:
+	switch {
+	case errors.As(err, new(*types.InternalServiceError)), errors.As(err, new(*types.ServiceBusyError)), errors.As(err, new(*TimeoutError)):
 		return true
 	}
 
@@ -1980,8 +1980,8 @@ func IsTransientError(err error) bool {
 
 // IsBackgroundTransientError checks if the error is a transient error on background jobs
 func IsBackgroundTransientError(err error) bool {
-	switch err.(type) {
-	case *types.InternalServiceError, *TimeoutError:
+	switch {
+	case errors.As(err, new(*types.InternalServiceError)), errors.As(err, new(*TimeoutError)):
 		return true
 	}
 

--- a/common/persistence/elasticsearch/es_visibility_metric_clients.go
+++ b/common/persistence/elasticsearch/es_visibility_metric_clients.go
@@ -22,6 +22,7 @@ package elasticsearch
 
 import (
 	"context"
+	"errors"
 
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -389,12 +390,12 @@ func (p *visibilityMetricsClient) DeleteUninitializedWorkflowExecution(
 
 func (p *visibilityMetricsClient) updateErrorMetric(scopeWithDomainTag metrics.Scope, scope int, err error) {
 
-	switch err.(type) {
-	case *types.BadRequestError:
+	switch {
+	case errors.As(err, new(*types.BadRequestError)):
 		scopeWithDomainTag.IncCounter(metrics.ElasticsearchErrBadRequestCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.ElasticsearchFailuresPerDomain)
 
-	case *types.ServiceBusyError:
+	case errors.As(err, new(*types.ServiceBusyError)):
 		scopeWithDomainTag.IncCounter(metrics.ElasticsearchErrBusyCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.ElasticsearchFailuresPerDomain)
 	default:

--- a/common/persistence/elasticsearch/es_visibility_store.go
+++ b/common/persistence/elasticsearch/es_visibility_store.go
@@ -816,11 +816,12 @@ func (v *esVisibilityStore) getValueOfSearchAfterInJSON(token *es.ElasticVisibil
 	case types.IndexedValueTypeInt, types.IndexedValueTypeDatetime, types.IndexedValueTypeBool:
 		sortVal, err = token.SortValue.(json.Number).Int64()
 		if err != nil {
-			err, ok := err.(*strconv.NumError) // field not present, ES will return big int +-9223372036854776000
-			if !ok {
+			var typedErr *strconv.NumError
+			// field not present, ES will return big int +-9223372036854776000
+			if !errors.As(err, &typedErr) {
 				return "", err
 			}
-			if err.Num[0] == '-' { // desc
+			if typedErr.Num[0] == '-' { // desc
 				sortVal = math.MinInt64
 			} else { // asc
 				sortVal = math.MaxInt64

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -304,8 +304,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutions() {
 	s.mockESClient.On("Search", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListOpenWorkflowExecutions(ctx, testRequest)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutions failed"))
 }
 
@@ -325,8 +324,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
 	s.mockESClient.On("Search", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListClosedWorkflowExecutions(ctx, testRequest)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutions failed"))
 }
 
@@ -354,8 +352,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 	s.mockESClient.On("Search", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByType(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutionsByType failed"))
 }
 
@@ -439,8 +436,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 	s.mockESClient.On("Search", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByType(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByType failed"))
 }
 
@@ -469,8 +465,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 	s.mockESClient.On("Search", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutionsByWorkflowID failed"))
 }
 
@@ -499,8 +494,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
 	s.mockESClient.On("Search", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByWorkflowID failed"))
 }
 
@@ -530,8 +524,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
 	s.mockESClient.On("Search", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByStatus(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByStatus failed"))
 }
 
@@ -564,9 +557,9 @@ func (s *ESVisibilitySuite) TestDeserializePageToken() {
 	result, err = es.DeserializePageToken(badInput)
 	s.Error(err)
 	s.Nil(result)
-	err, ok := err.(*types.BadRequestError)
-	s.True(ok)
-	s.True(strings.Contains(err.Error(), "unable to deserialize page token"))
+	var typedError *types.BadRequestError
+	s.ErrorAs(err, &typedError)
+	s.True(strings.Contains(typedError.Error(), "unable to deserialize page token"))
 
 	token = &es.ElasticVisibilityPageToken{SortValue: int64(64), TieBreaker: "unique"}
 	data, _ = es.SerializePageToken(token)
@@ -864,15 +857,13 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 	s.mockESClient.On("SearchByQuery", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ListWorkflowExecutions(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ListWorkflowExecutions failed"))
 
 	request.Query = `invalid query`
 	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	s.Error(err)
-	_, ok = err.(*types.BadRequestError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.BadRequestError))
 	s.True(strings.Contains(err.Error(), "Error when parse query"))
 }
 
@@ -900,8 +891,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 	request.Query = `invalid query`
 	_, err = s.visibilityStore.ScanWorkflowExecutions(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.BadRequestError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.BadRequestError))
 	s.True(strings.Contains(err.Error(), "Error when parse query"))
 
 	// test internal error
@@ -909,8 +899,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 	s.mockESClient.On("ScanByQuery", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()
 	_, err = s.visibilityStore.ScanWorkflowExecutions(ctx, request)
 	s.Error(err)
-	_, ok = err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
 }
 
@@ -938,16 +927,14 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 
 	_, err = s.visibilityStore.CountWorkflowExecutions(ctx, request)
 	s.Error(err)
-	_, ok := err.(*types.InternalServiceError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.InternalServiceError))
 	s.True(strings.Contains(err.Error(), "CountWorkflowExecutions failed"))
 
 	// test bad request
 	request.Query = `invalid query`
 	_, err = s.visibilityStore.CountWorkflowExecutions(ctx, request)
 	s.Error(err)
-	_, ok = err.(*types.BadRequestError)
-	s.True(ok)
+	s.ErrorAs(err, new(*types.BadRequestError))
 	s.True(strings.Contains(err.Error(), "Error when parse query"))
 }
 

--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -305,7 +305,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutions() {
 	_, err = s.visibilityStore.ListOpenWorkflowExecutions(ctx, testRequest)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutions failed"))
+	s.ErrorContains(err, "ListOpenWorkflowExecutions failed")
 }
 
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
@@ -325,7 +325,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutions() {
 	_, err = s.visibilityStore.ListClosedWorkflowExecutions(ctx, testRequest)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutions failed"))
+	s.ErrorContains(err, "ListClosedWorkflowExecutions failed")
 }
 
 func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
@@ -353,7 +353,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByType() {
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByType(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutionsByType failed"))
+	s.ErrorContains(err, "ListOpenWorkflowExecutionsByType failed")
 }
 
 func (s *ESVisibilitySuite) TestListAllWorkflowExecutions() {
@@ -437,7 +437,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByType() {
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByType(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByType failed"))
+	s.ErrorContains(err, "ListClosedWorkflowExecutionsByType failed")
 }
 
 func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
@@ -466,7 +466,7 @@ func (s *ESVisibilitySuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 	_, err = s.visibilityStore.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListOpenWorkflowExecutionsByWorkflowID failed"))
+	s.ErrorContains(err, "ListOpenWorkflowExecutionsByWorkflowID failed")
 }
 
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
@@ -495,7 +495,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByWorkflowID() {
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByWorkflowID failed"))
+	s.ErrorContains(err, "ListClosedWorkflowExecutionsByWorkflowID failed")
 }
 
 func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
@@ -525,7 +525,7 @@ func (s *ESVisibilitySuite) TestListClosedWorkflowExecutionsByStatus() {
 	_, err = s.visibilityStore.ListClosedWorkflowExecutionsByStatus(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListClosedWorkflowExecutionsByStatus failed"))
+	s.ErrorContains(err, "ListClosedWorkflowExecutionsByStatus failed")
 }
 
 func (s *ESVisibilitySuite) TestGetNextPageToken() {
@@ -559,7 +559,7 @@ func (s *ESVisibilitySuite) TestDeserializePageToken() {
 	s.Nil(result)
 	var typedError *types.BadRequestError
 	s.ErrorAs(err, &typedError)
-	s.True(strings.Contains(typedError.Error(), "unable to deserialize page token"))
+	s.ErrorContains(typedError, "unable to deserialize page token")
 
 	token = &es.ElasticVisibilityPageToken{SortValue: int64(64), TieBreaker: "unique"}
 	data, _ = es.SerializePageToken(token)
@@ -858,13 +858,13 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 	_, err = s.visibilityStore.ListWorkflowExecutions(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ListWorkflowExecutions failed"))
+	s.ErrorContains(err, "ListWorkflowExecutions failed")
 
 	request.Query = `invalid query`
 	_, err = s.visibilityStore.ListWorkflowExecutions(context.Background(), request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.BadRequestError))
-	s.True(strings.Contains(err.Error(), "Error when parse query"))
+	s.ErrorContains(err, "Error when parse query")
 }
 
 func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
@@ -892,7 +892,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 	_, err = s.visibilityStore.ScanWorkflowExecutions(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.BadRequestError))
-	s.True(strings.Contains(err.Error(), "Error when parse query"))
+	s.ErrorContains(err, "Error when parse query")
 
 	// test internal error
 	request.Query = `CloseStatus = 5`
@@ -900,7 +900,7 @@ func (s *ESVisibilitySuite) TestScanWorkflowExecutions() {
 	_, err = s.visibilityStore.ScanWorkflowExecutions(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "ScanWorkflowExecutions failed"))
+	s.ErrorContains(err, "ScanWorkflowExecutions failed")
 }
 
 func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
@@ -928,14 +928,14 @@ func (s *ESVisibilitySuite) TestCountWorkflowExecutions() {
 	_, err = s.visibilityStore.CountWorkflowExecutions(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.InternalServiceError))
-	s.True(strings.Contains(err.Error(), "CountWorkflowExecutions failed"))
+	s.ErrorContains(err, "CountWorkflowExecutions failed")
 
 	// test bad request
 	request.Query = `invalid query`
 	_, err = s.visibilityStore.CountWorkflowExecutions(ctx, request)
 	s.Error(err)
 	s.ErrorAs(err, new(*types.BadRequestError))
-	s.True(strings.Contains(err.Error(), "Error when parse query"))
+	s.ErrorContains(err, "Error when parse query")
 }
 
 func (s *ESVisibilitySuite) TestTimeProcessFunc() {

--- a/common/persistence/nosql/nosql_config_store.go
+++ b/common/persistence/nosql/nosql_config_store.go
@@ -22,6 +22,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber/cadence/common/config"
@@ -62,7 +63,7 @@ func (m *nosqlConfigStore) FetchConfig(ctx context.Context, configType persisten
 func (m *nosqlConfigStore) UpdateConfig(ctx context.Context, value *persistence.InternalConfigStoreEntry) error {
 	err := m.db.InsertConfig(ctx, value)
 	if err != nil {
-		if _, ok := err.(*nosqlplugin.ConditionFailure); ok {
+		if errors.As(err, new(*nosqlplugin.ConditionFailure)) {
 			return &persistence.ConditionFailedError{Msg: fmt.Sprintf("Version %v already exists. Condition Failed", value.Version)}
 		}
 		return convertCommonErrors(m.db, "UpdateConfig", err)

--- a/common/persistence/nosql/nosql_domain_store.go
+++ b/common/persistence/nosql/nosql_domain_store.go
@@ -22,6 +22,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber/cadence/common"
@@ -84,7 +85,7 @@ func (m *nosqlDomainStore) CreateDomain(
 	err = m.db.InsertDomain(ctx, row)
 
 	if err != nil {
-		if _, ok := err.(*types.DomainAlreadyExistsError); ok {
+		if errors.As(err, new(*types.DomainAlreadyExistsError)) {
 			return nil, err
 		}
 		return nil, convertCommonErrors(m.db, "CreateDomain", err)

--- a/common/persistence/nosql/nosql_execution_store.go
+++ b/common/persistence/nosql/nosql_execution_store.go
@@ -22,6 +22,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber/cadence/common/log"
@@ -119,8 +120,8 @@ func (d *nosqlExecutionStore) CreateWorkflowExecution(
 		shardCondition,
 	)
 	if err != nil {
-		conditionFailureErr, isConditionFailedError := err.(*nosqlplugin.WorkflowOperationConditionFailure)
-		if isConditionFailedError {
+		var conditionFailureErr *nosqlplugin.WorkflowOperationConditionFailure
+		if errors.As(err, &conditionFailureErr) {
 			switch {
 			case conditionFailureErr.UnknownConditionFailureDetails != nil:
 				return nil, &persistence.ShardOwnershipLostError{
@@ -846,8 +847,8 @@ func (d *nosqlExecutionStore) CreateFailoverMarkerTasks(
 	})
 
 	if err != nil {
-		conditionFailureErr, isConditionFailedError := err.(*nosqlplugin.ShardOperationConditionFailure)
-		if isConditionFailedError {
+		var conditionFailureErr *nosqlplugin.ShardOperationConditionFailure
+		if errors.As(err, &conditionFailureErr) {
 			return &persistence.ShardOwnershipLostError{
 				ShardID: d.shardID,
 				Msg: fmt.Sprintf("Failed to create workflow execution.  Request RangeID: %v, columns: (%v)",

--- a/common/persistence/nosql/nosql_execution_store_util.go
+++ b/common/persistence/nosql/nosql_execution_store_util.go
@@ -23,6 +23,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -724,8 +725,8 @@ func (d *nosqlExecutionStore) prepareCurrentWorkflowRequestForCreateWorkflowTxn(
 
 func (d *nosqlExecutionStore) processUpdateWorkflowResult(err error, rangeID int64) error {
 	if err != nil {
-		conditionFailureErr, isConditionFailedError := err.(*nosqlplugin.WorkflowOperationConditionFailure)
-		if isConditionFailedError {
+		var conditionFailureErr *nosqlplugin.WorkflowOperationConditionFailure
+		if errors.As(err, &conditionFailureErr) {
 			switch {
 			case conditionFailureErr.UnknownConditionFailureDetails != nil:
 				return &persistence.ConditionFailedError{
@@ -770,7 +771,7 @@ func (d *nosqlExecutionStore) assertNotCurrentExecution(
 		DomainID:   domainID,
 		WorkflowID: workflowID,
 	}); err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			// allow bypassing no current record
 			return nil
 		}

--- a/common/persistence/nosql/nosql_execution_store_util_test.go
+++ b/common/persistence/nosql/nosql_execution_store_util_test.go
@@ -1255,8 +1255,7 @@ func TestNosqlExecutionStoreUtilsExtended(t *testing.T) {
 			},
 			validate: func(t *testing.T, _ interface{}, err error) {
 				assert.Error(t, err)
-				_, ok := err.(*persistence.CurrentWorkflowConditionFailedError)
-				assert.True(t, ok)
+				assert.True(t, errors.As(err, new(*persistence.CurrentWorkflowConditionFailedError)))
 			},
 		},
 		{
@@ -1278,8 +1277,7 @@ func TestNosqlExecutionStoreUtilsExtended(t *testing.T) {
 			},
 			validate: func(t *testing.T, _ interface{}, err error) {
 				assert.Error(t, err)
-				_, ok := err.(*persistence.ShardOwnershipLostError)
-				assert.True(t, ok)
+				assert.True(t, errors.As(err, new(*persistence.ShardOwnershipLostError)))
 			},
 		},
 		{
@@ -1299,8 +1297,7 @@ func TestNosqlExecutionStoreUtilsExtended(t *testing.T) {
 					"test-domain-id", "test-workflow-id", "test-run-id", executionInfo, 123, request)
 			},
 			validate: func(t *testing.T, result interface{}, err error) {
-				_, ok := err.(*persistence.CurrentWorkflowConditionFailedError)
-				assert.False(t, ok)
+				assert.False(t, errors.As(err, new(*persistence.CurrentWorkflowConditionFailedError)))
 			},
 		},
 		{

--- a/common/persistence/nosql/nosql_queue_store.go
+++ b/common/persistence/nosql/nosql_queue_store.go
@@ -22,6 +22,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber/cadence/common/config"
@@ -130,7 +131,7 @@ func (q *nosqlQueueStore) tryEnqueue(
 		Payload:   messagePayload,
 	})
 	if err != nil {
-		if _, ok := err.(*nosqlplugin.ConditionFailure); ok {
+		if errors.As(err, new(*nosqlplugin.ConditionFailure)) {
 			return emptyMessageID, &persistence.ConditionFailedError{Msg: fmt.Sprintf("message ID %v exists in queue", messageID)}
 		}
 
@@ -330,7 +331,7 @@ func (q *nosqlQueueStore) updateQueueMetadata(
 ) error {
 	err := q.db.UpdateQueueMetadataCas(ctx, *metadata)
 	if err != nil {
-		if _, ok := err.(*nosqlplugin.ConditionFailure); ok {
+		if errors.As(err, new(*nosqlplugin.ConditionFailure)) {
 			return &types.InternalServiceError{
 				Message: "UpdateQueueMetadata operation encounter concurrent write.",
 			}

--- a/common/persistence/nosql/nosql_shard_store.go
+++ b/common/persistence/nosql/nosql_shard_store.go
@@ -22,6 +22,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber/cadence/common/config"
@@ -65,8 +66,8 @@ func (sh *nosqlShardStore) CreateShard(
 	}
 	err = storeShard.db.InsertShard(ctx, request.ShardInfo)
 	if err != nil {
-		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
-		if ok {
+		var conditionFailure *nosqlplugin.ShardOperationConditionFailure
+		if errors.As(err, &conditionFailure) {
 			return &persistence.ShardAlreadyExistError{
 				Msg: fmt.Sprintf("Shard already exists in executions table.  ShardId: %v, request_range_id: %v, actual_range_id : %v, columns: (%v)",
 					request.ShardInfo.ShardID, request.ShardInfo.RangeID, conditionFailure.RangeID, conditionFailure.Details),
@@ -139,8 +140,8 @@ func (sh *nosqlShardStore) updateRangeID(
 	}
 	err = storeShard.db.UpdateRangeID(ctx, shardID, rangeID, previousRangeID)
 	if err != nil {
-		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
-		if ok {
+		var conditionFailure *nosqlplugin.ShardOperationConditionFailure
+		if errors.As(err, &conditionFailure) {
 			return &persistence.ShardOwnershipLostError{
 				ShardID: shardID,
 				Msg: fmt.Sprintf("Failed to update shard rangeID.  request_range_id: %v, actual_range_id : %v, columns: (%v)",
@@ -163,8 +164,8 @@ func (sh *nosqlShardStore) UpdateShard(
 	}
 	err = storeShard.db.UpdateShard(ctx, request.ShardInfo, request.PreviousRangeID)
 	if err != nil {
-		conditionFailure, ok := err.(*nosqlplugin.ShardOperationConditionFailure)
-		if ok {
+		var conditionFailure *nosqlplugin.ShardOperationConditionFailure
+		if errors.As(err, &conditionFailure) {
 			return &persistence.ShardOwnershipLostError{
 				ShardID: request.ShardInfo.ShardID,
 				Msg: fmt.Sprintf("Failed to update shard rangeID.  request_range_id: %v, actual_range_id : %v, columns: (%v)",

--- a/common/persistence/nosql/nosql_task_store.go
+++ b/common/persistence/nosql/nosql_task_store.go
@@ -23,6 +23,7 @@ package nosql
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"time"
@@ -151,8 +152,8 @@ func (t *nosqlTaskStore) LeaseTaskList(
 		}, currTL.RangeID-1)
 	}
 	if err != nil {
-		conditionFailure, ok := err.(*nosqlplugin.TaskOperationConditionFailure)
-		if ok {
+		var conditionFailure *nosqlplugin.TaskOperationConditionFailure
+		if errors.As(err, &conditionFailure) {
 			return nil, &persistence.ConditionFailedError{
 				Msg: fmt.Sprintf("leaseTaskList: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",
 					request.TaskList, request.TaskType, currTL.RangeID, conditionFailure.RangeID),
@@ -199,8 +200,8 @@ func (t *nosqlTaskStore) UpdateTaskList(
 	}
 
 	if err != nil {
-		conditionFailure, ok := err.(*nosqlplugin.TaskOperationConditionFailure)
-		if ok {
+		var conditionFailure *nosqlplugin.TaskOperationConditionFailure
+		if errors.As(err, &conditionFailure) {
 			return nil, &persistence.ConditionFailedError{
 				Msg: fmt.Sprintf("Failed to update task list. name: %v, type: %v, rangeID: %v, columns: (%v)",
 					tli.Name, tli.TaskType, tli.RangeID, conditionFailure.Details),
@@ -237,8 +238,8 @@ func (t *nosqlTaskStore) DeleteTaskList(
 	}, request.RangeID)
 
 	if err != nil {
-		conditionFailure, ok := err.(*nosqlplugin.TaskOperationConditionFailure)
-		if ok {
+		var conditionFailure *nosqlplugin.TaskOperationConditionFailure
+		if errors.As(err, &conditionFailure) {
 			return &persistence.ConditionFailedError{
 				Msg: fmt.Sprintf("Failed to delete task list. name: %v, type: %v, rangeID: %v, columns: (%v)",
 					request.TaskListName, request.TaskListType, request.RangeID, conditionFailure.Details),
@@ -291,8 +292,8 @@ func (t *nosqlTaskStore) CreateTasks(
 	err = storeShard.db.InsertTasks(ctx, tasks, tasklistCondition)
 
 	if err != nil {
-		conditionFailure, ok := err.(*nosqlplugin.TaskOperationConditionFailure)
-		if ok {
+		var conditionFailure *nosqlplugin.TaskOperationConditionFailure
+		if errors.As(err, &conditionFailure) {
 			return nil, &persistence.ConditionFailedError{
 				Msg: fmt.Sprintf("Failed to insert tasks. name: %v, type: %v, rangeID: %v, columns: (%v)",
 					request.TaskListInfo.Name, request.TaskListInfo.TaskType, request.TaskListInfo.RangeID, conditionFailure.Details),

--- a/common/persistence/persistence-tests/configStorePersistenceTest.go
+++ b/common/persistence/persistence-tests/configStorePersistenceTest.go
@@ -100,7 +100,7 @@ func (s *ConfigStorePersistenceSuite) TestUpdateVersionCollisionFailure() {
 
 	err = s.UpdateDynamicConfig(ctx, snapshot, 2)
 	var condErr *p.ConditionFailedError
-	s.True(errors.As(err, &condErr))
+	s.ErrorAs(err, &condErr)
 }
 
 func (s *ConfigStorePersistenceSuite) TestUpdateIncrementalVersionSuccess() {

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -243,9 +243,10 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionWithWorkflowRequestsD
 	req.WorkflowRequestMode = p.CreateWorkflowRequestModeNew
 	_, err = s.ExecutionManager.CreateWorkflowExecution(ctx, req)
 	s.Error(err)
-	s.IsType(&p.DuplicateRequestError{}, err)
-	s.Equal(persistence.WorkflowRequestTypeStart, err.(*persistence.DuplicateRequestError).RequestType)
-	s.Equal(runID, err.(*persistence.DuplicateRequestError).RunID)
+	var typedErr *p.DuplicateRequestError
+	s.ErrorAs(err, &typedErr)
+	s.Equal(persistence.WorkflowRequestTypeStart, typedErr.RequestType)
+	s.Equal(runID, typedErr.RunID)
 	req.WorkflowRequestMode = p.CreateWorkflowRequestModeReplicated
 	_, err = s.ExecutionManager.CreateWorkflowExecution(ctx, req)
 	s.Error(err)
@@ -574,9 +575,10 @@ func (s *ExecutionManagerSuite) TestUpdateWorkflowExecutionWithWorkflowRequestsD
 	}
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(ctx, updateReq)
 	s.Error(err)
-	s.IsType(&p.DuplicateRequestError{}, err)
-	s.Equal(persistence.WorkflowRequestTypeSignal, err.(*persistence.DuplicateRequestError).RequestType)
-	s.Equal(runID, err.(*persistence.DuplicateRequestError).RunID)
+	var typedErr *p.DuplicateRequestError
+	s.ErrorAs(err, &typedErr)
+	s.Equal(persistence.WorkflowRequestTypeSignal, typedErr.RequestType)
+	s.Equal(runID, typedErr.RunID)
 	updateReq.WorkflowRequestMode = p.CreateWorkflowRequestModeReplicated
 	_, err = s.ExecutionManager.UpdateWorkflowExecution(ctx, updateReq)
 	s.Nil(err)
@@ -1065,8 +1067,8 @@ func (s *ExecutionManagerSuite) TestCreateWorkflowExecutionBrandNew() {
 	s.Nil(err)
 	_, err = s.ExecutionManager.CreateWorkflowExecution(ctx, req)
 	s.NotNil(err)
-	alreadyStartedErr, ok := err.(*p.WorkflowExecutionAlreadyStartedError)
-	s.True(ok, "err is not WorkflowExecutionAlreadyStartedError")
+	var alreadyStartedErr *p.WorkflowExecutionAlreadyStartedError
+	s.ErrorAs(err, &alreadyStartedErr)
 	s.Equal(req.NewWorkflowSnapshot.ExecutionInfo.CreateRequestID, alreadyStartedErr.StartRequestID)
 	s.Equal(workflowExecution.GetRunID(), alreadyStartedErr.RunID)
 	s.Equal(0, alreadyStartedErr.CloseStatus)

--- a/common/persistence/persistence-tests/matchingPersistenceTest.go
+++ b/common/persistence/persistence-tests/matchingPersistenceTest.go
@@ -368,8 +368,7 @@ func (s *MatchingPersistenceSuite) TestLeaseAndUpdateTaskList() {
 		RangeID:  1,
 	})
 	s.Error(err)
-	_, ok := err.(*p.ConditionFailedError)
-	s.True(ok)
+	s.ErrorAs(err, new(*p.ConditionFailedError))
 
 	taskListInfo := &p.TaskListInfo{
 		DomainID: domainID,

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -23,6 +23,7 @@ package persistencetests
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 	"math/rand"
@@ -1884,8 +1885,7 @@ func (s *TestBase) Publish(
 }
 
 func isMessageIDConflictError(err error) bool {
-	_, ok := err.(*persistence.ConditionFailedError)
-	return ok
+	return errors.As(err, new(*persistence.ConditionFailedError))
 }
 
 // GetReplicationMessages is a utility method to get messages from the queue

--- a/common/persistence/persistence-tests/visibilitySamplingClient_test.go
+++ b/common/persistence/persistence-tests/visibilitySamplingClient_test.go
@@ -153,8 +153,8 @@ func (s *VisibilitySamplingSuite) TestListOpenWorkflowExecutions() {
 	// no remaining tokens
 	_, err = s.client.ListOpenWorkflowExecutions(ctx, request)
 	s.Error(err)
-	errDetail, ok := err.(*types.ServiceBusyError)
-	s.True(ok)
+	var errDetail *types.ServiceBusyError
+	s.ErrorAs(err, &errDetail)
 	s.Equal(listErrMsg, errDetail.Message)
 }
 
@@ -173,8 +173,8 @@ func (s *VisibilitySamplingSuite) TestListClosedWorkflowExecutions() {
 	// no remaining tokens
 	_, err = s.client.ListClosedWorkflowExecutions(ctx, request)
 	s.Error(err)
-	errDetail, ok := err.(*types.ServiceBusyError)
-	s.True(ok)
+	var errDetail *types.ServiceBusyError
+	s.ErrorAs(err, &errDetail)
 	s.Equal(listErrMsg, errDetail.Message)
 }
 
@@ -197,8 +197,8 @@ func (s *VisibilitySamplingSuite) TestListOpenWorkflowExecutionsByType() {
 	// no remaining tokens
 	_, err = s.client.ListOpenWorkflowExecutionsByType(ctx, request)
 	s.Error(err)
-	errDetail, ok := err.(*types.ServiceBusyError)
-	s.True(ok)
+	var errDetail *types.ServiceBusyError
+	s.ErrorAs(err, &errDetail)
 	s.Equal(listErrMsg, errDetail.Message)
 }
 
@@ -221,8 +221,8 @@ func (s *VisibilitySamplingSuite) TestListClosedWorkflowExecutionsByType() {
 	// no remaining tokens
 	_, err = s.client.ListClosedWorkflowExecutionsByType(ctx, request)
 	s.Error(err)
-	errDetail, ok := err.(*types.ServiceBusyError)
-	s.True(ok)
+	var errDetail *types.ServiceBusyError
+	s.ErrorAs(err, &errDetail)
 	s.Equal(listErrMsg, errDetail.Message)
 }
 
@@ -245,8 +245,8 @@ func (s *VisibilitySamplingSuite) TestListOpenWorkflowExecutionsByWorkflowID() {
 	// no remaining tokens
 	_, err = s.client.ListOpenWorkflowExecutionsByWorkflowID(ctx, request)
 	s.Error(err)
-	errDetail, ok := err.(*types.ServiceBusyError)
-	s.True(ok)
+	var errDetail *types.ServiceBusyError
+	s.ErrorAs(err, &errDetail)
 	s.Equal(listErrMsg, errDetail.Message)
 }
 
@@ -269,8 +269,8 @@ func (s *VisibilitySamplingSuite) TestListClosedWorkflowExecutionsByWorkflowID()
 	// no remaining tokens
 	_, err = s.client.ListClosedWorkflowExecutionsByWorkflowID(ctx, request)
 	s.Error(err)
-	errDetail, ok := err.(*types.ServiceBusyError)
-	s.True(ok)
+	var errDetail *types.ServiceBusyError
+	s.ErrorAs(err, &errDetail)
 	s.Equal(listErrMsg, errDetail.Message)
 }
 
@@ -293,7 +293,7 @@ func (s *VisibilitySamplingSuite) TestListClosedWorkflowExecutionsByStatus() {
 	// no remaining tokens
 	_, err = s.client.ListClosedWorkflowExecutionsByStatus(ctx, request)
 	s.Error(err)
-	errDetail, ok := err.(*types.ServiceBusyError)
-	s.True(ok)
+	var errDetail *types.ServiceBusyError
+	s.ErrorAs(err, &errDetail)
 	s.Equal(listErrMsg, errDetail.Message)
 }

--- a/common/persistence/pinot/pinot_visibility_metric_clients.go
+++ b/common/persistence/pinot/pinot_visibility_metric_clients.go
@@ -22,6 +22,7 @@ package pinotvisibility
 
 import (
 	"context"
+	"errors"
 
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -385,12 +386,12 @@ func (p *pinotVisibilityMetricsClient) DeleteUninitializedWorkflowExecution(
 
 func (p *pinotVisibilityMetricsClient) updateErrorMetric(scopeWithDomainTag metrics.Scope, scope int, err error) {
 
-	switch err.(type) {
-	case *types.BadRequestError:
+	switch {
+	case errors.As(err, new(*types.BadRequestError)):
 		scopeWithDomainTag.IncCounter(metrics.PinotErrBadRequestCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.PinotFailuresPerDomain)
 
-	case *types.ServiceBusyError:
+	case errors.As(err, new(*types.ServiceBusyError)):
 		scopeWithDomainTag.IncCounter(metrics.PinotErrBusyCounterPerDomain)
 		scopeWithDomainTag.IncCounter(metrics.PinotFailuresPerDomain)
 	default:

--- a/common/persistence/sql/sqlplugin/postgres/db.go
+++ b/common/persistence/sql/sqlplugin/postgres/db.go
@@ -23,6 +23,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"time"
 
 	"github.com/jmoiron/sqlx"
@@ -56,8 +57,8 @@ const ErrInsufficientResources = "53000"
 const ErrTooManyConnections = "53300"
 
 func (pdb *db) IsDupEntryError(err error) bool {
-	sqlErr, ok := err.(*pq.Error)
-	return ok && sqlErr.Code == ErrDupEntry
+	var sqlErr *pq.Error
+	return errors.As(err, &sqlErr) && sqlErr.Code == ErrDupEntry
 }
 
 func (pdb *db) IsNotFoundError(err error) bool {
@@ -69,8 +70,8 @@ func (pdb *db) IsTimeoutError(err error) bool {
 }
 
 func (pdb *db) IsThrottlingError(err error) bool {
-	sqlErr, ok := err.(*pq.Error)
-	if ok {
+	var sqlErr *pq.Error
+	if errors.As(err, &sqlErr) {
 		if sqlErr.Code == ErrTooManyConnections ||
 			sqlErr.Code == ErrInsufficientResources {
 			return true

--- a/host/archival_test.go
+++ b/host/archival_test.go
@@ -24,6 +24,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -208,7 +209,7 @@ func (s *IntegrationSuite) isMutableStateDeleted(domainID string, execution *typ
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTestPersistenceTimeout)
 		_, err := s.testCluster.testBase.ExecutionManager.GetWorkflowExecution(ctx, request)
 		cancel()
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			return true
 		}
 		time.Sleep(retryBackoffTime)

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -23,6 +23,7 @@ package host
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -813,7 +814,7 @@ func (c *cadenceImpl) createSystemDomain() error {
 		FailoverVersion:   common.EmptyVersion,
 	})
 	if err != nil {
-		if _, ok := err.(*types.DomainAlreadyExistsError); ok {
+		if errors.As(err, new(*types.DomainAlreadyExistsError)) {
 			return nil
 		}
 		return fmt.Errorf("failed to create cadence-system domain: %v", err)

--- a/host/query_workflow_test.go
+++ b/host/query_workflow_test.go
@@ -210,8 +210,8 @@ func (s *IntegrationSuite) TestQueryWorkflow_Sticky() {
 	}
 	queryResult = <-queryResultCh
 	s.NotNil(queryResult.Err)
-	queryFailError, ok := queryResult.Err.(*types.QueryFailedError)
-	s.True(ok)
+	var queryFailError *types.QueryFailedError
+	s.ErrorAs(err, &queryFailError)
 	s.Equal("unknown-query-type", queryFailError.Message)
 }
 
@@ -523,8 +523,8 @@ func (s *IntegrationSuite) TestQueryWorkflow_NonSticky() {
 	}
 	queryResult = <-queryResultCh
 	s.NotNil(queryResult.Err)
-	queryFailError, ok := queryResult.Err.(*types.QueryFailedError)
-	s.True(ok)
+	var queryFailError *types.QueryFailedError
+	s.ErrorAs(err, &queryFailError)
 	s.Equal("unknown-query-type", queryFailError.Message)
 
 	// advance the state of the decider
@@ -1416,6 +1416,7 @@ func (s *IntegrationSuite) TestQueryWorkflow_BeforeFirstDecision() {
 		},
 	})
 	s.Nil(queryResp)
-	s.IsType(&types.QueryFailedError{}, err)
-	s.Equal("workflow must handle at least one decision task before it can be queried", err.(*types.QueryFailedError).Message)
+	var queryErr *types.QueryFailedError
+	s.ErrorAs(err, &queryErr)
+	s.Equal("workflow must handle at least one decision task before it can be queried", queryErr.Message)
 }

--- a/host/signal_workflow_test.go
+++ b/host/signal_workflow_test.go
@@ -1574,7 +1574,9 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	cancel()
 	s.Nil(resp)
 	s.Error(err)
-	errMsg := err.(*types.WorkflowExecutionAlreadyStartedError).GetMessage()
+	var alreadyStartedErr *types.WorkflowExecutionAlreadyStartedError
+	s.ErrorAs(err, &alreadyStartedErr)
+	errMsg := alreadyStartedErr.GetMessage()
 	s.True(strings.Contains(errMsg, "reject duplicate workflow ID"))
 
 	// test policy WorkflowIDReusePolicyAllowDuplicateFailedOnly
@@ -1585,7 +1587,8 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	cancel()
 	s.Nil(resp)
 	s.Error(err)
-	errMsg = err.(*types.WorkflowExecutionAlreadyStartedError).GetMessage()
+	s.ErrorAs(err, &alreadyStartedErr)
+	errMsg = alreadyStartedErr.GetMessage()
 	s.True(strings.Contains(errMsg, "allow duplicate workflow ID if last run failed"))
 
 	// test policy WorkflowIDReusePolicyAllowDuplicate

--- a/host/signal_workflow_test.go
+++ b/host/signal_workflow_test.go
@@ -26,7 +26,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pborman/uuid"
@@ -1576,8 +1575,7 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	s.Error(err)
 	var alreadyStartedErr *types.WorkflowExecutionAlreadyStartedError
 	s.ErrorAs(err, &alreadyStartedErr)
-	errMsg := alreadyStartedErr.GetMessage()
-	s.True(strings.Contains(errMsg, "reject duplicate workflow ID"))
+	s.ErrorContains(alreadyStartedErr, "reject duplicate workflow ID")
 
 	// test policy WorkflowIDReusePolicyAllowDuplicateFailedOnly
 	wfIDReusePolicy = types.WorkflowIDReusePolicyAllowDuplicateFailedOnly
@@ -1588,8 +1586,7 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	s.Nil(resp)
 	s.Error(err)
 	s.ErrorAs(err, &alreadyStartedErr)
-	errMsg = alreadyStartedErr.GetMessage()
-	s.True(strings.Contains(errMsg, "allow duplicate workflow ID if last run failed"))
+	s.ErrorContains(alreadyStartedErr, "allow duplicate workflow ID if last run failed")
 
 	// test policy WorkflowIDReusePolicyAllowDuplicate
 	wfIDReusePolicy = types.WorkflowIDReusePolicyAllowDuplicate

--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -802,7 +802,7 @@ func (adh *adminHandlerImpl) GetWorkflowExecutionRawHistoryV2(
 		DomainName:    request.GetDomain(),
 	})
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			// when no events can be returned from DB, DB layer will return
 			// EntityNotExistsError, this API shall return empty response
 			return &types.GetWorkflowExecutionRawHistoryV2Response{

--- a/service/frontend/wrappers/clusterredirection/policy.go
+++ b/service/frontend/wrappers/clusterredirection/policy.go
@@ -22,6 +22,7 @@ package clusterredirection
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/uber/cadence/common/cache"
@@ -235,8 +236,8 @@ func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) withRedirect(ctx con
 }
 
 func (policy *selectedOrAllAPIsForwardingRedirectionPolicy) isDomainNotActiveError(err error) (string, bool) {
-	domainNotActiveErr, ok := err.(*types.DomainNotActiveError)
-	if !ok {
+	var domainNotActiveErr *types.DomainNotActiveError
+	if !errors.As(err, &domainNotActiveErr) {
 		return "", false
 	}
 	return domainNotActiveErr.ActiveCluster, true

--- a/service/history/decision/task_handler.go
+++ b/service/history/decision/task_handler.go
@@ -22,6 +22,7 @@ package decision
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/pborman/uuid"
@@ -1074,7 +1075,7 @@ func (handler *taskHandlerImpl) validateDecisionAttr(
 ) error {
 
 	if err := validationFn(); err != nil {
-		if _, ok := err.(*types.BadRequestError); ok {
+		if errors.As(err, new(*types.BadRequestError)) {
 			return handler.handlerFailDecision(failedCause, err.Error())
 		}
 		return err

--- a/service/history/engine/engineimpl/history_engine2_test.go
+++ b/service/history/engine/engineimpl/history_engine2_test.go
@@ -1225,9 +1225,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_StillRunning_NonDeDup() {
 			RequestID:                           "newRequestID",
 		},
 	})
-	if _, ok := err.(*types.WorkflowExecutionAlreadyStartedError); !ok {
-		s.Fail("return err is not *types.WorkflowExecutionAlreadyStartedError")
-	}
+	s.ErrorAs(err, new(*types.WorkflowExecutionAlreadyStartedError))
 	s.Nil(resp)
 }
 
@@ -1425,9 +1423,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevSuccess() {
 		})
 
 		if expectedErrs[index] {
-			if _, ok := err.(*types.WorkflowExecutionAlreadyStartedError); !ok {
-				s.Fail("return err is not *types.WorkflowExecutionAlreadyStartedError")
-			}
+			s.ErrorAs(err, new(*types.WorkflowExecutionAlreadyStartedError))
 			s.Nil(resp)
 		} else {
 			s.Nil(err)
@@ -1515,9 +1511,7 @@ func (s *engine2Suite) TestStartWorkflowExecution_NotRunning_PrevFail() {
 			})
 
 			if expectedErrs[j] {
-				if _, ok := err.(*types.WorkflowExecutionAlreadyStartedError); !ok {
-					s.Fail("return err is not *types.WorkflowExecutionAlreadyStartedError")
-				}
+				s.ErrorAs(err, new(*types.WorkflowExecutionAlreadyStartedError))
 				s.Nil(resp)
 			} else {
 				s.Nil(err)

--- a/service/history/engine/engineimpl/poll_mutable_state.go
+++ b/service/history/engine/engineimpl/poll_mutable_state.go
@@ -24,6 +24,7 @@ package engineimpl
 import (
 	"bytes"
 	"context"
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -120,8 +121,7 @@ func (e *historyEngineImpl) getMutableState(
 }
 
 func (e *historyEngineImpl) updateEntityNotExistsErrorOnPassiveCluster(err error, domainID string) error {
-	switch err.(type) {
-	case *types.EntityNotExistsError:
+	if errors.As(err, new(*types.EntityNotExistsError)) {
 		domainEntry, domainCacheErr := e.shard.GetDomainCache().GetDomainByID(domainID)
 		if domainCacheErr != nil {
 			return err // if could not access domain cache simply return original error

--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -23,6 +23,7 @@ package engineimpl
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -232,7 +233,8 @@ func (e *historyEngineImpl) startWorkflowHelper(
 		return nil, t
 	}
 	// handle already started error
-	if t, ok := err.(*persistence.WorkflowExecutionAlreadyStartedError); ok {
+	var t *persistence.WorkflowExecutionAlreadyStartedError
+	if errors.As(err, &t) {
 
 		if t.StartRequestID == request.GetRequestID() {
 			return &types.StartWorkflowExecutionResponse{

--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1145,7 +1145,7 @@ func createWorkflowExecutionWithRetry(
 		return err
 	}
 	isRetryable := func(err error) bool {
-		if _, ok := err.(*persistence.TimeoutError); ok {
+		if errors.As(err, new(*persistence.TimeoutError)) {
 			// TODO: is timeout error retryable for create workflow?
 			// if we treat it as retryable, user may receive workflowAlreadyRunning error
 			// on the first start workflow execution request.
@@ -1236,7 +1236,7 @@ func updateWorkflowExecutionWithRetry(
 	// checker, _ := taskvalidator.NewWfChecker(zapLogger, metricsClient, domainCache, executionManager, historymanager)
 
 	isRetryable := func(err error) bool {
-		if _, ok := err.(*persistence.TimeoutError); ok {
+		if errors.As(err, new(*persistence.TimeoutError)) {
 			// timeout error is not retryable for update workflow execution
 			return false
 		}

--- a/service/history/ndc/activity_replicator.go
+++ b/service/history/ndc/activity_replicator.go
@@ -24,6 +24,7 @@ package ndc
 
 import (
 	ctx "context"
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common"
@@ -100,7 +101,7 @@ func (r *activityReplicatorImpl) SyncActivity(
 
 	mutableState, err := context.LoadWorkflowExecution(ctx)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			return err
 		}
 

--- a/service/history/ndc/workflow_resetter_test.go
+++ b/service/history/ndc/workflow_resetter_test.go
@@ -251,8 +251,8 @@ func (s *workflowResetterSuite) TestResetWorkflow_Error() {
 	s.IsType(&types.RetryTaskV2Error{}, err)
 	s.Nil(rebuiltMutableState)
 
-	retryErr, isRetryError := err.(*types.RetryTaskV2Error)
-	s.True(isRetryError)
+	var retryErr *types.RetryTaskV2Error
+	s.ErrorAs(err, &retryErr)
 	expectedErr := &types.RetryTaskV2Error{
 		Message:         resendOnResetWorkflowMessage,
 		DomainID:        s.domainID,

--- a/service/history/queue/task_allocator.go
+++ b/service/history/queue/task_allocator.go
@@ -72,7 +72,7 @@ func (t *taskAllocatorImpl) VerifyActiveTask(taskDomainID string, task interface
 	if err != nil {
 		// it is possible that the domain is deleted
 		// we should treat that domain as active
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			t.logger.Warn("Cannot find domain", tag.WorkflowDomainID(taskDomainID))
 			return false, err
 		}
@@ -108,7 +108,7 @@ func (t *taskAllocatorImpl) VerifyFailoverActiveTask(targetDomainIDs map[string]
 		if err != nil {
 			// it is possible that the domain is deleted
 			// we should treat that domain as not active
-			if _, ok := err.(*types.EntityNotExistsError); !ok {
+			if !errors.As(err, new(*types.EntityNotExistsError)) {
 				t.logger.Warn("Cannot find domain", tag.WorkflowDomainID(taskDomainID))
 				return false, err
 			}
@@ -139,7 +139,7 @@ func (t *taskAllocatorImpl) VerifyStandbyTask(standbyCluster string, taskDomainI
 	if err != nil {
 		// it is possible that the domain is deleted
 		// we should treat that domain as not active
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			t.logger.Warn("Cannot find domain", tag.WorkflowDomainID(taskDomainID))
 			return false, err
 		}

--- a/service/history/queue/timer_queue_standby_processor.go
+++ b/service/history/queue/timer_queue_standby_processor.go
@@ -21,6 +21,8 @@
 package queue
 
 import (
+	"errors"
+
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/persistence"
@@ -62,7 +64,7 @@ func newTimerQueueStandbyProcessor(
 					return true, nil
 				}
 			} else {
-				if _, ok := err.(*types.EntityNotExistsError); !ok {
+				if !errors.As(err, new(*types.EntityNotExistsError)) {
 					// retry the task if failed to find the domain
 					logger.Warn("Cannot find domain", tag.WorkflowDomainID(timer.DomainID))
 					return false, err

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -555,7 +555,7 @@ func newTransferQueueStandbyProcessor(
 					return true, nil
 				}
 			} else {
-				if _, ok := err.(*types.EntityNotExistsError); !ok {
+				if !errors.As(err, new(*types.EntityNotExistsError)) {
 					// retry the task if failed to find the domain
 					logger.Warn("Cannot find domain", tag.WorkflowDomainID(task.DomainID))
 					return false, err

--- a/service/history/replication/task_executor.go
+++ b/service/history/replication/task_executor.go
@@ -22,6 +22,7 @@ package replication
 
 import (
 	"context"
+	"errors"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
@@ -306,6 +307,9 @@ func (e *taskExecutorImpl) filterTask(
 }
 
 func toRetryTaskV2Error(err error) (*types.RetryTaskV2Error, bool) {
-	retError, ok := err.(*types.RetryTaskV2Error)
-	return retError, ok
+	var retError *types.RetryTaskV2Error
+	if errors.As(err, &retError) {
+		return retError, true
+	}
+	return nil, false
 }

--- a/service/history/shard/context.go
+++ b/service/history/shard/context.go
@@ -1103,7 +1103,7 @@ func (s *contextImpl) persistShardInfoLocked(
 
 	if err != nil {
 		// Shard is stolen, trigger history engine shutdown
-		if _, ok := err.(*persistence.ShardOwnershipLostError); ok {
+		if errors.As(err, new(*persistence.ShardOwnershipLostError)) {
 			s.logger.Warn(
 				"Closing shard: updateShardInfoLocked failed due to stolen shard.",
 				tag.Error(err),
@@ -1452,8 +1452,7 @@ func acquireShard(
 		if persistence.IsTransientError(err) {
 			return true
 		}
-		_, ok := err.(*persistence.ShardAlreadyExistError)
-		return ok
+		return errors.As(err, new(*persistence.ShardAlreadyExistError))
 	}
 
 	getShard := func() error {
@@ -1464,7 +1463,7 @@ func acquireShard(
 			shardInfo = resp.ShardInfo
 			return nil
 		}
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			return err
 		}
 

--- a/service/history/task/priority_assigner.go
+++ b/service/history/task/priority_assigner.go
@@ -21,6 +21,7 @@
 package task
 
 import (
+	"errors"
 	"sync"
 
 	"github.com/uber/cadence/common"
@@ -134,7 +135,7 @@ func (a *priorityAssignerImpl) Assign(queueTask Task) error {
 func (a *priorityAssignerImpl) getDomainInfo(domainID string) (string, bool, error) {
 	domainEntry, err := a.domainCache.GetDomainByID(domainID)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			a.logger.Warn("Cannot find domain", tag.WorkflowDomainID(domainID))
 			return "", false, err
 		}

--- a/service/history/task/task_util.go
+++ b/service/history/task/task_util.go
@@ -22,6 +22,7 @@ package task
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/golang/mock/gomock"
@@ -273,7 +274,7 @@ func loadMutableStateForTimerTask(
 ) (execution.MutableState, error) {
 	msBuilder, err := wfContext.LoadWorkflowExecution(ctx)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			// this could happen if this is a duplicate processing of the task, and the execution has already completed.
 			return nil, nil
 		}
@@ -328,7 +329,7 @@ func loadMutableStateForTransferTask(
 
 	msBuilder, err := wfContext.LoadWorkflowExecution(ctx)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			// this could happen if this is a duplicate processing of the task, and the execution has already completed.
 			return nil, nil
 		}
@@ -384,7 +385,7 @@ func loadMutableStateForCrossClusterTask(
 
 	msBuilder, err := wfContext.LoadWorkflowExecution(ctx)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			// this could happen if this is a duplicate processing of the task, and the execution has already completed.
 			return nil, nil
 		}

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -285,7 +285,7 @@ func (t *transferActiveTaskExecutor) processDecisionTask(
 	}
 
 	err = t.pushDecision(ctx, task, taskList, decisionTimeout, mutableState.GetExecutionInfo().PartitionConfig)
-	if _, ok := err.(*types.StickyWorkerUnavailableError); ok {
+	if errors.As(err, new(*types.StickyWorkerUnavailableError)) {
 		// sticky worker is unavailable, switch to non-sticky task list
 		taskList = &types.TaskList{
 			Name: mutableState.GetExecutionInfo().TaskList,
@@ -802,7 +802,7 @@ func (t *transferActiveTaskExecutor) processStartChildExecution(
 	var targetDomainName string
 	var targetDomainEntry *cache.DomainCacheEntry
 	if targetDomainEntry, err = t.shard.GetDomainCache().GetDomainByID(task.TargetDomainID); err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			return err
 		}
 		// TODO: handle the case where target domain does not exist
@@ -1613,7 +1613,7 @@ func startWorkflowWithRetry(
 	// Get parent domain name
 	domainName, err := domainCache.GetDomainName(task.DomainID)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			return "", err
 		}
 		// it is possible that the domain got deleted. Use domainID instead as this is only needed for the history event

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -23,6 +23,7 @@ package task
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -165,7 +166,7 @@ func (t *transferTaskExecutorBase) recordWorkflowStarted(
 	domain := defaultDomainName
 
 	if domainEntry, err := t.shard.GetDomainCache().GetDomainByID(domainID); err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			return err
 		}
 	} else {
@@ -238,7 +239,7 @@ func (t *transferTaskExecutorBase) upsertWorkflowExecution(
 
 	domain, err := t.shard.GetDomainCache().GetDomainName(domainID)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			return err
 		}
 		domain = defaultDomainName
@@ -446,6 +447,5 @@ func copySearchAttributes(
 }
 
 func isWorkflowNotExistError(err error) bool {
-	_, ok := err.(*types.EntityNotExistsError)
-	return ok
+	return errors.As(err, new(*types.EntityNotExistsError))
 }

--- a/service/history/workflow/util.go
+++ b/service/history/workflow/util.go
@@ -22,6 +22,7 @@ package workflow
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common/cache"
@@ -261,7 +262,7 @@ UpdateHistoryLoop:
 		}
 
 		err = workflowContext.GetContext().UpdateWorkflowExecutionAsActive(ctx, now)
-		if _, ok := err.(*persistence.DuplicateRequestError); ok {
+		if errors.As(err, new(*persistence.DuplicateRequestError)) {
 			return nil
 		}
 		if execution.IsConflictError(err) {

--- a/service/matching/tasklist/forwarder.go
+++ b/service/matching/tasklist/forwarder.go
@@ -283,7 +283,7 @@ func (fwdr *Forwarder) refreshTokenC(value *atomic.Value, curr *int32, maxLimit 
 }
 
 func (fwdr *Forwarder) handleErr(err error) error {
-	if _, ok := err.(*types.ServiceBusyError); ok {
+	if errors.As(err, new(*types.ServiceBusyError)) {
 		return errForwarderSlowDown
 	}
 	return err

--- a/service/worker/batcher/workflow.go
+++ b/service/worker/batcher/workflow.go
@@ -22,6 +22,7 @@ package batcher
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -491,7 +492,7 @@ func processTask(
 		err = procFn(wf.GetWorkflowID(), wf.GetRunID())
 		if err != nil {
 			// EntityNotExistsError means wf is not running or deleted
-			if _, ok := err.(*types.EntityNotExistsError); ok {
+			if errors.As(err, new(*types.EntityNotExistsError)) {
 				continue
 			}
 			return err
@@ -505,7 +506,7 @@ func processTask(
 		})
 		if err != nil {
 			// EntityNotExistsError means wf is deleted
-			if _, ok := err.(*types.EntityNotExistsError); ok {
+			if errors.As(err, new(*types.EntityNotExistsError)) {
 				continue
 			}
 			return err

--- a/service/worker/parentclosepolicy/workflow.go
+++ b/service/worker/parentclosepolicy/workflow.go
@@ -22,6 +22,7 @@ package parentclosepolicy
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/rand"
 	"time"
@@ -197,12 +198,12 @@ func ProcessorActivity(ctx context.Context, request Request) error {
 			err = fmt.Errorf("unknown parent close policy: %v", execution.Policy)
 		}
 		if err != nil {
-			switch err.(type) {
-			case *types.EntityNotExistsError,
-				*types.WorkflowExecutionAlreadyCompletedError,
-				*types.CancellationAlreadyRequestedError:
+			switch {
+			case errors.As(err, new(*types.EntityNotExistsError)),
+				errors.As(err, new(*types.WorkflowExecutionAlreadyCompletedError)),
+				errors.As(err, new(*types.CancellationAlreadyRequestedError)):
 				err = nil
-			case *types.DomainNotActiveError:
+			case errors.As(err, new(*types.DomainNotActiveError)):
 				var domainEntry *cache.DomainCacheEntry
 				if domainEntry, err = domainCache.GetDomainByID(domainID); err == nil {
 					cluster := domainEntry.GetReplicationConfig().ActiveClusterName

--- a/service/worker/scanner/history/scavenger.go
+++ b/service/worker/scanner/history/scavenger.go
@@ -22,6 +22,7 @@ package history
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"go.uber.org/cadence/activity"
@@ -250,7 +251,7 @@ func (s *Scavenger) startTaskProcessor(
 			})
 
 			if err != nil {
-				if _, ok := err.(*types.EntityNotExistsError); ok {
+				if errors.As(err, new(*types.EntityNotExistsError)) {
 					// deleting history branch
 					var branchToken []byte
 					branchToken, err = p.NewHistoryBranchTokenByBranchID(task.treeID, task.branchID)

--- a/service/worker/scanner/tasklist/db.go
+++ b/service/worker/scanner/tasklist/db.go
@@ -22,6 +22,7 @@ package tasklist
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/uber/cadence/common/backoff"
@@ -136,8 +137,7 @@ func (s *Scavenger) deleteTaskList(info *p.TaskListInfo) error {
 	throttleRetry := backoff.NewThrottleRetry(
 		backoff.WithRetryPolicy(retryForeverPolicy),
 		backoff.WithRetryableError(func(err error) bool {
-			_, ok := err.(*types.ServiceBusyError)
-			return ok
+			return errors.As(err, new(*types.ServiceBusyError))
 		}),
 	)
 	return throttleRetry.Do(context.Background(), op)

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -24,6 +24,7 @@ package worker
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync/atomic"
 
@@ -447,7 +448,7 @@ func (s *Service) registerSystemDomain(domain string) {
 		FailoverVersion: common.EmptyVersion,
 	})
 	if err != nil {
-		if _, ok := err.(*types.DomainAlreadyExistsError); ok {
+		if errors.As(err, new(*types.DomainAlreadyExistsError)) {
 			return
 		}
 		s.GetLogger().Fatal("failed to register system domain", tag.Error(err))

--- a/tools/cli/admin_failover_commands.go
+++ b/tools/cli/admin_failover_commands.go
@@ -23,6 +23,7 @@ package cli
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os/user"
 	"time"
@@ -290,10 +291,10 @@ func failoverStart(c *cli.Context, params *startParams) {
 
 		// block if there is an on-going failover drill
 		if err := executePauseOrResume(c, failovermanager.DrillWorkflowID, true); err != nil {
-			switch err.(type) {
-			case *types.EntityNotExistsError:
+			switch {
+			case errors.As(err, new(*types.EntityNotExistsError)):
 				break
-			case *types.WorkflowExecutionAlreadyCompletedError:
+			case errors.As(err, new(*types.WorkflowExecutionAlreadyCompletedError)):
 				break
 			default:
 				ErrorAndExit("Failed to send pase signal to drill workflow", err)

--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -140,7 +140,7 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) {
 	defer cancel()
 	err = d.registerDomain(ctx, request)
 	if err != nil {
-		if _, ok := err.(*types.DomainAlreadyExistsError); !ok {
+		if errors.As(err, new(*types.DomainAlreadyExistsError)) {
 			ErrorAndExit("Register Domain operation failed.", err)
 		} else {
 			ErrorAndExit(fmt.Sprintf("Domain %s already registered.", domainName), err)
@@ -178,7 +178,7 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) {
 			Name: common.StringPtr(domainName),
 		})
 		if err != nil {
-			if _, ok := err.(*types.EntityNotExistsError); !ok {
+			if errors.As(err, new(*types.EntityNotExistsError)) {
 				ErrorAndExit("Operation UpdateDomain failed.", err)
 			} else {
 				ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)
@@ -261,7 +261,7 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) {
 	updateRequest.SecurityToken = securityToken
 	_, err := d.updateDomain(ctx, updateRequest)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			ErrorAndExit("Operation UpdateDomain failed.", err)
 		} else {
 			ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)
@@ -297,7 +297,7 @@ func (d *domainCLIImpl) DeprecateDomain(c *cli.Context) {
 		SecurityToken: securityToken,
 	})
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			ErrorAndExit("Operation DeprecateDomain failed.", err)
 		} else {
 			ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)
@@ -420,7 +420,7 @@ func (d *domainCLIImpl) DescribeDomain(c *cli.Context) {
 	defer cancel()
 	resp, err := d.describeDomain(ctx, &request)
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); !ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			ErrorAndExit("Operation DescribeDomain failed.", err)
 		}
 		ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)

--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -140,7 +140,7 @@ func (d *domainCLIImpl) RegisterDomain(c *cli.Context) {
 	defer cancel()
 	err = d.registerDomain(ctx, request)
 	if err != nil {
-		if errors.As(err, new(*types.DomainAlreadyExistsError)) {
+		if !errors.As(err, new(*types.DomainAlreadyExistsError)) {
 			ErrorAndExit("Register Domain operation failed.", err)
 		} else {
 			ErrorAndExit(fmt.Sprintf("Domain %s already registered.", domainName), err)
@@ -178,7 +178,7 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) {
 			Name: common.StringPtr(domainName),
 		})
 		if err != nil {
-			if errors.As(err, new(*types.EntityNotExistsError)) {
+			if !errors.As(err, new(*types.EntityNotExistsError)) {
 				ErrorAndExit("Operation UpdateDomain failed.", err)
 			} else {
 				ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)
@@ -261,7 +261,7 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) {
 	updateRequest.SecurityToken = securityToken
 	_, err := d.updateDomain(ctx, updateRequest)
 	if err != nil {
-		if errors.As(err, new(*types.EntityNotExistsError)) {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			ErrorAndExit("Operation UpdateDomain failed.", err)
 		} else {
 			ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)
@@ -297,7 +297,7 @@ func (d *domainCLIImpl) DeprecateDomain(c *cli.Context) {
 		SecurityToken: securityToken,
 	})
 	if err != nil {
-		if errors.As(err, new(*types.EntityNotExistsError)) {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			ErrorAndExit("Operation DeprecateDomain failed.", err)
 		} else {
 			ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)
@@ -420,7 +420,7 @@ func (d *domainCLIImpl) DescribeDomain(c *cli.Context) {
 	defer cancel()
 	resp, err := d.describeDomain(ctx, &request)
 	if err != nil {
-		if errors.As(err, new(*types.EntityNotExistsError)) {
+		if !errors.As(err, new(*types.EntityNotExistsError)) {
 			ErrorAndExit("Operation DescribeDomain failed.", err)
 		}
 		ErrorAndExit(fmt.Sprintf("Domain %s does not exist.", domainName), err)

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -189,7 +189,7 @@ func showHistoryHelper(c *cli.Context, wid, rid string) {
 		},
 	})
 	if err != nil {
-		if _, ok := err.(*types.EntityNotExistsError); ok {
+		if errors.As(err, new(*types.EntityNotExistsError)) {
 			fmt.Printf("%s %s\n", colorRed("Error:"), err)
 			return
 		}
@@ -1479,7 +1479,7 @@ func processResets(c *cli.Context, domain string, wes chan types.WorkflowExecuti
 				if err == nil {
 					break
 				}
-				if _, ok := err.(*types.BadRequestError); ok {
+				if errors.As(err, new(*types.BadRequestError)) {
 					break
 				}
 				fmt.Println("failed and retry...: ", wid, rid, err)

--- a/tools/common/schema/handler_test.go
+++ b/tools/common/schema/handler_test.go
@@ -21,6 +21,7 @@
 package schema
 
 import (
+	"errors"
 	"os"
 	"testing"
 
@@ -110,8 +111,7 @@ func (s *HandlerTestSuite) assertValidateSetupSucceeds(input *SetupConfig) {
 func (s *HandlerTestSuite) assertValidateSetupFails(input *SetupConfig) {
 	err := validateSetupConfig(input)
 	s.NotNil(err)
-	_, ok := err.(*ConfigError)
-	s.True(ok)
+	s.True(errors.As(err, new(*ConfigError)))
 }
 
 func (s *HandlerTestSuite) assertValidateUpdateSucceeds(input *UpdateConfig) {
@@ -122,6 +122,5 @@ func (s *HandlerTestSuite) assertValidateUpdateSucceeds(input *UpdateConfig) {
 func (s *HandlerTestSuite) assertValidateUpdateFails(input *UpdateConfig) {
 	err := validateUpdateConfig(input)
 	s.NotNil(err)
-	_, ok := err.(*ConfigError)
-	s.True(ok)
+	s.True(errors.As(err, new(*ConfigError)))
 }

--- a/tools/common/schema/handler_test.go
+++ b/tools/common/schema/handler_test.go
@@ -21,7 +21,6 @@
 package schema
 
 import (
-	"errors"
 	"os"
 	"testing"
 
@@ -111,7 +110,7 @@ func (s *HandlerTestSuite) assertValidateSetupSucceeds(input *SetupConfig) {
 func (s *HandlerTestSuite) assertValidateSetupFails(input *SetupConfig) {
 	err := validateSetupConfig(input)
 	s.NotNil(err)
-	s.True(errors.As(err, new(*ConfigError)))
+	s.ErrorAs(err, new(*ConfigError))
 }
 
 func (s *HandlerTestSuite) assertValidateUpdateSucceeds(input *UpdateConfig) {
@@ -122,5 +121,5 @@ func (s *HandlerTestSuite) assertValidateUpdateSucceeds(input *UpdateConfig) {
 func (s *HandlerTestSuite) assertValidateUpdateFails(input *UpdateConfig) {
 	err := validateUpdateConfig(input)
 	s.NotNil(err)
-	s.True(errors.As(err, new(*ConfigError)))
+	s.ErrorAs(err, new(*ConfigError))
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I've switched all direct error handling to usage of either errors.Is or errors.As. 
I've split the PR into commits so it can be reviewed commit by commit.
Most of the changes are converting expressions to an identical one so no logical changes are expected:
```
if _, ok := err.(*customErr); ok {
```
to 
```
if errors.As(err, new(*customErr)) {
```
There were a couple of more complicated cases, but all could be resolved.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a mandatory step to improve existing error handling that does not provide a clear path of where the error is coming from. In all style guides, error wrapping is recommended, but the codebase should be ready to handle wrapped errors instead of exact type checks.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit/integration tests.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Potentially, some errors could be misclassified.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
