### PR TITLE
Add In Clause handling in json indexed col (Attr)

### DIFF
--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -71,7 +71,7 @@ func (qv *VisibilityQueryValidator) ValidateQuery(whereClause string) (string, e
 
 		stmt, err := sqlparser.Parse(placeholderQuery)
 		if err != nil {
-			return "", &types.BadRequestError{Message: "Invalid query." + err.Error()}
+			return "", &types.BadRequestError{Message: "Invalid query: " + err.Error()}
 		}
 
 		sel, ok := stmt.(*sqlparser.Select)

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -71,7 +71,7 @@ func (qv *VisibilityQueryValidator) ValidateQuery(whereClause string) (string, e
 
 		stmt, err := sqlparser.Parse(placeholderQuery)
 		if err != nil {
-			return "", &types.BadRequestError{Message: "Invalid query."}
+			return "", &types.BadRequestError{Message: "Invalid query." + err.Error()}
 		}
 
 		sel, ok := stmt.(*sqlparser.Select)
@@ -313,6 +313,36 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 	return buf.String(), nil
 }
 
+func (qv *VisibilityQueryValidator) processInClause(expr sqlparser.Expr) (string, error) {
+	comparisonExpr, ok := expr.(*sqlparser.ComparisonExpr)
+	if !ok {
+		return "", errors.New("invalid IN expression")
+	}
+
+	colName, ok := comparisonExpr.Left.(*sqlparser.ColName)
+	if !ok {
+		return "", errors.New("invalid IN expression, left")
+	}
+
+	colNameStr := colName.Name.String()
+	valTuple, ok := comparisonExpr.Right.(sqlparser.ValTuple)
+	if !ok {
+		return "", errors.New("invalid IN expression, right")
+	}
+
+	values := make([]string, len(valTuple))
+	for i, val := range valTuple {
+		sqlVal, ok := val.(*sqlparser.SQLVal)
+		if !ok {
+			return "", errors.New("invalid IN expression, value")
+		}
+		values[i] = "''" + string(sqlVal.Val) + "''"
+	}
+
+	return fmt.Sprintf("JSON_MATCH(Attr, '\"$.%s\" IN (%s)') or JSON_MATCH(Attr, '\"$.%s[*]\" IN (%s)')",
+		colNameStr, strings.Join(values, ","), colNameStr, strings.Join(values, ",")), nil
+}
+
 func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (string, error) {
 	comparisonExpr := expr.(*sqlparser.ComparisonExpr)
 
@@ -329,6 +359,12 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 		return "", fmt.Errorf("invalid search attribute")
 	}
 
+	// process IN clause in json indexed col: Attr
+	operator := strings.ToLower(comparisonExpr.Operator)
+	if operator == sqlparser.InStr {
+		return qv.processInClause(expr)
+	}
+
 	// get the column value
 	colVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal)
 	if !ok {
@@ -337,7 +373,6 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 
 	// get the value type
 	indexValType := common.ConvertIndexedValueTypeToInternalType(valType, log.NewNoop())
-	operator := comparisonExpr.Operator
 	colValStr := string(colVal.Val)
 
 	switch indexValType {

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -80,7 +80,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case7: invalid sql query": {
 			query: "Invalid SQL",
-			err:   "Invalid query.syntax error at position 38 near 'sql'",
+			err:   "Invalid query: syntax error at position 38 near 'sql'",
 		},
 		"Case8-1: query with missing val": {
 			query:     "CloseTime = missing",
@@ -112,7 +112,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case12-1: security SQL injection - with another statement": {
 			query: "WorkflowID = 'wid'; SELECT * FROM important_table;",
-			err:   "Invalid query.syntax error at position 53 near 'select'",
+			err:   "Invalid query: syntax error at position 53 near 'select'",
 		},
 		"Case12-2: security SQL injection - with union": {
 			query: "WorkflowID = 'wid' union select * from dummy",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -247,7 +247,15 @@ func TestValidateQuery(t *testing.T) {
 			query:     "CustomKeywordField in (123, 456)",
 			validated: "JSON_MATCH(Attr, '\"$.CustomKeywordField\" IN (''123'',''456'')') or JSON_MATCH(Attr, '\"$.CustomKeywordField[*]\" IN (''123'',''456'')')",
 		},
-		"case20-3: in clause in Attr with invalid IN expression, value": {
+		"case20-3-1: in clause in Attr with a string value, double quote": {
+			query:     "CustomKeywordField in (\"abc\")",
+			validated: "JSON_MATCH(Attr, '\"$.CustomKeywordField\" IN (''abc'')') or JSON_MATCH(Attr, '\"$.CustomKeywordField[*]\" IN (''abc'')')",
+		},
+		"case20-3-2: in clause in Attr with a string value, single quote": {
+			query:     "CustomKeywordField in ('abc')",
+			validated: "JSON_MATCH(Attr, '\"$.CustomKeywordField\" IN (''abc'')') or JSON_MATCH(Attr, '\"$.CustomKeywordField[*]\" IN (''abc'')')",
+		},
+		"case20-4: in clause in Attr with invalid IN expression, value": {
 			query:     "CustomKeywordField in (abc)",
 			validated: "",
 			err:       "invalid IN expression, value",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added `IN` Clause handling for json indexed col (Attr)
And unit test with 100% coverage of the new function. 

<!-- Tell your future self why have you made these changes -->
**Why?**
One customer complained that they had error when using `IN` Clause after we migrated their domain to Pinot. Because previously ES supported that. 
Pinot DOES supported this for all other system keys; but in a json indexed col like `ATTR` (we stored this column in a json format), we need to handle `IN` clause in a _different_ way. 

Sample query:
if we input:
`BinaryChecksums IN ("uDeploy:e6b658fc4ae98445a356d2218316081f7113fcdf")`
It would be processed to:
`and JSON_MATCH(Attr, '"$.BinaryChecksums" IN (''uDeploy:e6b658fc4ae98445a356d2218316081f7113fcdf'')') 
or JSON_MATCH(Attr, '"$.BinaryChecksums[*]" IN (''uDeploy:e6b658fc4ae98445a356d2218316081f7113fcdf'')')`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
