### PR TITLE
feat: [Cadence Schedules] Add proto mappers for schedule state and info types

### DIFF
--- a/common/types/mapper/proto/schedule.go
+++ b/common/types/mapper/proto/schedule.go
@@ -189,3 +189,169 @@ func ToSchedulePolicies(t *apiv1.SchedulePolicies) *types.SchedulePolicies {
 		ConcurrencyLimit: t.ConcurrencyLimit,
 	}
 }
+
+// --- State/info type mappers ---
+
+func FromSchedulePauseInfo(t *types.SchedulePauseInfo) *apiv1.SchedulePauseInfo {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.SchedulePauseInfo{
+		Reason:   t.Reason,
+		PausedAt: timeToTimestamp(&t.PausedAt),
+		PausedBy: t.PausedBy,
+	}
+}
+
+func ToSchedulePauseInfo(t *apiv1.SchedulePauseInfo) *types.SchedulePauseInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.SchedulePauseInfo{
+		Reason:   t.Reason,
+		PausedAt: timestampToTimeVal(t.PausedAt),
+		PausedBy: t.PausedBy,
+	}
+}
+
+func FromScheduleState(t *types.ScheduleState) *apiv1.ScheduleState {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.ScheduleState{
+		Paused:    t.Paused,
+		PauseInfo: FromSchedulePauseInfo(t.PauseInfo),
+	}
+}
+
+func ToScheduleState(t *apiv1.ScheduleState) *types.ScheduleState {
+	if t == nil {
+		return nil
+	}
+	return &types.ScheduleState{
+		Paused:    t.Paused,
+		PauseInfo: ToSchedulePauseInfo(t.PauseInfo),
+	}
+}
+
+func FromBackfillInfo(t *types.BackfillInfo) *apiv1.BackfillInfo {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.BackfillInfo{
+		BackfillId:    t.BackfillID,
+		StartTime:     timeToTimestamp(&t.StartTime),
+		EndTime:       timeToTimestamp(&t.EndTime),
+		RunsCompleted: t.RunsCompleted,
+		RunsTotal:     t.RunsTotal,
+	}
+}
+
+func ToBackfillInfo(t *apiv1.BackfillInfo) *types.BackfillInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.BackfillInfo{
+		BackfillID:    t.BackfillId,
+		StartTime:     timestampToTimeVal(t.StartTime),
+		EndTime:       timestampToTimeVal(t.EndTime),
+		RunsCompleted: t.RunsCompleted,
+		RunsTotal:     t.RunsTotal,
+	}
+}
+
+func FromBackfillInfoArray(t []*types.BackfillInfo) []*apiv1.BackfillInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*apiv1.BackfillInfo, len(t))
+	for i := range t {
+		v[i] = FromBackfillInfo(t[i])
+	}
+	return v
+}
+
+func ToBackfillInfoArray(t []*apiv1.BackfillInfo) []*types.BackfillInfo {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.BackfillInfo, len(t))
+	for i := range t {
+		v[i] = ToBackfillInfo(t[i])
+	}
+	return v
+}
+
+func FromScheduleInfo(t *types.ScheduleInfo) *apiv1.ScheduleInfo {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.ScheduleInfo{
+		LastRunTime:      timeToTimestamp(&t.LastRunTime),
+		NextRunTime:      timeToTimestamp(&t.NextRunTime),
+		TotalRuns:        t.TotalRuns,
+		CreateTime:       timeToTimestamp(&t.CreateTime),
+		LastUpdateTime:   timeToTimestamp(&t.LastUpdateTime),
+		OngoingBackfills: FromBackfillInfoArray(t.OngoingBackfills),
+	}
+}
+
+func ToScheduleInfo(t *apiv1.ScheduleInfo) *types.ScheduleInfo {
+	if t == nil {
+		return nil
+	}
+	return &types.ScheduleInfo{
+		LastRunTime:      timestampToTimeVal(t.LastRunTime),
+		NextRunTime:      timestampToTimeVal(t.NextRunTime),
+		TotalRuns:        t.TotalRuns,
+		CreateTime:       timestampToTimeVal(t.CreateTime),
+		LastUpdateTime:   timestampToTimeVal(t.LastUpdateTime),
+		OngoingBackfills: ToBackfillInfoArray(t.OngoingBackfills),
+	}
+}
+
+func FromScheduleListEntry(t *types.ScheduleListEntry) *apiv1.ScheduleListEntry {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.ScheduleListEntry{
+		ScheduleId:     t.ScheduleID,
+		WorkflowType:   FromWorkflowType(t.WorkflowType),
+		State:          FromScheduleState(t.State),
+		CronExpression: t.CronExpression,
+	}
+}
+
+func ToScheduleListEntry(t *apiv1.ScheduleListEntry) *types.ScheduleListEntry {
+	if t == nil {
+		return nil
+	}
+	return &types.ScheduleListEntry{
+		ScheduleID:     t.ScheduleId,
+		WorkflowType:   ToWorkflowType(t.WorkflowType),
+		State:          ToScheduleState(t.State),
+		CronExpression: t.CronExpression,
+	}
+}
+
+func FromScheduleListEntryArray(t []*types.ScheduleListEntry) []*apiv1.ScheduleListEntry {
+	if t == nil {
+		return nil
+	}
+	v := make([]*apiv1.ScheduleListEntry, len(t))
+	for i := range t {
+		v[i] = FromScheduleListEntry(t[i])
+	}
+	return v
+}
+
+func ToScheduleListEntryArray(t []*apiv1.ScheduleListEntry) []*types.ScheduleListEntry {
+	if t == nil {
+		return nil
+	}
+	v := make([]*types.ScheduleListEntry, len(t))
+	for i := range t {
+		v[i] = ToScheduleListEntry(t[i])
+	}
+	return v
+}

