### PR TITLE
Fix encoding bug to index context header in search attributes

### DIFF
--- a/service/history/task/transfer_active_task_executor.go
+++ b/service/history/task/transfer_active_task_executor.go
@@ -1051,7 +1051,7 @@ func (t *transferActiveTaskExecutor) processRecordWorkflowStartedOrUpsertHelper(
 		if attributes := startEvent.GetWorkflowExecutionStartedEventAttributes(); attributes != nil && attributes.Header != nil {
 			// fail open to avoid blocking the task processing
 			if newSearchAttr, err := appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields, t.config.ValidSearchAttributes()); err != nil {
-				t.logger.Error("error adding context key to search attributes", tag.Error(err))
+				t.logger.Error("failed to add headers to search attributes", tag.Error(err))
 			} else {
 				searchAttr = newSearchAttr
 			}

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -22,6 +22,7 @@ package task
 
 import (
 	"context"
+	"encoding/json"
 	"math/rand"
 	"strconv"
 	"testing"
@@ -1978,8 +1979,12 @@ func createRecordWorkflowExecutionStartedRequest(
 	}
 	var searchAttributes map[string][]byte
 	if enableContextHeaderInVisibility {
+		contextValueJsonString, err := json.Marshal("contextValue")
+		if err != nil {
+			panic(err) // must not happen in tests
+		}
 		searchAttributes = map[string][]byte{
-			"Header.contextKey": []byte("contextValue"),
+			"Header.contextKey": contextValueJsonString,
 		}
 	}
 	return &persistence.RecordWorkflowExecutionStartedRequest{
@@ -2128,8 +2133,12 @@ func createUpsertWorkflowSearchAttributesRequest(
 	}
 	var searchAttributes map[string][]byte
 	if enableContextHeaderInVisibility {
+		contextValueJsonString, err := json.Marshal("contextValue")
+		if err != nil {
+			panic(err) // must not happen in tests
+		}
 		searchAttributes = map[string][]byte{
-			"Header.contextKey": []byte("contextValue"),
+			"Header.contextKey": contextValueJsonString,
 		}
 	}
 

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1736,6 +1736,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTask()
 		"RecordWorkflowExecutionStarted",
 		mock.Anything,
 		createRecordWorkflowExecutionStartedRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			false),
 	).Once().Return(nil)
@@ -1785,6 +1786,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskWi
 		"RecordWorkflowExecutionStarted",
 		mock.Anything,
 		createRecordWorkflowExecutionStartedRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			true),
 	).Once().Return(nil)
@@ -1817,6 +1819,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 		"UpsertWorkflowExecution",
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			false),
 	).Once().Return(nil)
@@ -1856,6 +1859,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttribu
 		"UpsertWorkflowExecution",
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			true),
 	).Once().Return(nil)
@@ -1958,6 +1962,7 @@ func createAddDecisionTaskRequest(
 }
 
 func createRecordWorkflowExecutionStartedRequest(
+	t *testing.T,
 	domainName string,
 	startEvent *types.HistoryEvent,
 	transferTask Task,
@@ -1979,12 +1984,12 @@ func createRecordWorkflowExecutionStartedRequest(
 	}
 	var searchAttributes map[string][]byte
 	if enableContextHeaderInVisibility {
-		contextValueJsonString, err := json.Marshal("contextValue")
+		contextValueJSONString, err := json.Marshal("contextValue")
 		if err != nil {
-			panic(err) // must not happen in tests
+			t.Fatal(err)
 		}
 		searchAttributes = map[string][]byte{
-			"Header.contextKey": contextValueJsonString,
+			"Header.contextKey": contextValueJSONString,
 		}
 	}
 	return &persistence.RecordWorkflowExecutionStartedRequest{
@@ -2111,6 +2116,7 @@ func createTestChildWorkflowExecutionRequest(
 }
 
 func createUpsertWorkflowSearchAttributesRequest(
+	t *testing.T,
 	domainName string,
 	startEvent *types.HistoryEvent,
 	transferTask Task,
@@ -2133,12 +2139,12 @@ func createUpsertWorkflowSearchAttributesRequest(
 	}
 	var searchAttributes map[string][]byte
 	if enableContextHeaderInVisibility {
-		contextValueJsonString, err := json.Marshal("contextValue")
+		contextValueJSONString, err := json.Marshal("contextValue")
 		if err != nil {
-			panic(err) // must not happen in tests
+			t.Fatal(err)
 		}
 		searchAttributes = map[string][]byte{
-			"Header.contextKey": contextValueJsonString,
+			"Header.contextKey": contextValueJSONString,
 		}
 	}
 

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -497,7 +497,7 @@ func (t *transferStandbyTaskExecutor) processRecordWorkflowStartedOrUpsertHelper
 		if attributes := startEvent.GetWorkflowExecutionStartedEventAttributes(); attributes != nil && attributes.Header != nil {
 			// fail open to avoid blocking the task processing
 			if newSearchAttr, err := appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields, t.config.ValidSearchAttributes()); err != nil {
-				t.logger.Error("unable to parse search attributes", tag.Error(err))
+				t.logger.Error("failed to add headers to search attributes", tag.Error(err))
 			} else {
 				searchAttr = newSearchAttr
 			}

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -495,7 +495,12 @@ func (t *transferStandbyTaskExecutor) processRecordWorkflowStartedOrUpsertHelper
 	searchAttr := copySearchAttributes(executionInfo.SearchAttributes)
 	if t.config.EnableContextHeaderInVisibility(domainEntry.GetInfo().Name) {
 		if attributes := startEvent.GetWorkflowExecutionStartedEventAttributes(); attributes != nil && attributes.Header != nil {
-			searchAttr = appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields, t.config.ValidSearchAttributes())
+			// fail open to avoid blocking the task processing
+			if newSearchAttr, err := appendContextHeaderToSearchAttributes(searchAttr, attributes.Header.Fields, t.config.ValidSearchAttributes()); err != nil {
+				t.logger.Error("unable to parse search attributes", tag.Error(err))
+			} else {
+				searchAttr = newSearchAttr
+			}
 		}
 	}
 

--- a/service/history/task/transfer_standby_task_executor_test.go
+++ b/service/history/task/transfer_standby_task_executor_test.go
@@ -801,6 +801,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTask(
 		"RecordWorkflowExecutionStarted",
 		mock.Anything,
 		createRecordWorkflowExecutionStartedRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			false),
 	).Return(nil).Once()
@@ -855,6 +856,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskW
 		"RecordWorkflowExecutionStarted",
 		mock.Anything,
 		createRecordWorkflowExecutionStartedRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			true),
 	).Return(nil).Once()
@@ -890,6 +892,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 		"UpsertWorkflowExecution",
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			false),
 	).Return(nil).Once()
@@ -934,6 +937,7 @@ func (s *transferStandbyTaskExecutorSuite) TestProcessUpsertWorkflowSearchAttrib
 		"UpsertWorkflowExecution",
 		mock.Anything,
 		createUpsertWorkflowSearchAttributesRequest(
+			s.T(),
 			s.domainName, startEvent, transferTask, mutableState, 2, s.mockShard.GetTimeSource().Now(),
 			true),
 	).Return(nil).Once()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

json marshal raw string bytes before store in search attributes

<!-- Tell your future self why have you made these changes -->
**Why?**

Context Header stores the raw string bytes; but search attributes should store json strings rather than raw string bytes. Otherwise, it will cause unmarshal error in creating visibility message. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
