### PR TITLE
refactor(active-active): Refactor mutable state to accept currentVersion as input

### DIFF
--- a/service/history/execution/mutable_state_builder_methods_activity_test.go
+++ b/service/history/execution/mutable_state_builder_methods_activity_test.go
@@ -68,7 +68,7 @@ func testMutableStateBuilder(t *testing.T) *mutableStateBuilder {
 	mockShard.Resource.MatchingClient.EXPECT().AddActivityTask(gomock.Any(), gomock.Any()).Return(&types.AddActivityTaskResponse{}, nil).AnyTimes()
 	mockShard.Resource.DomainCache.EXPECT().GetDomainID(constants.TestDomainName).Return(constants.TestDomainID, nil).AnyTimes()
 	mockShard.Resource.DomainCache.EXPECT().GetDomainByID(constants.TestDomainID).Return(&cache.DomainCacheEntry{}, nil).AnyTimes()
-	return newMutableStateBuilder(mockShard, logger, constants.TestLocalDomainEntry)
+	return newMutableStateBuilder(mockShard, logger, constants.TestLocalDomainEntry, constants.TestLocalDomainEntry.GetFailoverVersion())
 }
 
 func Test__AddActivityTaskScheduledEvent(t *testing.T) {

--- a/service/history/execution/mutable_state_builder_methods_child_workflow_test.go
+++ b/service/history/execution/mutable_state_builder_methods_child_workflow_test.go
@@ -739,6 +739,7 @@ func loadMutableState(t *testing.T, ctx *shard.TestContext, state *persistence.W
 	m := newMutableStateBuilder(ctx,
 		log.NewNoop(),
 		domain,
+		domain.GetFailoverVersion(),
 	)
 	err := m.Load(context.Background(), state)
 	assert.NoError(t, err)

--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -117,7 +117,7 @@ func (s *mutableStateSuite) SetupTest() {
 
 	s.mockShard.Resource.DomainCache.EXPECT().GetDomainID(constants.TestDomainName).Return(constants.TestDomainID, nil).AnyTimes()
 
-	s.msBuilder = newMutableStateBuilder(s.mockShard, s.logger, constants.TestLocalDomainEntry)
+	s.msBuilder = newMutableStateBuilder(s.mockShard, s.logger, constants.TestLocalDomainEntry, constants.TestLocalDomainEntry.GetFailoverVersion())
 }
 
 func (s *mutableStateSuite) TearDownTest() {
@@ -1956,7 +1956,7 @@ func TestMutableStateBuilder_CopyToPersistence_roundtrip(t *testing.T) {
 		activeClusterManager := activecluster.NewMockManager(ctrl)
 		shardContext.EXPECT().GetActiveClusterManager().Return(activeClusterManager).AnyTimes()
 
-		msb := newMutableStateBuilder(shardContext, log.NewNoop(), constants.TestGlobalDomainEntry)
+		msb := newMutableStateBuilder(shardContext, log.NewNoop(), constants.TestGlobalDomainEntry, constants.TestGlobalDomainEntry.GetFailoverVersion())
 
 		msb.Load(context.Background(), execution)
 
@@ -3894,7 +3894,7 @@ func createMSBWithMocks(mockCache *events.MockCache, shardContext *shardCtx.Mock
 		domainEntry = constants.TestGlobalDomainEntry
 	}
 
-	msb := newMutableStateBuilder(shardContext, log.NewNoop(), domainEntry)
+	msb := newMutableStateBuilder(shardContext, log.NewNoop(), domainEntry, domainEntry.GetFailoverVersion())
 	return msb
 }
 

--- a/service/history/execution/mutable_state_decision_task_manager_test.go
+++ b/service/history/execution/mutable_state_decision_task_manager_test.go
@@ -61,7 +61,7 @@ func TestReplicateDecisionTaskCompletedEvent(t *testing.T) {
 	mockShard.Resource.DomainCache.EXPECT().GetDomainID(constants.TestDomainName).Return(constants.TestDomainID, nil).AnyTimes()
 
 	m := &mutableStateDecisionTaskManagerImpl{
-		msb: newMutableStateBuilder(mockShard, logger, constants.TestLocalDomainEntry),
+		msb: newMutableStateBuilder(mockShard, logger, constants.TestLocalDomainEntry, constants.TestLocalDomainEntry.GetFailoverVersion()),
 	}
 	eventType := types.EventTypeActivityTaskCompleted
 	e := &types.HistoryEvent{
@@ -77,7 +77,7 @@ func TestReplicateDecisionTaskCompletedEvent(t *testing.T) {
 	assert.NoError(t, err)
 
 	// test when config is nil
-	m.msb = newMutableStateBuilder(mockShard, logger, constants.TestLocalDomainEntry)
+	m.msb = newMutableStateBuilder(mockShard, logger, constants.TestLocalDomainEntry, constants.TestLocalDomainEntry.GetFailoverVersion())
 	m.msb.config = nil
 	err = m.ReplicateDecisionTaskCompletedEvent(e)
 	assert.NoError(t, err)

--- a/service/history/execution/mutable_state_util_test.go
+++ b/service/history/execution/mutable_state_util_test.go
@@ -343,7 +343,7 @@ func TestCreatePersistenceMutableState(t *testing.T) {
 	mockShardContext.EXPECT().GetDomainCache().Return(mockDomainCache)
 	mockShardContext.EXPECT().GetLogger().Return(logger).AnyTimes()
 
-	builder := newMutableStateBuilder(mockShardContext, logger, constants.TestLocalDomainEntry)
+	builder := newMutableStateBuilder(mockShardContext, logger, constants.TestLocalDomainEntry, constants.TestLocalDomainEntry.GetFailoverVersion())
 	builder.pendingActivityInfoIDs[0] = &persistence.ActivityInfo{}
 	builder.pendingTimerInfoIDs["some-key"] = &persistence.TimerInfo{}
 	builder.pendingSignalInfoIDs[0] = &persistence.SignalInfo{}

--- a/service/history/execution/state_builder.go
+++ b/service/history/execution/state_builder.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -488,10 +489,12 @@ func (b *stateBuilderImpl) ApplyEvents(
 
 			// The length of newRunHistory can be zero in resend case
 			if len(newRunHistory) != 0 {
+				domainEntry := b.mutableState.GetDomainEntry()
 				newRunMutableStateBuilder = NewMutableStateBuilderWithVersionHistories(
 					b.shard,
 					b.logger,
-					b.mutableState.GetDomainEntry(),
+					domainEntry,
+					constants.EmptyVersion,
 				)
 				newRunStateBuilder := NewStateBuilder(b.shard, b.logger, newRunMutableStateBuilder)
 				newRunID := event.WorkflowExecutionContinuedAsNewEventAttributes.GetNewExecutionRunID()

--- a/service/history/execution/state_rebuilder.go
+++ b/service/history/execution/state_rebuilder.go
@@ -210,6 +210,7 @@ func (r *stateRebuilderImpl) initializeBuilders(
 		r.shard,
 		r.logger,
 		domainEntry,
+		constants.EmptyVersion,
 	)
 	stateBuilder := NewStateBuilder(
 		r.shard,

--- a/service/history/ndc/history_replicator.go
+++ b/service/history/ndc/history_replicator.go
@@ -29,6 +29,7 @@ import (
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/cache"
 	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/errors"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -286,6 +287,7 @@ func NewHistoryReplicator(
 				shard,
 				logger,
 				domainEntry,
+				constants.EmptyVersion,
 			)
 		},
 		newReplicationTaskFn:                                         newReplicationTask,
@@ -419,6 +421,7 @@ func applyStartEvents(
 		return err
 	}
 	requestID := uuid.New() // requestID used for start workflow execution request.  This is not on the history event.
+	// since it's replicated from the other cluster, we don't care the active cluster policy, because the failover version will be updated after ApplyEvents
 	mutableState := newMutableState(domainEntry, task.getLogger())
 	stateBuilder := newStateBuilder(mutableState, task.getLogger())
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Refactor mutable state to accept currentVersion as input

<!-- Tell your future self why have you made these changes -->
**Why?**
A change prepared for history refactoring

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests & simulation tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
