### PR TITLE
Enrich async API request processing error logs

### DIFF
--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1084,6 +1084,10 @@ func AsyncWFQueueID(queueID string) Tag {
 	return newStringTag("async-wf-queue-id", queueID)
 }
 
+func AsyncWFRequestType(requestType string) Tag {
+	return newStringTag("async-wf-request-type", requestType)
+}
+
 func GlobalRatelimiterKey(globalKey string) Tag {
 	return newStringTag("global-ratelimit-key", globalKey)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Async API request messages are consumed from a queue and it can fail for various reasons such as hitting the domain's rate limit. The error logs didn't include domain information which makes it hard to troubleshoot. Adding more log tags to relevant logs.
