### PR TITLE
feat: [Cadence Schedules] Add scheduler workflow skeleton with signal handling and ContinueAsNew

### DIFF
--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -1,0 +1,111 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scheduler
+
+import (
+	"time"
+
+	"github.com/uber/cadence/common/types"
+)
+
+const (
+	WorkflowTypeName = "cadence-sys-scheduler-workflow"
+	TaskListName     = "cadence-sys-scheduler-tasklist"
+
+	SignalNamePause    = "scheduler-pause"
+	SignalNameUnpause  = "scheduler-unpause"
+	SignalNameUpdate   = "scheduler-update"
+	SignalNameBackfill = "scheduler-backfill"
+	SignalNameDelete   = "scheduler-delete"
+
+	StartWorkflowActivityName = "scheduler-start-workflow"
+
+	maxIterationsBeforeContinueAsNew = 500
+)
+
+// SchedulerWorkflowInput is the input to the scheduler workflow.
+// It carries the schedule definition and any prior state (for ContinueAsNew).
+type SchedulerWorkflowInput struct {
+	Domain     string                 `json:"domain"`
+	ScheduleID string                 `json:"scheduleId"`
+	Spec       types.ScheduleSpec     `json:"spec"`
+	Action     types.ScheduleAction   `json:"action"`
+	Policies   types.SchedulePolicies `json:"policies"`
+	State      SchedulerWorkflowState `json:"state"`
+}
+
+// SchedulerWorkflowState is the mutable runtime state that survives ContinueAsNew.
+type SchedulerWorkflowState struct {
+	Paused       bool      `json:"paused"`
+	PauseReason  string    `json:"pauseReason,omitempty"`
+	PausedBy     string    `json:"pausedBy,omitempty"`
+	Deleted      bool      `json:"-"` // transient flag, not persisted across ContinueAsNew
+	LastRunTime  time.Time `json:"lastRunTime,omitempty"`
+	NextRunTime  time.Time `json:"nextRunTime,omitempty"`
+	TotalRuns    int64     `json:"totalRuns"`
+	MissedRuns   int64     `json:"missedRuns"`
+	SkippedRuns  int64     `json:"skippedRuns"`
+	Iterations   int       `json:"iterations"`
+	BufferedRuns int       `json:"bufferedRuns"`
+}
+
+// PauseSignal is the payload sent with a pause signal.
+type PauseSignal struct {
+	Reason   string `json:"reason,omitempty"`
+	PausedBy string `json:"pausedBy,omitempty"`
+}
+
+// UnpauseSignal is the payload sent with an unpause signal.
+type UnpauseSignal struct {
+	Reason        string                      `json:"reason,omitempty"`
+	CatchUpPolicy types.ScheduleCatchUpPolicy `json:"catchUpPolicy,omitempty"`
+}
+
+// UpdateSignal is the payload sent with an update signal.
+type UpdateSignal struct {
+	Spec     *types.ScheduleSpec     `json:"spec,omitempty"`
+	Action   *types.ScheduleAction   `json:"action,omitempty"`
+	Policies *types.SchedulePolicies `json:"policies,omitempty"`
+}
+
+// BackfillSignal is the payload sent with a backfill signal.
+type BackfillSignal struct {
+	StartTime     time.Time                   `json:"startTime"`
+	EndTime       time.Time                   `json:"endTime"`
+	OverlapPolicy types.ScheduleOverlapPolicy `json:"overlapPolicy"`
+	BackfillID    string                      `json:"backfillId,omitempty"`
+}
+
+// StartWorkflowRequest is the input to the start-workflow activity.
+type StartWorkflowRequest struct {
+	Domain        string                    `json:"domain"`
+	ScheduleID    string                    `json:"scheduleId"`
+	Action        types.StartWorkflowAction `json:"action"`
+	ScheduledTime time.Time                 `json:"scheduledTime"`
+}
+
+// StartWorkflowResult is the output of the start-workflow activity.
+type StartWorkflowResult struct {
+	WorkflowID string `json:"workflowId"`
+	RunID      string `json:"runId"`
+	Started    bool   `json:"started"`
+	Skipped    bool   `json:"skipped"`
+}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -1,0 +1,331 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scheduler
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"go.uber.org/cadence/workflow"
+	"go.uber.org/zap"
+
+	"github.com/uber/cadence/common/types"
+)
+
+// signalChannels bundles the signal channels used by the scheduler workflow
+type signalChannels struct {
+	pause    workflow.Channel
+	unpause  workflow.Channel
+	update   workflow.Channel
+	backfill workflow.Channel
+	delete   workflow.Channel
+}
+
+func init() {
+	workflow.RegisterWithOptions(SchedulerWorkflow, workflow.RegisterOptions{Name: WorkflowTypeName})
+}
+
+// SchedulerWorkflow is a long-running workflow that manages a single schedule.
+// It computes the next fire time from the cron expression, waits via a timer,
+// and dispatches the configured action. Signals control pause/unpause, update,
+// backfill, and deletion.
+//
+// The main loop follows a state-machine pattern: all inputs (signals and timer)
+// uniformly mutate state, and then a single decision point inspects the resulting
+// state to determine what to do next. ContinueAsNew is triggered on any
+// state-changing signal (pause, unpause, update) so the new execution's input
+// is always the authoritative source of truth.
+func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error {
+	logger := workflow.GetLogger(ctx)
+	logger.Info("scheduler workflow started",
+		zap.String("domain", input.Domain),
+		zap.String("scheduleId", input.ScheduleID),
+		zap.Bool("paused", input.State.Paused),
+	)
+
+	state := &input.State
+
+	chs := signalChannels{
+		pause:    workflow.GetSignalChannel(ctx, SignalNamePause),
+		unpause:  workflow.GetSignalChannel(ctx, SignalNameUnpause),
+		update:   workflow.GetSignalChannel(ctx, SignalNameUpdate),
+		backfill: workflow.GetSignalChannel(ctx, SignalNameBackfill),
+		delete:   workflow.GetSignalChannel(ctx, SignalNameDelete),
+	}
+
+	sched, err := cron.ParseStandard(input.Spec.CronExpression)
+	if err != nil {
+		logger.Error("invalid cron expression, terminating", zap.String("cron", input.Spec.CronExpression), zap.Error(err))
+		return fmt.Errorf("invalid cron expression %q: %w", input.Spec.CronExpression, err)
+	}
+
+	for {
+		state.Iterations++
+
+		// Set up timer only when not paused. When paused, applyAllInputs
+		// blocks on signals alone until an unpause or delete arrives.
+		var timerFuture workflow.Future
+		var timerCancel func()
+		if !state.Paused {
+			now := workflow.Now(ctx)
+			nextRun := computeNextRunTime(sched, now, input.Spec)
+			if nextRun.IsZero() {
+				logger.Info("schedule has no more runs (past end time), completing")
+				return nil
+			}
+			state.NextRunTime = nextRun
+
+			dur := nextRun.Sub(now)
+			if dur < 0 {
+				dur = 0
+			}
+			var timerCtx workflow.Context
+			timerCtx, timerCancel = workflow.WithCancel(ctx)
+			timerFuture = workflow.NewTimer(timerCtx, dur)
+		}
+
+		changed := applyAllInputs(ctx, logger, timerFuture, chs, state, &input)
+
+		if timerCancel != nil {
+			timerCancel()
+		}
+
+		if state.Deleted {
+			logger.Info("schedule deleted")
+			return nil
+		}
+		if changed || state.Iterations >= maxIterationsBeforeContinueAsNew {
+			return safeContinueAsNew(ctx, logger, chs.delete, input, state)
+		}
+	}
+}
+
+// applyAllInputs blocks until at least one input (signal or timer) arrives,
+// processes it, then drains any remaining buffered signals.
+// Signals and the timer are treated uniformly: each mutates state without
+// triggering side effects (no timer cancellation, no ContinueAsNew).
+// Returns true if a state-changing signal (pause, unpause, update) was received.
+func applyAllInputs(
+	ctx workflow.Context,
+	logger *zap.Logger,
+	timerFuture workflow.Future,
+	chs signalChannels,
+	state *SchedulerWorkflowState,
+	input *SchedulerWorkflowInput,
+) bool {
+	selector := workflow.NewSelector(ctx)
+	stateChanged := false
+
+	if timerFuture != nil {
+		selector.AddFuture(timerFuture, func(f workflow.Future) {
+			if f.Get(ctx, nil) != nil {
+				return
+			}
+			state.LastRunTime = state.NextRunTime
+			state.TotalRuns++
+			logger.Info("schedule fired",
+				zap.Time("scheduledTime", state.NextRunTime),
+				zap.Int64("totalRuns", state.TotalRuns),
+			)
+		})
+	}
+
+	selector.AddReceive(chs.pause, func(c workflow.Channel, more bool) {
+		var sig PauseSignal
+		c.Receive(ctx, &sig)
+		if handlePause(logger, sig, state) {
+			stateChanged = true
+		}
+	})
+
+	selector.AddReceive(chs.unpause, func(c workflow.Channel, more bool) {
+		var sig UnpauseSignal
+		c.Receive(ctx, &sig)
+		if handleUnpause(logger, sig, state) {
+			stateChanged = true
+		}
+	})
+
+	selector.AddReceive(chs.update, func(c workflow.Channel, more bool) {
+		var sig UpdateSignal
+		c.Receive(ctx, &sig)
+		if handleUpdate(logger, sig, input) {
+			stateChanged = true
+		}
+	})
+
+	selector.AddReceive(chs.backfill, func(c workflow.Channel, more bool) {
+		var sig BackfillSignal
+		c.Receive(ctx, &sig)
+		handleBackfill(logger, sig, state)
+	})
+
+	selector.AddReceive(chs.delete, func(c workflow.Channel, more bool) {
+		c.Receive(ctx, nil)
+		state.Deleted = true
+	})
+
+	selector.Select(ctx)
+
+	if drainBufferedSignals(logger, chs, state, input) {
+		stateChanged = true
+	}
+
+	return stateChanged
+}
+
+// drainBufferedSignals processes any remaining buffered signals without blocking.
+// Delete signals are checked first to prevent signal loss across ContinueAsNew boundaries.
+// Returns true if a state-changing signal was found.
+func drainBufferedSignals(
+	logger *zap.Logger,
+	chs signalChannels,
+	state *SchedulerWorkflowState,
+	input *SchedulerWorkflowInput,
+) bool {
+	if chs.delete.ReceiveAsync(nil) {
+		state.Deleted = true
+		return false
+	}
+
+	stateChanged := false
+	for {
+		var sig PauseSignal
+		if !chs.pause.ReceiveAsync(&sig) {
+			break
+		}
+		if handlePause(logger, sig, state) {
+			stateChanged = true
+		}
+	}
+	for {
+		var sig UnpauseSignal
+		if !chs.unpause.ReceiveAsync(&sig) {
+			break
+		}
+		if handleUnpause(logger, sig, state) {
+			stateChanged = true
+		}
+	}
+	for {
+		var sig UpdateSignal
+		if !chs.update.ReceiveAsync(&sig) {
+			break
+		}
+		if handleUpdate(logger, sig, input) {
+			stateChanged = true
+		}
+	}
+	for {
+		var sig BackfillSignal
+		if !chs.backfill.ReceiveAsync(&sig) {
+			break
+		}
+		handleBackfill(logger, sig, state)
+	}
+
+	return stateChanged
+}
+
+func handlePause(logger *zap.Logger, sig PauseSignal, state *SchedulerWorkflowState) bool {
+	state.Paused = true
+	state.PauseReason = sig.Reason
+	state.PausedBy = sig.PausedBy
+	logger.Info("schedule paused", zap.String("reason", sig.Reason), zap.String("pausedBy", sig.PausedBy))
+	return true
+}
+
+func handleUnpause(logger *zap.Logger, sig UnpauseSignal, state *SchedulerWorkflowState) bool {
+	if !state.Paused {
+		logger.Info("ignoring unpause signal, schedule is not paused")
+		return false
+	}
+	state.Paused = false
+	state.PauseReason = ""
+	state.PausedBy = ""
+	logger.Info("schedule unpaused", zap.String("reason", sig.Reason), zap.String("catchUpPolicy", sig.CatchUpPolicy.String()))
+	return true
+}
+
+func handleUpdate(logger *zap.Logger, sig UpdateSignal, input *SchedulerWorkflowInput) bool {
+	if sig.Spec == nil && sig.Action == nil && sig.Policies == nil {
+		logger.Info("ignoring empty update signal")
+		return false
+	}
+	changed := false
+	if sig.Spec != nil {
+		if _, err := cron.ParseStandard(sig.Spec.CronExpression); err != nil {
+			logger.Error("ignoring update with invalid cron expression",
+				zap.String("cron", sig.Spec.CronExpression), zap.Error(err))
+		} else {
+			input.Spec = *sig.Spec
+			changed = true
+		}
+	}
+	if sig.Action != nil {
+		input.Action = *sig.Action
+		changed = true
+	}
+	if sig.Policies != nil {
+		input.Policies = *sig.Policies
+		changed = true
+	}
+	if changed {
+		logger.Info("schedule updated")
+	}
+	return changed
+}
+
+func handleBackfill(logger *zap.Logger, sig BackfillSignal, state *SchedulerWorkflowState) {
+	logger.Info("backfill signal received",
+		zap.Time("startTime", sig.StartTime),
+		zap.Time("endTime", sig.EndTime),
+		zap.String("overlapPolicy", sig.OverlapPolicy.String()),
+		zap.String("backfillId", sig.BackfillID),
+	)
+}
+
+// computeNextRunTime determines the next fire time for the cron schedule,
+// respecting the spec's StartTime and EndTime boundaries.
+func computeNextRunTime(sched cron.Schedule, now time.Time, spec types.ScheduleSpec) time.Time {
+	if !spec.StartTime.IsZero() && now.Before(spec.StartTime) {
+		now = spec.StartTime.Add(-time.Second)
+	}
+	next := sched.Next(now)
+	if !spec.EndTime.IsZero() && next.After(spec.EndTime) {
+		return time.Time{}
+	}
+	return next
+}
+
+// safeContinueAsNew drains the delete channel before performing ContinueAsNew.
+// Buffered signals are not carried across ContinueAsNew boundaries, so a delete
+// signal that arrived alongside a state-changing signal would be lost without this check.
+func safeContinueAsNew(ctx workflow.Context, logger *zap.Logger, deleteCh workflow.Channel, input SchedulerWorkflowInput, state *SchedulerWorkflowState) error {
+	if deleteCh.ReceiveAsync(nil) {
+		logger.Info("schedule deleted (caught before ContinueAsNew)")
+		return nil
+	}
+	state.Iterations = 0
+	input.State = *state
+	return workflow.NewContinueAsNewError(ctx, WorkflowTypeName, input)
+}

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -1,0 +1,312 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scheduler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/robfig/cron/v3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/uber/cadence/common/types"
+)
+
+var testLogger = zap.NewNop()
+
+func mustParseCron(t *testing.T, expr string) cron.Schedule {
+	t.Helper()
+	s, err := cron.ParseStandard(expr)
+	require.NoError(t, err)
+	return s
+}
+
+func TestComputeNextRunTime(t *testing.T) {
+	now := time.Date(2026, 1, 15, 10, 30, 0, 0, time.UTC)
+
+	tests := []struct {
+		name     string
+		cron     string
+		now      time.Time
+		spec     types.ScheduleSpec
+		wantZero bool
+		wantTime time.Time
+	}{
+		{
+			name:     "every hour - next on the hour",
+			cron:     "0 * * * *",
+			now:      now,
+			spec:     types.ScheduleSpec{},
+			wantTime: time.Date(2026, 1, 15, 11, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "every day at midnight",
+			cron:     "0 0 * * *",
+			now:      now,
+			spec:     types.ScheduleSpec{},
+			wantTime: time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "now is before startTime - uses startTime as base",
+			cron:     "0 * * * *",
+			now:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			spec:     types.ScheduleSpec{StartTime: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)},
+			wantTime: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "next run is after endTime - returns zero",
+			cron:     "0 0 * * *",
+			now:      time.Date(2026, 1, 15, 23, 0, 0, 0, time.UTC),
+			spec:     types.ScheduleSpec{EndTime: time.Date(2026, 1, 15, 23, 59, 0, 0, time.UTC)},
+			wantZero: true,
+		},
+		{
+			name:     "next run is before endTime - returns next",
+			cron:     "0 * * * *",
+			now:      now,
+			spec:     types.ScheduleSpec{EndTime: time.Date(2026, 12, 31, 0, 0, 0, 0, time.UTC)},
+			wantTime: time.Date(2026, 1, 15, 11, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "startTime and endTime together - within window",
+			cron: "0 * * * *",
+			now:  time.Date(2026, 6, 1, 5, 30, 0, 0, time.UTC),
+			spec: types.ScheduleSpec{
+				StartTime: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+				EndTime:   time.Date(2026, 6, 2, 0, 0, 0, 0, time.UTC),
+			},
+			wantTime: time.Date(2026, 6, 1, 6, 0, 0, 0, time.UTC),
+		},
+		{
+			name:     "every minute",
+			cron:     "* * * * *",
+			now:      now,
+			spec:     types.ScheduleSpec{},
+			wantTime: time.Date(2026, 1, 15, 10, 31, 0, 0, time.UTC),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sched := mustParseCron(t, tt.cron)
+			got := computeNextRunTime(sched, tt.now, tt.spec)
+			if tt.wantZero {
+				assert.True(t, got.IsZero(), "expected zero time, got %v", got)
+			} else {
+				assert.Equal(t, tt.wantTime, got)
+			}
+		})
+	}
+}
+
+func TestHandlePause(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      SchedulerWorkflowState
+		sig          PauseSignal
+		wantPaused   bool
+		wantReason   string
+		wantPausedBy string
+		wantChanged  bool
+	}{
+		{
+			name:         "pause from running",
+			initial:      SchedulerWorkflowState{},
+			sig:          PauseSignal{Reason: "maintenance", PausedBy: "admin@test.com"},
+			wantPaused:   true,
+			wantReason:   "maintenance",
+			wantPausedBy: "admin@test.com",
+			wantChanged:  true,
+		},
+		{
+			name:         "pause overwrites previous pause reason",
+			initial:      SchedulerWorkflowState{Paused: true, PauseReason: "old", PausedBy: "old-user"},
+			sig:          PauseSignal{Reason: "new reason", PausedBy: "new-user"},
+			wantPaused:   true,
+			wantReason:   "new reason",
+			wantPausedBy: "new-user",
+			wantChanged:  true,
+		},
+		{
+			name:         "pause with empty reason",
+			initial:      SchedulerWorkflowState{},
+			sig:          PauseSignal{},
+			wantPaused:   true,
+			wantReason:   "",
+			wantPausedBy: "",
+			wantChanged:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := tt.initial
+			changed := handlePause(testLogger, tt.sig, &state)
+			assert.Equal(t, tt.wantChanged, changed)
+			assert.Equal(t, tt.wantPaused, state.Paused)
+			assert.Equal(t, tt.wantReason, state.PauseReason)
+			assert.Equal(t, tt.wantPausedBy, state.PausedBy)
+		})
+	}
+}
+
+func TestHandleUnpause(t *testing.T) {
+	tests := []struct {
+		name         string
+		initial      SchedulerWorkflowState
+		sig          UnpauseSignal
+		wantPaused   bool
+		wantReason   string
+		wantPausedBy string
+		wantChanged  bool
+	}{
+		{
+			name:         "unpause from paused",
+			initial:      SchedulerWorkflowState{Paused: true, PauseReason: "maintenance", PausedBy: "admin"},
+			sig:          UnpauseSignal{Reason: "maintenance done"},
+			wantPaused:   false,
+			wantReason:   "",
+			wantPausedBy: "",
+			wantChanged:  true,
+		},
+		{
+			name:         "unpause when not paused is a no-op",
+			initial:      SchedulerWorkflowState{Paused: false},
+			sig:          UnpauseSignal{Reason: "shouldn't matter"},
+			wantPaused:   false,
+			wantReason:   "",
+			wantPausedBy: "",
+			wantChanged:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := tt.initial
+			changed := handleUnpause(testLogger, tt.sig, &state)
+			assert.Equal(t, tt.wantChanged, changed)
+			assert.Equal(t, tt.wantPaused, state.Paused)
+			assert.Equal(t, tt.wantReason, state.PauseReason)
+			assert.Equal(t, tt.wantPausedBy, state.PausedBy)
+		})
+	}
+}
+
+func TestHandleUpdate(t *testing.T) {
+	original := SchedulerWorkflowInput{
+		Domain:     "test-domain",
+		ScheduleID: "sched-1",
+		Spec:       types.ScheduleSpec{CronExpression: "0 * * * *"},
+		Action: types.ScheduleAction{
+			StartWorkflow: &types.StartWorkflowAction{
+				WorkflowType: &types.WorkflowType{Name: "old-workflow"},
+			},
+		},
+		Policies: types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicySkipNew},
+	}
+
+	tests := []struct {
+		name        string
+		sig         UpdateSignal
+		wantCron    string
+		wantWF      string
+		wantPol     types.ScheduleOverlapPolicy
+		wantChanged bool
+	}{
+		{
+			name: "update spec only",
+			sig: UpdateSignal{
+				Spec: &types.ScheduleSpec{CronExpression: "*/5 * * * *"},
+			},
+			wantCron:    "*/5 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: true,
+		},
+		{
+			name: "update action only",
+			sig: UpdateSignal{
+				Action: &types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "new-workflow"},
+					},
+				},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "new-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: true,
+		},
+		{
+			name: "update policies only",
+			sig: UpdateSignal{
+				Policies: &types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicyConcurrent},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicyConcurrent,
+			wantChanged: true,
+		},
+		{
+			name:        "nil fields leave input unchanged",
+			sig:         UpdateSignal{},
+			wantCron:    "0 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: false,
+		},
+		{
+			name: "invalid cron expression is rejected, spec unchanged",
+			sig: UpdateSignal{
+				Spec: &types.ScheduleSpec{CronExpression: "not-a-cron"},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "old-workflow",
+			wantPol:     types.ScheduleOverlapPolicySkipNew,
+			wantChanged: false,
+		},
+		{
+			name: "invalid cron rejected but action and policies still applied",
+			sig: UpdateSignal{
+				Spec:     &types.ScheduleSpec{CronExpression: "bad"},
+				Action:   &types.ScheduleAction{StartWorkflow: &types.StartWorkflowAction{WorkflowType: &types.WorkflowType{Name: "new-workflow"}}},
+				Policies: &types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicyConcurrent},
+			},
+			wantCron:    "0 * * * *",
+			wantWF:      "new-workflow",
+			wantPol:     types.ScheduleOverlapPolicyConcurrent,
+			wantChanged: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			input := original
+			changed := handleUpdate(testLogger, tt.sig, &input)
+			assert.Equal(t, tt.wantChanged, changed)
+			assert.Equal(t, tt.wantCron, input.Spec.CronExpression)
+			assert.Equal(t, tt.wantWF, input.Action.StartWorkflow.WorkflowType.Name)
+			assert.Equal(t, tt.wantPol, input.Policies.OverlapPolicy)
+		})
+	}
+}


