### PR TITLE
refactor unit test cases for ConstructStartWorkflowRequest to reduce code duplication

### DIFF
--- a/tools/cli/workflow_commands.go
+++ b/tools/cli/workflow_commands.go
@@ -483,7 +483,7 @@ func constructStartWorkflowRequest(c *cli.Context) (*types.StartWorkflowExecutio
 
 	memoFields, err := processMemo(c)
 	if err != nil {
-		return nil, commoncli.Problem("Error processing memo: ", err)
+		return nil, commoncli.Problem("error processing memo: ", err)
 	}
 	if len(memoFields) != 0 {
 		startRequest.Memo = &types.Memo{Fields: memoFields}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed and why?**
- Unit test cases for the function ConstructStartWorkflowRequest has been refactored

<!-- Tell your future self why have you made these changes -->
**Why?**
- To reduce code duplication.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
N/A
<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
N/A
<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
N/A