### PR TITLE
fix: revert addition of host tag to persistence calls

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2226,7 +2226,6 @@ const (
 	PersistenceFailures
 	PersistenceLatency
 	PersistenceLatencyHistogram
-	PersistenceQuota
 	PersistenceErrShardExistsCounter
 	PersistenceErrShardOwnershipLostCounter
 	PersistenceErrConditionFailedCounter
@@ -3044,7 +3043,6 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		PersistenceFailures:                                          {metricName: "persistence_errors", metricType: Counter},
 		PersistenceLatency:                                           {metricName: "persistence_latency", metricType: Timer},
 		PersistenceLatencyHistogram:                                  {metricName: "persistence_latency_histogram", metricType: Histogram, buckets: PersistenceLatencyBuckets},
-		PersistenceQuota:                                             {metricName: "persistence_quota", metricType: Gauge},
 		PersistenceErrShardExistsCounter:                             {metricName: "persistence_errors_shard_exists", metricType: Counter},
 		PersistenceErrShardOwnershipLostCounter:                      {metricName: "persistence_errors_shard_ownership_lost", metricType: Counter},
 		PersistenceErrConditionFailedCounter:                         {metricName: "persistence_errors_condition_failed", metricType: Counter},

--- a/common/metrics/tags.go
+++ b/common/metrics/tags.go
@@ -72,7 +72,6 @@ const (
 	isRetry                   = "is_retry"
 	queryConsistencyLevel     = "query_consistency_level"
 	budgetManagerName         = "budget_manager_name"
-	datastore                 = "datastore"
 
 	// limiter-side tags
 	globalRatelimitKey            = "global_ratelimit_key"
@@ -359,11 +358,6 @@ func HandoverTypeTag(handoverType string) Tag {
 
 func ExecutorStatusTag(status string) Tag {
 	return metricWithUnknown("executor_status", status)
-}
-
-// DatastoreTag returns a new datastore tag.
-func DatastoreTag(value string) Tag {
-	return metricWithUnknown(datastore, value)
 }
 
 func TaskCategoryTag(category string) Tag {

--- a/common/persistence/client/factory.go
+++ b/common/persistence/client/factory.go
@@ -106,7 +106,6 @@ type (
 	Datastore struct {
 		factory   DataStoreFactory
 		ratelimit quotas.Limiter
-		name      string
 	}
 	factoryImpl struct {
 		sync.RWMutex
@@ -116,7 +115,6 @@ type (
 		datastores    map[storeType]Datastore
 		clusterName   string
 		dc            *p.DynamicConfiguration
-		hostname      string
 	}
 
 	storeType int
@@ -158,7 +156,6 @@ func NewFactory(
 	metricsClient metrics.Client,
 	logger log.Logger,
 	dc *p.DynamicConfiguration,
-	hostname string,
 ) Factory {
 	factory := &factoryImpl{
 		config:        cfg,
@@ -166,7 +163,6 @@ func NewFactory(
 		logger:        logger,
 		clusterName:   clusterName,
 		dc:            dc,
-		hostname:      hostname,
 	}
 	limiters := buildRatelimiters(cfg, persistenceMaxQPS)
 	factory.init(clusterName, limiters)
@@ -185,10 +181,10 @@ func (f *factoryImpl) NewTaskManager() (p.TaskManager, error) {
 		result = errorinjectors.NewTaskManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewTaskManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewTaskManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if f.metricsClient != nil {
-		result = metered.NewTaskManager(result, f.metricsClient, f.logger, f.config, f.hostname, ds.name)
+		result = metered.NewTaskManager(result, f.metricsClient, f.logger, f.config)
 	}
 	return result, nil
 }
@@ -205,10 +201,10 @@ func (f *factoryImpl) NewShardManager() (p.ShardManager, error) {
 		result = errorinjectors.NewShardManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewShardManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewShardManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if f.metricsClient != nil {
-		result = metered.NewShardManager(result, f.metricsClient, f.logger, f.config, f.hostname, ds.name)
+		result = metered.NewShardManager(result, f.metricsClient, f.logger, f.config)
 	}
 	return result, nil
 }
@@ -225,10 +221,10 @@ func (f *factoryImpl) NewHistoryManager() (p.HistoryManager, error) {
 		result = errorinjectors.NewHistoryManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewHistoryManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewHistoryManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if f.metricsClient != nil {
-		result = metered.NewHistoryManager(result, f.metricsClient, f.logger, f.config, f.hostname, ds.name)
+		result = metered.NewHistoryManager(result, f.metricsClient, f.logger, f.config)
 	}
 	return result, nil
 }
@@ -247,10 +243,10 @@ func (f *factoryImpl) NewDomainManager() (p.DomainManager, error) {
 		result = errorinjectors.NewDomainManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewDomainManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewDomainManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if f.metricsClient != nil {
-		result = metered.NewDomainManager(result, f.metricsClient, f.logger, f.config, f.hostname, ds.name)
+		result = metered.NewDomainManager(result, f.metricsClient, f.logger, f.config)
 	}
 	return result, nil
 }
@@ -284,10 +280,10 @@ func (f *factoryImpl) NewExecutionManager(shardID int) (p.ExecutionManager, erro
 		result = errorinjectors.NewExecutionManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewExecutionManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewExecutionManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if f.metricsClient != nil {
-		result = metered.NewExecutionManager(result, f.metricsClient, f.logger, f.config, f.dc.PersistenceSampleLoggingRate, f.dc.EnableShardIDMetrics, f.hostname, ds.name)
+		result = metered.NewExecutionManager(result, f.metricsClient, f.logger, f.config, f.dc.PersistenceSampleLoggingRate, f.dc.EnableShardIDMetrics)
 	}
 	return result, nil
 }
@@ -418,7 +414,7 @@ func newPinotVisibilityManager(
 	// wrap with rate limiter
 	if visibilityConfig.PersistenceMaxQPS != nil && visibilityConfig.PersistenceMaxQPS() != 0 {
 		pinotRateLimiter := quotas.NewDynamicRateLimiter(visibilityConfig.PersistenceMaxQPS.AsFloat64())
-		visibilityFromPinot = ratelimited.NewVisibilityManager(visibilityFromPinot, pinotRateLimiter, metricsClient, "pinot", callerBypass)
+		visibilityFromPinot = ratelimited.NewVisibilityManager(visibilityFromPinot, pinotRateLimiter, callerBypass)
 	}
 
 	if metricsClient != nil {
@@ -449,7 +445,7 @@ func newESVisibilityManager(
 	// wrap with rate limiter
 	if visibilityConfig.PersistenceMaxQPS != nil && visibilityConfig.PersistenceMaxQPS() != 0 {
 		esRateLimiter := quotas.NewDynamicRateLimiter(visibilityConfig.PersistenceMaxQPS.AsFloat64())
-		visibilityFromES = ratelimited.NewVisibilityManager(visibilityFromES, esRateLimiter, metricsClient, "elasticsearch", callerBypass)
+		visibilityFromES = ratelimited.NewVisibilityManager(visibilityFromES, esRateLimiter, callerBypass)
 	}
 	if metricsClient != nil {
 		// wrap with metrics
@@ -479,7 +475,7 @@ func (f *factoryImpl) newDBVisibilityManager(
 		result = errorinjectors.NewVisibilityManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewVisibilityManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewVisibilityManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if visibilityConfig.EnableDBVisibilitySampling != nil && visibilityConfig.EnableDBVisibilitySampling() {
 		result = sampled.NewVisibilityManager(result, sampled.Params{
@@ -495,7 +491,7 @@ func (f *factoryImpl) newDBVisibilityManager(
 		})
 	}
 	if f.metricsClient != nil {
-		result = metered.NewVisibilityManager(result, f.metricsClient, f.logger, f.config, f.hostname, ds.name)
+		result = metered.NewVisibilityManager(result, f.metricsClient, f.logger, f.config)
 	}
 
 	return result, nil
@@ -512,10 +508,10 @@ func (f *factoryImpl) NewDomainReplicationQueueManager() (p.QueueManager, error)
 		result = errorinjectors.NewQueueManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewQueueManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewQueueManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if f.metricsClient != nil {
-		result = metered.NewQueueManager(result, f.metricsClient, f.logger, f.config, f.hostname, ds.name)
+		result = metered.NewQueueManager(result, f.metricsClient, f.logger, f.config)
 	}
 
 	return result, nil
@@ -532,10 +528,10 @@ func (f *factoryImpl) NewConfigStoreManager() (p.ConfigStoreManager, error) {
 		result = errorinjectors.NewConfigStoreManager(result, errorRate, f.logger, time.Now())
 	}
 	if ds.ratelimit != nil {
-		result = ratelimited.NewConfigStoreManager(result, ds.ratelimit, f.metricsClient, ds.name, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
+		result = ratelimited.NewConfigStoreManager(result, ds.ratelimit, quotas.NewCallerBypass(f.dc.RateLimiterBypassCallerTypes))
 	}
 	if f.metricsClient != nil {
-		result = metered.NewConfigStoreManager(result, f.metricsClient, f.logger, f.config, f.hostname, ds.name)
+		result = metered.NewConfigStoreManager(result, f.metricsClient, f.logger, f.config)
 	}
 
 	return result, nil
@@ -553,7 +549,7 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 	if defaultCfg.Cassandra != nil {
 		f.logger.Warn("Cassandra config is deprecated, please use NoSQL with pluginName of cassandra.")
 	}
-	defaultDataStore := Datastore{ratelimit: limiters[f.config.DefaultStore], name: f.config.DefaultStore}
+	defaultDataStore := Datastore{ratelimit: limiters[f.config.DefaultStore]}
 	switch {
 	case defaultCfg.NoSQL != nil:
 		parser := f.getParser()
@@ -594,7 +590,7 @@ func (f *factoryImpl) init(clusterName string, limiters map[string]quotas.Limite
 	if visibilityCfg.Cassandra != nil {
 		f.logger.Warn("Cassandra config is deprecated, please use NoSQL with pluginName of cassandra.")
 	}
-	visibilityDataStore := Datastore{ratelimit: limiters[f.config.VisibilityStore], name: f.config.VisibilityStore}
+	visibilityDataStore := Datastore{ratelimit: limiters[f.config.VisibilityStore]}
 	switch {
 	case visibilityCfg.NoSQL != nil:
 		parser := f.getParser()

--- a/common/persistence/client/factory_test.go
+++ b/common/persistence/client/factory_test.go
@@ -279,7 +279,7 @@ func makeFactoryWithMetrics(t *testing.T, withMetrics bool) Factory {
 		},
 	}
 
-	return NewFactory(cfg, qpsFn, "test cluster", met, logger, pdc, "")
+	return NewFactory(cfg, qpsFn, "test cluster", met, logger, pdc)
 }
 
 func mockDatastore(t *testing.T, fact Factory, store storeType) *MockDataStoreFactory {

--- a/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
+++ b/common/persistence/persistence-tests/dbVisibilityPersistenceTest.go
@@ -62,7 +62,7 @@ func (s *DBVisibilityPersistenceSuite) SetupSuite() {
 	}
 	clusterName := s.ClusterMetadata.GetCurrentClusterName()
 	vCfg := s.VisibilityTestCluster.Config()
-	visibilityFactory := client.NewFactory(&vCfg, nil, clusterName, nil, s.Logger, &s.DynamicConfiguration, "test-host")
+	visibilityFactory := client.NewFactory(&vCfg, nil, clusterName, nil, s.Logger, &s.DynamicConfiguration)
 	// SQL currently doesn't have support for visibility manager
 	var err error
 	s.VisibilityMgr, err = visibilityFactory.NewVisibilityManager(

--- a/common/persistence/persistence-tests/persistenceTestBase.go
+++ b/common/persistence/persistence-tests/persistenceTestBase.go
@@ -232,7 +232,7 @@ func (s *TestBase) Setup() {
 	cfg := s.DefaultTestCluster.Config()
 	scope := tally.NewTestScope(service.History, make(map[string]string))
 	metricsClient := metrics.NewClient(scope, service.GetMetricsServiceIdx(service.History, s.Logger), metrics.HistogramMigration{})
-	factory := client.NewFactory(&cfg, nil, clusterName, metricsClient, s.Logger, &s.DynamicConfiguration, "test-host")
+	factory := client.NewFactory(&cfg, nil, clusterName, metricsClient, s.Logger, &s.DynamicConfiguration)
 
 	s.TaskMgr, err = factory.NewTaskManager()
 	s.fatalOnError("NewTaskManager", err)

--- a/common/persistence/wrappers/metered/base.go
+++ b/common/persistence/wrappers/metered/base.go
@@ -45,8 +45,6 @@ type base struct {
 	enableLatencyHistogramMetrics bool
 	sampleLoggingRate             dynamicproperties.IntPropertyFn
 	enableShardIDMetrics          dynamicproperties.BoolPropertyFn
-	hostname                      string
-	datastoreName                 string
 }
 
 func (p *base) updateErrorMetricPerDomain(scope metrics.ScopeIdx, err error, scopeWithDomainTag metrics.Scope, logger log.Logger) {
@@ -126,12 +124,6 @@ func (p *base) updateErrorMetric(scope metrics.ScopeIdx, err error, metricsScope
 }
 
 func (p *base) call(scope metrics.ScopeIdx, op func() error, tags ...metrics.Tag) error {
-	if p.hostname != "" {
-		tags = append(tags, metrics.HostTag(p.hostname))
-	}
-	if p.datastoreName != "" {
-		tags = append(tags, metrics.DatastoreTag(p.datastoreName))
-	}
 	metricsScope := p.metricClient.Scope(scope, tags...)
 	if len(tags) > 0 {
 		metricsScope.IncCounter(metrics.PersistenceRequestsPerDomain)
@@ -163,12 +155,6 @@ func (p *base) call(scope metrics.ScopeIdx, op func() error, tags ...metrics.Tag
 }
 
 func (p *base) callWithoutDomainTag(scope metrics.ScopeIdx, op func() error, tags ...metrics.Tag) error {
-	if p.hostname != "" {
-		tags = append(tags, metrics.HostTag(p.hostname))
-	}
-	if p.datastoreName != "" {
-		tags = append(tags, metrics.DatastoreTag(p.datastoreName))
-	}
 	metricsScope := p.metricClient.Scope(scope, tags...)
 	metricsScope.IncCounter(metrics.PersistenceRequests)
 	before := time.Now()
@@ -186,12 +172,6 @@ func (p *base) callWithoutDomainTag(scope metrics.ScopeIdx, op func() error, tag
 }
 
 func (p *base) callWithDomainAndShardScope(scope metrics.ScopeIdx, op func() error, domainTag metrics.Tag, shardIDTag metrics.Tag, additionalTags ...metrics.Tag) error {
-	if p.hostname != "" {
-		additionalTags = append(additionalTags, metrics.HostTag(p.hostname))
-	}
-	if p.datastoreName != "" {
-		additionalTags = append(additionalTags, metrics.DatastoreTag(p.datastoreName))
-	}
 	domainMetricsScope := p.metricClient.Scope(scope, append([]metrics.Tag{domainTag}, additionalTags...)...)
 	shardOperationsMetricsScope := p.metricClient.Scope(scope, append([]metrics.Tag{shardIDTag}, additionalTags...)...)
 	shardOverallMetricsScope := p.metricClient.Scope(metrics.PersistenceShardRequestCountScope, shardIDTag)

--- a/common/persistence/wrappers/metered/configstore_generated.go
+++ b/common/persistence/wrappers/metered/configstore_generated.go
@@ -25,8 +25,6 @@ func NewConfigStoreManager(
 	metricClient metrics.Client,
 	logger log.Logger,
 	cfg *config.Persistence,
-	hostname string,
-	datastoreName string,
 ) persistence.ConfigStoreManager {
 	return &meteredConfigStoreManager{
 		wrapped: wrapped,
@@ -34,8 +32,6 @@ func NewConfigStoreManager(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/metered/domain_generated.go
+++ b/common/persistence/wrappers/metered/domain_generated.go
@@ -25,8 +25,6 @@ func NewDomainManager(
 	metricClient metrics.Client,
 	logger log.Logger,
 	cfg *config.Persistence,
-	hostname string,
-	datastoreName string,
 ) persistence.DomainManager {
 	return &meteredDomainManager{
 		wrapped: wrapped,
@@ -34,8 +32,6 @@ func NewDomainManager(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/metered/execution_generated.go
+++ b/common/persistence/wrappers/metered/execution_generated.go
@@ -30,8 +30,6 @@ func NewExecutionManager(
 	cfg *config.Persistence,
 	sampleLoggingRate dynamicproperties.IntPropertyFn,
 	enableShardIDMetrics dynamicproperties.BoolPropertyFn,
-	hostname string,
-	datastoreName string,
 ) persistence.ExecutionManager {
 	return &meteredExecutionManager{
 		wrapped: wrapped,
@@ -41,8 +39,6 @@ func NewExecutionManager(
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
 			sampleLoggingRate:             sampleLoggingRate,
 			enableShardIDMetrics:          enableShardIDMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/metered/history_generated.go
+++ b/common/persistence/wrappers/metered/history_generated.go
@@ -25,8 +25,6 @@ func NewHistoryManager(
 	metricClient metrics.Client,
 	logger log.Logger,
 	cfg *config.Persistence,
-	hostname string,
-	datastoreName string,
 ) persistence.HistoryManager {
 	return &meteredHistoryManager{
 		wrapped: wrapped,
@@ -34,8 +32,6 @@ func NewHistoryManager(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/metered/metered_test.go
+++ b/common/persistence/wrappers/metered/metered_test.go
@@ -58,7 +58,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
 				wrapped := persistence.NewMockConfigStoreManager(ctrl)
 
-				newObj := NewConfigStoreManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true}, "test-host", "test")
+				newObj := NewConfigStoreManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
 
 				return newObj, wrapped
 			},
@@ -68,7 +68,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
 				wrapped := persistence.NewMockDomainManager(ctrl)
 
-				newObj := NewDomainManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true}, "test-host", "test")
+				newObj := NewDomainManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
 
 				return newObj, wrapped
 			},
@@ -78,7 +78,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
 				wrapped := persistence.NewMockHistoryManager(ctrl)
 
-				newObj := NewHistoryManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true}, "test-host", "test")
+				newObj := NewHistoryManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
 
 				return newObj, wrapped
 			},
@@ -88,7 +88,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
 				wrapped := persistence.NewMockQueueManager(ctrl)
 
-				newObj := NewQueueManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true}, "test-host", "test")
+				newObj := NewQueueManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
 
 				return newObj, wrapped
 			},
@@ -98,7 +98,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
 				wrapped := persistence.NewMockShardManager(ctrl)
 
-				newObj := NewShardManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true}, "test-host", "test")
+				newObj := NewShardManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
 
 				return newObj, wrapped
 			},
@@ -108,7 +108,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
 				wrapped := persistence.NewMockTaskManager(ctrl)
 
-				newObj := NewTaskManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true}, "test-host", "test")
+				newObj := NewTaskManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
 
 				return newObj, wrapped
 			},
@@ -118,7 +118,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 			prepareMock: func(t *testing.T, ctrl *gomock.Controller, newMetricsClient metrics.Client, newLogger log.Logger) (newManager any, mocked any) {
 				wrapped := persistence.NewMockVisibilityManager(ctrl)
 
-				newObj := NewVisibilityManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true}, "test-host", "test")
+				newObj := NewVisibilityManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true})
 
 				return newObj, wrapped
 			},
@@ -131,7 +131,7 @@ func TestWrappersAgainstPreviousImplementation(t *testing.T) {
 				wrapped.EXPECT().GetShardID().Return(0).AnyTimes()
 
 				newObj := NewExecutionManager(wrapped, newMetricsClient, newLogger, &config.Persistence{EnablePersistenceLatencyHistogramMetrics: true},
-					dynamicproperties.GetIntPropertyFn(1), dynamicproperties.GetBoolPropertyFn(true), "test-host", "test")
+					dynamicproperties.GetIntPropertyFn(1), dynamicproperties.GetBoolPropertyFn(true))
 
 				return newObj, wrapped
 			},

--- a/common/persistence/wrappers/metered/queue_generated.go
+++ b/common/persistence/wrappers/metered/queue_generated.go
@@ -25,8 +25,6 @@ func NewQueueManager(
 	metricClient metrics.Client,
 	logger log.Logger,
 	cfg *config.Persistence,
-	hostname string,
-	datastoreName string,
 ) persistence.QueueManager {
 	return &meteredQueueManager{
 		wrapped: wrapped,
@@ -34,8 +32,6 @@ func NewQueueManager(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/metered/shard_generated.go
+++ b/common/persistence/wrappers/metered/shard_generated.go
@@ -25,8 +25,6 @@ func NewShardManager(
 	metricClient metrics.Client,
 	logger log.Logger,
 	cfg *config.Persistence,
-	hostname string,
-	datastoreName string,
 ) persistence.ShardManager {
 	return &meteredShardManager{
 		wrapped: wrapped,
@@ -34,8 +32,6 @@ func NewShardManager(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/metered/task_generated.go
+++ b/common/persistence/wrappers/metered/task_generated.go
@@ -25,8 +25,6 @@ func NewTaskManager(
 	metricClient metrics.Client,
 	logger log.Logger,
 	cfg *config.Persistence,
-	hostname string,
-	datastoreName string,
 ) persistence.TaskManager {
 	return &meteredTaskManager{
 		wrapped: wrapped,
@@ -34,8 +32,6 @@ func NewTaskManager(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/metered/visibility_generated.go
+++ b/common/persistence/wrappers/metered/visibility_generated.go
@@ -25,8 +25,6 @@ func NewVisibilityManager(
 	metricClient metrics.Client,
 	logger log.Logger,
 	cfg *config.Persistence,
-	hostname string,
-	datastoreName string,
 ) persistence.VisibilityManager {
 	return &meteredVisibilityManager{
 		wrapped: wrapped,
@@ -34,8 +32,6 @@ func NewVisibilityManager(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
 		},
 	}
 }

--- a/common/persistence/wrappers/ratelimited/domain_generated.go
+++ b/common/persistence/wrappers/ratelimited/domain_generated.go
@@ -7,34 +7,27 @@ package ratelimited
 import (
 	"context"
 
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
 
 // ratelimitedDomainManager implements persistence.DomainManager interface instrumented with rate limiter.
 type ratelimitedDomainManager struct {
-	wrapped       persistence.DomainManager
-	rateLimiter   quotas.Limiter
-	metricsClient metrics.Client
-	datastoreName string
-	callerBypass  quotas.CallerBypass
+	wrapped      persistence.DomainManager
+	rateLimiter  quotas.Limiter
+	callerBypass quotas.CallerBypass
 }
 
 // NewDomainManager creates a new instance of DomainManager with ratelimiter.
 func NewDomainManager(
 	wrapped persistence.DomainManager,
 	rateLimiter quotas.Limiter,
-	metricsClient metrics.Client,
-	datastoreName string,
 	callerBypass quotas.CallerBypass,
 ) persistence.DomainManager {
 	return &ratelimitedDomainManager{
-		wrapped:       wrapped,
-		rateLimiter:   rateLimiter,
-		metricsClient: metricsClient,
-		datastoreName: datastoreName,
-		callerBypass:  callerBypass,
+		wrapped:      wrapped,
+		rateLimiter:  rateLimiter,
+		callerBypass: callerBypass,
 	}
 }
 
@@ -44,11 +37,6 @@ func (c *ratelimitedDomainManager) Close() {
 }
 
 func (c *ratelimitedDomainManager) CreateDomain(ctx context.Context, request *persistence.CreateDomainRequest) (cp1 *persistence.CreateDomainResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -57,11 +45,6 @@ func (c *ratelimitedDomainManager) CreateDomain(ctx context.Context, request *pe
 }
 
 func (c *ratelimitedDomainManager) DeleteDomain(ctx context.Context, request *persistence.DeleteDomainRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -70,11 +53,6 @@ func (c *ratelimitedDomainManager) DeleteDomain(ctx context.Context, request *pe
 }
 
 func (c *ratelimitedDomainManager) DeleteDomainByName(ctx context.Context, request *persistence.DeleteDomainByNameRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -83,11 +61,6 @@ func (c *ratelimitedDomainManager) DeleteDomainByName(ctx context.Context, reque
 }
 
 func (c *ratelimitedDomainManager) GetDomain(ctx context.Context, request *persistence.GetDomainRequest) (gp1 *persistence.GetDomainResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -96,11 +69,6 @@ func (c *ratelimitedDomainManager) GetDomain(ctx context.Context, request *persi
 }
 
 func (c *ratelimitedDomainManager) GetMetadata(ctx context.Context) (gp1 *persistence.GetMetadataResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -113,11 +81,6 @@ func (c *ratelimitedDomainManager) GetName() (s1 string) {
 }
 
 func (c *ratelimitedDomainManager) ListDomains(ctx context.Context, request *persistence.ListDomainsRequest) (lp1 *persistence.ListDomainsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -126,11 +89,6 @@ func (c *ratelimitedDomainManager) ListDomains(ctx context.Context, request *per
 }
 
 func (c *ratelimitedDomainManager) UpdateDomain(ctx context.Context, request *persistence.UpdateDomainRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return

--- a/common/persistence/wrappers/ratelimited/execution_generated.go
+++ b/common/persistence/wrappers/ratelimited/execution_generated.go
@@ -7,7 +7,6 @@ package ratelimited
 import (
 	"context"
 
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 	"github.com/uber/cadence/common/types"
@@ -15,27 +14,21 @@ import (
 
 // ratelimitedExecutionManager implements persistence.ExecutionManager interface instrumented with rate limiter.
 type ratelimitedExecutionManager struct {
-	wrapped       persistence.ExecutionManager
-	rateLimiter   quotas.Limiter
-	metricsClient metrics.Client
-	datastoreName string
-	callerBypass  quotas.CallerBypass
+	wrapped      persistence.ExecutionManager
+	rateLimiter  quotas.Limiter
+	callerBypass quotas.CallerBypass
 }
 
 // NewExecutionManager creates a new instance of ExecutionManager with ratelimiter.
 func NewExecutionManager(
 	wrapped persistence.ExecutionManager,
 	rateLimiter quotas.Limiter,
-	metricsClient metrics.Client,
-	datastoreName string,
 	callerBypass quotas.CallerBypass,
 ) persistence.ExecutionManager {
 	return &ratelimitedExecutionManager{
-		wrapped:       wrapped,
-		rateLimiter:   rateLimiter,
-		metricsClient: metricsClient,
-		datastoreName: datastoreName,
-		callerBypass:  callerBypass,
+		wrapped:      wrapped,
+		rateLimiter:  rateLimiter,
+		callerBypass: callerBypass,
 	}
 }
 
@@ -45,11 +38,6 @@ func (c *ratelimitedExecutionManager) Close() {
 }
 
 func (c *ratelimitedExecutionManager) CompleteHistoryTask(ctx context.Context, request *persistence.CompleteHistoryTaskRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -58,11 +46,6 @@ func (c *ratelimitedExecutionManager) CompleteHistoryTask(ctx context.Context, r
 }
 
 func (c *ratelimitedExecutionManager) ConflictResolveWorkflowExecution(ctx context.Context, request *persistence.ConflictResolveWorkflowExecutionRequest) (cp1 *persistence.ConflictResolveWorkflowExecutionResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -71,11 +54,6 @@ func (c *ratelimitedExecutionManager) ConflictResolveWorkflowExecution(ctx conte
 }
 
 func (c *ratelimitedExecutionManager) CreateFailoverMarkerTasks(ctx context.Context, request *persistence.CreateFailoverMarkersRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -84,11 +62,6 @@ func (c *ratelimitedExecutionManager) CreateFailoverMarkerTasks(ctx context.Cont
 }
 
 func (c *ratelimitedExecutionManager) CreateWorkflowExecution(ctx context.Context, request *persistence.CreateWorkflowExecutionRequest) (cp1 *persistence.CreateWorkflowExecutionResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -97,11 +70,6 @@ func (c *ratelimitedExecutionManager) CreateWorkflowExecution(ctx context.Contex
 }
 
 func (c *ratelimitedExecutionManager) DeleteActiveClusterSelectionPolicy(ctx context.Context, domainID string, workflowID string, runID string) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -110,11 +78,6 @@ func (c *ratelimitedExecutionManager) DeleteActiveClusterSelectionPolicy(ctx con
 }
 
 func (c *ratelimitedExecutionManager) DeleteCurrentWorkflowExecution(ctx context.Context, request *persistence.DeleteCurrentWorkflowExecutionRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -123,11 +86,6 @@ func (c *ratelimitedExecutionManager) DeleteCurrentWorkflowExecution(ctx context
 }
 
 func (c *ratelimitedExecutionManager) DeleteReplicationTaskFromDLQ(ctx context.Context, request *persistence.DeleteReplicationTaskFromDLQRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -136,11 +94,6 @@ func (c *ratelimitedExecutionManager) DeleteReplicationTaskFromDLQ(ctx context.C
 }
 
 func (c *ratelimitedExecutionManager) DeleteWorkflowExecution(ctx context.Context, request *persistence.DeleteWorkflowExecutionRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -149,11 +102,6 @@ func (c *ratelimitedExecutionManager) DeleteWorkflowExecution(ctx context.Contex
 }
 
 func (c *ratelimitedExecutionManager) GetActiveClusterSelectionPolicy(ctx context.Context, domainID string, wfID string, rID string) (ap1 *types.ActiveClusterSelectionPolicy, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -162,11 +110,6 @@ func (c *ratelimitedExecutionManager) GetActiveClusterSelectionPolicy(ctx contex
 }
 
 func (c *ratelimitedExecutionManager) GetCurrentExecution(ctx context.Context, request *persistence.GetCurrentExecutionRequest) (gp1 *persistence.GetCurrentExecutionResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -175,11 +118,6 @@ func (c *ratelimitedExecutionManager) GetCurrentExecution(ctx context.Context, r
 }
 
 func (c *ratelimitedExecutionManager) GetHistoryTasks(ctx context.Context, request *persistence.GetHistoryTasksRequest) (gp1 *persistence.GetHistoryTasksResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -192,11 +130,6 @@ func (c *ratelimitedExecutionManager) GetName() (s1 string) {
 }
 
 func (c *ratelimitedExecutionManager) GetReplicationDLQSize(ctx context.Context, request *persistence.GetReplicationDLQSizeRequest) (gp1 *persistence.GetReplicationDLQSizeResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -205,11 +138,6 @@ func (c *ratelimitedExecutionManager) GetReplicationDLQSize(ctx context.Context,
 }
 
 func (c *ratelimitedExecutionManager) GetReplicationTasksFromDLQ(ctx context.Context, request *persistence.GetReplicationTasksFromDLQRequest) (gp1 *persistence.GetHistoryTasksResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -222,11 +150,6 @@ func (c *ratelimitedExecutionManager) GetShardID() (i1 int) {
 }
 
 func (c *ratelimitedExecutionManager) GetWorkflowExecution(ctx context.Context, request *persistence.GetWorkflowExecutionRequest) (gp1 *persistence.GetWorkflowExecutionResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -235,11 +158,6 @@ func (c *ratelimitedExecutionManager) GetWorkflowExecution(ctx context.Context, 
 }
 
 func (c *ratelimitedExecutionManager) IsWorkflowExecutionExists(ctx context.Context, request *persistence.IsWorkflowExecutionExistsRequest) (ip1 *persistence.IsWorkflowExecutionExistsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -248,11 +166,6 @@ func (c *ratelimitedExecutionManager) IsWorkflowExecutionExists(ctx context.Cont
 }
 
 func (c *ratelimitedExecutionManager) ListConcreteExecutions(ctx context.Context, request *persistence.ListConcreteExecutionsRequest) (lp1 *persistence.ListConcreteExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -261,11 +174,6 @@ func (c *ratelimitedExecutionManager) ListConcreteExecutions(ctx context.Context
 }
 
 func (c *ratelimitedExecutionManager) ListCurrentExecutions(ctx context.Context, request *persistence.ListCurrentExecutionsRequest) (lp1 *persistence.ListCurrentExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -274,11 +182,6 @@ func (c *ratelimitedExecutionManager) ListCurrentExecutions(ctx context.Context,
 }
 
 func (c *ratelimitedExecutionManager) PutReplicationTaskToDLQ(ctx context.Context, request *persistence.PutReplicationTaskToDLQRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -287,11 +190,6 @@ func (c *ratelimitedExecutionManager) PutReplicationTaskToDLQ(ctx context.Contex
 }
 
 func (c *ratelimitedExecutionManager) RangeCompleteHistoryTask(ctx context.Context, request *persistence.RangeCompleteHistoryTaskRequest) (rp1 *persistence.RangeCompleteHistoryTaskResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -300,11 +198,6 @@ func (c *ratelimitedExecutionManager) RangeCompleteHistoryTask(ctx context.Conte
 }
 
 func (c *ratelimitedExecutionManager) RangeDeleteReplicationTaskFromDLQ(ctx context.Context, request *persistence.RangeDeleteReplicationTaskFromDLQRequest) (rp1 *persistence.RangeDeleteReplicationTaskFromDLQResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -313,11 +206,6 @@ func (c *ratelimitedExecutionManager) RangeDeleteReplicationTaskFromDLQ(ctx cont
 }
 
 func (c *ratelimitedExecutionManager) UpdateWorkflowExecution(ctx context.Context, request *persistence.UpdateWorkflowExecutionRequest) (up1 *persistence.UpdateWorkflowExecutionResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return

--- a/common/persistence/wrappers/ratelimited/history_generated.go
+++ b/common/persistence/wrappers/ratelimited/history_generated.go
@@ -7,43 +7,31 @@ package ratelimited
 import (
 	"context"
 
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
 
 // ratelimitedHistoryManager implements persistence.HistoryManager interface instrumented with rate limiter.
 type ratelimitedHistoryManager struct {
-	wrapped       persistence.HistoryManager
-	rateLimiter   quotas.Limiter
-	metricsClient metrics.Client
-	datastoreName string
-	callerBypass  quotas.CallerBypass
+	wrapped      persistence.HistoryManager
+	rateLimiter  quotas.Limiter
+	callerBypass quotas.CallerBypass
 }
 
 // NewHistoryManager creates a new instance of HistoryManager with ratelimiter.
 func NewHistoryManager(
 	wrapped persistence.HistoryManager,
 	rateLimiter quotas.Limiter,
-	metricsClient metrics.Client,
-	datastoreName string,
 	callerBypass quotas.CallerBypass,
 ) persistence.HistoryManager {
 	return &ratelimitedHistoryManager{
-		wrapped:       wrapped,
-		rateLimiter:   rateLimiter,
-		metricsClient: metricsClient,
-		datastoreName: datastoreName,
-		callerBypass:  callerBypass,
+		wrapped:      wrapped,
+		rateLimiter:  rateLimiter,
+		callerBypass: callerBypass,
 	}
 }
 
 func (c *ratelimitedHistoryManager) AppendHistoryNodes(ctx context.Context, request *persistence.AppendHistoryNodesRequest) (ap1 *persistence.AppendHistoryNodesResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -57,11 +45,6 @@ func (c *ratelimitedHistoryManager) Close() {
 }
 
 func (c *ratelimitedHistoryManager) DeleteHistoryBranch(ctx context.Context, request *persistence.DeleteHistoryBranchRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -70,11 +53,6 @@ func (c *ratelimitedHistoryManager) DeleteHistoryBranch(ctx context.Context, req
 }
 
 func (c *ratelimitedHistoryManager) ForkHistoryBranch(ctx context.Context, request *persistence.ForkHistoryBranchRequest) (fp1 *persistence.ForkHistoryBranchResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -83,11 +61,6 @@ func (c *ratelimitedHistoryManager) ForkHistoryBranch(ctx context.Context, reque
 }
 
 func (c *ratelimitedHistoryManager) GetAllHistoryTreeBranches(ctx context.Context, request *persistence.GetAllHistoryTreeBranchesRequest) (gp1 *persistence.GetAllHistoryTreeBranchesResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -96,11 +69,6 @@ func (c *ratelimitedHistoryManager) GetAllHistoryTreeBranches(ctx context.Contex
 }
 
 func (c *ratelimitedHistoryManager) GetHistoryTree(ctx context.Context, request *persistence.GetHistoryTreeRequest) (gp1 *persistence.GetHistoryTreeResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -113,11 +81,6 @@ func (c *ratelimitedHistoryManager) GetName() (s1 string) {
 }
 
 func (c *ratelimitedHistoryManager) ReadHistoryBranch(ctx context.Context, request *persistence.ReadHistoryBranchRequest) (rp1 *persistence.ReadHistoryBranchResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -126,11 +89,6 @@ func (c *ratelimitedHistoryManager) ReadHistoryBranch(ctx context.Context, reque
 }
 
 func (c *ratelimitedHistoryManager) ReadHistoryBranchByBatch(ctx context.Context, request *persistence.ReadHistoryBranchRequest) (rp1 *persistence.ReadHistoryBranchByBatchResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -139,11 +97,6 @@ func (c *ratelimitedHistoryManager) ReadHistoryBranchByBatch(ctx context.Context
 }
 
 func (c *ratelimitedHistoryManager) ReadRawHistoryBranch(ctx context.Context, request *persistence.ReadHistoryBranchRequest) (rp1 *persistence.ReadRawHistoryBranchResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return

--- a/common/persistence/wrappers/ratelimited/queue_generated.go
+++ b/common/persistence/wrappers/ratelimited/queue_generated.go
@@ -7,34 +7,27 @@ package ratelimited
 import (
 	"context"
 
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
 
 // ratelimitedQueueManager implements persistence.QueueManager interface instrumented with rate limiter.
 type ratelimitedQueueManager struct {
-	wrapped       persistence.QueueManager
-	rateLimiter   quotas.Limiter
-	metricsClient metrics.Client
-	datastoreName string
-	callerBypass  quotas.CallerBypass
+	wrapped      persistence.QueueManager
+	rateLimiter  quotas.Limiter
+	callerBypass quotas.CallerBypass
 }
 
 // NewQueueManager creates a new instance of QueueManager with ratelimiter.
 func NewQueueManager(
 	wrapped persistence.QueueManager,
 	rateLimiter quotas.Limiter,
-	metricsClient metrics.Client,
-	datastoreName string,
 	callerBypass quotas.CallerBypass,
 ) persistence.QueueManager {
 	return &ratelimitedQueueManager{
-		wrapped:       wrapped,
-		rateLimiter:   rateLimiter,
-		metricsClient: metricsClient,
-		datastoreName: datastoreName,
-		callerBypass:  callerBypass,
+		wrapped:      wrapped,
+		rateLimiter:  rateLimiter,
+		callerBypass: callerBypass,
 	}
 }
 
@@ -44,11 +37,6 @@ func (c *ratelimitedQueueManager) Close() {
 }
 
 func (c *ratelimitedQueueManager) DeleteMessageFromDLQ(ctx context.Context, request *persistence.DeleteMessageFromDLQRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -57,11 +45,6 @@ func (c *ratelimitedQueueManager) DeleteMessageFromDLQ(ctx context.Context, requ
 }
 
 func (c *ratelimitedQueueManager) DeleteMessagesBefore(ctx context.Context, request *persistence.DeleteMessagesBeforeRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -70,11 +53,6 @@ func (c *ratelimitedQueueManager) DeleteMessagesBefore(ctx context.Context, requ
 }
 
 func (c *ratelimitedQueueManager) EnqueueMessage(ctx context.Context, request *persistence.EnqueueMessageRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -83,11 +61,6 @@ func (c *ratelimitedQueueManager) EnqueueMessage(ctx context.Context, request *p
 }
 
 func (c *ratelimitedQueueManager) EnqueueMessageToDLQ(ctx context.Context, request *persistence.EnqueueMessageToDLQRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -96,11 +69,6 @@ func (c *ratelimitedQueueManager) EnqueueMessageToDLQ(ctx context.Context, reque
 }
 
 func (c *ratelimitedQueueManager) GetAckLevels(ctx context.Context, request *persistence.GetAckLevelsRequest) (gp1 *persistence.GetAckLevelsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -109,11 +77,6 @@ func (c *ratelimitedQueueManager) GetAckLevels(ctx context.Context, request *per
 }
 
 func (c *ratelimitedQueueManager) GetDLQAckLevels(ctx context.Context, request *persistence.GetDLQAckLevelsRequest) (gp1 *persistence.GetDLQAckLevelsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -122,11 +85,6 @@ func (c *ratelimitedQueueManager) GetDLQAckLevels(ctx context.Context, request *
 }
 
 func (c *ratelimitedQueueManager) GetDLQSize(ctx context.Context, request *persistence.GetDLQSizeRequest) (gp1 *persistence.GetDLQSizeResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -135,11 +93,6 @@ func (c *ratelimitedQueueManager) GetDLQSize(ctx context.Context, request *persi
 }
 
 func (c *ratelimitedQueueManager) RangeDeleteMessagesFromDLQ(ctx context.Context, request *persistence.RangeDeleteMessagesFromDLQRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -148,11 +101,6 @@ func (c *ratelimitedQueueManager) RangeDeleteMessagesFromDLQ(ctx context.Context
 }
 
 func (c *ratelimitedQueueManager) ReadMessages(ctx context.Context, request *persistence.ReadMessagesRequest) (rp1 *persistence.ReadMessagesResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -161,11 +109,6 @@ func (c *ratelimitedQueueManager) ReadMessages(ctx context.Context, request *per
 }
 
 func (c *ratelimitedQueueManager) ReadMessagesFromDLQ(ctx context.Context, request *persistence.ReadMessagesFromDLQRequest) (rp1 *persistence.ReadMessagesFromDLQResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -174,11 +117,6 @@ func (c *ratelimitedQueueManager) ReadMessagesFromDLQ(ctx context.Context, reque
 }
 
 func (c *ratelimitedQueueManager) UpdateAckLevel(ctx context.Context, request *persistence.UpdateAckLevelRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -187,11 +125,6 @@ func (c *ratelimitedQueueManager) UpdateAckLevel(ctx context.Context, request *p
 }
 
 func (c *ratelimitedQueueManager) UpdateDLQAckLevel(ctx context.Context, request *persistence.UpdateDLQAckLevelRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return

--- a/common/persistence/wrappers/ratelimited/task_generated.go
+++ b/common/persistence/wrappers/ratelimited/task_generated.go
@@ -7,34 +7,27 @@ package ratelimited
 import (
 	"context"
 
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
 
 // ratelimitedTaskManager implements persistence.TaskManager interface instrumented with rate limiter.
 type ratelimitedTaskManager struct {
-	wrapped       persistence.TaskManager
-	rateLimiter   quotas.Limiter
-	metricsClient metrics.Client
-	datastoreName string
-	callerBypass  quotas.CallerBypass
+	wrapped      persistence.TaskManager
+	rateLimiter  quotas.Limiter
+	callerBypass quotas.CallerBypass
 }
 
 // NewTaskManager creates a new instance of TaskManager with ratelimiter.
 func NewTaskManager(
 	wrapped persistence.TaskManager,
 	rateLimiter quotas.Limiter,
-	metricsClient metrics.Client,
-	datastoreName string,
 	callerBypass quotas.CallerBypass,
 ) persistence.TaskManager {
 	return &ratelimitedTaskManager{
-		wrapped:       wrapped,
-		rateLimiter:   rateLimiter,
-		metricsClient: metricsClient,
-		datastoreName: datastoreName,
-		callerBypass:  callerBypass,
+		wrapped:      wrapped,
+		rateLimiter:  rateLimiter,
+		callerBypass: callerBypass,
 	}
 }
 
@@ -44,11 +37,6 @@ func (c *ratelimitedTaskManager) Close() {
 }
 
 func (c *ratelimitedTaskManager) CompleteTask(ctx context.Context, request *persistence.CompleteTaskRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -57,11 +45,6 @@ func (c *ratelimitedTaskManager) CompleteTask(ctx context.Context, request *pers
 }
 
 func (c *ratelimitedTaskManager) CompleteTasksLessThan(ctx context.Context, request *persistence.CompleteTasksLessThanRequest) (cp1 *persistence.CompleteTasksLessThanResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -70,11 +53,6 @@ func (c *ratelimitedTaskManager) CompleteTasksLessThan(ctx context.Context, requ
 }
 
 func (c *ratelimitedTaskManager) CreateTasks(ctx context.Context, request *persistence.CreateTasksRequest) (cp1 *persistence.CreateTasksResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -83,11 +61,6 @@ func (c *ratelimitedTaskManager) CreateTasks(ctx context.Context, request *persi
 }
 
 func (c *ratelimitedTaskManager) DeleteTaskList(ctx context.Context, request *persistence.DeleteTaskListRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -100,11 +73,6 @@ func (c *ratelimitedTaskManager) GetName() (s1 string) {
 }
 
 func (c *ratelimitedTaskManager) GetOrphanTasks(ctx context.Context, request *persistence.GetOrphanTasksRequest) (gp1 *persistence.GetOrphanTasksResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -113,11 +81,6 @@ func (c *ratelimitedTaskManager) GetOrphanTasks(ctx context.Context, request *pe
 }
 
 func (c *ratelimitedTaskManager) GetTaskList(ctx context.Context, request *persistence.GetTaskListRequest) (gp1 *persistence.GetTaskListResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -126,11 +89,6 @@ func (c *ratelimitedTaskManager) GetTaskList(ctx context.Context, request *persi
 }
 
 func (c *ratelimitedTaskManager) GetTaskListSize(ctx context.Context, request *persistence.GetTaskListSizeRequest) (gp1 *persistence.GetTaskListSizeResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -139,11 +97,6 @@ func (c *ratelimitedTaskManager) GetTaskListSize(ctx context.Context, request *p
 }
 
 func (c *ratelimitedTaskManager) GetTasks(ctx context.Context, request *persistence.GetTasksRequest) (gp1 *persistence.GetTasksResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -152,11 +105,6 @@ func (c *ratelimitedTaskManager) GetTasks(ctx context.Context, request *persiste
 }
 
 func (c *ratelimitedTaskManager) LeaseTaskList(ctx context.Context, request *persistence.LeaseTaskListRequest) (lp1 *persistence.LeaseTaskListResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -165,11 +113,6 @@ func (c *ratelimitedTaskManager) LeaseTaskList(ctx context.Context, request *per
 }
 
 func (c *ratelimitedTaskManager) ListTaskList(ctx context.Context, request *persistence.ListTaskListRequest) (lp1 *persistence.ListTaskListResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -178,11 +121,6 @@ func (c *ratelimitedTaskManager) ListTaskList(ctx context.Context, request *pers
 }
 
 func (c *ratelimitedTaskManager) UpdateTaskList(ctx context.Context, request *persistence.UpdateTaskListRequest) (up1 *persistence.UpdateTaskListResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return

--- a/common/persistence/wrappers/ratelimited/visibility_generated.go
+++ b/common/persistence/wrappers/ratelimited/visibility_generated.go
@@ -7,34 +7,27 @@ package ratelimited
 import (
 	"context"
 
-	"github.com/uber/cadence/common/metrics"
 	"github.com/uber/cadence/common/persistence"
 	"github.com/uber/cadence/common/quotas"
 )
 
 // ratelimitedVisibilityManager implements persistence.VisibilityManager interface instrumented with rate limiter.
 type ratelimitedVisibilityManager struct {
-	wrapped       persistence.VisibilityManager
-	rateLimiter   quotas.Limiter
-	metricsClient metrics.Client
-	datastoreName string
-	callerBypass  quotas.CallerBypass
+	wrapped      persistence.VisibilityManager
+	rateLimiter  quotas.Limiter
+	callerBypass quotas.CallerBypass
 }
 
 // NewVisibilityManager creates a new instance of VisibilityManager with ratelimiter.
 func NewVisibilityManager(
 	wrapped persistence.VisibilityManager,
 	rateLimiter quotas.Limiter,
-	metricsClient metrics.Client,
-	datastoreName string,
 	callerBypass quotas.CallerBypass,
 ) persistence.VisibilityManager {
 	return &ratelimitedVisibilityManager{
-		wrapped:       wrapped,
-		rateLimiter:   rateLimiter,
-		metricsClient: metricsClient,
-		datastoreName: datastoreName,
-		callerBypass:  callerBypass,
+		wrapped:      wrapped,
+		rateLimiter:  rateLimiter,
+		callerBypass: callerBypass,
 	}
 }
 
@@ -44,11 +37,6 @@ func (c *ratelimitedVisibilityManager) Close() {
 }
 
 func (c *ratelimitedVisibilityManager) CountWorkflowExecutions(ctx context.Context, request *persistence.CountWorkflowExecutionsRequest) (cp1 *persistence.CountWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -57,11 +45,6 @@ func (c *ratelimitedVisibilityManager) CountWorkflowExecutions(ctx context.Conte
 }
 
 func (c *ratelimitedVisibilityManager) DeleteUninitializedWorkflowExecution(ctx context.Context, request *persistence.VisibilityDeleteWorkflowExecutionRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -70,11 +53,6 @@ func (c *ratelimitedVisibilityManager) DeleteUninitializedWorkflowExecution(ctx 
 }
 
 func (c *ratelimitedVisibilityManager) DeleteWorkflowExecution(ctx context.Context, request *persistence.VisibilityDeleteWorkflowExecutionRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -83,11 +61,6 @@ func (c *ratelimitedVisibilityManager) DeleteWorkflowExecution(ctx context.Conte
 }
 
 func (c *ratelimitedVisibilityManager) GetClosedWorkflowExecution(ctx context.Context, request *persistence.GetClosedWorkflowExecutionRequest) (gp1 *persistence.GetClosedWorkflowExecutionResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -100,11 +73,6 @@ func (c *ratelimitedVisibilityManager) GetName() (s1 string) {
 }
 
 func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutions(ctx context.Context, request *persistence.ListWorkflowExecutionsRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -113,11 +81,6 @@ func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutions(ctx context.
 }
 
 func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutionsByStatus(ctx context.Context, request *persistence.ListClosedWorkflowExecutionsByStatusRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -126,11 +89,6 @@ func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutionsByStatus(ctx 
 }
 
 func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutionsByType(ctx context.Context, request *persistence.ListWorkflowExecutionsByTypeRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -139,11 +97,6 @@ func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutionsByType(ctx co
 }
 
 func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutionsByWorkflowID(ctx context.Context, request *persistence.ListWorkflowExecutionsByWorkflowIDRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -152,11 +105,6 @@ func (c *ratelimitedVisibilityManager) ListClosedWorkflowExecutionsByWorkflowID(
 }
 
 func (c *ratelimitedVisibilityManager) ListOpenWorkflowExecutions(ctx context.Context, request *persistence.ListWorkflowExecutionsRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -165,11 +113,6 @@ func (c *ratelimitedVisibilityManager) ListOpenWorkflowExecutions(ctx context.Co
 }
 
 func (c *ratelimitedVisibilityManager) ListOpenWorkflowExecutionsByType(ctx context.Context, request *persistence.ListWorkflowExecutionsByTypeRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -178,11 +121,6 @@ func (c *ratelimitedVisibilityManager) ListOpenWorkflowExecutionsByType(ctx cont
 }
 
 func (c *ratelimitedVisibilityManager) ListOpenWorkflowExecutionsByWorkflowID(ctx context.Context, request *persistence.ListWorkflowExecutionsByWorkflowIDRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -191,11 +129,6 @@ func (c *ratelimitedVisibilityManager) ListOpenWorkflowExecutionsByWorkflowID(ct
 }
 
 func (c *ratelimitedVisibilityManager) ListWorkflowExecutions(ctx context.Context, request *persistence.ListWorkflowExecutionsByQueryRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -204,11 +137,6 @@ func (c *ratelimitedVisibilityManager) ListWorkflowExecutions(ctx context.Contex
 }
 
 func (c *ratelimitedVisibilityManager) RecordWorkflowExecutionClosed(ctx context.Context, request *persistence.RecordWorkflowExecutionClosedRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -217,11 +145,6 @@ func (c *ratelimitedVisibilityManager) RecordWorkflowExecutionClosed(ctx context
 }
 
 func (c *ratelimitedVisibilityManager) RecordWorkflowExecutionStarted(ctx context.Context, request *persistence.RecordWorkflowExecutionStartedRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -230,11 +153,6 @@ func (c *ratelimitedVisibilityManager) RecordWorkflowExecutionStarted(ctx contex
 }
 
 func (c *ratelimitedVisibilityManager) RecordWorkflowExecutionUninitialized(ctx context.Context, request *persistence.RecordWorkflowExecutionUninitializedRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -243,11 +161,6 @@ func (c *ratelimitedVisibilityManager) RecordWorkflowExecutionUninitialized(ctx 
 }
 
 func (c *ratelimitedVisibilityManager) ScanWorkflowExecutions(ctx context.Context, request *persistence.ListWorkflowExecutionsByQueryRequest) (lp1 *persistence.ListWorkflowExecutionsResponse, err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return
@@ -256,11 +169,6 @@ func (c *ratelimitedVisibilityManager) ScanWorkflowExecutions(ctx context.Contex
 }
 
 func (c *ratelimitedVisibilityManager) UpsertWorkflowExecution(ctx context.Context, request *persistence.UpsertWorkflowExecutionRequest) (err error) {
-	if c.metricsClient != nil {
-		scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	}
-
 	if !c.callerBypass.AllowLimiter(ctx, c.rateLimiter) {
 		err = ErrPersistenceLimitExceeded
 		return

--- a/common/persistence/wrappers/ratelimited/wrappers_test.go
+++ b/common/persistence/wrappers/ratelimited/wrappers_test.go
@@ -162,14 +162,14 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 	switch injector.(type) {
 	case *ratelimitedConfigStoreManager:
 		mocked := persistence.NewMockConfigStoreManager(ctrl)
-		object = NewConfigStoreManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewConfigStoreManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().UpdateDynamicConfig(gomock.Any(), gomock.Any(), gomock.Any()).Return(expectedErr)
 			mocked.EXPECT().FetchDynamicConfig(gomock.Any(), gomock.Any()).Return(&persistence.FetchDynamicConfigResponse{}, expectedErr)
 		}
 	case *ratelimitedDomainManager:
 		mocked := persistence.NewMockDomainManager(ctrl)
-		object = NewDomainManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewDomainManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().CreateDomain(gomock.Any(), gomock.Any()).Return(&persistence.CreateDomainResponse{}, expectedErr)
 			mocked.EXPECT().GetDomain(gomock.Any(), gomock.Any()).Return(&persistence.GetDomainResponse{}, expectedErr)
@@ -181,7 +181,7 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 		}
 	case *ratelimitedHistoryManager:
 		mocked := persistence.NewMockHistoryManager(ctrl)
-		object = NewHistoryManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewHistoryManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().AppendHistoryNodes(gomock.Any(), gomock.Any()).Return(&persistence.AppendHistoryNodesResponse{}, expectedErr)
 			mocked.EXPECT().ReadHistoryBranch(gomock.Any(), gomock.Any()).Return(&persistence.ReadHistoryBranchResponse{}, expectedErr)
@@ -194,7 +194,7 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 		}
 	case *ratelimitedQueueManager:
 		mocked := persistence.NewMockQueueManager(ctrl)
-		object = NewQueueManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewQueueManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().EnqueueMessage(gomock.Any(), gomock.Any()).Return(expectedErr)
 			mocked.EXPECT().ReadMessages(gomock.Any(), gomock.Any()).Return(&persistence.ReadMessagesResponse{Messages: []*persistence.QueueMessage{}}, expectedErr)
@@ -211,7 +211,7 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 		}
 	case *ratelimitedShardManager:
 		mocked := persistence.NewMockShardManager(ctrl)
-		object = NewShardManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewShardManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().GetShard(gomock.Any(), gomock.Any()).Return(&persistence.GetShardResponse{}, expectedErr)
 			mocked.EXPECT().UpdateShard(gomock.Any(), gomock.Any()).Return(expectedErr)
@@ -219,7 +219,7 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 		}
 	case *ratelimitedTaskManager:
 		mocked := persistence.NewMockTaskManager(ctrl)
-		object = NewTaskManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewTaskManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().CompleteTasksLessThan(gomock.Any(), gomock.Any()).Return(&persistence.CompleteTasksLessThanResponse{}, expectedErr)
 			mocked.EXPECT().CompleteTask(gomock.Any(), gomock.Any()).Return(expectedErr)
@@ -235,7 +235,7 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 		}
 	case *ratelimitedVisibilityManager:
 		mocked := persistence.NewMockVisibilityManager(ctrl)
-		object = NewVisibilityManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewVisibilityManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().DeleteUninitializedWorkflowExecution(gomock.Any(), gomock.Any()).Return(expectedErr)
 			mocked.EXPECT().DeleteWorkflowExecution(gomock.Any(), gomock.Any()).Return(expectedErr)
@@ -257,7 +257,7 @@ func builderForPassThrough(t *testing.T, injector any, limiter quotas.Limiter, e
 		}
 	case *ratelimitedExecutionManager:
 		mocked := persistence.NewMockExecutionManager(ctrl)
-		object = NewExecutionManager(mocked, limiter, nil, "test", callerBypass)
+		object = NewExecutionManager(mocked, limiter, callerBypass)
 		if expectCalls {
 			mocked.EXPECT().CreateWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.CreateWorkflowExecutionResponse{}, expectedErr)
 			mocked.EXPECT().GetWorkflowExecution(gomock.Any(), gomock.Any()).Return(&persistence.GetWorkflowExecutionResponse{}, expectedErr)
@@ -353,7 +353,7 @@ func TestVisibilityManagerBypassRateLimitForCallerTypes(t *testing.T) {
 			)
 
 			callerBypass := quotas.NewCallerBypass(dc.GetListProperty(dynamicproperties.RateLimiterBypassCallerTypes))
-			vm := NewVisibilityManager(mocked, &limiterNeverAllow{}, nil, "test", callerBypass)
+			vm := NewVisibilityManager(mocked, &limiterNeverAllow{}, callerBypass)
 
 			ctx := types.ContextWithCallerInfo(context.Background(), types.NewCallerInfo(tt.callerType))
 
@@ -384,7 +384,7 @@ func TestVisibilityManagerBypassRateLimitWithDynamicConfig(t *testing.T) {
 	)
 
 	callerBypass := quotas.NewCallerBypass(dc.GetListProperty(dynamicproperties.RateLimiterBypassCallerTypes))
-	vm := NewVisibilityManager(mocked, &limiterNeverAllow{}, nil, "test", callerBypass)
+	vm := NewVisibilityManager(mocked, &limiterNeverAllow{}, callerBypass)
 
 	t.Run("CLI bypasses rate limit", func(t *testing.T) {
 		ctx := types.ContextWithCallerInfo(context.Background(), types.NewCallerInfo(types.CallerTypeCLI))
@@ -425,7 +425,7 @@ func TestVisibilityManagerNoBypassWithoutDynamicConfig(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mocked := persistence.NewMockVisibilityManager(ctrl)
 
-	vm := NewVisibilityManager(mocked, &limiterNeverAllow{}, nil, "test", quotas.CallerBypass{})
+	vm := NewVisibilityManager(mocked, &limiterNeverAllow{}, quotas.CallerBypass{})
 
 	ctx := types.ContextWithCallerInfo(context.Background(), types.NewCallerInfo(types.CallerTypeCLI))
 
@@ -488,7 +488,7 @@ func TestShardManagerBypassRateLimitForCallerTypes(t *testing.T) {
 			)
 
 			callerBypass := quotas.NewCallerBypass(dc.GetListProperty(dynamicproperties.RateLimiterBypassCallerTypes))
-			sm := NewShardManager(mocked, &limiterNeverAllow{}, nil, "test", callerBypass)
+			sm := NewShardManager(mocked, &limiterNeverAllow{}, callerBypass)
 
 			ctx := types.ContextWithCallerInfo(context.Background(), types.NewCallerInfo(tt.callerType))
 
@@ -559,7 +559,7 @@ func TestHistoryManagerBypassRateLimitForCallerTypes(t *testing.T) {
 			)
 
 			callerBypass := quotas.NewCallerBypass(dc.GetListProperty(dynamicproperties.RateLimiterBypassCallerTypes))
-			hm := NewHistoryManager(mocked, &limiterNeverAllow{}, nil, "test", callerBypass)
+			hm := NewHistoryManager(mocked, &limiterNeverAllow{}, callerBypass)
 
 			ctx := types.ContextWithCallerInfo(context.Background(), types.NewCallerInfo(tt.callerType))
 

--- a/common/persistence/wrappers/templates/metered.tmpl
+++ b/common/persistence/wrappers/templates/metered.tmpl
@@ -22,8 +22,6 @@ func New{{.Interface.Name}}(
 	metricClient  metrics.Client,
 	logger        log.Logger,
 	cfg           *config.Persistence,
-	hostname      string,
-	datastoreName string,
 ) persistence.{{.Interface.Name}} {
     return &{{$decorator}}{
         wrapped: wrapped,
@@ -31,8 +29,6 @@ func New{{.Interface.Name}}(
 			metricClient:                  metricClient,
 			logger:                        logger,
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
         },
     }
 }

--- a/common/persistence/wrappers/templates/metered_execution.tmpl
+++ b/common/persistence/wrappers/templates/metered_execution.tmpl
@@ -25,8 +25,6 @@ func New{{.Interface.Name}}(
 	cfg          *config.Persistence,
     sampleLoggingRate dynamicproperties.IntPropertyFn,
     enableShardIDMetrics dynamicproperties.BoolPropertyFn,
-	hostname     string,
-	datastoreName string,
 ) persistence.{{.Interface.Name}} {
     return &{{$decorator}}{
         wrapped: wrapped,
@@ -36,8 +34,6 @@ func New{{.Interface.Name}}(
 			enableLatencyHistogramMetrics: cfg.EnablePersistenceLatencyHistogramMetrics,
 			sampleLoggingRate:             sampleLoggingRate,
 			enableShardIDMetrics:          enableShardIDMetrics,
-			hostname:                      hostname,
-			datastoreName:                 datastoreName,
         },
     }
 }

--- a/common/persistence/wrappers/templates/ratelimited.tmpl
+++ b/common/persistence/wrappers/templates/ratelimited.tmpl
@@ -12,8 +12,6 @@ import (
 type {{$decorator}} struct {
     wrapped      {{.Interface.Type}}
     rateLimiter  quotas.Limiter
-    metricsClient metrics.Client
-    datastoreName string
     callerBypass quotas.CallerBypass
 }
 
@@ -21,15 +19,11 @@ type {{$decorator}} struct {
 func New{{.Interface.Name}}(
     wrapped persistence.{{.Interface.Name}},
     rateLimiter quotas.Limiter,
-    metricsClient metrics.Client,
-    datastoreName string,
     callerBypass quotas.CallerBypass,
 ) persistence.{{.Interface.Name}} {
     return &{{$decorator}}{
         wrapped: wrapped,
         rateLimiter: rateLimiter,
-        metricsClient: metricsClient,
-        datastoreName: datastoreName,
         callerBypass: callerBypass,
     }
 }
@@ -37,11 +31,6 @@ func New{{.Interface.Name}}(
 {{range $method := .Interface.Methods}}
     {{- if (and $method.AcceptsContext $method.ReturnsError)}}
         func (c *{{$decorator}}) {{$method.Declaration}} {
-	        if c.metricsClient != nil {
-		        scope := c.metricsClient.Scope(metrics.PersistenceCreateShardScope, metrics.DatastoreTag(c.datastoreName))
-		        scope.UpdateGauge(metrics.PersistenceQuota, float64(c.rateLimiter.Limit()))
-	        }
-
 	        if !c.callerBypass.AllowLimiter({{(index $method.Params 0).Name}}, c.rateLimiter) {
 		        err = ErrPersistenceLimitExceeded
 		        return

--- a/common/resource/resource_impl.go
+++ b/common/resource/resource_impl.go
@@ -212,7 +212,6 @@ func New(
 		params.MetricsClient,
 		logger,
 		persistence.NewDynamicConfiguration(dynamicCollection),
-		params.HostName,
 	), &persistenceClient.Params{
 		PersistenceConfig: params.PersistenceConfig,
 		MetricsClient:     params.MetricsClient,

--- a/host/onebox.go
+++ b/host/onebox.go
@@ -913,7 +913,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 
 	var replicatorDomainCache cache.DomainCache
 	if c.workerConfig.EnableReplicator {
-		metadataManager := metered.NewDomainManager(c.domainManager, service.GetMetricsClient(), c.logger, &c.persistenceConfig, "onebox-worker", "onebox")
+		metadataManager := metered.NewDomainManager(c.domainManager, service.GetMetricsClient(), c.logger, &c.persistenceConfig)
 		replicatorDomainCache = cache.NewDomainCache(metadataManager, c.clusterMetadata, service.GetMetricsClient(), service.GetLogger())
 		replicatorDomainCache.Start()
 		defer replicatorDomainCache.Stop()
@@ -922,7 +922,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 
 	var clientWorkerDomainCache cache.DomainCache
 	if c.workerConfig.EnableArchiver {
-		metadataProxyManager := metered.NewDomainManager(c.domainManager, service.GetMetricsClient(), c.logger, &c.persistenceConfig, "onebox-worker", "onebox")
+		metadataProxyManager := metered.NewDomainManager(c.domainManager, service.GetMetricsClient(), c.logger, &c.persistenceConfig)
 		clientWorkerDomainCache = cache.NewDomainCache(metadataProxyManager, c.clusterMetadata, service.GetMetricsClient(), service.GetLogger())
 		clientWorkerDomainCache.Start()
 		defer clientWorkerDomainCache.Stop()
@@ -944,9 +944,7 @@ func (c *cadenceImpl) startWorker(hosts map[string][]membership.HostInfo, startW
 			c.domainManager,
 			service.GetMetricsClient(),
 			c.logger,
-			&c.persistenceConfig,
-			"onebox-worker",
-			"onebox")
+			&c.persistenceConfig)
 		asyncWFDomainCache = cache.NewDomainCache(
 			metadataProxyManager,
 			c.clusterMetadata,

--- a/tools/cli/database.go
+++ b/tools/cli/database.go
@@ -264,7 +264,6 @@ func (f *defaultManagerFactory) initPersistenceFactory(c *cli.Context) (client.F
 		&persistence.DynamicConfiguration{
 			EnableSQLAsyncTransaction: dynamicproperties.GetBoolPropertyFn(false),
 		},
-		"cadence-cli",
 	), nil
 }
 


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
Reverted the addition of host tag to persistence calls.


<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
The addition caused metrics to have a very high cardinality. The metric is not really necessary and was added to add more visibility to persistence requests.


<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad: "Tested locally" or "Added tests" -->
**How did you test it?**
Updated all the unit tests related to the metric added.


<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
This actually address the risk of metrics with very high cardinality


<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**
This revert addresses the issue of high metric cardinality introduced by https://github.com/cadence-workflow/cadence/pull/7530

<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**


---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
