### PR TITLE
bugfix: bad dynamicconfig filter/string mapping

### DIFF
--- a/common/dynamicconfig/config_test.go
+++ b/common/dynamicconfig/config_test.go
@@ -346,6 +346,17 @@ func TestDynamicConfigFilterTypeIsParseable(t *testing.T) {
 	}
 }
 
+func TestDynamicConfigFilterStringsCorrectly(t *testing.T) {
+	for _, filterString := range filters {
+		// filter-string-parsing and the resulting filter's String() must match
+		parsed := ParseFilter(filterString)
+		assert.Equal(t, filterString, parsed.String(), "filters need to String() correctly as some impls rely on it")
+	}
+	// should not be possible normally, but improper casting could trigger it
+	badFilter := Filter(len(filters))
+	assert.Equal(t, UnknownFilter.String(), badFilter.String(), "filters with indexes outside the list of known strings should String() to the unknown filter type")
+}
+
 func BenchmarkLogValue(b *testing.B) {
 	keys := []Key{
 		HistorySizeLimitError,

--- a/common/dynamicconfig/filter.go
+++ b/common/dynamicconfig/filter.go
@@ -31,10 +31,10 @@ import (
 type Filter int
 
 func (f Filter) String() string {
-	if f <= UnknownFilter || f > WorkflowID {
-		return filters[UnknownFilter]
+	if f >= 0 && int(f) < len(filters) {
+		return filters[f]
 	}
-	return filters[f]
+	return filters[0] // unknown
 }
 
 func ParseFilter(filterName string) Filter {

--- a/common/dynamicconfig/filter.go
+++ b/common/dynamicconfig/filter.go
@@ -31,10 +31,10 @@ import (
 type Filter int
 
 func (f Filter) String() string {
-	if f >= 0 && int(f) < len(filters) {
+	if f > UnknownFilter && int(f) < len(filters) {
 		return filters[f]
 	}
-	return filters[0] // unknown
+	return filters[UnknownFilter]
 }
 
 func ParseFilter(filterName string) Filter {


### PR DESCRIPTION
This logic desperately needs to be refactored, it's incredibly error-prone :\\
We should probably just use enumer's codegen tbh.  Or something similar.

Previously `String()` missed both `workflowType` and `ratelimitKey`.
The `String()` impl is now rewritten so it won't be missed with future additions, and there's a test to check it too.