### PR TITLE
Add tests for types/mapper/thrift/admin.go

### DIFF
--- a/common/types/mapper/thrift/admin_test.go
+++ b/common/types/mapper/thrift/admin_test.go
@@ -31,7 +31,228 @@ import (
 	"github.com/uber/cadence/.gen/go/admin"
 	"github.com/uber/cadence/.gen/go/shared"
 	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/common/types/testdata"
 )
+
+func TestAdminAddSearchAttributeRequest(t *testing.T) {
+	for _, item := range []*types.AddSearchAttributeRequest{nil, {}, &testdata.AdminAddSearchAttributeRequest} {
+		assert.Equal(t, item, ToAdminAddSearchAttributeRequest(FromAdminAddSearchAttributeRequest(item)))
+	}
+}
+func TestAdminCloseShardRequest(t *testing.T) {
+	for _, item := range []*types.CloseShardRequest{nil, {}, &testdata.AdminCloseShardRequest} {
+		assert.Equal(t, item, ToAdminCloseShardRequest(FromAdminCloseShardRequest(item)))
+	}
+}
+func TestAdminDeleteWorkflowRequest(t *testing.T) {
+	for _, item := range []*types.AdminDeleteWorkflowRequest{nil, {}, &testdata.AdminDeleteWorkflowRequest} {
+		assert.Equal(t, item, ToAdminDeleteWorkflowRequest(FromAdminDeleteWorkflowRequest(item)))
+	}
+}
+func TestAdminDeleteWorkflowResponse(t *testing.T) {
+	for _, item := range []*types.AdminDeleteWorkflowResponse{nil, {}, &testdata.AdminDeleteWorkflowResponse} {
+		assert.Equal(t, item, ToAdminDeleteWorkflowResponse(FromAdminDeleteWorkflowResponse(item)))
+	}
+}
+func TestAdminDescribeClusterResponse(t *testing.T) {
+	for _, item := range []*types.DescribeClusterResponse{nil, {}, &testdata.AdminDescribeClusterResponse} {
+		assert.Equal(t, item, ToAdminDescribeClusterResponse(FromAdminDescribeClusterResponse(item)))
+	}
+}
+func TestAdminDescribeHistoryHostRequest(t *testing.T) {
+	for _, item := range []*types.DescribeHistoryHostRequest{
+		nil,
+		&testdata.AdminDescribeHistoryHostRequest_ByHost,
+		&testdata.AdminDescribeHistoryHostRequest_ByShard,
+		&testdata.AdminDescribeHistoryHostRequest_ByExecution,
+	} {
+		assert.Equal(t, item, ToAdminDescribeHistoryHostRequest(FromAdminDescribeHistoryHostRequest(item)))
+	}
+}
+func TestAdminDescribeHistoryHostResponse(t *testing.T) {
+	for _, item := range []*types.DescribeHistoryHostResponse{nil, {}, &testdata.AdminDescribeHistoryHostResponse} {
+		assert.Equal(t, item, ToAdminDescribeHistoryHostResponse(FromAdminDescribeHistoryHostResponse(item)))
+	}
+}
+func TestAdminDescribeQueueRequest(t *testing.T) {
+	for _, item := range []*types.DescribeQueueRequest{nil, {}, &testdata.AdminDescribeQueueRequest} {
+		assert.Equal(t, item, ToAdminDescribeQueueRequest(FromAdminDescribeQueueRequest(item)))
+	}
+}
+func TestAdminDescribeQueueResponse(t *testing.T) {
+	for _, item := range []*types.DescribeQueueResponse{nil, {}, &testdata.AdminDescribeQueueResponse} {
+		assert.Equal(t, item, ToAdminDescribeQueueResponse(FromAdminDescribeQueueResponse(item)))
+	}
+}
+func TestAdminDescribeShardDistributionRequest(t *testing.T) {
+	for _, item := range []*types.DescribeShardDistributionRequest{nil, {}, &testdata.AdminDescribeShardDistributionRequest} {
+		assert.Equal(t, item, ToAdminDescribeShardDistributionRequest(FromAdminDescribeShardDistributionRequest(item)))
+	}
+}
+func TestAdminDescribeShardDistributionResponse(t *testing.T) {
+	for _, item := range []*types.DescribeShardDistributionResponse{nil, {}, &testdata.AdminDescribeShardDistributionResponse} {
+		assert.Equal(t, item, ToAdminDescribeShardDistributionResponse(FromAdminDescribeShardDistributionResponse(item)))
+	}
+}
+func TestAdminDescribeWorkflowExecutionRequest(t *testing.T) {
+	for _, item := range []*types.AdminDescribeWorkflowExecutionRequest{nil, {}, &testdata.AdminDescribeWorkflowExecutionRequest} {
+		assert.Equal(t, item, ToAdminDescribeWorkflowExecutionRequest(FromAdminDescribeWorkflowExecutionRequest(item)))
+	}
+}
+func TestAdminDescribeWorkflowExecutionResponse(t *testing.T) {
+	for _, item := range []*types.AdminDescribeWorkflowExecutionResponse{nil, {ShardID: "0"}, &testdata.AdminDescribeWorkflowExecutionResponse} {
+		assert.Equal(t, item, ToAdminDescribeWorkflowExecutionResponse(FromAdminDescribeWorkflowExecutionResponse(item)))
+	}
+}
+func TestAdminGetDomainIsolationGroupsRequest(t *testing.T) {
+	for _, item := range []*types.GetDomainIsolationGroupsRequest{nil, {}, &testdata.AdminGetDomainIsolationGroupsRequest} {
+		assert.Equal(t, item, ToAdminGetDomainIsolationGroupsRequest(FromAdminGetDomainIsolationGroupsRequest(item)))
+	}
+}
+func TestAdminGetDomainIsolationGroupsResponse(t *testing.T) {
+	for _, item := range []*types.GetDomainIsolationGroupsResponse{nil, {}, &testdata.AdminGetDomainIsolationGroupsResponse} {
+		assert.Equal(t, item, ToAdminGetDomainIsolationGroupsResponse(FromAdminGetDomainIsolationGroupsResponse(item)))
+	}
+}
+func TestAdminGetDomainReplicationMessagesRequest(t *testing.T) {
+	for _, item := range []*types.GetDomainReplicationMessagesRequest{nil, {}, &testdata.AdminGetDomainReplicationMessagesRequest} {
+		assert.Equal(t, item, ToAdminGetDomainReplicationMessagesRequest(FromAdminGetDomainReplicationMessagesRequest(item)))
+	}
+}
+func TestAdminGetDomainReplicationMessagesResponse(t *testing.T) {
+	for _, item := range []*types.GetDomainReplicationMessagesResponse{nil, {}, &testdata.AdminGetDomainReplicationMessagesResponse} {
+		assert.Equal(t, item, ToAdminGetDomainReplicationMessagesResponse(FromAdminGetDomainReplicationMessagesResponse(item)))
+	}
+}
+func TestAdminGetDynamicConfigRequest(t *testing.T) {
+	for _, item := range []*types.GetDynamicConfigRequest{nil, {}, &testdata.AdminGetDynamicConfigRequest} {
+		assert.Equal(t, item, ToAdminGetDynamicConfigRequest(FromAdminGetDynamicConfigRequest(item)))
+	}
+}
+func TestAdminGetDynamicConfigResponse(t *testing.T) {
+	for _, item := range []*types.GetDynamicConfigResponse{nil, {}, &testdata.AdminGetDynamicConfigResponse} {
+		assert.Equal(t, item, ToAdminGetDynamicConfigResponse(FromAdminGetDynamicConfigResponse(item)))
+	}
+}
+func TestAdminGetGlobalIsolationGroupsRequest(t *testing.T) {
+	for _, item := range []*types.GetGlobalIsolationGroupsRequest{nil, {}, &testdata.AdminGetGlobalIsolationGroupsRequest} {
+		assert.Equal(t, item, ToAdminGetGlobalIsolationGroupsRequest(FromAdminGetGlobalIsolationGroupsRequest(item)))
+	}
+}
+func TestAdminGetReplicationMessagesRequest(t *testing.T) {
+	for _, item := range []*types.GetReplicationMessagesRequest{nil, {}, &testdata.AdminGetReplicationMessagesRequest} {
+		assert.Equal(t, item, ToAdminGetReplicationMessagesRequest(FromAdminGetReplicationMessagesRequest(item)))
+	}
+}
+func TestAdminGetReplicationMessagesResponse(t *testing.T) {
+	for _, item := range []*types.GetReplicationMessagesResponse{nil, {}, &testdata.AdminGetReplicationMessagesResponse} {
+		assert.Equal(t, item, ToAdminGetReplicationMessagesResponse(FromAdminGetReplicationMessagesResponse(item)))
+	}
+}
+func TestAdminGetWorkflowExecutionRawHistoryV2Request(t *testing.T) {
+	for _, item := range []*types.GetWorkflowExecutionRawHistoryV2Request{nil, {}, &testdata.AdminGetWorkflowExecutionRawHistoryV2Request} {
+		assert.Equal(t, item, ToAdminGetWorkflowExecutionRawHistoryV2Request(FromAdminGetWorkflowExecutionRawHistoryV2Request(item)))
+	}
+}
+func TestAdminGetWorkflowExecutionRawHistoryV2Response(t *testing.T) {
+	for _, item := range []*types.GetWorkflowExecutionRawHistoryV2Response{nil, {}, &testdata.AdminGetWorkflowExecutionRawHistoryV2Response} {
+		assert.Equal(t, item, ToAdminGetWorkflowExecutionRawHistoryV2Response(FromAdminGetWorkflowExecutionRawHistoryV2Response(item)))
+	}
+}
+func TestAdminListDynamicConfigRequest(t *testing.T) {
+	for _, item := range []*types.ListDynamicConfigRequest{nil, {}, &testdata.AdminListDynamicConfigRequest} {
+		assert.Equal(t, item, ToAdminListDynamicConfigRequest(FromAdminListDynamicConfigRequest(item)))
+	}
+}
+func TestAdminListDynamicConfigResponse(t *testing.T) {
+	for _, item := range []*types.ListDynamicConfigResponse{nil, {}, &testdata.AdminListDynamicConfigResponse} {
+		assert.Equal(t, item, ToAdminListDynamicConfigResponse(FromAdminListDynamicConfigResponse(item)))
+	}
+}
+func TestAdminMaintainCorruptWorkflowRequest(t *testing.T) {
+	for _, item := range []*types.AdminMaintainWorkflowRequest{nil, {}, &testdata.AdminMaintainCorruptWorkflowRequest} {
+		assert.Equal(t, item, ToAdminMaintainCorruptWorkflowRequest(FromAdminMaintainCorruptWorkflowRequest(item)))
+	}
+}
+func TestAdminMaintainCorruptWorkflowResponse(t *testing.T) {
+	for _, item := range []*types.AdminMaintainWorkflowResponse{nil, {}, &testdata.AdminMaintainCorruptWorkflowResponse} {
+		assert.Equal(t, item, ToAdminMaintainCorruptWorkflowResponse(FromAdminMaintainCorruptWorkflowResponse(item)))
+	}
+}
+func TestAdminReapplyEventsRequest(t *testing.T) {
+	for _, item := range []*types.ReapplyEventsRequest{nil, {}, &testdata.AdminReapplyEventsRequest} {
+		assert.Equal(t, item, ToAdminReapplyEventsRequest(FromAdminReapplyEventsRequest(item)))
+	}
+}
+func TestAdminRefreshWorkflowTasksRequest(t *testing.T) {
+	for _, item := range []*types.RefreshWorkflowTasksRequest{nil, {}, &testdata.AdminRefreshWorkflowTasksRequest} {
+		assert.Equal(t, item, ToAdminRefreshWorkflowTasksRequest(FromAdminRefreshWorkflowTasksRequest(item)))
+	}
+}
+func TestAdminRemoveTaskRequest(t *testing.T) {
+	for _, item := range []*types.RemoveTaskRequest{nil, {}, &testdata.AdminRemoveTaskRequest} {
+		assert.Equal(t, item, ToAdminRemoveTaskRequest(FromAdminRemoveTaskRequest(item)))
+	}
+}
+func TestAdminResendReplicationTasksRequest(t *testing.T) {
+	for _, item := range []*types.ResendReplicationTasksRequest{nil, {}, &testdata.AdminResendReplicationTasksRequest} {
+		assert.Equal(t, item, ToAdminResendReplicationTasksRequest(FromAdminResendReplicationTasksRequest(item)))
+	}
+}
+func TestAdminResetQueueRequest(t *testing.T) {
+	for _, item := range []*types.ResetQueueRequest{nil, {}, &testdata.AdminResetQueueRequest} {
+		assert.Equal(t, item, ToAdminResetQueueRequest(FromAdminResetQueueRequest(item)))
+	}
+}
+
+func TestAdminGetCrossClusterTasksRequest(t *testing.T) {
+	for _, item := range []*types.GetCrossClusterTasksRequest{nil, {}, &testdata.AdminGetCrossClusterTasksRequest} {
+		assert.Equal(t, item, ToAdminGetCrossClusterTasksRequest(FromAdminGetCrossClusterTasksRequest(item)))
+	}
+}
+
+func TestAdminGetCrossClusterTasksResponse(t *testing.T) {
+	for _, item := range []*types.GetCrossClusterTasksResponse{nil, {}, &testdata.AdminGetCrossClusterTasksResponse} {
+		assert.Equal(t, item, ToAdminGetCrossClusterTasksResponse(FromAdminGetCrossClusterTasksResponse(item)))
+	}
+}
+
+func TestAdminRespondCrossClusterTasksCompletedRequest(t *testing.T) {
+	for _, item := range []*types.RespondCrossClusterTasksCompletedRequest{nil, {}, &testdata.AdminRespondCrossClusterTasksCompletedRequest} {
+		assert.Equal(t, item, ToAdminRespondCrossClusterTasksCompletedRequest(FromAdminRespondCrossClusterTasksCompletedRequest(item)))
+	}
+}
+
+func TestAdminRespondCrossClusterTasksCompletedResponse(t *testing.T) {
+	for _, item := range []*types.RespondCrossClusterTasksCompletedResponse{nil, {}, &testdata.AdminRespondCrossClusterTasksCompletedResponse} {
+		assert.Equal(t, item, ToAdminRespondCrossClusterTasksCompletedResponse(FromAdminRespondCrossClusterTasksCompletedResponse(item)))
+	}
+}
+func TestAdminUpdateDomainIsolationGroupsRequest(t *testing.T) {
+	for _, item := range []*types.UpdateDomainIsolationGroupsRequest{nil, {}, &testdata.AdminUpdateDomainIsolationGroupsRequest} {
+		assert.Equal(t, item, ToAdminUpdateDomainIsolationGroupsRequest(FromAdminUpdateDomainIsolationGroupsRequest(item)))
+	}
+}
+func TestAdminUpdateDomainIsolationGroupsResponse(t *testing.T) {
+	for _, item := range []*types.UpdateDomainIsolationGroupsResponse{nil, {}, &testdata.AdminUpdateDomainIsolationGroupsResponse} {
+		assert.Equal(t, item, ToAdminUpdateDomainIsolationGroupsResponse(FromAdminUpdateDomainIsolationGroupsResponse(item)))
+	}
+}
+func TestAdminRestoreDynamicConfigRequest(t *testing.T) {
+	for _, item := range []*types.RestoreDynamicConfigRequest{nil, {}, &testdata.AdminRestoreDynamicConfigRequest} {
+		assert.Equal(t, item, ToAdminRestoreDynamicConfigRequest(FromAdminRestoreDynamicConfigRequest(item)))
+	}
+}
+func TestAdminUpdateDynamicConfigRequest(t *testing.T) {
+	for _, item := range []*types.UpdateDynamicConfigRequest{nil, {}, &testdata.AdminUpdateDynamicConfigRequest} {
+		assert.Equal(t, item, ToAdminUpdateDynamicConfigRequest(FromAdminUpdateDynamicConfigRequest(item)))
+	}
+}
+func TestAdminUpdateGlobalIsolationGroupsResponse(t *testing.T) {
+	for _, item := range []*types.UpdateGlobalIsolationGroupsResponse{nil, {}, &testdata.AdminUpdateGlobalIsolationGroupsResponse} {
+		assert.Equal(t, item, ToAdminUpdateGlobalIsolationGroupsResponse(FromAdminUpdateGlobalIsolationGroupsResponse(item)))
+	}
+}
 
 func TestFromGetGlobalIsolationGroupsResponse(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add unit tests for types/mapper/thrift/admin.go . This is mostly just a copy+paste of the unit tests I previously wrote for the proto mappers. Since they round trip from the internal types and have functions with the same name they work out perfectly.

<!-- Tell your future self why have you made these changes -->
**Why?**
- Increase unit test coverage

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Running unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
