### PR TITLE
fix(shard-distributor): change log level to Error for missing executors

### DIFF
--- a/service/sharddistributor/leader/process/processor.go
+++ b/service/sharddistributor/leader/process/processor.go
@@ -420,7 +420,7 @@ func (p *namespaceProcessor) rebalanceShardsImpl(ctx context.Context, metricsLoo
 
 	activeExecutors := p.getActiveExecutors(namespaceState, staleExecutors)
 	if len(activeExecutors) == 0 {
-		p.logger.Info("No active executors found. Cannot assign shards.")
+		p.logger.Error("No active executors found. Cannot assign shards.")
 
 		// Cleanup stale executors even if no active executors remain
 		if len(staleExecutors) > 0 {


### PR DESCRIPTION
**What changed?**
Changed the log level from Info to Error for "No active executors found. Cannot assign shards." message.

**Why?**
This condition indicates a problem that should be investigated rather than normal operation.

**How did you test it?**
Unit tests pass.

**Potential risks**
None - log level change only.

**Release notes**
N/A

**Documentation Changes**
N/A