### PR TITLE
fix: tightning classifications a bit on history cleanup

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -1731,6 +1731,9 @@ type (
 
 // IsTimeoutError check whether error is TimeoutError
 func IsTimeoutError(err error) bool {
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
 	var timeoutError *TimeoutError
 	ok := errors.As(err, &timeoutError)
 	return ok

--- a/service/history/engine/engineimpl/start_workflow_execution.go
+++ b/service/history/engine/engineimpl/start_workflow_execution.go
@@ -390,6 +390,7 @@ func (e *historyEngineImpl) handleCreateWorkflowExecutionFailureCleanup(
 		errors.As(err, new(*types.ShardOwnershipLostError)) ||
 		errors.As(err, new(*types.WorkflowExecutionAlreadyStartedError)) ||
 		errors.As(err, new(*types.WorkflowExecutionAlreadyCompletedError)) ||
+		errors.As(err, new(*persistence.ShardOwnershipLostError)) ||
 		errors.As(err, new(*persistence.DuplicateRequestError))
 
 	if !isKnownFailureRequiringCleanup {


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**

Just tightening cleanup a little to just catch a few more minor cases where we should remove history after failing to start the workflow. 

<!-- Tell your future self why have you made these changes -->
**Why?**

This has been added after observing production rollouts. They're a nonessential change that shouldn't increase the risk at all. 

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
