### PR TITLE
Skip .git folder when searching for *.go files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,9 +126,12 @@ FRESH_ALL_SRC = $(shell \
 		-o -path './idls/*' \
 		-o -path './.build/*' \
 		-o -path './.bin/*' \
+		-o -path './.git/*' \
 	\) \
 	-prune \
-	-o -name '*.go' -print \
+	-o -name '*.go' \
+	-type f \
+	-print \
 )
 # most things can use a cached copy, e.g. all dependencies.
 # this will not include any files that are created during a `make` run, e.g. via protoc,


### PR DESCRIPTION
Apparently that was being searched, and it noticed a "thing.go" folder that git made!
So now this has two improvements:
1. it does not step into the `.git` folder, because obviously there is no source that needs formatting in there
2. it only finds files, `-type f`, because directories aren't source files

Both pretty obviously good to have in retrospect.

---

A way to validate this kind of change for the future:
1. change the `SHELL = ...` line near the top of the makefile to include a `-x` debug flag.
   `make` will now print all the `$(shell ...)` commands it runs, including this `find`.
2. copy it and run it by hand and check the output.
   in particular, this time I just had it find _all_ files to check where it looked, and made sure the list was reasonable
   (it included my local .idea, but that seems fine, it's small and has no go files)

I should've done 2 earlier when I added this `find` command, I likely would have noticed the directories and `.git` and removed them.  Sorry about that.