### PR TITLE
feat:[ShardDistributor] add external assignment in executor library

### DIFF
--- a/service/sharddistributor/canary/externalshardassignment/shardassigner.go
+++ b/service/sharddistributor/canary/externalshardassignment/shardassigner.go
@@ -99,7 +99,7 @@ func (s *ShardAssigner) process(ctx context.Context) {
 					Status: types.AssignmentStatusREADY,
 				},
 			}
-			s.executorclient.AssignShards(context.Background(), shardAssignment)
+			s.executorclient.AssignShardsFromLocalLogic(context.Background(), shardAssignment)
 			sp, err := s.executorclient.GetShardProcess(newAssignedShard)
 			if err != nil {
 				s.logger.Error("failed to get shard assigned", zap.String("shardKey", newAssignedShard), zap.Error(err))

--- a/service/sharddistributor/canary/externalshardassignment/shardassigner_test.go
+++ b/service/sharddistributor/canary/externalshardassignment/shardassigner_test.go
@@ -24,9 +24,9 @@ func TestSShardAssigner_Lifecycle(t *testing.T) {
 
 	namespace := "test-namespace"
 
-	executorclientmock.EXPECT().AssignShards(gomock.Any(), gomock.Any())
+	executorclientmock.EXPECT().AssignShardsFromLocalLogic(gomock.Any(), gomock.Any())
 	executorclientmock.EXPECT().GetShardProcess(gomock.Any()).Return(nil, assert.AnError)
-	executorclientmock.EXPECT().AssignShards(gomock.Any(), gomock.Any())
+	executorclientmock.EXPECT().AssignShardsFromLocalLogic(gomock.Any(), gomock.Any())
 	executorclientmock.EXPECT().GetShardProcess(gomock.Any()).Return(nil, assert.AnError)
 
 	params := ShardAssignerParams{

--- a/service/sharddistributor/canary/module.go
+++ b/service/sharddistributor/canary/module.go
@@ -4,7 +4,6 @@ import (
 	"go.uber.org/fx"
 
 	sharddistributorv1 "github.com/uber/cadence/.gen/proto/sharddistributor/v1"
-	exetrnalshardassignment "github.com/uber/cadence/service/sharddistributor/canary/externalshardassignment"
 	"github.com/uber/cadence/service/sharddistributor/canary/factory"
 	"github.com/uber/cadence/service/sharddistributor/canary/processor"
 	"github.com/uber/cadence/service/sharddistributor/canary/processorephemeral"
@@ -37,6 +36,7 @@ func opts(fixedNamespace, ephemeralNamespace, sharddistributorServiceName string
 		executorclient.ModuleWithNamespace[*processorephemeral.ShardProcessor](ephemeralNamespace),
 
 		processorephemeral.ShardCreatorModule(ephemeralNamespace),
-		exetrnalshardassignment.ShardAssignerModule(ephemeralNamespace),
+		// Enabling this back when we have dynamic config to enable it per namespace
+		// exetrnalshardassignment.ShardAssignerModule(ephemeralNamespace),
 	)
 }

--- a/service/sharddistributor/executorclient/client.go
+++ b/service/sharddistributor/executorclient/client.go
@@ -41,7 +41,8 @@ type Executor[SP ShardProcessor] interface {
 	Stop()
 
 	GetShardProcess(shardID string) (SP, error)
-	AssignShards(ctx context.Context, shardAssignment map[string]*types.ShardAssignment)
+	// Used during the migration during local-passthrough and local-passthrough-shadow
+	AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment)
 }
 
 type Params[SP ShardProcessor] struct {

--- a/service/sharddistributor/executorclient/clientimpl.go
+++ b/service/sharddistributor/executorclient/clientimpl.go
@@ -88,7 +88,7 @@ func (e *executorImpl[SP]) GetShardProcess(shardID string) (SP, error) {
 	return shardProcess.processor, nil
 }
 
-func (e *executorImpl[SP]) AssignShards(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) {
+func (e *executorImpl[SP]) AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) {
 	e.assignmentMutex.Lock()
 	defer e.assignmentMutex.Unlock()
 

--- a/service/sharddistributor/executorclient/clientimpl_test.go
+++ b/service/sharddistributor/executorclient/clientimpl_test.go
@@ -226,7 +226,7 @@ func TestAssignShards(t *testing.T) {
 	shardProcessorMock3.EXPECT().Start(gomock.Any())
 
 	// Update the shard assignment
-	executor.AssignShards(context.Background(), newAssignment)
+	executor.AssignShardsFromLocalLogic(context.Background(), newAssignment)
 	time.Sleep(10 * time.Millisecond) // Force the updateShardAssignment goroutines to run
 
 	// Assert that we now have the 2 shards in the assignment

--- a/service/sharddistributor/executorclient/interface_mock.go
+++ b/service/sharddistributor/executorclient/interface_mock.go
@@ -143,16 +143,16 @@ func (m *MockExecutor[SP]) EXPECT() *MockExecutorMockRecorder[SP] {
 	return m.recorder
 }
 
-// AssignShards mocks base method.
-func (m *MockExecutor[SP]) AssignShards(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) {
+// AssignShardsFromLocalLogic mocks base method.
+func (m *MockExecutor[SP]) AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AssignShards", ctx, shardAssignment)
+	m.ctrl.Call(m, "AssignShardsFromLocalLogic", ctx, shardAssignment)
 }
 
-// AssignShards indicates an expected call of AssignShards.
-func (mr *MockExecutorMockRecorder[SP]) AssignShards(ctx, shardAssignment any) *gomock.Call {
+// AssignShardsFromLocalLogic indicates an expected call of AssignShardsFromLocalLogic.
+func (mr *MockExecutorMockRecorder[SP]) AssignShardsFromLocalLogic(ctx, shardAssignment any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignShards", reflect.TypeOf((*MockExecutor[SP])(nil).AssignShards), ctx, shardAssignment)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignShardsFromLocalLogic", reflect.TypeOf((*MockExecutor[SP])(nil).AssignShardsFromLocalLogic), ctx, shardAssignment)
 }
 
 // GetShardProcess mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Adding a method to assign shards to an executor, this is communicating the assignment to the SD using heartbeat, this is the first step for the migration.

<!-- Tell your future self why have you made these changes -->
**Why?**
This is required during the migration to use the ShardDistributor, such that we can assign a specific shard to an executor and keep using the current sharding logic

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
integration in shard-distribution-canary with a dedicated module that execute the assignment

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**
no risk, since the executor client is not integrated with any service yet.

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
