### PR TITLE
fix(shard-distributor): fix a leader loss

### DIFF
--- a/service/sharddistributor/leader/election/election_test.go
+++ b/service/sharddistributor/leader/election/election_test.go
@@ -50,6 +50,7 @@ func TestElector_Run(t *testing.T) {
 		close(finished)
 		return nil
 	})
+	election.EXPECT().Cleanup(gomock.Any()).Return(nil)
 
 	leaderStore := store.NewMockElector(ctrl)
 	leaderStore.EXPECT().CreateElection(gomock.Any(), _testNamespace.Name).Return(election, nil)
@@ -228,6 +229,7 @@ func prepareRun(t *testing.T, onLeader, onResign ProcessFunc) (<-chan bool, runP
 
 	election := store.NewMockElection(ctrl)
 	election.EXPECT().Campaign(gomock.Any(), _testHost).Return(nil)
+	election.EXPECT().Cleanup(gomock.Any()).Return(nil)
 	election.EXPECT().Done().Return(electionCh)
 
 	leaderStore := store.NewMockElector(ctrl)
@@ -308,6 +310,7 @@ func TestOnLeader_Error(t *testing.T) {
 	election.EXPECT().Campaign(gomock.Any(), _testHost).Return(nil)
 	// Expect resignation after onLeader failure
 	election.EXPECT().Resign(gomock.Any()).Return(nil)
+	election.EXPECT().Cleanup(gomock.Any()).Return(nil)
 
 	leaderStore := store.NewMockElector(ctrl)
 	leaderStore.EXPECT().CreateElection(gomock.Any(), _testNamespace.Name).Return(election, nil)

--- a/service/sharddistributor/store/etcd/leaderstore/etcdleaderstore.go
+++ b/service/sharddistributor/store/etcd/leaderstore/etcdleaderstore.go
@@ -14,6 +14,12 @@ import (
 	"github.com/uber/cadence/service/sharddistributor/store"
 )
 
+const (
+	// defaultElectionTTL is the default time-to-live for an election session.
+	// If the leader does not renew its lease within this time, it will lose leadership.
+	defaultElectionTTL = 10 * time.Second
+)
+
 type LeaderStore struct {
 	client         *clientv3.Client
 	electionConfig etcdCfg
@@ -54,6 +60,10 @@ func NewLeaderStore(p StoreParams) (store.Elector, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if out.ElectionTTL == 0 {
+		out.ElectionTTL = defaultElectionTTL
 	}
 
 	p.Lifecycle.Append(fx.StopHook(etcdClient.Close))


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* When the leader election function is finished, `Election.Cleanup` is called to close `concurrency.Session`
* Set up `defaultTTL` in 10s


<!-- Tell your future self why have you made these changes -->
**Why?**
We observed a scenario where the leader status was lost if a failure occurred while watching keys in election.Campaign. election.Resign is called when runElection is finished. However, if a failure occurred during the key-watching phase of election.Campaign, concurrency.Session would clean up the internal leaderSession variable. Consequently, election.Resign failed to delete the keys stored in etcd, making the election campaign key not removed. 

Also because election.Cleanup was never called, the session remained open. The session's life is tied to an instance's lifetime. This allowed a single instance to hold two election campaign keys simultaneously. As a result, the etcd cluster could select a "zombie" key, causing the entire leader processing to become stuck.

Additionally, if ElectionTTL is not configured, it now defaults to 10s. The original default of 60s proved too long for leader election purposes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Unit test
* Run on dev cluster

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**

Reported issue in etcd: https://github.com/etcd-io/etcd/issues/21128