### PR TITLE
Fix DrainBacklogNoPollersIsolationGroup tests

### DIFF
--- a/common/cache/cache.go
+++ b/common/cache/cache.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/metrics"
 )
 
@@ -93,6 +94,10 @@ type Options struct {
 	// - when the cache is full
 	// - when the item is accessed
 	ActivelyEvict bool
+
+	// TimeSource is used to get the current time
+	// It is optional and defaults to clock.NewRealTimeSource()
+	TimeSource clock.TimeSource
 }
 
 // SimpleOptions provides options that can be used to configure SimpleCache

--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -118,7 +118,8 @@ func (s *matchingEngineSuite) SetupTest() {
 	s.mockExecutionManager = &mocks.ExecutionManager{}
 	s.controller = gomock.NewController(s.T())
 	s.mockHistoryClient = history.NewMockClient(s.controller)
-	s.taskManager = tasklist.NewTestTaskManager(s.T(), s.logger)
+	s.mockTimeSource = clock.NewMockedTimeSourceAt(time.Now())
+	s.taskManager = tasklist.NewTestTaskManager(s.T(), s.logger, s.mockTimeSource)
 	s.mockDomainCache = cache.NewMockDomainCache(s.controller)
 	s.mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry(matchingTestDomainName), nil).AnyTimes()
 	s.mockDomainCache.EXPECT().GetDomain(gomock.Any()).Return(cache.CreateDomainCacheEntry(matchingTestDomainName), nil).AnyTimes()
@@ -130,7 +131,6 @@ func (s *matchingEngineSuite) SetupTest() {
 	dc := dynamicconfig.NewCollection(dcClient, s.logger)
 	isolationGroupState, _ := defaultisolationgroupstate.NewDefaultIsolationGroupStateWatcherWithConfigStoreClient(s.logger, dc, s.mockDomainCache, s.mockIsolationStore, metrics.NewNoopMetricsClient())
 	s.partitioner = partition.NewDefaultPartitioner(s.logger, isolationGroupState)
-	s.mockTimeSource = clock.NewMockedTimeSourceAt(time.Unix(1000000, 0))
 	s.handlerContext = newHandlerContext(
 		context.Background(),
 		matchingTestDomainName,

--- a/service/matching/poller/history.go
+++ b/service/matching/poller/history.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/types"
 )
 
@@ -55,12 +56,13 @@ type History struct {
 // HistoryUpdatedFunc is a type for notifying applications when the poller history was updated
 type HistoryUpdatedFunc func()
 
-func NewPollerHistory(historyUpdatedFunc HistoryUpdatedFunc) *History {
+func NewPollerHistory(historyUpdatedFunc HistoryUpdatedFunc, timeSource clock.TimeSource) *History {
 	opts := &cache.Options{
 		InitialCapacity: pollerHistoryInitSize,
 		TTL:             pollerHistoryTTL,
 		Pin:             false,
 		MaxCount:        pollerHistoryInitMaxSize,
+		TimeSource:      timeSource,
 	}
 
 	return &History{

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -213,7 +213,7 @@ func NewManager(
 	tlMgr.pollerHistory = poller.NewPollerHistory(func() {
 		taskListTypeMetricScope.UpdateGauge(metrics.PollerPerTaskListCounter,
 			float64(len(tlMgr.pollerHistory.GetPollerInfo(time.Time{}))))
-	})
+	}, timeSource)
 
 	livenessInterval := taskListConfig.IdleTasklistCheckInterval()
 	tlMgr.liveness = liveness.NewLiveness(clock.NewRealTimeSource(), livenessInterval, func() {

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -157,7 +157,7 @@ func createTestTaskListManager(t *testing.T, logger log.Logger, controller *gomo
 }
 
 func createTestTaskListManagerWithConfig(t *testing.T, logger log.Logger, controller *gomock.Controller, cfg *config.Config) *taskListManagerImpl {
-	tm := NewTestTaskManager(t, logger)
+	tm := NewTestTaskManager(t, logger, clock.NewRealTimeSource())
 	mockPartitioner := partition.NewMockPartitioner(controller)
 	mockPartitioner.EXPECT().GetIsolationGroupByDomainID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", nil).AnyTimes()
 	mockDomainCache := cache.NewMockDomainCache(controller)
@@ -552,9 +552,9 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 	mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry("domainName"), nil).AnyTimes()
 	mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).AnyTimes()
 	logger := testlogger.New(t)
-	tm := NewTestTaskManager(t, logger)
-	taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 	timeSource := clock.NewRealTimeSource()
+	tm := NewTestTaskManager(t, logger, timeSource)
+	taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 	cfg := defaultTestConfig()
 	cfg.RangeSize = rangeSize
 	tlMgr, err := NewManager(
@@ -721,9 +721,9 @@ func TestTaskExpiryAndCompletion(t *testing.T) {
 			mockDomainCache.EXPECT().GetDomainByID(gomock.Any()).Return(cache.CreateDomainCacheEntry("domainName"), nil).AnyTimes()
 			mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).AnyTimes()
 			logger := testlogger.New(t)
-			tm := NewTestTaskManager(t, logger)
-			taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 			timeSource := clock.NewRealTimeSource()
+			tm := NewTestTaskManager(t, logger, timeSource)
+			taskListID := NewTestTaskListID(t, "domainId", "tl", 0)
 			cfg := defaultTestConfig()
 			cfg.RangeSize = rangeSize
 			cfg.MaxTaskDeleteBatchSize = dynamicconfig.GetIntPropertyFilteredByTaskListInfo(tc.batchSize)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix DrainBacklogNoPollersIsolationGroup tests

<!-- Tell your future self why have you made these changes -->
**Why?**
The tests are flaky because we're not using the same timeSource across different components, and this makes some tasks expire and the tests never end.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
