### PR TITLE
feat(domain multi-tenancy): Store task list name in history tasks

### DIFF
--- a/common/persistence/tasks.go
+++ b/common/persistence/tasks.go
@@ -40,7 +40,13 @@ type Task interface {
 	GetDomainID() string
 	GetWorkflowID() string
 	GetRunID() string
+	// GetTaskList returns the name of the task list the task is currently
+	// associated with. This may differ from the original task list if the
+	// task is a sticky decision task.
 	GetTaskList() string
+	// GetOriginalTaskList returns the task list on which the task was initially
+	// scheduled. It is used to enforce rate limits and ensure fair scheduling
+	// across task lists.
 	GetOriginalTaskList() string
 	GetVersion() int64
 	SetVersion(version int64)

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -145,6 +145,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowStartTasks(
 			VisibilityTimestamp: workflowTimeoutTimestamp,
 			Version:             startVersion,
 		},
+		TaskList: executionInfo.TaskList,
 	})
 
 	return nil
@@ -156,6 +157,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowCloseTasks(
 ) error {
 
 	executionInfo := r.mutableState.GetExecutionInfo()
+	taskList := executionInfo.TaskList
 	r.mutableState.AddTransferTasks(&persistence.CloseExecutionTask{
 		WorkflowIdentifier: persistence.WorkflowIdentifier{
 			DomainID:   executionInfo.DomainID,
@@ -166,6 +168,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowCloseTasks(
 			// TaskID and VisibilityTimestamp are set by shard context
 			Version: closeEvent.Version,
 		},
+		TaskList: taskList,
 	})
 
 	retentionInDays := defaultWorkflowRetentionInDays
@@ -202,6 +205,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowCloseTasks(
 			VisibilityTimestamp: closeTimestamp.Add(retentionDuration),
 			Version:             closeEvent.Version,
 		},
+		TaskList: taskList,
 	})
 
 	return nil
@@ -250,6 +254,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateDelayedDecisionTasks(
 			Version:             startVersion,
 		},
 		TimeoutType: firstDecisionDelayType,
+		TaskList:    executionInfo.TaskList,
 	})
 
 	return nil
@@ -272,6 +277,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateRecordWorkflowStartedTasks(
 			// TaskID and VisibilityTimestamp are set by shard context
 			Version: startVersion,
 		},
+		TaskList: executionInfo.TaskList,
 	})
 
 	return nil
@@ -291,6 +297,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateDecisionScheduleTasks(
 		}
 	}
 
+	originalTaskList := executionInfo.TaskList
 	r.mutableState.AddTransferTasks(&persistence.DecisionTask{
 		WorkflowIdentifier: persistence.WorkflowIdentifier{
 			DomainID:   executionInfo.DomainID,
@@ -301,9 +308,10 @@ func (r *mutableStateTaskGeneratorImpl) GenerateDecisionScheduleTasks(
 			// TaskID and VisibilityTimestamp are set by shard context
 			Version: decision.Version,
 		},
-		TargetDomainID: executionInfo.DomainID,
-		TaskList:       decision.TaskList,
-		ScheduleID:     decision.ScheduleID,
+		TargetDomainID:   executionInfo.DomainID,
+		TaskList:         decision.TaskList,
+		ScheduleID:       decision.ScheduleID,
+		OriginalTaskList: originalTaskList,
 	})
 
 	if scheduleToStartTimeout := r.mutableState.GetDecisionScheduleToStartTimeout(); scheduleToStartTimeout != 0 {
@@ -322,6 +330,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateDecisionScheduleTasks(
 			TimeoutType:     int(TimerTypeScheduleToStart),
 			EventID:         decision.ScheduleID,
 			ScheduleAttempt: decision.Attempt,
+			TaskList:        originalTaskList,
 		})
 	}
 
@@ -369,6 +378,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateDecisionStartTasks(
 		TimeoutType:     int(TimerTypeStartToClose),
 		EventID:         decision.ScheduleID,
 		ScheduleAttempt: decision.Attempt,
+		TaskList:        executionInfo.TaskList,
 	})
 
 	return nil
@@ -445,8 +455,9 @@ func (r *mutableStateTaskGeneratorImpl) GenerateActivityRetryTasks(
 			Version:             ai.Version,
 			VisibilityTimestamp: ai.ScheduledTime,
 		},
