### PR TITLE
Timeout invariant to identify and collect all timeouts in a workflow execution

### DIFF
--- a/common/diagnostics/invariants/invariant.go
+++ b/common/diagnostics/invariants/invariant.go
@@ -1,0 +1,15 @@
+package invariants
+
+import "context"
+
+// InvariantCheckResult is the result from the invariant check
+type InvariantCheckResult struct {
+	InvariantType string
+	Reason        string
+	Metadata      []byte
+}
+
+// Invariant represents a condition of a workflow execution.
+type Invariant interface {
+	Check(context.Context) ([]InvariantCheckResult, error)
+}

--- a/common/diagnostics/invariants/timeout.go
+++ b/common/diagnostics/invariants/timeout.go
@@ -64,7 +64,7 @@ func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
 			})
 		}
 	}
-	return nil, nil
+	return result, nil
 }
 
 func reasonForDecisionTaskTimeouts(event *types.HistoryEvent, allEvents []*types.HistoryEvent) (string, []byte) {

--- a/common/diagnostics/invariants/timeout.go
+++ b/common/diagnostics/invariants/timeout.go
@@ -1,0 +1,136 @@
+package invariants
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/uber/cadence/common/types"
+)
+
+type Timeout Invariant
+
+type timeout struct {
+	workflowExecutionHistory *types.GetWorkflowExecutionHistoryResponse
+}
+
+func NewTimeout(wfHistory *types.GetWorkflowExecutionHistoryResponse) Invariant {
+	return &timeout{
+		workflowExecutionHistory: wfHistory,
+	}
+}
+
+func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
+	result := make([]InvariantCheckResult, 0)
+	events := t.workflowExecutionHistory.GetHistory().GetEvents()
+	for _, event := range events {
+		if event.WorkflowExecutionTimedOutEventAttributes != nil {
+			timeoutType := event.GetWorkflowExecutionTimedOutEventAttributes().GetTimeoutType().String()
+			timeoutLimit := getWorkflowExecutionConfiguredTimeout(events)
+			result = append(result, InvariantCheckResult{
+				InvariantType: TimeoutTypeExecution.String(),
+				Reason:        timeoutType,
+				Metadata:      timeoutLimitInBytes(timeoutLimit),
+			})
+		}
+		if event.ActivityTaskTimedOutEventAttributes != nil {
+			timeoutType := event.GetActivityTaskTimedOutEventAttributes().GetTimeoutType()
+			eventScheduledID := event.GetActivityTaskTimedOutEventAttributes().GetScheduledEventID()
+			timeoutLimit, err := getActivityTaskConfiguredTimeout(eventScheduledID, timeoutType, events)
+			if err != nil {
+				return nil, err
+			}
+			result = append(result, InvariantCheckResult{
+				InvariantType: TimeoutTypeActivity.String(),
+				Reason:        timeoutType.String(),
+				Metadata:      timeoutLimitInBytes(timeoutLimit),
+			})
+		}
+		if event.DecisionTaskTimedOutEventAttributes != nil {
+			reason, metadata := reasonForDecisionTaskTimeouts(event, events)
+			result = append(result, InvariantCheckResult{
+				InvariantType: TimeoutTypeDecision.String(),
+				Reason:        reason,
+				Metadata:      metadata,
+			})
+		}
+		if event.ChildWorkflowExecutionTimedOutEventAttributes != nil {
+			timeoutType := event.GetChildWorkflowExecutionTimedOutEventAttributes().TimeoutType.String()
+			childWfInitiatedID := event.GetChildWorkflowExecutionTimedOutEventAttributes().GetInitiatedEventID()
+			timeoutLimit := getChildWorkflowExecutionConfiguredTimeout(childWfInitiatedID, events)
+			result = append(result, InvariantCheckResult{
+				InvariantType: TimeoutTypeChildWorkflow.String(),
+				Reason:        timeoutType,
+				Metadata:      timeoutLimitInBytes(timeoutLimit),
+			})
+		}
+	}
+	return nil, nil
+}
+
+func reasonForDecisionTaskTimeouts(event *types.HistoryEvent, allEvents []*types.HistoryEvent) (string, []byte) {
+	eventScheduledID := event.GetDecisionTaskTimedOutEventAttributes().GetScheduledEventID()
+	attr := event.GetDecisionTaskTimedOutEventAttributes()
+	cause := attr.GetCause()
+	switch cause {
+	case types.DecisionTaskTimedOutCauseTimeout:
+		return attr.TimeoutType.String(), timeoutLimitInBytes(getDecisionTaskConfiguredTimeout(eventScheduledID, allEvents))
+	case types.DecisionTaskTimedOutCauseReset:
+		newRunID := attr.GetNewRunID()
+		return attr.Reason, []byte(newRunID)
+	default:
+		return "valid cause not available for decision task timeout", nil
+	}
+}
+
+func getWorkflowExecutionConfiguredTimeout(events []*types.HistoryEvent) int32 {
+	for _, event := range events {
+		if event.ID == 1 { // event 1 is workflow execution started event
+			return event.GetWorkflowExecutionStartedEventAttributes().GetExecutionStartToCloseTimeoutSeconds()
+		}
+	}
+	return 0
+}
+
+func getActivityTaskConfiguredTimeout(eventScheduledID int64, timeoutType types.TimeoutType, events []*types.HistoryEvent) (int32, error) {
+	for _, event := range events {
+		if event.ID == eventScheduledID {
+			attr := event.GetActivityTaskScheduledEventAttributes()
+			switch timeoutType {
+			case types.TimeoutTypeHeartbeat:
+				return attr.GetHeartbeatTimeoutSeconds(), nil
+			case types.TimeoutTypeScheduleToClose:
+				return attr.GetScheduleToCloseTimeoutSeconds(), nil
+			case types.TimeoutTypeScheduleToStart:
+				return attr.GetScheduleToStartTimeoutSeconds(), nil
+			case types.TimeoutTypeStartToClose:
+				return attr.GetStartToCloseTimeoutSeconds(), nil
+			default:
+				return 0, fmt.Errorf("unknown timeout type")
+			}
+		}
+	}
+	return 0, fmt.Errorf("activity scheduled event not found")
+}
+
+func getDecisionTaskConfiguredTimeout(eventScheduledID int64, events []*types.HistoryEvent) int32 {
+	for _, event := range events {
+		if event.ID == eventScheduledID {
+			return event.GetDecisionTaskScheduledEventAttributes().GetStartToCloseTimeoutSeconds()
+		}
+	}
+	return 0
+}
+
+func getChildWorkflowExecutionConfiguredTimeout(wfInitiatedID int64, events []*types.HistoryEvent) int32 {
+	for _, event := range events {
+		if event.ID == wfInitiatedID {
+			return event.GetStartChildWorkflowExecutionInitiatedEventAttributes().GetExecutionStartToCloseTimeoutSeconds()
+		}
+	}
+	return 0
+}
+
+func timeoutLimitInBytes(val int32) []byte {
+	valInBytes, _ := json.Marshal(val)
+	return valInBytes
+}

