### PR TITLE
[CLI] ErrorAndExit deprecated

### DIFF
--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	"github.com/urfave/cli/v2"
-
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/service/worker/scanner/executions"
 )

--- a/tools/cli/admin.go
+++ b/tools/cli/admin.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"github.com/urfave/cli/v2"
+
 	"github.com/uber/cadence/common/reconciliation/invariant"
 	"github.com/uber/cadence/service/worker/scanner/executions"
 )

--- a/tools/cli/admin_async_queue_commands.go
+++ b/tools/cli/admin_async_queue_commands.go
@@ -38,10 +38,15 @@ func AdminGetAsyncWFConfig(c *cli.Context) error {
 		return err
 	}
 
-	domainName := getRequiredOption(c, FlagDomain)
-
-	ctx, cancel := newContext(c)
+	domainName, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not present:", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 
 	req := &types.GetDomainAsyncWorkflowConfiguratonRequest{
 		Domain: domainName,
@@ -68,8 +73,14 @@ func AdminUpdateAsyncWFConfig(c *cli.Context) error {
 		return err
 	}
 
-	domainName := getRequiredOption(c, FlagDomain)
-	asyncWFCfgJSON := getRequiredOption(c, FlagJSON)
+	domainName, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not present:", err)
+	}
+	asyncWFCfgJSON, err := getRequiredOption(c, FlagJSON)
+	if err != nil {
+		return commoncli.Problem("Required flag not present:", err)
+	}
 
 	var cfg types.AsyncWorkflowConfiguration
 	err = json.Unmarshal([]byte(asyncWFCfgJSON), &cfg)
