### PR TITLE
Matching simulation with more read partitions than write partitions

### DIFF
--- a/host/matching_simulation_test.go
+++ b/host/matching_simulation_test.go
@@ -86,7 +86,7 @@ type operationAggStats struct {
 func TestMatchingSimulationSuite(t *testing.T) {
 	flag.Parse()
 
-	confPath := os.Getenv("MATCHING_SIMULATION_CASE")
+	confPath := os.Getenv("MATCHING_SIMULATION_CONFIG")
 	if confPath == "" {
 		confPath = defaultTestCase
 	}

--- a/host/testdata/matching_simulation_more_read_partitions.yaml
+++ b/host/testdata/matching_simulation_more_read_partitions.yaml
@@ -1,0 +1,25 @@
+enablearchival: false
+clusterno: 1
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+matchingconfig:
+  nummatchinghosts: 4
+  simulationconfig:
+    tasklistwritepartitions: 2
+    tasklistreadpartitions: 4
+    numpollers: 10
+    numtaskgenerators: 2
+    taskspersecond: 40
+    maxtasktogenerate: 1500
+    polltimeout: 60s
+    forwardermaxoutstandingpolls: 1
+    forwardermaxoutstandingtasks: 1
+    forwardermaxratepersecond: 10
+    forwardermaxchildrenpernode: 20
+    localpollwaittime: 0ms
+    localtaskwaittime: 0ms
+workerconfig:
+  enableasyncwfconsumer: false

--- a/scripts/run_matching_simulator.sh
+++ b/scripts/run_matching_simulator.sh
@@ -5,22 +5,23 @@
 
 set -eo pipefail
 
-testName="test-$(date '+%Y-%m-%d-%H-%M-%S')"
+testCase="${1:-default}"
+testCfg="testdata/matching_simulation_$testCase.yaml"
+testName="test-$testCase-$(date '+%Y-%m-%d-%H-%M-%S')"
 resultFolder="matching-simulator-output"
 mkdir -p "$resultFolder"
 eventLogsFile="$resultFolder/events.json"
 testSummaryFile="$resultFolder/$testName-summary.txt"
-testCase="testdata/matching_simulation_${1:-default}.yaml"
 
 
 echo "Building test image"
 docker-compose -f docker/buildkite/docker-compose-local-matching-simulation.yml \
   build matching-simulator
 
-echo "Running the test"
+echo "Running the test $testCase"
 docker-compose \
   -f docker/buildkite/docker-compose-local-matching-simulation.yml \
-  run -e MATCHING_SIMULATION_CASE=$testCase --rm matching-simulator \
+  run -e MATCHING_SIMULATION_CONFIG=$testCfg --rm matching-simulator \
   | grep -a --line-buffered "Matching New Event" \
   | sed "s/Matching New Event: //" \
   | jq . > "$eventLogsFile"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a new matching simulation scenario to measure the impact of having more read partitions than write partitions on a tasklists.
- default case with 2 read and 2 write partitions
vs
- new case with 4 read, 2 write partitions


<!-- Tell your future self why have you made these changes -->
**Why?**
This comparison is interesting because tasklist partition increments are done in phases where first read partitions are increased and then write partitions are increased to the same. During that period, the poll requests routed to the partitions without any write activity would not find any tasks and must be forwarded to parent partition in order to find a task.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran `./scripts/run_matching_simulator.sh more_read_partitions` and `./scripts/run_matching_simulator.sh default`.

Highlights from the results:
|   |   |   | 
|---|---|---|
| Measurement | partitions r=2, w=2 | partitions r=4, w=2 |
| Tasks generated | 1500 |  1500 |
| Tasks polled | 1500 |  1500 |
| Avg Poll latency (ms) | 240 | 246 |
| P99 Task latency (ms) | 23 | 2325 |
| Max Task latency (ms) | 133 | 2977 |
| Simulation Duration (s) | 36.5 | 38.5 |
| Tasks Written to DB | 22 | 481 |
| Task forward attempts | 158 | 1219 |
| Sync matches | 1480 | 1115 |
| Async matches | 20 | 385 | 


Conclusion: Having more read partitions than read partitions clearly impacts the p99 task latencies and sync match rate in a negative way.
