### PR TITLE
Method in StartChildWorkflowExecutionInitiatedEventAttributes to fetch ExecutionStartToCloseTimeoutSeconds

### DIFF
--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -6204,6 +6204,14 @@ func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetParentClosePoli
 	return
 }
 
+// GetExecutionStartToCloseTimeoutSeconds is an internal getter (TBD...)
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+
 // StartTimeFilter is an internal type (TBD...)
 type StartTimeFilter struct {
 	EarliestTime *int64 `json:"earliestTime,omitempty"`


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
StartChildWorkflowExecutionInitiatedEventAttributes has new method to get ExecutionStartToCloseTimeoutSeconds

<!-- Tell your future self why have you made these changes -->
**Why?**
It makes it easy to fetch the timeout configured in child workflow

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risks as it just simply gets the value from the struct 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
