### PR TITLE
Increase Activity Rate Limiter Responsiveness

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2706,6 +2706,7 @@ const (
 	TaskLagPerTaskListGauge
 	TaskBacklogPerTaskListGauge
 	TaskCountPerTaskListGauge
+	RateLimitPerTaskListGauge
 	SyncMatchLocalPollLatencyPerTaskList
 	SyncMatchForwardPollLatencyPerTaskList
 	AsyncMatchLocalPollCounterPerTaskList
@@ -3460,6 +3461,7 @@ var MetricDefs = map[ServiceIdx]map[int]metricDefinition{
 		TaskLagPerTaskListGauge:                                 {metricName: "task_lag_per_tl", metricType: Gauge},
 		TaskBacklogPerTaskListGauge:                             {metricName: "task_backlog_per_tl", metricType: Gauge},
 		TaskCountPerTaskListGauge:                               {metricName: "task_count_per_tl", metricType: Gauge},
+		RateLimitPerTaskListGauge:                               {metricName: "rate_limit_per_tl", metricType: Gauge},
 		SyncMatchLocalPollLatencyPerTaskList:                    {metricName: "syncmatch_local_poll_latency_per_tl", metricRollupName: "syncmatch_local_poll_latency"},
 		SyncMatchForwardPollLatencyPerTaskList:                  {metricName: "syncmatch_forward_poll_latency_per_tl", metricRollupName: "syncmatch_forward_poll_latency"},
 		AsyncMatchLocalPollCounterPerTaskList:                   {metricName: "asyncmatch_local_poll_per_tl", metricRollupName: "asyncmatch_local_poll"},

--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -75,8 +75,6 @@ type (
 		MustOffer(ctx context.Context, task *InternalTask) error
 		Poll(ctx context.Context, isolationGroup string) (*InternalTask, error)
 		PollForQuery(ctx context.Context) (*InternalTask, error)
-		UpdateRatelimit(rps *float64)
-		Rate() float64
 		RefreshCancelContext()
 	}
 

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -419,20 +419,6 @@ func (mr *MockTaskMatcherMockRecorder) PollForQuery(ctx any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PollForQuery", reflect.TypeOf((*MockTaskMatcher)(nil).PollForQuery), ctx)
 }
 
-// Rate mocks base method.
-func (m *MockTaskMatcher) Rate() float64 {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Rate")
-	ret0, _ := ret[0].(float64)
-	return ret0
-}
-
-// Rate indicates an expected call of Rate.
-func (mr *MockTaskMatcherMockRecorder) Rate() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Rate", reflect.TypeOf((*MockTaskMatcher)(nil).Rate))
-}
-
 // RefreshCancelContext mocks base method.
 func (m *MockTaskMatcher) RefreshCancelContext() {
 	m.ctrl.T.Helper()
@@ -443,18 +429,6 @@ func (m *MockTaskMatcher) RefreshCancelContext() {
 func (mr *MockTaskMatcherMockRecorder) RefreshCancelContext() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshCancelContext", reflect.TypeOf((*MockTaskMatcher)(nil).RefreshCancelContext))
-}
-
-// UpdateRatelimit mocks base method.
-func (m *MockTaskMatcher) UpdateRatelimit(rps *float64) {
-	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UpdateRatelimit", rps)
-}
-
-// UpdateRatelimit indicates an expected call of UpdateRatelimit.
-func (mr *MockTaskMatcherMockRecorder) UpdateRatelimit(rps any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRatelimit", reflect.TypeOf((*MockTaskMatcher)(nil).UpdateRatelimit), rps)
 }
 
 // MockForwarder is a mock of Forwarder interface.

--- a/service/matching/tasklist/task_list_limiter.go
+++ b/service/matching/tasklist/task_list_limiter.go
@@ -1,0 +1,128 @@
+package tasklist
+
+import (
+	"context"
+	"math"
+	"sync"
+	"time"
+
+	"go.uber.org/atomic"
+	"golang.org/x/time/rate"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/service/matching/config"
+)
+
+const precision = 0.001
+
+type taskListLimiter struct {
+	backing           clock.Ratelimiter
+	timeSource        clock.TimeSource
+	scope             metrics.Scope
+	ttl               time.Duration
+	minBurst          int
+	lock              sync.Mutex
+	value             atomic.Float64
+	lastReceivedValue atomic.Time
+	lastUpdate        atomic.Time
+	countPartitions   func() int
+	partitions        int
+}
+
+func newTaskListLimiter(timeSource clock.TimeSource, scope metrics.Scope, config *config.TaskListConfig, numPartitions func() int) *taskListLimiter {
+	l := &taskListLimiter{
+		timeSource:      timeSource,
+		scope:           scope,
+		ttl:             config.TaskDispatchRPSTTL,
+		countPartitions: numPartitions,
+		minBurst:        config.MinTaskThrottlingBurstSize(),
+	}
+	l.value.Store(config.TaskDispatchRPS)
+	l.partitions = numPartitions()
+	now := timeSource.Now()
+	l.lastUpdate.Store(now)
+	l.lastReceivedValue.Store(now)
+	l.backing = clock.NewRatelimiter(l.getLimitAndBurst())
+	return l
+}
+
+func (l *taskListLimiter) Allow() bool {
+	return l.backing.Allow()
+}
+
+func (l *taskListLimiter) Wait(ctx context.Context) error {
+	return l.backing.Wait(ctx)
+}
+
+func (l *taskListLimiter) Reserve() clock.Reservation {
+	return l.backing.Reserve()
+}
+
+func (l *taskListLimiter) Limit() rate.Limit {
+	return l.backing.Limit()
+}
+
+func (l *taskListLimiter) ReportLimit(rps float64) {
+	now := l.timeSource.Now()
+	// Optimistically reject it without locking if it's >= current and within the TTL
+	if now.Sub(l.lastUpdate.Load()) < l.ttl {
+		current := l.value.Load()
+		if rps > current {
+			return
+		}
+		// If it's roughly equal to the current value, track the timestamp
+		// We'll maintain this value in the next update unless something lower
+		// comes along
+		if math.Abs(current-rps) < precision {
+			l.lastReceivedValue.Store(now)
+			return
+		}
+		// else if rps < current, we try to update
+	}
+	l.tryUpdate(rps)
+}
+
+func (l *taskListLimiter) tryUpdate(rps float64) {
+	l.lock.Lock()
+	defer l.lock.Unlock()
+	now := l.timeSource.Now()
+	current := l.value.Load()
+	lastUpdated := l.lastUpdate.Load()
+	ttlElapsed := now.Sub(lastUpdated) >= l.ttl
+	changed := false
+
+	// Take the lower value, or if the ttl expired and haven't received the current low value within the TTL, take the
+	// new value
+	if rps < current || (ttlElapsed && !l.lastReceivedValue.Load().After(now.Add(-l.ttl))) {
+		l.lastUpdate.Store(now)
+		l.value.Store(rps)
+		l.lastReceivedValue.Store(now)
+		l.partitions = l.countPartitions()
+		changed = true
+		l.scope.UpdateGauge(metrics.RateLimitPerTaskListGauge, rps)
+	} else if ttlElapsed {
+		// If the TTL elapsed, recalculate the partition count in case it changed
+		l.lastUpdate.Store(now)
+		newPartitions := l.countPartitions()
+		if newPartitions != l.partitions {
+			l.partitions = newPartitions
+			changed = true
+		}
+		l.scope.UpdateGauge(metrics.RateLimitPerTaskListGauge, current)
+	}
+
+	if changed {
+		l.backing.SetLimitAndBurst(l.getLimitAndBurst())
+	}
+}
+
+func (l *taskListLimiter) getLimitAndBurst() (rate.Limit, int) {
+	rps := l.value.Load()
+	rps = rps / float64(l.partitions)
+	burst := max(int(math.Ceil(rps)), l.minBurst)
+	if rps == 0 {
+		burst = 0
+	}
+	return rate.Limit(rps), burst
+}

--- a/service/matching/tasklist/task_list_limiter_test.go
+++ b/service/matching/tasklist/task_list_limiter_test.go
@@ -1,0 +1,148 @@
+package tasklist
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"golang.org/x/time/rate"
+
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/service/matching/config"
+)
+
+func TestTaskListLimiter(t *testing.T) {
+	const ttl = time.Second
+	const defaultRps = 100
+	cases := []struct {
+		name     string
+		fn       func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int)
+		expected rate.Limit
+	}{
+		{
+			name:     "no update",
+			fn:       func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {},
+			expected: rate.Limit(defaultRps),
+		},
+		{
+			name: "take lower",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				limiter.ReportLimit(1)
+			},
+			expected: rate.Limit(1),
+		},
+		{
+			name: "take lowest",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				limiter.ReportLimit(50)
+				limiter.ReportLimit(10)
+			},
+			expected: rate.Limit(10),
+		},
+		{
+			name: "ignore higher",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				limiter.ReportLimit(defaultRps + 1)
+			},
+			expected: rate.Limit(defaultRps),
+		},
+		{
+			name: "take higher after ttl",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				mockClock.Advance(ttl)
+				limiter.ReportLimit(101)
+			},
+			expected: rate.Limit(101),
+		},
+		{
+			name: "keep lower if reported within ttl",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				mockClock.Advance(time.Millisecond)
+				limiter.ReportLimit(defaultRps)
+				mockClock.Advance(ttl - time.Nanosecond)
+				limiter.ReportLimit(defaultRps + 1)
+			},
+			expected: rate.Limit(defaultRps),
+		},
+		{
+			name: "taker higher if lower not recently reported",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				mockClock.Advance(time.Millisecond)
+				limiter.ReportLimit(defaultRps)
+				mockClock.Advance(ttl + time.Nanosecond)
+				limiter.ReportLimit(defaultRps + 1)
+			},
+			expected: rate.Limit(defaultRps + 1),
+		},
+		{
+			name: "recalculate partitions on ttl expiration - lower limit",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				mockClock.Advance(ttl)
+				*numPartitions = 2
+				limiter.ReportLimit(50)
+			},
+			expected: rate.Limit(25),
+		},
+		{
+			name: "recalculate partitions on ttl expiration - equal limit",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				mockClock.Advance(ttl)
+				*numPartitions = 2
+				limiter.ReportLimit(defaultRps)
+			},
+			expected: rate.Limit(50),
+		},
+		{
+			name: "recalculate partitions on ttl expiration - higher limit",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				mockClock.Advance(ttl)
+				*numPartitions = 2
+				limiter.ReportLimit(defaultRps + 2)
+			},
+			expected: rate.Limit(51),
+		},
+		{
+			name: "recalculate partitions on early updates",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				*numPartitions = 2
+				limiter.ReportLimit(50)
+			},
+			expected: rate.Limit(25),
+		},
+		{
+			name: "recalculate partitions even when keeping lower limit",
+			fn: func(mockClock clock.MockedTimeSource, limiter *taskListLimiter, numPartitions *int) {
+				// lastUpdate time
+				limiter.ReportLimit(50)
+				mockClock.Advance(time.Nanosecond)
+				limiter.ReportLimit(50)
+				mockClock.Advance(ttl - time.Nanosecond)
+				*numPartitions = 2
+				// 100 won't be applied because we received 50 within the TTL, but
+				// it's been TTL since we last did an update so recalculate the partitions
+				limiter.ReportLimit(100)
+			},
+			expected: rate.Limit(25),
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockClock := clock.NewMockedTimeSource()
+			scope := metrics.NoopScope
+			numPartitions := 1
+			tlConfig := &config.TaskListConfig{
+				TaskDispatchRPSTTL: ttl,
+				TaskDispatchRPS:    defaultRps,
+				MinTaskThrottlingBurstSize: func() int {
+					return 1
+				},
+			}
+			limiter := newTaskListLimiter(mockClock, scope, tlConfig, func() int {
+				return numPartitions
+			})
+			tc.fn(mockClock, limiter, &numPartitions)
+			assert.Equal(t, tc.expected, limiter.Limit())
+		})
+	}
+}

