### PR TITLE
error-out if we can't Subscribe to membershipResolver

### DIFF
--- a/service/matching/handler/membership.go
+++ b/service/matching/handler/membership.go
@@ -58,7 +58,10 @@ func (e *matchingEngineImpl) subscribeToMembershipChanges() {
 	}
 
 	listener := make(chan *membership.ChangedEvent, subscriptionBufferSize)
-	e.membershipResolver.Subscribe(service.Matching, "matching-engine", listener)
+	if err := e.membershipResolver.Subscribe(service.Matching, "matching-engine", listener); err != nil {
+		e.logger.Error("Failed to subscribe to membership updates")
+		return
+	}
 
 	for {
 		select {


### PR DESCRIPTION
Should never happen, but it returns error on duplicate subscription
(name)

<!-- Describe what has changed in this PR -->
**What changed?**
Error-out when matching can't subscribe to membership change to track task-list ownership changes.

<!-- Tell your future self why have you made these changes -->
**Why?**
Returned error should always be handled

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit-test that checks for error-message and checks the subscription function fails

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Don't see any. This should never happen, and if it happens it is really an error

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
