### PR TITLE
Refactor PeerProvider & hashring interaction

### DIFF
--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -151,8 +151,8 @@ func (r *ring) Stop() {
 	r.value.Store(emptyHashring())
 
 	r.subscribers.Lock()
-	defer r.subscribers.Unlock()
 	r.subscribers.keys = make(map[string]chan<- *ChangedEvent)
+	r.subscribers.Unlock()
 	close(r.shutdownCh)
 
 	if success := common.AwaitWaitGroup(&r.shutdownWG, time.Minute); !success {
@@ -302,7 +302,7 @@ func (r *ring) refreshRingWorker() {
 			return
 		case <-r.refreshChan: // local signal or signal from provider
 			if err := r.refresh(); err != nil {
-				r.logger.Error("refreshing ring", tag.Error(err))
+				r.logger.Error("failed to refresh ring", tag.Error(err))
 			}
 		case <-refreshTicker.Chan(): // periodically force refreshing membership
 			r.signalSelf()

--- a/common/membership/peerprovider_mock.go
+++ b/common/membership/peerprovider_mock.go
@@ -109,17 +109,17 @@ func (mr *MockPeerProviderMockRecorder) Stop() *gomock.Call {
 }
 
 // Subscribe mocks base method.
-func (m *MockPeerProvider) Subscribe(name string, notifyChannel chan<- *ChangedEvent) error {
+func (m *MockPeerProvider) Subscribe(name string, handler func(ChangedEvent)) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Subscribe", name, notifyChannel)
+	ret := m.ctrl.Call(m, "Subscribe", name, handler)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Subscribe indicates an expected call of Subscribe.
-func (mr *MockPeerProviderMockRecorder) Subscribe(name, notifyChannel interface{}) *gomock.Call {
+func (mr *MockPeerProviderMockRecorder) Subscribe(name, handler interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockPeerProvider)(nil).Subscribe), name, notifyChannel)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Subscribe", reflect.TypeOf((*MockPeerProvider)(nil).Subscribe), name, handler)
 }
 
 // WhoAmI mocks base method.

--- a/common/membership/resolver.go
+++ b/common/membership/resolver.go
@@ -233,3 +233,7 @@ func (rpo *MultiringResolver) MemberCount(service string) (int, error) {
 	}
 	return ring.MemberCount(), nil
 }
+
+func (ce *ChangedEvent) Empty() bool {
+	return len(ce.HostsAdded) == 0 && len(ce.HostsUpdated) == 0 && len(ce.HostsRemoved) == 0
+}

--- a/common/membership/resolver_test.go
+++ b/common/membership/resolver_test.go
@@ -65,6 +65,7 @@ func TestMethodsAreRoutedToARing(t *testing.T) {
 	}
 
 	pp.EXPECT().GetMembers("test-worker").Return(hosts, nil).Times(1)
+	pp.EXPECT().WhoAmI().AnyTimes()
 
 	r, err := a.getRing("test-worker")
 	r.refresh()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
After changes:
 - hashring never misses updated (no "channel is full" situation possible)
 - subscribers of MultiringResolver (history, matching) will always get
   sane ChangedEvent which reflects the REAL changes (see details below)

Previously there were problems:
 - hashring subscribed to PeerProvider (ringpop/uns) with non-buffered channel
   which led to failures to write every time `ring` was doing something
   else than reading the channel (happened 60% of times based on error-logs).
   Switched to calling handlers instead which are implementing
   schedule-update with channel with cap=1 approach (see `signalSelf`).
   This approach never skips updates.
 - PeerProvider supplies ChangedEvent to `ring`, but in reality, we do
   not use it - we refresh everything from scratch. This makes very
   misleading to even rely on the ChangedEvent. Basically, we might be
   triggered by some event (host "c" appeared), but during refresh() we
   realise there are more changes (host "a" removed, host "c" added as
   well, etc.), and we notify our Subscribers with an absolutely
   irrelevant data.
 - Because of race condition in `Stop()` (we hold subscribers-list locked while we
   could notify subscribers at the same moment, and we were waiting for 
  `refreshRingWorker` to exit) we sometimes had issues with 1m delay which you could observe
   even in local setup with ^C being too slow.
 - Same misleading took place in other methods like
   `emitHashIdentifier`. It retrieved list of members from PeerProvider
   **independantly**, which could lead to emitting hash of a different
   state than members we just retrieved in refresh().
 - Some tests were working "by mistake": like
   `TestFailedLookupWillAskProvider` and
   `TestRefreshUpdatesRingOnlyWhenRingHasChanged`.

All in all, not methods are more synchronised, called more expectedly
(`compareMembers` should not make a new map), and notifiying subscribers
is **inseparable** from ring::refresh() like it should be.


<!-- Tell your future self why have you made these changes -->
**Why?**
We need to fix "channel is full" situation, and not just work it around, but fix with refactoring.
The reason why - there will be another diff which fixes interaction with MultiringResolver' subscribers.
(mainly, they should care about the pace and delays, not very-deep-internal `ring`).


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit-tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
If your code implements a custom PeerProvider (for instance, UNS at Uber), 
 you need to change interaction from channels to calling functions (handlers).
Just do the same small change as I did in `common/peerprovider/ringpopprovider/provider.go`

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
