### PR TITLE
refactor: Implement memory-efficient virtual Schedule for IWRR task pool

### DIFF
--- a/common/task/interface.go
+++ b/common/task/interface.go
@@ -92,16 +92,20 @@ type (
 		Len() int
 	}
 
-	// Schedule represents a virtual weighted round-robin schedule that computes
-	// the next value on-demand without materializing the entire schedule in memory
+	// Schedule represents a stateless schedule definition
 	Schedule[V any] interface {
-		// Next returns the next value in the schedule
-		// Wraps around to the beginning when reaching the end
-		// Returns zero value and false if the schedule is empty
-		Next() (V, bool)
+		// NewIterator creates a new stateful iterator for this schedule
+		NewIterator() Iterator[V]
 
-		// Len returns the total virtual length of the schedule (sum of all weights)
+		// Len returns the length of the schedule
 		Len() int
+	}
+
+	// Iterator represents a stateful iteration through a schedule
+	Iterator[V any] interface {
+		// Next returns the next value in the iteration
+		// Returns (value, true) if available, (zero value, false) if exhausted
+		TryNext() (V, bool)
 	}
 )
 

--- a/common/task/interface_mock.go
+++ b/common/task/interface_mock.go
@@ -503,3 +503,94 @@ func (mr *MockSequentialTaskQueueMockRecorder) Remove() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Remove", reflect.TypeOf((*MockSequentialTaskQueue)(nil).Remove))
 }
+
+// MockSchedule is a mock of Schedule interface.
+type MockSchedule[V any] struct {
+	ctrl     *gomock.Controller
+	recorder *MockScheduleMockRecorder[V]
+	isgomock struct{}
+}
+
+// MockScheduleMockRecorder is the mock recorder for MockSchedule.
+type MockScheduleMockRecorder[V any] struct {
+	mock *MockSchedule[V]
+}
+
+// NewMockSchedule creates a new mock instance.
+func NewMockSchedule[V any](ctrl *gomock.Controller) *MockSchedule[V] {
+	mock := &MockSchedule[V]{ctrl: ctrl}
+	mock.recorder = &MockScheduleMockRecorder[V]{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockSchedule[V]) EXPECT() *MockScheduleMockRecorder[V] {
+	return m.recorder
+}
+
+// Len mocks base method.
+func (m *MockSchedule[V]) Len() int {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Len")
+	ret0, _ := ret[0].(int)
+	return ret0
+}
+
+// Len indicates an expected call of Len.
+func (mr *MockScheduleMockRecorder[V]) Len() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Len", reflect.TypeOf((*MockSchedule[V])(nil).Len))
+}
+
+// NewIterator mocks base method.
+func (m *MockSchedule[V]) NewIterator() Iterator[V] {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewIterator")
+	ret0, _ := ret[0].(Iterator[V])
+	return ret0
+}
+
+// NewIterator indicates an expected call of NewIterator.
+func (mr *MockScheduleMockRecorder[V]) NewIterator() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewIterator", reflect.TypeOf((*MockSchedule[V])(nil).NewIterator))
+}
+
+// MockIterator is a mock of Iterator interface.
+type MockIterator[V any] struct {
+	ctrl     *gomock.Controller
+	recorder *MockIteratorMockRecorder[V]
+	isgomock struct{}
+}
+
+// MockIteratorMockRecorder is the mock recorder for MockIterator.
+type MockIteratorMockRecorder[V any] struct {
+	mock *MockIterator[V]
+}
+
+// NewMockIterator creates a new mock instance.
+func NewMockIterator[V any](ctrl *gomock.Controller) *MockIterator[V] {
+	mock := &MockIterator[V]{ctrl: ctrl}
+	mock.recorder = &MockIteratorMockRecorder[V]{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockIterator[V]) EXPECT() *MockIteratorMockRecorder[V] {
+	return m.recorder
+}
+
+// TryNext mocks base method.
+func (m *MockIterator[V]) TryNext() (V, bool) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TryNext")
+	ret0, _ := ret[0].(V)
+	ret1, _ := ret[1].(bool)
+	return ret0, ret1
+}
+
+// TryNext indicates an expected call of TryNext.
+func (mr *MockIteratorMockRecorder[V]) TryNext() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TryNext", reflect.TypeOf((*MockIterator[V])(nil).TryNext))
+}

