### PR TITLE
Fix bug that OpenSearch client not use external version for index requests

### DIFF
--- a/common/elasticsearch/client/os2/client_bulk.go
+++ b/common/elasticsearch/client/os2/client_bulk.go
@@ -80,6 +80,8 @@ func (v *bulkProcessor) Add(request *bulk.GenericBulkableAddRequest) {
 			return
 		}
 		req.Action = "index"
+		req.Version = &request.Version
+		req.VersionType = &request.VersionType
 		req.Body = bytes.NewReader(body)
 		callBackRequest = bulk.NewBulkIndexRequest().
 			ID(request.ID).

--- a/common/elasticsearch/client/os2/client_bulk_test.go
+++ b/common/elasticsearch/client/os2/client_bulk_test.go
@@ -25,6 +25,7 @@ package os2
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"testing"
@@ -32,7 +33,9 @@ import (
 	"github.com/opensearch-project/opensearch-go/v2/opensearchutil"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/uber/cadence/common/elasticsearch/bulk"
+	"github.com/uber/cadence/common/log/testlogger"
 )
 
 func TestStart(t *testing.T) {
@@ -275,4 +278,74 @@ func TestDecode(t *testing.T) {
 // Function to create a sample reader from a string
 func createReaderFromString(s string) io.Reader {
 	return bytes.NewBufferString(s)
+}
+
+// MockProcessor is a mock of the processor that will capture the requests.
+type MockProcessor struct {
+	mock.Mock
+}
+
+func (m *MockProcessor) Add(ctx context.Context, req opensearchutil.BulkIndexerItem) error {
+	args := m.Called(ctx, req)
+	return args.Error(0)
+}
+
+func (m *MockProcessor) Close(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockProcessor) Stats() opensearchutil.BulkIndexerStats {
+	args := m.Called()
+	return args.Get(0).(opensearchutil.BulkIndexerStats)
+}
+
+func TestBulkProcessorPayload(t *testing.T) {
+	mockProcessor := new(MockProcessor)
+	logger := testlogger.New(t)
+	v := &bulkProcessor{
+		processor: mockProcessor,
+		logger:    logger,
+	}
+
+	request := &bulk.GenericBulkableAddRequest{
+		Index:       "test-index",
+		ID:          "123",
+		Version:     1,
+		VersionType: "external",
+		RequestType: bulk.BulkableIndexRequest,
+		Doc: map[string]interface{}{
+			"field1": "value1",
+		},
+	}
+
+	expectedBody, err := json.Marshal(request.Doc)
+	assert.NoError(t, err)
+	expectedReq := opensearchutil.BulkIndexerItem{
+		Index:       "test-index",
+		DocumentID:  "123",
+		Action:      "index",
+		Version:     &request.Version,
+		VersionType: &request.VersionType,
+		Body:        bytes.NewReader(expectedBody),
+	}
+
+	mockProcessor.On("Add", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		actualReq := args.Get(1).(opensearchutil.BulkIndexerItem)
+
+		assert.Equal(t, expectedReq.Index, actualReq.Index)
+		assert.Equal(t, expectedReq.DocumentID, actualReq.DocumentID)
+		assert.Equal(t, expectedReq.Action, actualReq.Action)
+		assert.Equal(t, expectedReq.Version, actualReq.Version)
+		assert.Equal(t, expectedReq.VersionType, actualReq.VersionType)
+
+		var expectedDoc, actualDoc map[string]interface{}
+		assert.NoError(t, json.NewDecoder(expectedReq.Body).Decode(&expectedDoc))
+		assert.NoError(t, json.NewDecoder(actualReq.Body).Decode(&actualDoc))
+		assert.Equal(t, expectedDoc, actualDoc)
+
+	}).Return(nil)
+
+	v.Add(request)
+	mockProcessor.AssertExpectations(t)
 }

--- a/common/elasticsearch/client/os2/client_bulk_test.go
+++ b/common/elasticsearch/client/os2/client_bulk_test.go
@@ -32,8 +32,8 @@ import (
 
 	"github.com/opensearch-project/opensearch-go/v2/opensearchutil"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/stretchr/testify/mock"
+
 	"github.com/uber/cadence/common/elasticsearch/bulk"
 	"github.com/uber/cadence/common/log/testlogger"
 )

--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -269,7 +269,7 @@ func (p *ESProcessorImpl) shadowBulkAfterAction(id int64, requests []bulk.Generi
 		return
 	}
 	responseItems := response.Items
-	for i := 0; i < len(requests); i++ {
+	for i := 0; i < len(requests) && i < len(responseItems); i++ {
 		key := p.retrieveKafkaKey(requests[i])
 		if key == "" {
 			continue

--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -275,8 +275,8 @@ func (p *ESProcessorImpl) shadowBulkAfterAction(id int64, requests []bulk.Generi
 			continue
 		}
 		responseItem := responseItems[i]
-		//Tt is possible for err to be nil while the responses in response.Items might still contain errors or unsuccessful statuses for individual requests.
-		//This is because the err variable refers to the overall bulk request operation, but each individual request in the bulk operation has its own status code.
+		// It is possible for err to be nil while the responses in response.Items might still contain errors or unsuccessful statuses for individual requests.
+		// This is because the err variable refers to the overall bulk request operation, but each individual request in the bulk operation has its own status code.
 		for _, resp := range responseItem {
 			if !isResponseSuccess(resp.Status) {
 				wid, rid, domainID := p.getMsgWithInfo(key)

--- a/service/worker/indexer/esProcessor.go
+++ b/service/worker/indexer/esProcessor.go
@@ -269,14 +269,14 @@ func (p *ESProcessorImpl) shadowBulkAfterAction(id int64, requests []bulk.Generi
 		return
 	}
 	responseItems := response.Items
-	for i := 0; i < len(requests) && i < len(responseItems); i++ {
+	for i := 0; i < len(requests); i++ {
 		key := p.retrieveKafkaKey(requests[i])
 		if key == "" {
 			continue
 		}
 		responseItem := responseItems[i]
-		// It is possible for err to be nil while the responses in response.Items might still contain errors or unsuccessful statuses for individual requests.
-		// This is because the err variable refers to the overall bulk request operation, but each individual request in the bulk operation has its own status code.
+		//Tt is possible for err to be nil while the responses in response.Items might still contain errors or unsuccessful statuses for individual requests.
+		//This is because the err variable refers to the overall bulk request operation, but each individual request in the bulk operation has its own status code.
 		for _, resp := range responseItem {
 			if !isResponseSuccess(resp.Status) {
 				wid, rid, domainID := p.getMsgWithInfo(key)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
It is causing issue when reindexed from ElasticSearch during migration since the version is not respected

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
