### PR TITLE
refactor(active-active): Introduce ClusterAttribute internal type

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -6522,10 +6522,31 @@ func ToCronOverlapPolicy(p apiv1.CronOverlapPolicy) *types.CronOverlapPolicy {
 	return nil
 }
 
+func FromClusterAttribute(c *types.ClusterAttribute) *apiv1.ClusterAttribute {
+	if c == nil {
+		return nil
+	}
+	return &apiv1.ClusterAttribute{
+		Scope: c.Scope,
+		Name:  c.Name,
+	}
+}
+
+func ToClusterAttribute(c *apiv1.ClusterAttribute) *types.ClusterAttribute {
+	if c == nil {
+		return nil
+	}
+	return &types.ClusterAttribute{
+		Scope: c.Scope,
+		Name:  c.Name,
+	}
+}
+
 func FromActiveClusterSelectionPolicy(p *types.ActiveClusterSelectionPolicy) *apiv1.ActiveClusterSelectionPolicy {
 	if p == nil {
 		return nil
 	}
+	// TODO(active-active): Remove the switch statement once the strategy is removed
 	switch p.GetStrategy() {
 	case types.ActiveClusterSelectionStrategyRegionSticky:
 		return &apiv1.ActiveClusterSelectionPolicy{
@@ -6535,6 +6556,7 @@ func FromActiveClusterSelectionPolicy(p *types.ActiveClusterSelectionPolicy) *ap
 					StickyRegion: p.StickyRegion,
 				},
 			},
+			ClusterAttribute: FromClusterAttribute(p.ClusterAttribute),
 		}
 	case types.ActiveClusterSelectionStrategyExternalEntity:
 		return &apiv1.ActiveClusterSelectionPolicy{
@@ -6545,27 +6567,35 @@ func FromActiveClusterSelectionPolicy(p *types.ActiveClusterSelectionPolicy) *ap
 					ExternalEntityKey:  p.ExternalEntityKey,
 				},
 			},
+			ClusterAttribute: FromClusterAttribute(p.ClusterAttribute),
 		}
 	}
-	panic("unexpected enum value")
+	return &apiv1.ActiveClusterSelectionPolicy{
+		ClusterAttribute: FromClusterAttribute(p.ClusterAttribute),
+	}
 }
 
 func ToActiveClusterSelectionPolicy(p *apiv1.ActiveClusterSelectionPolicy) *types.ActiveClusterSelectionPolicy {
 	if p == nil {
 		return nil
 	}
+	// TODO(active-active): Remove the switch statement once the strategy is removed
 	switch p.Strategy {
 	case apiv1.ActiveClusterSelectionStrategy_ACTIVE_CLUSTER_SELECTION_STRATEGY_REGION_STICKY:
 		return &types.ActiveClusterSelectionPolicy{
 			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
 			StickyRegion:                   p.StrategyConfig.(*apiv1.ActiveClusterSelectionPolicy_ActiveClusterStickyRegionConfig).ActiveClusterStickyRegionConfig.StickyRegion,
+			ClusterAttribute:               ToClusterAttribute(p.ClusterAttribute),
 		}
 	case apiv1.ActiveClusterSelectionStrategy_ACTIVE_CLUSTER_SELECTION_STRATEGY_EXTERNAL_ENTITY:
 		return &types.ActiveClusterSelectionPolicy{
 			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyExternalEntity.Ptr(),
 			ExternalEntityType:             p.StrategyConfig.(*apiv1.ActiveClusterSelectionPolicy_ActiveClusterExternalEntityConfig).ActiveClusterExternalEntityConfig.ExternalEntityType,
 			ExternalEntityKey:              p.StrategyConfig.(*apiv1.ActiveClusterSelectionPolicy_ActiveClusterExternalEntityConfig).ActiveClusterExternalEntityConfig.ExternalEntityKey,
+			ClusterAttribute:               ToClusterAttribute(p.ClusterAttribute),
 		}
 	}
-	panic("unexpected enum value")
+	return &types.ActiveClusterSelectionPolicy{
+		ClusterAttribute: ToClusterAttribute(p.ClusterAttribute),
+	}
 }

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -1301,6 +1301,24 @@ func TestActiveClustersConversion(t *testing.T) {
 	}
 }
 
