### PR TITLE
Fix deadlock in sharded nosql store

### DIFF
--- a/common/persistence/nosql/sharded_nosql_store.go
+++ b/common/persistence/nosql/sharded_nosql_store.go
@@ -100,6 +100,8 @@ func (sn *shardedNosqlStoreImpl) GetDefaultShard() nosqlStore {
 }
 
 func (sn *shardedNosqlStoreImpl) Close() {
+	sn.RLock()
+	defer sn.RUnlock()
 	for name, shard := range sn.connectedShards {
 		sn.logger.Warn("Closing store shard", tag.StoreShard(name))
 		shard.Close()
@@ -135,8 +137,8 @@ func (sn *shardedNosqlStoreImpl) getShard(shardName string) (*nosqlStore, error)
 	}
 
 	sn.Lock()
+	defer sn.Unlock()
 	if shard, ok := sn.connectedShards[shardName]; ok { // read again to double-check
-		sn.Unlock()
 		return &shard, nil
 	}
 
@@ -146,7 +148,6 @@ func (sn *shardedNosqlStoreImpl) getShard(shardName string) (*nosqlStore, error)
 	}
 	sn.connectedShards[shardName] = *s
 	sn.logger.Info("Connected to store shard", tag.StoreShard(shardName))
-	sn.Unlock()
 	return s, nil
 }
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Sharded nosql store has a deadlock where the mutex is not unlocked in one of the error paths. 
This was reported in https://github.com/uber/cadence/issues/6492. 

<!-- Tell your future self why have you made these changes -->
**Why?**
Fix deadlock. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
First Reproduced the issue without fixing the code. Then applied the fix and ensured test is passing 
