### PR TITLE
Added feature to index context header in visibility

### DIFF
--- a/common/definition/indexedKeys.go
+++ b/common/definition/indexedKeys.go
@@ -52,13 +52,14 @@ const (
 	CadenceChangeVersion = "CadenceChangeVersion"
 )
 
-// valid non-indexed fields on ES
 const (
+	// Memo is valid non-indexed fields on ES
 	Memo = "Memo"
+	// Attr is prefix of custom search attributes
+	Attr = "Attr"
+	// HeaderFormat is the format of context headers in search attributes
+	HeaderFormat = "Header.%s"
 )
-
-// Attr is prefix of custom search attributes
-const Attr = "Attr"
 
 // defaultIndexedKeys defines all searchable keys
 var defaultIndexedKeys = createDefaultIndexedKeys()

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2538,8 +2538,6 @@ const (
 	// Default value: 400ms (400*time.Millisecond)
 	// Allowed filters: N/A
 	TransferProcessorVisibilityArchivalTimeLimit
-	//
-	TransferProcessorContextVisibility
 	// CrossClusterSourceProcessorMaxPollInterval is max poll interval for crossClusterQueueProcessor
 	// KeyName: history.crossClusterProcessorMaxPollInterval
 	// Value type: Duration

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -1695,6 +1695,12 @@ const (
 	// Default value: false
 	// Allowed filters: DomainName
 	EnableConsistentQueryByDomain
+	// EnableContextHeaderInVisibility is key for enable context header in visibility
+	// KeyName: history.enableContextHeaderInVisibility
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: DomainName
+	EnableContextHeaderInVisibility
 	// EnableCrossClusterEngine is used as an overall switch for the cross-cluster feature, a feature which, if not enabled
 	// can be quite expensive in terms of resources
 	// KeyName: history.enableCrossClusterEngine
@@ -2532,6 +2538,8 @@ const (
 	// Default value: 400ms (400*time.Millisecond)
 	// Allowed filters: N/A
 	TransferProcessorVisibilityArchivalTimeLimit
+	//
+	TransferProcessorContextVisibility
 	// CrossClusterSourceProcessorMaxPollInterval is max poll interval for crossClusterQueueProcessor
 	// KeyName: history.crossClusterProcessorMaxPollInterval
 	// Value type: Duration
@@ -4059,6 +4067,12 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "history.EnableConsistentQueryByDomain",
 		Filters:      []Filter{DomainName},
 		Description:  "EnableConsistentQueryByDomain indicates if consistent query is enabled for a domain",
+		DefaultValue: false,
+	},
+	EnableContextHeaderInVisibility: {
+		KeyName:      "history.enableContextHeaderInVisibility",
+		Filters:      []Filter{DomainName},
+		Description:  "EnableContextHeaderInVisibility is key for enable context header in visibility",
 		DefaultValue: false,
 	},
 	EnableCrossClusterEngine: {

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -302,6 +302,9 @@ type Config struct {
 	EnableConsistentQueryByDomain dynamicconfig.BoolPropertyFnWithDomainFilter
 	MaxBufferedQueryCount         dynamicconfig.IntPropertyFn
 
+	// EnableContextHeaderInVisibility whether to enable indexing context header in visibility
+	EnableContextHeaderInVisibility dynamicconfig.BoolPropertyFnWithDomainFilter
+
 	EnableCrossClusterEngine              dynamicconfig.BoolPropertyFn
 	EnableCrossClusterOperationsForDomain dynamicconfig.BoolPropertyFnWithDomainFilter
 
@@ -570,6 +573,7 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, s
 
 		EnableConsistentQuery:                 dc.GetBoolProperty(dynamicconfig.EnableConsistentQuery),
 		EnableConsistentQueryByDomain:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableConsistentQueryByDomain),
+		EnableContextHeaderInVisibility:       dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableContextHeaderInVisibility),
 		EnableCrossClusterEngine:              dc.GetBoolProperty(dynamicconfig.EnableCrossClusterEngine),
 		EnableCrossClusterOperationsForDomain: dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableCrossClusterOperationsForDomain),
 		MaxBufferedQueryCount:                 dc.GetIntProperty(dynamicconfig.MaxBufferedQueryCount),

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1047,7 +1047,7 @@ func (t *transferActiveTaskExecutor) processRecordWorkflowStartedOrUpsertHelper(
 	searchAttr := copySearchAttributes(executionInfo.SearchAttributes)
 	if t.config.EnableContextHeaderInVisibility(domainEntry.GetInfo().Name) {
 		if attributes := startEvent.GetWorkflowExecutionStartedEventAttributes(); attributes != nil && attributes.Header != nil {
-			searchAttr = appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields)
+			searchAttr = appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields, t.config.ValidSearchAttributes())
 		}
 	}
 	isCron := len(executionInfo.CronSchedule) > 0

