### PR TITLE
Update matching simulation test to support round robin load balancer

### DIFF
--- a/host/testcluster.go
+++ b/host/testcluster.go
@@ -431,6 +431,15 @@ func (tc *TestCluster) GetMatchingClient() MatchingClient {
 	return tc.host.GetMatchingClient()
 }
 
+func (tc *TestCluster) GetMatchingClients() []MatchingClient {
+	clients := tc.host.GetMatchingClients()
+	result := make([]MatchingClient, 0, len(clients))
+	for _, client := range clients {
+		result = append(result, client)
+	}
+	return result
+}
+
 // GetExecutionManagerFactory returns an execution manager factory from the test cluster
 func (tc *TestCluster) GetExecutionManagerFactory() persistence.ExecutionManagerFactory {
 	return tc.host.GetExecutionManagerFactory()

--- a/host/testdata/matching_simulation_round_robin_load_balancer.yaml
+++ b/host/testdata/matching_simulation_round_robin_load_balancer.yaml
@@ -1,0 +1,30 @@
+enablearchival: false
+clusterno: 1
+messagingclientconfig:
+  usemock: true
+historyconfig:
+  numhistoryshards: 4
+  numhistoryhosts: 1
+matchingconfig:
+  nummatchinghosts: 8
+  simulationconfig:
+    tasklistwritepartitions: 2
+    tasklistreadpartitions: 2
+    forwardermaxoutstandingpolls: 1
+    forwardermaxoutstandingtasks: 1
+    forwardermaxratepersecond: 10
+    forwardermaxchildrenpernode: 20
+    localpollwaittime: 0ms
+    localtaskwaittime: 0ms
+    recorddecisiontaskstartedtime: 13ms
+    tasklistloadbalancerstrategy: round-robin
+    tasks:
+      - numtaskgenerators: 100
+        taskspersecond: 300
+        maxtasktogenerate: 30000
+    pollers:
+      - taskprocesstime: 1ms
+        numpollers: 8
+        polltimeout: 60s
+workerconfig:
+  enableasyncwfconsumer: false


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update matching simulation test to use multiple matching clients

<!-- Tell your future self why have you made these changes -->
**Why?**
To support testing round robin load balancer, because it's using a cache in matching client. We need to use multiple clients to simulate the production environment.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
simulation test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
