### PR TITLE
Update CLI to use grpc transport by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ You can find a list of previous releases on the [github releases](https://github
 ## [Unreleased]
 Global ratelimiter, see [detailed doc](https://github.com/uber/cadence/blob/master/common/quotas/global/doc.go)
 
+Update CLI to use GRPC transport by default (originally tchannel).
+
 ## [1.2.13] - 2024-09-25
 See [Release Note](https://github.com/uber/cadence/releases/tag/v1.2.13) for details
 

--- a/tools/cli/app.go
+++ b/tools/cli/app.go
@@ -116,7 +116,7 @@ func NewCliApp(cf ClientFactory, opts ...CLIAppOptions) *cli.App {
 		&cli.StringFlag{
 			Name:    FlagTransport,
 			Aliases: []string{"t"},
-			Usage:   "optional argument for transport protocol format, either 'grpc' or 'tchannel'. Defaults to tchannel if not provided",
+			Usage:   "optional argument for transport protocol format, either 'grpc' or 'tchannel'. Defaults to grpc if not provided",
 			EnvVars: []string{"CADENCE_CLI_TRANSPORT_PROTOCOL"},
 		},
 		&cli.StringFlag{

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -124,15 +124,15 @@ func (b *clientFactory) ServerFrontendClient(c *cli.Context) (frontend.Client, e
 		return nil, commoncli.Problem("failed to create frontend client dependency", err)
 	}
 	clientConfig := b.dispatcher.ClientConfig(cadenceFrontendService)
-	if c.String(FlagTransport) == grpcTransport {
-		return grpcClient.NewFrontendClient(
-			apiv1.NewDomainAPIYARPCClient(clientConfig),
-			apiv1.NewWorkflowAPIYARPCClient(clientConfig),
-			apiv1.NewWorkerAPIYARPCClient(clientConfig),
-			apiv1.NewVisibilityAPIYARPCClient(clientConfig),
-		), nil
+	if c.String(FlagTransport) == thriftTransport {
+		return thrift.NewFrontendClient(serverFrontend.New(clientConfig)), nil
 	}
-	return thrift.NewFrontendClient(serverFrontend.New(clientConfig)), nil
+	return grpcClient.NewFrontendClient(
+		apiv1.NewDomainAPIYARPCClient(clientConfig),
+		apiv1.NewWorkflowAPIYARPCClient(clientConfig),
+		apiv1.NewWorkerAPIYARPCClient(clientConfig),
+		apiv1.NewVisibilityAPIYARPCClient(clientConfig),
+	), nil
 }
 
 // ServerAdminClient builds an admin client (based on server side thrift interface)
@@ -142,10 +142,10 @@ func (b *clientFactory) ServerAdminClient(c *cli.Context) (admin.Client, error) 
 		return nil, commoncli.Problem("failed to create admin client dependency", err)
 	}
 	clientConfig := b.dispatcher.ClientConfig(cadenceFrontendService)
-	if c.String(FlagTransport) == grpcTransport {
-		return grpcClient.NewAdminClient(adminv1.NewAdminAPIYARPCClient(clientConfig)), nil
+	if c.String(FlagTransport) == thriftTransport {
+		return thrift.NewAdminClient(serverAdmin.New(clientConfig)), nil
 	}
-	return thrift.NewAdminClient(serverAdmin.New(clientConfig)), nil
+	return grpcClient.NewAdminClient(adminv1.NewAdminAPIYARPCClient(clientConfig)), nil
 }
 
 // ServerFrontendClientForMigration builds a frontend client (based on server side thrift interface)
@@ -155,15 +155,15 @@ func (b *clientFactory) ServerFrontendClientForMigration(c *cli.Context) (fronte
 		return nil, commoncli.Problem("failed to create frontend client dependency", err)
 	}
 	clientConfig := b.dispatcherMigration.ClientConfig(cadenceFrontendService)
-	if c.String(FlagTransport) == grpcTransport {
-		return grpcClient.NewFrontendClient(
-			apiv1.NewDomainAPIYARPCClient(clientConfig),
-			apiv1.NewWorkflowAPIYARPCClient(clientConfig),
-			apiv1.NewWorkerAPIYARPCClient(clientConfig),
-			apiv1.NewVisibilityAPIYARPCClient(clientConfig),
-		), nil
+	if c.String(FlagTransport) == thriftTransport {
+		return thrift.NewFrontendClient(serverFrontend.New(clientConfig)), nil
 	}
-	return thrift.NewFrontendClient(serverFrontend.New(clientConfig)), nil
+	return grpcClient.NewFrontendClient(
+		apiv1.NewDomainAPIYARPCClient(clientConfig),
+		apiv1.NewWorkflowAPIYARPCClient(clientConfig),
+		apiv1.NewWorkerAPIYARPCClient(clientConfig),
+		apiv1.NewVisibilityAPIYARPCClient(clientConfig),
+	), nil
 }
 
 // ServerAdminClientForMigration builds an admin client (based on server side thrift interface)
@@ -173,10 +173,10 @@ func (b *clientFactory) ServerAdminClientForMigration(c *cli.Context) (admin.Cli
 		return nil, commoncli.Problem("failed to create admin client dependency", err)
 	}
 	clientConfig := b.dispatcherMigration.ClientConfig(cadenceFrontendService)
-	if c.String(FlagTransport) == grpcTransport {
-		return grpcClient.NewAdminClient(adminv1.NewAdminAPIYARPCClient(clientConfig)), nil
+	if c.String(FlagTransport) == thriftTransport {
+		return thrift.NewAdminClient(serverAdmin.New(clientConfig)), nil
 	}
-	return thrift.NewAdminClient(serverAdmin.New(clientConfig)), nil
+	return grpcClient.NewAdminClient(adminv1.NewAdminAPIYARPCClient(clientConfig)), nil
 }
 
 // ElasticSearchClient builds an ElasticSearch client
@@ -235,7 +235,7 @@ func (b *clientFactory) ensureDispatcherForMigration(c *cli.Context) error {
 }
 
 func (b *clientFactory) newClientDispatcher(c *cli.Context, hostPortOverride string) (*yarpc.Dispatcher, error) {
-	shouldUseGrpc := c.String(FlagTransport) == grpcTransport
+	shouldUseGrpc := c.String(FlagTransport) != thriftTransport
 
 	hostPort := tchannelPort
 	if shouldUseGrpc {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Update CLI to use grpc transport by default

<!-- Tell your future self why have you made these changes -->
**Why?**
Tchannel is being deprecated

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests, local tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
