### PR TITLE
refactor: remove time generation from sql db layer

### DIFF
--- a/common/persistence/sql/sql_history_store.go
+++ b/common/persistence/sql/sql_history_store.go
@@ -24,7 +24,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"time"
 
 	"github.com/uber/cadence/common"
 	"github.com/uber/cadence/common/constants"
@@ -100,7 +99,7 @@ func (m *sqlHistoryStore) AppendHistoryNodes(
 		treeInfo := &serialization.HistoryTreeInfo{
 			Ancestors:        ancestors,
 			Info:             request.Info,
-			CreatedTimestamp: time.Now(),
+			CreatedTimestamp: request.CurrentTimeStamp,
 		}
 
 		blob, err := m.parser.HistoryTreeInfoToBlob(treeInfo)
@@ -349,7 +348,7 @@ func (m *sqlHistoryStore) ForkHistoryBranch(
 	treeInfo := &serialization.HistoryTreeInfo{
 		Ancestors:        newAncestors,
 		Info:             request.Info,
-		CreatedTimestamp: time.Now(),
+		CreatedTimestamp: request.CurrentTimeStamp,
 	}
 
 	blob, err := m.parser.HistoryTreeInfoToBlob(treeInfo)


### PR DESCRIPTION

<!-- Describe what has changed in this PR -->
**What changed?**

Replaced time.Now() in sql_history/task stores with request.CurrentTime

<!-- Tell your future self why have you made these changes -->
**Why?**

I missed a couple of time.Now() calls still living in the sql store layer;  we should keep time generation out of low level persistence due to https://github.com/cadence-workflow/cadence/issues/6610 .

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**

Unit tests 

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
