### PR TITLE
feat(domain multi-tenancy): Update Cassandra schema to be synced with recent IDL changes

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -134,6 +134,7 @@ CREATE TYPE transfer_task (
   schedule_id                bigint,
   version                    bigint,       -- the failover version when this task is created, used to compare against the mutable state, in case the events got overwritten
   record_visibility          boolean,      -- indicates whether or not to create a visibility record
+  original_task_list         text,         -- the original task list of the task if the task is a sticky decision task
 );
 
 CREATE TYPE replication_task (
@@ -166,6 +167,7 @@ CREATE TYPE timer_task (
   event_id         bigint, -- Corresponds to event ID in history that is responsible for this timer.
   schedule_attempt bigint, -- Used to retry failed decision tasks using mutable state
   version          bigint, -- the failover version when this task is created, used to compare against the mutable state, in case the events got overwritten
+  task_list        text, -- the task list associated with the timer task
 );
 
 -- Workflow activity in progress mutable state
@@ -548,7 +550,7 @@ CREATE TABLE domain_audit_log (
     state_after blob, -- state_after stores the domain state after the request
     state_after_encoding text, -- the encoding type used for state_after
 
-    operation_type int, -- operation_type stores the type of operation that was performed. It is deserialized as an enum and can be used to customize the serialization/deserialization strategy. 
+    operation_type int, -- operation_type stores the type of operation that was performed. It is deserialized as an enum and can be used to customize the serialization/deserialization strategy.
 
     created_time timestamp, -- created_time the time this row was inserted
     last_updated_time timestamp,

--- a/schema/cassandra/cadence/versioned/v0.45/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.45/manifest.json
@@ -1,0 +1,9 @@
+{
+  "CurrVersion": "0.45",
+  "MinCompatibleVersion": "0.45",
+  "Description": "Adding original_task_list and task_list to transfer and timer tasks",
+  "SchemaUpdateCqlFiles": [
+    "transfer_task.cql",
+    "timer_task.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.45/timer_task.cql
+++ b/schema/cassandra/cadence/versioned/v0.45/timer_task.cql
@@ -1,0 +1,1 @@
+ALTER TYPE timer_task ADD task_list text;

--- a/schema/cassandra/cadence/versioned/v0.45/transfer_task.cql
+++ b/schema/cassandra/cadence/versioned/v0.45/transfer_task.cql
@@ -1,0 +1,1 @@
+ALTER TYPE transfer_task ADD original_task_list text;

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -23,7 +23,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.44"
+const Version = "0.45"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.10"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
Update Cassandra schema to add original_task_list and task_list to transfer and timer tasks.

<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
https://github.com/cadence-workflow/cadence/issues/7724

<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad: "Tested locally" or "Added tests" -->
**How did you test it?**
N/A

<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
N/A

<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**
N/A

<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**
N/A

**Detailed Description**
Update Cassandra schema to add original_task_list and task_list to transfer and timer tasks.

**Impact Analysis**
- **Backward Compatibility**: Yes
- **Forward Compatibility**: Yes

**Testing Plan**
- **Unit Tests**: Yes
- **Persistence Tests**: TBD
- **Integration Tests**: TBD
- **Compatibility Tests**: N/A
- 
**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter? No.
- Is it safe to rollback? Does the order of rollback matter? Yes. No.
- Is there a kill switch to mitigate the impact immediately? No.

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