-		EventID: ai.ScheduleID,
-		Attempt: int64(ai.Attempt),
+		EventID:  ai.ScheduleID,
+		Attempt:  int64(ai.Attempt),
+		TaskList: ai.TaskList,
 	})
 	return nil
 }
@@ -490,6 +501,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateChildWorkflowTasks(
 		TargetDomainID:   targetDomainID,
 		TargetWorkflowID: childWorkflowInfo.StartedWorkflowID,
 		InitiatedID:      childWorkflowInfo.InitiatedID,
+		TaskList:         executionInfo.TaskList,
 	}
 
 	r.mutableState.AddTransferTasks(startChildExecutionTask)
@@ -536,6 +548,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateRequestCancelExternalTasks(
 		TargetRunID:             targetRunID,
 		TargetChildWorkflowOnly: targetChildOnly,
 		InitiatedID:             scheduleID,
+		TaskList:                executionInfo.TaskList,
 	}
 
 	r.mutableState.AddTransferTasks(cancelExecutionTask)
@@ -583,6 +596,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateSignalExternalTasks(
 		TargetRunID:             targetRunID,
 		TargetChildWorkflowOnly: targetChildOnly,
 		InitiatedID:             scheduleID,
+		TaskList:                executionInfo.TaskList,
 	}
 
 	r.mutableState.AddTransferTasks(signalExecutionTask)
@@ -605,6 +619,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowSearchAttrTasks() error 
 			// TaskID and VisibilityTimestamp are set by shard context
 			Version: currentVersion, // task processing does not check this version
 		},
+		TaskList: executionInfo.TaskList,
 	})
 
 	return nil
@@ -625,6 +640,7 @@ func (r *mutableStateTaskGeneratorImpl) GenerateWorkflowResetTasks() error {
 			// TaskID and VisibilityTimestamp are set by shard context
 			Version: currentVersion,
 		},
+		TaskList: executionInfo.TaskList,
 	})
 
 	return nil

--- a/service/history/execution/mutable_state_task_generator_test.go
+++ b/service/history/execution/mutable_state_task_generator_test.go
@@ -196,6 +196,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowCloseTasks_NotActiv
 		DomainID:   "some-domain-id",
 		WorkflowID: "wf-id",
 		RunID:      "rid",
+		TaskList:   "task-list",
 	}).Times(1)
 	domainEntry := cache.NewGlobalDomainCacheEntryForTest(
 		&persistence.DomainInfo{},
@@ -224,6 +225,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowCloseTasks_NotActiv
 		TaskData: persistence.TaskData{
 			Version: constants.TestVersion,
 		},
+		TaskList: "task-list",
 	})
 
 	s.mockMutableState.EXPECT().AddTransferTasks(transferTasks).Times(1)
@@ -242,6 +244,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowCloseTasks_NotActiv
 			VisibilityTimestamp: expectedDeletionTS,
 			Version:             closeEvent.Version,
 		},
+		TaskList: "task-list",
 	})
 
 	err := s.taskGenerator.GenerateWorkflowCloseTasks(closeEvent, 1)
@@ -363,12 +366,13 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowStartTasks() {
 
 	for _, tc := range testCases {
 		s.T().Run(tc.name, func(t *testing.T) {
-			s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{WorkflowTimeout: tc.workflowTimeout, ExpirationTime: expirationTime}).Times(1)
+			s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{WorkflowTimeout: tc.workflowTimeout, ExpirationTime: expirationTime, TaskList: "task-list"}).Times(1)
 			s.mockMutableState.EXPECT().AddTimerTasks(&persistence.WorkflowTimeoutTask{
 				TaskData: persistence.TaskData{
 					VisibilityTimestamp: tc.visibilityTimestamp,
 					Version:             tc.startEvent.Version,
 				},
+				TaskList: "task-list",
 			}).Times(1)
 
 			err := s.taskGenerator.GenerateWorkflowStartTasks(startTime, tc.startEvent)
@@ -403,6 +407,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDelayedDecisionTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				}).Times(1)
 				s.mockMutableState.EXPECT().AddTimerTasks(&persistence.WorkflowBackoffTimerTask{
 					WorkflowIdentifier: persistence.WorkflowIdentifier{
@@ -415,6 +420,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDelayedDecisionTasks() {
 						Version:             constants.TestVersion,
 					},
 					TimeoutType: persistence.WorkflowBackoffTimeoutTypeCron,
+					TaskList:    "task-list",
 				}).Times(1)
 			},
 		},
