### PR TITLE
History QueueV2: Introduce pending task tracker component

### DIFF
--- a/service/history/queuev2/pending_task_tracker.go
+++ b/service/history/queuev2/pending_task_tracker.go
@@ -1,0 +1,90 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package queuev2
+
+import (
+	"github.com/uber/cadence/common/persistence"
+	ctask "github.com/uber/cadence/common/task"
+	"github.com/uber/cadence/service/history/task"
+)
+
+type (
+	// PendingTaskTracker tracks the pending tasks in a virtual slice.
+	PendingTaskTracker interface {
+		// AddTask adds a task to the pending task tracker.
+		AddTask(task.Task)
+		// PruneAckedTasks prunes the acked tasks from the pending task tracker.
+		PruneAckedTasks()
+		// GetMinimumTaskKey returns the minimum task key in the pending task tracker, if there are no pending tasks, it returns MaxHistoryTaskKey.
+		GetMinimumTaskKey() (persistence.HistoryTaskKey, bool)
+		// GetTasks returns all the tasks in the pending task tracker, the result should be read-only.
+		GetTasks() map[persistence.HistoryTaskKey]task.Task
+	}
+
+	pendingTaskTrackerImpl struct {
+		taskMap    map[persistence.HistoryTaskKey]task.Task
+		minTaskKey persistence.HistoryTaskKey
+	}
+)
+
+func NewPendingTaskTracker() PendingTaskTracker {
+	return &pendingTaskTrackerImpl{
+		taskMap: make(map[persistence.HistoryTaskKey]task.Task),
+	}
+}
+
+func (t *pendingTaskTrackerImpl) AddTask(task task.Task) {
+	if len(t.taskMap) == 0 {
+		t.minTaskKey = task.GetTaskKey()
+	} else if t.minTaskKey.Compare(task.GetTaskKey()) > 0 {
+		t.minTaskKey = task.GetTaskKey()
+	}
+
+	t.taskMap[task.GetTaskKey()] = task
+}
+
+func (t *pendingTaskTrackerImpl) GetMinimumTaskKey() (persistence.HistoryTaskKey, bool) {
+	if len(t.taskMap) == 0 {
+		return persistence.MaxHistoryTaskKey, false
+	}
+	return t.minTaskKey, true
+}
+
+func (t *pendingTaskTrackerImpl) GetTasks() map[persistence.HistoryTaskKey]task.Task {
+	return t.taskMap
+}
+
+func (t *pendingTaskTrackerImpl) PruneAckedTasks() {
+	minTaskKey := persistence.MaxHistoryTaskKey
+	for key, task := range t.taskMap {
+		if task.State() == ctask.TaskStateAcked {
+			delete(t.taskMap, key)
+			continue
+		}
+
+		if key.Compare(minTaskKey) < 0 {
+			minTaskKey = key
+		}
+	}
+	t.minTaskKey = minTaskKey
+}

--- a/service/history/queuev2/pending_task_tracker_test.go
+++ b/service/history/queuev2/pending_task_tracker_test.go
@@ -1,0 +1,144 @@
+package queuev2
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/persistence"
+	ctask "github.com/uber/cadence/common/task"
+	"github.com/uber/cadence/service/history/task"
+)
+
+func TestPendingTaskTracker(t *testing.T) {
+	testTime := time.Unix(0, 0)
+	tests := []struct {
+		name          string
+		setupTasks    func(ctrl *gomock.Controller) []*task.MockTask
+		pruneAcked    bool
+		wantMinKey    persistence.HistoryTaskKey
+		wantHasMinKey bool
+		wantTaskCount int
+	}{
+		{
+			name:          "empty tracker",
+			setupTasks:    func(ctrl *gomock.Controller) []*task.MockTask { return []*task.MockTask{} },
+			wantMinKey:    persistence.MaxHistoryTaskKey,
+			wantHasMinKey: false,
+			wantTaskCount: 0,
+		},
+		{
+			name: "single task",
+			setupTasks: func(ctrl *gomock.Controller) []*task.MockTask {
+				mockTask := task.NewMockTask(ctrl)
+				mockTask.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 1)).AnyTimes()
+				mockTask.EXPECT().State().Return(ctask.TaskStatePending).AnyTimes()
+				return []*task.MockTask{mockTask}
+			},
+			wantMinKey:    persistence.NewHistoryTaskKey(testTime, 1),
+			wantHasMinKey: true,
+			wantTaskCount: 1,
+		},
+		{
+			name: "multiple tasks",
+			setupTasks: func(ctrl *gomock.Controller) []*task.MockTask {
+				task1 := task.NewMockTask(ctrl)
+				task1.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 3)).AnyTimes()
+				task1.EXPECT().State().Return(ctask.TaskStatePending).AnyTimes()
+
+				task2 := task.NewMockTask(ctrl)
+				task2.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 1)).AnyTimes()
+				task2.EXPECT().State().Return(ctask.TaskStatePending).AnyTimes()
+
+				task3 := task.NewMockTask(ctrl)
+				task3.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 2)).AnyTimes()
+				task3.EXPECT().State().Return(ctask.TaskStatePending).AnyTimes()
+
+				return []*task.MockTask{task1, task2, task3}
+			},
+			wantMinKey:    persistence.NewHistoryTaskKey(testTime, 1),
+			wantHasMinKey: true,
+			wantTaskCount: 3,
+		},
+		{
+			name: "prune acked tasks",
+			setupTasks: func(ctrl *gomock.Controller) []*task.MockTask {
+				task1 := task.NewMockTask(ctrl)
+				task1.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 1)).AnyTimes()
+				task1.EXPECT().State().Return(ctask.TaskStateAcked).AnyTimes()
+
+				task2 := task.NewMockTask(ctrl)
+				task2.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 2)).AnyTimes()
+				task2.EXPECT().State().Return(ctask.TaskStatePending).AnyTimes()
+
+				task3 := task.NewMockTask(ctrl)
+				task3.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 3)).AnyTimes()
+				task3.EXPECT().State().Return(ctask.TaskStateAcked).AnyTimes()
+
+				return []*task.MockTask{task1, task2, task3}
+			},
+			pruneAcked:    true,
+			wantMinKey:    persistence.NewHistoryTaskKey(testTime, 2),
+			wantHasMinKey: true,
+			wantTaskCount: 1,
+		},
+		{
+			name: "all tasks acked",
+			setupTasks: func(ctrl *gomock.Controller) []*task.MockTask {
+				task1 := task.NewMockTask(ctrl)
+				task1.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 1)).AnyTimes()
+				task1.EXPECT().State().Return(ctask.TaskStateAcked).AnyTimes()
+
+				task2 := task.NewMockTask(ctrl)
+				task2.EXPECT().GetTaskKey().Return(persistence.NewHistoryTaskKey(testTime, 2)).AnyTimes()
+				task2.EXPECT().State().Return(ctask.TaskStateAcked).AnyTimes()
+
+				return []*task.MockTask{task1, task2}
+			},
+			pruneAcked:    true,
+			wantMinKey:    persistence.MaxHistoryTaskKey,
+			wantHasMinKey: false,
+			wantTaskCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracker := NewPendingTaskTracker()
+
+			ctrl := gomock.NewController(t)
+			inputTasks := tt.setupTasks(ctrl)
+			// Setup tasks
+			for _, task := range inputTasks {
+				tracker.AddTask(task)
+			}
+
+			// Prune acked tasks if needed
+			if tt.pruneAcked {
+				tracker.PruneAckedTasks()
+			}
+
+			// Test GetMinimumTaskKey
+			gotMinKey, gotHasMinKey := tracker.GetMinimumTaskKey()
+			assert.Equal(t, tt.wantMinKey, gotMinKey)
+			assert.Equal(t, tt.wantHasMinKey, gotHasMinKey)
+
+			// Test GetTasks
+			tasks := tracker.GetTasks()
+			assert.Equal(t, tt.wantTaskCount, len(tasks))
+
+			// Verify all tasks are in the map
+			for _, task := range inputTasks {
+				if tt.pruneAcked && task.State() == ctask.TaskStateAcked {
+					_, exists := tasks[task.GetTaskKey()]
+					assert.False(t, exists, "Acked task should not be in the map")
+				} else {
+					_, exists := tasks[task.GetTaskKey()]
+					assert.True(t, exists, "Task should be in the map")
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Introduce pending task tracker component for history queuev2, which has the same functionality as the [outstandingTasks](https://github.com/cadence-workflow/cadence/blob/master/service/history/queue/processing_queue.go#L42) map in history queuev1's processing queue

<!-- Tell your future self why have you made these changes -->
**Why?**
This component tracks the state of history tasks in memory.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
The component is not used, no risk in this PR

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
