### PR TITLE
Minor metrics / log improvement for global ratelimiter

### DIFF
--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -257,10 +257,12 @@ func AsyncWFRequestTypeTag(value string) Tag {
 	return metricWithUnknown(asyncWFRequestType, value)
 }
 
-// GlobalRatelimiterKeyTag reports the full (global) ratelimit key being used, e.g. "user:domain-x",
-// though the value will be sanitized and may appear as "user_domain_x" or similar.
+// GlobalRatelimiterKeyTag reports the local ratelimit key being used, e.g. "domain-x".
+// This will likely be ambiguous if it is not combined with the collection name,
+// but keeping this untouched helps keep the values template-friendly and correlate-able
+// in metrics dashboards and queries.
 func GlobalRatelimiterKeyTag(value string) Tag {
-	return simpleMetric{key: globalRatelimitKey, value: sanitizer.Value(value)}
+	return simpleMetric{key: globalRatelimitKey, value: value}
 }
 
 // GlobalRatelimiterTypeTag reports the "limit usage type" being reported, e.g. global vs local


### PR DESCRIPTION
Ran into some issues building a dashboard with these, as the collecton's `worker_domain_name` value does not automatically relate to everything else's `domain-name` value, and addressing that is... sadly difficult in our monitoring systems.

Regardless, I think using local keys is probably better.  We already have the collection name in logs and metrics, and this way you can search for the domain name and find all of these at once (easier for browsing randomly) and it's no harder to narrow down either (just also search by collection).
