### PR TITLE
fix(cadence-matching): assigning lock for newProcessor

### DIFF
--- a/service/matching/tasklist/shard_processor.go
+++ b/service/matching/tasklist/shard_processor.go
@@ -22,7 +22,7 @@ type ShardProcessorParams struct {
 
 type shardProcessorImpl struct {
 	shardID       string
-	taskListsLock sync.RWMutex           // locks mutation of taskLists
+	taskListsLock *sync.RWMutex          // locks mutation of taskLists
 	taskLists     map[Identifier]Manager // Convert to LRU cache
 	Status        atomic.Int32
 	reportLock    sync.RWMutex
@@ -38,12 +38,13 @@ func NewShardProcessor(params ShardProcessorParams) (ShardProcessor, error) {
 		return nil, err
 	}
 	shardprocessor := &shardProcessorImpl{
-		shardID:     params.ShardID,
-		taskLists:   params.TaskLists,
-		shardReport: executorclient.ShardReport{},
-		reportTime:  params.TimeSource.Now(),
-		reportTTL:   params.ReportTTL,
-		timeSource:  params.TimeSource,
+		shardID:       params.ShardID,
+		taskListsLock: params.TaskListsLock,
+		taskLists:     params.TaskLists,
+		shardReport:   executorclient.ShardReport{},
+		reportTime:    params.TimeSource.Now(),
+		reportTTL:     params.ReportTTL,
+		timeSource:    params.TimeSource,
 	}
 	shardprocessor.SetShardStatus(types.ShardStatusREADY)
 	shardprocessor.shardReport = executorclient.ShardReport{


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
assigning the lock in the initialization

<!-- Tell your future self why have you made these changes -->
**Why?**
the lock was passed as parameter, but not assigned in the initialization


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
running matching instance locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
