### PR TITLE
Persist failover history in DomainInfo data

### DIFF
--- a/common/constants.go
+++ b/common/constants.go
@@ -166,6 +166,8 @@ const (
 	DomainDataKeyForManagedFailover = "IsManagedByCadence"
 	// DomainDataKeyForPreferredCluster is the key of DomainData for domain rebalance
 	DomainDataKeyForPreferredCluster = "PreferredCluster"
+	// DomainDataKeyForFailoverHistory is the key of DomainData for failover history
+	DomainDataKeyForFailoverHistory = "FailoverHistory"
 	// DomainDataKeyForReadGroups stores which groups have read permission of the domain API
 	DomainDataKeyForReadGroups = "READ_GROUPS"
 	// DomainDataKeyForWriteGroups stores which groups have write permission of the domain API
@@ -269,3 +271,24 @@ const (
 	// WorkflowIDRateLimitReason is the reason set in ServiceBusyError when workflow ID rate limit is exceeded
 	WorkflowIDRateLimitReason = "external-workflow-id-rate-limit"
 )
+
+type (
+	// FailoverType is the enum for representing different failover types
+	FailoverType int
+)
+
+const (
+	FailoverTypeForce = iota + 1
+	FailoverTypeGrace
+)
+
+func (v FailoverType) String() string {
+	switch v {
+	case FailoverTypeForce:
+		return "Force"
+	case FailoverTypeGrace:
+		return "Grace"
+	default:
+		return "Unknown"
+	}
+}

--- a/common/domain/handler_MasterCluster_test.go
+++ b/common/domain/handler_MasterCluster_test.go
@@ -22,6 +22,7 @@ package domain
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 	"testing"
@@ -50,13 +51,14 @@ type (
 	domainHandlerGlobalDomainEnabledPrimaryClusterSuite struct {
 		*persistencetests.TestBase
 
-		minRetentionDays     int
-		maxBadBinaryCount    int
-		domainManager        persistence.DomainManager
-		mockProducer         *mocks.KafkaProducer
-		mockDomainReplicator Replicator
-		archivalMetadata     archiver.ArchivalMetadata
-		mockArchiverProvider *provider.MockArchiverProvider
+		minRetentionDays       int
+		maxBadBinaryCount      int
+		failoverHistoryMaxSize int
+		domainManager          persistence.DomainManager
+		mockProducer           *mocks.KafkaProducer
+		mockDomainReplicator   Replicator
+		archivalMetadata       archiver.ArchivalMetadata
+		mockArchiverProvider   *provider.MockArchiverProvider
 
 		handler *handlerImpl
 	}
@@ -89,6 +91,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) SetupTest() {
 	dcCollection := dc.NewCollection(dc.NewNopClient(), logger)
 	s.minRetentionDays = 1
 	s.maxBadBinaryCount = 10
+	s.failoverHistoryMaxSize = 5
 	s.domainManager = s.TestBase.DomainManager
 	s.mockProducer = &mocks.KafkaProducer{}
 	s.mockDomainReplicator = NewDomainReplicator(s.mockProducer, logger)
@@ -102,9 +105,10 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) SetupTest() {
 	)
 	s.mockArchiverProvider = &provider.MockArchiverProvider{}
 	domainConfig := Config{
-		MinRetentionDays:  dc.GetIntPropertyFn(s.minRetentionDays),
-		MaxBadBinaryCount: dc.GetIntPropertyFilteredByDomain(s.maxBadBinaryCount),
-		FailoverCoolDown:  dc.GetDurationPropertyFnFilteredByDomain(0 * time.Second),
+		MinRetentionDays:       dc.GetIntPropertyFn(s.minRetentionDays),
+		MaxBadBinaryCount:      dc.GetIntPropertyFilteredByDomain(s.maxBadBinaryCount),
+		FailoverCoolDown:       dc.GetDurationPropertyFnFilteredByDomain(0 * time.Second),
+		FailoverHistoryMaxSize: dc.GetIntPropertyFilteredByDomain(s.failoverHistoryMaxSize),
 	}
 	s.handler = NewHandler(
 		domainConfig,
@@ -114,7 +118,7 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) SetupTest() {
 		s.mockDomainReplicator,
 		s.archivalMetadata,
 		s.mockArchiverProvider,
-		clock.NewRealTimeSource(),
+		clock.NewMockedTimeSource(),
 	).(*handlerImpl)
 }
 
