### PR TITLE
fix: Handle duplicate child workflow events

### DIFF
--- a/service/history/execution/mutable_state_builder_test.go
+++ b/service/history/execution/mutable_state_builder_test.go
@@ -3655,11 +3655,11 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1, event2}
 			},
 			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
-				assert.Equal(t, 0, logs.FilterMessage("Duplicate activity task event found").Len())
+				assert.Equal(t, 0, logs.FilterMessage("Duplicate event found").Len())
 			},
 		},
 		{
-			name: "started event duplicated",
+			name: "activity started event duplicated",
 			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskStarted)
 				event1.ActivityTaskStartedEventAttributes = &types.ActivityTaskStartedEventAttributes{
@@ -3675,11 +3675,11 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
 			},
 			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
-				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
 			},
 		},
 		{
-			name: "completed event duplicated",
+			name: "activty completed event duplicated",
 			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCompleted)
 				event1.ActivityTaskCompletedEventAttributes = &types.ActivityTaskCompletedEventAttributes{
@@ -3693,11 +3693,11 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
 			},
 			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
-				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
 			},
 		},
 		{
-			name: "canceled event duplicated",
+			name: "activity canceled event duplicated",
 			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskCanceled)
 				event1.ActivityTaskCanceledEventAttributes = &types.ActivityTaskCanceledEventAttributes{
@@ -3711,11 +3711,11 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
 			},
 			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
-				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
 			},
 		},
 		{
-			name: "failed event duplicated",
+			name: "activity failed event duplicated",
 			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskFailed)
 				event1.ActivityTaskFailedEventAttributes = &types.ActivityTaskFailedEventAttributes{
@@ -3729,11 +3729,11 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
 			},
 			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
-				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
 			},
 		},
 		{
-			name: "timed out event duplicated",
+			name: "activity timed out event duplicated",
 			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
 				event1 := msb.CreateNewHistoryEvent(types.EventTypeActivityTaskTimedOut)
 				event1.ActivityTaskTimedOutEventAttributes = &types.ActivityTaskTimedOutEventAttributes{
@@ -3747,7 +3747,105 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
 			},
 			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
-				assert.Equal(t, 1, logs.FilterMessage("Duplicate activity task event found").Len())
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "child workflow started event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionStarted)
+				event1.ChildWorkflowExecutionStartedEventAttributes = &types.ChildWorkflowExecutionStartedEventAttributes{
+					InitiatedEventID: 1,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionStarted)
+				event2.ChildWorkflowExecutionStartedEventAttributes = &types.ChildWorkflowExecutionStartedEventAttributes{
+					InitiatedEventID: 1,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "child workflow completed event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionCompleted)
+				event1.ChildWorkflowExecutionCompletedEventAttributes = &types.ChildWorkflowExecutionCompletedEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionCompleted)
+				event2.ChildWorkflowExecutionCompletedEventAttributes = &types.ChildWorkflowExecutionCompletedEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "child workflow failed event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionFailed)
+				event1.ChildWorkflowExecutionFailedEventAttributes = &types.ChildWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionFailed)
+				event2.ChildWorkflowExecutionFailedEventAttributes = &types.ChildWorkflowExecutionFailedEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "child workflow timed out event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionTimedOut)
+				event1.ChildWorkflowExecutionTimedOutEventAttributes = &types.ChildWorkflowExecutionTimedOutEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionTimedOut)
+				event2.ChildWorkflowExecutionTimedOutEventAttributes = &types.ChildWorkflowExecutionTimedOutEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
+			},
+		},
+		{
+			name: "child workflow canceled event duplicated",
+			buildEvents: func(msb *mutableStateBuilder) ([]*types.HistoryEvent, []*types.HistoryEvent) {
+				event1 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionCanceled)
+				event1.ChildWorkflowExecutionCanceledEventAttributes = &types.ChildWorkflowExecutionCanceledEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+				event2 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionCanceled)
+				event2.ChildWorkflowExecutionCanceledEventAttributes = &types.ChildWorkflowExecutionCanceledEventAttributes{
+					InitiatedEventID: 1,
+					StartedEventID:   2,
+				}
+
+				return []*types.HistoryEvent{event1, event2}, []*types.HistoryEvent{event1}
+			},
+			assertions: func(t *testing.T, logs *observer.ObservedLogs) {
+				assert.Equal(t, 1, logs.FilterMessage("Duplicate event found").Len())
 			},
 		},
 		{
@@ -3830,8 +3928,28 @@ func Test__reorderAndFilterDuplicateEvents(t *testing.T) {
 				event3.ActivityTaskTimedOutEventAttributes = &types.ActivityTaskTimedOutEventAttributes{
 					ScheduledEventID: 1,
 				}
+				event4 := msb.CreateNewHistoryEvent(types.EventTypeStartChildWorkflowExecutionInitiated)
+				event4.StartChildWorkflowExecutionInitiatedEventAttributes = &types.StartChildWorkflowExecutionInitiatedEventAttributes{}
+				event5 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionStarted)
+				event5.ChildWorkflowExecutionStartedEventAttributes = &types.ChildWorkflowExecutionStartedEventAttributes{
+					InitiatedEventID: 4,
+				}
+				event6 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionStarted)
+				event6.ChildWorkflowExecutionStartedEventAttributes = &types.ChildWorkflowExecutionStartedEventAttributes{
+					InitiatedEventID: 4,
+				}
+				event7 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionCompleted)
+				event7.ChildWorkflowExecutionCompletedEventAttributes = &types.ChildWorkflowExecutionCompletedEventAttributes{
+					InitiatedEventID: 4,
+					StartedEventID:   5,
+				}
+				event8 := msb.CreateNewHistoryEvent(types.EventTypeChildWorkflowExecutionCompleted)
+				event8.ChildWorkflowExecutionCompletedEventAttributes = &types.ChildWorkflowExecutionCompletedEventAttributes{
+					InitiatedEventID: 4,
+					StartedEventID:   5,
+				}
 
-				return []*types.HistoryEvent{event2, event1, event3}, []*types.HistoryEvent{event1, event2}
+				return []*types.HistoryEvent{event2, event1, event3, event4, event5, event6, event7, event8}, []*types.HistoryEvent{event1, event4, event5, event2, event7}
 			},
 		},
 	}


### PR DESCRIPTION
We should certainly explore a more generic or generally better solution for this (maybe comparing HistoryEvent attributes?), but for now I think it's reasonable to repeat the fix we did for activities. We still don't know the root cause of this.

<!-- Describe what has changed in this PR -->
**What changed?**
- Handle duplicate buffered Child Workflow Events

<!-- Tell your future self why have you made these changes -->
**Why?**
- We recently observed a scenario where these were duplicated, similar to activities.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
