### PR TITLE
Wrap errors from child workflow in canary sanity workflow

### DIFF
--- a/canary/sanity.go
+++ b/canary/sanity.go
@@ -22,9 +22,9 @@ package canary
 
 import (
 	"fmt"
-	"go.uber.org/multierr"
 
 	"go.uber.org/cadence/workflow"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 )
 

--- a/canary/sanity.go
+++ b/canary/sanity.go
@@ -21,8 +21,8 @@
 package canary
 
 import (
-	"errors"
 	"fmt"
+	"go.uber.org/multierr"
 
 	"go.uber.org/cadence/workflow"
 	"go.uber.org/zap"
@@ -116,9 +116,7 @@ func joinChildWorkflows(ctx workflow.Context, names []string, selector workflow.
 		selector.Select(ctx)
 		var err1 error
 		resultC.Receive(ctx, &err1)
-		if err1 != nil {
-			err = errors.Join(err, err1)
-		}
+		err = multierr.Append(err, err1)
 	}
 	return err
 }


### PR DESCRIPTION
What changed?
Wrap errors when joining Child Workflows and joined all errors to sanity error

Why?
Previously only the last error from the child workflows was being set to sanity error, and it was not clear if the error was from a child workflow or from sanity workflow.

How did you test it?

Potential risks

Release notes

Documentation Changes

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
