### PR TITLE
Bump docker/build-push-action to v5

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Push to Docker Hub (server build)
-        uses: docker/build-push-action@v1
+        uses: docker/build-push-action@v5
         with:
           username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
@@ -32,7 +32,7 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
       - name: Push to Docker Hub (auto-setup build)
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Upgrading action to v5 to support `platforms` setting.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is follow up for https://github.com/uber/cadence/pull/5962. 

Current action is reporting this warning: `Warning: Unexpected input(s) 'platforms', valid inputs are ['entryPoint', 'args', 'username', 'password', 'registry', 'repository', 'tags', 'tag_with_ref', 'tag_with_sha', 'path', 'dockerfile', 'target', 'always_pull', 'build_args', 'cache_froms', 'labels', 'add_git_labels', 'push']`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
