### PR TITLE
Debug es-analyzer II: CadenceChangeVersion workflow

### DIFF
--- a/service/worker/esanalyzer/analyzer.go
+++ b/service/worker/esanalyzer/analyzer.go
@@ -122,19 +122,15 @@ func New(
 	var indexName string
 	var pinotTableName string
 
-	// if esClient != nil {
-	//	mode = ES
-	//	indexName = esConfig.Indices[common.VisibilityAppName]
-	//	pinotTableName = ""
-	// } else if pinotClient != nil {
-	//	mode = Pinot
-	//	indexName = ""
-	//	pinotTableName = pinotConfig.Table
-	// }
-
-	mode = Pinot
-	indexName = ""
-	pinotTableName = pinotConfig.Table
+	if esClient != nil {
+		mode = ES
+		indexName = esConfig.Indices[common.VisibilityAppName]
+		pinotTableName = ""
+	} else if pinotClient != nil {
+		mode = Pinot
+		indexName = ""
+		pinotTableName = pinotConfig.Table
+	}
 
 	return &Analyzer{
 		svcClient:           svcClient,

--- a/service/worker/esanalyzer/analyzer.go
+++ b/service/worker/esanalyzer/analyzer.go
@@ -122,15 +122,19 @@ func New(
 	var indexName string
 	var pinotTableName string
 
-	if esClient != nil {
-		mode = ES
-		indexName = esConfig.Indices[common.VisibilityAppName]
-		pinotTableName = ""
-	} else if pinotClient != nil {
-		mode = Pinot
-		indexName = ""
-		pinotTableName = pinotConfig.Table
-	}
+	//if esClient != nil {
+	//	mode = ES
+	//	indexName = esConfig.Indices[common.VisibilityAppName]
+	//	pinotTableName = ""
+	//} else if pinotClient != nil {
+	//	mode = Pinot
+	//	indexName = ""
+	//	pinotTableName = pinotConfig.Table
+	//}
+
+	mode = Pinot
+	indexName = ""
+	pinotTableName = pinotConfig.Table
 
 	return &Analyzer{
 		svcClient:           svcClient,

--- a/service/worker/esanalyzer/analyzer.go
+++ b/service/worker/esanalyzer/analyzer.go
@@ -122,15 +122,15 @@ func New(
 	var indexName string
 	var pinotTableName string
 
-	//if esClient != nil {
+	// if esClient != nil {
 	//	mode = ES
 	//	indexName = esConfig.Indices[common.VisibilityAppName]
 	//	pinotTableName = ""
-	//} else if pinotClient != nil {
+	// } else if pinotClient != nil {
 	//	mode = Pinot
 	//	indexName = ""
 	//	pinotTableName = pinotConfig.Table
-	//}
+	// }
 
 	mode = Pinot
 	indexName = ""

--- a/service/worker/esanalyzer/analyzer_test.go
+++ b/service/worker/esanalyzer/analyzer_test.go
@@ -565,8 +565,8 @@ func TestEmitWorkflowTypeCountMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test0", 1},
-					{"test1", 2},
+					{"test0", float64(1)},
+					{"test1", float64(2)},
 				}, nil).Times(1)
 			},
 			expectedErr: nil,
@@ -657,16 +657,16 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-version0", 1},
-					{"test-wf-version1", 20},
+					{"test-wf-version0", float64(10)},
+					{"test-wf-version1", float64(20)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-version3", 10},
-					{"test-wf-version4", 2},
+					{"test-wf-version3", float64(10)},
+					{"test-wf-version4", float64(2)},
 				}, nil).Times(1)
 			},
 			expectedErr: nil,
@@ -718,8 +718,8 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 			},
 			expectedErr: fmt.Errorf("error querying workflow versions for workflow type: test-wf-type0: error: domain error"),
@@ -731,8 +731,8 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return(nil, fmt.Errorf("pinot error")).Times(1)
 			},
