### PR TITLE
docs: Use gitar for validating PR descriptions instead of template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -16,19 +16,3 @@
 
 **Documentation Changes**
 
----
-
-## Reviewer Validation
-
-**PR Description Quality** (check these before reviewing code):
-
-- [ ] **"What changed"** provides a clear 1-2 line summary
-  - [ ] Project Issue is linked
-- [ ] **"Why"** explains the full motivation with sufficient context
-- [ ] **Testing is documented:**
-  - [ ] Unit test commands are included (with exact `go test` invocation)
-  - [ ] Integration test setup/commands included (if integration tests were run)
-  - [ ] Canary testing details included (if canary was mentioned)
-- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
-- [ ] **Release notes** included if this completes a user-facing feature
-- [ ] **Documentation** needs are addressed (or noted if uncertain)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Removes the PR description template. 

**Why?**

We have validated that auto-review via gitar/copilot with a constructed rule can perform most of the initial validation of the PR description for us. Rather than continue to clutter our gitlog and reviewers energy during a review with a manual checklist it is better to remove it. 

**How did you test it?**

Not relevant. 

**Potential risks**

We could lose access to gitar/github copilot at which point we would be back to square one, at which point we would need to revert to a manual checklist via a simple revert of this PR. 

**Release notes**

N/A

**Documentation Changes**

N/A