@@ -433,6 +439,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDelayedDecisionTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				}).Times(1)
 				s.mockMutableState.EXPECT().AddTimerTasks(&persistence.WorkflowBackoffTimerTask{
 					WorkflowIdentifier: persistence.WorkflowIdentifier{
@@ -445,6 +452,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDelayedDecisionTasks() {
 						Version:             constants.TestVersion,
 					},
 					TimeoutType: persistence.WorkflowBackoffTimeoutTypeRetry,
+					TaskList:    "task-list",
 				}).Times(1)
 			},
 		},
@@ -463,6 +471,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDelayedDecisionTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				}).Times(1)
 				s.mockMutableState.EXPECT().AddTimerTasks(&persistence.WorkflowBackoffTimerTask{
 					WorkflowIdentifier: persistence.WorkflowIdentifier{
@@ -475,6 +484,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDelayedDecisionTasks() {
 						Version:             constants.TestVersion,
 					},
 					TimeoutType: persistence.WorkflowBackoffTimeoutTypeCron,
+					TaskList:    "task-list",
 				}).Times(1)
 			},
 		},
@@ -531,6 +541,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateRecordWorkflowStartedTasks(
 		DomainID:   "domain-id",
 		WorkflowID: "wf-id",
 		RunID:      "rid",
+		TaskList:   "task-list",
 	}).Times(1)
 	s.mockMutableState.EXPECT().AddTransferTasks(&persistence.RecordWorkflowStartedTask{
 		WorkflowIdentifier: persistence.WorkflowIdentifier{
@@ -541,6 +552,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateRecordWorkflowStartedTasks(
 		TaskData: persistence.TaskData{
 			Version: startEvent.Version,
 		},
+		TaskList: "task-list",
 	}).Times(1)
 
 	err := s.taskGenerator.GenerateRecordWorkflowStartedTasks(startEvent)
@@ -555,6 +567,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionScheduleTasks() {
 		DomainID:   constants.TestDomainID,
 		WorkflowID: constants.TestWorkflowID,
 		RunID:      constants.TestRunID,
+		TaskList:   "task-list",
 	}
 
 	decision := &DecisionInfo{
@@ -583,9 +596,10 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionScheduleTasks() {
 					TaskData: persistence.TaskData{
 						Version: decision.Version,
 					},
-					TargetDomainID: executionInfo.DomainID,
-					TaskList:       decision.TaskList,
-					ScheduleID:     decision.ScheduleID,
+					TargetDomainID:   executionInfo.DomainID,
+					TaskList:         decision.TaskList,
+					ScheduleID:       decision.ScheduleID,
+					OriginalTaskList: "task-list",
 				}).Times(1)
 				s.mockMutableState.EXPECT().GetDecisionScheduleToStartTimeout().Return(time.Duration(0)).Times(1)
 			},
@@ -603,9 +617,10 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionScheduleTasks() {
 					TaskData: persistence.TaskData{
 						Version: decision.Version,
 					},
-					TargetDomainID: executionInfo.DomainID,
-					TaskList:       decision.TaskList,
-					ScheduleID:     decision.ScheduleID,
+					TargetDomainID:   executionInfo.DomainID,
+					TaskList:         decision.TaskList,
+					ScheduleID:       decision.ScheduleID,
+					OriginalTaskList: "task-list",
 				}).Times(1)
 				scheduleToStartTimeout := time.Duration(1)
 				s.mockMutableState.EXPECT().GetDecisionScheduleToStartTimeout().Return(scheduleToStartTimeout).Times(1)
@@ -622,6 +637,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionScheduleTasks() {
 					TimeoutType:     int(TimerTypeScheduleToStart),
 					EventID:         decision.ScheduleID,
 					ScheduleAttempt: decision.Attempt,
+					TaskList:        "task-list",
 				}).Times(1)
 			},
 		},
@@ -683,6 +699,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionStartTasks() {
 					WorkflowID:                  "wf-id",
 					RunID:                       "rid",
 					DecisionStartToCloseTimeout: defaultStartToCloseTimeout,
+					TaskList:                    "task-list",
 				}).Times(1)
 				startToCloseTimeout := getNextDecisionTimeout(decision.Attempt, time.Duration(defaultStartToCloseTimeout)*time.Second)
 				decision.DecisionTimeout = int32(startToCloseTimeout.Seconds())
