### PR TITLE
wrapped error support in transport mappers

### DIFF
--- a/common/types/mapper/errorutils/convert.go
+++ b/common/types/mapper/errorutils/convert.go
@@ -1,0 +1,37 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package errorutils
+
+import "errors"
+
+// ConvertError checks if an error is of type T and if so, converts it using f.
+func ConvertError[T, V error](err error, fn func(T) V) (bool, V) {
+	var (
+		e   T
+		res V
+	)
+	if !errors.As(err, &e) {
+		return false, res
+	}
+	return true, fn(e)
+}

--- a/common/types/mapper/errorutils/convert_test.go
+++ b/common/types/mapper/errorutils/convert_test.go
@@ -1,0 +1,68 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package errorutils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConvertError(t *testing.T) {
+	t.Run("sample error", func(t *testing.T) {
+		err := &sampleError{
+			message: "test",
+		}
+		isError, converted := ConvertError(err, sampleErrorConvertor)
+		assert.True(t, isError, "is error")
+		assert.Error(t, converted, "converted error")
+		assert.Equal(t, err.message, converted.message)
+	})
+	t.Run("nil error is propagated as nil", func(t *testing.T) {
+		isError, converted := ConvertError(nil, sampleErrorConvertor)
+		assert.False(t, isError, "is error")
+		assert.Nil(t, converted, "converted error")
+	})
+}
+
+type sampleError struct {
+	message string
+}
+
+func (s *sampleError) Error() string {
+	return "sample error"
+}
+
+type convertedError struct {
+	message string
+}
+
+func (c *convertedError) Error() string {
+	return "converted error"
+}
+
+func sampleErrorConvertor(e *sampleError) *convertedError {
+	return &convertedError{
+		message: e.message,
+	}
+}

--- a/common/types/mapper/thrift/errors.go
+++ b/common/types/mapper/thrift/errors.go
@@ -21,9 +21,7 @@
 package thrift
 
 import (
-	"github.com/uber/cadence/.gen/go/history"
-	"github.com/uber/cadence/.gen/go/shared"
-	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/mapper/errorutils"
 )
 
 // FromError convert error to Thrift type if it comes as its internal equivalent
@@ -32,52 +30,55 @@ func FromError(err error) error {
 		return nil
 	}
 
-	switch e := err.(type) {
-	case *types.AccessDeniedError:
-		return FromAccessDeniedError(e)
-	case *types.BadRequestError:
-		return FromBadRequestError(e)
-	case *types.CancellationAlreadyRequestedError:
-		return FromCancellationAlreadyRequestedError(e)
-	case *types.ClientVersionNotSupportedError:
-		return FromClientVersionNotSupportedError(e)
-	case *types.FeatureNotEnabledError:
-		return FromFeatureNotEnabledError(e)
-	case *types.CurrentBranchChangedError:
-		return FromCurrentBranchChangedError(e)
-	case *types.DomainAlreadyExistsError:
-		return FromDomainAlreadyExistsError(e)
-	case *types.DomainNotActiveError:
-		return FromDomainNotActiveError(e)
-	case *types.EntityNotExistsError:
-		return FromEntityNotExistsError(e)
-	case *types.WorkflowExecutionAlreadyCompletedError:
-		return FromWorkflowExecutionAlreadyCompletedError(e)
-	case *types.InternalDataInconsistencyError:
-		return FromInternalDataInconsistencyError(e)
-	case *types.InternalServiceError:
-		return FromInternalServiceError(e)
-	case *types.LimitExceededError:
-		return FromLimitExceededError(e)
-	case *types.QueryFailedError:
-		return FromQueryFailedError(e)
-	case *types.RemoteSyncMatchedError:
-		return FromRemoteSyncMatchedError(e)
-	case *types.RetryTaskV2Error:
-		return FromRetryTaskV2Error(e)
-	case *types.ServiceBusyError:
-		return FromServiceBusyError(e)
-	case *types.WorkflowExecutionAlreadyStartedError:
-		return FromWorkflowExecutionAlreadyStartedError(e)
-	case *types.ShardOwnershipLostError:
-		return FromShardOwnershipLostError(e)
-	case *types.EventAlreadyStartedError:
-		return FromEventAlreadyStartedError(e)
-	case *types.StickyWorkerUnavailableError:
-		return FromStickyWorkerUnavailableError(e)
-	default:
-		return err
+	var (
+		ok       bool
+		typedErr error
+	)
+	if ok, typedErr = errorutils.ConvertError(err, FromAccessDeniedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromBadRequestError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromCancellationAlreadyRequestedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromClientVersionNotSupportedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromFeatureNotEnabledError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromCurrentBranchChangedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromDomainAlreadyExistsError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromDomainNotActiveError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromEntityNotExistsError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromWorkflowExecutionAlreadyCompletedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromInternalDataInconsistencyError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromInternalServiceError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromLimitExceededError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromQueryFailedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromRemoteSyncMatchedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromRetryTaskV2Error); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromServiceBusyError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromWorkflowExecutionAlreadyStartedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromShardOwnershipLostError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromEventAlreadyStartedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, FromStickyWorkerUnavailableError); ok {
+		return typedErr
 	}
