### PR TITLE
Switch to codecov action v5+ for tokenless uploads

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,9 +23,8 @@ jobs:
         run: make cover_profile
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.5.0 # https://github.com/codecov/codecov-action
+        uses: codecov/codecov-action@v5.0.7 # https://github.com/codecov/codecov-action
         with:
           file: .build/coverage/unit_cover.out
           exclude: ./
-          token: ${{ secrets.CODECOV_TOKEN }}
           slug: cadence-workflow/cadence

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,8 +23,9 @@ jobs:
         run: make cover_profile
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5.0.7 # https://github.com/codecov/codecov-action
+        uses: codecov/codecov-action@v4.5.0 # https://github.com/codecov/codecov-action
         with:
           file: .build/coverage/unit_cover.out
           exclude: ./
+          token: ${{ secrets.CODECOV_TOKEN }}
           slug: cadence-workflow/cadence

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -28,5 +28,5 @@ jobs:
           files: .build/coverage/unit_cover.out
           exclude: ./
           # token: ${{ secrets.CODECOV_TOKEN }}
-          token: not-actual-token
+          # token: not-actual-token
           slug: cadence-workflow/cadence

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -23,9 +23,9 @@ jobs:
         run: make cover_profile
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4.5.0 # https://github.com/codecov/codecov-action
+        uses: codecov/codecov-action@v5.0.7 # https://github.com/codecov/codecov-action
         with:
           file: .build/coverage/unit_cover.out
           exclude: ./
-          token: ${{ secrets.CODECOV_TOKEN }}
+          # token: ${{ secrets.CODECOV_TOKEN }}
           slug: cadence-workflow/cadence

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,7 +25,8 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5.0.7 # https://github.com/codecov/codecov-action
         with:
-          file: .build/coverage/unit_cover.out
+          files: .build/coverage/unit_cover.out
           exclude: ./
           # token: ${{ secrets.CODECOV_TOKEN }}
+          token: not-actual-token
           slug: cadence-workflow/cadence

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -49,23 +49,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-<<<<<<< HEAD
       - name: Login to Docker Hub
-<<<<<<< HEAD
         if: ${{ needs.meta.outputs.push_enabled == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
-=======
-
-      # secrets are not available for forks so cannot test this on a PR. Push is disabled so don't need it anyway
-      # - name: Login to Docker Hub
-      #   uses: docker/login-action@v3
-      #   with:
-      #     username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
-      #     password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
->>>>>>> 6ffd2351b (try without docker login. no push anyway)
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
@@ -91,8 +80,6 @@ jobs:
         uses: actions/checkout@v4
       - name: Login to Docker Hub
         if: ${{ needs.meta.outputs.push_enabled == 'true' }}
-=======
->>>>>>> 5a55c4b5c (fix format)
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -85,7 +85,7 @@ jobs:
 >>>>>>> 5a55c4b5c (fix format)
         uses: docker/login-action@v3
         with:
-          username: ${{ vars.CADENCE_SERVER_DOCKERHUB_USERNAME }}
+          username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Login to Docker Hub
+<<<<<<< HEAD
         if: ${{ needs.meta.outputs.push_enabled == 'true' }}
         uses: docker/login-action@v3
         with:
@@ -80,6 +81,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Login to Docker Hub
         if: ${{ needs.meta.outputs.push_enabled == 'true' }}
+=======
+>>>>>>> 5a55c4b5c (fix format)
         uses: docker/login-action@v3
         with:
           username: ${{ vars.CADENCE_SERVER_DOCKERHUB_USERNAME }}

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -82,7 +82,7 @@ jobs:
         if: ${{ needs.meta.outputs.push_enabled == 'true' }}
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
+          username: ${{ vars.CADENCE_SERVER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3

--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -49,6 +49,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+<<<<<<< HEAD
       - name: Login to Docker Hub
 <<<<<<< HEAD
         if: ${{ needs.meta.outputs.push_enabled == 'true' }}
@@ -56,6 +57,15 @@ jobs:
         with:
           username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
           password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
+=======
+
+      # secrets are not available for forks so cannot test this on a PR. Push is disabled so don't need it anyway
+      # - name: Login to Docker Hub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.CADENCE_SERVER_DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.CADENCE_SERVER_DOCKERHUB_TOKEN }}
+>>>>>>> 6ffd2351b (try without docker login. no push anyway)
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
After moving to new github org codecov integration got messed up. There's a tokenless upload feature which requires codecov action v5 so upgrading it to try.
https://docs.codecov.com/docs/codecov-tokens#uploading-without-a-token