### PR TITLE
Fix appendOrMergeSlice method of virtual queue manager

### DIFF
--- a/service/history/queuev2/virtual_queue_manager.go
+++ b/service/history/queuev2/virtual_queue_manager.go
@@ -221,6 +221,7 @@ func (m *virtualQueueManagerImpl) AddNewVirtualSliceToRootQueue(s VirtualSlice) 
 func (m *virtualQueueManagerImpl) appendOrMergeSlice(vq VirtualQueue, s VirtualSlice) {
 	now := m.timeSource.Now()
 	newVirtualSliceState := s.GetState()
+	// TODO: we should set a limit on the number of virtual slices to prevent the size of queue state from being too large to be stored in database
 	if now.After(m.nextForceNewSliceTime) {
 		m.logger.Debug("append new slice to virtual queue", tag.Dynamic("currentTime", now), tag.Dynamic("nextForceNewSliceTime", m.nextForceNewSliceTime), tag.Dynamic("inclusiveMinTaskKey", newVirtualSliceState.Range.InclusiveMinTaskKey), tag.Dynamic("exclusiveMaxTaskKey", newVirtualSliceState.Range.ExclusiveMaxTaskKey))
 		vq.AppendSlices(s)
@@ -228,5 +229,5 @@ func (m *virtualQueueManagerImpl) appendOrMergeSlice(vq VirtualQueue, s VirtualS
 		return
 	}
 	m.logger.Debug("merge slice to virtual queue", tag.Dynamic("currentTime", now), tag.Dynamic("nextForceNewSliceTime", m.nextForceNewSliceTime), tag.Dynamic("inclusiveMinTaskKey", newVirtualSliceState.Range.InclusiveMinTaskKey), tag.Dynamic("exclusiveMaxTaskKey", newVirtualSliceState.Range.ExclusiveMaxTaskKey))
-	vq.MergeSlices(s)
+	vq.MergeWithLastSlice(s)
 }

--- a/service/history/queuev2/virtual_queue_manager_test.go
+++ b/service/history/queuev2/virtual_queue_manager_test.go
@@ -491,7 +491,7 @@ func TestVirtualQueueManager_AddNewVirtualSlice(t *testing.T) {
 			},
 			newSlice: nil, // Will be replaced with mock
 			setupMockQueues: func(mocks map[int64]*MockVirtualQueue, slice *MockVirtualSlice) {
-				mocks[rootQueueID].EXPECT().MergeSlices(slice)
+				mocks[rootQueueID].EXPECT().MergeWithLastSlice(slice)
 				slice.EXPECT().GetState().Return(VirtualSliceState{
 					Range: Range{
 						InclusiveMinTaskKey: persistence.NewImmediateTaskKey(1),

--- a/service/history/queuev2/virtual_queue_mock.go
+++ b/service/history/queuev2/virtual_queue_mock.go
@@ -110,6 +110,18 @@ func (mr *MockVirtualQueueMockRecorder) MergeSlices(arg0 ...any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeSlices", reflect.TypeOf((*MockVirtualQueue)(nil).MergeSlices), arg0...)
 }
 
+// MergeWithLastSlice mocks base method.
+func (m *MockVirtualQueue) MergeWithLastSlice(arg0 VirtualSlice) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "MergeWithLastSlice", arg0)
+}
+
+// MergeWithLastSlice indicates an expected call of MergeWithLastSlice.
+func (mr *MockVirtualQueueMockRecorder) MergeWithLastSlice(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MergeWithLastSlice", reflect.TypeOf((*MockVirtualQueue)(nil).MergeWithLastSlice), arg0)
+}
+
 // Pause mocks base method.
 func (m *MockVirtualQueue) Pause(arg0 time.Duration) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This is a fix for https://github.com/cadence-workflow/cadence/pull/7161

<!-- Tell your future self why have you made these changes -->
**Why?**
The original PR was to split a virtual queue into virtual slices to prevent a virtual slice from growing too large. However, the `MergeSlices` method nullify the effect of `AppendSlices` method because that method merges all the existing virtual slices in the virtual queue with the incoming virtual slices, which is not expected when we add new tasks to the virtual queue.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests & integration tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

history queue v2 might be broken and workflows can get stuck

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
