### PR TITLE
chore: replace x/exp/maps with maps

### DIFF
--- a/client/history/peer_resolver_test.go
+++ b/client/history/peer_resolver_test.go
@@ -22,6 +22,7 @@ package history
 
 import (
 	"errors"
+	"maps"
 	"slices"
 	"testing"
 
@@ -30,7 +31,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber/ringpop-go/hashring"
 	gomock "go.uber.org/mock/gomock"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/membership"
@@ -295,7 +295,7 @@ func TestPeerResolver(t *testing.T) {
 
 			// small sanity check: sharded response should return all inputs
 			assertAllKeysPresent := func(t *testing.T, sharded map[Peer][]string, limits []string) {
-				responded := maps.Values(sharded)
+				responded := slices.Collect(maps.Values(sharded))
 				assert.ElementsMatchf(t,
 					limits,
 					slices.Concat(responded...), // flatten the [][]string

--- a/common/archiver/gcloud/go.sum
+++ b/common/archiver/gcloud/go.sum
@@ -359,8 +359,6 @@ golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0
 golang.org/x/crypto v0.38.0 h1:jt+WWG8IZlBnVbomuhg2Mdq0+BBQaHbtqHEFEigjUV8=
 golang.org/x/crypto v0.38.0/go.mod h1:MvrbAqul58NNYPKnOra203SB9vpuZW0e+RRZV+Ggqjw=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b h1:kLiC65FbiHWFAOu+lxwNPujcsl8VYyTYYEZnsOO1WK4=
-golang.org/x/exp v0.0.0-20231226003508-02704c960a9b/go.mod h1:iRJReGqOEeBhDZGkGbynYwcHlctCvnjTYIamk7uXpHI=
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e h1:qyrTQ++p1afMkO4DPEeLGq/3oTsdlvdH4vqZUBWzUKM=
 golang.org/x/exp/typeparams v0.0.0-20220218215828-6cf2b201936e/go.mod h1:AbB0pIl9nAr9wVwH+Z2ZpaocVmF5I4GyWCDIsVjR0bk=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=

--- a/common/metrics/config_test.go
+++ b/common/metrics/config_test.go
@@ -1,9 +1,8 @@
 package metrics
 
 import (
+	"maps"
 	"testing"
-
-	"golang.org/x/exp/maps"
 )
 
 func TestHistogramMigrationMetricsExist(t *testing.T) {

--- a/common/quotas/global/algorithm/requestweighted_fuzz_test.go
+++ b/common/quotas/global/algorithm/requestweighted_fuzz_test.go
@@ -24,12 +24,11 @@ package algorithm
 
 import (
 	"encoding/binary"
+	"maps"
 	"math"
+	"slices"
 	"testing"
 	"time"
-
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 
 	"github.com/uber/cadence/common/dynamicconfig/dynamicproperties"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -114,8 +113,8 @@ func FuzzMultiUpdate(f *testing.F) {
 				t.Error("no keys")
 			}
 
-			keys := maps.Keys(keySet)
-			idents := maps.Keys(identSet)
+			keys := slices.Collect(maps.Keys(keySet))
+			idents := slices.Collect(maps.Keys(identSet))
 			slices.Sort(keys)
 			slices.Sort(idents)
 

--- a/common/quotas/global/algorithm/requestweighted_test.go
+++ b/common/quotas/global/algorithm/requestweighted_test.go
@@ -24,8 +24,10 @@ package algorithm
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"math/rand"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -35,7 +37,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/uber-go/tally"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/clock"
@@ -591,7 +592,7 @@ func TestConcurrent(t *testing.T) {
 					err := agg.Update(UpdateParams{ID: host, Load: updates, Elapsed: updateRate})
 					require.NoError(t, err)
 				} else {
-					_, err := agg.HostUsage(host, maps.Keys(updates))
+					_, err := agg.HostUsage(host, slices.Collect(maps.Keys(updates)))
 					require.NoError(t, err)
 				}
 			}
@@ -1022,7 +1023,7 @@ func BenchmarkNormalUse(b *testing.B) {
 		rounds = append(rounds, round{
 			host:    Identity(fmt.Sprintf("host %d", rand.Intn(hosts))),
 			load:    reqs,
-			keys:    maps.Keys(reqs),
+			keys:    slices.Collect(maps.Keys(reqs)),
 			elapsed: time.Duration(rand.Int63n(updateRate.Nanoseconds())),
 		})
 	}

--- a/common/quotas/global/rpc/client_test.go
+++ b/common/quotas/global/rpc/client_test.go
@@ -26,15 +26,16 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math"
 	"reflect"
+	"slices"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/client/history"
 	"github.com/uber/cadence/common/log/testlogger"
@@ -179,7 +180,7 @@ func (a matchrequest) Matches(x interface{}) bool {
 		keys[k] = struct{}{}
 	}
 	gotKeys := map[string]struct{}{}
-	for _, k := range stringy(maps.Keys(up.Load)) {
+	for _, k := range stringy(slices.Collect(maps.Keys(up.Load))) {
 		gotKeys[k] = struct{}{}
 	}
 	a.t.Logf("want keys: %v, got keys: %v", maps.Keys(keys), maps.Keys(gotKeys))

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -26,9 +26,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"math/rand"
 	"reflect"
 	"runtime"
+	"slices"
 	"strconv"
 	"sync"
 	"testing"
@@ -40,7 +42,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc/yarpcerrors"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common/backoff"
 	"github.com/uber/cadence/common/constants"
@@ -1653,7 +1654,7 @@ func TestCheckEventBlobSizeLimit(t *testing.T) {
 			assertMetrics: func(snapshot tally.Snapshot) {
 				counters := snapshot.Counters()
 				assert.Len(t, counters, 1)
-				values := maps.Values(counters)
+				values := slices.Collect(maps.Values(counters))
 				assert.Equal(t, "test.blob_size_exceed_limit", values[0].Name())
 				assert.Equal(t, int64(1), values[0].Value())
 			},

--- a/service/history/decision/checker_test.go
+++ b/service/history/decision/checker_test.go
@@ -23,7 +23,8 @@
 package decision
 
 import (
-	"sort"
+	"maps"
+	"slices"
 	"testing"
 	"time"
 
@@ -33,7 +34,6 @@ import (
 	"github.com/uber-go/tally"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/zap/zaptest/observer"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
@@ -795,7 +795,7 @@ func TestWorkflowSizeChecker_failWorkflowIfBlobSizeExceedsLimit(t *testing.T) {
 			assertLogsAndMetrics: func(t *testing.T, logs *observer.ObservedLogs, scope tally.TestScope) {
 				assert.Empty(t, logs.All())
 				// ensure metrics with the size is emitted.
-				timerData := maps.Values(scope.Snapshot().Timers())
+				timerData := slices.Collect(maps.Values(scope.Snapshot().Timers()))
 				assert.Len(t, timerData, 2)
 				assert.Equal(t, "test.event_blob_size", timerData[0].Name())
 			},
@@ -887,13 +887,13 @@ func TestWorkflowSizeChecker_failWorkflowSizeExceedsLimit(t *testing.T) {
 			assertLogsAndMetrics: func(t *testing.T, logs *observer.ObservedLogs, scope tally.TestScope) {
 				assert.Empty(t, logs.All())
 				// ensure metrics with the size is emitted.
-				timerData := maps.Values(scope.Snapshot().Timers())
+				timerData := slices.Collect(maps.Values(scope.Snapshot().Timers()))
 				assert.Len(t, timerData, 4)
 				timerNames := make([]string, 0, 4)
 				for _, timer := range timerData {
 					timerNames = append(timerNames, timer.Name())
 				}
-				sort.Strings(timerNames)
+				slices.Sort(timerNames)
 
 				// timers are duplicated for specific domain and domain: all
 				assert.Equal(t, []string{"test.history_count", "test.history_count", "test.history_size", "test.history_size"}, timerNames)

--- a/service/history/execution/mutable_state_builder.go
+++ b/service/history/execution/mutable_state_builder.go
@@ -24,12 +24,13 @@ package execution
 import (
 	"context"
 	"fmt"
+	"maps"
 	"math/rand"
 	"runtime/debug"
+	"slices"
 	"time"
 
 	"github.com/pborman/uuid"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
@@ -1486,18 +1487,18 @@ func (e *mutableStateBuilder) CloseTransactionAsMutation(
 		ExecutionInfo:    e.executionInfo,
 		VersionHistories: e.versionHistories,
 
-		UpsertActivityInfos:       maps.Values(e.updateActivityInfos),
-		DeleteActivityInfos:       maps.Keys(e.deleteActivityInfos),
-		UpsertTimerInfos:          maps.Values(e.updateTimerInfos),
-		DeleteTimerInfos:          maps.Keys(e.deleteTimerInfos),
-		UpsertChildExecutionInfos: maps.Values(e.updateChildExecutionInfos),
-		DeleteChildExecutionInfos: maps.Keys(e.deleteChildExecutionInfos),
-		UpsertRequestCancelInfos:  maps.Values(e.updateRequestCancelInfos),
-		DeleteRequestCancelInfos:  maps.Keys(e.deleteRequestCancelInfos),
-		UpsertSignalInfos:         maps.Values(e.updateSignalInfos),
-		DeleteSignalInfos:         maps.Keys(e.deleteSignalInfos),
-		UpsertSignalRequestedIDs:  maps.Keys(e.updateSignalRequestedIDs),
-		DeleteSignalRequestedIDs:  maps.Keys(e.deleteSignalRequestedIDs),
+		UpsertActivityInfos:       slices.Collect(maps.Values(e.updateActivityInfos)),
+		DeleteActivityInfos:       slices.Collect(maps.Keys(e.deleteActivityInfos)),
+		UpsertTimerInfos:          slices.Collect(maps.Values(e.updateTimerInfos)),
+		DeleteTimerInfos:          slices.Collect(maps.Keys(e.deleteTimerInfos)),
+		UpsertChildExecutionInfos: slices.Collect(maps.Values(e.updateChildExecutionInfos)),
+		DeleteChildExecutionInfos: slices.Collect(maps.Keys(e.deleteChildExecutionInfos)),
+		UpsertRequestCancelInfos:  slices.Collect(maps.Values(e.updateRequestCancelInfos)),
+		DeleteRequestCancelInfos:  slices.Collect(maps.Keys(e.deleteRequestCancelInfos)),
+		UpsertSignalInfos:         slices.Collect(maps.Values(e.updateSignalInfos)),
+		DeleteSignalInfos:         slices.Collect(maps.Keys(e.deleteSignalInfos)),
+		UpsertSignalRequestedIDs:  slices.Collect(maps.Keys(e.updateSignalRequestedIDs)),
+		DeleteSignalRequestedIDs:  slices.Collect(maps.Keys(e.deleteSignalRequestedIDs)),
 		NewBufferedEvents:         e.updateBufferedEvents,
 		ClearBufferedEvents:       e.clearBufferedEvents,
 
@@ -1575,12 +1576,12 @@ func (e *mutableStateBuilder) CloseTransactionAsSnapshot(
 		ExecutionInfo:    e.executionInfo,
 		VersionHistories: e.versionHistories,
 
-		ActivityInfos:       maps.Values(e.pendingActivityInfoIDs),
-		TimerInfos:          maps.Values(e.pendingTimerInfoIDs),
-		ChildExecutionInfos: maps.Values(e.pendingChildExecutionInfoIDs),
-		RequestCancelInfos:  maps.Values(e.pendingRequestCancelInfoIDs),
-		SignalInfos:         maps.Values(e.pendingSignalInfoIDs),
-		SignalRequestedIDs:  maps.Keys(e.pendingSignalRequestedIDs),
+		ActivityInfos:       slices.Collect(maps.Values(e.pendingActivityInfoIDs)),
+		TimerInfos:          slices.Collect(maps.Values(e.pendingTimerInfoIDs)),
+		ChildExecutionInfos: slices.Collect(maps.Values(e.pendingChildExecutionInfoIDs)),
+		RequestCancelInfos:  slices.Collect(maps.Values(e.pendingRequestCancelInfoIDs)),
+		SignalInfos:         slices.Collect(maps.Values(e.pendingSignalInfoIDs)),
+		SignalRequestedIDs:  slices.Collect(maps.Keys(e.pendingSignalRequestedIDs)),
 
 		TasksByCategory: map[persistence.HistoryTaskCategory][]persistence.Task{
 			persistence.HistoryTaskCategoryTransfer:    e.insertTransferTasks,

--- a/service/history/execution/mutable_state_util_test_helpers.go
+++ b/service/history/execution/mutable_state_util_test_helpers.go
@@ -24,9 +24,8 @@ package execution
 
 import (
 	"encoding/json"
+	"slices"
 	"testing"
-
-	"golang.org/x/exp/slices"
 
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/persistence"

--- a/service/history/handler/handler.go
+++ b/service/history/handler/handler.go
@@ -24,6 +24,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sync"
 	"sync/atomic"
@@ -31,7 +32,6 @@ import (
 
 	"github.com/pborman/uuid"
 	"go.uber.org/yarpc/yarpcerrors"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 
 	"github.com/uber/cadence/common"
@@ -2092,7 +2092,7 @@ func (h *handlerImpl) RatelimitUpdate(
 	//
 	// "_" is ignoring "used RPS" data here.  it is likely useful for being friendlier
 	// to brief, bursty-but-within-limits load, but that has not yet been built.
-	weights, err := h.ratelimitAggregator.HostUsage(arg.ID, maps.Keys(arg.Load))
+	weights, err := h.ratelimitAggregator.HostUsage(arg.ID, slices.Collect(maps.Keys(arg.Load)))
 	if err != nil {
 		return nil, h.error(fmt.Errorf("failed to retrieve updated weights: %w", err), scope, "", "", "")
 	}

--- a/service/history/queuev2/convert.go
+++ b/service/history/queuev2/convert.go
@@ -2,10 +2,9 @@ package queuev2
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"time"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/types"
@@ -113,7 +112,7 @@ func ToPersistencePredicate(predicate Predicate) *types.Predicate {
 	case *emptyPredicate:
 		return &types.Predicate{PredicateType: types.PredicateTypeEmpty, EmptyPredicateAttributes: &types.EmptyPredicateAttributes{}}
 	case *domainIDPredicate:
-		domainIDs := maps.Keys(p.domainIDs)
+		domainIDs := slices.Collect(maps.Keys(p.domainIDs))
 		slices.Sort(domainIDs)
 		return &types.Predicate{PredicateType: types.PredicateTypeDomainID, DomainIDPredicateAttributes: &types.DomainIDPredicateAttributes{DomainIDs: domainIDs, IsExclusive: &p.isExclusive}}
 	default:

--- a/service/matching/tasklist/isolation_balancer.go
+++ b/service/matching/tasklist/isolation_balancer.go
@@ -23,10 +23,9 @@
 package tasklist
 
 import (
+	"maps"
 	"math"
 	"slices"
-
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/metrics"
@@ -84,7 +83,7 @@ func (i *isolationBalancer) adjustWritePartitions(metrics *aggregatePartitionMet
 }
 
 func (i *isolationBalancer) reset() {
-	maps.Clear(i.groupState)
+	clear(i.groupState)
 }
 
 func (i *isolationBalancer) refreshGroups(metrics *aggregatePartitionMetrics, writePartitions map[int]*types.TaskListPartition) {
@@ -243,7 +242,7 @@ func (i *isolationBalancer) applyGroupChanges(m *aggregatePartitionMetrics, part
 		if len(groups) == 0 {
 			result[id] = &types.TaskListPartition{}
 		} else {
-			asSlice := maps.Keys(groups)
+			asSlice := slices.Collect(maps.Keys(groups))
 			// Sort for the sake of stability
 			slices.Sort(asSlice)
 			result[id] = &types.TaskListPartition{IsolationGroups: asSlice}
@@ -303,7 +302,7 @@ func ensureMinimumGroupsPerPartition(minGroups int, groupSizePerPartition map[st
 	// in size, so we use a simple heuristic of minimizing the difference in total size between the two partitions that
 	// we're considering.
 	changed := false
-	partitionIDsByGroupCount := maps.Keys(groupsByPartitionID)
+	partitionIDsByGroupCount := slices.Collect(maps.Keys(groupsByPartitionID))
 	slices.SortFunc(partitionIDsByGroupCount, func(a, b int) int {
 		aLen := len(groupsByPartitionID[a])
 		bLen := len(groupsByPartitionID[b])

--- a/simulation/matching/matching_simulation_test.go
+++ b/simulation/matching/matching_simulation_test.go
@@ -41,6 +41,7 @@ import (
 	"math/rand"
 	"os"
 	"reflect"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -53,7 +54,6 @@ import (
 	"github.com/stretchr/testify/suite"
 	"go.uber.org/mock/gomock"
 	"go.uber.org/yarpc"
-	"golang.org/x/exp/slices"
 	"golang.org/x/time/rate"
 
 	"github.com/uber/cadence/client/history"

--- a/tools/cli/admin_task_list_commands.go
+++ b/tools/cli/admin_task_list_commands.go
@@ -24,13 +24,13 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"slices"
 	"strings"
 
 	"github.com/urfave/cli/v2"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/maps"
 
 	"github.com/uber/cadence/client/frontend"
 	"github.com/uber/cadence/common/constants"
@@ -161,7 +161,7 @@ func AdminListTaskList(c *cli.Context) error {
 		row.ActivityPollerCount = len(taskList.GetPollers())
 		tlByName[name] = row
 	}
-	table := maps.Values(tlByName)
+	table := slices.Collect(maps.Values(tlByName))
 	slices.SortFunc(table, func(a, b TaskListRow) int {
 		return strings.Compare(a.Name, b.Name)
 	})


### PR DESCRIPTION
Pretty straightforward, except that `import "maps"` returns a sequence rather than a slice, so all this also needs `slices.Collect`.
That seems minor enough to be worth the switch though.
