### PR TITLE
refactor: Introduce TTLChannel component

### DIFF
--- a/common/task/iwrr_schedule_test.go
+++ b/common/task/iwrr_schedule_test.go
@@ -135,20 +135,38 @@ func TestIWRRSchedule_LargeWeights(t *testing.T) {
 
 	iter := schedule.NewIterator()
 
-	// Count how many times each item appears
-	counts := make(map[*testWeightedItem]int)
+	// IWRR pattern for [100, 50, 25]:
+	// Rounds 99-50 (50 rounds): only item 0 (weight 100 > round)
+	// Rounds 49-25 (25 rounds): items 0, 1 (weights 100, 50 > round)
+	// Rounds 24-0 (25 rounds): items 0, 1, 2 (all weights > round)
+	var expectedSequence []*testWeightedItem
 
-	for {
-		item, ok := iter.TryNext()
-		if !ok {
-			break
-		}
-		counts[item]++
+	// First 50 rounds: only item 0
+	for i := 0; i < 50; i++ {
+		expectedSequence = append(expectedSequence, items[0])
 	}
 
-	assert.Equal(t, 100, counts[items[0]], "item 0 should appear 100 times")
-	assert.Equal(t, 50, counts[items[1]], "item 1 should appear 50 times")
-	assert.Equal(t, 25, counts[items[2]], "item 2 should appear 25 times")
+	// Next 25 rounds: items 0, 1
+	for i := 0; i < 25; i++ {
+		expectedSequence = append(expectedSequence, items[0], items[1])
+	}
+
+	// Last 25 rounds: items 0, 1, 2
+	for i := 0; i < 25; i++ {
+		expectedSequence = append(expectedSequence, items[0], items[1], items[2])
+	}
+
+	// Verify the sequence
+	for i, expected := range expectedSequence {
+		item, ok := iter.TryNext()
+		require.True(t, ok, "iteration %d should succeed", i)
+		assert.Equal(t, expected, item, "iteration %d", i)
+	}
+
+	// Should be exhausted
+	item, ok := iter.TryNext()
+	assert.False(t, ok)
+	assert.Nil(t, item)
 }
 
 func TestIWRRSchedule_ChannelWithZeroWeight(t *testing.T) {

--- a/common/task/ttl_channel.go
+++ b/common/task/ttl_channel.go
@@ -1,0 +1,77 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package task
+
+import (
+	"sync/atomic"
+	"time"
+)
+
+// TTLChannel is a channel with a last write time and reference count
+type TTLChannel[V any] struct {
+	c             chan V
+	lastWriteTime atomic.Int64
+	refCount      atomic.Int32
+}
+
+func NewTTLChannel[V any](bufferSize int) *TTLChannel[V] {
+	return &TTLChannel[V]{
+		c: make(chan V, bufferSize),
+	}
+}
+
+func (c *TTLChannel[V]) IncRef() {
+	c.refCount.Add(1)
+}
+
+func (c *TTLChannel[V]) DecRef() {
+	c.refCount.Add(-1)
+}
+
+func (c *TTLChannel[V]) RefCount() int32 {
+	return c.refCount.Load()
+}
+
+func (c *TTLChannel[V]) LastWriteTime() time.Time {
+	return time.Unix(c.lastWriteTime.Load(), 0)
+}
+
+func (c *TTLChannel[V]) UpdateLastWriteTime(now time.Time) {
+	c.lastWriteTime.Store(now.Unix())
+}
+
+func (c *TTLChannel[V]) Chan() chan V {
+	return c.c
+}
+
+func (c *TTLChannel[V]) Len() int {
+	return len(c.c)
+}
+
+func (c *TTLChannel[V]) Cap() int {
+	return cap(c.c)
+}
+
+func (c *TTLChannel[V]) ShouldCleanup(now time.Time, ttl time.Duration) bool {
+	return now.Sub(c.LastWriteTime()) > ttl && c.Len() == 0 && c.RefCount() == 0
+}

--- a/common/task/ttl_channel_test.go
+++ b/common/task/ttl_channel_test.go
@@ -1,0 +1,394 @@
+// The MIT License (MIT)
+
+// Copyright (c) 2017-2020 Uber Technologies Inc.
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+package task
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewTTLChannel(t *testing.T) {
+	tests := []struct {
+		name       string
+		bufferSize int
+	}{
+		{
+			name:       "unbuffered channel",
+			bufferSize: 0,
+		},
+		{
+			name:       "small buffer",
+			bufferSize: 10,
+		},
+		{
+			name:       "large buffer",
+			bufferSize: 1000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := NewTTLChannel[int](tt.bufferSize)
+			require.NotNil(t, ch)
+			assert.NotNil(t, ch.Chan())
+			assert.Equal(t, tt.bufferSize, ch.Cap())
+			assert.Equal(t, 0, ch.Len())
+			assert.Equal(t, int32(0), ch.RefCount())
+		})
+	}
+}
+
+func TestTTLChannel_RefCount(t *testing.T) {
+	ch := NewTTLChannel[int](10)
+
+	// Initial ref count should be 0
+	assert.Equal(t, int32(0), ch.RefCount())
+
+	// Add refs
+	ch.IncRef()
+	assert.Equal(t, int32(1), ch.RefCount())
+
+	ch.IncRef()
+	assert.Equal(t, int32(2), ch.RefCount())
+
+	ch.IncRef()
+	assert.Equal(t, int32(3), ch.RefCount())
+
+	// Decrement refs
+	ch.DecRef()
+	assert.Equal(t, int32(2), ch.RefCount())
+
+	ch.DecRef()
+	assert.Equal(t, int32(1), ch.RefCount())
+
+	ch.DecRef()
+	assert.Equal(t, int32(0), ch.RefCount())
+}
+
+func TestTTLChannel_RefCount_MultipleAddDec(t *testing.T) {
+	ch := NewTTLChannel[string](5)
+
+	// Add multiple refs
+	for i := 0; i < 100; i++ {
+		ch.IncRef()
+	}
+	assert.Equal(t, int32(100), ch.RefCount())
+
+	// Decrement all refs
+	for i := 0; i < 100; i++ {
+		ch.DecRef()
+	}
+	assert.Equal(t, int32(0), ch.RefCount())
+}
+
+func TestTTLChannel_LastWriteTime(t *testing.T) {
+	ch := NewTTLChannel[int](10)
+
+	// Initial last write time should be zero (Unix epoch)
+	assert.Equal(t, time.Unix(0, 0), ch.LastWriteTime())
+
+	// Update last write time
+	now := time.Now()
+	ch.UpdateLastWriteTime(now)
+
+	// Should return the updated time (truncated to seconds)
+	expected := time.Unix(now.Unix(), 0)
+	assert.Equal(t, expected, ch.LastWriteTime())
+
+	// Update with a different time
+	later := now.Add(1 * time.Hour)
+	ch.UpdateLastWriteTime(later)
+
+	expected = time.Unix(later.Unix(), 0)
+	assert.Equal(t, expected, ch.LastWriteTime())
+}
+
+func TestTTLChannel_Chan(t *testing.T) {
+	ch := NewTTLChannel[int](10)
+
+	// Should return the underlying channel
+	c := ch.Chan()
+	require.NotNil(t, c)
+
+	// Should be able to send and receive
+	c <- 42
+	val := <-c
+	assert.Equal(t, 42, val)
+}
+
+func TestTTLChannel_Len(t *testing.T) {
+	ch := NewTTLChannel[int](10)
+
+	// Initially empty
+	assert.Equal(t, 0, ch.Len())
+
+	// Add items
+	ch.Chan() <- 1
+	assert.Equal(t, 1, ch.Len())
+
+	ch.Chan() <- 2
+	assert.Equal(t, 2, ch.Len())
+
+	ch.Chan() <- 3
+	assert.Equal(t, 3, ch.Len())
+
+	// Remove items
+	<-ch.Chan()
+	assert.Equal(t, 2, ch.Len())
+
+	<-ch.Chan()
+	assert.Equal(t, 1, ch.Len())
+
+	<-ch.Chan()
+	assert.Equal(t, 0, ch.Len())
+}
+
+func TestTTLChannel_Cap(t *testing.T) {
+	tests := []struct {
+		name       string
+		bufferSize int
+	}{
+		{
+			name:       "unbuffered",
+			bufferSize: 0,
+		},
+		{
+			name:       "buffered 1",
+			bufferSize: 1,
+		},
+		{
+			name:       "buffered 100",
+			bufferSize: 100,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := NewTTLChannel[int](tt.bufferSize)
+			assert.Equal(t, tt.bufferSize, ch.Cap())
+		})
+	}
+}
+
+func TestTTLChannel_ShouldCleanup(t *testing.T) {
+	tests := []struct {
+		name           string
+		refCount       int32
+		channelLen     int
+		timeSinceWrite time.Duration
+		ttl            time.Duration
+		expected       bool
+	}{
+		{
+			name:           "should cleanup - all conditions met",
+			refCount:       0,
+			channelLen:     0,
+			timeSinceWrite: 2 * time.Hour,
+			ttl:            1 * time.Hour,
+			expected:       true,
+		},
+		{
+			name:           "should not cleanup - has references",
+			refCount:       1,
+			channelLen:     0,
+			timeSinceWrite: 2 * time.Hour,
+			ttl:            1 * time.Hour,
+			expected:       false,
+		},
+		{
+			name:           "should not cleanup - channel not empty",
+			refCount:       0,
+			channelLen:     1,
+			timeSinceWrite: 2 * time.Hour,
+			ttl:            1 * time.Hour,
+			expected:       false,
+		},
+		{
+			name:           "should not cleanup - not expired",
+			refCount:       0,
+			channelLen:     0,
+			timeSinceWrite: 30 * time.Minute,
+			ttl:            1 * time.Hour,
+			expected:       false,
+		},
+		{
+			name:           "should not cleanup - just before TTL boundary",
+			refCount:       0,
+			channelLen:     0,
+			timeSinceWrite: 1*time.Hour - 1*time.Second,
+			ttl:            1 * time.Hour,
+			expected:       false,
+		},
+		{
+			name:           "should cleanup - slightly past TTL",
+			refCount:       0,
+			channelLen:     0,
+			timeSinceWrite: 1*time.Hour + 1*time.Second,
+			ttl:            1 * time.Hour,
+			expected:       true,
+		},
+		{
+			name:           "should not cleanup - multiple issues",
+			refCount:       2,
+			channelLen:     3,
+			timeSinceWrite: 30 * time.Minute,
+			ttl:            1 * time.Hour,
+			expected:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ch := NewTTLChannel[int](10)
+
+			// Set up ref count
+			for i := int32(0); i < tt.refCount; i++ {
+				ch.IncRef()
+			}
+
+			// Set up channel length
+			for i := 0; i < tt.channelLen; i++ {
+				ch.Chan() <- i
+			}
+
+			// Set up last write time
+			lastWriteTime := time.Now().Add(-tt.timeSinceWrite)
+			ch.UpdateLastWriteTime(lastWriteTime)
+
+			// Check should cleanup
+			now := time.Now()
+			result := ch.ShouldCleanup(now, tt.ttl)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestTTLChannel_ShouldCleanup_EdgeCases(t *testing.T) {
+	t.Run("zero TTL", func(t *testing.T) {
+		ch := NewTTLChannel[int](10)
+		// Use time truncated to seconds to match what gets stored
+		now := time.Unix(time.Now().Unix(), 0)
+		ch.UpdateLastWriteTime(now)
+
+		// Even with zero TTL, should cleanup only if time has passed
+		assert.False(t, ch.ShouldCleanup(now, 0))
+		assert.True(t, ch.ShouldCleanup(now.Add(1*time.Second), 0))
+	})
+
+	t.Run("never written", func(t *testing.T) {
+		ch := NewTTLChannel[int](10)
+		now := time.Now()
+		ttl := 1 * time.Hour
+
+		// Channel was never written to (lastWriteTime is Unix epoch)
+		// Should cleanup since time.Now() - Unix(0) > ttl
+		assert.True(t, ch.ShouldCleanup(now, ttl))
+	})
+
+	t.Run("negative ref count", func(t *testing.T) {
+		ch := NewTTLChannel[int](10)
+		now := time.Now()
+		ch.UpdateLastWriteTime(now.Add(-2 * time.Hour))
+
+		// Manually set negative ref count (shouldn't happen in practice)
+		ch.DecRef()
+		assert.Equal(t, int32(-1), ch.RefCount())
+
+		// Should not cleanup with negative ref count
+		// (even though it's an error state, better safe than sorry)
+		assert.False(t, ch.ShouldCleanup(now, 1*time.Hour))
+	})
+}
+
+func TestTTLChannel_ConcurrentRefCount(t *testing.T) {
+	ch := NewTTLChannel[int](10)
+	iterations := 1000
+
+	// Concurrently add refs
+	done := make(chan bool)
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < iterations; j++ {
+				ch.IncRef()
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Should have 10 * iterations refs
+	expected := int32(10 * iterations)
+	assert.Equal(t, expected, ch.RefCount())
+
+	// Concurrently decrement refs
+	for i := 0; i < 10; i++ {
+		go func() {
+			for j := 0; j < iterations; j++ {
+				ch.DecRef()
+			}
+			done <- true
+		}()
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Should be back to 0
+	assert.Equal(t, int32(0), ch.RefCount())
+}
+
+func TestTTLChannel_ConcurrentTimeUpdate(t *testing.T) {
+	ch := NewTTLChannel[int](10)
+	iterations := 100
+
+	// Concurrently update time
+	done := make(chan bool)
+	baseTime := time.Now()
+
+	for i := 0; i < 10; i++ {
+		go func(offset int) {
+			for j := 0; j < iterations; j++ {
+				ch.UpdateLastWriteTime(baseTime.Add(time.Duration(offset+j) * time.Second))
+			}
+			done <- true
+		}(i * iterations)
+	}
+
+	// Wait for all goroutines
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Should have some valid time (exact value depends on interleaving)
+	lastTime := ch.LastWriteTime()
+	assert.True(t, !lastTime.Before(baseTime), "last write time should not be before base time")
+}

--- a/common/task/weighted_channel_pool.go
+++ b/common/task/weighted_channel_pool.go
@@ -38,10 +38,8 @@ const defaultIdleChannelTTLInSeconds = 3600
 
 type (
 	weightedChannel[V any] struct {
-		weight        int
-		c             chan V
-		refCount      atomic.Int32
-		lastWriteTime atomic.Int64
+		*TTLChannel[V]
+		weight int
 	}
 
 	WeightedRoundRobinChannelPoolOptions struct {
@@ -127,9 +125,10 @@ func (p *WeightedRoundRobinChannelPool[K, V]) doCleanup() {
 	p.Lock()
 	defer p.Unlock()
 	var channelsToCleanup []K
-	now := p.timeSource.Now().Unix()
+	now := p.timeSource.Now()
+	ttl := time.Duration(p.idleChannelTTLInSeconds) * time.Second
 	for k, v := range p.channelMap {
-		if now-v.lastWriteTime.Load() > p.idleChannelTTLInSeconds && len(v.c) == 0 && v.refCount.Load() == 0 {
+		if v.ShouldCleanup(now, ttl) {
 			channelsToCleanup = append(channelsToCleanup, k)
 		}
 	}
@@ -147,40 +146,34 @@ func (p *WeightedRoundRobinChannelPool[K, V]) doCleanup() {
 func (p *WeightedRoundRobinChannelPool[K, V]) GetOrCreateChannel(key K, weight int) (chan V, func()) {
 	p.RLock()
 	if v := p.channelMap[key]; v != nil && v.weight == weight {
-		v.refCount.Add(1)
-		v.lastWriteTime.Store(p.timeSource.Now().Unix())
+		v.IncRef()
+		v.UpdateLastWriteTime(p.timeSource.Now())
 		p.RUnlock()
-		return v.c, func() {
-			v.refCount.Add(-1)
-		}
+		return v.Chan(), v.DecRef
 	}
 	p.RUnlock()
 
 	p.Lock()
 	defer p.Unlock()
 	if v := p.channelMap[key]; v != nil {
-		v.refCount.Add(1)
-		v.lastWriteTime.Store(p.timeSource.Now().Unix())
+		v.IncRef()
+		v.UpdateLastWriteTime(p.timeSource.Now())
 		if v.weight != weight {
 			v.weight = weight
 			p.updateScheduleLocked()
 		}
-		return v.c, func() {
-			v.refCount.Add(-1)
-		}
+		return v.Chan(), v.DecRef
 	}
 
 	v := &weightedChannel[V]{
-		weight: weight,
-		c:      make(chan V, p.bufferSize),
+		TTLChannel: NewTTLChannel[V](p.bufferSize),
+		weight:     weight,
 	}
 	p.channelMap[key] = v
-	v.refCount.Add(1)
-	v.lastWriteTime.Store(p.timeSource.Now().Unix())
+	v.IncRef()
+	v.UpdateLastWriteTime(p.timeSource.Now())
 	p.updateScheduleLocked()
-	return v.c, func() {
-		v.refCount.Add(-1)
-	}
+	return v.Chan(), v.DecRef
 }
 
 func (p *WeightedRoundRobinChannelPool[K, V]) GetAllChannels() []chan V {
@@ -188,7 +181,7 @@ func (p *WeightedRoundRobinChannelPool[K, V]) GetAllChannels() []chan V {
 	defer p.RUnlock()
 	allChannels := make([]chan V, 0, len(p.channelMap))
 	for _, v := range p.channelMap {
-		allChannels = append(allChannels, v.c)
+		allChannels = append(allChannels, v.Chan())
 	}
 	return allChannels
 }


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Introduce TTLChannel type and a few helper methods
- Also update a test for iwrrSchedule to improve coverage

This is a change for https://github.com/cadence-workflow/cadence/issues/7724

**Why?**
- TTLChannel is created to be a reusable component for future changes.

**How did you test it?**
cd common/task && go test ./...

**Potential risks**
If TTLChannel has a bug, it may lead to orphaned items in weighted channel pool or unprocessed tasks from a TTLChannel that shouldn't be cleaned up.

**Release notes**
N/A

**Documentation Changes**
N/A