--- a/common/types/mapper/proto/schedule_test.go
+++ b/common/types/mapper/proto/schedule_test.go
@@ -56,6 +56,36 @@ func TestSchedulePolicies(t *testing.T) {
 	}
 }
 
+func TestSchedulePauseInfo(t *testing.T) {
+	for _, item := range []*types.SchedulePauseInfo{nil, {}, &testdata.SchedulePauseInfo} {
+		assert.Equal(t, item, ToSchedulePauseInfo(FromSchedulePauseInfo(item)))
+	}
+}
+
+func TestScheduleState(t *testing.T) {
+	for _, item := range []*types.ScheduleState{nil, {}, &testdata.ScheduleState} {
+		assert.Equal(t, item, ToScheduleState(FromScheduleState(item)))
+	}
+}
+
+func TestBackfillInfo(t *testing.T) {
+	for _, item := range []*types.BackfillInfo{nil, {}, &testdata.ScheduleBackfillInfo} {
+		assert.Equal(t, item, ToBackfillInfo(FromBackfillInfo(item)))
+	}
+}
+
+func TestScheduleInfo(t *testing.T) {
+	for _, item := range []*types.ScheduleInfo{nil, {}, &testdata.ScheduleInfo} {
+		assert.Equal(t, item, ToScheduleInfo(FromScheduleInfo(item)))
+	}
+}
+
+func TestScheduleListEntry(t *testing.T) {
+	for _, item := range []*types.ScheduleListEntry{nil, {}, &testdata.ScheduleListEntry} {
+		assert.Equal(t, item, ToScheduleListEntry(FromScheduleListEntry(item)))
+	}
+}
+
 func scheduleFuzzer(f *fuzz.Fuzzer) *fuzz.Fuzzer {
 	return f.Funcs(
 		func(t *time.Time, c fuzz.Continue) {
@@ -150,6 +180,96 @@ func TestSchedulePoliciesFuzz(t *testing.T) {
 			return "nil"
 		}
 		if orig.OverlapPolicy == 0 && orig.CatchUpPolicy == 0 && orig.CatchUpWindow == 0 && !orig.PauseOnFailure {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestSchedulePauseInfoFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.SchedulePauseInfo
+		fuzzer.Fuzz(&orig)
+		out := ToSchedulePauseInfo(FromSchedulePauseInfo(orig))
+		assert.Equal(t, orig, out, "SchedulePauseInfo did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Reason == "" && orig.PausedAt.IsZero() && orig.PausedBy == "" {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestScheduleStateFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.ScheduleState
+		fuzzer.Fuzz(&orig)
+		out := ToScheduleState(FromScheduleState(orig))
+		assert.Equal(t, orig, out, "ScheduleState did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if !orig.Paused && orig.PauseInfo == nil {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestBackfillInfoFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.BackfillInfo
+		fuzzer.Fuzz(&orig)
+		out := ToBackfillInfo(FromBackfillInfo(orig))
+		assert.Equal(t, orig, out, "BackfillInfo did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.BackfillID == "" && orig.StartTime.IsZero() && orig.EndTime.IsZero() {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestScheduleInfoFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.ScheduleInfo
+		fuzzer.Fuzz(&orig)
+		out := ToScheduleInfo(FromScheduleInfo(orig))
+		assert.Equal(t, orig, out, "ScheduleInfo did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.OngoingBackfills == nil {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestScheduleListEntryFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.ScheduleListEntry
+		fuzzer.Fuzz(&orig)
+		out := ToScheduleListEntry(FromScheduleListEntry(orig))
+		assert.Equal(t, orig, out, "ScheduleListEntry did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.ScheduleID == "" && orig.WorkflowType == nil && orig.State == nil && orig.CronExpression == "" {
 			return "empty"
 		}
 		return "filled"

--- a/common/types/testdata/schedule.go
+++ b/common/types/testdata/schedule.go
@@ -28,9 +28,11 @@ import (
 )
 
 var (
-	// Test data for schedule spec
-	scheduleTime1 = time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)     // March 1, 2026
-	scheduleTime4 = time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC) // December 31, 2026
+	scheduleTime1 = time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC)
+	scheduleTime2 = time.Date(2026, 6, 15, 12, 30, 0, 0, time.UTC)
+	scheduleTime3 = time.Date(2026, 9, 1, 8, 0, 0, 0, time.UTC)
+	scheduleTime4 = time.Date(2026, 12, 31, 23, 59, 59, 0, time.UTC)
+	scheduleTime5 = time.Date(2026, 1, 15, 14, 0, 0, 0, time.UTC)
 
 	ScheduleSpec = types.ScheduleSpec{
 		CronExpression: "*/5 * * * *",
@@ -62,5 +64,48 @@ var (
 		PauseOnFailure:   true,
 		BufferLimit:      5,
 		ConcurrencyLimit: 2,
+	}
+
+	SchedulePauseInfo = types.SchedulePauseInfo{
+		Reason:   "maintenance window",
+		PausedAt: scheduleTime2,
+		PausedBy: "sample_admin@uber.com",
+	}
+
+	ScheduleState = types.ScheduleState{
+		Paused:    true,
+		PauseInfo: &SchedulePauseInfo,
+	}
+
+	ScheduleBackfillInfo = types.BackfillInfo{
+		BackfillID:    "backfill-001",
+		StartTime:     scheduleTime1,
+		EndTime:       scheduleTime3,
+		RunsCompleted: 15,
+		RunsTotal:     30,
+	}
+
+	ScheduleBackfillInfo2 = types.BackfillInfo{
+		BackfillID:    "backfill-002",
+		StartTime:     scheduleTime3,
+		EndTime:       scheduleTime4,
+		RunsCompleted: 0,
+		RunsTotal:     10,
+	}
+
+	ScheduleInfo = types.ScheduleInfo{
+		LastRunTime:      scheduleTime2,
+		NextRunTime:      scheduleTime3,
+		TotalRuns:        42,
+		CreateTime:       scheduleTime5,
+		LastUpdateTime:   scheduleTime2,
+		OngoingBackfills: []*types.BackfillInfo{&ScheduleBackfillInfo, &ScheduleBackfillInfo2},
+	}
+
+	ScheduleListEntry = types.ScheduleListEntry{
+		ScheduleID:     "my-schedule-id",
+		WorkflowType:   &WorkflowType,
+		State:          &ScheduleState,
+		CronExpression: "*/5 * * * *",
 	}
 )


### PR DESCRIPTION
**What changed?**
Add bidirectional proto mappers (From\*/To\*) for schedule state and info types: SchedulePauseInfo, ScheduleState, BackfillInfo, ScheduleInfo, and ScheduleListEntry, along with array helpers for BackfillInfo and ScheduleListEntry slices.

This is part 2 of the mapper layer for Cadence Schedules (follows #[7765](https://github.com/cadence-workflow/cadence/pull/7765)).

**Why?**
These mappers are needed to convert between internal Go types and proto wire format for schedule state/info structures. They will be used by the request/response mappers (next PR) and ultimately by the gRPC handler layer for the schedule API.

**How did you test it?**
cd common/types/mapper/proto && go test ./... 

**Potential risks**
Low. These are pure mapping functions with no side effects. The mappers are not yet wired into any handler, so there is no runtime impact until request/response mappers are added in a follow-up PR.

**Release notes**
N/A

**Documentation Changes**
N/A
---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
