### PR TITLE
fix: Replace tokenbucket with standard limiter on CLI

### DIFF
--- a/tools/cli/admin_elastic_search_commands.go
+++ b/tools/cli/admin_elastic_search_commands.go
@@ -209,6 +209,10 @@ func AdminDelete(c *cli.Context) error {
 	}
 	batchSize := c.Int(FlagBatchSize)
 	rps := c.Int(FlagRPS)
+	if rps <= 0 {
+		err = fmt.Errorf("FlagRPS must be positive value but got %v", rps)
+		return commoncli.Problem("Invalid RPS value: ", err)
+	}
 	ratelimiter := clock.NewRatelimiter(rate.Limit(rps), rps)
 
 	// This is only executed from the CLI by an admin user


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replaced `common/tokenbucket` with `common/clock/ratelimiter` in the CLI's `AdminDelete` function (`tools/cli/admin_elastic_search_commands.go`).

<!-- Tell your future self why have you made these changes -->
**Why?**
This PR is the first step toward resolving the issue #7562.
The current custom `tokenbucket` implementation is only used in two places
- The `AdminDelete` function: Uses only basic rate limiting, seems straightforward to replace.
- The `common/persistence/wrappers/sampled` module: Required priority support, which `common/clock/ratelimiter` does not currently support.

To replace the custom ratelimiter in the `AdminDelete` function, I followed the comments on the ratelimiter.go 84 line and used the `Wait` function to ensure it waits until a token is available. This allows the implementation to leverage context-based cancellation.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Ran unit tests in `admin_elastic_search_commands_test.go`
<img width="443" height="307" alt="image" src="https://github.com/user-attachments/assets/0ee5f1ff-d809-4850-9cae-10e865b6e4f7" />

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
