### PR TITLE
[code-coverage] Add tests for mutable_state_util.go

### DIFF
--- a/service/history/execution/mutable_state_util_test.go
+++ b/service/history/execution/mutable_state_util_test.go
@@ -21,16 +21,27 @@
 package execution
 
 import (
+	"errors"
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber-go/tally"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/testing/testdatagen/idlfuzzedtestdata"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/testdata"
+	"github.com/uber/cadence/service/history/config"
+	"github.com/uber/cadence/service/history/constants"
+	"github.com/uber/cadence/service/history/events"
+	"github.com/uber/cadence/service/history/shard"
 )
 
 func TestCopyActivityInfo(t *testing.T) {
@@ -315,4 +326,253 @@ func TestConvertWorkflowRequests(t *testing.T) {
 	}
 
 	assert.ElementsMatch(t, expectedOutputs, convertWorkflowRequests(inputs))
+}
+
+func TestCreatePersistenceMutableState(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockShardContext := shard.NewMockContext(ctrl)
+	logger := testlogger.New(t)
+	mockEventsCache := events.NewMockCache(ctrl)
+	mockDomainCache := cache.NewMockDomainCache(ctrl)
+	mockShardContext.EXPECT().GetClusterMetadata().Return(constants.TestClusterMetadata).Times(2)
+	mockShardContext.EXPECT().GetEventsCache().Return(mockEventsCache)
+	mockShardContext.EXPECT().GetConfig().Return(config.NewForTest())
+	mockShardContext.EXPECT().GetTimeSource().Return(clock.NewMockedTimeSource())
+	mockShardContext.EXPECT().GetMetricsClient().Return(metrics.NewClient(tally.NoopScope, metrics.History))
+	mockShardContext.EXPECT().GetDomainCache().Return(mockDomainCache)
+
+	builder := newMutableStateBuilder(mockShardContext, logger, constants.TestLocalDomainEntry)
+	builder.pendingActivityInfoIDs[0] = &persistence.ActivityInfo{}
+	builder.pendingTimerInfoIDs["some-key"] = &persistence.TimerInfo{}
+	builder.pendingSignalInfoIDs[0] = &persistence.SignalInfo{}
+	builder.pendingChildExecutionInfoIDs[0] = &persistence.ChildExecutionInfo{}
+	builder.bufferedEvents = []*types.HistoryEvent{{}}
+	builder.updateBufferedEvents = []*types.HistoryEvent{{}}
+	builder.versionHistories = &persistence.VersionHistories{CurrentVersionHistoryIndex: 0, Histories: []*persistence.VersionHistory{}}
+	builder.pendingRequestCancelInfoIDs[0] = &persistence.RequestCancelInfo{}
+	builder.decisionTaskManager.(*mutableStateDecisionTaskManagerImpl).HasInFlightDecision()
+	builder.executionInfo.DecisionStartedID = 1
+
+	mutableState := CreatePersistenceMutableState(builder)
+	assert.NotNil(t, mutableState)
+}
+
+func TestGetChildExecutionDomainName(t *testing.T) {
+	t.Run("nonempty domain ID", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{DomainID: testdata.DomainID}
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		expected := testdata.DomainName
+		mockDomainCache.EXPECT().GetDomainName(childInfo.DomainID).Return(expected, nil)
+		name, err := GetChildExecutionDomainName(childInfo, mockDomainCache, constants.TestLocalDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, name)
+	})
+
+	t.Run("nonempty domain name", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{DomainNameDEPRECATED: testdata.DomainName}
+		parentDomainEntry := constants.TestLocalDomainEntry
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		name, err := GetChildExecutionDomainName(childInfo, mockDomainCache, parentDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, testdata.DomainName, name)
+	})
+
+	t.Run("empty childInfo", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{}
+		parentDomainEntry := constants.TestLocalDomainEntry
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		name, err := GetChildExecutionDomainName(childInfo, mockDomainCache, parentDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, parentDomainEntry.GetInfo().Name, name)
+	})
+}
+
+func TestGetChildExecutionDomainID(t *testing.T) {
+	t.Run("nonempty domain ID", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{DomainID: testdata.DomainID}
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		name, err := GetChildExecutionDomainID(childInfo, mockDomainCache, constants.TestLocalDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, testdata.DomainID, name)
+	})
+
+	t.Run("nonempty domain name", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{DomainNameDEPRECATED: testdata.DomainName}
+		parentDomainEntry := constants.TestLocalDomainEntry
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		mockDomainCache.EXPECT().GetDomainID(testdata.DomainName).Return(testdata.DomainID, nil)
+		name, err := GetChildExecutionDomainID(childInfo, mockDomainCache, parentDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, testdata.DomainID, name)
+	})
+
+	t.Run("empty childInfo", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{}
+		parentDomainEntry := constants.TestLocalDomainEntry
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		name, err := GetChildExecutionDomainID(childInfo, mockDomainCache, parentDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, parentDomainEntry.GetInfo().ID, name)
+	})
+}
+
+func TestGetChildExecutionDomainEntry(t *testing.T) {
+	t.Run("nonempty domain ID", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{DomainID: testdata.DomainID}
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		expected := &cache.DomainCacheEntry{}
+		mockDomainCache.EXPECT().GetDomainByID(childInfo.DomainID).Return(expected, nil)
+		entry, err := GetChildExecutionDomainEntry(childInfo, mockDomainCache, constants.TestLocalDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, entry)
+	})
+
+	t.Run("nonempty domain name", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{DomainNameDEPRECATED: testdata.DomainName}
+		parentDomainEntry := constants.TestLocalDomainEntry
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		expected := &cache.DomainCacheEntry{}
+		mockDomainCache.EXPECT().GetDomain(childInfo.DomainNameDEPRECATED).Return(expected, nil)
+		entry, err := GetChildExecutionDomainEntry(childInfo, mockDomainCache, parentDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, expected, entry)
+	})
+
+	t.Run("empty childInfo", func(t *testing.T) {
+		childInfo := &persistence.ChildExecutionInfo{}
+		parentDomainEntry := constants.TestLocalDomainEntry
+		mockDomainCache := cache.NewMockDomainCache(gomock.NewController(t))
+		entry, err := GetChildExecutionDomainEntry(childInfo, mockDomainCache, parentDomainEntry)
+		assert.Nil(t, err)
+		assert.Equal(t, parentDomainEntry, entry)
+	})
+}
+
+func TestConvert(t *testing.T) {
+	t.Run("convertSyncActivityInfos", func(t *testing.T) {
+		activityInfos := map[int64]*persistence.ActivityInfo{1: {Version: 1, ScheduleID: 1}}
+		inputs := map[int64]struct{}{1: {}}
+		outputs := convertSyncActivityInfos(activityInfos, inputs)
+		assert.NotNil(t, outputs)
+		assert.Equal(t, 1, len(outputs))
+		assert.Equal(t, int64(1), outputs[0].(*persistence.SyncActivityTask).ScheduledID)
+		assert.Equal(t, int64(1), outputs[0].GetVersion())
+	})
+
+	t.Run("convertUpdateRequestCancelInfos", func(t *testing.T) {
+		key := int64(0)
+		inputs := map[int64]*persistence.RequestCancelInfo{key: {}}
+		outputs := convertUpdateRequestCancelInfos(inputs)
+		assert.NotNil(t, outputs)
+		assert.Equal(t, 1, len(outputs))
+		assert.Equal(t, inputs[key], outputs[0])
+	})
+
+	t.Run("convertPendingRequestCancelInfos", func(t *testing.T) {
+		key := int64(0)
+		inputs := map[int64]*persistence.RequestCancelInfo{key: {}}
+		outputs := convertPendingRequestCancelInfos(inputs)
+		assert.NotNil(t, outputs)
+		assert.Equal(t, 1, len(outputs))
+		assert.Equal(t, inputs[key], outputs[0])
+	})
+
+	t.Run("convertInt64SetToSlice", func(t *testing.T) {
+		key := int64(0)
+		inputs := map[int64]struct{}{key: {}}
+		outputs := convertInt64SetToSlice(inputs)
+		assert.NotNil(t, outputs)
+		assert.Equal(t, 1, len(outputs))
+		assert.Equal(t, key, outputs[0])
+	})
+
+	t.Run("convertUpdateChildExecutionInfos", func(t *testing.T) {
+		key := int64(0)
+		inputs := map[int64]*persistence.ChildExecutionInfo{key: {}}
+		outputs := convertUpdateChildExecutionInfos(inputs)
+		assert.NotNil(t, outputs)
+		assert.Equal(t, 1, len(outputs))
+		assert.Equal(t, inputs[key], outputs[0])
+	})
+
+	t.Run("convertUpdateSignalInfos", func(t *testing.T) {
+		key := int64(0)
+		inputs := map[int64]*persistence.SignalInfo{key: {}}
+		outputs := convertUpdateSignalInfos(inputs)
+		assert.NotNil(t, outputs)
+		assert.Equal(t, 1, len(outputs))
+		assert.Equal(t, inputs[key], outputs[0])
+	})
+}
+
+func TestScheduleDecision(t *testing.T) {
+	t.Run("mutable state has pending decision", func(t *testing.T) {
+		mockMutableState := NewMockMutableState(gomock.NewController(t))
+		mockMutableState.EXPECT().HasPendingDecision().Return(true)
+		err := ScheduleDecision(mockMutableState)
+		assert.Nil(t, err)
+	})
+
+	t.Run("internal service error", func(t *testing.T) {
+		mockMutableState := NewMockMutableState(gomock.NewController(t))
+		mockMutableState.EXPECT().HasPendingDecision().Return(false)
+		mockMutableState.EXPECT().AddDecisionTaskScheduledEvent(false).Return(nil, errors.New("some error"))
+		err := ScheduleDecision(mockMutableState)
+		assert.NotNil(t, err)
+		assert.Equal(t, "Failed to add decision scheduled event.", err.Error())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		mockMutableState := NewMockMutableState(gomock.NewController(t))
+		mockMutableState.EXPECT().HasPendingDecision().Return(false)
+		mockMutableState.EXPECT().AddDecisionTaskScheduledEvent(false).Return(nil, nil)
+		err := ScheduleDecision(mockMutableState)
+		assert.Nil(t, err)
+	})
+}
+
+func TestFailDecision(t *testing.T) {
+	t.Run("failure", func(t *testing.T) {
+		mockMutableState := NewMockMutableState(gomock.NewController(t))
+		decision := &DecisionInfo{}
+		failureCause := new(types.DecisionTaskFailedCause)
+		mockMutableState.EXPECT().AddDecisionTaskFailedEvent(
+			decision.ScheduleID,
+			decision.StartedID,
+			*failureCause,
+			nil,
+			IdentityHistoryService,
+			"",
+			"",
+			"",
+			"",
+			int64(0),
+			"",
+		).Return(nil, errors.New("some error adding failed event"))
+		err := FailDecision(mockMutableState, decision, *failureCause)
+		assert.NotNil(t, err)
+		assert.Equal(t, "some error adding failed event", err.Error())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		mockMutableState := NewMockMutableState(gomock.NewController(t))
+		decision := &DecisionInfo{}
+		failureCause := new(types.DecisionTaskFailedCause)
+		mockMutableState.EXPECT().AddDecisionTaskFailedEvent(
+			decision.ScheduleID,
+			decision.StartedID,
+			*failureCause,
+			nil,
+			IdentityHistoryService,
+			"",
+			"",
+			"",
+			"",
+			int64(0),
+			"",
+		).Return(nil, nil)
+		mockMutableState.EXPECT().FlushBufferedEvents()
+		err := FailDecision(mockMutableState, decision, *failureCause)
+		assert.Nil(t, err)
+	})
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added tests to improve code coverage in service/history/execution/mutable_state_util_test.go

<!-- Tell your future self why have you made these changes -->
**Why?**
Code Coverage Initiative 📈

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
