### PR TITLE
Allow pprof to be started when using docker-compose

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -142,7 +142,11 @@ services:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT_0 }}
         {{- end }}
-
+        {{- if .Env.FRONTEND_PPROF_PORT }}
+        pprof:
+            port: {{ .Env.FRONTEND_PPROF_PORT }}
+            host: {{ default .Env.BIND_ON_IP "localhost" }}
+        {{- end }}
     matching:
         rpc:
             port: {{ default .Env.MATCHING_PORT "7935" }}
@@ -164,7 +168,11 @@ services:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT_1 }}
         {{- end }}
-
+      {{- if .Env.MATCHING_PPROF_PORT }}
+        pprof:
+            port: {{ .Env.MATCHING_PPROF_PORT }}
+            host: {{ default .Env.BIND_ON_IP "localhost" }}
+      {{- end }}
     history:
         rpc:
             port: {{ default .Env.HISTORY_PORT "7934" }}
@@ -186,7 +194,11 @@ services:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT_2 }}
         {{- end }}
-
+      {{- if .Env.HISTORY_PPROF_PORT }}
+        pprof:
+            port: {{ .Env.HISTORY_PPROF_PORT }}
+            host: {{ default .Env.BIND_ON_IP "localhost" }}
+      {{- end }}
     worker:
         rpc:
             port: {{ default .Env.WORKER_PORT "7939" }}
@@ -207,7 +219,11 @@ services:
                 timerType: {{ default .Env.PROMETHEUS_TIMER_TYPE "histogram" }}
                 listenAddress: {{ .Env.PROMETHEUS_ENDPOINT_3 }}
         {{- end }}
-
+      {{- if .Env.WORKER_PPROF_PORT }}
+        pprof:
+            port: {{ .Env.WORKER_PPROF_PORT }}
+            host: {{ default .Env.BIND_ON_IP "localhost" }}
+      {{- end }}
 clusterGroupMetadata:
     clusterRedirectionPolicy:
         policy: {{ default .Env.CLUSTER_REDIRECT_POLICY "all-domain-apis-forwarding" }}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,6 +36,7 @@ services:
      - "7935:7935"
      - "7939:7939"
      - "7833:7833"
+     - "7936:7936"
     environment:
       - "CASSANDRA_SEEDS=cassandra"
       - "PROMETHEUS_ENDPOINT_0=0.0.0.0:8000"
@@ -43,6 +44,7 @@ services:
       - "PROMETHEUS_ENDPOINT_2=0.0.0.0:8002"
       - "PROMETHEUS_ENDPOINT_3=0.0.0.0:8003"
       - "DYNAMIC_CONFIG_FILE_PATH=config/dynamicconfig/development.yaml"
+      - "FRONTEND_PPROF_PORT=7936"
       - "LOG_LEVEL=debug"
     depends_on:
       cassandra:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Extending docker template to allow pprof port to be passed

<!-- Tell your future self why have you made these changes -->
**Why?**
It makes it possible to check profiles when using `docker-compose up`

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Local docker image build with command `docker build . -t ubercadence/cadence-server:pprof  --build-arg TARGET=auto-setup`

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
