### PR TITLE
chore: Add a metric to monitor the size of weighted channel pool

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2469,6 +2469,8 @@ const (
 	BudgetManagerHardCapExceeded
 	BudgetManagerSoftCapExceeded
 
+	WeightedChannelPoolSizeGauge
+
 	NumCommonMetrics // Needs to be last on this list for iota numbering
 )
 
@@ -3293,6 +3295,8 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		BudgetManagerActiveCacheCount: {metricName: "budget_manager_active_cache_count", metricType: Gauge},
 		BudgetManagerHardCapExceeded:  {metricName: "budget_manager_hard_cap_exceeded", metricType: Counter},
 		BudgetManagerSoftCapExceeded:  {metricName: "budget_manager_soft_cap_exceeded", metricType: Counter},
+
+		WeightedChannelPoolSizeGauge: {metricName: "weighted_channel_pool_size", metricType: Gauge},
 	},
 	History: {
 		TaskRequests:                     {metricName: "task_requests", metricType: Counter},

--- a/common/task/weighted_channel_pool_test.go
+++ b/common/task/weighted_channel_pool_test.go
@@ -31,12 +31,14 @@ import (
 
 	"github.com/uber/cadence/common/clock"
 	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/common/metrics"
 )
 
 func TestGetOrCreateChannel(t *testing.T) {
 	timeSource := clock.NewMockedTimeSource()
 	pool := NewWeightedRoundRobinChannelPool[string, int](
 		testlogger.New(t),
+		metrics.NoopScope,
 		timeSource,
 		WeightedRoundRobinChannelPoolOptions{
 			BufferSize:              1000,
@@ -61,6 +63,7 @@ func TestGetOrCreateChannelConcurrent(t *testing.T) {
 	timeSource := clock.NewMockedTimeSource()
 	pool := NewWeightedRoundRobinChannelPool[string, int](
 		testlogger.New(t),
+		metrics.NoopScope,
 		timeSource,
 		WeightedRoundRobinChannelPoolOptions{
 			BufferSize:              1000,
@@ -107,6 +110,7 @@ func TestGetSchedule(t *testing.T) {
 	timeSource := clock.NewMockedTimeSource()
 	pool := NewWeightedRoundRobinChannelPool[string, int](
 		testlogger.New(t),
+		metrics.NoopScope,
 		timeSource,
 		WeightedRoundRobinChannelPoolOptions{
 			BufferSize:              1000,
@@ -151,6 +155,7 @@ func TestCleanup(t *testing.T) {
 	timeSource := clock.NewRealTimeSource()
 	pool := NewWeightedRoundRobinChannelPool[string, int](
 		testlogger.New(t),
+		metrics.NoopScope,
 		timeSource,
 		WeightedRoundRobinChannelPoolOptions{
 			BufferSize:              1000,

--- a/common/task/weighted_round_robin_task_scheduler.go
+++ b/common/task/weighted_round_robin_task_scheduler.go
@@ -66,16 +66,21 @@ func NewWeightedRoundRobinTaskScheduler[K comparable](
 	processor Processor,
 	options *WeightedRoundRobinTaskSchedulerOptions[K],
 ) (Scheduler, error) {
+	metricsScope := metricsClient.Scope(metrics.TaskSchedulerScope)
 	scheduler := &weightedRoundRobinTaskSchedulerImpl[K]{
 		status: common.DaemonStatusInitialized,
-		pool: NewWeightedRoundRobinChannelPool[K, PriorityTask](logger, timeSource, WeightedRoundRobinChannelPoolOptions{
-			BufferSize:              options.QueueSize,
-			IdleChannelTTLInSeconds: defaultIdleChannelTTLInSeconds,
-		}),
+		pool: NewWeightedRoundRobinChannelPool[K, PriorityTask](
+			logger,
+			metricsScope,
+			timeSource,
+			WeightedRoundRobinChannelPoolOptions{
+				BufferSize:              options.QueueSize,
+				IdleChannelTTLInSeconds: defaultIdleChannelTTLInSeconds,
+			}),
 		shutdownCh:   make(chan struct{}),
 		notifyCh:     make(chan struct{}, 1),
 		logger:       logger,
-		metricsScope: metricsClient.Scope(metrics.TaskSchedulerScope),
+		metricsScope: metricsScope,
 		options:      options,
 		processor:    processor,
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Add a metric to monitor the size of weighted channel pool

<!-- Tell your future self why have you made these changes -->
**Why?**
Improve observability

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**


<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
