### PR TITLE
Fix backlog count for sticky tasklist

### DIFF
--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -378,9 +378,11 @@ func (c *taskListManagerImpl) GetTask(
 	// here λ is the QPS and W is the average match latency which is 10ms
 	// so the backlog hint should be backlog count + L.
 	smoothingNumber := int64(0)
-	qps := c.qpsTracker.QPS()
-	if qps > 0.01 {
-		smoothingNumber = int64(math.Ceil(qps * 0.01))
+	if c.taskListKind != types.TaskListKindSticky {
+		qps := c.qpsTracker.QPS()
+		if qps > 0.01 {
+			smoothingNumber = int64(math.Ceil(qps * 0.01))
+		}
 	}
 	task.BacklogCountHint = c.taskAckManager.GetBacklogCount() + smoothingNumber
 	return task, nil


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Do not adding smoothing number to backlog count hint for sticky tasklists

<!-- Tell your future self why have you made these changes -->
**Why?**
There is a "bug"(?) in Go SDK that make pollers to poll sticky tasklists if the backlog size is not 0. As a result, without this fix, pollers using Go SDK will always poll sticky tasklists and have no chance to poll normal decision tasklists.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
