### PR TITLE
Update CLI json printing to use new writer interface for testability

### DIFF
--- a/tools/cli/admin_async_queue_commands.go
+++ b/tools/cli/admin_async_queue_commands.go
@@ -63,7 +63,7 @@ func AdminGetAsyncWFConfig(c *cli.Context) error {
 	}
 
 	fmt.Printf("Async workflow queue config for domain %s:\n", domainName)
-	prettyPrintJSONObject(resp.Configuration)
+	prettyPrintJSONObject(getDeps(c).Output(), resp.Configuration)
 	return nil
 }
 

--- a/tools/cli/admin_cluster_commands.go
+++ b/tools/cli/admin_cluster_commands.go
@@ -102,7 +102,7 @@ func AdminDescribeCluster(c *cli.Context) error {
 		return commoncli.Problem("Operation DescribeCluster failed.", err)
 	}
 
-	prettyPrintJSONObject(response)
+	prettyPrintJSONObject(getDeps(c).Output(), response)
 	return nil
 }
 

--- a/tools/cli/admin_commands.go
+++ b/tools/cli/admin_commands.go
@@ -132,7 +132,7 @@ func AdminDescribeWorkflow(c *cli.Context) error {
 	if err != nil {
 		return err
 	}
-	prettyPrintJSONObject(resp)
+	prettyPrintJSONObject(getDeps(c).Output(), resp)
 
 	if resp != nil {
 		msStr := resp.GetMutableStateInDatabase()
@@ -157,13 +157,13 @@ func AdminDescribeWorkflow(c *cli.Context) error {
 		if err != nil {
 			return commoncli.Problem("thriftrwEncoder.Decode err", err)
 		}
-		prettyPrintJSONObject(branchInfo)
+		prettyPrintJSONObject(getDeps(c).Output(), branchInfo)
 		if ms.ExecutionInfo.AutoResetPoints != nil {
-			fmt.Println("auto-reset-points:")
+			getDeps(c).Output().Write([]byte("auto-reset-points:"))
 			for _, p := range ms.ExecutionInfo.AutoResetPoints.Points {
 				createT := time.Unix(0, p.GetCreatedTimeNano())
 				expireT := time.Unix(0, p.GetExpiringTimeNano())
-				fmt.Println(p.GetBinaryChecksum(), p.GetRunID(), p.GetFirstDecisionCompletedID(), p.GetResettable(), createT, expireT)
+				getDeps(c).Output().Write([]byte(fmt.Sprintln(p.GetBinaryChecksum(), p.GetRunID(), p.GetFirstDecisionCompletedID(), p.GetResettable(), createT, expireT)))
 			}
 		}
 	}
@@ -329,7 +329,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 			return commoncli.Problem("thriftrwEncoder.Decode err", err)
 		}
 		fmt.Println("deleting history events for ...")
-		prettyPrintJSONObject(branchInfo)
+		prettyPrintJSONObject(getDeps(c).Output(), branchInfo)
 		err = histV2.DeleteHistoryBranch(ctx, &persistence.DeleteHistoryBranchRequest{
 			BranchToken: branchToken,
 			ShardID:     &shardIDInt,
@@ -497,7 +497,7 @@ func AdminDescribeShard(c *cli.Context) error {
 		return commoncli.Problem("Failed to describe shard.", err)
 	}
 
-	prettyPrintJSONObject(shard)
+	prettyPrintJSONObject(getDeps(c).Output(), shard)
 	return nil
 }
 
@@ -663,7 +663,7 @@ func AdminDescribeHistoryHost(c *cli.Context) error {
 	if !printFully {
 		resp.ShardIDs = nil
 	}
-	prettyPrintJSONObject(resp)
+	prettyPrintJSONObject(getDeps(c).Output(), resp)
 	return nil
 }
 

--- a/tools/cli/admin_config_store_commands.go
+++ b/tools/cli/admin_config_store_commands.go
@@ -88,7 +88,7 @@ func AdminGetDynamicConfig(c *cli.Context) error {
 				}
 				cliEntries = append(cliEntries, cliEntry)
 			}
-			prettyPrintJSONObject(cliEntries)
+			prettyPrintJSONObject(getDeps(c).Output(), cliEntries)
 		}
 	} else {
 		parsedFilters, err := parseInputFilterArray(filters)
@@ -115,7 +115,7 @@ func AdminGetDynamicConfig(c *cli.Context) error {
 		if umVal == nil {
 			fmt.Printf("No values stored for specified dynamic config.\n")
 		} else {
-			prettyPrintJSONObject(umVal)
+			prettyPrintJSONObject(getDeps(c).Output(), umVal)
 		}
 	}
 	return nil
@@ -241,7 +241,7 @@ func AdminListDynamicConfig(c *cli.Context) error {
 			}
 			cliEntries = append(cliEntries, cliEntry)
 		}
