### PR TITLE
feat: Add domain audit table

### DIFF
--- a/schema/cassandra/README.md
+++ b/schema/cassandra/README.md
@@ -24,7 +24,7 @@ Q: How do I update existing schema ?
 * Create a new schema version directory under ./schema/keyspace/versioned/vx.x
   * Add a manifest.json
   * Add your changes in a cql file
-* Update the unit test within ./tools/cassandra/updateTask_test.go `TestDryrun` with your version x.x
+* Update the unit test within ./tools/common/schema/updatetask_test.go `TestReadSchemaDirFromEmbeddings` with your version x.x
 * Once you are done with these use the ./cadence-cassandra-tool to update the schema
 
 Q: What's the format of manifest.json

--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -537,3 +537,29 @@ CREATE TABLE cluster_config (
   encoding text,
 PRIMARY KEY (row_type, version)
 ) WITH CLUSTERING ORDER BY (version DESC);
+
+CREATE TABLE domain_audit_log (
+    domain_id uuid,
+    event_id uuid, -- event_id is the unique identifier for this change to the domain
+
+    state_before blob, -- state_before stores the domain state before the request
+    state_before_encoding text, -- the encoding type used for state_before
+
+    state_after blob, -- state_after stores the domain state after the request
+    state_after_encoding text, -- the encoding type used for state_after
+
+    operation_type int, -- operation_type stores the type of operation that was performed. It is deserialized as an enum and can be used to customize the serialization/deserialization strategy. 
+
+    created_time timestamp, -- created_time the time this row was inserted
+    last_updated_time timestamp,
+
+    identity text, -- the unique identifier of the user that made the change
+    identity_type text, -- identity_type can be used to delineate between service, user, or other identities
+
+    comment text, -- comment can be used when manual updates or creates are performed on the database as an audit trail
+
+    PRIMARY KEY ((domain_id, operation_type), created_time, event_id)
+) WITH CLUSTERING ORDER BY (created_time DESC, event_id ASC)
+  AND COMPACTION = {
+      'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+  };

--- a/schema/cassandra/cadence/versioned/v0.44/domain_audit_log.cql
+++ b/schema/cassandra/cadence/versioned/v0.44/domain_audit_log.cql
@@ -1,0 +1,25 @@
+CREATE TABLE domain_audit_log (
+    domain_id uuid,
+    event_id uuid, -- event_id is the unique identifier for this change to the domain
+
+    state_before blob, -- state_before stores the domain state before the request
+    state_before_encoding text, -- the encoding type used for state_before
+
+    state_after blob, -- state_after stores the domain state after the request
+    state_after_encoding text, -- the encoding type used for state_after
+
+    operation_type int, -- operation_type stores the type of operation that was performed. It is deserialized as an enum and can be used to customize the serialization/deserialization strategy. 
+
+    created_time timestamp, -- created_time the time this row was inserted
+    last_updated_time timestamp,
+
+    identity text, -- the unique identifier of the user that made the change
+    identity_type text, -- identity_type can be used to delineate between service, user, or other identities
+
+    comment text, -- comment can be used when manual updates or creates are performed on the database as an audit trail
+
+    PRIMARY KEY ((domain_id, operation_type), created_time, event_id)
+) WITH CLUSTERING ORDER BY (created_time DESC, event_id ASC)
+  AND COMPACTION = {
+      'class': 'org.apache.cassandra.db.compaction.LeveledCompactionStrategy'
+  };

--- a/schema/cassandra/cadence/versioned/v0.44/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.44/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.44",
+  "MinCompatibleVersion": "0.44",
+  "Description": "Adding domain_audit_log table to track domain update and failover history",
+  "SchemaUpdateCqlFiles": [
+    "domain_audit_log.cql"
+  ]
+}

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -23,7 +23,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.43"
+const Version = "0.44"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.9"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Adds the domain_audit_log table. 

<!-- Tell your future self why have you made these changes -->
**Why?**

This is the first step of the persistence implementation for a persisted audit_log for domain changes. It will only be used for changes to the ReplicationConfig initially, replacing FailoverHistory in the domains metadata.  

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit tests, manual POC. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

Something is wrong with the schema definition (or the primary key definition) and we need to modify the table later. Ideally this is caught before it gets much further than this. 

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

N/A

**Detailed Description**
[In-depth description of the changes made to the schema or interfaces, specifying new fields, removed fields, or modified data structures]

The domain_audit_log table has been added to the Cassandra schema. It will not exist in SQL etc. for now, and is planned to be added early next year. 

**Impact Analysis**
- **Backward Compatibility**: [Analysis of backward compatibility]
- **Forward Compatibility**: [Analysis of forward compatibility]

N/A

**Testing Plan**
- **Unit Tests**: [Do we have unit test covering the change?]
- **Persistence Tests**: [If the change is related to a data type which is persisted, do we have persistence tests covering the change?]
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

This should be covered by future integration & persistence tests - but is not yet. They will be added in a follow up PR. 

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter? No
- Is it safe to rollback? Does the order of rollback matter? Yes, until applications start using it. 
- Is there a kill switch to mitigate the impact immediately? No. 
---