### PR TITLE
refactor(matching): replace callback with explicit Registry

### DIFF
--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -229,20 +229,20 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 	tlm, err := s.matchingEngine.getTaskListManager(context.Background(), taskListID, tlKind)
 	s.Require().NoError(err)
 	params := tasklist.ManagerParams{
-		s.matchingEngine.domainCache,
-		s.matchingEngine.logger,
-		s.matchingEngine.metricsClient,
-		s.matchingEngine.taskManager,
-		s.matchingEngine.clusterMetadata,
-		s.matchingEngine.isolationState,
-		s.matchingEngine.matchingClient,
-		s.matchingEngine.removeTaskListManager,
-		taskListID, // same taskListID as above
-		tlKind,
-		s.matchingEngine.config,
-		s.matchingEngine.timeSource,
-		s.matchingEngine.timeSource.Now(),
-		s.matchingEngine.historyService,
+		DomainCache:     s.matchingEngine.domainCache,
+		Logger:          s.matchingEngine.logger,
+		MetricsClient:   s.matchingEngine.metricsClient,
+		TaskManager:     s.matchingEngine.taskManager,
+		ClusterMetadata: s.matchingEngine.clusterMetadata,
+		IsolationState:  s.matchingEngine.isolationState,
+		MatchingClient:  s.matchingEngine.matchingClient,
+		Registry:        s.matchingEngine, // Engine implements ManagerRegistry
+		TaskList:        taskListID,       // same taskListID as above
+		TaskListKind:    tlKind,
+		Cfg:             s.matchingEngine.config,
+		TimeSource:      s.matchingEngine.timeSource,
+		CreateTime:      s.matchingEngine.timeSource.Now(),
+		HistoryService:  s.matchingEngine.historyService,
 	}
 	tlm2, err := tasklist.NewManager(params)
 	s.Require().NoError(err)

--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -21,6 +21,7 @@
 // SOFTWARE.
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist Manager
+//go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist ManagerRegistry
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist TaskMatcher
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist Forwarder
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist TaskCompleter
@@ -37,6 +38,14 @@ import (
 )
 
 type (
+	// ManagerRegistry is implemented by components that track/own task list managers.
+	// Managers notify their registry when they stop so they can be cleaned up.
+	ManagerRegistry interface {
+		// UnregisterManager is called by a Manager when it stops, allowing the registry
+		// to clean up resources and remove the manager from its tracking structures.
+		UnregisterManager(mgr Manager)
+	}
+
 	Manager interface {
 		Start(ctx context.Context) error
 		Stop()

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -20,6 +20,42 @@ import (
 	executorclient "github.com/uber/cadence/service/sharddistributor/client/executorclient"
 )
 
+// MockManagerRegistry is a mock of ManagerRegistry interface.
+type MockManagerRegistry struct {
+	ctrl     *gomock.Controller
+	recorder *MockManagerRegistryMockRecorder
+	isgomock struct{}
+}
+
+// MockManagerRegistryMockRecorder is the mock recorder for MockManagerRegistry.
+type MockManagerRegistryMockRecorder struct {
+	mock *MockManagerRegistry
+}
+
+// NewMockManagerRegistry creates a new mock instance.
+func NewMockManagerRegistry(ctrl *gomock.Controller) *MockManagerRegistry {
+	mock := &MockManagerRegistry{ctrl: ctrl}
+	mock.recorder = &MockManagerRegistryMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockManagerRegistry) EXPECT() *MockManagerRegistryMockRecorder {
+	return m.recorder
+}
+
+// UnregisterManager mocks base method.
+func (m *MockManagerRegistry) UnregisterManager(mgr Manager) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "UnregisterManager", mgr)
+}
+
+// UnregisterManager indicates an expected call of UnregisterManager.
+func (mr *MockManagerRegistryMockRecorder) UnregisterManager(mgr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterManager", reflect.TypeOf((*MockManagerRegistry)(nil).UnregisterManager), mgr)
+}
+
 // MockManager is a mock of Manager interface.
 type MockManager struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION




<!-- Describe what has changed in this PR -->
**What changed?**
Replace the generic CloseCallback function parameter in task list manager
with an explicit ManagerRegistry interface that makes the parent-child
relationship between the matching engine and its task list managers more
obvious and maintainable.

Changes:
- Added ManagerRegistry interface with UnregisterManager method
- Updated ManagerParams to use Registry field instead of CloseCallback
- matchingEngineImpl now explicitly implements ManagerRegistry
- Updated task list manager Stop() to call registry.UnregisterManager()


<!-- Tell your future self why have you made these changes -->
**Why?**
Benefits:
- Self-documenting: parameter name and interface clearly convey ownership
- Discoverable: IDEs can show implementation relationships
- Extensible: can add more lifecycle methods to interface if needed

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit-tests
The functionality remains identical - managers still notify their parent
when stopping so they can be removed from the tracking map.


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
