### PR TITLE
Add adapater functions for delayStart and jitterStart in child workflow

### DIFF
--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -5212,6 +5212,8 @@ func FromStartChildWorkflowExecutionInitiatedEventAttributes(t *types.StartChild
 		Header:                              FromHeader(t.Header),
 		Memo:                                FromMemo(t.Memo),
 		SearchAttributes:                    FromSearchAttributes(t.SearchAttributes),
+		DelayStartSeconds:                   t.DelayStartSeconds,
+		JitterStartSeconds:                  t.JitterStartSeconds,
 		FirstRunAtTimestamp:                 t.FirstRunAtTimestamp,
 	}
 }
@@ -5238,6 +5240,8 @@ func ToStartChildWorkflowExecutionInitiatedEventAttributes(t *shared.StartChildW
 		Header:                              ToHeader(t.Header),
 		Memo:                                ToMemo(t.Memo),
 		SearchAttributes:                    ToSearchAttributes(t.SearchAttributes),
+		DelayStartSeconds:                   t.DelayStartSeconds,
+		JitterStartSeconds:                  t.JitterStartSeconds,
 		FirstRunAtTimestamp:                 t.FirstRunAtTimestamp,
 	}
 }

--- a/common/types/testdata/history.go
+++ b/common/types/testdata/history.go
@@ -492,6 +492,8 @@ var (
 		Header:                              &Header,
 		Memo:                                &Memo,
 		SearchAttributes:                    &SearchAttributes,
+		DelayStartSeconds:                   &Duration3,
+		JitterStartSeconds:                  &Duration4,
 		FirstRunAtTimestamp:                 &Timestamp1,
 	}
 	StartChildWorkflowExecutionFailedEventAttributes = types.StartChildWorkflowExecutionFailedEventAttributes{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
We recently uncovered missing adapter functions for delay start and jitter start in StartChildWorkflowExecutionInitiatedEventAttributes

<!-- Tell your future self why have you made these changes -->
**Why?**
Currently delaystart and jitterstart features are not working in child workflow partly due to this reason.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
