### PR TITLE
Fix a bug where an error is improperly returned and add unit test for workflow_commands

### DIFF
--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -1079,7 +1079,9 @@ func describeWorkflowHelper(c *cli.Context, wid, rid string) error {
 		o = resp
 	} else {
 		o, err = convertDescribeWorkflowExecutionResponse(resp, frontendClient, c)
-		return commoncli.Problem("WF helper describe failed: ", err)
+		if err != nil {
+			return commoncli.Problem("WF helper describe failed: ", err)
+		}
 	}
 
 	prettyPrintJSONObject(o)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix a bug where an error is improperly returned, it is returning error even err is nil
Add more unit test for PrintAutoResetPoints, DescribeWorkflow, DescribeWorkflowWithID, ListAllWorkflow, ConvertSearchAttributeToMapOfInterface and GetAllWorkflowIDsByQuery, GetWorkflowStatus

<!-- Tell your future self why have you made these changes -->
**Why?**
Increase test coverage

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
