### PR TITLE
Turns out I was wrong, we need these

### DIFF
--- a/common/membership/resolver.go
+++ b/common/membership/resolver.go
@@ -99,7 +99,8 @@ func NewResolver(
 	metrics metrics.Client,
 ) (*MultiringResolver, error) {
 	return NewMultiringResolver([]string{
-		// these are the sharded services
+		service.Frontend,
+		service.Worker,
 		service.Matching,
 		service.History,
 	}, provider, logger.WithTags(tag.ComponentServiceResolver), metrics), nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Corrects an earlier PR removing these (mistakenly). I wasn't aware of some of the less obvious use-cases for the hashring. 

<!-- Tell your future self why have you made these changes -->
**Why?**

@Shaddoll  is catching my mistakes:
> I think workers probably need them
> the domain metadata replication is sharded
> frontend uses hashring to get the number of hosts
> (which is used by old rate limiter)

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
