### PR TITLE
Define feature flags to support virtual queue split for history queue v2

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -964,6 +964,7 @@ const (
 	// Allowed filters: N/A
 	QueueProcessorSplitMaxLevel
 	QueueMaxPendingTaskCount
+	QueueCriticalPendingTaskCount
 	// TimerTaskBatchSize is batch size for timer processor to process tasks
 	// KeyName: history.timerTaskBatchSize
 	// Value type: Int
@@ -1512,6 +1513,8 @@ const (
 	// Value type: Int
 	// Default value: 30
 	DeleteHistoryEventContextTimeout
+
+	QueueMaxVirtualQueueCount
 
 	// LastIntKey must be the last one in this const group
 	LastIntKey
@@ -2101,6 +2104,8 @@ const (
 
 	EnableTransferQueueV2
 	EnableTimerQueueV2
+	EnableTransferQueueV2PendingTaskCountAlert
+	EnableTimerQueueV2PendingTaskCountAlert
 
 	// LastBoolKey must be the last one in this const group
 	LastBoolKey
@@ -3554,6 +3559,11 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "QueueMaxPendingTaskCount is the max number of pending tasks in the queue",
 		DefaultValue: 10000,
 	},
+	QueueCriticalPendingTaskCount: {
+		KeyName:      "history.queueCriticalPendingTaskCount",
+		Description:  "QueueCriticalPendingTaskCount is the critical pending task count for the queue, which is supposed to be less than QueueMaxPendingTaskCount",
+		DefaultValue: 9000,
+	},
 	TimerTaskBatchSize: {
 		KeyName:      "history.timerTaskBatchSize",
 		Description:  "TimerTaskBatchSize is batch size for timer processor to process tasks",
@@ -4018,10 +4028,15 @@ var IntKeys = map[IntKey]DynamicInt{
 		Description:  "The number of attempts to push Isolation group configuration to the config store",
 		DefaultValue: 2,
 	},
-	DeleteHistoryEventContextTimeout: DynamicInt{
+	DeleteHistoryEventContextTimeout: {
 		KeyName:      "system.deleteHistoryEventContextTimeout",
 		Description:  "This is the number of seconds allowed for a deleteHistoryEvent task to the database",
 		DefaultValue: 30,
+	},
+	QueueMaxVirtualQueueCount: {
+		KeyName:      "history.queueMaxVirtualQueueCount",
+		Description:  "QueueMaxVirtualQueueCount is the max number of virtual queues",
+		DefaultValue: 2,
 	},
 }
 
@@ -4613,6 +4628,18 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	EnableTimerQueueV2: {
 		KeyName:      "history.enableTimerQueueV2",
 		Description:  "EnableTimerQueueV2 is to enable timer queue v2",
+		Filters:      []Filter{ShardID},
+		DefaultValue: false,
+	},
+	EnableTransferQueueV2PendingTaskCountAlert: {
+		KeyName:      "history.enableTransferQueueV2PendingTaskCountAlert",
+		Description:  "EnableTransferQueueV2PendingTaskCountAlert is to enable transfer queue v2 pending task count alert",
+		Filters:      []Filter{ShardID},
+		DefaultValue: false,
+	},
+	EnableTimerQueueV2PendingTaskCountAlert: {
+		KeyName:      "history.enableTimerQueueV2PendingTaskCountAlert",
+		Description:  "EnableTimerQueueV2PendingTaskCountAlert is to enable timer queue v2 pending task count alert",
 		Filters:      []Filter{ShardID},
 		DefaultValue: false,
 	},

--- a/common/log/tag/tags.go
+++ b/common/log/tag/tags.go
@@ -1211,3 +1211,7 @@ func PendingTaskCount(count int) Tag {
 func VirtualQueueID(id int64) Tag {
 	return newInt64("virtual-queue-id", id)
 }
+
+func AlertType(alertType int) Tag {
+	return newInt("alert-type", alertType)
+}

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -112,9 +112,13 @@ type Config struct {
 	ResurrectionCheckMinDelay                dynamicproperties.DurationPropertyFnWithDomainFilter
 
 	// History Queue (v2) settings
-	EnableTimerQueueV2       dynamicproperties.BoolPropertyFnWithShardIDFilter
-	EnableTransferQueueV2    dynamicproperties.BoolPropertyFnWithShardIDFilter
-	QueueMaxPendingTaskCount dynamicproperties.IntPropertyFn
+	EnableTimerQueueV2                         dynamicproperties.BoolPropertyFnWithShardIDFilter
+	EnableTransferQueueV2                      dynamicproperties.BoolPropertyFnWithShardIDFilter
+	QueueMaxPendingTaskCount                   dynamicproperties.IntPropertyFn
+	EnableTimerQueueV2PendingTaskCountAlert    dynamicproperties.BoolPropertyFnWithShardIDFilter
+	EnableTransferQueueV2PendingTaskCountAlert dynamicproperties.BoolPropertyFnWithShardIDFilter
+	QueueCriticalPendingTaskCount              dynamicproperties.IntPropertyFn
+	QueueMaxVirtualQueueCount                  dynamicproperties.IntPropertyFn
 
 	// QueueProcessor settings
 	QueueProcessorEnableSplit                          dynamicproperties.BoolPropertyFn
@@ -406,7 +410,13 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		EnableDropStuckTaskByDomainID:            dc.GetBoolPropertyFilteredByDomainID(dynamicproperties.EnableDropStuckTaskByDomainID),
 		ResurrectionCheckMinDelay:                dc.GetDurationPropertyFilteredByDomain(dynamicproperties.ResurrectionCheckMinDelay),
 
-		QueueMaxPendingTaskCount: dc.GetIntProperty(dynamicproperties.QueueMaxPendingTaskCount),
+		EnableTimerQueueV2:                         dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTimerQueueV2),
+		EnableTransferQueueV2:                      dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTransferQueueV2),
+		QueueMaxPendingTaskCount:                   dc.GetIntProperty(dynamicproperties.QueueMaxPendingTaskCount),
+		EnableTimerQueueV2PendingTaskCountAlert:    dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTimerQueueV2PendingTaskCountAlert),
+		EnableTransferQueueV2PendingTaskCountAlert: dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTransferQueueV2PendingTaskCountAlert),
+		QueueCriticalPendingTaskCount:              dc.GetIntProperty(dynamicproperties.QueueCriticalPendingTaskCount),
+		QueueMaxVirtualQueueCount:                  dc.GetIntProperty(dynamicproperties.QueueMaxVirtualQueueCount),
 
 		QueueProcessorEnableSplit:                          dc.GetBoolProperty(dynamicproperties.QueueProcessorEnableSplit),
 		QueueProcessorSplitMaxLevel:                        dc.GetIntProperty(dynamicproperties.QueueProcessorSplitMaxLevel),
@@ -442,7 +452,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		TimerProcessorHistoryArchivalSizeLimit:               dc.GetIntProperty(dynamicproperties.TimerProcessorHistoryArchivalSizeLimit),
 		TimerProcessorArchivalTimeLimit:                      dc.GetDurationProperty(dynamicproperties.TimerProcessorArchivalTimeLimit),
 		DisableTimerFailoverQueue:                            dc.GetBoolProperty(dynamicproperties.DisableTimerFailoverQueue),
-		EnableTimerQueueV2:                                   dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTimerQueueV2),
 		TransferTaskBatchSize:                                dc.GetIntProperty(dynamicproperties.TransferTaskBatchSize),
 		TransferTaskDeleteBatchSize:                          dc.GetIntProperty(dynamicproperties.TransferTaskDeleteBatchSize),
 		TransferProcessorFailoverMaxStartJitterInterval:      dc.GetDurationProperty(dynamicproperties.TransferProcessorFailoverMaxStartJitterInterval),
