### PR TITLE
Add tests for history decision task handler

### DIFF
--- a/service/history/decision/task_handler_test.go
+++ b/service/history/decision/task_handler_test.go
@@ -25,7 +25,6 @@ package decision
 import (
 	"context"
 	"errors"
-	"github.com/uber/cadence/common/backoff"
 	"testing"
 	"time"
 
@@ -34,6 +33,7 @@ import (
 	"github.com/uber-go/tally"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/testlogger"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The following tests added in service/history/decision:
TestHandleDecisionStartTimer
TestHandleDecisionCompleteWorkflow
TestHandleDecisionFailWorkflow

<!-- Tell your future self why have you made these changes -->
**Why?**
improve code coverage in the package

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
