### PR TITLE
Added internal count metrics in addition to the external counts that are already there

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2476,6 +2476,7 @@ const (
 	WorkflowIDCacheSizeGauge
 	WorkflowIDCacheRequestsExternalRatelimitedCounter
 	WorkflowIDCacheRequestsExternalMaxRequestsPerSecondsTimer
+	WorkflowIDCacheRequestsInternalMaxRequestsPerSecondsTimer
 	WorkflowIDCacheRequestsInternalRatelimitedCounter
 	NumHistoryMetrics
 )
@@ -3115,6 +3116,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		WorkflowIDCacheSizeGauge:                                     {metricName: "workflow_id_cache_size", metricType: Gauge},
 		WorkflowIDCacheRequestsExternalRatelimitedCounter:            {metricName: "workflow_id_external_requests_ratelimited", metricType: Counter},
 		WorkflowIDCacheRequestsExternalMaxRequestsPerSecondsTimer:    {metricName: "workflow_id_external_requests_max_requests_per_seconds", metricType: Timer},
+		WorkflowIDCacheRequestsInternalMaxRequestsPerSecondsTimer:    {metricName: "workflow_id_internal_requests_max_requests_per_seconds", metricType: Timer},
 		WorkflowIDCacheRequestsInternalRatelimitedCounter:            {metricName: "workflow_id_internal_requests_ratelimited", metricType: Counter},
 	},
 	Matching: {

--- a/service/history/workflowcache/metrics.go
+++ b/service/history/workflowcache/metrics.go
@@ -50,6 +50,7 @@ func (cm *workflowIDCountMetric) updatePerDomainMaxWFRequestCount(
 	domainName string,
 	timeSource clock.TimeSource,
 	metricsClient metrics.Client,
+	metric int,
 ) {
 	cm.Lock()
 	defer cm.Unlock()
@@ -61,5 +62,5 @@ func (cm *workflowIDCountMetric) updatePerDomainMaxWFRequestCount(
 
 	// We can just use the upper of the metric, so it is not an issue to emit all the counts
 	metricsClient.Scope(metrics.HistoryClientWfIDCacheScope, metrics.DomainTag(domainName)).
-		RecordTimer(metrics.WorkflowIDCacheRequestsExternalMaxRequestsPerSecondsTimer, time.Duration(cm.count))
+		RecordTimer(metric, time.Duration(cm.count))
 }

--- a/service/history/workflowcache/metrics_test.go
+++ b/service/history/workflowcache/metrics_test.go
@@ -35,6 +35,7 @@ import (
 
 func TestUpdatePerDomainMaxWFRequestCount(t *testing.T) {
 	domainName := "some domain name"
+	metric := metrics.WorkflowIDCacheRequestsInternalMaxRequestsPerSecondsTimer
 
 	cases := []struct {
 		name                             string
@@ -45,8 +46,8 @@ func TestUpdatePerDomainMaxWFRequestCount(t *testing.T) {
 			name: "Single workflowID",
 			updatePerDomainMaxWFRequestCount: func(metricsClient metrics.Client, timeSource clock.MockedTimeSource) {
 				workflowID1 := &workflowIDCountMetric{}
-				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 1
-				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 2
+				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 1
+				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 2
 			},
 			expecetMetrics: []time.Duration{1, 2},
 		},
@@ -54,14 +55,14 @@ func TestUpdatePerDomainMaxWFRequestCount(t *testing.T) {
 			name: "Separate workflowIDs",
 			updatePerDomainMaxWFRequestCount: func(metricsClient metrics.Client, timeSource clock.MockedTimeSource) {
 				workflowID1 := &workflowIDCountMetric{}
-				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 1
+				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 1
 
 				workflowID2 := &workflowIDCountMetric{}
-				workflowID2.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 1
-				workflowID2.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 2
-				workflowID2.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 3
+				workflowID2.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 1
+				workflowID2.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 2
+				workflowID2.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 3
 
-				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 2
+				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 2
 
 			},
 			expecetMetrics: []time.Duration{1, 1, 2, 3, 2},
@@ -70,11 +71,11 @@ func TestUpdatePerDomainMaxWFRequestCount(t *testing.T) {
 			name: "Reset",
 			updatePerDomainMaxWFRequestCount: func(metricsClient metrics.Client, timeSource clock.MockedTimeSource) {
 				workflowID1 := &workflowIDCountMetric{}
-				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 1
-				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 2
+				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 1
+				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 2
 
 				timeSource.Advance(1100 * time.Millisecond)
-				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient) // Emits 1
+				workflowID1.updatePerDomainMaxWFRequestCount(domainName, timeSource, metricsClient, metric) // Emits 1
 			},
 			expecetMetrics: []time.Duration{1, 2, 1},
 		},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added new metric which gives the max per workflow ID rps we have seen for the domain every second


<!-- Tell your future self why have you made these changes -->
**Why?**
This will help users understand how close they are to the per workflow ID rate limits


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests 


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Just adding a metric, so should be safe

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
