### PR TITLE
Added tests for AdminDBScan method 

### DIFF
--- a/tools/cli/admin_db_scan_command.go
+++ b/tools/cli/admin_db_scan_command.go
@@ -108,9 +108,8 @@ func AdminDBScan(c *cli.Context) error {
 				break
 			}
 			return commoncli.Problem("Error decoding input file", err)
-		} else {
-			data = append(data, exec)
 		}
+		data = append(data, exec)
 	}
 
 	if len(data) == 0 {
@@ -132,7 +131,7 @@ func AdminDBScan(c *cli.Context) error {
 			continue
 		}
 
-		fmt.Println(string(data))
+		getDeps(c).Output().Write(data)
 	}
 	return nil
 }

--- a/tools/cli/admin_db_scan_command_test.go
+++ b/tools/cli/admin_db_scan_command_test.go
@@ -1,0 +1,91 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/uber/cadence/tools/cli/clitest"
+	"github.com/urfave/cli/v2"
+)
+
+func TestAdminDBScan(t *testing.T) {
+
+	cases := []struct {
+		name        string
+		testSetup   func(td *cliTestData) *cli.Context
+		errContains string // empty if no error is expected
+	}{
+		{
+			name: "scan type not provided",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app)
+			},
+			errContains: "unknown scan type",
+		},
+		{
+			name: "unknown scan type provided",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "some_unknown_scan_type"),
+				)
+			},
+			errContains: "unknown scan type",
+		},
+		{
+			name: "number of shards not provided",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+				)
+			},
+			errContains: "Required flag not found",
+		},
+		{
+			name: "invariant collection not provided",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 1),
+				)
+			},
+			errContains: "no invariants for scan type \"ConcreteExecutionType\" and collections []",
+		},
+		{
+			name: "invalid invariant collection provided",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 1),
+					clitest.StringSliceArgument("invariant_collection", "some_unknown_invariant_collection"),
+				)
+			},
+			errContains: "unknown invariant collection: some_unknown_invariant_collection",
+		},
+		{
+			name: "input file not found",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 1),
+					clitest.StringSliceArgument("invariant_collection", "CollectionHistory"),
+					clitest.StringArgument("input_file", "testdata/scan_input.json"),
+				)
+			},
+			errContains: "Input file not found",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			td := newCLITestData(t)
+			testCtx := tc.testSetup(td)
+			err := AdminDBScan(testCtx)
+			if tc.errContains != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tc.errContains)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/tools/cli/admin_db_scan_command_test.go
+++ b/tools/cli/admin_db_scan_command_test.go
@@ -1,15 +1,87 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package cli
 
 import (
 	"testing"
 
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/uber/cadence/common"
+	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/tools/cli/clitest"
 	"github.com/urfave/cli/v2"
 )
 
 func TestAdminDBScan(t *testing.T) {
+	td := newCLITestData(t)
 
+	expectWorkFlow(td, "test-workflow-id1")
+	expectWorkFlow(td, "test-workflow-id2")
+	expectWorkFlow(td, "test-workflow-id3")
+
+	cliCtx := clitest.NewCLIContext(t, td.app,
+		clitest.StringArgument("scan_type", "CurrentExecutionType"),
+		clitest.IntArgument("number_of_shards", 16384),
+		clitest.StringSliceArgument("invariant_collection", "CollectionMutableState"),
+		clitest.StringArgument("input_file", "testdata/scan_input.json"),
+	)
+
+	err := AdminDBScan(cliCtx)
+	assert.NoError(t, err)
+}
+
+func expectWorkFlow(td *cliTestData, workflowID string) {
+	shardId1 := common.WorkflowIDToHistoryShard(workflowID, 16384)
+	mockExecutionManager := persistence.NewMockExecutionManager(td.ctrl)
+	mockExecutionManager.EXPECT().Close().Times(1)
+	td.mockManagerFactory.EXPECT().
+		initializeExecutionManager(gomock.Any(), shardId1).
+		Return(mockExecutionManager, nil).
+		Times(1)
+
+	mockHistoryManager := persistence.NewMockHistoryManager(td.ctrl)
+	mockHistoryManager.EXPECT().Close().Times(1)
+	td.mockManagerFactory.EXPECT().
+		initializeHistoryManager(gomock.Any()).
+		Return(mockHistoryManager, nil).
+		Times(1)
+
+	mockExecutionManager.EXPECT().GetCurrentExecution(gomock.Any(), gomock.Any()).
+		Return(&persistence.GetCurrentExecutionResponse{
+			RunID: "test-run-id1",
+			State: persistence.WorkflowStateCompleted,
+		}, nil).
+		Times(1)
+	mockExecutionManager.EXPECT().GetShardID().Return(shardId1).Times(1)
+	mockExecutionManager.EXPECT().IsWorkflowExecutionExists(gomock.Any(), gomock.Any()).
+		Return(&persistence.IsWorkflowExecutionExistsResponse{
+			Exists: true,
+		}, nil).
+		Times(1)
+}
+
+func TestAdminDBScanErrorCases(t *testing.T) {
 	cases := []struct {
 		name        string
 		testSetup   func(td *cliTestData) *cli.Context
@@ -45,7 +117,7 @@ func TestAdminDBScan(t *testing.T) {
 			testSetup: func(td *cliTestData) *cli.Context {
 				return clitest.NewCLIContext(t, td.app,
 					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
-					clitest.IntArgument("number_of_shards", 1),
+					clitest.IntArgument("number_of_shards", 16384),
 				)
 			},
 			errContains: "no invariants for scan type \"ConcreteExecutionType\" and collections []",
@@ -55,7 +127,7 @@ func TestAdminDBScan(t *testing.T) {
 			testSetup: func(td *cliTestData) *cli.Context {
 				return clitest.NewCLIContext(t, td.app,
 					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
-					clitest.IntArgument("number_of_shards", 1),
+					clitest.IntArgument("number_of_shards", 16384),
 					clitest.StringSliceArgument("invariant_collection", "some_unknown_invariant_collection"),
 				)
 			},
@@ -66,12 +138,103 @@ func TestAdminDBScan(t *testing.T) {
 			testSetup: func(td *cliTestData) *cli.Context {
 				return clitest.NewCLIContext(t, td.app,
 					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
-					clitest.IntArgument("number_of_shards", 1),
+					clitest.IntArgument("number_of_shards", 16384),
+					clitest.StringSliceArgument("invariant_collection", "CollectionHistory"),
+					clitest.StringArgument("input_file", "testdata/non-existant-file.json"),
+				)
+			},
+			errContains: "Input file not found",
+		},
+		{
+			name: "input file is empty",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 16384),
+					clitest.StringSliceArgument("invariant_collection", "CollectionHistory"),
+					clitest.StringArgument("input_file", "testdata/scan_input_empty.json"),
+				)
+			},
+			errContains: "Input file contained no data to scan",
+		},
+		{
+			name: "bad data in input file",
+			testSetup: func(td *cliTestData) *cli.Context {
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 16384),
+					clitest.StringSliceArgument("invariant_collection", "CollectionHistory"),
+					clitest.StringArgument("input_file", "testdata/scan_input_bad_data.json"),
+				)
+			},
+			errContains: "Error decoding input file",
+		},
+		{
+			name: "execution manager initialization error",
+			testSetup: func(td *cliTestData) *cli.Context {
+				td.mockManagerFactory.EXPECT().
+					initializeExecutionManager(gomock.Any(), gomock.Any()).
+					Return(nil, assert.AnError)
+
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 16384),
 					clitest.StringSliceArgument("invariant_collection", "CollectionHistory"),
 					clitest.StringArgument("input_file", "testdata/scan_input.json"),
 				)
 			},