@@ -461,7 +470,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		TransferProcessorValidationInterval:                  dc.GetDurationProperty(dynamicproperties.TransferProcessorValidationInterval),
 		TransferProcessorVisibilityArchivalTimeLimit:         dc.GetDurationProperty(dynamicproperties.TransferProcessorVisibilityArchivalTimeLimit),
 		DisableTransferFailoverQueue:                         dc.GetBoolProperty(dynamicproperties.DisableTransferFailoverQueue),
-		EnableTransferQueueV2:                                dc.GetBoolPropertyFilteredByShardID(dynamicproperties.EnableTransferQueueV2),
 
 		ReplicatorTaskDeleteBatchSize:          dc.GetIntProperty(dynamicproperties.ReplicatorTaskDeleteBatchSize),
 		ReplicatorReadTaskMaxRetryCount:        dc.GetIntProperty(dynamicproperties.ReplicatorReadTaskMaxRetryCount),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -271,6 +271,10 @@ func TestNewConfig(t *testing.T) {
 		"EnableTransferQueueV2":                                {dynamicproperties.EnableTransferQueueV2, true},
 		"EnableTimerQueueV2":                                   {dynamicproperties.EnableTimerQueueV2, true},
 		"QueueMaxPendingTaskCount":                             {dynamicproperties.QueueMaxPendingTaskCount, 99},
+		"EnableTimerQueueV2PendingTaskCountAlert":              {dynamicproperties.EnableTimerQueueV2PendingTaskCountAlert, true},
+		"EnableTransferQueueV2PendingTaskCountAlert":           {dynamicproperties.EnableTransferQueueV2PendingTaskCountAlert, true},
+		"QueueCriticalPendingTaskCount":                        {dynamicproperties.QueueCriticalPendingTaskCount, 100},
+		"QueueMaxVirtualQueueCount":                            {dynamicproperties.QueueMaxVirtualQueueCount, 101},
 	}
 	client := dynamicconfig.NewInMemoryClient()
 	for fieldName, expected := range fields {

--- a/service/history/queuev2/mitigator.go
+++ b/service/history/queuev2/mitigator.go
@@ -2,7 +2,9 @@
 package queuev2
 
 import (
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
 	"github.com/uber/cadence/common/metrics"
 )
 
@@ -11,25 +13,54 @@ type (
 		Mitigate(Alert)
 	}
 
+	MitigatorOptions struct {
+		MaxVirtualQueueCount dynamicproperties.IntPropertyFn
+	}
+
 	mitigatorImpl struct {
-		monitor      Monitor
-		logger       log.Logger
-		metricsScope metrics.Scope
+		virtualQueueManager VirtualQueueManager
+		monitor             Monitor
+		logger              log.Logger
+		metricsScope        metrics.Scope
+		options             *MitigatorOptions
+
+		handlers map[AlertType]func(Alert)
 	}
 )
 
 func NewMitigator(
+	virtualQueueManager VirtualQueueManager,
 	monitor Monitor,
 	logger log.Logger,
 	metricsScope metrics.Scope,
+	options *MitigatorOptions,
 ) Mitigator {
-	return &mitigatorImpl{
+	m := &mitigatorImpl{
 		monitor:      monitor,
 		logger:       logger,
 		metricsScope: metricsScope,
+		options:      options,
 	}
+	m.handlers = map[AlertType]func(Alert){
+		AlertTypeQueuePendingTaskCount: m.handleQueuePendingTaskCount,
+	}
+	return m
 }
 
 func (m *mitigatorImpl) Mitigate(alert Alert) {
-	// TODO: implement the mitigation logic
+	handler, ok := m.handlers[alert.AlertType]
+	if !ok {
+		m.logger.Error("unknown queue alert type", tag.AlertType(int(alert.AlertType)))
+		return
+	}
+	handler(alert)
+
+	m.monitor.ResolveAlert(alert.AlertType)
+}
+
+func (m *mitigatorImpl) handleQueuePendingTaskCount(alert Alert) {
+	// TODO: implement the algorithm to mitigate the queue pending task count
+	// the idea is to scan all the virtual queues and get the number of pending tasks in each domain per virtual slice
+	// use a greedy algorithm to split virtual slices by the domain with the most number of pending tasks, clear tasks from that domain
+	// until the total number of pending tasks is below the critical pending task count
 }

--- a/service/history/queuev2/mitigator_test.go
+++ b/service/history/queuev2/mitigator_test.go
@@ -1,0 +1,118 @@
+package queuev2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
+)
+
+func TestNewMitigator(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+	mockMonitor := NewMockMonitor(ctrl)
+	logger := testlogger.New(t)
+	metricsScope := metrics.NoopScope
+	options := &MitigatorOptions{
+		MaxVirtualQueueCount: dynamicproperties.GetIntPropertyFn(10),
+	}
+
+	mitigator := NewMitigator(
+		mockVirtualQueueManager,
+		mockMonitor,
+		logger,
+		metricsScope,
+		options,
+	)
+
+	require.NotNil(t, mitigator)
+
+	// Verify internal structure
+	impl, ok := mitigator.(*mitigatorImpl)
+	require.True(t, ok)
+	assert.Equal(t, mockMonitor, impl.monitor)
+	assert.Equal(t, logger, impl.logger)
+	assert.Equal(t, metricsScope, impl.metricsScope)
+	assert.Equal(t, options, impl.options)
+
+	// Verify handlers are properly initialized
+	assert.NotNil(t, impl.handlers)
+	assert.Len(t, impl.handlers, 1)
+	_, exists := impl.handlers[AlertTypeQueuePendingTaskCount]
+	assert.True(t, exists)
+}
+
+func TestMitigator_Mitigate_KnownAlertType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+	mockMonitor := NewMockMonitor(ctrl)
+	logger := testlogger.New(t)
+	metricsScope := metrics.NoopScope
+	options := &MitigatorOptions{
+		MaxVirtualQueueCount: dynamicproperties.GetIntPropertyFn(10),
+	}
+
+	mitigator := NewMitigator(
+		mockVirtualQueueManager,
+		mockMonitor,
+		logger,
+		metricsScope,
+		options,
+	)
+	impl, ok := mitigator.(*mitigatorImpl)
+	require.True(t, ok)
+	handlerCalled := false
+	impl.handlers[AlertTypeQueuePendingTaskCount] = func(alert Alert) {
+		handlerCalled = true
+	}
+
+	alert := Alert{
+		AlertType: AlertTypeQueuePendingTaskCount,
+		AlertAttributesQueuePendingTaskCount: &AlertAttributesQueuePendingTaskCount{
+			CurrentPendingTaskCount:  150,
+			CriticalPendingTaskCount: 100,
+		},
+	}
+
+	// Expect ResolveAlert to be called on the monitor
+	mockMonitor.EXPECT().ResolveAlert(AlertTypeQueuePendingTaskCount).Times(1)
+
+	mitigator.Mitigate(alert)
+	assert.True(t, handlerCalled)
+}
+
+func TestMitigator_Mitigate_UnknownAlertType(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+	mockMonitor := NewMockMonitor(ctrl)
+	logger := testlogger.New(t)
+	metricsScope := metrics.NoopScope
+	options := &MitigatorOptions{
+		MaxVirtualQueueCount: dynamicproperties.GetIntPropertyFn(10),
+	}
+
+	mitigator := NewMitigator(
+		mockVirtualQueueManager,
+		mockMonitor,
+		logger,
+		metricsScope,
+		options,
+	)
+
+	// Create an alert with an unknown/unhandled alert type
+	unknownAlertType := AlertType(999)
+	alert := Alert{
+		AlertType: unknownAlertType,
+	}
+
+	mitigator.Mitigate(alert)
+}

