### PR TITLE
improve no-data fallback mode for global ratelimiters

### DIFF
--- a/common/quotas/global/collection/internal/fallback.go
+++ b/common/quotas/global/collection/internal/fallback.go
@@ -117,7 +117,7 @@ const (
 // NewFallbackLimiter returns a quotas.Limiter that uses a simpler fallback when necessary,
 // and attempts to keep both the fallback and the "real" limiter "warm" by mirroring calls
 // between the two regardless of which is being used.
-func NewFallbackLimiter(fallback quotas.Limiter) *FallbackLimiter {
+	func NewFallbackLimiter(fallback quotas.Limiter) *FallbackLimiter {
 	l := &FallbackLimiter{
 		// start from 0 as a default, the limiter is unused until it is updated.
 		//

--- a/service/frontend/service.go
+++ b/service/frontend/service.go
@@ -242,8 +242,14 @@ func (s *Service) createGlobalQuotaCollections() (globalRatelimiterCollections, 
 
 	// to safely shadow global ratelimits, we must make duplicate *quota.Collection collections
 	// so they do not share data when the global limiter decides to use its local fallback.
-	// these are then combined into the global/algorithm.Collection to handle all limiting calls
-	local, global := s.createBaseLimiters(), s.createBaseLimiters()
+	// these are then combined into the global/algorithm.Collection to handle all limiting calls.
+	//
+	// local limiters have a burst multiplier of 1, which means RPS == burst, as this is the historical behavior.
+	//
+	// global limiters use a larger burst in their fallback limiter only (i.e. when in "local, no data yet" mode)
+	// to improve behavior for users who are low volume but send small bursts of requests that might exceed the
+	// normal local limit.  this gives some time for the collection to gather data and adjust to the real load.
+	local, global := s.createBaseLimiters(1), s.createBaseLimiters(5)
 
 	user, err := create("user", local.user, global.user, s.config.GlobalDomainUserRPS)
 	combinedErr = multierr.Combine(combinedErr, err)
@@ -264,13 +270,14 @@ func (s *Service) createGlobalQuotaCollections() (globalRatelimiterCollections, 
 		async:      async,
 	}, combinedErr
 }
-func (s *Service) createBaseLimiters() ratelimiterCollections {
+func (s *Service) createBaseLimiters(burstMultiplier float64) ratelimiterCollections {
 	create := func(shared, perInstance dynamicproperties.IntPropertyFnWithDomainFilter) *quotas.Collection {
-		return quotas.NewCollection(permember.NewPerMemberDynamicRateLimiterFactory(
+		return quotas.NewCollection(permember.NewPerMemberBurstyDynamicRateLimiterFactory(
 			service.Frontend,
 			shared,
 			perInstance,
 			s.GetMembershipResolver(),
+			burstMultiplier,
 		))
 	}
 	return ratelimiterCollections{


### PR DESCRIPTION
bursts are surprisingly bad even in global mode, so this raises the burst in that scenario.
when global usage is known, the unused-rps-boosting should take care of it, unless they are approaching their RPS (in which case reducing the burst is good).

(this is not yet complete, just proof-of-concept-ing for now and letting CI tell me if there are surprises)