+
+	return err
 }
 
 // ToError convert error to internal type if it comes as its thrift equivalent
@@ -86,50 +87,53 @@ func ToError(err error) error {
 		return nil
 	}
 
-	switch e := err.(type) {
-	case *shared.AccessDeniedError:
-		return ToAccessDeniedError(e)
-	case *shared.BadRequestError:
-		return ToBadRequestError(e)
-	case *shared.CancellationAlreadyRequestedError:
-		return ToCancellationAlreadyRequestedError(e)
-	case *shared.ClientVersionNotSupportedError:
-		return ToClientVersionNotSupportedError(e)
-	case *shared.FeatureNotEnabledError:
-		return ToFeatureNotEnabledError(e)
-	case *shared.CurrentBranchChangedError:
-		return ToCurrentBranchChangedError(e)
-	case *shared.DomainAlreadyExistsError:
-		return ToDomainAlreadyExistsError(e)
-	case *shared.DomainNotActiveError:
-		return ToDomainNotActiveError(e)
-	case *shared.EntityNotExistsError:
-		return ToEntityNotExistsError(e)
-	case *shared.WorkflowExecutionAlreadyCompletedError:
-		return ToWorkflowExecutionAlreadyCompletedError(e)
-	case *shared.InternalDataInconsistencyError:
-		return ToInternalDataInconsistencyError(e)
-	case *shared.InternalServiceError:
-		return ToInternalServiceError(e)
-	case *shared.LimitExceededError:
-		return ToLimitExceededError(e)
-	case *shared.QueryFailedError:
-		return ToQueryFailedError(e)
-	case *shared.RemoteSyncMatchedError:
-		return ToRemoteSyncMatchedError(e)
-	case *shared.RetryTaskV2Error:
-		return ToRetryTaskV2Error(e)
-	case *shared.ServiceBusyError:
-		return ToServiceBusyError(e)
-	case *shared.WorkflowExecutionAlreadyStartedError:
-		return ToWorkflowExecutionAlreadyStartedError(e)
-	case *history.ShardOwnershipLostError:
-		return ToShardOwnershipLostError(e)
-	case *history.EventAlreadyStartedError:
-		return ToEventAlreadyStartedError(e)
-	case *shared.StickyWorkerUnavailableError:
-		return ToStickyWorkerUnavailableError(e)
-	default:
-		return err
+	var (
+		ok       bool
+		typedErr error
+	)
+	if ok, typedErr = errorutils.ConvertError(err, ToAccessDeniedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToBadRequestError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToCancellationAlreadyRequestedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToClientVersionNotSupportedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToFeatureNotEnabledError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToCurrentBranchChangedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToDomainAlreadyExistsError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToDomainNotActiveError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToEntityNotExistsError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToWorkflowExecutionAlreadyCompletedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToInternalDataInconsistencyError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToInternalServiceError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToLimitExceededError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToQueryFailedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToRemoteSyncMatchedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToRetryTaskV2Error); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToServiceBusyError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToWorkflowExecutionAlreadyStartedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToShardOwnershipLostError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToEventAlreadyStartedError); ok {
+		return typedErr
+	} else if ok, typedErr = errorutils.ConvertError(err, ToStickyWorkerUnavailableError); ok {
+		return typedErr
 	}
+
+	return err
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I've added support for wrapped errors for transport level.


<!-- Tell your future self why have you made these changes -->
**Why?**
This will allow us to return wrapped errors in services and not think about transport-level conversions.

Alternatively, we could introduce error methods To/FromProto and To/FromThrift, so instead of type assertion, we just return the result, I've tried it, but it complicates the error code significantly, while the generic solution is easier to understand.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unti tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
