### PR TITLE
Handle not equal in custom keyword field

### DIFF
--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -411,6 +411,7 @@ func processEqual(colNameStr string, colValStr string) string {
 }
 
 func processCustomKeyword(operator string, colNameStr string, colValStr string) string {
+	// edge case
 	if operator == "!=" {
 		return fmt.Sprintf("JSON_MATCH(Attr, '\"$.%s\"%s''%s''') and JSON_MATCH(Attr, '\"$.%s[*]\"%s''%s''')",
 			colNameStr, operator, colValStr, colNameStr, operator, colValStr)

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -411,6 +411,11 @@ func processEqual(colNameStr string, colValStr string) string {
 }
 
 func processCustomKeyword(operator string, colNameStr string, colValStr string) string {
+	if operator == "!=" {
+		return fmt.Sprintf("JSON_MATCH(Attr, '\"$.%s\"%s''%s''') and JSON_MATCH(Attr, '\"$.%s[*]\"%s''%s''')",
+			colNameStr, operator, colValStr, colNameStr, operator, colValStr)
+	}
+
 	return fmt.Sprintf("(JSON_MATCH(Attr, '\"$.%s\"%s''%s''') or JSON_MATCH(Attr, '\"$.%s[*]\"%s''%s'''))",
 		colNameStr, operator, colValStr, colNameStr, operator, colValStr)
 }

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -94,6 +94,10 @@ func TestValidateQuery(t *testing.T) {
 			query: "CustomKeywordField = missing",
 			err:   "invalid comparison expression, right",
 		},
+		"Case8-4: query with custom keyword field not equal": {
+			query:     "CustomKeywordField != 0",
+			validated: "JSON_MATCH(Attr, '\"$.CustomKeywordField\"!=''0''') and JSON_MATCH(Attr, '\"$.CustomKeywordField[*]\"!=''0''')",
+		},
 		"Case9: invalid where expression": {
 			query: "InvalidWhereExpr",
 			err:   "invalid where clause",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
When operation is "!=" for a custom keyword type, use "and" clause instead of "or" clause to connect the queries. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Context: the reason why we used 2 queries and connect those with "or" is that a custom keyword field can be either a value or an array (a list). 

Thus when it comes with a "!=" operation, it was not returning correct result, because the query results included unnecessary parts. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test
manual test in Pinot

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
