### PR TITLE
feat: Extract cadence-caller-type from headers

### DIFF
--- a/common/headers.go
+++ b/common/headers.go
@@ -20,6 +20,8 @@
 
 package common
 
+import "github.com/uber/cadence/common/types"
+
 const (
 	// LibraryVersionHeaderName refers to the name of the
 	// tchannel / http header that contains the client
@@ -56,5 +58,5 @@ const (
 	ClientIsolationGroupHeaderName = "cadence-client-isolation-group"
 
 	// CallerTypeHeaderName refers to the name of the header that contains the caller type (CLI, UI, SDK, internal, etc.)
-	CallerTypeHeaderName = "cadence-caller-type"
+	CallerTypeHeaderName = types.CallerTypeHeaderName
 )


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Created ways to extract CallerInfo headers, such as cadence-caller-type, and either return CallerInfo or return a context with the CallerInfo in it.

If cadence-caller-type is not provided or is an empty string, the value assigned is "unknown".

<!-- Tell your future self why have you made these changes -->
**Why?**
We want to categorize caller types for auditing and rate limiting purposes.

We should be able to add CallerInfo to the context so it can propagate downstream as well as being able to extract directly from headers when that's not necessary.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
Unit tests.

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
No risks.

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
