### PR TITLE
fix(postgres): improve timer task pagination

### DIFF
--- a/common/persistence/sql/sqlplugin/postgres/execution.go
+++ b/common/persistence/sql/sqlplugin/postgres/execution.go
@@ -110,9 +110,9 @@ workflow_id = :workflow_id
 
 	getTimerTasksQuery = `SELECT visibility_timestamp, task_id, data, data_encoding FROM timer_tasks
   WHERE shard_id = $1
-  AND ((visibility_timestamp >= $2 AND task_id >= $3) OR visibility_timestamp > $4)
-  AND visibility_timestamp < $5
-  ORDER BY visibility_timestamp,task_id LIMIT $6`
+  AND (visibility_timestamp, task_id) >= ($2, $3)
+  AND visibility_timestamp < $4
+  ORDER BY visibility_timestamp,task_id LIMIT $5`
 
 	deleteTimerTaskQuery             = `DELETE FROM timer_tasks WHERE shard_id = $1 AND visibility_timestamp = $2 AND task_id = $3`
 	rangeDeleteTimerTaskQuery        = `DELETE FROM timer_tasks WHERE shard_id = $1 AND visibility_timestamp >= $2 AND visibility_timestamp < $3`
@@ -368,7 +368,7 @@ func (pdb *db) SelectFromTimerTasks(ctx context.Context, filter *sqlplugin.Timer
 	filter.MinVisibilityTimestamp = pdb.converter.ToPostgresDateTime(filter.MinVisibilityTimestamp)
 	filter.MaxVisibilityTimestamp = pdb.converter.ToPostgresDateTime(filter.MaxVisibilityTimestamp)
 	err := pdb.driver.SelectContext(ctx, dbShardID, &rows, getTimerTasksQuery, filter.ShardID, filter.MinVisibilityTimestamp,
-		filter.TaskID, filter.MinVisibilityTimestamp, filter.MaxVisibilityTimestamp, filter.PageSize)
+		filter.TaskID, filter.MaxVisibilityTimestamp, filter.PageSize)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Replace OR-based cursor predicate with tuple comparison on(visibility_timestamp, task_id) so postgres can apply it as an Index Cond instead of a Filter, enabling an efficient ordered range scan using the existing index/PK. Update `SelectFromTimerTasks` parameter order.

<!-- Tell your future self why have you made these changes -->
**Why?**
Users have reported that the latency of the pagination query is high


<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Mannually:   Started Cadence with pg ->  - Launched ~2000 workflows to generate timer tasks -> Compared EXPLAIN plans.
Performance comparison `EXPLAIN (ANALYZE, BUFFERS)`:

Before (OR-based cursor predicate)
```
docker exec -i dev-postgres-1 psql -U postgres -d cadence -v ON_ERROR_STOP=1 -c "EXPLAIN (ANALYZE, BUFFERS) SELECT visibility_timestamp, task_id, data, data_encoding FROM timer_tasks WHERE shard_id = 1 AND ((visibility_timestamp >= TIMESTAMP '2026-01-21 14:30:25.566' AND task_id >= 1049182) OR visibility_timestamp > TIMESTAMP '2026-01-21 14:30:25.566') AND visibility_timestamp < TIMESTAMP '2026-01-21 15:30:36.123' ORDER BY visibility_timestamp, task_id LIMIT 100;"
                                                                                                    QUERY PLAN                                                                                                    
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..76.61 rows=100 width=159) (actual time=1.211..1.387 rows=100 loops=1)
   Buffers: shared hit=1158
   ->  Index Scan using timer_tasks_pkey on timer_tasks  (cost=0.29..1726.06 rows=2261 width=159) (actual time=1.210..1.375 rows=100 loops=1)
         Index Cond: ((shard_id = 1) AND (visibility_timestamp < '2026-01-21 15:30:36.123'::timestamp without time zone))
         Filter: (((visibility_timestamp >= '2026-01-21 14:30:25.566'::timestamp without time zone) AND (task_id >= 1049182)) OR (visibility_timestamp > '2026-01-21 14:30:25.566'::timestamp without time zone))
         Rows Removed by Filter: 1155
         Buffers: shared hit=1158
 Planning:
   Buffers: shared hit=156
 Planning Time: 0.533 ms
 Execution Time: 1.426 ms
(11 rows)
```

Execution Time: 1.426 ms
Shared buffer hits: 1158
Rows removed by filter: 1155
Cursor applied as Filter (scan + discard)

After (tuple comparison cursor)
```
docker exec -i dev-postgres-1 psql -U postgres -d cadence -v ON_ERROR_STOP=1 -c "EXPLAIN (ANALYZE, BUFFERS) SELECT visibility_timestamp, task_id, data, data_encoding FROM timer_tasks WHERE shard_id = 1 AND (visibility_timestamp, task_id) >= (TIMESTAMP '2026-01-21 14:30:25.566', 1049182) AND visibility_timestamp < TIMESTAMP '2026-01-21 15:30:36.123' ORDER BY visibility_timestamp, task_id LIMIT 100;"
                                                                                                                QUERY PLAN                                                                                                                 
-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.29..104.31 rows=100 width=159) (actual time=0.028..0.233 rows=100 loops=1)
   Buffers: shared hit=92
   ->  Index Scan using timer_tasks_pkey on timer_tasks  (cost=0.29..1648.04 rows=1584 width=159) (actual time=0.026..0.222 rows=100 loops=1)
         Index Cond: ((shard_id = 1) AND (ROW(visibility_timestamp, task_id) >= ROW('2026-01-21 14:30:25.566'::timestamp without time zone, 1049182)) AND (visibility_timestamp < '2026-01-21 15:30:36.123'::timestamp without time zone))
         Buffers: shared hit=92
 Planning:
   Buffers: shared hit=138
 Planning Time: 0.459 ms
 Execution Time: 0.280 ms
(9 rows)
```
Execution Time: 0.280 ms
Shared buffer hits: 92
Rows removed by filter: 0
Cursor applied as Index Cond (ordered range scan)

Improvements (tested locally)
5× faster execution
12× fewer buffer hits 
43× faster time to first row
Eliminated wasted scanning of 1155 rows

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
