### PR TITLE
Move idls onto the main repo, rather than an unknown SHA, and sync with go module

### DIFF
--- a/.buildkite/pipeline-master.yml
+++ b/.buildkite/pipeline-master.yml
@@ -34,6 +34,18 @@ agents:
 
 steps:
 
+  - label: ":on: IDL submodule points to master"
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                  - |-
+                    make .idl-status
+
   - label: ":golang: unit test"
     artifact_paths:
       - ".build/coverage/*.out"

--- a/.buildkite/pipeline-pull-request.yml
+++ b/.buildkite/pipeline-pull-request.yml
@@ -34,6 +34,18 @@ agents:
 
 steps:
 
+  - label: ":on: IDL submodule points to master"
+    plugins:
+      - kubernetes:
+          <<: *kubernetes
+          podSpec:
+            <<: *podSpec
+            containers:
+              - <<: *commandContainer
+                command:
+                  - |-
+                    make .idl-status
+
   - label: ":golang: unit test"
     artifact_paths:
       - ".build/coverage/*.out"

--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,14 @@ $(STABLE_BIN)/$(PROTOC_VERSION_BIN): | $(STABLE_BIN)
 	  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
 	  exit 1; \
 	fi
+	idlsha="$$(git ls-tree HEAD idls | awk '{print substr($$3,0,12)}')"; \
+	gosha="$$(go list -m github.com/uber/cadence-idl | tr '-' '\n' | tail -n1)"; \
+	if [[ "$$idlsha" != "$$gosha" ]]; then \
+	  >&2 echo "IDL submodule sha ($$idlsha) does not match go module sha ($$gosha)."; \
+	  >&2 echo "Make sure they are in sync before merging."; \
+	  exit 1; \
+	fi
+
 
 # ====================================
 # Codegen targets

--- a/Makefile
+++ b/Makefile
@@ -252,7 +252,7 @@ $(STABLE_BIN)/$(PROTOC_VERSION_BIN): | $(STABLE_BIN)
 	$Q unzip -q $(STABLE_BIN)/protoc.zip -d $(PROTOC_UNZIP_DIR)
 	$Q cp $(PROTOC_UNZIP_DIR)/bin/protoc $@
 
-# checks that the idl submodule points to a commit on master.
+# checks that the idl submodule points to a commit on master, and that it matches the go module (which must be a pseudo version).
 # this is only used in an explicit CI step, because it's expected to fail when developing.
 #
 # `git ls-tree HEAD idls` is selected because this only cares about the committed/checked-out target,

--- a/Makefile
+++ b/Makefile
@@ -257,6 +257,8 @@ $(STABLE_BIN)/$(PROTOC_VERSION_BIN): | $(STABLE_BIN)
 #
 # `git ls-tree HEAD idls` is selected because this only cares about the committed/checked-out target,
 # not whatever the current status is, because only the committed value will exist for others.
+#
+# and last but not least: this avoids using `go` to make this check take only a couple seconds.
 .idl-status:
 	branches="$$(git submodule foreach git branch master --contains HEAD)"; \
 	if ! (echo "$$branches" | grep -q master); then \
@@ -265,7 +267,7 @@ $(STABLE_BIN)/$(PROTOC_VERSION_BIN): | $(STABLE_BIN)
 	  exit 1; \
 	fi
 	idlsha="$$(git ls-tree HEAD idls | awk '{print substr($$3,0,12)}')"; \
-	gosha="$$(go list -m github.com/uber/cadence-idl | tr '-' '\n' | tail -n1)"; \
+	gosha="$$(grep github.com/uber/cadence-idl go.mod | tr '-' '\n' | tail -n1)"; \
 	if [[ "$$idlsha" != "$$gosha" ]]; then \
 	  >&2 echo "IDL submodule sha ($$idlsha) does not match go module sha ($$gosha)."; \
 	  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \

--- a/Makefile
+++ b/Makefile
@@ -252,6 +252,19 @@ $(STABLE_BIN)/$(PROTOC_VERSION_BIN): | $(STABLE_BIN)
 	$Q unzip -q $(STABLE_BIN)/protoc.zip -d $(PROTOC_UNZIP_DIR)
 	$Q cp $(PROTOC_UNZIP_DIR)/bin/protoc $@
 
+# checks that the idl submodule points to a commit on master.
+# this is only used in an explicit CI step, because it's expected to fail when developing.
+#
+# `git ls-tree HEAD idls` is selected because this only cares about the committed/checked-out target,
+# not whatever the current status is, because only the committed value will exist for others.
+.idl-status:
+	branches="$$(git submodule foreach git branch master --contains HEAD)"; \
+	if ! (echo "$$branches" | grep -q master); then \
+	  >&2 echo "IDL submodule points to a commit ($$(git submodule foreach git rev-parse HEAD | tail -n 1)) that is not on master."; \
+	  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
+	  exit 1; \
+	fi
+
 # ====================================
 # Codegen targets
 # ====================================

--- a/Makefile
+++ b/Makefile
@@ -268,7 +268,7 @@ $(STABLE_BIN)/$(PROTOC_VERSION_BIN): | $(STABLE_BIN)
 	gosha="$$(go list -m github.com/uber/cadence-idl | tr '-' '\n' | tail -n1)"; \
 	if [[ "$$idlsha" != "$$gosha" ]]; then \
 	  >&2 echo "IDL submodule sha ($$idlsha) does not match go module sha ($$gosha)."; \
