### PR TITLE
[Wf-Diagnostics] Point to activity task for activity failures

### DIFF
--- a/service/worker/diagnostics/invariant/failure/types.go
+++ b/service/worker/diagnostics/invariant/failure/types.go
@@ -22,6 +22,8 @@
 
 package failure
 
+import "github.com/uber/cadence/common/types"
+
 type ErrorType string
 
 const (
@@ -47,5 +49,7 @@ func (f FailureType) String() string {
 }
 
 type failureMetadata struct {
-	Identity string
+	Identity          string
+	ActivityScheduled *types.ActivityTaskScheduledEventAttributes
+	ActivityStarted   *types.ActivityTaskStartedEventAttributes
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Failure metadata has details on activity task scheduled and started event attributes

<!-- Tell your future self why have you made these changes -->
**Why?**
To provide more info on the activity that failed

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
