### PR TITLE
Fix port string to uint16 parsing

### DIFF
--- a/common/peerprovider/ringpopprovider/provider.go
+++ b/common/peerprovider/ringpopprovider/provider.go
@@ -294,7 +294,7 @@ func (r *Provider) Subscribe(name string, notifyChannel chan<- *membership.Chang
 }
 
 func labelToPort(label string) (uint16, error) {
-	port, err := strconv.ParseInt(label, 0, 16)
+	port, err := strconv.ParseUint(label, 0, 16)
 	if err != nil {
 		return 0, err
 	}

--- a/common/peerprovider/ringpopprovider/provider.go
+++ b/common/peerprovider/ringpopprovider/provider.go
@@ -294,7 +294,7 @@ func (r *Provider) Subscribe(name string, notifyChannel chan<- *membership.Chang
 }
 
 func labelToPort(label string) (uint16, error) {
-	port, err := strconv.ParseUint(label, 0, 16)
+	port, err := strconv.ParseUint(label, 10, 16)
 	if err != nil {
 		return 0, err
 	}

--- a/common/peerprovider/ringpopprovider/provider_test.go
+++ b/common/peerprovider/ringpopprovider/provider_test.go
@@ -132,3 +132,39 @@ func (c *TestRingpopCluster) FindHostByAddr(addr string) (HostInfo, bool) {
 	}
 	return HostInfo{}, false
 }
+
+func TestLabelToPort(t *testing.T) {
+	tests := []struct {
+		label   string
+		want    uint16
+		wantErr bool
+	}{
+		{
+			label: "0",
+			want:  0,
+		},
+		{
+			label: "1234",
+			want:  1234,
+		},
+		{
+			label:   "-1",
+			wantErr: true,
+		},
+		{
+			label: "65535",
+			want:  65535,
+		},
+		{
+			label:   "65536", // greater than max uint16 (2^16-1)
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		got, err := labelToPort(tc.label)
+		if got != tc.want || (err != nil) != tc.wantErr {
+			t.Errorf("labelToPort(%v) = %v, %v; want %v, %v", tc.label, got, err, tc.want, tc.wantErr)
+		}
+	}
+}

--- a/common/peerprovider/ringpopprovider/provider_test.go
+++ b/common/peerprovider/ringpopprovider/provider_test.go
@@ -152,6 +152,10 @@ func TestLabelToPort(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			label: "32768",
+			want:  32768,
+		},
+		{
 			label: "65535",
 			want:  65535,
 		},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Port strings are parsed to uint16 in ringpop library. Ports can be numbered from 0 to 65535 which is uint16 range. 
Currently the parsing is done using `ParseInt` instead of `ParseUint` which fails to parse ports greater than 32767.


<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid bugs for port numbers > 32767.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test.
