### PR TITLE
fix(shard-manager): Correctly parse when time is zero

### DIFF
--- a/service/sharddistributor/store/etcd/etcdtypes/state_test.go
+++ b/service/sharddistributor/store/etcd/etcdtypes/state_test.go
@@ -223,6 +223,29 @@ func TestAssignedState_JSONMarshalling(t *testing.T) {
 	}
 }
 
+func TestAssignedState_JSONUnmarshalWithZeroLastUpdated(t *testing.T) {
+	tests := map[string]struct {
+		jsonStr string
+	}{
+		"last_updated is string zero": {
+			jsonStr: `{"assigned_shards":{"1":{"status":"AssignmentStatusREADY"}},"last_updated":"0"}`,
+		},
+		"last_updated is numeric zero": {
+			jsonStr: `{"assigned_shards":{"1":{"status":"AssignmentStatusREADY"}},"last_updated":0}`,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var unmarshalled AssignedState
+			err := json.Unmarshal([]byte(tc.jsonStr), &unmarshalled)
+			require.NoError(t, err)
+			require.Equal(t, types.AssignmentStatusREADY, unmarshalled.AssignedShards["1"].Status)
+			require.True(t, time.Time(unmarshalled.LastUpdated).IsZero())
+		})
+	}
+}
+
 func TestShardStatistics_FieldNumberMatched(t *testing.T) {
 	require.Equal(t,
 		reflect.TypeOf(ShardStatistics{}).NumField(),

--- a/service/sharddistributor/store/etcd/etcdtypes/time.go
+++ b/service/sharddistributor/store/etcd/etcdtypes/time.go
@@ -39,10 +39,16 @@ func (t Time) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
 // It decodes the time from time.RFC3339Nano format.
+// It also handles the special case where the value is "0" or 0 (zero),
+// which is treated as the zero value of time.Time.
 func (t *Time) UnmarshalJSON(data []byte) error {
 	str := string(data)
 	if len(str) >= 2 && str[0] == '"' && str[len(str)-1] == '"' {
 		str = str[1 : len(str)-1]
+	}
+	if str == "0" {
+		*t = Time(time.Time{})
+		return nil
 	}
 	parsed, err := ParseTime(str)
 	if err != nil {

--- a/service/sharddistributor/store/etcd/etcdtypes/time_test.go
+++ b/service/sharddistributor/store/etcd/etcdtypes/time_test.go
@@ -89,6 +89,16 @@ func TestTimeUnmarshalJSON(t *testing.T) {
 			expectTime: Time(time.Date(2025, 11, 17, 23, 2, 3, 456789012, time.UTC)),
 			expectErr:  "",
 		},
+		"zero string": {
+			input:      []byte(`"0"`),
+			expectTime: Time(time.Time{}),
+			expectErr:  "",
+		},
+		"zero number": {
+			input:      []byte(`0`),
+			expectTime: Time(time.Time{}),
+			expectErr:  "",
+		},
 		"invalid format": {
 			input:      []byte(`"not-a-time"`),
 			expectTime: Time{},


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
Added a check in etcdtypes/time.go to detect if time equals to zero and return zero value of time.Time instead of trying to RFC3339Nano parsing.

<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
When the last_updated field in assigned_state is equal to zero we try to parse it to RFC3339Nano format and get an error when fetching the assigned_state value. 

<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad: "Tested locally" or "Added tests" -->
**How did you test it?**
Added unit tests and checked with go test -v ./service/sharddistributor/store/etcd/etcdtypes

<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
N/A

<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**
N/A

<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**
N/A

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
