### PR TITLE
fix: add nil pointer check for active cluster selection policy mappers

### DIFF
--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -7059,9 +7059,9 @@ func ToActiveClusterSelectionPolicy(t *shared.ActiveClusterSelectionPolicy) *typ
 	}
 	return &types.ActiveClusterSelectionPolicy{
 		ActiveClusterSelectionStrategy: ToActiveClusterSelectionStrategy(t.Strategy),
-		ExternalEntityType:             *t.ExternalEntityType,
-		ExternalEntityKey:              *t.ExternalEntityKey,
-		StickyRegion:                   *t.StickyRegion,
+		ExternalEntityType:             t.GetExternalEntityType(),
+		ExternalEntityKey:              t.GetExternalEntityKey(),
+		StickyRegion:                   t.GetStickyRegion(),
 		ClusterAttribute:               ToClusterAttribute(t.ClusterAttribute),
 	}
 }

--- a/common/types/mapper/thrift/shared_test.go
+++ b/common/types/mapper/thrift/shared_test.go
@@ -3591,6 +3591,8 @@ func TestQueueStateConversion(t *testing.T) {
 	}
 }
 
+// TODO: The way we're testing mappers doesn't have good coverage. The round trip tests don't cover serialization and deserialization of thrift.
+// We should also generate test data in thrift types and do round trip tests from thrift to internal and back to thrift.
 func TestActiveClusterSelectionPolicyConversion(t *testing.T) {
 	testCases := []*types.ActiveClusterSelectionPolicy{
 		nil,


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- add nil pointer check for active cluster selection policy mappers

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to remove those fields from ActiveClusterSelectionPolicy. However, the change is not safe to rollback because of the nil-pointer dereference of the new data that doesn't have those fields serialized into thrift. This change is to create a commit that's safe to be rolled back.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
