### PR TITLE
[Wf-Diagnostics] Unmarshal metadata for timeout issues and rootcause

### DIFF
--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -111,7 +111,7 @@ func Test__rootCauseTimeouts(t *testing.T) {
 		},
 	}
 	taskListBacklog := int64(10)
-	taskListBacklogInBytes, err := json.Marshal(taskListBacklog)
+	taskListBacklogInBytes, err := json.Marshal(invariants.PollersMetadata{TaskListBacklog: taskListBacklog})
 	require.NoError(t, err)
 	expectedRootCause := []invariants.InvariantRootCauseResult{
 		{

--- a/service/worker/diagnostics/invariants/types.go
+++ b/service/worker/diagnostics/invariants/types.go
@@ -75,3 +75,15 @@ type ActivityTimeoutMetadata struct {
 	HeartBeatTimeout  time.Duration
 	Tasklist          *types.TaskList
 }
+
+type DecisionTimeoutMetadata struct {
+	ConfiguredTimeout time.Duration
+}
+
+type PollersMetadata struct {
+	TaskListBacklog int64
+}
+
+type HeartbeatingMetadata struct {
+	TimeElapsed time.Duration
+}

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -166,3 +166,116 @@ func (s *diagnosticsWorkflowTestSuite) queryDiagnostics() DiagnosticsWorkflowRes
 	s.NoError(err)
 	return result
 }
+
+func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutIssues() {
+	workflowTimeoutData := invariants.ExecutionTimeoutMetadata{
+		ExecutionTime:     110 * time.Second,
+		ConfiguredTimeout: 110 * time.Second,
+		LastOngoingEvent: &types.HistoryEvent{
+			ID:        1,
+			Timestamp: common.Int64Ptr(testTimeStamp),
+			WorkflowExecutionStartedEventAttributes: &types.WorkflowExecutionStartedEventAttributes{
+				ExecutionStartToCloseTimeoutSeconds: common.Int32Ptr(workflowTimeoutSecond),
+			},
+		},
+	}
+	workflowTimeoutDataInBytes, err := json.Marshal(workflowTimeoutData)
+	s.NoError(err)
+	childWorkflowTimeoutData := invariants.ChildWfTimeoutMetadata{
+		ExecutionTime:     110 * time.Second,
+		ConfiguredTimeout: 110 * time.Second,
+	}
+	childWorkflowTimeoutDataInBytes, err := json.Marshal(childWorkflowTimeoutData)
+	s.NoError(err)
+	activityTimeoutData := invariants.ActivityTimeoutMetadata{
+		TimeoutType:       types.TimeoutTypeStartToClose.Ptr(),
+		ConfiguredTimeout: 5 * time.Second,
+		TimeElapsed:       5 * time.Second,
+		HeartBeatTimeout:  0,
+	}
+	activityTimeoutDataInBytes, err := json.Marshal(activityTimeoutData)
+	s.NoError(err)
+	descTimeoutData := invariants.DecisionTimeoutMetadata{
+		ConfiguredTimeout: 5 * time.Second,
+	}
+	descTimeoutDataInBytes, err := json.Marshal(activityTimeoutData)
+	s.NoError(err)
+	issues := []invariants.InvariantCheckResult{
+		{
+			InvariantType: invariants.TimeoutTypeExecution.String(),
+			Reason:        "START_TO_CLOSE",
+			Metadata:      workflowTimeoutDataInBytes,
+		},
+		{
+			InvariantType: invariants.TimeoutTypeActivity.String(),
+			Reason:        "START_TO_CLOSE",
+			Metadata:      activityTimeoutDataInBytes,
+		},
+		{
+			InvariantType: invariants.TimeoutTypeDecision.String(),
+			Reason:        "START_TO_CLOSE",
+			Metadata:      descTimeoutDataInBytes,
+		},
+		{
+			InvariantType: invariants.TimeoutTypeChildWorkflow.String(),
+			Reason:        "START_TO_CLOSE",
+			Metadata:      childWorkflowTimeoutDataInBytes,
+		},
+	}
+	timeoutIssues := []*timeoutIssuesResult{
+		{
+			InvariantType:    invariants.TimeoutTypeExecution.String(),
+			Reason:           "START_TO_CLOSE",
+			ExecutionTimeout: &workflowTimeoutData,
+		},
+		{
+			InvariantType:   invariants.TimeoutTypeActivity.String(),
+			Reason:          "START_TO_CLOSE",
+			ActivityTimeout: &activityTimeoutData,
+		},
+		{
+			InvariantType:   invariants.TimeoutTypeDecision.String(),
+			Reason:          "START_TO_CLOSE",
+			DecisionTimeout: &descTimeoutData,
+		},
+		{
+			InvariantType:  invariants.TimeoutTypeChildWorkflow.String(),
+			Reason:         "START_TO_CLOSE",
+			ChildWfTimeout: &childWorkflowTimeoutData,
+		},
+	}
+	result, err := retrieveTimeoutIssues(issues)
+	s.NoError(err)
+	s.Equal(timeoutIssues, result)
+}
+
+func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRootCause() {
+	taskListBacklog := int64(10)
+	pollersMetadataInBytes, err := json.Marshal(invariants.PollersMetadata{TaskListBacklog: taskListBacklog})
+	s.NoError(err)
+	heartBeatingMetadataInBytes, err := json.Marshal(invariants.HeartbeatingMetadata{TimeElapsed: 5 * time.Second})
+	s.NoError(err)
+	rootCause := []invariants.InvariantRootCauseResult{
+		{
+			RootCause: invariants.RootCauseTypePollersStatus,
+			Metadata:  pollersMetadataInBytes,
+		},
+		{
+			RootCause: invariants.RootCauseTypeHeartBeatingNotEnabled,
+			Metadata:  heartBeatingMetadataInBytes,
+		},
+	}
+	timeoutRootCause := []*timeoutRootCauseResult{
+		{
+			RootCauseType:   invariants.RootCauseTypePollersStatus.String(),
+			PollersMetadata: &invariants.PollersMetadata{TaskListBacklog: taskListBacklog},
+		},
+		{
+			RootCauseType:        invariants.RootCauseTypeHeartBeatingNotEnabled.String(),
+			HeartBeatingMetadata: &invariants.HeartbeatingMetadata{TimeElapsed: 5 * time.Second},
+		},
+	}
+	result, err := retrieveTimeoutRootCause(rootCause)
+	s.NoError(err)
+	s.Equal(timeoutRootCause, result)
+}

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -133,12 +133,12 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	var result DiagnosticsWorkflowResult
 	s.NoError(s.workflowEnv.GetWorkflowResult(&result))
-	s.ElementsMatch(timeoutIssues, result.TimeoutIssues)
-	s.ElementsMatch(timeoutRootCause, result.TimeoutRootCause)
+	s.ElementsMatch(timeoutIssues, result.Timeouts.Issues)
+	s.ElementsMatch(timeoutRootCause, result.Timeouts.RootCause)
 
 	queriedResult := s.queryDiagnostics()
-	s.ElementsMatch(queriedResult.TimeoutIssues, result.TimeoutIssues)
-	s.ElementsMatch(queriedResult.TimeoutRootCause, result.TimeoutRootCause)
+	s.ElementsMatch(queriedResult.Timeouts.Issues, result.Timeouts.Issues)
+	s.ElementsMatch(queriedResult.Timeouts.RootCause, result.Timeouts.RootCause)
 }
 
 func (s *diagnosticsWorkflowTestSuite) TestWorkflow_Error() {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Diagnostics workflow result now has unmarshalled timeout issues and rootcause metadata information

<!-- Tell your future self why have you made these changes -->
**Why?**
[]byte format will be hard to fetch the results from

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
