### PR TITLE
Add a wait time for pollers

### DIFF
--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -2852,6 +2852,13 @@ const (
 	// Default value: 30 seconds
 	HistoryGlobalRatelimiterGCAfter
 
+	// LocalPollWaitTime is the wait time for a poller to wait before considering request forwarding
+	// KeyName: matching.localPollWaitTime
+	// Value type: Duration
+	// Default value: 10ms
+	// Allowed filters: domainName, taskListName, taskListType
+	LocalPollWaitTime
+
 	// LastDurationKey must be the last one in this const group
 	LastDurationKey
 )
@@ -5134,6 +5141,12 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		KeyName:      "history.globalRatelimiterGCAfter",
 		Description:  "HistoryGlobalRatelimiterGCAfter defines how long to wait until a host's data is considered entirely useless, e.g. host has likely disappeared, its weight is very low, and the data can be deleted.",
 		DefaultValue: 30 * time.Second,
+	},
+	LocalPollWaitTime: {
+		KeyName:      "matching.localPollWaitTime",
+		Filters:      []Filter{DomainName, TaskListName, TaskType},
+		Description:  "LocalPollWaitTime is the time a poller waits before considering request forwarding.",
+		DefaultValue: time.Millisecond * 10,
 	},
 }
 

--- a/service/matching/config/config.go
+++ b/service/matching/config/config.go
@@ -51,6 +51,7 @@ type (
 		ForwarderMaxRatePerSecond    dynamicconfig.IntPropertyFnWithTaskListInfoFilters
 		ForwarderMaxChildrenPerNode  dynamicconfig.IntPropertyFnWithTaskListInfoFilters
 		AsyncTaskDispatchTimeout     dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
+		LocalPollWaitTime            dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
 
 		// Time to hold a poll request before returning an empty response if there are no tasks
 		LongPollExpirationInterval dynamicconfig.DurationPropertyFnWithTaskListInfoFilters
@@ -102,6 +103,7 @@ type (
 		MinTaskThrottlingBurstSize    func() int
 		MaxTaskDeleteBatchSize        func() int
 		AsyncTaskDispatchTimeout      func() time.Duration
+		LocalPollWaitTime             func() time.Duration
 		// taskWriter configuration
 		OutstandingTaskAppendsThreshold func() int
 		MaxTaskBatchSize                func() int
@@ -154,6 +156,7 @@ func NewConfig(dc *dynamicconfig.Collection, hostName string) *Config {
 		EnableTasklistIsolation:         dc.GetBoolPropertyFilteredByDomain(dynamicconfig.EnableTasklistIsolation),
 		AllIsolationGroups:              mapIGs(dc.GetListProperty(dynamicconfig.AllIsolationGroups)()),
 		AsyncTaskDispatchTimeout:        dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.AsyncTaskDispatchTimeout),
+		LocalPollWaitTime:               dc.GetDurationPropertyFilteredByTaskListInfo(dynamicconfig.LocalPollWaitTime),
 		HostName:                        hostName,
 		TaskDispatchRPS:                 100000.0,
 		TaskDispatchRPSTTL:              time.Minute,

--- a/service/matching/config/config_test.go
+++ b/service/matching/config/config_test.go
@@ -73,6 +73,7 @@ func TestNewConfig(t *testing.T) {
 		"EnableTasklistIsolation":         {dynamicconfig.EnableTasklistIsolation, false},
 		"AllIsolationGroups":              {dynamicconfig.AllIsolationGroups, []interface{}{"a", "b", "c"}},
 		"AsyncTaskDispatchTimeout":        {dynamicconfig.AsyncTaskDispatchTimeout, time.Duration(25)},
+		"LocalPollWaitTime":               {dynamicconfig.LocalPollWaitTime, time.Duration(10)},
 		"HostName":                        {nil, hostname},
 		"TaskDispatchRPS":                 {nil, 100000.0},
 		"TaskDispatchRPSTTL":              {nil, time.Minute},

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -721,6 +721,9 @@ func newTaskListConfig(id *Identifier, cfg *config.Config, domainName string) *c
 		AsyncTaskDispatchTimeout: func() time.Duration {
 			return cfg.AsyncTaskDispatchTimeout(domainName, taskListName, taskType)
 		},
+		LocalPollWaitTime: func() time.Duration {
+			return cfg.LocalPollWaitTime(domainName, taskListName, taskType)
+		},
 		ForwarderConfig: config.ForwarderConfig{
 			ForwarderMaxOutstandingPolls: func() int {
 				return cfg.ForwarderMaxOutstandingPolls(domainName, taskListName, taskType)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a wait time for pollers

<!-- Tell your future self why have you made these changes -->
**Why?**
We've observed pollers being forwarded even though there are tasks in the backlog of local partition. Forwarding is more expensive and has higher latency, so we add a wait time to reduce the number of poll forwarding.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
manual tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk. This is protected by a dynamicconfig.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
