### PR TITLE
[Wf-Diagnostics] Set query handler for diagnostics workflow to provide result

### DIFF
--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -33,8 +33,9 @@ import (
 )
 
 const (
-	diagnosticsWorkflow = "diagnostics-workflow"
-	tasklist            = "wf-diagnostics"
+	diagnosticsWorkflow    = "diagnostics-workflow"
+	tasklist               = "wf-diagnostics"
+	queryDiagnosticsReport = "query-diagnostics-report"
 
 	retrieveWfExecutionHistoryActivity = "retrieveWfExecutionHistory"
 	identifyTimeoutsActivity           = "identifyTimeouts"
@@ -54,6 +55,14 @@ type DiagnosticsWorkflowResult struct {
 }
 
 func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (DiagnosticsWorkflowResult, error) {
+	var result DiagnosticsWorkflowResult
+	err := workflow.SetQueryHandler(ctx, queryDiagnosticsReport, func() (DiagnosticsWorkflowResult, error) {
+		return result, nil
+	})
+	if err != nil {
+		return result, err
+	}
+
 	activityOptions := workflow.ActivityOptions{
 		ScheduleToCloseTimeout: time.Second * 10,
 		ScheduleToStartTimeout: time.Second * 5,
@@ -62,15 +71,17 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	activityCtx := workflow.WithActivityOptions(ctx, activityOptions)
 
 	var wfExecutionHistory *types.GetWorkflowExecutionHistoryResponse
-	err := workflow.ExecuteActivity(activityCtx, w.retrieveExecutionHistory, retrieveExecutionHistoryInputParams{
+	err = workflow.ExecuteActivity(activityCtx, w.retrieveExecutionHistory, retrieveExecutionHistoryInputParams{
 		Domain: params.Domain,
 		Execution: &types.WorkflowExecution{
 			WorkflowID: params.WorkflowID,
 			RunID:      params.RunID,
 		}}).Get(ctx, &wfExecutionHistory)
 	if err != nil {
-		return DiagnosticsWorkflowResult{}, fmt.Errorf("RetrieveExecutionHistory: %w", err)
+		return result, fmt.Errorf("RetrieveExecutionHistory: %w", err)
 	}
+
+	result.Runbooks = []string{linkToTimeoutsRunbook}
 
 	var checkResult []invariants.InvariantCheckResult
 	err = workflow.ExecuteActivity(activityCtx, w.identifyTimeouts, identifyTimeoutsInputParams{
@@ -78,8 +89,9 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		Domain:  params.Domain,
 	}).Get(ctx, &checkResult)
 	if err != nil {
-		return DiagnosticsWorkflowResult{}, fmt.Errorf("IdentifyTimeouts: %w", err)
+		return result, fmt.Errorf("IdentifyTimeouts: %w", err)
 	}
+	result.Issues = checkResult
 
 	var rootCauseResult []invariants.InvariantRootCauseResult
 	err = workflow.ExecuteActivity(activityCtx, w.rootCauseTimeouts, rootCauseTimeoutsParams{
@@ -88,12 +100,9 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 		Issues:  checkResult,
 	}).Get(ctx, &rootCauseResult)
 	if err != nil {
-		return DiagnosticsWorkflowResult{}, fmt.Errorf("RootCauseTimeouts: %w", err)
+		return result, fmt.Errorf("RootCauseTimeouts: %w", err)
 	}
+	result.RootCause = rootCauseResult
 
-	return DiagnosticsWorkflowResult{
-		Issues:    checkResult,
-		RootCause: rootCauseResult,
-		Runbooks:  []string{linkToTimeoutsRunbook},
-	}, nil
+	return result, nil
 }

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -122,6 +122,10 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 	s.NoError(s.workflowEnv.GetWorkflowResult(&result))
 	s.ElementsMatch(issues, result.Issues)
 	s.ElementsMatch(rootCause, result.RootCause)
+
+	queriedResult := s.queryDiagnostics()
+	s.ElementsMatch(queriedResult.Issues, result.Issues)
+	s.ElementsMatch(queriedResult.RootCause, result.RootCause)
 }
 
 func (s *diagnosticsWorkflowTestSuite) TestWorkflow_Error() {
@@ -138,4 +142,14 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow_Error() {
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	s.Error(s.workflowEnv.GetWorkflowError())
 	s.EqualError(s.workflowEnv.GetWorkflowError(), errExpected.Error())
+}
+
+func (s *diagnosticsWorkflowTestSuite) queryDiagnostics() DiagnosticsWorkflowResult {
+	queryFuture, err := s.workflowEnv.QueryWorkflow(queryDiagnosticsReport)
+	s.NoError(err)
+
+	var result DiagnosticsWorkflowResult
+	err = queryFuture.Get(&result)
+	s.NoError(err)
+	return result
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Diagnostics workflow has a query handler that provides the diagnostics result

<!-- Tell your future self why have you made these changes -->
**Why?**
Diagnostics workflow start will be triggered via api/cli and result will be fetched via query

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
