### PR TITLE
Avoid retry when deletes non exists visibility message

### DIFF
--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -148,9 +148,10 @@ func (p *ESProcessorImpl) bulkAfterAction(id int64, requests []bulk.GenericBulka
 					tag.WorkflowDomainID(domainID))
 
 				// check if it is a delete request and status code
+				// 404 means the document does not exist
 				// 409 means means the document's version does not match (or if the document has been updated or deleted by another process)
 				// this can happen during the data migration, the doc was deleted in the old index but not exists in the new index
-				if err.Status == 409 && p.isDeleteRequest(request) {
+				if p.isDeleteRequest(request) && (err.Status == 409 || err.Status == 404) {
 					p.logger.Info("Delete request encountered a version conflict. Acknowledging to prevent retry.",
 						tag.ESResponseStatus(err.Status), tag.ESRequest(request.String()),
 						tag.WorkflowID(wid),

--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -151,16 +151,24 @@ func (p *ESProcessorImpl) bulkAfterAction(id int64, requests []bulk.GenericBulka
 				// 404 means the document does not exist
 				// 409 means means the document's version does not match (or if the document has been updated or deleted by another process)
 				// this can happen during the data migration, the doc was deleted in the old index but not exists in the new index
-				if p.isDeleteRequest(request) && (err.Status == 409 || err.Status == 404) {
-					p.logger.Info("Delete request encountered a version conflict. Acknowledging to prevent retry.",
-						tag.ESResponseStatus(err.Status), tag.ESRequest(request.String()),
-						tag.WorkflowID(wid),
-						tag.WorkflowRunID(rid),
-						tag.WorkflowDomainID(domainID))
-					p.ackKafkaMsg(key)
-				} else {
-					p.nackKafkaMsg(key)
+				if err.Status == 409 || err.Status == 404 {
+					status := err.Status
+					req, err := request.Source()
+					if err == nil {
+						if p.isDeleteRequest(req) {
+							p.logger.Info("Delete request encountered a version conflict. Acknowledging to prevent retry.",
+								tag.ESResponseStatus(status), tag.ESRequest(request.String()),
+								tag.WorkflowID(wid),
+								tag.WorkflowRunID(rid),
+								tag.WorkflowDomainID(domainID))
+							p.ackKafkaMsg(key)
+						}
+					} else {
+						p.logger.Error("Get request source err.", tag.Error(err), tag.ESRequest(request.String()))
+						p.scope.IncCounter(metrics.ESProcessorCorruptedData)
+					}
 				}
+				p.nackKafkaMsg(key)
 			} else {
 				p.logger.Error("ES request failed", tag.ESRequest(request.String()))
 			}
@@ -238,7 +246,7 @@ func (p *ESProcessorImpl) retrieveKafkaKey(request bulk.GenericBulkableRequest) 
 	}
 
 	var key string
-	if len(req) == 2 { // index or update requests
+	if !p.isDeleteRequest(req) { // index or update requests
 		var body map[string]interface{}
 		if err := json.Unmarshal([]byte(req[1]), &body); err != nil {
 			p.logger.Error("Unmarshal index request body err.", tag.Error(err))
@@ -301,23 +309,14 @@ func (p *ESProcessorImpl) hashFn(key interface{}) uint32 {
 	return uint32(common.WorkflowIDToHistoryShard(id, numOfShards))
 }
 
-func (p *ESProcessorImpl) isDeleteRequest(request bulk.GenericBulkableRequest) bool {
-	req, err := request.Source()
-	if err != nil {
-		p.logger.Error("Get request source err.", tag.Error(err), tag.ESRequest(request.String()))
-		p.scope.IncCounter(metrics.ESProcessorCorruptedData)
-		return false // don't nack the message, let the processor retry
-	}
-
-	if len(req) == 1 {
-		// The Source() method typically returns a slice of strings, where each string represents a part of the bulk request in JSON format.
-		// For delete operations, the Source() method typically returns only one part
-		// The metadata that specifies the delete action, including _index and _id.
-		// "{\"delete\":{\"_index\":\"my-index\",\"_id\":\"1\"}}"
-		return true
-	}
-
-	return false
+func (p *ESProcessorImpl) isDeleteRequest(request []string) bool {
+	// The Source() method typically returns a slice of strings, where each string represents a part of the bulk request in JSON format.
+	// For delete operations, the Source() method typically returns only one part
+	// The metadata that specifies the delete action, including _index and _id.
+	// "{\"delete\":{\"_index\":\"my-index\",\"_id\":\"1\"}}"
+	// For index/update operations, the Source() method typically returns two parts
+	// reference: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/docs-bulk.html
+	return len(request) == 1
 }
 
 // 409 - Version Conflict

--- a/service/worker/indexer/esProcessor_test.go
+++ b/service/worker/indexer/esProcessor_test.go
@@ -402,3 +402,28 @@ func (s *esProcessorSuite) TestIsErrorRetriable() {
 		s.Equal(test.expected, isResponseRetriable(test.input.Status))
 	}
 }
+
+func (s *esProcessorSuite) TestIsDeleteRequest() {
+	tests := []struct {
+		request   bulk.GenericBulkableRequest
+		bIsDelete bool
+	}{
+		{
+			request: bulk.NewBulkIndexRequest().
+				ID("request.ID").
+				Index("request.Index").
+				Version(int64(0)).
+				VersionType("request.VersionType").Doc("request.Doc"),
+			bIsDelete: false,
+		},
+		{
+			request: bulk.NewBulkDeleteRequest().
+				ID("request.ID").
+				Index("request.Index"),
+			bIsDelete: true,
+		},
+	}
+	for _, test := range tests {
+		s.Equal(test.bIsDelete, s.esProcessor.isDeleteRequest(test.request))
+	}
+}

--- a/service/worker/indexer/esProcessor_test.go
+++ b/service/worker/indexer/esProcessor_test.go
@@ -462,14 +462,17 @@ func (s *esProcessorSuite) TestIsDeleteRequest() {
 		},
 	}
 	for _, test := range tests {
-		s.Equal(test.bIsDelete, s.esProcessor.isDeleteRequest(test.request))
+		req, _ := test.request.Source()
+		s.Equal(test.bIsDelete, s.esProcessor.isDeleteRequest(req))
 	}
 }
 
 func (s *esProcessorSuite) TestIsDeleteRequest_Error() {
 	request := &MockBulkableRequest{}
 	s.mockScope.On("IncCounter", mock.AnythingOfType("int")).Return()
-	s.False(s.esProcessor.isDeleteRequest(request))
+	req, err := request.Source()
+	s.False(s.esProcessor.isDeleteRequest(req))
+	s.Error(err)
 }
 
 // MockBulkableRequest is a mock implementation of the GenericBulkableRequest interface


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Check if GenericBulkableRequest is delete request to avoid retry during migration

<!-- Tell your future self why have you made these changes -->
**Why?**
This can happen during migration from ES to OS.
The doc can be deleted during double writes, but it doesn't exist in the destination source, it will nack the kafka message and keep retrying

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test
Tested in dev manually

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
