### PR TITLE
fixes a dumb refactoring bug

### DIFF
--- a/common/isolationgroup/defaultisolationgroupstate/state_test.go
+++ b/common/isolationgroup/defaultisolationgroupstate/state_test.go
@@ -85,7 +85,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return false },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {},
 			domainAffordance: func(mock *cache.MockDomainCache) {
@@ -109,7 +109,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -139,7 +139,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -164,7 +164,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -193,7 +193,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -213,7 +213,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {},
 			domainAffordance: func(mock *cache.MockDomainCache) {
@@ -227,7 +227,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -247,7 +247,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 			},
@@ -263,7 +263,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: []string{"zone-1", "zone-2"},
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 			},
@@ -279,7 +279,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 			availablePollerIsolationGroups: nil,
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -311,7 +311,7 @@ func TestAvailableIsolationGroupsHandler(t *testing.T) {
 				config:                     td.cfg,
 				metricsClient:              metrics.NewNoopMetricsClient(),
 			}
-			res, err := handler.AvailableIsolationGroupsByDomainID(context.TODO(), "domain-id", td.availablePollerIsolationGroups)
+			res, err := handler.AvailableIsolationGroupsByDomainID(context.TODO(), "domain-id", "a-tasklist", td.availablePollerIsolationGroups)
 			assert.Equal(t, td.expected, res)
 			if td.expectedErr != nil {
 				assert.Equal(t, td.expectedErr.Error(), err.Error())
@@ -353,7 +353,7 @@ func TestIsDrainedHandler(t *testing.T) {
 			requestIsolationgroup: "zone-3", // no config specified for this
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -372,7 +372,7 @@ func TestIsDrainedHandler(t *testing.T) {
 			requestIsolationgroup: "zone-2", // no config specified for this
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return true },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {
 				client.EXPECT().GetListValue(
@@ -391,7 +391,7 @@ func TestIsDrainedHandler(t *testing.T) {
 			requestIsolationgroup: "zone-2", // no config specified for this
 			cfg: defaultConfig{
 				IsolationGroupEnabled: func(string) bool { return false },
-				AllIsolationGroups:    []string{"zone-1", "zone-2", "zone-3"},
+				AllIsolationGroups:    func() []string { return []string{"zone-1", "zone-2", "zone-3"} },
 			},
 			dcAffordance: func(client *dynamicconfig.MockClient) {},
 			domainAffordance: func(mock *cache.MockDomainCache) {

--- a/common/isolationgroup/defaultisolationgroupstate/types.go
+++ b/common/isolationgroup/defaultisolationgroupstate/types.go
@@ -38,6 +38,6 @@ type isolationGroups struct {
 type defaultConfig struct {
 	// IsolationGroupEnabled is a domain-based configuration value for whether this feature is enabled at all
 	IsolationGroupEnabled dynamicconfig.BoolPropertyFnWithDomainFilter
-	// AllIsolationGroups is a static list of all the possible isolation group names
-	AllIsolationGroups []string
+	// AllIsolationGroups is all the possible isolation-groups available for a region
+	AllIsolationGroups func() []string
 }

--- a/common/isolationgroup/interface.go
+++ b/common/isolationgroup/interface.go
@@ -43,5 +43,5 @@ type State interface {
 
 	// AvailableIsolationGroupsByDomainID returns the available isolation zones for a domain.
 	// Takes into account global and domain zones
-	AvailableIsolationGroupsByDomainID(ctx context.Context, domainID string, availableIsolationGroups []string) (types.IsolationGroupConfiguration, error)
+	AvailableIsolationGroupsByDomainID(ctx context.Context, domainID string, tasklistName string, availableIsolationGroups []string) (types.IsolationGroupConfiguration, error)
 }

--- a/common/isolationgroup/isolation_group_mock.go
+++ b/common/isolationgroup/isolation_group_mock.go
@@ -59,18 +59,18 @@ func (m *MockState) EXPECT() *MockStateMockRecorder {
 }
 
 // AvailableIsolationGroupsByDomainID mocks base method.
-func (m *MockState) AvailableIsolationGroupsByDomainID(ctx context.Context, domainID string, availableIsolationGroups []string) (types.IsolationGroupConfiguration, error) {
+func (m *MockState) AvailableIsolationGroupsByDomainID(ctx context.Context, domainID, tasklistName string, availableIsolationGroups []string) (types.IsolationGroupConfiguration, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "AvailableIsolationGroupsByDomainID", ctx, domainID, availableIsolationGroups)
+	ret := m.ctrl.Call(m, "AvailableIsolationGroupsByDomainID", ctx, domainID, tasklistName, availableIsolationGroups)
 	ret0, _ := ret[0].(types.IsolationGroupConfiguration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // AvailableIsolationGroupsByDomainID indicates an expected call of AvailableIsolationGroupsByDomainID.
-func (mr *MockStateMockRecorder) AvailableIsolationGroupsByDomainID(ctx, domainID, availableIsolationGroups interface{}) *gomock.Call {
+func (mr *MockStateMockRecorder) AvailableIsolationGroupsByDomainID(ctx, domainID, tasklistName, availableIsolationGroups interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIsolationGroupsByDomainID", reflect.TypeOf((*MockState)(nil).AvailableIsolationGroupsByDomainID), ctx, domainID, availableIsolationGroups)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AvailableIsolationGroupsByDomainID", reflect.TypeOf((*MockState)(nil).AvailableIsolationGroupsByDomainID), ctx, domainID, tasklistName, availableIsolationGroups)
 }
 
 // IsDrained mocks base method.

--- a/common/partition/default-partitioner.go
+++ b/common/partition/default-partitioner.go
@@ -75,7 +75,7 @@ func NewDefaultPartitioner(
 	}
 }
 
-func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, domainID string, wfPartitionData PartitionConfig, availablePollerIsolationGroups []string) (string, error) {
+func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, pollerInfo PollerInfo, wfPartitionData PartitionConfig) (string, error) {
 	if wfPartitionData == nil {
 		return "", ErrInvalidPartitionConfig
 	}
@@ -84,7 +84,7 @@ func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, do
 		return "", ErrInvalidPartitionConfig
 	}
 
-	available, err := r.isolationGroupState.AvailableIsolationGroupsByDomainID(ctx, domainID, availablePollerIsolationGroups)
+	available, err := r.isolationGroupState.AvailableIsolationGroupsByDomainID(ctx, pollerInfo.DomainID, pollerInfo.TasklistName, pollerInfo.AvailableIsolationGroups)
 	if err != nil {
 		return "", fmt.Errorf("failed to get available isolation groups: %w", err)
 	}
@@ -93,7 +93,7 @@ func (r *defaultPartitioner) GetIsolationGroupByDomainID(ctx context.Context, do
 		return "", ErrNoIsolationGroupsAvailable
 	}
 
-	ig := r.pickIsolationGroup(wfPartition, available)
+	ig := r.pickIsolationGroup(wfPartition, available, pollerInfo)
 	return ig, nil
 }
 
@@ -108,7 +108,7 @@ func mapPartitionConfigToDefaultPartitionConfig(config PartitionConfig) defaultW
 
 // picks an isolation group to run in. if the workflow was started there, it'll attempt to pin it, unless there is an explicit
 // drain.
-func (r *defaultPartitioner) pickIsolationGroup(wfPartition defaultWorkflowPartitionConfig, available types.IsolationGroupConfiguration) string {
+func (r *defaultPartitioner) pickIsolationGroup(wfPartition defaultWorkflowPartitionConfig, available types.IsolationGroupConfiguration, pollerInfo PollerInfo) string {
 	_, isAvailable := available[wfPartition.WorkflowStartIsolationGroup]
 	if isAvailable {
 		return wfPartition.WorkflowStartIsolationGroup
@@ -128,6 +128,7 @@ func (r *defaultPartitioner) pickIsolationGroup(wfPartition defaultWorkflowParti
 		tag.FallbackIsolationGroup(fallback),
 		tag.IsolationGroup(wfPartition.WorkflowStartIsolationGroup),
 		tag.PollerGroupsConfiguration(available),
+		tag.WorkflowTaskListName(pollerInfo.TasklistName),
 		tag.WorkflowID(wfPartition.WFID),
 	)
 	return fallback

--- a/common/partition/default-partitioner_test.go
+++ b/common/partition/default-partitioner_test.go
@@ -96,7 +96,7 @@ func TestPickingAZone(t *testing.T) {
 				log:                 testlogger.New(t),
 				isolationGroupState: nil,
 			}
-			res := partitioner.pickIsolationGroup(td.wfPartitionCfg, td.availablePartitionGroups)
+			res := partitioner.pickIsolationGroup(td.wfPartitionCfg, td.availablePartitionGroups, PollerInfo{})
 			assert.Equal(t, td.expected, res)
 		})
 	}
@@ -134,6 +134,7 @@ func TestDefaultPartitionerFallbackPickerDistribution(t *testing.T) {
 func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 
 	domainID := "some-domain-id"
+	sampleTasklist := "a-tasklist"
 	validIsolationGroup := types.IsolationGroupConfiguration{
 		"zone-2": {
 			Name:  "zone-2",
@@ -160,7 +161,7 @@ func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 			},
 			incomingContext: context.Background(),
 			stateAffordance: func(state *isolationgroup.MockState) {
-				state.EXPECT().AvailableIsolationGroupsByDomainID(gomock.Any(), domainID, isolationGroups).Return(validIsolationGroup, nil)
+				state.EXPECT().AvailableIsolationGroupsByDomainID(gomock.Any(), domainID, sampleTasklist, isolationGroups).Return(validIsolationGroup, nil)
 			},
 			expectedValue: "zone-2",
 		},
@@ -171,7 +172,7 @@ func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 			},
 			incomingContext: context.Background(),
 			stateAffordance: func(state *isolationgroup.MockState) {
-				state.EXPECT().AvailableIsolationGroupsByDomainID(gomock.Any(), domainID, isolationGroups).Return(validIsolationGroup, nil)
+				state.EXPECT().AvailableIsolationGroupsByDomainID(gomock.Any(), domainID, sampleTasklist, isolationGroups).Return(validIsolationGroup, nil)
 			},
 			expectedValue: "zone-3",
 		},
@@ -182,7 +183,7 @@ func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 			},
 			incomingContext: context.Background(),
 			stateAffordance: func(state *isolationgroup.MockState) {
-				state.EXPECT().AvailableIsolationGroupsByDomainID(gomock.Any(), domainID, isolationGroups).Return(
+				state.EXPECT().AvailableIsolationGroupsByDomainID(gomock.Any(), domainID, sampleTasklist, isolationGroups).Return(
 					types.IsolationGroupConfiguration{}, nil)
 			},
 			expectedValue: "",
@@ -210,7 +211,11 @@ func TestDefaultPartitioner_GetIsolationGroupByDomainID(t *testing.T) {
 			ig := isolationgroup.NewMockState(ctrl)
 			td.stateAffordance(ig)
 			partitioner := NewDefaultPartitioner(testlogger.New(t), ig)
-			res, err := partitioner.GetIsolationGroupByDomainID(td.incomingContext, domainID, td.partitionKeyPassedIn, isolationGroups)
+			res, err := partitioner.GetIsolationGroupByDomainID(td.incomingContext, PollerInfo{
+				DomainID:                 domainID,
+				TasklistName:             sampleTasklist,
+				AvailableIsolationGroups: isolationGroups,
+			}, td.partitionKeyPassedIn)
 
 			assert.Equal(t, td.expectedValue, res)
 			assert.Equal(t, td.expectedError, err)

--- a/common/partition/interface.go
+++ b/common/partition/interface.go
@@ -26,9 +26,18 @@ package partition
 
 import "context"
 
+// PollerInfo captures relevant information from the poller side
+type PollerInfo struct {
+	DomainID     string
+	TasklistName string
+	// The isolation groups that are known to have pollers in them and are able to receive tasks
+	// for this domain and tasklist.
+	AvailableIsolationGroups []string
+}
+
 type Partitioner interface {
 	// GetIsolationGroupByDomainID gets where the task workflow should be executing. Largely used by Matching
 	// when determining which isolationGroup to place the tasks in.
 	// Implementations ought to return (nil, nil) for when the feature is not enabled.
-	GetIsolationGroupByDomainID(ctx context.Context, DomainID string, partitionKey PartitionConfig, availableIsolationGroups []string) (string, error)
+	GetIsolationGroupByDomainID(ctx context.Context, pollerinfo PollerInfo, partitionKey PartitionConfig) (string, error)
 }

--- a/common/partition/partitioning_mock.go
+++ b/common/partition/partitioning_mock.go
@@ -57,16 +57,16 @@ func (m *MockPartitioner) EXPECT() *MockPartitionerMockRecorder {
 }
 
 // GetIsolationGroupByDomainID mocks base method.
-func (m *MockPartitioner) GetIsolationGroupByDomainID(ctx context.Context, DomainID string, partitionKey PartitionConfig, availableIsolationGroups []string) (string, error) {
+func (m *MockPartitioner) GetIsolationGroupByDomainID(ctx context.Context, pollerinfo PollerInfo, partitionKey PartitionConfig) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetIsolationGroupByDomainID", ctx, DomainID, partitionKey, availableIsolationGroups)
+	ret := m.ctrl.Call(m, "GetIsolationGroupByDomainID", ctx, pollerinfo, partitionKey)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetIsolationGroupByDomainID indicates an expected call of GetIsolationGroupByDomainID.
-func (mr *MockPartitionerMockRecorder) GetIsolationGroupByDomainID(ctx, DomainID, partitionKey, availableIsolationGroups interface{}) *gomock.Call {
+func (mr *MockPartitionerMockRecorder) GetIsolationGroupByDomainID(ctx, pollerinfo, partitionKey interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsolationGroupByDomainID", reflect.TypeOf((*MockPartitioner)(nil).GetIsolationGroupByDomainID), ctx, DomainID, partitionKey, availableIsolationGroups)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetIsolationGroupByDomainID", reflect.TypeOf((*MockPartitioner)(nil).GetIsolationGroupByDomainID), ctx, pollerinfo, partitionKey)
 }

--- a/common/resource/resource_test_utils.go
+++ b/common/resource/resource_test_utils.go
@@ -165,7 +165,7 @@ func NewTest(
 
 	partitionMock := partition.NewMockPartitioner(controller)
 	mockZone := "zone1"
-	partitionMock.EXPECT().GetIsolationGroupByDomainID(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(mockZone, nil)
+	partitionMock.EXPECT().GetIsolationGroupByDomainID(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(mockZone, nil)
 
 	scope := tally.NewTestScope("test", nil)
 

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -699,7 +699,13 @@ func (c *taskListManagerImpl) getIsolationGroupForTask(ctx context.Context, task
 				pollerIsolationGroups = c.config.AllIsolationGroups()
 			}
 		}
-		group, err := c.partitioner.GetIsolationGroupByDomainID(ctx, taskInfo.DomainID, partitionConfig, pollerIsolationGroups)
+
+		group, err := c.partitioner.GetIsolationGroupByDomainID(ctx,
+			partition.PollerInfo{
+				DomainID:                 taskInfo.DomainID,
+				Tasklist:                 c.taskListID.name,
+				AvailableIsolationGroups: pollerIsolationGroups,
+			}, partitionConfig)
 		if err != nil {
 			// For a sticky tasklist, return StickyUnavailableError to let it be added to the non-sticky tasklist.
 			if err == partition.ErrNoIsolationGroupsAvailable && c.taskListKind == types.TaskListKindSticky {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
I made a dumb refactoring bug when changing AllIsolationGroups from a static list to a dynamic function. This fixes that and does some small refactoring to allow for tasklist information to be passed in on the partitioner.

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
