### PR TITLE
[Wf-Diagnostics] Emit usage logs after workflow diagnostics run

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -254,6 +254,8 @@ func (s *server) startService() common.Daemon {
 		log.Fatalf("error creating async queue provider: %v", err)
 	}
 
+	params.KafkaConfig = s.cfg.Kafka
+
 	params.Logger.Info("Starting service " + s.name)
 
 	var daemon common.Daemon

--- a/common/resource/params.go
+++ b/common/resource/params.go
@@ -55,18 +55,19 @@ type (
 		ThrottledLogger log.Logger
 		HostName        string
 
-		MetricScope                tally.Scope
-		MembershipResolver         membership.Resolver
-		RPCFactory                 common.RPCFactory
-		PProfInitializer           common.PProfInitializer
-		PersistenceConfig          config.Persistence
-		ClusterMetadata            cluster.Metadata
-		ReplicatorConfig           config.Replicator
-		MetricsClient              metrics.Client
-		MessagingClient            messaging.Client
-		BlobstoreClient            blobstore.Client
-		ESClient                   es.GenericClient
-		ESConfig                   *config.ElasticSearchConfig
+		MetricScope        tally.Scope
+		MembershipResolver membership.Resolver
+		RPCFactory         common.RPCFactory
+		PProfInitializer   common.PProfInitializer
+		PersistenceConfig  config.Persistence
+		ClusterMetadata    cluster.Metadata
+		ReplicatorConfig   config.Replicator
+		MetricsClient      metrics.Client
+		MessagingClient    messaging.Client
+		BlobstoreClient    blobstore.Client
+		ESClient           es.GenericClient
+		ESConfig           *config.ElasticSearchConfig
+
 		DynamicConfig              dynamicconfig.Client
 		ClusterRedirectionPolicy   *config.ClusterRedirectionPolicy
 		PublicClient               workflowserviceclient.Interface
@@ -78,6 +79,7 @@ type (
 		IsolationGroupState        isolationgroup.State     // This can be nil, the default state store will be chosen if so
 		Partitioner                partition.Partitioner
 		PinotConfig                *config.PinotVisibilityConfig
+		KafkaConfig                config.KafkaConfig
 		PinotClient                pinot.GenericClient
 		OSClient                   es.GenericClient
 		OSConfig                   *config.ElasticSearchConfig

--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -225,6 +225,7 @@ func (wh *WorkflowHandler) DiagnoseWorkflowExecution(ctx context.Context, reques
 		Domain:     request.GetDomain(),
 		WorkflowID: request.GetWorkflowExecution().GetWorkflowID(),
 		RunID:      request.GetWorkflowExecution().GetRunID(),
+		Identity:   request.Identity,
 	}
 	inputInBytes, err := json.Marshal(diagnosticWorkflowInput)
 	if err != nil {

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -24,9 +24,9 @@ package diagnostics
 
 import (
 	"context"
-	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariants"
 )
 

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -25,12 +25,17 @@ package diagnostics
 import (
 	"context"
 
+	"github.com/uber/cadence/common/messaging"
+	"github.com/uber/cadence/common/messaging/kafka"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariants"
 )
 
-const linkToTimeoutsRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
+const (
+	linkToTimeoutsRunbook = "https://cadenceworkflow.io/docs/workflow-troubleshooting/timeouts/"
+	WfDiagnosticsAppName  = "workflow-diagnostics"
+)
 
 type retrieveExecutionHistoryInputParams struct {
 	Domain    string
@@ -75,8 +80,21 @@ func (w *dw) rootCauseTimeouts(ctx context.Context, info rootCauseTimeoutsParams
 }
 
 func (w *dw) emitUsageLogs(ctx context.Context, info analytics.WfDiagnosticsUsageData) error {
+	client := w.newMessagingClient()
+	return emit(ctx, info, client)
+}
+
+func (w *dw) newMessagingClient() messaging.Client {
+	return kafka.NewKafkaClient(&w.kafkaCfg, w.metricsClient, w.logger, w.tallyScope, true)
+}
+
+func emit(ctx context.Context, info analytics.WfDiagnosticsUsageData, client messaging.Client) error {
+	producer, err := client.NewProducer(WfDiagnosticsAppName)
+	if err != nil {
+		return err
+	}
 	emitter := analytics.NewEmitter(analytics.EmitterParams{
-		Producer: w.producer,
+		Producer: producer,
 	})
 	return emitter.EmitUsageData(ctx, info)
 }

--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/service/worker/diagnostics/invariants"
@@ -71,4 +72,11 @@ func (w *dw) rootCauseTimeouts(ctx context.Context, info rootCauseTimeoutsParams
 		Domain:                   info.Domain,
 	})
 	return timeoutInvariant.RootCause(ctx, info.Issues)
+}
+
+func (w *dw) emitUsageLogs(ctx context.Context, info analytics.WfDiagnosticsUsageData) error {
+	emitter := analytics.NewEmitter(analytics.EmitterParams{
+		Producer: w.producer,
+	})
+	return emitter.EmitUsageData(ctx, info)
 }

--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -25,8 +25,6 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
-	"github.com/uber/cadence/common/messaging"
-	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"testing"
 	"time"
 
@@ -36,7 +34,9 @@ import (
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"github.com/uber/cadence/service/worker/diagnostics/invariants"
 )
 

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -24,7 +24,6 @@ package diagnostics
 
 import (
 	"context"
-	"github.com/uber/cadence/common/messaging"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
@@ -35,6 +34,7 @@ import (
 
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/metrics"
 )
 

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -85,11 +85,6 @@ func (w *dw) Start() error {
 		MaxConcurrentActivityTaskPollers: 10,
 		MaxConcurrentDecisionTaskPollers: 10,
 	}
-	producer, err := w.messagingClient.NewProducer(WfDiagnosticsAppName)
-	if err != nil {
-		return err
-	}
-	w.producer = producer
 	newWorker := worker.New(w.svcClient, common.SystemLocalDomainName, tasklist, workerOpts)
 	newWorker.RegisterWorkflowWithOptions(w.DiagnosticsWorkflow, workflow.RegisterOptions{Name: diagnosticsWorkflow})
 	newWorker.RegisterWorkflowWithOptions(w.DiagnosticsStarterWorkflow, workflow.RegisterOptions{Name: diagnosticsStarterWorkflow})
@@ -98,6 +93,12 @@ func (w *dw) Start() error {
 	newWorker.RegisterActivityWithOptions(w.rootCauseTimeouts, activity.RegisterOptions{Name: rootCauseTimeoutsActivity})
 	newWorker.RegisterActivityWithOptions(w.emitUsageLogs, activity.RegisterOptions{Name: emitUsageLogsActivity})
 	w.worker = newWorker
+
+	producer, err := w.messagingClient.NewProducer(WfDiagnosticsAppName)
+	if err != nil {
+		return err
+	}
+	w.producer = producer
 	return newWorker.Start()
 }
 

--- a/service/worker/diagnostics/module.go
+++ b/service/worker/diagnostics/module.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/common/messaging"
 
 	"github.com/opentracing/opentracing-go"
 	"github.com/uber-go/tally"
@@ -37,33 +38,41 @@ import (
 	"github.com/uber/cadence/common/metrics"
 )
 
+const (
+	WfDiagnosticsAppName = "workflow-diagnostics"
+)
+
 type DiagnosticsWorkflow interface {
 	Start() error
 	Stop()
 }
 
 type dw struct {
-	svcClient     workflowserviceclient.Interface
-	clientBean    client.Bean
-	metricsClient metrics.Client
-	tallyScope    tally.Scope
-	worker        worker.Worker
+	svcClient       workflowserviceclient.Interface
+	clientBean      client.Bean
+	metricsClient   metrics.Client
+	messagingClient messaging.Client
+	tallyScope      tally.Scope
+	worker          worker.Worker
+	producer        messaging.Producer
 }
 
 type Params struct {
-	ServiceClient workflowserviceclient.Interface
-	ClientBean    client.Bean
-	MetricsClient metrics.Client
-	TallyScope    tally.Scope
+	ServiceClient   workflowserviceclient.Interface
+	ClientBean      client.Bean
+	MetricsClient   metrics.Client
+	TallyScope      tally.Scope
+	MessagingClient messaging.Client
 }
 
 // New creates a new diagnostics workflow.
 func New(params Params) DiagnosticsWorkflow {
 	return &dw{
-		svcClient:     params.ServiceClient,
-		metricsClient: params.MetricsClient,
-		tallyScope:    params.TallyScope,
-		clientBean:    params.ClientBean,
+		svcClient:       params.ServiceClient,
+		metricsClient:   params.MetricsClient,
+		tallyScope:      params.TallyScope,
+		clientBean:      params.ClientBean,
+		messagingClient: params.MessagingClient,
 	}
 }
 
@@ -76,12 +85,18 @@ func (w *dw) Start() error {
 		MaxConcurrentActivityTaskPollers: 10,
 		MaxConcurrentDecisionTaskPollers: 10,
 	}
+	producer, err := w.messagingClient.NewProducer(WfDiagnosticsAppName)
+	if err != nil {
+		return err
+	}
+	w.producer = producer
 	newWorker := worker.New(w.svcClient, common.SystemLocalDomainName, tasklist, workerOpts)
 	newWorker.RegisterWorkflowWithOptions(w.DiagnosticsWorkflow, workflow.RegisterOptions{Name: diagnosticsWorkflow})
 	newWorker.RegisterWorkflowWithOptions(w.DiagnosticsStarterWorkflow, workflow.RegisterOptions{Name: diagnosticsStarterWorkflow})
 	newWorker.RegisterActivityWithOptions(w.retrieveExecutionHistory, activity.RegisterOptions{Name: retrieveWfExecutionHistoryActivity})
 	newWorker.RegisterActivityWithOptions(w.identifyTimeouts, activity.RegisterOptions{Name: identifyTimeoutsActivity})
 	newWorker.RegisterActivityWithOptions(w.rootCauseTimeouts, activity.RegisterOptions{Name: rootCauseTimeoutsActivity})
+	newWorker.RegisterActivityWithOptions(w.emitUsageLogs, activity.RegisterOptions{Name: emitUsageLogsActivity})
 	w.worker = newWorker
 	return newWorker.Start()
 }

--- a/service/worker/diagnostics/module_test.go
+++ b/service/worker/diagnostics/module_test.go
@@ -25,16 +25,12 @@ package diagnostics
 import (
 	"testing"
 
-	"github.com/Shopify/sarama/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/shared"
 
 	"github.com/uber/cadence/client"
-	"github.com/uber/cadence/common/log/testlogger"
-	"github.com/uber/cadence/common/messaging"
-	"github.com/uber/cadence/common/messaging/kafka"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"
 )
@@ -51,18 +47,14 @@ func setuptest(t *testing.T) (DiagnosticsWorkflow, *resource.Test) {
 	ctrl := gomock.NewController(t)
 	mockClientBean := client.NewMockBean(ctrl)
 	mockResource := resource.NewTest(t, ctrl, metrics.Worker)
-	logger := testlogger.New(t)
-	messaginClientMock := messaging.NewMockClient(ctrl)
-	messaginClientMock.EXPECT().NewProducer(gomock.Any()).Return(kafka.NewKafkaProducer("test-topic", mocks.NewSyncProducer(t, nil), logger), nil).MinTimes(1)
 	sdkClient := mockResource.GetSDKClient()
 	mockResource.SDKClient.EXPECT().DescribeDomain(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&shared.DescribeDomainResponse{}, nil).AnyTimes()
 	mockResource.SDKClient.EXPECT().PollForDecisionTask(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&shared.PollForDecisionTaskResponse{}, nil).AnyTimes()
 	mockResource.SDKClient.EXPECT().PollForActivityTask(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&shared.PollForActivityTaskResponse{}, nil).AnyTimes()
 	return New(Params{
-		ServiceClient:   sdkClient,
-		ClientBean:      mockClientBean,
-		MetricsClient:   nil,
-		TallyScope:      tally.TestScope(nil),
-		MessagingClient: messaginClientMock,
+		ServiceClient: sdkClient,
+		ClientBean:    mockClientBean,
+		MetricsClient: nil,
+		TallyScope:    tally.TestScope(nil),
 	}), mockResource
 }

--- a/service/worker/diagnostics/module_test.go
+++ b/service/worker/diagnostics/module_test.go
@@ -23,18 +23,18 @@
 package diagnostics
 
 import (
-	"github.com/Shopify/sarama/mocks"
-	"github.com/uber/cadence/common/log/testlogger"
-	"github.com/uber/cadence/common/messaging"
-	"github.com/uber/cadence/common/messaging/kafka"
 	"testing"
 
+	"github.com/Shopify/sarama/mocks"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/cadence/.gen/go/shared"
 
 	"github.com/uber/cadence/client"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/messaging"
+	"github.com/uber/cadence/common/messaging/kafka"
 	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/resource"
 )

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -24,17 +24,23 @@ package diagnostics
 
 import (
 	"fmt"
+	"github.com/uber/cadence/service/worker/diagnostics/analytics"
+	"time"
 
 	"go.uber.org/cadence/workflow"
 )
 
 const (
 	diagnosticsStarterWorkflow = "diagnostics-starter-workflow"
+	emitUsageLogsActivity      = "emitUsageLogs"
 	queryDiagnosticsReport     = "query-diagnostics-report"
+
+	issueTypeTimeouts = "Timeout"
 )
 
 type DiagnosticsStarterWorkflowInput struct {
 	Domain     string
+	Identity   string
 	WorkflowID string
 	RunID      string
 }
@@ -43,7 +49,7 @@ type DiagnosticsStarterWorkflowResult struct {
 	DiagnosticsResult *DiagnosticsWorkflowResult
 }
 
-func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (*DiagnosticsStarterWorkflowResult, error) {
+func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params DiagnosticsStarterWorkflowInput) (*DiagnosticsStarterWorkflowResult, error) {
 	var result DiagnosticsWorkflowResult
 	err := workflow.SetQueryHandler(ctx, queryDiagnosticsReport, func() (DiagnosticsStarterWorkflowResult, error) {
 		return DiagnosticsStarterWorkflowResult{DiagnosticsResult: &result}, nil
@@ -52,14 +58,53 @@ func (w *dw) DiagnosticsStarterWorkflow(ctx workflow.Context, params Diagnostics
 		return nil, err
 	}
 
-	err = workflow.ExecuteChildWorkflow(ctx, w.DiagnosticsWorkflow, DiagnosticsWorkflowInput{
+	future := workflow.ExecuteChildWorkflow(ctx, w.DiagnosticsWorkflow, DiagnosticsWorkflowInput{
 		Domain:     params.Domain,
 		WorkflowID: params.WorkflowID,
 		RunID:      params.RunID,
-	}).Get(ctx, &result)
+	})
+
+	var childWfExec workflow.Execution
+	var childWfStart, childWfEnd time.Time
+	if err = future.GetChildWorkflowExecution().Get(ctx, &childWfExec); err != nil {
+		return nil, fmt.Errorf("Workflow Diagnostics start failed: %w", err)
+	}
+	childWfStart = workflow.Now(ctx)
+
+	err = future.Get(ctx, &result)
 	if err != nil {
-		return nil, fmt.Errorf("Workflow Diagnostics: %w", err)
+		return nil, fmt.Errorf("Workflow Diagnostics failed: %w", err)
+	}
+	childWfEnd = workflow.Now(ctx)
+
+	activityOptions := workflow.ActivityOptions{
+		ScheduleToCloseTimeout: time.Second * 10,
+		ScheduleToStartTimeout: time.Second * 5,
+		StartToCloseTimeout:    time.Second * 5,
+	}
+	activityCtx := workflow.WithActivityOptions(ctx, activityOptions)
+	err = workflow.ExecuteActivity(activityCtx, w.emitUsageLogs, analytics.WfDiagnosticsUsageData{
+		Domain:                params.Domain,
+		WorkflowID:            params.WorkflowID,
+		RunID:                 params.RunID,
+		Identity:              params.Identity,
+		IssueType:             getIssueType(result),
+		DiagnosticsWorkflowID: childWfExec.ID,
+		DiagnosticsRunID:      childWfExec.RunID,
+		DiagnosticsStartTime:  childWfStart,
+		DiagnosticsEndTime:    childWfEnd,
+	}).Get(ctx, nil)
+	if err != nil {
+		return nil, fmt.Errorf("EmitUsageLogs: %w", err)
 	}
 
 	return &DiagnosticsStarterWorkflowResult{DiagnosticsResult: &result}, nil
+}
+
+func getIssueType(result DiagnosticsWorkflowResult) string {
+	var issueType string
+	if result.Timeouts != nil {
+		issueType = issueTypeTimeouts
+	}
+	return issueType
 }

--- a/service/worker/diagnostics/parent_workflow.go
+++ b/service/worker/diagnostics/parent_workflow.go
@@ -24,10 +24,11 @@ package diagnostics
 
 import (
 	"fmt"
-	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 	"time"
 
 	"go.uber.org/cadence/workflow"
+
+	"github.com/uber/cadence/service/worker/diagnostics/analytics"
 )
 
 const (

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -74,6 +74,7 @@ func (s *diagnosticsWorkflowTestSuite) SetupTest() {
 	s.workflowEnv.RegisterActivityWithOptions(s.dw.retrieveExecutionHistory, activity.RegisterOptions{Name: retrieveWfExecutionHistoryActivity})
 	s.workflowEnv.RegisterActivityWithOptions(s.dw.identifyTimeouts, activity.RegisterOptions{Name: identifyTimeoutsActivity})
 	s.workflowEnv.RegisterActivityWithOptions(s.dw.rootCauseTimeouts, activity.RegisterOptions{Name: rootCauseTimeoutsActivity})
+	s.workflowEnv.RegisterActivityWithOptions(s.dw.emitUsageLogs, activity.RegisterOptions{Name: emitUsageLogsActivity})
 }
 
 func (s *diagnosticsWorkflowTestSuite) TearDownTest() {
@@ -131,6 +132,7 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 	s.workflowEnv.OnActivity(retrieveWfExecutionHistoryActivity, mock.Anything, mock.Anything).Return(nil, nil)
 	s.workflowEnv.OnActivity(identifyTimeoutsActivity, mock.Anything, mock.Anything).Return(issues, nil)
 	s.workflowEnv.OnActivity(rootCauseTimeoutsActivity, mock.Anything, mock.Anything).Return(rootCause, nil)
+	s.workflowEnv.OnActivity(emitUsageLogsActivity, mock.Anything, mock.Anything).Return(nil)
 	s.workflowEnv.ExecuteWorkflow(diagnosticsStarterWorkflow, params)
 	s.True(s.workflowEnv.IsWorkflowCompleted())
 	var result DiagnosticsStarterWorkflowResult

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/domain"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/tag"
@@ -68,6 +69,7 @@ type (
 
 	// Config contains all the service config for worker
 	Config struct {
+		KafkaCfg                            config.KafkaConfig
 		ArchiverConfig                      *archiver.Config
 		IndexerCfg                          *indexer.Config
 		ScannerCfg                          *scanner.Config
@@ -340,11 +342,12 @@ func (s *Service) startFixerWorkflowWorker() {
 
 func (s *Service) startDiagnostics() {
 	params := diagnostics.Params{
-		ServiceClient:   s.params.PublicClient,
-		MetricsClient:   s.GetMetricsClient(),
-		TallyScope:      s.params.MetricScope,
-		ClientBean:      s.GetClientBean(),
-		MessagingClient: s.GetMessagingClient(),
+		ServiceClient: s.params.PublicClient,
+		MetricsClient: s.GetMetricsClient(),
+		TallyScope:    s.params.MetricScope,
+		ClientBean:    s.GetClientBean(),
+		Logger:        s.GetLogger(),
+		KafkaCfg:      s.params.KafkaConfig,
 	}
 	if err := diagnostics.New(params).Start(); err != nil {
 		s.Stop()

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -340,10 +340,11 @@ func (s *Service) startFixerWorkflowWorker() {
 
 func (s *Service) startDiagnostics() {
 	params := diagnostics.Params{
-		ServiceClient: s.params.PublicClient,
-		MetricsClient: s.GetMetricsClient(),
-		TallyScope:    s.params.MetricScope,
-		ClientBean:    s.GetClientBean(),
+		ServiceClient:   s.params.PublicClient,
+		MetricsClient:   s.GetMetricsClient(),
+		TallyScope:      s.params.MetricScope,
+		ClientBean:      s.GetClientBean(),
+		MessagingClient: s.GetMessagingClient(),
 	}
 	if err := diagnostics.New(params).Start(); err != nil {
 		s.Stop()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Usage logs are emitted after workflow diagnostics run as an activity in the diagnostics starter workflow. Since this is a on demand usecase. kafka messaging client is only setup when needed

<!-- Tell your future self why have you made these changes -->
**Why?**
collect data for every workflow diagnostics run

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
