### PR TITLE
Fix replication metric emitter shutdown

### DIFF
--- a/service/history/replication/metrics_emitter_test.go
+++ b/service/history/replication/metrics_emitter_test.go
@@ -52,7 +52,9 @@ func TestMetricsEmitterStartStop(t *testing.T) {
 	testShardData := newTestShardData(timeSource, metadata)
 
 	metricsEmitter := NewMetricsEmitter(1, testShardData, fakeTaskReader{}, metrics.NewNoopMetricsClient())
+	metricsEmitter.interval = 5 * time.Millisecond
 	metricsEmitter.Start()
+	time.Sleep(20 * time.Millisecond) // let the metrics emitter run a few times
 	metricsEmitter.Stop()
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

MetricEmitterImpl was not waiting for underlying goroutine to finish before returning on `Stop()`. 
- Switched to ctx/cancel/waitgroup based implementation
- Used the same ctx in downstream calls so it doesn't stall on Stop
- Added new unit tests and verified no goroutine is leaking after stop.


<!-- Tell your future self why have you made these changes -->
**Why?**
`Stop`s should not leave goroutines behind.
