### PR TITLE
Always notify subscribers on membership change

### DIFF
--- a/common/membership/hashring_test.go
+++ b/common/membership/hashring_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/metrics"
 )
@@ -97,46 +98,60 @@ func Test_ring_compareMembers(t *testing.T) {
 
 }
 
-func TestFailedLookupWillAskProvider(t *testing.T) {
+type hashringTestData struct {
+	mockPeerProvider *MockPeerProvider
+	mockTimeSource   clock.TimeSource
+	hashRing         *ring
+}
+
+func newHashringTestData(t *testing.T) *hashringTestData {
+	var td hashringTestData
+
 	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td.mockPeerProvider = NewMockPeerProvider(ctrl)
+	td.mockTimeSource = clock.NewMockedTimeSourceAt(time.Now())
 
-	pp.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
-	pp.EXPECT().GetMembers("test-service").Times(1)
+	td.hashRing = newHashring("test-service", td.mockPeerProvider, td.mockTimeSource, log.NewNoop(), metrics.NoopScope(0))
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-	hr.Start()
-	_, err := hr.Lookup("a")
+	return &td
+}
+
+func TestFailedLookupWillAskProvider(t *testing.T) {
+	td := newHashringTestData(t)
+
+	td.mockPeerProvider.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
+	td.mockPeerProvider.EXPECT().GetMembers("test-service").Times(1)
+
+	td.hashRing.Start()
+	_, err := td.hashRing.Lookup("a")
 
 	assert.Error(t, err)
 }
 
 func TestRefreshUpdatesRingOnlyWhenRingHasChanged(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
 
-	pp.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
-	pp.EXPECT().GetMembers("test-service").Times(1).Return(randomHostInfo(3), nil)
+	td.mockPeerProvider.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
+	td.mockPeerProvider.EXPECT().GetMembers("test-service").Times(1).Return(randomHostInfo(3), nil)
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
 	// Start will also call .refresh()
-	hr.Start()
-	updatedAt := hr.members.refreshed
-	hr.refresh()
-	refreshed, err := hr.refresh()
+	td.hashRing.Start()
+	updatedAt := td.hashRing.members.refreshed
+	td.hashRing.refresh()
+	refreshed, err := td.hashRing.refresh()
 
 	assert.NoError(t, err)
 	assert.False(t, refreshed)
-	assert.Equal(t, updatedAt, hr.members.refreshed)
+	assert.Equal(t, updatedAt, td.hashRing.members.refreshed)
 
 }
 
 func TestRefreshWillNotifySubscribers(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
+
 	var hostsToReturn []HostInfo
-	pp.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
-	pp.EXPECT().GetMembers("test-service").Times(2).DoAndReturn(func(service string) ([]HostInfo, error) {
+	td.mockPeerProvider.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
+	td.mockPeerProvider.EXPECT().GetMembers("test-service").Times(2).DoAndReturn(func(service string) ([]HostInfo, error) {
 		hostsToReturn = randomHostInfo(5)
 		time.Sleep(time.Millisecond * 70)
 		return hostsToReturn, nil
@@ -148,13 +163,12 @@ func TestRefreshWillNotifySubscribers(t *testing.T) {
 		HostsRemoved: []string{"c"},
 	}
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-	hr.Start()
+	td.hashRing.Start()
 
 	var changeCh = make(chan *ChangedEvent, 2)
 	// Check if multiple subscribers will get notified
-	assert.NoError(t, hr.Subscribe("subscriber1", changeCh))
-	assert.NoError(t, hr.Subscribe("subscriber2", changeCh))
+	assert.NoError(t, td.hashRing.Subscribe("subscriber1", changeCh))
+	assert.NoError(t, td.hashRing.Subscribe("subscriber2", changeCh))
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -167,114 +181,99 @@ func TestRefreshWillNotifySubscribers(t *testing.T) {
 	}()
 
 	// to bypass internal check
-	hr.members.refreshed = time.Now().AddDate(0, 0, -1)
-	hr.refreshChan <- changed
+	td.hashRing.members.refreshed = time.Now().AddDate(0, 0, -1)
+	td.hashRing.refreshChan <- changed
 	wg.Wait() // wait until both subscribers will get notification
 	// Test if internal members are updated
-	assert.ElementsMatch(t, hr.Members(), hostsToReturn, "members should contain just-added nodes")
+	assert.ElementsMatch(t, td.hashRing.Members(), hostsToReturn, "members should contain just-added nodes")
 }
 
 func TestSubscribeIgnoresDuplicates(t *testing.T) {
 	var changeCh = make(chan *ChangedEvent)
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
 
-	hr := newHashring("test-watcher", pp, log.NewNoop(), metrics.NoopScope(0))
-
-	assert.NoError(t, hr.Subscribe("test-watcher", changeCh))
-	assert.Error(t, hr.Subscribe("test-watcher", changeCh))
-	assert.Equal(t, 1, len(hr.subscribers.keys))
+	assert.NoError(t, td.hashRing.Subscribe("test-service", changeCh))
+	assert.Error(t, td.hashRing.Subscribe("test-service", changeCh))
+	assert.Equal(t, 1, len(td.hashRing.subscribers.keys))
 }
 
 func TestUnsubcribeIgnoresDeletionOnEmpty(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-	assert.Equal(t, 0, len(hr.subscribers.keys))
-	assert.NoError(t, hr.Unsubscribe("test-service"))
-	assert.NoError(t, hr.Unsubscribe("test-service"))
-	assert.NoError(t, hr.Unsubscribe("test-service"))
+	assert.Equal(t, 0, len(td.hashRing.subscribers.keys))
+	assert.NoError(t, td.hashRing.Unsubscribe("test-service"))
+	assert.NoError(t, td.hashRing.Unsubscribe("test-service"))
+	assert.NoError(t, td.hashRing.Unsubscribe("test-service"))
 }
 
 func TestUnsubcribeDeletes(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
 	var changeCh = make(chan *ChangedEvent)
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-
-	assert.Equal(t, 0, len(hr.subscribers.keys))
-	assert.NoError(t, hr.Subscribe("testservice1", changeCh))
-	assert.Equal(t, 1, len(hr.subscribers.keys))
-	assert.NoError(t, hr.Unsubscribe("test-service"))
-	assert.Equal(t, 1, len(hr.subscribers.keys))
-	assert.NoError(t, hr.Unsubscribe("testservice1"))
-	assert.Equal(t, 0, len(hr.subscribers.keys))
+	assert.Equal(t, 0, len(td.hashRing.subscribers.keys))
+	assert.NoError(t, td.hashRing.Subscribe("testservice1", changeCh))
+	assert.Equal(t, 1, len(td.hashRing.subscribers.keys))
+	assert.NoError(t, td.hashRing.Unsubscribe("test-service"))
+	assert.Equal(t, 1, len(td.hashRing.subscribers.keys))
+	assert.NoError(t, td.hashRing.Unsubscribe("testservice1"))
+	assert.Equal(t, 0, len(td.hashRing.subscribers.keys))
 
 }
 
 func TestMemberCountReturnsNumber(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-	assert.Equal(t, 0, hr.MemberCount())
+	assert.Equal(t, 0, td.hashRing.MemberCount())
 
 	ring := emptyHashring()
 	for _, addr := range []string{"127", "128"} {
 		host := NewHostInfo(addr)
 		ring.AddMembers(host)
 	}
-	hr.value.Store(ring)
-	assert.Equal(t, 2, hr.MemberCount())
+	td.hashRing.value.Store(ring)
+	assert.Equal(t, 2, td.hashRing.MemberCount())
 }
 
 func TestErrorIsPropagatedWhenProviderFails(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
-	pp.EXPECT().GetMembers(gomock.Any()).Return(nil, errors.New("error"))
+	td := newHashringTestData(t)
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-	_, err := hr.refresh()
+	td.mockPeerProvider.EXPECT().GetMembers(gomock.Any()).Return(nil, errors.New("error"))
+
+	_, err := td.hashRing.refresh()
 	assert.Error(t, err)
 }
 
 func TestStopWillStopProvider(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
 
-	pp.EXPECT().Stop().Times(1)
+	td.mockPeerProvider.EXPECT().Stop().Times(1)
 
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-	hr.status = common.DaemonStatusStarted
-	hr.Stop()
-
+	td.hashRing.status = common.DaemonStatusStarted
+	td.hashRing.Stop()
 }
 
 func TestLookupAndRefreshRaceCondition(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	pp := NewMockPeerProvider(ctrl)
+	td := newHashringTestData(t)
 	var wg sync.WaitGroup
 
-	pp.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
-	pp.EXPECT().GetMembers("test-service").AnyTimes().DoAndReturn(func(service string) ([]HostInfo, error) {
+	td.mockPeerProvider.EXPECT().Subscribe(gomock.Any(), gomock.Any()).Times(1)
+	td.mockPeerProvider.EXPECT().GetMembers("test-service").AnyTimes().DoAndReturn(func(service string) ([]HostInfo, error) {
 		return randomHostInfo(5), nil
 	})
-	hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-	hr.Start()
+
+	td.hashRing.Start()
 	wg.Add(2)
 	go func() {
 		for i := 0; i < 50; i++ {
-			_, _ = hr.Lookup("a")
+			_, _ = td.hashRing.Lookup("a")
 		}
 		wg.Done()
 	}()
 	go func() {
 		for i := 0; i < 50; i++ {
 			// to bypass internal check
-			hr.members.refreshed = time.Now().AddDate(0, 0, -1)
-			_, err := hr.refresh()
+			td.hashRing.members.refreshed = time.Now().AddDate(0, 0, -1)
+			_, err := td.hashRing.refresh()
 			assert.NoError(t, err)
 		}
 		wg.Done()
@@ -322,24 +321,19 @@ func TestEmitHashringView(t *testing.T) {
 		},
 	}
 
-	for name, td := range tests {
+	for testName, testInput := range tests {
 
-		t.Run(name, func(t *testing.T) {
+		t.Run(testName, func(t *testing.T) {
+			td := newHashringTestData(t)
 
-			ctrl := gomock.NewController(t)
-			pp := NewMockPeerProvider(ctrl)
-
-			pp.EXPECT().GetMembers("test-service").DoAndReturn(func(service string) ([]HostInfo, error) {
-				return td.hosts, td.lookuperr
+			td.mockPeerProvider.EXPECT().GetMembers("test-service").DoAndReturn(func(service string) ([]HostInfo, error) {
+				return testInput.hosts, testInput.lookuperr
 			})
 
-			pp.EXPECT().WhoAmI().DoAndReturn(func() (HostInfo, error) {
-				return td.selfInfo, td.selfErr
+			td.mockPeerProvider.EXPECT().WhoAmI().DoAndReturn(func() (HostInfo, error) {
+				return testInput.selfInfo, testInput.selfErr
 			})
-
-			hr := newHashring("test-service", pp, log.NewNoop(), metrics.NoopScope(0))
-
-			assert.Equal(t, td.expectedResult, hr.emitHashIdentifier())
+			assert.Equal(t, testInput.expectedResult, td.hashRing.emitHashIdentifier())
 		})
 	}
 }

--- a/common/membership/resolver.go
+++ b/common/membership/resolver.go
@@ -29,6 +29,7 @@ import (
 	"sync/atomic"
 
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
@@ -116,7 +117,7 @@ func NewMultiringResolver(
 	}
 
 	for _, s := range services {
-		rpo.rings[s] = newHashring(s, provider, logger, metricsClient.Scope(metrics.HashringScope))
+		rpo.rings[s] = newHashring(s, provider, clock.NewRealTimeSource(), logger, metricsClient.Scope(metrics.HashringScope))
 	}
 	return rpo
 }


### PR DESCRIPTION
Currently there is an issue:
 - we loose lots of updates (a separate PR to address this)
 - we rely on periodic (every 10s) update to update membership
   regardless
 - but it doesn't notify subscribers

Because of that we were sometimes missing notifications in history and matching and didn't get any before the next rollout / restart.

<!-- Describe what has changed in this PR -->
**What changed?**
Subscribers of MultiringResolver were not notified if membership updated during periodic updates

<!-- Tell your future self why have you made these changes -->
**Why?**
Subscribers of MultiringResolver expect to be always notified on membership changes, and it doesn't really matter who triggered tag - membership update that we caught or periodic update which we do every 10s.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
This should just work this way, and it is been a mistake to decouple refresh/notify
Verified it on staging environments of Uber where we already see improvements during restart.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
If some subscribers rely on event triggered the change, it can be unexpected to see an empty one (but not nil!).
At the same time, we're currently doing the same if Lookup wasn't able to find a host - we were implicitely pushing an empty changedEvent to signal the channel.
Currently existing subscriber does not rely, they simply ignore the event. In fact - it is a mistake to do the opposite: the event just triggered refresh(), but then even the refresh() builds a ring from scratch ignoring the event.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Bugfix: Subscribers of MultiringResolver were not notified if membership updated during periodic updates

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