--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1045,6 +1045,11 @@ func (t *transferActiveTaskExecutor) processRecordWorkflowStartedOrUpsertHelper(
 	executionTimestamp := getWorkflowExecutionTimestamp(mutableState, startEvent)
 	visibilityMemo := getWorkflowMemo(executionInfo.Memo)
 	searchAttr := copySearchAttributes(executionInfo.SearchAttributes)
+	if t.config.EnableContextHeaderInVisibility(domainEntry.GetInfo().Name) {
+		if attributes := startEvent.GetWorkflowExecutionStartedEventAttributes(); attributes != nil && attributes.Header != nil {
+			searchAttr = appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields)
+		}
+	}
 	isCron := len(executionInfo.CronSchedule) > 0
 	numClusters := (int16)(len(domainEntry.GetReplicationConfig().Clusters))
 	updateTimestamp := t.shard.GetTimeSource().Now()

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1706,8 +1706,8 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTask()
 
 func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskWithContextHeader() {
 	// switch on context header in viz
-	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func(domain string) bool {return true}
-	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{}  {
+	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func(domain string) bool { return true }
+	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{} {
 		return map[string]interface{}{
 			"Header.contextKey": struct{}{},
 		}
@@ -1778,7 +1778,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
-		    false),
+			false),
 	).Once().Return(nil)
 
 	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
@@ -1787,8 +1787,8 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 
 func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttributesWithContextHeader() {
 	// switch on context header in viz
-	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func(domain string) bool {return true}
-	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{}  {
+	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func(domain string) bool { return true }
+	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{} {
 		return map[string]interface{}{
 			"Header.contextKey": struct{}{},
 		}
@@ -1817,7 +1817,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
-		    true),
+			true),
 	).Once().Return(nil)
 
 	err = s.transferActiveTaskExecutor.Execute(transferTask, true)
@@ -1939,7 +1939,7 @@ func createRecordWorkflowExecutionStartedRequest(
 	}
 	var searchAttributes map[string][]byte
 	if enableContextHeaderInVisibility {
-		searchAttributes = map[string][]byte {
+		searchAttributes = map[string][]byte{
 			"Header.contextKey": []byte("contextValue"),
 		}
 	}
@@ -2089,7 +2089,7 @@ func createUpsertWorkflowSearchAttributesRequest(
 	}
 	var searchAttributes map[string][]byte
 	if enableContextHeaderInVisibility {
-		searchAttributes = map[string][]byte {
+		searchAttributes = map[string][]byte{
 			"Header.contextKey": []byte("contextValue"),
 		}
 	}

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -495,7 +495,7 @@ func (t *transferStandbyTaskExecutor) processRecordWorkflowStartedOrUpsertHelper
 	searchAttr := copySearchAttributes(executionInfo.SearchAttributes)
 	if t.config.EnableContextHeaderInVisibility(domainEntry.GetInfo().Name) {
 		if attributes := startEvent.GetWorkflowExecutionStartedEventAttributes(); attributes != nil && attributes.Header != nil {
-			searchAttr = appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields)
+			searchAttr = appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields, t.config.ValidSearchAttributes())
 		}
 	}
 

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -483,7 +483,6 @@ func (t *transferStandbyTaskExecutor) processRecordWorkflowStartedOrUpsertHelper
 	startTimestamp := startEvent.GetTimestamp()
 	executionTimestamp := getWorkflowExecutionTimestamp(mutableState, startEvent)
 	visibilityMemo := getWorkflowMemo(executionInfo.Memo)
-	searchAttr := copySearchAttributes(executionInfo.SearchAttributes)
 	isCron := len(executionInfo.CronSchedule) > 0
 	updateTimestamp := t.shard.GetTimeSource().Now()
 
@@ -492,6 +491,13 @@ func (t *transferStandbyTaskExecutor) processRecordWorkflowStartedOrUpsertHelper
 		return err
 	}
 	numClusters := (int16)(len(domainEntry.GetReplicationConfig().Clusters))
