### PR TITLE
Makefile cleanup and closing "forgot about new submodule" gaps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -560,11 +560,10 @@ $Q cd $(1); go mod tidy || (echo "failed to tidy $(1), try manually copying go.m
 endef
 
 tidy: ## `go mod tidy` all packages
-	$Q # tidy in dependency order, so causes are clearer
 	$Q go mod tidy
-	$(call tidy_submodule,common/archiver/gcloud)
-	$(call tidy_submodule,service/sharddistributor/leader/leaderstore/etcd)
-	$(call tidy_submodule,cmd/server)
+	$(foreach submod,$(SUBMOD_DIRS) internal/tools,\
+		$(call tidy_submodule,$(submod)) $(NEWLINE)\
+	)
 
 clean: ## Clean build products
 	rm -f $(BINS)


### PR DESCRIPTION
Contains a few things, and will need to rebase on #6938 but:
- deleted the commented-out "copyright" stuff
- switched some simpler for loops over to `$(foreach ...)` which are a bit easier to read, and print more nicely with V=1 (you can see each fully-formed command as it is run, rather than one big for-loop for all steps)
  - it may not be a great option for complex stuff, as it seems like it can't blend newlines into the V=1 output.  but it seems probably worth it for essentially-single-line stuff, and arguably anything larger deserves to be in a separate script for readability anyway...
- made some more helper-vars for "all submodules" and similar
- switched some "./..." and "depends on some/go.mod" over to the helper vars, so they now check everything rather than just one or two

I've re-checked several times but I'm not actually confident that this plugs _all_ the "we added a new submodule and forgot to check in X" gaps... but it should be an improvement anyway.