### PR TITLE
Connection retaining mode for p2p peer chooser 

### DIFF
--- a/cmd/server/cadence/server.go
+++ b/cmd/server/cadence/server.go
@@ -155,8 +155,9 @@ func (s *server) startService() common.Daemon {
 	)
 
 	params.MetricScope = svcCfg.Metrics.NewScope(params.Logger, params.Name)
+	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, params.Logger))
 
-	rpcParams, err := rpc.NewParams(params.Name, s.cfg, dc, params.Logger)
+	rpcParams, err := rpc.NewParams(params.Name, s.cfg, dc, params.Logger, params.MetricsClient)
 	if err != nil {
 		log.Fatalf("error creating rpc factory params: %v", err)
 	}
@@ -181,8 +182,6 @@ func (s *server) startService() common.Daemon {
 	if err != nil {
 		log.Fatalf("ringpop provider failed: %v", err)
 	}
-
-	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, params.Logger))
 
 	params.MembershipResolver, err = membership.NewResolver(
 		peerProvider,

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -408,6 +408,11 @@ func Service(sv string) Tag {
 	return newStringTag("service", sv)
 }
 
+// DestService returns tag for destination service
+func DestService(sv string) Tag {
+	return newStringTag("dest-service", sv)
+}
+
 // Addresses returns tag for Addresses
 func Addresses(ads []string) Tag {
 	return newObjectTag("addresses", ads)

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -846,6 +846,9 @@ const (
 	// GlobalRatelimiterAggregator is the metrics scope for aggregator-side common/quotas/global behavior
 	GlobalRatelimiterAggregator
 
+	// P2PRPCPeerChooserScope is the metrics scope for P2P RPC peer chooser
+	P2PRPCPeerChooserScope
+
 	NumCommonScopes
 )
 
@@ -1741,6 +1744,8 @@ var ScopeDefs = map[ServiceIdx]map[int]scopeDefinition{
 		// currently used by both frontend and history, but may grow to other limiting-host-services.
 		GlobalRatelimiter:           {operation: "GlobalRatelimiter"},
 		GlobalRatelimiterAggregator: {operation: "GlobalRatelimiterAggregator"},
+
+		P2PRPCPeerChooserScope: {operation: "P2PRPCPeerChooser"},
 	},
 	// Frontend Scope Names
 	Frontend: {
@@ -2242,6 +2247,11 @@ const (
 	GlobalRatelimiterHostLimitsQueried
 	GlobalRatelimiterRemovedLimits
 	GlobalRatelimiterRemovedHostLimits
+
+	// p2p rpc metrics
+	P2PPeersCount
+	P2PPeerAdded
+	P2PPeerRemoved
 
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
@@ -2936,6 +2946,10 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		GlobalRatelimiterHostLimitsQueried: {metricName: "global_ratelimiter_host_limits_queried", metricType: Histogram, buckets: GlobalRatelimiterUsageHistogram},
 		GlobalRatelimiterRemovedLimits:     {metricName: "global_ratelimiter_removed_limits", metricType: Histogram, buckets: GlobalRatelimiterUsageHistogram},
 		GlobalRatelimiterRemovedHostLimits: {metricName: "global_ratelimiter_removed_host_limits", metricType: Histogram, buckets: GlobalRatelimiterUsageHistogram},
+
+		P2PPeersCount:  {metricName: "p2p_peers_count", metricType: Gauge},
+		P2PPeerAdded:   {metricName: "p2p_peer_added", metricType: Counter},
+		P2PPeerRemoved: {metricName: "p2p_peer_removed", metricType: Counter},
 	},
 	History: {
 		TaskRequests:             {metricName: "task_requests", metricType: Counter},

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2947,9 +2947,9 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		GlobalRatelimiterRemovedLimits:     {metricName: "global_ratelimiter_removed_limits", metricType: Histogram, buckets: GlobalRatelimiterUsageHistogram},
 		GlobalRatelimiterRemovedHostLimits: {metricName: "global_ratelimiter_removed_host_limits", metricType: Histogram, buckets: GlobalRatelimiterUsageHistogram},
 
-		P2PPeersCount:  {metricName: "p2p_peers_count", metricType: Gauge},
-		P2PPeerAdded:   {metricName: "p2p_peer_added", metricType: Counter},
-		P2PPeerRemoved: {metricName: "p2p_peer_removed", metricType: Counter},
+		P2PPeersCount:  {metricName: "peers_count", metricType: Gauge},
+		P2PPeerAdded:   {metricName: "peer_added", metricType: Counter},
+		P2PPeerRemoved: {metricName: "peer_removed", metricType: Counter},
 	},
 	History: {
 		TaskRequests:             {metricName: "task_requests", metricType: Counter},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -53,6 +53,7 @@ const (
 	transport                 = "transport"
 	caller                    = "caller"
 	service                   = "service"
+	destService               = "dest_service"
 	signalName                = "signalName"
 	workflowVersion           = "workflow_version"
 	shardID                   = "shard_id"
@@ -219,9 +220,14 @@ func CallerTag(value string) Tag {
 	return simpleMetric{key: caller, value: value}
 }
 
-// CallerTag returns a new RPC Caller type tag.
+// ServiceTag returns a new service tag.
 func ServiceTag(value string) Tag {
 	return simpleMetric{key: service, value: value}
+}
+
+// DestServiceTag returns a new destination service tag.
+func DestServiceTag(value string) Tag {
+	return simpleMetric{key: destService, value: value}
 }
 
 // Hosttag emits the host identifier

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -395,7 +395,9 @@ func (h *Impl) Start() {
 		h.logger.WithTags(tag.Error(err)).Fatal("fail to start PProf")
 	}
 
-	h.rpcFactory.Start(h.membershipResolver)
+	if err := h.rpcFactory.Start(h.membershipResolver); err != nil {
+		h.logger.WithTags(tag.Error(err)).Fatal("fail to start RPC factory")
+	}
 
 	if err := h.dispatcher.Start(); err != nil {
 		h.logger.WithTags(tag.Error(err)).Fatal("fail to start dispatcher")

--- a/common/resource/resource_impl_test.go
+++ b/common/resource/resource_impl_test.go
@@ -61,6 +61,7 @@ func TestStartStop(t *testing.T) {
 	hostName := "test-host"
 	metricsCl := metrics.NewNoopMetricsClient()
 	logger := testlogger.New(t)
+	metricCl := metrics.NewNoopMetricsClient()
 	dc := dynamicconfig.NewInMemoryClient()
 
 	// membership resolver mocks
@@ -82,7 +83,7 @@ func TestStartStop(t *testing.T) {
 		"primary-cluster":   {InitialFailoverVersion: 1, Enabled: true, RPCTransport: "tchannel", RPCAddress: "localhost:0"},
 		"secondary-cluster": {InitialFailoverVersion: 1, Enabled: true, RPCTransport: "tchannel", RPCAddress: "localhost:0"},
 	}, nil, metricsCl, logger)
-	directOutboundPCF := rpc.NewDirectPeerChooserFactory(serviceName, logger)
+	directOutboundPCF := rpc.NewDirectPeerChooserFactory(serviceName, logger, metricsCl)
 	directConnRetainFn := func(opts ...dynamicconfig.FilterOption) bool { return false }
 	pcf := rpc.NewMockPeerChooserFactory(ctrl)
 	peerChooser := rpc.NewMockPeerChooser(ctrl)

--- a/common/resource/resource_impl_test.go
+++ b/common/resource/resource_impl_test.go
@@ -61,7 +61,6 @@ func TestStartStop(t *testing.T) {
 	hostName := "test-host"
 	metricsCl := metrics.NewNoopMetricsClient()
 	logger := testlogger.New(t)
-	metricCl := metrics.NewNoopMetricsClient()
 	dc := dynamicconfig.NewInMemoryClient()
 
 	// membership resolver mocks

--- a/common/rpc/direct_peer_chooser.go
+++ b/common/rpc/direct_peer_chooser.go
@@ -22,17 +22,23 @@ package rpc
 
 import (
 	"context"
+	"fmt"
 	"sync"
 
 	"go.uber.org/yarpc/api/peer"
 	"go.uber.org/yarpc/api/transport"
 	"go.uber.org/yarpc/peer/direct"
+	"go.uber.org/yarpc/peer/hostport"
 	"go.uber.org/yarpc/yarpcerrors"
 
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
+)
+
+var (
+	noOpSubscriberInstance = &noOpSubscriber{}
 )
 
 // directPeerChooser is a peer.Chooser that chooses a peer based on the shard key.
@@ -45,6 +51,7 @@ type directPeerChooser struct {
 	legacyChooser        peer.Chooser
 	legacyChooserErr     error
 	mu                   sync.RWMutex
+	peers                map[string]peer.Peer
 }
 
 func newDirectChooser(serviceName string, t peer.Transport, logger log.Logger, enableConnRetainMode dynamicconfig.BoolPropertyFn) *directPeerChooser {
@@ -87,6 +94,7 @@ func (g *directPeerChooser) IsRunning() bool {
 }
 
 // Choose returns an existing peer for the shard key.
+// ShardKey is {host}:{port} of the peer. It could be tchannel or grpc address.
 func (g *directPeerChooser) Choose(ctx context.Context, req *transport.Request) (peer peer.Peer, onFinish func(error), err error) {
 	if g.enableConnRetainMode != nil && !g.enableConnRetainMode() {
 		return g.chooseFromLegacyDirectPeerChooser(ctx, req)
@@ -96,13 +104,85 @@ func (g *directPeerChooser) Choose(ctx context.Context, req *transport.Request) 
 		return nil, nil, yarpcerrors.InvalidArgumentErrorf("chooser requires ShardKey to be non-empty")
 	}
 
-	// TODO: implement connection retain mode
-	return nil, nil, yarpcerrors.UnimplementedErrorf("direct peer chooser conn retain mode unimplemented")
+	g.mu.RLock()
+	p, ok := g.peers[req.ShardKey]
+	if ok {
+		g.mu.RUnlock()
+		return p, func(error) {}, nil
+	}
+	g.mu.RUnlock()
+
+	// peer is not cached, add new peer
+	p, err = g.addPeer(req.ShardKey)
+	if err != nil {
+		return nil, nil, yarpcerrors.InternalErrorf("failed to add peer for shard key %v, err: %v", req.ShardKey, err)
+	}
+
+	return p, func(error) {}, nil
 }
 
 func (g *directPeerChooser) UpdatePeers(members []membership.HostInfo) {
-	// TODO: implement
 	g.logger.Debug("direct peer chooser got a membership update", tag.Counter(len(members)))
+
+	// Create a map of valid peer addresses given members list. This is used to remove peers that are not in the members list.
+	// Actual yarpc peers are not created for the members here. They are created lazily when a request comes in.
+	validPeerAddresses := make(map[string]bool)
+	for _, member := range members {
+		for _, portName := range []string{membership.PortTchannel, membership.PortGRPC} {
+			addr, err := member.GetNamedAddress(portName)
+			if err != nil {
+				g.logger.Error(fmt.Sprintf("failed to get %s address of member", portName), tag.Error(err), tag.Address(member.GetAddress()))
+				continue
+			}
+			validPeerAddresses[addr] = true
+		}
+	}
+
+	// Take a copy of the current peers to avoid keeping write lock while removing all peers.
+	peers := make(map[string]bool)
+	g.mu.RLock()
+	for addr := range g.peers {
+		peers[addr] = true
+	}
+	g.mu.RUnlock()
+
+	for addr := range peers {
+		if !validPeerAddresses[addr] {
+			g.removePeer(addr)
+		}
+	}
+
+	// todo: emit gauge metric for peers
+}
+
+func (g *directPeerChooser) removePeer(addr string) {
+	// TODO: is ReleasePeer thread safe? If not we need to hold the write lock while releasing the peer.
+	if err := g.t.ReleasePeer(g.peers[addr], noOpSubscriberInstance); err != nil {
+		g.logger.Error("failed to release peer", tag.Error(err), tag.Address(addr))
+	}
+
+	g.mu.Lock()
+	delete(g.peers, addr)
+	g.mu.Unlock()
+	g.logger.Debug("removed peer from direct peer chooser", tag.Address(addr))
+	// TODO: emit count metric
+}
+
+func (g *directPeerChooser) addPeer(addr string) (peer.Peer, error) {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	if p, ok := g.peers[addr]; ok {
+		return p, nil
+	}
+
+	p, err := g.t.RetainPeer(hostport.Identify(addr), noOpSubscriberInstance)
+	if err != nil {
+		return nil, err
+	}
+	g.peers[addr] = p
+	g.logger.Debug("added peer to direct peer chooser", tag.Address(addr))
+	// TODO: emit count metric
+	return p, nil
 }
 
 func (g *directPeerChooser) chooseFromLegacyDirectPeerChooser(ctx context.Context, req *transport.Request) (peer.Peer, func(error), error) {
@@ -142,3 +222,8 @@ func (g *directPeerChooser) getLegacyChooser() (peer.Chooser, bool) {
 
 	return g.legacyChooser, true
 }
+
+// noOpSubscriber is a peer.Subscriber that does nothing.
+type noOpSubscriber struct{}
+
+func (*noOpSubscriber) NotifyStatusChanged(peer.Identifier) {}

--- a/common/rpc/direct_peer_chooser.go
+++ b/common/rpc/direct_peer_chooser.go
@@ -68,7 +68,7 @@ func newDirectChooser(
 ) *directPeerChooser {
 	return &directPeerChooser{
 		serviceName:          serviceName,
-		logger:               logger,
+		logger:               logger.WithTags(tag.Service(serviceName)),
 		scope:                metricsCl.Scope(metrics.P2PRPCPeerChooserScope).Tagged(metrics.DestServiceTag(serviceName)),
 		t:                    t,
 		enableConnRetainMode: enableConnRetainMode,

--- a/common/rpc/direct_peer_chooser.go
+++ b/common/rpc/direct_peer_chooser.go
@@ -159,11 +159,13 @@ func (g *directPeerChooser) Choose(ctx context.Context, req *transport.Request) 
 // Do not create actual yarpc peers for the members. They are created lazily when a request comes in (Choose is called).
 func (g *directPeerChooser) UpdatePeers(serviceName string, members []membership.HostInfo) {
 	if g.serviceName != serviceName {
-		// This is not the service this chooser is created for. Ignore such updates.
+		// TODO: convert to debug log
+		g.logger.Info("This is not the service this chooser is created for. Ignore such updates.", tag.Service(g.serviceName), tag.Dynamic("members-service", serviceName))
 		return
 	}
 
-	g.logger.Debug("direct peer chooser got a membership update", tag.Counter(len(members)))
+	// TODO: convert to debug log
+	g.logger.Info("direct peer chooser got a membership update", tag.Counter(len(members)))
 
 	// If the chooser is not started, do not act on membership changes.
 	// If membership updates arrive after chooser is stopped, ignore them.
@@ -197,6 +199,9 @@ func (g *directPeerChooser) updatePeersInternal(members []membership.HostInfo) {
 		peers[addr] = true
 	}
 	g.mu.RUnlock()
+
+	// TODO: remove this log after verifying the behavior
+	g.logger.Info(fmt.Sprintf("valid peers: %v, current peers: %v", validPeerAddresses, peers))
 
 	for addr := range peers {
 		if !validPeerAddresses[addr] {

--- a/common/rpc/direct_peer_chooser.go
+++ b/common/rpc/direct_peer_chooser.go
@@ -159,7 +159,12 @@ func (g *directPeerChooser) Choose(ctx context.Context, req *transport.Request) 
 
 // UpdatePeers removes peers that are not in the members list.
 // Do not create actual yarpc peers for the members. They are created lazily when a request comes in (Choose is called).
-func (g *directPeerChooser) UpdatePeers(members []membership.HostInfo) {
+func (g *directPeerChooser) UpdatePeers(serviceName string, members []membership.HostInfo) {
+	if g.serviceName != serviceName {
+		// This is not the service this chooser is created for. Ignore such updates.
+		return
+	}
+
 	g.logger.Debug("direct peer chooser got a membership update", tag.Counter(len(members)))
 
 	// If the chooser is not started, do not act on membership changes.

--- a/common/rpc/direct_peer_chooser.go
+++ b/common/rpc/direct_peer_chooser.go
@@ -177,8 +177,6 @@ func (g *directPeerChooser) UpdatePeers(serviceName string, members []membership
 	}
 
 	g.updatePeersInternal(members)
-
-	g.scope.UpdateGauge(metrics.P2PPeersCount, float64(len(g.peers)))
 }
 
 func (g *directPeerChooser) updatePeersInternal(members []membership.HostInfo) {
@@ -219,11 +217,13 @@ func (g *directPeerChooser) removePeer(addr string) {
 	}
 
 	g.mu.Lock()
+	defer g.mu.Unlock()
+
 	delete(g.peers, addr)
-	g.mu.Unlock()
 	// TODO: change to debug level
 	g.logger.Info("removed peer from direct peer chooser", tag.Address(addr))
 	g.scope.IncCounter(metrics.P2PPeerRemoved)
+	g.scope.UpdateGauge(metrics.P2PPeersCount, float64(len(g.peers)))
 }
 
 func (g *directPeerChooser) addPeer(addr string) (peer.Peer, error) {
@@ -241,6 +241,7 @@ func (g *directPeerChooser) addPeer(addr string) (peer.Peer, error) {
 	// TODO: change to debug level
 	g.logger.Info("added peer to direct peer chooser", tag.Address(addr))
 	g.scope.IncCounter(metrics.P2PPeerAdded)
+	g.scope.UpdateGauge(metrics.P2PPeersCount, float64(len(g.peers)))
 	return p, nil
 }
 

--- a/common/rpc/direct_peer_chooser_test.go
+++ b/common/rpc/direct_peer_chooser_test.go
@@ -31,31 +31,52 @@ import (
 
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 )
 
 func TestDirectChooser(t *testing.T) {
-	req := &transport.Request{
-		Caller:   "caller",
-		Service:  "service",
-		ShardKey: "shard1",
+	newReq := func(shardKey string) *transport.Request {
+		return &transport.Request{
+			Caller:   "caller",
+			Service:  "service",
+			ShardKey: shardKey,
+		}
 	}
 
 	tests := []struct {
-		desc          string
-		retainConn    bool
-		req           *transport.Request
-		wantChooseErr bool
+		desc           string
+		retainConn     bool
+		req            *transport.Request
+		multipleChoose bool
+		wantChooseErr  bool
 	}{
 		{
-			desc:       "don't retain connection",
+			desc:       "legacy chooser",
 			retainConn: false,
-			req:        req,
+			req:        newReq("key"),
 		},
 		{
-			desc:          "retain connection",
-			retainConn:    true,
-			req:           req,
+			desc:          "legacy chooser - empty shard key",
+			retainConn:    false,
+			req:           newReq(""),
 			wantChooseErr: true,
+		},
+		{
+			desc:       "connection retain mode",
+			retainConn: true,
+			req:        newReq("key"),
+		},
+		{
+			desc:          "connection retain mode - empty shard key",
+			retainConn:    true,
+			req:           newReq(""),
+			wantChooseErr: true,
+		},
+		{
+			desc:           "connection retain mode - multiple choose should return chooser from cache",
+			retainConn:     true,
+			req:            newReq("key"),
+			multipleChoose: true,
 		},
 	}
 
@@ -64,14 +85,20 @@ func TestDirectChooser(t *testing.T) {
 			defer goleak.VerifyNone(t)
 
 			logger := testlogger.New(t)
+			metricCl := metrics.NewNoopMetricsClient()
 			serviceName := "service"
 			directConnRetainFn := func(opts ...dynamicconfig.FilterOption) bool { return tc.retainConn }
 			grpcTransport := grpc.NewTransport()
 
-			chooser := newDirectChooser(serviceName, grpcTransport, logger, directConnRetainFn)
+			chooser := newDirectChooser(serviceName, grpcTransport, logger, metricCl, directConnRetainFn)
+
+			assert.False(t, chooser.IsRunning(), "expected IsRunning()=false before Start()")
+
 			if err := chooser.Start(); err != nil {
 				t.Fatalf("failed to start direct peer chooser: %v", err)
 			}
+
+			assert.NoError(t, chooser.Start(), "starting again should be no-op")
 
 			assert.True(t, chooser.IsRunning())
 
@@ -84,13 +111,23 @@ func TestDirectChooser(t *testing.T) {
 				assert.NotNil(t, peer)
 				assert.NotNil(t, onFinish)
 
-				// call onFinish to release the peer
+				// call onFinish will release the peer for legacy chooser
 				onFinish(nil)
+			}
+
+			if tc.multipleChoose {
+				peer2, onFinish2, err2 := chooser.Choose(context.Background(), tc.req)
+				assert.NoError(t, err2)
+				assert.NotNil(t, onFinish2)
+				assert.Equal(t, peer, peer2)
+				onFinish2(nil)
 			}
 
 			if err := chooser.Stop(); err != nil {
 				t.Fatalf("failed to stop direct peer chooser: %v", err)
 			}
+
+			assert.NoError(t, chooser.Stop(), "stopping again should be no-op")
 		})
 	}
 }

--- a/common/rpc/factory.go
+++ b/common/rpc/factory.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/membership"
+	"github.com/uber/cadence/common/service"
 )
 
 const (
@@ -176,22 +177,27 @@ func (d *FactoryImpl) GetMaxMessageSize() int {
 }
 
 func (d *FactoryImpl) Start(peerLister PeerLister) error {
-	// subscribe to membership changes and notify outbounds builder for peer updates
 	d.peerLister = peerLister
-	ch := make(chan *membership.ChangedEvent, 1)
-	if err := d.peerLister.Subscribe(d.serviceName, factoryComponentName, ch); err != nil {
-		return fmt.Errorf("rpc factory failed to subscribe to membership updates: %v", err)
+	// subscribe to membership changes for history and matching. This is needed to update the peers for rpc
+	for _, svc := range []string{service.History, service.Matching} {
+		ch := make(chan *membership.ChangedEvent, 1)
+		if err := d.peerLister.Subscribe(svc, factoryComponentName, ch); err != nil {
+			return fmt.Errorf("rpc factory failed to subscribe to membership updates for svc: %v, err: %v", svc, err)
+		}
+		d.wg.Add(1)
+		go d.listenMembershipChanges(svc, ch)
 	}
-	d.wg.Add(1)
-	go d.listenMembershipChanges(ch)
 
 	return nil
 }
 
 func (d *FactoryImpl) Stop() error {
 	d.logger.Info("stopping rpc factory")
-	if err := d.peerLister.Unsubscribe(d.serviceName, factoryComponentName); err != nil {
-		d.logger.Error("rpc factory failed to unsubscribe from membership updates", tag.Error(err))
+
+	for _, svc := range []string{service.History, service.Matching} {
+		if err := d.peerLister.Unsubscribe(svc, factoryComponentName); err != nil {
+			d.logger.Error("rpc factory failed to unsubscribe from membership updates", tag.Error(err), tag.Service(svc))
+		}
 	}
 
 	d.cancelFn()
@@ -201,22 +207,22 @@ func (d *FactoryImpl) Stop() error {
 	return nil
 }
 
-func (d *FactoryImpl) listenMembershipChanges(ch chan *membership.ChangedEvent) {
+func (d *FactoryImpl) listenMembershipChanges(svc string, ch chan *membership.ChangedEvent) {
 	defer d.wg.Done()
 
 	for {
 		select {
 		case <-ch:
-			d.logger.Debug("rpc factory received membership changed event")
-			members, err := d.peerLister.Members(d.serviceName)
+			d.logger.Debug("rpc factory received membership changed event", tag.Service(svc))
+			members, err := d.peerLister.Members(svc)
 			if err != nil {
-				d.logger.Error("rpc factory failed to get members from membership resolver", tag.Error(err))
+				d.logger.Error("rpc factory failed to get members from membership resolver", tag.Error(err), tag.Service(svc))
 				continue
 			}
 
-			d.outbounds.UpdatePeers(members)
+			d.outbounds.UpdatePeers(svc, members)
 		case <-d.ctx.Done():
-			d.logger.Info("rpc factory stopped so listenMembershipChanges returning")
+			d.logger.Info("rpc factory stopped so listenMembershipChanges returning", tag.Service(svc))
 			return
 		}
 	}

--- a/common/rpc/factory_test.go
+++ b/common/rpc/factory_test.go
@@ -21,6 +21,7 @@
 package rpc
 
 import (
+	"errors"
 	"sync"
 	"testing"
 	"time"
@@ -62,34 +63,6 @@ func TestNewFactory(t *testing.T) {
 }
 
 func TestStartStop(t *testing.T) {
-	defer goleak.VerifyNone(t)
-
-	ctrl := gomock.NewController(t)
-	logger := testlogger.New(t)
-	serviceName := "service"
-	ob := NewMockOutboundsBuilder(ctrl)
-	var mu sync.Mutex
-	gotMembers := make(map[string][]membership.HostInfo)
-	outbounds := &Outbounds{
-		onUpdatePeers: func(svc string, members []membership.HostInfo) {
-			mu.Lock()
-			defer mu.Unlock()
-			gotMembers[svc] = members
-		},
-	}
-	ob.EXPECT().Build(gomock.Any(), gomock.Any()).Return(outbounds, nil).Times(1)
-	grpcMsgSize := 4 * 1024 * 1024
-	f := NewFactory(logger, Params{
-		ServiceName:     serviceName,
-		TChannelAddress: "localhost:0",
-		GRPCMaxMsgSize:  grpcMsgSize,
-		GRPCAddress:     "localhost:0",
-		HTTP: &httpParams{
-			Address: "localhost:0",
-		},
-		OutboundsBuilder: ob,
-	})
-
 	membersBySvc := map[string][]membership.HostInfo{
 		service.Matching: {
 			membership.NewHostInfo("localhost:9191"),
@@ -100,29 +73,114 @@ func TestStartStop(t *testing.T) {
 		},
 	}
 
-	peerLister := membership.NewMockResolver(ctrl)
-	for _, svc := range []string{service.Matching, service.History} {
-		peerLister.EXPECT().Subscribe(svc, factoryComponentName, gomock.Any()).
-			DoAndReturn(func(service, name string, notifyChannel chan<- *membership.ChangedEvent) error {
-				// Notify the channel once to validate listening logic is working
-				notifyChannel <- &membership.ChangedEvent{}
-				return nil
-			}).Times(1)
-		peerLister.EXPECT().Unsubscribe(svc, factoryComponentName).Return(nil).Times(1)
-		peerLister.EXPECT().Members(svc).Return(membersBySvc[svc], nil).Times(1)
+	tests := []struct {
+		desc             string
+		wantMembersBySvc map[string][]membership.HostInfo
+		mockFn           func(*membership.MockResolver)
+		wantStartErr     bool
+	}{
+		{
+			desc:             "success",
+			wantMembersBySvc: membersBySvc,
+			mockFn: func(peerLister *membership.MockResolver) {
+				for _, svc := range servicesToTalkP2P {
+					peerLister.EXPECT().Subscribe(svc, factoryComponentName, gomock.Any()).
+						DoAndReturn(func(service, name string, notifyChannel chan<- *membership.ChangedEvent) error {
+							// Notify the channel once to validate listening logic is working
+							notifyChannel <- &membership.ChangedEvent{}
+							return nil
+						}).Times(1)
+
+					peerLister.EXPECT().Members(svc).Return(membersBySvc[svc], nil).Times(1)
+					peerLister.EXPECT().Unsubscribe(svc, factoryComponentName).Return(nil).Times(1)
+				}
+			},
+		},
+		{
+			desc:         "subscription to membership updates fail",
+			wantStartErr: true,
+			mockFn: func(peerLister *membership.MockResolver) {
+				for i, svc := range servicesToTalkP2P {
+					if i == 0 {
+						// subscribe will only be called for the first service and after failing, it should not be called for the rest
+						peerLister.EXPECT().Subscribe(svc, factoryComponentName, gomock.Any()).Return(errors.New("failed")).Times(1)
+					}
+
+					// subscribe will be called for all services during stop
+					peerLister.EXPECT().Unsubscribe(svc, factoryComponentName).Return(nil).Times(1)
+				}
+			},
+		},
+		{
+			desc:             "unsubscirption from membership updates fail",
+			wantMembersBySvc: membersBySvc,
+			mockFn: func(peerLister *membership.MockResolver) {
+				for _, svc := range servicesToTalkP2P {
+					peerLister.EXPECT().Subscribe(svc, factoryComponentName, gomock.Any()).
+						DoAndReturn(func(service, name string, notifyChannel chan<- *membership.ChangedEvent) error {
+							// Notify the channel once to validate listening logic is working
+							notifyChannel <- &membership.ChangedEvent{}
+							return nil
+						}).Times(1)
+					peerLister.EXPECT().Members(svc).Return(membersBySvc[svc], nil).Times(1)
+					peerLister.EXPECT().Unsubscribe(svc, factoryComponentName).Return(errors.New("failed")).Times(1)
+				}
+			},
+		},
 	}
 
-	if err := f.Start(peerLister); err != nil {
-		t.Fatalf("Factory.Start() returned error: %v", err)
-	}
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			logger := testlogger.New(t)
+			serviceName := "service"
+			ob := NewMockOutboundsBuilder(ctrl)
+			var mu sync.Mutex
+			gotMembers := make(map[string][]membership.HostInfo)
+			outbounds := &Outbounds{
+				onUpdatePeers: func(svc string, members []membership.HostInfo) {
+					mu.Lock()
+					defer mu.Unlock()
+					gotMembers[svc] = members
+				},
+			}
+			ob.EXPECT().Build(gomock.Any(), gomock.Any()).Return(outbounds, nil).Times(1)
+			grpcMsgSize := 4 * 1024 * 1024
+			f := NewFactory(logger, Params{
+				ServiceName:     serviceName,
+				TChannelAddress: "localhost:0",
+				GRPCMaxMsgSize:  grpcMsgSize,
+				GRPCAddress:     "localhost:0",
+				HTTP: &httpParams{
+					Address: "localhost:0",
+				},
+				OutboundsBuilder: ob,
+			})
 
-	// Wait for membership changes to be processed
-	time.Sleep(100 * time.Millisecond)
-	mu.Lock()
-	assert.Equal(t, membersBySvc, gotMembers, "UpdatePeers not called with expected members")
-	mu.Unlock()
+			peerLister := membership.NewMockResolver(ctrl)
+			tc.mockFn(peerLister)
 
-	if err := f.Stop(); err != nil {
-		t.Fatalf("Factory.Stop() returned error: %v", err)
+			if err := f.Start(peerLister); err != nil {
+				if !tc.wantStartErr {
+					t.Fatalf("Factory.Start() returned error: %v", err)
+				}
+
+				// start failed expectedly. do not proceed with rest of the validations
+				f.Stop()
+				return
+			}
+
+			// Wait for membership changes to be processed
+			time.Sleep(100 * time.Millisecond)
+			mu.Lock()
+			assert.Equal(t, tc.wantMembersBySvc, gotMembers, "UpdatePeers not called with expected members")
+			mu.Unlock()
+
+			if err := f.Stop(); err != nil {
+				t.Fatalf("Factory.Stop() returned error: %v", err)
+			}
+
+			goleak.VerifyNone(t)
+		})
 	}
 }

--- a/common/rpc/outbounds_test.go
+++ b/common/rpc/outbounds_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/service"
 )
 
@@ -163,15 +164,16 @@ func TestDirectOutbound(t *testing.T) {
 	grpc := &grpc.Transport{}
 	tchannel := &tchannel.Transport{}
 	logger := testlogger.New(t)
+	metricCl := metrics.NewNoopMetricsClient()
 	falseFn := func(opts ...dynamicconfig.FilterOption) bool { return false }
 
-	o, err := NewDirectOutboundBuilder("cadence-history", false, nil, NewDirectPeerChooserFactory("cadence-history", logger), falseFn).Build(grpc, tchannel)
+	o, err := NewDirectOutboundBuilder("cadence-history", false, nil, NewDirectPeerChooserFactory("cadence-history", logger, metricCl), falseFn).Build(grpc, tchannel)
 	assert.NoError(t, err)
 	outbounds := o.Outbounds
 	assert.Equal(t, "cadence-history", outbounds["cadence-history"].ServiceName)
 	assert.NotNil(t, outbounds["cadence-history"].Unary)
 
-	o, err = NewDirectOutboundBuilder("cadence-history", true, nil, NewDirectPeerChooserFactory("cadence-history", logger), falseFn).Build(grpc, tchannel)
+	o, err = NewDirectOutboundBuilder("cadence-history", true, nil, NewDirectPeerChooserFactory("cadence-history", logger, metricCl), falseFn).Build(grpc, tchannel)
 	assert.NoError(t, err)
 	outbounds = o.Outbounds
 	assert.Equal(t, "cadence-history", outbounds["cadence-history"].ServiceName)

--- a/common/rpc/params.go
+++ b/common/rpc/params.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/config"
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/service"
 )
 
@@ -62,7 +63,7 @@ type httpParams struct {
 }
 
 // NewParams creates parameters for rpc.Factory from the given config
-func NewParams(serviceName string, config *config.Config, dc *dynamicconfig.Collection, logger log.Logger) (Params, error) {
+func NewParams(serviceName string, config *config.Config, dc *dynamicconfig.Collection, logger log.Logger, metricsCl metrics.Client) (Params, error) {
 	serviceConfig, err := config.GetServiceConfig(serviceName)
 	if err != nil {
 		return Params{}, err
@@ -143,14 +144,14 @@ func NewParams(serviceName string, config *config.Config, dc *dynamicconfig.Coll
 				service.History,
 				enableGRPCOutbound,
 				outboundTLS[service.History],
-				NewDirectPeerChooserFactory(service.History, logger),
+				NewDirectPeerChooserFactory(service.History, logger, metricsCl),
 				dc.GetBoolProperty(dynamicconfig.EnableConnectionRetainingDirectChooser),
 			),
 			NewDirectOutboundBuilder(
 				service.Matching,
 				enableGRPCOutbound,
 				outboundTLS[service.Matching],
-				NewDirectPeerChooserFactory(service.Matching, logger),
+				NewDirectPeerChooserFactory(service.Matching, logger, metricsCl),
 				dc.GetBoolProperty(dynamicconfig.EnableConnectionRetainingDirectChooser),
 			),
 			publicClientOutbound,

--- a/common/rpc/peer_chooser.go
+++ b/common/rpc/peer_chooser.go
@@ -100,8 +100,9 @@ func (f *dnsPeerChooserFactory) CreatePeerChooser(transport peer.Transport, opts
 
 func NewDirectPeerChooserFactory(serviceName string, logger log.Logger, metricsCl metrics.Client) PeerChooserFactory {
 	return &directPeerChooserFactory{
-		logger:    logger,
-		metricsCl: metricsCl,
+		serviceName: serviceName,
+		logger:      logger,
+		metricsCl:   metricsCl,
 	}
 }
 

--- a/common/rpc/peer_chooser.go
+++ b/common/rpc/peer_chooser.go
@@ -57,7 +57,7 @@ type (
 		peer.Chooser
 
 		// UpdatePeers updates the list of peers if needed.
-		UpdatePeers([]membership.HostInfo)
+		UpdatePeers(serviceName string, members []membership.HostInfo)
 	}
 
 	dnsPeerChooserFactory struct {
@@ -78,7 +78,7 @@ type defaultPeerChooser struct {
 }
 
 // UpdatePeers is a no-op for defaultPeerChooser. It is added to satisfy the PeerChooser interface.
-func (d *defaultPeerChooser) UpdatePeers(peers []membership.HostInfo) {}
+func (d *defaultPeerChooser) UpdatePeers(string, []membership.HostInfo) {}
 
 func NewDNSPeerChooserFactory(interval time.Duration, logger log.Logger) PeerChooserFactory {
 	if interval <= 0 {

--- a/common/rpc/peer_chooser_mock.go
+++ b/common/rpc/peer_chooser_mock.go
@@ -157,13 +157,13 @@ func (mr *MockPeerChooserMockRecorder) Stop() *gomock.Call {
 }
 
 // UpdatePeers mocks base method.
-func (m *MockPeerChooser) UpdatePeers(arg0 []membership.HostInfo) {
+func (m *MockPeerChooser) UpdatePeers(serviceName string, members []membership.HostInfo) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdatePeers", arg0)
+	m.ctrl.Call(m, "UpdatePeers", serviceName, members)
 }
 
 // UpdatePeers indicates an expected call of UpdatePeers.
-func (mr *MockPeerChooserMockRecorder) UpdatePeers(arg0 interface{}) *gomock.Call {
+func (mr *MockPeerChooserMockRecorder) UpdatePeers(serviceName, members interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePeers", reflect.TypeOf((*MockPeerChooser)(nil).UpdatePeers), arg0)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePeers", reflect.TypeOf((*MockPeerChooser)(nil).UpdatePeers), serviceName, members)
 }

--- a/common/rpc/peer_chooser_test.go
+++ b/common/rpc/peer_chooser_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/uber/cadence/common/dynamicconfig"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 )
 
 type (
@@ -82,8 +83,9 @@ func TestDNSPeerChooserFactory(t *testing.T) {
 
 func TestDirectPeerChooserFactory(t *testing.T) {
 	logger := testlogger.New(t)
+	metricCl := metrics.NewNoopMetricsClient()
 	serviceName := "service"
-	pcf := NewDirectPeerChooserFactory(serviceName, logger)
+	pcf := NewDirectPeerChooserFactory(serviceName, logger, metricCl)
 	directConnRetainFn := func(opts ...dynamicconfig.FilterOption) bool { return false }
 	grpcTransport := grpc.NewTransport()
 	chooser, err := pcf.CreatePeerChooser(grpcTransport, PeerChooserOptions{

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -562,12 +562,12 @@ func (c *cadenceImpl) startFrontend(hosts map[string][]membership.HostInfo, star
 	params.ThrottledLogger = c.logger
 	params.TimeSource = c.timeSource
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.FrontendPProfPort())
-	params.RPCFactory = c.newRPCFactory(service.Frontend, c.FrontendHost())
 	params.MetricScope = tally.NewTestScope(service.Frontend, make(map[string]string))
+	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
+	params.RPCFactory = c.newRPCFactory(service.Frontend, c.FrontendHost(), params.MetricsClient)
 	params.MembershipResolver = newMembershipResolver(params.Name, hosts, c.FrontendHost())
 	params.ClusterMetadata = c.clusterMetadata
 	params.MessagingClient = c.messagingClient
-	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 	params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.frontendDynCfgOverrides)
 	params.ArchivalMetadata = c.archiverMetadata
 	params.ArchiverProvider = c.archiverProvider
@@ -644,12 +644,12 @@ func (c *cadenceImpl) startHistory(hosts map[string][]membership.HostInfo, start
 		params.ThrottledLogger = c.logger
 		params.TimeSource = c.timeSource
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
-		params.RPCFactory = c.newRPCFactory(service.History, hostport)
 		params.MetricScope = tally.NewTestScope(service.History, make(map[string]string))
+		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
+		params.RPCFactory = c.newRPCFactory(service.History, hostport, params.MetricsClient)
 		params.MembershipResolver = newMembershipResolver(params.Name, hosts, hostport)
 		params.ClusterMetadata = c.clusterMetadata
 		params.MessagingClient = c.messagingClient
-		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 		integrationClient := newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.historyDynCfgOverrides)
 		c.overrideHistoryDynamicConfig(integrationClient)
 		params.DynamicConfig = integrationClient
@@ -723,11 +723,11 @@ func (c *cadenceImpl) startMatching(hosts map[string][]membership.HostInfo, star
 		params.ThrottledLogger = c.logger
 		params.TimeSource = c.timeSource
 		params.PProfInitializer = newPProfInitializerImpl(c.logger, pprofPorts[i])
-		params.RPCFactory = c.newRPCFactory(service.Matching, hostport)
 		params.MetricScope = tally.NewTestScope(service.Matching, map[string]string{"matching-host": matchingHost})
+		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
+		params.RPCFactory = c.newRPCFactory(service.Matching, hostport, params.MetricsClient)
 		params.MembershipResolver = newMembershipResolver(params.Name, hosts, hostport)
 		params.ClusterMetadata = c.clusterMetadata
-		params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 		params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.matchingDynCfgOverrides)
 		params.ArchivalMetadata = c.archiverMetadata
 		params.ArchiverProvider = c.archiverProvider
@@ -783,11 +783,11 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 	params.ThrottledLogger = c.logger
 	params.TimeSource = c.timeSource
 	params.PProfInitializer = newPProfInitializerImpl(c.logger, c.WorkerPProfPort())
-	params.RPCFactory = c.newRPCFactory(service.Worker, c.WorkerServiceHost())
 	params.MetricScope = tally.NewTestScope(service.Worker, make(map[string]string))
+	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
+	params.RPCFactory = c.newRPCFactory(service.Worker, c.WorkerServiceHost(), params.MetricsClient)
 	params.MembershipResolver = newMembershipResolver(params.Name, hosts, c.WorkerServiceHost())
 	params.ClusterMetadata = c.clusterMetadata
-	params.MetricsClient = metrics.NewClient(params.MetricScope, service.GetMetricsServiceIdx(params.Name, c.logger))
 	params.DynamicConfig = newIntegrationConfigClient(dynamicconfig.NewNopClient(), c.workerDynCfgOverrides)
 	params.ArchivalMetadata = c.archiverMetadata
 	params.ArchiverProvider = c.archiverProvider
@@ -1024,7 +1024,7 @@ func newPublicClient(dispatcher *yarpc.Dispatcher) cwsc.Interface {
 	)
 }
 
-func (c *cadenceImpl) newRPCFactory(serviceName string, host membership.HostInfo) rpc.Factory {
+func (c *cadenceImpl) newRPCFactory(serviceName string, host membership.HostInfo, metricsCl metrics.Client) rpc.Factory {
 	tchannelAddress, err := host.GetNamedAddress(membership.PortTchannel)
 	if err != nil {
 		c.logger.Fatal("failed to get PortTchannel port from host", tag.Value(host), tag.Error(err))
@@ -1040,7 +1040,7 @@ func (c *cadenceImpl) newRPCFactory(serviceName string, host membership.HostInfo
 		c.logger.Fatal("failed to get frontend PortGRPC", tag.Value(c.FrontendHost()), tag.Error(err))
 	}
 
-	directOutboundPCF := rpc.NewDirectPeerChooserFactory(serviceName, c.logger)
+	directOutboundPCF := rpc.NewDirectPeerChooserFactory(serviceName, c.logger, metricsCl)
 	directConnRetainFn := func(opts ...dynamicconfig.FilterOption) bool { return false }
 
 	return rpc.NewFactory(c.logger, rpc.Params{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This PR is continuation of PR #6345 to complete implementation of custom peer chooser. 
The custom chooser differs from yarpc's default "direct" chooser in how it handles connections. Direct chooser creates & releases p2p connections for each request. 
The new peer chooser retains connections until the peer disappears from member list. Peers are added as needed basis (when a request is about to be made to a target peer). 
There's going to be one peer chooser instance per target service which will cache active peers internally. 
Only matching and history are such target services that all other services communicate p2p.

This is hidden behind feature flag `system.enableConnectionRetainingDirectChooser` and yarpc's direct peer chooser will still be used by default. 


Other changes:
- Start/Stop and logging improvements to rpc factory
- Carry target service name to the UpdatePeers callbacks so it can be used to honor/ignore membership updates accordingly. 
- Handle Start/Stop for lazy initialized legacyChooser scenario for runtime dynamic config toggling

<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid unnecessary cost of recreating connections for each p2p request.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests
- Deployed to a dev environment and validated via logs & metrics
