### PR TITLE
feat: Add MySQL support for Domain Audit Log

### DIFF
--- a/common/persistence/sql/sqlplugin/mysql/domain_audit_log.go
+++ b/common/persistence/sql/sqlplugin/mysql/domain_audit_log.go
@@ -23,20 +23,80 @@ package mysql
 import (
 	"context"
 	"database/sql"
-	"errors"
 
 	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
 )
 
+const (
+	_insertDomainAuditLogQuery = `INSERT INTO domain_audit_log (
+		domain_id, event_id, state_before, state_before_encoding, state_after, state_after_encoding,
+		operation_type, created_time, last_updated_time, identity, identity_type, comment
+	) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+
+	_selectDomainAuditLogsQuery = `SELECT
+		event_id, domain_id, state_before, state_before_encoding, state_after, state_after_encoding,
+		operation_type, created_time, last_updated_time, identity, identity_type, comment
+	FROM domain_audit_log
+	WHERE domain_id = ? AND operation_type = ? AND created_time >= ?
+	AND (created_time < ? OR (created_time = ? AND event_id > ?))
+	ORDER BY created_time DESC, event_id ASC
+	LIMIT ?`
+	_selectAllDomainAuditLogsQuery = `SELECT
+		event_id, domain_id, state_before, state_before_encoding, state_after, state_after_encoding,
+		operation_type, created_time, last_updated_time, identity, identity_type, comment
+	FROM domain_audit_log
+	WHERE domain_id = ? AND operation_type = ? AND created_time >= ?
+	AND (created_time < ? OR (created_time = ? AND event_id > ?))
+	ORDER BY created_time DESC, event_id ASC`
+)
+
 // InsertIntoDomainAuditLog inserts a single row into domain_audit_log table
 func (mdb *DB) InsertIntoDomainAuditLog(ctx context.Context, row *sqlplugin.DomainAuditLogRow) (sql.Result, error) {
-	return nil, errors.New("not implemented")
+	return mdb.driver.ExecContext(
+		ctx,
+		sqlplugin.DbDefaultShard,
+		_insertDomainAuditLogQuery,
+		row.DomainID,
+		row.EventID,
+		row.StateBefore,
+		row.StateBeforeEncoding,
+		row.StateAfter,
+		row.StateAfterEncoding,
+		row.OperationType,
+		row.CreatedTime,
+		row.LastUpdatedTime,
+		row.Identity,
+		row.IdentityType,
+		row.Comment,
+	)
 }
 
-// SelectFromDomainAuditLogs returns audit log entries for a domain, operation type, and time range (optional)
+// SelectFromDomainAuditLogs returns audit log entries for a domain, operation type, and time range
 func (mdb *DB) SelectFromDomainAuditLogs(
 	ctx context.Context,
 	filter *sqlplugin.DomainAuditLogFilter,
 ) ([]*sqlplugin.DomainAuditLogRow, error) {
-	return nil, errors.New("not implemented")
+	args := []interface{}{
+		filter.DomainID,
+		filter.OperationType,
+		*filter.MinCreatedTime,
+		*filter.PageMaxCreatedTime,
+		*filter.PageMaxCreatedTime,
+		*filter.PageMinEventID,
+	}
+
+	var rows []*sqlplugin.DomainAuditLogRow
+	if filter.PageSize > 0 {
+		args = append(args, filter.PageSize)
+		err := mdb.driver.SelectContext(ctx, sqlplugin.DbDefaultShard, &rows, _selectDomainAuditLogsQuery, args...)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err := mdb.driver.SelectContext(ctx, sqlplugin.DbDefaultShard, &rows, _selectAllDomainAuditLogsQuery, args...)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return rows, nil
 }

--- a/common/persistence/sql/sqlplugin/mysql/domain_audit_log_test.go
+++ b/common/persistence/sql/sqlplugin/mysql/domain_audit_log_test.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package mysql
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+
+	"github.com/uber/cadence/common/constants"
+	"github.com/uber/cadence/common/persistence"
+	"github.com/uber/cadence/common/persistence/sql/sqldriver"
+	"github.com/uber/cadence/common/persistence/sql/sqlplugin"
+)
+
+func TestInsertIntoDomainAuditLog(t *testing.T) {
+	now := time.Now().UTC()
+
+	tests := []struct {
+		name      string
+		row       *sqlplugin.DomainAuditLogRow
+		mockSetup func(*sqldriver.MockDriver)
+		wantErr   bool
+	}{
+		{
+			name: "successfully inserted",
+			row: &sqlplugin.DomainAuditLogRow{
+				DomainID:            uuid.New(),
+				EventID:             uuid.New(),
+				StateBefore:         []byte("state-before"),
+				StateBeforeEncoding: constants.EncodingTypeJSON,
+				StateAfter:          []byte("state-after"),
+				StateAfterEncoding:  constants.EncodingTypeJSON,
+				OperationType:       persistence.DomainAuditOperationTypeFailover,
+				CreatedTime:         now,
+				LastUpdatedTime:     now,
+				Identity:            "test-identity",
+				IdentityType:        "user",
+				Comment:             "test comment",
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					sqlplugin.DbDefaultShard,
+					_insertDomainAuditLogQuery,
+					gomock.Any(),
+					gomock.Any(),
+					[]byte("state-before"),
+					constants.EncodingTypeJSON,
+					[]byte("state-after"),
+					constants.EncodingTypeJSON,
+					persistence.DomainAuditOperationTypeFailover,
+					now,
+					now,
+					"test-identity",
+					"user",
+					"test comment",
+				).Return(nil, nil)
+			},
+			wantErr: false,
+		},
+		{
+			name: "exec failed",
+			row: &sqlplugin.DomainAuditLogRow{
+				DomainID:      uuid.New(),
+				EventID:       uuid.New(),
+				OperationType: persistence.DomainAuditOperationTypeFailover,
+				CreatedTime:   now,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().ExecContext(
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+					gomock.Any(),
+				).Return(nil, errors.New("exec failed"))
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := &DB{
+				driver:    mockDriver,
+				converter: &converter{},
+			}
+
+			_, err := mdb.InsertIntoDomainAuditLog(context.Background(), tc.row)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSelectFromDomainAuditLogs(t *testing.T) {
+	domainID := "d1111111-1111-1111-1111-111111111111"
+	operationType := persistence.DomainAuditOperationTypeFailover
+	minTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	maxTime := time.Date(2024, 12, 31, 23, 59, 59, 0, time.UTC)
+
+	// Create times in descending order
+	createdTime1 := time.Date(2024, 7, 1, 12, 0, 0, 0, time.UTC)
+	createdTime2 := time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)
+	createdTime3 := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+	createdTime4 := time.Date(2024, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	eventID1 := "e1111111-1111-1111-1111-111111111111"
+	eventID2 := "e2222222-2222-2222-2222-222222222222"
+	eventID3 := "e3333333-3333-3333-3333-333333333333"
+	eventID4 := "e4444444-4444-4444-4444-444444444444"
+
+	// Default page cursor: maxCreatedTime with max UUID (no page token)
+	defaultPageMaxCreatedTime := maxTime
+	defaultPageMinEventID := "ffffffff-ffff-ffff-ffff-ffffffffffff"
+
+	tests := []struct {
+		name      string
+		filter    *sqlplugin.DomainAuditLogFilter
+		mockSetup func(*sqldriver.MockDriver)
+		wantRows  []*sqlplugin.DomainAuditLogRow
+		wantErr   bool
+	}{
+		{
+			name: "pageSize limits number of results; no pageToken",
+			filter: &sqlplugin.DomainAuditLogFilter{
+				DomainID:           domainID,
+				OperationType:      operationType,
+				MinCreatedTime:     &minTime,
+				PageSize:           2,
+				PageMaxCreatedTime: &defaultPageMaxCreatedTime,
+				PageMinEventID:     &defaultPageMinEventID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().SelectContext(
+					gomock.Any(),
+					sqlplugin.DbDefaultShard,
+					gomock.Any(),
+					_selectDomainAuditLogsQuery,
+					domainID, operationType, minTime, defaultPageMaxCreatedTime, defaultPageMaxCreatedTime, defaultPageMinEventID, 2,
+				).DoAndReturn(func(ctx context.Context, shardID int, dest interface{}, query string, args ...interface{}) error {
+					rows := dest.(*[]*sqlplugin.DomainAuditLogRow)
+					*rows = []*sqlplugin.DomainAuditLogRow{
+						{
+							EventID:       eventID1,
+							DomainID:      domainID,
+							CreatedTime:   createdTime1,
+							OperationType: operationType,
+						},
+						{
+							EventID:       eventID2,
+							DomainID:      domainID,
+							CreatedTime:   createdTime2,
+							OperationType: operationType,
+						},
+					}
+					return nil
+				})
+			},
+			wantRows: []*sqlplugin.DomainAuditLogRow{
+				{
+					EventID:       eventID1,
+					DomainID:      domainID,
+					CreatedTime:   createdTime1,
+					OperationType: operationType,
+				},
+				{
+					EventID:       eventID2,
+					DomainID:      domainID,
+					CreatedTime:   createdTime2,
+					OperationType: operationType,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "pageToken filters results by createdTime and eventID; pageSize is 0",
+			filter: &sqlplugin.DomainAuditLogFilter{
+				DomainID:           domainID,
+				OperationType:      operationType,
+				MinCreatedTime:     &minTime,
+				PageSize:           0,
+				PageMaxCreatedTime: &createdTime2,
+				PageMinEventID:     &eventID2,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().SelectContext(
+					gomock.Any(),
+					sqlplugin.DbDefaultShard,
+					gomock.Any(),
+					_selectAllDomainAuditLogsQuery,
+					domainID, operationType, minTime, createdTime2, createdTime2, eventID2,
+				).DoAndReturn(func(ctx context.Context, shardID int, dest interface{}, query string, args ...interface{}) error {
+					rows := dest.(*[]*sqlplugin.DomainAuditLogRow)
+					*rows = []*sqlplugin.DomainAuditLogRow{
+						{
+							EventID:       eventID3,
+							DomainID:      domainID,
+							CreatedTime:   createdTime3,
+							OperationType: operationType,
+						},
+						{
+							EventID:       eventID4,
+							DomainID:      domainID,
+							CreatedTime:   createdTime4,
+							OperationType: operationType,
+						},
+					}
+					return nil
+				})
+			},
+			wantRows: []*sqlplugin.DomainAuditLogRow{
+				{
+					EventID:       eventID3,
+					DomainID:      domainID,
+					CreatedTime:   createdTime3,
+					OperationType: operationType,
+				},
+				{
+					EventID:       eventID4,
+					DomainID:      domainID,
+					CreatedTime:   createdTime4,
+					OperationType: operationType,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "success with no results",
+			filter: &sqlplugin.DomainAuditLogFilter{
+				DomainID:           domainID,
+				OperationType:      operationType,
+				MinCreatedTime:     &minTime,
+				PageMaxCreatedTime: &defaultPageMaxCreatedTime,
+				PageMinEventID:     &defaultPageMinEventID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().SelectContext(
+					gomock.Any(),
+					sqlplugin.DbDefaultShard,
+					gomock.Any(),
+					_selectAllDomainAuditLogsQuery,
+					domainID, operationType, minTime, defaultPageMaxCreatedTime, defaultPageMaxCreatedTime, defaultPageMinEventID,
+				).DoAndReturn(func(ctx context.Context, shardID int, dest interface{}, query string, args ...interface{}) error {
+					return nil
+				})
+			},
+			wantRows: []*sqlplugin.DomainAuditLogRow{},
+			wantErr:  false,
+		},
+		{
+			name: "error when select fails",
+			filter: &sqlplugin.DomainAuditLogFilter{
+				DomainID:           domainID,
+				OperationType:      operationType,
+				MinCreatedTime:     &minTime,
+				PageMaxCreatedTime: &defaultPageMaxCreatedTime,
+				PageMinEventID:     &defaultPageMinEventID,
+			},
+			mockSetup: func(mockDriver *sqldriver.MockDriver) {
+				mockDriver.EXPECT().SelectContext(
+					gomock.Any(),
+					sqlplugin.DbDefaultShard,
+					gomock.Any(),
+					_selectAllDomainAuditLogsQuery,
+					domainID, operationType, minTime, defaultPageMaxCreatedTime, defaultPageMaxCreatedTime, defaultPageMinEventID,
+				).Return(errors.New("select failed"))
+			},
+			wantRows: nil,
+			wantErr:  true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+
+			mockDriver := sqldriver.NewMockDriver(ctrl)
+			tc.mockSetup(mockDriver)
+
+			mdb := &DB{
+				driver:    mockDriver,
+				converter: &converter{},
+			}
+
+			rows, err := mdb.SelectFromDomainAuditLogs(context.Background(), tc.filter)
+
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, len(tc.wantRows), len(rows), "number of rows should match")
+
+			for i, wantRow := range tc.wantRows {
+				if i < len(rows) {
+					assert.Equal(t, wantRow.EventID, rows[i].EventID, "row %d eventID", i)
+					assert.Equal(t, wantRow.DomainID, rows[i].DomainID, "row %d domainID", i)
+					assert.Equal(t, wantRow.OperationType, rows[i].OperationType, "row %d operationType", i)
+					assert.Equal(t, wantRow.CreatedTime.Unix(), rows[i].CreatedTime.Unix(), "row %d createdTime", i)
+				}
+			}
+		})
+	}
+}

--- a/host/persistence/mysql/mysql_persistence_test.go
+++ b/host/persistence/mysql/mysql_persistence_test.go
@@ -132,3 +132,13 @@ func TestMySQLConfigPersistence(t *testing.T) {
 	s.TestBase.Setup()
 	suite.Run(t, s)
 }
+
+func TestMySQLDomainAuditPersistence(t *testing.T) {
+	testflags.RequireMySQL(t)
+	s := new(pt.DomainAuditPersistenceSuite)
+	option, err := mysql.GetTestClusterOption()
+	assert.NoError(t, err)
+	s.TestBase = pt.NewTestBaseWithSQL(t, option)
+	s.TestBase.Setup()
+	suite.Run(t, s)
+}

--- a/schema/mysql/v8/cadence/schema.sql
+++ b/schema/mysql/v8/cadence/schema.sql
@@ -275,3 +275,20 @@ CREATE TABLE cluster_config (
   data_encoding  VARCHAR(16) NOT NULL,
   PRIMARY KEY (row_type, version)
 );
+
+CREATE TABLE domain_audit_log (
+  domain_id               VARCHAR(255) NOT NULL,
+  event_id                VARCHAR(255) NOT NULL,
+  --
+  state_before            BLOB NOT NULL,
+  state_before_encoding   VARCHAR(16) NOT NULL,
+  state_after             BLOB NOT NULL,
+  state_after_encoding    VARCHAR(16) NOT NULL,
+  operation_type          INT NOT NULL,
+  created_time            DATETIME(6) NOT NULL,
+  last_updated_time       DATETIME(6) NOT NULL,
+  identity                VARCHAR(255) NOT NULL,
+  identity_type           VARCHAR(255) NOT NULL,
+  comment                 VARCHAR(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (domain_id, operation_type, created_time, event_id)
+);

--- a/schema/mysql/v8/cadence/versioned/v0.7/domain_audit_log.sql
+++ b/schema/mysql/v8/cadence/versioned/v0.7/domain_audit_log.sql
@@ -1,0 +1,16 @@
+CREATE TABLE domain_audit_log (
+  domain_id               VARCHAR(255) NOT NULL,
+  event_id                VARCHAR(255) NOT NULL,
+  --
+  state_before            BLOB NOT NULL,
+  state_before_encoding   VARCHAR(16) NOT NULL,
+  state_after             BLOB NOT NULL,
+  state_after_encoding    VARCHAR(16) NOT NULL,
+  operation_type          INT NOT NULL,
+  created_time            DATETIME(6) NOT NULL,
+  last_updated_time       DATETIME(6) NOT NULL,
+  identity                VARCHAR(255) NOT NULL,
+  identity_type           VARCHAR(255) NOT NULL,
+  comment                 VARCHAR(255) NOT NULL DEFAULT '',
+  PRIMARY KEY (domain_id, operation_type, created_time, event_id)
+);

--- a/schema/mysql/v8/cadence/versioned/v0.7/manifest.json
+++ b/schema/mysql/v8/cadence/versioned/v0.7/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.7",
+  "MinCompatibleVersion": "0.7",
+  "Description": "create domain audit log table",
+  "SchemaUpdateCqlFiles": [
+    "domain_audit_log.sql"
+  ]
+}

--- a/schema/mysql/version.go
+++ b/schema/mysql/version.go
@@ -23,7 +23,7 @@ package mysql
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the MySQL database release version
-const Version = "0.6"
+const Version = "0.7"
 
 // VisibilityVersion is the MySQL visibility database release version
 const VisibilityVersion = "0.8"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -129,7 +129,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err = readSchemaDir(fsys, "0.3", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.4", "v0.5", "v0.6"}, ans)
+	s.Equal([]string{"v0.4", "v0.5", "v0.6", "v0.7"}, ans)
 
 	fsys, err = fs.Sub(mysql.SchemaFS, "v8/visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added MySQL support for DomainAudit.

- Created domain_audit_log table in MySQL schema
- Implemented InsertIntoDomainAuditLog and SelectFromDomainAuditLogs functions in MySQL

Fixes: #7603

**Why?**
DomainAudit allows all modifications made to a domain (e.g failovers) to be stored and retrieved. This has previously only been supported by NoSQL databases (Cassandra, MongoDB, DynamoDB) and PostgreSQL. MySQL support for DomainAudit is now added.

**How did you test it?**
- Unit tests: `go test ./common/persistence/sql/sqlplugin/mysql/ -run "TestInsertIntoDomainAuditLog|TestSelectFromDomainAuditLogs"`
- Integration tests: Ran `TestMySQLDomainAuditPersistence` on github actions

**Potential risks**
- MySQL schema is updated with a new table; it can be rolled back with MySQL database release version

**Release notes**
MySQL support is added for domain audit

**Documentation Changes**
N/A

---

**Detailed Description**
Added MySQL support for DomainAudit.

- Created domain_audit_log table in MySQL schema
- Implemented InsertIntoDomainAuditLog and SelectFromDomainAuditLogs functions in MySQL

**Impact Analysis**
- **Backward Compatibility**: MySQL support is integrated with existing domain audit logic
- **Forward Compatibility**: Does not change existing logic

**Testing Plan**
- **Unit Tests**: `go test ./common/persistence/sql/sqlplugin/mysql/ -run "TestInsertIntoDomainAuditLog|TestSelectFromDomainAuditLogs"`
- **Persistence Tests**: Ran `TestMySQLDomainAuditPersistence` on github actions
- **Integration Tests**: [Do we have integration test covering the change?]
- **Compatibility Tests**: [Have we done tests to test the backward and forward compatibility?]

**Rollout Plan**
- What is the rollout plan?
- Does the order of deployment matter?
- Is it safe to rollback? Does the order of rollback matter? MySQL schema is updated with a new table; it can be rolled back with MySQL database release version
- Is there a kill switch to mitigate the impact immediately?
---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
