### PR TITLE
[CLI] fix incorrect propagation of span context in start workflow

### DIFF
--- a/tools/cli/workflow_commands_test.go
+++ b/tools/cli/workflow_commands_test.go
@@ -92,7 +92,8 @@ func TestConstructStartWorkflowRequest(t *testing.T) {
 	assert.NotNil(t, request.WorkflowIDReusePolicy)
 	assert.Equal(t, int32(5), *request.DelayStartSeconds)
 	assert.Equal(t, int32(2), *request.JitterStartSeconds)
-	assert.Equal(t, map[string][]byte{"tracer-test-key": []byte("tracer-test-value")}, request.Header.Fields)
+	assert.Contains(t, request.Header.Fields, "mockpfx-baggage-tracer-test-key")
+	assert.Equal(t, []byte("tracer-test-value"), request.Header.Fields["mockpfx-baggage-tracer-test-key"])
 
 	firstRunAt, err := time.Parse(time.RFC3339, "2024-07-24T12:00:00Z")
 	assert.NoError(t, err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

* Use Tracer inject API to correctly pass span context  

<!-- Tell your future self why have you made these changes -->
**Why?**

Simply passing baggage key/values won't work. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
