### PR TITLE
fix(shard-distributor): remove usage of context from Start in canary

### DIFF
--- a/service/sharddistributor/canary/processor/shardprocessor.go
+++ b/service/sharddistributor/canary/processor/shardprocessor.go
@@ -49,10 +49,10 @@ func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 }
 
 // Start implements executorclient.ShardProcessor.
-func (p *ShardProcessor) Start(ctx context.Context) error {
+func (p *ShardProcessor) Start(_ context.Context) error {
 	p.logger.Info("Starting shard processor", zap.String("shardID", p.shardID))
 	p.goRoutineWg.Add(1)
-	go p.process(ctx)
+	go p.process()
 	return nil
 }
 
@@ -63,7 +63,7 @@ func (p *ShardProcessor) Stop() {
 	p.goRoutineWg.Wait()
 }
 
-func (p *ShardProcessor) process(ctx context.Context) {
+func (p *ShardProcessor) process() {
 	defer p.goRoutineWg.Done()
 
 	ticker := p.timeSource.NewTicker(processInterval)
@@ -71,9 +71,8 @@ func (p *ShardProcessor) process(ctx context.Context) {
 
 	for {
 		select {
-		case <-ctx.Done():
-			return
 		case <-p.stopChan:
+			p.logger.Info("Stopping shard processor", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps))
 			return
 		case <-ticker.Chan():
 			p.processSteps++


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* `context.Context` from `Start` `method in processor/processorephemeral.ShardProcessor` is not propagated to `process` method

<!-- Tell your future self why have you made these changes -->
**Why?**
`context.Context` can be directly propagated from an external RPC call, limiting the lifetime of a `ShardProcessor` to the RPC call's lifetime. `Stop` function is already responsible for an appropriate stopping of `ShardProcessor`. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Unit test
* Run canary on dev env
