### PR TITLE
Bugfix: server was ending when in log-debug mode

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -58,7 +58,7 @@ func startHandler(c *cli.Context) error {
 		return fmt.Errorf("Config file corrupted: %w", err)
 	}
 	if cfg.Log.Level == "debug" {
-		return fmt.Errorf("config=%v", cfg.String())
+		log.Printf("config=%v", cfg.String())
 	}
 	if cfg.DynamicConfig.Client == "" {
 		cfg.DynamicConfigClient.Filepath = constructPathIfNeed(rootDir, cfg.DynamicConfigClient.Filepath)


### PR DESCRIPTION
Unfortunately I missed a "log.Printf -> return fmt.Errorf" mistake in #6285.
I think it just got lost in the surrounding "log.Fatalf -> return fmt.Errorf" flood.

Oh well.  Easy fix.  This appears to be the only one.