### PR TITLE
Update Pinot query validator to support "like" in queries 

### DIFF
--- a/common/persistence/elasticsearch/es_visibility_store_test.go
+++ b/common/persistence/elasticsearch/es_visibility_store_test.go
@@ -846,7 +846,7 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 		s.True(strings.Contains(input.Query, `{"match_phrase":{"CloseStatus":{"query":"5"}}}`))
 		s.Equal(esIndexMaxResultWindow, input.MaxResultWindow)
 		return true
-	})).Return(testSearchResult, nil).Once()
+	})).Return(testSearchResult, nil).Twice()
 
 	request := &p.ListWorkflowExecutionsByQueryRequest{
 		DomainUUID: testDomainID,
@@ -859,6 +859,16 @@ func (s *ESVisibilitySuite) TestListWorkflowExecutions() {
 	defer cancel()
 
 	_, err := s.visibilityStore.ListWorkflowExecutions(ctx, request)
+	s.NoError(err)
+
+	requestWithLike := &p.ListWorkflowExecutionsByQueryRequest{
+		DomainUUID: testDomainID,
+		Domain:     testDomain,
+		PageSize:   10,
+		Query:      `CloseStatus like '5'`,
+	}
+
+	_, err = s.visibilityStore.ListWorkflowExecutions(ctx, requestWithLike)
 	s.NoError(err)
 
 	s.mockESClient.On("SearchByQuery", mock.Anything, mock.Anything).Return(nil, errTestESSearch).Once()

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -242,6 +242,15 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 	}
 	colNameStr := colName.Name.String()
 
+	if comparisonExpr.Operator == sqlparser.LikeStr {
+		colVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal)
+		if !ok {
+			return "", fmt.Errorf("right comparison is invalid: %v", comparisonExpr.Right)
+		}
+		colValStr := string(colVal.Val)
+		return processCustomString(comparisonExpr, colNameStr, colValStr), nil
+	}
+
 	if comparisonExpr.Operator != sqlparser.EqualStr && comparisonExpr.Operator != sqlparser.NotEqualStr {
 		if _, ok := timeSystemKeys[colNameStr]; ok {
 			sqlVal, ok := comparisonExpr.Right.(*sqlparser.SQLVal)

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -248,7 +248,7 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 			return "", fmt.Errorf("right comparison is invalid: %v", comparisonExpr.Right)
 		}
 		colValStr := string(colVal.Val)
-		return fmt.Sprintf("TEXT_MATCH(%s, %s)", colNameStr, colValStr), nil
+		return fmt.Sprintf("TEXT_MATCH(%s, '%s')", colNameStr, colValStr), nil
 	}
 
 	if comparisonExpr.Operator != sqlparser.EqualStr && comparisonExpr.Operator != sqlparser.NotEqualStr {

--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -248,7 +248,7 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 			return "", fmt.Errorf("right comparison is invalid: %v", comparisonExpr.Right)
 		}
 		colValStr := string(colVal.Val)
