### PR TITLE
Allow LIKE keyword to do partial term matching

### DIFF
--- a/common/pinot/pinotQueryValidator.go
+++ b/common/pinot/pinotQueryValidator.go
@@ -271,7 +271,7 @@ func (qv *VisibilityQueryValidator) processSystemKey(expr sqlparser.Expr) (strin
 			return "", fmt.Errorf("right comparison is invalid: %v", comparisonExpr.Right)
 		}
 		colValStr := string(colVal.Val)
-		return fmt.Sprintf("TEXT_MATCH(%s, '%s')", colNameStr, colValStr), nil
+		return fmt.Sprintf("TEXT_MATCH(%s, '/.*%s.*/')", colNameStr, colValStr), nil
 	}
 
 	if comparisonExpr.Operator != sqlparser.EqualStr && comparisonExpr.Operator != sqlparser.NotEqualStr {

--- a/common/pinot/pinotQueryValidator_test.go
+++ b/common/pinot/pinotQueryValidator_test.go
@@ -48,7 +48,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case2-2: simple query with partial match": {
 			query:     "WorkflowID like 'wid'",
-			validated: "TEXT_MATCH(WorkflowID, 'wid')",
+			validated: "TEXT_MATCH(WorkflowID, '/.*wid.*/')",
 		},
 		"Case2-3: invalid simple query with partial match": {
 			query: "WorkflowID like wid",
@@ -95,7 +95,7 @@ func TestValidateQuery(t *testing.T) {
 		},
 		"Case6-5: complex query with partial match": {
 			query:     "RunID like '123' or WorkflowID like '123'",
-			validated: "(TEXT_MATCH(RunID, '123') or TEXT_MATCH(WorkflowID, '123'))",
+			validated: "(TEXT_MATCH(RunID, '/.*123.*/') or TEXT_MATCH(WorkflowID, '/.*123.*/'))",
 		},
 		"Case7: invalid sql query": {
 			query: "Invalid SQL",


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
LIKE was using TEXT_MATCH() with term match and is now replaced with a regexp to allow partial match

<!-- Tell your future self why have you made these changes -->
**Why?**
TEXT_MATCH() with term match expects full term to be present

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests and running sample pinot queries against the data

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
