### PR TITLE
Bench test use grpc

### DIFF
--- a/bench/README.md
+++ b/bench/README.md
@@ -70,7 +70,7 @@ bench:
 ```yaml
 cadence:
   service: "cadence-frontend" # frontend service name
-  host: "127.0.0.1:7933" # frontend address
+  host: "127.0.0.1:7833" # frontend address
   #metrics: ... # optional detailed client side metrics like workflow latency  
 ```
 - **Metrics**: metrics configuration. Similar to server metric emitter, only M3/Statsd/Prometheus is supported. 

--- a/bench/lib/client.go
+++ b/bench/lib/client.go
@@ -29,7 +29,7 @@ import (
 	"go.uber.org/cadence/.gen/go/shared"
 	"go.uber.org/cadence/client"
 	"go.uber.org/yarpc"
-	"go.uber.org/yarpc/transport/tchannel"
+	"go.uber.org/yarpc/transport/grpc"
 )
 
 const workflowRetentionDays = 1
@@ -92,17 +92,14 @@ func NewCadenceClientForDomain(
 	domain string,
 ) (CadenceClient, error) {
 
-	ch, err := tchannel.NewChannelTransport(
-		tchannel.ServiceName(runtime.Bench.Name),
+	transport := grpc.NewTransport(
+		grpc.ServiceName(runtime.Bench.Name),
 	)
-	if err != nil {
-		return CadenceClient{}, fmt.Errorf("failed to create transport channel: %v", err)
-	}
 
 	dispatcher := yarpc.NewDispatcher(yarpc.Config{
 		Name: runtime.Bench.Name,
 		Outbounds: yarpc.Outbounds{
-			runtime.Cadence.ServiceName: {Unary: ch.NewSingleOutbound(runtime.Cadence.HostNameAndPort)},
+			runtime.Cadence.ServiceName: {Unary: transport.NewSingleOutbound(runtime.Cadence.HostNameAndPort)},
 		},
 	})
 

--- a/config/bench/development.yaml
+++ b/config/bench/development.yaml
@@ -5,7 +5,7 @@ bench:
 
 cadence:
   service: "cadence-frontend"
-  host: "${CADENCE_FRONTEND_ADDRESS:127.0.0.1:7933}"
+  host: "${CADENCE_FRONTEND_ADDRESS:127.0.0.1:7833}"
 
 metrics:
   statsd: ~


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Made bench workers to use grpc instead of tchannel transport, and changed development.yaml in config/bench to use 7833 port.


<!-- Tell your future self why have you made these changes -->
**Why?**
Since the thrift port is getting deprecated, it reduces the overhead of exposing thrift port of cadence service while bench testing.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
I tested this locally and workers started, All test cases passed. Since its a small change I didn't add test case.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
There is no risks for main code as it only changes bench client connection.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
No it doesn't require anything.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
Updated Readme in this PR itself
