### PR TITLE
Add additional options to matching simulation cases

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -169,6 +169,12 @@ type (
 		// The total QPS to generate tasks. Defaults to 40.
 		TasksPerSecond int
 
+		// The burst value for the rate limiter for task generation. Controls the maximum number of AddTask requests
+		// that can be sent concurrently. For example, if you have TasksPerSecond, TasksBurst, and NumTaskGenerators all
+		// set to 10 then every second you'll get 10 tasks added right at the start of the second. If you instead set
+		// TasksBurst to 1 then you'd get a steady stream of tasks, with one task every 100ms.
+		TasksBurst int
+
 		// Upper limit of tasks to generate. Task generators will stop if total number of tasks generated reaches MaxTaskToGenerate during simulation
 		// Defaults to 2k
 		MaxTaskToGenerate int
@@ -193,6 +199,11 @@ type (
 
 		// LocalTaskWaitTime. defaults to 0ms.
 		LocalTaskWaitTime time.Duration
+
+		// TaskProcessTime. The amount of time spent by the poller in-between requests
+		TaskProcessTime time.Duration
+		// RecordDecisionTaskStartedTime. The amount of time spent by History to complete RecordDecisionTaskStarted
+		RecordDecisionTaskStartedTime time.Duration
 	}
 
 	// CadenceParams contains everything needed to bootstrap Cadence

--- a/host/testdata/matching_simulation_burst.yaml
+++ b/host/testdata/matching_simulation_burst.yaml
@@ -8,16 +8,19 @@ historyconfig:
 matchingconfig:
   nummatchinghosts: 4
   simulationconfig:
-    tasklistwritepartitions: 2
-    tasklistreadpartitions: 2
-    numpollers: 10
-    numtaskgenerators: 2
-    taskspersecond: 200
-    maxtasktogenerate: 1500
+    tasklistwritepartitions: 4
+    tasklistreadpartitions: 4
+    numpollers: 8
+    numtaskgenerators: 10
+    taskspersecond: 500
+    maxtasktogenerate: 10000
     polltimeout: 60s
     forwardermaxoutstandingpolls: 1
     forwardermaxoutstandingtasks: 1
     forwardermaxratepersecond: 10
     forwardermaxchildrenpernode: 20
+    localpollwaittime: 0ms
+    localtaskwaittime: 0ms
+    taskprocesstime: 1ms
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_default.yaml
+++ b/host/testdata/matching_simulation_default.yaml
@@ -8,12 +8,12 @@ historyconfig:
 matchingconfig:
   nummatchinghosts: 4
   simulationconfig:
-    tasklistwritepartitions: 2
-    tasklistreadpartitions: 2
-    numpollers: 10
+    tasklistwritepartitions: 4
+    tasklistreadpartitions: 4
+    numpollers: 8
     numtaskgenerators: 2
-    taskspersecond: 40
-    maxtasktogenerate: 1500
+    taskspersecond: 80
+    maxtasktogenerate: 3000
     polltimeout: 60s
     forwardermaxoutstandingpolls: 1
     forwardermaxoutstandingtasks: 1
@@ -21,5 +21,6 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 0ms
     localtaskwaittime: 0ms
+    taskprocesstime: 1ms
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_no_forwarding.yaml
+++ b/host/testdata/matching_simulation_no_forwarding.yaml
@@ -9,17 +9,18 @@ matchingconfig:
   nummatchinghosts: 4
   simulationconfig:
     tasklistwritepartitions: 4
-    tasklistreadpartitions: 8
+    tasklistreadpartitions: 4
     numpollers: 8
     numtaskgenerators: 2
     taskspersecond: 80
     maxtasktogenerate: 3000
     polltimeout: 60s
-    forwardermaxoutstandingpolls: 1
-    forwardermaxoutstandingtasks: 1
+    forwardermaxoutstandingpolls: 0
+    forwardermaxoutstandingtasks: 0
     forwardermaxratepersecond: 10
     forwardermaxchildrenpernode: 20
     localpollwaittime: 0ms
     localtaskwaittime: 0ms
+    taskprocesstime: 1ms
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_throughput.yaml
+++ b/host/testdata/matching_simulation_throughput.yaml
@@ -8,10 +8,10 @@ historyconfig:
 matchingconfig:
   nummatchinghosts: 4
   simulationconfig:
-    tasklistwritepartitions: 4
-    tasklistreadpartitions: 8
+    tasklistwritepartitions: 1
+    tasklistreadpartitions: 1
     numpollers: 8
-    numtaskgenerators: 2
+    numtaskgenerators: 10
     taskspersecond: 80
     maxtasktogenerate: 3000
     polltimeout: 60s
@@ -21,5 +21,6 @@ matchingconfig:
     forwardermaxchildrenpernode: 20
     localpollwaittime: 0ms
     localtaskwaittime: 0ms
+    taskprocesstime: 1ms
 workerconfig:
   enableasyncwfconsumer: false


### PR DESCRIPTION
Add RecordDecisionTaskStartedTime to control the delay incurred by matching calling to history.

Add TaskProcessTime to control the delay in-between polls. This is meant to represent time the client spends executing the task.

Add TasksBurst to allow setting the burst value on the rate limiter, defaulting to a value of 1. Currently it uses the same value as the RPS which results in spikey behavior that causes sync matching to significantly underperform.

Allow ForwarderMaxOutstandingPolls and ForwarderMaxOutstandingTasks to be zero. It's interesting to see a control without any forwarding.

Additionally add a few test cases to showcase different behaviors of the current matching stack. This isn't a complete set yet but each of these brings some interesting behavior.

<!-- Describe what has changed in this PR -->
**What changed?**
- Modifications to matching simulator


<!-- Tell your future self why have you made these changes -->
**Why?**
- Addresses correctness in some existing results and allows for additional options to be set

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Running matching simulator

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- None.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
