### PR TITLE
feat: [Cadence Schedules] Add proto mappers for schedule CRUD request/response

### DIFF
--- a/common/types/mapper/proto/schedule.go
+++ b/common/types/mapper/proto/schedule.go
@@ -355,3 +355,175 @@ func ToScheduleListEntryArray(t []*apiv1.ScheduleListEntry) []*types.ScheduleLis
 	}
 	return v
 }
+
+// --- CRUD request/response mappers ---
+
+func FromCreateScheduleRequest(t *types.CreateScheduleRequest) *apiv1.CreateScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.CreateScheduleRequest{
+		Domain:           t.Domain,
+		ScheduleId:       t.ScheduleID,
+		Spec:             FromScheduleSpec(t.Spec),
+		Action:           FromScheduleAction(t.Action),
+		Policies:         FromSchedulePolicies(t.Policies),
+		Memo:             FromMemo(t.Memo),
+		SearchAttributes: FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+func ToCreateScheduleRequest(t *apiv1.CreateScheduleRequest) *types.CreateScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.CreateScheduleRequest{
+		Domain:           t.Domain,
+		ScheduleID:       t.ScheduleId,
+		Spec:             ToScheduleSpec(t.Spec),
+		Action:           ToScheduleAction(t.Action),
+		Policies:         ToSchedulePolicies(t.Policies),
+		Memo:             ToMemo(t.Memo),
+		SearchAttributes: ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+func FromCreateScheduleResponse(t *types.CreateScheduleResponse) *apiv1.CreateScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.CreateScheduleResponse{}
+}
+
+func ToCreateScheduleResponse(t *apiv1.CreateScheduleResponse) *types.CreateScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.CreateScheduleResponse{}
+}
+
+func FromDescribeScheduleRequest(t *types.DescribeScheduleRequest) *apiv1.DescribeScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.DescribeScheduleRequest{
+		Domain:     t.Domain,
+		ScheduleId: t.ScheduleID,
+	}
+}
+
+func ToDescribeScheduleRequest(t *apiv1.DescribeScheduleRequest) *types.DescribeScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeScheduleRequest{
+		Domain:     t.Domain,
+		ScheduleID: t.ScheduleId,
+	}
+}
+
+func FromDescribeScheduleResponse(t *types.DescribeScheduleResponse) *apiv1.DescribeScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.DescribeScheduleResponse{
+		Spec:             FromScheduleSpec(t.Spec),
+		Action:           FromScheduleAction(t.Action),
+		Policies:         FromSchedulePolicies(t.Policies),
+		State:            FromScheduleState(t.State),
+		Info:             FromScheduleInfo(t.Info),
+		Memo:             FromMemo(t.Memo),
+		SearchAttributes: FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+func ToDescribeScheduleResponse(t *apiv1.DescribeScheduleResponse) *types.DescribeScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.DescribeScheduleResponse{
+		Spec:             ToScheduleSpec(t.Spec),
+		Action:           ToScheduleAction(t.Action),
+		Policies:         ToSchedulePolicies(t.Policies),
+		State:            ToScheduleState(t.State),
+		Info:             ToScheduleInfo(t.Info),
+		Memo:             ToMemo(t.Memo),
+		SearchAttributes: ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+func FromUpdateScheduleRequest(t *types.UpdateScheduleRequest) *apiv1.UpdateScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.UpdateScheduleRequest{
+		Domain:           t.Domain,
+		ScheduleId:       t.ScheduleID,
+		Spec:             FromScheduleSpec(t.Spec),
+		Action:           FromScheduleAction(t.Action),
+		Policies:         FromSchedulePolicies(t.Policies),
+		SearchAttributes: FromSearchAttributes(t.SearchAttributes),
+	}
+}
+
+func ToUpdateScheduleRequest(t *apiv1.UpdateScheduleRequest) *types.UpdateScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.UpdateScheduleRequest{
+		Domain:           t.Domain,
+		ScheduleID:       t.ScheduleId,
+		Spec:             ToScheduleSpec(t.Spec),
+		Action:           ToScheduleAction(t.Action),
+		Policies:         ToSchedulePolicies(t.Policies),
+		SearchAttributes: ToSearchAttributes(t.SearchAttributes),
+	}
+}
+
+func FromUpdateScheduleResponse(t *types.UpdateScheduleResponse) *apiv1.UpdateScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.UpdateScheduleResponse{}
+}
+
+func ToUpdateScheduleResponse(t *apiv1.UpdateScheduleResponse) *types.UpdateScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.UpdateScheduleResponse{}
+}
+
+func FromDeleteScheduleRequest(t *types.DeleteScheduleRequest) *apiv1.DeleteScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.DeleteScheduleRequest{
+		Domain:     t.Domain,
+		ScheduleId: t.ScheduleID,
+	}
+}
+
+func ToDeleteScheduleRequest(t *apiv1.DeleteScheduleRequest) *types.DeleteScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.DeleteScheduleRequest{
+		Domain:     t.Domain,
+		ScheduleID: t.ScheduleId,
+	}
+}
+
+func FromDeleteScheduleResponse(t *types.DeleteScheduleResponse) *apiv1.DeleteScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.DeleteScheduleResponse{}
+}
+
+func ToDeleteScheduleResponse(t *apiv1.DeleteScheduleResponse) *types.DeleteScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.DeleteScheduleResponse{}
+}

