### PR TITLE
fix: Use domain id instead of domain name for replication

### DIFF
--- a/common/domain/replicationTaskExecutor.go
+++ b/common/domain/replicationTaskExecutor.go
@@ -234,7 +234,7 @@ func (h *domainReplicationTaskExecutorImpl) handleDomainUpdateReplicationTask(ct
 	// plus, we need to check whether the config version is <= the config version set in the input
 	// plus, we need to check whether the failover version is <= the failover version set in the input
 	originalDomainState, err := h.domainManager.GetDomain(ctx, &persistence.GetDomainRequest{
-		Name: task.Info.GetName(),
+		ID: task.GetID(),
 	})
 	intendedDomainState := originalDomainState.DeepCopy()
 

--- a/common/domain/replicationTaskExecutor_test.go
+++ b/common/domain/replicationTaskExecutor_test.go
@@ -179,9 +179,9 @@ func TestDomainReplicationTaskExecutor_Execute(t *testing.T) {
 					Return(&persistence.GetMetadataResponse{NotificationVersion: 123}, nil).
 					Times(1)
 
-				// Mock GetDomain to simulate domain fetch before update
+				// Mock GetDomain to simulate domain fetch before update (using ID)
 				mockDomainManager.EXPECT().
-					GetDomain(gomock.Any(), &persistence.GetDomainRequest{Name: "existingDomainName"}).
+					GetDomain(gomock.Any(), &persistence.GetDomainRequest{ID: "existingDomainID"}).
 					Return(&persistence.GetDomainResponse{
 						Info:              &persistence.DomainInfo{ID: "existingDomainID", Name: "existingDomainName"},
 						Config:            &persistence.DomainConfig{},
@@ -629,6 +629,7 @@ func TestHandleDomainUpdateReplicationTask(t *testing.T) {
 		{
 			name: "GetDomain Returns EntityNotExistsError - Triggers Domain Creation",
 			task: &types.DomainTaskAttributes{
+				ID: "nonexistentDomainID",
 				Info: &types.DomainInfo{
 					Name: "nonexistentDomain",
 				},
@@ -637,7 +638,7 @@ func TestHandleDomainUpdateReplicationTask(t *testing.T) {
 			setup: func(mockDomainManager *persistence.MockDomainManager, mockAuditManager *persistence.MockDomainAuditManager) {
 				mockDomainManager.EXPECT().
 					GetDomain(gomock.Any(), &persistence.GetDomainRequest{
-						Name: "nonexistentDomain",
+						ID: "nonexistentDomainID",
 					}).
 					Return(nil, &types.EntityNotExistsError{}).AnyTimes()
 
@@ -647,13 +648,9 @@ func TestHandleDomainUpdateReplicationTask(t *testing.T) {
 					AnyTimes()
 
 				mockDomainManager.EXPECT().
-					CreateDomain(gomock.Any(), &types.DomainTaskAttributes{
-						Info: &types.DomainInfo{
-							Name: "nonexistentDomain",
-						},
-					}).
+					CreateDomain(gomock.Any(), gomock.Any()).
 					Return(&persistence.CreateDomainResponse{
-						ID: "nonexistentDomain",
+						ID: "nonexistentDomainID",
 					}, nil).
 					AnyTimes()
 			},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Use domainID instead of domain name for replication

<!-- Tell your future self why have you made these changes -->
**Why?**

**The Problem**
For example, consider this scenario:

- DCA cluster originally had a local domain domain-A (ID=A), which was deleted
- PHX cluster had a separate local domain domain-A (ID=B) — same name, different ID
- DCA cluster recreated domain-A as a global domain (ID=C) with PHX as passive

When DCA sent the domain replication task to PHX, the task contained:
Domain ID = C
Domain Name = "domain-A"
The buggy code in handleDomainUpdateReplicationTask looked up the domain by name:
`originalDomainState, err := h.domainManager.GetDomain(ctx, &persistence.GetDomainRequest{
    ID: task.GetID(), 
})`
This lookup found PHX's local domain (ID=B) instead of recognizing that the global domain (ID=C) didn't exist and needed to be created.

**Consequence**
As a result:
The global domain (ID=C) was never properly created on PHX
Workflow history replication tasks referencing domainID=C failed because that domain didn't exist on PHX
Cadence kept retrying these failed replications, causing replication lag to increase

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit test

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

This change is backward compatible. The domain replication task format remains unchanged. The change only improves how the receiving cluster processes the task.
- If the new cluster (with this fix) is the passive/standby, it will correctly use ID for lookup, which is safer.
- If the old cluster is the passive/standby, it will still use Name for lookup — but this is the existing bug, not a new issue introduced by this change.
The fix doesn't introduce any new incompatibility. It only makes the passive cluster's handling more robust when it has this change deployed.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
