### PR TITLE
fix: correct cluster and other parsing for CLI for AA clusters

### DIFF
--- a/tools/cli/domain_commands.go
+++ b/tools/cli/domain_commands.go
@@ -1077,7 +1077,7 @@ func clustersToStrings(clusters []*types.ClusterReplicationConfiguration) []stri
 }
 
 func parseActiveClustersByClusterAttribute(clusters string) (types.ActiveClusters, error) {
-	split := regexp.MustCompile(`(?P<attribute>[a-zA-Z0-9_]+).(?P<scope>[a-zA-Z0-9_]+):(?P<name>[a-zA-Z0-9_-]+)`)
+	split := regexp.MustCompile(`(?P<attribute>[a-zA-Z0-9_-]+).(?P<scope>[a-zA-Z0-9_-]+):(?P<name>[a-zA-Z0-9_-]+)`)
 	matches := split.FindAllStringSubmatch(clusters, -1)
 	if len(matches) == 0 {
 		return types.ActiveClusters{}, fmt.Errorf("option %s format is invalid. Expected format is 'region.dca:dev2_dca,region.phx:dev2_phx'", FlagActiveClusters)

--- a/tools/cli/domain_commands_test.go
+++ b/tools/cli/domain_commands_test.go
@@ -437,6 +437,16 @@ func TestParseActiveClustersByClusterAttribute(t *testing.T) {
 				},
 			},
 		},
+		"other things can use dashes too": {
+			clusters: "region-us-east1.new-york:cluster-0-us-east-1",
+			expected: types.ActiveClusters{
+				AttributeScopes: map[string]types.ClusterAttributeScope{
+					"region-us-east1": {ClusterAttributes: map[string]types.ActiveClusterInfo{
+						"new-york": {ActiveClusterName: "cluster-0-us-east-1"},
+					}},
+				},
+			},
+		},
 		"duplicate keys consistutes an error in parsing and shouldn't be allowed": {
 			clusters:      "region.newyork:cluster0,region.newyork:cluster1",
 			expectedError: fmt.Errorf(`option active_clusters format is invalid. the key "newyork" was duplicated. This can only map to a single active cluster`),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

I forgot that clusters may validly have dashes in their name, so adding them

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
