### PR TITLE
chore(shard-manager): provide metadata in constructor

### DIFF
--- a/service/sharddistributor/client/executorclient/clientimpl.go
+++ b/service/sharddistributor/client/executorclient/clientimpl.go
@@ -138,10 +138,10 @@ func (e *executorImpl[SP]) Stop() {
 }
 
 func (e *executorImpl[SP]) GetShardProcess(ctx context.Context, shardID string) (SP, error) {
-	shardProcess, ok := e.managedProcessors.Load(shardID)
 	e.processorsToLastUse.Store(shardID, e.timeSource.Now())
-	if !ok {
 
+	shardProcess, ok := e.managedProcessors.Load(shardID)
+	if !ok {
 		if e.getMigrationMode() == types.MigrationModeLOCALPASSTHROUGH {
 			// Fail immediately if we are in LOCAL_PASSTHROUGH mode
 			var zero SP
@@ -162,6 +162,7 @@ func (e *executorImpl[SP]) GetShardProcess(ctx context.Context, shardID string) 
 			return zero, fmt.Errorf("shard process not found for shard ID: %s", shardID)
 		}
 	}
+
 	return shardProcess.processor, nil
 }
 


### PR DESCRIPTION
**What changed?**
Refactoring for #7712:
Providing shard executor metadata to the constructor instead of Initalising this separately.
In addition, unifying panic -> logger.Fatal as we do in other cases.

**Why?**

+Better readability as code is more aligned with other usages of log.Fatal.
Passing metadata to constructor allows to avoid partial structure initialization.

**How did you test it?**
go test -v ./service/matching/handler

**Potential risks**

**Release notes**

**Documentation Changes**


---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
