### PR TITLE
feat: [Cadence Schedules] Add scheduler worker registration and service wiring

### DIFF
--- a/common/dynamicconfig/dynamicproperties/constants.go
+++ b/common/dynamicconfig/dynamicproperties/constants.go
@@ -2014,6 +2014,12 @@ const (
 	// Default value: true
 	// Allowed filters: N/A
 	EnableBatcher
+	// EnableScheduler decides whether to start the scheduler worker for cron-based scheduling
+	// KeyName: worker.enableScheduler
+	// Value type: Bool
+	// Default value: false
+	// Allowed filters: N/A
+	EnableScheduler
 	// EnableParentClosePolicyWorker decides whether or not enable system workers for processing parent close policy task
 	// KeyName: system.enableParentClosePolicyWorker
 	// Value type: Bool
@@ -4742,6 +4748,11 @@ var BoolKeys = map[BoolKey]DynamicBool{
 		KeyName:      "worker.enableBatcher",
 		Description:  "EnableBatcher is decides whether start batcher in our worker",
 		DefaultValue: true,
+	},
+	EnableScheduler: {
+		KeyName:      "worker.enableScheduler",
+		Description:  "EnableScheduler decides whether to start the scheduler worker for cron-based scheduling",
+		DefaultValue: false,
 	},
 	EnableParentClosePolicyWorker: {
 		KeyName:      "system.enableParentClosePolicyWorker",

--- a/common/log/tag/values.go
+++ b/common/log/tag/values.go
@@ -127,6 +127,7 @@ var (
 	ComponentESVisibilityManager              = component("es-visibility-manager")
 	ComponentArchiver                         = component("archiver")
 	ComponentBatcher                          = component("batcher")
+	ComponentScheduler                        = component("scheduler")
 	ComponentWorker                           = component("worker")
 	ComponentServiceResolver                  = component("service-resolver")
 	ComponentFailoverCoordinator              = component("failover-coordinator")

--- a/service/worker/scheduler/client_worker.go
+++ b/service/worker/scheduler/client_worker.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package scheduler
+
+import (
+	"go.uber.org/cadence/.gen/go/cadence/workflowserviceclient"
+	"go.uber.org/cadence/worker"
+	"go.uber.org/cadence/workflow"
+
+	"github.com/uber/cadence/common/constants"
+	"github.com/uber/cadence/common/log"
+	"github.com/uber/cadence/common/log/tag"
+)
+
+type (
+	// BootstrapParams contains the parameters needed to create a scheduler worker.
+	BootstrapParams struct {
+		ServiceClient workflowserviceclient.Interface
+		Logger        log.Logger
+	}
+
+	// Scheduler is the background worker that polls the scheduler task list
+	// and executes schedule workflows.
+	Scheduler struct {
+		logger log.Logger
+		worker worker.Worker
+	}
+)
+
+// New creates a new Scheduler worker instance.
+// It registers the scheduler workflow and creates a Cadence SDK worker
+// for the scheduler task list in the system domain.
+func New(params *BootstrapParams) *Scheduler {
+	logger := params.Logger.WithTags(tag.ComponentScheduler)
+
+	wo := worker.Options{}
+	w := worker.New(params.ServiceClient, constants.SystemLocalDomainName, TaskListName, wo)
+	w.RegisterWorkflowWithOptions(SchedulerWorkflow, workflow.RegisterOptions{Name: WorkflowTypeName})
+
+	return &Scheduler{
+		logger: logger,
+		worker: w,
+	}
+}
+
+// Start begins polling the scheduler task list.
+func (s *Scheduler) Start() error {
+	s.logger.Info("scheduler worker starting")
+	if err := s.worker.Start(); err != nil {
+		s.worker.Stop()
+		return err
+	}
+	s.logger.Info("scheduler worker started")
+	return nil
+}
+
+// Stop stops the scheduler worker.
+func (s *Scheduler) Stop() {
+	s.logger.Info("scheduler worker stopping")
+	s.worker.Stop()
+	s.logger.Info("scheduler worker stopped")
+}

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -40,10 +40,6 @@ type signalChannels struct {
 	delete   workflow.Channel
 }
 
-func init() {
-	workflow.RegisterWithOptions(SchedulerWorkflow, workflow.RegisterOptions{Name: WorkflowTypeName})
-}
-
 // SchedulerWorkflow is a long-running workflow that manages a single schedule.
 // It computes the next fire time from the cron expression, waits via a timer,
 // and dispatches the configured action. Signals control pause/unpause, update,

--- a/service/worker/service.go
+++ b/service/worker/service.go
@@ -54,6 +54,7 @@ import (
 	"github.com/uber/cadence/service/worker/scanner/shardscanner"
 	"github.com/uber/cadence/service/worker/scanner/tasklist"
 	"github.com/uber/cadence/service/worker/scanner/timers"
+	"github.com/uber/cadence/service/worker/scheduler"
 )
 
 type (
@@ -84,6 +85,7 @@ type (
 		PersistenceGlobalMaxQPS             dynamicproperties.IntPropertyFn
 		PersistenceMaxQPS                   dynamicproperties.IntPropertyFn
 		EnableBatcher                       dynamicproperties.BoolPropertyFn
+		EnableScheduler                     dynamicproperties.BoolPropertyFn
 		EnableParentClosePolicyWorker       dynamicproperties.BoolPropertyFn
 		NumParentClosePolicySystemWorkflows dynamicproperties.IntPropertyFn
 		EnableFailoverManager               dynamicproperties.BoolPropertyFn
@@ -181,6 +183,7 @@ func NewConfig(params *resource.Params) *Config {
 			ESAnalyzerWorkflowTypeDomains:            dc.GetStringProperty(dynamicproperties.ESAnalyzerWorkflowTypeMetricDomains),
 		},
 		EnableBatcher:                       dc.GetBoolProperty(dynamicproperties.EnableBatcher),
+		EnableScheduler:                     dc.GetBoolProperty(dynamicproperties.EnableScheduler),
 		EnableParentClosePolicyWorker:       dc.GetBoolProperty(dynamicproperties.EnableParentClosePolicyWorker),
 		NumParentClosePolicySystemWorkflows: dc.GetIntProperty(dynamicproperties.NumParentClosePolicySystemWorkflows),
 		EnableESAnalyzer:                    dc.GetBoolProperty(dynamicproperties.EnableESAnalyzer),
@@ -244,6 +247,9 @@ func (s *Service) Start() {
 	if s.config.EnableBatcher() {
 		s.ensureDomainExists(constants.BatcherLocalDomainName)
 		s.startBatcher()
+	}
+	if s.config.EnableScheduler() {
+		s.startScheduler()
 	}
 	if s.config.EnableParentClosePolicyWorker() {
 		s.startParentClosePolicyProcessor()
@@ -335,6 +341,16 @@ func (s *Service) startBatcher() {
 	}
 	if err := batcher.New(params).Start(); err != nil {
 		s.GetLogger().Fatal("error starting batcher", tag.Error(err))
+	}
+}
+
+func (s *Service) startScheduler() {
+	params := &scheduler.BootstrapParams{
+		ServiceClient: s.params.PublicClient,
+		Logger:        s.GetLogger(),
+	}
+	if err := scheduler.New(params).Start(); err != nil {
+		s.GetLogger().Fatal("error starting scheduler", tag.Error(err))
 	}
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
Add the scheduler worker bootstrap that registers the SchedulerWorkflow with the Cadence SDK worker and wires it into the cadence-worker service. Key changes:
- Add service/worker/scheduler/client_worker.go with New(), Start(), Stop() following the batcher pattern
- Move workflow registration from init() to explicit registration in New() (addresses prior review feedback)
- Add EnableScheduler dynamic config (worker.enableScheduler, default false) to gate the feature
- Wire startScheduler() into service/worker/service.go Start() lifecycle

**Why?**
The scheduler workflow from [Diff](https://github.com/cadence-workflow/cadence/pull/7783) needs a Cadence SDK worker to execute it. This follows the established pattern for system workers (batcher, archiver) and uses a dynamic config flag to safely gate activation during development. The feature defaults to off, preventing accidental activation in production before the implementation is complete.

**How did you test it?**
cd service/worker/scheduler && go test ./... 
go build ./service/worker/...

**Potential risks**
Minimal. The feature is gated behind worker.enableScheduler (default false), so no existing behavior changes unless explicitly opted in.

**Release notes**
N/A (feature not completed)

**Documentation Changes**
N/A
