### PR TITLE
Fix workflow start logic for active-active domains

### DIFF
--- a/.github/workflows/replication-simulation.yml
+++ b/.github/workflows/replication-simulation.yml
@@ -17,6 +17,7 @@ jobs:
           - activeactive_cron
           - activeactive_regional_failover
           - activeactive_regional_failover_start_same_wfid
+          - activeactive_regional_failover_start_same_wfid_2
           - activepassive_to_activeactive
           - clusterredirection
           - reset

--- a/common/domain/attrValidator.go
+++ b/common/domain/attrValidator.go
@@ -22,7 +22,6 @@ package domain
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/uber/cadence/common/cluster"
 	"github.com/uber/cadence/common/persistence"
@@ -118,7 +117,6 @@ func (d *AttrValidatorImpl) validateDomainReplicationConfigForGlobalDomain(
 	}
 
 	if replicationConfig.IsActiveActive() {
-		// validate cluster names and check whether they exist
 		for _, cluster := range activeClusters.ActiveClustersByRegion {
 			if err := d.validateClusterName(cluster.ActiveClusterName); err != nil {
 				return err
@@ -127,12 +125,6 @@ func (d *AttrValidatorImpl) validateDomainReplicationConfigForGlobalDomain(
 			if !isInClusters(cluster.ActiveClusterName) {
 				return errActiveClusterNotInClusters
 			}
-		}
-
-		// check region mappings are valid
-		err := d.checkActiveClusterRegionMappings(activeClusters)
-		if err != nil {
-			return err
 		}
 	} else {
 		if err := d.validateClusterName(activeCluster); err != nil {
@@ -183,42 +175,5 @@ func (d *AttrValidatorImpl) validateClusterName(
 			clusterName,
 		)}
 	}
-	return nil
-}
-
-// checkActiveClusterRegionMappings validates:
-//  1. There's no cycle in region dependencies.
-//     e.g. Following not allowed: region0 maps to a cluster in region1, and region1 maps to a cluster in region0.
-//  2. There's at most one hop in the region dependency chain.
-//     e.g. Following not allowed: region0 maps to a cluster in region1, and region1 maps to a cluster in region2
-func (d *AttrValidatorImpl) checkActiveClusterRegionMappings(activeClusters *types.ActiveClusters) error {
-	inbounds := make(map[string][]string)
-	outbounds := make(map[string]string)
-	allClusters := d.clusterMetadata.GetAllClusterInfo()
-	for fromRegion, cluster := range activeClusters.ActiveClustersByRegion {
-		clusterInfo, ok := allClusters[cluster.ActiveClusterName]
-		if !ok {
-			return &types.BadRequestError{Message: fmt.Sprintf("Cluster %v not found", cluster.ActiveClusterName)}
-		}
-
-		toRegion := clusterInfo.Region
-		if fromRegion == toRegion {
-			continue
-		}
-
-		inbounds[toRegion] = append(inbounds[toRegion], fromRegion)
-		outbounds[fromRegion] = toRegion
-	}
-
-	// The entries that point to a cluster in the same region is omitted in inbounds and outbounds
-	// So if a region X is in inbounds it means a cluster in X region is used by other region(s).
-	// Region X must not be in outbounds. (allow at most one hop rule)
-	// Validating this also ensures that there's no cycle in region dependencies.
-	for toRegion := range inbounds {
-		if _, ok := outbounds[toRegion]; ok {
-			return &types.BadRequestError{Message: "Region " + toRegion + " cannot map to a cluster in another region because it is used as target region by other regions: " + strings.Join(inbounds[toRegion], ", ")}
-		}
-	}
-
 	return nil
 }

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -1384,10 +1384,6 @@ func (d *handlerImpl) updateReplicationConfig(
 				d.logger.Debugf("Setting activeCluster for region %v to %v. no update case, just copy the existing active cluster", region, activeCluster)
 			}
 		}
