### PR TITLE
Adding a test for admin_commands

### DIFF
--- a/tools/cli/admin_commands_test.go
+++ b/tools/cli/admin_commands_test.go
@@ -38,10 +38,12 @@ import (
 )
 
 const (
-	testShardID   = 1234
-	testCluster   = "test-cluster"
-	testDomain    = "test-domain"
-	testQueueType = 2 // transfer queue
+	testShardID      = 1234
+	testCluster      = "test-cluster"
+	testDomain       = "test-domain"
+	testTaskList     = "test-tasklist"
+	testTaskListType = "decision"
+	testQueueType    = 2 // transfer queue
 )
 
 type cliTestData struct {

--- a/tools/cli/admin_commands_test.go
+++ b/tools/cli/admin_commands_test.go
@@ -1,0 +1,163 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package cli
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/urfave/cli/v2"
+
+	"github.com/uber/cadence/client/admin"
+	"github.com/uber/cadence/client/frontend"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/tools/cli/clitest"
+)
+
+const (
+	testShardID   = 1234
+	testCluster   = "test-cluster"
+	testQueueType = 2 // transfer queue
+)
+
+type cliTestData struct {
+	serverFrontendClient *frontend.MockClient
+	serverAdminClient    *admin.MockClient
+	app                  *cli.App
+}
+
+func newCLITestData(t *testing.T) *cliTestData {
+	var td cliTestData
+
+	ctrl := gomock.NewController(t)
+
+	td.serverFrontendClient = frontend.NewMockClient(ctrl)
+	td.serverAdminClient = admin.NewMockClient(ctrl)
+
+	// Set up the CLI app and mock dependencies
+	td.app = NewCliApp(&clientFactoryMock{
+		serverFrontendClient: td.serverFrontendClient,
+		serverAdminClient:    td.serverAdminClient,
+	})
+
+	return &td
+}
+
+func TestAdminResetQueue(t *testing.T) {
+	tests := []struct {
+		name        string
+		testSetup   func(td *cliTestData) *cli.Context
+		errContains string // empty if no error is expected
+	}{
+		{
+			name: "no shardID argument",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app /* arguments are missing */)
+			},
+			errContains: "Required flag not found",
+		},
+		{
+			name: "missing cluster argument",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(
+					t,
+					td.app,
+					clitest.IntArgument(FlagShardID, testShardID),
+					/* no cluster argument */
+				)
+			},
+			errContains: "Required flag not found",
+		},
+		{
+			name: "missing queue type argument",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(
+					t,
+					td.app,
+					clitest.IntArgument(FlagShardID, testShardID),
+					clitest.StringArgument(FlagCluster, testCluster),
+					/* no queue type argument */
+				)
+			},
+			errContains: "Required flag not found",
+		},
+		{
+			name: "all arguments provided",
+			testSetup: func(td *cliTestData) *cli.Context {
+				cliCtx := clitest.NewCLIContext(
+					t,
+					td.app,
+					clitest.IntArgument(FlagShardID, testShardID),
+					clitest.StringArgument(FlagCluster, testCluster),
+					clitest.IntArgument(FlagQueueType, testQueueType),
+				)
+
+				td.serverAdminClient.EXPECT().ResetQueue(gomock.Any(), &types.ResetQueueRequest{
+					ShardID:     testShardID,
+					ClusterName: testCluster,
+					Type:        common.Int32Ptr(testQueueType),
+				})
+
+				return cliCtx
+			},
+			errContains: "",
+		},
+		{
+			name: "ResetQueue returns an error",
+			testSetup: func(td *cliTestData) *cli.Context {
+				cliCtx := clitest.NewCLIContext(
+					t,
+					td.app,
+					clitest.IntArgument(FlagShardID, testShardID),
+					clitest.StringArgument(FlagCluster, testCluster),
+					clitest.IntArgument(FlagQueueType, testQueueType),
+				)
+
+				td.serverAdminClient.EXPECT().ResetQueue(gomock.Any(), &types.ResetQueueRequest{
+					ShardID:     testShardID,
+					ClusterName: testCluster,
+					Type:        common.Int32Ptr(testQueueType),
+				}).Return(errors.New("critical error"))
+
+				return cliCtx
+			},
+			errContains: "Failed to reset queue",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			td := newCLITestData(t)
+			cliCtx := tt.testSetup(td)
+			err := AdminResetQueue(cliCtx)
+			if tt.errContains == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.ErrorContains(t, err, tt.errContains)
+			}
+		})
+	}
+}

--- a/tools/cli/admin_elastic_search_commands_test.go
+++ b/tools/cli/admin_elastic_search_commands_test.go
@@ -222,6 +222,13 @@ func TestAdminCatIndices(t *testing.T) {
 	}
 }
 
+func setContextMock(app *cli.App) *cli.Context {
+	set := flag.NewFlagSet("test", 0)
+	set.String(FlagDomain, "test-domain", "Domain flag")
+	c := cli.NewContext(app, set, nil)
+	return c
+}
+
 // getMockClient creates a mock elastic.Client using the provided HTTP handler and returns the client and the test server
 func getMockClient(t *testing.T, handler http.HandlerFunc) (*elastic.Client, *httptest.Server) {
 	// Create a mock HTTP test server

--- a/tools/cli/clitest/context.go
+++ b/tools/cli/clitest/context.go
@@ -1,0 +1,65 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package clitest
+
+import (
+	"flag"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// CliArgument is a way to apply argument to given flagset/context
+type CliArgument func(t *testing.T, flags *flag.FlagSet, c *cli.Context)
+
+// StringArgument introduces a new string argument for cli context
+func StringArgument(name, value string) CliArgument {
+	return func(t *testing.T, flags *flag.FlagSet, c *cli.Context) {
+		t.Helper()
+		flags.String(name, "", "")
+		require.NoError(t, c.Set(name, value))
+	}
+}
+
+// IntArgument introduces a new int argument for cli context
+func IntArgument(name string, value int) CliArgument {
+	return func(t *testing.T, flags *flag.FlagSet, c *cli.Context) {
+		t.Helper()
+		flags.Int(name, 0, "")
+		require.NoError(t, c.Set(name, strconv.Itoa(value)))
+	}
+}
+
+// NewCLIContext creates a new cli context with optional arguments
+// this is a useful to make testing of commands compact
+func NewCLIContext(t *testing.T, app *cli.App, args ...CliArgument) *cli.Context {
+	t.Helper()
+	flags := flag.NewFlagSet("test", 0)
+	cliCtx := cli.NewContext(app, flags, nil)
+	for _, arg := range args {
+		arg(t, flags, cliCtx)
+	}
+	return cliCtx
+}

--- a/tools/cli/clitest/context_test.go
+++ b/tools/cli/clitest/context_test.go
@@ -1,0 +1,41 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package clitest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+func TestNewCLIContext(t *testing.T) {
+	app := cli.NewApp()
+	ctx := NewCLIContext(t, app, StringArgument("region", "dca"), IntArgument("shards", 1024))
+
+	require.True(t, ctx.IsSet("region"))
+	require.Equal(t, "dca", ctx.String("region"))
+
+	require.True(t, ctx.IsSet("shards"))
+	require.Equal(t, 1024, ctx.Int("shards"))
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
For now it is a test for a single function: ResetQueue
Inroducing clitest package as a helper to write cli tests.
Previously we were mistakenly overriding flags in flag.FlagSet which
does not align with `context.IsSet()` - it thinks user did not provide
an argument.


<!-- Tell your future self why have you made these changes -->
**Why?**
Improving test-coverage

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit-test itself


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