--- a/common/task/iwrr_schedule.go
+++ b/common/task/iwrr_schedule.go
@@ -1,78 +1,114 @@
 package task
 
-import "sort"
+import "slices"
+
+var _ Schedule[chan any] = &iwrrSchedule[any]{}
+
+// scheduledChannel is a snapshot of the essential fields from weightedChannel
+// Used internally by iwrrSchedule to avoid race conditions with the original weightedChannel
+type scheduledChannel[V any] struct {
+	weight int
+	c      chan V
+}
 
 // iwrrSchedule implements Schedule using an efficient interleaved weighted round-robin algorithm
-// It computes the next channel on-demand without materializing the entire schedule
+// ref: https://en.wikipedia.org/wiki/Weighted_round_robin#Interleaved_WRR
+// It is stateless and creates iterators on demand
 type iwrrSchedule[V any] struct {
 	// Snapshot of channels sorted by weight (ascending)
-	channels weightedChannels[V]
+	channels []scheduledChannel[V]
 	// Maximum weight among all channels
 	maxWeight int
 	// Total virtual length (sum of all weights)
 	totalLen int
-	// Current iteration state
+}
+
+// iwrrIterator is a stateful iterator that tracks position in the schedule
+type iwrrIterator[V any] struct {
+	schedule     *iwrrSchedule[V]
 	currentRound int // Current round (maxWeight-1 down to 0)
 	currentIndex int // Index within current round's qualifying channels
 }
 
 // newIWRRSchedule creates a new IWRR schedule from a snapshot of weighted channels
