### PR TITLE
Integration of removal of ephemeral shards in the executor library

### DIFF
--- a/service/sharddistributor/executorclient/client.go
+++ b/service/sharddistributor/executorclient/client.go
@@ -21,7 +21,7 @@ import (
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interface_mock.go . ShardProcessorFactory,ShardProcessor,Executor
 
-type ShardStatus struct {
+type ShardReport struct {
 	ShardLoad float64
 	Status    types.ShardStatus
 }
@@ -29,7 +29,7 @@ type ShardStatus struct {
 type ShardProcessor interface {
 	Start(ctx context.Context)
 	Stop()
-	GetShardStatus() ShardStatus
+	GetShardReport() ShardReport
 }
 
 type ShardProcessorFactory[SP ShardProcessor] interface {

--- a/service/sharddistributor/executorclient/clientimpl.go
+++ b/service/sharddistributor/executorclient/clientimpl.go
@@ -130,7 +130,7 @@ func (e *executorImpl[SP]) heartbeat(ctx context.Context) (shardAssignments map[
 	shardStatusReports := make(map[string]*types.ShardStatusReport)
 	e.managedProcessors.Range(func(shardID string, managedProcessor *managedProcessor[SP]) bool {
 		if managedProcessor.getState() == processorStateStarted {
-			shardStatus := managedProcessor.processor.GetShardStatus()
+			shardStatus := managedProcessor.processor.GetShardReport()
 
 			shardStatusReports[shardID] = &types.ShardStatusReport{
 				ShardLoad: shardStatus.ShardLoad,

--- a/service/sharddistributor/executorclient/clientimpl_test.go
+++ b/service/sharddistributor/executorclient/clientimpl_test.go
@@ -119,9 +119,9 @@ func TestHeartbeat(t *testing.T) {
 	}, nil)
 
 	shardProcessorMock1 := NewMockShardProcessor(ctrl)
-	shardProcessorMock1.EXPECT().GetShardStatus().Return(ShardStatus{ShardLoad: 0.123, Status: types.ShardStatusREADY})
+	shardProcessorMock1.EXPECT().GetShardReport().Return(ShardReport{ShardLoad: 0.123, Status: types.ShardStatusREADY})
 	shardProcessorMock2 := NewMockShardProcessor(ctrl)
-	shardProcessorMock2.EXPECT().GetShardStatus().Return(ShardStatus{ShardLoad: 0.456, Status: types.ShardStatusREADY})
+	shardProcessorMock2.EXPECT().GetShardReport().Return(ShardReport{ShardLoad: 0.456, Status: types.ShardStatusREADY})
 
 	// Create the executor
 	executor := &executorImpl[*MockShardProcessor]{

--- a/service/sharddistributor/executorclient/interface_mock.go
+++ b/service/sharddistributor/executorclient/interface_mock.go
@@ -40,18 +40,18 @@ func (m *MockShardProcessor) EXPECT() *MockShardProcessorMockRecorder {
 	return m.recorder
 }
 
-// GetShardStatus mocks base method.
-func (m *MockShardProcessor) GetShardStatus() ShardStatus {
+// GetShardReport mocks base method.
+func (m *MockShardProcessor) GetShardReport() ShardReport {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetShardStatus")
-	ret0, _ := ret[0].(ShardStatus)
+	ret := m.ctrl.Call(m, "GetShardReport")
+	ret0, _ := ret[0].(ShardReport)
 	return ret0
 }
 
-// GetShardStatus indicates an expected call of GetShardStatus.
-func (mr *MockShardProcessorMockRecorder) GetShardStatus() *gomock.Call {
+// GetShardReport indicates an expected call of GetShardReport.
+func (mr *MockShardProcessorMockRecorder) GetShardReport() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardStatus", reflect.TypeOf((*MockShardProcessor)(nil).GetShardStatus))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardReport", reflect.TypeOf((*MockShardProcessor)(nil).GetShardReport))
 }
 
 // Start mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
The executor library now asks the processor for a struct of status information, 
The new struct contains the status of the shard so the processor can signal the state of the shard


<!-- Tell your future self why have you made these changes -->
**Why?**
This enables the executors to tell if an ephemeral shard should be delete. 

It also enables us to add more fields to the status in a backwards compatible way


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
This is not backwards compatible, but we are still in the prototype phase so noone is implementing this interface, except our own test service. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
