### PR TITLE
[frontend] Always log CheckEventBlobSizeLimit violations

### DIFF
--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -783,7 +783,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeat(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RecordActivityTaskHeartbeat"),
 	); err != nil {
 		// heartbeat details exceed size limit, we would fail the activity immediately with explicit error reason
@@ -879,7 +879,7 @@ func (wh *WorkflowHandler) RecordActivityTaskHeartbeatByID(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RecordActivityTaskHeartbeatByID"),
 	); err != nil {
 		// heartbeat details exceed size limit, we would fail the activity immediately with explicit error reason
@@ -976,7 +976,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompleted(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCompleted"),
 	); err != nil {
 		// result exceeds blob size limit, we would record it as failure
@@ -1081,7 +1081,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCompletedByID(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCompletedByID"),
 	); err != nil {
 		// result exceeds blob size limit, we would record it as failure
@@ -1177,7 +1177,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailed(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskFailed"),
 	); err != nil {
 		// details exceeds blob size limit, we would truncate the details and put a specific error reason
@@ -1271,7 +1271,7 @@ func (wh *WorkflowHandler) RespondActivityTaskFailedByID(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskFailedByID"),
 	); err != nil {
 		// details exceeds blob size limit, we would truncate the details and put a specific error reason
@@ -1358,7 +1358,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceled(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCanceled"),
 	); err != nil {
 		// details exceeds blob size limit, we would record it as failure
@@ -1463,7 +1463,7 @@ func (wh *WorkflowHandler) RespondActivityTaskCanceledByID(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondActivityTaskCanceledByID"),
 	); err != nil {
 		// details exceeds blob size limit, we would record it as failure
@@ -1650,7 +1650,7 @@ func (wh *WorkflowHandler) RespondDecisionTaskFailed(
 		taskToken.WorkflowID,
 		taskToken.RunID,
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondDecisionTaskFailed"),
 	); err != nil {
 		// details exceed, we would just truncate the size for decision task failed as the details is not used anywhere by client code
@@ -1715,7 +1715,7 @@ func (wh *WorkflowHandler) RespondQueryTaskCompleted(
 		"",
 		"",
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("RespondQueryTaskCompleted"),
 	); err != nil {
 		completeRequest = &types.RespondQueryTaskCompletedRequest{
@@ -1956,7 +1956,7 @@ func (wh *WorkflowHandler) validateStartWorkflowExecutionRequest(ctx context.Con
 		startRequest.GetWorkflowID(),
 		"",
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("StartWorkflowExecution"),
 	); err != nil {
 		return err
@@ -2306,7 +2306,7 @@ func (wh *WorkflowHandler) SignalWorkflowExecution(
 		signalRequest.GetWorkflowExecution().GetWorkflowID(),
 		signalRequest.GetWorkflowExecution().GetRunID(),
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("SignalWorkflowExecution"),
 	); err != nil {
 		return err
@@ -2539,7 +2539,7 @@ func (wh *WorkflowHandler) validateSignalWithStartWorkflowExecutionRequest(ctx c
 		signalWithStartRequest.GetWorkflowID(),
 		"",
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("SignalWithStartWorkflowExecution"),
 	); err != nil {
 		return err
@@ -2553,7 +2553,7 @@ func (wh *WorkflowHandler) validateSignalWithStartWorkflowExecutionRequest(ctx c
 		signalWithStartRequest.GetWorkflowID(),
 		"",
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("SignalWithStartWorkflowExecution"),
 	); err != nil {
 		return err
@@ -3449,7 +3449,7 @@ func (wh *WorkflowHandler) QueryWorkflow(
 		queryRequest.GetExecution().GetWorkflowID(),
 		queryRequest.GetExecution().GetRunID(),
 		scope,
-		wh.GetThrottledLogger(),
+		wh.GetLogger(),
 		tag.BlobSizeViolationOperation("QueryWorkflow")); err != nil {
 		return nil, err
 	}

--- a/service/history/decision/handler.go
+++ b/service/history/decision/handler.go
@@ -435,7 +435,7 @@ Update_History_Loop:
 				msBuilder,
 				executionStats,
 				handler.metricsClient.Scope(metrics.HistoryRespondDecisionTaskCompletedScope, metrics.DomainTag(domainName)),
-				handler.throttledLogger,
+				handler.logger,
 			)
 
 			decisionTaskHandler := newDecisionTaskHandler(


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Always log details on CheckEventBlobSizeLimit violations and failWorkflowIfBlobSizeExceedsLimit.

<!-- Tell your future self why have you made these changes -->
**Why?**
It is the only source that can point domain owners to specific workflow failures. Metrics do not have a workflow-id dimension, so we rely on logs to find exact workflows.
These operations lead to failure of either a workflow or request (in case of query) or data truncation - in case of activity failure result. Having too many of these violations is unexpected, and it should be easy to point customers to specific workflows.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If there are customers that have a lot of workflows with failures, we can bloat logs.
However, even in Uber's case, these violations are rare - since they are failing workflows.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
