### PR TITLE
Bug fix: custom query in Count doesn't return correct result

### DIFF
--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -537,7 +537,11 @@ func (v *pinotVisibilityStore) ScanWorkflowExecutions(ctx context.Context, reque
 }
 
 func (v *pinotVisibilityStore) CountWorkflowExecutions(ctx context.Context, request *p.CountWorkflowExecutionsRequest) (*p.CountWorkflowExecutionsResponse, error) {
-	query := v.getCountWorkflowExecutionsQuery(v.pinotClient.GetTableName(), request)
+	query, err := v.getCountWorkflowExecutionsQuery(v.pinotClient.GetTableName(), request)
+	if err != nil {
+		v.logger.Error(fmt.Sprintf("failed to build count workflow executions query %v", err))
+		return nil, err
+	}
 
 	resp, err := v.pinotClient.CountByQuery(query)
 	if err != nil {
@@ -822,9 +826,9 @@ func (f *PinotQueryFilter) addTimeRange(obj string, earliest interface{}, latest
 	f.string += fmt.Sprintf("%s BETWEEN %v AND %v\n", obj, earliest, latest)
 }
 
-func (v *pinotVisibilityStore) getCountWorkflowExecutionsQuery(tableName string, request *p.CountWorkflowExecutionsRequest) string {
+func (v *pinotVisibilityStore) getCountWorkflowExecutionsQuery(tableName string, request *p.CountWorkflowExecutionsRequest) (string, error) {
 	if request == nil {
-		return ""
+		return "", nil
 	}
 
 	query := NewPinotCountQuery(tableName)
@@ -837,7 +841,7 @@ func (v *pinotVisibilityStore) getCountWorkflowExecutionsQuery(tableName string,
 
 	// if customized query is empty, directly return
 	if requestQuery == "" {
-		return query.String()
+		return query.String(), nil
 	}
 
 	requestQuery = filterPrefix(requestQuery)
@@ -845,7 +849,7 @@ func (v *pinotVisibilityStore) getCountWorkflowExecutionsQuery(tableName string,
 	comparExpr, _ := parseOrderBy(requestQuery)
 	comparExpr, err := v.pinotQueryValidator.ValidateQuery(comparExpr)
 	if err != nil {
-		v.logger.Error(fmt.Sprintf("pinot query validator error: %s", err))
+		return "", fmt.Errorf("pinot query validator error: %w, query: %s", err, request.Query)
 	}
 
 	comparExpr = filterPrefix(comparExpr)
@@ -853,7 +857,7 @@ func (v *pinotVisibilityStore) getCountWorkflowExecutionsQuery(tableName string,
 		query.filters.addQuery(comparExpr)
 	}
 
-	return query.String()
+	return query.String(), nil
 }
 
 func (v *pinotVisibilityStore) getListWorkflowExecutionsByQueryQuery(tableName string, request *p.ListWorkflowExecutionsByQueryRequest) (string, error) {

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1192,6 +1192,15 @@ AND WorkflowID = 'wfid'
 			expectedRes:   expectEmptyQueryResult,
 			expectedError: nil,
 		},
+		"Case3: custom attr is missing case": {
+			request: &p.CountWorkflowExecutionsRequest{
+				DomainUUID: testDomainID,
+				Domain:     testDomain,
+				Query:      "CustomKeywordField = missing",
+			},
+			expectedRes:   "",
+			expectedError: fmt.Errorf("pinot query validator error: invalid comparison expression, right, query: CustomKeywordField = missing"),
+		},
 	}
 
 	for name, test := range tests {
@@ -1205,8 +1214,11 @@ AND WorkflowID = 'wfid'
 			}, mockProducer, log.NewNoop())
 			visibilityStore := mgr.(*pinotVisibilityStore)
 
-			res := visibilityStore.getCountWorkflowExecutionsQuery(testTableName, test.request)
+			res, err := visibilityStore.getCountWorkflowExecutionsQuery(testTableName, test.request)
 			assert.Equal(t, test.expectedRes, res)
+			if test.expectedError != nil {
+				assert.Equal(t, test.expectedError.Error(), err.Error())
+			}
 		})
 	}
 }

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1104,6 +1104,14 @@ func TestCountWorkflowExecutions(t *testing.T) {
 			},
 			expectedError: nil,
 		},
+		"Case3: query error case": {
+			request:      &p.CountWorkflowExecutionsRequest{Domain: testDomain, DomainUUID: testDomainID, Query: "CustomKeywordField = missing"},
+			expectedResp: nil,
+			pinotClientMockAffordance: func(mockPinotClient *pnt.MockGenericClient) {
+				mockPinotClient.EXPECT().GetTableName().Return(testTableName).Times(1)
+			},
+			expectedError: fmt.Errorf("pinot query validator error: invalid comparison expression, right, query: CustomKeywordField = missing"),
+		},
 	}
 
 	for name, test := range tests {

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -90,6 +90,10 @@ func TestValidateQuery(t *testing.T) {
 			query:     "CloseTime != missing",
 			validated: "CloseTime != -1",
 		},
+		"Case8-3: query with custom attr": {
+			query: "CustomKeywordField = missing",
+			err:   "invalid comparison expression, right",
+		},
 		"Case9: invalid where expression": {
 			query: "InvalidWhereExpr",
 			err:   "invalid where clause",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
CountQuery used to return an empty string when there are errors in the query and then log the error. Changed it to return error instead of log. 
Also updated tests in PinotQueryValidator and pinot_visibility_store

<!-- Tell your future self why have you made these changes -->
**Why?**
When a custom query has something like "CustomKeywordField = missing", the list APIs will return errors because "xxx = missing" is only supported for system keys. (Same for ES) In the current situation, the custom query in count return an empty string and thus Cadence will have a wrong result. This needs to be changed. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
