### PR TITLE
Allow filtering by CloseStatus in ListAllWorkflowExecutions api

### DIFF
--- a/common/persistence/dataVisibilityManagerInterfaces.go
+++ b/common/persistence/dataVisibilityManagerInterfaces.go
@@ -137,6 +137,7 @@ type (
 	ListAllWorkflowExecutionsRequest struct {
 		ListWorkflowExecutionsRequest
 		PartialMatch        bool
+		StatusFilter        []types.WorkflowExecutionCloseStatus
 		WorkflowSearchValue string // This value will be searched across workflow type, workflow ID and runID
 		SortColumn          string // This should be a valid search attribute
 		SortOrder           string // DESC or ASC

--- a/common/persistence/data_store_interfaces.go
+++ b/common/persistence/data_store_interfaces.go
@@ -710,6 +710,7 @@ type (
 	// InternalListAllWorkflowExecutionsByTypeRequest is used to list all open and closed executions with specific filters in a domain
 	InternalListAllWorkflowExecutionsByTypeRequest struct {
 		InternalListWorkflowExecutionsRequest
+		StatusFilter        []types.WorkflowExecutionCloseStatus
 		PartialMatch        bool
 		WorkflowSearchValue string // This value will be searched across workflow type, workflow ID and runID
 		SortColumn          string // This should be a valid search attribute

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1769,12 +1769,16 @@ func TestGetListAllWorkflowExecutionsQuery(t *testing.T) {
 				},
 				PartialMatch:        false,
 				WorkflowSearchValue: "123",
+				StatusFilter:        []types.WorkflowExecutionCloseStatus{types.WorkflowExecutionCloseStatusCompleted, types.WorkflowExecutionCloseStatusTimedOut},
 			},
 			expectResult: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
+AND ( CloseStatus = 'COMPLETED'
+OR CloseStatus = 'TIMED_OUT'
+ )
 AND ( WorkflowID = '123'
 OR WorkflowType = '123'
 OR RunID = '123'
@@ -1796,6 +1800,7 @@ LIMIT 0, 10
 				},
 				PartialMatch:        false,
 				WorkflowSearchValue: "123",
+				StatusFilter:        []types.WorkflowExecutionCloseStatus{types.WorkflowExecutionCloseStatusTerminated},
 				SortColumn:          CloseTime,
 				SortOrder:           AscendingOrder,
 			},
@@ -1804,6 +1809,8 @@ FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
 AND IsDeleted = false
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
+AND ( CloseStatus = 'TERMINATED'
+ )
 AND ( WorkflowID = '123'
 OR WorkflowType = '123'
 OR RunID = '123'

--- a/common/persistence/visibility_single_manager.go
+++ b/common/persistence/visibility_single_manager.go
@@ -273,6 +273,7 @@ func (v *visibilityManagerImpl) ListAllWorkflowExecutions(
 		SortColumn:          request.SortColumn,
 		SortOrder:           request.SortOrder,
 	}
+	copy(internalRequest.StatusFilter, request.StatusFilter)
 	if internalListRequest != nil {
 		internalRequest.InternalListWorkflowExecutionsRequest = *internalListRequest
 	}

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -3482,14 +3482,15 @@ func (v *ListOpenWorkflowExecutionsResponse) GetExecutions() (o []*WorkflowExecu
 
 // ListAllWorkflowExecutionsRequest is the request to ListAllWorkflowExecutions
 type ListAllWorkflowExecutionsRequest struct {
-	Domain              string           `json:"domain,omitempty"`
-	MaximumPageSize     int32            `json:"maximumPageSize,omitempty"`
-	NextPageToken       []byte           `json:"nextPageToken,omitempty"`
-	StartTimeFilter     *StartTimeFilter `json:"StartTimeFilter,omitempty"`
-	PartialMatch        bool             `json:"partialMatch,omitempty"`
-	WorkflowSearchValue string           `json:"workflowSearchValue,omitempty"`
-	SortColumn          string           `json:"sortColumn,omitempty"`
-	SortOrder           string           `json:"sortOrder,omitempty"`
+	Domain              string                         `json:"domain,omitempty"`
+	MaximumPageSize     int32                          `json:"maximumPageSize,omitempty"`
+	NextPageToken       []byte                         `json:"nextPageToken,omitempty"`
+	StartTimeFilter     *StartTimeFilter               `json:"StartTimeFilter,omitempty"`
+	PartialMatch        bool                           `json:"partialMatch,omitempty"`
+	StatusFilter        []WorkflowExecutionCloseStatus `json:"closeStatus,omitempty"`
+	WorkflowSearchValue string                         `json:"workflowSearchValue,omitempty"`
+	SortColumn          string                         `json:"sortColumn,omitempty"`
+	SortOrder           string                         `json:"sortOrder,omitempty"`
 }
 
 func (v *ListAllWorkflowExecutionsRequest) SerializeForLogging() (string, error) {

--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -3135,18 +3135,19 @@ func (wh *WorkflowHandler) ListAllWorkflowExecutions(
 		EarliestTime:  listRequest.StartTimeFilter.GetEarliestTime(),
 		LatestTime:    listRequest.StartTimeFilter.GetLatestTime(),
 	}
-
+	listallrequest := &persistence.ListAllWorkflowExecutionsRequest{
+		ListWorkflowExecutionsRequest: baseReq,
+		PartialMatch:                  listRequest.PartialMatch,
+		WorkflowSearchValue:           listRequest.WorkflowSearchValue,
+		SortColumn:                    listRequest.SortColumn,
+		SortOrder:                     listRequest.SortOrder,
+	}
+	copy(listallrequest.StatusFilter, listRequest.StatusFilter)
 	var persistenceResp *persistence.ListWorkflowExecutionsResponse
 
 	persistenceResp, err = wh.GetVisibilityManager().ListAllWorkflowExecutions(
 		ctx,
-		&persistence.ListAllWorkflowExecutionsRequest{
-			ListWorkflowExecutionsRequest: baseReq,
-			PartialMatch:                  listRequest.PartialMatch,
-			WorkflowSearchValue:           listRequest.WorkflowSearchValue,
-			SortColumn:                    listRequest.SortColumn,
-			SortOrder:                     listRequest.SortOrder,
-		},
+		listallrequest,
 	)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Filtering by a list of closestatus was not possible in listallworkflowexecutions api. This PR adds it

<!-- Tell your future self why have you made these changes -->
**Why?**
So webv4 can make it possible to filter on workflow status

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