@@ -700,6 +717,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionStartTasks() {
 					TimeoutType:     int(TimerTypeStartToClose),
 					EventID:         decision.ScheduleID,
 					ScheduleAttempt: decision.Attempt,
+					TaskList:        "task-list",
 				})
 				rand.Seed(seed)
 			},
@@ -713,6 +731,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionStartTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				})
 				s.mockMutableState.EXPECT().GetDecisionInfo(decisionScheduleID).Return(decision, true).Times(1)
 				s.mockMutableState.EXPECT().AddTimerTasks(&persistence.DecisionTimeoutTask{
@@ -728,6 +747,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionStartTasks() {
 					TimeoutType:     int(TimerTypeStartToClose),
 					EventID:         decision.ScheduleID,
 					ScheduleAttempt: decision.Attempt,
+					TaskList:        "task-list",
 				})
 			},
 		},
@@ -790,6 +810,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateActivityTransferTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				})
 				s.mockMutableState.EXPECT().GetActivityInfo(event.ID).Return(activityInfo, true).Times(1)
 				s.mockMutableState.EXPECT().AddTransferTasks(&persistence.ActivityTask{
@@ -815,6 +836,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateActivityTransferTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				})
 				s.mockMutableState.EXPECT().GetActivityInfo(event.ID).Return(activityInfo, true).Times(1)
 				s.mockDomainCache.EXPECT().GetDomainID(event.ActivityTaskScheduledEventAttributes.GetDomain()).Return(event.ActivityTaskScheduledEventAttributes.GetDomain(), nil).Times(1)
@@ -886,11 +908,13 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateActivityRetryTasks() {
 					ScheduledTime: time.Now(),
 					ScheduleID:    activityScheduleID,
 					Attempt:       1,
+					TaskList:      "task-list2",
 				}
 				s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				})
 				s.mockMutableState.EXPECT().GetActivityInfo(activityScheduleID).Return(ai, true).Times(1)
 				s.mockMutableState.EXPECT().AddTimerTasks(&persistence.ActivityRetryTimerTask{
@@ -903,8 +927,9 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateActivityRetryTasks() {
 						Version:             ai.Version,
 						VisibilityTimestamp: ai.ScheduledTime,
 					},
-					EventID: ai.ScheduleID,
-					Attempt: int64(ai.Attempt),
+					EventID:  ai.ScheduleID,
+					Attempt:  int64(ai.Attempt),
+					TaskList: "task-list2",
 				}).Times(1)
 			},
 		},
@@ -972,6 +997,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateChildWorkflowTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				})
 				s.mockMutableState.EXPECT().GetDomainEntry().Return(parentDomain).Times(1)
 				s.mockMutableState.EXPECT().GetChildExecutionInfo(eventID).Return(childWorkflowInfo, true).Times(1)
@@ -987,6 +1013,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateChildWorkflowTasks() {
 					TargetDomainID:   childWorkflowInfo.DomainID,
 					TargetWorkflowID: childWorkflowInfo.StartedWorkflowID,
 					InitiatedID:      childWorkflowInfo.InitiatedID,
+					TaskList:         "task-list",
 				}).Times(1)
 			},
 		},
@@ -1000,6 +1027,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateChildWorkflowTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				})
 				s.mockMutableState.EXPECT().GetDomainEntry().Return(parentDomain).Times(1)
 				s.mockMutableState.EXPECT().GetChildExecutionInfo(eventID).Return(childWorkflowInfo, true).Times(1)
@@ -1015,6 +1043,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateChildWorkflowTasks() {
 					TargetDomainID:   constants.TestDomainID,
 					TargetWorkflowID: childWorkflowInfo.StartedWorkflowID,
 					InitiatedID:      childWorkflowInfo.InitiatedID,
+					TaskList:         "task-list",
 				}).Times(1)
 			},
 		},
