### PR TITLE
feat: [Cadence Schedules] Add schedule API request/response types

### DIFF
--- a/common/types/schedule.go
+++ b/common/types/schedule.go
@@ -181,13 +181,13 @@ func (v *ScheduleSpec) GetJitter() (o time.Duration) {
 type StartWorkflowAction struct {
 	WorkflowType                        *WorkflowType     `json:"workflowType,omitempty"`
 	TaskList                            *TaskList         `json:"taskList,omitempty"`
-	Input                               []byte            `json:"-"`
+	Input                               []byte            `json:"-"` // Potential PII
 	WorkflowIDPrefix                    string            `json:"workflowIdPrefix,omitempty"`
 	ExecutionStartToCloseTimeoutSeconds *int32            `json:"executionStartToCloseTimeoutSeconds,omitempty"`
 	TaskStartToCloseTimeoutSeconds      *int32            `json:"taskStartToCloseTimeoutSeconds,omitempty"`
 	RetryPolicy                         *RetryPolicy      `json:"retryPolicy,omitempty"`
-	Memo                                *Memo             `json:"-"`
-	SearchAttributes                    *SearchAttributes `json:"-"`
+	Memo                                *Memo             `json:"-"` // Filtering PII
+	SearchAttributes                    *SearchAttributes `json:"-"` // Filtering PII
 }
 
 func (v *StartWorkflowAction) GetWorkflowType() *WorkflowType {
@@ -384,12 +384,12 @@ func (v *BackfillInfo) GetRunsTotal() (o int32) {
 
 // ScheduleInfo provides runtime information about the schedule.
 type ScheduleInfo struct {
-	LastRunTime      time.Time      `json:"lastRunTime,omitempty"`
-	NextRunTime      time.Time      `json:"nextRunTime,omitempty"`
-	TotalRuns        int64          `json:"totalRuns,omitempty"`
-	CreateTime       time.Time      `json:"createTime,omitempty"`
-	LastUpdateTime   time.Time      `json:"lastUpdateTime,omitempty"`
-	OngoingBackfills []BackfillInfo `json:"ongoingBackfills,omitempty"`
+	LastRunTime      time.Time       `json:"lastRunTime,omitempty"`
+	NextRunTime      time.Time       `json:"nextRunTime,omitempty"`
+	TotalRuns        int64           `json:"totalRuns,omitempty"`
+	CreateTime       time.Time       `json:"createTime,omitempty"`
+	LastUpdateTime   time.Time       `json:"lastUpdateTime,omitempty"`
+	OngoingBackfills []*BackfillInfo `json:"ongoingBackfills,omitempty"`
 }
 
 func (v *ScheduleInfo) GetLastRunTime() (o time.Time) {
@@ -427,7 +427,7 @@ func (v *ScheduleInfo) GetLastUpdateTime() (o time.Time) {
 	return
 }
 
-func (v *ScheduleInfo) GetOngoingBackfills() (o []BackfillInfo) {
+func (v *ScheduleInfo) GetOngoingBackfills() (o []*BackfillInfo) {
 	if v != nil {
 		return v.OngoingBackfills
 	}

--- a/common/types/schedule_service.go
+++ b/common/types/schedule_service.go
@@ -1,0 +1,463 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import "time"
+
+// --- Request/Response Types for Schedule APIs ---
+
+// ScheduleListEntry represents a single schedule in a list response.
+type ScheduleListEntry struct {
+	ScheduleID     string         `json:"scheduleId,omitempty"`
+	WorkflowType   *WorkflowType  `json:"workflowType,omitempty"`
+	State          *ScheduleState `json:"state,omitempty"`
+	CronExpression string         `json:"cronExpression,omitempty"`
+}
+
+func (v *ScheduleListEntry) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+func (v *ScheduleListEntry) GetWorkflowType() *WorkflowType {
+	if v != nil {
+		return v.WorkflowType
+	}
+	return nil
+}
+
+func (v *ScheduleListEntry) GetState() *ScheduleState {
+	if v != nil {
+		return v.State
+	}
+	return nil
+}
+
+func (v *ScheduleListEntry) GetCronExpression() (o string) {
+	if v != nil {
+		return v.CronExpression
+	}
+	return
+}
+
+// CreateScheduleRequest is the request to create a new schedule.
+type CreateScheduleRequest struct {
+	Domain           string            `json:"domain,omitempty"`
+	ScheduleID       string            `json:"scheduleId,omitempty"`
+	Spec             *ScheduleSpec     `json:"spec,omitempty"`
+	Action           *ScheduleAction   `json:"action,omitempty"`
+	Policies         *SchedulePolicies `json:"policies,omitempty"`
+	Memo             *Memo             `json:"-"` // Filtering PII
+	SearchAttributes *SearchAttributes `json:"-"` // Filtering PII
+}
+
+func (v *CreateScheduleRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *CreateScheduleRequest) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+func (v *CreateScheduleRequest) GetSpec() *ScheduleSpec {
+	if v != nil {
+		return v.Spec
+	}
+	return nil
+}
+
+func (v *CreateScheduleRequest) GetAction() *ScheduleAction {
+	if v != nil {
+		return v.Action
+	}
+	return nil
+}
+
+func (v *CreateScheduleRequest) GetPolicies() *SchedulePolicies {
+	if v != nil {
+		return v.Policies
+	}
+	return nil
+}
+
+func (v *CreateScheduleRequest) GetMemo() *Memo {
+	if v != nil {
+		return v.Memo
+	}
+	return nil
+}
+
+func (v *CreateScheduleRequest) GetSearchAttributes() *SearchAttributes {
+	if v != nil {
+		return v.SearchAttributes
+	}
+	return nil
+}
+
+// CreateScheduleResponse is the response for creating a schedule.
+type CreateScheduleResponse struct{}
+
+// DescribeScheduleRequest is the request to describe a schedule.
+type DescribeScheduleRequest struct {
+	Domain     string `json:"domain,omitempty"`
+	ScheduleID string `json:"scheduleId,omitempty"`
+}
+
+func (v *DescribeScheduleRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *DescribeScheduleRequest) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+// DescribeScheduleResponse is the response for describing a schedule.
+type DescribeScheduleResponse struct {
+	Spec             *ScheduleSpec     `json:"spec,omitempty"`
+	Action           *ScheduleAction   `json:"action,omitempty"`
+	Policies         *SchedulePolicies `json:"policies,omitempty"`
+	State            *ScheduleState    `json:"state,omitempty"`
+	Info             *ScheduleInfo     `json:"info,omitempty"`
+	Memo             *Memo             `json:"-"` // Filtering PII
+	SearchAttributes *SearchAttributes `json:"-"` // Filtering PII
+}
+
+func (v *DescribeScheduleResponse) GetSpec() *ScheduleSpec {
+	if v != nil {
+		return v.Spec
+	}
+	return nil
+}
+
+func (v *DescribeScheduleResponse) GetAction() *ScheduleAction {
+	if v != nil {
+		return v.Action
+	}
+	return nil
+}
+
+func (v *DescribeScheduleResponse) GetPolicies() *SchedulePolicies {
+	if v != nil {
+		return v.Policies
+	}
+	return nil
+}
+
+func (v *DescribeScheduleResponse) GetState() *ScheduleState {
+	if v != nil {
+		return v.State
+	}
+	return nil
+}
+
+func (v *DescribeScheduleResponse) GetInfo() *ScheduleInfo {
+	if v != nil {
+		return v.Info
+	}
+	return nil
+}
+
+func (v *DescribeScheduleResponse) GetMemo() *Memo {
+	if v != nil {
+		return v.Memo
+	}
+	return nil
+}
+
+func (v *DescribeScheduleResponse) GetSearchAttributes() *SearchAttributes {
+	if v != nil {
+		return v.SearchAttributes
+	}
+	return nil
+}
+
+// UpdateScheduleRequest is the request to update a schedule.
+type UpdateScheduleRequest struct {
+	Domain           string            `json:"domain,omitempty"`
+	ScheduleID       string            `json:"scheduleId,omitempty"`
+	Spec             *ScheduleSpec     `json:"spec,omitempty"`
+	Action           *ScheduleAction   `json:"action,omitempty"`
+	Policies         *SchedulePolicies `json:"policies,omitempty"`
+	Memo             *Memo             `json:"-"` // Filtering PII
+	SearchAttributes *SearchAttributes `json:"-"` // Filtering PII
+}
+
+func (v *UpdateScheduleRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *UpdateScheduleRequest) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+func (v *UpdateScheduleRequest) GetSpec() *ScheduleSpec {
+	if v != nil {
+		return v.Spec
+	}
+	return nil
+}
+
+func (v *UpdateScheduleRequest) GetAction() *ScheduleAction {
+	if v != nil {
+		return v.Action
+	}
+	return nil
+}
+
+func (v *UpdateScheduleRequest) GetPolicies() *SchedulePolicies {
+	if v != nil {
+		return v.Policies
+	}
+	return nil
+}
+
+func (v *UpdateScheduleRequest) GetMemo() *Memo {
+	if v != nil {
+		return v.Memo
+	}
+	return nil
+}
+
+func (v *UpdateScheduleRequest) GetSearchAttributes() *SearchAttributes {
+	if v != nil {
+		return v.SearchAttributes
+	}
+	return nil
+}
+
+// UpdateScheduleResponse is the response for updating a schedule.
+type UpdateScheduleResponse struct{}
+
+// DeleteScheduleRequest is the request to delete a schedule.
+type DeleteScheduleRequest struct {
+	Domain     string `json:"domain,omitempty"`
+	ScheduleID string `json:"scheduleId,omitempty"`
+}
+
+func (v *DeleteScheduleRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *DeleteScheduleRequest) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+// DeleteScheduleResponse is the response for deleting a schedule.
+type DeleteScheduleResponse struct{}
+
+// PauseScheduleRequest is the request to pause a schedule.
+type PauseScheduleRequest struct {
+	Domain     string `json:"domain,omitempty"`
+	ScheduleID string `json:"scheduleId,omitempty"`
+	Reason     string `json:"reason,omitempty"`
+}
+
+func (v *PauseScheduleRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *PauseScheduleRequest) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+func (v *PauseScheduleRequest) GetReason() (o string) {
+	if v != nil {
+		return v.Reason
+	}
+	return
+}
+
+// PauseScheduleResponse is the response for pausing a schedule.
+type PauseScheduleResponse struct{}
+
+// UnpauseScheduleRequest is the request to resume a paused schedule.
+type UnpauseScheduleRequest struct {
+	Domain        string                `json:"domain,omitempty"`
+	ScheduleID    string                `json:"scheduleId,omitempty"`
+	Reason        string                `json:"reason,omitempty"`
+	CatchUpPolicy ScheduleCatchUpPolicy `json:"catchUpPolicy,omitempty"`
+}
+
+func (v *UnpauseScheduleRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *UnpauseScheduleRequest) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+func (v *UnpauseScheduleRequest) GetReason() (o string) {
+	if v != nil {
+		return v.Reason
+	}
+	return
+}
+
+func (v *UnpauseScheduleRequest) GetCatchUpPolicy() (o ScheduleCatchUpPolicy) {
+	if v != nil {
+		return v.CatchUpPolicy
+	}
+	return
+}
+
+// UnpauseScheduleResponse is the response for resuming a schedule.
+type UnpauseScheduleResponse struct{}
+
+// ListSchedulesRequest is the request to list schedules in a domain.
+type ListSchedulesRequest struct {
+	Domain        string `json:"domain,omitempty"`
+	PageSize      int32  `json:"pageSize,omitempty"`
+	NextPageToken []byte `json:"nextPageToken,omitempty"`
+}
+
+func (v *ListSchedulesRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *ListSchedulesRequest) GetPageSize() (o int32) {
+	if v != nil {
+		return v.PageSize
+	}
+	return
+}
+
+func (v *ListSchedulesRequest) GetNextPageToken() (o []byte) {
+	if v != nil {
+		return v.NextPageToken
+	}
+	return
+}
+
+// ListSchedulesResponse is the response for listing schedules.
+type ListSchedulesResponse struct {
+	Schedules     []*ScheduleListEntry `json:"schedules,omitempty"`
+	NextPageToken []byte               `json:"nextPageToken,omitempty"`
+}
+
+func (v *ListSchedulesResponse) GetSchedules() (o []*ScheduleListEntry) {
+	if v != nil {
+		return v.Schedules
+	}
+	return
+}
+
+func (v *ListSchedulesResponse) GetNextPageToken() (o []byte) {
+	if v != nil {
+		return v.NextPageToken
+	}
+	return
+}
+
+// BackfillScheduleRequest is the request to trigger a backfill for a time range.
+type BackfillScheduleRequest struct {
+	Domain        string                `json:"domain,omitempty"`
+	ScheduleID    string                `json:"scheduleId,omitempty"`
+	StartTime     time.Time             `json:"startTime,omitempty"`
+	EndTime       time.Time             `json:"endTime,omitempty"`
+	OverlapPolicy ScheduleOverlapPolicy `json:"overlapPolicy,omitempty"`
+	BackfillID    string                `json:"backfillId,omitempty"`
+}
+
+func (v *BackfillScheduleRequest) GetDomain() (o string) {
+	if v != nil {
+		return v.Domain
+	}
+	return
+}
+
+func (v *BackfillScheduleRequest) GetScheduleID() (o string) {
+	if v != nil {
+		return v.ScheduleID
+	}
+	return
+}
+
+func (v *BackfillScheduleRequest) GetStartTime() (o time.Time) {
+	if v != nil {
+		return v.StartTime
+	}
+	return
+}
+
+func (v *BackfillScheduleRequest) GetEndTime() (o time.Time) {
+	if v != nil {
+		return v.EndTime
+	}
+	return
+}
+
+func (v *BackfillScheduleRequest) GetOverlapPolicy() (o ScheduleOverlapPolicy) {
+	if v != nil {
+		return v.OverlapPolicy
+	}
+	return
+}
+
+func (v *BackfillScheduleRequest) GetBackfillID() (o string) {
+	if v != nil {
+		return v.BackfillID
+	}
+	return
+}
+
+// BackfillScheduleResponse is the response for triggering a backfill.
+type BackfillScheduleResponse struct{}

--- a/common/types/schedule_service_test.go
+++ b/common/types/schedule_service_test.go
@@ -1,0 +1,165 @@
+// Copyright (c) 2024 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestScheduleListEntry_NilGetters(t *testing.T) {
+	var v *ScheduleListEntry
+	assert.Equal(t, "", v.GetScheduleID())
+	assert.Nil(t, v.GetWorkflowType())
+	assert.Nil(t, v.GetState())
+	assert.Equal(t, "", v.GetCronExpression())
+}
+
+func TestScheduleListEntry_Getters(t *testing.T) {
+	wt := &WorkflowType{Name: "test-wf"}
+	st := &ScheduleState{Paused: true}
+	v := &ScheduleListEntry{
+		ScheduleID:     "sched-1",
+		WorkflowType:   wt,
+		State:          st,
+		CronExpression: "*/5 * * * *",
+	}
+	assert.Equal(t, "sched-1", v.GetScheduleID())
+	assert.Equal(t, wt, v.GetWorkflowType())
+	assert.Equal(t, st, v.GetState())
+	assert.Equal(t, "*/5 * * * *", v.GetCronExpression())
+}
+
+func TestCreateScheduleRequest_NilGetters(t *testing.T) {
+	var v *CreateScheduleRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, "", v.GetScheduleID())
+	assert.Nil(t, v.GetSpec())
+	assert.Nil(t, v.GetAction())
+	assert.Nil(t, v.GetPolicies())
+	assert.Nil(t, v.GetMemo())
+	assert.Nil(t, v.GetSearchAttributes())
+}
+
+func TestDescribeScheduleRequest_NilGetters(t *testing.T) {
+	var v *DescribeScheduleRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, "", v.GetScheduleID())
+}
+
+func TestDescribeScheduleResponse_NilGetters(t *testing.T) {
+	var v *DescribeScheduleResponse
+	assert.Nil(t, v.GetSpec())
+	assert.Nil(t, v.GetAction())
+	assert.Nil(t, v.GetPolicies())
+	assert.Nil(t, v.GetState())
+	assert.Nil(t, v.GetInfo())
+	assert.Nil(t, v.GetMemo())
+	assert.Nil(t, v.GetSearchAttributes())
+}
+
+func TestUpdateScheduleRequest_NilGetters(t *testing.T) {
+	var v *UpdateScheduleRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, "", v.GetScheduleID())
+	assert.Nil(t, v.GetSpec())
+	assert.Nil(t, v.GetAction())
+	assert.Nil(t, v.GetPolicies())
+	assert.Nil(t, v.GetMemo())
+	assert.Nil(t, v.GetSearchAttributes())
+}
+
+func TestDeleteScheduleRequest_NilGetters(t *testing.T) {
+	var v *DeleteScheduleRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, "", v.GetScheduleID())
+}
+
+func TestPauseScheduleRequest_NilGetters(t *testing.T) {
+	var v *PauseScheduleRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, "", v.GetScheduleID())
+	assert.Equal(t, "", v.GetReason())
+}
+
+func TestUnpauseScheduleRequest_NilGetters(t *testing.T) {
+	var v *UnpauseScheduleRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, "", v.GetScheduleID())
+	assert.Equal(t, "", v.GetReason())
+	assert.Equal(t, ScheduleCatchUpPolicyInvalid, v.GetCatchUpPolicy())
+}
+
+func TestUnpauseScheduleRequest_Getters(t *testing.T) {
+	v := &UnpauseScheduleRequest{
+		Domain:        "test-domain",
+		ScheduleID:    "sched-1",
+		Reason:        "resuming",
+		CatchUpPolicy: ScheduleCatchUpPolicyAll,
+	}
+	assert.Equal(t, "test-domain", v.GetDomain())
+	assert.Equal(t, "sched-1", v.GetScheduleID())
+	assert.Equal(t, "resuming", v.GetReason())
+	assert.Equal(t, ScheduleCatchUpPolicyAll, v.GetCatchUpPolicy())
+}
+
+func TestListSchedulesRequest_NilGetters(t *testing.T) {
+	var v *ListSchedulesRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, int32(0), v.GetPageSize())
+	assert.Nil(t, v.GetNextPageToken())
+}
+
+func TestListSchedulesResponse_NilGetters(t *testing.T) {
+	var v *ListSchedulesResponse
+	assert.Nil(t, v.GetSchedules())
+	assert.Nil(t, v.GetNextPageToken())
+}
+
+func TestBackfillScheduleRequest_NilGetters(t *testing.T) {
+	var v *BackfillScheduleRequest
+	assert.Equal(t, "", v.GetDomain())
+	assert.Equal(t, "", v.GetScheduleID())
+	assert.Equal(t, time.Time{}, v.GetStartTime())
+	assert.Equal(t, time.Time{}, v.GetEndTime())
+	assert.Equal(t, ScheduleOverlapPolicyInvalid, v.GetOverlapPolicy())
+	assert.Equal(t, "", v.GetBackfillID())
+}
+
+func TestBackfillScheduleRequest_Getters(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	v := &BackfillScheduleRequest{
+		Domain:        "test-domain",
+		ScheduleID:    "sched-1",
+		StartTime:     now,
+		EndTime:       now.Add(time.Hour),
+		OverlapPolicy: ScheduleOverlapPolicyBuffer,
+		BackfillID:    "bf-1",
+	}
+	assert.Equal(t, "test-domain", v.GetDomain())
+	assert.Equal(t, "sched-1", v.GetScheduleID())
+	assert.Equal(t, now, v.GetStartTime())
+	assert.Equal(t, now.Add(time.Hour), v.GetEndTime())
+	assert.Equal(t, ScheduleOverlapPolicyBuffer, v.GetOverlapPolicy())
+	assert.Equal(t, "bf-1", v.GetBackfillID())
+}


### PR DESCRIPTION
**What changed?**
- Add request/response types for all Schedule CRUD and lifecycle APIs (Create, Describe, Update, Delete, Pause, Unpause, List, Backfill) in `common/types/schedule_service.go`
- Add `ScheduleListEntry` for paginated list responses
- Include nil-safe getters for every field on every type, consistent
  with existing patterns in `common/types/shared.go`
- Add `schedule_service_test.go` with nil-receiver and value getter tests

**Why?**
To support the new Cadence Schedules feature (pause/resume, catch-up, backfill), we need internal Go types to represent schedule entities within the server codebase. These types mirror the IDL definitions. This serves as the foundation for the scheduler workflow and API implementation.

Builds on [#7745](https://github.com/cadence-workflow/cadence/pull/7745) which introduced the core schedule types and enums.

**How did you test it?**
Added unit tests and ran go test ./.. on the added files 

**Potential risks**
N/A

**Release notes**
Added request/response types for cadence schedules

**Documentation Changes**
N/A

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)