-func newIWRRSchedule[V any](channels weightedChannels[V]) Schedule[*weightedChannel[V]] {
+// Channels with weight <= 0 are ignored
+func newIWRRSchedule[V any](channels weightedChannels[V]) *iwrrSchedule[V] {
 	if len(channels) == 0 {
 		return &iwrrSchedule[V]{}
 	}
 
-	// Make a copy to snapshot the channels
-	channelsCopy := make(weightedChannels[V], len(channels))
-	copy(channelsCopy, channels)
-
-	sort.Sort(channelsCopy)
-
-	maxWeight := channelsCopy[len(channelsCopy)-1].weight
+	// Filter out channels with weight <= 0 and copy only the fields we need
+	// This avoids race conditions with the original weightedChannel objects
+	channelsCopy := make([]scheduledChannel[V], 0, len(channels))
 	totalLen := 0
-	for _, ch := range channelsCopy {
-		totalLen += ch.weight
+	for _, ch := range channels {
+		if ch.weight > 0 {
+			channelsCopy = append(channelsCopy, scheduledChannel[V]{
+				weight: ch.weight,
+				c:      ch.c,
+			})
+			totalLen += ch.weight
+		}
 	}
 
+	// Return empty schedule if no valid channels
+	if len(channelsCopy) == 0 {
+		return &iwrrSchedule[V]{}
+	}
+
+	// Sort by weight (ascending)
+	slices.SortFunc(channelsCopy, func(a, b scheduledChannel[V]) int {
+		return a.weight - b.weight
+	})
+
+	maxWeight := channelsCopy[len(channelsCopy)-1].weight
+
 	return &iwrrSchedule[V]{
-		channels:     channelsCopy,
-		maxWeight:    maxWeight,
-		totalLen:     totalLen,
-		currentRound: maxWeight - 1,
-		currentIndex: len(channelsCopy) - 1,
+		channels:  channelsCopy,
+		maxWeight: maxWeight,
+		totalLen:  totalLen,
 	}
 }
 
-// Next returns the next weighted channel in the IWRR schedule
-// The algorithm processes rounds from maxWeight-1 down to 0
-// In each round r, channels with weight > r are included
-// Returns false when the schedule is exhausted (all rounds completed)
-func (s *iwrrSchedule[V]) Next() (*weightedChannel[V], bool) {
+// NewIterator creates a new stateful iterator for this schedule
+func (s *iwrrSchedule[V]) NewIterator() Iterator[chan V] {
 	if len(s.channels) == 0 {
-		return nil, false
+		return &iwrrIterator[V]{schedule: s}
 	}
-
-	// Find the next qualifying channel
-	for {
-		// Find channels that qualify for current round (weight > round)
-		// We iterate from highest weight to lowest
-		for s.currentIndex >= 0 && s.channels[s.currentIndex].weight > s.currentRound {
-			ch := s.channels[s.currentIndex]
-			s.currentIndex--
-			return ch, true
-		}
-
-		// Move to next round
-		s.currentRound--
-		if s.currentRound < 0 {
-			// Schedule exhausted - all rounds completed
-			return nil, false
-		}
-		s.currentIndex = len(s.channels) - 1
+	return &iwrrIterator[V]{
+		schedule:     s,
+		currentRound: s.maxWeight - 1,
+		currentIndex: len(s.channels) - 1,
 	}
 }
 
 // Len returns the total virtual length of the schedule
 func (s *iwrrSchedule[V]) Len() int {
 	return s.totalLen
+}
+
+// TryNext returns the next channel in the IWRR iteration
+// The algorithm processes rounds from maxWeight-1 down to 0
+// In each round r, channels with weight > r are included
+// Returns false when the iteration is exhausted (all rounds completed)
+func (it *iwrrIterator[V]) TryNext() (chan V, bool) {
+	if it.schedule == nil || len(it.schedule.channels) == 0 {
+		return nil, false
+	}
+
+	// Find the next qualifying channel
+	for it.currentRound >= 0 {
+		// Find channels that qualify for current round (weight > round)
+		// We iterate from highest weight to lowest
+		for it.currentIndex >= 0 && it.schedule.channels[it.currentIndex].weight > it.currentRound {
+			ch := it.schedule.channels[it.currentIndex].c
+			it.currentIndex--
+			return ch, true
+		}
+
+		// Move to next round
+		it.currentRound--
+		it.currentIndex = len(it.schedule.channels) - 1
+	}
+	return nil, false
 }

--- a/common/task/iwrr_schedule_test.go
+++ b/common/task/iwrr_schedule_test.go
@@ -1,7 +1,6 @@
 package task
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -13,9 +12,10 @@ func TestIWRRSchedule_Empty(t *testing.T) {
 
 	assert.Equal(t, 0, schedule.Len())
 
-	wc, ok := schedule.Next()
+	iter := schedule.NewIterator()
+	ch, ok := iter.TryNext()
 	assert.False(t, ok)
-	assert.Nil(t, wc)
+	assert.Nil(t, ch)
 }
 
 func TestIWRRSchedule_SingleChannel(t *testing.T) {
@@ -28,18 +28,19 @@ func TestIWRRSchedule_SingleChannel(t *testing.T) {
 	// Total length should be the weight
 	assert.Equal(t, 3, schedule.Len())
 
+	iter := schedule.NewIterator()
+
 	// Should return the channel 3 times
 	for i := 0; i < 3; i++ {
-		wc, ok := schedule.Next()
+		ch, ok := iter.TryNext()
 		assert.True(t, ok, "iteration %d should succeed", i)
-		assert.Equal(t, channels[0].c, wc.c)
-		assert.Equal(t, 3, wc.weight)
+		assert.Equal(t, channels[0].c, ch)
 	}
 
 	// Fourth call should return false (exhausted)
-	wc, ok := schedule.Next()
+	ch, ok := iter.TryNext()
 	assert.False(t, ok)
-	assert.Nil(t, wc)
+	assert.Nil(t, ch)
 }
 
 func TestIWRRSchedule_MultipleChannels_EqualWeights(t *testing.T) {
@@ -53,20 +54,22 @@ func TestIWRRSchedule_MultipleChannels_EqualWeights(t *testing.T) {
 
 	assert.Equal(t, 6, schedule.Len())
 
+	iter := schedule.NewIterator()
+
 	// With equal weights, IWRR should interleave: [2, 1, 0, 2, 1, 0]
 	// (highest index first in each round)
 	expectedOrder := []int{2, 1, 0, 2, 1, 0}
 
 	for i, expectedIdx := range expectedOrder {
-		wc, ok := schedule.Next()
+		ch, ok := iter.TryNext()
 		require.True(t, ok, "iteration %d should succeed", i)
-		assert.Equal(t, channels[expectedIdx].c, wc.c, "iteration %d", i)
+		assert.Equal(t, channels[expectedIdx].c, ch, "iteration %d", i)
 	}
 
 	// Should be exhausted
-	wc, ok := schedule.Next()
+	ch, ok := iter.TryNext()
 	assert.False(t, ok)
-	assert.Nil(t, wc)
+	assert.Nil(t, ch)
 }
 
 func TestIWRRSchedule_MultipleChannels_DifferentWeights(t *testing.T) {
@@ -80,6 +83,8 @@ func TestIWRRSchedule_MultipleChannels_DifferentWeights(t *testing.T) {
 	schedule := newIWRRSchedule[int](channels)
 
 	assert.Equal(t, 6, schedule.Len())
+
+	iter := schedule.NewIterator()
 
 	// IWRR with weights [1, 2, 3] processes rounds from 2 down to 0:
 	// Round 2: channels with weight > 2 → channel 2 (weight 3)
@@ -96,15 +101,15 @@ func TestIWRRSchedule_MultipleChannels_DifferentWeights(t *testing.T) {
 	}
 
 	for i, expectedCh := range expectedSequence {
-		wc, ok := schedule.Next()
+		ch, ok := iter.TryNext()
 		require.True(t, ok, "iteration %d should succeed", i)
-		assert.Equal(t, expectedCh, wc.c, "iteration %d", i)
+		assert.Equal(t, expectedCh, ch, "iteration %d", i)
 	}
 
 	// Should be exhausted
-	wc, ok := schedule.Next()
+	ch, ok := iter.TryNext()
 	assert.False(t, ok)
-	assert.Nil(t, wc)
+	assert.Nil(t, ch)
 }
 
 func TestIWRRSchedule_LargeWeights(t *testing.T) {
@@ -118,15 +123,17 @@ func TestIWRRSchedule_LargeWeights(t *testing.T) {
 
 	assert.Equal(t, 175, schedule.Len())
 
+	iter := schedule.NewIterator()
+
 	// Count how many times each channel appears
 	counts := make(map[chan int]int)
 
 	for {
-		wc, ok := schedule.Next()
+		ch, ok := iter.TryNext()
 		if !ok {
 			break
 		}
-		counts[wc.c]++
+		counts[ch]++
 	}
 
 	assert.Equal(t, 100, counts[channels[0].c], "channel 0 should appear 100 times")
@@ -145,43 +152,39 @@ func TestIWRRSchedule_ChannelWithZeroWeight(t *testing.T) {
 	// Total length should only count non-zero weights
 	assert.Equal(t, 3, schedule.Len())
 
+	iter := schedule.NewIterator()
+
 	// Should only return channel with weight 3
 	for i := 0; i < 3; i++ {
-		wc, ok := schedule.Next()
+		ch, ok := iter.TryNext()
 		require.True(t, ok, "iteration %d", i)
-		assert.Equal(t, channels[1].c, wc.c)
-		assert.Equal(t, 3, wc.weight)
+		assert.Equal(t, channels[1].c, ch)
 	}
 
 	// Should be exhausted
-	wc, ok := schedule.Next()
+	ch, ok := iter.TryNext()
 	assert.False(t, ok)
-	assert.Nil(t, wc)
+	assert.Nil(t, ch)
 }
 
 func TestIWRRSchedule_WeightedChannelFields(t *testing.T) {
-	// Verify that the returned weightedChannel has all fields accessible
-	refCount := atomic.Int32{}
-	refCount.Store(5)
-	lastWrite := atomic.Int64{}
-	lastWrite.Store(12345)
-
+	// Verify that the returned channel is correct
+	// Note: The schedule only stores weight and c internally, and returns only the channel
+	testChan := make(chan int, 10)
 	channels := []*weightedChannel[int]{
 		{
-			weight:        10,
-			c:             make(chan int, 10),
-			refCount:      refCount,
-			lastWriteTime: lastWrite,
+			weight: 10,
+			c:      testChan,
 		},
 	}
 
 	schedule := newIWRRSchedule[int](channels)
 
-	wc, ok := schedule.Next()
+	iter := schedule.NewIterator()
+
+	ch, ok := iter.TryNext()
 	require.True(t, ok)
-	assert.Equal(t, 10, wc.weight)
-	assert.Equal(t, channels[0].c, wc.c)
-	// Note: refCount and lastWriteTime are copied by value in the snapshot
+	assert.Equal(t, testChan, ch)
 }
 
 func TestIWRRSchedule_ExhaustedSchedule_MultipleCallsReturnFalse(t *testing.T) {
@@ -191,16 +194,18 @@ func TestIWRRSchedule_ExhaustedSchedule_MultipleCallsReturnFalse(t *testing.T) {
 
 	schedule := newIWRRSchedule[int](channels)
 
-	// Exhaust the schedule
-	wc, ok := schedule.Next()
+	iter := schedule.NewIterator()
+
+	// Exhaust the iterator
+	ch, ok := iter.TryNext()
 	assert.True(t, ok)
-	assert.NotNil(t, wc)
+	assert.NotNil(t, ch)
 
 	// Multiple calls after exhaustion should all return false
 	for i := 0; i < 5; i++ {
-		wc, ok := schedule.Next()
+		ch, ok := iter.TryNext()
 		assert.False(t, ok, "call %d after exhaustion", i)
-		assert.Nil(t, wc, "call %d after exhaustion", i)
+		assert.Nil(t, ch, "call %d after exhaustion", i)
 	}
 }
 
@@ -216,6 +221,8 @@ func TestIWRRSchedule_Ordering_Weights_5_3_1(t *testing.T) {
 
 	assert.Equal(t, 9, schedule.Len())
 
+	iter := schedule.NewIterator()
+
 	// IWRR pattern for [5, 3, 1]:
 	// Round 4: [0]         (weight 5 > 4)
 	// Round 3: [0]         (weight 5 > 3)
@@ -226,13 +233,48 @@ func TestIWRRSchedule_Ordering_Weights_5_3_1(t *testing.T) {
 	expectedPattern := []int{0, 0, 0, 1, 0, 1, 0, 1, 2}
 
 	for i, expectedIdx := range expectedPattern {
-		wc, ok := schedule.Next()
+		ch, ok := iter.TryNext()
 		require.True(t, ok, "iteration %d", i)
-		assert.Equal(t, channels[expectedIdx].c, wc.c, "iteration %d", i)
+		assert.Equal(t, channels[expectedIdx].c, ch, "iteration %d", i)
 	}
 
 	// Exhausted
-	wc, ok := schedule.Next()
+	ch, ok := iter.TryNext()
 	assert.False(t, ok)
-	assert.Nil(t, wc)
+	assert.Nil(t, ch)
+}
+
+func TestIWRRSchedule_StatelessSchedule_MultipleIterators(t *testing.T) {
+	// Test that the schedule is stateless and can create multiple independent iterators
+	c1 := make(chan int, 10)
+	c2 := make(chan int, 10)
+	channels := []*weightedChannel[int]{
+		{weight: 2, c: c1},
+		{weight: 1, c: c2},
+	}
+
+	schedule := newIWRRSchedule[int](channels)
+
+	// IWRR for weights [2, 1]: [c1, c1, c2]
+	// Create first iterator and consume partially
+	iter1 := schedule.NewIterator()
+	ch1, ok1 := iter1.TryNext()
+	require.True(t, ok1)
+	assert.Equal(t, c1, ch1)
+
+	// Create second iterator - should start from the beginning
+	iter2 := schedule.NewIterator()
+	ch2, ok2 := iter2.TryNext()
+	require.True(t, ok2)
+	assert.Equal(t, c1, ch2, "second iterator should start from beginning")
+
+	// First iterator should continue from where it left off
+	ch1, ok1 = iter1.TryNext()
+	require.True(t, ok1)
+	assert.Equal(t, c1, ch1)
+
+	// Second iterator should be independent and continue its own iteration
+	ch2, ok2 = iter2.TryNext()
+	require.True(t, ok2)
+	assert.Equal(t, c1, ch2)
 }

--- a/common/task/weighted_channel_pool.go
+++ b/common/task/weighted_channel_pool.go
@@ -64,7 +64,7 @@ type (
 		channelMap              map[K]*weightedChannel[V]
 
 		// a snapshot of the channels to be used for the IWRR schedule
-		iwrrSchedule atomic.Value // weightedChannels[V]
+		iwrrSchedule atomic.Value // Schedule[chan V]
 	}
 )
 
@@ -84,7 +84,7 @@ func NewWeightedRoundRobinChannelPool[K comparable, V any](
 		shutdownCh:              make(chan struct{}),
 	}
 	// Initialize with empty channels
-	wrr.iwrrSchedule.Store(weightedChannels[V]{})
+	wrr.iwrrSchedule.Store(newIWRRSchedule[V](nil))
 	return wrr
 }
 
@@ -195,8 +195,8 @@ func (p *WeightedRoundRobinChannelPool[K, V]) GetAllChannels() []chan V {
 	return allChannels
 }
 
-func (p *WeightedRoundRobinChannelPool[K, V]) GetSchedule() Schedule[*weightedChannel[V]] {
-	return newIWRRSchedule[V](p.iwrrSchedule.Load().(weightedChannels[V]))
+func (p *WeightedRoundRobinChannelPool[K, V]) GetSchedule() Schedule[chan V] {
+	return p.iwrrSchedule.Load().(Schedule[chan V])
 }
 
 func (p *WeightedRoundRobinChannelPool[K, V]) updateScheduleLocked() {
@@ -207,10 +207,10 @@ func (p *WeightedRoundRobinChannelPool[K, V]) updateScheduleLocked() {
 	}
 
 	// Create efficient schedule from snapshot
-	p.iwrrSchedule.Store(orderedChannels)
+	p.iwrrSchedule.Store(newIWRRSchedule[V](orderedChannels))
 
 	// Update memory gauge - now only stores channel references once, not weight times
-	memoryBytes := len(p.channelMap) * 28 // channel map entries
+	memoryBytes := len(p.channelMap) * 16 // channel map entries
 	p.metricsScope.UpdateGauge(metrics.WeightedChannelPoolSizeGauge, float64(memoryBytes))
 }
 

--- a/common/task/weighted_channel_pool_test.go
+++ b/common/task/weighted_channel_pool_test.go
@@ -128,12 +128,14 @@ func TestGetSchedule(t *testing.T) {
 	schedule := pool.GetSchedule()
 	assert.Equal(t, 6, schedule.Len())
 
+	iter1 := schedule.NewIterator()
+
 	// Verify IWRR sequence: [c3, c3, c2, c3, c2, c1]
 	expectedSequence1 := []chan int{c3, c3, c2, c3, c2, c1}
 	for _, expected := range expectedSequence1 {
-		wc, ok := schedule.Next()
+		ch, ok := iter1.TryNext()
 		assert.True(t, ok)
-		assert.Equal(t, expected, wc.c)
+		assert.Equal(t, expected, ch)
 	}
 
 	c4, releaseFn4 := pool.GetOrCreateChannel("k2", 4)
@@ -142,12 +144,14 @@ func TestGetSchedule(t *testing.T) {
 	schedule = pool.GetSchedule()
 	assert.Equal(t, 8, schedule.Len())
 
+	iter2 := schedule.NewIterator()
+
 	// Verify IWRR sequence after weight change: [c2, c2, c3, c2, c3, c2, c3, c1]
 	expectedSequence2 := []chan int{c2, c2, c3, c2, c3, c2, c3, c1}
 	for _, expected := range expectedSequence2 {
-		wc, ok := schedule.Next()
+		ch, ok := iter2.TryNext()
 		assert.True(t, ok)
-		assert.Equal(t, expected, wc.c)
+		assert.Equal(t, expected, ch)
 	}
 }
 

--- a/common/task/weighted_round_robin_task_scheduler.go
+++ b/common/task/weighted_round_robin_task_scheduler.go
@@ -191,16 +191,12 @@ func (w *weightedRoundRobinTaskSchedulerImpl[K]) dispatchTasks() {
 		hasTask = false
 		schedule := w.pool.GetSchedule()
 
-		// Iterate through the schedule using Next()
-		for {
-			wc, ok := schedule.Next()
-			if !ok {
-				// Schedule exhausted
-				break
-			}
-
+		// Create a new iterator for this dispatch cycle
+		iter := schedule.NewIterator()
+		// Iterate through the schedule using the iterator
+		for ch, ok := iter.TryNext(); ok; ch, ok = iter.TryNext() {
 			select {
-			case task := <-wc.c:
+			case task := <-ch:
 				hasTask = true
 				if err := w.processor.Submit(task); err != nil {
 					w.logger.Error("fail to submit task to processor", tag.Error(err))


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
  Replace materialized schedule slice with on-demand virtual schedule                                                                                                                                                           
  interface to dramatically reduce memory usage in weighted round-robin                                                                                                                                                       
  scheduling.

  Key changes:
  - Add Schedule[V] interface with NewIterator() and Len() methods
  - Add Iterator[V] interface with TryNext() method
  - Implement iwrrSchedule[V] and iwrrIterator[V] that computes next channel on-demand without
    materializing entire schedule in memory
  - Update WeightedRoundRobinTaskScheduler.dispatchTasks() to use
    Schedule interface
  - Add comprehensive unit tests for iwrrSchedule implementation

It will make it easier for us to implement a new scheduler required by https://github.com/cadence-workflow/cadence/issues/7724

**Why?**
  - Dramatically reduced memory footprint for high-weight scenarios
  - Cleaner separation of concerns (Schedule is abstracted from weighted channel pool)
  - Maintains IWRR algorithm correctness with comprehensive test coverage

  Memory improvements:
  - Before: stored N channel references where N = sum of all weights
    Example: weights [100,50,25] = 175 * 8 = 1400 bytes
  - After: stores each channel reference once with iteration state
    Example: weights [100,50,25] = 3 * 16 + 40 = 84 bytes
  - Result: ~94% memory reduction, scales with weight magnitude

**How did you test it?**
```
cd common/task && go test ./... -race
```

**Potential risks**
The history task scheduler may be broken causing Cadence to be down completely, if there is an uncaught bug.

**Release notes**
N/A

**Documentation Changes**
N/A

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
