### PR TITLE
fix search attribute error message typo

### DIFF
--- a/common/elasticsearch/validator/searchAttrValidator.go
+++ b/common/elasticsearch/validator/searchAttrValidator.go
@@ -103,7 +103,7 @@ func (sv *SearchAttributesValidator) ValidateSearchAttributes(input *types.Searc
 		if definition.IsSystemIndexedKey(key) {
 			sv.logger.WithTags(tag.ESKey(key), tag.WorkflowDomainName(domain)).
 				Error("illegal update of system reserved attribute")
-			return &types.BadRequestError{Message: fmt.Sprintf("%s is read-only Cadence reservered attribute", key)}
+			return &types.BadRequestError{Message: fmt.Sprintf("%s is read-only Cadence reserved attribute", key)}
 		}
 		// verify: size of single value <= limit
 		if len(val) > sv.searchAttributesSizeOfValueLimit(domain) {

--- a/common/elasticsearch/validator/searchAttrValidator_test.go
+++ b/common/elasticsearch/validator/searchAttrValidator_test.go
@@ -103,7 +103,7 @@ func (s *searchAttributesValidatorSuite) TestValidateSearchAttributes() {
 	}
 	attr.IndexedFields = fields
 	err = validator.ValidateSearchAttributes(attr, domain)
-	s.Equal(`StartTime is read-only Cadence reservered attribute`, err.Error())
+	s.Equal(`StartTime is read-only Cadence reserved attribute`, err.Error())
 
 	fields = map[string][]byte{
 		"CustomKeywordField": []byte(`"123456"`),


### PR DESCRIPTION
**What changed?**
Fix typo in search attributes error messages. Changing `reservered` to `reserved`

