### PR TITLE
Change permission of DescribeCluster to Read

### DIFF
--- a/service/frontend/templates/accesscontrolled.tmpl
+++ b/service/frontend/templates/accesscontrolled.tmpl
@@ -42,6 +42,9 @@ import (
 {{$permissionMap = set $permissionMap "RefreshWorkflowTasks" "PermissionWrite"}}
 {{$permissionMap = set $permissionMap "UpdateDomain" "PermissionAdmin"}}
 
+{{$adminPermissionMap := dict }}
+{{$adminPermissionMap = set $adminPermissionMap "DescribeCluster" "PermissionRead"}}
+
 {{$nonDomainAuthAPIs := list "RegisterDomain" "DescribeDomain" "UpdateDomain" "DeprecateDomain" "ListDomains" "GetSearchAttributes" "GetClusterInfo" "RecordActivityTaskHeartbeat" "RespondActivityTaskCanceled" "RespondActivityTaskCompleted" "RespondActivityTaskFailed" "RespondDecisionTaskCompleted" "RespondDecisionTaskFailed" "RespondQueryTaskCompleted"}}
 {{$taskListAuthAPIs := list "PollForActivityTask" "PollForDecisionTask"}}
 {{$workflowTypeAuthAPIs := list "SignalWithStartWorkflowExecution" "StartWorkflowExecution"}}
@@ -92,7 +95,11 @@ func (a *{{$decorator}}) {{$method.Declaration}} {
 	attr := &authorization.Attributes{
 		APIName: "{{$method.Name}}",
 		{{- if eq $interfaceType "admin.Handler"}}
+		{{- if hasKey $adminPermissionMap $method.Name}}
+		Permission: authorization.{{get $adminPermissionMap $method.Name}},
+		{{- else}}
 		Permission:  authorization.PermissionAdmin,
+		{{- end}}
 		{{- else if hasKey $permissionMap $method.Name}}
 		Permission: authorization.{{get $permissionMap $method.Name}},
 		{{- end}}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -25,6 +25,8 @@ package accesscontrolled
 import (
 	"context"
 	"errors"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/frontend/admin"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -88,6 +90,57 @@ func TestIsAuthorized(t *testing.T) {
 			} else {
 				assert.NoError(t, err)
 				assert.Equal(t, tc.isAuthorized, got)
+			}
+		})
+	}
+}
+
+func TestDescribeCluster(t *testing.T) {
+	someErr := errors.New("some random err")
+	testCases := []struct {
+		name      string
+		mockSetup func(*authorization.MockAuthorizer, *admin.MockHandler)
+		wantErr   error
+	}{
+		{
+			name: "Success case",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, adminHandler *admin.MockHandler) {
+				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{Decision: authorization.DecisionAllow}, nil)
+				adminHandler.EXPECT().DescribeCluster(gomock.Any()).Return(&types.DescribeClusterResponse{}, nil)
+			},
+			wantErr: nil,
+		},
+		{
+			name: "Error case - unauthorized",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, adminHandler *admin.MockHandler) {
+				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{Decision: authorization.DecisionDeny}, nil)
+			},
+			wantErr: errUnauthorized,
+		},
+		{
+			name: "Error case - authorization error",
+			mockSetup: func(authorizer *authorization.MockAuthorizer, adminHandler *admin.MockHandler) {
+				authorizer.EXPECT().Authorize(gomock.Any(), gomock.Any()).Return(authorization.Result{}, someErr)
+			},
+			wantErr: someErr,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			controller := gomock.NewController(t)
+
+			mockAuthorizer := authorization.NewMockAuthorizer(controller)
+			mockAdminHandler := admin.NewMockHandler(controller)
+			tc.mockSetup(mockAuthorizer, mockAdminHandler)
+
+			handler := &adminHandler{authorizer: mockAuthorizer, handler: mockAdminHandler}
+			_, err := handler.DescribeCluster(context.Background())
+			if tc.wantErr != nil {
+				assert.Error(t, err)
+				assert.ErrorIs(t, err, tc.wantErr)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
+++ b/service/frontend/wrappers/accesscontrolled/access_controlled_test.go
@@ -25,8 +25,6 @@ package accesscontrolled
 import (
 	"context"
 	"errors"
-	"github.com/uber/cadence/common/types"
-	"github.com/uber/cadence/service/frontend/admin"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -35,6 +33,8 @@ import (
 	"github.com/uber/cadence/common/authorization"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/metrics/mocks"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/frontend/admin"
 )
 
 func TestIsAuthorized(t *testing.T) {

--- a/service/frontend/wrappers/accesscontrolled/admin_generated.go
+++ b/service/frontend/wrappers/accesscontrolled/admin_generated.go
@@ -127,7 +127,7 @@ func (a *adminHandler) DeleteWorkflow(ctx context.Context, ap1 *types.AdminDelet
 func (a *adminHandler) DescribeCluster(ctx context.Context) (dp1 *types.DescribeClusterResponse, err error) {
 	attr := &authorization.Attributes{
 		APIName:    "DescribeCluster",
-		Permission: authorization.PermissionAdmin,
+		Permission: authorization.PermissionRead,
 	}
 	isAuthorized, err := a.isAuthorized(ctx, attr)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add DescribeCluster permission setting in gowrap template file of frontend server access control decorator.
- Run `make go-generate` to modify admin_generated.go


<!-- Tell your future self why have you made these changes -->
**Why?**
- To enable users with read level access to use cadence web.  As addressed in [this issue](https://github.com/uber/cadence/issues/5683).
- DescribeCluster is a read operation semantically.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Add unit test.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
