### PR TITLE
feat: [Cadence Schedules] Add schedule core types and enums

### DIFF
--- a/common/types/schedule.go
+++ b/common/types/schedule.go
@@ -1,0 +1,463 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// --- Enums ---
+
+// ScheduleOverlapPolicy defines behavior when a scheduled run overlaps with a previous run.
+type ScheduleOverlapPolicy int32
+
+const (
+	ScheduleOverlapPolicyInvalid           ScheduleOverlapPolicy = iota
+	ScheduleOverlapPolicySkipNew                                 // Skip if previous still running
+	ScheduleOverlapPolicyBuffer                                  // Buffer and execute sequentially
+	ScheduleOverlapPolicyConcurrent                              // Allow concurrent execution
+	ScheduleOverlapPolicyCancelPrevious                          // Cancel previous, start new
+	ScheduleOverlapPolicyTerminatePrevious                       // Terminate previous, start new
+)
+
+func (e ScheduleOverlapPolicy) Ptr() *ScheduleOverlapPolicy { return &e }
+
+func (e ScheduleOverlapPolicy) String() string {
+	switch e {
+	case ScheduleOverlapPolicyInvalid:
+		return "INVALID"
+	case ScheduleOverlapPolicySkipNew:
+		return "SKIP_NEW"
+	case ScheduleOverlapPolicyBuffer:
+		return "BUFFER"
+	case ScheduleOverlapPolicyConcurrent:
+		return "CONCURRENT"
+	case ScheduleOverlapPolicyCancelPrevious:
+		return "CANCEL_PREVIOUS"
+	case ScheduleOverlapPolicyTerminatePrevious:
+		return "TERMINATE_PREVIOUS"
+	}
+	return fmt.Sprintf("ScheduleOverlapPolicy(%d)", int32(e))
+}
+
+func (e *ScheduleOverlapPolicy) UnmarshalText(value []byte) error {
+	switch s := strings.ToUpper(string(value)); s {
+	case "INVALID":
+		*e = ScheduleOverlapPolicyInvalid
+	case "SKIP_NEW":
+		*e = ScheduleOverlapPolicySkipNew
+	case "BUFFER":
+		*e = ScheduleOverlapPolicyBuffer
+	case "CONCURRENT":
+		*e = ScheduleOverlapPolicyConcurrent
+	case "CANCEL_PREVIOUS":
+		*e = ScheduleOverlapPolicyCancelPrevious
+	case "TERMINATE_PREVIOUS":
+		*e = ScheduleOverlapPolicyTerminatePrevious
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ScheduleOverlapPolicy", err)
+		}
+		*e = ScheduleOverlapPolicy(val)
+	}
+	return nil
+}
+
+func (e ScheduleOverlapPolicy) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
+// ScheduleCatchUpPolicy defines how missed runs are handled on unpause or system recovery.
+type ScheduleCatchUpPolicy int32
+
+const (
+	ScheduleCatchUpPolicyInvalid ScheduleCatchUpPolicy = iota
+	ScheduleCatchUpPolicySkip                          // Skip all missed runs
+	ScheduleCatchUpPolicyOne                           // Run only the most recent missed time
+	ScheduleCatchUpPolicyAll                           // Run for each missed (up to window)
+)
+
+func (e ScheduleCatchUpPolicy) Ptr() *ScheduleCatchUpPolicy { return &e }
+
+func (e ScheduleCatchUpPolicy) String() string {
+	switch e {
+	case ScheduleCatchUpPolicyInvalid:
+		return "INVALID"
+	case ScheduleCatchUpPolicySkip:
+		return "SKIP"
+	case ScheduleCatchUpPolicyOne:
+		return "ONE"
+	case ScheduleCatchUpPolicyAll:
+		return "ALL"
+	}
+	return fmt.Sprintf("ScheduleCatchUpPolicy(%d)", int32(e))
+}
+
+func (e *ScheduleCatchUpPolicy) UnmarshalText(value []byte) error {
+	switch s := strings.ToUpper(string(value)); s {
+	case "INVALID":
+		*e = ScheduleCatchUpPolicyInvalid
+	case "SKIP":
+		*e = ScheduleCatchUpPolicySkip
+	case "ONE":
+		*e = ScheduleCatchUpPolicyOne
+	case "ALL":
+		*e = ScheduleCatchUpPolicyAll
+	default:
+		val, err := strconv.ParseInt(s, 10, 32)
+		if err != nil {
+			return fmt.Errorf("unknown enum value %q for %q: %v", s, "ScheduleCatchUpPolicy", err)
+		}
+		*e = ScheduleCatchUpPolicy(val)
+	}
+	return nil
+}
+
+func (e ScheduleCatchUpPolicy) MarshalText() ([]byte, error) {
+	return []byte(e.String()), nil
+}
+
+// --- Core Types ---
+
+// ScheduleSpec defines when a schedule should trigger.
+type ScheduleSpec struct {
+	CronExpression string        `json:"cronExpression,omitempty"`
+	StartTime      time.Time     `json:"startTime,omitempty"`
+	EndTime        time.Time     `json:"endTime,omitempty"`
+	Jitter         time.Duration `json:"jitter,omitempty"`
+}
+
+func (v *ScheduleSpec) GetCronExpression() (o string) {
+	if v != nil {
+		return v.CronExpression
+	}
+	return
+}
+
+func (v *ScheduleSpec) GetStartTime() (o time.Time) {
+	if v != nil {
+		return v.StartTime
+	}
+	return
+}
+
+func (v *ScheduleSpec) GetEndTime() (o time.Time) {
+	if v != nil {
+		return v.EndTime
+	}
+	return
+}
+
+func (v *ScheduleSpec) GetJitter() (o time.Duration) {
+	if v != nil {
+		return v.Jitter
+	}
+	return
+}
+
+// StartWorkflowAction defines a workflow to start when the schedule triggers.
+type StartWorkflowAction struct {
+	WorkflowType                        *WorkflowType     `json:"workflowType,omitempty"`
+	TaskList                            *TaskList         `json:"taskList,omitempty"`
+	Input                               []byte            `json:"-"`
+	WorkflowIDPrefix                    string            `json:"workflowIdPrefix,omitempty"`
+	ExecutionStartToCloseTimeoutSeconds *int32            `json:"executionStartToCloseTimeoutSeconds,omitempty"`
+	TaskStartToCloseTimeoutSeconds      *int32            `json:"taskStartToCloseTimeoutSeconds,omitempty"`
+	RetryPolicy                         *RetryPolicy      `json:"retryPolicy,omitempty"`
+	Memo                                *Memo             `json:"-"`
+	SearchAttributes                    *SearchAttributes `json:"-"`
+}
+
+func (v *StartWorkflowAction) GetWorkflowType() *WorkflowType {
+	if v != nil {
+		return v.WorkflowType
+	}
+	return nil
+}
+
+func (v *StartWorkflowAction) GetTaskList() *TaskList {
+	if v != nil {
+		return v.TaskList
+	}
+	return nil
+}
+
+func (v *StartWorkflowAction) GetWorkflowIDPrefix() (o string) {
+	if v != nil {
+		return v.WorkflowIDPrefix
+	}
+	return
+}
+
+func (v *StartWorkflowAction) GetExecutionStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.ExecutionStartToCloseTimeoutSeconds != nil {
+		return *v.ExecutionStartToCloseTimeoutSeconds
+	}
+	return
+}
+
+func (v *StartWorkflowAction) GetTaskStartToCloseTimeoutSeconds() (o int32) {
+	if v != nil && v.TaskStartToCloseTimeoutSeconds != nil {
+		return *v.TaskStartToCloseTimeoutSeconds
+	}
+	return
+}
+
+// ScheduleAction defines the action to take when the schedule triggers.
+// Exactly one action field must be set.
+type ScheduleAction struct {
+	StartWorkflow *StartWorkflowAction `json:"startWorkflow,omitempty"`
+}
+
+func (v *ScheduleAction) GetStartWorkflow() *StartWorkflowAction {
+	if v != nil {
+		return v.StartWorkflow
+	}
+	return nil
+}
+
+// SchedulePolicies configures schedule behavior.
+type SchedulePolicies struct {
+	OverlapPolicy    ScheduleOverlapPolicy `json:"overlapPolicy,omitempty"`
+	CatchUpPolicy    ScheduleCatchUpPolicy `json:"catchUpPolicy,omitempty"`
+	CatchUpWindow    time.Duration         `json:"catchUpWindow,omitempty"`
+	PauseOnFailure   bool                  `json:"pauseOnFailure,omitempty"`
+	BufferLimit      int32                 `json:"bufferLimit,omitempty"`
+	ConcurrencyLimit int32                 `json:"concurrencyLimit,omitempty"`
+}
+
+func (v *SchedulePolicies) GetOverlapPolicy() (o ScheduleOverlapPolicy) {
+	if v != nil {
+		return v.OverlapPolicy
+	}
+	return
+}
+
+func (v *SchedulePolicies) GetCatchUpPolicy() (o ScheduleCatchUpPolicy) {
+	if v != nil {
+		return v.CatchUpPolicy
+	}
+	return
+}
+
+func (v *SchedulePolicies) GetCatchUpWindow() (o time.Duration) {
+	if v != nil {
+		return v.CatchUpWindow
+	}
+	return
+}
+
+func (v *SchedulePolicies) GetPauseOnFailure() (o bool) {
+	if v != nil {
+		return v.PauseOnFailure
+	}
+	return
+}
+
+func (v *SchedulePolicies) GetBufferLimit() (o int32) {
+	if v != nil {
+		return v.BufferLimit
+	}
+	return
+}
+
+func (v *SchedulePolicies) GetConcurrencyLimit() (o int32) {
+	if v != nil {
+		return v.ConcurrencyLimit
+	}
+	return
+}
+
+// SchedulePauseInfo captures the state of a paused schedule (response-only, server-populated).
+type SchedulePauseInfo struct {
+	Reason   string    `json:"reason,omitempty"`
+	PausedAt time.Time `json:"pausedAt,omitempty"`
+	PausedBy string    `json:"pausedBy,omitempty"`
+}
+
+func (v *SchedulePauseInfo) GetReason() (o string) {
+	if v != nil {
+		return v.Reason
+	}
+	return
+}
+
+func (v *SchedulePauseInfo) GetPausedAt() (o time.Time) {
+	if v != nil {
+		return v.PausedAt
+	}
+	return
+}
+
+func (v *SchedulePauseInfo) GetPausedBy() (o string) {
+	if v != nil {
+		return v.PausedBy
+	}
+	return
+}
+
+// ScheduleState represents the current runtime state of a schedule.
+type ScheduleState struct {
+	Paused    bool               `json:"paused,omitempty"`
+	PauseInfo *SchedulePauseInfo `json:"pauseInfo,omitempty"`
+}
+
+func (v *ScheduleState) GetPaused() (o bool) {
+	if v != nil {
+		return v.Paused
+	}
+	return
+}
+
+func (v *ScheduleState) GetPauseInfo() *SchedulePauseInfo {
+	if v != nil {
+		return v.PauseInfo
+	}
+	return nil
+}
+
+// BackfillInfo tracks the progress of an ongoing backfill operation.
+type BackfillInfo struct {
+	BackfillID    string    `json:"backfillId,omitempty"`
+	StartTime     time.Time `json:"startTime,omitempty"`
+	EndTime       time.Time `json:"endTime,omitempty"`
+	RunsCompleted int32     `json:"runsCompleted,omitempty"`
+	RunsTotal     int32     `json:"runsTotal,omitempty"`
+}
+
+func (v *BackfillInfo) GetStartTime() (o time.Time) {
+	if v != nil {
+		return v.StartTime
+	}
+	return
+}
+
+func (v *BackfillInfo) GetEndTime() (o time.Time) {
+	if v != nil {
+		return v.EndTime
+	}
+	return
+}
+
+func (v *BackfillInfo) GetBackfillID() (o string) {
+	if v != nil {
+		return v.BackfillID
+	}
+	return
+}
+
+func (v *BackfillInfo) GetRunsCompleted() (o int32) {
+	if v != nil {
+		return v.RunsCompleted
+	}
+	return
+}
+
+func (v *BackfillInfo) GetRunsTotal() (o int32) {
+	if v != nil {
+		return v.RunsTotal
+	}
+	return
+}
+
+// ScheduleInfo provides runtime information about the schedule.
+type ScheduleInfo struct {
+	LastRunTime      time.Time      `json:"lastRunTime,omitempty"`
+	NextRunTime      time.Time      `json:"nextRunTime,omitempty"`
+	TotalRuns        int64          `json:"totalRuns,omitempty"`
+	CreateTime       time.Time      `json:"createTime,omitempty"`
+	LastUpdateTime   time.Time      `json:"lastUpdateTime,omitempty"`
+	OngoingBackfills []BackfillInfo `json:"ongoingBackfills,omitempty"`
+}
+
+func (v *ScheduleInfo) GetLastRunTime() (o time.Time) {
+	if v != nil {
+		return v.LastRunTime
+	}
+	return
+}
+
+func (v *ScheduleInfo) GetNextRunTime() (o time.Time) {
+	if v != nil {
+		return v.NextRunTime
+	}
+	return
+}
+
+func (v *ScheduleInfo) GetTotalRuns() (o int64) {
+	if v != nil {
+		return v.TotalRuns
+	}
+	return
+}
+
+func (v *ScheduleInfo) GetCreateTime() (o time.Time) {
+	if v != nil {
+		return v.CreateTime
+	}
+	return
+}
+
+func (v *ScheduleInfo) GetLastUpdateTime() (o time.Time) {
+	if v != nil {
+		return v.LastUpdateTime
+	}
+	return
+}
+
+func (v *ScheduleInfo) GetOngoingBackfills() (o []BackfillInfo) {
+	if v != nil {
+		return v.OngoingBackfills
+	}
+	return
+}
+
+func (v *StartWorkflowAction) GetInput() (o []byte) {
+	if v != nil {
+		return v.Input
+	}
+	return
+}
+
+func (v *StartWorkflowAction) GetRetryPolicy() *RetryPolicy {
+	if v != nil {
+		return v.RetryPolicy
+	}
+	return nil
+}
+
+func (v *StartWorkflowAction) GetMemo() *Memo {
+	if v != nil {
+		return v.Memo
+	}
+	return nil
+}
+
+func (v *StartWorkflowAction) GetSearchAttributes() *SearchAttributes {
+	if v != nil {
+		return v.SearchAttributes
+	}
+	return nil
+}