--- a/service/history/queuev2/queue_base_test.go
+++ b/service/history/queuev2/queue_base_test.go
@@ -178,7 +178,7 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 		initialVirtualSliceState  VirtualSliceState
 		expectedExclusiveAckLevel persistence.HistoryTaskKey
 		expectError               bool
-		setupMocks                func(*gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager)
+		setupMocks                func(*gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager, *MockMonitor, *MockMitigator)
 	}{
 		{
 			name:                     "Successfully update queue state with new ack level",
@@ -193,13 +193,16 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 			},
 			expectedExclusiveAckLevel: persistence.NewImmediateTaskKey(200),
 			expectError:               false,
-			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager) {
+			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager, *MockMonitor, *MockMitigator) {
 				mockShard := shard.NewMockContext(ctrl)
 				mockTaskProcessor := task.NewMockProcessor(ctrl)
 				mockTimeSource := clock.NewMockedTimeSource()
 				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
 				mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
+				mockMonitor := NewMockMonitor(ctrl)
+				mockMitigator := NewMockMitigator(ctrl)
 
+				mockMonitor.EXPECT().GetTotalPendingTaskCount().Return(100).Times(1)
 				mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).AnyTimes()
 				mockExecutionManager.EXPECT().RangeCompleteHistoryTask(gomock.Any(), &persistence.RangeCompleteHistoryTaskRequest{
 					TaskCategory:        persistence.HistoryTaskCategoryTransfer,
@@ -226,7 +229,7 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 					},
 				})
 
