### PR TITLE
Global ratelimiter fix: prevent low-weight hosts from becoming unusable

### DIFF
--- a/common/quotas/global/algorithm/scenarios_test.go
+++ b/common/quotas/global/algorithm/scenarios_test.go
@@ -1,0 +1,386 @@
+package algorithm
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWeightAlgorithms(t *testing.T) {
+	/*
+		No algorithm can perfectly predict the future, and some issues are discovered only after trying them out on widely-varying production usage.
+
+		So here are some samples of things we've thought of, how they behave, and maybe some comments on how we feel about them.
+		They are re-implemented here in a simplified form, because it's much easier and clearer (and more long-term implement-able) to do so.
+
+		All are bound to a single key across 3 hosts with a simple 15rps target (5 per host when balanced) (3 hosts chosen because there are many easy mistakes with 2).
+	*/
+	const rps = 15
+	max := func(a, b float64) float64 {
+		if a > b {
+			return a
+		}
+		return b
+	}
+	min := func(a, b float64) float64 {
+		if a < b {
+			return a
+		}
+		return b
+	}
+	_, _ = max, min
+
+	roundSchedule := func(low, high int) [][][3]float64 {
+		rounds := [][3]float64{
+			{float64(high), float64(high), float64(high)},
+			{float64(low), float64(low), float64(high)},
+			{float64(low), float64(high), float64(high)},
+			{float64(low), float64(low), float64(high)}, // TODO: test all this with much longer 1-sequences.  likely deserves a DSL.
+		}
+		// and repeat that cycle like 16x to let it stabilize
+		all := [][][3]float64{rounds} // 1
+		all = append(all, rounds)     // 2
+		all = append(all, all...)     // 4
+		all = append(all, all...)     // 8
+		all = append(all, all...)     // 16
+		return all
+	}
+
+	// helper to track accept and reject rates.
+	// requests must be an int-float64 (ensured above, by the round schedule)
+	track := func(accepts, rejects *float64, requests, rps float64) {
+		accepted := min(requests, math.Floor(rps))
+		*accepts += accepted
+		*rejects += requests - accepted
+	}
+
+	t.Run("v1 - simple running average", func(t *testing.T) {
+		// original algorithm, unfortunately has rather bad behavior with intermittent / low-volume usage.
+
+		update := func(prev float64, curr float64) float64 {
+			if prev == 0 {
+				return curr
+			}
+			return (prev / 2) + (curr / 2)
+		}
+		run := func(t *testing.T, low, high int) (h1Allowed, h2Allowed, h3Allowed float64, accepts, rejects [3]float64) {
+			var rps1, rps2, rps3 float64
+			for _, round := range roundSchedule(low, high) {
+				// clear each round so only the last round remains.
+				// these are nonsense on the first round, when rps start at zero (unrealistic)
+				accepts = [3]float64{0, 0, 0}
+				rejects = [3]float64{0, 0, 0}
+				for ri, r := range round {
+					h1, h2, h3 := r[0], r[1], r[2]
+					// find out how many would've been accepted and track it (this is what happens in the limiters, as they do this based on previous-round data)
+					track(&accepts[0], &rejects[0], h1, h1Allowed)
+					track(&accepts[1], &rejects[1], h2, h2Allowed)
+					track(&accepts[2], &rejects[2], h3, h3Allowed)
+					// update rps
+					rps1 = update(rps1, h1)
+					rps2 = update(rps2, h2)
+					rps3 = update(rps3, h3)
+					// figure out what to return
+					h1Allowed = rps * (rps1 / (rps1 + rps2 + rps3))
+					//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---- host's weight in cluster
+					h2Allowed = rps * (rps2 / (rps1 + rps2 + rps3))
+					h3Allowed = rps * (rps3 / (rps1 + rps2 + rps3))
+					t.Logf("round %d added [%.0f, %.0f, %.0f], "+
+						"got: [%0.3f, %0.3f, %0.3f], "+
+						"rps: [%0.3f, %0.3f, %0.3f]",
+						ri, h1, h2, h3,
+						rps1, rps2, rps3,
+						h1Allowed, h2Allowed, h3Allowed)
+				}
+			}
+			return
+		}
+		t.Run("zeros", func(t *testing.T) {
+			// zeros are the worst-case scenario here, greatly favoring the non-zero values.
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 0, 5)
+			assert.InDeltaf(t, 0.625, h1Allowed, 0.1, "intermittent host doesn't even allow one per second, well below actual usage")
+			assert.InDeltaf(t, 3.57, h2Allowed, 0.1, "alternating host allows better than average usage")
+			assert.InDeltaf(t, 10.7, h3Allowed, 0.1, "constant host allows all plus lots of room for more")
+			assert.Equal(t, [3]float64{0, 6, 20}, accepts, "bad accept outside constant")                           // these are the main problem
+			assert.Equal(t, [3]float64{5, 4, 0}, rejects, "high reject outside constant")                           // with this algorithm
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target") // a useful quality of this approach, it stays at the limit in all scenarios
+		})
+		t.Run("low non-zeros", func(t *testing.T) {
+			// even 1 instead of 0 does quite a lot better, though still not great
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 5)
+			assert.InDeltaf(t, 2.21, h1Allowed, 0.1, "intermittent host allows well below ideal")
+			assert.InDeltaf(t, 4.07, h2Allowed, 0.1, "alternating host allows most but still below ideal")
+			assert.InDeltaf(t, 8.72, h3Allowed, 0.1, "constant host allows all plus room for more")
+			assert.Equal(t, [3]float64{5, 9, 20}, accepts, "most accepted, all in constant")
+			assert.Equal(t, [3]float64{3, 3, 0}, rejects, "some rejects")
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target")
+		})
+		t.Run("balanced below", func(t *testing.T) {
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 3, 3)
+			assert.InDeltaf(t, 5, h1Allowed, 0.1, "allows exactly a third when load is evenly balanced")
+			assert.InDeltaf(t, 5, h2Allowed, 0.1, "allows exactly a third when load is evenly balanced")
+			assert.InDeltaf(t, 5, h3Allowed, 0.1, "allows exactly a third when load is evenly balanced")
+			assert.Equal(t, [3]float64{12, 12, 12}, accepts, "all accepted")
+			assert.Equal(t, [3]float64{0, 0, 0}, rejects, "no rejects")
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target")
+		})
+		t.Run("balanced above", func(t *testing.T) {
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 10, 10)
+			assert.InDeltaf(t, 5, h1Allowed, 0.1, "allows exactly a third when load is evenly balanced")
+			assert.InDeltaf(t, 5, h2Allowed, 0.1, "allows exactly a third when load is evenly balanced")
+			assert.InDeltaf(t, 5, h3Allowed, 0.1, "allows exactly a third when load is evenly balanced")
+			assert.Equal(t, [3]float64{20, 20, 20}, accepts, "balanced == accept at 5rps each")
+			assert.Equal(t, [3]float64{20, 20, 20}, rejects, "balanced == reject at 5rps each")
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target")
+		})
+		t.Run("over and under budget", func(t *testing.T) {
+			// goes between over and under budget, alternating rounds:
+			//   added [8, 8, 8], got: [4.733, 5.667, 8.000], rps: [3.859, 4.620, 6.522]
+			//   added [1, 1, 8], got: [2.867, 3.333, 8.000], rps: [3.028, 3.521, 8.451]
+			//   added [1, 8, 8], got: [1.933, 5.667, 8.000], rps: [1.859, 5.449, 7.692]
+			//   added [1, 1, 8], got: [1.467, 3.333, 8.000], rps: [1.719, 3.906, 9.375]
+			// low-usage keeps degrading despite there being more room for it to run than it does
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 8)
+			assert.InDeltaf(t, 1.7, h1Allowed, 0.1, "allows a small number when under-budget")
+			assert.InDeltaf(t, 3.9, h2Allowed, 0.1, "moderate boost above ")
+			assert.InDeltaf(t, 9.38, h3Allowed, 0.1, "would allow next request completely")
+			assert.Equal(t, [3]float64{4, 8, 29}, accepts, "mediocre accept outside constant host")
+			assert.Equal(t, [3]float64{7, 10, 3}, rejects, "high reject rates outside constant")
+			assert.InDeltaf(t, 15, h1Allowed+h2Allowed+h3Allowed, 0.1, "should be precisely at limit")
+		})
+	})
+	t.Run("v1 nonzero tweak - running average ignoring zeros", func(t *testing.T) {
+		// an idea to improve on the original: hosts never see their own degraded values, but others do.
+		// this allows others to act as if the host is idle (when it has been recently), but allows a periodic spike to go through.
+		updater := func() func(prev float64, curr float64) (actual, observed float64) {
+			var lastNonZero float64
+			return func(prev float64, curr float64) (actual, observed float64) {
+				defer func() {
+					if curr != 0 {
+						lastNonZero = curr
+					}
+				}()
+				if prev == 0 {
+					return curr, curr
+				}
+				actual = (prev / 2) + (curr / 2)
+				observed = (float64(lastNonZero) / 2) + (curr / 2)
+				// largely a hack so an abnormally low lastNonZero doesn't badly skew a weight.
+				// I don't really like this whole setup because of this.
+				if actual > observed {
+					observed = actual
+				}
+				return
+			}
+		}
+		run := func(t *testing.T, low, high int) (h1Allowed, h2Allowed, h3Allowed float64, accepts, rejects [3]float64) {
+			var rps1, rps2, rps3, obs1, obs2, obs3 float64
+			u1, u2, u3 := updater(), updater(), updater()
+			for _, round := range roundSchedule(low, high) {
+				// clear each round so only the last round remains.
+				// these are nonsense the first round, when rps are not known
+				accepts = [3]float64{0, 0, 0}
+				rejects = [3]float64{0, 0, 0}
+				for ri, r := range round {
+					h1, h2, h3 := r[0], r[1], r[2]
+					// find out how many would've been accepted and track it
+					track(&accepts[0], &rejects[0], h1, h1Allowed)
+					track(&accepts[1], &rejects[1], h2, h2Allowed)
+					track(&accepts[2], &rejects[2], h3, h3Allowed)
+					// update rps
+					rps1, obs1 = u1(rps1, h1)
+					rps2, obs2 = u2(rps2, h2)
+					rps3, obs3 = u3(rps3, h3)
+					h1Allowed = rps * (obs1 / (obs1 + rps2 + rps3))
+					//                 ^^^^----^^^^----------- each host uses their "imagined" value, not their real one.
+					h2Allowed = rps * (obs2 / (rps1 + obs2 + rps3))
+					h3Allowed = rps * (obs3 / (rps1 + rps2 + obs3))
+					t.Logf("round %d added [%.0f, %.0f, %.0f], got "+
+						"real: [%0.3f, %0.3f, %0.3f], "+
+						"observed: [%0.3f, %0.3f, %0.3f], "+
+						"rps: [%0.3f, %0.3f, %0.3f]",
+						ri, h1, h2, h3,
+						rps1, rps2, rps3,
+						obs1, obs2, obs3,
+						h1Allowed, h2Allowed, h3Allowed)
+				}
+			}
+			return
+		}
+		t.Run("zeros", func(t *testing.T) {
+			// handles zeros pretty well, the intermittent host allows most of the requests
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 0, 5)
+			assert.InDeltaf(t, 4.09, h1Allowed, 0.1, "intermittent host allows most of the requests")
+			assert.InDeltaf(t, 4.79, h2Allowed, 0.1, "alternating host allows rps near its average")
+			assert.InDeltaf(t, 10.71, h3Allowed, 0.1, "constant host allows rps well above what it receives")
+			assert.Equal(t, [3]float64{4, 8, 20}, accepts, "nearly ideal accept")
+			assert.Equal(t, [3]float64{1, 2, 0}, rejects, "low reject")
+			assert.InDeltaf(t, 19.6, h1Allowed+h2Allowed+h3Allowed, 0.1, "may allow a fair bit more requests than target RPS")
+		})
+		t.Run("low nonzeros", func(t *testing.T) {
+			// nonzeros are *nearly* the same as the original.  not awful but not good.
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 5)
+			assert.InDeltaf(t, 2.21, h1Allowed, 0.1, "same as original")
+			assert.InDeltaf(t, 4.87, h2Allowed, 0.1, "slightly above original, due to last-non-zero being higher than average more often")
+			assert.InDeltaf(t, 8.72, h3Allowed, 0.1, "same as original")
+			assert.Equal(t, [3]float64{5, 10, 20}, accepts, "one better than original")
+			assert.Equal(t, [3]float64{3, 2, 0}, rejects, "one better than original")
+			assert.InDeltaf(t, 15.79, h1Allowed+h2Allowed+h3Allowed, 0.1, "slightly above normal due to last-non-zero hack")
+		})
+		// with constant load it's always identical to the original.
+		t.Run("balanced below", func(t *testing.T) {
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 3, 3)
+			assert.InDeltaf(t, 5, h1Allowed, 0.1, "same as original")
+			assert.InDeltaf(t, 5, h2Allowed, 0.1, "same as original")
+			assert.InDeltaf(t, 5, h3Allowed, 0.1, "same as original")
+			assert.Equal(t, [3]float64{12, 12, 12}, accepts, "same as original")
+			assert.Equal(t, [3]float64{0, 0, 0}, rejects, "same as original")
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "same as original")
+		})
+		t.Run("balanced above", func(t *testing.T) {
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 10, 10)
+			assert.InDeltaf(t, 5, h1Allowed, 0.1, "same as original")
+			assert.InDeltaf(t, 5, h2Allowed, 0.1, "same as original")
+			assert.InDeltaf(t, 5, h3Allowed, 0.1, "same as original")
+			assert.Equal(t, [3]float64{20, 20, 20}, accepts, "same as original")
+			assert.Equal(t, [3]float64{20, 20, 20}, rejects, "same as original")
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "same as original")
+		})
+	})
+	t.Run("v1 limiter tweak - running average allowing portion of unused rps", func(t *testing.T) {
+		// same update math as the blind running average,
+		// but unused RPS get allocated to things below their local limit.
+		//
+		// the main goal here is to prevent pathological behavior when usage is low, infrequent, and imbalanced,
+		// as weight alone can badly degrade a lower-volume host until it rejects clearly-below-limit traffic.
+		//
+		// there are no doubt many other ways to address this, but this one is quite simple and does not change
+		// any core logic, it just lets low-RPS limiters "cheat fairly".
+		// hopefully this behaves more like what we want, but the extra complexity will need more monitoring
+		// to understand it whenever it fails to do so.
+		update := func(prev float64, curr float64) float64 {
+			if prev == 0 {
+				return curr
+			}
+			return (prev / 2) + (curr / 2)
+		}
+		run := func(t *testing.T, low, high int) (h1Allowed, h2Allowed, h3Allowed float64, accepts, rejects [3]float64) {
+			var rps1, rps2, rps3 float64
+			for _, round := range roundSchedule(low, high) {
+				// clear each round so only the last round remains.
+				// these are nonsense the first round, when rps are not known
+				accepts = [3]float64{0, 0, 0}
+				rejects = [3]float64{0, 0, 0}
+				for ri, r := range round {
+					h1, h2, h3 := r[0], r[1], r[2]
+					// find out how many would've been accepted and track it
+					track(&accepts[0], &rejects[0], h1, h1Allowed)
+					track(&accepts[1], &rejects[1], h2, h2Allowed)
+					track(&accepts[2], &rejects[2], h3, h3Allowed)
+					// update the rps
+					rps1 = update(rps1, h1)
+					rps2 = update(rps2, h2)
+					rps3 = update(rps3, h3)
+					allRps := rps1 + rps2 + rps3
+					// calculate fair weighted rps (same as original)
+					h1Fair := rps * (rps1 / allRps)
+					h2Fair := rps * (rps2 / allRps)
+					h3Fair := rps * (rps3 / allRps)
+
+					// and now: allow each host to use part of the unused rps (each host decides blindly because they're distributed)
+					//
+					// this would be done on the limiter side, comparing either:
+					// - (targetRPS - usedRPS) / numHostsInRing    (does not require change in exchanged data currently, stays near limit)
+					// - (targetRPS - usedRPS) / numHostsInvolved  (requires additional data to be returned, can approach 2x limit)
+					//
+					// it could also be done on agg side, but the limiter already needs to know rps and this does not *quite* need it in the agg.
+					// I'm not sure that moving this into the agg helps anything, and it'd need more state tracking to hold "real" and "allowed"
+					// rps values separately, so this will just stay in the limiter as part of a collection update cycle.
+					splitUnused := max(0, (rps-allRps)/3)
+					local := rps / 3.0
+					boostUnused := func(fair float64, used float64) float64 {
+						if fair < local {
+							// if allowed less than fallback local value, add unused up to local.
+							// this helps low-weight hosts recover when usage is low.
+							return min(local, fair+splitUnused)
+						} else {
+							// weighted higher than the average, trust the rps we get
+							return fair
+						}
+					}
+
+					// the only change on top of the original
+					h1Allowed = boostUnused(h1Fair, h1)
+					h2Allowed = boostUnused(h2Fair, h2)
+					h3Allowed = boostUnused(h3Fair, h3)
+					t.Logf("round %d added [%.0f, %.0f, %.0f], "+
+						"got usage: [%0.3f, %0.3f, %0.3f], "+
+						"unused: %0.3f (split %0.3f), "+
+						"fair rps: [%0.3f, %0.3f, %0.3f], "+
+						"adjusted rps: [%0.3f, %0.3f, %0.3f] ",
+						ri, h1, h2, h3,
+						rps1, rps2, rps3,
+						rps-allRps, splitUnused,
+						h1Fair, h2Fair, h3Fair,
+						h1Allowed, h2Allowed, h3Allowed)
+				}
+			}
+			return
+		}
+		t.Run("zeros", func(t *testing.T) {
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 0, 5)
+			assert.InDeltaf(t, 3.38, h1Allowed, 0.1, "intermittent host allows most of the requests")
+			assert.InDeltaf(t, 5.0, h2Allowed, 0.1, "alternating host allows all while usage is low")
+			assert.InDeltaf(t, 10.7, h3Allowed, 0.1, "constant host can grow if needed")
+			assert.Equal(t, [3]float64{3, 10, 20}, accepts, "very good accept") // this is the motivating reason for this algorithm
+			assert.Equal(t, [3]float64{2, 0, 0}, rejects, "just 2 rejects")     // along with this
+			assert.InDeltaf(t, 19.1, h1Allowed+h2Allowed+h3Allowed, 0.1, "may burst above limits until rebalanced")
+		})
+		t.Run("low nonzeros", func(t *testing.T) {
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 5)
+			assert.InDeltaf(t, 4.34, h1Allowed, 0.1, "allows most")
+			assert.InDeltaf(t, 5, h2Allowed, 0.1, "allows all")
+			assert.InDeltaf(t, 8.72, h3Allowed, 0.1, "constant host allows rps well above what it receives")
+			assert.Equal(t, [3]float64{7, 12, 20}, accepts, "almost perfect accept") // this is the motivating reason for this algorithm
+			assert.Equal(t, [3]float64{1, 0, 0}, rejects, "just one reject")         // along with this
+			assert.InDeltaf(t, 18.1, h1Allowed+h2Allowed+h3Allowed, 0.1, "may burst above limits until rebalanced")
+		})
+		t.Run("balanced below", func(t *testing.T) {
+			// low balanced usage is fine, just splits evenly.
+			// specifically: fair == actual+boost, which feels nicely balanced.
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 3, 3)
+			assert.InDeltaf(t, 5, h1Allowed, 0.1, "exactly a third when balanced")
+			assert.InDeltaf(t, 5, h2Allowed, 0.1, "exactly a third when balanced")
+			assert.InDeltaf(t, 5, h3Allowed, 0.1, "exactly a third when balanced")
+			assert.Equal(t, [3]float64{12, 12, 12}, accepts, "same as original")
+			assert.Equal(t, [3]float64{0, 0, 0}, rejects, "same as original")
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "should be precisely at limit")
+		})
+		t.Run("balanced above", func(t *testing.T) {
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 10, 10)
+			assert.InDeltaf(t, 5, h1Allowed, 0.1, "exactly a third when balanced + over limit")
+			assert.InDeltaf(t, 5, h2Allowed, 0.1, "exactly a third when balanced + over limit")
+			assert.InDeltaf(t, 5, h3Allowed, 0.1, "exactly a third when balanced + over limit")
+			assert.Equal(t, [3]float64{20, 20, 20}, accepts, "same as original")
+			assert.Equal(t, [3]float64{20, 20, 20}, rejects, "same as original")
+			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "should be precisely at limit")
+		})
+		t.Run("over and under budget", func(t *testing.T) {
+			// goes between over and under budget each round:
+			//   added [8, 8, 8], usage: [4.733, 5.667, 8.000], unused: -3.400 (split 0.000), fair rps: [3.859, 4.620, 6.522], adjusted rps: [3.859, 4.620, 6.522]
+			//   added [1, 1, 8], usage: [2.867, 3.333, 8.000], unused:  0.800 (split 0.267), fair rps: [3.028, 3.521, 8.451], adjusted rps: [3.295, 3.788, 8.451]
+			//   added [1, 8, 8], usage: [1.933, 5.667, 8.000], unused: -0.600 (split 0.000), fair rps: [1.859, 5.449, 7.692], adjusted rps: [1.859, 5.449, 7.692]
+			//   added [1, 1, 8], usage: [1.467, 3.333, 8.000], unused:  2.200 (split 0.733), fair rps: [1.719, 3.906, 9.375], adjusted rps: [2.452, 4.640, 9.375]
+			// the important part of this one is that the positive-unused values go to the lowest weights,
+			// on the assumption that the higher-weighted ones do not need it (their overage is already accounted for by their weight, note ^ 9.3 is above 8)
+			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 8)
+			assert.InDeltaf(t, 2.45, h1Allowed, 0.1, "moderately better than original")
+			assert.InDeltaf(t, 4.64, h2Allowed, 0.1, "moderately better than original")
+			assert.InDeltaf(t, 9.38, h3Allowed, 0.1, "same as original")
+			assert.Equal(t, [3]float64{5, 9, 29}, accepts, "slightly better than original")
+			assert.Equal(t, [3]float64{6, 9, 3}, rejects, "slightly better than original")
+			assert.InDeltaf(t, 16.4, h1Allowed+h2Allowed+h3Allowed, 0.1, "may burst above limits until rebalanced")
+		})
+	})
+}