-		return processCustomString(comparisonExpr, colNameStr, colValStr), nil
+		return fmt.Sprintf("TEXT_MATCH(%s, %s)", colNameStr, colValStr), nil
 	}
 
 	if comparisonExpr.Operator != sqlparser.EqualStr && comparisonExpr.Operator != sqlparser.NotEqualStr {

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -50,6 +50,9 @@ func TestValidateQuery(t *testing.T) {
 			query:     "WorkflowID like 'wid'",
 			validated: "(JSON_MATCH(Attr, '\"$.WorkflowID\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.WorkflowID', 'string'), 'wid*'))",
 		},
+		"Case2-3: invalid simple query with partial match": {
+			query: "WorkflowID like wid",
+			err:   "right comparison is invalid: &{<nil> wid { }}"},
 		"Case3-1: query with custom field": {
 			query:     "CustomStringField = 'custom'",
 			validated: "(JSON_MATCH(Attr, '\"$.CustomStringField\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.CustomStringField', 'string'), 'custom*'))",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -48,7 +48,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case2-2: simple query with partial match": {
 			query:     "WorkflowID like 'wid'",
-			validated: "TEXT_MATCH(WorkflowID, wid)",
+			validated: "TEXT_MATCH(WorkflowID, 'wid')",
 		},
 		"Case2-3: invalid simple query with partial match": {
 			query: "WorkflowID like wid",
@@ -87,7 +87,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case6-5: complex query with partial match": {
 			query:     "RunID like '123' or WorkflowID like '123'",
-			validated: "(TEXT_MATCH(RunID, 123) or TEXT_MATCH(WorkflowID, 123))",
+			validated: "(TEXT_MATCH(RunID, '123') or TEXT_MATCH(WorkflowID, '123'))",
 		},
 		"Case7: invalid sql query": {
 			query: "Invalid SQL",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -48,7 +48,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case2-2: simple query with partial match": {
 			query:     "WorkflowID like 'wid'",
-			validated: "(JSON_MATCH(Attr, '\"$.WorkflowID\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.WorkflowID', 'string'), 'wid*'))",
+			validated: "TEXT_MATCH(WorkflowID, wid)",
 		},
 		"Case2-3: invalid simple query with partial match": {
 			query: "WorkflowID like wid",
@@ -87,7 +87,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case6-5: complex query with partial match": {
 			query:     "RunID like '123' or WorkflowID like '123'",
-			validated: "((JSON_MATCH(Attr, '\"$.RunID\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.RunID', 'string'), '123*')) or (JSON_MATCH(Attr, '\"$.WorkflowID\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.WorkflowID', 'string'), '123*')))",
+			validated: "(TEXT_MATCH(RunID, 123) or TEXT_MATCH(WorkflowID, 123))",
 		},
 		"Case7: invalid sql query": {
 			query: "Invalid SQL",

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -42,9 +42,13 @@ func TestValidateQuery(t *testing.T) {
 			query:     "",
 			validated: "",
 		},
-		"Case2: simple query": {
+		"Case2-1: simple query": {
 			query:     "WorkflowID = 'wid'",
 			validated: "WorkflowID = 'wid'",
+		},
+		"Case2-2: simple query with partial match": {
+			query:     "WorkflowID like 'wid'",
+			validated: "(JSON_MATCH(Attr, '\"$.WorkflowID\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.WorkflowID', 'string'), 'wid*'))",
 		},
 		"Case3-1: query with custom field": {
 			query:     "CustomStringField = 'custom'",
@@ -77,6 +81,10 @@ func TestValidateQuery(t *testing.T) {
 		"Case6-4: complex query IV": {
 			query:     "WorkflowID = 'wid' and (CustomStringField = 'custom and custom2 or custom3 order by' or CustomIntField between 1 and 10)",
 			validated: "WorkflowID = 'wid' and ((JSON_MATCH(Attr, '\"$.CustomStringField\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.CustomStringField', 'string'), 'custom and custom2 or custom3 order by*')) or (JSON_MATCH(Attr, '\"$.CustomIntField\" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) >= 1 AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) <= 10))",
+		},
+		"Case6-5: complex query with partial match": {
+			query:     "RunID like '123' or WorkflowID like '123'",
+			validated: "((JSON_MATCH(Attr, '\"$.RunID\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.RunID', 'string'), '123*')) or (JSON_MATCH(Attr, '\"$.WorkflowID\" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.WorkflowID', 'string'), '123*')))",
 		},
 		"Case7: invalid sql query": {
 			query: "Invalid SQL",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update pinot query validator to allow "like" in queries to support partial match for system fields like WorkflowID, RunID or WorkflowType

The PR also verifies that ES will not error out for a query with "like". It converts it to match_phrase since wild card is not supported in elasticsql as of now [https://github.com/cch123/elasticsql/blob/master/readme.md]

<!-- Tell your future self why have you made these changes -->
**Why?**
pinot supports partial match with text_match() and this can be leveraged in ListWorkflowExecutions. Based on earlier tests, text_match() performs better than regexp_like(). This does need text index in pinot

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
