### PR TITLE
feat(cadence-matching): simplify the load calculation for shards

### DIFF
--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -75,6 +75,7 @@ type (
 		UpdateTaskListPartitionConfig(context.Context, *types.TaskListPartitionConfig) error
 		RefreshTaskListPartitionConfig(context.Context, *types.TaskListPartitionConfig) error
 		LoadBalancerHints() *types.LoadBalancerHints
+		QueriesPerSecond() float64
 		ReleaseBlockedPollers() error
 	}
 

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -221,6 +221,20 @@ func (mr *MockManagerMockRecorder) LoadBalancerHints() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LoadBalancerHints", reflect.TypeOf((*MockManager)(nil).LoadBalancerHints))
 }
 
+// QueriesPerSecond mocks base method.
+func (m *MockManager) QueriesPerSecond() float64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueriesPerSecond")
+	ret0, _ := ret[0].(float64)
+	return ret0
+}
+
+// QueriesPerSecond indicates an expected call of QueriesPerSecond.
+func (mr *MockManagerMockRecorder) QueriesPerSecond() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueriesPerSecond", reflect.TypeOf((*MockManager)(nil).QueriesPerSecond))
+}
+
 // RefreshTaskListPartitionConfig mocks base method.
 func (m *MockManager) RefreshTaskListPartitionConfig(arg0 context.Context, arg1 *types.TaskListPartitionConfig) error {
 	m.ctrl.T.Helper()

--- a/service/matching/tasklist/shard_processor.go
+++ b/service/matching/tasklist/shard_processor.go
@@ -107,10 +107,8 @@ func (sp *shardProcessorImpl) getShardLoad() float64 {
 	// we need to sum the rps for each of the tasklist to calculate the load.
 	for _, tlMgr := range sp.taskLists {
 		if tlMgr.TaskListID().name == sp.shardID {
-			lbh := tlMgr.LoadBalancerHints()
-			if lbh != nil {
-				load = load + lbh.RatePerSecond
-			}
+			qps := tlMgr.QueriesPerSecond()
+			load = load + qps
 		}
 	}
 	return load

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -398,6 +398,10 @@ func (c *taskListManagerImpl) LoadBalancerHints() *types.LoadBalancerHints {
 	}
 }
 
+func (c *taskListManagerImpl) QueriesPerSecond() float64 {
+	return c.qpsTracker.QPS()
+}
+
 func isTaskListPartitionConfigEqual(a types.TaskListPartitionConfig, b types.TaskListPartitionConfig) bool {
 	a.Version = b.Version
 	return reflect.DeepEqual(a, b)


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Instead of relying on LoadBalancerHints for load calculation, we rely on a new method QueriesPerSecond, which is only providing the value we are interested in

<!-- Tell your future self why have you made these changes -->
**Why?**
This is a more efficient way to get the load, since startWG.Wait() which is invoked in the LoadBalancerHints is stopping until the tasklist is started, but we don't really need to wait at startup, since the load will be 0.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
unit tests

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**
no risk, we are using the same value right now

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
