### PR TITLE
feat(domain multi-tenancy): Store original task list kind in transfertask

### DIFF
--- a/common/persistence/data_manager_interfaces.go
+++ b/common/persistence/data_manager_interfaces.go
@@ -488,6 +488,7 @@ type (
 		Version                 int64
 		RecordVisibility        bool
 		OriginalTaskList        string
+		OriginalTaskListKind    types.TaskListKind
 	}
 
 	// CrossClusterTaskInfo describes a cross-cluster task
@@ -1863,6 +1864,11 @@ func (t *TransferTaskInfo) GetOriginalTaskList() string {
 	return t.OriginalTaskList
 }
 
+// GetOriginalTaskListKind returns the original task list kind for transfer task
+func (t *TransferTaskInfo) GetOriginalTaskListKind() types.TaskListKind {
+	return t.OriginalTaskListKind
+}
+
 // String returns a string representation for transfer task
 func (t *TransferTaskInfo) String() string {
 	return fmt.Sprintf("%#v", t)
@@ -1890,12 +1896,13 @@ func (t *TransferTaskInfo) ToTask() (Task, error) {
 		}, nil
 	case TransferTaskTypeDecisionTask:
 		return &DecisionTask{
-			WorkflowIdentifier: workflowIdentifier,
-			TaskData:           taskData,
-			TargetDomainID:     t.TargetDomainID,
-			TaskList:           t.TaskList,
-			ScheduleID:         t.ScheduleID,
-			OriginalTaskList:   t.OriginalTaskList,
+			WorkflowIdentifier:   workflowIdentifier,
+			TaskData:             taskData,
+			TargetDomainID:       t.TargetDomainID,
+			TaskList:             t.TaskList,
+			ScheduleID:           t.ScheduleID,
+			OriginalTaskList:     t.OriginalTaskList,
+			OriginalTaskListKind: t.OriginalTaskListKind,
 		}, nil
 	case TransferTaskTypeCloseExecution:
 		return &CloseExecutionTask{

--- a/common/persistence/data_manager_interfaces_mock.go
+++ b/common/persistence/data_manager_interfaces_mock.go
@@ -85,6 +85,20 @@ func (mr *MockTaskMockRecorder) GetOriginalTaskList() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalTaskList", reflect.TypeOf((*MockTask)(nil).GetOriginalTaskList))
 }
 
+// GetOriginalTaskListKind mocks base method.
+func (m *MockTask) GetOriginalTaskListKind() types.TaskListKind {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOriginalTaskListKind")
+	ret0, _ := ret[0].(types.TaskListKind)
+	return ret0
+}
+
+// GetOriginalTaskListKind indicates an expected call of GetOriginalTaskListKind.
+func (mr *MockTaskMockRecorder) GetOriginalTaskListKind() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalTaskListKind", reflect.TypeOf((*MockTask)(nil).GetOriginalTaskListKind))
+}
+
 // GetRunID mocks base method.
 func (m *MockTask) GetRunID() string {
 	m.ctrl.T.Helper()

--- a/common/persistence/metered_test.go
+++ b/common/persistence/metered_test.go
@@ -359,7 +359,7 @@ func TestGetHistoryTasksResponseEstimatePayloadSize(t *testing.T) {
 			NextPageToken: []byte{1, 2, 3},
 		}
 
-		assert.Equal(t, uint64(127), response.ByteSize())
+		assert.Equal(t, uint64(135), response.ByteSize())
 	})
 
 	t.Run("a bigger response emits a bigger value", func(t *testing.T) {

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_cql.go
@@ -105,7 +105,8 @@ const (
 		`schedule_id: ?, ` +
 		`record_visibility: ?, ` +
 		`version: ?, ` +
-		`original_task_list: ?` +
+		`original_task_list: ?, ` +
+		`original_task_list_kind: ?` +
 		`}`
 
 	templateCrossClusterTaskType = templateTransferTaskType

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_parsing_utils.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_parsing_utils.go
@@ -559,6 +559,8 @@ func parseTransferTaskInfo(
 			info.Version = v.(int64)
 		case "original_task_list":
 			info.OriginalTaskList = v.(string)
+		case "original_task_list_kind":
+			info.OriginalTaskListKind = types.TaskListKind(int32(v.(int)))
 		}
 	}
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_parsing_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_parsing_utils_test.go
@@ -643,6 +643,7 @@ func Test_parseTransferTaskInfo(t *testing.T) {
 		"record_visibility":          true,
 		"version":                    int64(4),
 		"original_task_list":         "original_task_list",
+		"original_task_list_kind":    2,
 	}
 	expected := &persistence.TransferTaskInfo{
 		DomainID:                "domain_id",
@@ -661,6 +662,7 @@ func Test_parseTransferTaskInfo(t *testing.T) {
 		RecordVisibility:        true,
 		Version:                 int64(4),
 		OriginalTaskList:        "original_task_list",
+		OriginalTaskListKind:    types.TaskListKindEphemeral,
 	}
 	assert.Equal(t, expected, parseTransferTaskInfo(testInput))
 

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils.go
@@ -563,6 +563,7 @@ func createTransferTasks(
 			task.RecordVisibility,
 			task.Version,
 			task.OriginalTaskList,
+			int32(task.OriginalTaskListKind),
 			taskBlob,
 			taskEncoding,
 			// NOTE: use a constant here instead of task.VisibilityTimestamp so that we can query tasks with the same visibilityTimestamp

--- a/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
+++ b/common/persistence/nosql/nosqlplugin/cassandra/workflow_utils_test.go
@@ -1212,6 +1212,7 @@ func TestTransferTasks(t *testing.T) {
 						TaskList:                "tasklist_1",
 						ScheduleID:              14,
 						OriginalTaskList:        "original_tasklist_1",
+						OriginalTaskListKind:    types.TaskListKindEphemeral,
 					},
 					Task: &persistence.DataBlob{
 						Data:     []byte("tr1"),
@@ -1232,6 +1233,7 @@ func TestTransferTasks(t *testing.T) {
 						TaskList:                "tasklist_2",
 						ScheduleID:              3,
 						OriginalTaskList:        "original_tasklist_2",
+						OriginalTaskListKind:    types.TaskListKindEphemeral,
 					},
 					Task: &persistence.DataBlob{
 						Data:     []byte("tr2"),
@@ -1245,14 +1247,14 @@ func TestTransferTasks(t *testing.T) {
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_1, visibility_ts: 2023-12-12T22:08:41Z, ` +
 					`task_id: 355, target_domain_id: e2bf2c8f-0ddf-4451-8840-27cfe8addd62, target_domain_ids: map[],` +
 					`target_workflow_id: 20000000-0000-f000-f000-000000000001, target_run_id: 30000000-0000-f000-f000-000000000002, ` +
-					`target_child_workflow_only: true, task_list: tasklist_1, type: 0, schedule_id: 14, record_visibility: false, version: 1, original_task_list: original_tasklist_1}, ` +
+					`target_child_workflow_only: true, task_list: tasklist_1, type: 0, schedule_id: 14, record_visibility: false, version: 1, original_task_list: original_tasklist_1, original_task_list_kind: 2}, ` +
 					`[116 114 49], thriftrw, 946684800000, 355, 2025-01-06T15:00:00Z)`,
 				`INSERT INTO executions (shard_id, type, domain_id, workflow_id, run_id, transfer, data, data_encoding, visibility_ts, task_id, created_time) ` +
 					`VALUES(1000, 2, 10000000-3000-f000-f000-000000000000, 20000000-3000-f000-f000-000000000000, 30000000-3000-f000-f000-000000000000, ` +
 					`{domain_id: domain_xyz, workflow_id: workflow_xyz, run_id: rundid_2, visibility_ts: 2023-12-12T22:09:41Z, ` +
 					`task_id: 220, target_domain_id: e2bf2c8f-0ddf-4451-8840-27cfe8addd62, target_domain_ids: map[],` +
 					`target_workflow_id: 20000000-0000-f000-f000-000000000001, target_run_id: 30000000-0000-f000-f000-000000000002, ` +
-					`target_child_workflow_only: true, task_list: tasklist_2, type: 0, schedule_id: 3, record_visibility: false, version: 1, original_task_list: original_tasklist_2}, ` +
+					`target_child_workflow_only: true, task_list: tasklist_2, type: 0, schedule_id: 3, record_visibility: false, version: 1, original_task_list: original_tasklist_2, original_task_list_kind: 2}, ` +
 					`[116 114 50], thriftrw, 946684800000, 220, 2025-01-06T15:00:00Z)`,
 			},
 		},

--- a/common/persistence/persistence-tests/executionManagerTest.go
+++ b/common/persistence/persistence-tests/executionManagerTest.go
@@ -1395,10 +1395,11 @@ func (s *ExecutionManagerSuite) TestPersistenceStartWorkflow() {
 						TaskData: p.TaskData{
 							TaskID: s.GetNextSequenceNumber(),
 						},
-						TargetDomainID:   domainID,
-						TaskList:         "queue1",
-						ScheduleID:       int64(2),
-						OriginalTaskList: "queue1",
+						TargetDomainID:       domainID,
+						TaskList:             "queue1",
+						ScheduleID:           int64(2),
+						OriginalTaskList:     "queue1",
+						OriginalTaskListKind: types.TaskListKindEphemeral,
 					},
 				},
 			},
@@ -2364,6 +2365,7 @@ func (s *ExecutionManagerSuite) TestCancelTransferTaskTasks() {
 	s.Equal(false, task1.TargetChildWorkflowOnly)
 	s.Equal("queue1", task1.GetTaskList())
 	s.Equal("queue1", task1.GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, task1.GetOriginalTaskListKind())
 
 	err = s.CompleteTransferTask(ctx, task1.TaskID)
 	s.NoError(err)
@@ -2414,6 +2416,7 @@ func (s *ExecutionManagerSuite) TestCancelTransferTaskTasks() {
 	s.Equal(targetRunID, task2.TargetRunID)
 	s.Equal(targetChildWorkflowOnly, task2.TargetChildWorkflowOnly)
 	s.Equal("queue2", task2.GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, task2.GetOriginalTaskListKind())
 
 	err = s.CompleteTransferTask(ctx, task2.TaskID)
 	s.NoError(err)
@@ -2493,6 +2496,7 @@ func (s *ExecutionManagerSuite) TestSignalTransferTaskTasks() {
 	s.Equal(false, task1.TargetChildWorkflowOnly)
 	s.Equal("queue1", task1.GetTaskList())
 	s.Equal("queue1", task1.GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, task1.GetOriginalTaskListKind())
 
 	err = s.CompleteTransferTask(ctx, task1.TaskID)
 	s.NoError(err)
@@ -2543,6 +2547,7 @@ func (s *ExecutionManagerSuite) TestSignalTransferTaskTasks() {
 	s.Equal(targetRunID, task2.TargetRunID)
 	s.Equal(targetChildWorkflowOnly, task2.TargetChildWorkflowOnly)
 	s.Equal("queue2", task2.GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, task2.GetOriginalTaskListKind())
 
 	err = s.CompleteTransferTask(ctx, task2.TaskID)
 	s.NoError(err)
@@ -2710,9 +2715,11 @@ func (s *ExecutionManagerSuite) TestTransferTasksComplete() {
 				TaskID:              currentTransferID + 10002,
 				Version:             222,
 			},
-			TargetDomainID: domainID,
-			TaskList:       tasklist,
-			ScheduleID:     scheduleID,
+			TargetDomainID:       domainID,
+			TaskList:             tasklist,
+			ScheduleID:           scheduleID,
+			OriginalTaskList:     "original_tasklist",
+			OriginalTaskListKind: types.TaskListKindEphemeral,
 		},
 		&p.CloseExecutionTask{
 			WorkflowIdentifier: p.WorkflowIdentifier{
@@ -2826,13 +2833,37 @@ func (s *ExecutionManagerSuite) TestTransferTasksComplete() {
 		s.True(timeComparator(tasks[index].GetVisibilityTimestamp(), txTasks[index].GetVisibilityTimestamp(), TimePrecision))
 	}
 	s.Equal(p.TransferTaskTypeActivityTask, txTasks[0].GetTaskType())
+	s.Equal(tasklist, txTasks[0].GetTaskList())
+	s.Equal(tasklist, txTasks[0].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[0].GetOriginalTaskListKind())
 	s.Equal(p.TransferTaskTypeDecisionTask, txTasks[1].GetTaskType())
+	s.Equal(tasklist, txTasks[1].GetTaskList())
+	s.Equal("original_tasklist", txTasks[1].GetOriginalTaskList())
+	s.Equal(types.TaskListKindEphemeral, txTasks[1].GetOriginalTaskListKind())
 	s.Equal(p.TransferTaskTypeCloseExecution, txTasks[2].GetTaskType())
+	s.Equal(tasklist, txTasks[2].GetTaskList())
+	s.Equal(tasklist, txTasks[2].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[2].GetOriginalTaskListKind())
 	s.Equal(p.TransferTaskTypeCancelExecution, txTasks[3].GetTaskType())
+	s.Equal(tasklist, txTasks[3].GetTaskList())
+	s.Equal(tasklist, txTasks[3].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[3].GetOriginalTaskListKind())
 	s.Equal(p.TransferTaskTypeSignalExecution, txTasks[4].GetTaskType())
+	s.Equal(tasklist, txTasks[4].GetTaskList())
+	s.Equal(tasklist, txTasks[4].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[4].GetOriginalTaskListKind())
 	s.Equal(p.TransferTaskTypeStartChildExecution, txTasks[5].GetTaskType())
+	s.Equal(tasklist, txTasks[5].GetTaskList())
+	s.Equal(tasklist, txTasks[5].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[5].GetOriginalTaskListKind())
 	s.Equal(p.TransferTaskTypeRecordWorkflowClosed, txTasks[6].GetTaskType())
+	s.Equal(tasklist, txTasks[6].GetTaskList())
+	s.Equal(tasklist, txTasks[6].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[6].GetOriginalTaskListKind())
 	s.Equal(p.TransferTaskTypeRecordChildExecutionCompleted, txTasks[7].GetTaskType())
+	s.Equal(tasklist, txTasks[7].GetTaskList())
+	s.Equal(tasklist, txTasks[7].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[7].GetOriginalTaskListKind())
 
 	for idx := range txTasks {
 		// TODO: add a check similar to validateCrossClusterTasks
@@ -2919,9 +2950,11 @@ func (s *ExecutionManagerSuite) TestTransferTasksRangeComplete() {
 				TaskID:              currentTransferID + 10002,
 				Version:             222,
 			},
-			TargetDomainID: domainID,
-			TaskList:       tasklist,
-			ScheduleID:     scheduleID,
+			TargetDomainID:       domainID,
+			TaskList:             tasklist,
+			ScheduleID:           scheduleID,
+			OriginalTaskList:     "original_tasklist",
+			OriginalTaskListKind: types.TaskListKindEphemeral,
 		},
 		&p.CloseExecutionTask{
 			WorkflowIdentifier: p.WorkflowIdentifier{
@@ -3024,6 +3057,24 @@ func (s *ExecutionManagerSuite) TestTransferTasksRangeComplete() {
 	s.Equal(currentTransferID+10004, txTasks[3].GetTaskID())
 	s.Equal(currentTransferID+10005, txTasks[4].GetTaskID())
 	s.Equal(currentTransferID+10006, txTasks[5].GetTaskID())
+	s.Equal(tasklist, txTasks[0].GetTaskList())
+	s.Equal(tasklist, txTasks[1].GetTaskList())
+	s.Equal(tasklist, txTasks[2].GetTaskList())
+	s.Equal(tasklist, txTasks[3].GetTaskList())
+	s.Equal(tasklist, txTasks[4].GetTaskList())
+	s.Equal(tasklist, txTasks[5].GetTaskList())
+	s.Equal(tasklist, txTasks[0].GetOriginalTaskList())
+	s.Equal("original_tasklist", txTasks[1].GetOriginalTaskList())
+	s.Equal(tasklist, txTasks[2].GetOriginalTaskList())
+	s.Equal(tasklist, txTasks[3].GetOriginalTaskList())
+	s.Equal(tasklist, txTasks[4].GetOriginalTaskList())
+	s.Equal(tasklist, txTasks[5].GetOriginalTaskList())
+	s.Equal(types.TaskListKindNormal, txTasks[0].GetOriginalTaskListKind())
+	s.Equal(types.TaskListKindEphemeral, txTasks[1].GetOriginalTaskListKind())
+	s.Equal(types.TaskListKindNormal, txTasks[2].GetOriginalTaskListKind())
+	s.Equal(types.TaskListKindNormal, txTasks[3].GetOriginalTaskListKind())
+	s.Equal(types.TaskListKindNormal, txTasks[4].GetOriginalTaskListKind())
+	s.Equal(types.TaskListKindNormal, txTasks[5].GetOriginalTaskListKind())
 
 	err2 = s.RangeCompleteTransferTask(ctx, txTasks[0].GetTaskID(), txTasks[5].GetTaskID()+1)
 	s.NoError(err2)

--- a/common/persistence/serialization/task_serializer.go
+++ b/common/persistence/serialization/task_serializer.go
@@ -99,6 +99,7 @@ func (s *taskSerializerImpl) serializeTransferTask(task persistence.Task) (persi
 		info.TaskList = t.TaskList
 		info.ScheduleID = t.ScheduleID
 		info.OriginalTaskList = t.OriginalTaskList
+		info.OriginalTaskListKind = t.OriginalTaskListKind
 	case *persistence.CancelExecutionTask:
 		info.DomainID = MustParseUUID(t.DomainID)
 		info.WorkflowID = t.WorkflowID
@@ -192,12 +193,13 @@ func (s *taskSerializerImpl) deserializeTransferTask(blob *persistence.DataBlob)
 	switch info.GetTaskType() {
 	case persistence.TransferTaskTypeDecisionTask:
 		task = &persistence.DecisionTask{
-			WorkflowIdentifier: workflowIdentifier,
-			TaskData:           taskData,
-			TargetDomainID:     info.TargetDomainID.String(),
-			TaskList:           info.GetTaskList(),
-			ScheduleID:         info.GetScheduleID(),
-			OriginalTaskList:   info.GetOriginalTaskList(),
+			WorkflowIdentifier:   workflowIdentifier,
+			TaskData:             taskData,
+			TargetDomainID:       info.TargetDomainID.String(),
+			TaskList:             info.GetTaskList(),
+			ScheduleID:           info.GetScheduleID(),
+			OriginalTaskList:     info.GetOriginalTaskList(),
+			OriginalTaskListKind: info.GetOriginalTaskListKind(),
 		}
 	case persistence.TransferTaskTypeActivityTask:
 		task = &persistence.ActivityTask{

--- a/common/persistence/tasks.go
+++ b/common/persistence/tasks.go
@@ -48,6 +48,7 @@ type Task interface {
 	// scheduled. It is used to enforce rate limits and ensure fair scheduling
 	// across task lists.
 	GetOriginalTaskList() string
+	GetOriginalTaskListKind() types.TaskListKind
 	GetVersion() int64
 	SetVersion(version int64)
 	GetTaskID() int64
@@ -98,10 +99,11 @@ type (
 	DecisionTask struct {
 		WorkflowIdentifier
 		TaskData
-		TargetDomainID   string
-		TaskList         string
-		ScheduleID       int64
-		OriginalTaskList string
+		TargetDomainID       string
+		TaskList             string
+		ScheduleID           int64
+		OriginalTaskList     string
+		OriginalTaskListKind types.TaskListKind
 	}
 
 	// RecordWorkflowStartedTask identifites a transfer task for writing visibility open execution record
@@ -443,6 +445,10 @@ func (a *ActivityTask) GetOriginalTaskList() string {
 	return a.TaskList
 }
 
+func (a *ActivityTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (a *ActivityTask) ByteSize() uint64 {
 	return a.WorkflowIdentifier.ByteSize() + a.TaskData.ByteSize() + uint64(len(a.TargetDomainID)) + uint64(len(a.TaskList)) + 8
 }
@@ -493,25 +499,30 @@ func (d *DecisionTask) GetOriginalTaskList() string {
 	return d.OriginalTaskList
 }
 
+func (d *DecisionTask) GetOriginalTaskListKind() types.TaskListKind {
+	return d.OriginalTaskListKind
+}
+
 func (d *DecisionTask) ByteSize() uint64 {
-	return d.WorkflowIdentifier.ByteSize() + d.TaskData.ByteSize() + uint64(len(d.TargetDomainID)) + uint64(len(d.TaskList)) + uint64(len(d.OriginalTaskList)) + 8
+	return d.WorkflowIdentifier.ByteSize() + d.TaskData.ByteSize() + uint64(len(d.TargetDomainID)) + uint64(len(d.TaskList)) + uint64(len(d.OriginalTaskList)) + 16
 }
 
 func (d *DecisionTask) ToTransferTaskInfo() (*TransferTaskInfo, error) {
 	return &TransferTaskInfo{
-		TaskType:            TransferTaskTypeDecisionTask,
-		DomainID:            d.DomainID,
-		WorkflowID:          d.WorkflowID,
-		RunID:               d.RunID,
-		TaskID:              d.TaskID,
-		VisibilityTimestamp: d.VisibilityTimestamp,
-		Version:             d.Version,
-		TargetDomainID:      d.TargetDomainID,
-		TaskList:            d.TaskList,
-		ScheduleID:          d.ScheduleID,
-		OriginalTaskList:    d.OriginalTaskList,
-		TargetWorkflowID:    TransferTaskTransferTargetWorkflowID,
-		TargetRunID:         TransferTaskTransferTargetRunID,
+		TaskType:             TransferTaskTypeDecisionTask,
+		DomainID:             d.DomainID,
+		WorkflowID:           d.WorkflowID,
+		RunID:                d.RunID,
+		TaskID:               d.TaskID,
+		VisibilityTimestamp:  d.VisibilityTimestamp,
+		Version:              d.Version,
+		TargetDomainID:       d.TargetDomainID,
+		TaskList:             d.TaskList,
+		ScheduleID:           d.ScheduleID,
+		OriginalTaskList:     d.OriginalTaskList,
+		OriginalTaskListKind: d.OriginalTaskListKind,
+		TargetWorkflowID:     TransferTaskTransferTargetWorkflowID,
+		TargetRunID:          TransferTaskTransferTargetRunID,
 	}, nil
 }
 
@@ -542,6 +553,10 @@ func (a *RecordWorkflowStartedTask) GetTaskList() string {
 
 func (a *RecordWorkflowStartedTask) GetOriginalTaskList() string {
 	return a.TaskList
+}
+
+func (a *RecordWorkflowStartedTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
 }
 
 func (a *RecordWorkflowStartedTask) ByteSize() uint64 {
@@ -593,6 +608,10 @@ func (a *ResetWorkflowTask) GetOriginalTaskList() string {
 	return a.TaskList
 }
 
+func (a *ResetWorkflowTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (a *ResetWorkflowTask) ByteSize() uint64 {
 	return a.WorkflowIdentifier.ByteSize() + a.TaskData.ByteSize() + uint64(len(a.TaskList))
 }
@@ -640,6 +659,10 @@ func (a *CloseExecutionTask) GetTaskList() string {
 
 func (a *CloseExecutionTask) GetOriginalTaskList() string {
 	return a.TaskList
+}
+
+func (a *CloseExecutionTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
 }
 
 func (a *CloseExecutionTask) ByteSize() uint64 {
@@ -691,6 +714,10 @@ func (a *DeleteHistoryEventTask) GetOriginalTaskList() string {
 	return a.TaskList
 }
 
+func (a *DeleteHistoryEventTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (a *DeleteHistoryEventTask) ByteSize() uint64 {
 	return a.WorkflowIdentifier.ByteSize() + a.TaskData.ByteSize() + uint64(len(a.TaskList))
 }
@@ -735,6 +762,10 @@ func (d *DecisionTimeoutTask) GetTaskList() string {
 
 func (d *DecisionTimeoutTask) GetOriginalTaskList() string {
 	return d.TaskList
+}
+
+func (d *DecisionTimeoutTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
 }
 
 func (d *DecisionTimeoutTask) ByteSize() uint64 {
@@ -786,6 +817,10 @@ func (a *ActivityTimeoutTask) GetOriginalTaskList() string {
 	return a.TaskList
 }
 
+func (a *ActivityTimeoutTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (a *ActivityTimeoutTask) ByteSize() uint64 {
 	return a.WorkflowIdentifier.ByteSize() + a.TaskData.ByteSize() + 8 + 8 + 8 + uint64(len(a.TaskList))
 }
@@ -835,6 +870,10 @@ func (u *UserTimerTask) GetOriginalTaskList() string {
 	return u.TaskList
 }
 
+func (u *UserTimerTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (u *UserTimerTask) ByteSize() uint64 {
 	return u.WorkflowIdentifier.ByteSize() + u.TaskData.ByteSize() + 8 + uint64(len(u.TaskList))
 }
@@ -880,6 +919,10 @@ func (r *ActivityRetryTimerTask) GetTaskList() string {
 
 func (r *ActivityRetryTimerTask) GetOriginalTaskList() string {
 	return r.TaskList
+}
+
+func (r *ActivityRetryTimerTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
 }
 
 func (r *ActivityRetryTimerTask) ByteSize() uint64 {
@@ -930,6 +973,10 @@ func (r *WorkflowBackoffTimerTask) GetOriginalTaskList() string {
 	return r.TaskList
 }
 
+func (r *WorkflowBackoffTimerTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (r *WorkflowBackoffTimerTask) ByteSize() uint64 {
 	return r.WorkflowIdentifier.ByteSize() + r.TaskData.ByteSize() + 8 + uint64(len(r.TaskList))
 }
@@ -977,6 +1024,10 @@ func (u *WorkflowTimeoutTask) GetOriginalTaskList() string {
 	return u.TaskList
 }
 
+func (u *WorkflowTimeoutTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (u *WorkflowTimeoutTask) ByteSize() uint64 {
 	return u.WorkflowIdentifier.ByteSize() + u.TaskData.ByteSize() + uint64(len(u.TaskList))
 }
@@ -1021,6 +1072,10 @@ func (u *CancelExecutionTask) GetTaskList() string {
 
 func (u *CancelExecutionTask) GetOriginalTaskList() string {
 	return u.TaskList
+}
+
+func (u *CancelExecutionTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
 }
 
 func (u *CancelExecutionTask) ByteSize() uint64 {
@@ -1078,6 +1133,10 @@ func (u *SignalExecutionTask) GetOriginalTaskList() string {
 	return u.TaskList
 }
 
+func (u *SignalExecutionTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (u *SignalExecutionTask) ByteSize() uint64 {
 	return u.WorkflowIdentifier.ByteSize() + u.TaskData.ByteSize() + uint64(len(u.TargetDomainID)) + uint64(len(u.TargetWorkflowID)) + uint64(len(u.TargetRunID)) + 8 + 1 + uint64(len(u.TaskList))
 }
@@ -1133,6 +1192,10 @@ func (u *RecordChildExecutionCompletedTask) GetOriginalTaskList() string {
 	return u.TaskList
 }
 
+func (u *RecordChildExecutionCompletedTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (u *RecordChildExecutionCompletedTask) ByteSize() uint64 {
 	return u.WorkflowIdentifier.ByteSize() + u.TaskData.ByteSize() + uint64(len(u.TargetDomainID)) + uint64(len(u.TargetWorkflowID)) + uint64(len(u.TargetRunID)) + uint64(len(u.TaskList))
 }
@@ -1186,6 +1249,10 @@ func (u *UpsertWorkflowSearchAttributesTask) GetOriginalTaskList() string {
 	return u.TaskList
 }
 
+func (u *UpsertWorkflowSearchAttributesTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (u *UpsertWorkflowSearchAttributesTask) ByteSize() uint64 {
 	return u.WorkflowIdentifier.ByteSize() + u.TaskData.ByteSize() + uint64(len(u.TaskList))
 }
@@ -1233,6 +1300,10 @@ func (u *StartChildExecutionTask) GetTaskList() string {
 
 func (u *StartChildExecutionTask) GetOriginalTaskList() string {
 	return u.TaskList
+}
+
+func (u *StartChildExecutionTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
 }
 
 func (u *StartChildExecutionTask) ByteSize() uint64 {
@@ -1285,6 +1356,10 @@ func (u *RecordWorkflowClosedTask) GetOriginalTaskList() string {
 	return u.TaskList
 }
 
+func (u *RecordWorkflowClosedTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (u *RecordWorkflowClosedTask) ByteSize() uint64 {
 	return u.WorkflowIdentifier.ByteSize() + u.TaskData.ByteSize() + uint64(len(u.TaskList))
 }
@@ -1334,6 +1409,10 @@ func (a *HistoryReplicationTask) GetOriginalTaskList() string {
 	return ""
 }
 
+func (a *HistoryReplicationTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (a *HistoryReplicationTask) ByteSize() uint64 {
 	return a.WorkflowIdentifier.ByteSize() + a.TaskData.ByteSize() + 8 + 8 + uint64(len(a.BranchToken)) + uint64(len(a.NewRunBranchToken))
 }
@@ -1381,6 +1460,10 @@ func (a *SyncActivityTask) GetOriginalTaskList() string {
 	return ""
 }
 
+func (a *SyncActivityTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
+}
+
 func (a *SyncActivityTask) ByteSize() uint64 {
 	return a.WorkflowIdentifier.ByteSize() + a.TaskData.ByteSize() + 8
 }
@@ -1426,6 +1509,10 @@ func (a *FailoverMarkerTask) GetTaskList() string {
 
 func (a *FailoverMarkerTask) GetOriginalTaskList() string {
 	return ""
+}
+
+func (a *FailoverMarkerTask) GetOriginalTaskListKind() types.TaskListKind {
+	return types.TaskListKindNormal
 }
 
 func (a *FailoverMarkerTask) ByteSize() uint64 {

--- a/service/history/execution/mutable_state_task_generator.go
+++ b/service/history/execution/mutable_state_task_generator.go
@@ -308,10 +308,11 @@ func (r *mutableStateTaskGeneratorImpl) GenerateDecisionScheduleTasks(
 			// TaskID and VisibilityTimestamp are set by shard context
 			Version: decision.Version,
 		},
-		TargetDomainID:   executionInfo.DomainID,
-		TaskList:         decision.TaskList,
-		ScheduleID:       decision.ScheduleID,
-		OriginalTaskList: originalTaskList,
+		TargetDomainID:       executionInfo.DomainID,
+		TaskList:             decision.TaskList,
+		ScheduleID:           decision.ScheduleID,
+		OriginalTaskList:     originalTaskList,
+		OriginalTaskListKind: executionInfo.TaskListKind,
 	})
 
 	if scheduleToStartTimeout := r.mutableState.GetDecisionScheduleToStartTimeout(); scheduleToStartTimeout != 0 {

--- a/service/history/execution/mutable_state_task_generator_test.go
+++ b/service/history/execution/mutable_state_task_generator_test.go
@@ -564,10 +564,11 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionScheduleTasks() {
 	decisionScheduleID := int64(123)
 
 	executionInfo := &persistence.WorkflowExecutionInfo{
-		DomainID:   constants.TestDomainID,
-		WorkflowID: constants.TestWorkflowID,
-		RunID:      constants.TestRunID,
-		TaskList:   "task-list",
+		DomainID:     constants.TestDomainID,
+		WorkflowID:   constants.TestWorkflowID,
+		RunID:        constants.TestRunID,
+		TaskList:     "task-list",
+		TaskListKind: types.TaskListKindEphemeral,
 	}
 
 	decision := &DecisionInfo{
@@ -596,10 +597,11 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionScheduleTasks() {
 					TaskData: persistence.TaskData{
 						Version: decision.Version,
 					},
-					TargetDomainID:   executionInfo.DomainID,
-					TaskList:         decision.TaskList,
-					ScheduleID:       decision.ScheduleID,
-					OriginalTaskList: "task-list",
+					TargetDomainID:       executionInfo.DomainID,
+					TaskList:             decision.TaskList,
+					ScheduleID:           decision.ScheduleID,
+					OriginalTaskList:     "task-list",
+					OriginalTaskListKind: types.TaskListKindEphemeral,
 				}).Times(1)
 				s.mockMutableState.EXPECT().GetDecisionScheduleToStartTimeout().Return(time.Duration(0)).Times(1)
 			},
@@ -617,10 +619,11 @@ func (s *mutableStateTaskGeneratorSuite) TestGenerateDecisionScheduleTasks() {
 					TaskData: persistence.TaskData{
 						Version: decision.Version,
 					},
-					TargetDomainID:   executionInfo.DomainID,
-					TaskList:         decision.TaskList,
-					ScheduleID:       decision.ScheduleID,
-					OriginalTaskList: "task-list",
+					TargetDomainID:       executionInfo.DomainID,
+					TaskList:             decision.TaskList,
+					ScheduleID:           decision.ScheduleID,
+					OriginalTaskList:     "task-list",
+					OriginalTaskListKind: types.TaskListKindEphemeral,
 				}).Times(1)
 				scheduleToStartTimeout := time.Duration(1)
 				s.mockMutableState.EXPECT().GetDecisionScheduleToStartTimeout().Return(scheduleToStartTimeout).Times(1)

--- a/service/history/task/interface_mock.go
+++ b/service/history/task/interface_mock.go
@@ -154,6 +154,20 @@ func (mr *MockTaskMockRecorder) GetOriginalTaskList() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalTaskList", reflect.TypeOf((*MockTask)(nil).GetOriginalTaskList))
 }
 
+// GetOriginalTaskListKind mocks base method.
+func (m *MockTask) GetOriginalTaskListKind() types.TaskListKind {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOriginalTaskListKind")
+	ret0, _ := ret[0].(types.TaskListKind)
+	return ret0
+}
+
+// GetOriginalTaskListKind indicates an expected call of GetOriginalTaskListKind.
+func (mr *MockTaskMockRecorder) GetOriginalTaskListKind() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalTaskListKind", reflect.TypeOf((*MockTask)(nil).GetOriginalTaskListKind))
+}
+
 // GetQueueType mocks base method.
 func (m *MockTask) GetQueueType() QueueType {
 	m.ctrl.T.Helper()
@@ -626,6 +640,20 @@ func (m *MockCrossClusterTask) GetOriginalTaskList() string {
 func (mr *MockCrossClusterTaskMockRecorder) GetOriginalTaskList() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalTaskList", reflect.TypeOf((*MockCrossClusterTask)(nil).GetOriginalTaskList))
+}
+
+// GetOriginalTaskListKind mocks base method.
+func (m *MockCrossClusterTask) GetOriginalTaskListKind() types.TaskListKind {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOriginalTaskListKind")
+	ret0, _ := ret[0].(types.TaskListKind)
+	return ret0
+}
+
+// GetOriginalTaskListKind indicates an expected call of GetOriginalTaskListKind.
+func (mr *MockCrossClusterTaskMockRecorder) GetOriginalTaskListKind() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOriginalTaskListKind", reflect.TypeOf((*MockCrossClusterTask)(nil).GetOriginalTaskListKind))
 }
 
 // GetQueueType mocks base method.


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Update persistence layer to store original task list kind field of transfer task
- Set the original task list kind to mutable state's task list kind when generating decision task

related to https://github.com/cadence-workflow/cadence/issues/7724
**Why?**
The change was missed in https://github.com/cadence-workflow/cadence/pull/7729 and https://github.com/cadence-workflow/cadence/pull/7744

**How did you test it?**
cd common/persistence && go test ./...
cd service/history/execution && go test ./...

**Potential risks**
No risk

**Release notes**
N/A

**Documentation Changes**
N/A
