### PR TITLE
Fix bug that headers are removed in indexes for closed workflows

### DIFF
--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1863,7 +1863,7 @@ func createRecordWorkflowExecutionClosedRequest(
 		NumClusters:        numClusters,
 		UpdateTimestamp:    updateTime.UnixNano(),
 		CloseTimestamp:     *closeTimestamp,
-		RetentionSeconds:   int64(mutableState.GetDomainEntry().GetRetentionDays(taskInfo.GetWorkflowID())*24*3600),
+		RetentionSeconds:   int64(mutableState.GetDomainEntry().GetRetentionDays(taskInfo.GetWorkflowID()) * 24 * 3600),
 		SearchAttributes:   searchAttributes,
 	}
 }

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1559,7 +1559,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskWi
 	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{} {
 		return map[string]interface{}{
 			"Header_context_key": struct{}{},
-			"123456": struct{}{}, // unsanitizable key
+			"123456":             struct{}{}, // unsanitizable key
 		}
 	}
 

--- a/service/history/task/transfer_active_task_executor_test.go
+++ b/service/history/task/transfer_active_task_executor_test.go
@@ -1559,6 +1559,7 @@ func (s *transferActiveTaskExecutorSuite) TestProcessRecordWorkflowStartedTaskWi
 	s.mockShard.GetConfig().ValidSearchAttributes = func(opts ...dc.FilterOption) map[string]interface{} {
 		return map[string]interface{}{
 			"Header_context_key": struct{}{},
+			"123456": struct{}{}, // unsanitizable key
 		}
 	}
 

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -463,7 +463,7 @@ func getWorkflowHeaders(startEvent *types.HistoryEvent) map[string][]byte {
 	if attr == nil || attr.Header == nil {
 		return nil
 	}
-	headers := make(map[string][]byte)
+	headers := make(map[string][]byte, len(attr.Header.Fields))
 	for k, v := range attr.Header.Fields {
 		val := make([]byte, len(v))
 		copy(val, v)

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -26,6 +26,8 @@ import (
 	"fmt"
 	"time"
 
+	"go.uber.org/multierr"
+
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -41,7 +43,6 @@ import (
 	"github.com/uber/cadence/service/history/execution"
 	"github.com/uber/cadence/service/history/shard"
 	"github.com/uber/cadence/service/worker/archiver"
-	"go.uber.org/multierr"
 )
 
 const (

--- a/service/history/testing/workflow_util.go
+++ b/service/history/testing/workflow_util.go
@@ -66,6 +66,7 @@ func StartWorkflow(
 				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 				Header: &types.Header{Fields: map[string][]byte{
 					"context-key":         []byte("contextValue"),
+					"123456": []byte("123456"), // unsanitizable key
 					"invalid-context-key": []byte("invalidContextValue"),
 				}},
 			},

--- a/service/history/testing/workflow_util.go
+++ b/service/history/testing/workflow_util.go
@@ -66,7 +66,7 @@ func StartWorkflow(
 				TaskStartToCloseTimeoutSeconds:      common.Int32Ptr(1),
 				Header: &types.Header{Fields: map[string][]byte{
 					"context-key":         []byte("contextValue"),
-					"123456": []byte("123456"), // unsanitizable key
+					"123456":              []byte("123456"), // unsanitizable key
 					"invalid-context-key": []byte("invalidContextValue"),
 				}},
 			},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Cause:
For recording closed workflow task, headers are not appended into search attributes and thus the last closed event would remove the header in visibility. 

Fix
* move the logic to base transfer task
* header append logic should exist in every record update (recordstart, upsert, recordclose)

<!-- Tell your future self why have you made these changes -->
**Why?**

From staging and production rolled out environment, we found header are not indexed correctly for closed workflows. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
