### PR TITLE
feat(docker): add docker-compose configuration for OpenSearch

### DIFF
--- a/docker/docker-compose-opensearch.yml
+++ b/docker/docker-compose-opensearch.yml
@@ -56,6 +56,7 @@ services:
       - "5601:5601"
     environment:
       OPENSEARCH_HOSTS: '["http://opensearch:9200"]'
+      DISABLE_SECURITY_DASHBOARDS_PLUGIN: "true"
     depends_on:
       - opensearch
   cadence:


### PR DESCRIPTION
**What changed?**
Added a new `docker-compose-opensearch.yml` file that provides a complete deployment configuration for running Cadence with OpenSearch as the advanced visibility store. This mirrors the existing Elasticsearch docker-compose setups but uses OpenSearch 2.13.0.

The configuration includes:
- Cassandra for persistence
- OpenSearch 2.13.0 for advanced visibility (with security disabled for local dev)
- OpenSearch Dashboards on port 5601 for visualization
- Kafka for async workflow processing
- Cadence server configured with `ES_VERSION=os2`
- Cadence Web UI
- Prometheus and Grafana for monitoring

**Why?**
OpenSearch is a popular open-source fork of Elasticsearch that many organizations are adopting. Cadence already supports OpenSearch through the `ES_VERSION=os2` configuration, but there was no ready-to-use docker-compose file for users who want to quickly deploy Cadence with OpenSearch for local development or testing.

This addition:
- Provides parity with existing Elasticsearch deployment options (es.yml, es-v7.yml)
- Makes it easier for users to evaluate OpenSearch as an advanced visibility backend
- Offers an alternative for users who prefer OpenSearch over Elasticsearch

**How did you test it?**
Tested locally using Docker Desktop:
- Successfully deployed the full stack using `docker-compose -f docker/docker-compose-opensearch.yml up`
- Verified all services started correctly:
  - Cassandra health check passed
  - OpenSearch accessible on port 9200
  - OpenSearch Dashboards running on port 5601
  - Kafka broker operational
  - Cadence server connected to OpenSearch
  - Cadence Web UI accessible on port 8088
  - Prometheus and Grafana monitoring active

**Potential risks**
None. This is a new docker-compose configuration file that doesn't modify any existing code or configurations. Users must explicitly choose to use this file, so there's no impact on existing deployments or workflows.

**Release notes**
New Feature: Added `docker-compose-opensearch.yml` for deploying Cadence with OpenSearch 2.13.0 as the advanced visibility store. This provides users with an easy-to-use deployment option for testing and developing with OpenSearch.

**Documentation Changes**
May want to update the setup documentation at https://cadenceworkflow.io/docs/operation-guide/setup/ to mention the new OpenSearch docker-compose option alongside the existing Elasticsearch options. I can open a follow-up PR in the cadence-docs repo once this is merged.