--- a/service/matching/tasklist/task_reader.go
+++ b/service/matching/tasklist/task_reader.go
@@ -30,6 +30,8 @@ import (
 	"sync/atomic"
 	"time"
 
+	"golang.org/x/time/rate"
+
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/clock"
@@ -84,7 +86,7 @@ type (
 		onFatalErr               func()
 		dispatchTask             func(context.Context, *InternalTask) error
 		getIsolationGroupForTask func(context.Context, *persistence.TaskInfo) (string, time.Duration)
-		ratePerSecond            func() float64
+		rateLimit                func() rate.Limit
 
 		// stopWg is used to wait for all dispatchers to stop.
 		stopWg sync.WaitGroup
@@ -121,7 +123,7 @@ func newTaskReader(tlMgr *taskListManagerImpl, isolationGroups []string) *taskRe
 		onFatalErr:               tlMgr.Stop,
 		dispatchTask:             tlMgr.DispatchTask,
 		getIsolationGroupForTask: tlMgr.getIsolationGroupForTask,
-		ratePerSecond:            tlMgr.matcher.Rate,
+		rateLimit:                tlMgr.limiter.Limit,
 		throttleRetry: backoff.NewThrottleRetry(
 			backoff.WithRetryPolicy(persistenceOperationRetryPolicy),
 			backoff.WithRetryableError(persistence.IsTransientError),
@@ -379,7 +381,7 @@ func (tr *taskReader) completeTask(task *persistence.TaskInfo, err error) {
 }
 
 func (tr *taskReader) newDispatchContext(isolationGroup string, isolationDuration time.Duration) (context.Context, context.CancelFunc) {
-	rps := tr.ratePerSecond()
+	rps := float64(tr.rateLimit())
 	if isolationGroup != "" || rps > 1e-7 { // 1e-7 is a random number chosen to avoid overflow, normally user don't set such a low rps
 		timeout := tr.getDispatchTimeout(rps, isolationDuration)
 		domainEntry, err := tr.domainCache.GetDomainByID(tr.taskListID.GetDomainID())


### PR DESCRIPTION
The TaskList rate limiter allows for controlling the rate at which Cadence dispatches tasks to Workers. It is applied only to Activities, with each PollForActivityTaskRequest including the desired rate limit. The rate limit isn't persisted with the TaskListInfo, which means it needs to be re-applied any time TaskList ownership changes.

https://github.com/cadence-workflow/cadence/pull/6842 refactored DynamicRateLimiter to avoid re-evaluating the RPS constantly, and in doing so removed behavior to eagerly adopt a lower returned rate limit. This has resulted in periods immediately after deployments/restarts where the rate limit defaults to the very high initial value and dispatches tasks much faster than desired.

Introduce a new Limiter implementation specific for TaskLists that eagerly adopts lower reported rate limits, and introduce a new metric for the limit set on a TaskList to provide additional visibility into it.

<!-- Describe what has changed in this PR -->
**What changed?**
- Improve TaskList Rate Limiter responsiveness

<!-- Tell your future self why have you made these changes -->
**Why?**
- Stabilize Activity Dispatch RPS during deployments/restarts

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
