### PR TITLE
WIP: increase ratelimit-burst-size for global use

### DIFF
--- a/common/quotas/dynamicratelimiter.go
+++ b/common/quotas/dynamicratelimiter.go
@@ -24,6 +24,7 @@ package quotas
 
 import (
 	"context"
+	"time"
 
 	"golang.org/x/time/rate"
 
@@ -33,15 +34,20 @@ import (
 // DynamicRateLimiter implements a dynamic config wrapper around the rate limiter,
 // checks for updates to the dynamic config and updates the rate limiter accordingly
 type DynamicRateLimiter struct {
-	rps RPSFunc
-	rl  *RateLimiter
+	rps         RPSFunc
+	rl          *RateLimiter
+	burstWindow time.Duration
 }
 
 // NewDynamicRateLimiter returns a rate limiter which handles dynamic config
-func NewDynamicRateLimiter(rps RPSFunc) *DynamicRateLimiter {
+func NewDynamicRateLimiter(rps RPSFunc, burstWindow time.Duration) *DynamicRateLimiter {
 	initialRps := rps()
 	rl := NewRateLimiter(&initialRps, _defaultRPSTTL, _burstSize)
-	return &DynamicRateLimiter{rps, rl}
+	return &DynamicRateLimiter{
+		rps:         rps,
+		rl:          rl,
+		burstWindow: burstWindow,
+	}
 }
 
 // Allow immediately returns with true or false indicating if a rate limit

--- a/common/quotas/dynamicratelimiter.go
+++ b/common/quotas/dynamicratelimiter.go
@@ -39,14 +39,24 @@ type DynamicRateLimiter struct {
 	burstWindow time.Duration
 }
 
-// NewDynamicRateLimiter returns a rate limiter which handles dynamic config
-func NewDynamicRateLimiter(rps RPSFunc, burstWindow time.Duration) *DynamicRateLimiter {
+// NewDynamicRateLimiter returns a rate limiter which handles dynamic config.
+// This limiter allows one second of requests to burst.
+func NewDynamicRateLimiter(rps RPSFunc) *DynamicRateLimiter {
 	initialRps := rps()
 	rl := NewRateLimiter(&initialRps, _defaultRPSTTL, _burstSize)
 	return &DynamicRateLimiter{
-		rps:         rps,
-		rl:          rl,
-		burstWindow: burstWindow,
+		rps: rps,
+		rl:  rl,
+	}
+}
+
+// NewWindowedDynamicRateLimiter allows a configurable burst window, rather than one second.
+func NewWindowedDynamicRateLimiter(rps RPSFunc, burstWindow time.Duration) *DynamicRateLimiter {
+	initialRPS := rps()
+	rl := NewRateLimiterWithBurstWindow(&initialRPS, _defaultRPSTTL, burstWindow)
+	return &DynamicRateLimiter{
+		rps: rps,
+		rl:  rl,
 	}
 }
 

--- a/common/quotas/global/collection/internal/counted_test.go
+++ b/common/quotas/global/collection/internal/counted_test.go
@@ -172,7 +172,7 @@ func TestRegression_ReserveCountsCorrectly(t *testing.T) {
 		ts := clock.NewMockedTimeSource()
 		wrapped := clock.NewMockRatelimiter(ts, 1, 100)
 		l := NewFallbackLimiter(allowlimiter{})
-		l.Update(1)         // allows using primary, else it calls the fallback
+		l.Update(1, 1)      // allows using primary, else it calls the fallback
 		l.primary = wrapped // cheat, just swap it out
 
 		run(t, l, ts.Advance, func() UsageMetrics {

--- a/common/quotas/global/collection/internal/fallback.go
+++ b/common/quotas/global/collection/internal/fallback.go
@@ -151,7 +151,7 @@ func (b *FallbackLimiter) useFallback() bool {
 
 // Update adjusts the underlying "primary" ratelimit, and resets the fallback fuse.
 // This implies switching to the "primary" limiter - if that is not desired, call Reset() immediately after.
-func (b *FallbackLimiter) Update(lim rate.Limit) {
+func (b *FallbackLimiter) Update(lim rate.Limit, burst int) {
 	// caution: order here matters, to prevent potentially-old limiter values from being used
 	// before they are updated.
 	//
@@ -170,7 +170,7 @@ func (b *FallbackLimiter) Update(lim rate.Limit) {
 	}
 
 	b.primary.SetLimit(lim)
-	b.primary.SetBurst(max(1, int(lim))) // 0 burst blocks all requests, so allow at least 1 and rely on rps to fill sanely
+	b.primary.SetBurst(max(1, burst)) // 0 burst blocks all requests, so allow at least 1 and rely on rps to fill sanely
 }
 
 // FailedUpdate should be called when a limit fails to update from an aggregator,

--- a/common/quotas/permember_test.go
+++ b/common/quotas/permember_test.go
@@ -22,6 +22,7 @@ package quotas
 
 import (
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
@@ -62,6 +63,7 @@ func Test_PerMemberFactory(t *testing.T) {
 		func(string) int { return 20 },
 		func(string) int { return 3 },
 		resolver,
+		time.Second,
 	)
 
 	limiter := factory.GetLimiter("TestDomainName")


### PR DESCRIPTION
unfortunately much more work than expected, due to how intertwined some of this is.

fully separating out frontend limits would probably simplify things, but there's more work to do to get there.