+
+	searchAttr := copySearchAttributes(executionInfo.SearchAttributes)
+	if t.config.EnableContextHeaderInVisibility(domainEntry.GetInfo().Name) {
+		if attributes := startEvent.GetWorkflowExecutionStartedEventAttributes(); attributes != nil && attributes.Header != nil {
+			searchAttr = appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields)
+		}
+	}
 
 	if isRecordStart {
 		workflowStartedScope.IncCounter(metrics.WorkflowStartedCount)

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
+	dc "github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/mocks"
 	"github.com/uber/cadence/common/ndc"
@@ -814,6 +815,12 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskW
 	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func (domain string) bool {
 		return true
 	}
+	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{}  {
+		return map[string]interface{}{
+			"Header.contextKey": struct{}{},
+		}
+	}
+
 	workflowExecution, mutableState, err := test.StartWorkflow(s.mockShard, s.domainID)
 	s.NoError(err)
 	executionInfo := mutableState.GetExecutionInfo()
@@ -896,6 +903,11 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 	// switch on context header in viz
 	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func (domain string) bool {
 		return true
+	}
+	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{}  {
+		return map[string]interface{}{
+			"Header.contextKey": struct{}{},
+		}
 	}
 
 	workflowExecution, mutableState, decisionCompletionID, err := test.SetupWorkflowWithCompletedDecision(s.mockShard, s.domainID)

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -812,10 +812,10 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 
 func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskWithContextHeader() {
 	// switch on context header in viz
-	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func (domain string) bool {
+	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func(domain string) bool {
 		return true
 	}
-	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{}  {
+	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{} {
 		return map[string]interface{}{
 			"Header.contextKey": struct{}{},
 		}
@@ -891,7 +891,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
-		false),
+			false),
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)
@@ -901,10 +901,10 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 
 func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttributesTaskWithContextHeader() {
 	// switch on context header in viz
-	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func (domain string) bool {
+	s.mockShard.GetConfig().EnableContextHeaderInVisibility = func(domain string) bool {
 		return true
 	}
-	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{}  {
+	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{} {
 		return map[string]interface{}{
 			"Header.contextKey": struct{}{},
 		}
@@ -935,7 +935,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
-		true),
+			true),
 	).Return(nil).Once()
 
 	s.mockShard.SetCurrentTime(s.clusterName, now)

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -22,11 +22,13 @@ package task
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -395,6 +397,22 @@ func getWorkflowMemo(
 		return nil
 	}
 	return &types.Memo{Fields: memo}
+}
+
+func appendContextHeaderToSearchAttributes(attr, context map[string][]byte) map[string][]byte {
+	for k, v := range context {
+		key := fmt.Sprintf(definition.HeaderFormat, k)
+		if _, ok := attr[key]; ok { // skip if key already exists
+			continue
+		}
+		val := make([]byte, len(v))
+		copy(val, v)
+		if attr == nil {
+			attr = make(map[string][]byte)
+		}
+		attr[key] = val
+	}
+	return attr
 }
 
 func copySearchAttributes(

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -399,10 +399,13 @@ func getWorkflowMemo(
 	return &types.Memo{Fields: memo}
 }
 
-func appendContextHeaderToSearchAttributes(attr, context map[string][]byte) map[string][]byte {
+func appendContextHeaderToSearchAttributes(attr, context map[string][]byte, allowedKeys map[string]interface{}) map[string][]byte {
 	for k, v := range context {
 		key := fmt.Sprintf(definition.HeaderFormat, k)
 		if _, ok := attr[key]; ok { // skip if key already exists
+			continue
+		}
+		if _, allowed := allowedKeys[key]; !allowed { // skip if not allowed
 			continue
 		}
 		val := make([]byte, len(v))

--- a/service/history/testing/workflow_util.go
+++ b/service/history/testing/workflow_util.go
@@ -64,6 +64,8 @@ func StartWorkflow(
 				TaskList:                            &types.TaskList{Name: taskListName},
 				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(2),
 				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
+				Header: 							&types.Header{Fields: map[string][]byte{
+					"contextKey": []byte("contextValue")}},
 			},
 			PartitionConfig: map[string]string{"userid": uuid.New()},
 		},

--- a/service/history/testing/workflow_util.go
+++ b/service/history/testing/workflow_util.go
@@ -65,7 +65,9 @@ func StartWorkflow(
 				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(2),
 				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 				Header: 							&types.Header{Fields: map[string][]byte{
-					"contextKey": []byte("contextValue")}},
+					"contextKey": []byte("contextValue"),
+					"invalidContextKey": []byte("invalidContextValue"),
+				}},
 			},
 			PartitionConfig: map[string]string{"userid": uuid.New()},
 		},

--- a/service/history/testing/workflow_util.go
+++ b/service/history/testing/workflow_util.go
@@ -64,8 +64,8 @@ func StartWorkflow(
 				TaskList:                            &types.TaskList{Name: taskListName},
 				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(2),
 				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
-				Header: 							&types.Header{Fields: map[string][]byte{
-					"contextKey": []byte("contextValue"),
+				Header: &types.Header{Fields: map[string][]byte{
+					"contextKey":        []byte("contextValue"),
 					"invalidContextKey": []byte("invalidContextValue"),
 				}},
 			},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Context headers are now searchable using visibility. 

## API

As users, they can search workflows by headers through List*Workflows / CountWorkflows with [SQL-like queries]

```
Header.uberctx-tenancy = "uber/testing" AND CloseStatus != "completed" ORDER BY StartTime DESC
```

## Onboarding Steps

* Add "Header.XXX" to `frontend.validSearchAttributes`
* Enable "history.enableContextHeaderInVisibility"

<!-- Tell your future self why have you made these changes -->
**Why?**

Context headers are user propagated headers, including tracing baggages. Enable search-ability will enhance debugging and better observability. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit Test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
