### PR TITLE
Added a defensive check in the getTaskListManager function

### DIFF
--- a/common/errors/taskListNotOwnedByHostError.go
+++ b/common/errors/taskListNotOwnedByHostError.go
@@ -1,0 +1,24 @@
+package errors
+
+import "fmt"
+
+var _ error = &TaskListNotOwnnedByHostError{}
+
+type TaskListNotOwnnedByHostError struct {
+	OwnedByIdentity string
+	MyIdentity      string
+	TasklistName    string
+}
+
+func (m *TaskListNotOwnnedByHostError) Error() string {
+	return fmt.Sprintf("task list is not owned by this host: OwnedBy: %s, Me: %s, Tasklist: %s",
+		m.OwnedByIdentity, m.MyIdentity, m.TasklistName)
+}
+
+func NewTaskListNotOwnnedByHostError(ownedByIdentity string, myIdentity string, tasklistName string) *TaskListNotOwnnedByHostError {
+	return &TaskListNotOwnnedByHostError{
+		OwnedByIdentity: ownedByIdentity,
+		MyIdentity:      myIdentity,
+		TasklistName:    tasklistName,
+	}
+}

--- a/common/errors/taskListNotOwnedByHostError.go
+++ b/common/errors/taskListNotOwnedByHostError.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package errors
 
 import "fmt"

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -32,6 +32,7 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
+	cadence_errors "github.com/uber/cadence/common/errors"
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
@@ -213,7 +214,11 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *tasklist.Identifier, t
 	}
 
 	if tasklistOwner.Identity() != self.Identity() {
-		return nil, errors.New("task list is not owned by this host")
+		return nil, cadence_errors.NewTaskListNotOwnnedByHostError(
+			tasklistOwner.Identity(),
+			self.Identity(),
+			taskList.GetName(),
+		)
 	}
 
 	// If it gets here, write lock and check again in case a task list is created between the two locks

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -198,6 +198,24 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *tasklist.Identifier, t
 	}
 	e.taskListsLock.RUnlock()
 
+	// Defensive check to make sure we actually own the task list
+	//   If we try to create a task list manager for a task list that is not owned by us, return an error
+	//   The new task list manager will steel the task list from the current owner, which should only happen if
+	//   the task list is owned by the current host.
+	tasklistOwner, err := e.membershipResolver.Lookup(service.Matching, taskList.GetName())
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup task list owner: %w", err)
+	}
+
+	self, err := e.membershipResolver.WhoAmI()
+	if err != nil {
+		return nil, fmt.Errorf("failed to lookup self im membership: %w", err)
+	}
+
+	if tasklistOwner.Identity() != self.Identity() {
+		return nil, errors.New("task list is not owned by this host")
+	}
+
 	// If it gets here, write lock and check again in case a task list is created between the two locks
 	e.taskListsLock.Lock()
 	if result, ok := e.taskLists[*taskList]; ok {

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -201,9 +201,9 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *tasklist.Identifier, t
 
 	// Defensive check to make sure we actually own the task list
 	//   If we try to create a task list manager for a task list that is not owned by us, return an error
-	//   The new task list manager will steel the task list from the current owner, which should only happen if
+	//   The new task list manager will steal the task list from the current owner, which should only happen if
 	//   the task list is owned by the current host.
-	tasklistOwner, err := e.membershipResolver.Lookup(service.Matching, taskList.GetName())
+	taskListOwner, err := e.membershipResolver.Lookup(service.Matching, taskList.GetName())
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup task list owner: %w", err)
 	}
@@ -213,9 +213,9 @@ func (e *matchingEngineImpl) getTaskListManager(taskList *tasklist.Identifier, t
 		return nil, fmt.Errorf("failed to lookup self im membership: %w", err)
 	}
 
-	if tasklistOwner.Identity() != self.Identity() {
+	if taskListOwner.Identity() != self.Identity() {
 		return nil, cadence_errors.NewTaskListNotOwnnedByHostError(
-			tasklistOwner.Identity(),
+			taskListOwner.Identity(),
 			self.Identity(),
 			taskList.GetName(),
 		)

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -32,7 +32,6 @@ import (
 	"time"
 
 	"github.com/pborman/uuid"
-	cadence_errors "github.com/uber/cadence/common/errors"
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/client/matching"
@@ -42,6 +41,7 @@ import (
 	"github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
+	cadence_errors "github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"


### PR DESCRIPTION


<!-- Describe what has changed in this PR -->
**What changed?**
Added a check whether or not we should own a shard before we steal it. 

<!-- Tell your future self why have you made these changes -->
**Why?**
This makes sure we do not steal tasklists we do not own according to the
hashring.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests, local runs, and deployment in dev environments. 
I didn't see any ill effects from the change. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This code path is quite busy, so introducing a check might have performance impacts. 

There is a risk that correct requests are rejected because the matching host has a wrong view of the hash ring. I expect this to be transient, and everything should be retried. 

We introduce a new error, I have checked the callers and they should all handle unknown errors. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**