### PR TITLE
feat(shard-distributor-canary): add support for running multiple spectators

### DIFF
--- a/cmd/sharddistributor-canary/main_test.go
+++ b/cmd/sharddistributor-canary/main_test.go
@@ -17,5 +17,7 @@ func TestDependenciesAreSatisfied(t *testing.T) {
 		defaultNumExecutors,
 		defaultNumShardCreators,
 		defaultShardCreationInterval,
+		defaultNumSpectators,
+		defaultNumSpectators,
 	)))
 }

--- a/cmd/sharddistributor-canary/main_test.go
+++ b/cmd/sharddistributor-canary/main_test.go
@@ -15,5 +15,7 @@ func TestDependenciesAreSatisfied(t *testing.T) {
 		defaultCanaryGRPCPort,
 		defaultNumExecutors,
 		defaultNumExecutors,
+		defaultNumShardCreators,
+		defaultShardCreationInterval,
 	)))
 }

--- a/cmd/sharddistributor-canary/main_test.go
+++ b/cmd/sharddistributor-canary/main_test.go
@@ -8,5 +8,12 @@ import (
 )
 
 func TestDependenciesAreSatisfied(t *testing.T) {
-	assert.NoError(t, fx.ValidateApp(opts(defaultFixedNamespace, defaultEphemeralNamespace, defaultShardDistributorEndpoint, defaultCanaryGRPCPort)))
+	assert.NoError(t, fx.ValidateApp(opts(
+		defaultFixedNamespace,
+		defaultEphemeralNamespace,
+		defaultShardDistributorEndpoint,
+		defaultCanaryGRPCPort,
+		defaultNumExecutors,
+		defaultNumExecutors,
+	)))
 }

--- a/service/sharddistributor/canary/config/config.go
+++ b/service/sharddistributor/canary/config/config.go
@@ -1,5 +1,7 @@
 package config
 
