### PR TITLE
fix(active-active): Do not drop standby activity/decision transfer tasks in active-active domains too early

### DIFF
--- a/service/history/constants/test_constants.go
+++ b/service/history/constants/test_constants.go
@@ -34,6 +34,8 @@ var (
 	TestDomainID = "deadbeef-0123-4567-890a-bcdef0123456"
 	// TestActiveActiveDomainID is the active active domainID for test
 	TestActiveActiveDomainID = "965c78b7-1f6f-4122-9ba7-af6b7a55b27f"
+	// TestActiveActiveDomainName is the active active domain name for test
+	TestActiveActiveDomainName = "active-active-domain"
 	// TestDomainName is the domainName for test
 	TestDomainName = "some random domain name"
 	// TestRateLimitedDomainName is the domain name for testing task processing rate limits
@@ -88,7 +90,7 @@ var (
 	)
 
 	TestActiveActiveDomainEntry = cache.NewGlobalDomainCacheEntryForTest(
-		&persistence.DomainInfo{ID: TestActiveActiveDomainID, Name: TestDomainName},
+		&persistence.DomainInfo{ID: TestActiveActiveDomainID, Name: TestActiveActiveDomainName},
 		&persistence.DomainConfig{
 			Retention:                1,
 			VisibilityArchivalStatus: types.ArchivalStatusEnabled,

--- a/service/history/task/transfer_standby_task_executor.go
+++ b/service/history/task/transfer_standby_task_executor.go
@@ -635,15 +635,10 @@ func (t *transferStandbyTaskExecutor) pushActivity(
 		return nil
 	}
 
-	pushActivityInfo := postActionInfo.(*pushActivityToMatchingInfo)
-	timeout := min(pushActivityInfo.activityScheduleToStartTimeout, constants.MaxTaskTimeout)
-	taskList := &pushActivityInfo.tasklist
 	return t.transferTaskExecutorBase.pushActivity(
 		ctx,
 		task.(*persistence.ActivityTask),
-		taskList,
-		timeout,
-		pushActivityInfo.partitionConfig,
+		postActionInfo.(*pushActivityToMatchingInfo),
 	)
 }
 
@@ -658,14 +653,10 @@ func (t *transferStandbyTaskExecutor) pushDecision(
 		return nil
 	}
 
-	pushDecisionInfo := postActionInfo.(*pushDecisionToMatchingInfo)
-	timeout := min(pushDecisionInfo.decisionScheduleToStartTimeout, constants.MaxTaskTimeout)
 	return t.transferTaskExecutorBase.pushDecision(
 		ctx,
 		task.(*persistence.DecisionTask),
-		&pushDecisionInfo.tasklist,
-		timeout,
-		pushDecisionInfo.partitionConfig,
+		postActionInfo.(*pushDecisionToMatchingInfo),
 	)
 }
 

--- a/service/history/task/transfer_task_executor_base.go
+++ b/service/history/task/transfer_task_executor_base.go
@@ -32,6 +32,7 @@ import (
 	"github.com/uber/cadence/client/matching"
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/backoff"
+	"github.com/uber/cadence/common/constants"
 	"github.com/uber/cadence/common/definition"
 	"github.com/uber/cadence/common/log"
 	"github.com/uber/cadence/common/log/tag"
@@ -94,9 +95,7 @@ func newTransferTaskExecutorBase(
 func (t *transferTaskExecutorBase) pushActivity(
 	ctx context.Context,
 	task *persistence.ActivityTask,
-	taskList *types.TaskList,
-	activityScheduleToStartTimeout int32,
-	partitionConfig map[string]string,
+	pushActivityInfo *pushActivityToMatchingInfo,
 ) error {
 
 	ctx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
@@ -111,9 +110,18 @@ func (t *transferTaskExecutorBase) pushActivity(
 		return err
 	}
 	if !shouldPush {
-		return nil
+		// The domain is an active-active domain and the task is pending
+		// For the first few minutes, we will retry the task and then discard it if it is still pending.
+		if t.shard.GetTimeSource().Now().Before(task.GetVisibilityTimestamp().Add(t.config.StandbyTaskMissingEventsDiscardDelay())) {
+			err = standbyTaskPostActionNoOp(ctx, task, pushActivityInfo, t.logger)
+			return err
+		}
+		return standbyTaskPostActionTaskDiscarded(ctx, task, pushActivityInfo, t.logger)
 	}
 
+	activityScheduleToStartTimeout := min(pushActivityInfo.activityScheduleToStartTimeout, constants.MaxTaskTimeout)
+	taskList := &pushActivityInfo.tasklist
+	partitionConfig := pushActivityInfo.partitionConfig
 	_, err = t.matchingClient.AddActivityTask(ctx, &types.AddActivityTaskRequest{
 		DomainUUID:       task.TargetDomainID,
 		SourceDomainUUID: task.DomainID,
@@ -132,9 +140,7 @@ func (t *transferTaskExecutorBase) pushActivity(
 func (t *transferTaskExecutorBase) pushDecision(
 	ctx context.Context,
 	task *persistence.DecisionTask,
-	tasklist *types.TaskList,
-	decisionScheduleToStartTimeout int32,
-	partitionConfig map[string]string,
+	pushDecisionInfo *pushDecisionToMatchingInfo,
 ) error {
 
 	ctx, cancel := context.WithTimeout(ctx, taskRPCCallTimeout)
@@ -149,9 +155,17 @@ func (t *transferTaskExecutorBase) pushDecision(
 		return err
 	}
 	if !shouldPush {
-		return nil
+		// The domain is an active-active domain and the task is pending
+		// For the first few minutes, we will retry the task and then discard it if it is still pending.
+		if t.shard.GetTimeSource().Now().Before(task.GetVisibilityTimestamp().Add(t.config.StandbyTaskMissingEventsDiscardDelay())) {
+			return standbyTaskPostActionNoOp(ctx, task, pushDecisionInfo, t.logger)
+		}
+		return standbyTaskPostActionTaskDiscarded(ctx, task, pushDecisionInfo, t.logger)
 	}
 
+	decisionScheduleToStartTimeout := min(pushDecisionInfo.decisionScheduleToStartTimeout, constants.MaxTaskTimeout)
+	tasklist := &pushDecisionInfo.tasklist
+	partitionConfig := pushDecisionInfo.partitionConfig
 	_, err = t.matchingClient.AddDecisionTask(ctx, &types.AddDecisionTaskRequest{
 		DomainUUID: task.DomainID,
 		Execution: &types.WorkflowExecution{


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**
Do not drop standby activity or decision transfer tasks in active-active domains until the StandbyTaskMissingEventsDiscardDelay has elapsed

<!-- Tell your future self why have you made these changes -->
**Why?**
In the current implementation of active-active domains, standby decisions and activities cannot be pushed to matching. But if we drop the tasks, workflows can be stuck after failover. We keep redispatch the tasks for a period of time until dropping the tasks to reduce the probability of workflows being stuck after failover. A short replication lag also helps reduce the probability.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
