### PR TITLE
Update isolationLoadbalancer to use isolation group assignment

### DIFF
--- a/client/clientfactory.go
+++ b/client/clientfactory.go
@@ -164,7 +164,7 @@ func (cf *rpcClientFactory) NewMatchingClientWithTimeout(
 	defaultLoadBalancer := matching.NewLoadBalancer(partitionConfigProvider)
 	roundRobinLoadBalancer := matching.NewRoundRobinLoadBalancer(partitionConfigProvider)
 	weightedLoadBalancer := matching.NewWeightedLoadBalancer(roundRobinLoadBalancer, partitionConfigProvider, cf.logger)
-	igLoadBalancer := matching.NewIsolationLoadBalancer(weightedLoadBalancer, partitionConfigProvider, cf.allIsolationGroups)
+	igLoadBalancer := matching.NewIsolationLoadBalancer(weightedLoadBalancer, partitionConfigProvider, domainIDToName, cf.dynConfig)
 	loadBalancers := map[string]matching.LoadBalancer{
 		"random":      defaultLoadBalancer,
 		"round-robin": roundRobinLoadBalancer,

--- a/client/matching/partition_config_provider_mock.go
+++ b/client/matching/partition_config_provider_mock.go
@@ -91,6 +91,20 @@ func (mr *MockPartitionConfigProviderMockRecorder) GetNumberOfWritePartitions(do
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNumberOfWritePartitions", reflect.TypeOf((*MockPartitionConfigProvider)(nil).GetNumberOfWritePartitions), domainID, taskList, taskListType)
 }
 
+// GetPartitionConfig mocks base method.
+func (m *MockPartitionConfigProvider) GetPartitionConfig(domainID string, taskList types.TaskList, taskListType int) *types.TaskListPartitionConfig {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPartitionConfig", domainID, taskList, taskListType)
+	ret0, _ := ret[0].(*types.TaskListPartitionConfig)
+	return ret0
+}
+
+// GetPartitionConfig indicates an expected call of GetPartitionConfig.
+func (mr *MockPartitionConfigProviderMockRecorder) GetPartitionConfig(domainID, taskList, taskListType any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPartitionConfig", reflect.TypeOf((*MockPartitionConfigProvider)(nil).GetPartitionConfig), domainID, taskList, taskListType)
+}
+
 // UpdatePartitionConfig mocks base method.
 func (m *MockPartitionConfigProvider) UpdatePartitionConfig(domainID string, taskList types.TaskList, taskListType int, config *types.TaskListPartitionConfig) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Rather than arbitrarily assigning isolation groups to partitions, use the assignment stored in the database and cached in the client.

<!-- Describe what has changed in this PR -->
**What changed?**
- Update isolation load balancer to use the assigned isolation groups
- Refactor PartitionConfigProvider to expose partition configuration

<!-- Tell your future self why have you made these changes -->
**Why?**
- Enables isolation group assignment to influence task/poller routing

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Bugs in PartitionConfigProvider could impact TaskList partitioning, but isolation group assignment is behind a feature flag.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
