### PR TITLE
fix(matching): Limit context deadline when calling RecordTaskStarted

### DIFF
--- a/common/backoff/retry.go
+++ b/common/backoff/retry.go
@@ -22,6 +22,7 @@ package backoff
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"time"
 
@@ -32,6 +33,8 @@ import (
 type retryCountKeyType string
 
 const retryCountKey = retryCountKeyType("retryCount")
+
+var errCauseOperationTimeout = errors.New("operation timeout")
 
 type (
 	// Operation to retry
@@ -54,11 +57,13 @@ type (
 
 	// ThrottleRetry is used to run operation with retry and also avoid throttling dependencies
 	ThrottleRetry struct {
-		policy         RetryPolicy
-		isRetryable    IsRetryable
-		throttlePolicy RetryPolicy
-		isThrottle     IsRetryable
-		clock          clock.TimeSource
+		policy           RetryPolicy
+		isRetryable      IsRetryable
+		throttlePolicy   RetryPolicy
+		isThrottle       IsRetryable
+		clock            clock.TimeSource
+		operationTimeout time.Duration
+		expireContext    bool
 	}
 )
 
@@ -161,6 +166,27 @@ func WithThrottleError(isThrottle IsRetryable) ThrottleRetryOption {
 	}
 }
 
+// WithOperationTimeout establishes a timeout for each attempt of the Operation, running each in a child context that
+// will be cancelled after the specified operationTimeout.
+// Failures caused by the operationTimeout are considered retryable so long as the Operation returns an error that
+// is/wraps a context.DeadlineExceeded.
+// By default, there is no deadline for each operation.
+func WithOperationTimeout(operationTimeout time.Duration) ThrottleRetryOption {
+	return func(tr *ThrottleRetry) {
+		tr.operationTimeout = operationTimeout
+	}
+}
+
+// WithContextExpiration causes the ThrottleRetry to run operations within a child context with a deadline equivalent
+// to the RetryPolicy.Expiration. This ensures that across all attempts, the operations may not exceed the deadline
+// of the RetryPolicy.
+// By default, the RetryPolicy is only enforced by not starting additional attempts once it has expired.
+func WithContextExpiration() ThrottleRetryOption {
+	return func(tr *ThrottleRetry) {
+		tr.expireContext = true
+	}
+}
+
 func WithClock(clock clock.TimeSource) ThrottleRetryOption {
 	return func(tr *ThrottleRetry) {
 		tr.clock = clock
@@ -175,21 +201,29 @@ func (tr *ThrottleRetry) Do(ctx context.Context, op Operation) error {
 
 	r := NewRetrier(tr.policy, tr.clock)
 	t := NewRetrier(tr.throttlePolicy, tr.clock)
+	// If enabled and the RetryPolicy has an expiration, enforce it via context timeout
+	if expirationInterval := tr.policy.Expiration(); tr.expireContext && expirationInterval > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, expirationInterval)
+		defer cancel()
+	}
 	retryCount := 0
 	for {
 		// record the previous error before an operation
 		prevErr = err
 
-		// update context with retry count
-		ctx = context.WithValue(ctx, retryCountKey, retryCount)
+		// Avoid shadowing err
+		var attemptTimedOut bool
+		attemptTimedOut, err = tr.attempt(ctx, retryCount, op)
 		// operation completed successfully. No need to retry.
-		if err = op(ctx); err == nil {
+		if err == nil {
 			return nil
 		}
 		retryCount++
 
 		// Check if the error is retryable
-		if !tr.isRetryable(err) {
+		// Attempts timing out is considered retryable
+		if !attemptTimedOut && !tr.isRetryable(err) {
 			// The returned error will be preferred to a previous one if one exists. That's because the
 			// very last error is very likely a timeout error, and it's not useful for logging/troubleshooting
 			if prevErr != nil {
@@ -222,6 +256,28 @@ func (tr *ThrottleRetry) Do(ctx context.Context, op Operation) error {
 		case <-tr.clock.After(next):
 		}
 	}
+}
+
+func (tr *ThrottleRetry) attempt(ctx context.Context, retryCount int, op Operation) (bool, error) {
+	// update context with retry count
+	ctx = context.WithValue(ctx, retryCountKey, retryCount)
+	// If configured with an operation timeout, set it on the context
+	if tr.operationTimeout > 0 {
+		// Avoid shadowing ctx
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeoutCause(ctx, tr.operationTimeout, errCauseOperationTimeout)
+		defer cancel()
+	}
+	opErr := op(ctx)
+	// Confirm that the context was cancelled by the above timeout
+	// Validating the cause ensures that any other Context cancellation (incoming timeout, explicit cancel) doesn't
+	// get treated as an attempt timeout.
+	// Validating the returned error is/wraps a DeadlineExceeded adds confidence that it was caused by the context
+	// timing out.
+	if cause := context.Cause(ctx); errors.Is(cause, errCauseOperationTimeout) && errors.Is(opErr, context.DeadlineExceeded) {
+		return true, opErr
+	}
+	return false, opErr
 }
 
 // IgnoreErrors can be used as IsRetryable handler for Retry function to exclude certain errors from the retry list

--- a/common/backoff/retry_test.go
+++ b/common/backoff/retry_test.go
@@ -340,6 +340,152 @@ func (s *RetrySuite) TestRetryCountInContext() {
 	s.Equal([]int{0, 1, 2}, retryCounts)
 }
 
+func (s *RetrySuite) TestContextDeadline() {
+	cases := []struct {
+		name            string
+		policy          func() RetryPolicy
+		enforceDeadline bool
+		opts            []ThrottleRetryOption
+		expectedMin     time.Duration
+		expectedMax     time.Duration
+	}{
+		{
+			name: "no deadline",
+			policy: func() RetryPolicy {
+				policy := NewExponentialRetryPolicy(1 * time.Millisecond)
+				policy.SetExpirationInterval(NoInterval)
+				return policy
+			},
+			enforceDeadline: true,
+			expectedMin:     0,
+			expectedMax:     0,
+		},
+		{
+			name: "don't enforce deadline",
+			policy: func() RetryPolicy {
+				policy := NewExponentialRetryPolicy(1 * time.Millisecond)
+				policy.SetExpirationInterval(time.Hour)
+				return policy
+			},
+			enforceDeadline: false,
+			expectedMin:     0,
+			expectedMax:     0,
+		},
+		{
+			name: "expiration interval",
+			policy: func() RetryPolicy {
+				policy := NewExponentialRetryPolicy(1 * time.Millisecond)
+				policy.SetExpirationInterval(time.Hour)
+				return policy
+			},
+			enforceDeadline: true,
+			expectedMin:     50 * time.Minute,
+			expectedMax:     70 * time.Minute,
+		},
+		{
+			name: "operation timeout",
+			policy: func() RetryPolicy {
+				policy := NewExponentialRetryPolicy(1 * time.Millisecond)
+				policy.SetExpirationInterval(NoInterval)
+				return policy
+			},
+			enforceDeadline: true,
+			opts: []ThrottleRetryOption{
+				WithOperationTimeout(time.Hour),
+			},
+			expectedMin: 50 * time.Minute,
+			expectedMax: 70 * time.Minute,
+		},
+		{
+			name: "expiration interval lower, take lower",
+			policy: func() RetryPolicy {
+				policy := NewExponentialRetryPolicy(1 * time.Millisecond)
+				policy.SetExpirationInterval(time.Hour)
+				return policy
+			},
+			enforceDeadline: true,
+			opts: []ThrottleRetryOption{
+				WithOperationTimeout(10 * time.Hour),
+			},
+			expectedMin: 50 * time.Minute,
+			expectedMax: 70 * time.Minute,
+		},
+		{
+			name: "operation timeout lower, take lower",
+			policy: func() RetryPolicy {
+				policy := NewExponentialRetryPolicy(1 * time.Millisecond)
+				policy.SetExpirationInterval(10 * time.Hour)
+				return policy
+			},
+			enforceDeadline: true,
+			opts: []ThrottleRetryOption{
+				WithOperationTimeout(time.Hour),
+			},
+			expectedMin: 50 * time.Minute,
+			expectedMax: 70 * time.Minute,
+		},
+	}
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			var opts []ThrottleRetryOption
+			opts = append(opts, WithRetryPolicy(tc.policy()))
+			if tc.enforceDeadline {
+				opts = append(opts, WithContextExpiration())
+			}
+			if len(tc.opts) > 0 {
+				opts = append(opts, tc.opts...)
+			}
+			throttleRetry := NewThrottleRetry(opts...)
+			var result time.Duration
+
+			err := throttleRetry.Do(context.Background(), func(ctx context.Context) error {
+				if deadline, ok := ctx.Deadline(); ok {
+					result = deadline.Sub(time.Now())
+				} else {
+					result = 0
+				}
+				return nil
+			})
+			s.NoError(err, "somehow failed")
+			s.GreaterOrEqual(result, tc.expectedMin)
+			s.LessOrEqual(result, tc.expectedMax)
+		})
+	}
+}
+
+func (s *RetrySuite) TestOperationTimeoutIsRetryable() {
+	attempts := 0
+	op := func(ctx context.Context) error {
+		retryCount := ctx.Value(retryCountKey).(int)
+		attempts = max(attempts, retryCount)
+		// Return nil, indicating success
+		if retryCount == 3 {
+			return nil
+		}
+		// Return the DeadlineExceeded err
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	policy := NewExponentialRetryPolicy(time.Nanosecond)
+	policy.SetMaximumInterval(time.Nanosecond)
+	policy.SetMaximumAttempts(10)
+
+	throttleRetry := NewThrottleRetry(
+		WithRetryPolicy(policy),
+		// Operation timeout is retryable anyway
+		WithRetryableError(func(_ error) bool { return false }),
+		// Set a timeout such that it will instantly be canceled every time
+		WithOperationTimeout(time.Nanosecond),
+	)
+
+	err := throttleRetry.Do(context.Background(), op)
+	s.NoError(err, "somehow failed")
+	s.Equal(3, attempts)
+}
+
 func (e *someError) Error() string {
 	return "Some Error"
 }

--- a/common/backoff/retrypolicy.go
+++ b/common/backoff/retrypolicy.go
@@ -44,6 +44,9 @@ type (
 	// RetryPolicy is the API which needs to be implemented by various retry policy implementations
 	RetryPolicy interface {
 		ComputeNextDelay(elapsedTime time.Duration, numAttempts int) time.Duration
+		// Expiration returns the maximum time allowed by the RetryPolicy. A value of NoInterval (0) indicates that the
+		// RetryPolicy may take an unbounded amount of time.
+		Expiration() time.Duration
 	}
 
 	// Retrier manages the state of retry operation
@@ -194,6 +197,10 @@ func (p *ExponentialRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, num
 	return time.Duration(nextInterval)
 }
 
+func (p *ExponentialRetryPolicy) Expiration() time.Duration {
+	return p.expirationInterval
+}
+
 // ComputeNextDelay returns the next delay interval.
 func (tp MultiPhasesRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, numAttempts int) time.Duration {
 	previousStageRetryCount := 0
@@ -205,6 +212,18 @@ func (tp MultiPhasesRetryPolicy) ComputeNextDelay(elapsedTime time.Duration, num
 		previousStageRetryCount += policy.maximumAttempts
 	}
 	return done
+}
+
+func (tp MultiPhasesRetryPolicy) Expiration() time.Duration {
+	var sum time.Duration
+	for _, policy := range tp.policies {
+		exp := policy.Expiration()
+		if exp == NoInterval {
+			return NoInterval
+		}
+		sum += exp
+	}
+	return sum
 }
 
 // Reset will set the Retrier into initial state

--- a/common/util.go
+++ b/common/util.go
@@ -55,6 +55,10 @@ const (
 	historyServiceOperationMaxInterval        = 10 * time.Second
 	historyServiceOperationExpirationInterval = 30 * time.Second
 
+	recordTaskStartedInitialInterval    = 50 * time.Millisecond
+	recordTaskStartedMaxInterval        = 1 * time.Second
+	recordTaskStartedExpirationInterval = 3 * time.Second
+
 	matchingServiceOperationInitialInterval    = 1000 * time.Millisecond
 	matchingServiceOperationMaxInterval        = 10 * time.Second
 	matchingServiceOperationExpirationInterval = 30 * time.Second
@@ -159,6 +163,14 @@ func CreateHistoryServiceRetryPolicy() backoff.RetryPolicy {
 	policy := backoff.NewExponentialRetryPolicy(historyServiceOperationInitialInterval)
 	policy.SetMaximumInterval(historyServiceOperationMaxInterval)
 	policy.SetExpirationInterval(historyServiceOperationExpirationInterval)
+
+	return policy
+}
+
+func CreateRecordTaskStartedRetryPolicy() backoff.RetryPolicy {
+	policy := backoff.NewExponentialRetryPolicy(recordTaskStartedInitialInterval)
+	policy.SetMaximumInterval(recordTaskStartedMaxInterval)
+	policy.SetExpirationInterval(recordTaskStartedExpirationInterval)
 
 	return policy
 }

--- a/service/matching/handler/engine.go
+++ b/service/matching/handler/engine.go
@@ -67,6 +67,10 @@ const (
 	// _defaultSDReportTTL is the default TTL for shard status reports from matching executor to shard distributor.
 	// This controls how frequently the executor reports its shard load/status to the distributor.
 	_defaultSDReportTTL = 1 * time.Minute
+	// _recordTaskStartedTimeout is the maximum time allowed for RecordDecisionTaskStarted or RecordActivityTaskStarted
+	// Any time we spend attempting to start an individual task is blocking that poller from starting a different task.
+	// If a task is taking too long we'd rather try other tasks to maintain higher throughput.
+	_recordTaskStartedTimeout = time.Second
 )
 
 // Implements matching.Engine
@@ -116,7 +120,7 @@ type (
 )
 
 var (
-	historyServiceOperationRetryPolicy = common.CreateHistoryServiceRetryPolicy()
+	recordTaskStartedRetryPolicy = common.CreateRecordTaskStartedRetryPolicy()
 
 	errPumpClosed = errors.New("task list pump closed its channel")
 
@@ -1367,8 +1371,10 @@ func (e *matchingEngineImpl) recordDecisionTaskStarted(
 		return err
 	}
 	throttleRetry := backoff.NewThrottleRetry(
-		backoff.WithRetryPolicy(historyServiceOperationRetryPolicy),
+		backoff.WithRetryPolicy(recordTaskStartedRetryPolicy),
 		backoff.WithRetryableError(isMatchingRetryableError),
+		backoff.WithOperationTimeout(_recordTaskStartedTimeout),
+		backoff.WithContextExpiration(),
 	)
 	err := throttleRetry.Do(ctx, op)
 	return resp, err
@@ -1394,8 +1400,10 @@ func (e *matchingEngineImpl) recordActivityTaskStarted(
 		return err
 	}
 	throttleRetry := backoff.NewThrottleRetry(
-		backoff.WithRetryPolicy(historyServiceOperationRetryPolicy),
+		backoff.WithRetryPolicy(recordTaskStartedRetryPolicy),
 		backoff.WithRetryableError(isMatchingRetryableError),
+		backoff.WithOperationTimeout(_recordTaskStartedTimeout),
+		backoff.WithContextExpiration(),
 	)
 	err := throttleRetry.Do(ctx, op)
 	return resp, err


### PR DESCRIPTION
Calls from matching to history for RecordActivityTaskStarted or RecordDecisionTaskStarted keep the poller occupied while waiting for a response. High latency, especially from a single host or shard, can result in degraded throughput for a TaskList as a disproportionate amount of poller time is spent attempting to start these tasks.

Limit each call to a timeout of 1s, and enforce the expiration interval via a context timeout. Currently ThrottleRetry only prevents additional retries from occurring after the expiration interval. Depending on the incoming context, it's possible for a single attempt to outlast the entire expiration interval. Particularly in the context of matching, we have long pollers with very high context timeouts.

Add new options to ThrottleRetry to add a timeout for each attempt of the operation and to enforce the expiration interval via context timeout.

While it would be ideal to enforce the expiration interval by default, this would be a very risky change to make all at once. There are 68 different retry policies and it's likely that in some cases we have attempts that exceed the expiration interval. We should introduce this behavior gradually, ideally with metrics/logging to flag poorly configured RetryPolicies. Adding these metrics/logging is non-trivial and will be explored separately.

<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Limit RecordActivityTaskStarted/RecordDecisionTaskStarted to 1s per attempt and 3s total.

**Why?**
- Prevent bad hosts/shards from occupying a significant amount of poller time

**How did you test it?**
- Unit/integration tests

**Potential risks**
- If all history hosts become significantly degraded such that they have latency above 1s we will have two changes in behavior:
  - We would be unable to dispatch tasks
  - We would retry the tasks through matching by writing them to the end of the Tasks queue, creating additional load on Cassandra rather than hanging.

This seems like a reasonable compromise to be more resilient against individual hosts/shards.

**Release notes**


**Documentation Changes**

