### PR TITLE
[Wf-Diagnostics] Introduce Diagnostics starter workflow as parent workflow to run diagnostics

### DIFF
--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -221,7 +221,7 @@ func (wh *WorkflowHandler) DiagnoseWorkflowExecution(ctx context.Context, reques
 	diagnosticWorkflowID := fmt.Sprintf("%s-%s-%s", request.GetDomain(), wfExecution.GetWorkflowID(), wfExecution.GetRunID())
 	diagnosticWorkflowDomain := "cadence-system"
 
-	diagnosticWorkflowInput := diagnostics.DiagnosticsWorkflowInput{
+	diagnosticWorkflowInput := diagnostics.DiagnosticsStarterWorkflowInput{
 		Domain:     request.GetDomain(),
 		WorkflowID: request.GetWorkflowExecution().GetWorkflowID(),
 		RunID:      request.GetWorkflowExecution().GetRunID(),
@@ -235,7 +235,7 @@ func (wh *WorkflowHandler) DiagnoseWorkflowExecution(ctx context.Context, reques
 		Domain:     diagnosticWorkflowDomain,
 		WorkflowID: diagnosticWorkflowID,
 		WorkflowType: &types.WorkflowType{
-			Name: "diagnostics-workflow",
+			Name: "diagnostics-starter-workflow",
 		},
 		TaskList: &types.TaskList{
 			Name: "wf-diagnostics",

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -78,6 +78,7 @@ func (w *dw) Start() error {
 	}
 	newWorker := worker.New(w.svcClient, common.SystemLocalDomainName, tasklist, workerOpts)
 	newWorker.RegisterWorkflowWithOptions(w.DiagnosticsWorkflow, workflow.RegisterOptions{Name: diagnosticsWorkflow})
+	newWorker.RegisterWorkflowWithOptions(w.DiagnosticsStarterWorkflow, workflow.RegisterOptions{Name: diagnosticsStarterWorkflow})
 	newWorker.RegisterActivityWithOptions(w.retrieveExecutionHistory, activity.RegisterOptions{Name: retrieveWfExecutionHistoryActivity})
 	newWorker.RegisterActivityWithOptions(w.identifyTimeouts, activity.RegisterOptions{Name: identifyTimeoutsActivity})
 	newWorker.RegisterActivityWithOptions(w.rootCauseTimeouts, activity.RegisterOptions{Name: rootCauseTimeoutsActivity})

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"fmt"
+
 	"go.uber.org/cadence/workflow"
 )
 

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package diagnostics
 
 import (

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -1,0 +1,35 @@
+package diagnostics
+
+import (
+	"fmt"
+	"go.uber.org/cadence/workflow"
+)
+
+const (
+	diagnosticsStarterWorkflow = "diagnostics-starter-workflow"
+)
+
+type DiagnosticsStarterWorkflowInput struct {
+	Domain     string
+	WorkflowID string
+	RunID      string
+}
+
+type DiagnosticsStarterWorkflowResult struct {
+	DiagnosticsResult *DiagnosticsWorkflowResult
+}
+
+func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (*DiagnosticsStarterWorkflowResult, error) {
+	var result DiagnosticsWorkflowResult
+
+	err := workflow.ExecuteChildWorkflow(ctx, w.DiagnosticsWorkflow, DiagnosticsWorkflowInput{
+		Domain:     params.Domain,
+		WorkflowID: params.WorkflowID,
+		RunID:      params.RunID,
+	}).Get(ctx, &result)
+	if err != nil {
+		return nil, fmt.Errorf("Workflow Diagnostics: %w", err)
+	}
+
+	return &DiagnosticsStarterWorkflowResult{DiagnosticsResult: &result}, nil
+}

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -7,6 +7,7 @@ import (
 
 const (
 	diagnosticsStarterWorkflow = "diagnostics-starter-workflow"
+	queryDiagnosticsReport     = "query-diagnostics-report"
 )
 
 type DiagnosticsStarterWorkflowInput struct {
@@ -21,8 +22,14 @@ type DiagnosticsStarterWorkflowResult struct {
 
 func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (*DiagnosticsStarterWorkflowResult, error) {
 	var result DiagnosticsWorkflowResult
+	err := workflow.SetQueryHandler(ctx, queryDiagnosticsReport, func() (DiagnosticsStarterWorkflowResult, error) {
+		return DiagnosticsStarterWorkflowResult{DiagnosticsResult: &result}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
 
-	err := workflow.ExecuteChildWorkflow(ctx, w.DiagnosticsWorkflow, DiagnosticsWorkflowInput{
+	err = workflow.ExecuteChildWorkflow(ctx, w.DiagnosticsWorkflow, DiagnosticsWorkflowInput{
 		Domain:     params.Domain,
 		WorkflowID: params.WorkflowID,
 		RunID:      params.RunID,

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -35,9 +35,8 @@ import (
 )
 
 const (
-	diagnosticsWorkflow    = "diagnostics-workflow"
-	tasklist               = "diagnostics-wf-tasklist"
-	queryDiagnosticsReport = "query-diagnostics-report"
+	diagnosticsWorkflow = "diagnostics-workflow"
+	tasklist            = "diagnostics-wf-tasklist"
 
 	retrieveWfExecutionHistoryActivity = "retrieveWfExecutionHistory"
 	identifyTimeoutsActivity           = "identifyTimeouts"
@@ -82,13 +81,6 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	defer sw.Stop()
 
 	var timeoutsResult timeoutDiagnostics
-	err := workflow.SetQueryHandler(ctx, queryDiagnosticsReport, func() (DiagnosticsWorkflowResult, error) {
-		return DiagnosticsWorkflowResult{Timeouts: &timeoutsResult}, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	activityOptions := workflow.ActivityOptions{
 		ScheduleToCloseTimeout: time.Second * 10,
 		ScheduleToStartTimeout: time.Second * 5,
@@ -97,7 +89,7 @@ func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflo
 	activityCtx := workflow.WithActivityOptions(ctx, activityOptions)
 
 	var wfExecutionHistory *types.GetWorkflowExecutionHistoryResponse
-	err = workflow.ExecuteActivity(activityCtx, w.retrieveExecutionHistory, retrieveExecutionHistoryInputParams{
+	err := workflow.ExecuteActivity(activityCtx, w.retrieveExecutionHistory, retrieveExecutionHistoryInputParams{
 		Domain: params.Domain,
 		Execution: &types.WorkflowExecution{
 			WorkflowID: params.WorkflowID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
diagnostics workflow will run as child workflow within a starter parent workflow that will be triggered by frontend api

<!-- Tell your future self why have you made these changes -->
**Why?**
the parent workflow starts and waits for diagnostics to complete and then will execute an activity (will be added in future PR) to emit usage logs into kafka 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
