### PR TITLE
fix(jitter): allow input equal to 0 to be provided without panic

### DIFF
--- a/common/backoff/jitter.go
+++ b/common/backoff/jitter.go
@@ -47,7 +47,7 @@ func JitInt64(input int64, coefficient float64) int64 {
 // JitFloat64 return random number from (1-coefficient)*input to (1+coefficient)*input, inclusive, exclusive
 func JitFloat64(input float64, coefficient float64) float64 {
 	validateCoefficient(coefficient)
-	if coefficient == 0 {
+	if coefficient == 0 || input == 0 {
 		return input
 	}
 

--- a/common/backoff/jitter_test.go
+++ b/common/backoff/jitter_test.go
@@ -91,6 +91,10 @@ func (s *jitterSuite) TestJitFloat64WithZeroCoefficient() {
 	}
 }
 
+func (s *jitterSuite) TestJitFloat64WithZeroInput() {
+	s.Equal(float64(0), JitFloat64(0, 0.5))
+}
+
 func (s *jitterSuite) TestJitDuration() {
 	input := time.Duration(1099511627776)
 	coefficient := float64(0.1)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Check if input to Jit is zero and if it is, return the input as the result

<!-- Tell your future self why have you made these changes -->
**Why?**
JitInt64 calls rand.Int63n(0) which panics because you can't get a random number in the range [0,0). Same for JitFloat64.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
Currently, if the value is 0 it panics. This address the panic and allows the input to be zero.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
