### PR TITLE
feat(shard-distributor): add GetMetadata and GetNamespace methods to executor interface

### DIFF
--- a/service/sharddistributor/client/executorclient/client.go
+++ b/service/sharddistributor/client/executorclient/client.go
@@ -45,6 +45,9 @@ type Executor[SP ShardProcessor] interface {
 
 	GetShardProcess(ctx context.Context, shardID string) (SP, error)
 
+	// Get the namespace this executor is responsible for
+	GetNamespace() string
+
 	// Set metadata for the executor
 	SetMetadata(metadata map[string]string)
 	// Get the current metadata of the executor

--- a/service/sharddistributor/client/executorclient/clientimpl.go
+++ b/service/sharddistributor/client/executorclient/clientimpl.go
@@ -462,6 +462,10 @@ func (e *executorImpl[SP]) emitMetricsConvergence(converged bool) {
 	}
 }
 
+func (e *executorImpl[SP]) GetNamespace() string {
+	return e.namespace
+}
+
 func (e *executorImpl[SP]) SetMetadata(metadata map[string]string) {
 	e.metadata.Set(metadata)
 }

--- a/service/sharddistributor/client/executorclient/interface_mock.go
+++ b/service/sharddistributor/client/executorclient/interface_mock.go
@@ -171,6 +171,20 @@ func (mr *MockExecutorMockRecorder[SP]) GetMetadata() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetadata", reflect.TypeOf((*MockExecutor[SP])(nil).GetMetadata))
 }
 
+// GetNamespace mocks base method.
+func (m *MockExecutor[SP]) GetNamespace() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetNamespace")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetNamespace indicates an expected call of GetNamespace.
+func (mr *MockExecutorMockRecorder[SP]) GetNamespace() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetNamespace", reflect.TypeOf((*MockExecutor[SP])(nil).GetNamespace))
+}
+
 // GetShardProcess mocks base method.
 func (m *MockExecutor[SP]) GetShardProcess(ctx context.Context, shardID string) (SP, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
**What changed?**
Added `GetMetadata()` and `GetNamespace()` methods to the Executor interface, with implementations in executorImpl and updated mocks.

**Why?**
Allow components that interact with executors to access their metadata (like gRPC address) and namespace without additional lookups. This is needed for the canary ping handler to identify which executor is responding.

**How did you test it?**
Verified methods return correct values. Updated mock to include new methods.

**Potential risks**
None - this only adds interface methods that return existing data.

**Release notes**

**Documentation Changes**
None