### PR TITLE
feat: [Cadence Schedules] Add proto mappers for schedule action request/response

### DIFF
--- a/common/types/mapper/proto/schedule.go
+++ b/common/types/mapper/proto/schedule.go
@@ -527,3 +527,163 @@ func ToDeleteScheduleResponse(t *apiv1.DeleteScheduleResponse) *types.DeleteSche
 	}
 	return &types.DeleteScheduleResponse{}
 }
+
+// --- Action request/response mappers ---
+
+func FromPauseScheduleRequest(t *types.PauseScheduleRequest) *apiv1.PauseScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.PauseScheduleRequest{
+		Domain:     t.Domain,
+		ScheduleId: t.ScheduleID,
+		Reason:     t.Reason,
+	}
+}
+
+func ToPauseScheduleRequest(t *apiv1.PauseScheduleRequest) *types.PauseScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.PauseScheduleRequest{
+		Domain:     t.Domain,
+		ScheduleID: t.ScheduleId,
+		Reason:     t.Reason,
+	}
+}
+
+func FromPauseScheduleResponse(t *types.PauseScheduleResponse) *apiv1.PauseScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.PauseScheduleResponse{}
+}
+
+func ToPauseScheduleResponse(t *apiv1.PauseScheduleResponse) *types.PauseScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.PauseScheduleResponse{}
+}
+
+func FromUnpauseScheduleRequest(t *types.UnpauseScheduleRequest) *apiv1.UnpauseScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.UnpauseScheduleRequest{
+		Domain:        t.Domain,
+		ScheduleId:    t.ScheduleID,
+		Reason:        t.Reason,
+		CatchUpPolicy: FromScheduleCatchUpPolicy(t.CatchUpPolicy),
+	}
+}
+
+func ToUnpauseScheduleRequest(t *apiv1.UnpauseScheduleRequest) *types.UnpauseScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.UnpauseScheduleRequest{
+		Domain:        t.Domain,
+		ScheduleID:    t.ScheduleId,
+		Reason:        t.Reason,
+		CatchUpPolicy: ToScheduleCatchUpPolicy(t.CatchUpPolicy),
+	}
+}
+
+func FromUnpauseScheduleResponse(t *types.UnpauseScheduleResponse) *apiv1.UnpauseScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.UnpauseScheduleResponse{}
+}
+
+func ToUnpauseScheduleResponse(t *apiv1.UnpauseScheduleResponse) *types.UnpauseScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.UnpauseScheduleResponse{}
+}
+
+func FromListSchedulesRequest(t *types.ListSchedulesRequest) *apiv1.ListSchedulesRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.ListSchedulesRequest{
+		Domain:        t.Domain,
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+func ToListSchedulesRequest(t *apiv1.ListSchedulesRequest) *types.ListSchedulesRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.ListSchedulesRequest{
+		Domain:        t.Domain,
+		PageSize:      t.PageSize,
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+func FromListSchedulesResponse(t *types.ListSchedulesResponse) *apiv1.ListSchedulesResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.ListSchedulesResponse{
+		Schedules:     FromScheduleListEntryArray(t.Schedules),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+func ToListSchedulesResponse(t *apiv1.ListSchedulesResponse) *types.ListSchedulesResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.ListSchedulesResponse{
+		Schedules:     ToScheduleListEntryArray(t.Schedules),
+		NextPageToken: t.NextPageToken,
+	}
+}
+
+func FromBackfillScheduleRequest(t *types.BackfillScheduleRequest) *apiv1.BackfillScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.BackfillScheduleRequest{
+		Domain:        t.Domain,
+		ScheduleId:    t.ScheduleID,
+		StartTime:     timeToTimestamp(&t.StartTime),
+		EndTime:       timeToTimestamp(&t.EndTime),
+		OverlapPolicy: FromScheduleOverlapPolicy(t.OverlapPolicy),
+		BackfillId:    t.BackfillID,
+	}
+}
+
+func ToBackfillScheduleRequest(t *apiv1.BackfillScheduleRequest) *types.BackfillScheduleRequest {
+	if t == nil {
+		return nil
+	}
+	return &types.BackfillScheduleRequest{
+		Domain:        t.Domain,
+		ScheduleID:    t.ScheduleId,
+		StartTime:     timestampToTimeVal(t.StartTime),
+		EndTime:       timestampToTimeVal(t.EndTime),
+		OverlapPolicy: ToScheduleOverlapPolicy(t.OverlapPolicy),
+		BackfillID:    t.BackfillId,
+	}
+}
+
+func FromBackfillScheduleResponse(t *types.BackfillScheduleResponse) *apiv1.BackfillScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &apiv1.BackfillScheduleResponse{}
+}
+
+func ToBackfillScheduleResponse(t *apiv1.BackfillScheduleResponse) *types.BackfillScheduleResponse {
+	if t == nil {
+		return nil
+	}
+	return &types.BackfillScheduleResponse{}
+}