--- a/common/diagnostics/invariants/timeout_test.go
+++ b/common/diagnostics/invariants/timeout_test.go
@@ -1,0 +1,201 @@
+package invariants
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/stretchr/testify/require"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
+	"testing"
+)
+
+const (
+	workflowTimeoutSecond = int32(110)
+	taskTimeoutSecond     = int32(50)
+)
+
+func Test__Check(t *testing.T) {
+	workflowTimeoutSecondInBytes, err := json.Marshal(workflowTimeoutSecond)
+	taskTimeoutSecondInBytes, err := json.Marshal(taskTimeoutSecond)
+	require.NoError(t, err)
+	testCases := []struct {
+		name           string
+		testData       *types.GetWorkflowExecutionHistoryResponse
+		expectedResult []InvariantCheckResult
+		err            error
+	}{
+		{
+			name:     "workflow execution timeout",
+			testData: wfTimeoutHistory(),
+			expectedResult: []InvariantCheckResult{
+				{
+					InvariantType: TimeoutTypeExecution.String(),
+					Reason:        "START_TO_CLOSE",
+					Metadata:      workflowTimeoutSecondInBytes,
+				},
+			},
+			err: nil,
+		},
+		{
+			name:     "child workflow execution timeout",
+			testData: childWfTimeoutHistory(),
+			expectedResult: []InvariantCheckResult{
+				{
+					InvariantType: TimeoutTypeChildWorkflow.String(),
+					Reason:        "START_TO_CLOSE",
+					Metadata:      workflowTimeoutSecondInBytes,
+				},
+			},
+			err: nil,
+		},
+		{
+			name:     "activity timeout",
+			testData: activityTimeoutHistory(),
+			expectedResult: []InvariantCheckResult{
+				{
+					InvariantType: TimeoutTypeActivity.String(),
+					Reason:        "SCHEDULE_TO_START",
+					Metadata:      taskTimeoutSecondInBytes,
+				},
+				{
+					InvariantType: TimeoutTypeActivity.String(),
+					Reason:        "HEARTBEAT",
+					Metadata:      taskTimeoutSecondInBytes,
+				},
+			},
+			err: nil,
+		},
+		{
+			name:     "decision timeout",
+			testData: decisionTimeoutHistory(),
+			expectedResult: []InvariantCheckResult{
+				{
+					InvariantType: TimeoutTypeDecision.String(),
+					Reason:        "START_TO_CLOSE",
+					Metadata:      taskTimeoutSecondInBytes,
+				},
+				{
+					InvariantType: TimeoutTypeDecision.String(),
+					Reason:        "workflow reset",
+					Metadata:      []byte("new run ID"),
+				},
+			},
+			err: nil,
+		},
+	}
+	for _, tc := range testCases {
+		inv := NewTimeout(tc.testData)
+		result, err := inv.Check(context.Background())
+		require.Equal(t, tc.err, err)
+		require.Equal(t, len(tc.expectedResult), len(result))
+		for i := range result {
+			require.Equal(t, tc.expectedResult[i], result[i])
+		}
+
+	}
+}
+
+func wfTimeoutHistory() *types.GetWorkflowExecutionHistoryResponse {
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History: &types.History{
+			Events: []*types.HistoryEvent{
+				{
+					ID: 1,
+					WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+					},
+				},
+				{
+					WorkflowExecutionTimedOutEventAttributes: &types.WorkflowExecutionTimedOutEventAttributes{TimeoutType: types.TimeoutTypeStartToClose.Ptr()},
+				},
+			},
+		},
+	}
+}
+
+func childWfTimeoutHistory() *types.GetWorkflowExecutionHistoryResponse {
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History: &types.History{
+			Events: []*types.HistoryEvent{
+				{
+					ID: 22,
+					StartChildWorkflowExecutionInitiatedEventAttributes: &types.StartChildWorkflowExecutionInitiatedEventAttributes{
+						ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+					},
+				},
+				{
+					ChildWorkflowExecutionTimedOutEventAttributes: &types.ChildWorkflowExecutionTimedOutEventAttributes{
+						InitiatedEventID: 22,
+						TimeoutType:      types.TimeoutTypeStartToClose.Ptr()},
+				},
+			},
+		},
+	}
+}
+
+func activityTimeoutHistory() *types.GetWorkflowExecutionHistoryResponse {
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History: &types.History{
+			Events: []*types.HistoryEvent{
+				{
+					ID: 5,
+					ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+						ScheduleToStartTimeoutSeconds: common.Int32Ptr(taskTimeoutSecond),
+					},
+				},
+				{
+					ActivityTaskTimedOutEventAttributes: &types.ActivityTaskTimedOutEventAttributes{
+						ScheduledEventID: 5,
+						StartedEventID:   6,
+						TimeoutType:      types.TimeoutTypeScheduleToStart.Ptr(),
+					},
+				},
+				{
+					ID: 21,
+					ActivityTaskScheduledEventAttributes: &types.ActivityTaskScheduledEventAttributes{
+						HeartbeatTimeoutSeconds: common.Int32Ptr(taskTimeoutSecond),
+					},
+				},
+				{
+					ActivityTaskTimedOutEventAttributes: &types.ActivityTaskTimedOutEventAttributes{
+						ScheduledEventID: 21,
+						StartedEventID:   22,
+						TimeoutType:      types.TimeoutTypeHeartbeat.Ptr(),
+					},
+				},
+			},
+		},
+	}
+}
+
+func decisionTimeoutHistory() *types.GetWorkflowExecutionHistoryResponse {
+	return &types.GetWorkflowExecutionHistoryResponse{
+		History: &types.History{
+			Events: []*types.HistoryEvent{
+				{
+					ID: 13,
+					DecisionTaskScheduledEventAttributes: &types.DecisionTaskScheduledEventAttributes{
+						StartToCloseTimeoutSeconds: common.Int32Ptr(taskTimeoutSecond),
+					},
+				},
+				{
+					DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
+						ScheduledEventID: 13,
+						StartedEventID:   14,
+						Cause:            types.DecisionTaskTimedOutCauseTimeout.Ptr(),
+						TimeoutType:      types.TimeoutTypeStartToClose.Ptr(),
+					},
+				},
+				{
+					DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
+						ScheduledEventID: 3,
+						StartedEventID:   14,
+						Cause:            types.DecisionTaskTimedOutCauseReset.Ptr(),
+						Reason:           "workflow reset",
+						NewRunID:         "new run ID",
+					},
+				},
+			},
+		},
+	}
+}

