### PR TITLE
UNVERIFIED: fix nil panic due to nil msBuilder

### DIFF
--- a/service/history/execution/history_builder.go
+++ b/service/history/execution/history_builder.go
@@ -47,9 +47,10 @@ func NewHistoryBuilder(msBuilder MutableState) *HistoryBuilder {
 }
 
 // NewHistoryBuilderFromEvents creates a new history builder based on the given workflow history events
-func NewHistoryBuilderFromEvents(history []*types.HistoryEvent) *HistoryBuilder {
+func NewHistoryBuilderFromEvents(history []*types.HistoryEvent, msBuilder MutableState) *HistoryBuilder {
 	return &HistoryBuilder{
-		history: history,
+		history:   history,
+		msBuilder: msBuilder,
 	}
 }
 
@@ -345,7 +346,7 @@ func (b *HistoryBuilder) AddWorkflowExecutionTerminatedEvent(
 	details []byte,
 	identity string,
 ) *types.HistoryEvent {
-	event := b.msBuilder.CreateNewHistoryEvent(types.EventTypeWorkflowExecutionTerminated)
+	event := b.msBuilder.CreateNewHistoryEvent(types.EventTypeWorkflowExecutionTerminated) // b or msBuilder is nil here
 	event.WorkflowExecutionTerminatedEventAttributes = &types.WorkflowExecutionTerminatedEventAttributes{
 		Reason:   reason,
 		Details:  details,

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -1177,7 +1177,7 @@ func (e *mutableStateBuilder) AddWorkflowExecutionTerminatedEvent(
 		return nil, err
 	}
 
-	event := e.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity)
+	event := e.hBuilder.AddWorkflowExecutionTerminatedEvent(reason, details, identity) // hBuilder or hBuilder.msBuilder is nil here
 	if err := e.ReplicateWorkflowExecutionTerminatedEvent(firstEventID, event); err != nil {
 		return nil, err
 	}

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -513,7 +513,7 @@ func (b *stateBuilderImpl) ApplyEvents(
 	b.mutableState.GetExecutionInfo().SetLastFirstEventID(firstEvent.ID)
 	b.mutableState.GetExecutionInfo().SetNextEventID(lastEvent.ID + 1)
 
-	b.mutableState.SetHistoryBuilder(NewHistoryBuilderFromEvents(history))
+	b.mutableState.SetHistoryBuilder(NewHistoryBuilderFromEvents(history, b.mutableState)) // creates a builder without msBuilder, panics later.  TODO: unsure about what msb to use, but this is the closest
 
 	return newRunMutableStateBuilder, nil
 }

--- a/service/history/execution/state_builder_test.go
+++ b/service/history/execution/state_builder_test.go
@@ -114,7 +114,7 @@ func (s *stateBuilderSuite) mockUpdateVersion(events ...*types.HistoryEvent) {
 	for _, event := range events {
 		s.mockMutableState.EXPECT().UpdateCurrentVersion(event.Version, true).Times(1)
 	}
-	s.mockMutableState.EXPECT().SetHistoryBuilder(NewHistoryBuilderFromEvents(events)).Times(1)
+	s.mockMutableState.EXPECT().SetHistoryBuilder(NewHistoryBuilderFromEvents(events, s.mockMutableState)).Times(1)
 }
 
 func (s *stateBuilderSuite) toHistory(events ...*types.HistoryEvent) []*types.HistoryEvent {


### PR DESCRIPTION
`admin kafka rereplicate` is hitting nil panics on some workflows, and this appears to be the source: a nil mutablestate builder.

I've added it here and am running tests and it may be the fix, but I am NOT yet sure:
- why it was not added in the past
- why we did not notice until recently
- why this cyclic builder reference exists in the first place
- if this is the correct builder to use (I merely chose it because it was the closest one)

---

An example of the panic:
```
github.com/uber/cadence/common/log/loggerimpl.(*loggerImpl).Error
	external/com_github_uber_cadence/common/log/loggerimpl/logger.go:150
github.com/uber/cadence/common/log.CapturePanic
	external/com_github_uber_cadence/common/log/panic.go:46
github.com/uber/cadence/service/history/handler.(*handlerImpl).ReplicateEventsV2.func1
	external/com_github_uber_cadence/service/history/handler/handler.go:1439
runtime.gopanic
	GOROOT/src/runtime/panic.go:770
github.com/uber/cadence/service/history/ndc.(*historyReplicatorImpl).applyEvents.func1
	external/com_github_uber_cadence/service/history/ndc/history_replicator.go:218
runtime.gopanic
	GOROOT/src/runtime/panic.go:770
github.com/uber/cadence/service/history/ndc.(*transactionManagerForNewWorkflowImpl).executeTransaction.func1
	external/com_github_uber_cadence/service/history/ndc/new_workflow_transaction_manager.go:330
runtime.gopanic
	GOROOT/src/runtime/panic.go:770
runtime.panicmem
	GOROOT/src/runtime/panic.go:261
runtime.sigpanic
	GOROOT/src/runtime/signal_unix.go:881
github.com/uber/cadence/service/history/execution.(*HistoryBuilder).AddWorkflowExecutionTerminatedEvent
	external/com_github_uber_cadence/service/history/execution/history_builder.go:345
github.com/uber/cadence/service/history/execution.(*mutableStateBuilder).AddWorkflowExecutionTerminatedEvent
	external/com_github_uber_cadence/service/history/execution/mutable_state_builder.go:3313
github.com/uber/cadence/service/history/execution.(*workflowImpl).terminateWorkflow
	external/com_github_uber_cadence/service/history/execution/workflow.go:266
github.com/uber/cadence/service/history/execution.(*workflowImpl).SuppressBy
	external/com_github_uber_cadence/service/history/execution/workflow.go:192
github.com/uber/cadence/service/history/ndc.(*transactionManagerForNewWorkflowImpl).createAsZombie
	external/com_github_uber_cadence/service/history/ndc/new_workflow_transaction_manager.go:219
github.com/uber/cadence/service/history/ndc.(*transactionManagerForNewWorkflowImpl).executeTransaction
	external/com_github_uber_cadence/service/history/ndc/new_workflow_transaction_manager.go:346
github.com/uber/cadence/service/history/ndc.(*transactionManagerForNewWorkflowImpl).dispatchForNewWorkflow
	external/com_github_uber_cadence/service/history/ndc/new_workflow_transaction_manager.go:114
github.com/uber/cadence/service/history/ndc.(*transactionManagerImpl).createWorkflow
	external/com_github_uber_cadence/service/history/ndc/transaction_manager.go:200
github.com/uber/cadence/service/history/ndc.(*historyReplicatorImpl).applyStartEvents
	external/com_github_uber_cadence/service/history/ndc/history_replicator.go:304
github.com/uber/cadence/service/history/ndc.(*historyReplicatorImpl).applyEvents
	external/com_github_uber_cadence/service/history/ndc/history_replicator.go:226
github.com/uber/cadence/service/history/ndc.(*historyReplicatorImpl).ApplyEvents
	external/com_github_uber_cadence/service/history/ndc/history_replicator.go:197
github.com/uber/cadence/service/history/engine/engineimpl.(*historyEngineImpl).ReplicateEventsV2
	external/com_github_uber_cadence/service/history/engine/engineimpl/historyEngine.go:2838
github.com/uber/cadence/service/history/handler.(*handlerImpl).ReplicateEventsV2
	external/com_github_uber_cadence/service/history/handler/handler.go:1466
github.com/uber/cadence/service/history/wrappers/ratelimited.(*historyHandler).ReplicateEventsV2
	external/com_github_uber_cadence/service/history/wrappers/ratelimited/handler_generated.go:203
github.com/uber/cadence/service/history/wrappers/grpc.GRPCHandler.ReplicateEventsV2
	external/com_github_uber_cadence/service/history/wrappers/grpc/grpc_handler_generated.go:171
github.com/uber/cadence/.gen/proto/history/v1.(*_HistoryAPIYARPCHandler).ReplicateEventsV2
	external/com_github_uber_cadence/.gen/proto/history/v1/service.pb.yarpc.go:1595
go.uber.org/yarpc/encoding/protobuf.(*unaryHandler).Handle
	external/org_uber_go_yarpc/encoding/protobuf/inbound.go:56
... many yarpc middlewares later ...
google.golang.org/grpc.(*Server).processStreamingRPC
	external/org_golang_google_grpc/server.go:1550
google.golang.org/grpc.(*Server).handleStream
	external/org_golang_google_grpc/server.go:1636
google.golang.org/grpc.(*Server).serveStreams.func1.2
```
This appears to be a nil mutable state builder at service/history/execution/history_builder.go:345, which looks like it can only come from `HistoryBuilder` instances created by `NewHistoryBuilderFromEvents` because it doesn't set that field.

I have not yet figured out why that function doesn't set that field though.