-		prettyPrintJSONObject(cliEntries)
+		prettyPrintJSONObject(getDeps(c).Output(), cliEntries)
 	}
 	return nil
 }

--- a/tools/cli/admin_failover_commands.go
+++ b/tools/cli/admin_failover_commands.go
@@ -132,7 +132,7 @@ func AdminFailoverQuery(c *cli.Context) error {
 	if isWorkflowTerminated(descResp) {
 		result.State = failovermanager.WorkflowAborted
 	}
-	prettyPrintJSONObject(result)
+	prettyPrintJSONObject(getDeps(c).Output(), result)
 	return nil
 }
 

--- a/tools/cli/isolation-groups.go
+++ b/tools/cli/isolation-groups.go
@@ -52,9 +52,9 @@ func AdminGetGlobalIsolationGroups(c *cli.Context) error {
 	format := c.String(FlagFormat)
 	switch format {
 	case "json":
-		prettyPrintJSONObject(igs.IsolationGroups.ToPartitionList())
+		prettyPrintJSONObject(getDeps(c).Output(), igs.IsolationGroups.ToPartitionList())
 	default:
-		fmt.Print(renderIsolationGroups(igs.IsolationGroups))
+		getDeps(c).Output().Write(renderIsolationGroups(igs.IsolationGroups))
 	}
 	return nil
 }
@@ -124,9 +124,9 @@ func AdminGetDomainIsolationGroups(c *cli.Context) error {
 	format := c.String(FlagFormat)
 	switch format {
 	case "json":
-		prettyPrintJSONObject(igs.IsolationGroups.ToPartitionList())
+		prettyPrintJSONObject(getDeps(c).Output(), igs.IsolationGroups.ToPartitionList())
 	default:
-		fmt.Print(renderIsolationGroups(igs.IsolationGroups))
+		getDeps(c).Output().Write([]byte(renderIsolationGroups(igs.IsolationGroups)))
 	}
 	return nil
 }
@@ -248,18 +248,18 @@ examples:
 	return &req, nil
 }
 
-func renderIsolationGroups(igs types.IsolationGroupConfiguration) string {
+func renderIsolationGroups(igs types.IsolationGroupConfiguration) []byte {
 	output := &bytes.Buffer{}
 	w := tabwriter.NewWriter(output, 0, 0, 1, ' ', 0)
 	fmt.Fprintln(w, "Isolation Groups\tState")
 	if len(igs) == 0 {
-		return "-- No groups found --\n"
+		return []byte("-- No groups found --\n")
 	}
 	for _, v := range igs.ToPartitionList() {
 		fmt.Fprintf(w, "%s\t%s\n", v.Name, convertIsolationGroupStateToString(v.State))
 	}
 	w.Flush()
-	return output.String()
+	return output.Bytes()
 }
 
 func convertIsolationGroupStateToString(state types.IsolationGroupState) string {

--- a/tools/cli/isolation_groups_test.go
+++ b/tools/cli/isolation_groups_test.go
@@ -190,7 +190,7 @@ zone-4                  Unknown state: 5
 
 	for name, td := range tests {
 		t.Run(name, func(t *testing.T) {
-			assert.Equal(t, td.expectedOutput, renderIsolationGroups(td.input))
+			assert.Equal(t, td.expectedOutput, string(renderIsolationGroups(td.input)))
 		})
 	}
 }

--- a/tools/cli/utils.go
+++ b/tools/cli/utils.go
@@ -480,14 +480,14 @@ func getCurrentUserFromEnv() string {
 	return "unknown"
 }
 
-func prettyPrintJSONObject(o interface{}) {
+func prettyPrintJSONObject(writer io.Writer, o interface{}) {
 	b, err := json.MarshalIndent(o, "", "  ")
 	if err != nil {
 		fmt.Printf("Error when try to print pretty: %v\n", err)
 		fmt.Println(o)
 	}
-	os.Stdout.Write(b)
-	fmt.Println()
+	writer.Write(b)
+	writer.Write([]byte("\n"))
 }
 
 func mapKeysToArray(m map[string]string) []string {

--- a/tools/cli/workflow_batch_commands.go
+++ b/tools/cli/workflow_batch_commands.go
@@ -75,7 +75,7 @@ func TerminateBatchJob(c *cli.Context) error {
 	output := map[string]interface{}{
 		"msg": "batch job is terminated",
 	}
-	prettyPrintJSONObject(output)
+	prettyPrintJSONObject(getDeps(c).Output(), output)
 	return nil
 }
 
@@ -126,7 +126,7 @@ func DescribeBatchJob(c *cli.Context) error {
 			output["progress"] = hbd
 		}
 	}
-	prettyPrintJSONObject(output)
+	prettyPrintJSONObject(getDeps(c).Output(), output)
 	return nil
 }
 
@@ -177,7 +177,7 @@ func ListBatchJobs(c *cli.Context) error {
 
 		output = append(output, job)
 	}
-	prettyPrintJSONObject(output)
+	prettyPrintJSONObject(getDeps(c).Output(), output)
 	return nil
 }
 
