### PR TITLE
test: add DescribeCluster integration test

### DIFF
--- a/host/integration_test.go
+++ b/host/integration_test.go
@@ -4470,3 +4470,13 @@ func (s *IntegrationSuite) sendSignal(domainName string, execution *types.Workfl
 		Identity:          identity,
 	})
 }
+
+// TestDescribeCluster tests that DescribeCluster API returns a valid response without error
+func (s *IntegrationSuite) TestDescribeCluster() {
+	ctx, cancel := createContext()
+	defer cancel()
+
+	response, err := s.AdminClient.DescribeCluster(ctx)
+	s.Require().NoError(err)
+	s.Require().NotNil(response)
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Integration test for DescribeCluster has been added. 

<!-- Tell your future self why have you made these changes -->
**Why?**
The lack of this test caused this #[6338](https://github.com/uber/cadence/pull/6338), and was fixed in #6350

The responses' variables depend on each run, so they cannot be asserted. The test asserts only that the API can return the response without errors. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Run integration tests


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks
