### PR TITLE
fix: make CallerType in CallerInfo more flexible

### DIFF
--- a/common/types/caller.go
+++ b/common/types/caller.go
@@ -78,12 +78,7 @@ func (c CallerType) String() string {
 
 // ParseCallerType converts a string to CallerType
 func ParseCallerType(s string) CallerType {
-	switch CallerType(s) {
-	case CallerTypeCLI, CallerTypeUI, CallerTypeSDK, CallerTypeInternal:
-		return CallerType(s)
-	default:
-		return CallerTypeUnknown
-	}
+	return CallerType(s)
 }
 
 // ContextWithCallerInfo adds CallerInfo to context

--- a/common/types/caller_test.go
+++ b/common/types/caller_test.go
@@ -60,9 +60,9 @@ func TestParseCallerType(t *testing.T) {
 		{"sdk", "sdk", CallerTypeSDK},
 		{"internal", "internal", CallerTypeInternal},
 		{"unknown", "unknown", CallerTypeUnknown},
-		{"empty", "", CallerTypeUnknown},
-		{"invalid", "invalid", CallerTypeUnknown},
-		{"uppercase", "CLI", CallerTypeUnknown},
+		{"empty", "", CallerType("")},
+		{"custom value", "my-custom-tool", CallerType("my-custom-tool")},
+		{"uppercase", "CLI", CallerType("CLI")},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Make CallerType a string type in CallerInfo.

<!-- Tell your future self why have you made these changes -->
**Why?**
Make CallerType more flexible for users.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
