### PR TITLE
chore: Upgrade buf from v0.36.0 to v1.47.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -225,10 +225,10 @@ $(BUILD)/go_mod_check: go.mod internal/tools/go.mod go.work
 
 # https://docs.buf.build/
 # changing BUF_VERSION will automatically download and use the specified version.
-BUF_VERSION = 0.36.0
+BUF_VERSION = 1.47.2
 OS = $(shell uname -s)
 ARCH = $(shell $(EMULATE_X86) uname -m)
-BUF_URL = https://github.com/bufbuild/buf/releases/download/v$(BUF_VERSION)/buf-$(OS)-$(ARCH)
+BUF_URL = https://github.com/bufbuild/buf/releases/download/v$(BUF_VERSION)/buf-$(OS)-$(shell uname -m)
 # use BUF_VERSION_BIN as a bin prerequisite, not "buf", so the correct version will be used.
 # otherwise this must be a .PHONY rule, or the buf bin / symlink could become out of date.
 BUF_VERSION_BIN = buf-$(BUF_VERSION)


### PR DESCRIPTION
**What changed?**
- Upgrade buf to v1.47.2 which ships native arm64 binaries
- Use native arch for buf download URL instead of EMULATE_X86


**Why?**
buf v0.36.0 is 5 years old and only ships x86_64 binaries, which silently fails on Apple Silicon when Rosetta is not installed (the Makefile downloads a 404 HTML page instead of a real binary).


**How did you test it?**
proto-lint passes

**Potential risks**
Low risk. The buf binary is only used for proto-lint during development/CI. No runtime or schema changes.
The v1beta1 buf.yaml config is still supported by buf v1.47.2 (shows a deprecation warning but passes).
EMULATE_X86 is preserved for protoc which still requires it.

**Release notes**
N/A: build tooling only, no user-facing changes.

**Documentation Changes**
N/A

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
