### PR TITLE
fix: Failover-history mapping bug for thrift

### DIFF
--- a/common/types/mapper/thrift/shared.go
+++ b/common/types/mapper/thrift/shared.go
@@ -3405,11 +3405,10 @@ func ToClusterFailover(t *shared.ClusterFailover) *types.ClusterFailover {
 	if t == nil {
 		return nil
 	}
-	// TODO: Implement proper conversion for complex types
 	return &types.ClusterFailover{
-		FromCluster:      nil, // TODO: ToActiveClusterInfo(t.FromCluster),
-		ToCluster:        nil, // TODO: ToActiveClusterInfo(t.ToCluster),
-		ClusterAttribute: nil, // TODO: ToClusterAttribute(t.ClusterAttribute),
+		FromCluster:      ToActiveClusterInfo(t.FromCluster),
+		ToCluster:        ToActiveClusterInfo(t.ToCluster),
+		ClusterAttribute: ToClusterAttribute(t.ClusterAttribute),
 	}
 }
 
@@ -3418,11 +3417,10 @@ func FromClusterFailover(t *types.ClusterFailover) *shared.ClusterFailover {
 	if t == nil {
 		return nil
 	}
-	// TODO: Implement proper conversion for complex types
 	return &shared.ClusterFailover{
-		FromCluster:      nil, // TODO: FromActiveClusterInfo(t.FromCluster),
-		ToCluster:        nil, // TODO: FromActiveClusterInfo(t.ToCluster),
-		ClusterAttribute: nil, // TODO: FromClusterAttribute(t.ClusterAttribute),
+		FromCluster:      FromActiveClusterInfo(t.FromCluster),
+		ToCluster:        FromActiveClusterInfo(t.ToCluster),
+		ClusterAttribute: FromClusterAttribute(t.ClusterAttribute),
 	}
 }
 
@@ -3448,6 +3446,28 @@ func FromClusterFailoverArray(t []*types.ClusterFailover) []*shared.ClusterFailo
 		v[i] = FromClusterFailover(t[i])
 	}
 	return v
+}
+
+// ToActiveClusterInfo converts thrift ActiveClusterInfo type to internal
+func ToActiveClusterInfo(t *shared.ActiveClusterInfo) *types.ActiveClusterInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.ActiveClusterInfo{
+		ActiveClusterName: t.GetActiveClusterName(),
+		FailoverVersion:   t.GetFailoverVersion(),
+	}
+}
+
+// FromActiveClusterInfo converts internal ActiveClusterInfo type to thrift
+func FromActiveClusterInfo(t *types.ActiveClusterInfo) *shared.ActiveClusterInfo {
+	if t == nil {
+		return nil
+	}
+	return &shared.ActiveClusterInfo{
+		ActiveClusterName: &t.ActiveClusterName,
+		FailoverVersion:   &t.FailoverVersion,
+	}
 }
 
 // FromListOpenWorkflowExecutionsRequest converts internal ListOpenWorkflowExecutionsRequest type to thrift

--- a/common/types/mapper/thrift/shared_test.go
+++ b/common/types/mapper/thrift/shared_test.go
@@ -3701,18 +3701,13 @@ func TestClusterAttributeScopeConversion(t *testing.T) {
 }
 
 func TestListFailoverHistoryResponseConversion(t *testing.T) {
-	fuzzer := testdatagen.New(t,
-		func(v *types.FailoverEvent, c fuzz.Continue) {
-			c.Fuzz(v)
-			// Don't allow empty strings for ID - use nil or a non-empty string
-			if v.ID != nil && *v.ID == "" {
-				v.ID = nil
-			}
-		})
+	fuzzer := testdatagen.New(t)
 	for i := 0; i < 100; i++ {
 		var response types.ListFailoverHistoryResponse
 		fuzzer.Fuzz(&response)
 		thriftResponse := FromListFailoverHistoryResponse(&response)
-		assert.Equal(t, &response, ToListFailoverHistoryResponse(thriftResponse))
+
+		toResponse := ToListFailoverHistoryResponse(thriftResponse)
+		assert.Equal(t, &response, toResponse)
 	}
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Fixes an embarrasing thrift mapper bug that I left when merging. The more interesting question is why the test didn't pick it up. The reason was that it was manually constructing the failover event (which was nil), thus not actually generating data for it. I don't remember why that was present, but it doesn't seem valid.  

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

- Fixed / via unit tests 
- Manually 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