--- a/common/diagnostics/invariants/timeout_test.go
+++ b/common/diagnostics/invariants/timeout_test.go
@@ -188,11 +188,9 @@ func decisionTimeoutHistory() *types.GetWorkflowExecutionHistoryResponse {
 				},
 				{
 					DecisionTaskTimedOutEventAttributes: &types.DecisionTaskTimedOutEventAttributes{
-						ScheduledEventID: 3,
-						StartedEventID:   14,
-						Cause:            types.DecisionTaskTimedOutCauseReset.Ptr(),
-						Reason:           "workflow reset",
-						NewRunID:         "new run ID",
+						Cause:    types.DecisionTaskTimedOutCauseReset.Ptr(),
+						Reason:   "workflow reset",
+						NewRunID: "new run ID",
 					},
 				},
 			},

--- a/common/diagnostics/invariants/types.go
+++ b/common/diagnostics/invariants/types.go
@@ -1,0 +1,14 @@
+package invariants
+
+type TimeoutType string
+
+const (
+	TimeoutTypeExecution     TimeoutType = "The Workflow Execution has timed out"
+	TimeoutTypeActivity      TimeoutType = "Activity task has timed out"
+	TimeoutTypeDecision      TimeoutType = "Decision task has timed out"
+	TimeoutTypeChildWorkflow TimeoutType = "Child Workflow Execution has timed out"
+)
+
+func (tt TimeoutType) String() string {
+	return string(tt)
+}

