### PR TITLE
[CLI] add new valid search attribute key cases for context header

### DIFF
--- a/tools/cli/admin_cluster_commands.go
+++ b/tools/cli/admin_cluster_commands.go
@@ -36,7 +36,7 @@ import (
 
 // An indirection for the prompt function so that it can be mocked in the unit tests
 var promptFn = prompt
-var validSearchAttributeKey = regexp.MustCompile(`^[a-zA-Z][a-zA-Z_0-9]*$`)
+var validSearchAttributeKey = regexp.MustCompile(`^[a-zA-Z][a-zA-Z_.-0-9]*$`)
 
 // AdminAddSearchAttribute to whitelist search attribute
 func AdminAddSearchAttribute(c *cli.Context) {

--- a/tools/cli/admin_cluster_commands_test.go
+++ b/tools/cli/admin_cluster_commands_test.go
@@ -126,8 +126,8 @@ func TestValidSearchAttributeKey(t *testing.T) {
 	assert.NoError(t, validateSearchAttributeKey("cityId"))
 	assert.NoError(t, validateSearchAttributeKey("paymentProfileUUID"))
 	assert.NoError(t, validateSearchAttributeKey("job_type"))
+	assert.NoError(t, validateSearchAttributeKey("Header.ctx-tenancy"))
 
-	assert.Error(t, validateSearchAttributeKey("payments-biling-invoices-TransactionUUID"))
 	assert.Error(t, validateSearchAttributeKey("9lives"))
 	assert.Error(t, validateSearchAttributeKey("tax%"))
 }


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**

Allow "." and "-" in search attribute keys.

<!-- Tell your future self why have you made these changes -->
**Why?**

This is needed for indexing context header in search attributes 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
