### PR TITLE
feat(cli): Add --remote flag hint on delete workflow failure

### DIFF
--- a/tools/cli/admin_commands.go
+++ b/tools/cli/admin_commands.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	tableRenderSize = 10
+	remoteHint      = " (Hint: use --remote flag to run this operation via the server API instead of direct DB access)"
 )
 
 // AdminShowWorkflow shows history
@@ -289,7 +290,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 
 	resp, err := describeMutableState(c)
 	if err != nil {
-		return err
+		return commoncli.Problem("Failed to get workflow mutable state"+remoteHint, err)
 	}
 	msStr := resp.GetMutableStateInDatabase()
 	ms := persistence.WorkflowMutableState{}
@@ -307,11 +308,11 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 	histV2, err := getDeps(c).initializeHistoryManager(c)
 	defer histV2.Close()
 	if err != nil {
-		return commoncli.Problem("Error in Admin delete WF: ", err)
+		return commoncli.Problem("Unable to initialize history manager"+remoteHint, err)
 	}
 	exeStore, err := getDeps(c).initializeExecutionManager(c, shardIDInt)
 	if err != nil {
-		return commoncli.Problem("Error in Admin delete WF: ", err)
+		return commoncli.Problem("Unable to initialize execution manager"+remoteHint, err)
 	}
 	branchInfo := shared.HistoryBranch{}
 	thriftrwEncoder := codec.NewThriftRWEncoder()
@@ -340,7 +341,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 			if skipError {
 				fmt.Println("failed to delete history, ", err)
 			} else {
-				return commoncli.Problem("DeleteHistoryBranch err", err)
+				return commoncli.Problem("DeleteHistoryBranch err"+remoteHint, err)
 			}
 		}
 	}
@@ -357,7 +358,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 		if skipError {
 			fmt.Println("delete mutableState row failed, ", err)
 		} else {
-			return commoncli.Problem("delete mutableState row failed", err)
+			return commoncli.Problem("delete mutableState row failed"+remoteHint, err)
 		}
 	}
 	fmt.Println("delete mutableState row successfully")
@@ -373,7 +374,7 @@ func AdminDeleteWorkflow(c *cli.Context) error {
 		if skipError {
 			fmt.Println("delete current row failed, ", err)
 		} else {
-			return commoncli.Problem("delete current row failed", err)
+			return commoncli.Problem("delete current row failed"+remoteHint, err)
 		}
 	}
 	fmt.Println("delete current row successfully")


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
Added a new constant remoteHint with a helpful message
Added the hint to these error paths (when not using --remote):
Failed to get workflow mutable state
Unable to initialize history manager
Unable to initialize execution manager
DeleteHistoryBranch error
Delete mutableState row failed
Delete current row failed


<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
the adidition of --remote flag was not clear enough to the user.



---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
