### PR TITLE
fix: Revert "chore(active-active): remove deprecated fields (#7388)"

### DIFF
--- a/common/persistence/execution_manager_test.go
+++ b/common/persistence/execution_manager_test.go
@@ -1652,10 +1652,8 @@ func sampleActiveClusterSelectionPolicyData() *DataBlob {
 
 func sampleActiveClusterSelectionPolicy() *types.ActiveClusterSelectionPolicy {
 	return &types.ActiveClusterSelectionPolicy{
-		ClusterAttribute: &types.ClusterAttribute{
-			Scope: "region",
-			Name:  "us-west-1",
-		},
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:                   "region-1",
 	}
 }
 

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1498,10 +1498,8 @@ func (s *ExecutionManagerSuite) TestGetWorkflow() {
 				Memo:                        testMemo,
 				PartitionConfig:             testPartitionConfig,
 				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ClusterAttribute: &types.ClusterAttribute{
-						Scope: "region",
-						Name:  "us-west-1",
-					},
+					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+					StickyRegion:                   "region1",
 				},
 			},
 			ExecutionStats: &p.ExecutionStats{

--- a/common/persistence/serializer_test.go
+++ b/common/persistence/serializer_test.go
@@ -539,9 +539,9 @@ func generateActiveClusters() *types.ActiveClusters {
 
 func generateActiveClusterSelectionPolicy() *types.ActiveClusterSelectionPolicy {
 	return &types.ActiveClusterSelectionPolicy{
-		ClusterAttribute: &types.ClusterAttribute{
-			Scope: "region",
-			Name:  "us-west-1",
-		},
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:                   "region1",
+		ExternalEntityType:             "externalEntityType1",
+		ExternalEntityKey:              "externalEntityKey1",
 	}
 }

--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -6752,6 +6752,30 @@ func FromActiveClusterSelectionPolicy(p *types.ActiveClusterSelectionPolicy) *ap
 	if p == nil {
 		return nil
 	}
+	// TODO(active-active): Remove the switch statement once the strategy is removed
+	switch p.GetStrategy() {
+	case types.ActiveClusterSelectionStrategyRegionSticky:
+		return &apiv1.ActiveClusterSelectionPolicy{
+			Strategy: apiv1.ActiveClusterSelectionStrategy_ACTIVE_CLUSTER_SELECTION_STRATEGY_REGION_STICKY,
+			StrategyConfig: &apiv1.ActiveClusterSelectionPolicy_ActiveClusterStickyRegionConfig{
+				ActiveClusterStickyRegionConfig: &apiv1.ActiveClusterStickyRegionConfig{
+					StickyRegion: p.StickyRegion,
+				},
+			},
+			ClusterAttribute: FromClusterAttribute(p.ClusterAttribute),
+		}
+	case types.ActiveClusterSelectionStrategyExternalEntity:
+		return &apiv1.ActiveClusterSelectionPolicy{
+			Strategy: apiv1.ActiveClusterSelectionStrategy_ACTIVE_CLUSTER_SELECTION_STRATEGY_EXTERNAL_ENTITY,
+			StrategyConfig: &apiv1.ActiveClusterSelectionPolicy_ActiveClusterExternalEntityConfig{
+				ActiveClusterExternalEntityConfig: &apiv1.ActiveClusterExternalEntityConfig{
+					ExternalEntityType: p.ExternalEntityType,
+					ExternalEntityKey:  p.ExternalEntityKey,
+				},
+			},
+			ClusterAttribute: FromClusterAttribute(p.ClusterAttribute),
+		}
+	}
 	return &apiv1.ActiveClusterSelectionPolicy{
 		ClusterAttribute: FromClusterAttribute(p.ClusterAttribute),
 	}
@@ -6760,6 +6784,22 @@ func FromActiveClusterSelectionPolicy(p *types.ActiveClusterSelectionPolicy) *ap
 func ToActiveClusterSelectionPolicy(p *apiv1.ActiveClusterSelectionPolicy) *types.ActiveClusterSelectionPolicy {
 	if p == nil {
 		return nil
+	}
+	// TODO(active-active): Remove the switch statement once the strategy is removed
+	switch p.Strategy {
+	case apiv1.ActiveClusterSelectionStrategy_ACTIVE_CLUSTER_SELECTION_STRATEGY_REGION_STICKY:
+		return &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+			StickyRegion:                   p.StrategyConfig.(*apiv1.ActiveClusterSelectionPolicy_ActiveClusterStickyRegionConfig).ActiveClusterStickyRegionConfig.StickyRegion,
+			ClusterAttribute:               ToClusterAttribute(p.ClusterAttribute),
+		}
+	case apiv1.ActiveClusterSelectionStrategy_ACTIVE_CLUSTER_SELECTION_STRATEGY_EXTERNAL_ENTITY:
+		return &types.ActiveClusterSelectionPolicy{
+			ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyExternalEntity.Ptr(),
+			ExternalEntityType:             p.StrategyConfig.(*apiv1.ActiveClusterSelectionPolicy_ActiveClusterExternalEntityConfig).ActiveClusterExternalEntityConfig.ExternalEntityType,
+			ExternalEntityKey:              p.StrategyConfig.(*apiv1.ActiveClusterSelectionPolicy_ActiveClusterExternalEntityConfig).ActiveClusterExternalEntityConfig.ExternalEntityKey,
+			ClusterAttribute:               ToClusterAttribute(p.ClusterAttribute),
+		}
 	}
 	return &types.ActiveClusterSelectionPolicy{
 		ClusterAttribute: ToClusterAttribute(p.ClusterAttribute),

--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -7045,7 +7045,11 @@ func FromActiveClusterSelectionPolicy(t *types.ActiveClusterSelectionPolicy) *sh
 		return nil
 	}
 	return &shared.ActiveClusterSelectionPolicy{
-		ClusterAttribute: FromClusterAttribute(t.ClusterAttribute),
+		Strategy:           FromActiveClusterSelectionStrategy(t.ActiveClusterSelectionStrategy),
+		ExternalEntityType: &t.ExternalEntityType,
+		ExternalEntityKey:  &t.ExternalEntityKey,
+		StickyRegion:       &t.StickyRegion,
+		ClusterAttribute:   FromClusterAttribute(t.ClusterAttribute),
 	}
 }
 
@@ -7054,8 +7058,38 @@ func ToActiveClusterSelectionPolicy(t *shared.ActiveClusterSelectionPolicy) *typ
 		return nil
 	}
 	return &types.ActiveClusterSelectionPolicy{
-		ClusterAttribute: ToClusterAttribute(t.ClusterAttribute),
+		ActiveClusterSelectionStrategy: ToActiveClusterSelectionStrategy(t.Strategy),
+		ExternalEntityType:             *t.ExternalEntityType,
+		ExternalEntityKey:              *t.ExternalEntityKey,
+		StickyRegion:                   *t.StickyRegion,
+		ClusterAttribute:               ToClusterAttribute(t.ClusterAttribute),
 	}
