### PR TITLE
feat: Create CallerInfo struct to be used in context

### DIFF
--- a/common/types/caller.go
+++ b/common/types/caller.go
@@ -34,18 +34,30 @@ const (
 	CallerTypeInternal
 )
 
+// CallerInfo captures request source information for observability and resource management.
+//
+// Intent:
+//   - Track the source/origin/actor of API requests (CLI, UI, SDK, internal service calls)
+//   - Enable client-specific behavior and resource allocation decisions
+//   - Support future extensibility for additional caller metadata (e.g., identity, version)
+//
+// Consumers:
+//   - Logging and audit systems for request attribution
+//   - Metrics and monitoring for client-specific observability
+//   - Rate limiting and resource management based on caller information
+//
+// Lifecycle:
+//   - Should be set early in request processing, typically after authentication
+//   - Expected for external API calls (CLI, UI, SDK)
+//   - May be absent for internal service-to-service calls or unauthenticated endpoints
+//   - Set by authentication/authorization middleware or API gateway components
 type CallerInfo struct {
-	CallerType CallerType
+	callerType CallerType
 }
 
-// WithCallerType creates a new CallerInfo with the given CallerType
-func (c *CallerInfo) WithCallerType(callerType CallerType) *CallerInfo {
-	if c == nil {
-		return &CallerInfo{CallerType: callerType}
-	}
-	newInfo := *c
-	newInfo.CallerType = callerType
-	return &newInfo
+// NewCallerInfo creates a new CallerInfo
+func NewCallerInfo(callerType CallerType) *CallerInfo {
+	return &CallerInfo{callerType: callerType}
 }
 
 // GetCallerType returns the CallerType, or CallerTypeUnknown if CallerInfo is nil
@@ -53,7 +65,7 @@ func (c *CallerInfo) GetCallerType() CallerType {
 	if c == nil {
 		return CallerTypeUnknown
 	}
-	return c.CallerType
+	return c.callerType
 }
 
 type callerInfoContextKey string
@@ -91,16 +103,16 @@ func ParseCallerType(s string) CallerType {
 	}
 }
 
-// WithCallerInfo adds CallerInfo to context
-func WithCallerInfo(ctx context.Context, callerInfo *CallerInfo) context.Context {
+// ContextWithCallerInfo adds CallerInfo to context
+func ContextWithCallerInfo(ctx context.Context, callerInfo *CallerInfo) context.Context {
 	if callerInfo == nil {
 		return ctx
 	}
 	return context.WithValue(ctx, callerInfoKey, callerInfo)
 }
 
-// GetCallerInfo retrieves CallerInfo from context, returns nil if not set
-func GetCallerInfo(ctx context.Context) *CallerInfo {
+// CallerInfoFromContext retrieves CallerInfo from context, returns nil if not set
+func CallerInfoFromContext(ctx context.Context) *CallerInfo {
 	if ctx == nil {
 		return nil
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Created an extensible CallerInfo struct to be used for caller info in the request context.

<!-- Tell your future self why have you made these changes -->
**Why?**
Make the caller info extensible, allowing more information to be added easily.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
