### PR TITLE
chore(active-active): Remove RegionInformation from cluster group metadata

### DIFF
--- a/common/activecluster/manager_test.go
+++ b/common/activecluster/manager_test.go
@@ -200,14 +200,6 @@ func TestLookupNewWorkflow(t *testing.T) {
 					Region:                 "us-east",
 				},
 			},
-			Regions: map[string]config.RegionInformation{
-				"us-west": {
-					InitialFailoverVersion: 0,
-				},
-				"us-east": {
-					InitialFailoverVersion: 2,
-				},
-			},
 			FailoverVersionIncrement: 100,
 			CurrentClusterName:       "cluster0",
 		},
@@ -345,14 +337,6 @@ func TestLookupWorkflow(t *testing.T) {
 				"cluster1": {
 					InitialFailoverVersion: 3,
 					Region:                 "us-east",
-				},
-			},
-			Regions: map[string]config.RegionInformation{
-				"us-west": {
-					InitialFailoverVersion: 0,
-				},
-				"us-east": {
-					InitialFailoverVersion: 2,
 				},
 			},
 			FailoverVersionIncrement: 100,

--- a/common/cluster/metadata_test_utils.go
+++ b/common/cluster/metadata_test_utils.go
@@ -34,10 +34,6 @@ const (
 	TestAlternativeClusterInitialFailoverVersion = int64(1)
 	// TestDisabledClusterInitialFailoverVersion is initial failover version for disabled cluster
 	TestDisabledClusterInitialFailoverVersion = int64(2)
-	// TestRegion1InitialFailoverVersion is initial failover version for region1
-	TestRegion1InitialFailoverVersion = int64(3)
-	// TestRegion2InitialFailoverVersion is initial failover version for region2
-	TestRegion2InitialFailoverVersion = int64(4)
 	// TestFailoverVersionIncrement is failover version increment used for test
 	TestFailoverVersionIncrement = int64(10)
 	// TestCurrentClusterName is current cluster used for test
@@ -59,14 +55,6 @@ const (
 )
 
 var (
-	TestRegions = map[string]config.RegionInformation{
-		TestRegion1: {
-			InitialFailoverVersion: TestRegion1InitialFailoverVersion,
-		},
-		TestRegion2: {
-			InitialFailoverVersion: TestRegion2InitialFailoverVersion,
-		},
-	}
 	// TestAllClusterNames is the all cluster names used for test
 	TestAllClusterNames = []string{TestCurrentClusterName, TestAlternativeClusterName}
 	// TestAllClusterInfo is the same as above, just convenient for test mocking
@@ -147,7 +135,6 @@ func GetTestClusterMetadata(isPrimaryCluster bool) Metadata {
 			PrimaryClusterName:       primaryClusterName,
 			CurrentClusterName:       TestCurrentClusterName,
 			ClusterGroup:             TestAllClusterInfo,
-			Regions:                  TestRegions,
 		},
 		func(d string) bool { return false },
 		commonMetrics.NewNoopMetricsClient(),

--- a/common/config/cluster.go
+++ b/common/config/cluster.go
@@ -48,11 +48,6 @@ type (
 		// ClusterGroup contains information for each cluster within the replication group
 		// Key is the clusterName
 		ClusterGroup map[string]ClusterInformation `yaml:"clusterGroup"`
-		// Regions is a map of region name to region information.
-		// Key is the region name.
-		// Each cluster must belong to one and only one region. Specified in clusterGroup.
-		// Regions configuration is needed if active-active domains are enabled.
-		Regions map[string]RegionInformation `yaml:"regions"`
 		// Deprecated: please use ClusterGroup
 		ClusterInformation map[string]ClusterInformation `yaml:"clusterInformation"`
 	}
@@ -83,12 +78,6 @@ type (
 		TLS TLS `yaml:"tls"`
 		// Region is the region of the cluster.
 		Region string `yaml:"region"`
-	}
-
-	RegionInformation struct {
-		// InitialFailoverVersion is the identifier of each region.
-		// It is used for active-active domains to determine the region of workflows which don't have an external entity mapping. (origin stickyness)
-		InitialFailoverVersion int64 `yaml:"initialFailoverVersion"`
 	}
 
 	AuthorizationProvider struct {

--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -1466,14 +1466,7 @@ func (d *handlerImpl) activeClustersFromRegisterRequest(registerRequest *types.R
 	// Initialize ActiveClustersByRegion with given cluster names and their initial failover versions
 	activeClustersByRegion := make(map[string]types.ActiveClusterInfo, len(registerRequest.ActiveClustersByRegion))
 	clusters := d.clusterMetadata.GetAllClusterInfo()
-	regions := d.clusterMetadata.GetAllRegionInfo()
 	for region, cluster := range registerRequest.ActiveClustersByRegion {
-		if _, ok := regions[region]; !ok {
-			return nil, &types.BadRequestError{
-				Message: fmt.Sprintf("Region %v not found. Domain cannot be registered in this region.", region),
-			}
-		}
-
 		clusterInfo, ok := clusters[cluster]
 		if !ok {
 			return nil, &types.BadRequestError{

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -323,28 +323,6 @@ func TestRegisterDomain(t *testing.T) {
 			expectedErr: &types.BadRequestError{Message: "Invalid local domain active cluster"},
 		},
 		{
-			name: "active-active domain with an invalid region in request",
-			request: &types.RegisterDomainRequest{
-				Name:           "active-active-domain",
-				IsGlobalDomain: true,
-				ActiveClustersByRegion: map[string]string{
-					cluster.TestRegion1: cluster.TestCurrentClusterName,
-					"invalid-region":    cluster.TestAlternativeClusterName,
-				},
-				Clusters: []*types.ClusterReplicationConfiguration{
-					{ClusterName: cluster.TestCurrentClusterName},
-					{ClusterName: cluster.TestAlternativeClusterName},
-				},
-				WorkflowExecutionRetentionPeriodInDays: 3,
-			},
-			isPrimaryCluster: true,
-			mockSetup: func(mockDomainMgr *persistence.MockDomainManager, mockReplicator *MockReplicator, request *types.RegisterDomainRequest) {
-				mockDomainMgr.EXPECT().GetDomain(gomock.Any(), &persistence.GetDomainRequest{Name: request.Name}).Return(nil, &types.EntityNotExistsError{})
-			},
-			wantErr:     true,
-			expectedErr: &types.BadRequestError{},
-		},
-		{
 			name: "active-active domain with an invalid cluster in request",
 			request: &types.RegisterDomainRequest{
 				Name:           "active-active-domain",

--- a/docker/config_template.yaml
+++ b/docker/config_template.yaml
@@ -264,13 +264,6 @@ clusterGroupMetadata:
             region: "region1"
             {{- end }}
         {{- end }}
-    {{- if .Env.ENABLE_GLOBAL_ACTIVE_ACTIVE_DOMAIN }}
-    regions:
-        region0:
-            initialFailoverVersion: 1
-        region1:
-            initialFailoverVersion: 3
-    {{- end }}
 
 archival:
   history:


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Remove RegionInformation from cluster group metadata

<!-- Tell your future self why have you made these changes -->
**Why?**
There was a design decision change that removes the region concept.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests & replication simulation tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
Active-Active (experimental)
Breaking (experimental only): clusterGroupMetadata.regions removed. Remove the regions block from your config or the service will fail to start with yaml: unmarshal errors: field regions not found in type config.ClusterGroupMetadata.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
