### PR TITLE
Minor global ratelimiter fix: don't reduce values when "boosting"

### DIFF
--- a/common/quotas/global/collection/collection.go
+++ b/common/quotas/global/collection/collection.go
@@ -511,7 +511,9 @@ func boostRPS(target, fallback rate.Limit, weight float64, usedRPS float64) rate
 	// as overall usage increases, this "allowed overage" will shrink, helping
 	// ensure it keeps converging towards the global target RPS.
 	if baseline < fallback {
-		unused := float64(target) - usedRPS
+		// unused should not go below zero, e.g. if target was lowered,
+		// so this cannot reduce below the fair baseline.
+		unused := math.Max(0, float64(target)-usedRPS)
 		boosted := math.Min(
 			// with many bursty low-weight hosts, this may allow too much.
 			// currently this isn't really a concern, but this could be adjusted

--- a/common/quotas/global/collection/collection_test.go
+++ b/common/quotas/global/collection/collection_test.go
@@ -451,9 +451,9 @@ func TestBoostRPS(t *testing.T) {
 		"usage over target": {
 			targetLimit:   10,
 			fallbackLimit: 3,
-			weight:        0.1,
+			weight:        0.089,
 			usedRPS:       100,
-			resultLimit:   1, // should be weight-based at worst, and not be reduced by excess usage
+			resultLimit:   0.89, // should be weight-based at worst, and not be reduced by excess usage
 		},
 	}
 	for name, tc := range tests {

--- a/common/quotas/global/collection/collection_test.go
+++ b/common/quotas/global/collection/collection_test.go
@@ -448,6 +448,13 @@ func TestBoostRPS(t *testing.T) {
 			usedRPS:       2,
 			resultLimit:   8.9, // should not be boosted beyond fair, nor limited below it
 		},
+		"usage over target": {
+			targetLimit:   10,
+			fallbackLimit: 3,
+			weight:        0.1,
+			usedRPS:       100,
+			resultLimit:   1, // should be weight-based at worst, and not be reduced by excess usage
+		},
 	}
 	for name, tc := range tests {
 		name, tc := name, tc


### PR DESCRIPTION
Previously, if the target RPS was below the cluster's usage (say it was being reduced, or cluster usage was over target), `unused` could go below zero and set the RPS to *below* the fair-weighted value, and possibly even to a negative value.

That's unintended, the fair-weighted value is what we want even in an excess-load scenario.
Boosting was only intended to *increase* based on spare capacity, not decrease.
