### PR TITLE
allow config store pollInterval to be set using environment variables

### DIFF
--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -308,7 +308,7 @@ dynamicconfig:
   client: filebased
   filebased:
     filepath: {{ default .Env.DYNAMIC_CONFIG_FILE_PATH "/etc/cadence/config/dynamicconfig/development.yaml" }}
-    pollInterval: "60s"
+    pollInterval: {{ default .Env.DYNAMIC_CONFIG_POLL_INTERVAL "60s" }}
 
 blobstore:
   filestore:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
allow config store pollInterval to be set using environment variables

<!-- Tell your future self why have you made these changes -->
**Why?**

requested here: https://github.com/uber/cadence/issues/5076
