### PR TITLE
Add emitWorkflowVersionMetrics for pinot

### DIFF
--- a/service/worker/esanalyzer/analyzer_test.go
+++ b/service/worker/esanalyzer/analyzer_test.go
@@ -686,7 +686,7 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return(nil, fmt.Errorf("pinot error")).Times(1)
 			},
-			expectedErr: fmt.Errorf("pinot error"),
+			expectedErr: fmt.Errorf("failed to query Pinot to find workflow type count Info: test-domain, error: pinot error"),
 		},
 		"Case3: Aggregation is empty": {
 			domainCacheAffordance: func(mockDomainCache *cache.MockDomainCache) {

--- a/service/worker/esanalyzer/analyzer_test.go
+++ b/service/worker/esanalyzer/analyzer_test.go
@@ -416,7 +416,7 @@ func TestEmitWorkflowTypeCountMetricsESErrorCases(t *testing.T) {
 						Aggregations: map[string]json.RawMessage{},
 					}, nil).Times(1)
 			},
-			expectedErr: nil,
+			expectedErr: fmt.Errorf("aggregation failed for domain in ES: test-domain"),
 		},
 		"Case4: error unmarshalling aggregation": {
 			domainCacheAffordance: func(mockDomainCache *cache.MockDomainCache) {
@@ -501,7 +501,7 @@ func TestEmitWorkflowVersionMetricsESErrorCases(t *testing.T) {
 						Aggregations: map[string]json.RawMessage{},
 					}, nil).Times(1)
 			},
-			expectedErr: nil,
+			expectedErr: fmt.Errorf("aggregation failed for domain in ES: test-domain"),
 		},
 		"Case4: error unmarshalling aggregation": {
 			domainCacheAffordance: func(mockDomainCache *cache.MockDomainCache) {
@@ -596,7 +596,7 @@ func TestEmitWorkflowTypeCountMetricsPinot(t *testing.T) {
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{}, nil).Times(1)
 			},
-			expectedErr: nil,
+			expectedErr: fmt.Errorf("aggregation failed for domain in Pinot: test-domain"),
 		},
 		"Case4: error parsing workflow count": {
 			domainCacheAffordance: func(mockDomainCache *cache.MockDomainCache) {
@@ -696,7 +696,7 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{}, nil).Times(1)
 			},
-			expectedErr: nil,
+			expectedErr: fmt.Errorf("aggregation failed for domain in Pinot: test-domain"),
 		},
 		"Case4: error parsing workflow count": {
 			domainCacheAffordance: func(mockDomainCache *cache.MockDomainCache) {

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -213,7 +213,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 			zap.String("DomainName", domainName),
 			zap.String("VisibilityQuery", wfTypeCountPinotQuery),
 		)
-		return err
+		return fmt.Errorf("aggregation failed for domain in Pinot: %s", domainName)
 	}
 	var domainWorkflowTypeCount DomainWorkflowTypeCount
 	for _, row := range response {
@@ -267,7 +267,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsES(ctx context.Context, domainNam
 			zap.String("DomainName", domainName),
 			zap.String("VisibilityQuery", wfTypeCountEsQuery),
 		)
-		return err
+		return fmt.Errorf("aggregation failed for domain in ES: %s", domainName)
 	}
 	var domainWorkflowTypeCount DomainWorkflowTypeCount
 	err = json.Unmarshal(agg, &domainWorkflowTypeCount)

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/uber/cadence/common/pinot"
 	"time"
 
 	"go.uber.org/cadence"
