### PR TITLE
feat(domain multi-tenancy): Update Cassandra schema for transfer task

### DIFF
--- a/schema/cassandra/cadence/schema.cql
+++ b/schema/cassandra/cadence/schema.cql
@@ -135,6 +135,7 @@ CREATE TYPE transfer_task (
   version                    bigint,       -- the failover version when this task is created, used to compare against the mutable state, in case the events got overwritten
   record_visibility          boolean,      -- indicates whether or not to create a visibility record
   original_task_list         text,         -- the original task list of the task if the task is a sticky decision task
+  original_task_list_kind    int,          -- enum TaskListKind {Normal, Sticky, Ephemeral},
 );
 
 CREATE TYPE replication_task (

--- a/schema/cassandra/cadence/versioned/v0.46/manifest.json
+++ b/schema/cassandra/cadence/versioned/v0.46/manifest.json
@@ -1,0 +1,8 @@
+{
+  "CurrVersion": "0.46",
+  "MinCompatibleVersion": "0.46",
+  "Description": "Adding original_task_list_kind to transfer task",
+  "SchemaUpdateCqlFiles": [
+    "transfer_task.cql"
+  ]
+}

--- a/schema/cassandra/cadence/versioned/v0.46/transfer_task.cql
+++ b/schema/cassandra/cadence/versioned/v0.46/transfer_task.cql
@@ -1,0 +1,1 @@
+ALTER TYPE transfer_task ADD original_task_list_kind int;

--- a/schema/cassandra/version.go
+++ b/schema/cassandra/version.go
@@ -23,7 +23,7 @@ package cassandra
 // NOTE: whenever there is a new data base schema update, plz update the following versions
 
 // Version is the Cassandra database release version
-const Version = "0.45"
+const Version = "0.46"
 
 // VisibilityVersion is the Cassandra visibility database release version
 const VisibilityVersion = "0.10"

--- a/tools/common/schema/updatetask_test.go
+++ b/tools/common/schema/updatetask_test.go
@@ -116,7 +116,7 @@ func (s *UpdateTaskTestSuite) TestReadSchemaDirFromEmbeddings() {
 	s.NoError(err)
 	ans, err := readSchemaDir(fsys, "0.30", "")
 	s.NoError(err)
-	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45"}, ans)
+	s.Equal([]string{"v0.31", "v0.32", "v0.33", "v0.34", "v0.35", "v0.36", "v0.37", "v0.38", "v0.39", "v0.40", "v0.41", "v0.42", "v0.43", "v0.44", "v0.45", "v0.46"}, ans)
 
 	fsys, err = fs.Sub(cassandra.SchemaFS, "visibility/versioned")
 	s.NoError(err)


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Add original_task_list_kind field to transfer_task type in Cassandra's schema
- Related to https://github.com/cadence-workflow/cadence/issues/7724

**Why?**
It was missed in https://github.com/cadence-workflow/cadence/pull/7727 

**How did you test it?**
cd common/tools/common && go test ./...

**Potential risks**
This change is backward compatible and the version of schema is also updated

**Release notes**
N/A

**Documentation Changes**
N/A

### Detailed Description
Add originalTaskListKind field to TransferTaskInfo. We need this field to determine whether the original task list is a ephemeral task list or a normal task list and use this info to schedule tasks and emit metrics, because the cardinality of ephemeral task list is very large we need to normalize it to avoid creating lots of metrics series.

### Impact Analysis
- **Backward Compatibility**: Yes
- **Forward Compatibility**: Yes

### Testing Plan
- **Unit Tests**: In server repo
- **Persistence Tests**: In server repo
- **Integration Tests**: In server repo
- **Compatibility Tests**: N/A

### Rollout Plan
- What is the rollout plan? N/A
- Does the order of deployment matter? No.
- Is it safe to rollback? Does the order of rollback matter? Yes. No.
- Is there a kill switch to mitigate the impact immediately? No.

