### PR TITLE
fix: revert the incorrect "fix: test missing some AA config  (#7326)"

### DIFF
--- a/simulation/replication/testdata/replication_simulation_activeactive_regional_failover.yaml
+++ b/simulation/replication/testdata/replication_simulation_activeactive_regional_failover.yaml
@@ -59,10 +59,6 @@ operations:
       region:
         region0: cluster1 # this is changed from cluster0 to cluster1
         region1: cluster1
-    clusterAttributes:
-      region:
-        region0: cluster1
-        region1: cluster1
 
   # Start wf2 on cluster0 right before failover. It will be started by cluster0 workers and completed by cluster1 workers.
   - op: start_workflow


### PR DESCRIPTION
This reverts commit d0ee3a11b4e4f311becd4981db5e19c22dcc258c. I failed to read the code immediately around it, the data is being deserialized correctly. It is flaky and fails nondeterminstically I think, but I'm still working out the cause. 

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
