### PR TITLE
fix(shard-distributor): change to migration dynamic config name

### DIFF
--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -73,17 +73,17 @@ system.readVisibilityStoreName:
   - value: "db"
 matching.enableClientAutoConfig:
 - value: true
-shardDistributor.MigrationMode:
+shardDistributor.migrationMode:
   - value: "onboarded"
   - value: "local_pass"
     constraints:
-    namespace: "test-local-passthrough"
+      namespace: "test-local-passthrough"
   - value: "local_pass_shadow"
     constraints:
-    namespace: "test-local-passthrough-shadow"
+      namespace: "test-local-passthrough-shadow"
   - value: "distributed_pass"
     constraints:
-    namespace: "test-distributed-passthrough"
+      namespace: "test-distributed-passthrough"
   - value: "distributed_pass"
     constraints:
-    namespace: "test-external-assignment"
+      namespace: "test-external-assignment"


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed to use the standard naming convention was not reflected in development config

<!-- Tell your future self why have you made these changes -->
**Why?**
when starting the services only the namespaces with default behavior where receiving the righe configuration from SD. the misconfigured ones were still operating since the result was an invalid migration mode, but the shadow mode was not really tested in local environment after the change of the property name.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local development

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no, only affect local development

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
