### PR TITLE
chore: Update history task processor to switch to the new scheduler as the default

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -4058,7 +4058,7 @@ var IntKeys = map[IntKey]DynamicInt{
 	},
 	TaskSchedulerMigrationRatio: {
 		KeyName:      "history.taskSchedulerMigrationRatio",
-		Description:  "TaskSchedulerMigrationRatio is the ratio of task that is migrated to new scheduler",
+		Description:  "DEPRECATED: TaskSchedulerMigrationRatio is the ratio of task that is migrated to new scheduler",
 		DefaultValue: 0,
 	},
 	MaxActivityCountDispatchByDomain: {
@@ -4549,7 +4549,7 @@ var BoolKeys = map[BoolKey]DynamicBool{
 	},
 	TaskSchedulerEnableMigration: {
 		KeyName:      "history.taskSchedulerEnableMigration",
-		Description:  "TaskSchedulerEnableMigration indicates whether the task scheduler migration is enabled",
+		Description:  "DEPRECATED: TaskSchedulerEnableMigration indicates whether the task scheduler migration is enabled",
 		DefaultValue: false,
 	},
 	EnableAdminProtection: {

--- a/service/history/config/config.go
+++ b/service/history/config/config.go
@@ -102,8 +102,6 @@ type Config struct {
 	TaskSchedulerGlobalDomainRPS             dynamicproperties.IntPropertyFnWithDomainFilter
 	TaskSchedulerEnableRateLimiter           dynamicproperties.BoolPropertyFn
 	TaskSchedulerEnableRateLimiterShadowMode dynamicproperties.BoolPropertyFnWithDomainFilter
-	TaskSchedulerEnableMigration             dynamicproperties.BoolPropertyFn
-	TaskSchedulerMigrationRatio              dynamicproperties.IntPropertyFn
 	TaskCriticalRetryCount                   dynamicproperties.IntPropertyFn
 	ActiveTaskRedispatchInterval             dynamicproperties.DurationPropertyFn
 	StandbyTaskRedispatchInterval            dynamicproperties.DurationPropertyFn
@@ -409,8 +407,6 @@ func New(dc *dynamicconfig.Collection, numberOfShards int, maxMessageSize int, i
 		TaskSchedulerGlobalDomainRPS:             dc.GetIntPropertyFilteredByDomain(dynamicproperties.TaskSchedulerGlobalDomainRPS),
 		TaskSchedulerEnableRateLimiter:           dc.GetBoolProperty(dynamicproperties.TaskSchedulerEnableRateLimiter),
 		TaskSchedulerEnableRateLimiterShadowMode: dc.GetBoolPropertyFilteredByDomain(dynamicproperties.TaskSchedulerEnableRateLimiterShadowMode),
-		TaskSchedulerEnableMigration:             dc.GetBoolProperty(dynamicproperties.TaskSchedulerEnableMigration),
-		TaskSchedulerMigrationRatio:              dc.GetIntProperty(dynamicproperties.TaskSchedulerMigrationRatio),
 		TaskCriticalRetryCount:                   dc.GetIntProperty(dynamicproperties.TaskCriticalRetryCount),
 		ActiveTaskRedispatchInterval:             dc.GetDurationProperty(dynamicproperties.ActiveTaskRedispatchInterval),
 		StandbyTaskRedispatchInterval:            dc.GetDurationProperty(dynamicproperties.StandbyTaskRedispatchInterval),

--- a/service/history/config/config_test.go
+++ b/service/history/config/config_test.go
@@ -101,8 +101,6 @@ func TestNewConfig(t *testing.T) {
 		"TaskSchedulerDispatcherCount":                         {dynamicproperties.TaskSchedulerDispatcherCount, 35},
 		"TaskSchedulerRoundRobinWeights":                       {dynamicproperties.TaskSchedulerRoundRobinWeights, map[string]interface{}{"key": 1}},
 		"TaskSchedulerDomainRoundRobinWeights":                 {dynamicproperties.TaskSchedulerDomainRoundRobinWeights, map[string]interface{}{"key": 2}},
-		"TaskSchedulerEnableMigration":                         {dynamicproperties.TaskSchedulerEnableMigration, true},
-		"TaskSchedulerMigrationRatio":                          {dynamicproperties.TaskSchedulerMigrationRatio, 36},
 		"TaskCriticalRetryCount":                               {dynamicproperties.TaskCriticalRetryCount, 37},
 		"ActiveTaskRedispatchInterval":                         {dynamicproperties.ActiveTaskRedispatchInterval, time.Second},
 		"StandbyTaskRedispatchInterval":                        {dynamicproperties.StandbyTaskRedispatchInterval, time.Second},


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
- Update history task processor to switch to the new scheduler as the default
- Keep the migration framework for future migration support

<!-- Tell your future self why have you made these changes -->
**Why?**
Code cleanup & prepare for future migration

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
existing unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