@@ -332,7 +332,7 @@ func StartBatchJob(c *cli.Context) error {
 		"msg":   "batch job is started",
 		"jobID": workflowID,
 	}
-	prettyPrintJSONObject(output)
+	prettyPrintJSONObject(getDeps(c).Output(), output)
 	return nil
 }
 

--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -274,9 +274,9 @@ func showHistoryHelper(c *cli.Context, wid, rid string) error {
 		return commoncli.Problem("Error in convert describe wf: ", err)
 	}
 	if len(descOutput.PendingActivities) > 0 {
-		fmt.Println("============Workflow Pending activities============")
-		prettyPrintJSONObject(descOutput.PendingActivities)
-		fmt.Println("NOTE: ActivityStartedEvent with retry policy will be written into history when the activity is finished.")
+		getDeps(c).Output().Write([]byte("============Workflow Pending activities============\n"))
+		prettyPrintJSONObject(getDeps(c).Output(), descOutput.PendingActivities)
+		getDeps(c).Output().Write([]byte("NOTE: ActivityStartedEvent with retry policy will be written into history when the activity is finished.\n"))
 	}
 	return nil
 }
@@ -1084,7 +1084,7 @@ func describeWorkflowHelper(c *cli.Context, wid, rid string) error {
 		}
 	}
 
-	prettyPrintJSONObject(o)
+	prettyPrintJSONObject(getDeps(c).Output(), o)
 	return nil
 }
 
@@ -1845,7 +1845,7 @@ func ResetWorkflow(c *cli.Context) error {
 	if err != nil {
 		return commoncli.Problem("reset failed", err)
 	}
-	prettyPrintJSONObject(resp)
+	prettyPrintJSONObject(getDeps(c).Output(), resp)
 	return nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Exposing a new `WithIOHandler` option so that tests can override default output writer which is stdout. 
- Refactored `prettyPrintJSONObject` usages to use the app's IOHandler. This way all those corresponding commands can validate the output.

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve testability.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
```
go run cmd/tools/cli/main.go admin cluster d
{
  "supportedClientVersions": {
    "goSdk": "1.7.0",
    "javaSdk": "1.5.0"
  },
  "membershipInfo": {
    "currentHost": {
      "Identity": "172.19.0.6:7933"
    },
    "reachableMembers": [
      "172.19.0.6:7933",
      "172.19.0.6:7934",
      "172.19.0.6:7935",
      "172.19.0.6:7939"
    ],
    "rings": [
      {
        "role": "cadence-frontend",
        "memberCount": 1,
        "members": [
          {
            "Identity": "172.19.0.6:7933"
          }
        ]
      },
      {
        "role": "cadence-history",
        "memberCount": 1,
        "members": [
          {
            "Identity": "172.19.0.6:7934"
          }
        ]
      },
      {
        "role": "cadence-matching",
        "memberCount": 1,
        "members": [
          {
            "Identity": "172.19.0.6:7935"
          }
        ]
      },
      {
        "role": "cadence-worker",
        "memberCount": 1,
        "members": [
          {
            "Identity": "172.19.0.6:7939"
          }
        ]
      }
    ]
  },
  "persistenceInfo": {
    "historyStore": {
      "backend": "shardedNosql"
    },
    "visibilityStore": {
      "backend": "cassandra",
      "features": [
        {
          "key": "advancedVisibilityEnabled",
          "enabled": false
        }
      ]
    }
  }
}
```