### PR TITLE
feat(shard-distributor): add WatchNamespaceState streaming client support

### DIFF
--- a/client/sharddistributor/interface.go
+++ b/client/sharddistributor/interface.go
@@ -34,9 +34,16 @@ import (
 //go:generate gowrap gen -g -p . -i Client -t ../templates/retry.tmpl -o ../wrappers/retryable/sharddistributor_generated.go -v client=ShardDistributor
 //go:generate gowrap gen -g -p . -i Client -t ../templates/metered.tmpl -o ../wrappers/metered/sharddistributor_generated.go -v client=ShardDistributor
 //go:generate gowrap gen -g -p . -i Client -t ../templates/errorinjectors.tmpl -o ../wrappers/errorinjectors/sharddistributor_generated.go -v client=ShardDistributor
-//go:generate gowrap gen -g -p . -i Client -t ../templates/grpc.tmpl -o ../wrappers/grpc/sharddistributor_generated.go -v client=ShardDistributor -v package=apiv1 -v path=github.com/uber/cadence/proto/internal/uber/cadence/sharddistributor/v1 -v prefix=ShardDistributor
+//go:generate gowrap gen -g -p . -i Client -t ../templates/grpc.tmpl -o ../wrappers/grpc/sharddistributor_generated.go -v client=ShardDistributor -v package=sharddistributorv1 -v path=github.com/uber/cadence/.gen/proto/sharddistributor/v1 -v prefix=ShardDistributor
 //go:generate gowrap gen -g -p . -i Client -t ../templates/timeout.tmpl -o ../wrappers/timeout/sharddistributor_generated.go -v client=ShardDistributor
 
 type Client interface {
 	GetShardOwner(context.Context, *types.GetShardOwnerRequest, ...yarpc.CallOption) (*types.GetShardOwnerResponse, error)
+	WatchNamespaceState(context.Context, *types.WatchNamespaceStateRequest, ...yarpc.CallOption) (WatchNamespaceStateClient, error)
+}
+
+type WatchNamespaceStateClient interface {
+	Context() context.Context
+	Recv(...yarpc.StreamOption) (*types.WatchNamespaceStateResponse, error)
+	CloseSend(...yarpc.StreamOption) error
 }

--- a/client/sharddistributor/interface_mock.go
+++ b/client/sharddistributor/interface_mock.go
@@ -62,3 +62,98 @@ func (mr *MockClientMockRecorder) GetShardOwner(arg0, arg1 any, arg2 ...any) *go
 	varargs := append([]any{arg0, arg1}, arg2...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardOwner", reflect.TypeOf((*MockClient)(nil).GetShardOwner), varargs...)
 }
+
+// WatchNamespaceState mocks base method.
+func (m *MockClient) WatchNamespaceState(arg0 context.Context, arg1 *types.WatchNamespaceStateRequest, arg2 ...yarpc.CallOption) (WatchNamespaceStateClient, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{arg0, arg1}
+	for _, a := range arg2 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "WatchNamespaceState", varargs...)
+	ret0, _ := ret[0].(WatchNamespaceStateClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WatchNamespaceState indicates an expected call of WatchNamespaceState.
+func (mr *MockClientMockRecorder) WatchNamespaceState(arg0, arg1 any, arg2 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]any{arg0, arg1}, arg2...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WatchNamespaceState", reflect.TypeOf((*MockClient)(nil).WatchNamespaceState), varargs...)
+}
+
+// MockWatchNamespaceStateClient is a mock of WatchNamespaceStateClient interface.
+type MockWatchNamespaceStateClient struct {
+	ctrl     *gomock.Controller
+	recorder *MockWatchNamespaceStateClientMockRecorder
+	isgomock struct{}
+}
+
+// MockWatchNamespaceStateClientMockRecorder is the mock recorder for MockWatchNamespaceStateClient.
+type MockWatchNamespaceStateClientMockRecorder struct {
+	mock *MockWatchNamespaceStateClient
+}
+
+// NewMockWatchNamespaceStateClient creates a new mock instance.
+func NewMockWatchNamespaceStateClient(ctrl *gomock.Controller) *MockWatchNamespaceStateClient {
+	mock := &MockWatchNamespaceStateClient{ctrl: ctrl}
+	mock.recorder = &MockWatchNamespaceStateClientMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockWatchNamespaceStateClient) EXPECT() *MockWatchNamespaceStateClientMockRecorder {
+	return m.recorder
+}
+
+// CloseSend mocks base method.
+func (m *MockWatchNamespaceStateClient) CloseSend(arg0 ...yarpc.StreamOption) error {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "CloseSend", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CloseSend indicates an expected call of CloseSend.
+func (mr *MockWatchNamespaceStateClientMockRecorder) CloseSend(arg0 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CloseSend", reflect.TypeOf((*MockWatchNamespaceStateClient)(nil).CloseSend), arg0...)
+}
+
+// Context mocks base method.
+func (m *MockWatchNamespaceStateClient) Context() context.Context {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Context")
+	ret0, _ := ret[0].(context.Context)
+	return ret0
+}
+
+// Context indicates an expected call of Context.
+func (mr *MockWatchNamespaceStateClientMockRecorder) Context() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Context", reflect.TypeOf((*MockWatchNamespaceStateClient)(nil).Context))
+}
+
+// Recv mocks base method.
+func (m *MockWatchNamespaceStateClient) Recv(arg0 ...yarpc.StreamOption) (*types.WatchNamespaceStateResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []any{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "Recv", varargs...)
+	ret0, _ := ret[0].(*types.WatchNamespaceStateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Recv indicates an expected call of Recv.
+func (mr *MockWatchNamespaceStateClientMockRecorder) Recv(arg0 ...any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recv", reflect.TypeOf((*MockWatchNamespaceStateClient)(nil).Recv), arg0...)
+}

--- a/client/templates/grpc.tmpl
+++ b/client/templates/grpc.tmpl
@@ -18,6 +18,41 @@ import (
 {{range $method := .Interface.Methods}}
 {{$Request := printf "%sRequest" $method.Name}}
 {{$Response := printf "%sResponse" $method.Name}}
+{{- $isStreaming := false}}
+{{- range $method.Results}}
+	{{- if contains "Client" .Type}}
+		{{- $isStreaming = true}}
+	{{- end}}
+{{- end}}
+{{- if $isStreaming}}
+func (g {{$decorator}}) {{$method.Declaration}} {
+	stream, {{(index $method.Results 1).Name}} := g.c.{{$method.Name}}({{(index $method.Params 0).Name}}, proto.From{{$prefix}}{{$Request}}({{(index $method.Params 1).Name}}), {{(index $method.Params 2).Pass}})
+	if {{(index $method.Results 1).Name}} != nil {
+		return nil, proto.ToError({{(index $method.Results 1).Name}})
+	}
+	return &{{lower $method.Name}}Client{stream: stream}, nil
+}
+
+type {{lower $method.Name}}Client struct {
+	stream {{$package}}.{{$prefix}}APIService{{$method.Name}}YARPCClient
+}
+
+func (c *{{lower $method.Name}}Client) Context() context.Context {
+	return c.stream.Context()
+}
+
+func (c *{{lower $method.Name}}Client) Recv(options ...yarpc.StreamOption) (*types.{{$Response}}, error) {
+	response, err := c.stream.Recv(options...)
+	if err != nil {
+		return nil, proto.ToError(err)
+	}
+	return proto.To{{$prefix}}{{$Response}}(response), nil
+}
+
+func (c *{{lower $method.Name}}Client) CloseSend(options ...yarpc.StreamOption) error {
+	return proto.ToError(c.stream.CloseSend(options...))
+}
+{{- else}}
 func (g {{$decorator}}) {{$method.Declaration}} {
 	{{- if eq (len $method.Params) 2}}
 	{{- if eq (len $method.Results) 1}}
@@ -39,4 +74,5 @@ func (g {{$decorator}}) {{$method.Declaration}} {
 	return proto.To{{$prefix}}{{$Response}}(response), proto.ToError({{(index $method.Results 1).Name}})
 	{{- end}}
 }
+{{- end}}
 {{end}}

--- a/client/wrappers/errorinjectors/sharddistributor_generated.go
+++ b/client/wrappers/errorinjectors/sharddistributor_generated.go
@@ -59,3 +59,23 @@ func (c *sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.G
 	}
 	return
 }
+
+func (c *sharddistributorClient) WatchNamespaceState(ctx context.Context, wp1 *types.WatchNamespaceStateRequest, p1 ...yarpc.CallOption) (w1 sharddistributor.WatchNamespaceStateClient, err error) {
+	fakeErr := c.fakeErrFn(c.errorRate)
+	var forwardCall bool
+	if forwardCall = c.forwardCallFn(fakeErr); forwardCall {
+		w1, err = c.client.WatchNamespaceState(ctx, wp1, p1...)
+	}
+
+	if fakeErr != nil {
+		c.logger.Error(msgShardDistributorInjectedFakeErr,
+			tag.ShardDistributorClientOperationWatchNamespaceState,
+			tag.Error(fakeErr),
+			tag.Bool(forwardCall),
+			tag.ClientError(err),
+		)
+		err = fakeErr
+		return
+	}
+	return
+}

--- a/client/wrappers/grpc/sharddistributor_generated.go
+++ b/client/wrappers/grpc/sharddistributor_generated.go
@@ -9,6 +9,8 @@ import (
 
 	"go.uber.org/yarpc"
 
+	sharddistributorv1 "github.com/uber/cadence/.gen/proto/sharddistributor/v1"
+	"github.com/uber/cadence/client/sharddistributor"
 	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/common/types/mapper/proto"
 )
@@ -16,4 +18,32 @@ import (
 func (g sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.GetShardOwnerRequest, p1 ...yarpc.CallOption) (gp2 *types.GetShardOwnerResponse, err error) {
 	response, err := g.c.GetShardOwner(ctx, proto.FromShardDistributorGetShardOwnerRequest(gp1), p1...)
 	return proto.ToShardDistributorGetShardOwnerResponse(response), proto.ToError(err)
+}
+
+func (g sharddistributorClient) WatchNamespaceState(ctx context.Context, wp1 *types.WatchNamespaceStateRequest, p1 ...yarpc.CallOption) (w1 sharddistributor.WatchNamespaceStateClient, err error) {
+	stream, err := g.c.WatchNamespaceState(ctx, proto.FromShardDistributorWatchNamespaceStateRequest(wp1), p1...)
+	if err != nil {
+		return nil, proto.ToError(err)
+	}
+	return &watchnamespacestateClient{stream: stream}, nil
+}
+
+type watchnamespacestateClient struct {
+	stream sharddistributorv1.ShardDistributorAPIServiceWatchNamespaceStateYARPCClient
+}
+
+func (c *watchnamespacestateClient) Context() context.Context {
+	return c.stream.Context()
+}
+
+func (c *watchnamespacestateClient) Recv(options ...yarpc.StreamOption) (*types.WatchNamespaceStateResponse, error) {
+	response, err := c.stream.Recv(options...)
+	if err != nil {
+		return nil, proto.ToError(err)
+	}
+	return proto.ToShardDistributorWatchNamespaceStateResponse(response), nil
+}
+
+func (c *watchnamespacestateClient) CloseSend(options ...yarpc.StreamOption) error {
+	return proto.ToError(c.stream.CloseSend(options...))
 }

--- a/client/wrappers/metered/sharddistributor_generated.go
+++ b/client/wrappers/metered/sharddistributor_generated.go
@@ -49,3 +49,25 @@ func (c *sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.G
 	}
 	return gp2, err
 }
+
+func (c *sharddistributorClient) WatchNamespaceState(ctx context.Context, wp1 *types.WatchNamespaceStateRequest, p1 ...yarpc.CallOption) (w1 sharddistributor.WatchNamespaceStateClient, err error) {
+	retryCount := getRetryCountFromContext(ctx)
+
+	var scope metrics.Scope
+	if retryCount == -1 {
+		scope = c.metricsClient.Scope(metrics.ShardDistributorClientWatchNamespaceStateScope)
+	} else {
+		scope = c.metricsClient.Scope(metrics.ShardDistributorClientWatchNamespaceStateScope, metrics.IsRetryTag(retryCount > 0))
+	}
+
+	scope.IncCounter(metrics.CadenceClientRequests)
+
+	sw := scope.StartTimer(metrics.CadenceClientLatency)
+	w1, err = c.client.WatchNamespaceState(ctx, wp1, p1...)
+	sw.Stop()
+
+	if err != nil {
+		scope.IncCounter(metrics.CadenceClientFailures)
+	}
+	return w1, err
+}

--- a/client/wrappers/retryable/sharddistributor_generated.go
+++ b/client/wrappers/retryable/sharddistributor_generated.go
@@ -41,3 +41,14 @@ func (c *sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.G
 	err = c.throttleRetry.Do(ctx, op)
 	return resp, err
 }
+
+func (c *sharddistributorClient) WatchNamespaceState(ctx context.Context, wp1 *types.WatchNamespaceStateRequest, p1 ...yarpc.CallOption) (w1 sharddistributor.WatchNamespaceStateClient, err error) {
+	var resp sharddistributor.WatchNamespaceStateClient
+	op := func(ctx context.Context) error {
+		var err error
+		resp, err = c.client.WatchNamespaceState(ctx, wp1, p1...)
+		return err
+	}
+	err = c.throttleRetry.Do(ctx, op)
+	return resp, err
+}

--- a/client/wrappers/timeout/sharddistributor_generated.go
+++ b/client/wrappers/timeout/sharddistributor_generated.go
@@ -38,3 +38,9 @@ func (c *sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.G
 	defer cancel()
 	return c.client.GetShardOwner(ctx, gp1, p1...)
 }
+
+func (c *sharddistributorClient) WatchNamespaceState(ctx context.Context, wp1 *types.WatchNamespaceStateRequest, p1 ...yarpc.CallOption) (w1 sharddistributor.WatchNamespaceStateClient, err error) {
+	ctx, cancel := createContext(ctx, c.timeout)
+	defer cancel()
+	return c.client.WatchNamespaceState(ctx, wp1, p1...)
+}

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -455,8 +455,9 @@ var (
 	MatchingClientOperationUpdateTaskListPartitionConfig  = clientOperation("matching-update-task-list-partition-config")
 	MatchingClientOperationRefreshTaskListPartitionConfig = clientOperation("matching-refresh-task-list-partition-config")
 
-	ShardDistributorClientOperationGetShardOwner     = clientOperation("shard-distributor-get-shard-owner")
-	ShardDistributorExecutorClientOperationHeartbeat = clientOperation("shard-distributor-executor-heartbeat")
+	ShardDistributorClientOperationGetShardOwner       = clientOperation("shard-distributor-get-shard-owner")
+	ShardDistributorClientOperationWatchNamespaceState = clientOperation("shard-distributor-watch-namespace-state")
+	ShardDistributorExecutorClientOperationHeartbeat   = clientOperation("shard-distributor-executor-heartbeat")
 )
 
 // Pre-defined values for TagIDType

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -894,6 +894,9 @@ const (
 	// ShardDistributorClientGetShardOwnerScope tracks GetShardOwner calls made by service to shard distributor
 	ShardDistributorClientGetShardOwnerScope
 
+	// ShardDistributorClientWatchNamespaceStateScope tracks WatchNamespaceState calls made by service to shard distributor
+	ShardDistributorClientWatchNamespaceStateScope
+
 	// ShardDistributorExecutorClientHeartbeatScope tracks Heartbeat calls made by executor to shard distributor
 	ShardDistributorExecutorClientHeartbeatScope
 
@@ -1869,8 +1872,9 @@ var ScopeDefs = map[ServiceIdx]map[ScopeIdx]scopeDefinition{
 		P2PRPCPeerChooserScope:       {operation: "P2PRPCPeerChooser"},
 		PartitionConfigProviderScope: {operation: "PartitionConfigProvider"},
 
-		ShardDistributorClientGetShardOwnerScope:     {operation: "ShardDistributorClientGetShardOwner"},
-		ShardDistributorExecutorClientHeartbeatScope: {operation: "ShardDistributorExecutorHeartbeat"},
+		ShardDistributorClientGetShardOwnerScope:       {operation: "ShardDistributorClientGetShardOwner"},
+		ShardDistributorClientWatchNamespaceStateScope: {operation: "ShardDistributorClientWatchNamespaceState"},
+		ShardDistributorExecutorClientHeartbeatScope:   {operation: "ShardDistributorExecutorHeartbeat"},
 
 		LoadBalancerScope: {operation: "RRLoadBalancer"},
 


### PR DESCRIPTION
**What changed?**
Added client-side support for the `WatchNamespaceState` streaming RPC endpoint including interface definitions, mocks, and generated wrappers across all client layers (gRPC, retry, metrics, timeout, error injection).

**Why?**
Enables clients to consume the streaming `WatchNamespaceState` endpoint for real-time namespace state updates from the shard distributor service.

**How did you test it?**
- Generated code using `make go-generate`
- Verified build passes with `make build`

**Potential risks**
Low - adds new optional streaming client functionality without modifying existing behavior.

**Release notes**
Added client support for WatchNamespaceState streaming RPC in shard distributor.

**Documentation Changes**
None required - internal client interface changes only.