### PR TITLE
feat(executor-client): split function for local shard assignment

### DIFF
--- a/config/dynamicconfig/development.yaml
+++ b/config/dynamicconfig/development.yaml
@@ -73,17 +73,17 @@ system.readVisibilityStoreName:
   - value: "db"
 matching.enableClientAutoConfig:
 - value: true
-shardDistributor.MigrationMode:
+shardDistributor.migrationMode:
   - value: "onboarded"
   - value: "local_pass"
     constraints:
-    namespace: "test-local-passthrough"
+      namespace: "test-local-passthrough"
   - value: "local_pass_shadow"
     constraints:
-    namespace: "test-local-passthrough-shadow"
+      namespace: "test-local-passthrough-shadow"
   - value: "distributed_pass"
     constraints:
-    namespace: "test-distributed-passthrough"
+      namespace: "test-distributed-passthrough"
   - value: "distributed_pass"
     constraints:
-    namespace: "test-external-assignment"
+      namespace: "test-external-assignment"

--- a/service/sharddistributor/canary/executors/executors.go
+++ b/service/sharddistributor/canary/executors/executors.go
@@ -85,12 +85,6 @@ func NewExecutorsModule(params ExecutorsParams) {
 func Module(fixedNamespace, ephemeralNamespace, externalAssignmentNamespace string) fx.Option {
 	return fx.Module(
 		"Executors",
-		// Executors that are used for testing namespaces with the different modes of the migration
-		fx.Provide(
-			NewExecutorLocalPassthroughNamespace,
-			NewExecutorLocalPassthroughShadowNamespace,
-			NewExecutorDistributedPassthroughNamespace,
-		),
 		// Executor that is used for testing a namespace with fixed shards
 		fx.Provide(
 			func(params executorclient.Params[*processor.ShardProcessor]) (ExecutorResult, error) {

--- a/service/sharddistributor/canary/externalshardassignment/shardassigner.go
+++ b/service/sharddistributor/canary/externalshardassignment/shardassigner.go
@@ -2,6 +2,7 @@ package externalshardassignment
 
 import (
 	"context"
+	"math/rand"
 	"strconv"
 	"sync"
 	"time"
@@ -19,17 +20,19 @@ import (
 )
 
 const (
-	shardAssignmentInterval = 1 * time.Second
+	shardAssignmentInterval = 4 * time.Second
+	minimumAssignedShards   = 3
 )
 
 // ShardAssigneer assigns shards to the executor for canary testing
 type ShardAssigner struct {
-	logger         log.Logger
-	timeSource     clock.TimeSource
-	executorclient executorclient.Executor[*processorephemeral.ShardProcessor]
-	stopChan       chan struct{}
-	goRoutineWg    sync.WaitGroup
-	namespace      string
+	logger          log.Logger
+	timeSource      clock.TimeSource
+	shardProcessors map[string]*processorephemeral.ShardProcessor
+	executorclient  executorclient.Executor[*processorephemeral.ShardProcessor]
+	stopChan        chan struct{}
+	goRoutineWg     sync.WaitGroup
+	namespace       string
 }
 
 // ShardAssignerParams contains the dependencies needed to create a ShardParam
@@ -42,13 +45,15 @@ type ShardAssignerParams struct {
 
 // NewShardCreator creates a new ShardCreator instance with the given parameters and namespace
 func NewShardAssigner(params ShardAssignerParams, namespace string) *ShardAssigner {
+	sp := make(map[string]*processorephemeral.ShardProcessor)
 	return &ShardAssigner{
-		logger:         params.Logger,
-		timeSource:     params.TimeSource,
-		executorclient: params.Executorclient,
-		stopChan:       make(chan struct{}),
-		goRoutineWg:    sync.WaitGroup{},
-		namespace:      namespace,
+		logger:          params.Logger,
+		timeSource:      params.TimeSource,
+		shardProcessors: sp,
+		executorclient:  params.Executorclient,
+		stopChan:        make(chan struct{}),
+		goRoutineWg:     sync.WaitGroup{},
+		namespace:       namespace,
 	}
 }
 
@@ -92,6 +97,27 @@ func (s *ShardAssigner) process(ctx context.Context) {
 		case <-s.stopChan:
 			return
 		case <-ticker.Chan():
+			if len(s.shardProcessors) > minimumAssignedShards {
+				var shardToRemove string
+				shardToRemoveIndex := rand.Intn(len(s.shardProcessors))
+				for shardID := range s.shardProcessors {
+					if shardToRemoveIndex == 0 {
+						shardToRemove = shardID
+						break
+					}
+					shardToRemoveIndex--
+				}
+				err := s.executorclient.RemoveShardsFromLocalLogic([]string{shardToRemove})
+				if err != nil {
+					s.logger.Error("Failed to remove shards", tag.Error(err))
+					continue
+				}
+				delete(s.shardProcessors, shardToRemove)
+				s.logger.Info("Removed a shard from external source", tag.ShardKey(shardToRemove))
+
+			}
+
+			// Simulate the assignment of new shards
 			newAssignedShard := uuid.New().String()
 			s.logger.Info("Assign a new shard from external source", tag.ShardKey(newAssignedShard))
 			shardAssignment := map[string]*types.ShardAssignment{
@@ -99,14 +125,18 @@ func (s *ShardAssigner) process(ctx context.Context) {
 					Status: types.AssignmentStatusREADY,
 				},
 			}
-			s.executorclient.AssignShardsFromLocalLogic(context.Background(), shardAssignment)
+			err := s.executorclient.AssignShardsFromLocalLogic(context.Background(), shardAssignment)
+			if err != nil {
+				s.logger.Error("Failed to assign shard from external source", tag.Error(err))
+				continue
+			}
 			sp, err := s.executorclient.GetShardProcess(ctx, newAssignedShard)
 			if err != nil {
 				s.logger.Error("failed to get shard assigned", tag.ShardKey(newAssignedShard), tag.Error(err))
 			} else {
 				s.logger.Info("shard assigned", tag.ShardStatus(string(sp.GetShardReport().Status)), tag.ShardLoad(strconv.FormatFloat(sp.GetShardReport().ShardLoad, 'f', -1, 64)))
 			}
-
+			s.shardProcessors[newAssignedShard] = sp
 		}
 	}
 }

--- a/service/sharddistributor/canary/module.go
+++ b/service/sharddistributor/canary/module.go
@@ -48,6 +48,6 @@ func opts(names NamespacesNames) fx.Option {
 		// Instantiate executors for multiple namespaces
 		executors.Module(names.FixedNamespace, names.EphemeralNamespace, names.ExternalAssignmentNamespace),
 
-		processorephemeral.ShardCreatorModule([]string{names.EphemeralNamespace, names.ExternalAssignmentNamespace, "test-local-passthrough-shadow"}),
+		processorephemeral.ShardCreatorModule([]string{names.EphemeralNamespace}),
 	)
 }

--- a/service/sharddistributor/client/executorclient/client.go
+++ b/service/sharddistributor/client/executorclient/client.go
@@ -50,8 +50,10 @@ type Executor[SP ShardProcessor] interface {
 	// Get the current metadata of the executor
 	GetMetadata() map[string]string
 
-	// Used during the migration during local-passthrough and local-passthrough-shadow
-	AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment)
+	// AssignShardsFromLocalLogic is used for the migration during local-passthrough, local-passthrough-shadow, distributed-passthrough
+	AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) error
+	// RemoveShardsFromLocalLogic is used for the migration during local-passthrough, local-passthrough-shadow, distributed-passthrough
+	RemoveShardsFromLocalLogic(shardIDs []string) error
 }
 
 type Params[SP ShardProcessor] struct {

--- a/service/sharddistributor/client/executorclient/interface_mock.go
+++ b/service/sharddistributor/client/executorclient/interface_mock.go
@@ -144,9 +144,11 @@ func (m *MockExecutor[SP]) EXPECT() *MockExecutorMockRecorder[SP] {
 }
 
 // AssignShardsFromLocalLogic mocks base method.
-func (m *MockExecutor[SP]) AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) {
+func (m *MockExecutor[SP]) AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "AssignShardsFromLocalLogic", ctx, shardAssignment)
+	ret := m.ctrl.Call(m, "AssignShardsFromLocalLogic", ctx, shardAssignment)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // AssignShardsFromLocalLogic indicates an expected call of AssignShardsFromLocalLogic.
@@ -182,6 +184,20 @@ func (m *MockExecutor[SP]) GetShardProcess(ctx context.Context, shardID string) 
 func (mr *MockExecutorMockRecorder[SP]) GetShardProcess(ctx, shardID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardProcess", reflect.TypeOf((*MockExecutor[SP])(nil).GetShardProcess), ctx, shardID)
+}
+
+// RemoveShardsFromLocalLogic mocks base method.
+func (m *MockExecutor[SP]) RemoveShardsFromLocalLogic(shardIDs []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveShardsFromLocalLogic", shardIDs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveShardsFromLocalLogic indicates an expected call of RemoveShardsFromLocalLogic.
+func (mr *MockExecutorMockRecorder[SP]) RemoveShardsFromLocalLogic(shardIDs any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveShardsFromLocalLogic", reflect.TypeOf((*MockExecutor[SP])(nil).RemoveShardsFromLocalLogic), shardIDs)
 }
 
 // SetMetadata mocks base method.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Instead of having a function that replace the assignment generated with the local logic we have two different a functions, one to assign a new shard and the other to remove the assignment. Also these function are used in the canary to simulate the shard assignment.
The changes to the canary are made to make more similar to the matching service.


<!-- Tell your future self why have you made these changes -->
**Why?**
we need to onboard matching and to model the local logic with assignment replacement is adding too much complexity.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local testing and unit testing

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
the change is only used in canary service which has been tested

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
