### PR TITLE
feat(shard-distributor): improve spectator client logging

### DIFF
--- a/service/sharddistributor/client/spectatorclient/clientimpl.go
+++ b/service/sharddistributor/client/spectatorclient/clientimpl.go
@@ -96,11 +96,12 @@ func (s *spectatorImpl) watchLoop() {
 
 			s.logger.Error("Failed to create stream, retrying", tag.Error(err), tag.ShardNamespace(s.namespace))
 			if err := s.timeSource.SleepWithContext(s.ctx, backoff.JitDuration(streamRetryInterval, streamRetryJitterCoeff)); err != nil {
+				s.logger.Info("Shutting down waiting to retry stream creation, exiting watch loop", tag.ShardNamespace(s.namespace))
 				return // Context cancelled during sleep
 			}
 			continue
 		}
-
+		s.logger.Info("Stream created, entering receive loop", tag.ShardNamespace(s.namespace))
 		s.receiveLoop(stream)
 
 		if s.ctx.Err() != nil {


### PR DESCRIPTION
**What changed?**
Added info-level logging to the spectator client watchLoop to track stream lifecycle events.

**Why?**
Better observability for debugging stream creation and shutdown scenarios in the shard distributor spectator client.

**How did you test it?**
Local development environment testing.

**Potential risks**
Low - only adds logging, no behavioral changes.

**Release notes**
N/A

**Documentation Changes**
None