-				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager
+				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager, mockMonitor, mockMitigator
 			},
 		},
 		{
@@ -242,13 +245,16 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 			},
 			expectedExclusiveAckLevel: persistence.NewImmediateTaskKey(100),
 			expectError:               true,
-			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager) {
+			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager, *MockMonitor, *MockMitigator) {
 				mockShard := shard.NewMockContext(ctrl)
 				mockTaskProcessor := task.NewMockProcessor(ctrl)
 				mockTimeSource := clock.NewMockedTimeSource()
 				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
 				mockExecutionManager := persistence.NewMockExecutionManager(ctrl)
+				mockMonitor := NewMockMonitor(ctrl)
+				mockMitigator := NewMockMitigator(ctrl)
 
+				mockMonitor.EXPECT().GetTotalPendingTaskCount().Return(100).Times(1)
 				mockShard.EXPECT().GetExecutionManager().Return(mockExecutionManager).AnyTimes()
 				mockExecutionManager.EXPECT().RangeCompleteHistoryTask(gomock.Any(), &persistence.RangeCompleteHistoryTaskRequest{
 					TaskCategory:        persistence.HistoryTaskCategoryTransfer,
@@ -269,7 +275,7 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 					},
 				})
 
-				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager
+				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager, mockMonitor, mockMitigator
 			},
 		},
 		{
@@ -285,12 +291,15 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 			},
 			expectedExclusiveAckLevel: persistence.NewImmediateTaskKey(100),
 			expectError:               false,
