### PR TITLE
Fixed comment during refactoring

### DIFF
--- a/service/matching/tasklist/task_writer.go
+++ b/service/matching/tasklist/task_writer.go
@@ -226,7 +226,7 @@ writerLoop:
 					maxReadLevel = taskIDs[i]
 				}
 
-				r, err := w.db.CreateTasks(tasks)
+				resp, err := w.db.CreateTasks(tasks)
 				err = w.handleErr(err)
 				if err != nil {
 					w.logger.Error("Persistent store operation failure",
@@ -241,12 +241,11 @@ writerLoop:
 					atomic.StoreInt64(&w.maxReadLevel, maxReadLevel)
 				}
 
-				w.sendWriteResponse(reqs, err, r)
+				w.sendWriteResponse(reqs, err, resp)
 			}
 		case <-w.stopCh:
 			// we don't close the appendCh here
-			// because that can cause on a send on closed
-			// channel panic on the appendTask()
+			// because that can cause "send on closed channel" panic on the appendTask()
 			break writerLoop
 		}
 	}


### PR DESCRIPTION
Also renamed variable as `r` looks too short and stands more for reader
or ref rather than response/result.

<!-- Describe what has changed in this PR -->
comment to make more obvious since we talk about "send on closed channel" error here

<!-- Tell your future self why have you made these changes -->
Refactoring during deep dive session

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
