### PR TITLE
chore: fix Docker cqlsh install and improve simulation diagnostics

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ FROM alpine:3.18 AS dockerize
 # appears to require `docker buildx` or an explicit `--platform` at build time
 ARG TARGETARCH
 
-RUN apk add --no-cache openssl
+RUN apk add --no-cache openssl ca-certificates && update-ca-certificates
 
 ENV DOCKERIZE_VERSION=v0.9.3
 RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-$TARGETARCH-$DOCKERIZE_VERSION.tar.gz \
@@ -91,8 +91,8 @@ CMD /start-cadence.sh
 # All-in-one Cadence server (~450mb)
 FROM cadence-server AS cadence-auto-setup
 
-RUN apk add --update --no-cache ca-certificates py3-pip mysql-client
-RUN pip3 install cqlsh && cqlsh --version
+RUN apk add --update --no-cache ca-certificates py3-pip py3-setuptools py3-wheel mysql-client
+RUN pip3 install --no-build-isolation cqlsh && cqlsh --version
 
 COPY docker/start.sh /start.sh
 COPY docker/domain /etc/cadence/domain


### PR DESCRIPTION
**What changed?**
Fix Docker `cadence-auto-setup` image build and improve replication simulation test diagnostics.

- Install `py3-setuptools`, `py3-wheel`, and `ca-certificates` in Docker images so `pip3 install cqlsh` succeeds on newer Alpine/pip
- Add `--no-build-isolation` to cqlsh pip install
- Return structured JSON from simulation worker `/health` endpoint with cluster info, ready domain count, and last errors
- Add per-endpoint error/status logging in simulation health check with 1s HTTP client timeout to prevent hangs

**Why?**
These changes were extracted from the replication histogram metric PRs (#7683, #7684) where they were originally included to unblock CI. They are prerequisites for those PRs to pass CI, but are logically independent infrastructure fixes.

The Docker `cadence-auto-setup` image build was broken on Alpine 3.18 with newer pip versions. `pip3 install cqlsh` fails because `setuptools` and `wheel` are no longer bundled by default — they must be explicitly installed as system packages. The `--no-build-isolation` flag is also needed because cqlsh's build dependencies cannot be resolved in an isolated environment without pre-installed setuptools. The `ca-certificates` addition in the dockerize stage ensures HTTPS downloads (e.g. the dockerize release tarball via wget) succeed reliably. Without these fixes, all CI jobs that build or use the Docker image — including the replication simulation tests that validate the histogram additions — fail before any test code runs.

The simulation worker `/health` endpoint previously returned empty 200/503 responses with no body, making it impossible to diagnose readiness failures in CI logs. When a health check failed, the test logged only "Workers are not reporting healthy yet" with no indication of whether the failure was DNS resolution, connection refused, HTTP 503, or a specific domain not being ready. The structured JSON response and per-endpoint logging make CI failures immediately actionable.