### PR TITLE
Easier support for multiple instances locally 

### DIFF
--- a/config/development.yaml
+++ b/config/development.yaml
@@ -27,8 +27,8 @@ ringpop:
 services:
   frontend:
     rpc:
-      port: 7933
-      grpcPort: 7833
+      port: ${FRONTEND_PORT:7933}
+      grpcPort: ${FRONTEND_PORT_GRPC:7833}
       bindOnLocalHost: true
       grpcMaxMsgSize: 33554432
     metrics:
@@ -36,12 +36,12 @@ services:
         hostPort: "127.0.0.1:8125"
         prefix: "cadence"
     pprof:
-      port: 7936
+      port: ${FRONTEND_PORT_PPROF:7936}
 
   matching:
     rpc:
-      port: 7935
-      grpcPort: 7835
+      port: ${MATCHING_PORT:7935}
+      grpcPort: ${MATCHING_PORT_GRPC:7835}
       bindOnLocalHost: true
       grpcMaxMsgSize: 33554432
     metrics:
@@ -49,12 +49,12 @@ services:
         hostPort: "127.0.0.1:8125"
         prefix: "cadence"
     pprof:
-      port: 7938
+      port: ${MATCHING_PORT_PPROF:7938}
 
   history:
     rpc:
-      port: 7934
-      grpcPort: 7834
+      port: ${HISTORY_PORT:7934}
+      grpcPort: ${HISTORY_PORT_GRPC:7834}
       bindOnLocalHost: true
       grpcMaxMsgSize: 33554432
     metrics:
@@ -62,18 +62,18 @@ services:
         hostPort: "127.0.0.1:8125"
         prefix: "cadence"
     pprof:
-      port: 7937
+      port: ${HISTORY_PORT_PPROF:7937}
 
   worker:
     rpc:
-      port: 7939
+      port: ${WORKER_PORT:7939}
       bindOnLocalHost: true
     metrics:
       statsd:
         hostPort: "127.0.0.1:8125"
         prefix: "cadence"
     pprof:
-      port: 7940
+      port: ${WORKER_PORT_PPROF:7940}
 
 clusterGroupMetadata:
   failoverVersionIncrement: 10

--- a/scripts/run_several_instances.sh
+++ b/scripts/run_several_instances.sh
@@ -5,6 +5,13 @@
 
 set -eo pipefail
 
+ctrl_c() {
+  echo "Killing all the services"
+  pkill -9 -P $$
+}
+
+trap ctrl_c SIGINT
+
 # Start the services used in ringpop discovery on the default ports
 ./cadence-server start &
 

--- a/scripts/run_several_instances.sh
+++ b/scripts/run_several_instances.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# This script can be used to run several instances of the different cadence services (matching, history, frontend, etc)
+#
+
+set -eo pipefail
+
+# Start the services used in ringpop discovery on the default ports
+./cadence-server start &
+
+# Start two more instances of the frontend service on different ports
+FRONTEND_PORT=10001 FRONTEND_PORT_GRPC=10101 FRONTEND_PORT_PPROF=10201 \
+  ./cadence-server --env development start --services frontend &
+FRONTEND_PORT=10002 FRONTEND_PORT_GRPC=10102 FRONTEND_PORT_PPROF=10202 \
+  ./cadence-server --env development start --services frontend &
+
+# Start two more instances of the matching service on different ports
+MATCHING_PORT=11001 MATCHING_PORT_GRPC=11101 MATCHING_PORT_PPROF=11201 \
+  ./cadence-server --env development start --services matching &
+MATCHING_PORT=11002 MATCHING_PORT_GRPC=11102 MATCHING_PORT_PPROF=11202 \
+  ./cadence-server --env development start --services matching &
+
+# Start two more instances of the history service on different ports
+HISTORY_PORT=12001 HISTORY_PORT_GRPC=12101 HISTORY_PORT_PPROF=12201 \
+  ./cadence-server --env development start --services history &
+HISTORY_PORT=12002 HISTORY_PORT_GRPC=12102 HISTORY_PORT_PPROF=12202 \
+  ./cadence-server --env development start --services history &
+
+wait


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Make ports in development config configurable, so we can start several instances of the same service.
    - We keep the old defaults, so if nothing is specified everything works as before
- Added script that starts several instances of the services, mainly for illustrative purposes, but could be useful to quickly start 3 instances of each of frontend, history and matching.


<!-- Tell your future self why have you made these changes -->
**Why?**
- As we want to test things related to sharing we need to be able to have multiple instances of the services running, this enables this. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran locally, this is just a development setup

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
None

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
