### PR TITLE
chore(matching): introduce task list registry

### DIFF
--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -236,8 +236,8 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 		ClusterMetadata: s.matchingEngine.clusterMetadata,
 		IsolationState:  s.matchingEngine.isolationState,
 		MatchingClient:  s.matchingEngine.matchingClient,
-		Registry:        s.matchingEngine, // Engine implements ManagerRegistry
-		TaskList:        taskListID,       // same taskListID as above
+		Registry:        s.matchingEngine.taskListsRegistry,
+		TaskList:        taskListID, // same taskListID as above
 		TaskListKind:    tlKind,
 		Cfg:             s.matchingEngine.config,
 		TimeSource:      s.matchingEngine.timeSource,

--- a/service/matching/handler/membership.go
+++ b/service/matching/handler/membership.go
@@ -127,22 +127,21 @@ func (e *matchingEngineImpl) getNonOwnedTasklistsLocked() ([]tasklist.Manager, e
 
 	var toShutDown []tasklist.Manager
 
-	e.taskListsLock.RLock()
-	defer e.taskListsLock.RUnlock()
+	taskLists := e.taskListsRegistry.AllManagers()
 
 	self, err := e.membershipResolver.WhoAmI()
 	if err != nil {
 		return nil, fmt.Errorf("failed to lookup self im membership: %w", err)
 	}
 
-	for tl, manager := range e.taskLists {
-		taskListOwner, err := e.membershipResolver.Lookup(service.Matching, tl.GetName())
+	for _, tl := range taskLists {
+		taskListOwner, err := e.membershipResolver.Lookup(service.Matching, tl.TaskListID().GetName())
 		if err != nil {
 			return nil, fmt.Errorf("failed to lookup task list owner: %w", err)
 		}
 
 		if taskListOwner.Identity() != self.Identity() {
-			toShutDown = append(toShutDown, manager)
+			toShutDown = append(toShutDown, tl)
 		}
 	}
 

--- a/service/matching/handler/membership_test.go
+++ b/service/matching/handler/membership_test.go
@@ -197,13 +197,12 @@ func TestSubscriptionAndShutdown(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		config: &config.Config{
-			EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true },
-		},
-		shutdown:    make(chan struct{}),
-		logger:      log.NewNoop(),
-		domainCache: mockDomainCache,
-		executor:    mockExecutor,
+		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
+		shutdown:           make(chan struct{}),
+		logger:             log.NewNoop(),
+		domainCache:        mockDomainCache,
+		executor:           mockExecutor,
 	}
 
 	mockResolver.EXPECT().WhoAmI().Return(membership.NewDetailedHostInfo("host2", "host2", nil), nil).AnyTimes()
@@ -233,13 +232,12 @@ func TestSubscriptionAndErrorReturned(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		config: &config.Config{
-			EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true },
-		},
-		shutdown:    make(chan struct{}),
-		logger:      log.NewNoop(),
-		domainCache: mockDomainCache,
-		executor:    mockExecutor,
+		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
+		shutdown:           make(chan struct{}),
+		logger:             log.NewNoop(),
+		domainCache:        mockDomainCache,
+		executor:           mockExecutor,
 	}
 
 	// this should trigger the error case on a membership event
@@ -288,12 +286,11 @@ func TestSubscribeToMembershipChangesQuitsIfSubscribeFails(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		config: &config.Config{
-			EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true },
-		},
-		shutdown:    make(chan struct{}),
-		logger:      logger,
-		domainCache: mockDomainCache,
+		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
+		shutdown:           make(chan struct{}),
+		logger:             logger,
+		domainCache:        mockDomainCache,
 	}
 
 	mockResolver.EXPECT().Subscribe(service.Matching, "matching-engine", gomock.Any()).
@@ -337,13 +334,12 @@ func TestGetTasklistManagerShutdownScenario(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		config: &config.Config{
-			EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true },
-		},
-		shutdown:    make(chan struct{}),
-		logger:      log.NewNoop(),
-		domainCache: mockDomainCache,
-		executor:    mockExecutor,
+		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
+		shutdown:           make(chan struct{}),
+		logger:             log.NewNoop(),
+		domainCache:        mockDomainCache,
+		executor:           mockExecutor,
 	}
 
 	// set this engine to be shutting down to trigger the tasklistGetTasklistByID guard