--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -775,7 +775,7 @@ func (v *pinotVisibilityStore) getCountWorkflowExecutionsQuery(tableName string,
 	comparExpr, _ := parseOrderBy(requestQuery)
 	comparExpr, err := v.pinotQueryValidator.ValidateQuery(comparExpr)
 	if err != nil {
-		return "", fmt.Errorf("pinot query validator error: %w, query: %s", err, request.Query)
+		return "", &types.BadRequestError{Message: fmt.Sprintf("pinot query validator error: %s, query: %s", err.Error(), request.Query)}
 	}
 
 	comparExpr = filterPrefix(comparExpr)
@@ -819,7 +819,7 @@ func (v *pinotVisibilityStore) getListWorkflowExecutionsByQueryQuery(tableName s
 	comparExpr, orderBy := parseOrderBy(requestQuery)
 	comparExpr, err = v.pinotQueryValidator.ValidateQuery(comparExpr)
 	if err != nil {
-		return "", fmt.Errorf("pinot query validator error: %w, query: %s", err, request.Query)
+		return "", &types.BadRequestError{Message: fmt.Sprintf("pinot query validator error: %s, query: %s", err.Error(), request.Query)}
 	}
 
 	comparExpr = filterPrefix(comparExpr)

--- a/common/persistence/pinot/pinot_visibility_store.go
+++ b/common/persistence/pinot/pinot_visibility_store.go
@@ -762,7 +762,6 @@ func (v *pinotVisibilityStore) getCountWorkflowExecutionsQuery(tableName string,
 
 	// need to add Domain ID
 	query.filters.addEqual(DomainID, request.DomainUUID)
-	query.filters.addEqual(IsDeleted, false)
 
 	requestQuery := strings.TrimSpace(request.Query)
 
@@ -801,7 +800,6 @@ func (v *pinotVisibilityStore) getListWorkflowExecutionsByQueryQuery(tableName s
 
 	// need to add Domain ID
 	query.filters.addEqual(DomainID, request.DomainUUID)
-	query.filters.addEqual(IsDeleted, false)
 
 	requestQuery := strings.TrimSpace(request.Query)
 
@@ -960,7 +958,6 @@ func getListWorkflowExecutionsQuery(tableName string, request *p.InternalListWor
 
 	query := NewPinotQuery(tableName)
 	query.filters.addEqual(DomainID, request.DomainUUID)
-	query.filters.addEqual(IsDeleted, false)
 
 	earliest := request.EarliestTime.UnixMilli() - oneMicroSecondInNano
 	latest := request.LatestTime.UnixMilli() + oneMicroSecondInNano
@@ -988,7 +985,6 @@ func getListWorkflowExecutionsByTypeQuery(tableName string, request *p.InternalL
 	query := NewPinotQuery(tableName)
 
 	query.filters.addEqual(DomainID, request.DomainUUID)
-	query.filters.addEqual(IsDeleted, false)
 	query.filters.addEqual(WorkflowType, request.WorkflowTypeName)
 	earliest := request.EarliestTime.UnixMilli() - oneMicroSecondInNano
 	latest := request.LatestTime.UnixMilli() + oneMicroSecondInNano
@@ -1024,7 +1020,6 @@ func getListWorkflowExecutionsByWorkflowIDQuery(tableName string, request *p.Int
 	query := NewPinotQuery(tableName)
 
 	query.filters.addEqual(DomainID, request.DomainUUID)
-	query.filters.addEqual(IsDeleted, false)
 	query.filters.addEqual(WorkflowID, request.WorkflowID)
 	earliest := request.EarliestTime.UnixMilli() - oneMicroSecondInNano
 	latest := request.LatestTime.UnixMilli() + oneMicroSecondInNano
@@ -1060,7 +1055,6 @@ func getListWorkflowExecutionsByStatusQuery(tableName string, request *p.Interna
 	query := NewPinotQuery(tableName)
 
 	query.filters.addEqual(DomainID, request.DomainUUID)
-	query.filters.addEqual(IsDeleted, false)
 
 	status := 0
 	switch request.Status.String() {
@@ -1103,7 +1097,6 @@ func getGetClosedWorkflowExecutionQuery(tableName string, request *p.InternalGet
 	query := NewPinotQuery(tableName)
 
 	query.filters.addEqual(DomainID, request.DomainUUID)
-	query.filters.addEqual(IsDeleted, false)
 	query.filters.addGte(CloseStatus, 0)
 	query.filters.addEqual(WorkflowID, request.Execution.GetWorkflowID())
 

--- a/common/persistence/pinot/pinot_visibility_store_test.go
+++ b/common/persistence/pinot/pinot_visibility_store_test.go
@@ -1086,7 +1086,6 @@ func TestGetCountWorkflowExecutionsQuery(t *testing.T) {
 	expectEmptyQueryResult := fmt.Sprintf(`SELECT COUNT(*)
 FROM test-table-name
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 `)
 
 	request := &p.CountWorkflowExecutionsRequest{
@@ -1098,7 +1097,6 @@ AND IsDeleted = false
 	expectResult := fmt.Sprintf(`SELECT COUNT(*)
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND WorkflowID = 'wfid'
 `, testTableName)
 
@@ -1174,7 +1172,6 @@ func TestGetListWorkflowExecutionQuery(t *testing.T) {
 				`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND (JSON_MATCH(Attr, '"$.CustomKeywordField"=''keywordCustomized''') or JSON_MATCH(Attr, '"$.CustomKeywordField[*]"=''keywordCustomized'''))
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1193,7 +1190,6 @@ LIMIT 0, 10
 				`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND JSON_MATCH(Attr, '"$.CustomIntField"=''2''') and (JSON_MATCH(Attr, '"$.CustomKeywordField"=''Update2''') or JSON_MATCH(Attr, '"$.CustomKeywordField[*]"=''Update2'''))
 order by CustomDatetimeField DESC
 LIMIT 0, 10
@@ -1211,7 +1207,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND (JSON_MATCH(Attr, '"$.CustomKeywordField"=''keywordCustomized''') or JSON_MATCH(Attr, '"$.CustomKeywordField[*]"=''keywordCustomized''')) and (JSON_MATCH(Attr, '"$.CustomStringField" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.CustomStringField', 'string'), 'String and or order by*'))
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1229,7 +1224,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND ((JSON_MATCH(Attr, '"$.CustomStringField" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.CustomStringField', 'string'), 'Or*')) or (JSON_MATCH(Attr, '"$.CustomStringField" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.CustomStringField', 'string'), 'and*')))
 Order by StartTime DESC
 LIMIT 0, 10
@@ -1247,7 +1241,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND WorkflowID = 'wid' and ((JSON_MATCH(Attr, '"$.CustomStringField" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.CustomStringField', 'string'), 'custom and custom2 or custom3 order by*')) or (JSON_MATCH(Attr, '"$.CustomIntField" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) >= 1 AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) <= 10))
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1265,7 +1258,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND (JSON_MATCH(Attr, '"$.CustomIntField"=''1''') or JSON_MATCH(Attr, '"$.CustomIntField"=''2'''))
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1283,7 +1275,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseTime = -1 and WorkflowType = 'some-test-workflow'
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1301,7 +1292,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus < 0 and (JSON_MATCH(Attr, '"$.CustomKeywordField"=''keywordCustomized''') or JSON_MATCH(Attr, '"$.CustomKeywordField[*]"=''keywordCustomized''')) and (JSON_MATCH(Attr, '"$.CustomIntField" is not null') AND CAST(JSON_EXTRACT_SCALAR(Attr, '$.CustomIntField') AS INT) <= 10) and (JSON_MATCH(Attr, '"$.CustomStringField" is not null') AND REGEXP_LIKE(JSON_EXTRACT_SCALAR(Attr, '$.CustomStringField', 'string'), 'String field is for text*'))
 Order by DomainID Desc
 LIMIT 11, 10
@@ -1319,7 +1309,6 @@ LIMIT 11, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 Order by DomainId Desc
 LIMIT 0, 10
 `, testTableName),
@@ -1336,7 +1325,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus < 0
 Order BY StartTime DESC
 LIMIT 0, 10
@@ -1354,7 +1342,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 LIMIT 0, 10
 `, testTableName),
 		},
@@ -1364,7 +1351,6 @@ LIMIT 0, 10
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = ''
-AND IsDeleted = false
 LIMIT 0, 0
 `, testTableName),
 		},
@@ -1409,7 +1395,6 @@ func TestGetListWorkflowExecutionsQuery(t *testing.T) {
 	expectCloseResult := fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus >= 0
 Order BY StartTime DESC
@@ -1418,7 +1403,6 @@ LIMIT 0, 10
 	expectOpenResult := fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus < 0
 AND CloseTime = -1
@@ -1454,7 +1438,6 @@ func TestGetListWorkflowExecutionsByTypeQuery(t *testing.T) {
 	expectCloseResult := fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND WorkflowType = 'test-wf-type'
 AND CloseTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus >= 0
@@ -1464,7 +1447,6 @@ LIMIT 0, 10
 	expectOpenResult := fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND WorkflowType = 'test-wf-type'
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus < 0
@@ -1501,7 +1483,6 @@ func TestGetListWorkflowExecutionsByWorkflowIDQuery(t *testing.T) {
 	expectCloseResult := fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND WorkflowID = 'test-wid'
 AND CloseTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus >= 0
@@ -1511,7 +1492,6 @@ LIMIT 0, 10
 	expectOpenResult := fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND WorkflowID = 'test-wid'
 AND StartTime BETWEEN 1547596871371 AND 2547596873371
 AND CloseStatus < 0
@@ -1555,7 +1535,6 @@ func TestGetListWorkflowExecutionsByStatusQuery(t *testing.T) {
 			expectResult: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus = 0
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
@@ -1578,7 +1557,6 @@ LIMIT 0, 10
 			expectResult: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus = 1
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
@@ -1601,7 +1579,6 @@ LIMIT 0, 10
 			expectResult: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus = 2
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
@@ -1624,7 +1601,6 @@ LIMIT 0, 10
 			expectResult: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus = 3
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
@@ -1647,7 +1623,6 @@ LIMIT 0, 10
 			expectResult: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus = 4
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
@@ -1670,7 +1645,6 @@ LIMIT 0, 10
 			expectResult: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus = 5
 AND CloseTime BETWEEN 1547596872371 AND 2547596872371
 Order BY StartTime DESC
@@ -1706,7 +1680,6 @@ func TestGetGetClosedWorkflowExecutionQuery(t *testing.T) {
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus >= 0
 AND WorkflowID = 'test-wid'
 `, testTableName),
@@ -1724,7 +1697,6 @@ AND WorkflowID = 'test-wid'
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = 'bfd5c907-f899-4baf-a7b2-2ab85e623ebd'
-AND IsDeleted = false
 AND CloseStatus >= 0
 AND WorkflowID = 'test-wid'
 AND RunID = 'runid'
@@ -1736,7 +1708,6 @@ AND RunID = 'runid'
 			expectedOutput: fmt.Sprintf(`SELECT *
 FROM %s
 WHERE DomainID = ''
-AND IsDeleted = false
 AND CloseStatus >= 0
 AND WorkflowID = ''
 `, testTableName),

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -6204,6 +6204,14 @@ func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetParentClosePoli
 	return
 }
 
+// GetExecutionStartToCloseTimeoutSeconds is an internal getter (TBD...)
+func (v *StartChildWorkflowExecutionInitiatedEventAttributes) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+
 // StartTimeFilter is an internal type (TBD...)
 type StartTimeFilter struct {
 	EarliestTime *int64 `json:"earliestTime,omitempty"`

--- a/docker/buildkite/docker-compose-pinot.yml
+++ b/docker/buildkite/docker-compose-pinot.yml
@@ -82,7 +82,7 @@ services:
           - zookeeper
 
   pinot-controller:
-    image: apachepinot/pinot:0.12.1
+    image: apachepinot/pinot:1.1.0
     command: "StartController -zkAddress zookeeper:2181 -controllerPort 9001"
     container_name: pinot-controller
     restart: unless-stopped
@@ -97,7 +97,7 @@ services:
         aliases:
           - pinot-controller
   pinot-broker:
-    image: apachepinot/pinot:0.12.1
+    image: apachepinot/pinot:1.1.0
     command: "StartBroker -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-broker"
@@ -112,7 +112,7 @@ services:
         aliases:
           - pinot-broker
   pinot-server:
-    image: apachepinot/pinot:0.12.1
+    image: apachepinot/pinot:1.1.0
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-server"

--- a/docker/dev/cassandra-pinot-kafka.yml
+++ b/docker/dev/cassandra-pinot-kafka.yml
@@ -16,7 +16,7 @@ services:
       - ZOOKEEPER_CLIENT_PORT=2181
       - ZOOKEEPER_TICK_TIME=2000
   pinot-controller:
-    image: apachepinot/pinot:0.12.1
+    image: apachepinot/pinot:1.1.0
     command: "StartController -zkAddress zookeeper:2181 -controllerPort 9001"
     container_name: pinot-controller
     restart: unless-stopped
@@ -27,7 +27,7 @@ services:
     depends_on:
       - zookeeper
   pinot-broker:
-    image: apachepinot/pinot:0.12.1
+    image: apachepinot/pinot:1.1.0
     command: "StartBroker -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-broker"
@@ -38,7 +38,7 @@ services:
     depends_on:
       - pinot-controller
   pinot-server:
-    image: apachepinot/pinot:0.12.1
+    image: apachepinot/pinot:1.1.0
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-server"

--- a/docker/docker-compose-pinot.yml
+++ b/docker/docker-compose-pinot.yml
@@ -40,7 +40,7 @@ services:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
   pinot-controller:
-    image: apachepinot/pinot:0.11.0
+    image: apachepinot/pinot:1.1.0
     command: "StartController -zkAddress zookeeper:2181"
     container_name: pinot-controller
     restart: unless-stopped
@@ -51,7 +51,7 @@ services:
     depends_on:
       - zookeeper
   pinot-broker:
-    image: apachepinot/pinot:0.11.0
+    image: apachepinot/pinot:1.1.0
     command: "StartBroker -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-broker"
@@ -62,7 +62,7 @@ services:
     depends_on:
       - pinot-controller
   pinot-server:
-    image: apachepinot/pinot:0.11.0
+    image: apachepinot/pinot:1.1.0
     command: "StartServer -zkAddress zookeeper:2181"
     restart: unless-stopped
     container_name: "pinot-server"

--- a/host/membership_resolver.go
+++ b/host/membership_resolver.go
@@ -33,13 +33,13 @@ type simpleResolver struct {
 }
 
 // NewSimpleResolver returns a membership resolver interface
-func NewSimpleResolver(serviceName string, hosts map[string][]membership.HostInfo) membership.Resolver {
+func NewSimpleResolver(serviceName string, hosts map[string][]membership.HostInfo, currentHost membership.HostInfo) membership.Resolver {
 	resolvers := make(map[string]*simpleHashring, len(hosts))
 	for service, hostList := range hosts {
 		resolvers[service] = newSimpleHashring(hostList)
 	}
 	return &simpleResolver{
-		hostInfo:  hosts[serviceName][0],
+		hostInfo:  currentHost,
 		resolvers: resolvers,
 	}
 }

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -527,7 +527,7 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]membership.HostInfo, star
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.FrontendPProfPort())
 	params.RPCFactory = c.newRPCFactory(service.Frontend, c.FrontendHost())
 	params.MetricScope = tally.NewTestScope(service.Frontend, make(map[string]string))
-	params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+	params.MembershipResolver = newMembershipResolver(params.Name, hosts, c.FrontendHost())
 	params.ClusterMetadata = c.clusterMetadata
 	params.MessagingClient = c.messagingClient
 	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
@@ -609,7 +609,7 @@ func (c *cadenceImpl) startHistory(hosts map[string][]membership.HostInfo, start
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
 		params.RPCFactory = c.newRPCFactory(service.History, hostport)
 		params.MetricScope = tally.NewTestScope(service.History, make(map[string]string))
-		params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+		params.MembershipResolver = newMembershipResolver(params.Name, hosts, hostport)
 		params.ClusterMetadata = c.clusterMetadata
 		params.MessagingClient = c.messagingClient
 		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
@@ -688,7 +688,7 @@ func (c *cadenceImpl) startMatching(hosts map[string][]membership.HostInfo, star
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
 		params.RPCFactory = c.newRPCFactory(service.Matching, hostport)
 		params.MetricScope = tally.NewTestScope(service.Matching, map[string]string{"matching-host": matchingHost})
-		params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+		params.MembershipResolver = newMembershipResolver(params.Name, hosts, hostport)
 		params.ClusterMetadata = c.clusterMetadata
 		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 		params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.matchingDynCfgOverrides)
@@ -747,7 +747,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.WorkerPProfPort())
 	params.RPCFactory = c.newRPCFactory(service.Worker, c.WorkerServiceHost())
 	params.MetricScope = tally.NewTestScope(service.Worker, make(map[string]string))
-	params.MembershipResolver = newMembershipResolver(params.Name, hosts)
+	params.MembershipResolver = newMembershipResolver(params.Name, hosts, c.WorkerServiceHost())
 	params.ClusterMetadata = c.clusterMetadata
 	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 	params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.workerDynCfgOverrides)
@@ -965,8 +965,8 @@ func copyPersistenceConfig(pConfig config.Persistence) (config.Persistence, erro
 	return pConfig, nil
 }
 
-func newMembershipResolver(serviceName string, hosts map[string][]membership.HostInfo) membership.Resolver {
-	return NewSimpleResolver(serviceName, hosts)
+func newMembershipResolver(serviceName string, hosts map[string][]membership.HostInfo, currentHost membership.HostInfo) membership.Resolver {
+	return NewSimpleResolver(serviceName, hosts, currentHost)
 }
 
 func newPProfInitializerImpl(logger log.Logger, port int) common.PProfInitializer {

--- a/schema/pinot/cadence-visibility-config.json
+++ b/schema/pinot/cadence-visibility-config.json
@@ -27,19 +27,18 @@
       "stream.kafka.hlc.zk.connect.string": "zookeeper:2181/kafka",
       "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
       "stream.kafka.zk.broker.url": "zookeeper:2181/kafka",
-      "stream.kafka.broker.list": "kafka:9093",
-      "realtime.segment.flush.threshold.size": 30,
-      "realtime.segment.flush.threshold.rows": 30,
-      "realtime.segment.flush.threshold.time": "24h",
-      "realtime.segment.flush.threshold.segment.size": "50M"
+      "stream.kafka.broker.list": "kafka:9093"
     }
   },
   "routing": {
     "instanceSelectorType": "strictReplicaGroup"
   },
   "upsertConfig": {
-    "mode": "FULL"
+    "mode": "FULL",
+    "deleteRecordColumn": "IsDeleted",
+    "deletedKeysTTL": 86400,
+    "hashFunction": "NONE",
+    "enableSnapshot": false
   },
   "metadata": {}
 }
-

--- a/service/worker/esanalyzer/analyzer_test.go
+++ b/service/worker/esanalyzer/analyzer_test.go
@@ -565,8 +565,8 @@ func TestEmitWorkflowTypeCountMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test0", 1},
-					{"test1", 2},
+					{"test0", float64(1)},
+					{"test1", float64(2)},
 				}, nil).Times(1)
 			},
 			expectedErr: nil,
@@ -657,16 +657,16 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-version0", 1},
-					{"test-wf-version1", 20},
+					{"test-wf-version0", float64(10)},
+					{"test-wf-version1", float64(20)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-version3", 10},
-					{"test-wf-version4", 2},
+					{"test-wf-version3", float64(10)},
+					{"test-wf-version4", float64(2)},
 				}, nil).Times(1)
 			},
 			expectedErr: nil,
@@ -718,8 +718,8 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 			},
 			expectedErr: fmt.Errorf("error querying workflow versions for workflow type: test-wf-type0: error: domain error"),