@@ -819,6 +823,11 @@ func (s *domainHandlerGlobalDomainEnabledPrimaryClusterSuite) TestUpdateGetDomai
 		IsGlobalDomain:                         isGlobalDomain,
 	})
 	s.Nil(err)
+
+	var failoverHistory []FailoverEvent
+	failoverHistory = append(failoverHistory, FailoverEvent{EventTime: s.handler.timeSource.Now(), FromCluster: prevActiveClusterName, ToCluster: nextActiveClusterName, FailoverType: common.FailoverType(common.FailoverTypeForce).String()})
+	failoverHistoryJSON, _ := json.Marshal(failoverHistory)
+	data[common.DomainDataKeyForFailoverHistory] = string(failoverHistoryJSON)
 
 	fnTest := func(info *types.DomainInfo, config *types.DomainConfiguration,
 		replicationConfig *types.DomainReplicationConfiguration, isGlobalDomain bool, failoverVersion int64) {

--- a/common/domain/handler_NotMasterCluster_test.go
+++ b/common/domain/handler_NotMasterCluster_test.go
@@ -22,6 +22,7 @@ package domain
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"os"
 	"testing"
@@ -50,13 +51,14 @@ type (
 	domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite struct {
 		*persistencetests.TestBase
 
-		minRetentionDays     int
-		maxBadBinaryCount    int
-		domainManager        persistence.DomainManager
-		mockProducer         *mocks.KafkaProducer
-		mockDomainReplicator Replicator
-		archivalMetadata     archiver.ArchivalMetadata
-		mockArchiverProvider *provider.MockArchiverProvider
+		minRetentionDays       int
+		maxBadBinaryCount      int
+		failoverHistoryMaxSize int
+		domainManager          persistence.DomainManager
+		mockProducer           *mocks.KafkaProducer
+		mockDomainReplicator   Replicator
+		archivalMetadata       archiver.ArchivalMetadata
+		mockArchiverProvider   *provider.MockArchiverProvider
 
 		handler *handlerImpl
 	}
@@ -89,6 +91,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) SetupTest() {
 	dcCollection := dc.NewCollection(dc.NewNopClient(), logger)
 	s.minRetentionDays = 1
 	s.maxBadBinaryCount = 10
+	s.failoverHistoryMaxSize = 5
 	s.domainManager = s.TestBase.DomainManager
 	s.mockProducer = &mocks.KafkaProducer{}
 	s.mockDomainReplicator = NewDomainReplicator(s.mockProducer, logger)
@@ -102,9 +105,10 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) SetupTest() {
 	)
 	s.mockArchiverProvider = &provider.MockArchiverProvider{}
 	domainConfig := Config{
-		MinRetentionDays:  dc.GetIntPropertyFn(s.minRetentionDays),
-		MaxBadBinaryCount: dc.GetIntPropertyFilteredByDomain(s.maxBadBinaryCount),
-		FailoverCoolDown:  dc.GetDurationPropertyFnFilteredByDomain(0 * time.Second),
+		MinRetentionDays:       dc.GetIntPropertyFn(s.minRetentionDays),
+		MaxBadBinaryCount:      dc.GetIntPropertyFilteredByDomain(s.maxBadBinaryCount),
+		FailoverCoolDown:       dc.GetDurationPropertyFnFilteredByDomain(0 * time.Second),
+		FailoverHistoryMaxSize: dc.GetIntPropertyFilteredByDomain(s.failoverHistoryMaxSize),
 	}
 	s.handler = NewHandler(
 		domainConfig,
@@ -114,7 +118,7 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) SetupTest() {
 		s.mockDomainReplicator,
 		s.archivalMetadata,
 		s.mockArchiverProvider,
-		clock.NewRealTimeSource(),
+		clock.NewMockedTimeSource(),
 	).(*handlerImpl)
 }
 
@@ -682,6 +686,11 @@ func (s *domainHandlerGlobalDomainEnabledNotPrimaryClusterSuite) TestUpdateGetDo
 		FailoverVersion: s.ClusterMetadata.GetNextFailoverVersion(prevActiveClusterName, 0, "some-domain"),
 	})
 	s.Nil(err)
