### PR TITLE
feat(matching): use ShardProcessors instead of TaskListManagers

### DIFF
--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -681,6 +681,7 @@ func (s *matchingEngineSuite) SyncMatchTasks(taskType int, enableIsolation bool)
 	// So we can get snapshots
 	scope := tally.NewTestScope("test", nil)
 	s.matchingEngine.metricsClient = metrics.NewClient(scope, metrics.Matching, metrics.HistogramMigration{})
+	s.matchingEngine.taskListsFactory.MetricsClient = metrics.NewClient(scope, metrics.Matching, metrics.HistogramMigration{})
 
 	testParam := newTestParam(s.T(), taskType)
 	s.taskManager.SetRangeID(testParam.TaskListID, initialRangeID)
@@ -840,6 +841,7 @@ func (s *matchingEngineSuite) ConcurrentAddAndPollTasks(taskType int, workerCoun
 	}
 	scope := tally.NewTestScope("test", nil)
 	s.matchingEngine.metricsClient = metrics.NewClient(scope, metrics.Matching, metrics.HistogramMigration{})
+	s.matchingEngine.taskListsFactory.MetricsClient = metrics.NewClient(scope, metrics.Matching, metrics.HistogramMigration{})
 
 	const initialRangeID = 0
 	const rangeSize = 3

--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -38,7 +38,7 @@ import (
 
 type (
 	Manager interface {
-		Start() error
+		Start(ctx context.Context) error
 		Stop()
 		// AddTask adds a task to the task list. This method will first attempt a synchronous
 		// match with a poller. When that fails, task will be written to database and later

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -214,17 +214,17 @@ func (mr *MockManagerMockRecorder) ReleaseBlockedPollers() *gomock.Call {
 }
 
 // Start mocks base method.
-func (m *MockManager) Start() error {
+func (m *MockManager) Start(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start")
+	ret := m.ctrl.Call(m, "Start", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockManagerMockRecorder) Start() *gomock.Call {
+func (mr *MockManagerMockRecorder) Start(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockManager)(nil).Start), ctx)
 }
 
 // Stop mocks base method.
@@ -786,17 +786,17 @@ func (mr *MockShardProcessorMockRecorder) SetShardStatus(arg0 any) *gomock.Call 
 }
 
 // Start mocks base method.
-func (m *MockShardProcessor) Start() error {
+func (m *MockShardProcessor) Start(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Start")
+	ret := m.ctrl.Call(m, "Start", ctx)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Start indicates an expected call of Start.
-func (mr *MockShardProcessorMockRecorder) Start() *gomock.Call {
+func (mr *MockShardProcessorMockRecorder) Start(ctx any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockShardProcessor)(nil).Start))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockShardProcessor)(nil).Start), ctx)
 }
 
 // Stop mocks base method.

--- a/service/matching/tasklist/shard_processor_factory.go
+++ b/service/matching/tasklist/shard_processor_factory.go
@@ -1,0 +1,80 @@
+package tasklist
+
+import (
+	"time"
+
+	"github.com/uber/cadence/client/history"
+	"github.com/uber/cadence/client/matching"
+	"github.com/uber/cadence/common/cache"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/cluster"
+	"github.com/uber/cadence/common/isolationgroup"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/metrics"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/types"
+	"github.com/uber/cadence/service/matching/config"
+)
+
+// ShardProcessorFactory is a generic factory for creating ShardProcessor instances.
+type ShardProcessorFactory struct {
+	DomainCache     cache.DomainCache
+	Logger          log.Logger
+	MetricsClient   metrics.Client
+	TaskManager     persistence.TaskManager
+	ClusterMetadata cluster.Metadata
+	IsolationState  isolationgroup.State
+	MatchingClient  matching.Client
+	CloseCallback   func(processor ShardProcessor)
+	Cfg             *config.Config
+	TimeSource      clock.TimeSource
+	CreateTime      time.Time
+	HistoryService  history.Client
+}
+
+func (spf ShardProcessorFactory) NewShardProcessor(shardID string) (ShardProcessor, error) {
+	name, err := newTaskListName(shardID)
+	if err != nil {
+		return nil, err
+	}
+	identifier := &Identifier{
+		qualifiedTaskListName: name,
+	}
+	params := ManagerParams{
+		DomainCache:     spf.DomainCache,
+		Logger:          spf.Logger,
+		MetricsClient:   spf.MetricsClient,
+		TaskManager:     spf.TaskManager,
+		ClusterMetadata: spf.ClusterMetadata,
+		IsolationState:  spf.IsolationState,
+		MatchingClient:  spf.MatchingClient,
+		CloseCallback:   spf.CloseCallback,
+		TaskList:        identifier,
+		TaskListKind:    0,
+		Cfg:             spf.Cfg,
+		TimeSource:      spf.TimeSource,
+		CreateTime:      spf.TimeSource.Now(),
+		HistoryService:  spf.HistoryService,
+	}
+	return NewShardProcessor(params)
+}
+
+func (spf ShardProcessorFactory) NewShardProcessorWithTaskListIdentifier(taskListID *Identifier, taskListKind types.TaskListKind) (ShardProcessor, error) {
+	params := ManagerParams{
+		DomainCache:     spf.DomainCache,
+		Logger:          spf.Logger,
+		MetricsClient:   spf.MetricsClient,
+		TaskManager:     spf.TaskManager,
+		ClusterMetadata: spf.ClusterMetadata,
+		IsolationState:  spf.IsolationState,
+		MatchingClient:  spf.MatchingClient,
+		CloseCallback:   spf.CloseCallback,
+		TaskList:        taskListID,
+		TaskListKind:    taskListKind,
+		Cfg:             spf.Cfg,
+		TimeSource:      spf.TimeSource,
+		CreateTime:      spf.TimeSource.Now(),
+		HistoryService:  spf.HistoryService,
+	}
+	return NewShardProcessor(params)
+}

