### PR TITLE
fix(metrics): add dual-emission for replication fetched and lag raw

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -65,6 +65,11 @@ var HistogramMigrationMetrics = map[string]struct{}{
 
 	"replication_task_latency":    {},
 	"replication_task_latency_ns": {},
+
+	"replication_tasks_fetched":        {},
+	"replication_tasks_fetched_counts": {},
+	"replication_tasks_lag_raw":        {},
+	"replication_tasks_lag_raw_counts": {},
 }
 
 func (h HistogramMigration) EmitTimer(name string) bool {

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2737,8 +2737,10 @@ const (
 	ReplicationTasksLag
 	ExponentialReplicationTasksLag
 	ReplicationTasksLagRaw
+	ExponentialReplicationTasksLagRaw
 	ReplicationTasksDelay
 	ReplicationTasksFetched
+	ExponentialReplicationTasksFetched
 	ReplicationTasksReturned
 	ReplicationTasksReturnedDiff
 	ReplicationTasksAppliedLatency
@@ -3564,8 +3566,10 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 		ReplicationTasksLag:                                          {metricName: "replication_tasks_lag", metricType: Timer},
 		ExponentialReplicationTasksLag:                               {metricName: "replication_tasks_lag_counts", metricType: Histogram, intExponentialBuckets: Mid1To16k},
 		ReplicationTasksLagRaw:                                       {metricName: "replication_tasks_lag_raw", metricType: Timer},
+		ExponentialReplicationTasksLagRaw:                            {metricName: "replication_tasks_lag_raw_counts", metricType: Histogram, intExponentialBuckets: Mid1To16k},
 		ReplicationTasksDelay:                                        {metricName: "replication_tasks_delay", metricType: Histogram, buckets: ReplicationTaskDelayBucket},
 		ReplicationTasksFetched:                                      {metricName: "replication_tasks_fetched", metricType: Timer},
+		ExponentialReplicationTasksFetched:                           {metricName: "replication_tasks_fetched_counts", metricType: Histogram, intExponentialBuckets: Mid1To16k},
 		ReplicationTasksReturned:                                     {metricName: "replication_tasks_returned", metricType: Timer},
 		ReplicationTasksReturnedDiff:                                 {metricName: "replication_tasks_returned_diff", metricType: Timer},
 		ReplicationTasksAppliedLatency:                               {metricName: "replication_tasks_applied_latency", metricType: Timer},

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -141,7 +141,9 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 	if err != nil {
 		return nil, err
 	}
-	t.scope.RecordTimer(metrics.ReplicationTasksFetched, time.Duration(len(taskInfos)))
+	tasksFetched := len(taskInfos)
+	t.scope.RecordTimer(metrics.ReplicationTasksFetched, time.Duration(tasksFetched))
+	t.scope.IntExponentialHistogram(metrics.ExponentialReplicationTasksFetched, tasksFetched)
 
 	// Happy path assumption - we will push all tasks to replication tasks.
 	msgs := &types.ReplicationMessages{
@@ -162,7 +164,9 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 		oldestUnprocessedTaskTimestamp = t.timeSource.Now().UnixNano()
 	}
 
-	t.scope.RecordTimer(metrics.ReplicationTasksLagRaw, time.Duration(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID()-oldestUnprocessedTaskID))
+	lagRaw := int(t.ackLevels.UpdateIfNeededAndGetQueueMaxReadLevel(persistence.HistoryTaskCategoryReplication, pollingCluster).GetTaskID() - oldestUnprocessedTaskID)
+	t.scope.RecordTimer(metrics.ReplicationTasksLagRaw, time.Duration(lagRaw))
+	t.scope.IntExponentialHistogram(metrics.ExponentialReplicationTasksLagRaw, lagRaw)
 	t.scope.RecordHistogramDuration(metrics.ReplicationTasksDelay, time.Duration(oldestUnprocessedTaskTimestamp-t.timeSource.Now().UnixNano()))
 
 	// hydrate the tasks


### PR DESCRIPTION
Add integer histogram dual-emission for ReplicationTasksFetched and ReplicationTasksLagRaw, and include their names in HistogramMigrationMetrics for config consistency checks.

**What changed?**
Added integer histogram dual-emission for ReplicationTasksFetched and ReplicationTasksLagRaw in the replication task-ack path, while preserving existing timer emission for backwards compatibility. Also added the new metric names to HistogramMigrationMetrics for histogram-migration config validation consistency.

**Why?**
ReplicationTasksFetched and ReplicationTasksLagRaw were still timer-only in task_ack_manager, which left gaps in the ongoing timer-to-histogram migration for replication metrics.
This change aligns these two metrics with the established dual-emission migration pattern (keep timer + add histogram), and updates HistogramMigrationMetrics so YAML config validation recognizes the new names and fails fast on typos/unknown metrics.

**How did you test it?**
Replication unit tests:
go test ./service/history/replication/... -v -count=1
Histogram migration consistency test:
go test ./common/metrics/... -v -run TestHistogramMigration -count=1
Full local pre-PR checks:
make pr

**Potential risks**
Low risk.
No API/IDL changes.
No schema/storage changes.
Existing timer metrics are still emitted; this only adds histogram dual-emission.
Slight metrics volume increase for the two added histogram streams.

**Release notes**
Internal metrics migration improvement: added histogram dual-emission for replication task fetch-count and lag-raw metrics to support migration of closed-source alerting/dashboard consumers while retaining existing OSS timer behavior.

**Documentation Changes**
N/A (internal metrics instrumentation and migration allowlist consistency only).
