### PR TITLE
fix: [cadence-cli]Fix failover cli command

### DIFF
--- a/tools/cli/domain.go
+++ b/tools/cli/domain.go
@@ -162,7 +162,7 @@ func newDomainCommands() []*cli.Command {
 					return err
 				}
 				return withDomainClient(c, false, func(dc *domainCLIImpl) error {
-					return dc.UpdateDomain(c)
+					return dc.FailoverDomain(c)
 				})
 			},
 		},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Fix failover cli command by replacing UpdateDomain call that was mistakenly left out:c

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