-
-		// adjust failover versions so that same cluster in different regions have same failover versions
-		d.adjustFailoverVersions(finalActiveClusters)
-
 		config.ActiveClusters = &types.ActiveClusters{
 			ActiveClustersByRegion: finalActiveClusters,
 		}
@@ -1396,22 +1392,6 @@ func (d *handlerImpl) updateReplicationConfig(
 	}
 
 	return config, clusterUpdated, activeClusterUpdated, nil
-}
-
-func (d *handlerImpl) adjustFailoverVersions(activeClusters map[string]types.ActiveClusterInfo) {
-	clusterToRegions := make(map[string][]string)
-	clusterMaxFailoverVersion := make(map[string]int64)
-	for region, activeCluster := range activeClusters {
-		clusterToRegions[activeCluster.ActiveClusterName] = append(clusterToRegions[activeCluster.ActiveClusterName], region)
-		clusterMaxFailoverVersion[activeCluster.ActiveClusterName] = max(clusterMaxFailoverVersion[activeCluster.ActiveClusterName], activeCluster.FailoverVersion)
-	}
-	for cluster, regions := range clusterToRegions {
-		for _, region := range regions {
-			activeCluster := activeClusters[region]
-			activeCluster.FailoverVersion = clusterMaxFailoverVersion[cluster]
-			activeClusters[region] = activeCluster
-		}
-	}
 }
 
 func (d *handlerImpl) handleGracefulFailover(

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -1722,8 +1722,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 							ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
 								cluster.TestRegion1: {
 									ActiveClusterName: cluster.TestCurrentClusterName,
-									// This is incremented to match below.
-									FailoverVersion: cluster.TestCurrentClusterInitialFailoverVersion + cluster.TestFailoverVersionIncrement,
+									FailoverVersion:   cluster.TestCurrentClusterInitialFailoverVersion,
 								},
 								cluster.TestRegion2: {
 									ActiveClusterName: cluster.TestCurrentClusterName,
@@ -1787,7 +1786,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 						ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
 							cluster.TestRegion1: {
 								ActiveClusterName: cluster.TestCurrentClusterName,
-								FailoverVersion:   cluster.TestCurrentClusterInitialFailoverVersion + cluster.TestFailoverVersionIncrement,
+								FailoverVersion:   cluster.TestCurrentClusterInitialFailoverVersion,
 							},
 							cluster.TestRegion2: {
 								ActiveClusterName: cluster.TestCurrentClusterName,
@@ -1823,7 +1822,7 @@ func TestHandler_UpdateDomain(t *testing.T) {
 							ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
 								cluster.TestRegion1: {
 									ActiveClusterName: cluster.TestCurrentClusterName,
-									FailoverVersion:   cluster.TestCurrentClusterInitialFailoverVersion + cluster.TestFailoverVersionIncrement,
+									FailoverVersion:   cluster.TestCurrentClusterInitialFailoverVersion,
 								},
 								cluster.TestRegion2: {
 									ActiveClusterName: cluster.TestCurrentClusterName,
@@ -2886,7 +2885,7 @@ func TestUpdateReplicationConfig(t *testing.T) {
 					ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
 						cluster.TestRegion1: {
 							ActiveClusterName: cluster.TestCurrentClusterName,
-							FailoverVersion:   cluster.TestCurrentClusterInitialFailoverVersion + cluster.TestFailoverVersionIncrement,
+							FailoverVersion:   cluster.TestCurrentClusterInitialFailoverVersion,
 						},
 						cluster.TestRegion2: {
 							ActiveClusterName: cluster.TestCurrentClusterName,

--- a/config/dynamicconfig/replication_simulation_activeactive_regional_failover_start_same_wfid_2.yml
+++ b/config/dynamicconfig/replication_simulation_activeactive_regional_failover_start_same_wfid_2.yml
@@ -1,0 +1,22 @@
+# This file is used as dynamicconfig override for "activeactive_regional_failover_start_same_wfid_2" replication simulation scenario configured via simulation/replication/testdata/replication_simulation_activeactive_regional_failover_start_same_wfid_2.yaml
+system.writeVisibilityStoreName:
+  - value: "db"
+system.readVisibilityStoreName:
+  - value: "db"
+history.replicatorTaskBatchSize:
+  - value: 25
+    constraints: {}
+frontend.failoverCoolDown:
+  - value: 5s
+history.ReplicationTaskProcessorStartWait: # default is 5s. repl task processor sleeps this much before processing received messages.
+  - value: 10ms
+history.standbyTaskMissingEventsResendDelay:
+  - value: 5s
+history.standbyTaskMissingEventsDiscardDelay:
+  - value: 10s
+history.standbyClusterDelay:
+  - value: 10s
+history.enableTransferQueueV2:
+  - value: true
+history.enableTimerQueueV2:
+  - value: true

--- a/service/history/execution/workflow.go
+++ b/service/history/execution/workflow.go
@@ -112,6 +112,7 @@ func (r *workflowImpl) GetVectorClock() (int64, int64, error) {
 	return lastWriteVersion, lastEventTaskID, nil
 }
 
+// TODO(active-active): update this to make it work for active-active domains
 func (r *workflowImpl) HappensAfter(
 	that Workflow,
 ) (bool, error) {

--- a/simulation/replication/testdata/replication_simulation_activeactive_regional_failover_start_same_wfid_2.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive_regional_failover_start_same_wfid_2.yaml
@@ -1,0 +1,60 @@
+# This file is a replication simulation scenario spec.
+# It is parsed into ReplicationSimulationConfig struct.
+# Replication simulation for this file can be run via ./simulation/replication/run.sh activeactive_regional_failover_start_same_wfid_2
+# Dynamic config overrides can be set via config/dynamicconfig/replication_simulation_activeactive_regional_failover_start_same_wfid_2.yml
+clusters:
+  cluster0:
+    grpcEndpoint: "cadence-cluster0:7833"
+  cluster1:
+    grpcEndpoint: "cadence-cluster1:7833"
+
+# primaryCluster is where domain data is written to and replicates to others. e.g. domain registration
+primaryCluster: "cluster0"
+
+domains:
+  test-domain-aa:
+    activeClustersByRegion:
+      region0: cluster0
+      region1: cluster1
+
+operations:
+  # Start wf1 on cluster1 before failover.
+  - op: start_workflow
+    at: 0s
+    workflowID: wf1
+    workflowType: timer-activity-loop-workflow
+    cluster: cluster1
+    domain: test-domain-aa
+    workflowExecutionStartToCloseTimeout: 70s
+    workflowDuration: 60s
+
+
+  # Failover from cluster1 to cluster0
+  - op: change_active_clusters
+    at: 10s
+    domain: test-domain-aa
+    newActiveClustersByRegion:
+      region1: cluster0
+
+  # Attempt to start wf1 on cluster0. It should reject with error "Workflow execution is already running".
+  - op: start_workflow
+    at: 30s
+    workflowID: wf1
+    workflowType: timer-activity-loop-workflow
+    cluster: cluster0
+    domain: test-domain-aa
+    workflowExecutionStartToCloseTimeout: 70s
+    workflowDuration: 60s
+    want:
+      error: "Workflow execution is already running"
+
+  # Validate that wf1 is completed in cluster0.
+  - op: validate
+    at: 80s
+    workflowID: wf1
+    cluster: cluster1
+    domain: test-domain-aa
+    want:
+      status: completed
+      startedByWorkersInCluster: cluster1
+      completedByWorkersInCluster: cluster0


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This partially revert https://github.com/cadence-workflow/cadence/pull/7246 and apply a different fix for active-active start workflow issue

<!-- Tell your future self why have you made these changes -->
**Why?**
It doesn't make sense to compare the failover versions of active-active workflows that use different activeness-selection-policy. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
simulation test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**


Signed-off-by: Shaddoll@users.noreply.github.com
