### PR TITLE
Attempt at adding hostport info to logs

### DIFF
--- a/client/history/client.go
+++ b/client/history/client.go
@@ -158,6 +158,7 @@ func (c *clientImpl) DescribeHistoryHost(
 		peer, err = c.peerResolver.FromHostAddress(request.GetHostAddress())
 	}
 	if err != nil {
+		c.logger.Error("peer could not be resolved for host.", tag.Error(err), tag.Address(request.GetHostAddress()))
 		return nil, err
 	}
 

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -158,7 +158,7 @@ func (c *clientImpl) DescribeHistoryHost(
 		peer, err = c.peerResolver.FromHostAddress(request.GetHostAddress())
 	}
 	if err != nil {
-		c.logger.Error("peer could not be resolved for host.", tag.Error(err), tag.Address(request.GetHostAddress()))
+		c.logger.Error("peer could not be resolved for host.", tag.Error(err), tag.ShardID(int(request.GetShardIDForHost())), tag.WorkflowID(request.ExecutionForHost.GetWorkflowID()), tag.Address(request.GetHostAddress()))
 		return nil, err
 	}
 

--- a/client/history/client.go
+++ b/client/history/client.go
@@ -152,16 +152,26 @@ func (c *clientImpl) DescribeHistoryHost(
 
 	if request.ShardIDForHost != nil {
 		peer, err = c.peerResolver.FromShardID(int(request.GetShardIDForHost()))
+		if err != nil {
+			c.logger.Error("peer could not be resolved for host.", tag.Error(err), tag.ShardID(int(request.GetShardIDForHost())))
+			return nil, err
+		}
+
 	} else if request.ExecutionForHost != nil {
 		peer, err = c.peerResolver.FromWorkflowID(request.ExecutionForHost.GetWorkflowID())
+		if err != nil {
+			c.logger.Error("peer could not be resolved for workflow.", tag.Error(err), tag.WorkflowID(request.ExecutionForHost.GetWorkflowID()))
+			return nil, err
+		}
+
 	} else {
 		peer, err = c.peerResolver.FromHostAddress(request.GetHostAddress())
-	}
-	if err != nil {
-		c.logger.Error("peer could not be resolved for host.", tag.Error(err), tag.ShardID(int(request.GetShardIDForHost())), tag.WorkflowID(request.ExecutionForHost.GetWorkflowID()), tag.Address(request.GetHostAddress()))
-		return nil, err
-	}
+		if err != nil {
+			c.logger.Error("peer could not be resolved for address.", tag.Error(err), tag.Address(request.GetHostAddress()))
+			return nil, err
+		}
 
+	}
 	var response *types.DescribeHistoryHostResponse
 	op := func(ctx context.Context, peer string) error {
 		var err error


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Our internal ring-use / task-processing doesn't report the intended destination, so zone-specific issues can be hard to identify / hard to narrow to more specific causes. This is an attempt to make the logs more meaning ful. an attempt was already made but it's not the most optimal because of:
- results in a (tiny) performance degradation
- results in logs being totally spammed - you cannot aggregate this instead.

Trying to put a log at this location as we have a retrier that has access to that peer here is it's used nearly for all of the similar requests.
<!-- Tell your future self why have you made these changes -->
**Why?**
As a part of the incident resolution.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
