### PR TITLE
docs: Convert slack links to CNCF, add link to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,16 +2,14 @@
 
 This doc is intended for contributors to Cadence backend. Thanks for considering to contribute ❤️
 
-Once you go through rest of this doc and get familiar with local development setup, take a look at the list of issues labeled with
+> 📚 **New to contributing to Cadence?** Check out our [Contributing Guide](https://cadenceworkflow.io/community/how-to-contribute/getting-started) for an overview of the contribution process across all Cadence repositories. This document contains cadence backend specific setup and development instructions.
+
+Once you go through the rest of this doc and get familiar with local development setup, take a look at the list of issues labeled with
 [good first issue](https://github.com/cadence-workflow/cadence/labels/good%20first%20issue).
 These issues are a great way to start contributing to Cadence. Later when you are more familiar with Cadence, look at issues with
 [up-for-grabs](https://github.com/cadence-workflow/cadence/labels/up-for-grabs).
 
-Feel free to join our [slack workspace](http://t.uber.com/cadence-slack) to reach out and discuss issues with the team.
-
-
-:warning: Note:
->All contributors need to fill out the [Uber Contributor License Agreement](http://t.uber.com/cla) before we can merge in any of your changes
+Join our community on the CNCF Slack workspace at [cloud-native.slack.com](https://communityinviter.com/apps/cloud-native/cncf) in the **#cadence-users** channel to reach out and discuss issues with the team.
 
 ## Development Environment
 Below are the instructions of how to set up a development Environment.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Cadence
 [![Build Status](https://github.com/cadence-workflow/cadence/actions/workflows/ci-checks.yml/badge.svg)](https://github.com/cadence-workflow/cadence/actions/workflows/ci-checks.yml)
 [![Coverage](https://codecov.io/gh/cadence-workflow/cadence/graph/badge.svg?token=7SD244ImNF)](https://codecov.io/gh/cadence-workflow/cadence)
-[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](http://t.uber.com/cadence-slack)
+[![Slack Status](https://img.shields.io/badge/slack-join_chat-white.svg?logo=slack&style=social)](https://communityinviter.com/apps/cloud-native/cncf)
 [![Github release](https://img.shields.io/github/v/release/cadence-workflow/cadence.svg)](https://github.com/cadence-workflow/cadence/releases)
 [![License](https://img.shields.io/github/license/cadence-workflow/cadence.svg)](http://www.apache.org/licenses/LICENSE-2.0)
 
@@ -86,7 +86,7 @@ The easiest way to get the schema tool is via homebrew.
 
 We'd love your help in making Cadence great. Please review our [contribution guide](CONTRIBUTING.md).
 
-If you'd like to propose a new feature, first join the [Slack channel](http://t.uber.com/cadence-slack) to start a discussion.
+If you'd like to propose a new feature, first join the [CNCF Slack workspace](https://communityinviter.com/apps/cloud-native/cncf) in the **#cadence-users** channel to start a discussion.
 
 Please visit our [documentation](https://cadenceworkflow.io/docs/operation-guide/) site for production/cluster setup.
 
@@ -103,7 +103,7 @@ Visit [cadenceworkflow.io](https://cadenceworkflow.io) to learn more about Caden
   * Best for reporting bugs and feature requests
 * [StackOverflow](https://stackoverflow.com/questions/tagged/cadence-workflow)
   * Best for Q&A and general discusion
-* [Slack](http://t.uber.com/cadence-slack)
+* [Slack](https://communityinviter.com/apps/cloud-native/cncf) - Join **#cadence-users** channel on CNCF Slack
   * Best for contributing/development discussion
 
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Converts links from our old slack instance to the CNCF community inviter. 
Adds a link to our shared contributing guide to the contributing readme. 

<!-- Tell your future self why have you made these changes -->
**Why?**

The goal of the contribution guide is to move all common guides and processes between our repositories to a shared place – reducing conflicting information and streamlining the process to contribute to cadence. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

N/A

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

N/A