### PR TITLE
Revert multi-platform build and push when release new version

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -24,7 +24,6 @@ jobs:
           repository: ubercadence/server
           build_args: TARGET=server
           tag_with_ref: true
-          platforms: linux/amd64,linux/arm64
   push_server_auto_setup_to_registry:
     name: Push Docker server auto-setup images to Docker Hub
     runs-on: ubuntu-latest
@@ -39,4 +38,3 @@ jobs:
           repository: ubercadence/server
           build_args: TARGET=auto-setup
           tags: ${{ github.event.release.tag_name }}-auto-setup, latestRelease-auto-setup
-          platforms: linux/amd64,linux/arm64


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Revert multi-platform build and push when release new version, current docker drive doesn't support multi-platform build.
This can cause Github failed to push new images.

<!-- Tell your future self why have you made these changes -->
**Why?**
Docker drive doesn't support multi-platform build

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
