### PR TITLE
Deprecate unused persistence configs

### DIFF
--- a/common/config/config.go
+++ b/common/config/config.go
@@ -182,6 +182,7 @@ type (
 		AdvancedVisibilityStore string `yaml:"advancedVisibilityStore"`
 		// HistoryMaxConns is the desired number of conns to history store. Value specified
 		// here overrides the MaxConns config specified as part of datastore
+		// Deprecated: This value is not used
 		HistoryMaxConns int `yaml:"historyMaxConns"`
 		// EnablePersistenceLatencyHistogramMetrics is to enable latency histogram metrics for persistence layer
 		EnablePersistenceLatencyHistogramMetrics bool `yaml:"enablePersistenceLatencyHistogramMetrics"`

--- a/common/dynamicconfig/constants.go
+++ b/common/dynamicconfig/constants.go
@@ -657,6 +657,7 @@ const (
 	// Value type: Int
 	// Default value: 10
 	// Allowed filters: N/A
+	// Deprecated: not used
 	FrontendHistoryMgrNumConns
 	// FrontendThrottledLogRPS is the rate limit on number of log messages emitted per second for throttled logger
 	// KeyName: frontend.throttledLogRPS
@@ -1064,12 +1065,14 @@ const (
 	// Value type: Int
 	// Default value: 50
 	// Allowed filters: N/A
+	// Deprecated: not used
 	ExecutionMgrNumConns
 	// HistoryMgrNumConns is persistence connections number for HistoryManager
 	// KeyName: history.historyMgrNumConns
 	// Value type: Int
 	// Default value: 50
 	// Allowed filters: N/A
+	// Deprecated: not used
 	HistoryMgrNumConns
 	// MaximumBufferedEventsBatch is max number of buffer event in mutable state
 	// KeyName: history.maximumBufferedEventsBatch
@@ -3130,7 +3133,7 @@ var IntKeys = map[IntKey]DynamicInt{
 	},
 	FrontendHistoryMgrNumConns: {
 		KeyName:      "frontend.historyMgrNumConns",
-		Description:  "FrontendHistoryMgrNumConns is for persistence cluster.NumConns",
+		Description:  "Deprecated: not used. FrontendHistoryMgrNumConns is for persistence cluster.NumConns",
 		DefaultValue: 10,
 	},
 	FrontendThrottledLogRPS: {
@@ -3479,12 +3482,12 @@ var IntKeys = map[IntKey]DynamicInt{
 	},
 	ExecutionMgrNumConns: {
 		KeyName:      "history.executionMgrNumConns",
-		Description:  "ExecutionMgrNumConns is persistence connections number for ExecutionManager",
+		Description:  "Deprecated: not used. ExecutionMgrNumConns is persistence connections number for ExecutionManager",
 		DefaultValue: 50,
 	},
 	HistoryMgrNumConns: {
 		KeyName:      "history.historyMgrNumConns",
-		Description:  "HistoryMgrNumConns is persistence connections number for HistoryManager",
+		Description:  "Deprecated: not used. HistoryMgrNumConns is persistence connections number for HistoryManager",
 		DefaultValue: 50,
 	},
 	MaximumBufferedEventsBatch: {

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -966,8 +966,6 @@ func (c *cadenceImpl) GetExecutionManagerFactory() persistence.ExecutionManagerF
 }
 
 func (c *cadenceImpl) overrideHistoryDynamicConfig(client *dynamicClient) {
-	client.OverrideValue(dynamicconfig.HistoryMgrNumConns, c.historyConfig.NumHistoryShards)
-	client.OverrideValue(dynamicconfig.ExecutionMgrNumConns, c.historyConfig.NumHistoryShards)
 	client.OverrideValue(dynamicconfig.ReplicationTaskProcessorStartWait, time.Nanosecond)
 
 	if c.workerConfig.EnableIndexer {

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -80,9 +80,6 @@ type Config struct {
 	RequestIDMaxLength    dynamicconfig.IntPropertyFnWithDomainFilter
 	TaskListNameMaxLength dynamicconfig.IntPropertyFnWithDomainFilter
 
-	// Persistence settings
-	HistoryMgrNumConns dynamicconfig.IntPropertyFn
-
 	// security protection settings
 	EnableAdminProtection         dynamicconfig.BoolPropertyFn
 	AdminOperationToken           dynamicconfig.StringPropertyFn
@@ -163,7 +160,6 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		WorkflowTypeMaxLength:                       dc.GetIntPropertyFilteredByDomain(dynamicconfig.WorkflowTypeMaxLength),
 		RequestIDMaxLength:                          dc.GetIntPropertyFilteredByDomain(dynamicconfig.RequestIDMaxLength),
 		TaskListNameMaxLength:                       dc.GetIntPropertyFilteredByDomain(dynamicconfig.TaskListNameMaxLength),
-		HistoryMgrNumConns:                          dc.GetIntProperty(dynamicconfig.FrontendHistoryMgrNumConns),
 		EnableAdminProtection:                       dc.GetBoolProperty(dynamicconfig.EnableAdminProtection),
 		AdminOperationToken:                         dc.GetStringProperty(dynamicconfig.AdminOperationToken),
 		DisableListVisibilityByFilter:               dc.GetBoolPropertyFilteredByDomain(dynamicconfig.DisableListVisibilityByFilter),

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -78,7 +78,6 @@ func NewService(
 		isAdvancedVisExistInConfig,
 		params.HostName,
 	)
-	params.PersistenceConfig.HistoryMaxConns = serviceConfig.HistoryMgrNumConns()
 
 	serviceResource, err := resource.New(
 		params,

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -167,10 +167,6 @@ type Config struct {
 	ReplicatorUpperLatency                 dynamicconfig.DurationPropertyFn
 	ReplicatorCacheCapacity                dynamicconfig.IntPropertyFn
 
-	// Persistence settings
-	ExecutionMgrNumConns dynamicconfig.IntPropertyFn
-	HistoryMgrNumConns   dynamicconfig.IntPropertyFn
-
 	// System Limits
 	MaximumBufferedEventsBatch dynamicconfig.IntPropertyFn
 	MaximumSignalsPerExecution dynamicconfig.IntPropertyFnWithDomainFilter
@@ -451,8 +447,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		ReplicatorUpperLatency:                 dc.GetDurationProperty(dynamicconfig.ReplicatorUpperLatency),
 		ReplicatorCacheCapacity:                dc.GetIntProperty(dynamicconfig.ReplicatorCacheCapacity),
 
-		ExecutionMgrNumConns:            dc.GetIntProperty(dynamicconfig.ExecutionMgrNumConns),
-		HistoryMgrNumConns:              dc.GetIntProperty(dynamicconfig.HistoryMgrNumConns),
 		MaximumBufferedEventsBatch:      dc.GetIntProperty(dynamicconfig.MaximumBufferedEventsBatch),
 		MaximumSignalsPerExecution:      dc.GetIntPropertyFilteredByDomain(dynamicconfig.MaximumSignalsPerExecution),
 		ShardUpdateMinInterval:          dc.GetDurationProperty(dynamicconfig.ShardUpdateMinInterval),

--- a/service/history/service.go
+++ b/service/history/service.go
@@ -70,8 +70,6 @@ func NewService(
 		params.PersistenceConfig.IsAdvancedVisibilityConfigExist(),
 		params.HostName)
 
-	params.PersistenceConfig.HistoryMaxConns = serviceConfig.HistoryMgrNumConns()
-
 	serviceResource, err := resource.New(
 		params,
 		service.History,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Deprecating unused `config` and `dynamic config` keys.

Keeping config struct without changes to allow Cadence upgrade, just in case anyone has this set.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
