### PR TITLE
feat(shard-distributor): add GetAssignedShardsCount method and limiting in shard creator canary

### DIFF
--- a/service/sharddistributor/client/executorclient/client.go
+++ b/service/sharddistributor/client/executorclient/client.go
@@ -55,6 +55,9 @@ type Executor[SP ShardProcessor] interface {
 	// Get the current metadata of the executor
 	GetMetadata() map[string]string
 
+	// GetAssignedShardsCount returns the number of currently assigned shards
+	GetAssignedShardsCount() int64
+
 	// AssignShardsFromLocalLogic is used for the migration during local-passthrough, local-passthrough-shadow, distributed-passthrough
 	AssignShardsFromLocalLogic(ctx context.Context, shardAssignment map[string]*types.ShardAssignment) error
 	// RemoveShardsFromLocalLogic is used for the migration during local-passthrough, local-passthrough-shadow, distributed-passthrough

--- a/service/sharddistributor/client/executorclient/interface_mock.go
+++ b/service/sharddistributor/client/executorclient/interface_mock.go
@@ -204,6 +204,20 @@ func (mr *MockExecutorMockRecorder[SP]) AssignShardsFromLocalLogic(ctx, shardAss
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AssignShardsFromLocalLogic", reflect.TypeOf((*MockExecutor[SP])(nil).AssignShardsFromLocalLogic), ctx, shardAssignment)
 }
 
+// GetAssignedShardsCount mocks base method.
+func (m *MockExecutor[SP]) GetAssignedShardsCount() int64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAssignedShardsCount")
+	ret0, _ := ret[0].(int64)
+	return ret0
+}
+
+// GetAssignedShardsCount indicates an expected call of GetAssignedShardsCount.
+func (mr *MockExecutorMockRecorder[SP]) GetAssignedShardsCount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAssignedShardsCount", reflect.TypeOf((*MockExecutor[SP])(nil).GetAssignedShardsCount))
+}
+
 // GetMetadata mocks base method.
 func (m *MockExecutor[SP]) GetMetadata() map[string]string {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* `GetAssignedShardsCount` method was added to `Executor`
* `ShardCreator` will stop creating shards if the number of assigned shards is greater than the maximum number of assigned **shards**
* `managedProcessorsCount` counter was added to `Executor`


<!-- Tell your future self why have you made these changes -->
**Why?**
We observed some instability in the cluster caused by non-stop shard creation by canary. This PR limits canary to create no more than 1K shard per running instance. 

`managedProcessorsCount` was added to count number of created managed processor. `sync.Map` doesn't have `Len/Count` methods and only a [range over the whole Map](https://github.com/golang/go/issues/20680#issuecomment-308813150) is a way to get the size of the map. To avoid N operations, the counter was added. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Unit test
* Integration test
* Run on the dev env 
