### PR TITLE
feat(shard-distributor): change shard load to be based on shard id in canary

### DIFF
--- a/service/sharddistributor/canary/processor/shardprocessor.go
+++ b/service/sharddistributor/canary/processor/shardprocessor.go
@@ -2,6 +2,7 @@ package processor
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"time"
 
@@ -22,6 +23,7 @@ const (
 func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.Logger) *ShardProcessor {
 	return &ShardProcessor{
 		shardID:    shardID,
+		shardLoad:  shardLoadFromID(shardID),
 		timeSource: timeSource,
 		logger:     logger,
 		stopChan:   make(chan struct{}),
@@ -31,6 +33,7 @@ func NewShardProcessor(shardID string, timeSource clock.TimeSource, logger *zap.
 // ShardProcessor is a processor for a shard.
 type ShardProcessor struct {
 	shardID      string
+	shardLoad    float64
 	timeSource   clock.TimeSource
 	logger       *zap.Logger
 	stopChan     chan struct{}
@@ -43,7 +46,7 @@ var _ executorclient.ShardProcessor = (*ShardProcessor)(nil)
 // GetShardReport implements executorclient.ShardProcessor.
 func (p *ShardProcessor) GetShardReport() executorclient.ShardReport {
 	return executorclient.ShardReport{
-		ShardLoad: 1.0,                    // We return 1.0 for all shards for now.
+		ShardLoad: p.shardLoad,            // We return a load from shardID
 		Status:    types.ShardStatusREADY, // Report the shard as ready since it's actively processing
 	}
 }
@@ -79,4 +82,13 @@ func (p *ShardProcessor) process() {
 			p.logger.Info("Processing shard", zap.String("shardID", p.shardID), zap.Int("steps", p.processSteps))
 		}
 	}
+}
+
+// shardLoadFromID returns a shard load based on the shard ID.
+// If the shard ID is not a valid integer, it returns 1.0.
+func shardLoadFromID(shardID string) float64 {
+	if parsed, err := strconv.Atoi(shardID); err == nil && parsed > 0 {
+		return float64(parsed)
+	}
+	return 1.0
 }

--- a/service/sharddistributor/canary/processor/shardprocessor_test.go
+++ b/service/sharddistributor/canary/processor/shardprocessor_test.go
@@ -63,3 +63,23 @@ func TestShardProcessor_Start_Process_Stop(t *testing.T) {
 	// Assert that the processor has processed at least once
 	assert.Greater(t, processor.processSteps, 0)
 }
+
+func Test_shardLoadFromID(t *testing.T) {
+	tests := []struct {
+		shardID string
+		want    float64
+	}{
+		{"0", 1.0},
+		{"shard-1", 1.0},
+		{"42", 42.0},
+		{"999", 999.0},
+		{"", 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.shardID, func(t *testing.T) {
+			got := shardLoadFromID(tt.shardID)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* `ShardLoad` in fixed namespace in canary will be calculated based on `ShardID`

<!-- Tell your future self why have you made these changes -->
**Why?**
We need to have some different but static shard load to test different load balancing modes. The PR make shard load in fixed namespace be calculated from `ShardID`: if shardID is 2, shardLoad will be 2.0. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Unit test
* Run canary on dev env