+}
+
+func FromActiveClusterSelectionStrategy(t *types.ActiveClusterSelectionStrategy) *shared.ActiveClusterSelectionStrategy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case types.ActiveClusterSelectionStrategyRegionSticky:
+		return shared.ActiveClusterSelectionStrategyRegionSticky.Ptr()
+	case types.ActiveClusterSelectionStrategyExternalEntity:
+		return shared.ActiveClusterSelectionStrategyExternalEntity.Ptr()
+	}
+	panic("unexpected enum value")
+}
+
+func ToActiveClusterSelectionStrategy(t *shared.ActiveClusterSelectionStrategy) *types.ActiveClusterSelectionStrategy {
+	if t == nil {
+		return nil
+	}
+	switch *t {
+	case shared.ActiveClusterSelectionStrategyRegionSticky:
+		return types.ActiveClusterSelectionStrategyRegionSticky.Ptr()
+	case shared.ActiveClusterSelectionStrategyExternalEntity:
+		return types.ActiveClusterSelectionStrategyExternalEntity.Ptr()
+	}
+	panic("unexpected enum value")
 }
 
 // FromWorkflowExecutionTerminatedEventAttributes converts internal WorkflowExecutionTerminatedEventAttributes type to thrift

--- a/common/types/mapper/thrift/shared_test.go
+++ b/common/types/mapper/thrift/shared_test.go
@@ -3595,6 +3595,8 @@ func TestActiveClusterSelectionPolicyConversion(t *testing.T) {
 	testCases := []*types.ActiveClusterSelectionPolicy{
 		nil,
 		{},
+		&testdata.ActiveClusterSelectionPolicyExternalEntity,
+		&testdata.ActiveClusterSelectionPolicyRegionSticky,
 		&testdata.ActiveClusterSelectionPolicyWithClusterAttribute,
 	}
 

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -2752,7 +2752,22 @@ func (c *ClusterAttribute) Equals(other *ClusterAttribute) bool {
 	return c.Scope == other.Scope && c.Name == other.Name
 }
 
+type ActiveClusterSelectionStrategy int32
+
+const (
+	ActiveClusterSelectionStrategyRegionSticky ActiveClusterSelectionStrategy = iota
+	ActiveClusterSelectionStrategyExternalEntity
+)
+
 type ActiveClusterSelectionPolicy struct {
+	ActiveClusterSelectionStrategy *ActiveClusterSelectionStrategy `json:"activeClusterSelectionStrategy,omitempty"`
+
+	StickyRegion string `json:"stickyRegion,omitempty"`
+
+	ExternalEntityType string `json:"externalEntityType,omitempty"`
+	ExternalEntityKey  string `json:"externalEntityKey,omitempty"`
+
+	// TODO(active-active): Remove the fields above
 	ClusterAttribute *ClusterAttribute `json:"clusterAttribute,omitempty" yaml:"clusterAttribute,omitempty"`
 }
 
@@ -2771,7 +2786,54 @@ func (p *ActiveClusterSelectionPolicy) Equals(other *ActiveClusterSelectionPolic
 		return false
 	}
 
-	return p.ClusterAttribute.Equals(other.ClusterAttribute)
+	return p.GetStrategy() == other.GetStrategy() &&
+		p.StickyRegion == other.StickyRegion &&
+		p.ExternalEntityType == other.ExternalEntityType &&
+		p.ExternalEntityKey == other.ExternalEntityKey && p.ClusterAttribute.Equals(other.ClusterAttribute)
+}
+
+func (p *ActiveClusterSelectionPolicy) GetStrategy() ActiveClusterSelectionStrategy {
+	if p == nil || p.ActiveClusterSelectionStrategy == nil {
+		return ActiveClusterSelectionStrategyRegionSticky
+	}
+	return *p.ActiveClusterSelectionStrategy
+}
+
+func (e ActiveClusterSelectionStrategy) Ptr() *ActiveClusterSelectionStrategy {
+	return &e
+}
+
+func (e ActiveClusterSelectionStrategy) String() string {
+	switch e {
+	case ActiveClusterSelectionStrategyRegionSticky:
+		return "REGION_STICKY"
+	case ActiveClusterSelectionStrategyExternalEntity:
+		return "EXTERNAL_ENTITY"
+	}
+
+	return fmt.Sprintf("ActiveClusterSelectionStrategy(%d)", e)
+}
+
+func (e ActiveClusterSelectionStrategy) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
+func (e *ActiveClusterSelectionStrategy) UnmarshalText(value []byte) error {
+	switch s := strings.ToUpper(string(value)); s {
+	case "REGION_STICKY":
+		*e = ActiveClusterSelectionStrategyRegionSticky
+		return nil
+	case "EXTERNAL_ENTITY":
+		*e = ActiveClusterSelectionStrategyExternalEntity
+		return nil
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ActiveClusterSelectionStrategy", err)
+		}
+		*e = ActiveClusterSelectionStrategy(val)
+		return nil
+	}
 }
 
 // DomainStatus is an internal type (TBD...)