@@ -745,16 +745,16 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-version0", 1.5},
+					{"test-wf-version0", float64(3.14)},
 					{"test-wf-version1", 20},
 				}, nil).Times(1)
 			},
 			expectedErr: fmt.Errorf("error querying workflow versions for workflow type: " +
-				"test-wf-type0: error: error parsing workflow count for workflow version test-wf-version0"),
+				"test-wf-type0: error: error parsing workflow count for cadence version test-wf-version1"),
 		},
 	}
 

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -217,6 +217,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 	var domainWorkflowTypeCount DomainWorkflowTypeCount
 	for _, row := range response {
 		workflowType := row[0].(string)
+
 		workflowCount, ok := row[1].(int)
 		if !ok {
 			logger.Error("Error parsing workflow count",
@@ -224,6 +225,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
 				zap.Int("WorkflowCount", workflowCount),
+				zap.String("WorkflowCountType", fmt.Sprintf("%T", workflowCount)),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -218,6 +218,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 	for _, row := range response {
 		workflowType := row[0].(string)
 
+		// even though the count is a int, it is returned as a float64
 		workflowCount, ok := row[1].(float64)
 		if !ok {
 			logger.Error("Error parsing workflow count",

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -223,6 +223,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 				zap.Error(err),
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
+				zap.Int("WorkflowCount", workflowCount),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -225,7 +225,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
 				zap.Int("WorkflowCount", workflowCount),
-				zap.String("WorkflowCountType", fmt.Sprintf("%T", workflowCount)),
+				zap.String("WorkflowCountType", fmt.Sprintf("%T", row[1])),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -223,6 +223,7 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 				zap.Error(err),
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
+				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)
 		}

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -218,13 +218,13 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 	for _, row := range response {
 		workflowType := row[0].(string)
 
-		workflowCount, ok := row[1].(int)
+		workflowCount, ok := row[1].(float64)
 		if !ok {
 			logger.Error("Error parsing workflow count",
 				zap.Error(err),
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
-				zap.Int("WorkflowCount", workflowCount),
+				zap.Float64("WorkflowCount", workflowCount),
 				zap.String("WorkflowCountType", fmt.Sprintf("%T", row[1])),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -253,7 +253,7 @@ func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *za
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
 				zap.Int("WorkflowCount", workflowCount),
-				zap.String("WorkflowCountType", fmt.Sprintf("%T", workflowCount)),
+				zap.String("WorkflowCountType", fmt.Sprintf("%T", row[1])),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)
@@ -324,7 +324,7 @@ func (w *Workflow) queryWorkflowVersionsWithType(domainName string, wfType strin
 				zap.String("WorkflowVersion", workflowVersion),
 				zap.String("DomainName", domainName),
 				zap.Int("WorkflowCount", workflowCount),
-				zap.String("WorkflowCountType", fmt.Sprintf("%T", workflowCount)),
+				zap.String("WorkflowCountType", fmt.Sprintf("%T", row[1])),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return WorkflowVersionCount{}, fmt.Errorf("error parsing workflow count for cadence version %s", workflowVersion)

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -252,6 +252,7 @@ func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *za
 				zap.Error(err),
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
+				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)
 		}
@@ -320,6 +321,7 @@ func (w *Workflow) queryWorkflowVersionsWithType(domainName string, wfType strin
 				zap.Error(err),
 				zap.String("WorkflowVersion", workflowVersion),
 				zap.String("DomainName", domainName),
+				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return WorkflowVersionCount{}, fmt.Errorf("error parsing workflow count for workflow version %s", workflowVersion)
 		}

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -248,10 +248,11 @@ func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *za
 		workflowType := row[0].(string)
 		workflowCount, ok := row[1].(int)
 		if !ok {
-			logger.Error("Error parsing workflow count",
+			logger.Error("error parsing workflow count for cadence version",
 				zap.Error(err),
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
+				zap.Int("WorkflowCount", workflowCount),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)
@@ -317,13 +318,14 @@ func (w *Workflow) queryWorkflowVersionsWithType(domainName string, wfType strin
 		workflowVersion := row[0].(string)
 		workflowCount, ok := row[1].(int)
 		if !ok {
-			logger.Error("Error parsing workflow count",
+			logger.Error("error parsing workflow count for cadence version",
 				zap.Error(err),
 				zap.String("WorkflowVersion", workflowVersion),
 				zap.String("DomainName", domainName),
+				zap.Int("WorkflowCount", workflowCount),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
-			return WorkflowVersionCount{}, fmt.Errorf("error parsing workflow count for workflow version %s", workflowVersion)
+			return WorkflowVersionCount{}, fmt.Errorf("error parsing workflow count for cadence version %s", workflowVersion)
 		}
 		workflowVersions.WorkflowVersions = append(workflowVersions.WorkflowVersions, EsAggregateCount{
 			AggregateKey:   workflowVersion,

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -181,7 +181,7 @@ WHERE DomainID = '%s'
   AND CloseStatus = -1
   AND StartTime > 0
   AND WorkflowType = '%s'
-GROUP BY JSON_EXTRACT_SCALAR(Attr, '$.CadenceChangeVersion', 'STRING_ARRAY') AS CadenceChangeVersion
+GROUP BY JSON_EXTRACT_SCALAR(Attr, '$.CadenceChangeVersion', 'STRING_ARRAY')
 ORDER BY count DESC
 LIMIT 10
     `, w.analyzer.pinotTableName, domain.GetInfo().ID, wfType), nil

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -253,6 +253,7 @@ func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *za
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
 				zap.Int("WorkflowCount", workflowCount),
+				zap.String("WorkflowCountType", fmt.Sprintf("%T", workflowCount)),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)
@@ -323,6 +324,7 @@ func (w *Workflow) queryWorkflowVersionsWithType(domainName string, wfType strin
 				zap.String("WorkflowVersion", workflowVersion),
 				zap.String("DomainName", domainName),
 				zap.Int("WorkflowCount", workflowCount),
+				zap.String("WorkflowCountType", fmt.Sprintf("%T", workflowCount)),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return WorkflowVersionCount{}, fmt.Errorf("error parsing workflow count for cadence version %s", workflowVersion)

--- a/service/worker/esanalyzer/workflow.go
+++ b/service/worker/esanalyzer/workflow.go
@@ -246,13 +246,13 @@ func (w *Workflow) emitWorkflowVersionMetricsPinot(domainName string, logger *za
 	var domainWorkflowVersionCount DomainWorkflowVersionCount
 	for _, row := range response {
 		workflowType := row[0].(string)
-		workflowCount, ok := row[1].(int)
+		workflowCount, ok := row[1].(float64)
 		if !ok {
 			logger.Error("error parsing workflow count for cadence version",
 				zap.Error(err),
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
-				zap.Int("WorkflowCount", workflowCount),
+				zap.Float64("WorkflowCount", workflowCount),
 				zap.String("WorkflowCountType", fmt.Sprintf("%T", row[1])),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
@@ -317,13 +317,13 @@ func (w *Workflow) queryWorkflowVersionsWithType(domainName string, wfType strin
 	var workflowVersions WorkflowVersionCount
 	for _, row := range response {
 		workflowVersion := row[0].(string)
-		workflowCount, ok := row[1].(int)
+		workflowCount, ok := row[1].(float64)
 		if !ok {
 			logger.Error("error parsing workflow count for cadence version",
 				zap.Error(err),
 				zap.String("WorkflowVersion", workflowVersion),
 				zap.String("DomainName", domainName),
-				zap.Int("WorkflowCount", workflowCount),
+				zap.Float64("WorkflowCount", workflowCount),
 				zap.String("WorkflowCountType", fmt.Sprintf("%T", row[1])),
 				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
1. The workflowCount is not a int type, which caused errors in Mono repo. Simply change the casting would resolve this error.
2. The Pinot query for CadenceChangeVersion workflow has a small bug, deleted the AS clause in GroupBy fixed it.

<!-- Tell your future self why have you made these changes -->
**Why?**
Testing analyzer in mono repo.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test, manual test in mono repo- Staging env.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
