### PR TITLE
feat(scheduler): add describe query handler to expose schedule state

### DIFF
--- a/service/worker/scheduler/types.go
+++ b/service/worker/scheduler/types.go
@@ -36,6 +36,8 @@ const (
 	SignalNameBackfill = "scheduler-backfill"
 	SignalNameDelete   = "scheduler-delete"
 
+	QueryTypeDescribe = "scheduler-describe"
+
 	StartWorkflowActivityName = "scheduler-start-workflow"
 
 	maxIterationsBeforeContinueAsNew = 500
@@ -97,6 +99,24 @@ type BackfillSignal struct {
 	EndTime       time.Time                   `json:"endTime"`
 	OverlapPolicy types.ScheduleOverlapPolicy `json:"overlapPolicy"`
 	BackfillID    string                      `json:"backfillId,omitempty"`
+}
+
+// ScheduleDescription is the query result returned by the describe query handler.
+// It provides a snapshot of the schedule's current configuration and runtime state.
+type ScheduleDescription struct {
+	ScheduleID  string                 `json:"scheduleId"`
+	Domain      string                 `json:"domain"`
+	Spec        types.ScheduleSpec     `json:"spec"`
+	Action      types.ScheduleAction   `json:"action"`
+	Policies    types.SchedulePolicies `json:"policies"`
+	Paused      bool                   `json:"paused"`
+	PauseReason string                 `json:"pauseReason,omitempty"`
+	PausedBy    string                 `json:"pausedBy,omitempty"`
+	LastRunTime time.Time              `json:"lastRunTime,omitempty"`
+	NextRunTime time.Time              `json:"nextRunTime,omitempty"`
+	TotalRuns   int64                  `json:"totalRuns"`
+	MissedRuns  int64                  `json:"missedRuns"`
+	SkippedRuns int64                  `json:"skippedRuns"`
 }
 
 // StartWorkflowRequest is the input to the start-workflow activity.

--- a/service/worker/scheduler/workflow.go
+++ b/service/worker/scheduler/workflow.go
@@ -60,6 +60,13 @@ func SchedulerWorkflow(ctx workflow.Context, input SchedulerWorkflowInput) error
 
 	state := &input.State
 
+	err := workflow.SetQueryHandler(ctx, QueryTypeDescribe, func() (*ScheduleDescription, error) {
+		return buildScheduleDescription(&input, state), nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to register query handler: %w", err)
+	}
+
 	chs := signalChannels{
 		pause:    workflow.GetSignalChannel(ctx, SignalNamePause),
 		unpause:  workflow.GetSignalChannel(ctx, SignalNameUnpause),
@@ -376,6 +383,26 @@ func computeNextRunTime(sched cron.Schedule, now time.Time, spec types.ScheduleS
 		return time.Time{}
 	}
 	return next
+}
+
+// buildScheduleDescription creates a snapshot of the current schedule
+// configuration and runtime state for the describe query handler.
+func buildScheduleDescription(input *SchedulerWorkflowInput, state *SchedulerWorkflowState) *ScheduleDescription {
+	return &ScheduleDescription{
+		ScheduleID:  input.ScheduleID,
+		Domain:      input.Domain,
+		Spec:        input.Spec,
+		Action:      input.Action,
+		Policies:    input.Policies,
+		Paused:      state.Paused,
+		PauseReason: state.PauseReason,
+		PausedBy:    state.PausedBy,
+		LastRunTime: state.LastRunTime,
+		NextRunTime: state.NextRunTime,
+		TotalRuns:   state.TotalRuns,
+		MissedRuns:  state.MissedRuns,
+		SkippedRuns: state.SkippedRuns,
+	}
 }
 
 // safeContinueAsNew drains the delete channel before performing ContinueAsNew.

--- a/service/worker/scheduler/workflow_test.go
+++ b/service/worker/scheduler/workflow_test.go
@@ -119,6 +119,92 @@ func TestComputeNextRunTime(t *testing.T) {
 	}
 }
 
+func TestBuildScheduleDescription(t *testing.T) {
+	lastRun := time.Date(2026, 1, 15, 10, 0, 0, 0, time.UTC)
+	nextRun := time.Date(2026, 1, 15, 11, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name  string
+		input SchedulerWorkflowInput
+		state SchedulerWorkflowState
+		want  *ScheduleDescription
+	}{
+		{
+			name: "running schedule with counters",
+			input: SchedulerWorkflowInput{
+				ScheduleID: "sched-1",
+				Domain:     "test-domain",
+				Spec:       types.ScheduleSpec{CronExpression: "0 * * * *"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-wf"},
+					},
+				},
+				Policies: types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicySkipNew},
+			},
+			state: SchedulerWorkflowState{
+				LastRunTime: lastRun,
+				NextRunTime: nextRun,
+				TotalRuns:   42,
+				MissedRuns:  1,
+				SkippedRuns: 3,
+			},
+			want: &ScheduleDescription{
+				ScheduleID: "sched-1",
+				Domain:     "test-domain",
+				Spec:       types.ScheduleSpec{CronExpression: "0 * * * *"},
+				Action: types.ScheduleAction{
+					StartWorkflow: &types.StartWorkflowAction{
+						WorkflowType: &types.WorkflowType{Name: "my-wf"},
+					},
+				},
+				Policies:    types.SchedulePolicies{OverlapPolicy: types.ScheduleOverlapPolicySkipNew},
+				LastRunTime: lastRun,
+				NextRunTime: nextRun,
+				TotalRuns:   42,
+				MissedRuns:  1,
+				SkippedRuns: 3,
+			},
+		},
+		{
+			name: "paused schedule",
+			input: SchedulerWorkflowInput{
+				ScheduleID: "sched-2",
+				Domain:     "prod",
+				Spec:       types.ScheduleSpec{CronExpression: "0 0 * * *"},
+			},
+			state: SchedulerWorkflowState{
+				Paused:      true,
+				PauseReason: "maintenance",
+				PausedBy:    "admin@test.com",
+				TotalRuns:   10,
+			},
+			want: &ScheduleDescription{
+				ScheduleID:  "sched-2",
+				Domain:      "prod",
+				Spec:        types.ScheduleSpec{CronExpression: "0 0 * * *"},
+				Paused:      true,
+				PauseReason: "maintenance",
+				PausedBy:    "admin@test.com",
+				TotalRuns:   10,
+			},
+		},
+		{
+			name:  "fresh schedule with no runs",
+			input: SchedulerWorkflowInput{ScheduleID: "sched-new", Domain: "dev"},
+			state: SchedulerWorkflowState{},
+			want:  &ScheduleDescription{ScheduleID: "sched-new", Domain: "dev"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildScheduleDescription(&tt.input, &tt.state)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 func TestHandlePause(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
<!-- If you are new to contributing or want a refresher, please read ./pull_request_guidance.md -->
**What changed?**
- Registers a `scheduler-describe` query handler on the scheduler workflow so external callers (frontend DescribeSchedule API) can inspect the current schedule configuration and runtime state without signals or side effects.
- Returns spec, action, policies, pause status, next/last run times, and run counters (total, missed, skipped) as a `ScheduleDescription` struct.

**Why?**
Part of cadence schedules feature: query handler
Before we can build the frontend DescribeSchedule API, the workflow needs to expose its state via a query handler.

**How did you test it?**
Added table tests
and tested with go test ./..

**Potential risks**
N/A

**Release notes**
N/A

**Documentation Changes**
N/A
