### PR TITLE
Fix matching engine test for stealing lease case

### DIFF
--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -36,6 +36,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/suite"
 	"github.com/uber-go/tally"
+	"go.uber.org/goleak"
 	"go.uber.org/yarpc"
 
 	"github.com/uber/cadence/client/history"
@@ -958,6 +959,7 @@ func (s *matchingEngineSuite) TestMultipleEnginesDecisionsRangeStealing() {
 }
 
 func (s *matchingEngineSuite) MultipleEnginesTasksRangeStealing(taskType int) {
+	s.T().Cleanup(func() { goleak.VerifyNone(s.T()) })
 	// Add N tasks to engine1 and then N tasks to engine2. Then poll all tasks from engine2. Engine1 should be closed
 	const N = 10
 	const initialRangeID = 0

--- a/service/matching/handler/handler_test.go
+++ b/service/matching/handler/handler_test.go
@@ -123,9 +123,6 @@ func (s *handlerSuite) TestStart() {
 	handler := s.getHandler(cfg)
 
 	handler.Start()
-
-	wg := sync.WaitGroup{}
-	wg.Wait()
 }
 
 func (s *handlerSuite) TestStop() {

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -258,7 +258,7 @@ func (c *taskListManagerImpl) handleErr(err error) error {
 	if errors.As(err, &e) {
 		// This indicates the task list may have moved to another host.
 		c.scope.IncCounter(metrics.ConditionFailedErrorPerTaskListCounter)
-		c.logger.Debug("Stopping task list due to persistence condition failure.", tag.Error(err))
+		c.logger.Info("Stopping task list due to persistence condition failure.", tag.Error(err))
 		c.Stop()
 		if c.taskListKind == types.TaskListKindSticky {
 			// TODO: we don't see this error in our logs, we might be able to remove this error

--- a/service/matching/tasklist/task_writer.go
+++ b/service/matching/tasklist/task_writer.go
@@ -285,6 +285,9 @@ func (w *taskWriter) sendWriteResponse(reqs []*writeTaskRequest,
 			persistenceResponse: persistenceResponse,
 		}
 
-		req.responseCh <- resp
+		select {
+		case <-w.stopCh:
+		case req.responseCh <- resp:
+		}
 	}
 }

--- a/service/matching/tasklist/testing.go
+++ b/service/matching/tasklist/testing.go
@@ -87,6 +87,12 @@ func (m *TestTaskManager) LeaseTaskList(
 	tlm := m.getTaskListManager(NewTestTaskListID(m.t, request.DomainID, request.TaskList, request.TaskType))
 	tlm.Lock()
 	defer tlm.Unlock()
+	if request.RangeID > 0 && request.RangeID != tlm.rangeID {
+		return nil, &persistence.ConditionFailedError{
+			Msg: fmt.Sprintf("leaseTaskList:renew failed: taskList:%v, taskListType:%v, haveRangeID:%v, gotRangeID:%v",
+				request.TaskList, request.TaskType, request.RangeID, tlm.rangeID),
+		}
+	}
 	tlm.rangeID++
 	tlm.kind = request.TaskListKind
 	m.logger.Debug(fmt.Sprintf("testTaskManager.LeaseTaskList rangeID=%v", tlm.rangeID))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The `MultipleEnginesTasksRangeStealing` test was intended to cover the case of stealing lease from another tasklist manager but the implementation had a few issues:
1. It takes too long because it adds 1.6k tasks in total. Not needed to cover the scenario. 
Reduced it from 42s to 8s locally. Tests take longer in CI so this should help more in CI.

2. It expects `ConditionFailedError` to be returned while adding task to multiple engines. However the underlying tasklist detects `ConditionFailedError` and shuts itself down. So alternating the engines to add tasks doesn't work. 
Changed the logic to first add N tasks to engine1 and then N tasks to engine2. Validated engine1 no longer accepts new tasks because it was shut down.

3. Test implementation of task store wasn't checking current range id while renewing. Changed the logic to match the [actual implementation](https://github.com/uber/cadence/blob/6dee34c290f3a8251975b260b954ad31951c6945/common/persistence/nosql/nosql_task_store.go#L130-L141) 

Misc changes:
- Task writer could get stuck during shut down because an unbuffered channel write attempt in `taskWriterLoop`. Fixed it [here](https://github.com/uber/cadence/pull/6461/files#r1825431803).
- Tasklist manager shuts itself down when someone else steals the lease. The log for this was debug level. Since it's an important event in tasklist lifecycle changing that to info level to help troubleshooting. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve functional coverage
