### PR TITLE
[Wf-Diagnostics] Refactor to move all timeout related checks under one directory

### DIFF
--- a/service/worker/diagnostics/activities.go
+++ b/service/worker/diagnostics/activities.go
@@ -24,6 +24,7 @@ package diagnostics
 
 import (
 	"context"
+	"github.com/uber/cadence/service/worker/diagnostics/invariants/timeouts"
 
 	"github.com/uber/cadence/common/messaging"
 	"github.com/uber/cadence/common/messaging/kafka"
@@ -56,7 +57,7 @@ type identifyTimeoutsInputParams struct {
 }
 
 func (w *dw) identifyTimeouts(ctx context.Context, info identifyTimeoutsInputParams) ([]invariants.InvariantCheckResult, error) {
-	timeoutInvariant := invariants.NewTimeout(invariants.NewTimeoutParams{
+	timeoutInvariant := timeouts.NewTimeout(timeouts.NewTimeoutParams{
 		WorkflowExecutionHistory: info.History,
 		Domain:                   info.Domain,
 		ClientBean:               w.clientBean,
@@ -71,7 +72,7 @@ type rootCauseTimeoutsParams struct {
 }
 
 func (w *dw) rootCauseTimeouts(ctx context.Context, info rootCauseTimeoutsParams) ([]invariants.InvariantRootCauseResult, error) {
-	timeoutInvariant := invariants.NewTimeout(invariants.NewTimeoutParams{
+	timeoutInvariant := timeouts.NewTimeout(timeouts.NewTimeoutParams{
 		WorkflowExecutionHistory: info.History,
 		ClientBean:               w.clientBean,
 		Domain:                   info.Domain,

--- a/service/worker/diagnostics/activities_test.go
+++ b/service/worker/diagnostics/activities_test.go
@@ -25,6 +25,7 @@ package diagnostics
 import (
 	"context"
 	"encoding/json"
+	"github.com/uber/cadence/service/worker/diagnostics/invariants/timeouts"
 	"testing"
 	"time"
 
@@ -61,7 +62,7 @@ func Test__retrieveExecutionHistory(t *testing.T) {
 
 func Test__identifyTimeouts(t *testing.T) {
 	dwtest := testDiagnosticWorkflow(t)
-	workflowTimeoutData := invariants.ExecutionTimeoutMetadata{
+	workflowTimeoutData := timeouts.ExecutionTimeoutMetadata{
 		ExecutionTime:     110 * time.Second,
 		ConfiguredTimeout: 110 * time.Second,
 		LastOngoingEvent: &types.HistoryEvent{
@@ -76,7 +77,7 @@ func Test__identifyTimeouts(t *testing.T) {
 	require.NoError(t, err)
 	expectedResult := []invariants.InvariantCheckResult{
 		{
-			InvariantType: invariants.TimeoutTypeExecution.String(),
+			InvariantType: timeouts.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
 			Metadata:      workflowTimeoutDataInBytes,
 		},
@@ -88,7 +89,7 @@ func Test__identifyTimeouts(t *testing.T) {
 
 func Test__rootCauseTimeouts(t *testing.T) {
 	dwtest := testDiagnosticWorkflow(t)
-	workflowTimeoutData := invariants.ExecutionTimeoutMetadata{
+	workflowTimeoutData := timeouts.ExecutionTimeoutMetadata{
 		ExecutionTime:     110 * time.Second,
 		ConfiguredTimeout: 110 * time.Second,
 		LastOngoingEvent: &types.HistoryEvent{
@@ -107,13 +108,13 @@ func Test__rootCauseTimeouts(t *testing.T) {
 	require.NoError(t, err)
 	issues := []invariants.InvariantCheckResult{
 		{
-			InvariantType: invariants.TimeoutTypeExecution.String(),
+			InvariantType: timeouts.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
 			Metadata:      workflowTimeoutDataInBytes,
 		},
 	}
 	taskListBacklog := int64(10)
-	taskListBacklogInBytes, err := json.Marshal(invariants.PollersMetadata{TaskListBacklog: taskListBacklog})
+	taskListBacklogInBytes, err := json.Marshal(timeouts.PollersMetadata{TaskListBacklog: taskListBacklog})
 	require.NoError(t, err)
 	expectedRootCause := []invariants.InvariantRootCauseResult{
 		{

--- a/service/worker/diagnostics/invariants/invariant.go
+++ b/service/worker/diagnostics/invariants/invariant.go
@@ -22,7 +22,9 @@
 
 package invariants
 
-import "context"
+import (
+	"context"
+)
 
 // InvariantCheckResult is the result from the invariant check
 type InvariantCheckResult struct {
@@ -35,6 +37,19 @@ type InvariantCheckResult struct {
 type InvariantRootCauseResult struct {
 	RootCause RootCause
 	Metadata  []byte
+}
+
+type RootCause string
+
+const (
+	RootCauseTypeMissingPollers                      RootCause = "There are no pollers for the tasklist"
+	RootCauseTypePollersStatus                       RootCause = "There are pollers for the tasklist. Check backlog status"
+	RootCauseTypeHeartBeatingNotEnabled              RootCause = "HeartBeating not enabled for activity"
+	RootCauseTypeHeartBeatingEnabledMissingHeartbeat RootCause = "HeartBeating enabled for activity but timed out due to missing heartbeat"
+)
+
+func (r RootCause) String() string {
+	return string(r)
 }
 
 // Invariant represents a condition of a workflow execution.

--- a/service/worker/diagnostics/invariants/timeouts/timeout.go
+++ b/service/worker/diagnostics/invariants/timeouts/timeout.go
@@ -20,19 +20,20 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package invariants
+package timeouts
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/uber/cadence/service/worker/diagnostics/invariants"
 	"time"
 
 	"github.com/uber/cadence/client"
 	"github.com/uber/cadence/common/types"
 )
 
-type Timeout Invariant
+type Timeout invariants.Invariant
 
 type timeout struct {
 	workflowExecutionHistory *types.GetWorkflowExecutionHistoryResponse
@@ -46,7 +47,7 @@ type NewTimeoutParams struct {
 	ClientBean               client.Bean
 }
 
-func NewTimeout(p NewTimeoutParams) Invariant {
+func NewTimeout(p NewTimeoutParams) invariants.Invariant {
 	return &timeout{
 		workflowExecutionHistory: p.WorkflowExecutionHistory,
 		domain:                   p.Domain,
@@ -54,8 +55,8 @@ func NewTimeout(p NewTimeoutParams) Invariant {
 	}
 }
 
-func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
-	result := make([]InvariantCheckResult, 0)
+func (t *timeout) Check(context.Context) ([]invariants.InvariantCheckResult, error) {
+	result := make([]invariants.InvariantCheckResult, 0)
 	events := t.workflowExecutionHistory.GetHistory().GetEvents()
 	for _, event := range events {
 		if event.WorkflowExecutionTimedOutEventAttributes != nil {
@@ -66,7 +67,7 @@ func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
 				LastOngoingEvent:  events[len(events)-2],
 				Tasklist:          getWorkflowExecutionTasklist(events),
 			}
-			result = append(result, InvariantCheckResult{
+			result = append(result, invariants.InvariantCheckResult{
 				InvariantType: TimeoutTypeExecution.String(),
 				Reason:        event.GetWorkflowExecutionTimedOutEventAttributes().GetTimeoutType().String(),
 				Metadata:      marshalData(data),
@@ -77,7 +78,7 @@ func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
 			if err != nil {
 				return nil, err
 			}
-			result = append(result, InvariantCheckResult{
+			result = append(result, invariants.InvariantCheckResult{
 				InvariantType: TimeoutTypeActivity.String(),
 				Reason:        event.GetActivityTaskTimedOutEventAttributes().GetTimeoutType().String(),
 				Metadata:      marshalData(metadata),
@@ -85,7 +86,7 @@ func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
 		}
 		if event.DecisionTaskTimedOutEventAttributes != nil {
 			reason, metadata := reasonForDecisionTaskTimeouts(event, events)
-			result = append(result, InvariantCheckResult{
+			result = append(result, invariants.InvariantCheckResult{
 				InvariantType: TimeoutTypeDecision.String(),
 				Reason:        reason,
 				Metadata:      marshalData(metadata),
@@ -98,7 +99,7 @@ func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
 				ConfiguredTimeout: time.Duration(timeoutLimit) * time.Second,
 				Execution:         event.GetChildWorkflowExecutionTimedOutEventAttributes().WorkflowExecution,
 			}
-			result = append(result, InvariantCheckResult{
+			result = append(result, invariants.InvariantCheckResult{
 				InvariantType: TimeoutTypeChildWorkflow.String(),
 				Reason:        event.GetChildWorkflowExecutionTimedOutEventAttributes().TimeoutType.String(),
 				Metadata:      marshalData(data),
@@ -108,8 +109,8 @@ func (t *timeout) Check(context.Context) ([]InvariantCheckResult, error) {
 	return result, nil
 }
 
-func (t *timeout) RootCause(ctx context.Context, issues []InvariantCheckResult) ([]InvariantRootCauseResult, error) {
-	result := make([]InvariantRootCauseResult, 0)
+func (t *timeout) RootCause(ctx context.Context, issues []invariants.InvariantCheckResult) ([]invariants.InvariantRootCauseResult, error) {
+	result := make([]invariants.InvariantRootCauseResult, 0)
 	for _, issue := range issues {
 		pollerStatus, err := t.checkTasklist(ctx, issue)
 		if err != nil {
@@ -129,7 +130,7 @@ func (t *timeout) RootCause(ctx context.Context, issues []InvariantCheckResult) 
 	return result, nil
 }
 
-func (t *timeout) checkTasklist(ctx context.Context, issue InvariantCheckResult) (InvariantRootCauseResult, error) {
+func (t *timeout) checkTasklist(ctx context.Context, issue invariants.InvariantCheckResult) (invariants.InvariantRootCauseResult, error) {
 	var taskList *types.TaskList
 	var tasklistType *types.TaskListType
 	switch issue.InvariantType {
@@ -137,7 +138,7 @@ func (t *timeout) checkTasklist(ctx context.Context, issue InvariantCheckResult)
 		var metadata ExecutionTimeoutMetadata
 		err := json.Unmarshal(issue.Metadata, &metadata)
 		if err != nil {
-			return InvariantRootCauseResult{}, err
+			return invariants.InvariantRootCauseResult{}, err
 		}
 		taskList = metadata.Tasklist
 		tasklistType = types.TaskListTypeDecision.Ptr()
@@ -145,13 +146,13 @@ func (t *timeout) checkTasklist(ctx context.Context, issue InvariantCheckResult)
 		var metadata ActivityTimeoutMetadata
 		err := json.Unmarshal(issue.Metadata, &metadata)
 		if err != nil {
-			return InvariantRootCauseResult{}, err
+			return invariants.InvariantRootCauseResult{}, err
 		}
 		taskList = metadata.Tasklist
 		tasklistType = types.TaskListTypeActivity.Ptr()
 	}
 	if taskList == nil {
-		return InvariantRootCauseResult{}, fmt.Errorf("tasklist not set")
+		return invariants.InvariantRootCauseResult{}, fmt.Errorf("tasklist not set")
 	}
 
 	frontendClient := t.clientBean.GetFrontendClient()
@@ -161,25 +162,25 @@ func (t *timeout) checkTasklist(ctx context.Context, issue InvariantCheckResult)
 		TaskListType: tasklistType,
 	})
 	if err != nil {
-		return InvariantRootCauseResult{}, err
+		return invariants.InvariantRootCauseResult{}, err
 	}
 
 	tasklistBacklog := resp.GetTaskListStatus().GetBacklogCountHint()
 	polllersMetadataInBytes := marshalData(PollersMetadata{TaskListBacklog: tasklistBacklog})
 	if len(resp.GetPollers()) == 0 {
-		return InvariantRootCauseResult{
-			RootCause: RootCauseTypeMissingPollers,
+		return invariants.InvariantRootCauseResult{
+			RootCause: invariants.RootCauseTypeMissingPollers,
 			Metadata:  polllersMetadataInBytes,
 		}, nil
 	}
-	return InvariantRootCauseResult{
-		RootCause: RootCauseTypePollersStatus,
+	return invariants.InvariantRootCauseResult{
+		RootCause: invariants.RootCauseTypePollersStatus,
 		Metadata:  polllersMetadataInBytes,
 	}, nil
 
 }
 
-func checkHeartbeatStatus(issue InvariantCheckResult) ([]InvariantRootCauseResult, error) {
+func checkHeartbeatStatus(issue invariants.InvariantCheckResult) ([]invariants.InvariantRootCauseResult, error) {
 	var metadata ActivityTimeoutMetadata
 	err := json.Unmarshal(issue.Metadata, &metadata)
 	if err != nil {
@@ -189,18 +190,18 @@ func checkHeartbeatStatus(issue InvariantCheckResult) ([]InvariantRootCauseResul
 	heartbeatingMetadataInBytes := marshalData(HeartbeatingMetadata{TimeElapsed: metadata.TimeElapsed})
 
 	if metadata.HeartBeatTimeout == 0 && activityStarted(metadata) {
-		return []InvariantRootCauseResult{
+		return []invariants.InvariantRootCauseResult{
 			{
-				RootCause: RootCauseTypeHeartBeatingNotEnabled,
+				RootCause: invariants.RootCauseTypeHeartBeatingNotEnabled,
 				Metadata:  heartbeatingMetadataInBytes,
 			},
 		}, nil
 	}
 
 	if metadata.HeartBeatTimeout > 0 && metadata.TimeoutType.String() == types.TimeoutTypeHeartbeat.String() {
-		return []InvariantRootCauseResult{
+		return []invariants.InvariantRootCauseResult{
 			{
-				RootCause: RootCauseTypeHeartBeatingEnabledMissingHeartbeat,
+				RootCause: invariants.RootCauseTypeHeartBeatingEnabledMissingHeartbeat,
 				Metadata:  heartbeatingMetadataInBytes,
 			},
 		}, nil

--- a/service/worker/diagnostics/invariants/timeouts/timeout_utils.go
+++ b/service/worker/diagnostics/invariants/timeouts/timeout_utils.go
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package invariants
+package timeouts
 
 import (
 	"encoding/json"

--- a/service/worker/diagnostics/invariants/timeouts/types.go
+++ b/service/worker/diagnostics/invariants/timeouts/types.go
@@ -20,7 +20,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-package invariants
+package timeouts
 
 import (
 	"time"
@@ -37,21 +37,8 @@ const (
 	TimeoutTypeChildWorkflow TimeoutType = "Child Workflow Execution has timed out"
 )
 
-type RootCause string
-
-const (
-	RootCauseTypeMissingPollers                      RootCause = "There are no pollers for the tasklist"
-	RootCauseTypePollersStatus                       RootCause = "There are pollers for the tasklist. Check backlog status"
-	RootCauseTypeHeartBeatingNotEnabled              RootCause = "HeartBeating not enabled for activity"
-	RootCauseTypeHeartBeatingEnabledMissingHeartbeat RootCause = "HeartBeating enabled for activity but timed out due to missing heartbeat"
-)
-
 func (tt TimeoutType) String() string {
 	return string(tt)
-}
-
-func (r RootCause) String() string {
-	return string(r)
 }
 
 type ExecutionTimeoutMetadata struct {

--- a/service/worker/diagnostics/workflow.go
+++ b/service/worker/diagnostics/workflow.go
@@ -25,6 +25,7 @@ package diagnostics
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/uber/cadence/service/worker/diagnostics/invariants/timeouts"
 	"time"
 
 	"go.uber.org/cadence/workflow"
@@ -62,16 +63,16 @@ type timeoutDiagnostics struct {
 type timeoutIssuesResult struct {
 	InvariantType    string
 	Reason           string
-	ExecutionTimeout *invariants.ExecutionTimeoutMetadata
-	ActivityTimeout  *invariants.ActivityTimeoutMetadata
-	ChildWfTimeout   *invariants.ChildWfTimeoutMetadata
-	DecisionTimeout  *invariants.DecisionTimeoutMetadata
+	ExecutionTimeout *timeouts.ExecutionTimeoutMetadata
+	ActivityTimeout  *timeouts.ActivityTimeoutMetadata
+	ChildWfTimeout   *timeouts.ChildWfTimeoutMetadata
+	DecisionTimeout  *timeouts.DecisionTimeoutMetadata
 }
 
 type timeoutRootCauseResult struct {
 	RootCauseType        string
-	PollersMetadata      *invariants.PollersMetadata
-	HeartBeatingMetadata *invariants.HeartbeatingMetadata
+	PollersMetadata      *timeouts.PollersMetadata
+	HeartBeatingMetadata *timeouts.HeartbeatingMetadata
 }
 
 func (w *dw) DiagnosticsWorkflow(ctx workflow.Context, params DiagnosticsWorkflowInput) (*DiagnosticsWorkflowResult, error) {
@@ -140,8 +141,8 @@ func retrieveTimeoutIssues(issues []invariants.InvariantCheckResult) ([]*timeout
 	result := make([]*timeoutIssuesResult, 0)
 	for _, issue := range issues {
 		switch issue.InvariantType {
-		case invariants.TimeoutTypeExecution.String():
-			var metadata invariants.ExecutionTimeoutMetadata
+		case timeouts.TimeoutTypeExecution.String():
+			var metadata timeouts.ExecutionTimeoutMetadata
 			err := json.Unmarshal(issue.Metadata, &metadata)
 			if err != nil {
 				return nil, err
@@ -151,8 +152,8 @@ func retrieveTimeoutIssues(issues []invariants.InvariantCheckResult) ([]*timeout
 				Reason:           issue.Reason,
 				ExecutionTimeout: &metadata,
 			})
-		case invariants.TimeoutTypeActivity.String():
-			var metadata invariants.ActivityTimeoutMetadata
+		case timeouts.TimeoutTypeActivity.String():
+			var metadata timeouts.ActivityTimeoutMetadata
 			err := json.Unmarshal(issue.Metadata, &metadata)
 			if err != nil {
 				return nil, err
@@ -162,8 +163,8 @@ func retrieveTimeoutIssues(issues []invariants.InvariantCheckResult) ([]*timeout
 				Reason:          issue.Reason,
 				ActivityTimeout: &metadata,
 			})
-		case invariants.TimeoutTypeChildWorkflow.String():
-			var metadata invariants.ChildWfTimeoutMetadata
+		case timeouts.TimeoutTypeChildWorkflow.String():
+			var metadata timeouts.ChildWfTimeoutMetadata
 			err := json.Unmarshal(issue.Metadata, &metadata)
 			if err != nil {
 				return nil, err
@@ -173,8 +174,8 @@ func retrieveTimeoutIssues(issues []invariants.InvariantCheckResult) ([]*timeout
 				Reason:         issue.Reason,
 				ChildWfTimeout: &metadata,
 			})
-		case invariants.TimeoutTypeDecision.String():
-			var metadata invariants.DecisionTimeoutMetadata
+		case timeouts.TimeoutTypeDecision.String():
+			var metadata timeouts.DecisionTimeoutMetadata
 			err := json.Unmarshal(issue.Metadata, &metadata)
 			if err != nil {
 				return nil, err
@@ -194,7 +195,7 @@ func retrieveTimeoutRootCause(rootCause []invariants.InvariantRootCauseResult) (
 	for _, rc := range rootCause {
 		switch rc.RootCause {
 		case invariants.RootCauseTypePollersStatus, invariants.RootCauseTypeMissingPollers:
-			var metadata invariants.PollersMetadata
+			var metadata timeouts.PollersMetadata
 			err := json.Unmarshal(rc.Metadata, &metadata)
 			if err != nil {
 				return nil, err
@@ -204,7 +205,7 @@ func retrieveTimeoutRootCause(rootCause []invariants.InvariantRootCauseResult) (
 				PollersMetadata: &metadata,
 			})
 		case invariants.RootCauseTypeHeartBeatingNotEnabled, invariants.RootCauseTypeHeartBeatingEnabledMissingHeartbeat:
-			var metadata invariants.HeartbeatingMetadata
+			var metadata timeouts.HeartbeatingMetadata
 			err := json.Unmarshal(rc.Metadata, &metadata)
 			if err != nil {
 				return nil, err

--- a/service/worker/diagnostics/workflow_test.go
+++ b/service/worker/diagnostics/workflow_test.go
@@ -26,6 +26,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/uber/cadence/service/worker/diagnostics/invariants/timeouts"
 	"testing"
 	"time"
 
@@ -87,7 +88,7 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 		WorkflowID: "123",
 		RunID:      "abc",
 	}
-	workflowTimeoutData := invariants.ExecutionTimeoutMetadata{
+	workflowTimeoutData := timeouts.ExecutionTimeoutMetadata{
 		ExecutionTime:     110 * time.Second,
 		ConfiguredTimeout: 110 * time.Second,
 		LastOngoingEvent: &types.HistoryEvent{
@@ -102,20 +103,20 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 	s.NoError(err)
 	issues := []invariants.InvariantCheckResult{
 		{
-			InvariantType: invariants.TimeoutTypeExecution.String(),
+			InvariantType: timeouts.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
 			Metadata:      workflowTimeoutDataInBytes,
 		},
 	}
 	timeoutIssues := []*timeoutIssuesResult{
 		{
-			InvariantType:    invariants.TimeoutTypeExecution.String(),
+			InvariantType:    timeouts.TimeoutTypeExecution.String(),
 			Reason:           "START_TO_CLOSE",
 			ExecutionTimeout: &workflowTimeoutData,
 		},
 	}
 	taskListBacklog := int64(10)
-	pollersMetadataInBytes, err := json.Marshal(invariants.PollersMetadata{TaskListBacklog: taskListBacklog})
+	pollersMetadataInBytes, err := json.Marshal(timeouts.PollersMetadata{TaskListBacklog: taskListBacklog})
 	s.NoError(err)
 	rootCause := []invariants.InvariantRootCauseResult{
 		{
@@ -126,7 +127,7 @@ func (s *diagnosticsWorkflowTestSuite) TestWorkflow() {
 	timeoutRootCause := []*timeoutRootCauseResult{
 		{
 			RootCauseType:   invariants.RootCauseTypePollersStatus.String(),
-			PollersMetadata: &invariants.PollersMetadata{TaskListBacklog: taskListBacklog},
+			PollersMetadata: &timeouts.PollersMetadata{TaskListBacklog: taskListBacklog},
 		},
 	}
 	s.workflowEnv.OnActivity(retrieveWfExecutionHistoryActivity, mock.Anything, mock.Anything).Return(nil, nil)
@@ -172,7 +173,7 @@ func (s *diagnosticsWorkflowTestSuite) queryDiagnostics() DiagnosticsStarterWork
 }
 
 func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutIssues() {
-	workflowTimeoutData := invariants.ExecutionTimeoutMetadata{
+	workflowTimeoutData := timeouts.ExecutionTimeoutMetadata{
 		ExecutionTime:     110 * time.Second,
 		ConfiguredTimeout: 110 * time.Second,
 		LastOngoingEvent: &types.HistoryEvent{
@@ -185,13 +186,13 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutIssues() {
 	}
 	workflowTimeoutDataInBytes, err := json.Marshal(workflowTimeoutData)
 	s.NoError(err)
-	childWorkflowTimeoutData := invariants.ChildWfTimeoutMetadata{
+	childWorkflowTimeoutData := timeouts.ChildWfTimeoutMetadata{
 		ExecutionTime:     110 * time.Second,
 		ConfiguredTimeout: 110 * time.Second,
 	}
 	childWorkflowTimeoutDataInBytes, err := json.Marshal(childWorkflowTimeoutData)
 	s.NoError(err)
-	activityTimeoutData := invariants.ActivityTimeoutMetadata{
+	activityTimeoutData := timeouts.ActivityTimeoutMetadata{
 		TimeoutType:       types.TimeoutTypeStartToClose.Ptr(),
 		ConfiguredTimeout: 5 * time.Second,
 		TimeElapsed:       5 * time.Second,
@@ -199,51 +200,51 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutIssues() {
 	}
 	activityTimeoutDataInBytes, err := json.Marshal(activityTimeoutData)
 	s.NoError(err)
-	descTimeoutData := invariants.DecisionTimeoutMetadata{
+	descTimeoutData := timeouts.DecisionTimeoutMetadata{
 		ConfiguredTimeout: 5 * time.Second,
 	}
 	descTimeoutDataInBytes, err := json.Marshal(activityTimeoutData)
 	s.NoError(err)
 	issues := []invariants.InvariantCheckResult{
 		{
-			InvariantType: invariants.TimeoutTypeExecution.String(),
+			InvariantType: timeouts.TimeoutTypeExecution.String(),
 			Reason:        "START_TO_CLOSE",
 			Metadata:      workflowTimeoutDataInBytes,
 		},
 		{
-			InvariantType: invariants.TimeoutTypeActivity.String(),
+			InvariantType: timeouts.TimeoutTypeActivity.String(),
 			Reason:        "START_TO_CLOSE",
 			Metadata:      activityTimeoutDataInBytes,
 		},
 		{
-			InvariantType: invariants.TimeoutTypeDecision.String(),
+			InvariantType: timeouts.TimeoutTypeDecision.String(),
 			Reason:        "START_TO_CLOSE",
 			Metadata:      descTimeoutDataInBytes,
 		},
 		{
-			InvariantType: invariants.TimeoutTypeChildWorkflow.String(),
+			InvariantType: timeouts.TimeoutTypeChildWorkflow.String(),
 			Reason:        "START_TO_CLOSE",
 			Metadata:      childWorkflowTimeoutDataInBytes,
 		},
 	}
 	timeoutIssues := []*timeoutIssuesResult{
 		{
-			InvariantType:    invariants.TimeoutTypeExecution.String(),
+			InvariantType:    timeouts.TimeoutTypeExecution.String(),
 			Reason:           "START_TO_CLOSE",
 			ExecutionTimeout: &workflowTimeoutData,
 		},
 		{
-			InvariantType:   invariants.TimeoutTypeActivity.String(),
+			InvariantType:   timeouts.TimeoutTypeActivity.String(),
 			Reason:          "START_TO_CLOSE",
 			ActivityTimeout: &activityTimeoutData,
 		},
 		{
-			InvariantType:   invariants.TimeoutTypeDecision.String(),
+			InvariantType:   timeouts.TimeoutTypeDecision.String(),
 			Reason:          "START_TO_CLOSE",
 			DecisionTimeout: &descTimeoutData,
 		},
 		{
-			InvariantType:  invariants.TimeoutTypeChildWorkflow.String(),
+			InvariantType:  timeouts.TimeoutTypeChildWorkflow.String(),
 			Reason:         "START_TO_CLOSE",
 			ChildWfTimeout: &childWorkflowTimeoutData,
 		},
@@ -255,9 +256,9 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutIssues() {
 
 func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRootCause() {
 	taskListBacklog := int64(10)
-	pollersMetadataInBytes, err := json.Marshal(invariants.PollersMetadata{TaskListBacklog: taskListBacklog})
+	pollersMetadataInBytes, err := json.Marshal(timeouts.PollersMetadata{TaskListBacklog: taskListBacklog})
 	s.NoError(err)
-	heartBeatingMetadataInBytes, err := json.Marshal(invariants.HeartbeatingMetadata{TimeElapsed: 5 * time.Second})
+	heartBeatingMetadataInBytes, err := json.Marshal(timeouts.HeartbeatingMetadata{TimeElapsed: 5 * time.Second})
 	s.NoError(err)
 	rootCause := []invariants.InvariantRootCauseResult{
 		{
@@ -272,11 +273,11 @@ func (s *diagnosticsWorkflowTestSuite) Test__retrieveTimeoutRootCause() {
 	timeoutRootCause := []*timeoutRootCauseResult{
 		{
 			RootCauseType:   invariants.RootCauseTypePollersStatus.String(),
-			PollersMetadata: &invariants.PollersMetadata{TaskListBacklog: taskListBacklog},
+			PollersMetadata: &timeouts.PollersMetadata{TaskListBacklog: taskListBacklog},
 		},
 		{
 			RootCauseType:        invariants.RootCauseTypeHeartBeatingNotEnabled.String(),
-			HeartBeatingMetadata: &invariants.HeartbeatingMetadata{TimeElapsed: 5 * time.Second},
+			HeartBeatingMetadata: &timeouts.HeartbeatingMetadata{TimeElapsed: 5 * time.Second},
 		},
 	}
 	result, err := retrieveTimeoutRootCause(rootCause)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
ll timeout related checks moved under one directory

<!-- Tell your future self why have you made these changes -->
**Why?**
to add more invariants to run workflow diagnostics

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