--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -41,9 +41,23 @@ type (
 	// ManagerRegistry is implemented by components that track/own task list managers.
 	// Managers notify their registry when they stop so they can be cleaned up.
 	ManagerRegistry interface {
-		// UnregisterManager is called by a Manager when it stops, allowing the registry
-		// to clean up resources and remove the manager from its tracking structures.
-		UnregisterManager(mgr Manager)
+		// Register registers a manager for a given identifier.
+		// we can override the manager for the same identifier if it is already registered
+		// this case should be handled by the caller
+		Register(id Identifier, mgr Manager)
+
+		// Unregister unregisters a manager for a given identifier.
+		// it returns true if the manager was unregistered, false if it was not found
+		Unregister(mgr Manager) bool
+
+		// AllManagers returns a list of all managers.
+		AllManagers() []Manager
+
+		ManagersByDomainID(domainID string) []Manager
+		ManagersByTaskListName(name string) []Manager
+		// ManagerByTaskListIdentifier returns a manager for a given identifier.
+		// it returns the manager and true if it was found, false if it was not found
+		ManagerByTaskListIdentifier(id Identifier) (Manager, bool)
 	}
 
 	Manager interface {

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -44,16 +44,87 @@ func (m *MockManagerRegistry) EXPECT() *MockManagerRegistryMockRecorder {
 	return m.recorder
 }
 
-// UnregisterManager mocks base method.
-func (m *MockManagerRegistry) UnregisterManager(mgr Manager) {
+// AllManagers mocks base method.
+func (m *MockManagerRegistry) AllManagers() []Manager {
 	m.ctrl.T.Helper()
-	m.ctrl.Call(m, "UnregisterManager", mgr)
+	ret := m.ctrl.Call(m, "AllManagers")
+	ret0, _ := ret[0].([]Manager)
+	return ret0
 }
 
-// UnregisterManager indicates an expected call of UnregisterManager.
-func (mr *MockManagerRegistryMockRecorder) UnregisterManager(mgr any) *gomock.Call {
+// AllManagers indicates an expected call of AllManagers.
+func (mr *MockManagerRegistryMockRecorder) AllManagers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UnregisterManager", reflect.TypeOf((*MockManagerRegistry)(nil).UnregisterManager), mgr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllManagers", reflect.TypeOf((*MockManagerRegistry)(nil).AllManagers))
+}
+
+// ManagerByTaskListIdentifier mocks base method.
+func (m *MockManagerRegistry) ManagerByTaskListIdentifier(id Identifier) (Manager, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagerByTaskListIdentifier", id)
+	ret0, _ := ret[0].(Manager)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// ManagerByTaskListIdentifier indicates an expected call of ManagerByTaskListIdentifier.
+func (mr *MockManagerRegistryMockRecorder) ManagerByTaskListIdentifier(id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagerByTaskListIdentifier", reflect.TypeOf((*MockManagerRegistry)(nil).ManagerByTaskListIdentifier), id)
+}
+
+// ManagersByDomainID mocks base method.
+func (m *MockManagerRegistry) ManagersByDomainID(domainID string) []Manager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagersByDomainID", domainID)
+	ret0, _ := ret[0].([]Manager)
+	return ret0
+}
+
+// ManagersByDomainID indicates an expected call of ManagersByDomainID.
+func (mr *MockManagerRegistryMockRecorder) ManagersByDomainID(domainID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagersByDomainID", reflect.TypeOf((*MockManagerRegistry)(nil).ManagersByDomainID), domainID)
+}
+
+// ManagersByTaskListName mocks base method.
+func (m *MockManagerRegistry) ManagersByTaskListName(name string) []Manager {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ManagersByTaskListName", name)
+	ret0, _ := ret[0].([]Manager)
+	return ret0
+}
+
+// ManagersByTaskListName indicates an expected call of ManagersByTaskListName.
+func (mr *MockManagerRegistryMockRecorder) ManagersByTaskListName(name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagersByTaskListName", reflect.TypeOf((*MockManagerRegistry)(nil).ManagersByTaskListName), name)
+}
+
+// Register mocks base method.
+func (m *MockManagerRegistry) Register(id Identifier, mgr Manager) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "Register", id, mgr)
+}
+
+// Register indicates an expected call of Register.
+func (mr *MockManagerRegistryMockRecorder) Register(id, mgr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockManagerRegistry)(nil).Register), id, mgr)
+}
+
+// Unregister mocks base method.
+func (m *MockManagerRegistry) Unregister(mgr Manager) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Unregister", mgr)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// Unregister indicates an expected call of Unregister.
+func (mr *MockManagerRegistryMockRecorder) Unregister(mgr any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unregister", reflect.TypeOf((*MockManagerRegistry)(nil).Unregister), mgr)
 }
 
 // MockManager is a mock of Manager interface.

