### PR TITLE
[Wf-Diagnostics] remove heartbeat rootcause for other irrelevant timeouts

### DIFF
--- a/service/worker/diagnostics/invariants/types.go
+++ b/service/worker/diagnostics/invariants/types.go
@@ -44,7 +44,6 @@ const (
 	RootCauseTypePollersStatus                       RootCause = "There are pollers for the tasklist. Check backlog status"
 	RootCauseTypeHeartBeatingNotEnabled              RootCause = "HeartBeating not enabled for activity"
 	RootCauseTypeHeartBeatingEnabledMissingHeartbeat RootCause = "HeartBeating enabled for activity but timed out due to missing heartbeat"
-	RootCauseTypeHeartBeatingEnabledActivityTimedOut RootCause = "HeartBeating enabled for activity but activity timed out due to other configured timeouts"
 )
 
 func (tt TimeoutType) String() string {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update the way wf-diagnostics provides heart beating as a solution for activity timeouts 

<!-- Tell your future self why have you made these changes -->
**Why?**
Rootcause mentioning heartbeat is not relevant for schedule to start timeouts or for non heartbeat timeouts with heart beating enabled

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