-			errContains: "Input file not found",
+			errContains: "Execution check failed: initialize execution manager: assert.AnError general error for testing",
+		},
+		{
+			name: "historyV2 manager initialization error",
+			testSetup: func(td *cliTestData) *cli.Context {
+				shardId1 := common.WorkflowIDToHistoryShard("test-workflow-id1", 16384)
+				mockExecutionManager := persistence.NewMockExecutionManager(td.ctrl)
+				mockExecutionManager.EXPECT().Close()
+				td.mockManagerFactory.EXPECT().
+					initializeExecutionManager(gomock.Any(), shardId1).
+					Return(mockExecutionManager, nil)
+
+				td.mockManagerFactory.EXPECT().
+					initializeHistoryManager(gomock.Any()).
+					Return(nil, assert.AnError)
+
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 16384),
+					clitest.StringSliceArgument("invariant_collection", "CollectionHistory"),
+					clitest.StringArgument("input_file", "testdata/scan_input.json"),
+				)
+			},
+			errContains: "Execution check failed: initialize history manager: assert.AnError general error for testing",
+		},
+		{
+			name: "failed to fetch execution",
+			testSetup: func(td *cliTestData) *cli.Context {
+				shardId1 := common.WorkflowIDToHistoryShard("test-workflow-id1", 16384)
+				mockExecutionManager := persistence.NewMockExecutionManager(td.ctrl)
+				mockExecutionManager.EXPECT().Close()
+				td.mockManagerFactory.EXPECT().
+					initializeExecutionManager(gomock.Any(), shardId1).
+					Return(mockExecutionManager, nil)
+
+				mockHistoryManager := persistence.NewMockHistoryManager(td.ctrl)
+				mockHistoryManager.EXPECT().Close()
+				td.mockManagerFactory.EXPECT().
+					initializeHistoryManager(gomock.Any()).
+					Return(mockHistoryManager, nil)
+
+				mockExecutionManager.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).
+					Return(nil, assert.AnError)
+
+				return clitest.NewCLIContext(t, td.app,
+					clitest.StringArgument("scan_type", "ConcreteExecutionType"),
+					clitest.IntArgument("number_of_shards", 16384),
+					clitest.StringSliceArgument("invariant_collection", "CollectionHistory"),
+					clitest.StringArgument("input_file", "testdata/scan_input.json"),
+				)
+			},
+			errContains: "Execution check failed: fetching execution: assert.AnError general error for testing",
 		},
 	}
 
