### PR TITLE
fix: Allow failovers of cluster attributes for active-active domains

### DIFF
--- a/common/domain/handler.go
+++ b/common/domain/handler.go
@@ -661,7 +661,7 @@ func (d *handlerImpl) handleFailoverRequest(ctx context.Context,
 		return nil, err
 	}
 
-	d.logger.Info("faiover request succeeded",
+	d.logger.Info("Failover request succeeded",
 		tag.WorkflowDomainName(intendedDomainState.Info.Name),
 		tag.WorkflowDomainID(intendedDomainState.Info.ID),
 	)

--- a/common/types/mapper/proto/api.go
+++ b/common/types/mapper/proto/api.go
@@ -4538,9 +4538,13 @@ func ToFailoverDomainRequest(t *apiv1.FailoverDomainRequest) *types.FailoverDoma
 	if t == nil {
 		return nil
 	}
+	var domainActiveClusterName *string
+	if t.DomainActiveClusterName != "" {
+		domainActiveClusterName = common.StringPtr(t.DomainActiveClusterName)
+	}
 	return &types.FailoverDomainRequest{
 		DomainName:              t.DomainName,
-		DomainActiveClusterName: common.StringPtr(t.DomainActiveClusterName),
+		DomainActiveClusterName: domainActiveClusterName,
 		ActiveClusters:          ToActiveClusters(t.ActiveClusters),
 	}
 }

--- a/common/types/testdata/service_frontend.go
+++ b/common/types/testdata/service_frontend.go
@@ -82,6 +82,17 @@ var (
 		DeleteBadBinary:                        common.StringPtr(DeleteBadBinary),
 		FailoverTimeoutInSeconds:               &Duration1,
 	}
+	FailoverDomainRequest = types.FailoverDomainRequest{
+		DomainName:              DomainName,
+		DomainActiveClusterName: common.StringPtr(ClusterName1),
+		ActiveClusters:          &ActiveClusters,
+	}
+	FailoverDomainRequest_OnlyActiveClusters = types.FailoverDomainRequest{
+		DomainName: DomainName,
+		// Explicitly set to nil to test ActiveActive failovers
+		DomainActiveClusterName: nil,
+		ActiveClusters:          &ActiveClusters,
+	}
 	ActiveClusters = types.ActiveClusters{
 		AttributeScopes: map[string]types.ClusterAttributeScope{
 			"region": {

--- a/service/frontend/api/domain_handlers.go
+++ b/service/frontend/api/domain_handlers.go
@@ -207,7 +207,10 @@ func (wh *WorkflowHandler) FailoverDomain(ctx context.Context, failoverRequest *
 		tag.WorkflowDomainName(domainName),
 		tag.OperationName("FailoverDomain"))
 
-	logger.Info(fmt.Sprintf("Failover domain is requested. Request: %#v.", failoverRequest))
+	logger.Info("Failover domain requested.",
+		tag.ActiveClusterName(failoverRequest.GetDomainActiveClusterName()),
+		tag.Dynamic("active-clusters-by-cluster-attribute", failoverRequest.ActiveClusters),
+	)
 
 	failoverResp, err := wh.domainHandler.FailoverDomain(ctx, failoverRequest)
 	if err != nil {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Modified the FailoverDomain request mapper to allow a null ActiveClusterName to be specified. In turn, this allows active-active domains to only modify their cluster attributes without changing the default ActiveClusterName. 

<!-- Tell your future self why have you made these changes -->
**Why?**

Active-Active domains are partitioned by 'cluster attributes'. Each cluster attribute operates as its own independent active-passive domain within the larger domain. As they are independent, it needs to be possible to failover attributes without amending the global default for a given domain. This fix brings the FailoverDomain endpoint inline with the expected behavior for an active-active domain. 

Because the proto mapper was assigning a non-null string pointer when nil was passed to the API the later validateFailoverRequest functions were treating this as the specification of a null ActiveClusterName (which is invalid). 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Added unit tests: `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`

Ran integration tests:

```bash
// Before fix
./cadence --domain test25 --transport grpc --address localhost:7833 domain failover --active_clusters location.london:cluster1
Error: Operation FailoverDomain failed.
Error details:
  ActiveClusterName is required for all global domains.

// After fix
./cadence --domain test25 --transport grpc --address localhost:7833 domain failover --active_clusters location.london:cluster1
Domain test25 successfully failed over.
```

Also tested on our canary domains in staging. 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

N/A

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

N/A

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

N/A