### PR TITLE
Fixing test flakyness by switching to mocked time

### DIFF
--- a/service/history/shard/context_test.go
+++ b/service/history/shard/context_test.go
@@ -38,6 +38,7 @@ import (
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -286,6 +287,9 @@ func (s *contextTestSuite) TestDomainNotificationVersion() {
 }
 
 func (s *contextTestSuite) TestTimerMaxReadLevel() {
+	// this test requires mocked time since we're comparing timestamps
+	s.mockResource.TimeSource = clock.NewMockedTimeSource()
+
 	// get current cluster's level
 	gotLevel := s.context.UpdateTimerMaxReadLevel(cluster.TestCurrentClusterName)
 	wantLevel := s.mockResource.TimeSource.Now().Add(s.context.config.TimerProcessorMaxTimeShift()).Truncate(time.Millisecond)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
TestContextSuite/TestTimerMaxReadLevel is extremely flaky in github.
Unfortunately we can't switch to mocker timer as lots of tests rely on
it.


<!-- Tell your future self why have you made these changes -->
**Why?**
To have lower false-positive failureness.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit-test.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/uber/cadence-docs -->
**Documentation Changes**
