### PR TITLE
Add metrics to measure the time a task waiting in history queue

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2234,6 +2234,7 @@ const (
 	TaskBatchCompleteFailure
 	TaskProcessingLatency
 	TaskQueueLatency
+	ScheduleToStartHistoryQueueLatencyPerTaskList
 
 	TaskRequestsPerDomain
 	TaskLatencyPerDomain
@@ -2901,6 +2902,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskLimitExceededCounter: {metricName: "task_errors_limit_exceeded_counter", metricType: Counter},
 		TaskProcessingLatency:    {metricName: "task_latency_processing", metricType: Timer},
 		TaskQueueLatency:         {metricName: "task_latency_queue", metricType: Timer},
+		ScheduleToStartHistoryQueueLatencyPerTaskList: {metricName: "schedule_to_start_history_queue_latency_per_tl", metricType: Timer},
 
 		// per domain task metrics
 

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -1633,3 +1633,8 @@ func TestSecondsToDuration(t *testing.T) {
 		})
 	}
 }
+
+func TestNewPerTaskListScope(t *testing.T) {
+	assert.NotNil(t, NewPerTaskListScope("test-domain", "test-tasklist", types.TaskListKindNormal, metrics.NewNoopMetricsClient(), 0))
+	assert.NotNil(t, NewPerTaskListScope("test-domain", "test-tasklist", types.TaskListKindSticky, metrics.NewNoopMetricsClient(), 0))
+}

--- a/service/history/task/task.go
+++ b/service/history/task/task.go
@@ -346,6 +346,7 @@ func (t *taskImpl) Ack() {
 		t.scope.RecordTimer(metrics.TaskAttemptTimerPerDomain, time.Duration(t.attempt))
 		t.scope.RecordTimer(metrics.TaskLatencyPerDomain, time.Since(t.submitTime))
 		t.scope.RecordTimer(metrics.TaskQueueLatencyPerDomain, time.Since(t.GetVisibilityTimestamp()))
+
 	}
 
 	if t.eventLogger != nil && t.shouldProcessTask && t.attempt != 0 {

--- a/service/matching/handler/context.go
+++ b/service/matching/handler/context.go
@@ -24,11 +24,11 @@ import (
 	"context"
 	"sync"
 
+	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/types"
-	"github.com/uber/cadence/service/matching/tasklist"
 )
 
 type handlerContext struct {
@@ -47,7 +47,7 @@ func newHandlerContext(
 ) *handlerContext {
 	return &handlerContext{
 		Context: ctx,
-		scope:   tasklist.NewPerTaskListScope(domainName, taskList.GetName(), taskList.GetKind(), metricsClient, metricsScope).Tagged(metrics.GetContextTags(ctx)...),
+		scope:   common.NewPerTaskListScope(domainName, taskList.GetName(), taskList.GetKind(), metricsClient, metricsScope).Tagged(metrics.GetContextTags(ctx)...),
 		logger:  logger.WithTags(tag.WorkflowDomainName(domainName), tag.WorkflowTaskListName(taskList.GetName())),
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add metrics to measure the time a task waiting in history queue, which is from the time the task is written to database to the time the task is pushed to matching service

<!-- Tell your future self why have you made these changes -->
**Why?**
improve observability

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
