### PR TITLE
Concurrency primitives need concurrent tests

### DIFF
--- a/common/locks/lock_test.go
+++ b/common/locks/lock_test.go
@@ -65,6 +65,7 @@ func BenchmarkLock(b *testing.B) {
 		l.Unlock()
 	}
 }
+
 func BenchmarkStdlibLock(b *testing.B) {
 	var m sync.Mutex
 	for n := 0; n < b.N; n++ {

--- a/common/locks/lock_test.go
+++ b/common/locks/lock_test.go
@@ -65,7 +65,7 @@ func BenchmarkLock(b *testing.B) {
 		l.Unlock()
 	}
 }
-func BenchmarkPrimitiveLock(b *testing.B) {
+func BenchmarkStdlibLock(b *testing.B) {
 	var m sync.Mutex
 	for n := 0; n < b.N; n++ {
 		m.Lock()
@@ -84,7 +84,7 @@ func BenchmarkParallelLock(b *testing.B) {
 	})
 }
 
-func BenchmarkParallelPrimitiveLock(b *testing.B) {
+func BenchmarkParallelStdlibLock(b *testing.B) {
 	var m sync.Mutex
 	b.RunParallel(func(pb *testing.PB) {
 		for pb.Next() {

--- a/common/locks/lock_test.go
+++ b/common/locks/lock_test.go
@@ -65,6 +65,34 @@ func BenchmarkLock(b *testing.B) {
 		l.Unlock()
 	}
 }
+func BenchmarkPrimitiveLock(b *testing.B) {
+	var m sync.Mutex
+	for n := 0; n < b.N; n++ {
+		m.Lock()
+		m.Unlock()
+	}
+}
+
+func BenchmarkParallelLock(b *testing.B) {
+	l := NewMutex()
+	ctx := context.Background()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_ = l.Lock(ctx)
+			l.Unlock()
+		}
+	})
+}
+
+func BenchmarkParallelPrimitiveLock(b *testing.B) {
+	var m sync.Mutex
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			m.Lock()
+			m.Unlock()
+		}
+	})
+}
 
 func TestConcurrently(t *testing.T) {
 	defer goleak.VerifyNone(t)

--- a/common/locks/lock_test.go
+++ b/common/locks/lock_test.go
@@ -22,50 +22,38 @@ package locks
 
 import (
 	"context"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
+	"go.uber.org/goleak"
 )
 
-type (
-	LockSuite struct {
-		*require.Assertions // override suite.Suite.Assertions with require.Assertions; this means that s.NotNil(nil) will stop the test, not merely log an error
-		suite.Suite
-	}
-)
-
-func TestLockSuite(t *testing.T) {
-	suite.Run(t, new(LockSuite))
-}
-
-func (s *LockSuite) SetupTest() {
-	s.Assertions = require.New(s.T()) // Have to define our overridden assertions in the test setup. If we did it earlier, s.T() will return nil
-}
-
-func (s *LockSuite) TestBasicLocking() {
+func TestBasicLocking(t *testing.T) {
 	lock := NewMutex()
 	err1 := lock.Lock(context.Background())
-	s.Nil(err1)
+	require.Nil(t, err1)
 	lock.Unlock()
 }
 
-func (s *LockSuite) TestExpiredContext() {
+func TestExpiredContext(t *testing.T) {
 	lock := NewMutex()
 	err1 := lock.Lock(context.Background())
-	s.Nil(err1)
+	require.Nil(t, err1)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	cancel()
 	err2 := lock.Lock(ctx)
-	s.NotNil(err2)
-	s.Equal(err2, ctx.Err())
+	require.NotNil(t, err2)
+	require.Equal(t, err2, ctx.Err())
 
 	lock.Unlock()
 
 	err3 := lock.Lock(context.Background())
-	s.Nil(err3)
+	require.Nil(t, err3)
 	lock.Unlock()
 }
 
@@ -73,7 +61,44 @@ func BenchmarkLock(b *testing.B) {
 	l := NewMutex()
 	ctx := context.Background()
 	for n := 0; n < b.N; n++ {
-		l.Lock(ctx) //nolint:errcheck
-		l.Unlock()  //nolint:staticcheck
+		_ = l.Lock(ctx)
+		l.Unlock()
 	}
+}
+
+func TestConcurrently(t *testing.T) {
+	defer goleak.VerifyNone(t)
+
+	const (
+		tryDuration = time.Millisecond // long enough to ensure at least one acquire
+		tries       = 1000
+	)
+
+	// attempt to cancel all attempts within a reasonable amount of time
+	ctx, cancel := context.WithTimeout(context.Background(), tryDuration*tries*10)
+	defer cancel()
+	success, err := int32(0), int32(0)
+
+	m := NewMutex()
+	var wg sync.WaitGroup
+	for i := 0; i < tries; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(ctx, tryDuration)
+			defer cancel()
+			if m.Lock(ctx) == nil {
+				atomic.AddInt32(&success, 1)
+				time.Sleep(tryDuration / 10) // sleep for a fraction of the time, to guarantee some timeouts
+				m.Unlock()
+			} else {
+				atomic.AddInt32(&err, 1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	t.Logf("success: %v, err: %v", success, err)
+	assert.Greater(t, success, int32(1), "should have successfully acquired more than once, as once could be a fluke")
+	assert.NotZero(t, err, "should have timed out at least once")
 }


### PR DESCRIPTION
Spotted while looking into other racy code.
Honestly I think it's shocking that this was ever approved.
The good news though is that it does seem to work.

I also took the opportunity to remove the wildly unnecessary testify/suite, and add some comparative benchmarks:
```
BenchmarkLock-8                          2719692               450.3 ns/op           148 B/op          3 allocs/op
BenchmarkStdlibLock-8                   89316176                13.40 ns/op            0 B/op          0 allocs/op
BenchmarkParallelLock-8                  2119658               562.3 ns/op           148 B/op          3 allocs/op
BenchmarkParallelStdlibLock-8           10159339               111.6 ns/op             0 B/op          0 allocs/op
```
At the moment I'm not sure if this is an acceptable cost or not tbh (though it feels like "no").