### PR TITLE
Add duplicate columns with different index to improve Pinot partial match performance

### DIFF
--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -62,6 +62,9 @@ const (
 	IsDeleted            = "IsDeleted"   // used for Pinot deletion/rolling upsert only, not visible to user
 	EventTimeMs          = "EventTimeMs" // used for Pinot deletion/rolling upsert only, not visible to user
 	Memo                 = "Memo"
+	WfIDTextSearch       = "WorkflowIDTextSearch"   // used for text search which can improve the partial match performance on WorkflowID/RunID/WorkflowType text search columns
+	WfTypeTextSearch     = "WorkflowTypeTextSearch" // used for text search which can improve the partial match performance on WorkflowID/RunID/WorkflowType text search columns
+	RunIDTextSearch      = "RunIDTextSearch"        // used for text search which can improve the partial match performance on WorkflowID/RunID/WorkflowType text search columns
 
 	// used to be micro second
 	oneMicroSecondInNano = int64(time.Microsecond / time.Nanosecond)
@@ -615,7 +618,10 @@ func createVisibilityMessage(
 	m[UpdateTime] = updateTimeUnixMilli
 	m[ShardID] = shardID
 	m[IsDeleted] = isDeleted
-	m[EventTimeMs] = updateTimeUnixMilli // same as update time when record is upserted, could not use updateTime directly since this will be modified by Pinot
+	m[EventTimeMs] = updateTimeUnixMilli   // same as update time when record is upserted, could not use updateTime directly since this will be modified by Pinot
+	m[WfIDTextSearch] = wid                // used for text search which can improve the partial match performance
+	m[RunIDTextSearch] = rid               // used for text search which can improve the partial match performance
+	m[WfTypeTextSearch] = workflowTypeName // used for text search which can improve the partial match performance
 
 	SearchAttributes := make(map[string]interface{})
 	var err error


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add duplicate workflowID/runID/workflowType columns which will be applied text index to improve Pinot prefix partial match performance.

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently we applied inverted index for these 3 columns, the partial is kind of slow there. We want to apply text index but the columns can only have one index at a time. So we added 3 duplicate columns and apply text index (in monorepo) to improve the performance.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
