### PR TITLE
refactor: Refactor weighted channel pool and remove unused types

### DIFF
--- a/common/task/iwrr_schedule.go
+++ b/common/task/iwrr_schedule.go
@@ -4,10 +4,6 @@ import "slices"
 
 var _ Schedule[any] = &iwrrSchedule[any]{}
 
-type weightedItem interface {
-	Weight() int
-}
-
 // weightedContainer is a container for an item with a weight
 type weightedContainer[V any] struct {
 	weight int
@@ -30,27 +26,23 @@ type iwrrSchedule[V any] struct {
 type iwrrIterator[V any] struct {
 	schedule     *iwrrSchedule[V]
 	currentRound int // Current round (maxWeight-1 down to 0)
-	currentIndex int // Index within current round's qualifying channels
+	currentIndex int // Index within current round's qualifying items
 }
 
-// newIWRRSchedule creates a new IWRR schedule from a snapshot of weighted items
+// newIWRRSchedule creates a new IWRR schedule from a snapshot of weighted containers
 // Items with weight <= 0 are ignored
-func newIWRRSchedule[K comparable, V weightedItem](items map[K]V) *iwrrSchedule[V] {
+func newIWRRSchedule[K comparable, V any](items map[K]weightedContainer[V]) *iwrrSchedule[V] {
 	if len(items) == 0 {
 		return &iwrrSchedule[V]{}
 	}
 
-	// Filter out items with weight <= 0 and copy only the fields we need
+	// Filter out items with weight <= 0 and copy to slice
 	itemsCopy := make([]weightedContainer[V], 0, len(items))
 	totalLen := 0
-	for _, v := range items {
-		weight := v.Weight()
-		if weight > 0 {
-			itemsCopy = append(itemsCopy, weightedContainer[V]{
-				weight: weight,
-				item:   v,
-			})
-			totalLen += weight
+	for _, container := range items {
+		if container.weight > 0 {
+			itemsCopy = append(itemsCopy, container)
+			totalLen += container.weight
 		}
 	}
 

--- a/common/task/iwrr_schedule_test.go
+++ b/common/task/iwrr_schedule_test.go
@@ -7,14 +7,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// testWeightedItem is a simple implementation of weightedItem for testing
+// testWeightedItem is a simple implementation for testing
 type testWeightedItem struct {
-	weight int
-	id     int
+	id int
 }
 
-func (t *testWeightedItem) Weight() int {
-	return t.weight
+// toWeightedMap converts a map of items with weights to a map of weightedContainers
+func toWeightedMap(items map[int]*testWeightedItem, weights map[int]int) map[int]weightedContainer[*testWeightedItem] {
+	result := make(map[int]weightedContainer[*testWeightedItem])
+	for k, item := range items {
+		result[k] = weightedContainer[*testWeightedItem]{
+			item:   item,
+			weight: weights[k],
+		}
+	}
+	return result
 }
 
 func TestIWRRSchedule_Empty(t *testing.T) {
@@ -30,10 +37,13 @@ func TestIWRRSchedule_Empty(t *testing.T) {
 
 func TestIWRRSchedule_SingleChannel(t *testing.T) {
 	items := map[int]*testWeightedItem{
-		0: {weight: 3, id: 0},
+		0: {id: 0},
+	}
+	weights := map[int]int{
+		0: 3,
 	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	// Total length should be the weight
 	assert.Equal(t, 3, schedule.Len())
@@ -55,12 +65,17 @@ func TestIWRRSchedule_SingleChannel(t *testing.T) {
 
 func TestIWRRSchedule_MultipleChannels_EqualWeights(t *testing.T) {
 	items := map[int]*testWeightedItem{
-		0: {weight: 2, id: 0},
-		1: {weight: 2, id: 1},
-		2: {weight: 2, id: 2},
+		0: {id: 0},
+		1: {id: 1},
+		2: {id: 2},
+	}
+	weights := map[int]int{
+		0: 2,
+		1: 2,
+		2: 2,
 	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	assert.Equal(t, 6, schedule.Len())
 
@@ -85,12 +100,17 @@ func TestIWRRSchedule_MultipleChannels_EqualWeights(t *testing.T) {
 func TestIWRRSchedule_MultipleChannels_DifferentWeights(t *testing.T) {
 	// Create items with weights [1, 2, 3]
 	items := map[int]*testWeightedItem{
-		0: {weight: 1, id: 0},
-		1: {weight: 2, id: 1},
-		2: {weight: 3, id: 2},
+		0: {id: 0},
+		1: {id: 1},
+		2: {id: 2},
+	}
+	weights := map[int]int{
+		0: 1,
+		1: 2,
+		2: 3,
 	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	assert.Equal(t, 6, schedule.Len())
 
@@ -124,12 +144,17 @@ func TestIWRRSchedule_MultipleChannels_DifferentWeights(t *testing.T) {
 
 func TestIWRRSchedule_LargeWeights(t *testing.T) {
 	items := map[int]*testWeightedItem{
-		0: {weight: 100, id: 0},
-		1: {weight: 50, id: 1},
-		2: {weight: 25, id: 2},
+		0: {id: 0},
+		1: {id: 1},
+		2: {id: 2},
+	}
+	weights := map[int]int{
+		0: 100,
+		1: 50,
+		2: 25,
 	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	assert.Equal(t, 175, schedule.Len())
 
@@ -171,11 +196,15 @@ func TestIWRRSchedule_LargeWeights(t *testing.T) {
 
 func TestIWRRSchedule_ChannelWithZeroWeight(t *testing.T) {
 	items := map[int]*testWeightedItem{
-		0: {weight: 0, id: 0},
-		1: {weight: 3, id: 1},
+		0: {id: 0},
+		1: {id: 1},
+	}
+	weights := map[int]int{
+		0: 0,
+		1: 3,
 	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	// Total length should only count non-zero weights
 	assert.Equal(t, 3, schedule.Len())
@@ -198,14 +227,16 @@ func TestIWRRSchedule_ChannelWithZeroWeight(t *testing.T) {
 func TestIWRRSchedule_WeightedChannelFields(t *testing.T) {
 	// Verify that the returned item is correct
 	testItem := &testWeightedItem{
-		weight: 10,
-		id:     0,
+		id: 0,
 	}
 	items := map[int]*testWeightedItem{
 		0: testItem,
 	}
+	weights := map[int]int{
+		0: 10,
+	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	iter := schedule.NewIterator()
 
@@ -216,10 +247,13 @@ func TestIWRRSchedule_WeightedChannelFields(t *testing.T) {
 
 func TestIWRRSchedule_ExhaustedSchedule_MultipleCallsReturnFalse(t *testing.T) {
 	items := map[int]*testWeightedItem{
-		0: {weight: 1, id: 0},
+		0: {id: 0},
+	}
+	weights := map[int]int{
+		0: 1,
 	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	iter := schedule.NewIterator()
 
@@ -239,12 +273,17 @@ func TestIWRRSchedule_ExhaustedSchedule_MultipleCallsReturnFalse(t *testing.T) {
 func TestIWRRSchedule_Ordering_Weights_5_3_1(t *testing.T) {
 	// Test case from task pool tests: weights [5, 3, 1]
 	items := map[int]*testWeightedItem{
-		0: {weight: 5, id: 0},
-		1: {weight: 3, id: 1},
-		2: {weight: 1, id: 2},
+		0: {id: 0},
+		1: {id: 1},
+		2: {id: 2},
+	}
+	weights := map[int]int{
+		0: 5,
+		1: 3,
+		2: 1,
 	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	assert.Equal(t, 9, schedule.Len())
 
@@ -273,14 +312,18 @@ func TestIWRRSchedule_Ordering_Weights_5_3_1(t *testing.T) {
 
 func TestIWRRSchedule_StatelessSchedule_MultipleIterators(t *testing.T) {
 	// Test that the schedule is stateless and can create multiple independent iterators
-	item1 := &testWeightedItem{weight: 2, id: 0}
-	item2 := &testWeightedItem{weight: 1, id: 1}
+	item1 := &testWeightedItem{id: 0}
+	item2 := &testWeightedItem{id: 1}
 	items := map[int]*testWeightedItem{
 		0: item1,
 		1: item2,
 	}
+	weights := map[int]int{
+		0: 2,
+		1: 1,
+	}
 
-	schedule := newIWRRSchedule[int, *testWeightedItem](items)
+	schedule := newIWRRSchedule[int, *testWeightedItem](toWeightedMap(items, weights))
 
 	// IWRR for weights [2, 1]: [item1, item1, item2]
 	// Create first iterator and consume partially

--- a/common/task/ttl_channel.go
+++ b/common/task/ttl_channel.go
@@ -27,7 +27,7 @@ import (
 	"time"
 )
 
-// TTLChannel is a channel with a last write time and reference count
+// TTLChannel is a channel that can expire if it is not written to for a given amount of time.
 type TTLChannel[V any] struct {
 	c             chan V
 	lastWriteTime atomic.Int64

--- a/common/task/weighted_channel_pool.go
+++ b/common/task/weighted_channel_pool.go
@@ -37,11 +37,6 @@ import (
 const defaultIdleChannelTTLInSeconds = 3600
 
 type (
-	weightedChannel[V any] struct {
-		*TTLChannel[V]
-		weight int
-	}
-
 	WeightedRoundRobinChannelPoolOptions struct {
 		BufferSize              int
 		IdleChannelTTLInSeconds int64
@@ -57,10 +52,10 @@ type (
 		logger                  log.Logger
 		metricsScope            metrics.Scope
 		timeSource              clock.TimeSource
-		channelMap              map[K]*weightedChannel[V]
+		channelMap              map[K]weightedContainer[*TTLChannel[V]]
 
 		// a snapshot of the channels to be used for the IWRR schedule
-		iwrrSchedule atomic.Pointer[iwrrSchedule[*weightedChannel[V]]]
+		iwrrSchedule atomic.Pointer[iwrrSchedule[*TTLChannel[V]]]
 	}
 )
 
@@ -76,11 +71,12 @@ func NewWeightedRoundRobinChannelPool[K comparable, V any](
 		logger:                  logger,
 		metricsScope:            metricsScope,
 		timeSource:              timeSource,
-		channelMap:              make(map[K]*weightedChannel[V]),
+		channelMap:              make(map[K]weightedContainer[*TTLChannel[V]]),
 		shutdownCh:              make(chan struct{}),
 	}
-	// Initialize with empty channels
-	wrr.iwrrSchedule.Store(newIWRRSchedule[K, *weightedChannel[V]](nil))
+	// Initialize with empty schedule
+	schedule := newIWRRSchedule[K, *TTLChannel[V]](nil)
+	wrr.iwrrSchedule.Store(schedule)
 	return wrr
 }
 
@@ -127,8 +123,8 @@ func (p *WeightedRoundRobinChannelPool[K, V]) doCleanup() {
 	var channelsToCleanup []K
 	now := p.timeSource.Now()
 	ttl := time.Duration(p.idleChannelTTLInSeconds) * time.Second
-	for k, v := range p.channelMap {
-		if v.ShouldCleanup(now, ttl) {
+	for k, container := range p.channelMap {
+		if container.item.ShouldCleanup(now, ttl) {
 			channelsToCleanup = append(channelsToCleanup, k)
 		}
 	}
@@ -145,48 +141,51 @@ func (p *WeightedRoundRobinChannelPool[K, V]) doCleanup() {
 
 func (p *WeightedRoundRobinChannelPool[K, V]) GetOrCreateChannel(key K, weight int) (chan V, func()) {
 	p.RLock()
-	if v := p.channelMap[key]; v != nil && v.weight == weight {
-		v.IncRef()
-		v.UpdateLastWriteTime(p.timeSource.Now())
+	if container, exists := p.channelMap[key]; exists && container.weight == weight {
+		container.item.IncRef()
+		container.item.UpdateLastWriteTime(p.timeSource.Now())
 		p.RUnlock()
-		return v.Chan(), v.DecRef
+		return container.item.Chan(), container.item.DecRef
 	}
 	p.RUnlock()
 
 	p.Lock()
 	defer p.Unlock()
-	if v := p.channelMap[key]; v != nil {
-		v.IncRef()
-		v.UpdateLastWriteTime(p.timeSource.Now())
-		if v.weight != weight {
-			v.weight = weight
+	if container, exists := p.channelMap[key]; exists {
+		container.item.IncRef()
+		container.item.UpdateLastWriteTime(p.timeSource.Now())
+		if container.weight != weight {
+			p.channelMap[key] = weightedContainer[*TTLChannel[V]]{
+				item:   container.item,
+				weight: weight,
+			}
 			p.updateScheduleLocked()
 		}
-		return v.Chan(), v.DecRef
+		return container.item.Chan(), container.item.DecRef
 	}
 
-	v := &weightedChannel[V]{
-		TTLChannel: NewTTLChannel[V](p.bufferSize),
-		weight:     weight,
+	c := NewTTLChannel[V](p.bufferSize)
+	p.channelMap[key] = weightedContainer[*TTLChannel[V]]{
+		item:   c,
+		weight: weight,
 	}
-	p.channelMap[key] = v
-	v.IncRef()
-	v.UpdateLastWriteTime(p.timeSource.Now())
+	c.IncRef()
+	c.UpdateLastWriteTime(p.timeSource.Now())
 	p.updateScheduleLocked()
-	return v.Chan(), v.DecRef
+	return c.Chan(), c.DecRef
 }
 
 func (p *WeightedRoundRobinChannelPool[K, V]) GetAllChannels() []chan V {
 	p.RLock()
 	defer p.RUnlock()
 	allChannels := make([]chan V, 0, len(p.channelMap))
-	for _, v := range p.channelMap {
-		allChannels = append(allChannels, v.Chan())
+	for _, container := range p.channelMap {
+		allChannels = append(allChannels, container.item.Chan())
 	}
 	return allChannels
 }
 
-func (p *WeightedRoundRobinChannelPool[K, V]) GetSchedule() Schedule[*weightedChannel[V]] {
+func (p *WeightedRoundRobinChannelPool[K, V]) GetSchedule() Schedule[*TTLChannel[V]] {
 	return p.iwrrSchedule.Load()
 }
 
@@ -196,8 +195,4 @@ func (p *WeightedRoundRobinChannelPool[K, V]) updateScheduleLocked() {
 	// Update memory gauge - now only stores channel references once, not weight times
 	memoryBytes := len(p.channelMap) * 16 // channel map entries
 	p.metricsScope.UpdateGauge(metrics.WeightedChannelPoolSizeGauge, float64(memoryBytes))
-}
-
-func (w *weightedChannel[V]) Weight() int {
-	return w.weight
 }

--- a/common/task/weighted_channel_pool_test.go
+++ b/common/task/weighted_channel_pool_test.go
@@ -135,7 +135,7 @@ func TestGetSchedule(t *testing.T) {
 	for _, expected := range expectedSequence1 {
 		ch, ok := iter1.TryNext()
 		assert.True(t, ok)
-		assert.Equal(t, expected, ch.c)
+		assert.Equal(t, expected, ch.Chan())
 	}
 
 	c4, releaseFn4 := pool.GetOrCreateChannel("k2", 4)
@@ -151,7 +151,7 @@ func TestGetSchedule(t *testing.T) {
 	for _, expected := range expectedSequence2 {
 		ch, ok := iter2.TryNext()
 		assert.True(t, ok)
-		assert.Equal(t, expected, ch.c)
+		assert.Equal(t, expected, ch.Chan())
 	}
 }
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Remove weightedChannel type definition
- Remove weightedItem interface definition
- Refactor weighted channel pool to not depend on the removed types

It's a change for https://github.com/cadence-workflow/cadence/issues/7724

**Why?**
- weightedChannel is not needed because of weightedContainer type
- weightedItem is also not needed after code refactoring

**How did you test it?**
cd common/task && go test ./... -race

**Potential risks**
This is a code refactor with no behavior changes, so the risk is pretty low.

**Release notes**
N/A

**Documentation Changes**
N/A
