### PR TITLE
chore: (shard-distributor) extend shadow modes as fallback startegy

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2591,8 +2591,8 @@ const (
 	//
 	// - "hash_ring" means that the shards are distributed using a consistent hash ring, in particular using the ringpop library
 	// - "shard_distributor" means that the shards are distributed using the _highly experimental_ shard distributor service
-	// - "hash_ring-shadow-shard_distributor" means that the shards are distrubuted using the hash ring, but shadowed by the shard distributor
-	// - "shard_distributor-shadow-hash_ring" means that the shards are distrubuted using the shard distributor, but shadowed by the hash ring
+	// - "hash_ring-shadow-shard_distributor" means that shards are distributed using the hash ring, with the shard distributor shadowing the operation and serving as fallback in case of errors
+	// - "shard_distributor-shadow-hash_ring" means that the shards are distributed using the shard distributor, with the hash ring shadowing the operation and serving as fallback in case of errors
 	//
 	// KeyName: matching.shardDistributionMode
 	// Value type: string enum: "hash_ring" or "shard_distributor"

--- a/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
+++ b/service/sharddistributor/sharddistributorfx/sharddistributorfx.go
@@ -69,7 +69,7 @@ type registerHandlersParams struct {
 func registerHandlers(params registerHandlersParams) error {
 	dispatcher := params.RPCFactory.GetDispatcher()
 
-	rawHandler := handler.NewHandler(params.Logger, params.ShardDistributionCfg, params.Store)
+	rawHandler := handler.NewHandler(params.Logger, params.ShardDistributionCfg, params.Config, params.Store)
 	wrappedHandler := metered.NewMetricsHandler(rawHandler, params.Logger, params.MetricsClient)
 
 	executorHandler := handler.NewExecutorHandler(params.Logger, params.Store, params.TimeSource, params.ShardDistributionCfg, params.Config, params.MetricsClient)


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
Modified shadow mode behavior in the shard distributor resolver to:
  - Changed from async to synchronous shadowing - Both primary and shadow lookups now run synchronously (not in goroutines)
  - Added fallback logic - If the primary mode fails, automatically fallback to the shadow mode
  - Added onboarding check - Ephemeral shard assignment now requires namespace to be ONBOARDED to shard distributor
  part of https://github.com/cadence-workflow/cadence/issues/6862 

<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
- Fallback mechanism prevents complete failures when one mode has issues
- Prevents ephemeral shard creation for namespaces not yet onboarded to SD

<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad: "Tested locally" or "Added tests" -->
**How did you test it?**
  Updated unit tests to cover:
  - Both modes succeeding (comparison logic)
  - Primary failing, shadow succeeding (fallback scenarios)
  - Both failing (error propagation)
  - Ephemeral shard creation with/without onboarding state
  - All tests now validate synchronous behavior instead of async with sleep delays
  go test -v ./common/membership -run TestShardDistributorResolver
  go test -v ./service/sharddistributor/handler -run TestGetShardOwner



<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
Synchronous dual lookups add latency (runs both lookups serially vs. fire-and-forget) but the operation should be local most of the time so not a huge difference considering that handling of the go routine has been removed

<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**


<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**
 

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