-			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager) {
+			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager, *MockMonitor, *MockMitigator) {
 				mockShard := shard.NewMockContext(ctrl)
 				mockTaskProcessor := task.NewMockProcessor(ctrl)
 				mockTimeSource := clock.NewMockedTimeSource()
 				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+				mockMonitor := NewMockMonitor(ctrl)
+				mockMitigator := NewMockMitigator(ctrl)
 
+				mockMonitor.EXPECT().GetTotalPendingTaskCount().Return(100).Times(1)
 				mockShard.EXPECT().UpdateQueueState(
 					persistence.HistoryTaskCategoryTransfer,
 					gomock.Any(),
@@ -308,7 +317,7 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 					},
 				})
 
-				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager
+				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager, mockMonitor, mockMitigator
 			},
 		},
 		{
@@ -324,12 +333,15 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 			},
 			expectedExclusiveAckLevel: persistence.NewImmediateTaskKey(200),
 			expectError:               true,
-			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager) {
+			setupMocks: func(ctrl *gomock.Controller) (*shard.MockContext, *task.MockProcessor, clock.TimeSource, *MockVirtualQueueManager, *MockMonitor, *MockMitigator) {
 				mockShard := shard.NewMockContext(ctrl)
 				mockTaskProcessor := task.NewMockProcessor(ctrl)
 				mockTimeSource := clock.NewMockedTimeSource()
 				mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+				mockMonitor := NewMockMonitor(ctrl)
+				mockMitigator := NewMockMitigator(ctrl)
 
+				mockMonitor.EXPECT().GetTotalPendingTaskCount().Return(100).Times(1)
 				mockShard.EXPECT().UpdateQueueState(
 					persistence.HistoryTaskCategoryTransfer,
 					gomock.Any(),
@@ -347,7 +359,7 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 					},
 				})
 
-				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager
+				return mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager, mockMonitor, mockMitigator
 			},
 		},
 	}
@@ -357,7 +369,7 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 			// Setup
 			ctrl := gomock.NewController(t)
 