+import "time"
+
 // Config is the configuration for the shard distributor canary
 type Config struct {
 	Canary CanaryConfig `yaml:"canary"`
@@ -15,4 +17,15 @@ type CanaryConfig struct {
 	// Values more than 1 will create multiple executors processing the same ephemeral namespace
 	// Default: 1
 	NumEphemeralExecutors int `yaml:"numEphemeralExecutors"`
+
+	// NumShardCreators is the number of shard creators creating new ephemeral shards.
+	// ShardCreator uses Ping API of Canary and Spectator library to retrieve an owner of a new ephemeral shard
+	// This call causes a creation of the new ephemeral shard in the shard distributor service.
+	// Values more than 1 enable testing of concurrent shard creation.
+	// Default: 1
+	NumShardCreators int `yaml:"numShardCreators"`
+
+	// ShardCreationInterval is the interval between creating new ephemeral shards by each shard creator.
+	// Default: 1s
+	ShardCreationInterval time.Duration `yaml:"shardCreationInterval"`
 }

--- a/service/sharddistributor/canary/config/config.go
+++ b/service/sharddistributor/canary/config/config.go
@@ -13,10 +13,20 @@ type CanaryConfig struct {
 	// Default: 1
 	NumFixedExecutors int `yaml:"numFixedExecutors"`
 
+	// NumFixedSpectators is the number of spectators of fixed namespace
+	// Values more than 1 will create multiple spectators monitoring the same fixed namespace
+	// Default: 1
+	NumFixedSpectators int `yaml:"numFixedSpectators"`
+
 	// NumEphemeralExecutors is the number of executors of ephemeral namespace
 	// Values more than 1 will create multiple executors processing the same ephemeral namespace
 	// Default: 1
 	NumEphemeralExecutors int `yaml:"numEphemeralExecutors"`
+
+	// NumEphemeralSpectators is the number of spectators of ephemeral namespace
+	// Values more than 1 will create multiple spectators monitoring the same ephemeral namespace
+	// Default: 1
+	NumEphemeralSpectators int `yaml:"numEphemeralSpectators"`
 
 	// NumShardCreators is the number of shard creators creating new ephemeral shards.
 	// ShardCreator uses Ping API of Canary and Spectator library to retrieve an owner of a new ephemeral shard

--- a/service/sharddistributor/canary/config/config.go
+++ b/service/sharddistributor/canary/config/config.go
@@ -1,0 +1,18 @@
+package config
+
+// Config is the configuration for the shard distributor canary
+type Config struct {
+	Canary CanaryConfig `yaml:"canary"`
+}
+
+type CanaryConfig struct {
+	// NumFixedExecutors is the number of executors of fixed namespace
+	// Values more than 1 will create multiple executors processing the same fixed namespace
+	// Default: 1
+	NumFixedExecutors int `yaml:"numFixedExecutors"`
+
+	// NumEphemeralExecutors is the number of executors of ephemeral namespace
+	// Values more than 1 will create multiple executors processing the same ephemeral namespace
+	// Default: 1
+	NumEphemeralExecutors int `yaml:"numEphemeralExecutors"`
+}

--- a/service/sharddistributor/canary/executors/executors_test.go
+++ b/service/sharddistributor/canary/executors/executors_test.go
@@ -232,3 +232,111 @@ func createMockParams[SP executorclient.ShardProcessor](
 		TimeSource: clock.NewMockedTimeSource(),
 	}
 }
+
+func TestNewExecutorsWithFixedNamespace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tests := []struct {
+		name         string
+		namespace    string
+		numExecutors int
+		expected     int
+	}{
+		{
+			name:         "zero executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: 0,
+			expected:     1,
+		},
+		{
+			name:         "negative executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: -1,
+			expected:     1,
+		},
+		{
+			name:         "one executor",
+			namespace:    "test-namespace",
+			numExecutors: 1,
+			expected:     1,
+		},
+		{
+			name:         "two executors",
+			namespace:    "test-namespace",
+			numExecutors: 2,
+			expected:     2,
+		},
+		{
+			name:         "five executors",
+			namespace:    "test-namespace",
+			numExecutors: 5,
+			expected:     5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := createMockParams[*processor.ShardProcessor](ctrl, tt.namespace)
+			result, err := NewExecutorsWithFixedNamespace(params, tt.namespace, tt.numExecutors)
+
+			require.NoError(t, err)
+			assert.Len(t, result.Executors, tt.expected)
+			for _, executor := range result.Executors {
+				assert.NotNil(t, executor)
+			}
+		})
+	}
+}
+
+func TestNewExecutorsWithEphemeralNamespace(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	tests := []struct {
+		name         string
+		namespace    string
+		numExecutors int
+		expected     int
+	}{
+		{
+			name:         "zero executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: 0,
+			expected:     1,
+		},
+		{
+			name:         "negative executors defaults to one",
+			namespace:    "test-namespace",
+			numExecutors: -1,
+			expected:     1,
+		},
+		{
+			name:         "one executor",
+			namespace:    "test-namespace",
+			numExecutors: 1,
+			expected:     1,
+		},
+		{
+			name:         "two executors",
+			namespace:    "test-namespace",
+			numExecutors: 2,
+			expected:     2,
+		},
+		{
+			name:         "five executors",
+			namespace:    "test-namespace",
+			numExecutors: 5,
+			expected:     5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			params := createMockParams[*processorephemeral.ShardProcessor](ctrl, tt.namespace)
+			result, err := NewExecutorsWithEphemeralNamespace(params, tt.namespace, tt.numExecutors)
+
+			require.NoError(t, err)
+			assert.Len(t, result.Executors, tt.expected)
+			for _, executor := range result.Executors {
+				assert.NotNil(t, executor)
+			}
+		})
+	}
+}

--- a/service/sharddistributor/canary/module.go
+++ b/service/sharddistributor/canary/module.go
@@ -14,6 +14,7 @@ import (
 	"github.com/uber/cadence/service/sharddistributor/canary/processorephemeral"
 	"github.com/uber/cadence/service/sharddistributor/canary/sharddistributorclient"
 	"github.com/uber/cadence/service/sharddistributor/canary/sharddistributorexecutorclient"
+	"github.com/uber/cadence/service/sharddistributor/canary/spectators"
 	"github.com/uber/cadence/service/sharddistributor/client/executorclient"
 	"github.com/uber/cadence/service/sharddistributor/client/spectatorclient"
 )
