### PR TITLE
chore: add replication task processor histograms

### DIFF
--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2725,12 +2725,14 @@ const (
 	ReplicationTasksApplied
 	ReplicationTasksFailed
 	ReplicationTasksLag
+	ExponentialReplicationTasksLag
 	ReplicationTasksLagRaw
 	ReplicationTasksDelay
 	ReplicationTasksFetched
 	ReplicationTasksReturned
 	ReplicationTasksReturnedDiff
 	ReplicationTasksAppliedLatency
+	ExponentialReplicationTasksAppliedLatency
 	ReplicationTasksBatchSize
 	ReplicationDynamicTaskBatchSizerDecision
 	ReplicationDLQFailed
@@ -3539,12 +3541,14 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		ReplicationTasksApplied:                                      {metricName: "replication_tasks_applied", metricType: Counter},
 		ReplicationTasksFailed:                                       {metricName: "replication_tasks_failed", metricType: Counter},
 		ReplicationTasksLag:                                          {metricName: "replication_tasks_lag", metricType: Timer},
+		ExponentialReplicationTasksLag:                               {metricName: "replication_tasks_lag_ns", metricType: Histogram, exponentialBuckets: Mid1ms24h},
 		ReplicationTasksLagRaw:                                       {metricName: "replication_tasks_lag_raw", metricType: Timer},
 		ReplicationTasksDelay:                                        {metricName: "replication_tasks_delay", metricType: Histogram, buckets: ReplicationTaskDelayBucket},
 		ReplicationTasksFetched:                                      {metricName: "replication_tasks_fetched", metricType: Timer},
 		ReplicationTasksReturned:                                     {metricName: "replication_tasks_returned", metricType: Timer},
 		ReplicationTasksReturnedDiff:                                 {metricName: "replication_tasks_returned_diff", metricType: Timer},
 		ReplicationTasksAppliedLatency:                               {metricName: "replication_tasks_applied_latency", metricType: Timer},
+		ExponentialReplicationTasksAppliedLatency:                    {metricName: "replication_tasks_applied_latency_ns", metricType: Histogram, exponentialBuckets: Low1ms100s},
 		ReplicationTasksBatchSize:                                    {metricName: "replication_tasks_batch_size", metricType: Gauge},
 		ReplicationDynamicTaskBatchSizerDecision:                     {metricName: "replication_dynamic_task_batch_sizer_decision", metricType: Counter},
 		ReplicationDLQFailed:                                         {metricName: "replication_dlq_enqueue_failed", metricType: Counter},


### PR DESCRIPTION
**What changed?**
Emitted exponential histograms for replication tasks lag and applied latency alongside existing timers in the task processor. CadenceCDNC-17610

**Why?**
Replication lag and applied latency were only tracked as timers, which limits distribution analysis in M3/Grafana. Adding histogram variants preserves existing timer signals while enabling bucketed/percentile insights without changing replication processing logic. 

**How did you test it?**
Verified metric emission in uMonitor.

**Potential risks**
Low risk: additional histogram emission in replication task processor; minimal overhead.

**Release notes**
Replication now emits histogram variants for tasks lag and applied latency (replication_tasks_lag_ns, replication_tasks_applied_latency_ns). CadenceCDNC-17610

**Documentation Changes**
N/A