-			mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager := tt.setupMocks(ctrl)
+			mockShard, mockTaskProcessor, mockTimeSource, mockVirtualQueueManager, mockMonitor, mockMitigator := tt.setupMocks(ctrl)
 
 			queueBase := &queueBase{
 				shard:                 mockShard,
@@ -367,7 +379,8 @@ func TestQueueBase_UpdateQueueState(t *testing.T) {
 				logger:                testlogger.New(t),
 				category:              tt.category,
 				timeSource:            mockTimeSource,
-				monitor:               NewMonitor(tt.category),
+				monitor:               mockMonitor,
+				mitigator:             mockMitigator,
 				virtualQueueManager:   mockVirtualQueueManager,
 				exclusiveAckLevel:     tt.initialExclusiveAckLevel,
 				newVirtualSliceState:  tt.initialVirtualSliceState,
@@ -397,6 +410,7 @@ func TestQueueBase_HandleAlert(t *testing.T) {
 	mockTaskProcessor := task.NewMockProcessor(ctrl)
 	mockTimeSource := clock.NewMockedTimeSource()
 	mockVirtualQueueManager := NewMockVirtualQueueManager(ctrl)
+	mockMonitor := NewMockMonitor(ctrl)
 	mockMitigator := NewMockMitigator(ctrl)
 	mockMitigator.EXPECT().Mitigate(Alert{AlertType: AlertTypeQueuePendingTaskCount})
 
@@ -409,7 +423,7 @@ func TestQueueBase_HandleAlert(t *testing.T) {
 		logger:              testlogger.New(t),
 		category:            persistence.HistoryTaskCategoryTransfer,
 		timeSource:          mockTimeSource,
-		monitor:             NewMonitor(persistence.HistoryTaskCategoryTransfer),
+		monitor:             mockMonitor,
 		mitigator:           mockMitigator,
 		virtualQueueManager: mockVirtualQueueManager,
 		exclusiveAckLevel:   persistence.NewImmediateTaskKey(100),

--- a/service/history/queuev2/queue_immediate_test.go
+++ b/service/history/queuev2/queue_immediate_test.go
@@ -77,6 +77,9 @@ func TestImmediateQueue_LifeCycle(t *testing.T) {
 		UpdateAckIntervalJitterCoefficient:   dynamicproperties.GetFloatPropertyFn(0.1),
 		MaxPollRPS:                           dynamicproperties.GetIntPropertyFn(100),
 		MaxPendingTasksCount:                 dynamicproperties.GetIntPropertyFn(100),
+		CriticalPendingTaskCount:             dynamicproperties.GetIntPropertyFn(90),
+		EnablePendingTaskCountAlert:          func() bool { return true },
+		MaxVirtualQueueCount:                 dynamicproperties.GetIntPropertyFn(2),
 	}
 
 	queue := NewImmediateQueue(

--- a/service/history/queuev2/queue_scheduled_test.go
+++ b/service/history/queuev2/queue_scheduled_test.go
@@ -78,6 +78,9 @@ func TestScheduledQueue_LifeCycle(t *testing.T) {
 		MaxPollRPS:                           dynamicproperties.GetIntPropertyFn(100),
 		MaxPendingTasksCount:                 dynamicproperties.GetIntPropertyFn(100),
 		PollBackoffIntervalJitterCoefficient: dynamicproperties.GetFloatPropertyFn(0.0),
+		CriticalPendingTaskCount:             dynamicproperties.GetIntPropertyFn(90),
+		EnablePendingTaskCountAlert:          func() bool { return true },
+		MaxVirtualQueueCount:                 dynamicproperties.GetIntPropertyFn(2),
 	}
 
 	queue := NewScheduledQueue(

--- a/service/history/queuev2/timer_queue_factory.go
+++ b/service/history/queuev2/timer_queue_factory.go
@@ -153,6 +153,9 @@ func (f *timerQueueFactory) createQueuev2(
 			PollBackoffIntervalJitterCoefficient: config.QueueProcessorPollBackoffIntervalJitterCoefficient,
 			MaxStartJitterInterval:               dynamicproperties.GetDurationPropertyFn(0),
 			RedispatchInterval:                   config.ActiveTaskRedispatchInterval,
+			CriticalPendingTaskCount:             config.QueueCriticalPendingTaskCount,
+			EnablePendingTaskCountAlert:          func() bool { return config.EnableTimerQueueV2PendingTaskCountAlert(shard.GetShardID()) },
+			MaxVirtualQueueCount:                 config.QueueMaxVirtualQueueCount,
 		},
 	)
 }

--- a/service/history/queuev2/transfer_queue_factory.go
+++ b/service/history/queuev2/transfer_queue_factory.go
@@ -162,6 +162,9 @@ func (f *transferQueueFactory) createQueuev2(
 			ValidationInterval:                   config.TransferProcessorValidationInterval,
 			MaxStartJitterInterval:               dynamicproperties.GetDurationPropertyFn(0),
 			RedispatchInterval:                   config.ActiveTaskRedispatchInterval,
+			CriticalPendingTaskCount:             config.QueueCriticalPendingTaskCount,
+			EnablePendingTaskCountAlert:          func() bool { return config.EnableTransferQueueV2PendingTaskCountAlert(shard.GetShardID()) },
+			MaxVirtualQueueCount:                 config.QueueMaxVirtualQueueCount,
 		},
 	)
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Define feature flags to support virtual queue split for history queue v2

<!-- Tell your future self why have you made these changes -->
**Why?**
To support virtual queue split operation which prevents too many pending tasks from certain domains. This change doesn't include the actual implementation of split operation, only has some boilerplate code.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
