### PR TITLE
fix(active-active): Fix active workflow check for history APIs requiring runID

### DIFF
--- a/service/history/engine/engineimpl/history_engine2_test.go
+++ b/service/history/engine/engineimpl/history_engine2_test.go
@@ -150,6 +150,7 @@ func (s *engine2Suite) SetupTest() {
 			p.HistoryTaskCategoryTransfer: s.mockTxProcessor,
 			p.HistoryTaskCategoryTimer:    s.mockTimerProcessor,
 		},
+		activeClusterManager: s.mockActiveClusterMgr,
 	}
 	s.mockShard.SetEngine(h)
 	h.decisionHandler = decision.NewHandler(s.mockShard, h.executionCache, h.tokenSerializer)
@@ -173,10 +174,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyExpired() {
 	identity := "testIdentity"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	msBuilder := execution.NewMutableStateBuilderWithEventV2(
 		s.historyEngine.shard,
@@ -252,10 +253,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 	identity := "testIdentity"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	msBuilder := execution.NewMutableStateBuilderWithEventV2(
 		s.historyEngine.shard,
@@ -330,6 +331,12 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfNoExecution() {
 		RunID:      constants.TestRunID,
 	}
 
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+
 	identity := "testIdentity"
 	tl := "testTaskList"
 
@@ -359,6 +366,12 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfGetExecutionFailed() {
 		WorkflowID: "wId",
 		RunID:      constants.TestRunID,
 	}
+
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
 
 	identity := "testIdentity"
 	tl := "testTaskList"
@@ -394,10 +407,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfTaskAlreadyStarted() {
 	tl := "testTaskList"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, true)
 	ms := execution.CreatePersistenceMutableState(s.T(), msBuilder)
@@ -434,10 +447,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedIfTaskAlreadyCompleted() {
 	tl := "testTaskList"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, true)
 	test.AddDecisionTaskCompletedEvent(msBuilder, int64(2), int64(3), nil, identity)
@@ -477,10 +490,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedConflictOnUpdate() {
 	tl := "testTaskList"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(3)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, false)
 
@@ -532,10 +545,10 @@ func (s *engine2Suite) TestRecordDecisionTaskRetrySameRequest() {
 	requestID := "testRecordDecisionTaskRetrySameRequestID"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(3)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, false)
 	ms := execution.CreatePersistenceMutableState(s.T(), msBuilder)
@@ -583,10 +596,10 @@ func (s *engine2Suite) TestRecordDecisionTaskRetryDifferentRequest() {
 	requestID := "testRecordDecisionTaskRetrySameRequestID"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(3)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, false)
 	ms := execution.CreatePersistenceMutableState(s.T(), msBuilder)
@@ -632,10 +645,10 @@ func (s *engine2Suite) TestRecordDecisionTaskStartedMaxAttemptsExceeded() {
 	identity := "testIdentity"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(workflow.ConditionalRetryCount)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(workflow.ConditionalRetryCount + 1)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, false)
 	for i := 0; i < workflow.ConditionalRetryCount; i++ {
@@ -680,10 +693,10 @@ func (s *engine2Suite) TestRecordDecisionTaskSuccess() {
 	identity := "testIdentity"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(3)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, false)
 	ms := execution.CreatePersistenceMutableState(s.T(), msBuilder)
@@ -741,6 +754,12 @@ func (s *engine2Suite) TestRecordActivityTaskStartedIfNoExecution() {
 		RunID:      constants.TestRunID,
 	}
 
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+
 	identity := "testIdentity"
 	tl := "testTaskList"
 
@@ -781,7 +800,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedSuccess() {
 		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	activityID := "activity1_id"
 	activityType := "activity_type1"
@@ -833,7 +852,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedResurrected() {
 		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	timeSource := clock.NewMockedTimeSource()
 	s.historyEngine.timeSource = timeSource
@@ -888,7 +907,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedStaleState() {
 		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(workflow.ConditionalRetryCount)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(workflow.ConditionalRetryCount + 1)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, true)
 
@@ -930,7 +949,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedActivityNotPending() {
 		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	msBuilder := s.createExecutionStartedState(workflowExecution, tl, identity, true)
 
@@ -972,7 +991,7 @@ func (s *engine2Suite) TestRecordActivityTaskStartedActivityAlreadyStarted() {
 		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(3)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(6)
 
 	activityID := "activity1_id"
 	activityType := "activity_type1"
@@ -1308,10 +1327,10 @@ func (s *engine2Suite) TestRespondDecisionTaskCompletedRecordMarkerDecision() {
 	markerName := "marker name"
 
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: s.mockShard.GetClusterMetadata().GetCurrentClusterName(),
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   0,
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(3)
 
 	msBuilder := execution.NewMutableStateBuilderWithEventV2(
 		s.historyEngine.shard,

--- a/service/history/engine/engineimpl/history_engine3_eventsv2_test.go
+++ b/service/history/engine/engineimpl/history_engine3_eventsv2_test.go
@@ -153,10 +153,10 @@ func (s *engine3Suite) TestRecordDecisionTaskStartedSuccessStickyEnabled() {
 	s.mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return(constants.TestDomainName, nil).AnyTimes()
 	s.mockDomainCache.EXPECT().GetDomain(gomock.Any()).Return(testDomainEntry, nil).AnyTimes()
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: testDomainEntry.GetReplicationConfig().ActiveClusterName,
+		ActiveClusterName: s.historyEngine.clusterMetadata.GetCurrentClusterName(),
 		FailoverVersion:   testDomainEntry.GetFailoverVersion(),
 	}
-	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).AnyTimes()
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(2)
 
 	domainID := constants.TestDomainID
 	we := types.WorkflowExecution{

--- a/service/history/engine/engineimpl/history_engine_test.go
+++ b/service/history/engine/engineimpl/history_engine_test.go
@@ -175,9 +175,10 @@ func (s *engineSuite) SetupTest() {
 			persistence.HistoryTaskCategoryTransfer: s.mockTxProcessor,
 			persistence.HistoryTaskCategoryTimer:    s.mockTimerProcessor,
 		},
-		clientChecker:    cc.NewVersionChecker(),
-		eventsReapplier:  s.mockEventsReapplier,
-		workflowResetter: s.mockWorkflowResetter,
+		clientChecker:        cc.NewVersionChecker(),
+		eventsReapplier:      s.mockEventsReapplier,
+		workflowResetter:     s.mockWorkflowResetter,
+		activeClusterManager: s.mockShard.Resource.ActiveClusterMgr,
 	}
 	s.mockShard.SetEngine(h)
 	h.decisionHandler = decision.NewHandler(s.mockShard, h.executionCache, h.tokenSerializer)
@@ -1140,6 +1141,12 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedInvalidToken() {
 
 func (s *engineSuite) TestRespondDecisionTaskCompletedIfNoExecution() {
 
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).Times(1)
+
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
 		RunID:      constants.TestRunID,
@@ -1161,6 +1168,12 @@ func (s *engineSuite) TestRespondDecisionTaskCompletedIfNoExecution() {
 }
 
 func (s *engineSuite) TestRespondDecisionTaskCompletedIfGetExecutionFailed() {
+
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
 
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
@@ -2719,6 +2732,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedInvalidToken() {
 
 func (s *engineSuite) TestRespondActivityTaskCompletedIfNoExecution() {
 
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
 		RunID:      constants.TestRunID,
@@ -2741,6 +2760,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedIfNoExecution() {
 
 func (s *engineSuite) TestRespondActivityTaskCompletedIfNoRunID() {
 
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
 		ScheduleID: 2,
@@ -2761,6 +2786,12 @@ func (s *engineSuite) TestRespondActivityTaskCompletedIfNoRunID() {
 }
 
 func (s *engineSuite) TestRespondActivityTaskCompletedIfGetExecutionFailed() {
+
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
 
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
@@ -3331,6 +3362,12 @@ func (s *engineSuite) TestRespondActivityTaskFailedInvalidToken() {
 
 func (s *engineSuite) TestRespondActivityTaskFailedIfNoExecution() {
 
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
 		RunID:      constants.TestRunID,
@@ -3354,6 +3391,12 @@ func (s *engineSuite) TestRespondActivityTaskFailedIfNoExecution() {
 
 func (s *engineSuite) TestRespondActivityTaskFailedIfNoRunID() {
 
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
+
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
 		ScheduleID: 2,
@@ -3375,6 +3418,12 @@ func (s *engineSuite) TestRespondActivityTaskFailedIfNoRunID() {
 }
 
 func (s *engineSuite) TestRespondActivityTaskFailedIfGetExecutionFailed() {
+
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
 
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
@@ -4301,6 +4350,11 @@ func (s *engineSuite) TestRespondActivityTaskCanceledByID_Started() {
 }
 
 func (s *engineSuite) TestRespondActivityTaskCanceledIfNoRunID() {
+	testActiveClusterInfo := &types.ActiveClusterInfo{
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
+	}
+	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil)
 
 	taskToken, _ := json.Marshal(&common.TaskToken{
 		WorkflowID: "wId",
@@ -5663,14 +5717,10 @@ func (s *engineSuite) TestSignalWorkflowExecution_WorkflowCompleted() {
 
 func (s *engineSuite) TestRemoveSignalMutableState() {
 	testActiveClusterInfo := &types.ActiveClusterInfo{
-		ActiveClusterName: constants.TestLocalDomainEntry.GetReplicationConfig().ActiveClusterName,
-		FailoverVersion:   constants.TestLocalDomainEntry.GetFailoverVersion(),
+		ActiveClusterName: s.mockHistoryEngine.clusterMetadata.GetCurrentClusterName(),
+		FailoverVersion:   0,
 	}
 	s.mockShard.Resource.ActiveClusterMgr.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(testActiveClusterInfo, nil).AnyTimes()
-
-	removeRequest := &types.RemoveSignalMutableStateRequest{}
-	err := s.mockHistoryEngine.RemoveSignalMutableState(context.Background(), removeRequest)
-	s.Error(err)
 
 	workflowExecution := types.WorkflowExecution{
 		WorkflowID: "wId",
@@ -5679,7 +5729,7 @@ func (s *engineSuite) TestRemoveSignalMutableState() {
 	tasklist := "testTaskList"
 	identity := "testIdentity"
 	requestID := uuid.New()
-	removeRequest = &types.RemoveSignalMutableStateRequest{
+	removeRequest := &types.RemoveSignalMutableStateRequest{
 		DomainUUID:        constants.TestDomainID,
 		WorkflowExecution: &workflowExecution,
 		RequestID:         requestID,
@@ -5700,7 +5750,7 @@ func (s *engineSuite) TestRemoveSignalMutableState() {
 	s.mockExecutionMgr.On("GetWorkflowExecution", mock.Anything, mock.Anything).Return(gwmsResponse, nil).Once()
 	s.mockExecutionMgr.On("UpdateWorkflowExecution", mock.Anything, mock.Anything).Return(&persistence.UpdateWorkflowExecutionResponse{MutableStateUpdateSessionStats: &persistence.MutableStateUpdateSessionStats{}}, nil).Once()
 
-	err = s.mockHistoryEngine.RemoveSignalMutableState(context.Background(), removeRequest)
+	err := s.mockHistoryEngine.RemoveSignalMutableState(context.Background(), removeRequest)
 	s.Nil(err)
 }
 
@@ -6021,6 +6071,8 @@ func TestRecordChildExecutionCompleted(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockShard := shard.NewTestContext(t, ctrl, &persistence.ShardInfo{}, config.NewForTest())
 			mockDomainCache := mockShard.Resource.DomainCache
+			mockActiveClusterManager := mockShard.Resource.ActiveClusterMgr
+			mockActiveClusterManager.EXPECT().GetActiveClusterInfoByWorkflow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(&types.ActiveClusterInfo{ActiveClusterName: mockShard.GetClusterMetadata().GetCurrentClusterName(), FailoverVersion: 0}, nil).Times(1)
 			testDomainEntry := cache.NewLocalDomainCacheEntryForTest(
 				&persistence.DomainInfo{ID: constants.TestDomainID}, &persistence.DomainConfig{}, "",
 			)
@@ -6038,6 +6090,7 @@ func TestRecordChildExecutionCompleted(t *testing.T) {
 				updateWithActionFn: func(_ context.Context, _ log.Logger, _ execution.Cache, _ string, _ types.WorkflowExecution, _ bool, _ time.Time, actionFn func(wfContext execution.Context, mutableState execution.MutableState) error) error {
 					return actionFn(nil, ms)
 				},
+				activeClusterManager: mockActiveClusterManager,
 			}
 
 			err := historyEngine.RecordChildExecutionCompleted(context.Background(), tc.request)

--- a/service/history/engine/engineimpl/reapply_events.go
+++ b/service/history/engine/engineimpl/reapply_events.go
@@ -44,9 +44,11 @@ func (e *historyEngineImpl) ReapplyEvents(
 	reapplyEvents []*types.HistoryEvent,
 ) error {
 
-	domainEntry, err := e.getActiveDomainByID(domainUUID)
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, domainUUID, workflowID, runID)
 	if err != nil {
 		switch {
+		// TODO(active-active): should we remove this check for active-active domain?
+		// It was introduced in https://github.com/cadence-workflow/cadence/pull/3502
 		case domainEntry != nil && domainEntry.IsDomainPendingActive():
 			return nil
 		default:

--- a/service/history/engine/engineimpl/record_activity_task_started.go
+++ b/service/history/engine/engineimpl/record_activity_task_started.go
@@ -40,7 +40,7 @@ func (e *historyEngineImpl) RecordActivityTaskStarted(
 	request *types.RecordActivityTaskStartedRequest,
 ) (*types.RecordActivityTaskStartedResponse, error) {
 
-	domainEntry, err := e.getActiveDomainByID(request.DomainUUID)
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, request.DomainUUID, request.WorkflowExecution.WorkflowID, request.WorkflowExecution.RunID)
 	if err != nil {
 		return nil, err
 	}

--- a/service/history/engine/engineimpl/record_child_execution_completed.go
+++ b/service/history/engine/engineimpl/record_child_execution_completed.go
@@ -38,7 +38,7 @@ func (e *historyEngineImpl) RecordChildExecutionCompleted(
 	completionRequest *types.RecordChildExecutionCompletedRequest,
 ) error {
 
-	domainEntry, err := e.getActiveDomainByID(completionRequest.DomainUUID)
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, completionRequest.DomainUUID, completionRequest.WorkflowExecution.GetWorkflowID(), completionRequest.WorkflowExecution.GetRunID())
 	if err != nil {
 		return err
 	}

--- a/service/history/engine/engineimpl/remove_signal_mutable_state.go
+++ b/service/history/engine/engineimpl/remove_signal_mutable_state.go
@@ -35,7 +35,7 @@ func (e *historyEngineImpl) RemoveSignalMutableState(
 	request *types.RemoveSignalMutableStateRequest,
 ) error {
 
-	domainEntry, err := e.getActiveDomainByID(request.DomainUUID)
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, request.DomainUUID, request.WorkflowExecution.GetWorkflowID(), request.WorkflowExecution.GetRunID())
 	if err != nil {
 		return err
 	}

--- a/service/history/engine/engineimpl/respond_activity_task_canceled.go
+++ b/service/history/engine/engineimpl/respond_activity_task_canceled.go
@@ -39,18 +39,18 @@ func (e *historyEngineImpl) RespondActivityTaskCanceled(
 	req *types.HistoryRespondActivityTaskCanceledRequest,
 ) error {
 
-	domainEntry, err := e.getActiveDomainByID(req.DomainUUID)
-	if err != nil {
-		return err
-	}
-	domainID := domainEntry.GetInfo().ID
-	domainName := domainEntry.GetInfo().Name
-
 	request := req.CancelRequest
 	token, err0 := e.tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return workflow.ErrDeserializingToken
 	}
+
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, req.DomainUUID, token.WorkflowID, token.RunID)
+	if err != nil {
+		return err
+	}
+	domainID := domainEntry.GetInfo().ID
+	domainName := domainEntry.GetInfo().Name
 
 	workflowExecution := types.WorkflowExecution{
 		WorkflowID: token.WorkflowID,

--- a/service/history/engine/engineimpl/respond_activity_task_completed.go
+++ b/service/history/engine/engineimpl/respond_activity_task_completed.go
@@ -39,19 +39,18 @@ func (e *historyEngineImpl) RespondActivityTaskCompleted(
 	ctx context.Context,
 	req *types.HistoryRespondActivityTaskCompletedRequest,
 ) error {
-
-	domainEntry, err := e.getActiveDomainByID(req.DomainUUID)
-	if err != nil {
-		return err
-	}
-	domainID := domainEntry.GetInfo().ID
-	domainName := domainEntry.GetInfo().Name
-
 	request := req.CompleteRequest
 	token, err0 := e.tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return workflow.ErrDeserializingToken
 	}
+
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, req.DomainUUID, token.WorkflowID, token.RunID)
+	if err != nil {
+		return err
+	}
+	domainID := domainEntry.GetInfo().ID
+	domainName := domainEntry.GetInfo().Name
 
 	workflowExecution := types.WorkflowExecution{
 		WorkflowID: token.WorkflowID,

--- a/service/history/engine/engineimpl/respond_activity_task_failed.go
+++ b/service/history/engine/engineimpl/respond_activity_task_failed.go
@@ -39,19 +39,18 @@ func (e *historyEngineImpl) RespondActivityTaskFailed(
 	ctx context.Context,
 	req *types.HistoryRespondActivityTaskFailedRequest,
 ) error {
-
-	domainEntry, err := e.getActiveDomainByID(req.DomainUUID)
-	if err != nil {
-		return err
-	}
-	domainID := domainEntry.GetInfo().ID
-	domainName := domainEntry.GetInfo().Name
-
 	request := req.FailedRequest
 	token, err0 := e.tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return workflow.ErrDeserializingToken
 	}
+
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, req.DomainUUID, token.WorkflowID, token.RunID)
+	if err != nil {
+		return err
+	}
+	domainID := domainEntry.GetInfo().ID
+	domainName := domainEntry.GetInfo().Name
 
 	workflowExecution := types.WorkflowExecution{
 		WorkflowID: token.WorkflowID,

--- a/service/history/engine/engineimpl/respond_activity_task_heartbeat.go
+++ b/service/history/engine/engineimpl/respond_activity_task_heartbeat.go
@@ -41,18 +41,17 @@ func (e *historyEngineImpl) RecordActivityTaskHeartbeat(
 	ctx context.Context,
 	req *types.HistoryRecordActivityTaskHeartbeatRequest,
 ) (*types.RecordActivityTaskHeartbeatResponse, error) {
-
-	domainEntry, err := e.getActiveDomainByID(req.DomainUUID)
-	if err != nil {
-		return nil, err
-	}
-	domainID := domainEntry.GetInfo().ID
-
 	request := req.HeartbeatRequest
 	token, err0 := e.tokenSerializer.Deserialize(request.TaskToken)
 	if err0 != nil {
 		return nil, workflow.ErrDeserializingToken
 	}
+
+	domainEntry, err := e.getActiveDomainByWorkflow(ctx, req.DomainUUID, token.WorkflowID, token.RunID)
+	if err != nil {
+		return nil, err
+	}
+	domainID := domainEntry.GetInfo().ID
 
 	workflowExecution := types.WorkflowExecution{
 		WorkflowID: token.WorkflowID,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use the active cluster info of workflow's cluster attribute to check if workflow is active in the current cluster

<!-- Tell your future self why have you made these changes -->
**Why?**
The active cluster of a workflow should be determined by the cluster attribute

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
