### PR TITLE
chore(metrics): add dual-emission for replication task generation latency

### DIFF
--- a/common/metrics/config.go
+++ b/common/metrics/config.go
@@ -41,6 +41,9 @@ func (h *HistogramMigration) UnmarshalYAML(read func(any) error) error {
 // This is likely best done in an `init` func, to ensure it happens early enough
 // and does not race with config reading.
 var HistogramMigrationMetrics = map[string]struct{}{
+	"task_latency":    {},
+	"task_latency_ns": {},
+
 	"task_latency_processing":    {},
 	"task_latency_processing_ns": {},
 

--- a/common/metrics/defs.go
+++ b/common/metrics/defs.go
@@ -2480,6 +2480,7 @@ const (
 const (
 	TaskRequests = iota + NumCommonMetrics
 	TaskLatency
+	ExponentialTaskLatency
 	TaskFailures
 	TaskDiscarded
 	TaskAttemptTimer
@@ -3309,6 +3310,7 @@ var MetricDefs = map[ServiceIdx]map[MetricIdx]metricDefinition{
 	History: {
 		TaskRequests:                     {metricName: "task_requests", metricType: Counter},
 		TaskLatency:                      {metricName: "task_latency", metricType: Timer},
+		ExponentialTaskLatency:           {metricName: "task_latency_ns", metricType: Histogram, exponentialBuckets: Low1ms100s},
 		TaskAttemptTimer:                 {metricName: "task_attempt", metricType: Timer},
 		TaskFailures:                     {metricName: "task_errors", metricType: Counter},
 		TaskDiscarded:                    {metricName: "task_errors_discarded", metricType: Counter},

--- a/service/history/replication/task_ack_manager.go
+++ b/service/history/replication/task_ack_manager.go
@@ -131,8 +131,12 @@ func (t *TaskAckManager) getTasks(ctx context.Context, pollingCluster string, la
 		lastReadTaskID = previousReadTaskID
 	}
 
+	taskGeneratedStart := t.timeSource.Now()
 	taskGeneratedTimer := t.scope.StartTimer(metrics.TaskLatency)
 	defer taskGeneratedTimer.Stop()
+	defer func() {
+		t.scope.ExponentialHistogram(metrics.ExponentialTaskLatency, t.timeSource.Since(taskGeneratedStart))
+	}()
 
 	batchSize := t.dynamicTaskBatchSizer.value()
 	t.scope.UpdateGauge(metrics.ReplicationTasksBatchSize, float64(batchSize))


### PR DESCRIPTION
Add histogram dual-emission for TaskLatency in replication task ack manager and add task_latency names to HistogramMigrationMetrics for config consistency checks.

**What changed?**
Added histogram dual-emission for TaskLatency in service/history/replication/task_ack_manager.go (keep existing timer + emit task_latency_ns). Also added task_latency and task_latency_ns to HistogramMigrationMetrics so histogram-migration config name validation remains consistent.

**Why?**
In the replication task-ack path, task generation latency was still timer-only.
This change aligns it with the ongoing timer-to-histogram migration pattern by dual-emitting without breaking existing timer consumers. Updating HistogramMigrationMetrics ensures YAML config validation recognizes these migration metric names and fails fast on invalid entries.

**How did you test it?**
go test ./service/history/replication/... -count=1
go test ./common/metrics/... -run TestHistogramMigration -count=1
make pr

**Potential risks**
Low risk.
No API/IDL changes.
No schema/storage changes.
Existing timer emission is preserved; this only adds histogram emission for one metric path.
Minor increase in emitted metric volume.

**Release notes**
Internal metrics migration update: replication task-ack generation latency now dual-emits timer + histogram (task_latency and task_latency_ns) to support migration of downstream alerting/dashboard consumers.

**Documentation Changes**
N/A (internal metrics instrumentation/migration behavior only).