### PR TITLE
Using find instead of ** to locate Dockerfiles

### DIFF
--- a/scripts/check-go-toolchain.sh
+++ b/scripts/check-go-toolchain.sh
@@ -2,9 +2,6 @@
 
 set -eo pipefail
 
-# enable double-star
-shopt -s globstar
-
 fail=0
 bad() {
   echo -e "$@" >/dev/stderr
@@ -21,7 +18,7 @@ root="$(git rev-parse --show-toplevel)"
 # this SHOULD match the dependencies in the goversion-lint check to avoid skipping it
 
 # check dockerfiles
-for file in "$root"/**/Dockerfile; do
+while read file; do
   # find "FROM golang:1.22.3-alpine3.18 ..." lines
   line="$(grep -i 'from golang:' "$file")"
   # remove "from golang:" prefix
@@ -32,7 +29,7 @@ for file in "$root"/**/Dockerfile; do
   if [[ "$version" != "$target" ]]; then
     bad "Wrong Go version in file $file:\n\t$line"
   fi
-done
+done < <( find "$root" -name Dockerfile )
 
 # check workflows
 codecov_file="$root/.github/workflows/codecov.yml"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
./scripts/check-go-toolchain.sh recently started to use shopt globstar which is not always awailable in MacOS' old Bash

<!-- Tell your future self why have you made these changes -->
Fixing build on some laptops

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
The change' syntax should be recognized by early Bash versions
Just launched ./scripts/check-go-toolchain.sh

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