### PR DESCRIPTION

**What changed?**
Add the core scheduler workflow skeleton in `service/worker/scheduler/`:
- `types.go`: Workflow input/state types, signal payloads (pause, unpause, update, backfill, delete), activity I/O types, and constants
- `workflow.go`: Scheduler workflow with cron-based timer loop, signal handling, and ContinueAsNew

Key design decisions:
- **ContinueAsNew on state-changing signals**: Pause, unpause, and update signals trigger an immediate ContinueAsNew so the new execution's input is always the authoritative source of truth for the schedule's current configuration
- **Iteration safety net**: A hardcoded limit of 500 timer-fire iterations triggers ContinueAsNew as a fallback (~5K events out of 50K history limit)
- **Signal handling**: 5 signal channels (pause, unpause, update, backfill, delete) with dedicated handlers. Pause blocks via selector until unpause or delete arrives
- **Cron computation**: Uses existing `robfig/cron/v3` dependency, respects spec StartTime/EndTime boundaries


**Why?**
This establishes the core workflow structure for the Cadence Schedules feature. The scheduler workflow is the long-running process that manages a single schedule: computing fire times, dispatching actions, and responding to operational signals (pause/resume/update/delete).

Part of Cadence Schedules feature for pause/resume, catch-up, and backfill capabilities.


**How did you test it?**
Added unit tests
cd service/worker/scheduler && go test ./...

**Potential risks**
N/A: Internal workflow skeleton.

**Release notes**
N/A: Internal workflow skeleton.

**Documentation Changes**
N/A
