### PR TITLE
Fix metrics for task forwarding

### DIFF
--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -471,13 +471,12 @@ pollLoop:
 			return nil, fmt.Errorf("couldn't get task: %w", err)
 		}
 
-		e.emitForwardedFromStats(hCtx.scope, task.IsForwarded(), req.GetForwardedFrom())
-
 		if task.IsStarted() {
 			return task.PollForDecisionResponse(), nil
 			// TODO: Maybe add history expose here?
 		}
 
+		e.emitForwardedFromStats(hCtx.scope, task.IsForwarded(), req.GetForwardedFrom())
 		if task.IsQuery() {
 			task.Finish(nil) // this only means query task sync match succeed.
 
@@ -598,18 +597,17 @@ pollLoop:
 			return nil, err
 		}
 
-		e.emitForwardedFromStats(hCtx.scope, task.IsForwarded(), req.GetForwardedFrom())
-
 		if task.IsStarted() {
 			// tasks received from remote are already started. So, simply forward the response
 			return task.PollForActivityResponse(), nil
 		}
+		e.emitForwardedFromStats(hCtx.scope, task.IsForwarded(), req.GetForwardedFrom())
+		e.emitTaskIsolationMetrics(hCtx.scope, task.Event.PartitionConfig, req.GetIsolationGroup())
 		if task.ActivityTaskDispatchInfo != nil {
 			task.Finish(nil)
 			return e.createSyncMatchPollForActivityTaskResponse(task, task.ActivityTaskDispatchInfo), nil
 		}
 
-		e.emitTaskIsolationMetrics(hCtx.scope, task.Event.PartitionConfig, req.GetIsolationGroup())
 		resp, err := e.recordActivityTaskStarted(hCtx.Context, request, task)
 		if err != nil {
 			switch err.(type) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Do not emit task forwarding metrics for started tasks
- Emit task isolation metrics for local dispatch activities

<!-- Tell your future self why have you made these changes -->
**Why?**
- Task forwarding metrics for started tasks are already emitted in the forwarded tasklist
- Task isolation metrics are missing for local dispatch activities

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
