### PR TITLE
fix: Remove sync retry logic in AddTask function

### DIFF
--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -575,7 +575,8 @@ func (c *taskListManagerImpl) AddTask(ctx context.Context, params AddTaskParams)
 		// Persist the standby task, but the sync match still fails.
 		// Return the false syncMatch flag along with any error
 		_, err = c.taskWriter.appendTask(params.TaskInfo)
-		if err != nil {
+		if err == nil {
+			// Signal the task reader only if appendTask succeeded
 			c.taskReader.Signal()
 		}
 		return syncMatch, err


### PR DESCRIPTION
<!-- Describe what has changed in this PR -->
**What changed?**
Removed the sync match retry logic in the AddTask function.
> After the code review, I'll remove [executionWithRetry](https://github.com/cadence-workflow/cadence/blob/master/service/matching/tasklist/task_list_manager.go#L829) for following task.

<!-- Tell your future self why have you made these changes -->
**Why?**
This refactoring task is to resolve #7641.  
If synchronous matching fails, the task should simply be written to the database for later asynchronous matching.  
But the previous code attempted another synchronous match after failure, which is unnecessary retry logic.

<!-- How have you verified this change? Tested locally? Added a unit test? Checked in staging env? -->
**How did you test it?**
- Ran `go test -v ./service/matching/tasklist` and all tests passed

<!-- Assuming the worst case, what can be broken when deploying this change to production? -->
**Potential risks**

<!-- Is it notable for release? e.g. schema updates, configuration or data migration required? If so, please mention it, and also update CHANGELOG.md -->
**Release notes**

<!-- Is there any documentation updates should be made for config, https://cadenceworkflow.io/docs/operation-guide/setup/ ? If so, please open an PR in https://github.com/cadence-workflow/cadence-docs -->
**Documentation Changes**
