### PR TITLE
fix(active-active): Removes domain failover metadata for AA domains

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -437,7 +437,6 @@ func (d *handlerImpl) UpdateDomain(
 	isGlobalDomain := getResponse.IsGlobalDomain
 	gracefulFailoverEndTime := getResponse.FailoverEndTime
 	currentActiveCluster := replicationConfig.ActiveClusterName
-	currentActiveClusters := replicationConfig.ActiveClusters.DeepCopy()
 	previousFailoverVersion := getResponse.PreviousFailoverVersion
 	lastUpdatedTime := time.Unix(0, getResponse.LastUpdatedTime)
 
@@ -598,17 +597,7 @@ func (d *handlerImpl) UpdateDomain(
 					tag.Dynamic("failover-type", failoverType),
 				)
 
-				err = updateFailoverHistory(info, d.config, NewFailoverEvent(
-					now,
-					failoverType,
-					&currentActiveCluster,
-					updateRequest.ActiveClusterName,
-					nil,
-					replicationConfig.ActiveClusters,
-				))
-				if err != nil {
-					d.logger.Warn("failed to update failover history", tag.Error(err))
-				}
+				// todo (active-active): update failover history
 			}
 
 			// case 3. active-active domain's ActiveClusters is changed
@@ -628,17 +617,7 @@ func (d *handlerImpl) UpdateDomain(
 					tag.Dynamic("failover-type", failoverType),
 				)
 
-				err = updateFailoverHistory(info, d.config, NewFailoverEvent(
-					now,
-					failoverType,
-					&currentActiveCluster,
-					updateRequest.ActiveClusterName,
-					currentActiveClusters,
-					replicationConfig.ActiveClusters,
-				))
-				if err != nil {
-					d.logger.Warn("failed to update failover history", tag.Error(err))
-				}
+				// todo (active-active): update failover history
 			}
 
 			failoverNotificationVersion = notificationVersion
@@ -722,7 +701,6 @@ func (d *handlerImpl) FailoverDomain(
 	isGlobalDomain := getResponse.IsGlobalDomain
 	gracefulFailoverEndTime := getResponse.FailoverEndTime
 	currentActiveCluster := replicationConfig.ActiveClusterName
-	currentActiveClusters := replicationConfig.ActiveClusters.DeepCopy()
 	previousFailoverVersion := getResponse.PreviousFailoverVersion
 	lastUpdatedTime := time.Unix(0, getResponse.LastUpdatedTime)
 
@@ -832,18 +810,7 @@ func (d *handlerImpl) FailoverDomain(
 				tag.Dynamic("failover-version", failoverVersion),
 				tag.Dynamic("failover-type", failoverType),
 			)
-
-			err = updateFailoverHistory(info, d.config, NewFailoverEvent(
-				now,
-				failoverType,
-				&currentActiveCluster,
-				updateRequest.ActiveClusterName,
-				nil,
-				replicationConfig.ActiveClusters,
-			))
-			if err != nil {
-				d.logger.Warn("failed to update failover history", tag.Error(err))
-			}
+			// todo (active-active): update failover history
 		}
 
 		// case 3. active-active domain's ActiveClusters is changed
@@ -861,18 +828,7 @@ func (d *handlerImpl) FailoverDomain(
 				tag.Dynamic("failover-version", failoverVersion),
 				tag.Dynamic("failover-type", failoverType),
 			)
-
-			err = updateFailoverHistory(info, d.config, NewFailoverEvent(
-				now,
-				failoverType,
-				&currentActiveCluster,
-				nil,
-				currentActiveClusters,
-				replicationConfig.ActiveClusters,
-			))
-			if err != nil {
-				d.logger.Warn("failed to update failover history", tag.Error(err))
-			}
+			// todo (active-active): update failover history
 		}
 
 		failoverNotificationVersion = notificationVersion


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

We're going to store AA domain data in better place than the domain data string blob. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
