### PR TITLE
Temporary patch: ensure errors lead to exit(1) in main funcs

### DIFF
--- a/cmd/bench/main.go
+++ b/cmd/bench/main.go
@@ -152,5 +152,8 @@ func buildCLI() *cli.App {
 
 func main() {
 	app := buildCLI()
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(app.ErrWriter, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/canary/main.go
+++ b/cmd/canary/main.go
@@ -147,5 +147,8 @@ func buildCLI() *cli.App {
 
 func main() {
 	app := buildCLI()
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(app.ErrWriter, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -21,6 +21,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/uber/cadence/cmd/server/cadence"
@@ -37,5 +38,8 @@ import (
 // main entry point for the cadence server
 func main() {
 	app := cadence.BuildCLI(metrics.ReleaseVersion, metrics.Revision)
-	app.Run(os.Args)
+	if err := app.Run(os.Args); err != nil {
+		_, _ = fmt.Fprintln(app.ErrWriter, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/tools/cassandra/main.go
+++ b/cmd/tools/cassandra/main.go
@@ -21,6 +21,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/uber/cadence/tools/cassandra"
@@ -31,6 +32,7 @@ import (
 func main() {
 	err := cassandra.RunTool(os.Args)
 	if err != nil {
-		panic(err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/cmd/tools/cli/main.go
+++ b/cmd/tools/cli/main.go
@@ -37,7 +37,7 @@ import (
 func main() {
 	app := cli.NewCliApp()
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintln(os.Stderr, err.Error())
+		_, _ = fmt.Fprintln(app.ErrWriter, err)
 		os.Exit(1)
 	}
 }

--- a/cmd/tools/sql/main.go
+++ b/cmd/tools/sql/main.go
@@ -21,6 +21,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/uber/cadence/tools/sql"
@@ -32,6 +33,7 @@ import (
 func main() {
 	err := sql.RunTool(os.Args)
 	if err != nil {
-		panic(err)
+		_, _ = fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
 	}
 }

--- a/go.work.sum
+++ b/go.work.sum
@@ -547,6 +547,7 @@ github.com/shirou/gopsutil/v3 v3.22.4 h1:srAQaiX6jX/cYL6q29aE0m8lOskT9CurZ9N61YR
 github.com/shirou/gopsutil/v3 v3.22.4/go.mod h1:D01hZJ4pVHPpCTZ3m3T2+wDF2YAGfd+H4ifUguaQzHM=
 github.com/shurcooL/go v0.0.0-20180423040247-9e1955d9fb6e h1:MZM7FHLqUHYI0Y/mQAt3d2aYa0SiNms/hFqC9qJYolM=
 github.com/shurcooL/go-goon v0.0.0-20170922171312-37c2f522c041 h1:llrF3Fs4018ePo4+G/HV/uQUqEI1HMDjCeOf2V6puPc=
+github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/smartystreets/assertions v1.1.1 h1:T/YLemO5Yp7KPzS+lVtu+WsHn8yoSwTfItdAd1r3cck=
 github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/go-aws-auth v0.0.0-20180515143844-0c1422d1fdb9 h1:hp2CYQUINdZMHdvTdXtPOY2ainKl4IoMcpAXEf2xj3Q=


### PR DESCRIPTION
The main docker-compose.yml is currently erroring silently without printing anything due to... either the urfave/cli/v2 migration (i.e. changes in urfave), or simply a long-standing silent-failure bug that should be squashed.
So this changes all our `func main`s to check for error returns, and print and exit them.

We're going to be doing some rewriting of error handling in these CLIs very soon, so for now I'm just doing the simplest patch possible, to ease troubleshooting.