@@ -58,6 +59,9 @@ func opts(names NamespacesNames) fx.Option {
 
 		// Instantiate executors for multiple namespaces
 		executors.Module(names.FixedNamespace, names.EphemeralNamespace, names.ExternalAssignmentNamespace),
+
+		// Create multiple spectators for fixed and ephemeral namespaces based on config
+		spectators.Module(names.FixedNamespace, names.EphemeralNamespace),
 
 		processorephemeral.ShardCreatorModule([]string{names.EphemeralNamespace}),
 

--- a/service/sharddistributor/canary/module.go
+++ b/service/sharddistributor/canary/module.go
@@ -5,6 +5,7 @@ import (
 	"go.uber.org/yarpc"
 
 	sharddistributorv1 "github.com/uber/cadence/.gen/proto/sharddistributor/v1"
+	"github.com/uber/cadence/service/sharddistributor/canary/config"
 	"github.com/uber/cadence/service/sharddistributor/canary/executors"
 	"github.com/uber/cadence/service/sharddistributor/canary/factory"
 	"github.com/uber/cadence/service/sharddistributor/canary/handler"
@@ -23,6 +24,8 @@ type NamespacesNames struct {
 	EphemeralNamespace          string
 	ExternalAssignmentNamespace string
 	SharddistributorServiceName string
+
+	Config config.Config
 }
 
 func Module(namespacesNames NamespacesNames) fx.Option {
@@ -31,6 +34,8 @@ func Module(namespacesNames NamespacesNames) fx.Option {
 
 func opts(names NamespacesNames) fx.Option {
 	return fx.Options(
+		fx.Supply(names.Config),
+
 		fx.Provide(sharddistributorv1.NewFxShardDistributorExecutorAPIYARPCClient(names.SharddistributorServiceName)),
 		fx.Provide(sharddistributorv1.NewFxShardDistributorAPIYARPCClient(names.SharddistributorServiceName)),
 

--- a/service/sharddistributor/canary/spectators/spectators.go
+++ b/service/sharddistributor/canary/spectators/spectators.go
@@ -1,0 +1,61 @@
+package spectators
+
+import (
+	"go.uber.org/fx"
+
+	"github.com/uber/cadence/service/sharddistributor/canary/config"
+	"github.com/uber/cadence/service/sharddistributor/client/spectatorclient"
+)
+
+func Module(fixedNamespace, ephemeralNamespace string) fx.Option {
+	return fx.Module("Spectators",
+		fx.Provide(func(p Params) ([]spectatorclient.Spectator, error) {
+			return NewSpectators(p, fixedNamespace, ephemeralNamespace)
+		}),
+
+		fx.Invoke(func(spectators []spectatorclient.Spectator, lc fx.Lifecycle) {
+			for _, sp := range spectators {
+				lc.Append(fx.StartStopHook(sp.Start, sp.Stop))
+			}
+		}),
+	)
+}
+
+type Params struct {
+	fx.In
+
+	Config          config.Config
+	SpectatorParams spectatorclient.Params
+}
+
+func NewSpectators(p Params, fixedNamespace, ephemeralNamespace string) ([]spectatorclient.Spectator, error) {
+	fixed, err := NewSpectatorsWithNamespace(p.SpectatorParams, fixedNamespace, p.Config.Canary.NumFixedSpectators)
+	if err != nil {
+		return nil, err
+	}
+
+	ephemeral, err := NewSpectatorsWithNamespace(p.SpectatorParams, ephemeralNamespace, p.Config.Canary.NumEphemeralSpectators)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(fixed, ephemeral...), nil
+}
+
+func NewSpectatorsWithNamespace(params spectatorclient.Params, namespace string, numSpectators int) ([]spectatorclient.Spectator, error) {
+	var spectators []spectatorclient.Spectator
+
+	if numSpectators <= 0 {
+		numSpectators = 1
+	}
+
+	for i := 0; i < numSpectators; i++ {
+		spectator, err := spectatorclient.NewSpectatorWithNamespace(params, namespace)
+		if err != nil {
+			return nil, err
+		}
+		spectators = append(spectators, spectator)
+	}
+
+	return spectators, nil
+}

--- a/service/sharddistributor/canary/spectators/spectators_test.go
+++ b/service/sharddistributor/canary/spectators/spectators_test.go
@@ -1,0 +1,237 @@
+package spectators
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uber-go/tally"
+
+	"github.com/uber/cadence/client/sharddistributor"
+	"github.com/uber/cadence/common/clock"
+	"github.com/uber/cadence/common/log/testlogger"
+	"github.com/uber/cadence/service/sharddistributor/canary/config"
+	"github.com/uber/cadence/service/sharddistributor/client/clientcommon"
+	"github.com/uber/cadence/service/sharddistributor/client/spectatorclient"
+)
+
+func TestNewSpectatorsWithNamespace(t *testing.T) {
+	tests := []struct {
+		name          string
+		numSpectators int
+		expectedCount int
+	}{
+		{
+			name:          "positive number of spectators",
+			numSpectators: 3,
+			expectedCount: 3,
+		},
+		{
+			name:          "zero spectators defaults to 1",
+			numSpectators: 0,
+			expectedCount: 1,
+		},
+		{
+			name:          "negative spectators defaults to 1",
+			numSpectators: -5,
+			expectedCount: 1,
+		},
+		{
+			name:          "one spectator",
+			numSpectators: 1,
+			expectedCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			namespace := "test-namespace"
+			params := createTestSpectatorParams(t, namespace)
+
+			spectators, err := NewSpectatorsWithNamespace(params, namespace, tc.numSpectators)
+
+			require.NoError(t, err)
+			assert.Len(t, spectators, tc.expectedCount)
+		})
+	}
+}
+
+func TestNewSpectators(t *testing.T) {
+	t.Run("creates fixed and ephemeral spectators", func(t *testing.T) {
+		fixedNamespace := "fixed-ns"
+		ephemeralNamespace := "ephemeral-ns"
+
+		cfg := config.Config{
+			Canary: config.CanaryConfig{
+				NumFixedSpectators:     2,
+				NumEphemeralSpectators: 3,
+			},
+		}
+
+		spectatorParams := createTestSpectatorParams(t, fixedNamespace, ephemeralNamespace)
+
+		p := Params{
+			Config:          cfg,
+			SpectatorParams: spectatorParams,
+		}
+
+		spectators, err := NewSpectators(p, fixedNamespace, ephemeralNamespace)
+
+		require.NoError(t, err)
+		assert.Len(t, spectators, 5) // 2 fixed + 3 ephemeral
+	})
+
+	t.Run("uses default of 1 when spectator counts are zero", func(t *testing.T) {
+		fixedNamespace := "fixed-ns"
+		ephemeralNamespace := "ephemeral-ns"
+
+		cfg := config.Config{
+			Canary: config.CanaryConfig{
+				NumFixedSpectators:     0,
+				NumEphemeralSpectators: 0,
+			},
+		}
+
+		spectatorParams := createTestSpectatorParams(t, fixedNamespace, ephemeralNamespace)
+
+		p := Params{
+			Config:          cfg,
+			SpectatorParams: spectatorParams,
+		}
+
+		spectators, err := NewSpectators(p, fixedNamespace, ephemeralNamespace)
+
+		require.NoError(t, err)
+		assert.Len(t, spectators, 2) // 1 fixed + 1 ephemeral (defaults)
+	})
+}
+
+func TestNewSpectators_ErrorCases(t *testing.T) {
+	t.Run("returns error when fixed namespace config is missing", func(t *testing.T) {
+		fixedNamespace := "missing-fixed-ns"
+		ephemeralNamespace := "ephemeral-ns"
+
+		cfg := config.Config{
+			Canary: config.CanaryConfig{
+				NumFixedSpectators:     1,
+				NumEphemeralSpectators: 1,
+			},
+		}
+
+		// Only configure ephemeral namespace, not fixed
+		spectatorParams := createTestSpectatorParams(t, ephemeralNamespace)
+
+		p := Params{
+			Config:          cfg,
+			SpectatorParams: spectatorParams,
+		}
+
+		spectators, err := NewSpectators(p, fixedNamespace, ephemeralNamespace)
+
+		assert.Error(t, err)
+		assert.Nil(t, spectators)
+	})
+
+	t.Run("returns error when ephemeral namespace config is missing", func(t *testing.T) {
+		fixedNamespace := "fixed-ns"
+		ephemeralNamespace := "missing-ephemeral-ns"
+
+		cfg := config.Config{
+			Canary: config.CanaryConfig{
+				NumFixedSpectators:     1,
+				NumEphemeralSpectators: 1,
+			},
+		}
+
+		// Only configure fixed namespace, not ephemeral
+		spectatorParams := createTestSpectatorParams(t, fixedNamespace)
+
+		p := Params{
+			Config:          cfg,
+			SpectatorParams: spectatorParams,
+		}
+
+		spectators, err := NewSpectators(p, fixedNamespace, ephemeralNamespace)
+
+		assert.Error(t, err)
+		assert.Nil(t, spectators)
+	})
+}
+
+func TestModule(t *testing.T) {
+	t.Run("module returns valid fx.Option", func(t *testing.T) {
+		fixedNamespace := "fixed-ns"
+		ephemeralNamespace := "ephemeral-ns"
+
+		option := Module(fixedNamespace, ephemeralNamespace)
+
+		// Verify the module returns a valid fx.Option
+		assert.NotNil(t, option)
+	})
+}
+
+func TestNewSpectatorsWithNamespace_MultipleSpectators(t *testing.T) {
+	t.Run("creates requested number of spectators", func(t *testing.T) {
+		namespace := "test-ns"
+		numSpectators := 5
+		params := createTestSpectatorParams(t, namespace)
+
+		spectators, err := NewSpectatorsWithNamespace(params, namespace, numSpectators)
+
+		require.NoError(t, err)
+		assert.Len(t, spectators, numSpectators)
+
+		// Verify each spectator is non-nil
+		for i, sp := range spectators {
+			assert.NotNil(t, sp, "spectator at index %d should not be nil", i)
+		}
+	})
+}
+
+// createTestSpectatorParams creates a spectatorclient.Params for testing with the given namespaces
+func createTestSpectatorParams(t *testing.T, namespaces ...string) spectatorclient.Params {
+	t.Helper()
+
+	var namespaceConfigs []clientcommon.NamespaceConfig
+	for _, ns := range namespaces {
+		namespaceConfigs = append(namespaceConfigs, clientcommon.NamespaceConfig{
+			Namespace:         ns,
+			HeartBeatInterval: time.Second,
+			TTLShard:          time.Minute,
+			TTLReport:         time.Second * 30,
+		})
+	}
+
+	return spectatorclient.Params{
+		Client:       sharddistributor.NewMockClient(nil),
+		MetricsScope: tally.NoopScope,
+		Logger:       testlogger.New(t),
+		Config: clientcommon.Config{
+			Namespaces: namespaceConfigs,
+		},
+		TimeSource: clock.NewRealTimeSource(),
+	}
+}
+
+// TestNewSpectatorsWithNamespace_ErrorPropagation tests that errors from NewSpectatorWithNamespace are propagated
+func TestNewSpectatorsWithNamespace_ErrorPropagation(t *testing.T) {
+	t.Run("propagates error when spectator creation fails", func(t *testing.T) {
+		namespace := "unconfigured-namespace"
+		// Create params without the namespace configured to trigger an error
+		params := spectatorclient.Params{
+			Client:       sharddistributor.NewMockClient(nil),
+			MetricsScope: tally.NoopScope,
+			Logger:       testlogger.New(t),
+			Config: clientcommon.Config{
+				Namespaces: []clientcommon.NamespaceConfig{}, // Empty - no namespaces configured
+			},
+			TimeSource: clock.NewRealTimeSource(),
+		}
+
+		spectators, err := NewSpectatorsWithNamespace(params, namespace, 1)
+
+		assert.Error(t, err)
+		assert.Nil(t, spectators)
+	})
+}


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
* Modified shard-distributor-canary to support for running multiple spectators 


<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
* Loading testing requires us to be able to run multiple spectators to simulate spectator clients


<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `ETCD=1 go test -v ./service/sharddistributor-run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad: "Tested locally" or "Added tests" -->
**How did you test it?**
* Unit test by  `ETCD=1 go test -v ./service/sharddistributor-run TestFailoverDomainRequest` 
* Local run of sd-canary by `make sharddistributor-canary && ./sharddistributor-canary start --num-spectators=5`


<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
* No risks


<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**


<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**


---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