--- a/common/types/schedule_test.go
+++ b/common/types/schedule_test.go
@@ -1,0 +1,177 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduleOverlapPolicy_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want ScheduleOverlapPolicy
+		err  bool
+	}{
+		{name: "invalid", text: "INVALID", want: ScheduleOverlapPolicyInvalid},
+		{name: "skip_new", text: "SKIP_NEW", want: ScheduleOverlapPolicySkipNew},
+		{name: "buffer", text: "BUFFER", want: ScheduleOverlapPolicyBuffer},
+		{name: "concurrent", text: "CONCURRENT", want: ScheduleOverlapPolicyConcurrent},
+		{name: "cancel_previous", text: "CANCEL_PREVIOUS", want: ScheduleOverlapPolicyCancelPrevious},
+		{name: "terminate_previous", text: "TERMINATE_PREVIOUS", want: ScheduleOverlapPolicyTerminatePrevious},
+		{name: "lowercase", text: "skip_new", want: ScheduleOverlapPolicySkipNew},
+		{name: "numeric", text: "2", want: ScheduleOverlapPolicy(2)},
+		{name: "unknown", text: "UNKNOWN", err: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ScheduleOverlapPolicy
+			err := got.UnmarshalText([]byte(tt.text))
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestScheduleOverlapPolicy_MarshalText(t *testing.T) {
+	tests := []struct {
+		name string
+		val  ScheduleOverlapPolicy
+		want string
+	}{
+		{name: "invalid", val: ScheduleOverlapPolicyInvalid, want: "INVALID"},
+		{name: "skip_new", val: ScheduleOverlapPolicySkipNew, want: "SKIP_NEW"},
+		{name: "buffer", val: ScheduleOverlapPolicyBuffer, want: "BUFFER"},
+		{name: "concurrent", val: ScheduleOverlapPolicyConcurrent, want: "CONCURRENT"},
+		{name: "cancel_previous", val: ScheduleOverlapPolicyCancelPrevious, want: "CANCEL_PREVIOUS"},
+		{name: "terminate_previous", val: ScheduleOverlapPolicyTerminatePrevious, want: "TERMINATE_PREVIOUS"},
+		{name: "unknown_numeric", val: ScheduleOverlapPolicy(99), want: "ScheduleOverlapPolicy(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := tt.val.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, string(b))
+		})
+	}
+}
+
+func TestScheduleOverlapPolicy_RoundTrip(t *testing.T) {
+	for _, val := range []ScheduleOverlapPolicy{
+		ScheduleOverlapPolicyInvalid,
+		ScheduleOverlapPolicySkipNew,
+		ScheduleOverlapPolicyBuffer,
+		ScheduleOverlapPolicyConcurrent,
+		ScheduleOverlapPolicyCancelPrevious,
+		ScheduleOverlapPolicyTerminatePrevious,
+	} {
+		b, err := val.MarshalText()
+		assert.NoError(t, err)
+		var got ScheduleOverlapPolicy
+		err = got.UnmarshalText(b)
+		assert.NoError(t, err)
+		assert.Equal(t, val, got)
+	}
+}
+
+func TestScheduleCatchUpPolicy_UnmarshalText(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want ScheduleCatchUpPolicy
+		err  bool
+	}{
+		{name: "invalid", text: "INVALID", want: ScheduleCatchUpPolicyInvalid},
+		{name: "skip", text: "SKIP", want: ScheduleCatchUpPolicySkip},
+		{name: "one", text: "ONE", want: ScheduleCatchUpPolicyOne},
+		{name: "all", text: "ALL", want: ScheduleCatchUpPolicyAll},
+		{name: "lowercase", text: "all", want: ScheduleCatchUpPolicyAll},
+		{name: "numeric", text: "1", want: ScheduleCatchUpPolicy(1)},
+		{name: "unknown", text: "UNKNOWN", err: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var got ScheduleCatchUpPolicy
+			err := got.UnmarshalText([]byte(tt.text))
+			if tt.err {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestScheduleCatchUpPolicy_MarshalText(t *testing.T) {
+	tests := []struct {
+		name string
+		val  ScheduleCatchUpPolicy
+		want string
+	}{
+		{name: "invalid", val: ScheduleCatchUpPolicyInvalid, want: "INVALID"},
+		{name: "skip", val: ScheduleCatchUpPolicySkip, want: "SKIP"},
+		{name: "one", val: ScheduleCatchUpPolicyOne, want: "ONE"},
+		{name: "all", val: ScheduleCatchUpPolicyAll, want: "ALL"},
+		{name: "unknown_numeric", val: ScheduleCatchUpPolicy(99), want: "ScheduleCatchUpPolicy(99)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b, err := tt.val.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, tt.want, string(b))
+		})
+	}
+}
+
+func TestScheduleCatchUpPolicy_RoundTrip(t *testing.T) {
+	for _, val := range []ScheduleCatchUpPolicy{
+		ScheduleCatchUpPolicyInvalid,
+		ScheduleCatchUpPolicySkip,
+		ScheduleCatchUpPolicyOne,
+		ScheduleCatchUpPolicyAll,
+	} {
+		b, err := val.MarshalText()
+		assert.NoError(t, err)
+		var got ScheduleCatchUpPolicy
+		err = got.UnmarshalText(b)
+		assert.NoError(t, err)
+		assert.Equal(t, val, got)
+	}
+}
+
+func TestScheduleOverlapPolicy_Ptr(t *testing.T) {
+	val := ScheduleOverlapPolicyBuffer
+	ptr := val.Ptr()
+	assert.Equal(t, &val, ptr)
+}
+
+func TestScheduleCatchUpPolicy_Ptr(t *testing.T) {
+	val := ScheduleCatchUpPolicyAll
+	ptr := val.Ptr()
+	assert.Equal(t, &val, ptr)
+}


### PR DESCRIPTION
**What changed?**
Added internal Go types for Cadence Schedules (enums, core structs) mirroring api/v1/schedule.proto. 

**Why?**
To support the new Cadence Schedules feature (pause/resume, catch-up, backfill), we need internal Go types to represent schedule entities within the server codebase. These types mirror the IDL definitions and include standard helper methods (Getters, String/Enum marshalling) required for internal usage. This serves as the foundation for the scheduler workflow and API implementation.
Proto definitions: https://github.com/cadence-workflow/cadence-idl/pull/246

**How did you test it?**
Ran unit tests for enum marshalling/unmarshalling:
go test -v ./common/types/ -run TestSchedule

**Potential risks**
N/A - Purely additive type definitions; not yet wired into any active code paths.

**Release notes**
Added core internal types for Cadence Schedules.

**Documentation Changes**
N/A

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
