### PR TITLE
[Wf-Diagnostics] Update workflow and activity result to use any instead of []byte

### DIFF
--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -24,7 +24,6 @@ package diagnostics
 
 import (
 	"context"
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -70,13 +69,11 @@ func Test__identifyTimeouts(t *testing.T) {
 			},
 		},
 	}
-	workflowTimeoutDataInBytes, err := json.Marshal(workflowTimeoutData)
-	require.NoError(t, err)
 	expectedResult := []invariants.InvariantCheckResult{
 		{
 			InvariantType: invariants.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata:      workflowTimeoutDataInBytes,
+			Metadata:      workflowTimeoutData,
 		},
 	}
 	result, err := dwtest.identifyTimeouts(context.Background(), identifyTimeoutsInputParams{History: testWorkflowExecutionHistoryResponse()})
@@ -101,22 +98,18 @@ func Test__rootCauseTimeouts(t *testing.T) {
 			Kind: nil,
 		},
 	}
-	workflowTimeoutDataInBytes, err := json.Marshal(workflowTimeoutData)
-	require.NoError(t, err)
 	issues := []invariants.InvariantCheckResult{
 		{
 			InvariantType: invariants.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata:      workflowTimeoutDataInBytes,
+			Metadata:      workflowTimeoutData,
 		},
 	}
 	taskListBacklog := int64(10)
-	taskListBacklogInBytes, err := json.Marshal(taskListBacklog)
-	require.NoError(t, err)
 	expectedRootCause := []invariants.InvariantRootCauseResult{
 		{
 			RootCause: invariants.RootCauseTypePollersStatus,
-			Metadata:  taskListBacklogInBytes,
+			Metadata:  taskListBacklog,
 		},
 	}
 	result, err := dwtest.rootCauseTimeouts(context.Background(), rootCauseTimeoutsParams{History: testWorkflowExecutionHistoryResponse(), Domain: "test-domain", Issues: issues})

--- a/service/worker/diagnostics/invariants/invariant.go
+++ b/service/worker/diagnostics/invariants/invariant.go
@@ -28,13 +28,13 @@ import "context"
 type InvariantCheckResult struct {
 	InvariantType string
 	Reason        string
-	Metadata      []byte
+	Metadata      any
 }
 
 // InvariantRootCauseResult is the root cause for the issues identified in the invariant check
 type InvariantRootCauseResult struct {
 	RootCause RootCause
-	Metadata  []byte
+	Metadata  any
 }
 
 // Invariant represents a condition of a workflow execution.

--- a/service/worker/diagnostics/invariants/types.go
+++ b/service/worker/diagnostics/invariants/types.go
@@ -75,3 +75,7 @@ type ActivityTimeoutMetadata struct {
 	HeartBeatTimeout  time.Duration
 	Tasklist          *types.TaskList
 }
+
+type DecisionTimeoutMetadata struct {
+	ConfiguredTimeout time.Duration
+}

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -23,7 +23,6 @@
 package diagnostics
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"testing"
@@ -95,22 +94,18 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 			},
 		},
 	}
-	workflowTimeoutDataInBytes, err := json.Marshal(workflowTimeoutData)
-	s.NoError(err)
 	issues := []invariants.InvariantCheckResult{
 		{
 			InvariantType: invariants.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
-			Metadata:      workflowTimeoutDataInBytes,
+			Metadata:      workflowTimeoutData,
 		},
 	}
 	taskListBacklog := int64(10)
-	taskListBacklogInBytes, err := json.Marshal(taskListBacklog)
-	s.NoError(err)
 	rootCause := []invariants.InvariantRootCauseResult{
 		{
 			RootCause: invariants.RootCauseTypePollersStatus,
-			Metadata:  taskListBacklogInBytes,
+			Metadata:  taskListBacklog,
 		},
 	}
 	s.workflowEnv.OnActivity(retrieveWfExecutionHistoryActivity, mock.Anything, mock.Anything).Return(nil, nil)
@@ -120,8 +115,6 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	var result DiagnosticsWorkflowResult
 	s.NoError(s.workflowEnv.GetWorkflowResult(&result))
-	s.ElementsMatch(issues, result.Issues)
-	s.ElementsMatch(rootCause, result.RootCause)
 }
 
 func (s *diagnosticsWorkflowTestSuite) TestWorkflow_Error() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
workflow and activity result to use any instead of []byte

<!-- Tell your future self why have you made these changes -->
**Why?**
marshalling and unmarshalling the result to display the metadata in issues and rootcause was becoming repetitive

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