@@ -1154,6 +1183,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateSignalExternalTasks() {
 					DomainID:   "domain-id",
 					WorkflowID: "wf-id",
 					RunID:      "rid",
+					TaskList:   "task-list",
 				})
 				s.mockMutableState.EXPECT().GetSignalInfo(event.ID).Return(nil, true).Times(1)
 				s.mockDomainCache.EXPECT().GetDomainID(event.SignalExternalWorkflowExecutionInitiatedEventAttributes.GetDomain()).
@@ -1171,6 +1201,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateSignalExternalTasks() {
 					TargetWorkflowID: event.SignalExternalWorkflowExecutionInitiatedEventAttributes.WorkflowExecution.GetWorkflowID(),
 					TargetRunID:      event.SignalExternalWorkflowExecutionInitiatedEventAttributes.WorkflowExecution.GetRunID(),
 					InitiatedID:      event.ID,
+					TaskList:         "task-list",
 				}).Times(1)
 			},
 		},
@@ -1216,6 +1247,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowSearchAttrTasks() {
 		DomainID:   "domain-id",
 		WorkflowID: "wf-id",
 		RunID:      "run-id",
+		TaskList:   "task-list",
 	}).Times(1)
 	s.mockMutableState.EXPECT().GetCurrentVersion().Return(version).Times(1)
 	s.mockMutableState.EXPECT().AddTransferTasks(&persistence.UpsertWorkflowSearchAttributesTask{
@@ -1227,6 +1259,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowSearchAttrTasks() {
 		TaskData: persistence.TaskData{
 			Version: version,
 		},
+		TaskList: "task-list",
 	}).Times(1)
 
 	err := s.taskGenerator.GenerateWorkflowSearchAttrTasks()
@@ -1240,6 +1273,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowResetTasks() {
 		DomainID:   "domain-id",
 		WorkflowID: "wf-id",
 		RunID:      "run-id",
+		TaskList:   "task-list",
 	}).Times(1)
 	s.mockMutableState.EXPECT().GetCurrentVersion().Return(version).Times(1)
 	s.mockMutableState.EXPECT().AddTransferTasks(&persistence.ResetWorkflowTask{
@@ -1251,6 +1285,7 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateWorkflowResetTasks() {
 		TaskData: persistence.TaskData{
 			Version: version,
 		},
+		TaskList: "task-list",
 	}).Times(1)
 
 	err := s.taskGenerator.GenerateWorkflowResetTasks()
@@ -1422,6 +1457,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 					DomainID:   constants.TestDomainID,
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
+					TaskList:   "task-list",
 				}).AnyTimes()
 				mockMutableState.EXPECT().HasParentExecution().Return(false).AnyTimes()
 				mockMutableState.EXPECT().GetPendingChildExecutionInfos().Return(nil).AnyTimes()
@@ -1437,6 +1473,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 						VisibilityTimestamp: now,
 						Version:             version,
 					},
+					TaskList: "task-list",
 				},
 				&persistence.DeleteHistoryEventTask{
 					WorkflowIdentifier: persistence.WorkflowIdentifier{
@@ -1448,6 +1485,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 						VisibilityTimestamp: time.Unix(0, closeEvent.GetTimestamp()).Add(retention),
 						Version:             version,
 					},
+					TaskList: "task-list",
 				},
 			},
 		},
@@ -1463,6 +1501,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 					ParentRunID:      "parent runID",
 					InitiatedID:      101,
 					CloseStatus:      persistence.WorkflowCloseStatusCompleted,
+					TaskList:         "task-list",
 				}).AnyTimes()
 				mockMutableState.EXPECT().HasParentExecution().Return(true).AnyTimes()
 				mockMutableState.EXPECT().GetPendingChildExecutionInfos().Return(map[int64]*persistence.ChildExecutionInfo{
@@ -1481,6 +1520,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 						VisibilityTimestamp: now,
 						Version:             version,
 					},
+					TaskList: "task-list",
 				},
 				&persistence.DeleteHistoryEventTask{
 					WorkflowIdentifier: persistence.WorkflowIdentifier{
@@ -1492,6 +1532,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 						VisibilityTimestamp: time.Unix(0, closeEvent.GetTimestamp()).Add(retention),
 						Version:             version,
 					},
+					TaskList: "task-list",
 				},
 			},
 		},
@@ -1502,6 +1543,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 					DomainID:   constants.TestDomainID,
 					WorkflowID: constants.TestWorkflowID,
 					RunID:      constants.TestRunID,
