### PR TITLE
feat(shard-manager): Add host tag to executor client metric

### DIFF
--- a/service/sharddistributor/client/executorclient/client.go
+++ b/service/sharddistributor/client/executorclient/client.go
@@ -3,6 +3,7 @@ package executorclient
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/google/uuid"
 	"github.com/uber-go/tally"
@@ -119,9 +120,18 @@ func newExecutorWithConfig[SP ShardProcessor](params Params[SP], namespaceConfig
 	// TODO: get executor ID from environment
 	executorID := uuid.New().String()
 
+	hostname, err := os.Hostname()
+	if err != nil {
+		return nil, fmt.Errorf("get hostname: %w", err)
+	}
+
 	metricsScope := params.MetricsScope.Tagged(map[string]string{
 		metrics.OperationTagName: metricsconstants.ShardDistributorExecutorOperationTagName,
 		"namespace":              namespaceConfig.Namespace,
+	})
+
+	hostMetricsScope := metricsScope.Tagged(map[string]string{
+		"host": hostname,
 	})
 
 	executor := &executorImpl[SP]{
@@ -135,6 +145,7 @@ func newExecutorWithConfig[SP ShardProcessor](params Params[SP], namespaceConfig
 		timeSource:             params.TimeSource,
 		stopC:                  make(chan struct{}),
 		metrics:                metricsScope,
+		hostMetrics:            hostMetricsScope,
 		metadata: syncExecutorMetadata{
 			data: params.Metadata,
 		},

--- a/service/sharddistributor/client/executorclient/clientimpl.go
+++ b/service/sharddistributor/client/executorclient/clientimpl.go
@@ -107,6 +107,7 @@ type executorImpl[SP ShardProcessor] struct {
 	processLoopWG          sync.WaitGroup
 	assignmentMutex        sync.Mutex
 	metrics                tally.Scope
+	hostMetrics            tally.Scope
 	migrationMode          atomic.Int32
 	metadata               syncExecutorMetadata
 	drainObserver          clientcommon.DrainSignalObserver
@@ -361,7 +362,7 @@ func (e *executorImpl[SP]) sendHeartbeat(ctx context.Context, status types.Execu
 		return true
 	})
 
-	e.metrics.Gauge(metricsconstants.ShardDistributorExecutorOwnedShards).Update(float64(len(shardStatusReports)))
+	e.hostMetrics.Gauge(metricsconstants.ShardDistributorExecutorOwnedShards).Update(float64(len(shardStatusReports)))
 
 	// Create the request
 	request := &types.ExecutorHeartbeatRequest{

--- a/service/sharddistributor/client/executorclient/clientimpl_test.go
+++ b/service/sharddistributor/client/executorclient/clientimpl_test.go
@@ -81,6 +81,7 @@ func newTestExecutor(
 	return &executorImpl[*MockShardProcessor]{
 		logger:                 log.NewNoop(),
 		metrics:                tally.NoopScope,
+		hostMetrics:            tally.NoopScope,
 		shardDistributorClient: client,
 		shardProcessorFactory:  factory,
 		namespace:              "test-namespace",


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Added a host tag to the `shard_distributor_executor_owned_shards` gauge metric so that each executor instance reports which host it is running on alongside how many shards it owns.
- Resolved the hostname via os.Hostname() once at executor construction time in newExecutorWithConfig
- Created a separate hostMetrics scope - tagged with host, and used exclusively for the owned shards gauge
- Other executor metrics continue to use the untagged scope to avoid unnecessary cardinality increase

**Why?**
Without the host tag, the shard_distributor_executor_owned_shards gauge aggregates across all executor instances, making it impossible to tell how shards are distributed per host.

**How did you test it?**
Unit tests with `go test -v ./service/sharddistributor/client/executorclient `

**Potential risks**
Adding the host tag increase the cardinality 

**Release notes**
Added host tag for `shard_distributor_executor_owned_shards` gauge metric 

**Documentation Changes**
Executor client metric `shard_distributor_executor_owned_shards` gauge metric includes a host tag to enable per-host visibility of shard ownership.

---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
