### PR TITLE
Make dns updater stoppable to prevent goroutine leaks in tests

### DIFF
--- a/common/rpc/outbounds_test.go
+++ b/common/rpc/outbounds_test.go
@@ -217,5 +217,5 @@ func (f fakePeerChooserFactory) CreatePeerChooser(transport peer.Transport, opts
 	if err != nil {
 		return nil, err
 	}
-	return &defaultPeerChooser{Chooser: chooser}, nil
+	return &defaultPeerChooser{actual: chooser}, nil
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
`dnsUpdater` component has a [never ending goroutine](https://github.com/uber/cadence/blob/d2d1d471663517f37f5d7bb8e534bfbc3227e7e1/common/rpc/dns_updater.go#L72) which breaks leak detection in rpc package tests. Changing that to be a stoppable component.

<!-- Tell your future self why have you made these changes -->
**Why?**
Avoid goroutine leaks in components.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
` go test -timeout 60s -count=10 github.com/uber/cadence/common/rpc` 

This command was reproducing the goleak detection issues in rpc package before the change. After the change it passes consistently.