### PR TITLE
Add support for isolation groups to matching simulator

### DIFF
--- a/host/onebox.go
+++ b/host/onebox.go
@@ -159,29 +159,6 @@ type (
 
 		// Number of task list read partitions defaults to 1
 		TaskListReadPartitions int
-
-		// Number of pollers defaults to 10
-		NumPollers int
-
-		// Number of task generators defaults to 1
-		NumTaskGenerators int
-
-		// The total QPS to generate tasks. Defaults to 40.
-		TasksPerSecond int
-
-		// The burst value for the rate limiter for task generation. Controls the maximum number of AddTask requests
-		// that can be sent concurrently. For example, if you have TasksPerSecond, TasksBurst, and NumTaskGenerators all
-		// set to 10 then every second you'll get 10 tasks added right at the start of the second. If you instead set
-		// TasksBurst to 1 then you'd get a steady stream of tasks, with one task every 100ms.
-		TasksBurst int
-
-		// Upper limit of tasks to generate. Task generators will stop if total number of tasks generated reaches MaxTaskToGenerate during simulation
-		// Defaults to 2k
-		MaxTaskToGenerate int
-
-		// Poll request timeout defaults to 1 second
-		PollTimeout time.Duration
-
 		// At most N polls will be forwarded at a time. defaults to 20
 		ForwarderMaxOutstandingPolls int
 
@@ -200,10 +177,45 @@ type (
 		// LocalTaskWaitTime. defaults to 0ms.
 		LocalTaskWaitTime time.Duration
 
-		// TaskProcessTime. The amount of time spent by the poller in-between requests
-		TaskProcessTime time.Duration
 		// RecordDecisionTaskStartedTime. The amount of time spent by History to complete RecordDecisionTaskStarted
 		RecordDecisionTaskStartedTime time.Duration
+
+		// The pollers that will be created to process
+		Pollers []SimulationPollerConfiguration
+
+		Tasks []SimulationTaskConfiguration
+	}
+
+	SimulationPollerConfiguration struct {
+		// The isolation group that pollers will be created with. Optional.
+		IsolationGroup string
+		// The number of pollers that will be created with this configuration. Defaults to 1
+		NumPollers int
+		// TaskProcessTime. The amount of time spent by the poller in-between requests. Defaults to 1ms
+		TaskProcessTime time.Duration
+		// Poll request timeout defaults to 15 seconds
+		PollTimeout time.Duration
+	}
+
+	SimulationTaskConfiguration struct {
+		// The isolation groups that tasks will be evenly distributed between
+		IsolationGroups []string
+
+		// Number of task generators defaults to 1
+		NumTaskGenerators int
+
+		// The total QPS to generate tasks. Defaults to 40.
+		TasksPerSecond int
+
+		// The burst value for the rate limiter for task generation. Controls the maximum number of AddTask requests
+		// that can be sent concurrently. For example, if you have TasksPerSecond, TasksBurst, and NumTaskGenerators all
+		// set to 10 then every second you'll get 10 tasks added right at the start of the second. If you instead set
+		// TasksBurst to 1 then you'd get a steady stream of tasks, with one task every 100ms.
+		TasksBurst int
+
+		// Upper limit of tasks to generate. Task generators will stop if total number of tasks generated reaches MaxTaskToGenerate during simulation
+		// Defaults to 2k
+		MaxTaskToGenerate int
 	}
 
 	// CadenceParams contains everything needed to bootstrap Cadence

--- a/host/testdata/matching_simulation_burst.yaml
+++ b/host/testdata/matching_simulation_burst.yaml
@@ -10,17 +10,19 @@ matchingconfig:
   simulationconfig:
     tasklistwritepartitions: 4
     tasklistreadpartitions: 4
-    numpollers: 8
-    numtaskgenerators: 10
-    taskspersecond: 500
-    maxtasktogenerate: 10000
-    polltimeout: 60s
     forwardermaxoutstandingpolls: 1
     forwardermaxoutstandingtasks: 1
     forwardermaxratepersecond: 10
     forwardermaxchildrenpernode: 20
     localpollwaittime: 0ms
     localtaskwaittime: 0ms
-    taskprocesstime: 1ms
+    tasks:
+      - numtaskgenerators: 10
+        taskspersecond: 500
+        maxtasktogenerate: 10000
+    pollers:
+      - taskprocesstime: 1ms
+        numpollers: 8
+        polltimeout: 60s
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_default.yaml
+++ b/host/testdata/matching_simulation_default.yaml
@@ -10,17 +10,19 @@ matchingconfig:
   simulationconfig:
     tasklistwritepartitions: 4
     tasklistreadpartitions: 4
-    numpollers: 8
-    numtaskgenerators: 2
-    taskspersecond: 80
-    maxtasktogenerate: 3000
-    polltimeout: 60s
     forwardermaxoutstandingpolls: 1
     forwardermaxoutstandingtasks: 1
     forwardermaxratepersecond: 10
     forwardermaxchildrenpernode: 20
     localpollwaittime: 0ms
     localtaskwaittime: 0ms
-    taskprocesstime: 1ms
+    tasks:
+      - numtaskgenerators: 2
+        taskspersecond: 80
+        maxtasktogenerate: 3000
+    pollers:
+      - taskprocesstime: 1ms
+        numpollers: 8
+        polltimeout: 60s
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_more_read_partitions.yaml
+++ b/host/testdata/matching_simulation_more_read_partitions.yaml
@@ -10,16 +10,19 @@ matchingconfig:
   simulationconfig:
     tasklistwritepartitions: 4
     tasklistreadpartitions: 8
-    numpollers: 8
-    numtaskgenerators: 2
-    taskspersecond: 80
-    maxtasktogenerate: 3000
-    polltimeout: 60s
     forwardermaxoutstandingpolls: 1
     forwardermaxoutstandingtasks: 1
     forwardermaxratepersecond: 10
     forwardermaxchildrenpernode: 20
     localpollwaittime: 0ms
     localtaskwaittime: 0ms
+    tasks:
+      - numtaskgenerators: 2
+        taskspersecond: 80
+        maxtasktogenerate: 3000
+    pollers:
+      - taskprocesstime: 1ms
+        numpollers: 8
+        polltimeout: 60s
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_no_forwarding.yaml
+++ b/host/testdata/matching_simulation_no_forwarding.yaml
@@ -10,17 +10,19 @@ matchingconfig:
   simulationconfig:
     tasklistwritepartitions: 4
     tasklistreadpartitions: 4
-    numpollers: 8
-    numtaskgenerators: 2
-    taskspersecond: 80
-    maxtasktogenerate: 3000
-    polltimeout: 60s
     forwardermaxoutstandingpolls: 0
     forwardermaxoutstandingtasks: 0
     forwardermaxratepersecond: 10
     forwardermaxchildrenpernode: 20
     localpollwaittime: 0ms
     localtaskwaittime: 0ms
-    taskprocesstime: 1ms
+    tasks:
+      - numtaskgenerators: 2
+        taskspersecond: 80
+        maxtasktogenerate: 3000
+    pollers:
+      - taskprocesstime: 1ms
+        numpollers: 8
+        polltimeout: 60s
 workerconfig:
   enableasyncwfconsumer: false

--- a/host/testdata/matching_simulation_zonal_isolation.yaml
+++ b/host/testdata/matching_simulation_zonal_isolation.yaml
@@ -8,8 +8,8 @@ historyconfig:
 matchingconfig:
   nummatchinghosts: 4
   simulationconfig:
-    tasklistwritepartitions: 1
-    tasklistreadpartitions: 1
+    tasklistwritepartitions: 2
+    tasklistreadpartitions: 2
     forwardermaxoutstandingpolls: 1
     forwardermaxoutstandingtasks: 1
     forwardermaxratepersecond: 10
@@ -19,10 +19,16 @@ matchingconfig:
     tasks:
       - numtaskgenerators: 2
         taskspersecond: 80
-        maxtasktogenerate: 3000
+        maxtasktogenerate:  3000
+        isolationgroups: ['a', 'b']
     pollers:
-      - taskprocesstime: 1ms
-        numpollers: 8
+      - isolationgroup: 'a'
+        taskprocesstime: 1ms
+        numpollers: 4
+        polltimeout: 60s
+      - isolationgroup: 'b'
+        taskprocesstime: 1ms
+        numpollers: 4
         polltimeout: 60s
 workerconfig:
   enableasyncwfconsumer: false


### PR DESCRIPTION
This fundamentally restructures how pollers and task generators are configured, but allows for granular control across isolation groups.

<!-- Describe what has changed in this PR -->
**What changed?**
- Adds support for isolation groups and restructures poller/task generation to allow for multiple independent configurations to be executing concurrently.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enables improvements in isolation group throughput

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Running the matching simulator

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
