### PR TITLE
fix(RangeCompleteHistoryTask): fix infinite loop when page size provided is <= 0

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -2410,7 +2410,8 @@ func IsBackgroundTransientError(err error) bool {
 func HasMoreRowsToDelete(rowsDeleted, batchSize int) bool {
 	if rowsDeleted < batchSize || // all target tasks are deleted
 		rowsDeleted == UnknownNumRowsAffected || // underlying database does not support rows affected, so pageSize is not honored and all target tasks are deleted
-		rowsDeleted > batchSize { // pageSize is not honored and all tasks are deleted
+		rowsDeleted > batchSize ||
+		batchSize <= 0 { // if batchSize is <= 0 the attempt is for the request to be unbounded and remove all rows from min to max
 		return false
 	}
 	return true

--- a/common/persistence/data_manager_interfaces_test.go
+++ b/common/persistence/data_manager_interfaces_test.go
@@ -227,6 +227,9 @@ func TestHasMoreRowsToDelete(t *testing.T) {
 	assert.False(t, HasMoreRowsToDelete(11, 10))
 	assert.False(t, HasMoreRowsToDelete(9, 10))
 	assert.False(t, HasMoreRowsToDelete(-1, 10))
+	assert.False(t, HasMoreRowsToDelete(100, 0))
+	assert.False(t, HasMoreRowsToDelete(0, 0))
+	assert.False(t, HasMoreRowsToDelete(50, -1))
 
 }
 func TestTransferTaskInfo(t *testing.T) {


### PR DESCRIPTION
#7470
<!-- Describe what has changed in this PR -->
**What changed?**
Add a check to exit completion loop if pageSize is less or equal to 0.

<!-- Tell your future self why have you made these changes -->
**Why?**
When pageSize/batchSize is set to zero it's an unbounded request for completion in sql dbs. It's not used by non sql dbs. That means that we don't need to execute it again within the same request.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