--- a/common/types/mapper/proto/schedule_test.go
+++ b/common/types/mapper/proto/schedule_test.go
@@ -417,3 +417,145 @@ func TestDeleteScheduleRequestFuzz(t *testing.T) {
 		return "filled"
 	})
 }
+
+// --- Action request/response deterministic tests ---
+
+func TestPauseScheduleRequest(t *testing.T) {
+	for _, item := range []*types.PauseScheduleRequest{nil, {}, &testdata.PauseScheduleRequest} {
+		assert.Equal(t, item, ToPauseScheduleRequest(FromPauseScheduleRequest(item)))
+	}
+}
+
+func TestPauseScheduleResponse(t *testing.T) {
+	for _, item := range []*types.PauseScheduleResponse{nil, {}, &testdata.PauseScheduleResponse} {
+		assert.Equal(t, item, ToPauseScheduleResponse(FromPauseScheduleResponse(item)))
+	}
+}
+
+func TestUnpauseScheduleRequest(t *testing.T) {
+	for _, item := range []*types.UnpauseScheduleRequest{nil, {}, &testdata.UnpauseScheduleRequest} {
+		assert.Equal(t, item, ToUnpauseScheduleRequest(FromUnpauseScheduleRequest(item)))
+	}
+}
+
+func TestUnpauseScheduleResponse(t *testing.T) {
+	for _, item := range []*types.UnpauseScheduleResponse{nil, {}, &testdata.UnpauseScheduleResponse} {
+		assert.Equal(t, item, ToUnpauseScheduleResponse(FromUnpauseScheduleResponse(item)))
+	}
+}
+
+func TestListSchedulesRequest(t *testing.T) {
+	for _, item := range []*types.ListSchedulesRequest{nil, {}, &testdata.ListSchedulesRequest} {
+		assert.Equal(t, item, ToListSchedulesRequest(FromListSchedulesRequest(item)))
+	}
+}
+
+func TestListSchedulesResponse(t *testing.T) {
+	for _, item := range []*types.ListSchedulesResponse{nil, {}, &testdata.ListSchedulesResponse} {
+		assert.Equal(t, item, ToListSchedulesResponse(FromListSchedulesResponse(item)))
+	}
+}
+
+func TestBackfillScheduleRequest(t *testing.T) {
+	for _, item := range []*types.BackfillScheduleRequest{nil, {}, &testdata.BackfillScheduleRequest} {
+		assert.Equal(t, item, ToBackfillScheduleRequest(FromBackfillScheduleRequest(item)))
+	}
+}
+
+func TestBackfillScheduleResponse(t *testing.T) {
+	for _, item := range []*types.BackfillScheduleResponse{nil, {}, &testdata.BackfillScheduleResponse} {
+		assert.Equal(t, item, ToBackfillScheduleResponse(FromBackfillScheduleResponse(item)))
+	}
+}
+
+// --- Action request/response fuzz tests ---
+
+func TestPauseScheduleRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.PauseScheduleRequest
+		fuzzer.Fuzz(&orig)
+		out := ToPauseScheduleRequest(FromPauseScheduleRequest(orig))
+		assert.Equal(t, orig, out, "PauseScheduleRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.ScheduleID == "" {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestUnpauseScheduleRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.UnpauseScheduleRequest
+		fuzzer.Fuzz(&orig)
+		out := ToUnpauseScheduleRequest(FromUnpauseScheduleRequest(orig))
+		assert.Equal(t, orig, out, "UnpauseScheduleRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.ScheduleID == "" {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestListSchedulesRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.ListSchedulesRequest
+		fuzzer.Fuzz(&orig)
+		out := ToListSchedulesRequest(FromListSchedulesRequest(orig))
+		assert.Equal(t, orig, out, "ListSchedulesRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.NextPageToken == nil {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestListSchedulesResponseFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.ListSchedulesResponse
+		fuzzer.Fuzz(&orig)
+		out := ToListSchedulesResponse(FromListSchedulesResponse(orig))
+		assert.Equal(t, orig, out, "ListSchedulesResponse did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Schedules == nil && orig.NextPageToken == nil {
+			return "empty"
+		}
+		return "filled"
+	})
+}
+
+func TestBackfillScheduleRequestFuzz(t *testing.T) {
+	testutils.EnsureFuzzCoverage(t, []string{"nil", "empty", "filled"}, func(t *testing.T, f *fuzz.Fuzzer) string {
+		fuzzer := scheduleFuzzer(f)
+		var orig *types.BackfillScheduleRequest
+		fuzzer.Fuzz(&orig)
+		out := ToBackfillScheduleRequest(FromBackfillScheduleRequest(orig))
+		assert.Equal(t, orig, out, "BackfillScheduleRequest did not survive round-tripping")
+
+		if orig == nil {
+			return "nil"
+		}
+		if orig.Domain == "" && orig.ScheduleID == "" {
+			return "empty"
+		}
+		return "filled"
+	})
+}

