### PR TITLE
[Wf-Diagnostics] add timeout error to failures

### DIFF
--- a/service/worker/diagnostics/invariant/failure/failure.go
+++ b/service/worker/diagnostics/invariant/failure/failure.go
@@ -84,6 +84,9 @@ func errorTypeFromReason(reason string) ErrorType {
 	if strings.Contains(reason, "Panic") {
 		return PanicError
 	}
+	if strings.Contains(reason, "Timeout") {
+		return TimeoutError
+	}
 	return CustomError
 }
 

--- a/service/worker/diagnostics/invariant/failure/failure_test.go
+++ b/service/worker/diagnostics/invariant/failure/failure_test.go
@@ -71,7 +71,7 @@ func Test__Check(t *testing.T) {
 				},
 				{
 					InvariantType: WorkflowFailed.String(),
-					Reason:        CustomError.String(),
+					Reason:        TimeoutError.String(),
 					Metadata:      metadataInBytes,
 				},
 			},
@@ -123,7 +123,7 @@ func failedWfHistory() *types.GetWorkflowExecutionHistoryResponse {
 				},
 				{
 					WorkflowExecutionFailedEventAttributes: &types.WorkflowExecutionFailedEventAttributes{
-						Reason:                       common.StringPtr("custom error"),
+						Reason:                       common.StringPtr("cadenceInternal:Timeout START_TO_CLOSE"),
 						Details:                      []byte("test-activity-failure"),
 						DecisionTaskCompletedEventID: 10,
 					},

--- a/service/worker/diagnostics/invariant/failure/types.go
+++ b/service/worker/diagnostics/invariant/failure/types.go
@@ -28,6 +28,7 @@ const (
 	CustomError  ErrorType = "The failure is caused by a specific custom error returned from the service code"
 	GenericError ErrorType = "The failure is because of an error returned from the service code"
 	PanicError   ErrorType = "The failure is caused by a panic in the service code"
+	TimeoutError ErrorType = "The failure is caused by a timeout during the execution"
 )
 
 func (e ErrorType) String() string {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
add timeout error to failures

<!-- Tell your future self why have you made these changes -->
**Why?**
when an activity times out and as a result, a workflow fails, it throws a timeout error which is not the same as workflow timeout 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
