### PR TITLE
fix: field mapping for list-failover-history should do graceful/force failover types 

### DIFF
--- a/common/persistence/domain_audit_log.go
+++ b/common/persistence/domain_audit_log.go
@@ -73,10 +73,16 @@ func (auditLog *DomainAuditLog) ToFailoverEvents() *types.FailoverEvent {
 		}
 	}
 
+	failoverType := types.FailoverTypeForce
+	if auditLog.StateAfter.FailoverEndTime != nil {
+		failoverType = types.FailoverTypeGraceful
+	}
+
 	return &types.FailoverEvent{
 		ID:               &auditLog.EventID,
 		CreatedTime:      common.Ptr(auditLog.CreatedTime.UnixNano()),
 		ClusterFailovers: clusterFailovers,
+		FailoverType:     &failoverType,
 	}
 }
 

--- a/common/persistence/domain_audit_log_test.go
+++ b/common/persistence/domain_audit_log_test.go
@@ -53,8 +53,9 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 				OperationType: DomainAuditOperationTypeFailover,
 			},
 			expected: &types.FailoverEvent{
-				ID:          stringPtr("event-1"),
-				CreatedTime: int64Ptr(now.UnixNano()),
+				ID:           stringPtr("event-1"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: []*types.ClusterFailover{
 					{
 						FromCluster: &types.ActiveClusterInfo{
@@ -117,8 +118,9 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 				OperationType: DomainAuditOperationTypeFailover,
 			},
 			expected: &types.FailoverEvent{
-				ID:          stringPtr("event-2"),
-				CreatedTime: int64Ptr(now.UnixNano()),
+				ID:           stringPtr("event-2"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: []*types.ClusterFailover{
 					{
 						FromCluster: &types.ActiveClusterInfo{
@@ -179,8 +181,9 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 				OperationType: DomainAuditOperationTypeFailover,
 			},
 			expected: &types.FailoverEvent{
-				ID:          stringPtr("event-3"),
-				CreatedTime: int64Ptr(now.UnixNano()),
+				ID:           stringPtr("event-3"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: []*types.ClusterFailover{
 					{
 						FromCluster: &types.ActiveClusterInfo{
@@ -251,8 +254,9 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 				OperationType: DomainAuditOperationTypeFailover,
 			},
 			expected: &types.FailoverEvent{
-				ID:          stringPtr("event-4"),
-				CreatedTime: int64Ptr(now.UnixNano()),
+				ID:           stringPtr("event-4"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: []*types.ClusterFailover{
 					{
 						FromCluster: &types.ActiveClusterInfo{
@@ -311,8 +315,9 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 				OperationType: DomainAuditOperationTypeFailover,
 			},
 			expected: &types.FailoverEvent{
-				ID:          stringPtr("event-5"),
-				CreatedTime: int64Ptr(now.UnixNano()),
+				ID:           stringPtr("event-5"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: []*types.ClusterFailover{
 					{
 						ToCluster: &types.ActiveClusterInfo{
@@ -359,6 +364,7 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 			expected: &types.FailoverEvent{
 				ID:               stringPtr("event-6"),
 				CreatedTime:      int64Ptr(now.UnixNano()),
+				FailoverType:     types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: nil,
 			},
 		},
@@ -373,6 +379,7 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 			},
 			expected: &types.FailoverEvent{
 				ID:               stringPtr("event-7"),
+				FailoverType:     types.FailoverTypeForce.Ptr(),
 				CreatedTime:      int64Ptr(now.UnixNano()),
 				ClusterFailovers: nil,
 			},
@@ -425,8 +432,9 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 				OperationType: DomainAuditOperationTypeFailover,
 			},
 			expected: &types.FailoverEvent{
-				ID:          stringPtr("event-8"),
-				CreatedTime: int64Ptr(now.UnixNano()),
+				ID:           stringPtr("event-8"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: []*types.ClusterFailover{
 					{
 						FromCluster: &types.ActiveClusterInfo{
@@ -489,8 +497,9 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 				OperationType: DomainAuditOperationTypeFailover,
 			},
 			expected: &types.FailoverEvent{
-				ID:          stringPtr("event-9"),
-				CreatedTime: int64Ptr(now.UnixNano()),
+				ID:           stringPtr("event-9"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeForce.Ptr(),
 				ClusterFailovers: []*types.ClusterFailover{
 					{
 						FromCluster: &types.ActiveClusterInfo{
@@ -512,6 +521,44 @@ func TestDomainAuditLog_ToFailoverEvents(t *testing.T) {
 						ClusterAttribute: &types.ClusterAttribute{
 							Scope: "region",
 							Name:  "us-west",
+						},
+					},
+				},
+			},
+		},
+		"graceful failover": {
+			auditLog: &DomainAuditLog{
+				EventID:     "event-9",
+				DomainID:    "domain-9",
+				CreatedTime: now,
+				StateBefore: &GetDomainResponse{
+					ReplicationConfig: &DomainReplicationConfig{
+						ActiveClusterName: "region-us-east",
+					},
+					FailoverVersion: 800,
+				},
+				StateAfter: &GetDomainResponse{
+					ReplicationConfig: &DomainReplicationConfig{
+						ActiveClusterName: "region-us-west",
+					},
+					FailoverVersion: 801,
+					FailoverEndTime: int64Ptr(now.Add(1 * time.Hour).UnixNano()),
+				},
+				OperationType: DomainAuditOperationTypeFailover,
+			},
+			expected: &types.FailoverEvent{
+				ID:           stringPtr("event-9"),
+				CreatedTime:  int64Ptr(now.UnixNano()),
+				FailoverType: types.FailoverTypeGraceful.Ptr(),
+				ClusterFailovers: []*types.ClusterFailover{
+					{
+						FromCluster: &types.ActiveClusterInfo{
+							ActiveClusterName: "region-us-east",
+							FailoverVersion:   800,
+						},
+						ToCluster: &types.ActiveClusterInfo{
+							ActiveClusterName: "region-us-west",
+							FailoverVersion:   801,
 						},
 					},
 				},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
This fixes a field mapping for failover type which I missed. While we don't support graceful failover with the failover endpoint presently, and may not decide to support it in the future, it's a valid type of failover for now and we should include it's info in the history. 

<!-- Tell your future self why have you made these changes -->
**Why?**


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

tested by running locally and printing the output in JSON, where it's rendered

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
