### PR TITLE
feat: Add cadence-caller-type to cli header

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -54,4 +54,7 @@ const (
 
 	// ClientIsolationGroupHeaderName refers to the name of the header that contains the isolation group which the client request is from
 	ClientIsolationGroupHeaderName = "cadence-client-isolation-group"
+
+	// CallerTypeHeaderName refers to the name of the header that contains the caller type (CLI, UI, SDK, internal, etc.)
+	CallerTypeHeaderName = "cadence-caller-type"
 )

--- a/tools/cli/factory.go
+++ b/tools/cli/factory.go
@@ -52,6 +52,7 @@ import (
 	"github.com/uber/cadence/common"
 	cc "github.com/uber/cadence/common/client"
 	"github.com/uber/cadence/common/config"
+	"github.com/uber/cadence/common/types"
 	"github.com/uber/cadence/tools/common/commoncli"
 )
 
@@ -305,7 +306,8 @@ func (vm *versionMiddleware) Call(ctx context.Context, request *transport.Reques
 	request.Headers = request.Headers.
 		With(common.ClientImplHeaderName, cc.CLI).
 		With(common.FeatureVersionHeaderName, cc.SupportedCLIVersion).
-		With(common.ClientFeatureFlagsHeaderName, cc.FeatureFlagsHeader(cc.DefaultCLIFeatureFlags))
+		With(common.ClientFeatureFlagsHeaderName, cc.FeatureFlagsHeader(cc.DefaultCLIFeatureFlags)).
+		With(common.CallerTypeHeaderName, types.CallerTypeCLI.String())
 	if jwtKey, ok := ctx.Value(CtxKeyJWT).(string); ok {
 		request.Headers = request.Headers.With(common.AuthorizationTokenHeaderName, jwtKey)
 	}


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Added cadence-caller-type to cli header with the value "cli".

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to have more information about the caller when receiving and processing requests. There is some overlap with the exiting cadence-client-name header but they will serve different purposes.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Tested locally

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risk, just adding a new header

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
