### PR TITLE
fix(histograms): depend only on the histogram config, not all config

### DIFF
--- a/common/config/fx.go
+++ b/common/config/fx.go
@@ -27,6 +27,8 @@ import (
 	"os"
 
 	"go.uber.org/fx"
+
+	"github.com/uber/cadence/common/metrics"
 )
 
 // Module returns a config.Provider that could be used byother components.
@@ -59,6 +61,7 @@ type Result struct {
 
 	Config        Config
 	ServiceConfig Service
+	Histograms    metrics.HistogramMigration
 }
 
 // LookupEnvFunc returns the value of the environment variable given by key.
@@ -97,5 +100,6 @@ func New(p Params) (Result, error) {
 	return Result{
 		Config:        cfg,
 		ServiceConfig: svcCfg,
+		Histograms:    cfg.Histograms,
 	}, nil
 }

--- a/common/metrics/metricsfx/metricsfx.go
+++ b/common/metrics/metricsfx/metricsfx.go
@@ -34,18 +34,12 @@ import (
 
 // Module provides metrics client for fx application.
 var Module = fx.Module("metricsfx",
-	fx.Provide(func(c config.Config) metrics.HistogramMigration {
-		return c.Histograms
-	}),
 	fx.Provide(buildClient))
 
 // ModuleForExternalScope provides metrics client for fx application when tally.Scope is created outside.
 var ModuleForExternalScope = fx.Module("metricsfx",
 	fx.Provide(func(params serviceIdxParams) metrics.ServiceIdx {
 		return service.GetMetricsServiceIdx(params.ServiceFullName, params.Logger)
-	}),
-	fx.Provide(func(c config.Config) metrics.HistogramMigration {
-		return c.Histograms
 	}),
 	fx.Provide(buildClientFromTally))
 

--- a/common/metrics/metricsfx/metricsfx_test.go
+++ b/common/metrics/metricsfx/metricsfx_test.go
@@ -22,7 +22,7 @@ func TestModule(t *testing.T) {
 			func() config.Service {
 				return config.Service{}
 			}),
-		fx.Provide(func() config.Config { return config.Config{} }),
+		fx.Provide(func() metrics.HistogramMigration { return metrics.HistogramMigration{} }),
 		Module,
 		fx.Invoke(func(mc metrics.Client) {}))
 	fxApp.RequireStart().RequireStop()
@@ -35,7 +35,7 @@ func TestModuleWithExternalScope(t *testing.T) {
 			fx.Annotated{
 				Target: func() string { return service.Frontend },
 				Name:   "service-full-name"}),
-		fx.Provide(func() config.Config { return config.Config{} }),
+		fx.Provide(func() metrics.HistogramMigration { return metrics.HistogramMigration{} }),
 		ModuleForExternalScope,
 		fx.Invoke(func(mc metrics.Client) {}))
 	fxApp.RequireStart().RequireStop()


### PR DESCRIPTION
Followup on #7298 to be a bit easier to set up.
This is pretty minor, but helps us internally (and possibly others) by not requiring the "main" config object (which we do not use internally, at least in our main service binary).

Anyone using the standard fx startup should be unaffected, as it now also provides the finer-grained histogram config.
Otherwise, if you get an error about `metrics.HistogramMigration` not being provided: just `fx.Provide(func(...) metrics.HistogramMigration { ... })` it however you like.

And, last but not least: apparently automerge used an old commit message for #7298.  Apologies about that, check the PR for an updated and much more descriptive description.

Signed-off-by: Steven L <imgroxx@gmail.com>
