### PR TITLE
fix(active-active): Fix domain update for cluster attributes

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -437,7 +437,7 @@ func (d *handlerImpl) UpdateDomain(
 	isGlobalDomain := getResponse.IsGlobalDomain
 	gracefulFailoverEndTime := getResponse.FailoverEndTime
 	currentActiveCluster := replicationConfig.ActiveClusterName
-	currentActiveClusters := replicationConfig.ActiveClusters
+	currentActiveClusters := replicationConfig.ActiveClusters.DeepCopy()
 	previousFailoverVersion := getResponse.PreviousFailoverVersion
 	lastUpdatedTime := time.Unix(0, getResponse.LastUpdatedTime)
 
@@ -733,7 +733,7 @@ func (d *handlerImpl) FailoverDomain(
 	isGlobalDomain := getResponse.IsGlobalDomain
 	gracefulFailoverEndTime := getResponse.FailoverEndTime
 	currentActiveCluster := replicationConfig.ActiveClusterName
-	currentActiveClusters := replicationConfig.ActiveClusters
+	currentActiveClusters := replicationConfig.ActiveClusters.DeepCopy()
 	previousFailoverVersion := getResponse.PreviousFailoverVersion
 	lastUpdatedTime := time.Unix(0, getResponse.LastUpdatedTime)
 
@@ -1635,8 +1635,12 @@ func (d *handlerImpl) updateReplicationConfig(
 				d.logger.Debugf("Setting activeCluster for region %v to %v. no update case, just copy the existing active cluster", region, activeCluster)
 			}
 		}
-		config.ActiveClusters = &types.ActiveClusters{
-			ActiveClustersByRegion: finalActiveClusters,
+		if config.ActiveClusters == nil {
+			config.ActiveClusters = &types.ActiveClusters{
+				ActiveClustersByRegion: finalActiveClusters,
+			}
+		} else {
+			config.ActiveClusters.ActiveClustersByRegion = finalActiveClusters
 		}
 		d.logger.Debugf("Setting active clusters to %v, updateRequest.ActiveClusters.ActiveClustersByRegion: %v", finalActiveClusters, updateRequest.ActiveClusters.ActiveClustersByRegion)
 		activeClusterUpdated = true

--- a/common/domain/handler_test.go
+++ b/common/domain/handler_test.go
@@ -2756,6 +2756,7 @@ func TestUpdateDeleteBadBinary(t *testing.T) {
 	}
 }
 
+// TODO(active-active): Update the test to use cluster attributes once region is removed
 func TestUpdateReplicationConfig(t *testing.T) {
 	cfg := func() *persistence.DomainReplicationConfig {
 		return &persistence.DomainReplicationConfig{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix domain update

<!-- Tell your future self why have you made these changes -->
**Why?**
Cluster attributes are not merged correctly for domain update. It's quite tedious to add unit tests for domain handler while keeping activeClustersByRegion field. We'll add more unit tests once that field is removed.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests & manual tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
