### PR TITLE
Current refresh interval is too high

### DIFF
--- a/common/membership/hashring.go
+++ b/common/membership/hashring.go
@@ -47,8 +47,8 @@ import (
 var ErrInsufficientHosts = &types.InternalServiceError{Message: "Not enough hosts to serve the request"}
 
 const (
-	minRefreshInternal     = time.Second * 4
-	defaultRefreshInterval = time.Second * 10
+	minRefreshInternal     = time.Second
+	defaultRefreshInterval = 2 * time.Second
 	replicaPoints          = 100
 )
 


### PR DESCRIPTION
There is no need to keep it is 10 seconds as we are requesting internal
state of ringpop/uns any way.

<!-- Describe what has changed in this PR -->
Decreased refresh intervla

<!-- Tell your future self why have you made these changes -->
Having them 2 seconds for throttle and 10s for full refresh is too much as we deal with just 3-4 of them in every cadence process.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
