### PR TITLE
feat(active-active): compressing-cluster-attr-with-snappy

### DIFF
--- a/common/persistence/domain_manager.go
+++ b/common/persistence/domain_manager.go
@@ -241,7 +241,10 @@ func (m *domainManagerImpl) toInternalDomainReplicationConfig(rc *DomainReplicat
 	if rc == nil {
 		return InternalDomainReplicationConfig{}, nil
 	}
-	activeClustersConfig, err := m.serializer.SerializeActiveClusters(rc.ActiveClusters, encodingType)
+
+	// active clusters don't use the default encoding due to their likely being quite large
+	// and so we're explicitly opting to use snappy / compressed encoding
+	activeClustersConfig, err := m.serializer.SerializeActiveClusters(rc.ActiveClusters, constants.EncodingTypeThriftRWSnappy)
 	if err != nil {
 		return InternalDomainReplicationConfig{}, err
 	}

--- a/common/persistence/domain_manager_test.go
+++ b/common/persistence/domain_manager_test.go
@@ -134,7 +134,7 @@ func testFixtureDomainReplicationConfigInternalWithActiveClusters() *InternalDom
 				ClusterName: "cluster-2",
 			},
 		},
-		ActiveClustersConfig: &DataBlob{Encoding: constants.EncodingTypeThriftRW, Data: []byte("active-clusters-config")},
+		ActiveClustersConfig: &DataBlob{Encoding: constants.EncodingTypeThriftRWSnappy, Data: []byte("active-clusters-config")},
 	}
 }
 
@@ -170,7 +170,7 @@ func TestCreateDomain(t *testing.T) {
 					SerializeAsyncWorkflowsConfig(&types.AsyncWorkflowConfiguration{Enabled: true, PredefinedQueueName: "q", QueueType: "kafka"}, constants.EncodingTypeThriftRW).
 					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRW, Data: []byte("async-workflow-config")}, nil).Times(1)
 				mockSerializer.EXPECT().
-					SerializeActiveClusters(nil, constants.EncodingTypeThriftRW).
+					SerializeActiveClusters(nil, constants.EncodingTypeThriftRWSnappy).
 					Return(nil, nil).Times(1)
 
 				expectedReq := &InternalCreateDomainRequest{
@@ -225,8 +225,8 @@ func TestCreateDomain(t *testing.T) {
 					SerializeAsyncWorkflowsConfig(&types.AsyncWorkflowConfiguration{Enabled: true, PredefinedQueueName: "q", QueueType: "kafka"}, constants.EncodingTypeThriftRW).
 					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRW, Data: []byte("async-workflow-config")}, nil).Times(1)
 				mockSerializer.EXPECT().
-					SerializeActiveClusters(testFixtureDomainReplicationConfigWithActiveClusters().ActiveClusters, constants.EncodingTypeThriftRW).
-					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRW, Data: []byte("active-clusters-config")}, nil).Times(1)
+					SerializeActiveClusters(testFixtureDomainReplicationConfigWithActiveClusters().ActiveClusters, constants.EncodingTypeThriftRWSnappy).
+					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRWSnappy, Data: []byte("active-clusters-config")}, nil).Times(1)
 
 				expectedReq := &InternalCreateDomainRequest{
 					Info: testFixtureDomainInfo(),
@@ -508,7 +508,7 @@ func TestUpdateDomain(t *testing.T) {
 					SerializeAsyncWorkflowsConfig(&types.AsyncWorkflowConfiguration{Enabled: true, PredefinedQueueName: "q", QueueType: "kafka"}, constants.EncodingTypeThriftRW).
 					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRW, Data: []byte("async-workflow-config")}, nil).Times(1)
 				mockSerializer.EXPECT().
-					SerializeActiveClusters(nil, constants.EncodingTypeThriftRW).
+					SerializeActiveClusters(nil, constants.EncodingTypeThriftRWSnappy).
 					Return(nil, nil).Times(1)
 				mockStore.EXPECT().
 					UpdateDomain(gomock.Any(), &InternalUpdateDomainRequest{
@@ -562,8 +562,8 @@ func TestUpdateDomain(t *testing.T) {
 					SerializeAsyncWorkflowsConfig(&types.AsyncWorkflowConfiguration{Enabled: true, PredefinedQueueName: "q", QueueType: "kafka"}, constants.EncodingTypeThriftRW).
 					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRW, Data: []byte("async-workflow-config")}, nil).Times(1)
 				mockSerializer.EXPECT().
-					SerializeActiveClusters(testFixtureDomainReplicationConfigWithActiveClusters().ActiveClusters, constants.EncodingTypeThriftRW).
-					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRW, Data: []byte("active-clusters-config")}, nil).Times(1)
+					SerializeActiveClusters(testFixtureDomainReplicationConfigWithActiveClusters().ActiveClusters, constants.EncodingTypeThriftRWSnappy).
+					Return(&DataBlob{Encoding: constants.EncodingTypeThriftRWSnappy, Data: []byte("active-clusters-config")}, nil).Times(1)
 				mockStore.EXPECT().
 					UpdateDomain(gomock.Any(), &InternalUpdateDomainRequest{
 						Info: testFixtureDomainInfo(),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
switches the Cluster attributes as they're stored in the DB to use snappy, since they're expected to potentially be somewhat large. 

I expect this to be a backwards compatible change due to the existing records being persisted with the encoding type, and that's what local testing showed to be true.  

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- [X] Tested manually 
- [X] Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