@@ -77,8 +88,11 @@ func AdminUpdateAsyncWFConfig(c *cli.Context) error {
 		return commoncli.Problem("Failed to parse async workflow config", err)
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 
 	req := &types.UpdateDomainAsyncWorkflowConfiguratonRequest{
 		Domain:        domainName,

--- a/tools/cli/admin_async_queue_commands.go
+++ b/tools/cli/admin_async_queue_commands.go
@@ -45,7 +45,7 @@ func AdminGetAsyncWFConfig(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 
 	req := &types.GetDomainAsyncWorkflowConfiguratonRequest{
@@ -91,7 +91,7 @@ func AdminUpdateAsyncWFConfig(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 
 	req := &types.UpdateDomainAsyncWorkflowConfiguratonRequest{

--- a/tools/cli/admin_cluster_commands.go
+++ b/tools/cli/admin_cluster_commands.go
@@ -40,12 +40,18 @@ var promptFn = prompt
 
 // AdminAddSearchAttribute to whitelist search attribute
 func AdminAddSearchAttribute(c *cli.Context) error {
-	key := getRequiredOption(c, FlagSearchAttributesKey)
+	key, err := getRequiredOption(c, FlagSearchAttributesKey)
+	if err != nil {
+		return commoncli.Problem("Required flag not present:", err)
+	}
 	if err := visibility.ValidateSearchAttributeKey(key); err != nil {
 		return commoncli.Problem("Invalid search-attribute key.", err)
 	}
 
-	valType := getRequiredIntOption(c, FlagSearchAttributesType)
+	valType, err := getRequiredIntOption(c, FlagSearchAttributesType)
+	if err != nil {
+		return commoncli.Problem("Required flag not present:", err)
+	}
 	if !isValueTypeValid(valType) {
 		return commoncli.Problem("Unknown Search Attributes value type.", nil)
 	}
@@ -59,7 +65,10 @@ func AdminAddSearchAttribute(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	defer cancel()
 	request := &types.AddSearchAttributeRequest{
 		SearchAttribute: map[string]types.IndexedValueType{
@@ -83,8 +92,11 @@ func AdminDescribeCluster(c *cli.Context) error {
 		return err
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating :", err)
+	}
 	response, err := adminClient.DescribeCluster(ctx)
 	if err != nil {
 		return commoncli.Problem("Operation DescribeCluster failed.", err)
@@ -99,9 +111,11 @@ func AdminRebalanceStart(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	tcCtx, cancel := newContext(c)
+	tcCtx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Context not created:", err)
+	}
 	workflowID := failovermanager.RebalanceWorkflowID
 	rbParams := &failovermanager.RebalanceParams{
 		BatchFailoverSize:              100,
@@ -111,8 +125,12 @@ func AdminRebalanceStart(c *cli.Context) error {
 	if err != nil {
 		return commoncli.Problem("Failed to serialize params for failover workflow", err)
 	}
+	op, err := getOperator()
+	if err != nil {
+		return commoncli.Problem("Failed to get operator", err)
+	}
 	memo, err := getWorkflowMemo(map[string]interface{}{
-		common.MemoKeyForOperator: getOperator(),
+		common.MemoKeyForOperator: op,
 	})
 	if err != nil {
 		return commoncli.Problem("Failed to serialize memo", err)

--- a/tools/cli/admin_cluster_commands.go
+++ b/tools/cli/admin_cluster_commands.go
@@ -67,7 +67,7 @@ func AdminAddSearchAttribute(c *cli.Context) error {
 	}
 	ctx, cancel, err := newContext(c)
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	defer cancel()
 	request := &types.AddSearchAttributeRequest{
@@ -95,7 +95,7 @@ func AdminDescribeCluster(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating :", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	response, err := adminClient.DescribeCluster(ctx)
 	if err != nil {

--- a/tools/cli/admin_commands.go
+++ b/tools/cli/admin_commands.go
@@ -55,7 +55,7 @@ func AdminShowWorkflow(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	serializer := persistence.NewPayloadSerializer()
 	var history []*persistence.DataBlob
@@ -189,7 +189,7 @@ func describeMutableState(c *cli.Context) (*types.AdminDescribeWorkflowExecution
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return nil, commoncli.Problem("Error in creating context: %v", err)
+		return nil, commoncli.Problem("Error in creating context: ", err)
 	}
 	resp, err := adminClient.DescribeWorkflowExecution(
 		ctx,
@@ -233,7 +233,7 @@ func AdminMaintainCorruptWorkflow(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	_, err = adminClient.MaintainCorruptWorkflow(ctx, request)
 	if err != nil {
@@ -260,7 +260,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	// With remote flag, we run the command on the server side using existing APIs
 	// Without remote, commands are run directly through some DB clients. This is
@@ -394,7 +394,7 @@ func AdminGetDomainIDOrName(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	if len(domainID) > 0 {
 		domain, err := domainManager.GetDomain(ctx, &persistence.GetDomainRequest{ID: domainID})
@@ -459,7 +459,7 @@ func AdminRemoveTask(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	req := &types.RemoveTaskRequest{
 		ShardID:             int32(shardID),
@@ -485,7 +485,7 @@ func AdminDescribeShard(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	shardManager, err := initializeShardManager(c)
 	if err != nil {
@@ -514,7 +514,7 @@ func AdminSetShardRangeID(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	shardManager, err := initializeShardManager(c)
 	if err != nil {
@@ -687,7 +687,7 @@ func AdminRefreshWorkflowTasks(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	err = adminClient.RefreshWorkflowTasks(ctx, &types.RefreshWorkflowTasksRequest{
 		Domain: domain,
@@ -725,7 +725,7 @@ func AdminResetQueue(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	req := &types.ResetQueueRequest{
 		ShardID:     int32(shardID),
@@ -764,7 +764,7 @@ func AdminDescribeQueue(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	req := &types.DescribeQueueRequest{
 		ShardID:     int32(shardID),

--- a/tools/cli/admin_commands.go
+++ b/tools/cli/admin_commands.go
@@ -52,13 +52,19 @@ func AdminShowWorkflow(c *cli.Context) error {
 	maxEventID := c.Int64(FlagMaxEventID)
 	outputFileName := c.String(FlagOutputFilename)
 	domainName := c.String(FlagDomain)
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	serializer := persistence.NewPayloadSerializer()
 	var history []*persistence.DataBlob
 	if len(tid) != 0 {
 		thriftrwEncoder := codec.NewThriftRWEncoder()
-		histV2 := initializeHistoryManager(c)
+		histV2, err := initializeHistoryManager(c)
+		if err != nil {
+			return commoncli.Problem("Error in Admin delete WF: ", err)
+		}
 		branchToken, err := thriftrwEncoder.Encode(&shared.HistoryBranch{
 			TreeID:   &tid,
 			BranchID: &bid,
@@ -170,13 +176,21 @@ func describeMutableState(c *cli.Context) (*types.AdminDescribeWorkflowExecution
 		return nil, err
 	}
 
-	domain := getRequiredOption(c, FlagDomain)
-	wid := getRequiredOption(c, FlagWorkflowID)
+	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return nil, commoncli.Problem("Required flag not found", err)
+	}
+	wid, err := getRequiredOption(c, FlagWorkflowID)
+	if err != nil {
+		return nil, commoncli.Problem("Required flag not found", err)
+	}
 	rid := c.String(FlagRunID)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return nil, commoncli.Problem("Error in creating context: %v", err)
+	}
 	resp, err := adminClient.DescribeWorkflowExecution(
 		ctx,
 		&types.AdminDescribeWorkflowExecutionRequest{
@@ -195,7 +209,10 @@ func describeMutableState(c *cli.Context) (*types.AdminDescribeWorkflowExecution
 
 // AdminMaintainCorruptWorkflow deletes workflow from DB if it's corrupt
 func AdminMaintainCorruptWorkflow(c *cli.Context) error {
-	domainName := getRequiredOption(c, FlagDomain)
+	domainName, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	workflowID := c.String(FlagWorkflowID)
 	runID := c.String(FlagRunID)
 	skipErrors := c.Bool(FlagSkipErrorMode)
@@ -213,8 +230,11 @@ func AdminMaintainCorruptWorkflow(c *cli.Context) error {
 		SkipErrors: skipErrors,
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	_, err = adminClient.MaintainCorruptWorkflow(ctx, request)
 	if err != nil {
 		return commoncli.Problem("Operation AdminMaintainCorruptWorkflow failed.", err)
@@ -225,15 +245,23 @@ func AdminMaintainCorruptWorkflow(c *cli.Context) error {
 
 // AdminDeleteWorkflow delete a workflow execution for admin
 func AdminDeleteWorkflow(c *cli.Context) error {
-	domain := getRequiredOption(c, FlagDomain)
-	wid := getRequiredOption(c, FlagWorkflowID)
+	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	wid, err := getRequiredOption(c, FlagWorkflowID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	rid := c.String(FlagRunID)
 	remote := c.Bool(FlagRemote)
 	skipError := c.Bool(FlagSkipErrorMode)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	// With remote flag, we run the command on the server side using existing APIs
 	// Without remote, commands are run directly through some DB clients. This is
 	// useful if server is down somehow. However, we only support couple DB clients
@@ -275,10 +303,15 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 	if err != nil {
 		return commoncli.Problem("strconv.Atoi(shardID) err", err)
 	}
-	histV2 := initializeHistoryManager(c)
+	histV2, err := initializeHistoryManager(c)
 	defer histV2.Close()
-	exeStore := initializeExecutionStore(c, shardIDInt)
-
+	if err != nil {
+		return commoncli.Problem("Error in Admin delete WF: ", err)
+	}
+	exeStore, err := initializeExecutionStore(c, shardIDInt)
+	if err != nil {
+		return commoncli.Problem("Error in Admin delete WF: ", err)
+	}
 	branchInfo := shared.HistoryBranch{}
 	thriftrwEncoder := codec.NewThriftRWEncoder()
 	branchTokens := [][]byte{ms.ExecutionInfo.BranchToken}
@@ -354,10 +387,15 @@ func AdminGetDomainIDOrName(c *cli.Context) error {
 		return commoncli.Problem("Need either domainName or domainID", nil)
 	}
 
-	domainManager := initializeDomainManager(c)
-
-	ctx, cancel := newContext(c)
+	domainManager, err := initializeDomainManager(c)
+	if err != nil {
+		return commoncli.Problem("Error in Admin delete WF: ", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	if len(domainID) > 0 {
 		domain, err := domainManager.GetDomain(ctx, &persistence.GetDomainRequest{ID: domainID})
 		if err != nil {
@@ -376,7 +414,10 @@ func AdminGetDomainIDOrName(c *cli.Context) error {
 
 // AdminGetShardID get shardID
 func AdminGetShardID(c *cli.Context) error {
-	wid := getRequiredOption(c, FlagWorkflowID)
+	wid, err := getRequiredOption(c, FlagWorkflowID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	numberOfShards := c.Int(FlagNumberOfShards)
 
 	if numberOfShards <= 0 {
@@ -394,18 +435,32 @@ func AdminRemoveTask(c *cli.Context) error {
 		return err
 	}
 
-	shardID := getRequiredIntOption(c, FlagShardID)
-	taskID := getRequiredInt64Option(c, FlagTaskID)
-	typeID := getRequiredIntOption(c, FlagTaskType)
+	shardID, err := getRequiredIntOption(c, FlagShardID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	taskID, err := getRequiredInt64Option(c, FlagTaskID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	typeID, err := getRequiredIntOption(c, FlagTaskType)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	var visibilityTimestamp int64
 	if common.TaskType(typeID) == common.TaskTypeTimer {
-		visibilityTimestamp = getRequiredInt64Option(c, FlagTaskVisibilityTimestamp)
+		visibilityTimestamp, err = getRequiredInt64Option(c, FlagTaskVisibilityTimestamp)
+		if err != nil {
+			return commoncli.Problem("Required flag not found", err)
+		}
 	}
 	var clusterName string
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	req := &types.RemoveTaskRequest{
 		ShardID:             int32(shardID),
 		Type:                common.Int32Ptr(int32(typeID)),
@@ -423,12 +478,19 @@ func AdminRemoveTask(c *cli.Context) error {
 
 // AdminDescribeShard describes shard by shard id
 func AdminDescribeShard(c *cli.Context) error {
-	sid := getRequiredIntOption(c, FlagShardID)
-
-	ctx, cancel := newContext(c)
+	sid, err := getRequiredIntOption(c, FlagShardID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-	shardManager := initializeShardManager(c)
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
+	shardManager, err := initializeShardManager(c)
+	if err != nil {
+		return commoncli.Problem("Error in Admin delete WF: ", err)
+	}
 	getShardReq := &persistence.GetShardRequest{ShardID: sid}
 	shard, err := shardManager.GetShard(ctx, getShardReq)
 	if err != nil {
@@ -441,13 +503,23 @@ func AdminDescribeShard(c *cli.Context) error {
 
 // AdminSetShardRangeID set shard rangeID by shard id
 func AdminSetShardRangeID(c *cli.Context) error {
-	sid := getRequiredIntOption(c, FlagShardID)
-	rid := getRequiredInt64Option(c, FlagRangeID)
-
-	ctx, cancel := newContext(c)
+	sid, err := getRequiredIntOption(c, FlagShardID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	rid, err := getRequiredInt64Option(c, FlagRangeID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-	shardManager := initializeShardManager(c)
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
+	shardManager, err := initializeShardManager(c)
+	if err != nil {
+		return commoncli.Problem("Error in Admin delete WF: ", err)
+	}
 	getShardResp, err := shardManager.GetShard(ctx, &persistence.GetShardRequest{ShardID: sid})
 	if err != nil {
 		return commoncli.Problem("Failed to get shardInfo.", err)
@@ -477,11 +549,15 @@ func AdminCloseShard(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	sid := getRequiredIntOption(c, FlagShardID)
-
-	ctx, cancel := newContext(c)
+	sid, err := getRequiredIntOption(c, FlagShardID)
+	if err != nil {
+		return commoncli.Problem("Required option not found", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context", err)
+	}
 	req := &types.CloseShardRequest{}
 	req.ShardID = int32(sid)
 
@@ -504,9 +580,11 @@ func AdminDescribeShardDistribution(c *cli.Context) error {
 		return err
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context", err)
+	}
 	req := &types.DescribeShardDistributionRequest{
 		PageSize: int32(c.Int(FlagPageSize)),
 		PageID:   int32(c.Int(FlagPageID)),
@@ -561,9 +639,11 @@ func AdminDescribeHistoryHost(c *cli.Context) error {
 		return commoncli.Problem("at least one of them is required to provide to lookup host: workflowID, shardID and host address", nil)
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context", err)
+	}
 	req := &types.DescribeHistoryHostRequest{}
 	if len(wid) > 0 {
 		req.ExecutionForHost = &types.WorkflowExecution{WorkflowID: wid}
@@ -594,13 +674,21 @@ func AdminRefreshWorkflowTasks(c *cli.Context) error {
 		return err
 	}
 
-	domain := getRequiredOption(c, FlagDomain)
-	wid := getRequiredOption(c, FlagWorkflowID)
+	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	wid, err := getRequiredOption(c, FlagWorkflowID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	rid := c.String(FlagRunID)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	err = adminClient.RefreshWorkflowTasks(ctx, &types.RefreshWorkflowTasksRequest{
 		Domain: domain,
 		Execution: &types.WorkflowExecution{
@@ -622,13 +710,23 @@ func AdminResetQueue(c *cli.Context) error {
 		return err
 	}
 
-	shardID := getRequiredIntOption(c, FlagShardID)
-	clusterName := getRequiredOption(c, FlagCluster)
-	typeID := getRequiredIntOption(c, FlagQueueType)
-
-	ctx, cancel := newContext(c)
+	shardID, err := getRequiredIntOption(c, FlagShardID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	clusterName, err := getRequiredOption(c, FlagCluster)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	typeID, err := getRequiredIntOption(c, FlagQueueType)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	req := &types.ResetQueueRequest{
 		ShardID:     int32(shardID),
 		ClusterName: clusterName,
@@ -650,13 +748,24 @@ func AdminDescribeQueue(c *cli.Context) error {
 		return err
 	}
 
-	shardID := getRequiredIntOption(c, FlagShardID)
-	clusterName := getRequiredOption(c, FlagCluster)
-	typeID := getRequiredIntOption(c, FlagQueueType)
+	shardID, err := getRequiredIntOption(c, FlagShardID)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	clusterName, err := getRequiredOption(c, FlagCluster)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	typeID, err := getRequiredIntOption(c, FlagQueueType)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	req := &types.DescribeQueueRequest{
 		ShardID:     int32(shardID),
 		ClusterName: clusterName,

--- a/tools/cli/admin_config_store_commands.go
+++ b/tools/cli/admin_config_store_commands.go
@@ -65,7 +65,7 @@ func AdminGetDynamicConfig(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	if len(filters) == 0 {
 		req := &types.ListDynamicConfigRequest{
@@ -137,7 +137,7 @@ func AdminUpdateDynamicConfig(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	var parsedValues []*types.DynamicConfigValue
 
@@ -189,7 +189,7 @@ func AdminRestoreDynamicConfig(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	parsedFilters, err := parseInputFilterArray(filters)
 	if err != nil {
@@ -219,7 +219,7 @@ func AdminListDynamicConfig(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	req := &types.ListDynamicConfigRequest{
 		ConfigName: "", // empty string means all config values

--- a/tools/cli/admin_config_store_commands.go
+++ b/tools/cli/admin_config_store_commands.go
@@ -56,12 +56,17 @@ func AdminGetDynamicConfig(c *cli.Context) error {
 		return err
 	}
 
-	dcName := getRequiredOption(c, FlagDynamicConfigName)
+	dcName, err := getRequiredOption(c, FlagDynamicConfigName)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	filters := c.StringSlice(FlagDynamicConfigFilter)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	if len(filters) == 0 {
 		req := &types.ListDynamicConfigRequest{
 			ConfigName: dcName,
@@ -123,12 +128,17 @@ func AdminUpdateDynamicConfig(c *cli.Context) error {
 		return err
 	}
 
-	dcName := getRequiredOption(c, FlagDynamicConfigName)
+	dcName, err := getRequiredOption(c, FlagDynamicConfigName)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	dcValues := c.StringSlice(FlagDynamicConfigValue)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	var parsedValues []*types.DynamicConfigValue
 
 	if dcValues != nil {
@@ -170,12 +180,17 @@ func AdminRestoreDynamicConfig(c *cli.Context) error {
 		return err
 	}
 
-	dcName := getRequiredOption(c, FlagDynamicConfigName)
+	dcName, err := getRequiredOption(c, FlagDynamicConfigName)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	filters := c.StringSlice(FlagDynamicConfigFilter)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	parsedFilters, err := parseInputFilterArray(filters)
 	if err != nil {
 		return commoncli.Problem("Failed to parse input filter array", err)
@@ -201,9 +216,11 @@ func AdminListDynamicConfig(c *cli.Context) error {
 		return err
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: %v", err)
+	}
 	req := &types.ListDynamicConfigRequest{
 		ConfigName: "", // empty string means all config values
 	}

--- a/tools/cli/admin_db_clean_command.go
+++ b/tools/cli/admin_db_clean_command.go
@@ -134,12 +134,12 @@ func fixExecution(
 	execManager, err := initializeExecutionStore(c, execution.Execution.(entity.Entity).GetShardID())
 	defer execManager.Close()
 	if err != nil {
-		return invariant.ManagerFixResult{}, fmt.Errorf("Error in fix execution: %v", err)
+		return invariant.ManagerFixResult{}, fmt.Errorf("Error in fix execution: %w", err)
 	}
 	historyV2Mgr, err := initializeHistoryManager(c)
 	defer historyV2Mgr.Close()
 	if err != nil {
-		return invariant.ManagerFixResult{}, fmt.Errorf("Error in fix execution: %v", err)
+		return invariant.ManagerFixResult{}, fmt.Errorf("Error in fix execution: %w", err)
 	}
 	pr := persistence.NewPersistenceRetryer(
 		execManager,
@@ -156,7 +156,7 @@ func fixExecution(
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return invariant.ManagerFixResult{}, fmt.Errorf("Context not created: %v", err)
+		return invariant.ManagerFixResult{}, fmt.Errorf("Context not created: %w", err)
 	}
 	return invariant.NewInvariantManager(ivs).RunFixes(ctx, execution.Execution), nil
 }

--- a/tools/cli/admin_db_clean_command.go
+++ b/tools/cli/admin_db_clean_command.go
@@ -44,7 +44,11 @@ import (
 // AdminDBClean is the command to clean up unhealthy executions.
 // Input is a JSON stream provided via STDIN or a file.
 func AdminDBClean(c *cli.Context) error {
-	scanType, err := executions.ScanTypeString(getRequiredOption(c, FlagScanType))
+	flagscantype, err := getRequiredOption(c, FlagScanType)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
+	scanType, err := executions.ScanTypeString(flagscantype)
 
 	if err != nil {
 		return commoncli.Problem("unknown scan type", err)
@@ -80,8 +84,10 @@ func AdminDBClean(c *cli.Context) error {
 		)
 	}
 
-	input := getInputFile(c.String(FlagInputFile))
-
+	input, err := getInputFile(c.String(FlagInputFile))
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
 	dec := json.NewDecoder(input)
 	var data []*store.ScanOutputEntity
 
@@ -100,10 +106,14 @@ func AdminDBClean(c *cli.Context) error {
 	}
 
 	for _, e := range data {
+		result, err := fixExecution(c, invariants, e)
+		if err != nil {
+			return commoncli.Problem("Error in fix execution: ", err)
+		}
 		out := store.FixOutputEntity{
 			Execution: e.Execution,
 			Input:     *e,
-			Result:    fixExecution(c, invariants, e),
+			Result:    result,
 		}
 		data, err := json.Marshal(out)
 		if err != nil {
@@ -120,13 +130,17 @@ func fixExecution(
 	c *cli.Context,
 	invariants []executions.InvariantFactory,
 	execution *store.ScanOutputEntity,
-) invariant.ManagerFixResult {
-	execManager := initializeExecutionStore(c, execution.Execution.(entity.Entity).GetShardID())
+) (invariant.ManagerFixResult, error) {
+	execManager, err := initializeExecutionStore(c, execution.Execution.(entity.Entity).GetShardID())
 	defer execManager.Close()
-
-	historyV2Mgr := initializeHistoryManager(c)
+	if err != nil {
+		return invariant.ManagerFixResult{}, fmt.Errorf("Error in fix execution: %v", err)
+	}
+	historyV2Mgr, err := initializeHistoryManager(c)
 	defer historyV2Mgr.Close()
-
+	if err != nil {
+		return invariant.ManagerFixResult{}, fmt.Errorf("Error in fix execution: %v", err)
+	}
 	pr := persistence.NewPersistenceRetryer(
 		execManager,
 		historyV2Mgr,
@@ -139,8 +153,10 @@ func fixExecution(
 		ivs = append(ivs, fn(pr, cache.NewNoOpDomainCache()))
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
-	return invariant.NewInvariantManager(ivs).RunFixes(ctx, execution.Execution)
+	if err != nil {
+		return invariant.ManagerFixResult{}, fmt.Errorf("Context not created: %v", err)
+	}
+	return invariant.NewInvariantManager(ivs).RunFixes(ctx, execution.Execution), nil
 }

--- a/tools/cli/admin_db_decode_thrift.go
+++ b/tools/cli/admin_db_decode_thrift.go
@@ -77,7 +77,10 @@ type decodeError struct {
 
 // AdminDBDataDecodeThrift is the command to decode thrift binary into JSON
 func AdminDBDataDecodeThrift(c *cli.Context) error {
-	input := getRequiredOption(c, FlagInput)
+	input, err := getRequiredOption(c, FlagInput)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	encoding := c.String(FlagInputEncoding)
 	data, err := decodeUserInput(input, encoding)
 	if err != nil {

--- a/tools/cli/admin_db_scan_command.go
+++ b/tools/cli/admin_db_scan_command.go
@@ -142,12 +142,12 @@ func checkExecution(
 	execManager, err := initializeExecutionStore(c, common.WorkflowIDToHistoryShard(req.WorkflowID, numberOfShards))
 	defer execManager.Close()
 	if err != nil {
-		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in execution check: %v", err)
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in execution check: %w", err)
 	}
 	historyV2Mgr, err := initializeHistoryManager(c)
 	defer historyV2Mgr.Close()
 	if err != nil {
-		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in execution check: %v", err)
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in execution check: %w", err)
 	}
 	pr := persistence.NewPersistenceRetryer(
 		execManager,
@@ -158,12 +158,12 @@ func checkExecution(
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in creating context: %v", err)
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in creating context: %w", err)
 	}
 	execution, err := fetcher(ctx, pr, req)
 
 	if err != nil {
-		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in check execution: %v", err)
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in check execution: %w", err)
 	}
 
 	var ivs []invariant.Invariant

--- a/tools/cli/admin_db_scan_command.go
+++ b/tools/cli/admin_db_scan_command.go
@@ -56,7 +56,10 @@ func AdminDBScan(c *cli.Context) error {
 		return commoncli.Problem("unknown scan type", err)
 	}
 
-	numberOfShards := getRequiredIntOption(c, FlagNumberOfShards)
+	numberOfShards, err := getRequiredIntOption(c, FlagNumberOfShards)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	collectionSlice := c.StringSlice(FlagInvariantCollection)
 
 	var collections []invariant.Collection
@@ -88,8 +91,10 @@ func AdminDBScan(c *cli.Context) error {
 	}
 	ef := scanType.ToExecutionFetcher()
 
-	input := getInputFile(c.String(FlagInputFile))
-
+	input, err := getInputFile(c.String(FlagInputFile))
+	if err != nil {
+		return commoncli.Problem("Input file not found", err)
+	}
 	dec := json.NewDecoder(input)
 	if err != nil {
 		return commoncli.Problem("", err)
@@ -108,7 +113,10 @@ func AdminDBScan(c *cli.Context) error {
 	}
 
 	for _, e := range data {
-		execution, result := checkExecution(c, numberOfShards, e, invariants, ef)
+		execution, result, err := checkExecution(c, numberOfShards, e, invariants, ef)
+		if err != nil {
+			return commoncli.Problem("Execution check failed", err)
+		}
 		out := store.ScanOutputEntity{
 			Execution: execution,
 			Result:    result,
@@ -130,26 +138,32 @@ func checkExecution(
 	req fetcher.ExecutionRequest,
 	invariants []executions.InvariantFactory,
 	fetcher executions.ExecutionFetcher,
-) (interface{}, invariant.ManagerCheckResult) {
-	execManager := initializeExecutionStore(c, common.WorkflowIDToHistoryShard(req.WorkflowID, numberOfShards))
+) (interface{}, invariant.ManagerCheckResult, error) {
+	execManager, err := initializeExecutionStore(c, common.WorkflowIDToHistoryShard(req.WorkflowID, numberOfShards))
 	defer execManager.Close()
-
-	historyV2Mgr := initializeHistoryManager(c)
+	if err != nil {
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in execution check: %v", err)
+	}
+	historyV2Mgr, err := initializeHistoryManager(c)
 	defer historyV2Mgr.Close()
-
+	if err != nil {
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in execution check: %v", err)
+	}
 	pr := persistence.NewPersistenceRetryer(
 		execManager,
 		historyV2Mgr,
 		common.CreatePersistenceRetryPolicy(),
 	)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in creating context: %v", err)
+	}
 	execution, err := fetcher(ctx, pr, req)
 
 	if err != nil {
-		return nil, invariant.ManagerCheckResult{}
+		return nil, invariant.ManagerCheckResult{}, fmt.Errorf("Error in check execution: %v", err)
 	}
 
 	var ivs []invariant.Invariant
@@ -158,12 +172,15 @@ func checkExecution(
 		ivs = append(ivs, fn(pr, cache.NewNoOpDomainCache()))
 	}
 
-	return execution, invariant.NewInvariantManager(ivs).RunChecks(ctx, execution)
+	return execution, invariant.NewInvariantManager(ivs).RunChecks(ctx, execution), nil
 }
 
 // AdminDBScanUnsupportedWorkflow is to scan DB for unsupported workflow for a new release
 func AdminDBScanUnsupportedWorkflow(c *cli.Context) error {
-	outputFile := getOutputFile(c.String(FlagOutputFilename))
+	outputFile, err := getOutputFile(c.String(FlagOutputFilename))
+	if err != nil {
+		return commoncli.Problem("Error in admin db scan unsupported wf: ", err)
+	}
 	startShardID := c.Int(FlagLowerShardBound)
 	endShardID := c.Int(FlagUpperShardBound)
 
@@ -183,9 +200,11 @@ func listExecutionsByShardID(
 	outputFile *os.File,
 ) error {
 
-	client := initializeExecutionStore(c, shardID)
+	client, err := initializeExecutionStore(c, shardID)
 	defer client.Close()
-
+	if err != nil {
+		commoncli.Problem("Error in Admin DB unsupported WF scan: ", err)
+	}
 	paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
 		ctx, cancel := context.WithTimeout(c.Context, listContextTimeout)
 		defer cancel()

--- a/tools/cli/admin_dlq_commands.go
+++ b/tools/cli/admin_dlq_commands.go
@@ -209,11 +209,11 @@ func AdminGetDLQMessages(c *cli.Context) error {
 
 				events, err := deserializeBatchEvents(task.GetHistoryTaskV2Attributes().GetEvents())
 				if err != nil {
-					return nil, fmt.Errorf("Error in deserializing batch events: %v", err)
+					return nil, fmt.Errorf("Error in deserializing batch events: %w", err)
 				}
 				newRunEvents, err := deserializeBatchEvents(task.GetHistoryTaskV2Attributes().GetNewRunEvents())
 				if err != nil {
-					return nil, fmt.Errorf("Error in deserializing new run batch events: %v", err)
+					return nil, fmt.Errorf("Error in deserializing new run batch events: %w", err)
 				}
 				domainName, err := getDomainName(info.DomainID)
 				if err != nil {
@@ -405,7 +405,7 @@ func readShardsFromStdin() chan int {
 				break
 			}
 			if err != nil {
-				fmt.Printf("Unable to read from stdin: %v", err)
+				fmt.Printf("Unable to read from stdin: %w", err)
 				continue
 			}
 			shard, err := strconv.ParseInt(strings.TrimSpace(line), 10, 64)
@@ -438,7 +438,7 @@ func deserializeBatchEvents(blob *types.DataBlob) ([]*types.HistoryEvent, error)
 	serializer := persistence.NewPayloadSerializer()
 	events, err := serializer.DeserializeBatchEvents(persistence.NewDataBlobFromInternal(blob))
 	if err != nil {
-		return nil, fmt.Errorf("Failed to decode DLQ history replication events: %v", err)
+		return nil, fmt.Errorf("Failed to decode DLQ history replication events: %w", err)
 	}
 	return events, nil
 }

--- a/tools/cli/admin_dlq_commands.go
+++ b/tools/cli/admin_dlq_commands.go
@@ -293,7 +293,7 @@ func AdminPurgeDLQMessages(c *cli.Context) error {
 	for shardID := range getShards(c) {
 		ctx, cancel, err := newContext(c)
 		if err != nil {
-			return commoncli.Problem("Error in creating context: %v", err)
+			return commoncli.Problem("Error in creating context: ", err)
 		}
 		err = adminClient.PurgeDLQMessages(ctx, &types.PurgeDLQMessagesRequest{
 			Type:                  dlqType,

--- a/tools/cli/admin_dlq_commands.go
+++ b/tools/cli/admin_dlq_commands.go
@@ -74,9 +74,11 @@ type HistoryDLQCountRow struct {
 // AdminCountDLQMessages returns info how many and where DLQ messages are queued
 func AdminCountDLQMessages(c *cli.Context) error {
 	force := c.Bool(FlagForce)
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context: ", err)
+	}
 	adminClient, err := getDeps(c).ServerAdminClient(c)
 	if err != nil {
 		return err
@@ -126,9 +128,11 @@ func AdminCountDLQMessages(c *cli.Context) error {
 
 // AdminGetDLQMessages gets DLQ metadata
 func AdminGetDLQMessages(c *cli.Context) error {
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context:", err)
+	}
 	client, err := getDeps(c).ServerFrontendClient(c)
 	if err != nil {
 		return err
@@ -137,10 +141,18 @@ func AdminGetDLQMessages(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-
-	dlqType := toQueueType(getRequiredOption(c, FlagDLQType))
-	sourceCluster := getRequiredOption(c, FlagSourceCluster)
-
+	fdlqtype, err := getRequiredOption(c, FlagDLQType)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	dlqType, err := toQueueType(fdlqtype)
+	if err != nil {
+		return commoncli.Problem("Failed to convert queue type", err)
+	}
+	sourceCluster, err := getRequiredOption(c, FlagSourceCluster)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
 	remainingMessageCount := common.EndMessageID
 	if c.IsSet(FlagMaxMessageCount) {
 		remainingMessageCount = c.Int64(FlagMaxMessageCount)
@@ -195,9 +207,14 @@ func AdminGetDLQMessages(c *cli.Context) error {
 					taskType = task.TaskType
 				}
 
-				events := deserializeBatchEvents(task.GetHistoryTaskV2Attributes().GetEvents())
-				newRunEvents := deserializeBatchEvents(task.GetHistoryTaskV2Attributes().GetNewRunEvents())
-
+				events, err := deserializeBatchEvents(task.GetHistoryTaskV2Attributes().GetEvents())
+				if err != nil {
+					return nil, fmt.Errorf("Error in deserializing batch events: %v", err)
+				}
+				newRunEvents, err := deserializeBatchEvents(task.GetHistoryTaskV2Attributes().GetNewRunEvents())
+				if err != nil {
+					return nil, fmt.Errorf("Error in deserializing new run batch events: %v", err)
+				}
 				domainName, err := getDomainName(info.DomainID)
 				if err != nil {
 					return nil, err
@@ -252,8 +269,18 @@ func AdminGetDLQMessages(c *cli.Context) error {
 
 // AdminPurgeDLQMessages deletes messages from DLQ
 func AdminPurgeDLQMessages(c *cli.Context) error {
-	dlqType := getRequiredOption(c, FlagDLQType)
-	sourceCluster := getRequiredOption(c, FlagSourceCluster)
+	fdlqtype, err := getRequiredOption(c, FlagDLQType)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	dlqType, err := toQueueType(fdlqtype)
+	if err != nil {
+		return commoncli.Problem("Failed to convert queue type", err)
+	}
+	sourceCluster, err := getRequiredOption(c, FlagSourceCluster)
+	if err != nil {
+		return commoncli.Problem("Required option not found", err)
+	}
 	var lastMessageID *int64
 	if c.IsSet(FlagLastMessageID) {
 		lastMessageID = common.Int64Ptr(c.Int64(FlagLastMessageID))
@@ -264,9 +291,12 @@ func AdminPurgeDLQMessages(c *cli.Context) error {
 		return err
 	}
 	for shardID := range getShards(c) {
-		ctx, cancel := newContext(c)
-		err := adminClient.PurgeDLQMessages(ctx, &types.PurgeDLQMessagesRequest{
-			Type:                  toQueueType(dlqType),
+		ctx, cancel, err := newContext(c)
+		if err != nil {
+			return commoncli.Problem("Error in creating context: %v", err)
+		}
+		err = adminClient.PurgeDLQMessages(ctx, &types.PurgeDLQMessagesRequest{
+			Type:                  dlqType,
 			SourceCluster:         sourceCluster,
 			ShardID:               int32(shardID),
 			InclusiveEndMessageID: lastMessageID,
@@ -284,8 +314,18 @@ func AdminPurgeDLQMessages(c *cli.Context) error {
 
 // AdminMergeDLQMessages merges message from DLQ
 func AdminMergeDLQMessages(c *cli.Context) error {
-	dlqType := getRequiredOption(c, FlagDLQType)
-	sourceCluster := getRequiredOption(c, FlagSourceCluster)
+	fdlqtype, err := getRequiredOption(c, FlagDLQType)
+	if err != nil {
+		return commoncli.Problem("Required flag not found", err)
+	}
+	dlqType, err := toQueueType(fdlqtype)
+	if err != nil {
+		return commoncli.Problem("Failed to convert queue type", err)
+	}
+	sourceCluster, err := getRequiredOption(c, FlagSourceCluster)
+	if err != nil {
+		return commoncli.Problem("Required option not found", err)
+	}
 	var lastMessageID *int64
 	if c.IsSet(FlagLastMessageID) {
 		lastMessageID = common.Int64Ptr(c.Int64(FlagLastMessageID))
@@ -298,7 +338,7 @@ func AdminMergeDLQMessages(c *cli.Context) error {
 ShardIDLoop:
 	for shardID := range getShards(c) {
 		request := &types.MergeDLQMessagesRequest{
-			Type:                  toQueueType(dlqType),
+			Type:                  dlqType,
 			SourceCluster:         sourceCluster,
 			ShardID:               int32(shardID),
 			InclusiveEndMessageID: lastMessageID,
@@ -306,7 +346,11 @@ ShardIDLoop:
 		}
 
 		for {
-			ctx, cancel := newContext(c)
+			ctx, cancel, err := newContext(c)
+			defer cancel()
+			if err != nil {
+				return commoncli.Problem("Error in creating context:", err)
+			}
 			response, err := adminClient.MergeDLQMessages(ctx, request)
 			cancel()
 			if err != nil {
@@ -376,28 +420,27 @@ func readShardsFromStdin() chan int {
 	return shards
 }
 
-func toQueueType(dlqType string) *types.DLQType {
+func toQueueType(dlqType string) (*types.DLQType, error) {
 	switch dlqType {
 	case "domain":
-		return types.DLQTypeDomain.Ptr()
+		return types.DLQTypeDomain.Ptr(), nil
 	case "history":
-		return types.DLQTypeReplication.Ptr()
+		return types.DLQTypeReplication.Ptr(), nil
 	default:
-		ErrorAndExit("The queue type is not supported.", fmt.Errorf("the queue type is not supported. Type: %v", dlqType))
+		return nil, fmt.Errorf("the queue type is not supported. Type: %v", dlqType)
 	}
-	return nil
 }
 
-func deserializeBatchEvents(blob *types.DataBlob) []*types.HistoryEvent {
+func deserializeBatchEvents(blob *types.DataBlob) ([]*types.HistoryEvent, error) {
 	if blob == nil {
-		return nil
+		return nil, nil
 	}
 	serializer := persistence.NewPayloadSerializer()
 	events, err := serializer.DeserializeBatchEvents(persistence.NewDataBlobFromInternal(blob))
 	if err != nil {
-		ErrorAndExit("Failed to decode DLQ history replication events", err)
+		return nil, fmt.Errorf("Failed to decode DLQ history replication events: %v", err)
 	}
-	return events
+	return events, nil
 }
 
 func collectEventIDs(events []*types.HistoryEvent) []int64 {

--- a/tools/cli/admin_dlq_commands.go
+++ b/tools/cli/admin_dlq_commands.go
@@ -347,7 +347,6 @@ ShardIDLoop:
 
 		for {
 			ctx, cancel, err := newContext(c)
-			defer cancel()
 			if err != nil {
 				return commoncli.Problem("Error in creating context:", err)
 			}
@@ -405,7 +404,7 @@ func readShardsFromStdin() chan int {
 				break
 			}
 			if err != nil {
-				fmt.Printf("Unable to read from stdin: %w", err)
+				fmt.Printf("Unable to read from stdin: %v", err)
 				continue
 			}
 			shard, err := strconv.ParseInt(strings.TrimSpace(line), 10, 64)

--- a/tools/cli/admin_elastic_search_commands.go
+++ b/tools/cli/admin_elastic_search_commands.go
@@ -497,7 +497,7 @@ func generateCSVReport(reportFileName string, headers []string, tableData [][]st
 	}
 	_, err = f.WriteString(csvContent)
 	if err != nil {
-		fmt.Printf("Error write to file, err: %w", err)
+		fmt.Printf("Error write to file, err: %v", err)
 	}
 	return f.Close()
 }

--- a/tools/cli/admin_elastic_search_commands.go
+++ b/tools/cli/admin_elastic_search_commands.go
@@ -497,7 +497,7 @@ func generateCSVReport(reportFileName string, headers []string, tableData [][]st
 	}
 	_, err = f.WriteString(csvContent)
 	if err != nil {
-		fmt.Printf("Error write to file, err: %v", err)
+		fmt.Printf("Error write to file, err: %w", err)
 	}
 	return f.Close()
 }

--- a/tools/cli/admin_failover_commands.go
+++ b/tools/cli/admin_failover_commands.go
@@ -109,7 +109,7 @@ func AdminFailoverQuery(c *cli.Context) error {
 	tcCtx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	workflowID := getFailoverWorkflowID(c)
 	runID := getRunID(c)
@@ -180,7 +180,7 @@ func AdminFailoverRollback(c *cli.Context) error {
 	tcCtx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	runID := getRunID(c)
 
@@ -312,11 +312,11 @@ func failoverStart(c *cli.Context, params *startParams) error {
 	tcCtx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	op, err := getOperator()
 	if err != nil {
-		return commoncli.Problem("Error in getting operator: %v", err)
+		return commoncli.Problem("Error in getting operator: ", err)
 	}
 	memo, err := getWorkflowMemo(map[string]interface{}{
 		common.MemoKeyForOperator: op,
@@ -410,7 +410,7 @@ func executePauseOrResume(c *cli.Context, workflowID string, isPause bool) error
 	tcCtx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	runID := getRunID(c)
 	var signalName string

--- a/tools/cli/admin_failover_commands.go
+++ b/tools/cli/admin_failover_commands.go
@@ -392,7 +392,7 @@ func getFailoverWorkflowID(c *cli.Context) string {
 func getOperator() (string, error) {
 	user, err := user.Current()
 	if err != nil {
-		return "", fmt.Errorf("Unable to get operator info %v", err)
+		return "", fmt.Errorf("Unable to get operator info %w", err)
 	}
 
 	return fmt.Sprintf("%s (username: %s)", user.Name, user.Username), nil

--- a/tools/cli/admin_kafka_commands.go
+++ b/tools/cli/admin_kafka_commands.go
@@ -174,10 +174,10 @@ func getOutputFile(outputFile string) (*os.File, error) {
 	}
 	f, err := os.Create(outputFile)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create output file %v", err)
+		return nil, fmt.Errorf("failed to create output file %w", err)
 	}
 
-	return f, nil 
+	return f, nil
 }
 
 func startReader(file *os.File, readerCh chan<- []byte) error {
@@ -411,7 +411,7 @@ func deserializeMessages(messages [][]byte, skipErrors bool) ([]*types.Replicati
 		}
 		replicationTasks = append(replicationTasks, thrift.ToReplicationTask(&task))
 	}
-	return replicationTasks, skipped, nil 
+	return replicationTasks, skipped, nil
 }
 
 func decode(message []byte, val *replicator.ReplicationTask) error {

--- a/tools/cli/admin_task_list_commands.go
+++ b/tools/cli/admin_task_list_commands.go
@@ -53,15 +53,24 @@ func AdminDescribeTaskList(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	domain := getRequiredOption(c, FlagDomain)
-	taskList := getRequiredOption(c, FlagTaskList)
+	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
+	taskList, err := getRequiredOption(c, FlagTaskList)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
 	taskListType := types.TaskListTypeDecision
 	if strings.ToLower(c.String(FlagTaskListType)) == "activity" {
 		taskListType = types.TaskListTypeActivity
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context:", err)
+	}
 	request := &types.DescribeTaskListRequest{
 		Domain:                domain,
 		TaskList:              &types.TaskList{Name: taskList},
@@ -96,10 +105,15 @@ func AdminListTaskList(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	domain := getRequiredOption(c, FlagDomain)
-
-	ctx, cancel := newContext(c)
+	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context: ", err)
+	}
 	request := &types.GetTaskListsByDomainRequest{
 		Domain: domain,
 	}

--- a/tools/cli/admin_timers.go
+++ b/tools/cli/admin_timers.go
@@ -38,7 +38,7 @@ import (
 
 // LoadCloser loads timer task information
 type LoadCloser interface {
-	Load() []*persistence.TimerTaskInfo
+	Load() ([]*persistence.TimerTaskInfo, error)
 	Close()
 }
 
@@ -74,24 +74,29 @@ type jsonPrinter struct {
 }
 
 // NewDBLoadCloser creates a new LoadCloser to load timer task information from database
-func NewDBLoadCloser(c *cli.Context) LoadCloser {
-	shardID := getRequiredIntOption(c, FlagShardID)
-	executionManager := initializeExecutionStore(c, shardID)
+func NewDBLoadCloser(c *cli.Context) (LoadCloser, error) {
+	shardID, err := getRequiredIntOption(c, FlagShardID)
+	if err != nil {
+		return nil, fmt.Errorf("error in NewDBLoadCloser: failed to get shard ID: %w", err)
+	}
+	executionManager, err := initializeExecutionStore(c, shardID)
+	if err != nil {
+		return nil, fmt.Errorf("error in NewDBLoadCloser: failed to initialize execution store: %w", err)
+	}
 	return &dbLoadCloser{
 		ctx:              c,
 		executionManager: executionManager,
-	}
+	}, nil
 }
 
-// NewFileLoadCloser creates a new LoadCloser to load timer task information from file
-func NewFileLoadCloser(c *cli.Context) LoadCloser {
+func NewFileLoadCloser(c *cli.Context) (LoadCloser, error) {
 	file, err := os.Open(c.String(FlagInputFile))
 	if err != nil {
-		ErrorAndExit("cannot open file", err)
+		return nil, fmt.Errorf("error in NewFileLoadCloser: cannot open file: %w", err)
 	}
 	return &fileLoadCloser{
 		file: file,
-	}
+	}, nil
 }
 
 // NewReporter creates a new Reporter
@@ -139,7 +144,11 @@ func (r *Reporter) filter(timers []*persistence.TimerTaskInfo) []*persistence.Ti
 
 // Report loads, filters and prints timer tasks
 func (r *Reporter) Report() error {
-	return r.printer.Print(r.filter(r.loader.Load()))
+	loader, err := r.loader.Load()
+	if err != nil {
+		return err
+	}
+	return r.printer.Print(r.filter(loader))
 }
 
 // AdminTimers is used to list scheduled timers.
@@ -159,10 +168,17 @@ func AdminTimers(c *cli.Context) error {
 
 	// setup loader
 	var loader LoadCloser
+	var err error
 	if !c.IsSet(FlagInputFile) {
-		loader = NewDBLoadCloser(c)
+		loader, err = NewDBLoadCloser(c)
+		if err != nil {
+			return commoncli.Problem("Error in timer: ", err)
+		}
 	} else {
-		loader = NewFileLoadCloser(c)
+		loader, err = NewFileLoadCloser(c)
+		if err != nil {
+			return commoncli.Problem("Error in timer: ", err)
+		}
 	}
 	defer loader.Close()
 
@@ -216,18 +232,18 @@ func (jp *jsonPrinter) Print(timers []*persistence.TimerTaskInfo) error {
 	return nil
 }
 
-func (cl *dbLoadCloser) Load() []*persistence.TimerTaskInfo {
+func (cl *dbLoadCloser) Load() ([]*persistence.TimerTaskInfo, error) {
 	batchSize := cl.ctx.Int(FlagBatchSize)
 	startDate := cl.ctx.String(FlagStartDate)
 	endDate := cl.ctx.String(FlagEndDate)
 
 	st, err := parseSingleTs(startDate)
 	if err != nil {
-		ErrorAndExit("wrong date format for "+FlagStartDate, err)
+		return nil, fmt.Errorf("wrong date format for "+FlagEndDate+" Error: %v", err)
 	}
 	et, err := parseSingleTs(endDate)
 	if err != nil {
-		ErrorAndExit("wrong date format for "+FlagEndDate, err)
+		return nil, fmt.Errorf("wrong date format for "+FlagEndDate+" Error: %v", err)
 	}
 
 	var timers []*persistence.TimerTaskInfo
@@ -254,10 +270,11 @@ func (cl *dbLoadCloser) Load() []*persistence.TimerTaskInfo {
 		resp := &persistence.GetTimerIndexTasksResponse{}
 
 		op := func() error {
-			ctx, cancel := newContext(cl.ctx)
+			ctx, cancel, err := newContext(cl.ctx)
 			defer cancel()
-
-			var err error
+			if err != nil {
+				return commoncli.Problem("Error in creating context:", err)
+			}
 			resp, err = cl.executionManager.GetTimerIndexTasks(ctx, &req)
 			return err
 		}
@@ -265,13 +282,13 @@ func (cl *dbLoadCloser) Load() []*persistence.TimerTaskInfo {
 		err = throttleRetry.Do(cl.ctx.Context, op)
 
 		if err != nil {
-			ErrorAndExit("cannot get timer tasks for shard", err)
+			return nil, fmt.Errorf("cannot get timer tasks for shard: %v", err)
 		}
 
 		token = resp.NextPageToken
 		timers = append(timers, resp.Timers...)
 	}
-	return timers
+	return timers, nil
 }
 
 func (cl *dbLoadCloser) Close() {
@@ -280,7 +297,7 @@ func (cl *dbLoadCloser) Close() {
 	}
 }
 
-func (fl *fileLoadCloser) Load() []*persistence.TimerTaskInfo {
+func (fl *fileLoadCloser) Load() ([]*persistence.TimerTaskInfo, error) {
 	var data []*persistence.TimerTaskInfo
 	dec := json.NewDecoder(fl.file)
 
@@ -290,10 +307,11 @@ func (fl *fileLoadCloser) Load() []*persistence.TimerTaskInfo {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				break
 			}
+			return nil, fmt.Errorf("error decoding timer: %w", err)
 		}
 		data = append(data, &timer)
 	}
-	return data
+	return data, nil 
 }
 
 func (fl *fileLoadCloser) Close() {

--- a/tools/cli/admin_timers.go
+++ b/tools/cli/admin_timers.go
@@ -311,7 +311,7 @@ func (fl *fileLoadCloser) Load() ([]*persistence.TimerTaskInfo, error) {
 		}
 		data = append(data, &timer)
 	}
-	return data, nil 
+	return data, nil
 }
 
 func (fl *fileLoadCloser) Close() {

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -657,8 +657,9 @@ func (s *cliAppSuite) TestObserveWorkflowWithID() {
 
 // TestParseTime tests the parsing of date argument in UTC and UnixNano formats
 func (s *cliAppSuite) TestParseTime() {
-	pt, err :=  parseTime("", 100)
-	s.Equal(int64(100),pt)
+	pt, err := parseTime("", 100)
+	s.NoError(err)
+	s.Equal(int64(100), pt)
 	pt, err = parseTime("2018-06-07T15:04:05+00:00", 0)
 	s.Equal(int64(1528383845000000000), pt)
 	pt, err = parseTime("1528383845000000000", 0)
@@ -752,6 +753,7 @@ func (s *cliAppSuite) TestParseTimeDateRange() {
 	delta := int64(50 * time.Millisecond)
 	for _, te := range tests {
 		pt, err := parseTime(te.timeStr, te.defVal)
+		s.NoError(err)
 		s.True(te.expected <= pt)
 		pt, err = parseTime(te.timeStr, te.defVal)
 		s.True(te.expected+delta >= pt)
@@ -811,29 +813,18 @@ func (s *cliAppSuite) TestIsAttributeName() {
 
 func (s *cliAppSuite) TestGetWorkflowIdReusePolicy() {
 	res, err := getWorkflowIDReusePolicy(2)
+	s.NoError(err)
 	s.Equal(res.String(), types.WorkflowIDReusePolicyRejectDuplicate.String())
 }
 
 func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_ExceedRange() {
-	oldOsExit := osExit
-	defer func() { osExit = oldOsExit }()
-	var errorCode int
-	osExit = func(code int) {
-		errorCode = code
-	}
-	getWorkflowIDReusePolicy(2147483647)
-	s.Equal(1, errorCode)
+	_, err := getWorkflowIDReusePolicy(2147483647)
+	s.Error(err)
 }
 
 func (s *cliAppSuite) TestGetWorkflowIdReusePolicy_Failed_Negative() {
-	oldOsExit := osExit
-	defer func() { osExit = oldOsExit }()
-	var errorCode int
-	osExit = func(code int) {
-		errorCode = code
-	}
-	getWorkflowIDReusePolicy(-1)
-	s.Equal(1, errorCode)
+	_, err := getWorkflowIDReusePolicy(-1)
+	s.Error(err)
 }
 
 func (s *cliAppSuite) TestGetSearchAttributes() {

--- a/tools/cli/app_test.go
+++ b/tools/cli/app_test.go
@@ -657,9 +657,12 @@ func (s *cliAppSuite) TestObserveWorkflowWithID() {
 
 // TestParseTime tests the parsing of date argument in UTC and UnixNano formats
 func (s *cliAppSuite) TestParseTime() {
-	s.Equal(int64(100), parseTime("", 100))
-	s.Equal(int64(1528383845000000000), parseTime("2018-06-07T15:04:05+00:00", 0))
-	s.Equal(int64(1528383845000000000), parseTime("1528383845000000000", 0))
+	pt, err :=  parseTime("", 100)
+	s.Equal(int64(100),pt)
+	pt, err = parseTime("2018-06-07T15:04:05+00:00", 0)
+	s.Equal(int64(1528383845000000000), pt)
+	pt, err = parseTime("1528383845000000000", 0)
+	s.Equal(int64(1528383845000000000), pt)
 }
 
 // TestParseTimeDateRange tests the parsing of date argument in time range format, N<duration>
@@ -748,8 +751,10 @@ func (s *cliAppSuite) TestParseTimeDateRange() {
 	}
 	delta := int64(50 * time.Millisecond)
 	for _, te := range tests {
-		s.True(te.expected <= parseTime(te.timeStr, te.defVal))
-		s.True(te.expected+delta >= parseTime(te.timeStr, te.defVal))
+		pt, err := parseTime(te.timeStr, te.defVal)
+		s.True(te.expected <= pt)
+		pt, err = parseTime(te.timeStr, te.defVal)
+		s.True(te.expected+delta >= pt)
 	}
 }
 
@@ -805,7 +810,7 @@ func (s *cliAppSuite) TestIsAttributeName() {
 }
 
 func (s *cliAppSuite) TestGetWorkflowIdReusePolicy() {
-	res := getWorkflowIDReusePolicy(2)
+	res, err := getWorkflowIDReusePolicy(2)
 	s.Equal(res.String(), types.WorkflowIDReusePolicyRejectDuplicate.String())
 }
 

--- a/tools/cli/cluster_commands.go
+++ b/tools/cli/cluster_commands.go
@@ -53,8 +53,11 @@ func GetSearchAttributes(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context:", err)
+	}
 
 	resp, err := wfClient.GetSearchAttributes(ctx)
 	if err != nil {

--- a/tools/cli/database.go
+++ b/tools/cli/database.go
@@ -183,7 +183,7 @@ func initializeShardManager(c *cli.Context) (persistence.ShardManager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("Failed to initialize shard manager %w", err)
 	}
-	return shardManager, nil 
+	return shardManager, nil
 }
 
 func initializeDomainManager(c *cli.Context) (persistence.DomainManager, error) {
@@ -284,7 +284,7 @@ func createDataStore(c *cli.Context) (config.DataStore, error) {
 		}
 	}
 	fmt.Errorf("The DB type is not supported. Options are: %s. Error %v", supportedDBs, nil)
-	return config.DataStore{}, nil 
+	return config.DataStore{}, nil
 }
 
 func overrideNoSQLDataStore(c *cli.Context, cfg *config.NoSQL) {

--- a/tools/cli/database.go
+++ b/tools/cli/database.go
@@ -153,11 +153,11 @@ func getDBFlags() []cli.Flag {
 func initializeExecutionStore(c *cli.Context, shardID int) (persistence.ExecutionManager, error) {
 	factory, err := getPersistenceFactory(c)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+		return nil, fmt.Errorf("Failed to get persistence factory: %w", err)
 	}
 	historyManager, err := factory.NewExecutionManager(shardID)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize history manager", err)
+		return nil, fmt.Errorf("Failed to initialize history manager %w", err)
 	}
 	return historyManager, nil
 }
@@ -165,11 +165,11 @@ func initializeExecutionStore(c *cli.Context, shardID int) (persistence.Executio
 func initializeHistoryManager(c *cli.Context) (persistence.HistoryManager, error) {
 	factory, err := getPersistenceFactory(c)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+		return nil, fmt.Errorf("Failed to get persistence factory: %w", err)
 	}
 	historyManager, err := factory.NewHistoryManager()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize history manager", err)
+		return nil, fmt.Errorf("Failed to initialize history manager %w", err)
 	}
 	return historyManager, nil
 }
@@ -177,11 +177,11 @@ func initializeHistoryManager(c *cli.Context) (persistence.HistoryManager, error
 func initializeShardManager(c *cli.Context) (persistence.ShardManager, error) {
 	factory, err := getPersistenceFactory(c)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+		return nil, fmt.Errorf("Failed to get persistence factory: %w", err)
 	}
 	shardManager, err := factory.NewShardManager()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize shard manager %v", err)
+		return nil, fmt.Errorf("Failed to initialize shard manager %w", err)
 	}
 	return shardManager, nil 
 }
@@ -189,11 +189,11 @@ func initializeShardManager(c *cli.Context) (persistence.ShardManager, error) {
 func initializeDomainManager(c *cli.Context) (persistence.DomainManager, error) {
 	factory, err := getPersistenceFactory(c)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+		return nil, fmt.Errorf("Failed to get persistence factory: %w", err)
 	}
 	domainManager, err := factory.NewDomainManager()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to initialize domain manager: %v", err)
+		return nil, fmt.Errorf("Failed to initialize domain manager: %w", err)
 	}
 	return domainManager, nil
 }
@@ -205,7 +205,7 @@ func getPersistenceFactory(c *cli.Context) (client.Factory, error) {
 	if persistenceFactory == nil {
 		persistenceFactory, err = initPersistenceFactory(c)
 		if err != nil {
-			return persistenceFactory, fmt.Errorf("%v", err)
+			return persistenceFactory, fmt.Errorf("%w", err)
 		}
 	}
 	return persistenceFactory, nil
@@ -232,7 +232,7 @@ func initPersistenceFactory(c *cli.Context) (client.Factory, error) {
 	defaultStore := cfg.Persistence.DataStores[cfg.Persistence.DefaultStore]
 	defaultStore, err = overrideDataStore(c, defaultStore)
 	if err != nil {
-		return nil, fmt.Errorf("Error in init persistence factory: %v", err)
+		return nil, fmt.Errorf("Error in init persistence factory: %w", err)
 	}
 	cfg.Persistence.DataStores[cfg.Persistence.DefaultStore] = defaultStore
 
@@ -259,7 +259,7 @@ func overrideDataStore(c *cli.Context, ds config.DataStore) (config.DataStore, e
 		var err error
 		ds, err = createDataStore(c)
 		if err != nil {
-			return config.DataStore{}, fmt.Errorf("Error in overriding data store: %v", err)
+			return config.DataStore{}, fmt.Errorf("Error in overriding data store: %w", err)
 		}
 	}
 

--- a/tools/cli/database.go
+++ b/tools/cli/database.go
@@ -150,52 +150,68 @@ func getDBFlags() []cli.Flag {
 	}
 }
 
-func initializeExecutionStore(c *cli.Context, shardID int) persistence.ExecutionManager {
-	factory := getPersistenceFactory(c)
+func initializeExecutionStore(c *cli.Context, shardID int) (persistence.ExecutionManager, error) {
+	factory, err := getPersistenceFactory(c)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+	}
 	historyManager, err := factory.NewExecutionManager(shardID)
 	if err != nil {
-		ErrorAndExit("Failed to initialize history manager", err)
+		return nil, fmt.Errorf("Failed to initialize history manager", err)
 	}
-	return historyManager
+	return historyManager, nil
 }
 
-func initializeHistoryManager(c *cli.Context) persistence.HistoryManager {
-	factory := getPersistenceFactory(c)
+func initializeHistoryManager(c *cli.Context) (persistence.HistoryManager, error) {
+	factory, err := getPersistenceFactory(c)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+	}
 	historyManager, err := factory.NewHistoryManager()
 	if err != nil {
-		ErrorAndExit("Failed to initialize history manager", err)
+		return nil, fmt.Errorf("Failed to initialize history manager", err)
 	}
-	return historyManager
+	return historyManager, nil
 }
 
-func initializeShardManager(c *cli.Context) persistence.ShardManager {
-	factory := getPersistenceFactory(c)
+func initializeShardManager(c *cli.Context) (persistence.ShardManager, error) {
+	factory, err := getPersistenceFactory(c)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+	}
 	shardManager, err := factory.NewShardManager()
 	if err != nil {
-		ErrorAndExit("Failed to initialize shard manager", err)
+		return nil, fmt.Errorf("Failed to initialize shard manager %v", err)
 	}
-	return shardManager
+	return shardManager, nil 
 }
 
-func initializeDomainManager(c *cli.Context) persistence.DomainManager {
-	factory := getPersistenceFactory(c)
+func initializeDomainManager(c *cli.Context) (persistence.DomainManager, error) {
+	factory, err := getPersistenceFactory(c)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get persistence factory: %v", err)
+	}
 	domainManager, err := factory.NewDomainManager()
 	if err != nil {
-		ErrorAndExit("Failed to initialize domain manager", err)
+		return nil, fmt.Errorf("Failed to initialize domain manager: %v", err)
 	}
-	return domainManager
+	return domainManager, nil
 }
 
 var persistenceFactory client.Factory
 
-func getPersistenceFactory(c *cli.Context) client.Factory {
+func getPersistenceFactory(c *cli.Context) (client.Factory, error) {
+	var err error
 	if persistenceFactory == nil {
-		persistenceFactory = initPersistenceFactory(c)
+		persistenceFactory, err = initPersistenceFactory(c)
+		if err != nil {
+			return persistenceFactory, fmt.Errorf("%v", err)
+		}
 	}
-	return persistenceFactory
+	return persistenceFactory, nil
 }
 
-func initPersistenceFactory(c *cli.Context) client.Factory {
+func initPersistenceFactory(c *cli.Context) (client.Factory, error) {
 	cfg, err := getDeps(c).ServerConfig(c)
 
 	if err != nil {
@@ -214,7 +230,10 @@ func initPersistenceFactory(c *cli.Context) client.Factory {
 
 	// If there are any overrides provided via CLI flags, apply them here
 	defaultStore := cfg.Persistence.DataStores[cfg.Persistence.DefaultStore]
-	defaultStore = overrideDataStore(c, defaultStore)
+	defaultStore, err = overrideDataStore(c, defaultStore)
+	if err != nil {
+		return nil, fmt.Errorf("Error in init persistence factory: %v", err)
+	}
 	cfg.Persistence.DataStores[cfg.Persistence.DefaultStore] = defaultStore
 
 	cfg.Persistence.TransactionSizeLimit = dynamicconfig.GetIntPropertyFn(common.DefaultTransactionSizeLimit)
@@ -231,13 +250,17 @@ func initPersistenceFactory(c *cli.Context) client.Factory {
 		&persistence.DynamicConfiguration{
 			EnableSQLAsyncTransaction: dynamicconfig.GetBoolPropertyFn(false),
 		},
-	)
+	), nil
 }
 
-func overrideDataStore(c *cli.Context, ds config.DataStore) config.DataStore {
+func overrideDataStore(c *cli.Context, ds config.DataStore) (config.DataStore, error) {
 	if c.IsSet(FlagDBType) {
 		// overriding DBType will wipe out all settings, everything will be set from flags only
-		ds = createDataStore(c)
+		var err error
+		ds, err = createDataStore(c)
+		if err != nil {
+			return config.DataStore{}, fmt.Errorf("Error in overriding data store: %v", err)
+		}
 	}
 
 	if ds.NoSQL != nil {
@@ -247,21 +270,21 @@ func overrideDataStore(c *cli.Context, ds config.DataStore) config.DataStore {
 		overrideSQLDataStore(c, ds.SQL)
 	}
 
-	return ds
+	return ds, nil
 }
 
-func createDataStore(c *cli.Context) config.DataStore {
+func createDataStore(c *cli.Context) (config.DataStore, error) {
 	dbType := c.String(FlagDBType)
 	switch dbType {
 	case cassandra.PluginName:
-		return config.DataStore{NoSQL: &config.NoSQL{PluginName: cassandra.PluginName}}
+		return config.DataStore{NoSQL: &config.NoSQL{PluginName: cassandra.PluginName}}, nil
 	default:
 		if sql.PluginRegistered(dbType) {
-			return config.DataStore{SQL: &config.SQL{PluginName: dbType}}
+			return config.DataStore{SQL: &config.SQL{PluginName: dbType}}, nil
 		}
 	}
-	ErrorAndExit(fmt.Sprintf("The DB type is not supported. Options are: %s.", supportedDBs), nil)
-	return config.DataStore{}
+	fmt.Errorf("The DB type is not supported. Options are: %s. Error %v", supportedDBs, nil)
+	return config.DataStore{}, nil 
 }
 
 func overrideNoSQLDataStore(c *cli.Context, cfg *config.NoSQL) {

--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -23,8 +23,9 @@ package cli
 import (
 	"fmt"
 
-	"github.com/uber/cadence/tools/common/commoncli"
 	"github.com/urfave/cli/v2"
+
+	"github.com/uber/cadence/tools/common/commoncli"
 )
 
 // by default we don't require any domain data. But this can be overridden by calling SetRequiredDomainDataKeys()

--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -23,6 +23,7 @@ package cli
 import (
 	"fmt"
 
+	"github.com/uber/cadence/tools/common/commoncli"
 	"github.com/urfave/cli/v2"
 )
 
@@ -99,7 +100,10 @@ func newDomainCommands() []*cli.Command {
 			Action: func(c *cli.Context) error {
 				// exit on error already handled in the command
 				// TODO best practice is to return error if validation fails
-				NewDomainMigrationCommand(c).Validation(c)
+				err := NewDomainMigrationCommand(c).Validation(c)
+				if err != nil {
+					return commoncli.Problem("Failed validation: ", err)
+				}
 				return nil
 			},
 		},

--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -183,7 +183,7 @@ func (d *domainCLIImpl) UpdateDomain(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	if c.IsSet(FlagActiveClusterName) {
 		activeCluster := c.String(FlagActiveClusterName)
@@ -315,7 +315,7 @@ func (d *domainCLIImpl) DeprecateDomain(c *cli.Context) error {
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	if !force {
 		wfc, err := getWorkflowClient(c)
@@ -401,7 +401,7 @@ func (d *domainCLIImpl) getAllDomains(c *cli.Context) ([]*types.DescribeDomainRe
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return nil, commoncli.Problem("Error in creating context: %v", err)
+		return nil, commoncli.Problem("Error in creating context: ", err)
 	}
 	for more := true; more; more = len(token) > 0 {
 		listRequest := &types.ListDomainsRequest{
@@ -431,7 +431,7 @@ func (d *domainCLIImpl) failover(c *cli.Context, domainName string, targetCluste
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return commoncli.Problem("Error in creating context: %v", err)
+		return commoncli.Problem("Error in creating context: ", err)
 	}
 	_, err = d.updateDomain(ctx, updateRequest)
 	return err

--- a/tools/cli/domain_migration_command.go
+++ b/tools/cli/domain_migration_command.go
@@ -161,7 +161,7 @@ func (d *domainMigrationCLIImpl) Validation(c *cli.Context) error {
 	}
 	wg := &sync.WaitGroup{}
 	errCh := make(chan error, len(checkers)) // Channel to capture errors
-	results := make([]DomainMigrationRow, len(checkers)) 
+	results := make([]DomainMigrationRow, len(checkers))
 	var err error
 	for i := range checkers {
 		go func(i int) {
@@ -171,7 +171,7 @@ func (d *domainMigrationCLIImpl) Validation(c *cli.Context) error {
 				errCh <- fmt.Errorf("Error in checkers: %w", err)
 				return
 			}
-			errCh <- nil 
+			errCh <- nil
 		}(i)
 	}
 
@@ -191,7 +191,7 @@ func (d *domainMigrationCLIImpl) Validation(c *cli.Context) error {
 	}
 
 	if err := Render(c, results, renderOpts); err != nil {
-		return fmt.Errorf("Failed to render", err)
+		return fmt.Errorf("failed to render: %w", err)
 	}
 	return nil
 }

--- a/tools/cli/domain_migration_command.go
+++ b/tools/cli/domain_migration_command.go
@@ -174,7 +174,7 @@ func (d *domainMigrationCLIImpl) Validation(c *cli.Context) error {
 			errCh <- nil 
 		}(i)
 	}
-	
+
 	wg.Wait()
 	close(errCh)
 	for err := range errCh {
@@ -202,19 +202,19 @@ func (d *domainMigrationCLIImpl) DomainMetaDataCheck(c *cli.Context) (DomainMigr
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Error in Domain meta data check: %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Error in Domain meta data check: %w", err)
 	}
 	currResp, err := d.frontendClient.DescribeDomain(ctx, &types.DescribeDomainRequest{
 		Name: &domain,
 	})
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Could not describe old domain, Please check to see if old domain exists before migrating. %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Could not describe old domain, Please check to see if old domain exists before migrating. %w", err)
 	}
 	newResp, err := d.destinationClient.DescribeDomain(ctx, &types.DescribeDomainRequest{
 		Name: &newDomain,
 	})
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Could not describe new domain, Please check to see if new domain exists before migrating. %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Could not describe new domain, Please check to see if new domain exists before migrating. %w", err)
 	}
 	validationResult, mismatchedMetaData := metaDataValidation(currResp, newResp)
 	validationRow := DomainMigrationRow{
@@ -243,7 +243,7 @@ func metaDataValidation(currResp *types.DescribeDomainResponse, newResp *types.D
 func (d *domainMigrationCLIImpl) DomainWorkFlowCheck(c *cli.Context) (DomainMigrationRow, error) {
 	countWorkFlows, err := d.countLongRunningWorkflow(c)
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Error in Domain flow check: %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Error in Domain flow check: %w", err)
 	}
 	check := countWorkFlows == 0
 	dmr := DomainMigrationRow{
@@ -266,11 +266,11 @@ func (d *domainMigrationCLIImpl) countLongRunningWorkflow(c *cli.Context) (int, 
 	ctx, cancel, err := newContextForLongPoll(c)
 	defer cancel()
 	if err != nil {
-		return 0, fmt.Errorf("Error in creating long context: %v", err)
+		return 0, fmt.Errorf("Error in creating long context: %w", err)
 	}
 	response, err := d.frontendClient.CountWorkflowExecutions(ctx, request)
 	if err != nil {
-		return 0, fmt.Errorf("Failed to count workflow. %v", err)
+		return 0, fmt.Errorf("Failed to count workflow. %w", err)
 	}
 	return int(response.GetCount()), nil
 }
@@ -279,7 +279,7 @@ func (d *domainMigrationCLIImpl) SearchAttributesChecker(c *cli.Context) (Domain
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Error in creating long context: %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Error in creating long context: %w", err)
 	}
 	// getting user provided search attributes
 	searchAttributes := c.StringSlice(FlagSearchAttribute)
@@ -309,13 +309,13 @@ func (d *domainMigrationCLIImpl) SearchAttributesChecker(c *cli.Context) (Domain
 	// getting search attributes for current domain
 	currentSearchAttributes, err := d.frontendClient.GetSearchAttributes(ctx)
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Unable to get search attributes for new domain. %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Unable to get search attributes for new domain. %w", err)
 	}
 
 	// getting search attributes for new domain
 	destinationSearchAttributes, err := d.destinationClient.GetSearchAttributes(ctx)
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Unable to get search attributes for new domain. %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Unable to get search attributes for new domain. %w", err)
 	}
 
 	currentSearchAttrs := currentSearchAttributes.Keys
@@ -375,11 +375,11 @@ func (d *domainMigrationCLIImpl) DynamicConfigCheck(c *cli.Context) (DomainMigra
 	ctx, cancel, err := newContext(c)
 	defer cancel()
 	if err != nil {
-		return DomainMigrationRow{}, fmt.Errorf("Failed to create context: %v", err)
+		return DomainMigrationRow{}, fmt.Errorf("Failed to create context: %w", err)
 	}
 	currentDomainID, err1 := getDomainID(ctx, currDomain, d.frontendClient)
 	destinationDomainID, err2 := getDomainID(ctx, newDomain, d.destinationClient)
-	if currentDomainID == "" || err1 != nil{
+	if currentDomainID == "" || err1 != nil {
 		return DomainMigrationRow{}, fmt.Errorf("Failed to get domainID for the current domain. %v", nil)
 	}
 
@@ -529,7 +529,7 @@ func (d *domainMigrationCLIImpl) DynamicConfigCheck(c *cli.Context) (DomainMigra
 func getDomainID(c context.Context, domain string, client frontend.Client) (string, error) {
 	resp, err := client.DescribeDomain(c, &types.DescribeDomainRequest{Name: &domain})
 	if err != nil {
-		return "", fmt.Errorf("Failed to describe domain. %v", err)
+		return "", fmt.Errorf("Failed to describe domain. %w", err)
 	}
 
 	return resp.DomainInfo.GetUUID(), nil

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -360,7 +360,7 @@ func initializeLogger(
 ) (log.Logger, error) {
 	zapLogger, err := serviceConfig.Log.NewZapLogger()
 	if err != nil {
-		return nil, fmt.Errorf("failed to create zap logger, err: ", err)
+		return nil, fmt.Errorf("failed to create zap logger, err: %w", err)
 	}
 	return loggerimpl.NewLogger(zapLogger), nil
 }

--- a/tools/cli/domain_utils.go
+++ b/tools/cli/domain_utils.go
@@ -21,8 +21,8 @@
 package cli
 
 import (
-	"strings"
 	"fmt"
+	"strings"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/uber-go/tally"
@@ -288,20 +288,20 @@ func initializeAdminDomainHandler(c *cli.Context) (domain.Handler, error) {
 	metricsClient := initializeMetricsClient()
 	logger, err := initializeLogger(configuration)
 	if err != nil {
-		return nil, fmt.Errorf("Error in init admin domain handler: %v", err)
+		return nil, fmt.Errorf("Error in init admin domain handler: %w", err)
 	}
 	clusterMetadata := initializeClusterMetadata(configuration, metricsClient, logger)
 	metadataMgr, err := initializeDomainManager(c)
 	if err != nil {
-		return nil, fmt.Errorf("Error in init admin domain handler: %v", err)
+		return nil, fmt.Errorf("Error in init admin domain handler: %w", err)
 	}
 	dynamicConfig, err := initializeDynamicConfig(configuration, logger)
 	if err != nil {
-		return nil, fmt.Errorf("Error in init admin domain handler: %v", err)
+		return nil, fmt.Errorf("Error in init admin domain handler: %w", err)
 	}
 	archivalprovider, err := initializeArchivalProvider(configuration, clusterMetadata, metricsClient, logger)
 	if err != nil {
-		return nil, fmt.Errorf("Error in init admin domain handler: %v", err)
+		return nil, fmt.Errorf("Error in init admin domain handler: %w", err)
 	}
 	domainhandler := initializeDomainHandler(
 		logger,
@@ -320,12 +320,12 @@ func loadConfig(
 	zone := getZone(context)
 	configDir, err := getConfigDir(context)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to load config. %v", err)
+		return nil, fmt.Errorf("Unable to load config. %w", err)
 	}
 	var cfg config.Config
 	err = config.Load(env, configDir, zone, &cfg)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to load config. %v", err)
+		return nil, fmt.Errorf("Unable to load config. %w", err)
 	}
 	return &cfg, nil
 }
@@ -426,7 +426,7 @@ func initializeArchivalProvider(
 		visibilityArchiverBootstrapContainer,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Error initializing archival provider. %v", err)
+		return nil, fmt.Errorf("Error initializing archival provider. %w", err)
 	}
 	return archiverProvider, nil
 }
@@ -455,7 +455,7 @@ func initializeDynamicConfig(
 		doneChan,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("Error initializing dynamic config. %v", err)
+		return nil, fmt.Errorf("Error initializing dynamic config. %w", err)
 	}
 	return dynamicconfig.NewCollection(dynamicConfigClient, logger), nil
 }

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -88,6 +88,7 @@ type clientFactory struct {
 }
 
 // NewClientFactory creates a new ClientFactory
+
 func NewClientFactory(logger *zap.Logger) ClientFactory {
 	return &clientFactory{
 		logger: logger,
@@ -179,7 +180,12 @@ func (b *clientFactory) ServerAdminClientForMigration(c *cli.Context) (admin.Cli
 
 // ElasticSearchClient builds an ElasticSearch client
 func (b *clientFactory) ElasticSearchClient(c *cli.Context) (*elastic.Client, error) {
-	url := getRequiredOption(c, FlagURL)
+
+	url, err := getRequiredOption(c, FlagURL)
+	if err != nil {
+		return nil, fmt.Errorf("Required flag not present %v", err)
+	}
+
 	retrier := elastic.NewBackoffRetrier(elastic.NewExponentialBackoff(128*time.Millisecond, 513*time.Millisecond))
 
 	client, err := elastic.NewClient(

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -183,7 +183,7 @@ func (b *clientFactory) ElasticSearchClient(c *cli.Context) (*elastic.Client, er
 
 	url, err := getRequiredOption(c, FlagURL)
 	if err != nil {
-		return nil, fmt.Errorf("Required flag not present %v", err)
+		return nil, fmt.Errorf("Required flag not present %w", err)
 	}
 
 	retrier := elastic.NewBackoffRetrier(elastic.NewExponentialBackoff(128*time.Millisecond, 513*time.Millisecond))

--- a/tools/cli/isolation-groups.go
+++ b/tools/cli/isolation-groups.go
@@ -38,9 +38,11 @@ func AdminGetGlobalIsolationGroups(c *cli.Context) error {
 		return err
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error creating context:", err)
+	}
 	req := &types.GetGlobalIsolationGroupsRequest{}
 	igs, err := adminClient.GetGlobalIsolationGroups(ctx, req)
 	if err != nil {
@@ -63,9 +65,11 @@ func AdminUpdateGlobalIsolationGroups(c *cli.Context) error {
 		return err
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error creating context:", err)
+	}
 	err = validateIsolationGroupUpdateArgs(
 		c.String(FlagDomain),
 		c.String(FlagDomain),
@@ -103,8 +107,11 @@ func AdminGetDomainIsolationGroups(c *cli.Context) error {
 	}
 	domain := c.String(FlagDomain)
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error creating context:", err)
+	}
 
 	req := &types.GetDomainIsolationGroupsRequest{
 		Domain: domain,
@@ -143,8 +150,11 @@ func AdminUpdateDomainIsolationGroups(c *cli.Context) error {
 		return commoncli.Problem("invalid args:", err)
 	}
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error creating context:", err)
+	}
 
 	cfg, err := parseIsolationGroupCliInputCfg(
 		c.StringSlice(FlagIsolationGroupSetDrains),

--- a/tools/cli/render.go
+++ b/tools/cli/render.go
@@ -77,7 +77,7 @@ type RenderOptions struct {
 func Render(c *cli.Context, data interface{}, opts RenderOptions) (err error) {
 	defer func() {
 		if err != nil {
-			ErrorAndExit("failed to render", err)
+			fmt.Errorf("failed to render: %v", err)
 		}
 	}()
 

--- a/tools/cli/render.go
+++ b/tools/cli/render.go
@@ -77,7 +77,7 @@ type RenderOptions struct {
 func Render(c *cli.Context, data interface{}, opts RenderOptions) (err error) {
 	defer func() {
 		if err != nil {
-			fmt.Errorf("failed to render: %v", err)
+			fmt.Errorf("failed to render: %w", err)
 		}
 	}()
 

--- a/tools/cli/task_list_commands.go
+++ b/tools/cli/task_list_commands.go
@@ -49,13 +49,21 @@ func DescribeTaskList(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	domain := getRequiredOption(c, FlagDomain)
-	taskList := getRequiredOption(c, FlagTaskList)
+	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
+	taskList, err := getRequiredOption(c, FlagTaskList)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
 	taskListType := strToTaskListType(c.String(FlagTaskListType)) // default type is decision
 
-	ctx, cancel := newContext(c)
+	ctx, cancel, err := newContext(c)
 	defer cancel()
-
+	if err != nil {
+		return commoncli.Problem("Error in creating context:", err)
+	}
 	request := &types.DescribeTaskListRequest{
 		Domain: domain,
 		TaskList: &types.TaskList{
@@ -82,11 +90,19 @@ func ListTaskListPartitions(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	domain := getRequiredOption(c, FlagDomain)
-	taskList := getRequiredOption(c, FlagTaskList)
-
-	ctx, cancel := newContext(c)
+	domain, err := getRequiredOption(c, FlagDomain)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
+	taskList, err := getRequiredOption(c, FlagTaskList)
+	if err != nil {
+		return commoncli.Problem("Required flag not found: ", err)
+	}
+	ctx, cancel, err := newContext(c)
 	defer cancel()
+	if err != nil {
+		return commoncli.Problem("Error in creating context:", err)
+	}
 	request := &types.ListTaskListPartitionsRequest{
 		Domain:   domain,
 		TaskList: &types.TaskList{Name: taskList},

--- a/tools/cli/utils.go
+++ b/tools/cli/utils.go
@@ -524,12 +524,6 @@ func printError(msg string, err error) {
 	}
 }
 
-// ErrorAndExit print easy to understand error msg first then error detail in a new line
-// func ErrorAndExit(msg string, err error) {
-// 	printError(msg, err)
-// 	osExit(1)
-// }
-
 func getWorkflowClient(c *cli.Context) (frontend.Client, error) {
 	return getDeps(c).ServerFrontendClient(c)
 }
@@ -730,7 +724,7 @@ func processJWTFlags(ctx context.Context, cliCtx *cli.Context) (context.Context,
 	} else if path != "" {
 		token, err = createJWT(path)
 		if err != nil {
-			return nil, fmt.Errorf("error creating JWT token: %v", err)
+			return nil, fmt.Errorf("error creating JWT token: %w", err)
 		}
 	}
 
@@ -740,7 +734,7 @@ func processJWTFlags(ctx context.Context, cliCtx *cli.Context) (context.Context,
 func populateContextFromCLIContext(ctx context.Context, cliCtx *cli.Context) (context.Context, error) {
 	ctx, err := processJWTFlags(ctx, cliCtx)
 	if err != nil {
-		return nil, fmt.Errorf("error while populating context from CLI: %v", err)
+		return nil, fmt.Errorf("error while populating context from CLI: %w", err)
 	}
 	return ctx, nil
 }
@@ -758,13 +752,13 @@ func newIndefiniteContext(c *cli.Context) (context.Context, context.CancelFunc, 
 		ctx, cancel, err := newTimedContext(c, time.Duration(c.Int(FlagContextTimeout))*time.Second)
 		defer cancel()
 		if err != nil {
-			return nil, nil, fmt.Errorf("Error in new indifinite context: %v", err)
+			return nil, nil, fmt.Errorf("Error in new indifinite context: %w", err)
 		}
 		return ctx, cancel, nil
 	}
 	ctx, err := populateContextFromCLIContext(c.Context, c)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error in newIndefiniteContext: %v", err)
+		return nil, nil, fmt.Errorf("error in newIndefiniteContext: %w", err)
 	}
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -779,7 +773,7 @@ func newTimedContext(c *cli.Context, timeout time.Duration) (context.Context, co
 
 	ctx, err := populateContextFromCLIContext(c.Context, c)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%v", err)
+		return nil, nil, fmt.Errorf("%w", err)
 	}
 	ctx, time_out := context.WithTimeout(ctx, timeout)
 
@@ -822,7 +816,7 @@ func processJSONInputHelper(c *cli.Context, jType jsonType) (string, error) {
 		// #nosec
 		data, err := ioutil.ReadFile(inputFile)
 		if err != nil {
-			return "", fmt.Errorf("Error reading input file: %v", err)
+			return "", fmt.Errorf("Error reading input file: %w", err)
 		}
 		input = string(data)
 	}
@@ -1028,7 +1022,7 @@ func getWorkflowMemo(input map[string]interface{}) (*types.Memo, error) {
 	for k, v := range input {
 		memoBytes, err := json.Marshal(v)
 		if err != nil {
-			return nil, fmt.Errorf("encode workflow memo error: %v", err.Error())
+			return nil, fmt.Errorf("encode workflow memo error: %w", err.Error())
 		}
 		memo[k] = memoBytes
 	}

--- a/tools/cli/utils.go
+++ b/tools/cli/utils.go
@@ -773,11 +773,11 @@ func newTimedContext(c *cli.Context, timeout time.Duration) (context.Context, co
 
 	ctx, err := populateContextFromCLIContext(c.Context, c)
 	if err != nil {
-		return nil, nil, fmt.Errorf("%w", err)
+		return nil, nil, fmt.Errorf("error populate context from CLI context: %w", err)
 	}
-	ctx, time_out := context.WithTimeout(ctx, timeout)
+	ctx, timeOut := context.WithTimeout(ctx, timeout)
 
-	return ctx, time_out, nil
+	return ctx, timeOut, nil
 }
 
 // process and validate input provided through cmd or file
@@ -816,13 +816,13 @@ func processJSONInputHelper(c *cli.Context, jType jsonType) (string, error) {
 		// #nosec
 		data, err := ioutil.ReadFile(inputFile)
 		if err != nil {
-			return "", fmt.Errorf("Error reading input file: %w", err)
+			return "", fmt.Errorf("error reading input file: %w", err)
 		}
 		input = string(data)
 	}
 	if input != "" {
 		if err := validateJSONs(input); err != nil {
-			return "", fmt.Errorf("Input is not valid JSON, or JSONs concatenated with spaces/newlines.", err)
+			return "", fmt.Errorf("input is not valid JSON: %w", err)
 		}
 	}
 	return input, nil
@@ -844,7 +844,7 @@ func processMultipleJSONValues(rawValue string) ([]string, error) {
 		values = append(values, sc.Value().String())
 	}
 	if err := sc.Error(); err != nil {
-		return nil, fmt.Errorf("Parse json error.", err)
+		return nil, fmt.Errorf("parse json error: %w", err)
 	}
 	return values, nil
 }
@@ -977,7 +977,7 @@ func getInputFile(inputFile string) (*os.File, error) {
 	if len(inputFile) == 0 {
 		info, err := os.Stdin.Stat()
 		if err != nil {
-			return nil, fmt.Errorf("Failed to stat stdin file handle", err)
+			return nil, fmt.Errorf("failed to stat stdin file handle: %w", err)
 		}
 		if info.Mode()&os.ModeCharDevice != 0 || info.Size() <= 0 {
 			fmt.Fprintln(os.Stderr, "Provide a filename or pass data to STDIN")
@@ -989,7 +989,7 @@ func getInputFile(inputFile string) (*os.File, error) {
 	// #nosec
 	f, err := os.Open(inputFile)
 	if err != nil {
-		return nil, fmt.Errorf(fmt.Sprintf("Failed to open input file for reading: %v", inputFile), err)
+		return nil, fmt.Errorf("failed to open input file for reading: %v: %w", inputFile, err)
 	}
 	return f, nil
 }
@@ -1022,7 +1022,7 @@ func getWorkflowMemo(input map[string]interface{}) (*types.Memo, error) {
 	for k, v := range input {
 		memoBytes, err := json.Marshal(v)
 		if err != nil {
-			return nil, fmt.Errorf("encode workflow memo error: %w", err.Error())
+			return nil, fmt.Errorf("encode workflow memo error: %w", err)
 		}
 		memo[k] = memoBytes
 	}

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -540,14 +540,14 @@ func processMemo(c *cli.Context) (map[string][]byte, error) {
 	memoKeys := processMultipleKeys(c.String(FlagMemoKey), " ")
 	jsoninputhandler, err := processJSONInputHelper(c, jsonTypeMemo)
 	if err != nil {
-		return nil, fmt.Errorf("Error in process header: %w", err)
+		return nil, fmt.Errorf("error in process header: %w", err)
 	}
 	memoValues, err := processMultipleJSONValues(jsoninputhandler)
 	if err != nil {
-		return nil, fmt.Errorf("Error in process header: %w", err)
+		return nil, fmt.Errorf("error in process header: %w", err)
 	}
 	if len(memoKeys) != len(memoValues) {
-		return nil, fmt.Errorf("Number of memo keys and values are not equal.", nil)
+		return nil, fmt.Errorf("number of memo keys and values are not equal")
 	}
 
 	return mapFromKeysValues(memoKeys, memoValues), nil
@@ -798,11 +798,11 @@ func constructSignalWithStartWorkflowRequest(c *cli.Context) (*types.SignalWithS
 	}
 	signalname, err := getRequiredOption(c, FlagName)
 	if err != nil {
-		return nil, fmt.Errorf("Required flag not present %w", err)
+		return nil, fmt.Errorf("required flag not present %w", err)
 	}
 	jsoninputsignal, err := processJSONInputSignal(c)
 	if err != nil {
-		return nil, fmt.Errorf("Error processing json input signal: ", err)
+		return nil, fmt.Errorf("error processing json input signal: %w", err)
 	}
 	return &types.SignalWithStartWorkflowExecutionRequest{
 		Domain:                              startRequest.Domain,
@@ -834,14 +834,6 @@ func processJSONInputSignal(c *cli.Context) (string, error) {
 
 // QueryWorkflow query workflow execution
 func QueryWorkflow(c *cli.Context) error {
-	domain, err := getRequiredOption(c, FlagDomain)
-	if err != nil {
-		return commoncli.Problem("Required flag not found for domain: ", err)
-	}
-	workflowID, err := getRequiredOption(c, FlagWorkflowID)
-	if err != nil {
-		return commoncli.Problem("Required flag not found for workflow ID: ", err)
-	}
 	queryType, err := getRequiredOption(c, FlagQueryType)
 	if err != nil {
 		return commoncli.Problem("Required flag not found for query type: ", err)
@@ -1171,7 +1163,7 @@ func convertDescribeWorkflowExecutionResponse(resp *types.DescribeWorkflowExecut
 	info := resp.WorkflowExecutionInfo
 	searchattributes, err := convertSearchAttributesToMapOfInterface(info.SearchAttributes, wfClient, c)
 	if err != nil {
-		return nil, fmt.Errorf("Error converting search attributes: ", err)
+		return nil, fmt.Errorf("error converting search attributes: %w", err)
 	}
 	executionInfo := workflowExecutionInfo{
 		Execution:        info.Execution,

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -385,7 +385,7 @@ func constructStartWorkflowRequest(c *cli.Context) (*types.StartWorkflowExecutio
 	reusePolicy := defaultWorkflowIDReusePolicy.Ptr()
 	wfidreusepolicy, err := getWorkflowIDReusePolicy(c.Int(FlagWorkflowIDReusePolicy))
 	if err != nil {
-		return nil, commoncli.Problem("Error getting wf reuse policy: %v", err)
+		return nil, commoncli.Problem("Error getting wf reuse policy: ", err)
 	}
 	if c.IsSet(FlagWorkflowIDReusePolicy) {
 		reusePolicy = wfidreusepolicy
@@ -458,7 +458,7 @@ func constructStartWorkflowRequest(c *cli.Context) (*types.StartWorkflowExecutio
 
 	memoFields, err := processMemo(c)
 	if err != nil {
-		return nil, commoncli.Problem("Error processing memo: %v", err)
+		return nil, commoncli.Problem("Error processing memo: ", err)
 	}
 	if len(memoFields) != 0 {
 		startRequest.Memo = &types.Memo{Fields: memoFields}

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -466,7 +466,7 @@ func constructStartWorkflowRequest(c *cli.Context) (*types.StartWorkflowExecutio
 
 	searchAttrFields, err := processSearchAttr(c)
 	if err != nil {
-		return nil, commoncli.Problem("error processing search attributes: %v", err)
+		return nil, commoncli.Problem("error processing search attributes: ", err)
 	}
 	if len(searchAttrFields) != 0 {
 		startRequest.SearchAttributes = &types.SearchAttributes{IndexedFields: searchAttrFields}
@@ -513,11 +513,11 @@ func processHeader(c *cli.Context) (map[string][]byte, error) {
 	headerKeys := processMultipleKeys(c.String(FlagHeaderKey), " ")
 	jsoninputhandler, err := processJSONInputHelper(c, jsonTypeHeader)
 	if err != nil {
-		return nil, fmt.Errorf("Error in process header: %v", err)
+		return nil, fmt.Errorf("Error in process header: %w", err)
 	}
 	headerValues, err := processMultipleJSONValues(jsoninputhandler)
 	if err != nil {
-		return nil, fmt.Errorf("Error in process header: %v", err)
+		return nil, fmt.Errorf("Error in process header: %w", err)
 	}
 	if len(headerKeys) != len(headerValues) {
 		return nil, commoncli.Problem("Number of header keys and values are not equal.", nil)
@@ -540,11 +540,11 @@ func processMemo(c *cli.Context) (map[string][]byte, error) {
 	memoKeys := processMultipleKeys(c.String(FlagMemoKey), " ")
 	jsoninputhandler, err := processJSONInputHelper(c, jsonTypeMemo)
 	if err != nil {
-		return nil, fmt.Errorf("Error in process header: %v", err)
+		return nil, fmt.Errorf("Error in process header: %w", err)
 	}
 	memoValues, err := processMultipleJSONValues(jsoninputhandler)
 	if err != nil {
-		return nil, fmt.Errorf("Error in process header: %v", err)
+		return nil, fmt.Errorf("Error in process header: %w", err)
 	}
 	if len(memoKeys) != len(memoValues) {
 		return nil, fmt.Errorf("Number of memo keys and values are not equal.", nil)
@@ -563,8 +563,8 @@ func printWorkflowProgress(c *cli.Context, domain, wid, rid string) error {
 	}
 	timeElapse := 1
 	isTimeElapseExist := false
-	doneChan := make(chan bool) // Channel to signal completion
-	errChan := make(chan error)  // Separate channel for errors
+	doneChan := make(chan bool)       // Channel to signal completion
+	errChan := make(chan error)       // Separate channel for errors
 	var lastEvent *types.HistoryEvent // Used to print result of this run
 	ticker := time.NewTicker(time.Second).C
 
@@ -798,7 +798,7 @@ func constructSignalWithStartWorkflowRequest(c *cli.Context) (*types.SignalWithS
 	}
 	signalname, err := getRequiredOption(c, FlagName)
 	if err != nil {
-		return nil, fmt.Errorf("Required flag not present %v", err)
+		return nil, fmt.Errorf("Required flag not present %w", err)
 	}
 	jsoninputsignal, err := processJSONInputSignal(c)
 	if err != nil {
@@ -820,7 +820,7 @@ func constructSignalWithStartWorkflowRequest(c *cli.Context) (*types.SignalWithS
 		Memo:                                startRequest.Memo,
 		SearchAttributes:                    startRequest.SearchAttributes,
 		Header:                              startRequest.Header,
-		SignalName:                      	 signalname,
+		SignalName:                          signalname,
 		SignalInput:                         []byte(jsoninputsignal),
 		DelayStartSeconds:                   startRequest.DelayStartSeconds,
 		JitterStartSeconds:                  startRequest.JitterStartSeconds,
@@ -1083,7 +1083,7 @@ func describeWorkflowHelper(c *cli.Context, wid, rid string) error {
 	if printRaw {
 		o = resp
 	} else {
-		o , err= convertDescribeWorkflowExecutionResponse(resp, frontendClient, c)
+		o, err = convertDescribeWorkflowExecutionResponse(resp, frontendClient, c)
 		return commoncli.Problem("WF helper describe failed: ", err)
 	}
 
@@ -1239,7 +1239,7 @@ func convertDescribeWorkflowExecutionResponse(resp *types.DescribeWorkflowExecut
 		PendingActivities:      pendingActs,
 		PendingChildren:        resp.PendingChildren,
 		PendingDecision:        pendingDecision,
-	}, nil 
+	}, nil
 }
 
 func convertSearchAttributesToMapOfInterface(searchAttributes *types.SearchAttributes,
@@ -1485,7 +1485,7 @@ func displayWorkflows(c *cli.Context, workflows []*types.WorkflowExecutionInfo) 
 	return Render(c, table, tableOptions)
 }
 
-func listWorkflowExecutions(client frontend.Client, pageSize int, domain, query string, c *cli.Context) (getWorkflowPageFn) {
+func listWorkflowExecutions(client frontend.Client, pageSize int, domain, query string, c *cli.Context) getWorkflowPageFn {
 	return func(nextPageToken []byte) ([]*types.WorkflowExecutionInfo, []byte, error) {
 		request := &types.ListWorkflowExecutionsRequest{
 			Domain:        domain,
@@ -1538,7 +1538,7 @@ func listOpenWorkflow(client frontend.Client, pageSize int, earliestTime, latest
 	}
 }
 
-func listClosedWorkflow(client frontend.Client, pageSize int, earliestTime, latestTime int64, domain, workflowID, workflowType string, workflowStatus types.WorkflowExecutionCloseStatus, c *cli.Context) (getWorkflowPageFn) {
+func listClosedWorkflow(client frontend.Client, pageSize int, earliestTime, latestTime int64, domain, workflowID, workflowType string, workflowStatus types.WorkflowExecutionCloseStatus, c *cli.Context) getWorkflowPageFn {
 	return func(nextPageToken []byte) ([]*types.WorkflowExecutionInfo, []byte, error) {
 		request := &types.ListClosedWorkflowExecutionsRequest{
 			Domain:          domain,
@@ -1584,11 +1584,11 @@ func listWorkflows(c *cli.Context) (getWorkflowPageFn, error) {
 	}
 	earliestTime, err := parseTime(c.String(FlagEarliestTime), 0)
 	if err != nil {
-		return nil, fmt.Errorf("Error in listing workflows: %v", err)
+		return nil, fmt.Errorf("Error in listing workflows: %w", err)
 	}
 	latestTime, err := parseTime(c.String(FlagLatestTime), time.Now().UnixNano())
 	if err != nil {
-		return nil, fmt.Errorf("Error in listing workflows: %v", err)
+		return nil, fmt.Errorf("Error in listing workflows: %w", err)
 	}
 	workflowID := c.String(FlagWorkflowID)
 	workflowType := c.String(FlagWorkflowType)
@@ -1931,7 +1931,7 @@ func ResetInBatch(c *cli.Context) error {
 		return commoncli.Problem("Required flag not found: ", err)
 	}
 	batchResetParams := batchResetParamsType{
-		reason:           	  rsn,
+		reason:               rsn,
 		skipCurrentOpen:      c.Bool(FlagSkipCurrentOpen),
 		skipCurrentCompleted: c.Bool(FlagSkipCurrentCompleted),
 		nonDeterministicOnly: c.Bool(FlagNonDeterministicOnly),
@@ -2055,7 +2055,7 @@ func loadWorkflowIDsFromFile(excludeFileName, separator string) (map[string]bool
 		// #nosec
 		excFile, err := os.Open(excludeFileName)
 		if err != nil {
-			return nil, fmt.Errorf("Open failed2 %v", err)
+			return nil, fmt.Errorf("Open failed2 %w", err)
 		}
 		defer excFile.Close()
 		scanner := bufio.NewScanner(excFile)
@@ -2075,7 +2075,7 @@ func loadWorkflowIDsFromFile(excludeFileName, separator string) (map[string]bool
 			excludeWIDs[wid] = true
 		}
 	}
-	return excludeWIDs, nil 
+	return excludeWIDs, nil
 }
 
 func printErrorAndReturn(msg string, err error) error {
@@ -2251,11 +2251,11 @@ func getResetEventIDByType(
 	case resetTypeDecisionCompletedTime:
 		earliestTime, err := parseTime(c.String(FlagEarliestTime), 0)
 		if err != nil {
-			return "", 0, fmt.Errorf("Get reset event id by type failed: %v", err)
+			return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
 		}
 		decisionFinishID, err = getEarliestDecisionID(ctx, domain, wid, rid, earliestTime, frontendClient)
 		if err != nil {
-			return "", 0, fmt.Errorf("Get reset event id by type failed: %v", err)
+			return "", 0, fmt.Errorf("Get reset event id by type failed: %w", err)
 		}
 	case resetTypeFirstDecisionScheduled:
 		decisionFinishID, err = getFirstDecisionTaskByType(ctx, domain, wid, rid, frontendClient, types.EventTypeDecisionTaskScheduled)


### PR DESCRIPTION
Towards Issue #6317 
<!-- Describe what has changed in this PR -->
ErrorAndExit function is deprecated.  Now every error is propagated instead of exiting directly.


<!-- Tell your future self why have you made these changes -->
For best practices


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->


<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->