@@ -82,7 +245,7 @@ func TestAdminDBScan(t *testing.T) {
 			err := AdminDBScan(testCtx)
 			if tc.errContains != "" {
 				assert.Error(t, err)
-				assert.Contains(t, err.Error(), tc.errContains)
+				assert.ErrorContains(t, err, tc.errContains)
 			} else {
 				assert.NoError(t, err)
 			}

--- a/tools/cli/clitest/context.go
+++ b/tools/cli/clitest/context.go
@@ -25,6 +25,7 @@ package clitest
 import (
 	"flag"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -67,6 +68,15 @@ func Int64Argument(name string, value int64) CliArgument {
 		t.Helper()
 		flags.Int64(name, value, "")
 		require.NoError(t, c.Set(name, strconv.FormatInt(value, 10)))
+	}
+}
+
+// StringSliceArgument introduces a new string slice argument for cli context
+func StringSliceArgument(name string, values ...string) CliArgument {
+	return func(t *testing.T, flags *flag.FlagSet, c *cli.Context) {
+		t.Helper()
+		flags.Var(cli.NewStringSlice(values...), name, "")
+		require.NoError(t, c.Set(name, strings.Join(values, " ")))
 	}
 }
 

--- a/tools/cli/clitest/context.go
+++ b/tools/cli/clitest/context.go
@@ -25,7 +25,6 @@ package clitest
 import (
 	"flag"
 	"strconv"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -75,8 +74,10 @@ func Int64Argument(name string, value int64) CliArgument {
 func StringSliceArgument(name string, values ...string) CliArgument {
 	return func(t *testing.T, flags *flag.FlagSet, c *cli.Context) {
 		t.Helper()
-		flags.Var(cli.NewStringSlice(values...), name, "")
-		require.NoError(t, c.Set(name, strings.Join(values, " ")))
+		flags.Var(&cli.StringSlice{}, name, "")
+		for _, v := range values {
+			require.NoError(t, c.Set(name, v))
+		}
 	}
 }
 

--- a/tools/cli/clitest/context_test.go
+++ b/tools/cli/clitest/context_test.go
@@ -39,6 +39,7 @@ func TestNewCLIContext(t *testing.T) {
 		BoolArgument("verbose", true),
 		BoolArgument("exit-if-error", false),
 		Int64Argument("bytes-per-minute", 999876543210),
+		StringSliceArgument("tags", "tag1", "tag2"),
 	)
 
 	assert.True(t, ctx.IsSet("region"))
@@ -55,6 +56,9 @@ func TestNewCLIContext(t *testing.T) {
 
 	assert.True(t, ctx.IsSet("bytes-per-minute"))
 	assert.Equal(t, int64(999876543210), ctx.Int64("bytes-per-minute"))
+
+	assert.True(t, ctx.IsSet("tags"))
+	assert.Equal(t, []string{"tag1", "tag2"}, ctx.StringSlice("tags"))
 
 	assert.False(t, ctx.IsSet("should-not-exist"))
 }

--- a/tools/cli/testdata/scan_input.json
+++ b/tools/cli/testdata/scan_input.json
@@ -1,0 +1,3 @@
+{"DomainID":"test-domain-id1","WorkflowID":"test-workflow-id1","RunID":"test-run-id1","DomainName":"test-domain-name1"}
+{"DomainID":"test-domain-id2","WorkflowID":"test-workflow-id2","RunID":"test-run-id2","DomainName":"test-domain-name2"}
+{"DomainID":"test-domain-id3","WorkflowID":"test-workflow-id3","RunID":"test-run-id3","DomainName":"test-domain-name3"}

--- a/tools/cli/testdata/scan_input_bad_data.json
+++ b/tools/cli/testdata/scan_input_bad_data.json
@@ -1,0 +1,2 @@
+We should error on invalid data, this is invalid data
+{"DomainID":"test-domain-id1","WorkflowID":"test-workflow-id1","RunID":"test-run-id1","DomainName":"test-domain-name1"}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added tests for AdminDBScan method. 

This unveiled 3 issues with the code
- We called defer on results before checking the error leading to nil ptr crashes 
- If the input file had invalid data the method would go into an infinite loop
- If the input file was empty the command would just succeed with no output

Aditionally this
- Fixes the error wrapping in the function
- Adds a `StringSliceArgument` to the `clitest` package
- Adds `testdata` files for the `AdminDBScan` method as it reads a file

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve test coverage and fix the bugs 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