--- a/common/types/testdata/schedule.go
+++ b/common/types/testdata/schedule.go
@@ -153,4 +153,43 @@ var (
 	}
 
 	DeleteScheduleResponse = types.DeleteScheduleResponse{}
+
+	PauseScheduleRequest = types.PauseScheduleRequest{
+		Domain:     DomainName,
+		ScheduleID: "my-schedule-id",
+		Reason:     "maintenance window",
+	}
+
+	PauseScheduleResponse = types.PauseScheduleResponse{}
+
+	UnpauseScheduleRequest = types.UnpauseScheduleRequest{
+		Domain:        DomainName,
+		ScheduleID:    "my-schedule-id",
+		Reason:        "maintenance complete",
+		CatchUpPolicy: types.ScheduleCatchUpPolicyOne,
+	}
+
+	UnpauseScheduleResponse = types.UnpauseScheduleResponse{}
+
+	ListSchedulesRequest = types.ListSchedulesRequest{
+		Domain:        DomainName,
+		PageSize:      10,
+		NextPageToken: []byte("next-page-token"),
+	}
+
+	ListSchedulesResponse = types.ListSchedulesResponse{
+		Schedules:     []*types.ScheduleListEntry{&ScheduleListEntry},
+		NextPageToken: []byte("next-page-token-2"),
+	}
+
+	BackfillScheduleRequest = types.BackfillScheduleRequest{
+		Domain:        DomainName,
+		ScheduleID:    "my-schedule-id",
+		StartTime:     scheduleTime1,
+		EndTime:       scheduleTime3,
+		OverlapPolicy: types.ScheduleOverlapPolicyConcurrent,
+		BackfillID:    "backfill-003",
+	}
+
+	BackfillScheduleResponse = types.BackfillScheduleResponse{}
 )


### PR DESCRIPTION
**What changed?**
Add bidirectional proto mappers (From*/To*) for schedule action request/response types:
- PauseScheduleRequest/Response, UnpauseScheduleRequest/Response
- ListSchedulesRequest/Response, BackfillScheduleRequest/Response

This completes the mapper layer for all schedule proto RPCs.

**Why?**
These mappers are needed to bridge internal Go types (`common/types`) and generated protobuf types for the remaining schedule action APIs (Pause, Unpause, List, Backfill). Previous PRs covered core types (PR4a), state/info types (PR4b), and CRUD request/response types (PR4c).

Part of Cadence Schedules feature for pause/resume, catch-up, and backfill capabilities.


**How did you test it?**
`cd common/types/mapper/proto && go test ./...`

**Potential risks**
N/A: New mapper functions and tests only, no runtime behavior changes.

**Release notes**
N/A

**Documentation Changes**
N/A
---

## Reviewer Validation

**PR Description Quality** (check these before reviewing code):

- [ ] **"What changed"** provides a clear 1-2 line summary
  - [ ] Project Issue is linked
- [ ] **"Why"** explains the full motivation with sufficient context
- [ ] **Testing is documented:**
  - [ ] Unit test commands are included (with exact `go test` invocation)
  - [ ] Integration test setup/commands included (if integration tests were run)
  - [ ] Canary testing details included (if canary was mentioned)
- [ ] **Potential risks** section is thoughtfully filled out (or legitimately N/A)
- [ ] **Release notes** included if this completes a user-facing feature
- [ ] **Documentation** needs are addressed (or noted if uncertain)