--- a/service/matching/tasklist/shard_processor.go
+++ b/service/matching/tasklist/shard_processor.go
@@ -13,23 +13,21 @@ import (
 )
 
 type ShardProcessorParams struct {
-	ShardID       string
-	TaskListsLock *sync.RWMutex
-	TaskLists     map[Identifier]Manager
-	ReportTTL     time.Duration
-	TimeSource    clock.TimeSource
+	ShardID           string
+	TaskListsRegistry ManagerRegistry
+	ReportTTL         time.Duration
+	TimeSource        clock.TimeSource
 }
 
 type shardProcessorImpl struct {
-	shardID       string
-	taskListsLock *sync.RWMutex          // locks mutation of taskLists
-	taskLists     map[Identifier]Manager // Convert to LRU cache
-	Status        atomic.Int32
-	reportLock    sync.RWMutex
-	shardReport   executorclient.ShardReport
-	reportTime    time.Time
-	reportTTL     time.Duration
-	timeSource    clock.TimeSource
+	shardID           string
+	taskListsRegistry ManagerRegistry
+	Status            atomic.Int32
+	reportLock        sync.RWMutex
+	shardReport       executorclient.ShardReport
+	reportTime        time.Time
+	reportTTL         time.Duration
+	timeSource        clock.TimeSource
 }
 
 func NewShardProcessor(params ShardProcessorParams) (ShardProcessor, error) {
@@ -38,13 +36,12 @@ func NewShardProcessor(params ShardProcessorParams) (ShardProcessor, error) {
 		return nil, err
 	}
 	shardprocessor := &shardProcessorImpl{
-		shardID:       params.ShardID,
-		taskListsLock: params.TaskListsLock,
-		taskLists:     params.TaskLists,
-		shardReport:   executorclient.ShardReport{},
-		reportTime:    params.TimeSource.Now(),
-		reportTTL:     params.ReportTTL,
-		timeSource:    params.TimeSource,
+		shardID:           params.ShardID,
+		taskListsRegistry: params.TaskListsRegistry,
+		shardReport:       executorclient.ShardReport{},
+		reportTime:        params.TimeSource.Now(),
+		reportTTL:         params.ReportTTL,
+		timeSource:        params.TimeSource,
 	}
 	shardprocessor.SetShardStatus(types.ShardStatusREADY)
 	shardprocessor.shardReport = executorclient.ShardReport{
@@ -64,14 +61,7 @@ func (sp *shardProcessorImpl) Start(ctx context.Context) error {
 
 // Stop is stopping the tasklist when a shard is not assigned to this executor anymore.
 func (sp *shardProcessorImpl) Stop() {
-	sp.taskListsLock.RLock()
-	var toShutDown []Manager
-	for _, tlMgr := range sp.taskLists {
-		if tlMgr.TaskListID().name == sp.shardID {
-			toShutDown = append(toShutDown, tlMgr)
-		}
-	}
-	sp.taskListsLock.RUnlock()
+	toShutDown := sp.taskListsRegistry.ManagersByTaskListName(sp.shardID)
 	for _, tlMgr := range toShutDown {
 		tlMgr.Stop()
 	}
@@ -97,19 +87,15 @@ func (sp *shardProcessorImpl) SetShardStatus(status types.ShardStatus) {
 }
 
 func (sp *shardProcessorImpl) getShardLoad() float64 {
-	sp.taskListsLock.RLock()
-	defer sp.taskListsLock.RUnlock()
 	var load float64
 
 	// We assign a shard only based on the task list name
 	// so task lists of different task type (decisions/activities), of different kind (normal, sticky, ephemeral) or partitions
 	// will be assigned all to the same matching instance (executor)
 	// we need to sum the rps for each of the tasklist to calculate the load.
-	for _, tlMgr := range sp.taskLists {
-		if tlMgr.TaskListID().name == sp.shardID {
-			qps := tlMgr.QueriesPerSecond()
-			load = load + qps
-		}
+	for _, tlMgr := range sp.taskListsRegistry.ManagersByTaskListName(sp.shardID) {
+		qps := tlMgr.QueriesPerSecond()
+		load = load + qps
 	}
 	return load
 }
@@ -118,11 +104,8 @@ func validateSPParams(params ShardProcessorParams) error {
 	if params.ShardID == "" {
 		return errors.New("ShardID must be specified")
 	}
-	if params.TaskListsLock == nil {
-		return errors.New("TaskListsLock must be specified")
-	}
-	if params.TaskLists == nil {
-		return errors.New("TaskLists must be specified")
+	if params.TaskListsRegistry == nil {
+		return errors.New("TaskListsRegistry must be specified")
 	}
 	if params.TimeSource == nil {
 		return errors.New("TimeSource must be specified")

--- a/service/matching/tasklist/shard_processor_factory.go
+++ b/service/matching/tasklist/shard_processor_factory.go
@@ -1,7 +1,6 @@
 package tasklist
 
 import (
-	"sync"
 	"time"
 
 	"github.com/uber/cadence/common/clock"
@@ -9,20 +8,18 @@ import (
 
 // ShardProcessorFactory is a generic factory for creating ShardProcessor instances.
 type ShardProcessorFactory struct {
-	TaskListsLock *sync.RWMutex          // locks mutation of taskLists
-	TaskLists     map[Identifier]Manager // Convert to LRU cache
-	ReportTTL     time.Duration
-	TimeSource    clock.TimeSource
+	TaskListsRegistry ManagerRegistry
+	ReportTTL         time.Duration
+	TimeSource        clock.TimeSource
 }
 
 func (spf ShardProcessorFactory) NewShardProcessor(shardID string) (ShardProcessor, error) {
 
 	params := ShardProcessorParams{
-		ShardID:       shardID,
-		TaskListsLock: spf.TaskListsLock,
-		TaskLists:     spf.TaskLists,
-		ReportTTL:     spf.ReportTTL,
-		TimeSource:    spf.TimeSource,
+		ShardID:           shardID,
+		TaskListsRegistry: spf.TaskListsRegistry,
+		ReportTTL:         spf.ReportTTL,
+		TimeSource:        spf.TimeSource,
 	}
 	return NewShardProcessor(params)
 }

--- a/service/matching/tasklist/shard_processor_test.go
+++ b/service/matching/tasklist/shard_processor_test.go
@@ -1,7 +1,6 @@
 package tasklist
 
 import (
-	"sync"
 	"testing"
 	"time"
 
@@ -14,98 +13,65 @@ import (
 	"github.com/uber/cadence/common/types"
 )
 
-func paramsForTaskListManager(taskListID *Identifier) ShardProcessorParams {
-	var mutex sync.RWMutex
-	taskList := make(map[Identifier]Manager)
-	params := ShardProcessorParams{
-		ShardID:       taskListID.GetName(),
-		TaskListsLock: &mutex,
-		TaskLists:     taskList,
-		ReportTTL:     1 * time.Millisecond,
-		TimeSource:    clock.NewRealTimeSource(),
+func mustNewIdentifier(domainID, name string, taskType int) *Identifier {
+	id, err := NewIdentifier(domainID, name, taskType)
+	if err != nil {
+		panic(err)
 	}
-	return params
+	return id
 }
 
-func paramsForTaskListManagerWithStopCallback(t *testing.T, taskListID *Identifier) ShardProcessorParams {
-	params := paramsForTaskListManager(taskListID)
-	mockCtrl := gomock.NewController(t)
-	mockManager := NewMockManager(mockCtrl)
-	params.TaskLists[*taskListID] = mockManager
-	mockManager.EXPECT().TaskListID().Return(
-		taskListID).Times(1)
-	mockManager.EXPECT().Stop().Do(
-		func() {
-			delete(params.TaskLists, *taskListID)
-		},
-	)
-	return params
+var testIdentifier = mustNewIdentifier("domain-id", "tl", persistence.TaskListTypeDecision)
+
+type shardProcessorTestData struct {
+	mockRegistry   *MockManagerRegistry
+	shardProcessor ShardProcessor
 }
 
-func TestNewShardProcessor(t *testing.T) {
-	t.Run("NewShardProcessor fails with empty params", func(t *testing.T) {
-		params := ShardProcessorParams{}
-		sp, err := NewShardProcessor(params)
-		require.Nil(t, sp)
-		require.Error(t, err)
-	})
+func newShardProcessorTestData(t *testing.T, taskListID *Identifier) shardProcessorTestData {
+	ctrl := gomock.NewController(t)
 
-	t.Run("NewShardProcessor success", func(t *testing.T) {
-		tlID, err := NewIdentifier("domain-id", "tl", persistence.TaskListTypeDecision)
-		require.NoError(t, err)
-		params := paramsForTaskListManager(tlID)
-		sp, err := NewShardProcessor(params)
-		require.NoError(t, err)
-		require.NotNil(t, sp)
-	})
+	mockRegistry := NewMockManagerRegistry(ctrl)
+	mockRegistry.EXPECT().ManagersByTaskListName(taskListID.GetName()).Return([]Manager{}).AnyTimes()
+
+	params := ShardProcessorParams{
+		ShardID:           taskListID.GetName(),
+		TaskListsRegistry: mockRegistry,
+		ReportTTL:         1 * time.Millisecond,
+		TimeSource:        clock.NewRealTimeSource(),
+	}
+
+	shardProcessor, err := NewShardProcessor(params)
+	require.NoError(t, err)
+	return shardProcessorTestData{
+		mockRegistry:   mockRegistry,
+		shardProcessor: shardProcessor,
+	}
 }
 
-func TestStop(t *testing.T) {
-	t.Run("Stop ShardProcessor", func(t *testing.T) {
-		tlID, err := NewIdentifier("domain-id", "tl", persistence.TaskListTypeDecision)
-		require.NoError(t, err)
-		params := paramsForTaskListManagerWithStopCallback(t, tlID)
-
-		sp, err := NewShardProcessor(params)
-		require.NoError(t, err)
-		params.TaskListsLock.RLock()
-		require.Equal(t, 1, len(params.TaskLists))
-		params.TaskListsLock.RUnlock()
-
-		sp.Stop()
-		params.TaskListsLock.RLock()
-		require.Equal(t, 0, len(params.TaskLists))
-		params.TaskListsLock.RUnlock()
-	})
+func TestNewShardProcessorFailsWithEmptyParams(t *testing.T) {
+	params := ShardProcessorParams{}
+	sp, err := NewShardProcessor(params)
+	require.Nil(t, sp)
+	require.Error(t, err)
 }
 
 func TestGetShardReport(t *testing.T) {
-	t.Run("GetShardReport success", func(t *testing.T) {
-		tlID, err := NewIdentifier("domain-id", "tl", persistence.TaskListTypeDecision)
-		require.NoError(t, err)
-		params := paramsForTaskListManager(tlID)
-		sp, err := NewShardProcessor(params)
-		require.NoError(t, err)
-		shardReport := sp.GetShardReport()
-		require.NotNil(t, shardReport)
-		require.Equal(t, float64(0), shardReport.ShardLoad)
-		require.Equal(t, types.ShardStatusREADY, shardReport.Status)
-	})
+	td := newShardProcessorTestData(t, testIdentifier)
+
+	shardReport := td.shardProcessor.GetShardReport()
+	require.NotNil(t, shardReport)
+	require.Equal(t, float64(0), shardReport.ShardLoad)
+	require.Equal(t, types.ShardStatusREADY, shardReport.Status)
 }
 
 func TestSetShardStatus(t *testing.T) {
 	defer goleak.VerifyNone(t)
+	td := newShardProcessorTestData(t, testIdentifier)
 
-	t.Run("SetShardStatus success", func(t *testing.T) {
-		tlID, err := NewIdentifier("domain-id", "tl", persistence.TaskListTypeDecision)
-		require.NoError(t, err)
-		params := paramsForTaskListManager(tlID)
-		sp, err := NewShardProcessor(params)
-		require.NoError(t, err)
-		sp.SetShardStatus(types.ShardStatusREADY)
-		shardReport := sp.GetShardReport()
-		require.NotNil(t, shardReport)
-		require.Equal(t, float64(0), shardReport.ShardLoad)
-		require.Equal(t, types.ShardStatusREADY, shardReport.Status)
-	})
+	td.shardProcessor.SetShardStatus(types.ShardStatusREADY)
+	shardReport := td.shardProcessor.GetShardReport()
+	require.NotNil(t, shardReport)
+	require.Equal(t, float64(0), shardReport.ShardLoad)
+	require.Equal(t, types.ShardStatusREADY, shardReport.Status)
 }

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -318,7 +318,7 @@ func (c *taskListManagerImpl) Stop() {
 	}
 
 	// Notify parent registry to unregister this manager
-	c.registry.UnregisterManager(c)
+	c.registry.Unregister(c)
 
 	if c.adaptiveScaler != nil {
 		c.adaptiveScaler.Stop()

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -91,7 +91,7 @@ func setupMocksForTaskListManager(t *testing.T, taskListID *Identifier, taskList
 	config := config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), "hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
 	mockHistoryService := history.NewMockClient(ctrl)
 	mockRegistry := NewMockManagerRegistry(ctrl)
-	mockRegistry.EXPECT().UnregisterManager(gomock.Any()).AnyTimes()
+	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	params := ManagerParams{
 		DomainCache:     deps.mockDomainCache,
 		Logger:          logger,
@@ -239,7 +239,7 @@ func createTestTaskListManagerWithConfig(t *testing.T, logger log.Logger, contro
 	mockMatchingClient.EXPECT().RefreshTaskListPartitionConfig(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	mockHistoryService := history.NewMockClient(controller)
 	mockRegistry := NewMockManagerRegistry(controller)
-	mockRegistry.EXPECT().UnregisterManager(gomock.Any()).AnyTimes()
+	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	tl := "tl"
 	dID := "domain"
 	tlID, err := NewIdentifier(dID, tl, persistence.TaskListTypeActivity)
@@ -284,14 +284,14 @@ func TestTaskListManagerRegistryNotification(t *testing.T) {
 	// Replace the registry with our mock
 	tlm.registry = mockRegistry
 
-	// Expect UnregisterManager to be called exactly once with the manager instance
-	mockRegistry.EXPECT().UnregisterManager(tlm).Times(1)
+	// Expect Unregister to be called exactly once with the manager instance
+	mockRegistry.EXPECT().Unregister(tlm).Times(1)
 
 	// Start the manager
 	err := tlm.Start(context.Background())
 	require.NoError(t, err)
 
-	// Stop should call UnregisterManager
+	// Stop should call Unregister
 	tlm.Stop()
 	// Verify the manager stopped
 	require.Equal(t, int32(1), tlm.stopped)
@@ -965,7 +965,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 	cfg.RangeSize = rangeSize
 	cfg.ReadRangeSize = dynamicproperties.GetIntPropertyFn(rangeSize / 2)
 	mockRegistry := NewMockManagerRegistry(controller)
-	mockRegistry.EXPECT().UnregisterManager(gomock.Any()).AnyTimes()
+	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	params := ManagerParams{
 		DomainCache:     mockDomainCache,
 		Logger:          logger,
@@ -1099,7 +1099,7 @@ func TestTaskListReaderPumpAdvancesAckLevelAfterEmptyReads(t *testing.T) {
 	cfg.ReadRangeSize = dynamicproperties.GetIntPropertyFn(rangeSize / 2)
 
 	mockRegistry := NewMockManagerRegistry(controller)
-	mockRegistry.EXPECT().UnregisterManager(gomock.Any()).AnyTimes()
+	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	params := ManagerParams{
 		DomainCache:     mockDomainCache,
 		Logger:          logger,
@@ -1249,7 +1249,7 @@ func TestTaskExpiryAndCompletion(t *testing.T) {
 			// on enqueuing a task to task buffer
 			cfg.IdleTasklistCheckInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(20 * time.Millisecond)
 			mockRegistry := NewMockManagerRegistry(controller)
-			mockRegistry.EXPECT().UnregisterManager(gomock.Any()).AnyTimes()
+			mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 			params := ManagerParams{
 				DomainCache:     mockDomainCache,
 				Logger:          logger,

--- a/service/matching/tasklist/task_list_registry.go
+++ b/service/matching/tasklist/task_list_registry.go
@@ -1,0 +1,98 @@
+package tasklist
+
+import (
+	"sync"
+
+	"github.com/uber/cadence/common/metrics"
+)
+
+type taskListRegistryImpl struct {
+	sync.RWMutex
+	taskLists     map[Identifier]Manager
+	metricsClient metrics.Client
+}
+
+func NewManagerRegistry(metricsClient metrics.Client) ManagerRegistry {
+	return &taskListRegistryImpl{
+		taskLists:     make(map[Identifier]Manager),
+		metricsClient: metricsClient,
+	}
+}
+
+func (r *taskListRegistryImpl) Register(id Identifier, mgr Manager) {
+	r.Lock()
+	defer r.Unlock()
+
+	// we can override the manager for the same identifier if it is already registered
+	// this case should be handled by the caller
+	r.taskLists[id] = mgr
+	r.updateMetricsLocked()
+}
+
+func (r *taskListRegistryImpl) Unregister(mgr Manager) bool {
+	id := mgr.TaskListID()
+	r.Lock()
+	defer r.Unlock()
+
+	// we need to make sure we still hold the given `mgr` or we already replaced with a new one.
+	currentTlMgr, ok := r.taskLists[*id]
+	if ok && currentTlMgr == mgr {
+		delete(r.taskLists, *id)
+		r.updateMetricsLocked()
+		return true
+	}
+
+	return false
+}
+
+func (r *taskListRegistryImpl) ManagersByDomainID(domainID string) []Manager {
+	r.RLock()
+	defer r.RUnlock()
+
+	var res []Manager
+	for tl, tlm := range r.taskLists {
+		if tl.GetDomainID() == domainID {
+			res = append(res, tlm)
+		}
+	}
+	return res
+}
+
+func (r *taskListRegistryImpl) ManagersByTaskListName(name string) []Manager {
+	r.RLock()
+	defer r.RUnlock()
+
+	var res []Manager
+	for _, tlm := range r.taskLists {
+		if tlm.TaskListID().GetName() == name {
+			res = append(res, tlm)
+		}
+	}
+	return res
+}
+
+func (r *taskListRegistryImpl) ManagerByTaskListIdentifier(id Identifier) (Manager, bool) {
+	r.RLock()
+	defer r.RUnlock()
+
+	tlMgr, ok := r.taskLists[id]
+	return tlMgr, ok
+}
+
+func (r *taskListRegistryImpl) AllManagers() []Manager {
+	r.RLock()
+	defer r.RUnlock()
+
+	res := make([]Manager, 0, len(r.taskLists))
+	for _, tlMgr := range r.taskLists {
+		res = append(res, tlMgr)
+	}
+	return res
+}
+
+func (r *taskListRegistryImpl) updateMetricsLocked() {
+	r.metricsClient.Scope(metrics.MatchingTaskListMgrScope).UpdateGauge(
+		metrics.TaskListManagersGauge,
+		float64(len(r.taskLists)),
+	)
+}

--- a/service/matching/tasklist/task_list_registry_test.go
+++ b/service/matching/tasklist/task_list_registry_test.go
@@ -1,0 +1,105 @@
+package tasklist
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/metrics"
+	metricsmocks "github.com/uber/cadence/common/metrics/mocks"
+	"github.com/uber/cadence/common/persistence"
+)
+
+func mustNewIdentifierForTest(t *testing.T, domainID, taskListName string) *Identifier {
+	t.Helper()
+	id, err := NewIdentifier(domainID, taskListName, persistence.TaskListTypeDecision)
+	require.NoError(t, err)
+	return id
+}
+
+func newMockManagerWithID(t *testing.T, ctrl *gomock.Controller, id *Identifier) *MockManager {
+	t.Helper()
+	mgr := NewMockManager(ctrl)
+	mgr.EXPECT().TaskListID().Return(id).AnyTimes()
+	return mgr
+}
+
+func TestTaskListRegistry_RegisterLookupAndUnregister(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	metricsClient := metricsmocks.Client{}
+	metricsScope := metricsmocks.Scope{}
+	metricsClient.On("Scope", metrics.MatchingTaskListMgrScope).Return(&metricsScope)
+	registry := NewManagerRegistry(&metricsClient)
+
+	id := mustNewIdentifierForTest(t, "domain-a", "task-list-a")
+
+	initialMgr := newMockManagerWithID(t, ctrl, id)
+	updatedMgr := newMockManagerWithID(t, ctrl, id)
+
+	metricsScope.On("UpdateGauge", metrics.TaskListManagersGauge, float64(1)).Once()
+	registry.Register(*id, initialMgr)
+	got, ok := registry.ManagerByTaskListIdentifier(*id)
+	require.True(t, ok)
+	assert.Equal(t, initialMgr, got)
+
+	// Re-register with the same identifier should replace the manager.
+	metricsScope.On("UpdateGauge", metrics.TaskListManagersGauge, float64(1)).Once()
+	registry.Register(*id, updatedMgr)
+	got, ok = registry.ManagerByTaskListIdentifier(*id)
+	require.True(t, ok)
+	assert.Equal(t, updatedMgr, got)
+
+	// Unregister should not remove a replaced/stale manager.
+	assert.False(t, registry.Unregister(initialMgr))
+	got, ok = registry.ManagerByTaskListIdentifier(*id)
+	require.True(t, ok)
+	assert.Equal(t, updatedMgr, got)
+
+	// Unregistering the current manager should remove the entry.
+	metricsScope.On("UpdateGauge", metrics.TaskListManagersGauge, float64(0)).Once()
+	assert.True(t, registry.Unregister(updatedMgr))
+	_, ok = registry.ManagerByTaskListIdentifier(*id)
+	assert.False(t, ok)
+
+	metricsClient.AssertExpectations(t)
+	metricsScope.AssertExpectations(t)
+}
+
+func TestTaskListRegistry_Filters(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	registry := NewManagerRegistry(metrics.NewNoopMetricsClient())
+
+	domainA1 := mustNewIdentifierForTest(t, "domain-a", "shared-name")
+	domainA2 := mustNewIdentifierForTest(t, "domain-a", "other-name")
+	domainB1 := mustNewIdentifierForTest(t, "domain-b", "shared-name")
+
+	mgrA1 := newMockManagerWithID(t, ctrl, domainA1)
+	mgrA2 := newMockManagerWithID(t, ctrl, domainA2)
+	mgrB1 := newMockManagerWithID(t, ctrl, domainB1)
+
+	registry.Register(*domainA1, mgrA1)
+	registry.Register(*domainA2, mgrA2)
+	registry.Register(*domainB1, mgrB1)
+
+	t.Run("all managers", func(t *testing.T) {
+		assert.ElementsMatch(t, []Manager{mgrA1, mgrA2, mgrB1}, registry.AllManagers())
+	})
+
+	t.Run("managers by domain", func(t *testing.T) {
+		assert.ElementsMatch(t, []Manager{mgrA1, mgrA2}, registry.ManagersByDomainID("domain-a"))
+		assert.ElementsMatch(t, []Manager{mgrB1}, registry.ManagersByDomainID("domain-b"))
+		assert.Empty(t, registry.ManagersByDomainID("missing-domain"))
+	})
+
+	t.Run("managers by task list name", func(t *testing.T) {
+		assert.ElementsMatch(
+			t,
+			[]Manager{mgrA1, mgrB1},
+			registry.ManagersByTaskListName("shared-name"),
+		)
+		assert.ElementsMatch(t, []Manager{mgrA2}, registry.ManagersByTaskListName("other-name"))
+		assert.Empty(t, registry.ManagersByTaskListName("missing-name"))
+	})
+}


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
First step (refactoring) for #7712.
Abstracting the way task-lists are managed by introducing a manager registry.


<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
Abstracting the way task-lists are managed simplifies matcher: it
doesn't need to care how task-lists managers are stored, retrieved
and deleted and don't need to care about the locks anymore.

In addition, this brings ability to introduce optimized views (like per-domain or
per-shard-name) transparently (preserving the same interface). This will
avoid quadratic complexity in shard-processor' functions which
previously had to iterate over the entire list of task list managers for every single shard.
This should greatly impact performance in production where we have
thousands of task-lists in a single matching instance.


<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad**How did you test it?**
Introduced a new unit-test and ran it with: `go test -v ./service/matching/tasklist/task_list_registry_test.go`
Also tested the package overall: `go test -v ./service/matching/...`
Also checked by running cadence-server locally with hello-world workflow.ce-server locally with hello-world workflow.


<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
None, this should be a transparent optimisation


<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**


<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**


---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)