--- a/common/types/mapper/proto/schedule_test.go
+++ b/common/types/mapper/proto/schedule_test.go
@@ -275,3 +275,145 @@ func TestScheduleListEntryFuzz(t *testing.T) {
 		return "filled"
 	})
 }
+
+// --- CRUD request/response deterministic tests ---
+
+func TestCreateScheduleRequest(t *testing.T) {
+	for _, item := range []*types.CreateScheduleRequest{nil, {}, &testdata.CreateScheduleRequest} {
+		assert.Equal(t, item, ToCreateScheduleRequest(FromCreateScheduleRequest(item)))
+	}
+}
+
+func TestCreateScheduleResponse(t *testing.T) {
+	for _, item := range []*types.CreateScheduleResponse{nil, {}, &testdata.CreateScheduleResponse} {
+		assert.Equal(t, item, ToCreateScheduleResponse(FromCreateScheduleResponse(item)))
+	}
+}
+
+func TestDescribeScheduleRequest(t *testing.T) {
+	for _, item := range []*types.DescribeScheduleRequest{nil, {}, &testdata.DescribeScheduleRequest} {
+		assert.Equal(t, item, ToDescribeScheduleRequest(FromDescribeScheduleRequest(item)))
+	}
+}
+
+func TestDescribeScheduleResponse(t *testing.T) {
+	for _, item := range []*types.DescribeScheduleResponse{nil, {}, &testdata.DescribeScheduleResponse} {
+		assert.Equal(t, item, ToDescribeScheduleResponse(FromDescribeScheduleResponse(item)))
+	}
+}
+
+func TestUpdateScheduleRequest(t *testing.T) {
+	for _, item := range []*types.UpdateScheduleRequest{nil, {}, &testdata.UpdateScheduleRequest} {
+		assert.Equal(t, item, ToUpdateScheduleRequest(FromUpdateScheduleRequest(item)))
+	}
+}
+
+func TestUpdateScheduleResponse(t *testing.T) {
+	for _, item := range []*types.UpdateScheduleResponse{nil, {}, &testdata.UpdateScheduleResponse} {
+		assert.Equal(t, item, ToUpdateScheduleResponse(FromUpdateScheduleResponse(item)))
+	}
+}
+
+func TestDeleteScheduleRequest(t *testing.T) {
+	for _, item := range []*types.DeleteScheduleRequest{nil, {}, &testdata.DeleteScheduleRequest} {
+		assert.Equal(t, item, ToDeleteScheduleRequest(FromDeleteScheduleRequest(item)))
+	}
+}
+
+func TestDeleteScheduleResponse(t *testing.T) {
+	for _, item := range []*types.DeleteScheduleResponse{nil, {}, &testdata.DeleteScheduleResponse} {
+		assert.Equal(t, item, ToDeleteScheduleResponse(FromDeleteScheduleResponse(item)))
+	}
+}
+
+// --- CRUD request/response fuzz tests ---
+
+func TestCreateScheduleRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.CreateScheduleRequest
+		fuzzer.Fuzz(&orig)
+		out := ToCreateScheduleRequest(FromCreateScheduleRequest(orig))
+		assert.Equal(t, orig, out, "CreateScheduleRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.ScheduleID == "" && orig.Spec == nil {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestDescribeScheduleRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.DescribeScheduleRequest
+		fuzzer.Fuzz(&orig)
+		out := ToDescribeScheduleRequest(FromDescribeScheduleRequest(orig))
+		assert.Equal(t, orig, out, "DescribeScheduleRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.ScheduleID == "" {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestDescribeScheduleResponseFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.DescribeScheduleResponse
+		fuzzer.Fuzz(&orig)
+		out := ToDescribeScheduleResponse(FromDescribeScheduleResponse(orig))
+		assert.Equal(t, orig, out, "DescribeScheduleResponse did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Spec == nil && orig.Action == nil && orig.State == nil {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestUpdateScheduleRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.UpdateScheduleRequest
+		fuzzer.Fuzz(&orig)
+		out := ToUpdateScheduleRequest(FromUpdateScheduleRequest(orig))
+		assert.Equal(t, orig, out, "UpdateScheduleRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.ScheduleID == "" && orig.Spec == nil {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestDeleteScheduleRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.DeleteScheduleRequest
+		fuzzer.Fuzz(&orig)
+		out := ToDeleteScheduleRequest(FromDeleteScheduleRequest(orig))
+		assert.Equal(t, orig, out, "DeleteScheduleRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.ScheduleID == "" {
+			return "empty"
+		}
+		return "filled"
+	})
+}

--- a/common/types/testdata/schedule.go
+++ b/common/types/testdata/schedule.go
@@ -108,4 +108,49 @@ var (
 		State:          &ScheduleState,
 		CronExpression: "*/5 * * * *",
 	}
+
+	CreateScheduleRequest = types.CreateScheduleRequest{
+		Domain:           DomainName,
+		ScheduleID:       "my-schedule-id",
+		Spec:             &ScheduleSpec,
+		Action:           &ScheduleAction,
+		Policies:         &SchedulePolicies,
+		Memo:             &Memo,
+		SearchAttributes: &SearchAttributes,
+	}
+
+	CreateScheduleResponse = types.CreateScheduleResponse{}
+
+	DescribeScheduleRequest = types.DescribeScheduleRequest{
+		Domain:     DomainName,
+		ScheduleID: "my-schedule-id",
+	}
+
+	DescribeScheduleResponse = types.DescribeScheduleResponse{
+		Spec:             &ScheduleSpec,
+		Action:           &ScheduleAction,
+		Policies:         &SchedulePolicies,
+		State:            &ScheduleState,
+		Info:             &ScheduleInfo,
+		Memo:             &Memo,
+		SearchAttributes: &SearchAttributes,
+	}
+
+	UpdateScheduleRequest = types.UpdateScheduleRequest{
+		Domain:           DomainName,
+		ScheduleID:       "my-schedule-id",
+		Spec:             &ScheduleSpec,
+		Action:           &ScheduleAction,
+		Policies:         &SchedulePolicies,
+		SearchAttributes: &SearchAttributes,
+	}
+
+	UpdateScheduleResponse = types.UpdateScheduleResponse{}
+
+	DeleteScheduleRequest = types.DeleteScheduleRequest{
+		Domain:     DomainName,
+		ScheduleID: "my-schedule-id",
+	}
+
+	DeleteScheduleResponse = types.DeleteScheduleResponse{}
 )


### PR DESCRIPTION
**What changed?**
Add bidirectional proto mappers (From\*/To\*) for schedule CRUD request/response types: CreateScheduleRequest/Response, DescribeScheduleRequest/Response, UpdateScheduleRequest/Response, and DeleteScheduleRequest/Response.

This is part 3 of the mapper layer for Cadence Schedules (follows #[7765](https://github.com/cadence-workflow/cadence/pull/7756), #[7771](https://github.com/cadence-workflow/cadence/pull/7771)). 

**Why?**
These mappers convert between internal Go types and proto wire format for schedule CRUD operations. They compose the core type mappers (ScheduleSpec, ScheduleAction, SchedulePolicies) and state/info mappers (ScheduleState, ScheduleInfo) from previous PRs into full request/response structures. They will be used by the gRPC handler layer for the schedule API.

**How did you test it?**
cd common/types/mapper/proto && go test ./... 

**Potential risks**
Low. These are pure mapping functions with no side effects. 

**Release notes**
N/A

**Documentation Changes**
N/A
---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
