### PR TITLE
feat(shard-distributor-canary): add support of multiple executors

### DIFF
--- a/cmd/sharddistributor-canary/main_test.go
+++ b/cmd/sharddistributor-canary/main_test.go
@@ -8,5 +8,12 @@ import (
 )
 
 func TestDependenciesAreSatisfied(t *testing.T) {
-	assert.NoError(t, fx.ValidateApp(opts(defaultFixedNamespace, defaultEphemeralNamespace, defaultShardDistributorEndpoint, defaultCanaryGRPCPort)))
+	assert.NoError(t, fx.ValidateApp(opts(
+		defaultFixedNamespace,
+		defaultEphemeralNamespace,
+		defaultShardDistributorEndpoint,
+		defaultCanaryGRPCPort,
+		defaultNumExecutors,
+		defaultNumExecutors,
+	)))
 }

--- a/service/sharddistributor/canary/config/config.go
+++ b/service/sharddistributor/canary/config/config.go
@@ -1,0 +1,18 @@
+package config
+
+// Config is the configuration for the shard distributor canary
+type Config struct {
+	Canary CanaryConfig `yaml:"canary"`
+}
+
+type CanaryConfig struct {
+	// NumFixedExecutors is the number of executors of fixed namespace
+	// Values more than 1 will create multiple executors processing the same fixed namespace
+	// Default: 1
+	NumFixedExecutors int `yaml:"numFixedExecutors"`
+
+	// NumEphemeralExecutors is the number of executors of ephemeral namespace
+	// Values more than 1 will create multiple executors processing the same ephemeral namespace
+	// Default: 1
+	NumEphemeralExecutors int `yaml:"numEphemeralExecutors"`
+}

--- a/service/sharddistributor/canary/executors/executors_test.go
+++ b/service/sharddistributor/canary/executors/executors_test.go
@@ -232,3 +232,111 @@ func createMockParams[SP executorclient.ShardProcessor](
 		TimeSource: clock.NewMockedTimeSource(),
 	}
 }
+
+func TestNewExecutorsWithFixedNamespace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tests := []struct {
+		name         string
+		namespace    string
+		numExecutors int
+		expected     int
+	}{
+		{
+			name:         "zero executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: 0,
+			expected:     1,
+		},
+		{
+			name:         "negative executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: -1,
+			expected:     1,
+		},
+		{
+			name:         "one executor",
+			namespace:    "test-namespace",
+			numExecutors: 1,
+			expected:     1,
+		},
+		{
+			name:         "two executors",
+			namespace:    "test-namespace",
+			numExecutors: 2,
+			expected:     2,
+		},
+		{
+			name:         "five executors",
+			namespace:    "test-namespace",
+			numExecutors: 5,
+			expected:     5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := createMockParams[*processor.ShardProcessor](ctrl, tt.namespace)
+			result, err := NewExecutorsWithFixedNamespace(params, tt.namespace, tt.numExecutors)
+
+			require.NoError(t, err)
+			assert.Len(t, result.Executors, tt.expected)
+			for _, executor := range result.Executors {
+				assert.NotNil(t, executor)
+			}
+		})
+	}
+}
+
+func TestNewExecutorsWithEphemeralNamespace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tests := []struct {
+		name         string
+		namespace    string
+		numExecutors int
+		expected     int
+	}{
+		{
+			name:         "zero executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: 0,
+			expected:     1,
+		},
+		{
+			name:         "negative executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: -1,
+			expected:     1,
+		},
+		{
+			name:         "one executor",
+			namespace:    "test-namespace",
+			numExecutors: 1,
+			expected:     1,
+		},
+		{
+			name:         "two executors",
+			namespace:    "test-namespace",
+			numExecutors: 2,
+			expected:     2,
+		},
+		{
+			name:         "five executors",
+			namespace:    "test-namespace",
+			numExecutors: 5,
+			expected:     5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := createMockParams[*processorephemeral.ShardProcessor](ctrl, tt.namespace)
+			result, err := NewExecutorsWithEphemeralNamespace(params, tt.namespace, tt.numExecutors)
+
+			require.NoError(t, err)
+			assert.Len(t, result.Executors, tt.expected)
+			for _, executor := range result.Executors {
+				assert.NotNil(t, executor)
+			}
+		})
+	}
+}

--- a/service/sharddistributor/canary/module.go
+++ b/service/sharddistributor/canary/module.go
@@ -5,6 +5,7 @@ import (
 	"go.uber.org/yarpc"
 
 	sharddistributorv1 "github.com/uber/cadence/.gen/proto/sharddistributor/v1"
+	"github.com/uber/cadence/service/sharddistributor/canary/config"
 	"github.com/uber/cadence/service/sharddistributor/canary/executors"
 	"github.com/uber/cadence/service/sharddistributor/canary/factory"
 	"github.com/uber/cadence/service/sharddistributor/canary/handler"
@@ -23,6 +24,8 @@ type NamespacesNames struct {
 	EphemeralNamespace          string
 	ExternalAssignmentNamespace string
 	SharddistributorServiceName string
+
+	Config config.Config
 }
 
 func Module(namespacesNames NamespacesNames) fx.Option {
@@ -31,6 +34,8 @@ func Module(namespacesNames NamespacesNames) fx.Option {
 
 func opts(names NamespacesNames) fx.Option {
 	return fx.Options(
+		fx.Supply(names.Config),
+
 		fx.Provide(sharddistributorv1.NewFxShardDistributorExecutorAPIYARPCClient(names.SharddistributorServiceName)),
 		fx.Provide(sharddistributorv1.NewFxShardDistributorAPIYARPCClient(names.SharddistributorServiceName)),
 


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* `shard-distributor-canary` got an option to run multiple executors for fixed and ephemeral namespaces
* `num-executors` (for both namespaces), `num-ephemeral-executors`, `num-fixed-executors` flags were added to configure how many executors should be run
* `config` folder was added


<!-- Tell your future self why have you made these changes -->
**Why?**
* For testing purposes, It is easier to run multiple executors in one binary to simulate multiple running instances, so there is no need to change configuration files to run multiple instances of canary. 
* `config` was added to make advanced configuration for canary running internally without using flags. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Unit test
* Local run
* Run on dev cluster
* Run `make sharddistributor-canary && ./sharddistributor-canary start --num-executors=10`