### PR TITLE
Make Frontend warmup duration configurable

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2412,6 +2412,12 @@ const (
 	// Default value: 0
 	// Allowed filters: N/A
 	FrontendShutdownDrainDuration
+	// FrontendWarmupDuration is the duration before a frontend host reports its status as healthy
+	// KeyName: frontend.warmupDuration
+	// Value type: Duration
+	// Default value: 30s
+	// Allowed filters: N/A
+	FrontendWarmupDuration
 	// FrontendFailoverCoolDown is duration between two domain failvoers
 	// KeyName: frontend.failoverCoolDown
 	// Value type: Duration
@@ -4877,6 +4883,11 @@ var DurationKeys = map[DurationKey]DynamicDuration{
 		KeyName:      "frontend.shutdownDrainDuration",
 		Description:  "FrontendShutdownDrainDuration is the duration of traffic drain during shutdown",
 		DefaultValue: 0,
+	},
+	FrontendWarmupDuration: {
+		KeyName:      "frontend.warmupDuration",
+		Description:  "FrontendWarmupDuration is the duration before a frontend host reports its status as healthy",
+		DefaultValue: 30 * time.Second,
 	},
 	FrontendFailoverCoolDown: {
 		KeyName:      "frontend.failoverCoolDown",

--- a/host/testdata/dynamicconfig/integration_queuev2_test.yaml
+++ b/host/testdata/dynamicconfig/integration_queuev2_test.yaml
@@ -4,3 +4,6 @@ history.enableTimerQueueV2:
 history.enableTransferQueueV2:
 - value: true
   constraints: {}
+frontend.warmupDuration:
+- value: "1s"
+  constraints: {}

--- a/host/testdata/dynamicconfig/integration_test.yaml
+++ b/host/testdata/dynamicconfig/integration_test.yaml
@@ -1,0 +1,3 @@
+frontend.warmupDuration:
+- value: "1s"
+  constraints: {}

--- a/service/frontend/api/handler.go
+++ b/service/frontend/api/handler.go
@@ -154,10 +154,7 @@ func NewWorkflowHandler(
 
 // Start starts the handler
 func (wh *WorkflowHandler) Start() {
-	// TODO: Get warmup duration from config. Even better, run proactive checks such as probing downstream connections.
-	const warmUpDuration = 30 * time.Second
-
-	warmupTimer := time.NewTimer(warmUpDuration)
+	warmupTimer := time.NewTimer(wh.config.WarmupDuration())
 	go func() {
 		<-warmupTimer.C
 		wh.GetLogger().Warn("Service warmup duration has elapsed.")

--- a/service/frontend/config/config.go
+++ b/service/frontend/config/config.go
@@ -61,6 +61,7 @@ type Config struct {
 	EnableQueryAttributeValidation    dynamicproperties.BoolPropertyFn
 	DisallowQuery                     dynamicproperties.BoolPropertyFnWithDomainFilter
 	ShutdownDrainDuration             dynamicproperties.DurationPropertyFn
+	WarmupDuration                    dynamicproperties.DurationPropertyFn
 	Lockdown                          dynamicproperties.BoolPropertyFnWithDomainFilter
 
 	// global ratelimiter config, uses GlobalDomain*RPS for RPS configuration
@@ -166,6 +167,7 @@ func NewConfig(dc *dynamicconfig.Collection, numHistoryShards int, isAdvancedVis
 		BlobSizeLimitWarn:                           dc.GetIntPropertyFilteredByDomain(dynamicproperties.BlobSizeLimitWarn),
 		ThrottledLogRPS:                             dc.GetIntProperty(dynamicproperties.FrontendThrottledLogRPS),
 		ShutdownDrainDuration:                       dc.GetDurationProperty(dynamicproperties.FrontendShutdownDrainDuration),
+		WarmupDuration:                              dc.GetDurationProperty(dynamicproperties.FrontendWarmupDuration),
 		EnableDomainNotActiveAutoForwarding:         dc.GetBoolPropertyFilteredByDomain(dynamicproperties.EnableDomainNotActiveAutoForwarding),
 		EnableGracefulFailover:                      dc.GetBoolProperty(dynamicproperties.EnableGracefulFailover),
 		DomainFailoverRefreshInterval:               dc.GetDurationProperty(dynamicproperties.DomainFailoverRefreshInterval),

--- a/service/frontend/config/config_test.go
+++ b/service/frontend/config/config_test.go
@@ -86,6 +86,7 @@ func TestNewConfig(t *testing.T) {
 		"BlobSizeLimitWarn":                           {dynamicproperties.BlobSizeLimitWarn, 30},
 		"ThrottledLogRPS":                             {dynamicproperties.FrontendThrottledLogRPS, 31},
 		"ShutdownDrainDuration":                       {dynamicproperties.FrontendShutdownDrainDuration, time.Duration(32)},
+		"WarmupDuration":                              {dynamicproperties.FrontendWarmupDuration, time.Duration(40)},
 		"EnableDomainNotActiveAutoForwarding":         {dynamicproperties.EnableDomainNotActiveAutoForwarding, true},
 		"EnableGracefulFailover":                      {dynamicproperties.EnableGracefulFailover, false},
 		"DomainFailoverRefreshInterval":               {dynamicproperties.DomainFailoverRefreshInterval, time.Duration(33)},


### PR DESCRIPTION
If an integration test completes faster than this duration it causes the test to fail due to late logging. This can happen particularly frequently with the SQLite persistence layer, since it's all in-process.

<!-- Describe what has changed in this PR -->
**What changed?**
- Introduced new dynamic config setting for warmup duration

<!-- Tell your future self why have you made these changes -->
**Why?**
- To reduce it in integration tests, reducing flakiness.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Running the integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- None

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
