### PR TITLE
fix: exclude experimental shard-distributor from default services

### DIFF
--- a/cmd/server/cadence/cadence.go
+++ b/cmd/server/cadence/cadence.go
@@ -43,6 +43,7 @@ import (
 
 // validServices is the list of all valid cadence services
 var validServices = service.ShortNames(service.List)
+var defaultServices = service.ShortNames(service.ListWithRing)
 
 func isValidService(in string) bool {
 	for _, s := range validServices {
@@ -107,7 +108,7 @@ func BuildCLI(releaseVersion string, gitRevision string) *cli.App {
 				&cli.StringFlag{
 					Name:    "services",
 					Aliases: []string{"s"},
-					Value:   strings.Join(validServices, ","),
+					Value:   strings.Join(defaultServices, ","),
 					Usage:   "list of services to start",
 				},
 			},


### PR DESCRIPTION
**What changed?**
Changed the default services list to use `ListWithRing` instead of `List`, excluding the experimental shard-distributor service from being started by default.

**Why?**
The shard-distributor is an experimental service that should not be started by default. Users can still explicitly start it when needed for testing.

**How did you test it?**
Verified that `ListWithRing` contains only services with hash ring support (frontend, history, matching, worker) and excludes shard-distributor.

**Potential risks**
Low risk. Only changes default behavior when no explicit service list is provided. Explicit starts of shard-distributor still work.

**Release notes**
The experimental shard-distributor service is no longer started by default. To start it, explicitly specify it in the services list.

**Documentation Changes**
None required.