### PR TITLE
Get rid of time.After in for loops

### DIFF
--- a/service/history/engine/engineimpl/query_workflow.go
+++ b/service/history/engine/engineimpl/query_workflow.go
@@ -87,7 +87,7 @@ func (e *historyEngineImpl) QueryWorkflow(
 	}
 	deadline := time.Now().Add(queryFirstDecisionTaskWaitTime)
 	for mutableStateResp.GetPreviousStartedEventID() <= 0 && time.Now().Before(deadline) {
-		<-time.After(queryFirstDecisionTaskCheckInterval)
+		time.Sleep(queryFirstDecisionTaskCheckInterval)
 		mutableStateResp, err = e.getMutableState(ctx, request.GetDomainUUID(), execution)
 		if err != nil {
 			return nil, err

--- a/service/history/queue/transfer_queue_processor.go
+++ b/service/history/queue/transfer_queue_processor.go
@@ -363,6 +363,14 @@ func (t *transferQueueProcessor) completeTransferLoop() {
 	completeTimer := time.NewTimer(t.config.TransferProcessorCompleteTransferInterval())
 	defer completeTimer.Stop()
 
+	// Create a retryTimer once, and reset it as needed
+	retryTimer := time.NewTimer(0)
+	defer retryTimer.Stop()
+	// Stop it immediately because we don't want it to fire initially
+	if !retryTimer.Stop() {
+		<-retryTimer.C
+	}
+
 	for {
 		select {
 		case <-t.shutdownChan:
@@ -387,12 +395,15 @@ func (t *transferQueueProcessor) completeTransferLoop() {
 					t.Stop()
 					return
 				}
-
+				// Reset the retryTimer for the delay between attempts
+				// TODO: the first retry has 0 backoff, revisit it to see if it's expected
+				retryDuration := time.Duration(attempt*100) * time.Millisecond
+				retryTimer.Reset(retryDuration)
 				select {
 				case <-t.shutdownChan:
 					t.drain()
 					return
-				case <-time.After(time.Duration(attempt*100) * time.Millisecond):
+				case <-retryTimer.C:
 					// do nothing. retry loop will continue
 				}
 			}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replace time.After in for loops with NewTimer + Reset or Sleep

<!-- Tell your future self why have you made these changes -->
**Why?**
before go 1.23, time.After in for loops can use a lot of memory if the timeout is too long and don't expire. 
after go 1.23, time.After does allocation a lot in for loops.
NewTimer + Reset gets rid of this problem.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