+					TaskList:   "task-list",
 				}).AnyTimes()
 				mockMutableState.EXPECT().HasParentExecution().Return(false).AnyTimes()
 				mockMutableState.EXPECT().GetPendingChildExecutionInfos().Return(nil).AnyTimes()
@@ -1517,6 +1559,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 						VisibilityTimestamp: now,
 						Version:             version,
 					},
+					TaskList: "task-list",
 				},
 				&persistence.DeleteHistoryEventTask{
 					WorkflowIdentifier: persistence.WorkflowIdentifier{
@@ -1528,6 +1571,7 @@ func GenerateWorkflowCloseTasksTestCases(retention time.Duration, closeEvent *ty
 						VisibilityTimestamp: time.Unix(0, closeEvent.GetTimestamp()).Add(retention),
 						Version:             version,
 					},
+					TaskList: "task-list",
 				},
 			},
 		},

--- a/service/history/execution/timer_sequence.go
+++ b/service/history/execution/timer_sequence.go
@@ -162,7 +162,8 @@ func (t *timerSequenceImpl) CreateNextUserTimer() (bool, error) {
 			VisibilityTimestamp: firstTimerTask.Timestamp,
 			Version:             t.mutableState.GetCurrentVersion(),
 		},
-		EventID: firstTimerTask.EventID,
+		EventID:  firstTimerTask.EventID,
+		TaskList: executionInfo.TaskList,
 	})
 	return true, nil
 }
@@ -210,6 +211,7 @@ func (t *timerSequenceImpl) CreateNextActivityTimer() (bool, error) {
 		TimeoutType: int(firstTimerTask.TimerType),
 		EventID:     firstTimerTask.EventID,
 		Attempt:     int64(firstTimerTask.Attempt),
+		TaskList:    activityInfo.TaskList,
 	})
 	return true, nil
 }

--- a/service/history/execution/timer_sequence_test.go
+++ b/service/history/execution/timer_sequence_test.go
@@ -103,6 +103,7 @@ func (s *timerSequenceSuite) TestCreateNextUserTimer_NotCreated() {
 		DomainID:   "domain-id",
 		WorkflowID: "wf-id",
 		RunID:      "run-id",
+		TaskList:   "task-list",
 	}).Times(1)
 	s.mockMutableState.EXPECT().GetPendingTimerInfos().Return(timerInfos).Times(1)
 	s.mockMutableState.EXPECT().GetUserTimerInfoByEventID(timerInfo.StartedID).Return(timerInfo, true).Times(1)
@@ -122,7 +123,8 @@ func (s *timerSequenceSuite) TestCreateNextUserTimer_NotCreated() {
 			VisibilityTimestamp: timerInfo.ExpiryTime,
 			Version:             currentVersion,
 		},
-		EventID: timerInfo.StartedID,
+		EventID:  timerInfo.StartedID,
+		TaskList: "task-list",
 	}).Times(1)
 
 	modified, err := s.timerSequence.CreateNextUserTimer()
@@ -146,6 +148,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_AlreadyCreated() {
 		LastHeartBeatUpdatedTime: time.Time{},
 		TimerTaskStatus:          TimerTaskStatusCreatedScheduleToClose | TimerTaskStatusCreatedScheduleToStart,
 		Attempt:                  12,
+		TaskList:                 "task-list",
 	}
 	activityInfos := map[int64]*persistence.ActivityInfo{activityInfo.ScheduleID: activityInfo}
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(activityInfos).Times(1)
@@ -172,12 +175,14 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated() {
 		LastHeartBeatUpdatedTime: time.Time{},
 		TimerTaskStatus:          TimerTaskStatusNone,
 		Attempt:                  12,
+		TaskList:                 "task-list",
 	}
 	activityInfos := map[int64]*persistence.ActivityInfo{activityInfo.ScheduleID: activityInfo}
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   "domain-id",
 		WorkflowID: "wf-id",
 		RunID:      "run-id",
+		TaskList:   "task-list2",
 	}).Times(1)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(activityInfos).Times(1)
 	s.mockMutableState.EXPECT().GetActivityInfo(activityInfo.ScheduleID).Return(activityInfo, true).Times(1)
@@ -202,6 +207,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_NotCreated() {
 		TimeoutType: int(types.TimeoutTypeScheduleToStart),
 		EventID:     activityInfo.ScheduleID,
 		Attempt:     int64(activityInfo.Attempt),
+		TaskList:    "task-list",
 	}).Times(1)
 
 	modified, err := s.timerSequence.CreateNextActivityTimer()