+func TestClusterAttribute(t *testing.T) {
+	for _, item := range []*types.ClusterAttribute{nil, {}, &testdata.ClusterAttribute} {
+		assert.Equal(t, item, ToClusterAttribute(FromClusterAttribute(item)))
+	}
+}
+
+// TODO(active-active): Remove the comment once the strategy is removed
+/*
+func TestActiveClusterSelectionPolicy(t *testing.T) {
+	for _, item := range []*types.ActiveClusterSelectionPolicy{
+		nil,
+		{},
+		&testdata.ActiveClusterSelectionPolicyWithClusterAttribute,
+	} {
+		assert.Equal(t, item, ToActiveClusterSelectionPolicy(FromActiveClusterSelectionPolicy(item)))
+	}
+}*/
+
 func TestClusterAttributeScopeConversion(t *testing.T) {
 	testCases := []*types.ClusterAttributeScope{
 		nil,

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -6838,6 +6838,26 @@ func ToWorkflowExecutionStartedEventAttributes(t *shared.WorkflowExecutionStarte
 	}
 }
 
+func FromClusterAttribute(t *types.ClusterAttribute) *shared.ClusterAttribute {
+	if t == nil {
+		return nil
+	}
+	return &shared.ClusterAttribute{
+		Scope: &t.Scope,
+		Name:  &t.Name,
+	}
+}
+
+func ToClusterAttribute(t *shared.ClusterAttribute) *types.ClusterAttribute {
+	if t == nil {
+		return nil
+	}
+	return &types.ClusterAttribute{
+		Scope: t.GetScope(),
+		Name:  t.GetName(),
+	}
+}
+
 func FromActiveClusterSelectionPolicy(t *types.ActiveClusterSelectionPolicy) *shared.ActiveClusterSelectionPolicy {
 	if t == nil {
 		return nil
@@ -6847,6 +6867,7 @@ func FromActiveClusterSelectionPolicy(t *types.ActiveClusterSelectionPolicy) *sh
 		ExternalEntityType: &t.ExternalEntityType,
 		ExternalEntityKey:  &t.ExternalEntityKey,
 		StickyRegion:       &t.StickyRegion,
+		ClusterAttribute:   FromClusterAttribute(t.ClusterAttribute),
 	}
 }
 
@@ -6859,6 +6880,7 @@ func ToActiveClusterSelectionPolicy(t *shared.ActiveClusterSelectionPolicy) *typ
 		ExternalEntityType:             *t.ExternalEntityType,
 		ExternalEntityKey:              *t.ExternalEntityKey,
 		StickyRegion:                   *t.StickyRegion,
+		ClusterAttribute:               ToClusterAttribute(t.ClusterAttribute),
 	}
 }
 

--- a/common/types/mapper/thrift/shared_test.go
+++ b/common/types/mapper/thrift/shared_test.go
@@ -3565,8 +3565,10 @@ func TestQueueStateConversion(t *testing.T) {
 func TestActiveClusterSelectionPolicyConversion(t *testing.T) {
 	testCases := []*types.ActiveClusterSelectionPolicy{
 		nil,
+		{},
 		&testdata.ActiveClusterSelectionPolicyExternalEntity,
 		&testdata.ActiveClusterSelectionPolicyRegionSticky,
+		&testdata.ActiveClusterSelectionPolicyWithClusterAttribute,
 	}
 
 	for _, original := range testCases {

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -2550,6 +2550,21 @@ func (v *ActiveClusters) DeepCopy() *ActiveClusters {
 	}
 }
 
+type ClusterAttribute struct {
+	Scope string `json:"scope,omitempty"`
+	Name  string `json:"name,omitempty"`
+}
+
+func (c *ClusterAttribute) Equals(other *ClusterAttribute) bool {
+	if c == nil && other == nil {
+		return true
+	}
+	if c == nil || other == nil {
+		return false
+	}
+	return c.Scope == other.Scope && c.Name == other.Name
+}
+
 type ActiveClusterSelectionStrategy int32
 
 const (
@@ -2564,6 +2579,9 @@ type ActiveClusterSelectionPolicy struct {
 
 	ExternalEntityType string `json:"externalEntityType,omitempty"`
 	ExternalEntityKey  string `json:"externalEntityKey,omitempty"`
+
+	// TODO(active-active): Remove the fields above
+	ClusterAttribute *ClusterAttribute `json:"clusterAttribute,omitempty"`
 }
 
 func (p *ActiveClusterSelectionPolicy) Equals(other *ActiveClusterSelectionPolicy) bool {
@@ -2577,7 +2595,7 @@ func (p *ActiveClusterSelectionPolicy) Equals(other *ActiveClusterSelectionPolic
 	return p.GetStrategy() == other.GetStrategy() &&
 		p.StickyRegion == other.StickyRegion &&
 		p.ExternalEntityType == other.ExternalEntityType &&
-		p.ExternalEntityKey == other.ExternalEntityKey
+		p.ExternalEntityKey == other.ExternalEntityKey && p.ClusterAttribute.Equals(other.ClusterAttribute)
 }
 
 func (p *ActiveClusterSelectionPolicy) GetStrategy() ActiveClusterSelectionStrategy {

--- a/common/types/testdata/common.go
+++ b/common/types/testdata/common.go
@@ -509,5 +509,12 @@ var (
 		ExternalEntityType:             "externalEntityType1",
 		ExternalEntityKey:              "externalEntityKey1",
 	}
+	ClusterAttribute = types.ClusterAttribute{
+		Scope: "region",
+		Name:  "us-west-1",
+	}
+	ActiveClusterSelectionPolicyWithClusterAttribute = types.ActiveClusterSelectionPolicy{
+		ClusterAttribute: &ClusterAttribute,
+	}
 	CronOverlapPolicy = types.CronOverlapPolicySkipped
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Introduce ClusterAttribute internal type and mappers
- Update ActiveSelectionPolicy to include ClusterAttribute field

<!-- Tell your future self why have you made these changes -->
**Why?**
Refactor the implementation of active-active

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests and replication simulation tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
