### PR TITLE
Added tests for AdminDBScanUnsupportedWorkflow

### DIFF
--- a/tools/cli/admin_db_scan_command.go
+++ b/tools/cli/admin_db_scan_command.go
@@ -207,10 +207,10 @@ func listExecutionsByShardID(
 ) error {
 
 	client, err := getDeps(c).initializeExecutionManager(c, shardID)
-	defer client.Close()
 	if err != nil {
-		commoncli.Problem("Error in Admin DB unsupported WF scan: ", err)
+		commoncli.Problem("initialize execution manager:", err)
 	}
+	defer client.Close()
 	paginationFunc := func(paginationToken []byte) ([]interface{}, []byte, error) {
 		ctx, cancel := context.WithTimeout(c.Context, listContextTimeout)
 		defer cancel()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added test for AdminDBScanUnsupportedWorkflow this makes the coverage of this file 87% (according to goland) 

Some error cases are not tested, some are "the os failed" which cannot really be tested.


<!-- Tell your future self why have you made these changes -->
**Why?**
Increase coverage


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
