### PR TITLE
chore: Prevent files in a worktree from breaking make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -433,9 +433,9 @@ MAYBE_TOUCH_COPYRIGHT=
 $(BUILD)/fmt: $(ALL_SRC) $(BIN)/goimports $(BIN)/gci | $(BUILD)
 	$Q echo "removing unused imports..."
 	$Q # goimports thrashes on internal/tools, sadly.  just hide it.
-	$Q find . \( -path './vendor/*' -o -path './idls/*' -o -path './.build/*' -o -path './.bin/*' -o -path './.git/*' -o -path './.worktrees/*' \) -prune -o -name '*.go' -type f -not -path './internal/tools/tools.go' -print | xargs $(BIN)/goimports -w
+	$Q echo $(filter-out ./internal/tools/tools.go,$(FRESH_ALL_SRC)) | xargs $(BIN)/goimports -w
 	$Q echo "grouping imports..."
-	$Q find . \( -path './vendor/*' -o -path './idls/*' -o -path './.build/*' -o -path './.bin/*' -o -path './.git/*' -o -path './.worktrees/*' \) -prune -o -name '*.go' -type f -print | xargs $(BIN)/gci write --section standard --section 'Prefix(github.com/uber/cadence/)' --section default --section blank
+	$Q echo $(FRESH_ALL_SRC) | xargs $(BIN)/gci write --section standard --section 'Prefix(github.com/uber/cadence/)' --section default --section blank
 	$Q touch $@
 # 	$Q $(MAYBE_TOUCH_COPYRIGHT)
 


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**

Filters out files in `.worktrees` from commands in make pr. 

**Why?**

One convention when using git worktrees is to store the worktree within `.worktrees` within the repository. This is ignored by git, but stores the entire file tree within the repository. Our make commands (like `fmt`, `lint`, etc.) all attempt to pass over all files within the repository bar a select few ignored folders. When many worktrees exist this results in too many arguments passed exceptions: 

```
removing unused imports...
make[2]: /bin/bash: Argument list too long
make[2]: *** [.build/fmt] Error 1
make[1]: *** [go-generate] Error 2

failed `make go-generate `, check output above
make: *** [pr] Error 1
```

This PR ignores the `.worktrees` folder to prevent this from happening. 

**How did you test it?**

Locally with:

```
make lint
make fmt
make pr
```

**Potential risks**

This doesn't fix this problem for any arbitrary worktree setup - just if you use the `.worktree` convention. If your worktrees are stored outside the repo you will be fine, but any other convention e.g `.w` would run into the same issue. 

**Release notes**

N/A

**Documentation Changes**

N/A