### PR TITLE
feat(shard-distributor-canary): add support of multiple shard creators

### DIFF
--- a/cmd/sharddistributor-canary/main_test.go
+++ b/cmd/sharddistributor-canary/main_test.go
@@ -15,5 +15,7 @@ func TestDependenciesAreSatisfied(t *testing.T) {
 		defaultCanaryGRPCPort,
 		defaultNumExecutors,
 		defaultNumExecutors,
+		defaultNumShardCreators,
+		defaultShardCreationInterval,
 	)))
 }

--- a/service/sharddistributor/canary/config/config.go
+++ b/service/sharddistributor/canary/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Config is the configuration for the shard distributor canary
 type Config struct {
 	Canary CanaryConfig `yaml:"canary"`
@@ -15,4 +17,15 @@ type CanaryConfig struct {
 	// Values more than 1 will create multiple executors processing the same ephemeral namespace
 	// Default: 1
 	NumEphemeralExecutors int `yaml:"numEphemeralExecutors"`
+
+	// NumShardCreators is the number of shard creators creating new ephemeral shards.
+	// ShardCreator uses Ping API of Canary and Spectator library to retrieve an owner of a new ephemeral shard
+	// This call causes a creation of the new ephemeral shard in the shard distributor service.
+	// Values more than 1 enable testing of concurrent shard creation.
+	// Default: 1
+	NumShardCreators int `yaml:"numShardCreators"`
+
+	// ShardCreationInterval is the interval between creating new ephemeral shards by each shard creator.
+	// Default: 1s
+	ShardCreationInterval time.Duration `yaml:"shardCreationInterval"`
 }


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
* Multiple instances of `ShardCreator` are enabled to run 

<!-- Tell your future self why have you made these changes -->
**Why?**
* `ShardCreator` is used for new ephemeral shard creation. This PR enables running multiple instances for load testing purposes. 


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
* Run locally
* Run on dev cluster
