### PR TITLE
Add TrySplitbyPredicate method to virtual slice

### DIFF
--- a/service/history/queuev2/virtual_slice_mock.go
+++ b/service/history/queuev2/virtual_slice_mock.go
@@ -127,6 +127,22 @@ func (mr *MockVirtualSliceMockRecorder) TryMergeWithVirtualSlice(arg0 any) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryMergeWithVirtualSlice", reflect.TypeOf((*MockVirtualSlice)(nil).TryMergeWithVirtualSlice), arg0)
 }
 
+// TrySplitByPredicate mocks base method.
+func (m *MockVirtualSlice) TrySplitByPredicate(arg0 Predicate) (VirtualSlice, VirtualSlice, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TrySplitByPredicate", arg0)
+	ret0, _ := ret[0].(VirtualSlice)
+	ret1, _ := ret[1].(VirtualSlice)
+	ret2, _ := ret[2].(bool)
+	return ret0, ret1, ret2
+}
+
+// TrySplitByPredicate indicates an expected call of TrySplitByPredicate.
+func (mr *MockVirtualSliceMockRecorder) TrySplitByPredicate(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TrySplitByPredicate", reflect.TypeOf((*MockVirtualSlice)(nil).TrySplitByPredicate), arg0)
+}
+
 // TrySplitByTaskKey mocks base method.
 func (m *MockVirtualSlice) TrySplitByTaskKey(arg0 persistence.HistoryTaskKey) (VirtualSlice, VirtualSlice, bool) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add TrySplitbyPredicate method to virtual slice

<!-- Tell your future self why have you made these changes -->
**Why?**
Define helper functions for virtual queue split

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
