### PR TITLE
ci: Validate that an issue is linked in PR description

### DIFF
--- a/.gitar/rules/issue-linking-required.md
+++ b/.gitar/rules/issue-linking-required.md
@@ -33,6 +33,7 @@ PRs with titles starting with these conventional commit prefixes are exempt:
 - `chore:` - Maintenance tasks, dependency updates
 - `ci:` - CI/CD configuration changes
 - `style:` - Code formatting or style changes
+- `revert:` - Pull Request Reverts
 
 Examples:
 - ✅ Skip: `docs: Update installation instructions`


### PR DESCRIPTION
**What changed?**

Validates whether the PR description contains a relevant GitHub issue. 

**Why?**

We are aiming to improve the transparency of documentation, ease the process for creating new releases, and improve the context given to a reviewer for a PR. Adding an issue link reduces the need for duplication of reasoning (the issue should document part of the "why" for a given PR) and makes it easier for the release engineer to identify which commits relate to which issues. 

We're using a gitar rule because:
* its very easy to get started with and iterate on
* we aren't allowed to use GitHub workflows that comment on PRs - which reduces the usability of open source GitHub actions 

Unfortunately the gitar rule will be more expensive (an LLM request per PR update) and less deterministic. We will reevaluate as we test other actions. 

**How did you test it?**

Tested via this PR and its integration with gitar. 

**Potential risks**

None. 

**Release notes**

N/A

**Documentation Changes**

N/A

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [x] **"What changed"** provides a clear 1-2 line summary
  - [x] Project Issue is linked
- [x] **"Why"** explains the full motivation with sufficient context
- [x] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [x] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [x] **Release notes** included if this completes a user-facing feature
- [x] **Documentation** needs are addressed (or noted if uncertain)