@@ -731,8 +731,8 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return(nil, fmt.Errorf("pinot error")).Times(1)
 			},
@@ -745,16 +745,16 @@ func TestEmitWorkflowVersionMetricsPinot(t *testing.T) {
 			},
 			PinotClientAffordance: func(mockPinotClient *pinot.MockGenericClient) {
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-type0", 100},
-					{"test-wf-type1", 200},
+					{"test-wf-type0", float64(100)},
+					{"test-wf-type1", float64(200)},
 				}, nil).Times(1)
 				mockPinotClient.EXPECT().SearchAggr(gomock.Any()).Return([][]interface{}{
-					{"test-wf-version0", 1.5},
+					{"test-wf-version0", float64(3.14)},
 					{"test-wf-version1", 20},
 				}, nil).Times(1)
 			},
 			expectedErr: fmt.Errorf("error querying workflow versions for workflow type: " +
-				"test-wf-type0: error: error parsing workflow count for workflow version test-wf-version0"),
+				"test-wf-type0: error: error parsing workflow count for cadence version test-wf-version1"),
 		},
 	}
 

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -217,12 +217,17 @@ func (w *Workflow) emitWorkflowTypeCountMetricsPinot(domainName string, logger *
 	var domainWorkflowTypeCount DomainWorkflowTypeCount
 	for _, row := range response {
 		workflowType := row[0].(string)
-		workflowCount, ok := row[1].(int)
+
+		// even though the count is a int, it is returned as a float64, need to pay attention to this
+		workflowCount, ok := row[1].(float64)
 		if !ok {
 			logger.Error("Error parsing workflow count",
 				zap.Error(err),
 				zap.String("WorkflowType", workflowType),
 				zap.String("DomainName", domainName),
+				zap.Float64("WorkflowCount", workflowCount),
+				zap.String("WorkflowCountType", fmt.Sprintf("%T", row[1])),
+				zap.String("raw data", fmt.Sprintf("%#v", response)),
 			)
 			return fmt.Errorf("error parsing workflow count for workflow type %s", workflowType)
 		}

--- a/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
+++ b/service/worker/esanalyzer/domainWorkflowTypeCountWorkflow.go
@@ -176,7 +176,6 @@ func (w *Workflow) getDomainWorkflowTypeCountPinotQuery(domainName string) (stri
 SELECT WorkflowType, COUNT(*) AS count
 FROM %s
 WHERE DomainID = '%s'
-AND IsDeleted = false
 AND CloseStatus = -1
 AND StartTime > 0
 GROUP BY WorkflowType


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Introducing an interface that can check and collect all timeouts within a workflow execution history

<!-- Tell your future self why have you made these changes -->
**Why?**
This invariant will be used within the workflow diagnostics to run checks to identify timeouts in workflow execution

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
