### PR TITLE
fix(cadence-matching): do not delete sp when onboarded to SD

### DIFF
--- a/service/sharddistributor/client/executorclient/client.go
+++ b/service/sharddistributor/client/executorclient/client.go
@@ -35,6 +35,7 @@ type ShardProcessor interface {
 	Start(ctx context.Context) error
 	Stop()
 	GetShardReport() ShardReport
+	SetShardStatus(types.ShardStatus)
 }
 
 type ShardProcessorFactory[SP ShardProcessor] interface {

--- a/service/sharddistributor/client/executorclient/interface_mock.go
+++ b/service/sharddistributor/client/executorclient/interface_mock.go
@@ -101,6 +101,18 @@ func (mr *MockShardProcessorMockRecorder) GetShardReport() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetShardReport", reflect.TypeOf((*MockShardProcessor)(nil).GetShardReport))
 }
 
+// SetShardStatus mocks base method.
+func (m *MockShardProcessor) SetShardStatus(arg0 types.ShardStatus) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "SetShardStatus", arg0)
+}
+
+// SetShardStatus indicates an expected call of SetShardStatus.
+func (mr *MockShardProcessorMockRecorder) SetShardStatus(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetShardStatus", reflect.TypeOf((*MockShardProcessor)(nil).SetShardStatus), arg0)
+}
+
 // Start mocks base method.
 func (m *MockShardProcessor) Start(ctx context.Context) error {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
When onboarded to shard manager, do not delete the shard processors and just mark the shards as done. https://github.com/cadence-workflow/cadence/issues/6862 

<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
When a task list expires we also want to stop processing the shard. In a local_pass and local_pass_shadow mode (when decision about sharding are still based on ringpop) we need to delete the shard processor, since shard manager is not handling any assignment in that case. In the case of onboarding, it is shard manager that decide how to assign shards, in case of deletion of shard processors, the shard are still getting assigned and the number of shards grows because they are not considered as done.

<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad: "Tested locally" or "Added tests" -->
**How did you test it?**
added unit tests, and deployed to a staging environment where the sd is used for sharding
go test -v -run TestShardCleanupLoop ./service/sharddistributor/client/executorclient/ -timeout 30s

<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
shard assignment can be affected, but the shard-manager is still in development face and not set to be used as default

<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**


<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**


---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
