### PR TITLE
Support custom address broadcasting for ringpop to work in k8s

### DIFF
--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -328,7 +328,14 @@ func (r *ring) emitHashIdentifier() float64 {
 	// in-case it overflowed something. The number itself is meaningless, so additional precision
 	// doesn't really give any advantage, besides reducing the risk of collision
 	trimmedForMetric := float64(hashedView % 1000)
-	r.logger.Debug("Hashring view", tag.Dynamic("hashring-view", sb.String()), tag.Dynamic("trimmed-hash-id", trimmedForMetric), tag.Service(r.service))
+	r.logger.Debug("Hashring view",
+		tag.Dynamic("hashring-view", sb.String()),
+		tag.Dynamic("trimmed-hash-id", trimmedForMetric),
+		tag.Service(r.service),
+		tag.Dynamic("self-addr", self.addr),
+		tag.Dynamic("self-identity", self.identity),
+		tag.Dynamic("self-ip", self.ip),
+	)
 	r.scope.Tagged(
 		metrics.ServiceTag(r.service),
 		metrics.HostTag(self.identity),

--- a/common/peerprovider/ringpopprovider/config.go
+++ b/common/peerprovider/ringpopprovider/config.go
@@ -65,6 +65,10 @@ const (
 type Config struct {
 	// Name to be used in ringpop advertisement
 	Name string `yaml:"name" validate:"nonzero"`
+	// BroadcastAddress is communicated with peers to connect to this container/host.
+	// This is useful when running cadence in K8s and the containers need to listen on 0.0.0.0 but advertise their pod IP to peers.
+	// If not set, the listen address will be used as broadcast address.
+	BroadcastAddress string `yaml:"broadcastAddress"`
 	// BootstrapMode is a enum that defines the ringpop bootstrap method, currently supports: hosts, files, custom, dns, and dns-srv
 	BootstrapMode BootstrapMode `yaml:"bootstrapMode"`
 	// BootstrapHosts is a list of seed hosts to be used for ringpop bootstrap

--- a/common/peerprovider/ringpopprovider/config_test.go
+++ b/common/peerprovider/ringpopprovider/config_test.go
@@ -118,6 +118,7 @@ func (s *RingpopSuite) TestDNSMode() {
 	s.Nil(err)
 	s.Equal("test", cfg.Name)
 	s.Equal(BootstrapModeDNS, cfg.BootstrapMode)
+	s.Equal("10.66.1.71", cfg.BroadcastAddress)
 	s.Nil(cfg.validate())
 	logger := testlogger.New(s.T())
 
@@ -297,6 +298,7 @@ maxJoinDuration: 30s`
 func getDNSConfig() string {
 	return `name: "test"
 bootstrapMode: "dns"
+broadcastAddress: "10.66.1.71"
 bootstrapHosts:
 - example.net:1111
 - example.net:1112

--- a/common/peerprovider/ringpopprovider/provider.go
+++ b/common/peerprovider/ringpopprovider/provider.go
@@ -23,13 +23,11 @@
 package ringpopprovider
 
 import (
-	"context"
 	"fmt"
 	"net"
 	"strconv"
 	"sync"
 	"sync/atomic"
-	"time"
 
 	"github.com/uber/ringpop-go"
 	"github.com/uber/ringpop-go/events"
@@ -39,7 +37,6 @@ import (
 	"go.uber.org/yarpc/transport/tchannel"
 
 	"github.com/uber/cadence/common"
-	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
@@ -106,24 +103,6 @@ func New(
 	return NewRingpopProvider(service, rp, portMap, bootstrapOpts, logger), nil
 }
 
-func broadcastAddrResolver(ch *tcg.Channel, broadcastIP net.IP) func() (string, error) {
-	return func() (string, error) {
-		peerInfo := ch.PeerInfo()
-		if peerInfo.IsEphemeralHostPort() {
-			// not listening yet
-			return "", ringpop.ErrEphemeralAddress
-		}
-
-		_, port, err := net.SplitHostPort(peerInfo.HostPort)
-		if err != nil {
-			return "", fmt.Errorf("failed splitting tchannel's hostport %q, err: %w", peerInfo.HostPort, err)
-		}
-
-		// return broadcast_ip:listen_port
-		return net.JoinHostPort(broadcastIP.String(), port), nil
-	}
-}
-
 // NewRingpopProvider sets up ringpop based peer provider
 func NewRingpopProvider(
 	service string,
@@ -153,15 +132,8 @@ func (r *Provider) Start() {
 		return
 	}
 
-	op := func() error {
-		_, err := r.ringpop.Bootstrap(r.bootParams)
-		if err != nil {
-			r.logger.Warn("unable to bootstrap ringpop, will retry", tag.Error(err))
-		}
-		return err
-	}
-	retry := backoff.NewThrottleRetry(backoff.WithRetryPolicy(bootstrapRetryPolicy()))
-	if err := retry.Do(context.Background(), op); err != nil {
+	_, err := r.ringpop.Bootstrap(r.bootParams)
+	if err != nil {
 		r.logger.Fatal("unable to bootstrap ringpop", tag.Error(err))
 	}
 
@@ -337,9 +309,20 @@ func labelToPort(label string) (uint16, error) {
 	return uint16(port), nil
 }
 
-func bootstrapRetryPolicy() backoff.RetryPolicy {
-	policy := backoff.NewExponentialRetryPolicy(5 * time.Second)
-	policy.SetMaximumInterval(5 * time.Second)
-	policy.SetExpirationInterval(45 * time.Second)
-	return policy
+func broadcastAddrResolver(ch *tcg.Channel, broadcastIP net.IP) func() (string, error) {
+	return func() (string, error) {
+		peerInfo := ch.PeerInfo()
+		if peerInfo.IsEphemeralHostPort() {
+			// not listening yet
+			return "", ringpop.ErrEphemeralAddress
+		}
+
+		_, port, err := net.SplitHostPort(peerInfo.HostPort)
+		if err != nil {
+			return "", fmt.Errorf("failed splitting tchannel's hostport %q, err: %w", peerInfo.HostPort, err)
+		}
+
+		// return broadcast_ip:listen_port
+		return net.JoinHostPort(broadcastIP.String(), port), nil
+	}
 }

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -97,6 +97,7 @@ persistence:
 
 ringpop:
     name: cadence
+    broadcastAddress: {{ default .Env.BROADCAST_ADDRESS "" }}
     bootstrapMode: {{ default .Env.RINGPOP_BOOTSTRAP_MODE "hosts" }}
     {{- if .Env.RINGPOP_SEEDS }}
     bootstrapHosts:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Current ringpop initialization is making it difficult to run ringpop in K8s like environments. Ringpop is initialized with the address that the service instance (container) is going to listen on and it gets advertised to peers. This is problematic because listen address of replicas are not unique and cannot be used to communicate peer to peer.
Local listen address (BIND_ON_IP) should be set to 0.0.0.0 and the pod's ip address (10.x.y.z) should be used to join the ring for p2p. Pod's IP address is accessible by other pods in the k8s cluster.

This PR introduces `ringpop.broadcastAddress` config which will make ringpop work in k8s environments.

For example:
- History-service-container-replica-1: 
     listens and serves on `0.0.0.0:7934`
     broadcasts itself to peers as `10.66.1.71` (its own pod ip)
     
- History-service-container-replica-2: 
     listens and serves on `0.0.0.0:7934`
     broadcasts itself to peers as `10.66.1.75` (its own pod ip)

A [headless k8s service](https://stackoverflow.com/questions/52707840/what-is-a-headless-service-what-does-it-do-accomplish-and-what-are-some-legiti) can be used for discovery which will return list of pod ips `10.x.y.z`.

This can be achieved on K8s by passing pod's IP address as an env variable.
```
 - name: BIND_ON_IP
    value: 0.0.0.0
 - name: BROADCAST_ADDRESS
    valueFrom:  
       fieldRef:
          fieldPath: status.podIP
```    
     
Ringpop config would look like this:
```
ringpop:
    name: cadence
    broadcastAddress: 10.66.1.71
    bootstrapMode: dns
    bootstrapHosts:
    - cadence-history-headless.namespace.svc.cluster.local:7934
   ..
```

Other misc changes:
- Added backoff retry for ringpop bootstrap initialization
- Added self addr/identity/ip tags to hashring view log


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Locally built a cadence image and tried it on a K8s cluster. 
- Added unit tests for ringpop provider