@@ -226,12 +232,14 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_HeartbeatTimer() {
 		LastHeartBeatUpdatedTime: time.Time{},
 		TimerTaskStatus:          TimerTaskStatusNone,
 		Attempt:                  12,
+		TaskList:                 "task-list",
 	}
 	activityInfos := map[int64]*persistence.ActivityInfo{activityInfo.ScheduleID: activityInfo}
 	s.mockMutableState.EXPECT().GetExecutionInfo().Return(&persistence.WorkflowExecutionInfo{
 		DomainID:   "domain-id",
 		WorkflowID: "wf-id",
 		RunID:      "run-id",
+		TaskList:   "task-list2",
 	}).Times(1)
 	s.mockMutableState.EXPECT().GetPendingActivityInfos().Return(activityInfos).Times(1)
 	s.mockMutableState.EXPECT().GetActivityInfo(activityInfo.ScheduleID).Return(activityInfo, true).Times(1)
@@ -259,6 +267,7 @@ func (s *timerSequenceSuite) TestCreateNextActivityTimer_HeartbeatTimer() {
 		TimeoutType: int(types.TimeoutTypeHeartbeat),
 		EventID:     activityInfo.ScheduleID,
 		Attempt:     int64(activityInfo.Attempt),
+		TaskList:    "task-list",
 	}).Times(1)
 
 	modified, err := s.timerSequence.CreateNextActivityTimer()


### PR DESCRIPTION
<!-- 1-2 line summary of WHAT changed technically:
- Always link the relevant projects GitHub issue, unless it is a minor bugfix
- Good: "Modified FailoverDomain mapper to allow null ActiveClusterName #320"
- Bad: "added nil check" -->
**What changed?**
Store task list name in history tasks which will be used to ensure fair scheduling across task lists in history.

<!-- Your goal is to provide all the required context for a future maintainer 
to understand the reasons for making this change (see https://cbea.ms/git-commit/#why-not-how).
How did this work previously (and what was wrong with it)? What has changed, and why did you solve it 
this way?
- Good: "Active-active domains have independent cluster attributes per region. Previously,
  modifying cluster attributes required spedifying the default ActiveClusterName which
  updates the global domain default. This prevents operators from updating regional
  configurations without affecting the primary cluster designation. This change allows
  attribute updates to be independent of active cluster selection."
- Bad: "Improves domain handling" -->
**Why?**
We store the task list property of history tasks so that we can use that property to ensure fair scheduling of history tasks across task lists. This is a part of project https://github.com/cadence-workflow/cadence/issues/7724

<!-- Include specific test commands and setup. Please include the exact commands such that
another maintainer or contributor can reproduce the test steps taken. 
- e.g Unit test commands with exact invocation
  `go test -v ./common/types/mapper/proto -run TestFailoverDomainRequest`
- For integration tests include setup steps and test commands
  Example: "Started local server with `./cadence start`, then ran `make test_e2e`"
- For local simulation testing include setup steps for the server and how you ran the tests
- Good: Full commands that reviewers can copy-paste to verify
- Bad: "Tested locally" or "Added tests" -->
**How did you test it?**
unit test
`cd ./service/history/execution && go test ./...`

<!-- If there are risks that the release engineer should know about document them here. 
For example:
- Has an API/IDL been modified? Is it backwards/forwards compatible? If not, what are the repecussions? 
- Has a schema change been introduced? Is it possible to roll back?
- Has a feature flag been re-used for a new purpose? 
- Is there a potential performance concern? Is the change modifying core task processing logic? 
- If truly N/A, you can mark it as such -->
**Potential risks**
N/A

<!-- If this PR completes a user facing feature or changes functionality add release notes here.
Your release notes should allow a user and the release engineer to understand the changes with little context.
Always ensure that the description contains a link to the relevant GitHub issue. -->
**Release notes**
N/A

<!-- Consider whether this change requires documentation updates in the Cadence-Docs repo
- If yes: mention what needs updating (or link to docs PR in cadence-docs repo)
- If in doubt, add a note about potential doc needs
- Only mark N/A if you're certain no docs are affected -->
**Documentation Changes**
N/A

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
