### PR TITLE
Add metrics for tasks already started in matching

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2558,6 +2558,8 @@ const (
 	PollLocalMatchLatencyPerTaskList
 	PollForwardMatchLatencyPerTaskList
 	PollLocalMatchAfterForwardFailedLatencyPerTaskList
+	PollDecisionTaskAlreadyStartedCounter
+	PollActivityTaskAlreadyStartedCounter
 
 	NumMatchingMetrics
 )
@@ -3227,6 +3229,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PollLocalMatchLatencyPerTaskList:                        {metricName: "poll_local_match_latency_per_tl", metricRollupName: "poll_local_match_latency", metricType: Timer},
 		PollForwardMatchLatencyPerTaskList:                      {metricName: "poll_forward_match_latency_per_tl", metricRollupName: "poll_forward_match_latency", metricType: Timer},
 		PollLocalMatchAfterForwardFailedLatencyPerTaskList:      {metricName: "poll_local_match_after_forward_failed_latency_per_tl", metricRollupName: "poll_local_match_after_forward_failed_latency", metricType: Timer},
+		PollDecisionTaskAlreadyStartedCounter:                   {metricName: "poll_decision_task_already_started", metricType: Counter},
+		PollActivityTaskAlreadyStartedCounter:                   {metricName: "poll_activity_task_already_started", metricType: Counter},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2558,8 +2558,8 @@ const (
 	PollLocalMatchLatencyPerTaskList
 	PollForwardMatchLatencyPerTaskList
 	PollLocalMatchAfterForwardFailedLatencyPerTaskList
-	PollDecisionTaskAlreadyStartedCounter
-	PollActivityTaskAlreadyStartedCounter
+	PollDecisionTaskAlreadyStartedCounterPerTaskList
+	PollActivityTaskAlreadyStartedCounterPerTaskList
 
 	NumMatchingMetrics
 )
@@ -3229,8 +3229,8 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		PollLocalMatchLatencyPerTaskList:                        {metricName: "poll_local_match_latency_per_tl", metricRollupName: "poll_local_match_latency", metricType: Timer},
 		PollForwardMatchLatencyPerTaskList:                      {metricName: "poll_forward_match_latency_per_tl", metricRollupName: "poll_forward_match_latency", metricType: Timer},
 		PollLocalMatchAfterForwardFailedLatencyPerTaskList:      {metricName: "poll_local_match_after_forward_failed_latency_per_tl", metricRollupName: "poll_local_match_after_forward_failed_latency", metricType: Timer},
-		PollDecisionTaskAlreadyStartedCounter:                   {metricName: "poll_decision_task_already_started", metricType: Counter},
-		PollActivityTaskAlreadyStartedCounter:                   {metricName: "poll_activity_task_already_started", metricType: Counter},
+		PollDecisionTaskAlreadyStartedCounterPerTaskList:        {metricName: "poll_decision_task_already_started_per_tl", metricType: Counter},
+		PollActivityTaskAlreadyStartedCounterPerTaskList:        {metricName: "poll_activity_task_already_started_per_tl", metricType: Counter},
 	},
 	Worker: {
 		ReplicatorMessages:                            {metricName: "replicator_messages"},

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -595,7 +595,7 @@ pollLoop:
 				hCtx.scope.
 					Tagged(metrics.DomainTag(domainName)).
 					Tagged(metrics.TaskListTag(taskListName)).
-					IncCounter(metrics.PollDecisionTaskAlreadyStartedCounter)
+					IncCounter(metrics.PollDecisionTaskAlreadyStartedCounterPerTaskList)
 
 				e.emitInfoOrDebugLog(
 					task.Event.DomainID,
@@ -714,7 +714,7 @@ pollLoop:
 				hCtx.scope.
 					Tagged(metrics.DomainTag(domainName)).
 					Tagged(metrics.TaskListTag(taskListName)).
-					IncCounter(metrics.PollActivityTaskAlreadyStartedCounter)
+					IncCounter(metrics.PollActivityTaskAlreadyStartedCounterPerTaskList)
 
 				e.emitInfoOrDebugLog(
 					task.Event.DomainID,

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -591,6 +591,12 @@ pollLoop:
 		if err != nil {
 			switch err.(type) {
 			case *types.EntityNotExistsError, *types.WorkflowExecutionAlreadyCompletedError, *types.EventAlreadyStartedError:
+				domainName, _ := e.domainCache.GetDomainName(domainID)
+				hCtx.scope.
+					Tagged(metrics.DomainTag(domainName)).
+					Tagged(metrics.TaskListTag(taskListName)).
+					IncCounter(metrics.PollDecisionTaskAlreadyStartedCounter)
+
 				e.emitInfoOrDebugLog(
 					task.Event.DomainID,
 					"Duplicated decision task",
@@ -703,6 +709,13 @@ pollLoop:
 		if err != nil {
 			switch err.(type) {
 			case *types.EntityNotExistsError, *types.WorkflowExecutionAlreadyCompletedError, *types.EventAlreadyStartedError:
+				domainName, _ := e.domainCache.GetDomainName(domainID)
+
+				hCtx.scope.
+					Tagged(metrics.DomainTag(domainName)).
+					Tagged(metrics.TaskListTag(taskListName)).
+					IncCounter(metrics.PollActivityTaskAlreadyStartedCounter)
+
 				e.emitInfoOrDebugLog(
 					task.Event.DomainID,
 					"Duplicated activity task",


### PR DESCRIPTION
What changed?
Added metrics to PollForDecisionTask and PollForActivityTask to track when the task being polled has already started and therefore discarded.

Why?
This metric will give visibility to the accumulation of stale tasks in matching and will serve as a baseline for future work on that part.

How did you test it?

Potential risks

Release notes

Documentation Changes
