### PR TITLE
We now do not log on recent shard closed errors from the getWorkflowExecutionWithRetry function

### DIFF
--- a/service/history/execution/context.go
+++ b/service/history/execution/context.go
@@ -1214,7 +1214,7 @@ func getWorkflowExecutionWithRetry(
 		// If error is shard closed, only log error if shard has been closed for a while,
 		// otherwise always log
 		var shardClosedError *shard.ErrShardClosed
-		if !errors.As(err, &shardClosedError) || time.Since(shardClosedError.ClosedAt) > shard.TimeBeforeShardClosedIsError {
+		if !errors.As(err, &shardClosedError) || shardContext.GetTimeSource().Since(shardClosedError.ClosedAt) > shard.TimeBeforeShardClosedIsError {
 			logger.Error("Persistent fetch operation failure", tag.StoreOperationGetWorkflowExecution, tag.Error(err))
 		}
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We now do not log on recent shard closed errors from the getWorkflowExecutionWithRetry function, for other errors we still log all

<!-- Tell your future self why have you made these changes -->
**Why?**
Shard closed error are expected for a short time after a shard has been stolen, so there is no reason to do error logs on it for the first short while. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Minimal only touches logging logic

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
