### PR TITLE
[Wf-Diagnostics] add cancellation request to failure invariant checks

### DIFF
--- a/service/worker/diagnostics/invariant/failure/types.go
+++ b/service/worker/diagnostics/invariant/failure/types.go
@@ -27,10 +27,11 @@ import "github.com/uber/cadence/common/types"
 type ErrorType string
 
 const (
-	CustomError  ErrorType = "The failure is caused by a specific custom error returned from the service code"
-	GenericError ErrorType = "The failure is because of an error returned from the service code"
-	PanicError   ErrorType = "The failure is caused by a panic in the service code"
-	TimeoutError ErrorType = "The failure is caused by a timeout during the execution"
+	CustomError    ErrorType = "The failure is caused by a specific custom error returned from the service code"
+	GenericError   ErrorType = "The failure is because of an error returned from the service code"
+	PanicError     ErrorType = "The failure is caused by a panic in the service code"
+	CancelledError ErrorType = "The failure is caused by context cancellation"
+	TimeoutError   ErrorType = "The failure is caused by a timeout during the execution"
 )
 
 func (e ErrorType) String() string {
@@ -49,7 +50,9 @@ func (f FailureType) String() string {
 }
 
 type failureMetadata struct {
-	Identity          string
-	ActivityScheduled *types.ActivityTaskScheduledEventAttributes
-	ActivityStarted   *types.ActivityTaskStartedEventAttributes
+	Identity              string
+	ActivityScheduled     *types.ActivityTaskScheduledEventAttributes
+	ActivityStarted       *types.ActivityTaskStartedEventAttributes
+	ActivityCancellations []*types.ActivityTaskCancelRequestedEventAttributes
+	WorkflowCancellations []*types.WorkflowExecutionCancelRequestedEventAttributes
 }

--- a/service/worker/diagnostics/invariant/interface.go
+++ b/service/worker/diagnostics/invariant/interface.go
@@ -48,6 +48,7 @@ const (
 	RootCauseTypeHeartBeatingNotEnabled              RootCause = "HeartBeating not enabled for activity"
 	RootCauseTypeHeartBeatingEnabledMissingHeartbeat RootCause = "HeartBeating enabled for activity but timed out due to missing heartbeat"
 	RootCauseTypeServiceSideIssue                    RootCause = "There is an issue in the worker service code that is causing this failure. Check identity for service logs"
+	RootCauseTypeCancellation                        RootCause = "Cancellation was requested within the execution"
 )
 
 func (r RootCause) String() string {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
cancellation related failures and data is added to failure invariant

<!-- Tell your future self why have you made these changes -->
**Why?**
activity failures and workflow failures can be caused by cancellation requests made within the workflow itself

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
