### PR TITLE
Include a zero bucket, zeros are being reported as 1

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -3327,6 +3327,7 @@ var PersistenceLatencyBuckets = tally.DurationBuckets([]time.Duration{
 // GlobalRatelimiterUsageHistogram contains buckets for tracking how many ratelimiters are
 // in which state (startup, healthy, failing).
 var GlobalRatelimiterUsageHistogram = tally.ValueBuckets{
+	0, // need an explicit 0 to record zeros
 	1, 2, 5, 10,
 	25, 50, 100,
 	250, 500, 1000,


### PR DESCRIPTION
With a min bucket of `1`, a `0` is reported as a `1`, which is quite misleading for this kind of use.

Sorta obvious in retrospect, but we have so few histograms anywhere that I apparently don't have any safe habits built up.