### PR TITLE
Lock down a single Go version for everything, forever

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG TARGET=server
 ARG GOPROXY
 
 # Build Cadence binaries
-FROM golang:1.20-alpine3.18 AS builder
+FROM golang:1.22.3-alpine3.18 AS builder
 
 ARG RELEASE_VERSION
 

--- a/docker/buildkite/Dockerfile
+++ b/docker/buildkite/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20-bullseye
+FROM golang:1.22.3-bullseye
 
 # Tried to set Python to ignore warnings due to the instructions at this link:
 # https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

--- a/go.work
+++ b/go.work
@@ -22,3 +22,12 @@ use (
 // DO NOT include, tools dependencies are intentionally separate.
 // ./internal/tools
 )
+
+// technically only a minimum version, but forced to be precise in makefile targets.
+// must be kept in sync with docker files to avoid double-downloading.
+//
+// this should be safe to raise any time as it only impacts us, as this affects the
+// Go version used to build within this workspace only, it does not affect dependencies.
+// but note that it needs to be a version that docker + mac + linux all support, as
+// they all must be in sync.
+toolchain go1.22.3

--- a/scripts/check-go-toolchain.sh
+++ b/scripts/check-go-toolchain.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+set -eo pipefail
+
+# enable double-star
+shopt -s globstar
+
+fail=0
+bad() {
+  echo -e "$@" >/dev/stderr
+  fail=1
+}
+
+if [[ $V == 1 ]]; then
+  set -x
+fi
+
+target="${1#go}"
+root="$(git rev-parse --show-toplevel)"
+# this SHOULD match the dependencies in the goversion-lint check to avoid skipping it
+for file in "$root"/**/Dockerfile; do
+  # find "FROM golang:1.22.3-alpine3.18 ..." lines
+  line="$(grep -i 'from golang:' "$file")"
+  # remove "from golang:" prefix
+  version="${line#*golang:}"
+  # remove "-alpine..." suffix
+  version="${version%-*}"
+  # and make sure it matches
+  if [[ "$version" != "$target" ]]; then
+    bad "Wrong Go version in file $file:\n\t$line"
+  fi
+done
+
+if [[ $fail == 1 ]]; then
+  bad "Makefile pins Go to go${target}, Dockerfiles should too."
+  bad "Non-matching versions lead to pointless double-downloading to get the correct version."
+  exit 1
+fi


### PR DESCRIPTION
Go 1.21 brought us "toolchains":
We can now describe the version we want, and the Go CLI will automagically download, install, and use that version, with no extra effort.

So let's use that!

This does a few things:
- sets a `go.work` toolchain (if there's a `go.work` file, toolchains in individual `go.mod` files are ignored)
- exports `GOTOOLCHAIN=...` inside the Makefile, so ALL makefile-driven builds by everyone use exactly the same version (you can override this with an explicit `GOTOOLCHAIN`)
- updates our dockerfiles (it would just download [wrong version in docker image] and then auto-download the right one, which is a waste of time)
- adds a lint script to ensure ^ all that stays up to date
