### PR TITLE
fix(admin): return nil response when DescribeWorkflowExecution errors

### DIFF
--- a/service/frontend/admin/handler.go
+++ b/service/frontend/admin/handler.go
@@ -281,7 +281,7 @@ func (adh *adminHandlerImpl) DescribeWorkflowExecution(
 		Execution:  request.Execution,
 	})
 	if err != nil {
-		return &types.AdminDescribeWorkflowExecutionResponse{}, err
+		return nil, err
 	}
 	return &types.AdminDescribeWorkflowExecutionResponse{
 		ShardID:                shardIDForOutput,

--- a/service/frontend/wrappers/thrift/admin_handler_test.go
+++ b/service/frontend/wrappers/thrift/admin_handler_test.go
@@ -73,9 +73,9 @@ func TestAdminThriftHandler(t *testing.T) {
 		assert.Equal(t, expectedErr, err)
 	})
 	t.Run("DescribeWorkflowExecution", func(t *testing.T) {
-		h.EXPECT().DescribeWorkflowExecution(ctx, &types.AdminDescribeWorkflowExecutionRequest{}).Return(&types.AdminDescribeWorkflowExecutionResponse{}, internalErr).Times(1)
+		h.EXPECT().DescribeWorkflowExecution(ctx, &types.AdminDescribeWorkflowExecutionRequest{}).Return(nil, internalErr).Times(1)
 		resp, err := th.DescribeWorkflowExecution(ctx, &admin.DescribeWorkflowExecutionRequest{})
-		assert.Equal(t, admin.DescribeWorkflowExecutionResponse{ShardId: common.StringPtr(""), HistoryAddr: common.StringPtr(""), MutableStateInCache: common.StringPtr(""), MutableStateInDatabase: common.StringPtr("")}, *resp)
+		assert.Nil(t, resp)
 		assert.Equal(t, expectedErr, err)
 	})
 	t.Run("GetDLQReplicationMessages", func(t *testing.T) {


### PR DESCRIPTION
Fixes #7660

**What changed?**
- Modified `DescribeWorkflowExecution` in admin handler to return `nil` instead of an empty struct when an error occurs
- Updated the corresponding thrift wrapper test to expect `nil` response on error

**Why?**
When `DescribeWorkflowExecution` encountered an error (e.g., workflow does not exist), it returned an empty `AdminDescribeWorkflowExecutionResponse{}` struct with `ShardID: ""`. The gRPC transport layer then called `stringToInt32("")` on this empty ShardID, which caused a panic: `strconv.Atoi: parsing "": invalid syntax`.

**How did you test it?**
- Verified the fix addresses the root cause: returning `nil` when there's an error prevents the gRPC mapper from attempting to convert an empty string to int32
- Updated the existing unit test in `admin_handler_test.go` to verify the new behavior

**Potential risks**
Low risk - the change aligns with the expected behavior of returning an error without a partial response. The thrift wrapper already handles nil responses correctly via its mapper functions.

**Release notes**
Fixed a panic in AdminHandler's DescribeWorkflowExecution endpoint when using gRPC transport with non-existent workflows.

**Documentation Changes**
None required.