### PR TITLE
Fix membership resolver used in integration tests

### DIFF
--- a/host/membership_resolver.go
+++ b/host/membership_resolver.go
@@ -33,13 +33,13 @@ type simpleResolver struct {
 }
 
 // NewSimpleResolver returns a membership resolver interface
-func NewSimpleResolver(serviceName string, hosts map[string][]membership.HostInfo) membership.Resolver {
+func NewSimpleResolver(serviceName string, hosts map[string][]membership.HostInfo, currentHost membership.HostInfo) membership.Resolver {
 	resolvers := make(map[string]*simpleHashring, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newSimpleHashring(hostList)
 	}
 	return &simpleResolver{
-		hostInfo:  hosts[serviceName][0],
+		hostInfo:  currentHost,
 		resolvers: resolvers,
 	}
 }

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -527,7 +527,7 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]membership.HostInfo, star
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.FrontendPProfPort())
 	params.RPCFactory = c.newRPCFactory(service.Frontend, c.FrontendHost())
 	params.MetricScope = tally.NewTestScope(service.Frontend, make(map[string]string))
-	params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+	params.MembershipResolver = newMembershipResolver(params.Name, hosts, c.FrontendHost())
 	params.ClusterMetadata = c.clusterMetadata
 	params.MessagingClient = c.messagingClient
 	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
@@ -609,7 +609,7 @@ func (c *cadenceImpl) startHistory(hosts map[string][]membership.HostInfo, start
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
 		params.RPCFactory = c.newRPCFactory(service.History, hostport)
 		params.MetricScope = tally.NewTestScope(service.History, make(map[string]string))
-		params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+		params.MembershipResolver = newMembershipResolver(params.Name, hosts, hostport)
 		params.ClusterMetadata = c.clusterMetadata
 		params.MessagingClient = c.messagingClient
 		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
@@ -688,7 +688,7 @@ func (c *cadenceImpl) startMatching(hosts map[string][]membership.HostInfo, star
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
 		params.RPCFactory = c.newRPCFactory(service.Matching, hostport)
 		params.MetricScope = tally.NewTestScope(service.Matching, map[string]string{"matching-host": matchingHost})
-		params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+		params.MembershipResolver = newMembershipResolver(params.Name, hosts, hostport)
 		params.ClusterMetadata = c.clusterMetadata
 		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 		params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.matchingDynCfgOverrides)
@@ -747,7 +747,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.WorkerPProfPort())
 	params.RPCFactory = c.newRPCFactory(service.Worker, c.WorkerServiceHost())
 	params.MetricScope = tally.NewTestScope(service.Worker, make(map[string]string))
-	params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+	params.MembershipResolver = newMembershipResolver(params.Name, hosts, c.WorkerServiceHost())
 	params.ClusterMetadata = c.clusterMetadata
 	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 	params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.workerDynCfgOverrides)
@@ -965,8 +965,8 @@ func copyPersistenceConfig(pConfig config.Persistence) (config.Persistence, erro
 	return pConfig, nil
 }
 
-func newMembershipResolver(serviceName string, hosts map[string][]membership.HostInfo) membership.Resolver {
-	return NewSimpleResolver(serviceName, hosts)
+func newMembershipResolver(serviceName string, hosts map[string][]membership.HostInfo, currentHost membership.HostInfo) membership.Resolver {
+	return NewSimpleResolver(serviceName, hosts, currentHost)
 }
 
 func newPProfInitializerImpl(logger log.Logger, port int) common.PProfInitializer {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix membership resolver used in integration tests

<!-- Tell your future self why have you made these changes -->
**Why?**
The matching simulation test is failing on some API calls after this https://github.com/uber/cadence/pull/6199 got merged.
The AddDecisionTask and PollForDecisionTask API fails due to TaskListNotOwnedByHostError

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Existing tests and matching simulation test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
