### PR TITLE
fix: Treat yarpc Cancelled errors as transient

### DIFF
--- a/common/util.go
+++ b/common/util.go
@@ -327,6 +327,7 @@ func IsServiceTransientError(err error) bool {
 		// We only selectively retry the following yarpc errors client can safe retry with a backoff
 		if yarpcerrors.IsUnavailable(err) ||
 			yarpcerrors.IsUnknown(err) ||
+			yarpcerrors.IsCancelled(err) ||
 			yarpcerrors.IsInternal(err) {
 			return true
 		}

--- a/common/util_test.go
+++ b/common/util_test.go
@@ -59,6 +59,10 @@ func TestIsServiceTransientError(t *testing.T) {
 			err:  context.DeadlineExceeded,
 			want: false,
 		},
+		"YARPCCanceled": {
+			err:  yarpcerrors.CancelledErrorf("connection closing"),
+			want: true,
+		},
 		"YARPCDeadlineExceeded": {
 			err:  yarpcerrors.DeadlineExceededErrorf("yarpc deadline exceeded"),
 			want: false,


### PR DESCRIPTION
Our direct peer provider caches connections between hosts, maintaining them until the host is no longer a peer. When that happens we close the connection, which makes any open requests to that host fail with an error including a status code of Cancelled.

Since this can happen at any time with any of our peers, we should retry these requests. These retries are going to re-execute the entire operation, recalculating the host and connection to use.

The other time we would see this error is during host shutdown, when we also close the connections. This is one of the last actions taken during shutdown, so it's unlikely for components to observe it. Even if there are components that have shutdown handling and currently rely on this error to stop an asynchronous process, marking this as retryable would only delay their incorrect shutdown rather than preventing it outright.

<!-- Describe what has changed in this PR -->
**What changed?**
- Treat yarpc Cancelled as retryable

<!-- Tell your future self why have you made these changes -->
**Why?**
- Retry transient failures

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit and integration tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
- Low. At most this could impact shutdown performance, delaying the completion of bad acting components that have no other shutdown mechanism.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
