### PR TITLE
[cli]Make security token an optinal argument

### DIFF
--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -349,10 +349,7 @@ func (d *domainCLIImpl) DeleteDomain(c *cli.Context) error {
 	if err != nil {
 		return commoncli.Problem("Required flag not found: ", err)
 	}
-	securityToken, err := getRequiredOption(c, FlagSecurityToken)
-	if err != nil {
-		return commoncli.Problem("Required flag not provided: ", err)
-	}
+	securityToken := c.String(FlagSecurityToken)
 
 	ctx, cancel, err := newContext(c)
 	defer cancel()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed required flag option type for security token in delete domain command.

<!-- Tell your future self why have you made these changes -->
**Why?**
We are planning to remove security token dependency after enforcing admin authorization.
Making the security token an optional field won't break the current process. The command will fail with Permission denied if the security token is not provided.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
