### PR TITLE
Added a mode tag to the workflow ID ratelimit metric and log

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -438,6 +438,11 @@ func Name(k string) Tag {
 	return newStringTag("name", k)
 }
 
+// Mode returns tag for Mode
+func Mode(mode string) Tag {
+	return newStringTag("mode", mode)
+}
+
 // Value returns tag for Value
 func Value(v interface{}) Tag {
 	return newObjectTag("value", v)

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -64,6 +64,7 @@ const (
 	workflowCloseStatus       = "workflow_close_status"
 	isolationEnabled          = "isolation_enabled"
 	topic                     = "topic"
+	mode                      = "mode"
 
 	// limiter-side tags
 	globalRatelimitKey            = "global_ratelimit_key"
@@ -322,4 +323,8 @@ func IsolationEnabledTag(enabled bool) Tag {
 
 func TopicTag(value string) Tag {
 	return metricWithUnknown(topic, value)
+}
+
+func ModeTag(value string) Tag {
+	return metricWithUnknown(mode, value)
 }

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -110,6 +110,8 @@ func (s *Service) Start() {
 		DomainCache:                    s.Resource.GetDomainCache(),
 		Logger:                         s.Resource.GetLogger(),
 		MetricsClient:                  s.Resource.GetMetricsClient(),
+		RatelimitExternalPerWorkflowID: s.config.WorkflowIDCacheExternalEnabled,
+		RatelimitInternalPerWorkflowID: s.config.WorkflowIDCacheInternalEnabled,
 	})
 
 	rawHandler := handler.NewHandler(s.Resource, s.config, wfIDCache, s.config.WorkflowIDInternalRateLimitEnabled)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added tag to logs and metrics describing the mode of the ratelimiting


<!-- Tell your future self why have you made these changes -->
**Why?**
We can then e.g. find all domains that were _acctually_ ratelimited. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Should just be a metric/log change, so should be low risk

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