--- a/common/quotas/global/algorithm/scenarios_test.go
+++ b/common/quotas/global/algorithm/scenarios_test.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package algorithm
 
 import (
@@ -387,10 +409,9 @@ func TestWeightAlgorithms(t *testing.T) {
 							// if allowed less than fallback local value, add unused up to local fallback.
 							// this helps low-weight hosts accept requests when there is unused RPS.
 							return min(local, fair+splitUnused)
-						} else {
-							// weighted higher than the average, trust the rps we get
-							return fair
 						}
+						// weighted higher than the average, trust the rps we get
+						return fair
 					}
 
 					// the only change on top of the original

--- a/common/quotas/global/algorithm/scenarios_test.go
+++ b/common/quotas/global/algorithm/scenarios_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestWeightAlgorithms(t *testing.T) {
@@ -16,7 +17,7 @@ func TestWeightAlgorithms(t *testing.T) {
 
 		All are bound to a single key across 3 hosts with a simple 15rps target (5 per host when balanced) (3 hosts chosen because there are many easy mistakes with 2).
 	*/
-	const rps = 15
+	const targetRPS = 15
 	max := func(a, b float64) float64 {
 		if a > b {
 			return a
@@ -31,108 +32,177 @@ func TestWeightAlgorithms(t *testing.T) {
 	}
 	_, _ = max, min
 
-	roundSchedule := func(low, high int) [][][3]float64 {
-		rounds := [][3]float64{
-			{float64(high), float64(high), float64(high)},
-			{float64(low), float64(low), float64(high)},
-			{float64(low), float64(high), float64(high)},
-			{float64(low), float64(low), float64(high)}, // TODO: test all this with much longer 1-sequences.  likely deserves a DSL.
+	roundSchedule := func(low, high int) [][][3]int {
+		rounds := [][3]int{
+			{high, high, high},
+			{low, low, high},
+			{low, high, high},
+			{low, low, high},
 		}
 		// and repeat that cycle like 16x to let it stabilize
-		all := [][][3]float64{rounds} // 1
-		all = append(all, rounds)     // 2
-		all = append(all, all...)     // 4
-		all = append(all, all...)     // 8
-		all = append(all, all...)     // 16
+		all := [][][3]int{rounds} // 1
+		all = append(all, rounds) // 2
+		all = append(all, all...) // 4
+		all = append(all, all...) // 8
+		all = append(all, all...) // 16
 		return all
 	}
 
 	// helper to track accept and reject rates.
 	// requests must be an int-float64 (ensured above, by the round schedule)
-	track := func(accepts, rejects *float64, requests, rps float64) {
-		accepted := min(requests, math.Floor(rps))
+	track := func(accepts, rejects *float64, requests int, rps float64) {
+		accepted := min(float64(requests), math.Floor(rps))
 		*accepts += accepted
-		*rejects += requests - accepted
+		*rejects += float64(requests) - accepted
+	}
+
+	type data struct {
+		// target for the immediate next period of time, as a sample of how target RPSes settle over time
+		targetRPS [3]float64 // rps that should be allowed by the limiter hosts at the end of the last round
+
+		// these are all "last-round aggregate" info, currently 4 call/update cycles.
+
+		callRPS       [3]float64 // rps that was sent
+		accepts       [3]float64 // actually-accepted rps per host
+		rejects       [3]float64 // actually-rejected requests per host
+		cumulativeRPS float64
+	}
+	check := func(t *testing.T, expected, actual data) {
+		t.Helper()
+		deltaslice := func(e, a [3]float64, msg string) {
+			t.Helper()
+			assert.InDeltaSlicef(t,
+				[]float64{e[0], e[1], e[2]}, // InDeltaSlicef does not handle arrays, only slices
+				[]float64{a[0], a[1], a[2]},
+				0.1, msg+", wanted [%.2f, %.2f, %.2f] but got [%.2f, %.2f, %.2f]", // copy/paste-friendly format
+				e[0], e[1], e[2],
+				a[0], a[1], a[2],
+			)
+		}
+
+		// sanity checks to catch missing fields
+		require.NotEmptyf(t, expected.targetRPS, "expected targetRPS = [%.2f, %.2f, %.2f]", actual.targetRPS[0], actual.targetRPS[1], actual.targetRPS[2])
+		require.NotEmptyf(t, expected.callRPS, "expected callRPS = [%.2f, %.2f, %.2f]", actual.callRPS[0], actual.callRPS[1], actual.callRPS[2])
+		require.NotEmptyf(t, expected.accepts, "expected accepts = [%.2f, %.2f, %.2f]", actual.accepts[0], actual.accepts[1], actual.accepts[2])
+		// rejects can be empty, that's not crazy
+		require.NotEmptyf(t, expected.cumulativeRPS, "expected cumulativeRPS = %v", actual.cumulativeRPS)
+
+		deltaslice(expected.targetRPS, actual.targetRPS, "target RPS does not match")
+		deltaslice(expected.callRPS, actual.callRPS, "call RPS does not match")
+		deltaslice(expected.accepts, actual.accepts, "wrong number of per-host accepted requests")
+		deltaslice(expected.rejects, actual.rejects, "wrong number of per-host rejected requests")
+		assert.InDeltaf(t, expected.cumulativeRPS, actual.cumulativeRPS, 0.1, "cumulative RPS does not match")
+	}
+	divide := func(ary [3]float64, by int) [3]float64 {
+		return [3]float64{
+			ary[0] / float64(by),
+			ary[1] / float64(by),
+			ary[2] / float64(by),
+		}
 	}
 
 	t.Run("v1 - simple running average", func(t *testing.T) {
 		// original algorithm, unfortunately has rather bad behavior with intermittent / low-volume usage.
 
-		update := func(prev float64, curr float64) float64 {
+		average := func(prev float64, curr int) float64 {
 			if prev == 0 {
-				return curr
+				// special case, also matches real implementation:
+				// don't grow from zero, assume traffic is steady-ish and the first data is a good starting point.
+				// otherwise a common "deploy -> data loss" scenario may mean rejecting a lot of valid traffic.
+				return float64(curr)
 			}
-			return (prev / 2) + (curr / 2)
+			return (prev / 2) + (float64(curr) / 2)
 		}
-		run := func(t *testing.T, low, high int) (h1Allowed, h2Allowed, h3Allowed float64, accepts, rejects [3]float64) {
-			var rps1, rps2, rps3 float64
-			for _, round := range roundSchedule(low, high) {
-				// clear each round so only the last round remains.
-				// these are nonsense on the first round, when rps start at zero (unrealistic)
-				accepts = [3]float64{0, 0, 0}
-				rejects = [3]float64{0, 0, 0}
+		run := func(t *testing.T, schedule [][][3]int) (results data) {
+			hostRPS := [3]float64{}
+			// results.targetRPS = [3]float64{0, 0, 0} // else they're NaN
+			for _, round := range schedule {
+				// cleared each round so only the last round remains,
+				// and divided by num-rounds at the end to get an RPS-like count.
+				//
+				// these are nonsense on the first round, when rps start at zero,
+				// which unrealistic as data is only returned when non-zero data is submitted.
+				results.accepts = [3]float64{0, 0, 0}
+				results.rejects = [3]float64{0, 0, 0}
+				results.callRPS = [3]float64{0, 0, 0}
 				for ri, r := range round {
-					h1, h2, h3 := r[0], r[1], r[2]
-					// find out how many would've been accepted and track it (this is what happens in the limiters, as they do this based on previous-round data)
-					track(&accepts[0], &rejects[0], h1, h1Allowed)
-					track(&accepts[1], &rejects[1], h2, h2Allowed)
-					track(&accepts[2], &rejects[2], h3, h3Allowed)
-					// update rps
-					rps1 = update(rps1, h1)
-					rps2 = update(rps2, h2)
-					rps3 = update(rps3, h3)
-					// figure out what to return
-					h1Allowed = rps * (rps1 / (rps1 + rps2 + rps3))
-					//                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^---- host's weight in cluster
-					h2Allowed = rps * (rps2 / (rps1 + rps2 + rps3))
-					h3Allowed = rps * (rps3 / (rps1 + rps2 + rps3))
-					t.Logf("round %d added [%.0f, %.0f, %.0f], "+
-						"got: [%0.3f, %0.3f, %0.3f], "+
+					// keep track of call RPS
+					results.callRPS[0] += float64(r[0])
+					results.callRPS[1] += float64(r[1])
+					results.callRPS[2] += float64(r[2])
+					// find out how many would've been accepted and track it (uses previous-round target-RPS because limiters always lag by an update cycle)
+					track(&results.accepts[0], &results.rejects[0], r[0], results.targetRPS[0])
+					track(&results.accepts[1], &results.rejects[1], r[1], results.targetRPS[1])
+					track(&results.accepts[2], &results.rejects[2], r[2], results.targetRPS[2])
+					// update per-host RPS (running average in aggregator)
+					hostRPS[0] = average(hostRPS[0], r[0])
+					hostRPS[1] = average(hostRPS[1], r[1])
+					hostRPS[2] = average(hostRPS[2], r[2])
+
+					// update RPS that limiters allow.
+					// this is based on weighted data only, nothing directly from the current batch of data
+					totalRPS := hostRPS[0] + hostRPS[1] + hostRPS[2]
+					//                            vvvvvvvvvvvvvvvvvvvvv---- host's weight in cluster
+					results.targetRPS[0] = targetRPS * (hostRPS[0] / totalRPS)
+					results.targetRPS[1] = targetRPS * (hostRPS[1] / totalRPS)
+					results.targetRPS[2] = targetRPS * (hostRPS[2] / totalRPS)
+
+					t.Logf("round %d: "+
+						"calls: [%d, %d, %d], "+
+						"real: [%0.3f, %0.3f, %0.3f], "+
 						"rps: [%0.3f, %0.3f, %0.3f]",
-						ri, h1, h2, h3,
-						rps1, rps2, rps3,
-						h1Allowed, h2Allowed, h3Allowed)
+						ri,
+						r[0], r[1], r[2],
+						hostRPS[0], hostRPS[1], hostRPS[2],
+						results.targetRPS[0], results.targetRPS[1], results.targetRPS[2])
 				}
+
+				// and divide to get accept/reject-RPS (much more scale-agnostic)
+				results.accepts = divide(results.accepts, len(round))
+				results.rejects = divide(results.rejects, len(round))
+				results.callRPS = divide(results.callRPS, len(round))
+				results.cumulativeRPS = results.targetRPS[0] + results.targetRPS[1] + results.targetRPS[2]
 			}
 			return
 		}
 		t.Run("zeros", func(t *testing.T) {
 			// zeros are the worst-case scenario here, greatly favoring the non-zero values.
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 0, 5)
-			assert.InDeltaf(t, 0.625, h1Allowed, 0.1, "intermittent host doesn't even allow one per second, well below actual usage")
-			assert.InDeltaf(t, 3.57, h2Allowed, 0.1, "alternating host allows better than average usage")
-			assert.InDeltaf(t, 10.7, h3Allowed, 0.1, "constant host allows all plus lots of room for more")
-			assert.Equal(t, [3]float64{0, 6, 20}, accepts, "bad accept outside constant")                           // these are the main problem
-			assert.Equal(t, [3]float64{5, 4, 0}, rejects, "high reject outside constant")                           // with this algorithm
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target") // a useful quality of this approach, it stays at the limit in all scenarios
+			check(t, data{
+				targetRPS:     [3]float64{0.63, 3.57, 10.7}, // intermittent allows far too few, constant is allowed over 2x what it uses
+				callRPS:       [3]float64{1.25, 2.50, 5.00}, // all at or below per-host limit at all times, not just in aggregate
+				accepts:       [3]float64{0.00, 1.50, 5.00}, // this is the main problems with this algorithm: bad behavior when imbalanced but low usage.
+				rejects:       [3]float64{1.25, 1.00, 0.00},
+				cumulativeRPS: targetRPS, // but this is useful and simple: it always tries to enforce the "real" target, never over or under.
+			}, run(t, roundSchedule(0, 5)))
 		})
 		t.Run("low non-zeros", func(t *testing.T) {
 			// even 1 instead of 0 does quite a lot better, though still not great
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 5)
-			assert.InDeltaf(t, 2.21, h1Allowed, 0.1, "intermittent host allows well below ideal")
-			assert.InDeltaf(t, 4.07, h2Allowed, 0.1, "alternating host allows most but still below ideal")
-			assert.InDeltaf(t, 8.72, h3Allowed, 0.1, "constant host allows all plus room for more")
-			assert.Equal(t, [3]float64{5, 9, 20}, accepts, "most accepted, all in constant")
-			assert.Equal(t, [3]float64{3, 3, 0}, rejects, "some rejects")
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target")
+			check(t, data{
+				targetRPS:     [3]float64{2.21, 4.07, 8.72},
+				callRPS:       [3]float64{2.00, 3.00, 5.00},
+				accepts:       [3]float64{1.25, 2.25, 5.00}, // constant use behaves well, others are not great
+				rejects:       [3]float64{0.75, 0.75, 0.00},
+				cumulativeRPS: targetRPS,
+			}, run(t, roundSchedule(1, 5)))
 		})
 		t.Run("balanced below", func(t *testing.T) {
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 3, 3)
-			assert.InDeltaf(t, 5, h1Allowed, 0.1, "allows exactly a third when load is evenly balanced")
-			assert.InDeltaf(t, 5, h2Allowed, 0.1, "allows exactly a third when load is evenly balanced")
-			assert.InDeltaf(t, 5, h3Allowed, 0.1, "allows exactly a third when load is evenly balanced")
-			assert.Equal(t, [3]float64{12, 12, 12}, accepts, "all accepted")
-			assert.Equal(t, [3]float64{0, 0, 0}, rejects, "no rejects")
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target")
+			// ideal scenario for this algorithm: constant and balanced
+			check(t, data{
+				targetRPS:     [3]float64{5, 5, 5}, // even usage == even weights == even allowances
+				callRPS:       [3]float64{3, 3, 3},
+				accepts:       [3]float64{3, 3, 3}, // accepts all requests perfectly.
+				rejects:       [3]float64{0, 0, 0},
+				cumulativeRPS: targetRPS,
+			}, run(t, roundSchedule(3, 3)))
 		})
 		t.Run("balanced above", func(t *testing.T) {
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 10, 10)
-			assert.InDeltaf(t, 5, h1Allowed, 0.1, "allows exactly a third when load is evenly balanced")
-			assert.InDeltaf(t, 5, h2Allowed, 0.1, "allows exactly a third when load is evenly balanced")
-			assert.InDeltaf(t, 5, h3Allowed, 0.1, "allows exactly a third when load is evenly balanced")
-			assert.Equal(t, [3]float64{20, 20, 20}, accepts, "balanced == accept at 5rps each")
-			assert.Equal(t, [3]float64{20, 20, 20}, rejects, "balanced == reject at 5rps each")
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "total allowed rps does not exceed target")
+			check(t, data{
+				targetRPS:     [3]float64{5, 5, 5},
+				callRPS:       [3]float64{10, 10, 10},
+				accepts:       [3]float64{5, 5, 5}, // accepts exactly their intended rps
+				rejects:       [3]float64{5, 5, 5}, // rejects everything else
+				cumulativeRPS: targetRPS,
+			}, run(t, roundSchedule(10, 10)))
 		})
 		t.Run("over and under budget", func(t *testing.T) {
 			// goes between over and under budget, alternating rounds:
@@ -141,111 +211,123 @@ func TestWeightAlgorithms(t *testing.T) {
 			//   added [1, 8, 8], got: [1.933, 5.667, 8.000], rps: [1.859, 5.449, 7.692]
 			//   added [1, 1, 8], got: [1.467, 3.333, 8.000], rps: [1.719, 3.906, 9.375]
 			// low-usage keeps degrading despite there being more room for it to run than it does
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 8)
-			assert.InDeltaf(t, 1.7, h1Allowed, 0.1, "allows a small number when under-budget")
-			assert.InDeltaf(t, 3.9, h2Allowed, 0.1, "moderate boost above ")
-			assert.InDeltaf(t, 9.38, h3Allowed, 0.1, "would allow next request completely")
-			assert.Equal(t, [3]float64{4, 8, 29}, accepts, "mediocre accept outside constant host")
-			assert.Equal(t, [3]float64{7, 10, 3}, rejects, "high reject rates outside constant")
-			assert.InDeltaf(t, 15, h1Allowed+h2Allowed+h3Allowed, 0.1, "should be precisely at limit")
+			check(t, data{
+				targetRPS:     [3]float64{1.72, 3.91, 9.38}, // doesn't seem too unfair at a glance
+				callRPS:       [3]float64{2.75, 4.50, 8.00},
+				accepts:       [3]float64{1.00, 2.00, 7.25}, // but high unfair-reject rate outside constant (less than half accepted)
+				rejects:       [3]float64{1.75, 2.50, 0.75},
+				cumulativeRPS: targetRPS,
+			}, run(t, roundSchedule(1, 8)))
 		})
 	})
 	t.Run("v1 nonzero tweak - running average ignoring zeros", func(t *testing.T) {
 		// an idea to improve on the original: hosts never see their own degraded values, but others do.
 		// this allows others to act as if the host is idle (when it has been recently), but allows a periodic spike to go through.
-		updater := func() func(prev float64, curr float64) (actual, observed float64) {
+		//
+		// this has not been deployed, it was just an idea that IMO did not pan out.
+		updater := func() func(prev float64, curr int) (actual, observed float64) {
 			var lastNonZero float64
-			return func(prev float64, curr float64) (actual, observed float64) {
+			return func(prev float64, curr int) (actual, observed float64) {
 				defer func() {
 					if curr != 0 {
-						lastNonZero = curr
+						lastNonZero = float64(curr)
 					}
 				}()
 				if prev == 0 {
-					return curr, curr
+					return float64(curr), float64(curr)
 				}
-				actual = (prev / 2) + (curr / 2)
-				observed = (float64(lastNonZero) / 2) + (curr / 2)
+				actual = (prev / 2) + (float64(curr) / 2)
+				observed = (lastNonZero / 2) + (float64(curr) / 2)
 				// largely a hack so an abnormally low lastNonZero doesn't badly skew a weight.
-				// I don't really like this whole setup because of this.
+				// I don't really like this whole setup because of this, it feels hard to predict.
 				if actual > observed {
 					observed = actual
 				}
 				return
 			}
 		}
-		run := func(t *testing.T, low, high int) (h1Allowed, h2Allowed, h3Allowed float64, accepts, rejects [3]float64) {
+		run := func(t *testing.T, schedule [][][3]int) (results data) {
 			var rps1, rps2, rps3, obs1, obs2, obs3 float64
 			u1, u2, u3 := updater(), updater(), updater()
-			for _, round := range roundSchedule(low, high) {
+			for _, round := range schedule {
 				// clear each round so only the last round remains.
 				// these are nonsense the first round, when rps are not known
-				accepts = [3]float64{0, 0, 0}
-				rejects = [3]float64{0, 0, 0}
+				results.accepts = [3]float64{0, 0, 0}
+				results.rejects = [3]float64{0, 0, 0}
+				results.callRPS = [3]float64{0, 0, 0}
 				for ri, r := range round {
-					h1, h2, h3 := r[0], r[1], r[2]
+					results.callRPS[0] += float64(r[0])
+					results.callRPS[1] += float64(r[1])
+					results.callRPS[2] += float64(r[2])
 					// find out how many would've been accepted and track it
-					track(&accepts[0], &rejects[0], h1, h1Allowed)
-					track(&accepts[1], &rejects[1], h2, h2Allowed)
-					track(&accepts[2], &rejects[2], h3, h3Allowed)
-					// update rps
-					rps1, obs1 = u1(rps1, h1)
-					rps2, obs2 = u2(rps2, h2)
-					rps3, obs3 = u3(rps3, h3)
-					h1Allowed = rps * (obs1 / (obs1 + rps2 + rps3))
-					//                 ^^^^----^^^^----------- each host uses their "imagined" value, not their real one.
-					h2Allowed = rps * (obs2 / (rps1 + obs2 + rps3))
-					h3Allowed = rps * (obs3 / (rps1 + rps2 + obs3))
-					t.Logf("round %d added [%.0f, %.0f, %.0f], got "+
+					track(&results.accepts[0], &results.rejects[0], r[0], results.targetRPS[0])
+					track(&results.accepts[1], &results.rejects[1], r[1], results.targetRPS[1])
+					track(&results.accepts[2], &results.rejects[2], r[2], results.targetRPS[2])
+					// update rps and "ignore-zero" observed-rps
+					rps1, obs1 = u1(rps1, r[0])
+					rps2, obs2 = u2(rps2, r[1])
+					rps3, obs3 = u3(rps3, r[2])
+					//                                 vvvv----vvvv----------- each host uses their "imagined" value, not their real one.
+					results.targetRPS[0] = targetRPS * (obs1 / (obs1 + rps2 + rps3))
+					results.targetRPS[1] = targetRPS * (obs2 / (rps1 + obs2 + rps3))
+					results.targetRPS[2] = targetRPS * (obs3 / (rps1 + rps2 + obs3))
+					t.Logf("round %d: "+
+						"calls: [%d, %d, %d], "+
 						"real: [%0.3f, %0.3f, %0.3f], "+
 						"observed: [%0.3f, %0.3f, %0.3f], "+
 						"rps: [%0.3f, %0.3f, %0.3f]",
-						ri, h1, h2, h3,
+						ri, r[0], r[1], r[2],
 						rps1, rps2, rps3,
 						obs1, obs2, obs3,
-						h1Allowed, h2Allowed, h3Allowed)
+						results.targetRPS[0], results.targetRPS[1], results.targetRPS[2])
 				}
+				results.accepts = divide(results.accepts, len(round))
+				results.rejects = divide(results.rejects, len(round))
+				results.callRPS = divide(results.callRPS, len(round))
+				results.cumulativeRPS = results.targetRPS[0] + results.targetRPS[1] + results.targetRPS[2]
 			}
 			return
 		}
 		t.Run("zeros", func(t *testing.T) {
 			// handles zeros pretty well, the intermittent host allows most of the requests
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 0, 5)
-			assert.InDeltaf(t, 4.09, h1Allowed, 0.1, "intermittent host allows most of the requests")
-			assert.InDeltaf(t, 4.79, h2Allowed, 0.1, "alternating host allows rps near its average")
-			assert.InDeltaf(t, 10.71, h3Allowed, 0.1, "constant host allows rps well above what it receives")
-			assert.Equal(t, [3]float64{4, 8, 20}, accepts, "nearly ideal accept")
-			assert.Equal(t, [3]float64{1, 2, 0}, rejects, "low reject")
-			assert.InDeltaf(t, 19.6, h1Allowed+h2Allowed+h3Allowed, 0.1, "may allow a fair bit more requests than target RPS")
+			check(t, data{
+				targetRPS:     [3]float64{4.09, 4.79, 10.7},
+				callRPS:       [3]float64{1.25, 2.50, 5.00},
+				accepts:       [3]float64{1.00, 2.00, 5.00}, // quite good accept/reject rates despite zeros
+				rejects:       [3]float64{0.25, 0.50, 0.00},
+				cumulativeRPS: targetRPS + 4.6, // may allow moderate bit over desired RPS
+			}, run(t, roundSchedule(0, 5)))
 		})
 		t.Run("low nonzeros", func(t *testing.T) {
 			// nonzeros are *nearly* the same as the original.  not awful but not good.
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 5)
-			assert.InDeltaf(t, 2.21, h1Allowed, 0.1, "same as original")
-			assert.InDeltaf(t, 4.87, h2Allowed, 0.1, "slightly above original, due to last-non-zero being higher than average more often")
-			assert.InDeltaf(t, 8.72, h3Allowed, 0.1, "same as original")
-			assert.Equal(t, [3]float64{5, 10, 20}, accepts, "one better than original")
-			assert.Equal(t, [3]float64{3, 2, 0}, rejects, "one better than original")
-			assert.InDeltaf(t, 15.79, h1Allowed+h2Allowed+h3Allowed, 0.1, "slightly above normal due to last-non-zero hack")
+			check(t, data{
+				targetRPS:     [3]float64{2.21, 4.87, 8.72},
+				callRPS:       [3]float64{2.00, 3.00, 5.00},
+				accepts:       [3]float64{1.25, 2.50, 5.00}, // almost the same as original
+				rejects:       [3]float64{0.75, 0.50, 0.00},
+				cumulativeRPS: targetRPS + 0.8, // close but still a bit above
+			}, run(t, roundSchedule(1, 5)))
 		})
 		// with constant load it's always identical to the original.
 		t.Run("balanced below", func(t *testing.T) {
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 3, 3)
-			assert.InDeltaf(t, 5, h1Allowed, 0.1, "same as original")
-			assert.InDeltaf(t, 5, h2Allowed, 0.1, "same as original")
-			assert.InDeltaf(t, 5, h3Allowed, 0.1, "same as original")
-			assert.Equal(t, [3]float64{12, 12, 12}, accepts, "same as original")
-			assert.Equal(t, [3]float64{0, 0, 0}, rejects, "same as original")
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "same as original")
+			// same behavior as original
+			check(t, data{
+				targetRPS:     [3]float64{5, 5, 5},
+				callRPS:       [3]float64{3, 3, 3},
+				accepts:       [3]float64{3, 3, 3},
+				rejects:       [3]float64{0, 0, 0},
+				cumulativeRPS: targetRPS,
+			}, run(t, roundSchedule(3, 3)))
 		})
 		t.Run("balanced above", func(t *testing.T) {
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 10, 10)
-			assert.InDeltaf(t, 5, h1Allowed, 0.1, "same as original")
-			assert.InDeltaf(t, 5, h2Allowed, 0.1, "same as original")
-			assert.InDeltaf(t, 5, h3Allowed, 0.1, "same as original")
-			assert.Equal(t, [3]float64{20, 20, 20}, accepts, "same as original")
-			assert.Equal(t, [3]float64{20, 20, 20}, rejects, "same as original")
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "same as original")
+			// same behavior as original
+			check(t, data{
+				targetRPS:     [3]float64{5, 5, 5},
+				callRPS:       [3]float64{10, 10, 10},
+				accepts:       [3]float64{5, 5, 5},
+				rejects:       [3]float64{5, 5, 5},
+				cumulativeRPS: targetRPS,
+			}, run(t, roundSchedule(10, 10)))
 		})
 	})
 	t.Run("v1 limiter tweak - running average allowing portion of unused rps", func(t *testing.T) {
@@ -259,50 +341,51 @@ func TestWeightAlgorithms(t *testing.T) {
 		// any core logic, it just lets low-RPS limiters "cheat fairly".
 		// hopefully this behaves more like what we want, but the extra complexity will need more monitoring
 		// to understand it whenever it fails to do so.
-		update := func(prev float64, curr float64) float64 {
+
+		average := func(prev float64, curr int) float64 {
+			// same as original
 			if prev == 0 {
-				return curr
+				return float64(curr)
 			}
-			return (prev / 2) + (curr / 2)
+			return (prev / 2) + (float64(curr) / 2)
 		}
-		run := func(t *testing.T, low, high int) (h1Allowed, h2Allowed, h3Allowed float64, accepts, rejects [3]float64) {
+		run := func(t *testing.T, schedule [][][3]int) (results data) {
 			var rps1, rps2, rps3 float64
-			for _, round := range roundSchedule(low, high) {
+			for _, round := range schedule {
 				// clear each round so only the last round remains.
 				// these are nonsense the first round, when rps are not known
-				accepts = [3]float64{0, 0, 0}
-				rejects = [3]float64{0, 0, 0}
+				results.accepts = [3]float64{0, 0, 0}
+				results.rejects = [3]float64{0, 0, 0}
+				results.callRPS = [3]float64{0, 0, 0}
 				for ri, r := range round {
-					h1, h2, h3 := r[0], r[1], r[2]
-					// find out how many would've been accepted and track it
-					track(&accepts[0], &rejects[0], h1, h1Allowed)
-					track(&accepts[1], &rejects[1], h2, h2Allowed)
-					track(&accepts[2], &rejects[2], h3, h3Allowed)
-					// update the rps
-					rps1 = update(rps1, h1)
-					rps2 = update(rps2, h2)
-					rps3 = update(rps3, h3)
+					// all the same as the original
+					results.callRPS[0] += float64(r[0])
+					results.callRPS[1] += float64(r[1])
+					results.callRPS[2] += float64(r[2])
+					track(&results.accepts[0], &results.rejects[0], r[0], results.targetRPS[0])
+					track(&results.accepts[1], &results.rejects[1], r[1], results.targetRPS[1])
+					track(&results.accepts[2], &results.rejects[2], r[2], results.targetRPS[2])
+					rps1 = average(rps1, r[0])
+					rps2 = average(rps2, r[1])
+					rps3 = average(rps3, r[2])
 					allRps := rps1 + rps2 + rps3
-					// calculate fair weighted rps (same as original)
-					h1Fair := rps * (rps1 / allRps)
-					h2Fair := rps * (rps2 / allRps)
-					h3Fair := rps * (rps3 / allRps)
+					fair0 := targetRPS * (rps1 / allRps)
+					fair1 := targetRPS * (rps2 / allRps)
+					fair2 := targetRPS * (rps3 / allRps)
 
 					// and now: allow each host to use part of the unused rps (each host decides blindly because they're distributed)
 					//
-					// this would be done on the limiter side, comparing either:
+					// this can be done entirely on the limiter side, comparing either:
 					// - (targetRPS - usedRPS) / numHostsInRing    (does not require change in exchanged data currently, stays near limit)
 					// - (targetRPS - usedRPS) / numHostsInvolved  (requires additional data to be returned, can approach 2x limit)
 					//
 					// it could also be done on agg side, but the limiter already needs to know rps and this does not *quite* need it in the agg.
-					// I'm not sure that moving this into the agg helps anything, and it'd need more state tracking to hold "real" and "allowed"
-					// rps values separately, so this will just stay in the limiter as part of a collection update cycle.
-					splitUnused := max(0, (rps-allRps)/3)
-					local := rps / 3.0
+					splitUnused := max(0, (targetRPS-allRps)/3)
+					local := targetRPS / 3.0
 					boostUnused := func(fair float64, used float64) float64 {
 						if fair < local {
-							// if allowed less than fallback local value, add unused up to local.
-							// this helps low-weight hosts recover when usage is low.
+							// if allowed less than fallback local value, add unused up to local fallback.
+							// this helps low-weight hosts accept requests when there is unused RPS.
 							return min(local, fair+splitUnused)
 						} else {
 							// weighted higher than the average, trust the rps we get
@@ -311,60 +394,69 @@ func TestWeightAlgorithms(t *testing.T) {
 					}
 
 					// the only change on top of the original
-					h1Allowed = boostUnused(h1Fair, h1)
-					h2Allowed = boostUnused(h2Fair, h2)
-					h3Allowed = boostUnused(h3Fair, h3)
-					t.Logf("round %d added [%.0f, %.0f, %.0f], "+
-						"got usage: [%0.3f, %0.3f, %0.3f], "+
+					results.targetRPS[0] = boostUnused(fair0, float64(r[0]))
+					results.targetRPS[1] = boostUnused(fair1, float64(r[1]))
+					results.targetRPS[2] = boostUnused(fair2, float64(r[2]))
+					t.Logf("round %d: "+
+						"calls: [%d, %d, %d], "+
+						"real: [%0.3f, %0.3f, %0.3f], "+
 						"unused: %0.3f (split %0.3f), "+
-						"fair rps: [%0.3f, %0.3f, %0.3f], "+
+						"original rps: [%0.3f, %0.3f, %0.3f], "+
 						"adjusted rps: [%0.3f, %0.3f, %0.3f] ",
-						ri, h1, h2, h3,
+						ri,
+						r[0], r[1], r[2],
 						rps1, rps2, rps3,
-						rps-allRps, splitUnused,
-						h1Fair, h2Fair, h3Fair,
-						h1Allowed, h2Allowed, h3Allowed)
+						targetRPS-allRps, splitUnused,
+						fair0, fair1, fair2, // same as original logic
+						results.targetRPS[0], results.targetRPS[1], results.targetRPS[2])
 				}
+				results.accepts = divide(results.accepts, len(round))
+				results.rejects = divide(results.rejects, len(round))
+				results.callRPS = divide(results.callRPS, len(round))
+				results.cumulativeRPS = results.targetRPS[0] + results.targetRPS[1] + results.targetRPS[2]
 			}
 			return
 		}
+
 		t.Run("zeros", func(t *testing.T) {
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 0, 5)
-			assert.InDeltaf(t, 3.38, h1Allowed, 0.1, "intermittent host allows most of the requests")
-			assert.InDeltaf(t, 5.0, h2Allowed, 0.1, "alternating host allows all while usage is low")
-			assert.InDeltaf(t, 10.7, h3Allowed, 0.1, "constant host can grow if needed")
-			assert.Equal(t, [3]float64{3, 10, 20}, accepts, "very good accept") // this is the motivating reason for this algorithm
-			assert.Equal(t, [3]float64{2, 0, 0}, rejects, "just 2 rejects")     // along with this
-			assert.InDeltaf(t, 19.1, h1Allowed+h2Allowed+h3Allowed, 0.1, "may burst above limits until rebalanced")
+			check(t, data{
+				targetRPS:     [3]float64{3.38, 5.00, 10.7},
+				callRPS:       [3]float64{1.25, 2.50, 5.00},
+				accepts:       [3]float64{0.75, 2.50, 5.00}, // very close, a main motivating reason for this approach
+				rejects:       [3]float64{0.50, 0.00, 0.00},
+				cumulativeRPS: targetRPS + 4.1, // when very low, allows moderate bit above
+			}, run(t, roundSchedule(0, 5)))
 		})
 		t.Run("low nonzeros", func(t *testing.T) {
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 5)
-			assert.InDeltaf(t, 4.34, h1Allowed, 0.1, "allows most")
-			assert.InDeltaf(t, 5, h2Allowed, 0.1, "allows all")
-			assert.InDeltaf(t, 8.72, h3Allowed, 0.1, "constant host allows rps well above what it receives")
-			assert.Equal(t, [3]float64{7, 12, 20}, accepts, "almost perfect accept") // this is the motivating reason for this algorithm
-			assert.Equal(t, [3]float64{1, 0, 0}, rejects, "just one reject")         // along with this
-			assert.InDeltaf(t, 18.1, h1Allowed+h2Allowed+h3Allowed, 0.1, "may burst above limits until rebalanced")
+
+			check(t, data{
+				targetRPS:     [3]float64{4.34, 5.00, 8.72},
+				callRPS:       [3]float64{2.00, 3.00, 5.00},
+				accepts:       [3]float64{1.75, 3.00, 5.00}, // almost perfect, a main motivating reason for this approach
+				rejects:       [3]float64{0.25, 0.00, 0.00},
+				cumulativeRPS: targetRPS + 3.1, // less overage but still moderate
+			}, run(t, roundSchedule(1, 5)))
 		})
 		t.Run("balanced below", func(t *testing.T) {
 			// low balanced usage is fine, just splits evenly.
 			// specifically: fair == actual+boost, which feels nicely balanced.
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 3, 3)
-			assert.InDeltaf(t, 5, h1Allowed, 0.1, "exactly a third when balanced")
-			assert.InDeltaf(t, 5, h2Allowed, 0.1, "exactly a third when balanced")
-			assert.InDeltaf(t, 5, h3Allowed, 0.1, "exactly a third when balanced")
-			assert.Equal(t, [3]float64{12, 12, 12}, accepts, "same as original")
-			assert.Equal(t, [3]float64{0, 0, 0}, rejects, "same as original")
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "should be precisely at limit")
+
+			check(t, data{
+				targetRPS:     [3]float64{5, 5, 5},
+				callRPS:       [3]float64{3, 3, 3},
+				accepts:       [3]float64{3, 3, 3},
+				rejects:       [3]float64{0, 0, 0},
+				cumulativeRPS: targetRPS, // balanced use == limits to target
+			}, run(t, roundSchedule(3, 3)))
 		})
 		t.Run("balanced above", func(t *testing.T) {
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 10, 10)
-			assert.InDeltaf(t, 5, h1Allowed, 0.1, "exactly a third when balanced + over limit")
-			assert.InDeltaf(t, 5, h2Allowed, 0.1, "exactly a third when balanced + over limit")
-			assert.InDeltaf(t, 5, h3Allowed, 0.1, "exactly a third when balanced + over limit")
-			assert.Equal(t, [3]float64{20, 20, 20}, accepts, "same as original")
-			assert.Equal(t, [3]float64{20, 20, 20}, rejects, "same as original")
-			assert.InDeltaf(t, rps, h1Allowed+h2Allowed+h3Allowed, 0.1, "should be precisely at limit")
+			check(t, data{
+				targetRPS:     [3]float64{5, 5, 5},
+				callRPS:       [3]float64{10, 10, 10},
+				accepts:       [3]float64{5, 5, 5}, // balanced + over = fair
+				rejects:       [3]float64{5, 5, 5},
+				cumulativeRPS: targetRPS, // over use == limits to target
+			}, run(t, roundSchedule(10, 10)))
 		})
 		t.Run("over and under budget", func(t *testing.T) {
 			// goes between over and under budget each round:
@@ -374,13 +466,13 @@ func TestWeightAlgorithms(t *testing.T) {
 			//   added [1, 1, 8], usage: [1.467, 3.333, 8.000], unused:  2.200 (split 0.733), fair rps: [1.719, 3.906, 9.375], adjusted rps: [2.452, 4.640, 9.375]
 			// the important part of this one is that the positive-unused values go to the lowest weights,
 			// on the assumption that the higher-weighted ones do not need it (their overage is already accounted for by their weight, note ^ 9.3 is above 8)
-			h1Allowed, h2Allowed, h3Allowed, accepts, rejects := run(t, 1, 8)
-			assert.InDeltaf(t, 2.45, h1Allowed, 0.1, "moderately better than original")
-			assert.InDeltaf(t, 4.64, h2Allowed, 0.1, "moderately better than original")
-			assert.InDeltaf(t, 9.38, h3Allowed, 0.1, "same as original")
-			assert.Equal(t, [3]float64{5, 9, 29}, accepts, "slightly better than original")
-			assert.Equal(t, [3]float64{6, 9, 3}, rejects, "slightly better than original")
-			assert.InDeltaf(t, 16.4, h1Allowed+h2Allowed+h3Allowed, 0.1, "may burst above limits until rebalanced")
+			check(t, data{
+				targetRPS:     [3]float64{2.45, 4.65, 9.38},
+				callRPS:       [3]float64{2.75, 4.50, 8.00},
+				accepts:       [3]float64{1.25, 2.25, 7.25}, // slightly better than orig
+				rejects:       [3]float64{1.50, 2.25, 0.75},
+				cumulativeRPS: targetRPS + 1.4, // allows moderate bit above as it's low after the calls
+			}, run(t, roundSchedule(1, 8)))
 		})
 	})
 }


### PR DESCRIPTION
From a problem suspected all along but rather conclusively shown in production:
Intermittent or mildly spiking requests are assigned a low weight, leading to rejected requests even when well below intended limits.

As a pathological example, given 1,000 RPS:
- Constant use of ~100/s going to some hosts
- A cronjob somewhere does like 10 rps every dozen or two seconds, to different hosts

This leads to the constant-receiving hosts having something like 99.5+% of the weight of the cluster,
because the cronjob host gets <1 RPS inferred by the time it tries to send more requests.
Since its allowance is so low, it rejects like 9/10ths of the requests, despite there being *tons* of room left in the quota.

We don't have a lot of these, but we do have a few, and they look quite wrong at a glance and are a bit hard to understand.
That seems worth trying to address before widespread use, even if it makes the whole system a bit more complicated.

---

Included in this PR are tests of 3 algorithms:
- The current one
- The one I want to implement
- An idea I had along the way but I do not like
  - I'm happy to delete this if we don't think it's worth the amount of code involved

I have not yet implemented it because I figured we'd talk about the results first and decide if more time should be spent
trying to find other approaches.

If we do move forward with it, I see a few possible implementations:

1. Add "target RPS" dynamicconfig to aggregators, have them return the same weight-data but adjusted to account for the "low-weight boost"
   - I've been avoiding putting this in aggregators to keep it more "pure"... but that isn't particularly important.
   - It'd be a smallish change, but "adjust weight by target, return as weight to limiter, which converts back to target" feels odd.
2. Add "used RPS" to aggregators' response data, so the limiter can do this calculation locally
   - A simple IDL change would be needed.
   - Since this is not "used" yet I'm inclined to just leave it incompatible and "break" the existing one.  Then we can verify that it
     behaves reasonably and uses the fallback logic like it should.
   - This is probably the most "normal" way to implement this.  It'll look fairly reasonable in the end.
3. Implement the pluggable / not-hardcoded API for all this, so we can have both algorithms side by side and compare / shadow / etc.
   - I think we'll want this eventually.  I doubt this is the ideal algorithm, even if I am relatively confident it's better.
   - I don't think it's worth it *quite* yet.  This is still "v0.9" territory and not worth keeping the old one if we have something
     we think is better in ~all scenarios.
   - Clearly the most amount of work of the three options, mostly due to needing to add a plugin system and plugin-lookups all over.
     I do not think it's going to be difficult or risky, just "the most work".

I'm inclined to do 2 for "don't leave the old impl, and test the failure paths" purposes, but honestly I'm up for any of them.
None feel like a bad choice since I've already found all the code-paths where things need to go, when building this out the first time,
and I've been thinking about what I'd need to do for the remaining bits since near the beginning.
