### PR TITLE
Switch quotas.Collection to clock.Ratelimiter, minor fixes along the way

### DIFF
--- a/common/quotas/dynamicratelimiter.go
+++ b/common/quotas/dynamicratelimiter.go
@@ -25,7 +25,7 @@ package quotas
 import (
 	"context"
 
-	"golang.org/x/time/rate"
+	"github.com/uber/cadence/common/clock"
 )
 
 // DynamicRateLimiter implements a dynamic config wrapper around the rate limiter,
@@ -58,7 +58,7 @@ func (d *DynamicRateLimiter) Wait(ctx context.Context) error {
 }
 
 // Reserve reserves a rate limit token
-func (d *DynamicRateLimiter) Reserve() *rate.Reservation {
+func (d *DynamicRateLimiter) Reserve() clock.Reservation {
 	rps := d.rps()
 	d.rl.UpdateMaxDispatch(&rps)
 	return d.rl.Reserve()

--- a/common/quotas/dynamicratelimiterfactory.go
+++ b/common/quotas/dynamicratelimiterfactory.go
@@ -24,7 +24,9 @@
 
 package quotas
 
-import "github.com/uber/cadence/common/dynamicconfig"
+import (
+	"github.com/uber/cadence/common/dynamicconfig"
+)
 
 // LimiterFactory is used to create a Limiter for a given domain
 type LimiterFactory interface {

--- a/common/quotas/interfaces.go
+++ b/common/quotas/interfaces.go
@@ -25,7 +25,7 @@ package quotas
 import (
 	"context"
 
-	"golang.org/x/time/rate"
+	"github.com/uber/cadence/common/clock"
 )
 
 // RPSFunc returns a float64 as the RPS
@@ -40,6 +40,10 @@ type Info struct {
 }
 
 // Limiter corresponds to basic rate limiting functionality.
+//
+// TODO: This can likely be replaced with clock.Ratelimiter, now that it exists,
+// but it is being left as a read-only mirror for now as only these methods are
+// currently needed in areas that currently use this Limiter.
 type Limiter interface {
 	// Allow attempts to allow a request to go through. The method returns
 	// immediately with a true or false indicating if the request can make
@@ -51,7 +55,7 @@ type Limiter interface {
 	Wait(ctx context.Context) error
 
 	// Reserve reserves a rate limit token
-	Reserve() *rate.Reservation
+	Reserve() clock.Reservation
 }
 
 // Policy corresponds to a quota policy. A policy allows implementing layered

--- a/common/quotas/limiter_mock.go
+++ b/common/quotas/limiter_mock.go
@@ -31,7 +31,8 @@ import (
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
-	rate "golang.org/x/time/rate"
+
+	clock "github.com/uber/cadence/common/clock"
 )
 
 // MockLimiter is a mock of Limiter interface.
@@ -72,10 +73,10 @@ func (mr *MockLimiterMockRecorder) Allow() *gomock.Call {
 }
 
 // Reserve mocks base method.
-func (m *MockLimiter) Reserve() *rate.Reservation {
+func (m *MockLimiter) Reserve() clock.Reservation {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Reserve")
-	ret0, _ := ret[0].(*rate.Reservation)
+	ret0, _ := ret[0].(clock.Reservation)
 	return ret0
 }
 

--- a/common/quotas/limiter_test.go
+++ b/common/quotas/limiter_test.go
@@ -26,7 +26,8 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	"golang.org/x/time/rate"
+
+	"github.com/uber/cadence/common/clock"
 )
 
 const (
@@ -39,7 +40,7 @@ func TestNewRateLimiter(t *testing.T) {
 	t.Parallel()
 	maxDispatch := 0.01
 	rl := NewRateLimiter(&maxDispatch, time.Second, _minBurst)
-	limiter := rl.goRateLimiter.Load().(*rate.Limiter)
+	limiter := rl.goRateLimiter.Load().(clock.Ratelimiter)
 	assert.Equal(t, _minBurst, limiter.Burst())
 }
 

--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -115,9 +115,8 @@ func newTaskMatcher(config *config.TaskListConfig, fwdr *Forwarder, scope metric
 //   - context deadline is exceeded
 //   - task is matched and consumer returns error in response channel
 func (tm *TaskMatcher) Offer(ctx context.Context, task *InternalTask) (bool, error) {
-	var err error
 	if !task.IsForwarded() {
-		err = tm.ratelimit(ctx)
+		err := tm.ratelimit(ctx)
 		if err != nil {
 			tm.scope.IncCounter(metrics.SyncThrottlePerTaskListCounter)
 			return false, err
@@ -129,7 +128,7 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *InternalTask) (bool, err
 		if task.ResponseC != nil {
 			// if there is a response channel, block until resp is received
 			// and return error if the response contains error
-			err = <-task.ResponseC
+			err := <-task.ResponseC
 			return true, err
 		}
 		return false, nil

--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -26,8 +26,7 @@ import (
 	"fmt"
 	"time"
 
-	"golang.org/x/time/rate"
-
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -117,9 +116,8 @@ func newTaskMatcher(config *config.TaskListConfig, fwdr *Forwarder, scope metric
 //   - task is matched and consumer returns error in response channel
 func (tm *TaskMatcher) Offer(ctx context.Context, task *InternalTask) (bool, error) {
 	var err error
-	var rsv *rate.Reservation
 	if !task.IsForwarded() {
-		rsv, err = tm.ratelimit(ctx)
+		err = tm.ratelimit(ctx)
 		if err != nil {
 			tm.scope.IncCounter(metrics.SyncThrottlePerTaskListCounter)
 			return false, err
@@ -156,11 +154,6 @@ func (tm *TaskMatcher) Offer(ctx context.Context, task *InternalTask) (bool, err
 			}
 		}
 
-		if rsv != nil {
-			// there was a ratelimit token we consumed
-			// return it since we did not really do any work
-			rsv.Cancel()
-		}
 		return false, nil
 	}
 }
@@ -222,7 +215,7 @@ func (tm *TaskMatcher) OfferQuery(ctx context.Context, task *InternalTask) (*typ
 // MustOffer blocks until a consumer is found to handle this task
 // Returns error only when context is canceled, expired or the ratelimit is set to zero (allow nothing)
 func (tm *TaskMatcher) MustOffer(ctx context.Context, task *InternalTask) error {
-	if _, err := tm.ratelimit(ctx); err != nil {
+	if err := tm.ratelimit(ctx); err != nil {
 		return fmt.Errorf("rate limit error dispatching: %w", err)
 	}
 
@@ -445,32 +438,17 @@ func (tm *TaskMatcher) fwdrAddReqTokenC() <-chan *ForwarderReqToken {
 	return tm.fwdr.AddReqTokenC()
 }
 
-func (tm *TaskMatcher) ratelimit(ctx context.Context) (*rate.Reservation, error) {
-	select {
-	case <-ctx.Done():
-		return nil, ctx.Err()
-	default:
+func (tm *TaskMatcher) ratelimit(ctx context.Context) error {
+	err := tm.limiter.Wait(ctx)
+	if errors.Is(err, clock.ErrCannotWait) {
+		// "err != ctx.Err()" may also be correct, as that would mean "gave up due to context".
+		//
+		// in this branch: either the request would wait longer than ctx's timeout,
+		// or the limiter's config does not allow any operations at all (burst 0).
+		// in either case, this is returned immediately.
+		return ErrTasklistThrottled
 	}
-
-	deadline, ok := ctx.Deadline()
-	if !ok {
-		if err := tm.limiter.Wait(ctx); err != nil {
-			return nil, err
-		}
-		return nil, nil
-	}
-
-	rsv := tm.limiter.Reserve()
-	// If we have to wait too long for reservation, give up and return
-	if !rsv.OK() || rsv.Delay() > time.Until(deadline) {
-		if rsv.OK() { // if we were indeed given a reservation, return it before we bail out
-			rsv.Cancel()
-		}
-		return nil, ErrTasklistThrottled
-	}
-
-	time.Sleep(rsv.Delay())
-	return rsv, nil
+	return err
 }
 
 func (tm *TaskMatcher) isForwardingAllowed() bool {

--- a/service/matching/tasklist/matcher.go
+++ b/service/matching/tasklist/matcher.go
@@ -447,7 +447,7 @@ func (tm *TaskMatcher) ratelimit(ctx context.Context) error {
 		// in either case, this is returned immediately.
 		return ErrTasklistThrottled
 	}
-	return err
+	return err // nil if success, non-nil if canceled
 }
 
 func (tm *TaskMatcher) isForwardingAllowed() bool {

--- a/service/matching/tasklist/matcher_test.go
+++ b/service/matching/tasklist/matcher_test.go
@@ -29,8 +29,10 @@ import (
 
 	"github.com/golang/mock/gomock"
 	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/yarpc"
+	"golang.org/x/time/rate"
 
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
@@ -39,6 +41,7 @@ import (
 	"github.com/uber/cadence/common/log/loggerimpl"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/quotas"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/matching/config"
 )
@@ -609,6 +612,223 @@ func (t *MatcherTestSuite) newTaskInfo() *persistence.TaskInfo {
 		ScheduleID:             rand.Int63(),
 		ScheduleToStartTimeout: rand.Int31(),
 	}
+}
+
+func TestRatelimitBehavior(t *testing.T) {
+	const (
+		granularity = 100 * time.Millisecond
+		precision   = float64(granularity / 10) // for elapsed-time delta checks
+	)
+
+	// code prior to ~june 2024, kept around until new behavior is thoroughly validated,
+	// largely to make regression tests easier to build if we encounter problems
+	orig := func(ctx context.Context, limiter *rate.Limiter) (*rate.Reservation, error) {
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		default:
+		}
+
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			if err := limiter.Wait(ctx); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		}
+
+		rsv := limiter.Reserve()
+		// If we have to wait too long for reservation, give up and return
+		if !rsv.OK() || rsv.Delay() > time.Until(deadline) {
+			if rsv.OK() { // if we were indeed given a reservation, return it before we bail out
+				rsv.Cancel()
+			}
+			return nil, ErrTasklistThrottled
+		}
+
+		time.Sleep(rsv.Delay())
+		return rsv, nil
+	}
+	tests := map[string]struct {
+		run         func(allowable func(ctx context.Context) (*rate.Reservation, error)) error
+		err         error
+		duration    time.Duration
+		beginTokens int
+		endTokens   int
+	}{
+		"no deadline returns immediately if available": {
+			run: func(allowable func(ctx context.Context) (*rate.Reservation, error)) error {
+				_, err := allowable(context.Background())
+				return err
+			},
+			duration:    0,
+			beginTokens: 1,
+		},
+		"no deadline waits until available": {
+			run: func(allowable func(ctx context.Context) (*rate.Reservation, error)) error {
+				_, err := allowable(context.Background())
+				return err
+			},
+			duration: granularity,
+		},
+		"canceling no deadline while waiting returns ctx err": {
+			run: func(allowable func(ctx context.Context) (*rate.Reservation, error)) error {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				go func() {
+					time.Sleep(granularity / 2)
+					cancel()
+				}()
+				_, err := allowable(ctx)
+				return err
+			},
+			err:      context.Canceled,
+			duration: granularity / 2,
+		},
+		"returns immediately if canceled": {
+			run: func(allowable func(ctx context.Context) (*rate.Reservation, error)) error {
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+				_, err := allowable(ctx)
+				return err
+			},
+			err:         context.Canceled,
+			duration:    0,
+			beginTokens: 1,
+			endTokens:   1,
+		},
+		"sufficient deadline returns immediately if available": {
+			run: func(allowable func(ctx context.Context) (*rate.Reservation, error)) error {
+				ctx, cancel := context.WithTimeout(context.Background(), granularity*2)
+				defer cancel()
+				_, err := allowable(ctx)
+				return err
+			},
+			duration:    0,
+			beginTokens: 1,
+		},
+		"sufficient deadline waits": {
+			run: func(allowable func(ctx context.Context) (*rate.Reservation, error)) error {
+				ctx, cancel := context.WithTimeout(context.Background(), granularity*2)
+				defer cancel()
+				_, err := allowable(ctx)
+				return err
+			},
+			duration: granularity,
+		},
+		"insufficient deadline stops immediately": {
+			run: func(allowable func(ctx context.Context) (*rate.Reservation, error)) error {
+				ctx, cancel := context.WithTimeout(context.Background(), granularity/2)
+				defer cancel()
+				_, err := allowable(ctx)
+				return err
+			},
+			err:         ErrTasklistThrottled,
+			duration:    0,
+			beginTokens: 0,
+		},
+	}
+	for name, test := range tests {
+		test := test // closure copy
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			check := func(t *testing.T, allow func() bool, allowable func(ctx context.Context) (*rate.Reservation, error)) {
+				for allow() {
+					// drain tokens to start
+				}
+				if test.beginTokens > 0 {
+					time.Sleep(time.Duration(test.beginTokens) * granularity)
+				}
+				start := time.Now()
+				err := test.run(allowable)
+				dur := time.Since(start).Round(time.Millisecond)
+
+				if test.err != nil {
+					assert.ErrorIs(t, err, test.err, "wrong err returned, got %v", err)
+				} else {
+					assert.NoError(t, err)
+				}
+				assert.InDeltaf(t, test.duration, dur, precision, "duration should be within %v of %v, was %v", time.Duration(precision), test.duration, dur)
+				availableTokens := 0
+				for allow() {
+					availableTokens++
+				}
+				assert.Equal(t, test.endTokens, availableTokens, "should have %v tokens available after the test runs", test.endTokens)
+
+			}
+			t.Run("orig", func(t *testing.T) {
+				t.Parallel()
+				perSecond := time.Second / granularity
+				limiter := rate.NewLimiter(rate.Limit(perSecond), int(perSecond))
+				check(t, limiter.Allow, func(ctx context.Context) (*rate.Reservation, error) {
+					return orig(ctx, limiter)
+				})
+			})
+			t.Run("current", func(t *testing.T) {
+				t.Parallel()
+				perSecond := float64(time.Second / granularity)
+				limiter := quotas.NewRateLimiter(&perSecond, time.Minute, int(perSecond))
+				check(t, limiter.Allow, func(ctx context.Context) (*rate.Reservation, error) {
+					return nil, (&TaskMatcher{limiter: limiter}).ratelimit(ctx)
+				})
+			})
+		})
+	}
+
+	t.Run("known different behavior", func(t *testing.T) {
+		t.Run("canceling while waiting with a deadline", func(t *testing.T) {
+			cancelWhileWaiting := func(cb func(context.Context) error) (time.Duration, error) {
+				// sufficient deadline, but canceled after half a token recovers
+				ctx, cancel := context.WithTimeout(context.Background(), granularity*2)
+				defer cancel()
+				go func() {
+					time.Sleep(granularity / 2)
+					cancel()
+				}()
+
+				start := time.Now()
+				err := cb(ctx)
+				elapsed := time.Since(start)
+				return elapsed, err
+			}
+			t.Run("orig does not stop", func(t *testing.T) {
+				perSecond := time.Second / granularity
+				limit := rate.NewLimiter(rate.Limit(perSecond), int(perSecond))
+				for limit.Allow() {
+					// drain tokens to start
+				}
+
+				elapsed, err := cancelWhileWaiting(func(ctx context.Context) error {
+					_, err := orig(ctx, limit)
+					return err
+				})
+
+				assert.NoError(t, err, "continues waiting and returns successfully despite being canceled")
+				assert.InDeltaf(t, granularity, elapsed, precision, "waits until a full token would recover")
+				assert.False(t, limit.Allow(), "consumes the token that was recovered")
+				time.Sleep(granularity / 2)
+				assert.False(t, limit.Allow(), "did not have 0.5 tokens available after waiting") // should be 0.5 now though
+			})
+			t.Run("new code stops quickly", func(t *testing.T) {
+				perSecond := float64(time.Second / granularity)
+				limit := quotas.NewRateLimiter(&perSecond, time.Minute, int(perSecond))
+				for limit.Allow() {
+					// drain tokens to start
+				}
+
+				elapsed, err := cancelWhileWaiting(func(ctx context.Context) error {
+					return (&TaskMatcher{limiter: limit}).ratelimit(ctx)
+				})
+
+				assert.ErrorIs(t, err, context.Canceled, "gives up and returns context error")
+				assert.InDeltaf(t, granularity/2, elapsed, precision, "waits only until canceled")
+				assert.False(t, limit.Allow(), "does not yet have a full token, only 0.5")
+				time.Sleep(granularity / 2)
+				// note this is false in the original code
+				assert.True(t, limit.Allow(), "0.5 -> 1 tokens recovered shows 0.5 were available after waiting")
+			})
+		})
+	})
 }
 
 // Try to ensure a blocking callback in a goroutine is not running until the thing immediately

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -70,7 +70,7 @@ func TestDeliverBufferTasks(t *testing.T) {
 			rps := 0.1
 			tlm.matcher.UpdateRatelimit(&rps)
 			tlm.taskReader.taskBuffers[defaultTaskBufferIsolationGroup] <- &persistence.TaskInfo{}
-			_, err := tlm.matcher.ratelimit(context.Background()) // consume the token
+			err := tlm.matcher.ratelimit(context.Background()) // consume the token
 			assert.NoError(t, err)
 			tlm.taskReader.cancelFunc()
 		},


### PR DESCRIPTION
Partly this is worth doing at some point regardless, and partly this is a
bit of a blocker for the global ratelimiter, as it needs to expose some
Reservation-using APIs to fit into existing ratelimiter code.

This has a larger blast-radius than I'd like, as it's not just frontend,
but it should be safe - the clock.Ratelimiter is pretty thoroughly tested,
and the small changes in behavior seem in line with what the code around
it expects to happen, rather than what *actually* happens.
