### PR TITLE
fix(shard-distributor): prevent context cancellation in streaming WatchNamespaceState RPC

### DIFF
--- a/client/templates/timeout.tmpl
+++ b/client/templates/timeout.tmpl
@@ -5,7 +5,7 @@
 {{ $Decorator := (printf "%s%s" $ClientName .Interface.Name) }}
 {{$largeTimeoutAPIs := list "adminClient.GetCrossClusterTasks" "adminClient.GetReplicationMessages"}}
 {{$longPollTimeoutAPIs := list "frontendClient.ListArchivedWorkflowExecutions" "frontendClient.PollForActivityTask" "frontendClient.PollForDecisionTask" "matchingClient.PollForActivityTask" "matchingClient.PollForDecisionTask"}}
-{{$noTimeoutAPIs := list "historyClient.GetReplicationMessages" "historyClient.GetDLQReplicationMessages" "historyClient.CountDLQMessages" "historyClient.ReadDLQMessages" "historyClient.PurgeDLQMessages" "historyClient.MergeDLQMessages" "historyClient.GetCrossClusterTasks" "historyClient.GetFailoverInfo" "matchingClient.GetTaskListsByDomain"}}
+{{$noTimeoutAPIs := list "historyClient.GetReplicationMessages" "historyClient.GetDLQReplicationMessages" "historyClient.CountDLQMessages" "historyClient.ReadDLQMessages" "historyClient.PurgeDLQMessages" "historyClient.MergeDLQMessages" "historyClient.GetCrossClusterTasks" "historyClient.GetFailoverInfo" "matchingClient.GetTaskListsByDomain" "sharddistributorClient.WatchNamespaceState"}}
 {{/*
  $fieldMap defines a map of the decorator struct fields
  with field name as the key and field type as the value

--- a/client/wrappers/timeout/sharddistributor_generated.go
+++ b/client/wrappers/timeout/sharddistributor_generated.go
@@ -40,7 +40,5 @@ func (c *sharddistributorClient) GetShardOwner(ctx context.Context, gp1 *types.G
 }
 
 func (c *sharddistributorClient) WatchNamespaceState(ctx context.Context, wp1 *types.WatchNamespaceStateRequest, p1 ...yarpc.CallOption) (w1 sharddistributor.WatchNamespaceStateClient, err error) {
-	ctx, cancel := createContext(ctx, c.timeout)
-	defer cancel()
 	return c.client.WatchNamespaceState(ctx, wp1, p1...)
 }


### PR DESCRIPTION
**What changed?**
Added `sharddistributorClient.WatchNamespaceState` to the `noTimeoutAPIs` list in the timeout wrapper template and regenerated the wrapper code.

**Why?**
The timeout wrapper was immediately cancelling the context for streaming RPCs, causing `WatchNamespaceState` streams to fail with "context canceled" errors. For streaming RPCs, the context must remain alive for the stream's entire lifetime, not just the initial call.

**How did you test it?**
Verified locally that WatchNamespaceState streams now remain open without premature cancellation.

**Potential risks**
Low risk. This only affects the WatchNamespaceState streaming RPC, allowing it to stay open as intended rather than being cancelled immediately.

**Release notes**


**Documentation Changes**
None