### PR TITLE
fix: updates cluster-attr fields to persistence tests

### DIFF
--- a/common/persistence/persistence-tests/metadataPersistenceV2Test.go
+++ b/common/persistence/persistence-tests/metadataPersistenceV2Test.go
@@ -996,12 +996,22 @@ func (m *MetadataPersistenceSuiteV2) TestUpdateDomain() {
 	notificationVersion++
 	lastUpdateTime++
 	activeClusters := &types.ActiveClusters{
+		// todo (david.porter) remove this once we have completely migrated to AttributeScopes
 		ActiveClustersByRegion: map[string]types.ActiveClusterInfo{
 			"region1": {
 				ActiveClusterName: updateClusters[0].ClusterName,
 			},
 			"region2": {
 				ActiveClusterName: updateClusters[1].ClusterName,
+			},
+		},
+		AttributeScopes: map[string]types.ClusterAttributeScope{
+			"city": {
+				ClusterAttributes: map[string]types.ActiveClusterInfo{
+					"seattle": {
+						ActiveClusterName: updateClusters[0].ClusterName,
+					},
+				},
 			},
 		},
 	}
@@ -1054,6 +1064,7 @@ func (m *MetadataPersistenceSuiteV2) TestUpdateDomain() {
 	m.Equal(asyncWFCfg1, resp7.Config.AsyncWorkflowConfig)
 	m.Equal(updateClusterActive, resp7.ReplicationConfig.ActiveClusterName)
 	m.Equal(activeClusters.ActiveClustersByRegion, resp7.ReplicationConfig.ActiveClusters.ActiveClustersByRegion)
+	m.Equal(activeClusters.AttributeScopes, resp7.ReplicationConfig.ActiveClusters.AttributeScopes)
 	m.Equal(len(updateClusters), len(resp7.ReplicationConfig.Clusters))
 	for index := range clusters {
 		m.Equal(updateClusters[index], resp7.ReplicationConfig.Clusters[index])


### PR DESCRIPTION
epic: #6697 

<!-- Describe what has changed in this PR -->
**What changed?**

ensures that cluster-attributes are persisted correctly

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
