### PR TITLE
fix(active-active): Fix active selection policy type conversion

### DIFF
--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -6753,7 +6753,12 @@ func FromActiveClusterSelectionPolicy(p *types.ActiveClusterSelectionPolicy) *ap
 		return nil
 	}
 	// TODO(active-active): Remove the switch statement once the strategy is removed
-	switch p.GetStrategy() {
+	if p.ActiveClusterSelectionStrategy == nil {
+		return &apiv1.ActiveClusterSelectionPolicy{
+			ClusterAttribute: FromClusterAttribute(p.ClusterAttribute),
+		}
+	}
+	switch *p.ActiveClusterSelectionStrategy {
 	case types.ActiveClusterSelectionStrategyRegionSticky:
 		return &apiv1.ActiveClusterSelectionPolicy{
 			Strategy: apiv1.ActiveClusterSelectionStrategy_ACTIVE_CLUSTER_SELECTION_STRATEGY_REGION_STICKY,

--- a/common/types/mapper/proto/api_test.go
+++ b/common/types/mapper/proto/api_test.go
@@ -1343,17 +1343,17 @@ func TestClusterAttribute(t *testing.T) {
 	}
 }
 
-// TODO(active-active): Remove the comment once the strategy is removed
-/*
 func TestActiveClusterSelectionPolicy(t *testing.T) {
 	for _, item := range []*types.ActiveClusterSelectionPolicy{
 		nil,
 		{},
 		&testdata.ActiveClusterSelectionPolicyWithClusterAttribute,
+		&testdata.ActiveClusterSelectionPolicyRegionSticky,
+		&testdata.ActiveClusterSelectionPolicyExternalEntity,
 	} {
 		assert.Equal(t, item, ToActiveClusterSelectionPolicy(FromActiveClusterSelectionPolicy(item)))
 	}
-}*/
+}
 
 func TestClusterAttributeScopeConversion(t *testing.T) {
 	testCases := []*types.ClusterAttributeScope{

--- a/common/types/shared.go
+++ b/common/types/shared.go
@@ -2793,17 +2793,7 @@ func (p *ActiveClusterSelectionPolicy) Equals(other *ActiveClusterSelectionPolic
 		return false
 	}
 
-	return p.GetStrategy() == other.GetStrategy() &&
-		p.StickyRegion == other.StickyRegion &&
-		p.ExternalEntityType == other.ExternalEntityType &&
-		p.ExternalEntityKey == other.ExternalEntityKey && p.ClusterAttribute.Equals(other.ClusterAttribute)
-}
-
-func (p *ActiveClusterSelectionPolicy) GetStrategy() ActiveClusterSelectionStrategy {
-	if p == nil || p.ActiveClusterSelectionStrategy == nil {
-		return ActiveClusterSelectionStrategyRegionSticky
-	}
-	return *p.ActiveClusterSelectionStrategy
+	return p.ClusterAttribute.Equals(other.ClusterAttribute)
 }
 
 func (e ActiveClusterSelectionStrategy) Ptr() *ActiveClusterSelectionStrategy {

--- a/service/history/execution/workflow_test.go
+++ b/service/history/execution/workflow_test.go
@@ -439,10 +439,12 @@ func TestWorkflowHappensAfter(t *testing.T) {
 	laterTime := baseTime.Add(time.Hour)
 
 	// Helper function to create ActiveClusterSelectionPolicy
-	createPolicy := func(strategy types.ActiveClusterSelectionStrategy, region string) *types.ActiveClusterSelectionPolicy {
+	createPolicy := func(scope, name string) *types.ActiveClusterSelectionPolicy {
 		return &types.ActiveClusterSelectionPolicy{
-			ActiveClusterSelectionStrategy: &strategy,
-			StickyRegion:                   region,
+			ClusterAttribute: &types.ClusterAttribute{
+				Scope: scope,
+				Name:  name,
+			},
 		}
 	}
 
@@ -457,8 +459,8 @@ func TestWorkflowHappensAfter(t *testing.T) {
 		}
 	}
 
-	policy1 := createPolicy(types.ActiveClusterSelectionStrategyRegionSticky, "region-1")
-	policy2 := createPolicy(types.ActiveClusterSelectionStrategyRegionSticky, "region-2")
+	policy1 := createPolicy("region", "region-1")
+	policy2 := createPolicy("region", "region-2")
 
 	tests := []struct {
 		name            string


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Fix active selection policy type conversion
- Update equals method of active selection policy to not compare deprecated fields

<!-- Tell your future self why have you made these changes -->
**Why?**
Empty values shouldn't be converted to default values because those fields are being removed. Otherwise, we'll see this in Cadence Web.
<img width="610" height="216" alt="Screenshot 2025-11-03 at 10 54 54 AM" src="https://github.com/user-attachments/assets/601ab987-bed3-489f-ac97-b749c22387b4" />


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
