### PR TITLE
fix(shard-distributor): generate unique shard key for each namespace in canary

### DIFF
--- a/service/sharddistributor/canary/processorephemeral/shardcreator.go
+++ b/service/sharddistributor/canary/processorephemeral/shardcreator.go
@@ -89,8 +89,8 @@ func (s *ShardCreator) process(ctx context.Context) {
 		case <-s.stopChan:
 			return
 		case <-ticker.Chan():
-			shardKey := uuid.New().String()
 			for _, namespace := range s.namespaces {
+				shardKey := uuid.New().String()
 				s.logger.Info("Creating shard", zap.String("shardKey", shardKey), zap.String("namespace", namespace))
 				response, err := s.shardDistributor.GetShardOwner(ctx, &types.GetShardOwnerRequest{
 					ShardKey:  shardKey,


### PR DESCRIPTION
**What changed?**
Moved shard key UUID generation inside the namespace loop in the canary shard creator.

**Why?**
Previously, a single shard key was generated outside the loop and reused for all namespaces. This made it difficult to differentiate shards across different namespaces during testing.

**How did you test it?**
Verified locally that each namespace now receives a unique shard key per iteration.

**Potential risks**
Low - this only affects the canary testing code, not production behavior.

**Release notes**
N/A - canary test fix only

**Documentation Changes**
None