### PR TITLE
fix(shard-distributor): Handle ErrShardAlreadyAssigned as success in assignEphemeralShard

### DIFF
--- a/service/sharddistributor/handler/handler.go
+++ b/service/sharddistributor/handler/handler.go
@@ -136,6 +136,15 @@ func (h *handlerImpl) assignEphemeralShard(ctx context.Context, namespace string
 
 	// Assign the shard to the executor with the least assigned shards
 	err = h.storage.AssignShard(ctx, namespace, shardID, executorID)
+	// If shard is already assigned, return the assigned owner
+	var alreadyAssigned *store.ErrShardAlreadyAssigned
+	if errors.As(err, &alreadyAssigned) {
+		return &types.GetShardOwnerResponse{
+			Owner:     alreadyAssigned.AssignedTo,
+			Namespace: namespace,
+			Metadata:  alreadyAssigned.Metadata,
+		}, nil
+	}
 	if err != nil {
 		return nil, &types.InternalServiceError{Message: fmt.Sprintf("assign ephemeral shard: %v", err)}
 	}

--- a/service/sharddistributor/store/etcd/executorstore/etcdstore.go
+++ b/service/sharddistributor/store/etcd/executorstore/etcdstore.go
@@ -551,7 +551,7 @@ func (s *executorStoreImpl) AssignShard(ctx context.Context, namespace, shardID,
 			return fmt.Errorf("checking shard owner: %w", err)
 		}
 		if err == nil {
-			return &store.ErrShardAlreadyAssigned{ShardID: shardID, AssignedTo: shardOwner.ExecutorID}
+			return &store.ErrShardAlreadyAssigned{ShardID: shardID, AssignedTo: shardOwner.ExecutorID, Metadata: shardOwner.Metadata}
 		}
 
 		// TODO: Extract to higher level so that statistics updates are prepared

--- a/service/sharddistributor/store/etcd/executorstore/etcdstore_test.go
+++ b/service/sharddistributor/store/etcd/executorstore/etcdstore_test.go
@@ -625,7 +625,11 @@ func TestAssignShardErrors(t *testing.T) {
 	// Case 1: Assigning an already-assigned shard.
 	err = executorStore.AssignShard(ctx, tc.Namespace, shardID1, activeExecutorID)
 	require.Error(t, err, "Should fail to assign an already-assigned shard")
-	assert.ErrorAs(t, err, new(*store.ErrShardAlreadyAssigned))
+	var alreadyAssigned *store.ErrShardAlreadyAssigned
+	require.ErrorAs(t, err, &alreadyAssigned)
+	assert.Equal(t, shardID1, alreadyAssigned.ShardID)
+	assert.Equal(t, activeExecutorID, alreadyAssigned.AssignedTo)
+	assert.NotNil(t, alreadyAssigned.Metadata)
 
 	// Case 2: Assigning to a non-existent executor.
 	err = executorStore.AssignShard(ctx, tc.Namespace, shardID2, "non-existent-executor")

--- a/service/sharddistributor/store/store.go
+++ b/service/sharddistributor/store/store.go
@@ -25,6 +25,7 @@ var (
 type ErrShardAlreadyAssigned struct {
 	ShardID    string
 	AssignedTo string
+	Metadata   map[string]string
 }
 
 func (e *ErrShardAlreadyAssigned) Error() string {


### PR DESCRIPTION
**What changed?**

Handle `ErrShardAlreadyAssigned` as a successful response in `assignEphemeralShard` instead of returning an `InternalServiceError`. Added `Metadata` field to `ErrShardAlreadyAssigned` to include executor metadata directly in the error.

**Why?**

When multiple concurrent requests try to assign the same ephemeral shard, the first succeeds and subsequent ones receive `ErrShardAlreadyAssigned`. Previously this bubbled up as an `InternalServiceError`, causing unnecessary errors for clients. Since shard assignment is idempotent, we should return the already-assigned owner as a successful response. The error now includes metadata to avoid an extra `GetExecutor` DB call.

**How did you test it?**

```
go test -v ./service/sharddistributor/handler/... -run TestGetShardOwner
go test -v ./service/sharddistributor/store/...
```

**Potential risks**

N/A - This is a purely additive change that treats an existing error condition as success.

**Release notes**

N/A - Internal implementation detail.

**Documentation Changes**

N/A