### PR TITLE
[CLI] replace BackgroundContext with CLI's context

### DIFF
--- a/tools/cli/admin_db_scan_command.go
+++ b/tools/cli/admin_db_scan_command.go
@@ -187,7 +187,7 @@ func listExecutionsByShardID(
 	defer client.Close()
 
 	paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), listContextTimeout)
+		ctx, cancel := context.WithTimeout(c.Context, listContextTimeout)
 		defer cancel()
 
 		resp, err := client.ListConcreteExecutions(

--- a/tools/cli/admin_elastic_search_commands.go
+++ b/tools/cli/admin_elastic_search_commands.go
@@ -87,7 +87,7 @@ type ESIndexRow struct {
 func AdminCatIndices(c *cli.Context) error {
 	esClient := cFactory.ElasticSearchClient(c)
 
-	ctx := context.Background()
+	ctx := c.Context
 	resp, err := esClient.CatIndices().Do(ctx)
 	if err != nil {
 		return commoncli.Problem("Unable to cat indices", err)
@@ -124,7 +124,7 @@ func AdminIndex(c *cli.Context) error {
 
 	bulkRequest := esClient.Bulk()
 	bulkConductFn := func() error {
-		_, err := bulkRequest.Do(context.Background())
+		_, err := bulkRequest.Do(c.Context)
 		if err != nil {
 			return commoncli.Problem("Bulk failed", err)
 		}
@@ -206,7 +206,7 @@ func AdminDelete(c *cli.Context) error {
 		if !ok {
 			time.Sleep(waitTime)
 		}
-		_, err := bulkRequest.Do(context.Background())
+		_, err := bulkRequest.Do(c.Context)
 		if err != nil {
 			return commoncli.Problem(fmt.Sprintf("Bulk failed, current processed row %d", i), err)
 		}
@@ -330,7 +330,7 @@ func GenerateReport(c *cli.Context) error {
 		reportFilePath = "./report." + reportFormat
 	}
 	esClient := cFactory.ElasticSearchClient(c)
-	ctx := context.Background()
+	ctx := c.Context
 
 	// convert sql to dsl
 	e := esql.NewESql()

--- a/tools/cli/admin_elastic_search_commands.go
+++ b/tools/cli/admin_elastic_search_commands.go
@@ -22,7 +22,6 @@ package cli
 
 import (
 	"bufio"
-	"context"
 	"encoding/json"
 	"fmt"
 	"math"

--- a/tools/cli/admin_kafka_commands.go
+++ b/tools/cli/admin_kafka_commands.go
@@ -497,7 +497,7 @@ func AdminRereplicate(c *cli.Context) error {
 	if c.IsSet(FlagContextTimeout) {
 		contextTimeout = time.Duration(c.Int(FlagContextTimeout)) * time.Second
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+	ctx, cancel := context.WithTimeout(c.Context, contextTimeout)
 	defer cancel()
 
 	return doRereplicate(

--- a/tools/cli/admin_timers.go
+++ b/tools/cli/admin_timers.go
@@ -263,7 +263,7 @@ func (cl *dbLoadCloser) Load() []*persistence.TimerTaskInfo {
 			return err
 		}
 
-		err = throttleRetry.Do(context.Background(), op)
+		err = throttleRetry.Do(c.Context, op)
 
 		if err != nil {
 			ErrorAndExit("cannot get timer tasks for shard", err)

--- a/tools/cli/admin_timers.go
+++ b/tools/cli/admin_timers.go
@@ -23,7 +23,6 @@
 package cli
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -263,7 +262,7 @@ func (cl *dbLoadCloser) Load() []*persistence.TimerTaskInfo {
 			return err
 		}
 
-		err = throttleRetry.Do(c.Context, op)
+		err = throttleRetry.Do(cl.ctx.Context, op)
 
 		if err != nil {
 			ErrorAndExit("cannot get timer tasks for shard", err)

--- a/tools/cli/utils.go
+++ b/tools/cli/utils.go
@@ -755,14 +755,14 @@ func newIndefiniteContext(c *cli.Context) (context.Context, context.CancelFunc) 
 		return newTimedContext(c, time.Duration(c.Int(FlagContextTimeout))*time.Second)
 	}
 
-	return context.WithCancel(populateContextFromCLIContext(context.Background(), c))
+	return context.WithCancel(populateContextFromCLIContext(c.Context, c))
 }
 
 func newTimedContext(c *cli.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
 	if overrideTimeout := c.Int(FlagContextTimeout); overrideTimeout > 0 {
 		timeout = time.Duration(overrideTimeout) * time.Second
 	}
-	ctx := populateContextFromCLIContext(context.Background(), c)
+	ctx := populateContextFromCLIContext(c.Context, c)
 	return context.WithTimeout(ctx, timeout)
 }
 

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -1419,7 +1419,7 @@ func listArchivedWorkflows(c *cli.Context) getWorkflowPageFn {
 			NextPageToken: nextPageToken,
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), contextTimeout)
+		ctx, cancel := context.WithTimeout(c.Context, contextTimeout)
 		defer cancel()
 
 		result, err := wfClient.ListArchivedWorkflowExecutions(ctx, request)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Instead of using background context. Use CLI's provided context.

<!-- Tell your future self why have you made these changes -->
**Why?**

New CLI framework allows passing a root context from `app.RunContext`. We want to follow this practice to simplify things like jwt / opentracing propagation. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