+
+	var failoverHistory []FailoverEvent
+	failoverHistory = append(failoverHistory, FailoverEvent{EventTime: s.handler.timeSource.Now(), FromCluster: prevActiveClusterName, ToCluster: nextActiveClusterName, FailoverType: common.FailoverType(common.FailoverTypeForce).String()})
+	failoverHistoryJSON, _ := json.Marshal(failoverHistory)
+	data[common.DomainDataKeyForFailoverHistory] = string(failoverHistoryJSON)
 
 	fnTest := func(info *types.DomainInfo, config *types.DomainConfiguration,
 		replicationConfig *types.DomainReplicationConfiguration, isGlobalDomain bool, failoverVersion int64) {

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -630,6 +630,12 @@ const (
 	// Default value: 10000
 	// Allowed filters: N/A
 	VisibilityArchivalQueryMaxPageSize
+	// FrontendFailoverHistoryMaxSize is the maximum size for the number of failover event records in a domain failover history
+	// KeyName: frontend.failoverHistoryMaxSize
+	// Value type: Int
+	// Default value: 5
+	// Allowed filters: DomainName
+	FrontendFailoverHistoryMaxSize
 
 	// key for matching
 
@@ -3138,6 +3144,12 @@ var IntKeys = map[IntKey]DynamicInt{
 		KeyName:      "frontend.visibilityArchivalQueryMaxPageSize",
 		Description:  "VisibilityArchivalQueryMaxPageSize is the maximum page size for a visibility archival query",
 		DefaultValue: 10000,
+	},
+	FrontendFailoverHistoryMaxSize: {
+		KeyName:      "frontend.failoverHistoryMaxSize",
+		Filters:      []Filter{DomainName},
+		Description:  "FrontendFailoverHistoryMaxSize is the maximum size for the number of failover event records in a domain failover history",
+		DefaultValue: 5,
 	},
 	MatchingUserRPS: {
 		KeyName:      "matching.rps",

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -188,6 +188,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 			MaxRetentionDays:       dc.GetIntProperty(dynamicconfig.MaxRetentionDays),
 			FailoverCoolDown:       dc.GetDurationPropertyFilteredByDomain(dynamicconfig.FrontendFailoverCoolDown),
 			RequiredDomainDataKeys: dc.GetMapProperty(dynamicconfig.RequiredDomainDataKeys),
+			FailoverHistoryMaxSize: dc.GetIntPropertyFilteredByDomain(dynamicconfig.FrontendFailoverHistoryMaxSize),
 		},
 		HostName: hostName,
 	}

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -111,6 +111,7 @@ func TestNewConfig(t *testing.T) {
 		"MaxRetentionDays":       {dynamicconfig.MaxRetentionDays, 42},
 		"FailoverCoolDown":       {dynamicconfig.FrontendFailoverCoolDown, time.Duration(43)},
 		"RequiredDomainDataKeys": {dynamicconfig.RequiredDomainDataKeys, map[string]interface{}{"bar": "baz"}},
+		"FailoverHistoryMaxSize": {dynamicconfig.FrontendFailoverHistoryMaxSize, 44},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	dc := dynamicconfig.NewCollection(client, testlogger.New(t))


### PR DESCRIPTION
Persist failover history in DomainInfo data

**What changed?**
Added functionality to persist recent failover event data in the DomainInfo whenever a valid failover is executed.
`FailoverEvent` contains the failover `timestamp`, `fromCluster`, `toCluster`, and `FailoverType`("Force"/"Grace") information.
`FailoverHistory` is the key in the `DomainInfo` `data`. It's a slice stored as a string containing the `FailoverEvents`, with max size defined by `dynamicconfig.FrontendFailoverHistoryMaxSize`. It has a default value of 5 and domain filter allowed.
`FailoverHistory` always keep the n most recent `FailoverEvents` and it's sorted by descending timestamp.

**Why?**
Persist failover information, improving failover visibility to clients and the cadence team.

**How did you test it?**
Unit tests and integration tests. Tested locally, triggering failovers in a multiple Cadence clusters with replication environment.

**Potential risks**
The change does not affect the logic of UpdateDomain. It adds the failover info to the DomainInfo data. The main risk is that we introduce something that can cause the code to panic. Errors while adding the FailoverHistory are logged as warnings and do not return/interrupt the UpdateDomain action.

**Release notes**

**Documentation Changes**