@@ -146,6 +147,47 @@ func (w *Workflow) getWorkflowVersionQuery(domainName string) (string, error) {
     `, domain.GetInfo().ID), nil
 }
 
+func (w *Workflow) getWorkflowTypePinotQuery(domainName string) (string, error) {
+	domain, err := w.analyzer.domainCache.GetDomain(domainName)
+	if err != nil {
+		return "", err
+	}
+	// exclude uninitialized workflow executions by checking whether record has start time field
+	// there's a "LIMIT 10" because in ES, Aggr clause by default returns the top 10 results
+	return fmt.Sprintf(`
+SELECT WorkflowType, COUNT(*) AS count
+FROM %s
+WHERE DomainID = '%s'
+  AND CloseStatus = -1
+  AND StartTime > 0
+GROUP BY WorkflowType
+ORDER BY count DESC
+LIMIT 10
+OFFSET 0
+    `, w.analyzer.pinotTableName, domain.GetInfo().ID), nil
+}
+
+func (w *Workflow) getWorkflowVersionPinotQuery(domainName string, wfType string) (string, error) {
+	domain, err := w.analyzer.domainCache.GetDomain(domainName)
+	if err != nil {
+		return "", err
+	}
+	// exclude uninitialized workflow executions by checking whether record has start time field
+	// there's a "LIMIT 10" because in ES, Aggr clause by default returns the top 10 results
+	return fmt.Sprintf(`
+SELECT JSON_EXTRACT_SCALAR(Attr, '$.CadenceChangeVersion', 'STRING_ARRAY') AS CadenceChangeVersion, COUNT(*) AS count
+FROM %s
+WHERE DomainID = '%s'
+  AND CloseStatus = -1
+  AND StartTime > 0
+  AND WorkflowType = '%s'
+GROUP BY JSON_EXTRACT_SCALAR(Attr, '$.CadenceChangeVersion', 'STRING_ARRAY') AS CadenceChangeVersion
+ORDER BY count DESC
+LIMIT 10
+OFFSET 0
+    `, w.analyzer.pinotTableName, domain.GetInfo().ID, wfType), nil
+}
+
 // emitWorkflowVersionMetrics is an activity that emits the running WF versions of a domain
 func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 	logger := activity.GetLogger(ctx)
@@ -160,6 +202,8 @@ func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 			switch w.analyzer.readMode {
 			case ES:
 				err = w.emitWorkflowVersionMetricsES(ctx, domainName, logger)
+			case Pinot:
+				err = w.emitWorkflowVersionMetricsPinot(domainName, logger)
 			default:
 				err = w.emitWorkflowVersionMetricsES(ctx, domainName, logger)
 			}
@@ -169,6 +213,123 @@ func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *zap.Logger) error {
+	wfVersionPinotQuery, err := w.getWorkflowTypePinotQuery(domainName)
+	if err != nil {
+		logger.Error("Failed to get Pinot query to find workflow version Info",
+			zap.Error(err),
+			zap.String("DomainName", domainName),
+		)
+		return err
+	}
+	response, err := w.analyzer.pinotClient.SearchAggr(&pinot.SearchRequest{Query: wfVersionPinotQuery})
+	if err != nil {
+		logger.Error("Failed to query Pinot to find workflow type count Info",
+			zap.Error(err),
+			zap.String("VisibilityQuery", wfVersionPinotQuery),
+			zap.String("DomainName", domainName),
+		)
+		return err
+	}
+	foundAggregation := len(response) > 0
+
+	if !foundAggregation {
+		logger.Error("Pinot error: aggregation failed.",
+			zap.Error(err),
+			zap.String("Aggregation", fmt.Sprintf("%v", response)),
+			zap.String("DomainName", domainName),
+			zap.String("VisibilityQuery", wfVersionPinotQuery),
+		)
+		return err
+	}
+	var domainWorkflowVersionCount DomainWorkflowVersionCount
+	for _, row := range response {
+		workflowType := row[0].(string)
+		workflowCount, ok := row[1].(int)
+		if !ok {
+			logger.Error("Error parsing workflow count",
+				zap.Error(err),
+				zap.String("WorkflowType", workflowType),
+				zap.String("DomainName", domainName),
+			)
+			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)
+		}
+		workflowVersions, err := w.queryWorkflowVersionsWithType(domainName, workflowType, logger)
+
+		if err != nil {
+			logger.Error("Error querying workflow versions",
+				zap.Error(err),
+				zap.String("WorkflowType", workflowType),
+				zap.String("DomainName", domainName),
+			)
+			return fmt.Errorf("error querying workflow versions for workflow type: %s: error: %s", workflowType, err.Error())
+		}
+
+		domainWorkflowVersionCount.WorkflowTypes = append(domainWorkflowVersionCount.WorkflowTypes, WorkflowTypeCount{
+			EsAggregateCount: EsAggregateCount{
+				AggregateKey:   workflowType,
+				AggregateCount: int64(workflowCount),
+			},
+			WorkflowVersions: workflowVersions,
+		})
+	}
+
+	for _, workflowType := range domainWorkflowVersionCount.WorkflowTypes {
+		for _, workflowVersion := range workflowType.WorkflowVersions.WorkflowVersions {
+			w.analyzer.tallyScope.Tagged(
+				map[string]string{domainTag: domainName, workflowVersionTag: workflowVersion.AggregateKey, workflowTypeTag: workflowType.AggregateKey},
+			).Gauge(workflowVersionCountMetrics).Update(float64(workflowVersion.AggregateCount))
+		}
+	}
+	return nil
+}
+
+func (w *Workflow) queryWorkflowVersionsWithType(domainName string, wfType string, logger *zap.Logger) (WorkflowVersionCount, error) {
+	wfVersionPinotQuery, err := w.getWorkflowVersionPinotQuery(domainName, wfType)
+	if err != nil {
+		logger.Error("Failed to get Pinot query to find workflow version Info",
+			zap.Error(err),
+			zap.String("DomainName", domainName),
+		)
+		return WorkflowVersionCount{}, err
+	}
+
+	response, err := w.analyzer.pinotClient.SearchAggr(&pinot.SearchRequest{Query: wfVersionPinotQuery})
+	if err != nil {
+		logger.Error("Failed to query Pinot to find workflow type count Info",
+			zap.Error(err),
+			zap.String("VisibilityQuery", wfVersionPinotQuery),
+			zap.String("DomainName", domainName),
+		)
+		return WorkflowVersionCount{}, err
+	}
+	foundAggregation := len(response) > 0
+
+	// if no CadenceChangeVersion is found, return an empty WorkflowVersionCount, no errors
+	if !foundAggregation {
+		return WorkflowVersionCount{}, nil
+	}
+
+	var workflowVersions WorkflowVersionCount
+	for _, row := range response {
+		workflowVersion := row[0].(string)
+		workflowCount, ok := row[1].(int)
+		if !ok {
+			logger.Error("Error parsing workflow count",
+				zap.Error(err),
+				zap.String("WorkflowVersion", workflowVersion),
+				zap.String("DomainName", domainName),
+			)
+			return WorkflowVersionCount{}, fmt.Errorf("error parsing workflow count for workflow version %s", workflowVersion)
+		}
+		workflowVersions.WorkflowVersions = append(workflowVersions.WorkflowVersions, EsAggregateCount{
+			AggregateKey:   workflowVersion,
+			AggregateCount: int64(workflowCount),
+		})
+	}
+	return workflowVersions, nil
 }
 
 func (w *Workflow) emitWorkflowVersionMetricsES(ctx context.Context, domainName string, logger *zap.Logger) error {

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -219,7 +219,7 @@ func (w *Workflow) emitWorkflowVersionMetrics(ctx context.Context) error {
 func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *zap.Logger) error {
 	wfVersionPinotQuery, err := w.getWorkflowTypePinotQuery(domainName)
 	if err != nil {
-		logger.Error("Failed to get Pinot query to find workflow version Info",
+		logger.Error("Failed to get Pinot query to find workflow type Info",
 			zap.Error(err),
 			zap.String("DomainName", domainName),
 		)

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -232,7 +232,7 @@ func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *za
 			zap.String("VisibilityQuery", wfVersionPinotQuery),
 			zap.String("DomainName", domainName),
 		)
-		return err
+		return fmt.Errorf("failed to query Pinot to find workflow type count Info: %s, error: %s", domainName, err.Error())
 	}
 	foundAggregation := len(response) > 0
 

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/uber/cadence/common/pinot"
 	"time"
 
 	"go.uber.org/cadence"
@@ -32,6 +31,8 @@ import (
 	cclient "go.uber.org/cadence/client"
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
+
+	"github.com/uber/cadence/common/pinot"
 )
 
 const (

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -243,7 +243,7 @@ func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *za
 			zap.String("DomainName", domainName),
 			zap.String("VisibilityQuery", wfVersionPinotQuery),
 		)
-		return err
+		return fmt.Errorf("aggregation failed for domain in Pinot: %s", domainName)
 	}
 	var domainWorkflowVersionCount DomainWorkflowVersionCount
 	for _, row := range response {
@@ -360,7 +360,7 @@ func (w *Workflow) emitWorkflowVersionMetricsES(ctx context.Context, domainName 
 			zap.String("DomainName", domainName),
 			zap.String("VisibilityQuery", wfVersionEsQuery),
 		)
-		return err
+		return fmt.Errorf("aggregation failed for domain in ES: %s", domainName)
 	}
 	var domainWorkflowVersionCount DomainWorkflowVersionCount
 	err = json.Unmarshal(agg, &domainWorkflowVersionCount)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add emitWorkflowVersionMetrics for pinot. Because pinot doesn't support one aggr inside of anther like ES, I had to separate the query into 2. 

1. find the aggr of workflowTypes,  (the top 10 count of workflowTypes)
2. find the aggr of CadenceChangeVersion under a specific workflowType (the top 10 count of CadenceChangeVersion in a specific workflowType)

<!-- Tell your future self why have you made these changes -->
**Why?**
To make ES analyzer becomes a generic visibility analyzer

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
At worst, query time might be 10x. 
But doesn't matter too much. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
