### PR TITLE
fix: [Cadence Schedules] Removing memo as it cannot be updated

### DIFF
--- a/common/types/schedule_service.go
+++ b/common/types/schedule_service.go
@@ -210,7 +210,6 @@ type UpdateScheduleRequest struct {
 	Spec             *ScheduleSpec     `json:"spec,omitempty"`
 	Action           *ScheduleAction   `json:"action,omitempty"`
 	Policies         *SchedulePolicies `json:"policies,omitempty"`
-	Memo             *Memo             `json:"-"` // Filtering PII
 	SearchAttributes *SearchAttributes `json:"-"` // Filtering PII
 }
 
@@ -245,13 +244,6 @@ func (v *UpdateScheduleRequest) GetAction() *ScheduleAction {
 func (v *UpdateScheduleRequest) GetPolicies() *SchedulePolicies {
 	if v != nil {
 		return v.Policies
-	}
-	return nil
-}
-
-func (v *UpdateScheduleRequest) GetMemo() *Memo {
-	if v != nil {
-		return v.Memo
 	}
 	return nil
 }

--- a/common/types/schedule_service_test.go
+++ b/common/types/schedule_service_test.go
@@ -85,7 +85,6 @@ func TestUpdateScheduleRequest_NilGetters(t *testing.T) {
 	assert.Nil(t, v.GetSpec())
 	assert.Nil(t, v.GetAction())
 	assert.Nil(t, v.GetPolicies())
-	assert.Nil(t, v.GetMemo())
 	assert.Nil(t, v.GetSearchAttributes())
 }
 


### PR DESCRIPTION
**What changed?**
Removing memo as it cannot be updated from UpdateScheduleRequest

**Why?**
Cannot be updated once created for schedule
Memo is set at StartWorkflowExecution and is immutable. SearchAttributes can be upserted.


**How did you test it?**
Design phase of feature

**Potential risks**
N.A.

**Release notes**
Removing memo as part of updateRequest

**Documentation Changes**
N/A
---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
