### PR TITLE
Remove global domain checks and add unit test in isolation-groups

### DIFF
--- a/tools/cli/isolation-groups.go
+++ b/tools/cli/isolation-groups.go
@@ -72,7 +72,6 @@ func AdminUpdateGlobalIsolationGroups(c *cli.Context) error {
 	}
 	err = validateIsolationGroupUpdateArgs(
 		c.String(FlagDomain),
-		c.String(FlagDomain),
 		c.StringSlice(FlagIsolationGroupSetDrains),
 		c.String(FlagJSON),
 		c.Bool(FlagIsolationGroupsRemoveAllDrains),
@@ -140,7 +139,6 @@ func AdminUpdateDomainIsolationGroups(c *cli.Context) error {
 
 	err = validateIsolationGroupUpdateArgs(
 		c.String(FlagDomain),
-		c.String(FlagDomain),
 		c.StringSlice(FlagIsolationGroupSetDrains),
 		c.String(FlagJSON),
 		c.Bool(FlagIsolationGroupsRemoveAllDrains),
@@ -179,16 +177,12 @@ func AdminUpdateDomainIsolationGroups(c *cli.Context) error {
 
 func validateIsolationGroupUpdateArgs(
 	domainArgs string,
-	globalDomainArg string,
 	setDrainsArgs []string,
 	jsonCfgArgs string,
 	removeAllDrainsArgs bool,
 	requiresDomain bool,
 ) error {
 	if requiresDomain {
-		if globalDomainArg != "" {
-			return fmt.Errorf("the flag '--domain' has to go at the end")
-		}
 		if domainArgs == "" {
 			return fmt.Errorf("the --domain flag is required")
 		}

--- a/tools/cli/isolation_groups_test.go
+++ b/tools/cli/isolation_groups_test.go
@@ -40,7 +40,6 @@ func TestValidateIsolationGroupArgs(t *testing.T) {
 
 	tests := map[string]struct {
 		domainArgs          string
-		globalDomainArg     string
 		setDrainsArgs       []string
 		jsonConfigArgs      string
 		removeAllDrainsArgs bool
@@ -49,45 +48,32 @@ func TestValidateIsolationGroupArgs(t *testing.T) {
 		expectedErr    error
 	}{
 		"valid inputs for doing a drain": {
-			domainArgs:      "some-domain",
-			globalDomainArg: "",
-			setDrainsArgs:   []string{"zone-1", "zone-2"},
-			jsonConfigArgs:  "",
+			domainArgs:     "some-domain",
+			setDrainsArgs:  []string{"zone-1", "zone-2"},
+			jsonConfigArgs: "",
 
 			expectedErr: nil,
 		},
 		"valid json input": {
-			domainArgs:      "some-domain",
-			globalDomainArg: "",
-			setDrainsArgs:   nil,
-			jsonConfigArgs:  "{}",
+			domainArgs:     "some-domain",
+			setDrainsArgs:  nil,
+			jsonConfigArgs: "{}",
 
 			expectedErr: nil,
 		},
 		"invalid - no domain": {
-			domainArgs:      "",
-			globalDomainArg: "",
-			setDrainsArgs:   nil,
-			jsonConfigArgs:  "{}",
-			requiresDomain:  true,
+			domainArgs:     "",
+			setDrainsArgs:  nil,
+			jsonConfigArgs: "{}",
+			requiresDomain: true,
 
 			expectedErr: errors.New("the --domain flag is required"),
 		},
-		"invalid - global domain": {
-			domainArgs:      "",
-			globalDomainArg: "second domain",
-			setDrainsArgs:   nil,
-			jsonConfigArgs:  "{}",
-			requiresDomain:  true,
-
-			expectedErr: errors.New("the flag '--domain' has to go at the end"),
-		},
 		"invalid - no config domain": {
-			domainArgs:      "domain",
-			globalDomainArg: "",
-			setDrainsArgs:   nil,
-			jsonConfigArgs:  "",
-			requiresDomain:  true,
+			domainArgs:     "domain",
+			setDrainsArgs:  nil,
+			jsonConfigArgs: "",
+			requiresDomain: true,
 
 			expectedErr: errors.New("need to specify either \"set-drains\", \"json\" or \"remove-all-drains\" flags"),
 		},
@@ -97,7 +83,6 @@ func TestValidateIsolationGroupArgs(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			assert.Equal(t, td.expectedErr, validateIsolationGroupUpdateArgs(
 				td.domainArgs,
-				td.globalDomainArg,
 				td.setDrainsArgs,
 				td.jsonConfigArgs,
 				td.removeAllDrainsArgs,
@@ -336,6 +321,220 @@ func TestAdminUpdateGlobalIsolationGroups(t *testing.T) {
 
 			// Call the function under test
 			err := AdminUpdateGlobalIsolationGroups(c)
+
+			// Check the expected outcome
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAdminGetDomainIsolationGroups(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// Define table-driven tests
+	tests := []struct {
+		name             string
+		setupMocks       func(*admin.MockClient)
+		expectedError    string
+		flagDomain       string
+		flagFormat       string
+		mockDepsError    error
+		mockContextError error
+	}{
+		{
+			name: "Success with JSON format",
+			setupMocks: func(client *admin.MockClient) {
+				expectedResponse := &types.GetDomainIsolationGroupsResponse{
+					IsolationGroups: types.IsolationGroupConfiguration{
+						"zone-1": {
+							Name:  "zone-1",
+							State: types.IsolationGroupStateHealthy,
+						},
+						"zone-2": {
+							Name:  "zone-2",
+							State: types.IsolationGroupStateDrained,
+						},
+					},
+				}
+				client.EXPECT().
+					GetDomainIsolationGroups(gomock.Any(), gomock.Any()).
+					Return(expectedResponse, nil).
+					Times(1)
+			},
+			expectedError: "",
+			flagDomain:    "test-domain",
+			flagFormat:    "json",
+		},
+		{
+			name: "Success with other format",
+			setupMocks: func(client *admin.MockClient) {
+				expectedResponse := &types.GetDomainIsolationGroupsResponse{
+					IsolationGroups: types.IsolationGroupConfiguration{
+						"zone-1": {
+							Name:  "zone-1",
+							State: types.IsolationGroupStateHealthy,
+						},
+						"zone-2": {
+							Name:  "zone-2",
+							State: types.IsolationGroupStateDrained,
+						},
+					},
+				}
+				client.EXPECT().
+					GetDomainIsolationGroups(gomock.Any(), gomock.Any()).
+					Return(expectedResponse, nil).
+					Times(1)
+			},
+			expectedError: "",
+			flagDomain:    "test-domain",
+			flagFormat:    "else",
+		},
+		{
+			name: "Failed to get domain isolation groups",
+			setupMocks: func(client *admin.MockClient) {
+				client.EXPECT().
+					GetDomainIsolationGroups(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("failed to get isolation-groups")).
+					Times(1)
+			},
+			expectedError: "failed to get isolation-groups",
+			flagDomain:    "test-domain",
+			flagFormat:    "json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock the admin client
+			adminClient := admin.NewMockClient(mockCtrl)
+
+			// Set up mocks for the current test case
+			tt.setupMocks(adminClient)
+
+			// Create mock app with clientFactoryMock, including any deps errors
+			app := NewCliApp(&clientFactoryMock{
+				serverAdminClient: adminClient,
+			})
+
+			// Set up CLI context with flags
+			set := flag.NewFlagSet("test", 0)
+			set.String(FlagDomain, tt.flagDomain, "Domain flag")
+			set.String(FlagFormat, tt.flagFormat, "Format flag")
+			c := cli.NewContext(app, set, nil)
+
+			// Call the function under test
+			err := AdminGetDomainIsolationGroups(c)
+
+			// Check the expected outcome
+			if tt.expectedError != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAdminUpdateDomainIsolationGroups(t *testing.T) {
+	mockCtrl := gomock.NewController(t)
+	defer mockCtrl.Finish()
+
+	// Define table-driven tests
+	tests := []struct {
+		name             string
+		setupMocks       func(*admin.MockClient)
+		expectedError    string
+		flagDomain       string
+		flagJSON         string
+		flagDrains       []string
+		removeAllDrains  bool
+		mockContextError error
+		validationError  error // simulate validation errors
+		parseConfigError error
+	}{
+		{
+			name: "Success",
+			setupMocks: func(client *admin.MockClient) {
+				client.EXPECT().
+					UpdateDomainIsolationGroups(gomock.Any(), gomock.Any()).
+					Return(&types.UpdateDomainIsolationGroupsResponse{}, nil).
+					Times(1)
+			},
+			expectedError:   "",
+			flagDomain:      "test-domain",
+			flagJSON:        `[{"Name": "zone-123", "State": 2}]`,
+			flagDrains:      []string{"zone-1"},
+			removeAllDrains: false,
+		},
+		{
+			name: "Validation error", // This simulates a failure due to invalid arguments
+			setupMocks: func(client *admin.MockClient) {
+				// No call to mock admin client as validation fails
+			},
+			expectedError:   "invalid args:",
+			flagDomain:      "",
+			flagJSON:        "",
+			flagDrains:      []string{},
+			removeAllDrains: false,
+			validationError: fmt.Errorf("the --domain flag is required"), // Simulate validation failure
+		},
+		{
+			name: "Parse config error", // This simulates an error during parsing of the input config
+			setupMocks: func(client *admin.MockClient) {
+				// No call setup for this test case as parsing fails
+			},
+			expectedError:    "failed to parse input:",
+			flagDomain:       "test-domain",
+			flagJSON:         `[{"Name": "zone-123", "State": "123123"}]`,
+			flagDrains:       []string{"zone-1"},
+			removeAllDrains:  false,
+			parseConfigError: fmt.Errorf("config parsing failed"), // Simulate config parsing failure
+		},
+		{
+			name: "Failed to update isolation groups", // This simulates a failure when updating the isolation groups
+			setupMocks: func(client *admin.MockClient) {
+				client.EXPECT().
+					UpdateDomainIsolationGroups(gomock.Any(), gomock.Any()).
+					Return(nil, fmt.Errorf("update failed")).
+					Times(1)
+			},
+			expectedError:   "failed to update isolation-groups",
+			flagDomain:      "test-domain",
+			flagJSON:        `[{"Name": "zone-123", "State": 2}]`,
+			flagDrains:      []string{"zone-1"},
+			removeAllDrains: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Mock the admin client
+			adminClient := admin.NewMockClient(mockCtrl)
+
+			// Set up mocks for the current test case
+			tt.setupMocks(adminClient)
+
+			// Create mock app with clientFactoryMock
+			app := NewCliApp(&clientFactoryMock{
+				serverAdminClient: adminClient,
+			})
+
+			// Set up CLI context with flags
+			set := flag.NewFlagSet("test", 0)
+			set.String(FlagDomain, tt.flagDomain, "Domain flag")
+			set.String(FlagJSON, tt.flagJSON, "JSON flag")
+			set.Bool(FlagIsolationGroupsRemoveAllDrains, tt.removeAllDrains, "RemoveAllDrains flag")
+			c := cli.NewContext(app, set, nil)
+
+			// Call the function under test
+			err := AdminUpdateDomainIsolationGroups(c)
 
 			// Check the expected outcome
 			if tt.expectedError != "" {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Given that GlobalString is being deprecated in V2 [CLI](https://github.com/urfave/cli/blob/main/docs/migrate-v1-to-v2.md#globalstring-globalbool-and-its-likes-are-deprecated), we removed now dysfunction global string check.
We also add unit tests to isolation-groups command

<!-- Tell your future self why have you made these changes -->
**Why?**
Right now due to global string check, the updateIsolationGroup function does not work. We need to remove the check to address this bug.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests,
Also testable by running following commands:
`make bins`
`./cadence  admin isolation-groups get-domain --domain do` this should work
`./cadence --domain balh admin isolation-groups get-domain` this should not work

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
