### PR TITLE
Removes a dependency on service startup for unneeded services

### DIFF
--- a/common/membership/resolver.go
+++ b/common/membership/resolver.go
@@ -98,7 +98,11 @@ func NewResolver(
 	logger log.Logger,
 	metrics metrics.Client,
 ) (*MultiringResolver, error) {
-	return NewMultiringResolver(service.List, provider, logger.WithTags(tag.ComponentServiceResolver), metrics), nil
+	return NewMultiringResolver([]string{
+		// these are the sharded services
+		service.Matching,
+		service.History,
+	}, provider, logger.WithTags(tag.ComponentServiceResolver), metrics), nil
 }
 
 // NewMultiringResolver creates hashrings for all services


### PR DESCRIPTION
Removes the use of use of hashring for frontend, workers and shard manager

<!-- Describe what has changed in this PR -->
**What changed?**

This removes rings for everything except matching and history.


<!-- Tell your future self why have you made these changes -->
**Why?**
It's currently breaking startup under our config, expecting the shard-manager service to be started up.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
