### PR TITLE
Benchmark concurrent Cassandra LWTs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -52,6 +52,7 @@ ignore:
   - "common/domain/errors.go"
   - "common/log/**"
   - "common/metrics/**"
+  - "common/persistence/nosql/nosqlplugin/cassandra/admin.go"
   - "common/persistence/nosql/nosqlplugin/dynamodb/**"
   - "common/persistence/nosql/nosqlplugin/mongodb/**"
   - "common/types/shared.go" # 8k lines of getters. Not worth testing manually but consider switching to generated code.

--- a/common/persistence/nosql/nosqlplugin/cassandra/admin.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/admin.go
@@ -41,8 +41,8 @@ const (
 
 var _ nosqlplugin.AdminDB = (*cdb)(nil)
 
-func (db *cdb) SetupTestDatabase(schemaBaseDir string) error {
-	err := db.createCassandraKeyspace(db.session, db.cfg.Keyspace, 1, true)
+func (db *cdb) SetupTestDatabase(schemaBaseDir string, replicas int) error {
+	err := db.createCassandraKeyspace(db.session, db.cfg.Keyspace, replicas, true)
 	if err != nil {
 		return err
 	}

--- a/common/persistence/nosql/nosqlplugin/dynamodb/admin.go
+++ b/common/persistence/nosql/nosqlplugin/dynamodb/admin.go
@@ -25,7 +25,7 @@ import "github.com/uber/cadence/common/persistence/nosql/nosqlplugin"
 
 var _ nosqlplugin.AdminDB = (*ddb)(nil)
 
-func (db *ddb) SetupTestDatabase(schemaBaseDir string) error {
+func (db *ddb) SetupTestDatabase(schemaBaseDir string, replicas int) error {
 	panic("TODO")
 }
 

--- a/common/persistence/nosql/nosqlplugin/interfaces.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces.go
@@ -40,7 +40,7 @@ type (
 
 	// AdminDB is for tooling and testing
 	AdminDB interface {
-		SetupTestDatabase(schemaBaseDir string) error
+		SetupTestDatabase(schemaBaseDir string, replicas int) error
 		TeardownTestDatabase() error
 	}
 

--- a/common/persistence/nosql/nosqlplugin/interfaces_mock.go
+++ b/common/persistence/nosql/nosqlplugin/interfaces_mock.go
@@ -115,17 +115,17 @@ func (m *MockAdminDB) EXPECT() *MockAdminDBMockRecorder {
 }
 
 // SetupTestDatabase mocks base method.
-func (m *MockAdminDB) SetupTestDatabase(schemaBaseDir string) error {
+func (m *MockAdminDB) SetupTestDatabase(schemaBaseDir string, replicas int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SetupTestDatabase", schemaBaseDir)
+	ret := m.ctrl.Call(m, "SetupTestDatabase", schemaBaseDir, replicas)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SetupTestDatabase indicates an expected call of SetupTestDatabase.
-func (mr *MockAdminDBMockRecorder) SetupTestDatabase(schemaBaseDir interface{}) *gomock.Call {
+func (mr *MockAdminDBMockRecorder) SetupTestDatabase(schemaBaseDir, replicas interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupTestDatabase", reflect.TypeOf((*MockAdminDB)(nil).SetupTestDatabase), schemaBaseDir)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetupTestDatabase", reflect.TypeOf((*MockAdminDB)(nil).SetupTestDatabase), schemaBaseDir, replicas)
 }
 
 // TeardownTestDatabase mocks base method.

--- a/common/persistence/nosql/nosqlplugin/mongodb/admin.go
+++ b/common/persistence/nosql/nosqlplugin/mongodb/admin.go
@@ -36,7 +36,7 @@ const (
 	testSchemaDir = "schema/mongodb/"
 )
 
-func (db *mdb) SetupTestDatabase(schemaBaseDir string) error {
+func (db *mdb) SetupTestDatabase(schemaBaseDir string, replicas int) error {
 	if schemaBaseDir == "" {
 		var err error
 		schemaBaseDir, err = nosqlplugin.GetDefaultTestSchemaDir(testSchemaDir)

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -70,6 +70,8 @@ type (
 		SchemaDir       string           `yaml:"-"`
 		ClusterMetadata cluster.Metadata `yaml:"-"`
 		ProtoVersion    int              `yaml:"-"`
+		Replicas        int              `yaml:"-"`
+		MaxConns        int              `yaml:"-"`
 	}
 
 	// TestBase wraps the base setup needed to create workflows over persistence layer.
@@ -138,6 +140,8 @@ func NewTestBaseWithNoSQL(t *testing.T, options *TestBaseOptions) *TestBase {
 		Host:         options.DBHost,
 		Port:         options.DBPort,
 		ProtoVersion: options.ProtoVersion,
+		Replicas:     options.Replicas,
+		MaxConns:     options.MaxConns,
 	})
 	metadata := options.ClusterMetadata
 	if metadata.GetCurrentClusterName() == "" {

--- a/docker/buildkite/docker-compose-cassandra-lwt.yml
+++ b/docker/buildkite/docker-compose-cassandra-lwt.yml
@@ -1,0 +1,58 @@
+version: "3.5"
+
+services:
+  cassandra:
+    image: cassandra:4.1.1
+    ports:
+      - "9042:9042"
+    networks:
+      services-network:
+        aliases:
+          - cassandra
+    environment:
+      - "MAX_HEAP_SIZE=256M"
+      - "HEAP_NEWSIZE=128M"
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
+
+  test-cass-lwt:
+    build:
+      context: ../../
+      dockerfile: ./docker/buildkite/Dockerfile
+    command:
+      - /bin/sh
+      - -e
+      - -c
+      - >
+        go test -timeout 60s
+        -run ^TestCassandraLWT$
+        -count 1
+        -v
+        github.com/uber/cadence/host
+        | tee test.log
+    ports:
+      - "7933:7933"
+      - "7934:7934"
+      - "7935:7935"
+      - "7939:7939"
+    environment:
+      - "CASSANDRA_HOST=cassandra"
+      - "CASSANDRA=1"
+      - "CASSANDRA_SEEDS=cassandra"
+    depends_on:
+      cassandra:
+        condition: service_healthy
+    volumes:
+      - ../../:/cadence
+    networks:
+      services-network:
+        aliases:
+          - integration-test
+
+networks:
+  services-network:
+    name: services-network
+    driver: bridge

--- a/docker/buildkite/docker-compose-cassandra-lwt.yml
+++ b/docker/buildkite/docker-compose-cassandra-lwt.yml
@@ -31,6 +31,7 @@ services:
         -run ^TestCassandraLWT$
         -count 1
         -v
+        -tags cassandralwt
         github.com/uber/cadence/host
         | tee test.log
     ports:

--- a/docker/buildkite/docker-compose-cassandra-lwt.yml
+++ b/docker/buildkite/docker-compose-cassandra-lwt.yml
@@ -1,22 +1,47 @@
 version: "3.5"
 
 services:
-  cassandra:
+  cass1:
+    container_name: cass1
+    hostname: cass1
     image: cassandra:4.1.1
     ports:
       - "9042:9042"
-    networks:
-      services-network:
-        aliases:
-          - cassandra
-    environment:
-      - "MAX_HEAP_SIZE=256M"
-      - "HEAP_NEWSIZE=128M"
+    environment: &environment    # Declare and save environments variables into "environment"
+      MAX_HEAP_SIZE: 256M
+      HEAP_NEWSIZE: 128M
+      CASSANDRA_SEEDS: "cass1,cass2"    # The first two nodes will be seeds
+      CASSANDRA_CLUSTER_NAME: SolarSystem
+      CASSANDRA_DC: Mars
+      CASSANDRA_RACK: West
+      CASSANDRA_ENDPOINT_SNITCH: GossipingPropertyFileSnitch
+      CASSANDRA_NUM_TOKENS: 128
     healthcheck:
       test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
       interval: 15s
       timeout: 30s
       retries: 10
+    networks:
+      services-network:
+        aliases:
+          - integration-test
+
+  cass2:
+    container_name: cass2
+    hostname: cass2
+    image: cassandra:4.1.1
+    ports:
+      - "9043:9042"
+    environment: *environment # point to "environment" to use the same environment variables as cass1
+    healthcheck:
+      test: ["CMD", "cqlsh", "-u cassandra", "-p cassandra" ,"-e describe keyspaces"]
+      interval: 15s
+      timeout: 30s
+      retries: 10
+    networks:
+      services-network:
+        aliases:
+          - integration-test
 
   test-cass-lwt:
     build:
@@ -27,7 +52,7 @@ services:
       - -e
       - -c
       - >
-        go test -timeout 60s
+        go test -timeout 180s
         -run ^TestCassandraLWT$
         -count 1
         -v
@@ -40,11 +65,13 @@ services:
       - "7935:7935"
       - "7939:7939"
     environment:
-      - "CASSANDRA_HOST=cassandra"
+      # - "CASSANDRA_HOST=cass1"
       - "CASSANDRA=1"
-      - "CASSANDRA_SEEDS=cassandra"
+      - "CASSANDRA_SEEDS=cass1,cass2"
     depends_on:
-      cassandra:
+      cass1:
+        condition: service_healthy
+      cass2:
         condition: service_healthy
     volumes:
       - ../../:/cadence

--- a/host/cassandra_lwt_test.go
+++ b/host/cassandra_lwt_test.go
@@ -1,0 +1,329 @@
+// Copyright (c) 2018 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+//go:build !race && cassandralwt
+// +build !race,cassandralwt
+
+/*
+To run locally:
+
+1. Stop the previous run if any
+
+	docker-compose -f docker/buildkite/docker-compose-cassandra-lwt.yml down
+
+2. Build the integration-test-async-wf image
+
+	docker-compose -f docker/buildkite/docker-compose-cassandra-lwt.yml build test-cass-lwt
+
+3. Run the test in the docker container
+
+	docker-compose -f docker/buildkite/docker-compose-cassandra-lwt.yml run --rm test-cass-lwt
+
+4. Full test run logs can be found at test.log file
+*/
+
+/*
+Local run results with different concurrency levels:
+	Total updates: 1000, concurrency: 1, success: 1000, failed: 0, avg duration: 7.41ms, max duration: 26.9ms, min duration: 4.8ms, elapsed: 7.42s
+	Total updates: 1000, concurrency: 10, success: 1000, failed: 0, avg duration: 54.54ms, max duration: 808.2ms, min duration: 2.8ms, elapsed: 5.16s
+	Total updates: 1000, concurrency: 20, success: 999, failed: 1, avg duration: 90.61ms, max duration: 1.075s, min duration: 2.8ms, elapsed: 4.63s
+	Total updates: 1000, concurrency: 40, success: 993, failed: 7, avg duration: 145.95ms, max duration: 1.071s, min duration: 2.2ms, elapsed: 3.78s
+	Total updates: 1000, concurrency: 80, success: 976, failed: 24, avg duration: 254.02ms, max duration: 1.093s, min duration: 1.4ms, elapsed: 3.36s
+*/
+
+package host
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pborman/uuid"
+	"go.uber.org/multierr"
+
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/checksum"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/persistence/nosql/nosqlplugin/cassandra/gocql/public"
+	persistencetests "github.com/uber/cadence/common/persistence/persistence-tests"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/testflags"
+)
+
+const (
+	updateRequestsChannelSize = 1000
+	concurrency               = 100
+	totalUpdates              = 1000
+)
+
+type updateStats struct {
+	updateNum int
+	duration  time.Duration
+	err       error
+}
+
+type aggStats struct {
+	successCnt    int
+	failCnt       int
+	totalDuration time.Duration
+	maxDuration   time.Duration
+	minDuration   time.Duration
+	errs          error
+}
+
+func TestCassandraLWT(t *testing.T) {
+	flag.Parse()
+	testflags.RequireCassandra(t)
+	t.Logf("Running Cassandra LWT tests, concurrency: %d", concurrency)
+
+	testBase := public.NewTestBaseWithPublicCassandra(t, &persistencetests.TestBaseOptions{})
+	testBase.Setup()
+	defer testBase.TearDownWorkflowStore()
+
+	// Create workflows
+	workflows := make([]*persistence.WorkflowMutableState, 0, concurrency)
+	for i := 0; i < concurrency; i++ {
+		wfID := fmt.Sprintf("workflow-%v", i)
+		info, err := createWorkflow(testBase, wfID)
+		if err != nil {
+			t.Fatalf("createWorkflow failed: %v", err)
+		}
+
+		workflows = append(workflows, info)
+	}
+
+	t.Logf("Created %d workflows", concurrency)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	var wg sync.WaitGroup
+	updateRequestsCh := make(chan int, updateRequestsChannelSize)
+
+	// Start a goroutine to consume the update stats
+	var aggStats aggStats
+	statsCh := make(chan updateStats, totalUpdates)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < totalUpdates; i++ {
+			stats := <-statsCh
+			if stats.err != nil {
+				aggStats.errs = multierr.Append(aggStats.errs, fmt.Errorf("updateNum: %v, duration: %v, err: %v", stats.updateNum, stats.duration, stats.err))
+				aggStats.failCnt++
+			} else {
+				aggStats.successCnt++
+			}
+
+			aggStats.totalDuration += stats.duration
+			if aggStats.maxDuration < stats.duration {
+				aggStats.maxDuration = stats.duration
+			}
+			if aggStats.minDuration == 0 || aggStats.minDuration > stats.duration {
+				aggStats.minDuration = stats.duration
+			}
+		}
+	}()
+
+	// Start concurrent handlers to update the workflows. Each one will update its own workflow
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go updateHandler(ctx, testBase, updateRequestsCh, statsCh, &wg, i, workflows[i])
+	}
+
+	// wait a bit before starting the updates
+	time.Sleep(1 * time.Second)
+
+	now := time.Now()
+	for i := 0; i < totalUpdates; i++ {
+		updateRequestsCh <- i
+	}
+
+	// close the channel to signal the handlers to exit
+	close(updateRequestsCh)
+
+	// wait for the updates to complete
+	wg.Wait()
+
+	elapsed := time.Since(now)
+	t.Logf("Total updates: %v, concurrency: %d, success: %v, failed: %v, avg duration: %v, max duration: %v, min duration: %v, elapsed: %v",
+		totalUpdates,
+		concurrency,
+		aggStats.successCnt,
+		aggStats.failCnt,
+		aggStats.totalDuration/time.Duration(totalUpdates),
+		aggStats.maxDuration,
+		aggStats.minDuration,
+		elapsed,
+	)
+	if aggStats.errs != nil {
+		t.Fatalf("Errors: %v", aggStats.errs)
+	}
+}
+
+func updateHandler(
+	ctx context.Context,
+	s *persistencetests.TestBase,
+	incomingUpdatesCh chan int,
+	statsCh chan updateStats,
+	wg *sync.WaitGroup,
+	handlerNo int,
+	info *persistence.WorkflowMutableState,
+) {
+	defer wg.Done()
+	for {
+		select {
+		case <-ctx.Done():
+			s.T().Logf("updateHandler %v exiting because context done", handlerNo)
+			return
+		case updateNum, ok := <-incomingUpdatesCh:
+			if !ok {
+				s.T().Logf("updateHandler %v exiting because channel closed", handlerNo)
+				return
+			}
+			now := time.Now()
+			err := updateWorkflow(s, info)
+			elapsed := time.Since(now)
+			statsCh <- updateStats{
+				updateNum: updateNum,
+				duration:  elapsed,
+				err:       err,
+			}
+		}
+	}
+}
+
+// createWorkflow creates a new workflow and returns the workflow info to be used for updates
+// the parameters of the workflow including the workflow id do not matter for the test.
+// all workflows are handled by same shard's ExecutionManager
+func createWorkflow(s *persistencetests.TestBase, wfID string) (*persistence.WorkflowMutableState, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	domainID := uuid.New()
+	workflowExecution := types.WorkflowExecution{
+		WorkflowID: wfID,
+		RunID:      uuid.New(),
+	}
+
+	tasklist := "tasklist1"
+	workflowType := "workflowtype1"
+	workflowTimeout := int32(10)
+	decisionTimeout := int32(14)
+	lastProcessedEventID := int64(0)
+	nextEventID := int64(3)
+	csum := checksum.Checksum{
+		Flavor:  checksum.FlavorIEEECRC32OverThriftBinary,
+		Version: 22,
+		Value:   uuid.NewRandom(),
+	}
+	versionHistory := persistence.NewVersionHistory([]byte{}, []*persistence.VersionHistoryItem{
+		{
+			EventID: nextEventID,
+			Version: common.EmptyVersion,
+		},
+	})
+	versionHistories := persistence.NewVersionHistories(versionHistory)
+
+	req := &persistence.CreateWorkflowExecutionRequest{
+		NewWorkflowSnapshot: persistence.WorkflowSnapshot{
+			ExecutionInfo: &persistence.WorkflowExecutionInfo{
+				CreateRequestID:             uuid.New(),
+				DomainID:                    domainID,
+				WorkflowID:                  workflowExecution.GetWorkflowID(),
+				RunID:                       workflowExecution.GetRunID(),
+				FirstExecutionRunID:         workflowExecution.GetRunID(),
+				TaskList:                    tasklist,
+				WorkflowTypeName:            workflowType,
+				WorkflowTimeout:             workflowTimeout,
+				DecisionStartToCloseTimeout: decisionTimeout,
+				LastFirstEventID:            common.FirstEventID,
+				NextEventID:                 nextEventID,
+				LastProcessedEvent:          lastProcessedEventID,
+				State:                       persistence.WorkflowStateCreated,
+				CloseStatus:                 persistence.WorkflowCloseStatusNone,
+			},
+			ExecutionStats:   &persistence.ExecutionStats{},
+			Checksum:         csum,
+			VersionHistories: versionHistories,
+		},
+		RangeID: s.ShardInfo.RangeID,
+		Mode:    persistence.CreateWorkflowModeBrandNew,
+	}
+
+	_, err := s.ExecutionManager.CreateWorkflowExecution(ctx, req)
+	if err != nil {
+		return nil, fmt.Errorf("ExecutionManager.CreateWorkflowExecution failed: %v", err)
+	}
+
+	info, err := s.GetWorkflowExecutionInfo(ctx, domainID, workflowExecution)
+	if err != nil {
+		return nil, fmt.Errorf("GetWorkflowExecutionInfo failed: %v", err)
+	}
+	if info.ExecutionInfo.State != persistence.WorkflowStateCreated {
+		return nil, fmt.Errorf("Unexpected state: %v", info.ExecutionInfo.State)
+	}
+	if info.ExecutionInfo.CloseStatus != persistence.WorkflowCloseStatusNone {
+		return nil, fmt.Errorf("Unexpected close status: %v", info.ExecutionInfo.CloseStatus)
+	}
+
+	return info, nil
+}
+
+func updateWorkflow(s *persistencetests.TestBase, info *persistence.WorkflowMutableState) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	updatedInfo := info.ExecutionInfo
+	updatedStats := info.ExecutionStats
+	updatedInfo.State = persistence.WorkflowStateRunning
+	nextEventID := int64(3)
+	csum := checksum.Checksum{
+		Flavor:  checksum.FlavorIEEECRC32OverThriftBinary,
+		Version: 22,
+		Value:   uuid.NewRandom(),
+	}
+	versionHistory := persistence.NewVersionHistory([]byte{}, []*persistence.VersionHistoryItem{
+		{
+			EventID: nextEventID,
+			Version: common.EmptyVersion,
+		},
+	})
+	versionHistories := persistence.NewVersionHistories(versionHistory)
+	_, err := s.ExecutionManager.UpdateWorkflowExecution(ctx, &persistence.UpdateWorkflowExecutionRequest{
+		UpdateWorkflowMutation: persistence.WorkflowMutation{
+			ExecutionInfo:    updatedInfo,
+			ExecutionStats:   updatedStats,
+			Condition:        nextEventID,
+			Checksum:         csum,
+			VersionHistories: versionHistories,
+		},
+		RangeID: s.ShardInfo.RangeID,
+		Mode:    persistence.UpdateWorkflowModeUpdateCurrent,
+	})
+
+	if err == nil {
+		return nil
+	}
+
+	return fmt.Errorf("ExecutionManager.UpdateWorkflowExecution failed: %v", err)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
### Cassandra LWT overview
Cadence uses Cassandra's LWT (aka Compare and Swap) queries to ensure consistent atomic updates for various scenarios. LWTs are implemented using [Paxos](https://github.com/apache/cassandra/blob/trunk/src/java/org/apache/cassandra/service/paxos/Paxos.md) based coordination between nodes. LWTs are scoped to the partition key. Running multiple concurrent LWTs for the same partition can impact each other due to the coordination/conflict resolution mechanisms inherent in the Paxos algorithm and its adaptations for LWTs.
1. Contention and Backoff:
When multiple coordinators attempt to perform writes to the same partition simultaneously, they may clash, leading to contention.
Cassandra employs randomized exponential backoff to mitigate this, meaning that conflicting LWTs will experience delays as they retry their operations with new ballot numbers.
2. Quorum Requirements:
Each LWT must reach a quorum of nodes to proceed with its stages (prepare, propose, commit). If multiple LWTs are running concurrently, they may compete for the same set of nodes to form a quorum, potentially causing delays or retries.
3. Proposals and Commits:
The need to re-propose values in case of in-progress Paxos sessions can delay LWTs. If an LWT detects an uncommitted value, it must complete or supersede it before proceeding, adding latency.
4. Consistency and Order:
Cassandra ensures that once a value is decided (accepted by a quorum), no earlier proposal can be reproposed. Concurrent LWTs must navigate this rule, meaning that operations started later might see the effects of earlier ones, ensuring linearizability but potentially causing additional rounds of coordination.

This PR benchmarks the impact of concurrency by generating 1k `UpdateWorkflow` LWT queries on same partition with different concurrency limits. The goal is to measure whether tuning LWT concurrency is worth it and potentially help prevent hot partition problems that we face in some environments under high load.

### Benchmark setup
- LWT queries are given 1s timeout.
- All failures are due to timeout ` Operation timed out - received only 0 responses`.
- Failed queries are not retried so Elapsed time should be read as "time to attempt 1k queries with given concurrency". 

#### Benchmark with single node Cassandra

| Total Updates | Concurrency | Success | Failed | Avg Duration (ms) | Max Duration (ms) | Min Duration (ms) | Elapsed (s) |
|---------------|-------------|---------|--------|-------------------|-------------------|-------------------|-------------|
| 1000          | 1           | 1000    | 0      | 7.41              | 26.9              | 4.8               | 7.42        |
| 1000          | 10          | 1000    | 0      | 54.54             | 808.2             | 2.8               | 5.16        |
| 1000          | 20          | 999     | 1      | 90.61             | 1075              | 2.8               | 4.63        |
| 1000          | 40          | 993     | 7      | 145.95            | 1071              | 2.2               | 3.78        |
| 1000          | 80          | 976     | 24     | 254.02            | 1093              | 1.4               | 3.36        |


#### Benchmark with 2 nodes Cassandra and replication_factor: 2

| Total Updates | Concurrency | Success | Failed | Avg Duration (ms) | Max Duration (ms) | Min Duration (ms) | Elapsed (s) |
|---------------|-------------|---------|--------|-------------------|-------------------|-------------------|-------------|
| 1000          | 1           | 1000    | 0      | 11.75             | 50.09             | 6.69              | 11.76       |
| 1000          | 10          | 900     | 100    | 370.96            | 1120              | 7.92              | 37.31       |
| 1000          | 20          | 642     | 358    | 602.63            | 1120              | 5.95              | 30.40       |
| 1000          | 40          | 365     | 635    | 826.45            | 1130              | 7.83              | 21.12       |
| 1000          | 80          | 64      | 936    | 1000              | 1120              | 6.87              | 12.93       |


**Notes on results**
- Ratio of queries that timeout is proportional to the concurrency limit
- The impact of high concurrency is more drastic with replication factor > 1 as expected
- Increasing concurrency gives the impression of higher throughput but average query latency increases drastically.

### What is next?
`UpdateWorkflow` queries for a given partition are originated from single Cadence History service host (corresponding shard owner history engine instance). This means we can easily control the concurrency by introducing a similar implementation. A number between (1, 10) seem to promise best latency and throughput. In order to decide exact concurrency limit we can try two approaches: 
     - Benchmark this in a prod-like environment and come up with a good enough number that will handle the volume of queries with minimal contention. 
     - Introduce an adaptive concurrency limiter that dynamically increases/decreases concurrency based on ratio of timeouts.
