### PR TITLE
Update integration tests to use grpc

### DIFF
--- a/host/decision_test.go
+++ b/host/decision_test.go
@@ -103,7 +103,6 @@ func (s *IntegrationSuite) TestDecisionHeartbeatingWithEmptyResult() {
 		cancel()
 		if _, ok := err2.(*types.EntityNotExistsError); ok {
 			hbTimeout++
-			s.Nil(resp2)
 
 			ctx, cancel := createContext()
 			resp, err := s.engine.PollForDecisionTask(ctx, &types.PollForDecisionTaskRequest{

--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -131,11 +131,10 @@ func (s *IntegrationSuite) TestStartWorkflowExecution() {
 	}
 	ctx, cancel = createContext()
 	defer cancel()
-	we2, err2 := s.engine.StartWorkflowExecution(ctx, newRequest)
+	_, err2 := s.engine.StartWorkflowExecution(ctx, newRequest)
 	s.NotNil(err2)
 	s.IsType(&types.WorkflowExecutionAlreadyStartedError{}, err2)
 	s.T().Logf("Unable to start workflow execution: %v\n", err2.Error())
-	s.Nil(we2)
 }
 
 func (s *IntegrationSuite) TestStartWorkflowExecution_StartTimestampMatch() {
@@ -270,11 +269,10 @@ func (s *IntegrationSuite) TestStartWorkflowExecution_IDReusePolicy() {
 	for _, policy := range policies {
 		newRequest := createStartRequest(policy)
 		ctx, cancel := createContext()
-		we1, err1 := s.engine.StartWorkflowExecution(ctx, newRequest)
+		_, err1 := s.engine.StartWorkflowExecution(ctx, newRequest)
 		cancel()
 		s.Error(err1)
 		s.IsType(&types.WorkflowExecutionAlreadyStartedError{}, err1)
-		s.Nil(we1)
 	}
 
 	// Test TerminateIfRunning policy when workflow is running
@@ -371,20 +369,18 @@ GetHistoryLoop:
 	newRequest = createStartRequest(policy)
 	ctx, cancel = createContext()
 	defer cancel()
-	we3, err3 = s.engine.StartWorkflowExecution(ctx, newRequest)
+	_, err3 = s.engine.StartWorkflowExecution(ctx, newRequest)
 	s.Error(err3)
 	s.IsType(&types.WorkflowExecutionAlreadyStartedError{}, err3)
-	s.Nil(we3)
 
 	// test policy RejectDuplicate
 	policy = types.WorkflowIDReusePolicyRejectDuplicate
 	newRequest = createStartRequest(policy)
 	ctx, cancel = createContext()
 	defer cancel()
-	we3, err3 = s.engine.StartWorkflowExecution(ctx, newRequest)
+	_, err3 = s.engine.StartWorkflowExecution(ctx, newRequest)
 	s.Error(err3)
 	s.IsType(&types.WorkflowExecutionAlreadyStartedError{}, err3)
-	s.Nil(we3)
 
 	// test policy AllowDuplicate
 	policy = types.WorkflowIDReusePolicyAllowDuplicate

--- a/host/query_workflow_test.go
+++ b/host/query_workflow_test.go
@@ -933,7 +933,6 @@ func (s *IntegrationSuite) TestQueryWorkflow_Consistent_Timeout() {
 	// wait for query to timeout
 	queryResult := <-queryResultCh
 	s.Error(queryResult.Err) // got a timeout error
-	s.Nil(queryResult.Resp)
 }
 
 func (s *IntegrationSuite) TestQueryWorkflow_Consistent_BlockedByStarted_NonSticky() {
@@ -1408,14 +1407,13 @@ func (s *IntegrationSuite) TestQueryWorkflow_BeforeFirstDecision() {
 	ctx, cancel = createContext()
 	defer cancel()
 	// query workflow without any decision task should produce an error
-	queryResp, err := s.engine.QueryWorkflow(ctx, &types.QueryWorkflowRequest{
+	_, err := s.engine.QueryWorkflow(ctx, &types.QueryWorkflowRequest{
 		Domain:    s.domainName,
 		Execution: workflowExecution,
 		Query: &types.WorkflowQuery{
 			QueryType: queryType,
 		},
 	})
-	s.Nil(queryResp)
 	s.IsType(&types.QueryFailedError{}, err)
 	s.Equal("workflow must handle at least one decision task before it can be queried", err.(*types.QueryFailedError).Message)
 }

--- a/host/signal_workflow_test.go
+++ b/host/signal_workflow_test.go
@@ -1570,9 +1570,8 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 		WorkflowIDReusePolicy:               &wfIDReusePolicy,
 	}
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
-	resp, err := s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
+	_, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
 	cancel()
-	s.Nil(resp)
 	s.Error(err)
 	errMsg := err.(*types.WorkflowExecutionAlreadyStartedError).GetMessage()
 	s.True(strings.Contains(errMsg, "reject duplicate workflow ID"))
@@ -1581,9 +1580,8 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	wfIDReusePolicy = types.WorkflowIDReusePolicyAllowDuplicateFailedOnly
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	sRequest.RequestID = uuid.New()
-	resp, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
+	_, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
 	cancel()
-	s.Nil(resp)
 	s.Error(err)
 	errMsg = err.(*types.WorkflowExecutionAlreadyStartedError).GetMessage()
 	s.True(strings.Contains(errMsg, "allow duplicate workflow ID if last run failed"))
@@ -1592,7 +1590,7 @@ func (s *IntegrationSuite) TestSignalWithStartWorkflow_IDReusePolicy() {
 	wfIDReusePolicy = types.WorkflowIDReusePolicyAllowDuplicate
 	ctx, cancel = context.WithTimeout(context.Background(), 5*time.Second)
 	sRequest.RequestID = uuid.New()
-	resp, err = s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
+	resp, err := s.engine.SignalWithStartWorkflowExecution(ctx, sRequest)
 	cancel()
 	s.Nil(err)
 	s.NotEmpty(resp.GetRunID())


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update integration tests to use grpc
- Remove nil check for responses with errors (somehow grpc returns empty struct instead of nil for error response)

<!-- Tell your future self why have you made these changes -->
**Why?**
- Tchannel is going to be deprecated
- We have features only available in grpc

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