--- a/common/types/testdata/common.go
+++ b/common/types/testdata/common.go
@@ -500,6 +500,15 @@ var (
 		},
 		ExclusiveMaxReadLevel: &TaskKey,
 	}
+	ActiveClusterSelectionPolicyRegionSticky = types.ActiveClusterSelectionPolicy{
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:                   "region1",
+	}
+	ActiveClusterSelectionPolicyExternalEntity = types.ActiveClusterSelectionPolicy{
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyExternalEntity.Ptr(),
+		ExternalEntityType:             "externalEntityType1",
+		ExternalEntityKey:              "externalEntityKey1",
+	}
 	ClusterAttribute = types.ClusterAttribute{
 		Scope: "region",
 		Name:  "us-west-1",

--- a/common/types/testdata/history.go
+++ b/common/types/testdata/history.go
@@ -276,7 +276,7 @@ var (
 		Header:                              &Header,
 		PartitionConfig:                     PartitionConfig,
 		RequestID:                           RequestID,
-		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyWithClusterAttribute,
+		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyExternalEntity,
 		CronOverlapPolicy:                   &CronOverlapPolicy,
 	}
 	WorkflowExecutionCompletedEventAttributes = types.WorkflowExecutionCompletedEventAttributes{
@@ -476,7 +476,7 @@ var (
 		Header:                              &Header,
 		Memo:                                &Memo,
 		SearchAttributes:                    &SearchAttributes,
-		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyWithClusterAttribute,
+		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyExternalEntity,
 		CronOverlapPolicy:                   &CronOverlapPolicy,
 	}
 	StartChildWorkflowExecutionInitiatedEventAttributes = types.StartChildWorkflowExecutionInitiatedEventAttributes{

--- a/common/types/testdata/service_frontend.go
+++ b/common/types/testdata/service_frontend.go
@@ -346,7 +346,7 @@ var (
 		SearchAttributes:                    &SearchAttributes,
 		Header:                              &Header,
 		FirstRunAtTimeStamp:                 &Timestamp1,
-		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyWithClusterAttribute,
+		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyExternalEntity,
 	}
 	StartWorkflowExecutionResponse = types.StartWorkflowExecutionResponse{
 		RunID: RunID,
@@ -385,7 +385,7 @@ var (
 		SearchAttributes:                    &SearchAttributes,
 		Header:                              &Header,
 		FirstRunAtTimestamp:                 &Timestamp1,
-		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyWithClusterAttribute,
+		ActiveClusterSelectionPolicy:        &ActiveClusterSelectionPolicyRegionSticky,
 	}
 	SignalWithStartWorkflowExecutionAsyncRequest = types.SignalWithStartWorkflowExecutionAsyncRequest{
 		SignalWithStartWorkflowExecutionRequest: &SignalWithStartWorkflowExecutionRequest,

--- a/service/frontend/api/handler_test.go
+++ b/service/frontend/api/handler_test.go
@@ -2227,10 +2227,8 @@ func (s *workflowHandlerSuite) TestRestartWorkflowExecution() {
 								Name: "tasklist",
 							},
 							ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-								ClusterAttribute: &types.ClusterAttribute{
-									Scope: "region",
-									Name:  "us-west-1",
-								},
+								ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+								StickyRegion:                   "us-west-1",
 							},
 						},
 					}},
@@ -2242,11 +2240,11 @@ func (s *workflowHandlerSuite) TestRestartWorkflowExecution() {
 						if request.StartRequest.ActiveClusterSelectionPolicy == nil {
 							return nil, errors.New("expected ActiveClusterSelectionPolicy to be preserved")
 						}
-						if !request.StartRequest.ActiveClusterSelectionPolicy.ClusterAttribute.Equals(&types.ClusterAttribute{
-							Scope: "region",
-							Name:  "us-west-1",
-						}) {
-							return nil, errors.New("expected ActiveClusterSelectionPolicy to be preserved")
+						if *request.StartRequest.ActiveClusterSelectionPolicy.ActiveClusterSelectionStrategy != types.ActiveClusterSelectionStrategyRegionSticky {
+							return nil, errors.New("ActiveClusterSelectionStrategy not preserved")
+						}
+						if request.StartRequest.ActiveClusterSelectionPolicy.StickyRegion != "us-west-1" {
+							return nil, errors.New("StickyRegion not preserved")
 						}
 						return &types.StartWorkflowExecutionResponse{RunID: testRunID}, nil
 					},
@@ -4936,10 +4934,8 @@ func TestConstructRestartWorkflowRequest(t *testing.T) {
 				CronSchedule:                    "0 */2 * * *",
 				FirstDecisionTaskBackoffSeconds: common.Int32Ptr(30),
 				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
-					ClusterAttribute: &types.ClusterAttribute{
-						Scope: "region",
-						Name:  "us-west-1",
-					},
+					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+					StickyRegion:                   "us-west-2",
 				},
 			},
 			domain:      "test-domain",
@@ -4947,6 +4943,23 @@ func TestConstructRestartWorkflowRequest(t *testing.T) {
 			workflowID:  "test-workflow-id",
 			expectPanic: false,
 			description: "complete field validation ensures all fields are properly set",
+		},
+		{
+			name: "ActiveClusterSelectionPolicy with ExternalEntity strategy",
+			originalAttributes: &types.WorkflowExecutionStartedEventAttributes{
+				WorkflowType: &types.WorkflowType{Name: "testWorkflow"},
+				TaskList:     &types.TaskList{Name: "testTaskList"},
+				ActiveClusterSelectionPolicy: &types.ActiveClusterSelectionPolicy{
+					ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyExternalEntity.Ptr(),
+					ExternalEntityType:             "order",
+					ExternalEntityKey:              "order-789",
+				},
+			},
+			domain:      "test-domain",
+			identity:    "test-identity",
+			workflowID:  "test-workflow-id",
+			expectPanic: false,
+			description: "ExternalEntity policy should be completely preserved",
 		},
 		{
 			name: "nil ActiveClusterSelectionPolicy should remain nil",

--- a/service/history/execution/workflow_test.go
+++ b/service/history/execution/workflow_test.go
@@ -81,10 +81,8 @@ func (s *workflowSuite) TestGetMethods() {
 	lastEventVersion := int64(12)
 	startTimestamp := time.Now()
 	activeClusterSelectionPolicy := &types.ActiveClusterSelectionPolicy{
-		ClusterAttribute: &types.ClusterAttribute{
-			Scope: "region",
-			Name:  "us-west-1",
-		},
+		ActiveClusterSelectionStrategy: types.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:                   "region-1",
 	}
 	s.mockMutableState.EXPECT().GetLastWriteVersion().Return(lastEventVersion, nil).AnyTimes()
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
@@ -441,12 +439,10 @@ func TestWorkflowHappensAfter(t *testing.T) {
 	laterTime := baseTime.Add(time.Hour)
 
 	// Helper function to create ActiveClusterSelectionPolicy
-	createPolicy := func(scope, name string) *types.ActiveClusterSelectionPolicy {
+	createPolicy := func(strategy types.ActiveClusterSelectionStrategy, region string) *types.ActiveClusterSelectionPolicy {
 		return &types.ActiveClusterSelectionPolicy{
-			ClusterAttribute: &types.ClusterAttribute{
-				Scope: scope,
-				Name:  name,
-			},
+			ActiveClusterSelectionStrategy: &strategy,
+			StickyRegion:                   region,
 		}
 	}
 
@@ -461,8 +457,8 @@ func TestWorkflowHappensAfter(t *testing.T) {
 		}
 	}
 
-	policy1 := createPolicy("region", "us-west-1")
-	policy2 := createPolicy("region", "us-east-1")
+	policy1 := createPolicy(types.ActiveClusterSelectionStrategyRegionSticky, "region-1")
+	policy2 := createPolicy(types.ActiveClusterSelectionStrategyRegionSticky, "region-2")
 
 	tests := []struct {
 		name            string

--- a/tools/cli/admin_db_decode_thrift_test.go
+++ b/tools/cli/admin_db_decode_thrift_test.go
@@ -108,13 +108,12 @@ func TestThriftDecodeHelper(t *testing.T) {
 			encoding:  "hex",
 			wantObjFn: generateTestActiveClustersConfig,
 		},
-		/* TODO(Shaddoll): update this test once we pull the new IDL
 		{
 			desc:      "Active cluster selection policy",
-			input:     "0x590c00010b000100000006726567696f6e0b000200000007726567696f6e300008000a000000000b0014000000000b001e000000000b00280000000000",
+			input:     "5908000a000000000b001400000007726567696f6e300b001e000000000b00280000000000",
 			encoding:  "hex",
 			wantObjFn: generateTestActiveClusterSelectionPolicy,
-		},*/
+		},
 	}
 
 	for _, tc := range tests {
@@ -262,10 +261,10 @@ func generateTestTimerInfo(t *testing.T) codec.ThriftObject {
 func generateTestActiveClusterSelectionPolicy(t *testing.T) codec.ThriftObject {
 	t.Helper()
 	return &shared.ActiveClusterSelectionPolicy{
-		ClusterAttribute: &shared.ClusterAttribute{
-			Scope: common.StringPtr("region"),
-			Name:  common.StringPtr("region0"),
-		},
+		Strategy:           shared.ActiveClusterSelectionStrategyRegionSticky.Ptr(),
+		StickyRegion:       common.StringPtr("region0"),
+		ExternalEntityType: common.StringPtr(""),
+		ExternalEntityKey:  common.StringPtr(""),
 	}
 }
 


### PR DESCRIPTION
This reverts commit d09cb448c7bf00e7e7633b05df6d31d2d600f03a.

<!-- Describe what has changed in this PR -->
**What changed?**


<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