--- a/service/matching/tasklist/shard_processor_test.go
+++ b/service/matching/tasklist/shard_processor_test.go
@@ -46,7 +46,7 @@ func paramsForTaskListManager(t *testing.T, taskListID *Identifier, taskListKind
 		clusterMetadata,
 		deps.mockIsolationState,
 		deps.mockMatchingClient,
-		func(Manager) {},
+		func(ShardProcessor) {},
 		taskListID,
 		taskListKind,
 		cfg,

--- a/service/sharddistributor/canary/processor/shardprocessor.go
+++ b/service/sharddistributor/canary/processor/shardprocessor.go
@@ -49,10 +49,11 @@ func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 }
 
 // Start implements executorclient.ShardProcessor.
-func (p *ShardProcessor) Start(ctx context.Context) {
+func (p *ShardProcessor) Start(ctx context.Context) error {
 	p.logger.Info("Starting shard processor", zap.String("shardID", p.shardID))
 	p.goRoutineWg.Add(1)
 	go p.process(ctx)
+	return nil
 }
 
 // Stop implements executorclient.ShardProcessor.

--- a/service/sharddistributor/canary/processorephemeral/shardprocessor.go
+++ b/service/sharddistributor/canary/processorephemeral/shardprocessor.go
@@ -59,10 +59,11 @@ func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 }
 
 // Start implements executorclient.ShardProcessor.
-func (p *ShardProcessor) Start(ctx context.Context) {
+func (p *ShardProcessor) Start(ctx context.Context) error {
 	p.logger.Info("Starting shard processor", zap.String("shardID", p.shardID))
 	p.goRoutineWg.Add(1)
 	go p.process(ctx)
+	return nil
 }
 
 // Stop implements executorclient.ShardProcessor.

--- a/service/sharddistributor/client/executorclient/client.go
+++ b/service/sharddistributor/client/executorclient/client.go
@@ -30,7 +30,7 @@ type ShardReport struct {
 }
 
 type ShardProcessor interface {
-	Start(ctx context.Context)
+	Start(ctx context.Context) error
 	Stop()
 	GetShardReport() ShardReport
 }

--- a/service/sharddistributor/client/executorclient/interface_mock.go
+++ b/service/sharddistributor/client/executorclient/interface_mock.go
@@ -57,9 +57,11 @@ func (mr *MockShardProcessorMockRecorder) GetShardReport() *gomock.Call {
 }
 
 // Start mocks base method.
-func (m *MockShardProcessor) Start(ctx context.Context) {
+func (m *MockShardProcessor) Start(ctx context.Context) error {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "Start", ctx)
+	ret := m.ctrl.Call(m, "Start", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
 }
 
 // Start indicates an expected call of Start.


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Instead of using tasklistmanagers we start using the shardprocessor to onboard matching to the shardDistributor.
- The shardProcessor factory is introduced and used to create new shardProcessors. 
- The executor client library is changed to have Start() function which returns an error.

<!-- Tell your future self why have you made these changes -->
**Why?**
The executor library is using the concept of shardProcessor to monitor a shard, in the case of matching a shardProcessor can be seen as a task executor manager. 
The change in the executor library is necessary because moving the logic from the 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
tested locally and with unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
matching service could be affected since we are changing the way we create new tasks.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
