### PR TITLE
fix(cadence-matching): start and stop the executor

### DIFF
--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -173,11 +173,13 @@ func NewEngine(
 }
 
 func (e *matchingEngineImpl) Start() {
+	e.executor.Start(context.Background())
 	e.registerDomainFailoverCallback()
 }
 
 func (e *matchingEngineImpl) Stop() {
 	close(e.shutdown)
+	e.executor.Stop()
 	// Executes Stop() on each task list outside of lock
 	for _, l := range e.getTaskLists(math.MaxInt32) {
 		l.Stop()

--- a/service/matching/handler/membership_test.go
+++ b/service/matching/handler/membership_test.go
@@ -185,6 +185,8 @@ func TestMembershipSubscriptionRecoversAfterPanic(t *testing.T) {
 func TestSubscriptionAndShutdown(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockResolver := membership.NewMockResolver(ctrl)
+	mockExecutor := executorclient.NewMockExecutor[tasklist.ShardProcessor](ctrl)
+	mockExecutor.EXPECT().Stop()
 
 	shutdownWG := sync.WaitGroup{}
 	shutdownWG.Add(1)
@@ -200,6 +202,7 @@ func TestSubscriptionAndShutdown(t *testing.T) {
 		shutdown:    make(chan struct{}),
 		logger:      log.NewNoop(),
 		domainCache: mockDomainCache,
+		executor:    mockExecutor,
 	}
 
 	mockResolver.EXPECT().WhoAmI().Return(membership.NewDetailedHostInfo("host2", "host2", nil), nil).AnyTimes()
@@ -215,6 +218,8 @@ func TestSubscriptionAndShutdown(t *testing.T) {
 func TestSubscriptionAndErrorReturned(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockResolver := membership.NewMockResolver(ctrl)
+	mockExecutor := executorclient.NewMockExecutor[tasklist.ShardProcessor](ctrl)
+	mockExecutor.EXPECT().Stop()
 
 	mockDomainCache := cache.NewMockDomainCache(ctrl)
 
@@ -233,6 +238,7 @@ func TestSubscriptionAndErrorReturned(t *testing.T) {
 		shutdown:    make(chan struct{}),
 		logger:      log.NewNoop(),
 		domainCache: mockDomainCache,
+		executor:    mockExecutor,
 	}
 
 	// this should trigger the error case on a membership event
@@ -322,6 +328,7 @@ func TestGetTasklistManagerShutdownScenario(t *testing.T) {
 	mockExecutor := executorclient.NewMockExecutor[tasklist.ShardProcessor](ctrl)
 	mockExecutor.EXPECT().GetShardProcess(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	mockExecutor.EXPECT().IsOnboardedToSD().Return(false).AnyTimes()
+	mockExecutor.EXPECT().Stop()
 
 	shutdownWG := sync.WaitGroup{}
 	shutdownWG.Add(0)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- when we start and stop the engine we want to be able to start and stop the executor

<!-- Tell your future self why have you made these changes -->
**Why?**
- we need to start/stop heartbeating to the SD

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
local environment and deployed to staging

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
