### PR TITLE
chore: allowlist new histogram migration metrics per comment (follow-up to #7685)

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -44,6 +44,13 @@ var HistogramMigrationMetrics = map[string]struct{}{
 	"task_latency_processing":    {},
 	"task_latency_processing_ns": {},
 
+	// Replication task processor histograms (PR #7685).
+	// Dual-emitted as timer + histogram.
+	"replication_tasks_lag":                {},
+	"replication_tasks_lag_ns":             {},
+	"replication_tasks_applied_latency":    {},
+	"replication_tasks_applied_latency_ns": {},
+
 	"replication_task_latency":    {},
 	"replication_task_latency_ns": {},
 }


### PR DESCRIPTION
**What changed?**

Added the new replication task processor histogram metric names to common/metrics/config.go’s HistogramMigrationMetrics allowlist so emission can be controlled via histogram-migration config (follow-up to #7685 and review comment).

**Why?**

Cadence only applies histogram-migration config (and validates configured metric names) for metrics present in HistogramMigrationMetrics. The histogram variants introduced in #7685 (e.g. replication_tasks_lag_ns, replication_tasks_applied_latency_ns) weren’t allowlisted, so operators couldn’t selectively enable/disable timer vs histogram emission (and mis-typed config keys wouldn’t be caught). This change allowlists those names to make rollout and configuration explicit and safe.

**How did you test it?**

go test ./common/metrics -count=1

**Potential risks**

Low. This only adjusts which metric names are eligible for histogram-migration gating/validation. If an operator configures histogram migration for these metrics, behavior will now follow that config; typos will fail fast instead of being silently ignored.

**Release notes**

N/A (no user-facing behavior change by default; enables operator-controlled rollout for metrics introduced in #7685).

**Documentation Changes**
N/A.