### PR TITLE
Pass dynamic map into pinot query validator

### DIFF
--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -94,7 +94,7 @@ func NewPinotVisibilityStore(
 		producer:            producer,
 		logger:              logger.WithTags(tag.ComponentPinotVisibilityManager),
 		config:              config,
-		pinotQueryValidator: pnt.NewPinotQueryValidator(config.ValidSearchAttributes()),
+		pinotQueryValidator: pnt.NewPinotQueryValidator(config.ValidSearchAttributes),
 	}
 }
 

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -25,6 +25,7 @@ package pinot
 import (
 	"errors"
 	"fmt"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"strconv"
 	"strings"
 	"time"
@@ -39,7 +40,7 @@ import (
 
 // VisibilityQueryValidator for sql query validation
 type VisibilityQueryValidator struct {
-	validSearchAttributes map[string]interface{}
+	validSearchAttributes dynamicconfig.MapPropertyFn
 }
 
 var timeSystemKeys = map[string]bool{
@@ -50,7 +51,7 @@ var timeSystemKeys = map[string]bool{
 }
 
 // NewPinotQueryValidator create VisibilityQueryValidator
-func NewPinotQueryValidator(validSearchAttributes map[string]interface{}) *VisibilityQueryValidator {
+func NewPinotQueryValidator(validSearchAttributes dynamicconfig.MapPropertyFn) *VisibilityQueryValidator {
 	return &VisibilityQueryValidator{
 		validSearchAttributes: validSearchAttributes,
 	}
@@ -226,7 +227,7 @@ func (qv *VisibilityQueryValidator) validateComparisonExpr(expr sqlparser.Expr) 
 
 // IsValidSearchAttributes return true if key is registered
 func (qv *VisibilityQueryValidator) IsValidSearchAttributes(key string) bool {
-	validAttr := qv.validSearchAttributes
+	validAttr := qv.validSearchAttributes()
 	_, isValidKey := validAttr[key]
 	return isValidKey
 }
@@ -354,7 +355,7 @@ func (qv *VisibilityQueryValidator) processCustomKey(expr sqlparser.Expr) (strin
 	colNameStr := colName.Name.String()
 
 	// check type: if is IndexedValueTypeString, change to like statement for partial match
-	valType, ok := qv.validSearchAttributes[colNameStr]
+	valType, ok := qv.validSearchAttributes()[colNameStr]
 	if !ok {
 		return "", fmt.Errorf("invalid search attribute")
 	}

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -25,7 +25,6 @@ package pinot
 import (
 	"errors"
 	"fmt"
-	"github.com/uber/cadence/common/dynamicconfig"
 	"strconv"
 	"strings"
 	"time"
@@ -34,6 +33,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/definition"
+	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/types"
 )

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -265,7 +265,7 @@ func TestValidateQuery(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			validSearchAttr := dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys())
-			qv := NewPinotQueryValidator(validSearchAttr())
+			qv := NewPinotQueryValidator(validSearchAttr)
 			validated, err := qv.ValidateQuery(test.query)
 			if err != nil {
 				assert.Equal(t, test.err, err.Error())
@@ -298,7 +298,7 @@ func TestProcessInClause_FailedInputExprCases(t *testing.T) {
 
 	// Create a new VisibilityQueryValidator
 	validSearchAttr := dynamicconfig.GetMapPropertyFn(definition.GetDefaultIndexedKeys())
-	qv := NewPinotQueryValidator(validSearchAttr())
+	qv := NewPinotQueryValidator(validSearchAttr)
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Pass dynamic map into pinot query validator

<!-- Tell your future self why have you made these changes -->
**Why?**
If we pass in a static map, the value will be fixed when query validator is initialized. Thus, when we white list new attributes, we will have to restart service in order to refresh the map. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
