### PR TITLE
Add topic tag to producer metrics

### DIFF
--- a/common/messaging/kafka/client_impl.go
+++ b/common/messaging/kafka/client_impl.go
@@ -141,7 +141,8 @@ func (c *clientImpl) newProducerByTopic(topic string) (messaging.Producer, error
 
 	if c.metricsClient != nil {
 		c.logger.Info("Create producer with metricsClient")
-		return messaging.NewMetricProducer(NewKafkaProducer(topic, producer, c.logger), c.metricsClient), nil
+		withMetricsOpt := messaging.WithMetricTags(metrics.TopicTag(topic))
+		return messaging.NewMetricProducer(NewKafkaProducer(topic, producer, c.logger), c.metricsClient, withMetricsOpt), nil
 	}
 	return NewKafkaProducer(topic, producer, c.logger), nil
 }

--- a/common/messaging/metrics_producer_test.go
+++ b/common/messaging/metrics_producer_test.go
@@ -1,0 +1,112 @@
+// Copyright (c) 2017 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package messaging
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/metrics/mocks"
+)
+
+func TestPublish(t *testing.T) {
+	tests := []struct {
+		desc                string
+		tags                []metrics.Tag
+		producerFails       bool
+		metricsClientMockFn func() *mocks.Client
+	}{
+		{
+			desc:          "success",
+			producerFails: false,
+			tags: []metrics.Tag{
+				metrics.TopicTag("test-topic-1"),
+			},
+			metricsClientMockFn: func() *mocks.Client {
+				metricsClient := &mocks.Client{}
+				metricsScope := &mocks.Scope{}
+				metricsClient.
+					On("Scope", metrics.MessagingClientPublishScope, metrics.TopicTag("test-topic-1")).
+					Return(metricsScope).
+					Once()
+				metricsScope.On("IncCounter", metrics.CadenceClientRequests).Once()
+
+				sw := metrics.NoopScope(metrics.MessagingClientPublishScope).StartTimer(-1)
+				metricsScope.On("StartTimer", metrics.CadenceClientLatency).Return(sw).Once()
+				return metricsClient
+			},
+		},
+		{
+			desc:          "failure",
+			producerFails: true,
+			tags: []metrics.Tag{
+				metrics.TopicTag("test-topic-2"),
+			},
+			metricsClientMockFn: func() *mocks.Client {
+				metricsClient := &mocks.Client{}
+				metricsScope := &mocks.Scope{}
+				metricsClient.
+					On("Scope", metrics.MessagingClientPublishScope, metrics.TopicTag("test-topic-2")).
+					Return(metricsScope).
+					Once()
+				metricsScope.On("IncCounter", metrics.CadenceClientRequests).Once()
+				metricsScope.On("IncCounter", metrics.CadenceClientFailures).Once()
+
+				sw := metrics.NoopScope(metrics.MessagingClientPublishScope).StartTimer(-1)
+				metricsScope.On("StartTimer", metrics.CadenceClientLatency).Return(sw).Once()
+				return metricsClient
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			// setup
+			ctrl := gomock.NewController(t)
+			mockProducer := NewMockProducer(ctrl)
+			msg := "custom-message"
+			if tc.producerFails {
+				mockProducer.EXPECT().Publish(gomock.Any(), msg).Return(errors.New("publish failed")).Times(1)
+			} else {
+				mockProducer.EXPECT().Publish(gomock.Any(), msg).Return(nil).Times(1)
+			}
+			metricsClient := tc.metricsClientMockFn()
+
+			// create producer and call publish
+			p := NewMetricProducer(mockProducer, metricsClient, WithMetricTags(tc.tags...))
+			err := p.Publish(context.Background(), msg)
+
+			// validations
+			if tc.producerFails != (err != nil) {
+				t.Errorf("expected producer to fail: %v, got: %v", tc.producerFails, err)
+			}
+			if err != nil {
+				return
+			}
+
+			metricsClient.AssertExpectations(t)
+		})
+	}
+}

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -63,6 +63,7 @@ const (
 	workflowTerminationReason = "workflow_termination_reason"
 	workflowCloseStatus       = "workflow_close_status"
 	isolationEnabled          = "isolation_enabled"
+	topic                     = "topic"
 
 	// limiter-side tags
 	globalRatelimitKey            = "global_ratelimit_key"
@@ -315,4 +316,8 @@ func IsolationEnabledTag(enabled bool) Tag {
 		v = "true"
 	}
 	return simpleMetric{key: isolationEnabled, value: v}
+}
+
+func TopicTag(value string) Tag {
+	return metricWithUnknown(topic, value)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Messaging producer (kafka) metrics were missing the topic tag which makes it impossible to make sense of count/latency metrics emitted by this component. In the past we only had visibility topics per environment so topic tag wasn't needed but with the introduction of Async APIs there can be multiple topics per environment.

Changes:
- Adding optional custom tag support to `messaging.NewMetricProducer`
- Pass topic tag option in the places calling this constructor
- Add unit tests

Misc change:
- Adding logs for async wf producer creation because producers are lazily initialized by Async API handlers and subject to 5m ttl. These logs will help us debug how often we re-create the producers for the same target topic.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests