### PR TITLE
Fix IDL submodule branch checking in CI workflows

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -14,6 +14,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true # ensures git submodules are intialized and updated
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Check IDL submodule status (must point to master)
         run: make .idl-status
@@ -28,6 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -61,6 +63,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -81,6 +84,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -112,6 +116,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -143,6 +148,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -174,6 +180,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -205,6 +212,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -236,6 +244,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -267,6 +276,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5
@@ -298,6 +308,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
+          fetch-depth: 0 # get full history for branch checking
 
       - name: Setup Go environment
         uses: actions/setup-go@v5


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Updated all actions/checkout@v4 steps in `.github/workflows/ci-checks.yml` to include `fetch-depth: 0`
This ensures full repository history is available for submodule branch validation

<!-- Tell your future self why have you made these changes -->
**Why?**
This PR addresses an issue where the .idl-status Makefile target was failing in CI because the GitHub Actions checkout was using shallow clones (--depth=1), which prevented proper branch checking for submodules.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Only CI pipeline change.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
