### PR TITLE
Changed the lint script so the fast tests are run first

### DIFF
--- a/scripts/buildkite/golint.sh
+++ b/scripts/buildkite/golint.sh
@@ -2,20 +2,32 @@
 
 set -ex
 
+verify_no_files_changed () {
+  # intentionally capture stderr, so status-errors are also PR-failing.
+  # in particular this catches "dubious ownership" failures, which otherwise
+  # do not fail this check and the $() hides the exit code.
+  if [ -n "$(git status --porcelain  2>&1)" ]; then
+    echo "There file changes after applying your diff and performing a build."
+    echo "Please run this command and commit the changes:"
+    echo "\tmake tidy && make copyright && make go-generate && make fmt && make lint"
+    git status --porcelain
+    git --no-pager diff
+    exit 1
+  fi
+}
+
+# Run the fast checks first, to fail quickly.
 make tidy
+make copyright
+make fmt
+make lint
+verify_no_files_changed
+
+# Run go-generate after the fast checks, to avoid unnecessary waiting
+# We need to run copyright, fmt and lint after, as the generated files
+# may change the output of these commands.
 make go-generate
 make copyright
 make fmt
 make lint
-
-# intentionally capture stderr, so status-errors are also PR-failing.
-# in particular this catches "dubious ownership" failures, which otherwise
-# do not fail this check and the $() hides the exit code.
-if [ -n "$(git status --porcelain  2>&1)" ]; then
-  echo "There file changes after applying your diff and performing a build."
-  echo "Please run this command and commit the changes:"
-  echo "\tmake tidy && make copyright && make go-generate && make fmt && make lint"
-  git status --porcelain
-  git --no-pager diff
-  exit 1
-fi
+verify_no_files_changed


### PR DESCRIPTION
This enables us to fail fast

<!-- Describe what has changed in this PR -->
**What changed?**
Changed the lint script so the fast tests are run first


<!-- Tell your future self why have you made these changes -->
**Why?**
go-generate takes up to 5 minutes and there is no reason to wait for this if the linter is failing. This should increase developer velocity by failing the lint check faster


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
