### PR TITLE
feat(matcher): lookup Managers by task-lists names at O(1)

### DIFF
--- a/service/matching/handler/engine_integration_test.go
+++ b/service/matching/handler/engine_integration_test.go
@@ -236,7 +236,7 @@ func (s *matchingEngineSuite) TestOnlyUnloadMatchingInstance() {
 		ClusterMetadata: s.matchingEngine.clusterMetadata,
 		IsolationState:  s.matchingEngine.isolationState,
 		MatchingClient:  s.matchingEngine.matchingClient,
-		Registry:        s.matchingEngine.taskListsRegistry,
+		Registry:        s.matchingEngine.taskListRegistry,
 		TaskList:        taskListID, // same taskListID as above
 		TaskListKind:    tlKind,
 		Cfg:             s.matchingEngine.config,

--- a/service/matching/handler/membership.go
+++ b/service/matching/handler/membership.go
@@ -127,7 +127,7 @@ func (e *matchingEngineImpl) getNonOwnedTasklistsLocked() ([]tasklist.Manager, e
 
 	var toShutDown []tasklist.Manager
 
-	taskLists := e.taskListsRegistry.AllManagers()
+	taskLists := e.taskListRegistry.AllManagers()
 
 	self, err := e.membershipResolver.WhoAmI()
 	if err != nil {

--- a/service/matching/handler/membership_test.go
+++ b/service/matching/handler/membership_test.go
@@ -197,7 +197,7 @@ func TestSubscriptionAndShutdown(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
 		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
 		shutdown:           make(chan struct{}),
 		logger:             log.NewNoop(),
@@ -232,7 +232,7 @@ func TestSubscriptionAndErrorReturned(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
 		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
 		shutdown:           make(chan struct{}),
 		logger:             log.NewNoop(),
@@ -286,7 +286,7 @@ func TestSubscribeToMembershipChangesQuitsIfSubscribeFails(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
 		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
 		shutdown:           make(chan struct{}),
 		logger:             logger,
@@ -334,7 +334,7 @@ func TestGetTasklistManagerShutdownScenario(t *testing.T) {
 	engine := matchingEngineImpl{
 		shutdownCompletion: &shutdownWG,
 		membershipResolver: mockResolver,
-		taskListsRegistry:  tasklist.NewManagerRegistry(metrics.NewNoopMetricsClient()),
+		taskListRegistry:   tasklist.NewTaskListRegistry(metrics.NewNoopMetricsClient()),
 		config:             &config.Config{EnableTasklistOwnershipGuard: func(opts ...dynamicproperties.FilterOption) bool { return true }},
 		shutdown:           make(chan struct{}),
 		logger:             log.NewNoop(),

--- a/service/matching/tasklist/interfaces.go
+++ b/service/matching/tasklist/interfaces.go
@@ -21,7 +21,7 @@
 // SOFTWARE.
 
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist Manager
-//go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist ManagerRegistry
+//go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist TaskListRegistry
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist TaskMatcher
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist Forwarder
 //go:generate mockgen -package $GOPACKAGE -source $GOFILE -destination interfaces_mock.go github.com/uber/cadence/service/matching/tasklist TaskCompleter
@@ -38,9 +38,9 @@ import (
 )
 
 type (
-	// ManagerRegistry is implemented by components that track/own task list managers.
-	// Managers notify their registry when they stop so they can be cleaned up.
-	ManagerRegistry interface {
+	// TaskListRegistry is a registry of task list managers
+	// it tracks all task list managers and provides a way to get them by identifier, domain ID, or task list name
+	TaskListRegistry interface {
 		// Register registers a manager for a given identifier.
 		// we can override the manager for the same identifier if it is already registered
 		// this case should be handled by the caller

--- a/service/matching/tasklist/interfaces_mock.go
+++ b/service/matching/tasklist/interfaces_mock.go
@@ -20,32 +20,32 @@ import (
 	executorclient "github.com/uber/cadence/service/sharddistributor/client/executorclient"
 )
 
-// MockManagerRegistry is a mock of ManagerRegistry interface.
-type MockManagerRegistry struct {
+// MockTaskListRegistry is a mock of TaskListRegistry interface.
+type MockTaskListRegistry struct {
 	ctrl     *gomock.Controller
-	recorder *MockManagerRegistryMockRecorder
+	recorder *MockTaskListRegistryMockRecorder
 	isgomock struct{}
 }
 
-// MockManagerRegistryMockRecorder is the mock recorder for MockManagerRegistry.
-type MockManagerRegistryMockRecorder struct {
-	mock *MockManagerRegistry
+// MockTaskListRegistryMockRecorder is the mock recorder for MockTaskListRegistry.
+type MockTaskListRegistryMockRecorder struct {
+	mock *MockTaskListRegistry
 }
 
-// NewMockManagerRegistry creates a new mock instance.
-func NewMockManagerRegistry(ctrl *gomock.Controller) *MockManagerRegistry {
-	mock := &MockManagerRegistry{ctrl: ctrl}
-	mock.recorder = &MockManagerRegistryMockRecorder{mock}
+// NewMockTaskListRegistry creates a new mock instance.
+func NewMockTaskListRegistry(ctrl *gomock.Controller) *MockTaskListRegistry {
+	mock := &MockTaskListRegistry{ctrl: ctrl}
+	mock.recorder = &MockTaskListRegistryMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockManagerRegistry) EXPECT() *MockManagerRegistryMockRecorder {
+func (m *MockTaskListRegistry) EXPECT() *MockTaskListRegistryMockRecorder {
 	return m.recorder
 }
 
 // AllManagers mocks base method.
-func (m *MockManagerRegistry) AllManagers() []Manager {
+func (m *MockTaskListRegistry) AllManagers() []Manager {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "AllManagers")
 	ret0, _ := ret[0].([]Manager)
@@ -53,13 +53,13 @@ func (m *MockManagerRegistry) AllManagers() []Manager {
 }
 
 // AllManagers indicates an expected call of AllManagers.
-func (mr *MockManagerRegistryMockRecorder) AllManagers() *gomock.Call {
+func (mr *MockTaskListRegistryMockRecorder) AllManagers() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllManagers", reflect.TypeOf((*MockManagerRegistry)(nil).AllManagers))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AllManagers", reflect.TypeOf((*MockTaskListRegistry)(nil).AllManagers))
 }
 
 // ManagerByTaskListIdentifier mocks base method.
-func (m *MockManagerRegistry) ManagerByTaskListIdentifier(id Identifier) (Manager, bool) {
+func (m *MockTaskListRegistry) ManagerByTaskListIdentifier(id Identifier) (Manager, bool) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ManagerByTaskListIdentifier", id)
 	ret0, _ := ret[0].(Manager)
@@ -68,13 +68,13 @@ func (m *MockManagerRegistry) ManagerByTaskListIdentifier(id Identifier) (Manage
 }
 
 // ManagerByTaskListIdentifier indicates an expected call of ManagerByTaskListIdentifier.
-func (mr *MockManagerRegistryMockRecorder) ManagerByTaskListIdentifier(id any) *gomock.Call {
+func (mr *MockTaskListRegistryMockRecorder) ManagerByTaskListIdentifier(id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagerByTaskListIdentifier", reflect.TypeOf((*MockManagerRegistry)(nil).ManagerByTaskListIdentifier), id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagerByTaskListIdentifier", reflect.TypeOf((*MockTaskListRegistry)(nil).ManagerByTaskListIdentifier), id)
 }
 
 // ManagersByDomainID mocks base method.
-func (m *MockManagerRegistry) ManagersByDomainID(domainID string) []Manager {
+func (m *MockTaskListRegistry) ManagersByDomainID(domainID string) []Manager {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ManagersByDomainID", domainID)
 	ret0, _ := ret[0].([]Manager)
@@ -82,13 +82,13 @@ func (m *MockManagerRegistry) ManagersByDomainID(domainID string) []Manager {
 }
 
 // ManagersByDomainID indicates an expected call of ManagersByDomainID.
-func (mr *MockManagerRegistryMockRecorder) ManagersByDomainID(domainID any) *gomock.Call {
+func (mr *MockTaskListRegistryMockRecorder) ManagersByDomainID(domainID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagersByDomainID", reflect.TypeOf((*MockManagerRegistry)(nil).ManagersByDomainID), domainID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagersByDomainID", reflect.TypeOf((*MockTaskListRegistry)(nil).ManagersByDomainID), domainID)
 }
 
 // ManagersByTaskListName mocks base method.
-func (m *MockManagerRegistry) ManagersByTaskListName(name string) []Manager {
+func (m *MockTaskListRegistry) ManagersByTaskListName(name string) []Manager {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ManagersByTaskListName", name)
 	ret0, _ := ret[0].([]Manager)
@@ -96,25 +96,25 @@ func (m *MockManagerRegistry) ManagersByTaskListName(name string) []Manager {
 }
 
 // ManagersByTaskListName indicates an expected call of ManagersByTaskListName.
-func (mr *MockManagerRegistryMockRecorder) ManagersByTaskListName(name any) *gomock.Call {
+func (mr *MockTaskListRegistryMockRecorder) ManagersByTaskListName(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagersByTaskListName", reflect.TypeOf((*MockManagerRegistry)(nil).ManagersByTaskListName), name)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ManagersByTaskListName", reflect.TypeOf((*MockTaskListRegistry)(nil).ManagersByTaskListName), name)
 }
 
 // Register mocks base method.
-func (m *MockManagerRegistry) Register(id Identifier, mgr Manager) {
+func (m *MockTaskListRegistry) Register(id Identifier, mgr Manager) {
 	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Register", id, mgr)
 }
 
 // Register indicates an expected call of Register.
-func (mr *MockManagerRegistryMockRecorder) Register(id, mgr any) *gomock.Call {
+func (mr *MockTaskListRegistryMockRecorder) Register(id, mgr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockManagerRegistry)(nil).Register), id, mgr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockTaskListRegistry)(nil).Register), id, mgr)
 }
 
 // Unregister mocks base method.
-func (m *MockManagerRegistry) Unregister(mgr Manager) bool {
+func (m *MockTaskListRegistry) Unregister(mgr Manager) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Unregister", mgr)
 	ret0, _ := ret[0].(bool)
@@ -122,9 +122,9 @@ func (m *MockManagerRegistry) Unregister(mgr Manager) bool {
 }
 
 // Unregister indicates an expected call of Unregister.
-func (mr *MockManagerRegistryMockRecorder) Unregister(mgr any) *gomock.Call {
+func (mr *MockTaskListRegistryMockRecorder) Unregister(mgr any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unregister", reflect.TypeOf((*MockManagerRegistry)(nil).Unregister), mgr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unregister", reflect.TypeOf((*MockTaskListRegistry)(nil).Unregister), mgr)
 }
 
 // MockManager is a mock of Manager interface.

--- a/service/matching/tasklist/shard_processor.go
+++ b/service/matching/tasklist/shard_processor.go
@@ -14,14 +14,14 @@ import (
 
 type ShardProcessorParams struct {
 	ShardID           string
-	TaskListsRegistry ManagerRegistry
+	TaskListsRegistry TaskListRegistry
 	ReportTTL         time.Duration
 	TimeSource        clock.TimeSource
 }
 
 type shardProcessorImpl struct {
 	shardID           string
-	taskListsRegistry ManagerRegistry
+	taskListsRegistry TaskListRegistry
 	Status            atomic.Int32
 	reportLock        sync.RWMutex
 	shardReport       executorclient.ShardReport

--- a/service/matching/tasklist/shard_processor_factory.go
+++ b/service/matching/tasklist/shard_processor_factory.go
@@ -8,7 +8,7 @@ import (
 
 // ShardProcessorFactory is a generic factory for creating ShardProcessor instances.
 type ShardProcessorFactory struct {
-	TaskListsRegistry ManagerRegistry
+	TaskListsRegistry TaskListRegistry
 	ReportTTL         time.Duration
 	TimeSource        clock.TimeSource
 }

--- a/service/matching/tasklist/shard_processor_test.go
+++ b/service/matching/tasklist/shard_processor_test.go
@@ -24,14 +24,14 @@ func mustNewIdentifier(domainID, name string, taskType int) *Identifier {
 var testIdentifier = mustNewIdentifier("domain-id", "tl", persistence.TaskListTypeDecision)
 
 type shardProcessorTestData struct {
-	mockRegistry   *MockManagerRegistry
+	mockRegistry   *MockTaskListRegistry
 	shardProcessor ShardProcessor
 }
 
 func newShardProcessorTestData(t *testing.T, taskListID *Identifier) shardProcessorTestData {
 	ctrl := gomock.NewController(t)
 
-	mockRegistry := NewMockManagerRegistry(ctrl)
+	mockRegistry := NewMockTaskListRegistry(ctrl)
 	mockRegistry.EXPECT().ManagersByTaskListName(taskListID.GetName()).Return([]Manager{}).AnyTimes()
 
 	params := ShardProcessorParams{

--- a/service/matching/tasklist/task_list_manager.go
+++ b/service/matching/tasklist/task_list_manager.go
@@ -94,7 +94,7 @@ type (
 		ClusterMetadata cluster.Metadata
 		IsolationState  isolationgroup.State
 		MatchingClient  matching.Client
-		Registry        ManagerRegistry // Registry that owns this manager, notified on Stop()
+		Registry        TaskListRegistry
 		TaskList        *Identifier
 		TaskListKind    types.TaskListKind
 		Cfg             *config.Config
@@ -140,7 +140,7 @@ type (
 		stopWG        sync.WaitGroup
 		stopped       int32
 		stoppedLock   sync.RWMutex
-		registry      ManagerRegistry // parent registry that tracks this manager
+		registry      TaskListRegistry
 		throttleRetry *backoff.ThrottleRetry
 
 		qpsTracker     stats.QPSTrackerGroup

--- a/service/matching/tasklist/task_list_manager_test.go
+++ b/service/matching/tasklist/task_list_manager_test.go
@@ -90,7 +90,7 @@ func setupMocksForTaskListManager(t *testing.T, taskListID *Identifier, taskList
 	deps.mockDomainCache.EXPECT().GetDomainName(gomock.Any()).Return("domainName", nil).Times(1)
 	config := config.NewConfig(dynamicconfig.NewCollection(dynamicClient, logger), "hostname", commonConfig.RPC{}, getIsolationgroupsHelper)
 	mockHistoryService := history.NewMockClient(ctrl)
-	mockRegistry := NewMockManagerRegistry(ctrl)
+	mockRegistry := NewMockTaskListRegistry(ctrl)
 	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	params := ManagerParams{
 		DomainCache:     deps.mockDomainCache,
@@ -238,7 +238,7 @@ func createTestTaskListManagerWithConfig(t *testing.T, logger log.Logger, contro
 	mockMatchingClient := matching.NewMockClient(controller)
 	mockMatchingClient.EXPECT().RefreshTaskListPartitionConfig(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
 	mockHistoryService := history.NewMockClient(controller)
-	mockRegistry := NewMockManagerRegistry(controller)
+	mockRegistry := NewMockTaskListRegistry(controller)
 	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	tl := "tl"
 	dID := "domain"
@@ -271,7 +271,7 @@ func createTestTaskListManagerWithConfig(t *testing.T, logger log.Logger, contro
 
 func TestTaskListManagerRegistryNotification(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	mockRegistry := NewMockManagerRegistry(ctrl)
+	mockRegistry := NewMockTaskListRegistry(ctrl)
 
 	// Create a minimal task list manager for testing
 	taskListID := NewTestTaskListID(t, uuid.New(), "test-tasklist", 0)
@@ -964,7 +964,7 @@ func TestTaskListManagerGetTaskBatch(t *testing.T) {
 	cfg := defaultTestConfig()
 	cfg.RangeSize = rangeSize
 	cfg.ReadRangeSize = dynamicproperties.GetIntPropertyFn(rangeSize / 2)
-	mockRegistry := NewMockManagerRegistry(controller)
+	mockRegistry := NewMockTaskListRegistry(controller)
 	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	params := ManagerParams{
 		DomainCache:     mockDomainCache,
@@ -1098,7 +1098,7 @@ func TestTaskListReaderPumpAdvancesAckLevelAfterEmptyReads(t *testing.T) {
 	cfg.RangeSize = rangeSize
 	cfg.ReadRangeSize = dynamicproperties.GetIntPropertyFn(rangeSize / 2)
 
-	mockRegistry := NewMockManagerRegistry(controller)
+	mockRegistry := NewMockTaskListRegistry(controller)
 	mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 	params := ManagerParams{
 		DomainCache:     mockDomainCache,
@@ -1248,7 +1248,7 @@ func TestTaskExpiryAndCompletion(t *testing.T) {
 			// set idle timer check to a really small value to assert that we don't accidentally drop tasks while blocking
 			// on enqueuing a task to task buffer
 			cfg.IdleTasklistCheckInterval = dynamicproperties.GetDurationPropertyFnFilteredByTaskListInfo(20 * time.Millisecond)
-			mockRegistry := NewMockManagerRegistry(controller)
+			mockRegistry := NewMockTaskListRegistry(controller)
 			mockRegistry.EXPECT().Unregister(gomock.Any()).AnyTimes()
 			params := ManagerParams{
 				DomainCache:     mockDomainCache,

--- a/service/matching/tasklist/task_list_registry.go
+++ b/service/matching/tasklist/task_list_registry.go
@@ -1,3 +1,25 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
 package tasklist
 
 import (
@@ -8,14 +30,23 @@ import (
 
 type taskListRegistryImpl struct {
 	sync.RWMutex
-	taskLists     map[Identifier]Manager
+	taskLists map[Identifier]Manager
+
+	// task lists indexed by domain ID and task list name
+	// to quickly get all task lists for a domain or a task list name
+	// they are always in sync with the taskLists map
+	taskListsByDomainID     map[string]map[Identifier]Manager
+	taskListsByTaskListName map[string]map[Identifier]Manager
+
 	metricsClient metrics.Client
 }
 
-func NewManagerRegistry(metricsClient metrics.Client) ManagerRegistry {
+func NewTaskListRegistry(metricsClient metrics.Client) TaskListRegistry {
 	return &taskListRegistryImpl{
-		taskLists:     make(map[Identifier]Manager),
-		metricsClient: metricsClient,
+		taskLists:               make(map[Identifier]Manager),
+		taskListsByDomainID:     make(map[string]map[Identifier]Manager),
+		taskListsByTaskListName: make(map[string]map[Identifier]Manager),
+		metricsClient:           metricsClient,
 	}
 }
 
@@ -26,6 +57,16 @@ func (r *taskListRegistryImpl) Register(id Identifier, mgr Manager) {
 	// we can override the manager for the same identifier if it is already registered
 	// this case should be handled by the caller
 	r.taskLists[id] = mgr
+
+	if _, ok := r.taskListsByDomainID[id.GetDomainID()]; !ok {
+		r.taskListsByDomainID[id.GetDomainID()] = make(map[Identifier]Manager)
+	}
+	if _, ok := r.taskListsByTaskListName[id.GetName()]; !ok {
+		r.taskListsByTaskListName[id.GetName()] = make(map[Identifier]Manager)
+	}
+
+	r.taskListsByDomainID[id.GetDomainID()][id] = mgr
+	r.taskListsByTaskListName[id.GetName()][id] = mgr
 	r.updateMetricsLocked()
 }
 
@@ -38,37 +79,22 @@ func (r *taskListRegistryImpl) Unregister(mgr Manager) bool {
 	currentTlMgr, ok := r.taskLists[*id]
 	if ok && currentTlMgr == mgr {
 		delete(r.taskLists, *id)
+
+		delete(r.taskListsByDomainID[id.GetDomainID()], *id)
+		if len(r.taskListsByDomainID[id.GetDomainID()]) == 0 {
+			delete(r.taskListsByDomainID, id.GetDomainID())
+		}
+
+		delete(r.taskListsByTaskListName[id.GetName()], *id)
+		if len(r.taskListsByTaskListName[id.GetName()]) == 0 {
+			delete(r.taskListsByTaskListName, id.GetName())
+		}
+
 		r.updateMetricsLocked()
 		return true
 	}
 
 	return false
-}
-
-func (r *taskListRegistryImpl) ManagersByDomainID(domainID string) []Manager {
-	r.RLock()
-	defer r.RUnlock()
-
-	var res []Manager
-	for tl, tlm := range r.taskLists {
-		if tl.GetDomainID() == domainID {
-			res = append(res, tlm)
-		}
-	}
-	return res
-}
-
-func (r *taskListRegistryImpl) ManagersByTaskListName(name string) []Manager {
-	r.RLock()
-	defer r.RUnlock()
-
-	var res []Manager
-	for _, tlm := range r.taskLists {
-		if tlm.TaskListID().GetName() == name {
-			res = append(res, tlm)
-		}
-	}
-	return res
 }
 
 func (r *taskListRegistryImpl) ManagerByTaskListIdentifier(id Identifier) (Manager, bool) {
@@ -86,6 +112,28 @@ func (r *taskListRegistryImpl) AllManagers() []Manager {
 	res := make([]Manager, 0, len(r.taskLists))
 	for _, tlMgr := range r.taskLists {
 		res = append(res, tlMgr)
+	}
+	return res
+}
+
+func (r *taskListRegistryImpl) ManagersByDomainID(domainID string) []Manager {
+	r.RLock()
+	defer r.RUnlock()
+
+	var res []Manager
+	for _, tlm := range r.taskListsByDomainID[domainID] {
+		res = append(res, tlm)
+	}
+	return res
+}
+
+func (r *taskListRegistryImpl) ManagersByTaskListName(name string) []Manager {
+	r.RLock()
+	defer r.RUnlock()
+
+	var res []Manager
+	for _, tlm := range r.taskListsByTaskListName[name] {
+		res = append(res, tlm)
 	}
 	return res
 }

--- a/service/matching/tasklist/task_list_registry_test.go
+++ b/service/matching/tasklist/task_list_registry_test.go
@@ -31,7 +31,7 @@ func TestTaskListRegistry_RegisterLookupAndUnregister(t *testing.T) {
 	metricsClient := metricsmocks.Client{}
 	metricsScope := metricsmocks.Scope{}
 	metricsClient.On("Scope", metrics.MatchingTaskListMgrScope).Return(&metricsScope)
-	registry := NewManagerRegistry(&metricsClient)
+	registry := NewTaskListRegistry(&metricsClient)
 
 	id := mustNewIdentifierForTest(t, "domain-a", "task-list-a")
 
@@ -63,13 +63,17 @@ func TestTaskListRegistry_RegisterLookupAndUnregister(t *testing.T) {
 	_, ok = registry.ManagerByTaskListIdentifier(*id)
 	assert.False(t, ok)
 
+	impl := registry.(*taskListRegistryImpl)
+	assert.Empty(t, impl.taskListsByDomainID, "should be empty because there are no other task lists for this domain")
+	assert.Empty(t, impl.taskListsByTaskListName, "should be empty because there are no other task lists for this task list name")
+
 	metricsClient.AssertExpectations(t)
 	metricsScope.AssertExpectations(t)
 }
 
 func TestTaskListRegistry_Filters(t *testing.T) {
 	ctrl := gomock.NewController(t)
-	registry := NewManagerRegistry(metrics.NewNoopMetricsClient())
+	registry := NewTaskListRegistry(metrics.NewNoopMetricsClient())
 
 	domainA1 := mustNewIdentifierForTest(t, "domain-a", "shared-name")
 	domainA2 := mustNewIdentifierForTest(t, "domain-a", "other-name")


### PR DESCRIPTION
**What changed?**
Getting rid of quadratic complexity for shard-manager' matching integration: #7712.
TaskListRegistry now maintains a mapping of domains and task list names 
to Managers.

Also renamed interface ManagerRegistry to TaskListRegistry to
align with Impl-struct name.

**Why?**
Previously filtering on domains and task-list names was inefficient since it had to iterate over all the task lists.
This made GetTaskListsByDomain API call slow, and shard_processor' periodic load reports were even
slower - we had to filter all the task-lists for every shard-name; essentially the reporting was O(n^2). In case of thousands of task-lists we have at Uber this is unacceptable.

**How did you test it?**
Added a new check for mapping in service/matching/tasklist/task_list_registry_test.go:TestTaskListRegistry_RegisterLookupAndUnregister.
Also ran matching' unit-tests: go test -v ./service/matching/...
Also checked by running cadence-server locally with hello-world workflow

**Potential risks**
I don't see any - the change is a transparent speedup.

**Release notes**
GetTaskListsByDomain API now does not require full-scan of task lists and should be much faster.

**Documentation Changes**


---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
