### PR TITLE
chore: change logger to warn for nil mutable state in executeDeleteHistoryEventTask

### DIFF
--- a/service/history/task/timer_task_executor_base.go
+++ b/service/history/task/timer_task_executor_base.go
@@ -101,7 +101,7 @@ func (t *timerTaskExecutorBase) executeDeleteHistoryEventTask(
 		return err
 	}
 	if mutableState == nil {
-		t.logger.Debug("could not load mutable state while attempting to clean up workflow",
+		t.logger.Warn("could not load mutable state while attempting to clean up workflow",
 			tag.WorkflowID(task.WorkflowID),
 			tag.WorkflowRunID(task.RunID),
 			tag.WorkflowDomainID(task.DomainID),


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Changed logger type from Debug to Warn.

<!-- Tell your future self why have you made these changes -->
**Why?**
It seems that there is a leak deleting history records from the db on workflow completion. Currently the logs type is Debug which makes it different to find it for a more in depth investigation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
