### PR TITLE
feat(active-active): Add GetActiveClusterSelectionPolicyForWorkflow method to active cluster manager

### DIFF
--- a/common/activecluster/manager_mock.go
+++ b/common/activecluster/manager_mock.go
@@ -86,6 +86,21 @@ func (mr *MockManagerMockRecorder) GetActiveClusterInfoByWorkflow(ctx, domainID,
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveClusterInfoByWorkflow", reflect.TypeOf((*MockManager)(nil).GetActiveClusterInfoByWorkflow), ctx, domainID, wfID, rID)
 }
 
+// GetActiveClusterSelectionPolicyForWorkflow mocks base method.
+func (m *MockManager) GetActiveClusterSelectionPolicyForWorkflow(ctx context.Context, domainID, wfID, rID string) (*types.ActiveClusterSelectionPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetActiveClusterSelectionPolicyForWorkflow", ctx, domainID, wfID, rID)
+	ret0, _ := ret[0].(*types.ActiveClusterSelectionPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetActiveClusterSelectionPolicyForWorkflow indicates an expected call of GetActiveClusterSelectionPolicyForWorkflow.
+func (mr *MockManagerMockRecorder) GetActiveClusterSelectionPolicyForWorkflow(ctx, domainID, wfID, rID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveClusterSelectionPolicyForWorkflow", reflect.TypeOf((*MockManager)(nil).GetActiveClusterSelectionPolicyForWorkflow), ctx, domainID, wfID, rID)
+}
+
 // LookupNewWorkflow mocks base method.
 func (m *MockManager) LookupNewWorkflow(ctx context.Context, domainID string, policy *types.ActiveClusterSelectionPolicy) (*LookupResult, error) {
 	m.ctrl.T.Helper()

--- a/common/activecluster/types.go
+++ b/common/activecluster/types.go
@@ -74,6 +74,9 @@ type Manager interface {
 	// GetActiveClusterInfoByWorkflow returns the active cluster info by workflow
 	// It will first look up the cluster selection policy for the workflow and then get the active cluster info by cluster attribute from the policy
 	GetActiveClusterInfoByWorkflow(ctx context.Context, domainID, wfID, rID string) (*types.ActiveClusterInfo, error)
+
+	// GetActiveClusterSelectionPolicyForWorkflow returns the active cluster selection policy for a workflow
+	GetActiveClusterSelectionPolicyForWorkflow(ctx context.Context, domainID, wfID, rID string) (*types.ActiveClusterSelectionPolicy, error)
 }
 
 type LookupResult struct {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Add GetActiveClusterSelectionPolicyForWorkflow method to active cluster manager
- Fix GetActiveClusterInfoByWorkflow method

<!-- Tell your future self why have you made these changes -->
**Why?**
GetActiveClusterInfoByWorkflow fail for SQL implementation because active-active is not implemented in SQL.


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
GetActiveClusterSelectionPolicyForWorkflow calls getClusterSelectionPolicy, which is covered by unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