-	  >&2 echo "Make sure they are in sync before merging."; \
+	  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
 	  exit 1; \
 	fi
 

--- a/Makefile
+++ b/Makefile
@@ -258,7 +258,8 @@ $(STABLE_BIN)/$(PROTOC_VERSION_BIN): | $(STABLE_BIN)
 # `git ls-tree HEAD idls` is selected because this only cares about the committed/checked-out target,
 # not whatever the current status is, because only the committed value will exist for others.
 #
-# and last but not least: this avoids using `go` to make this check take only a couple seconds.
+# and last but not least: this avoids using `go` to make this check take only a couple seconds in CI,
+# so the whole docker container doesn't have to be prepared.
 .idl-status:
 	branches="$$(git submodule foreach git branch master --contains HEAD)"; \
 	if ! (echo "$$branches" | grep -q master); then \


### PR DESCRIPTION
`idls/` and the `github.com/uber/cadence-idl` version in `go.mod` are currently out of sync and more than a little screwed up:
- the go module is on `0482c040f91d17be35cccee2bc1cf883f7344992`
- the IDL submodule is on `1cd936eb8e24d42f8d8cd38d6216e619c14c48d5`

The go module is currently on https://github.com/uber/cadence-idl/commit/0482c040f91d17be35cccee2bc1cf883f7344992
which is the latest `master` and seems fine.

The current IDL submodule: https://github.com/uber/cadence-idl/tree/1cd936eb8e24d42f8d8cd38d6216e619c14c48d5
doesn't belong to any branch (much less `master`), and is in danger of being GC'd if we don't do something about that.

It's probably from a temporary PR branch that was cleaned up as part of https://github.com/uber/cadence/pull/6178 (the contents are similar to https://github.com/uber/cadence-idl/tree/d92bb53292d64b698c0c5600bbd6e258e728a020 which was approved and _is_ on `master`), but I can't find `1cd936eb8e24d42f8d8cd38d6216e619c14c48d5` in any PR in either https://github.com/uber/cadence-idl or https://github.com/timl3136/cadence-idl so I'm really not sure.

So this PR contains a few changes:
- moves `idls/` to match `go.mod` SHA: `0482c040f91d17be35cccee2bc1cf883f7344992`
  - `d92bb53292d64b698c0c5600bbd6e258e728a020` did not build, as the service code for `ListAll...` was removed, which is also why I didn't just revert the related commits.
- adds a `make .idl-status` and CI steps to verify that this all stays in sync in the future, because this is all VERY easy to miss in PR reviews, and github's UI just makes it worse by hiding many of these details.

---

# Tested with:

works both locally and in CI on this PR:
```
$ make .idl-status
branches="$(git submodule foreach git branch master --contains HEAD)"; \
if ! (echo "$branches" | grep -q master); then \
  >&2 echo "IDL submodule points to a commit ($(git submodule foreach git rev-parse HEAD | tail -n 1)) that is not on master."; \
  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
  exit 1; \
fi
idlsha="$(git ls-tree HEAD idls | awk '{print substr($3,0,12)}')"; \
gosha="$(grep github.com/uber/cadence-idl go.mod | tr '-' '\n' | tail -n1)"; \
if [[ "$idlsha" != "$gosha" ]]; then \
  >&2 echo "IDL submodule sha ($idlsha) does not match go module sha ($gosha)."; \
  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
  exit 1; \
fi
# Successfully shut down Job API server
```

and failing on master for the submodule issue:
```
❯ make .idl-status
branches="$(git submodule foreach git branch master --contains HEAD)"; \
	if ! (echo "$branches" | grep -q master); then \
	  >&2 echo "IDL submodule points to a commit ($(git submodule foreach git rev-parse HEAD | tail -n 1)) that is not on master."; \
	  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
	  exit 1; \
	fi
IDL submodule points to a commit (1cd936eb8e24d42f8d8cd38d6216e619c14c48d5) that is not on master.
Make sure the IDL PR has been merged, and this PR is updated, before merging here.
make: *** [.idl-status] Error 1
```
and the `go.mod` drift when the git submodule is updated:
```
❯ make .idl-status
branches="$(git submodule foreach git branch master --contains HEAD)"; \
	if ! (echo "$branches" | grep -q master); then \
	  >&2 echo "IDL submodule points to a commit ($(git submodule foreach git rev-parse HEAD | tail -n 1)) that is not on master."; \
	  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
	  exit 1; \
	fi
idlsha="$(git ls-tree HEAD idls | awk '{print substr($3,0,12)}')"; \
	gosha="$(go list -m github.com/uber/cadence-idl | tr '-' '\n' | tail -n1)"; \
	if [[ "$idlsha" != "$gosha" ]]; then \
	  >&2 echo "IDL submodule sha ($idlsha) does not match go module sha ($gosha)."; \
	  >&2 echo "Make sure the IDL PR has been merged, and this PR is updated, before merging here."; \
	  exit 1; \
	fi
IDL submodule sha (d92bb53292d6) does not match go module sha (0482c040f91d).
Make sure the IDL PR has been merged, and this PR is updated, before merging here.
make: *** [.idl-status] Error 1
```

CI only checks the committed state so it's consistent and obvious in its behavior, but locally it can get a bit confused about non-committed differences.
This could be fixed, but... tbh I don't think it matters much.  PRs will always have committed values, and this really isn't local-run-intended because it's common for it to be out of sync while developing.